### PR TITLE
fix: define correct path for metrics

### DIFF
--- a/charts/ccsm-helm/templates/service-monitor.yaml
+++ b/charts/ccsm-helm/templates/service-monitor.yaml
@@ -11,6 +11,7 @@ spec:
       {{- toYaml .Values.global.labels | nindent 6 }}
   endpoints:
     - honorLabels: true
+      path: /actuator/prometheus
       port: http
       interval: {{ .Values.prometheusServiceMonitor.scrapeInterval }}
 {{- end }}

--- a/charts/ccsm-helm/test/golden/service-monitor.golden.yaml
+++ b/charts/ccsm-helm/test/golden/service-monitor.golden.yaml
@@ -18,5 +18,6 @@ spec:
       app: camunda-cloud-self-managed
   endpoints:
     - honorLabels: true
+      path: /actuator/prometheus
       port: http
       interval: 10s


### PR DESCRIPTION
I'm not sure if this is correct configuration, but tasklist and operator don't expose metrics on `/metrics` but on `/actuator/prometheus`. The `/actuator/prometheus` seems to be present on the broker and gateway as well.

For tasklist and operate I've found the corresponding documentation:
- [tasklist](https://docs.camunda.io/docs/self-managed/tasklist-deployment/configuration/#monitoring-and-health-probes)
- [operate](https://docs.camunda.io/docs/self-managed/operate-deployment/configuration/#monitoring-operate)