### PR TITLE
feat: add option to disable persistence for zeebe StS

### DIFF
--- a/charts/ccsm-helm/charts/zeebe/templates/statefulset.yaml
+++ b/charts/ccsm-helm/charts/zeebe/templates/statefulset.yaml
@@ -132,8 +132,10 @@ spec:
         - name: config
           mountPath: /usr/local/bin/startup.sh
           subPath: startup.sh
+        {{- if .Values.persistence.enabled }}
         - name: data
           mountPath: /usr/local/zeebe/data
+        {{- end }}
         - name: exporters
           mountPath: /exporters
         {{- if .Values.log4j2 }}
@@ -172,6 +174,7 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
 {{- end }}
+{{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:
       name: data
@@ -181,3 +184,4 @@ spec:
       resources:
         requests:
           storage: {{ .Values.pvcSize | quote }}
+{{- end -}}

--- a/charts/ccsm-helm/values.yaml
+++ b/charts/ccsm-helm/values.yaml
@@ -40,7 +40,7 @@ global:
     # Image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
     pullSecrets: [ ]
 
-  # Elasticsearch configuration which is shared between the sub charts  
+  # Elasticsearch configuration which is shared between the sub charts
   elasticsearch:
     # Elasticsearch.disableExporter if true, disables the elastic exporter in zeebe
     disableExporter: false
@@ -99,6 +99,9 @@ zeebe:
     -XX:ErrorFile=/usr/local/zeebe/data/zeebe_error%p.log
     -XX:+ExitOnOutOfMemoryError
 
+  persistence:
+    # Enabled if true, a PVC is created as part of the zeebe StatefulSet. CAVE: disabling persistence WILL lead to data loss, but can be preferable in a testing situation.
+    enabled: true
 
  # Service configuration for the broker service
   service:


### PR DESCRIPTION
closes #232

* Added `zeebe.persistence.enabled` value which defaults to `true`
* PVC and volume are only created when enabled
* test showing the omission of the `data` volume and the `volumeClaimTemplates` when `zeebe.persistence.enabled` is set to `false`:
  ```bash
  diff \
  <(helm template ccsm-helm-232 --dry-run --set elasticsearch.enabled=false --set tasklist.enabled=false --set operate.enabled=false .) \
  <(helm template ccsm-helm-232 --dry-run --set elasticsearch.enabled=false --set tasklist.enabled=false --set operate.enabled=false --set zeebe.persistence.enabled=false .)
  ```

  ```diff
  389,390d388
  <         - name: data
  <           mountPath: /usr/local/zeebe/data
  400,408d397
  <   volumeClaimTemplates:
  <   - metadata:
  <       name: data
  <     spec:
  <       accessModes: [ReadWriteOnce]
  <       storageClassName: 
  <       resources:
  <         requests:
  <           storage: "32Gi"
  ```
