### PR TITLE
Use relative DNS for clusters with non-default clusterDomain

### DIFF
--- a/charts/ccsm-helm/charts/zeebe/templates/statefulset.yaml
+++ b/charts/ccsm-helm/charts/zeebe/templates/statefulset.yaml
@@ -61,11 +61,11 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: ZEEBE_BROKER_NETWORK_ADVERTISEDHOST
-          value: "$(K8S_NAME).$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc.cluster.local"
+          value: "$(K8S_NAME).$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc"
         - name: ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS
           value:
           {{- range (untilStep 0 (int .Values.clusterSize) 1) }}
-            $(K8S_SERVICE_NAME)-{{ . }}.$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc.cluster.local:{{$.Values.service.internalPort}},
+            $(K8S_SERVICE_NAME)-{{ . }}.$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc:{{$.Values.service.internalPort}},
           {{- end }}
         - name: ZEEBE_BROKER_CLUSTER_CLUSTERNAME
           value: {{ tpl .Values.global.zeebeClusterName . }}

--- a/charts/ccsm-helm/test/zeebe/golden/statefulset.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe/golden/statefulset.golden.yaml
@@ -59,12 +59,12 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: ZEEBE_BROKER_NETWORK_ADVERTISEDHOST
-          value: "$(K8S_NAME).$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc.cluster.local"
+          value: "$(K8S_NAME).$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc"
         - name: ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS
           value:
-            $(K8S_SERVICE_NAME)-0.$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc.cluster.local:26502,
-            $(K8S_SERVICE_NAME)-1.$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc.cluster.local:26502,
-            $(K8S_SERVICE_NAME)-2.$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc.cluster.local:26502,
+            $(K8S_SERVICE_NAME)-0.$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc:26502,
+            $(K8S_SERVICE_NAME)-1.$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc:26502,
+            $(K8S_SERVICE_NAME)-2.$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc:26502,
         - name: ZEEBE_BROKER_CLUSTER_CLUSTERNAME
           value: ccsm-helm-test-zeebe
         - name: ZEEBE_LOG_LEVEL


### PR DESCRIPTION
Kubernetes clusters can override the clusterDomain, which defaults to `cluster.local`. For clusters using a non-default clusterDomain the value of `ZEEBE_BROKER_NETWORK_ADVERTISEDHOST` and `ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS` are incorrect.

A default `resolv.conf` for a Pod contains following `search`:

```bash
search $NAMESPACE.svc.$CLUSTER_DOMAIN svc.$CLUSTER_DOMAIN $CLUSTER_DOMAIN
```

Hence the `$CLUSTER_DOMAIN` part can be omitted from the mentioned environment variables.