### PR TITLE
Add Zeebe broker anti-affinity

### DIFF
--- a/charts/ccsm-helm/README.md
+++ b/charts/ccsm-helm/README.md
@@ -124,7 +124,7 @@ Information about Zeebe you can find [here](https://docs.camunda.io/docs/compone
 | | `containerSecurityContext` | Defines the security options the broker container should be run with | |
 | | `nodeSelector` | Can be used to define on which nodes the broker pods should run | `{ } ` |
 | | `tolerations` | Can be used to define [pod toleration's](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) | `[ ]` |
-| | `affinity` | Can be used to define [pod affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) | `{ }` |
+| | `affinity` | Can be used to define [pod affinity or anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity). The default defined PodAntiAffinity allows constraining on which nodes the [Zeebe pods are scheduled on](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity). It uses a hard requirement for scheduling and works based on the Zeebe pod labels. | `podAntiAffinity:</br>  requiredDuringSchedulingIgnoredDuringExecution:</br>  - labelSelector: </br>    matchExpressions:</br>    - key: "app.kubernetes.io/component"</br>    operator: In</br>    values:</br>    - zeebe-broker</br>  topologyKey: "kubernetes.io/hostname"` |
 | | `priorityClassName` | Can be used to define the broker [pods priority](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass) | `""` |
 | | `readinessProbe` | Configuration for the Zeebe broker readiness probe | |
 | | `readinessProbe.probePath` | Defines the readiness probe route used on the Zeebe brokers | `/ready` |

--- a/charts/ccsm-helm/test/zeebe/golden/statefulset.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe/golden/statefulset.golden.yaml
@@ -139,6 +139,16 @@ spec:
           defaultMode: 0744
       - name: exporters
         emptyDir: {}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                - zeebe-broker
+            topologyKey: kubernetes.io/hostname
   volumeClaimTemplates:
   - metadata:
       name: data

--- a/charts/ccsm-helm/values.yaml
+++ b/charts/ccsm-helm/values.yaml
@@ -178,8 +178,20 @@ zeebe:
   nodeSelector: { }
   # Tolerations can be used to define pod toleration's https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
   tolerations: [ ]
-  # Affinity can be used to define pod affinity https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
-  affinity: { }
+  # Affinity can be used to define pod affinity or anti-affinity https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+  # The default defined PodAntiAffinity allows constraining on which nodes the Zeebe pods are scheduled on https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  # It uses a hard requirement for scheduling and works based on the Zeebe pod labels
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: "app.kubernetes.io/component"
+                operator: In
+                values:
+                  - zeebe-broker
+          topologyKey: "kubernetes.io/hostname"
+
   # PriorityClassName can be used to define the broker pods priority https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass
   priorityClassName: ""
 


### PR DESCRIPTION
In order to not schedule pods on the same node, for stability but also performance reasons we add anti-affinity rules, similar to the ones we have in our SaaS offering.

related to https://github.com/camunda/camunda-platform-helm/issues/223