### PR TITLE
Add condition to it job

### DIFF
--- a/.github/workflows/go-it.yaml
+++ b/.github/workflows/go-it.yaml
@@ -13,6 +13,7 @@ env:
 
 jobs:  
   build:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     env:
       KUBECONFIG: .github/config/kubeconfig


### PR DESCRIPTION
> If external contributor create a PR gcloud auth fails with:
> 
> ```
> Error: google-github-actions/auth failed with: gitHub Actions did not inject $ACTIONS_ID_TOKEN_REQUEST_TOKEN or $ACTIONS_ID_TOKEN_REQUEST_URL into this job. This most likely means the GitHub Actions workflow permissions are incorrect, or this job is being run from a fork. For more information, please see https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
> ```

This happens since it needs write permission, but for forks github only allows read.

We can exclude PR's which come from forks see https://github.community/t/how-to-detect-a-pull-request-from-a-fork/18363/2 

closes https://github.com/camunda/camunda-platform-helm/issues/243