### PR TITLE
Fix matchLabel selectors

### DIFF
--- a/charts/ccsm-helm/charts/operate/templates/_helpers.tpl
+++ b/charts/ccsm-helm/charts/operate/templates/_helpers.tpl
@@ -19,11 +19,27 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
-Defines labels for operate.
+Defines extra labels for operate.
+*/}}
+{{- define "operate.extraLabels" -}}
+app.kubernetes.io/component: operate
+{{- end -}}
+
+{{/*
+Define common labels for operate, combining the match labels and transient labels, which might change on updating
+(version depending). These labels shouldn't be used on matchLabels selector, since the selectors are immutable.
 */}}
 {{- define "operate.labels" -}}
 {{- template "ccsm.labels" . }}
-app.kubernetes.io/component: operate
+{{ template "operate.extraLabels" . }}
+{{- end -}}
+
+{{/*
+Defines match labels for operate, which are extended by sub-charts and should be used in matchLabels selectors.
+*/}}
+{{- define "operate.matchLabels" -}}
+{{- template "ccsm.matchLabels" . }}
+{{ template "operate.extraLabels" . }}
 {{- end -}}
 
 {{/*

--- a/charts/ccsm-helm/charts/operate/templates/deployment.yaml
+++ b/charts/ccsm-helm/charts/operate/templates/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   replicas: 1
   selector:
-    matchLabels: {{- include "operate.labels" . | nindent 6 }}
+    matchLabels: {{- include "operate.matchLabels" . | nindent 6 }}
   template:
     metadata:
       labels: {{- include "operate.labels" . | nindent 8 }}

--- a/charts/ccsm-helm/charts/operate/templates/service.yaml
+++ b/charts/ccsm-helm/charts/operate/templates/service.yaml
@@ -18,4 +18,4 @@ spec:
     targetPort: 8080
     protocol: TCP
   selector:
-    {{- include "operate.labels" . | nindent 4 }}
+    {{- include "operate.matchLabels" . | nindent 4 }}

--- a/charts/ccsm-helm/charts/tasklist/templates/_helpers.tpl
+++ b/charts/ccsm-helm/charts/tasklist/templates/_helpers.tpl
@@ -19,9 +19,25 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
-Defines labels for tasklist.
+Defines extra labels for tasklist.
+*/}}
+{{- define "tasklist.extraLabels" -}}
+app.kubernetes.io/component: tasklist
+{{- end -}}
+
+{{/*
+Define common labels for tasklist, combining the match labels and transient labels, which might change on updating
+(version depending). These labels shouldn't be used on matchLabels selector, since the selectors are immutable.
 */}}
 {{- define "tasklist.labels" -}}
 {{- template "ccsm.labels" . }}
-app.kubernetes.io/component: tasklist
+{{ template "tasklist.extraLabels" . }}
+{{- end -}}
+
+{{/*
+Defines match labels for tasklist, which are extended by sub-charts and should be used in matchLabels selectors.
+*/}}
+{{- define "tasklist.matchLabels" -}}
+{{- template "ccsm.matchLabels" . }}
+{{ template "tasklist.extraLabels" . }}
 {{- end -}}

--- a/charts/ccsm-helm/charts/tasklist/templates/deployment.yaml
+++ b/charts/ccsm-helm/charts/tasklist/templates/deployment.yaml
@@ -8,7 +8,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "tasklist.labels" . | nindent 6 }}
+      {{- include "tasklist.matchLabels" . | nindent 6 }}
   template:
     metadata:
       labels: {{- include "tasklist.labels" . | nindent 8 }}

--- a/charts/ccsm-helm/charts/tasklist/templates/service.yaml
+++ b/charts/ccsm-helm/charts/tasklist/templates/service.yaml
@@ -11,4 +11,4 @@ spec:
     targetPort: 8080
     protocol: TCP
   selector:
-    {{- include "tasklist.labels" . | nindent 4 }}
+    {{- include "tasklist.matchLabels" . | nindent 4 }}

--- a/charts/ccsm-helm/charts/zeebe-gateway/templates/_helpers.tpl
+++ b/charts/ccsm-helm/charts/zeebe-gateway/templates/_helpers.tpl
@@ -19,11 +19,27 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
-Defines labels for the gateway.
+Defines extra labels for Zeebe gateway.
+*/}}
+{{- define "zeebe.extraLabels.gateway" -}}
+app.kubernetes.io/component: zeebe-gateway
+{{- end -}}
+
+{{/*
+Define common labels for Zeebe gateway, combining the match labels and transient labels, which might change on updating
+(version depending). These labels shouldn't be used on matchLabels selector, since the selectors are immutable.
 */}}
 {{- define "zeebe.labels.gateway" -}}
 {{- template "ccsm.labels" . }}
-app.kubernetes.io/component: zeebe-gateway
+{{ template "zeebe.extraLabels.gateway" . }}
+{{- end -}}
+
+{{/*
+Defines match labels for Zeebe gateway, which are extended by sub-charts and should be used in matchLabels selectors.
+*/}}
+{{- define "zeebe.matchLabels.gateway" -}}
+{{- template "ccsm.matchLabels" . }}
+{{ template "zeebe.extraLabels.gateway" . }}
 {{- end -}}
 
 {{/*

--- a/charts/ccsm-helm/charts/zeebe-gateway/templates/gateway-deployment.yaml
+++ b/charts/ccsm-helm/charts/zeebe-gateway/templates/gateway-deployment.yaml
@@ -9,7 +9,7 @@ spec:
   replicas: {{ .Values.replicas  }}
   selector:
     matchLabels:
-      {{- include "zeebe.labels.gateway" . | nindent 6 }}
+      {{- include "zeebe.matchLabels.gateway" . | nindent 6 }}
   template:
     metadata:
       labels:

--- a/charts/ccsm-helm/charts/zeebe-gateway/templates/gateway-poddisruptionbudget.yaml
+++ b/charts/ccsm-helm/charts/zeebe-gateway/templates/gateway-poddisruptionbudget.yaml
@@ -12,5 +12,5 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "zeebe.labels.gateway" . | nindent 6 }}
+      {{- include "zeebe.matchLabels.gateway" . | nindent 6 }}
 {{ end }}

--- a/charts/ccsm-helm/charts/zeebe-gateway/templates/gateway-service.yaml
+++ b/charts/ccsm-helm/charts/zeebe-gateway/templates/gateway-service.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   selector:
-    {{- include "zeebe.labels.gateway" . | nindent 6 }}
+    {{- include "zeebe.matchLabels.gateway" . | nindent 6 }}
   ports:
     - port: {{ .Values.service.httpPort }}
       protocol: TCP

--- a/charts/ccsm-helm/charts/zeebe/templates/_helpers.tpl
+++ b/charts/ccsm-helm/charts/zeebe/templates/_helpers.tpl
@@ -43,11 +43,27 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
-Defines labels for the broker.
+Defines extra labels for Zeebe broker.
+*/}}
+{{- define "zeebe.extraLabels.broker" -}}
+app.kubernetes.io/component: zeebe-broker
+{{- end -}}
+
+{{/*
+Define common labels for Zeebe broker, combining the match labels and transient labels, which might change on updating
+(version depending). These labels shouldn't be used on matchLabels selector, since the selectors are immutable.
 */}}
 {{- define "zeebe.labels.broker" -}}
 {{- template "ccsm.labels" . }}
-app.kubernetes.io/component: zeebe-broker
+{{ template "zeebe.extraLabels.broker" . }}
+{{- end -}}
+
+{{/*
+Defines match labels for Zeebe broker, which are extended by sub-charts and should be used in matchLabels selectors.
+*/}}
+{{- define "zeebe.matchLabels.broker" -}}
+{{- template "ccsm.matchLabels" . }}
+{{ template "zeebe.extraLabels.broker" . }}
 {{- end -}}
 
 {{/*

--- a/charts/ccsm-helm/charts/zeebe/templates/poddisruptionbudget.yaml
+++ b/charts/ccsm-helm/charts/zeebe/templates/poddisruptionbudget.yaml
@@ -12,5 +12,5 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "zeebe.labels.broker" . | nindent 6 }}
+      {{- include "zeebe.matchLabels.broker" . | nindent 6 }}
 {{ end }}

--- a/charts/ccsm-helm/charts/zeebe/templates/service.yaml
+++ b/charts/ccsm-helm/charts/zeebe/templates/service.yaml
@@ -23,4 +23,4 @@ spec:
     {{ .Values.service.extraPorts | toYaml | nindent 4 }}
     {{- end }}
   selector:
-    {{- include "zeebe.labels.broker" . | nindent 4 }}
+    {{- include "zeebe.matchLabels.broker" . | nindent 4 }}

--- a/charts/ccsm-helm/charts/zeebe/templates/statefulset.yaml
+++ b/charts/ccsm-helm/charts/zeebe/templates/statefulset.yaml
@@ -11,7 +11,7 @@ spec:
   replicas: {{ .Values.clusterSize  }}
   selector:
     matchLabels:
-      {{- include "zeebe.labels.broker" . | nindent 6 }}
+      {{- include "zeebe.matchLabels.broker" . | nindent 6 }}
   serviceName: {{ include "zeebe.names.broker" . }}
   updateStrategy:
     type: RollingUpdate

--- a/charts/ccsm-helm/templates/_helpers.tpl
+++ b/charts/ccsm-helm/templates/_helpers.tpl
@@ -7,16 +7,12 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
-Common labels
+Define common labels, combining the match labels and transient labels, which might change on updating
+(version depending). These labels shouldn't be used on matchLabels selector, since the selectors are immutable.
 */}}
 {{- define "ccsm.labels" -}}
-{{- if .Values.global.labels -}}
-{{ toYaml .Values.global.labels }}
-{{- end }}
-app.kubernetes.io/name: {{ template "ccsm.name" . }}
+{{- template "ccsm.matchLabels" . }}
 helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.image }}
     {{- if .Values.image.tag }}
 app.kubernetes.io/version: {{ .Values.image.tag | quote }}
@@ -26,6 +22,17 @@ app.kubernetes.io/version: {{ .Values.global.image.tag | quote }}
 {{- else }}
 app.kubernetes.io/version: {{ .Values.global.image.tag | quote }}
 {{- end }}
-app.kubernetes.io/part-of: camunda-cloud-self-managed
 {{- end -}}
 
+{{/*
+Common match labels, which are extended by sub-charts and should be used in matchLabels selectors.
+*/}}
+{{- define "ccsm.matchLabels" -}}
+{{- if .Values.global.labels -}}
+{{ toYaml .Values.global.labels }}
+{{- end }}
+app.kubernetes.io/name: {{ template "ccsm.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: camunda-cloud-self-managed
+{{- end -}}

--- a/charts/ccsm-helm/test/golden/curator-configmap.golden.yaml
+++ b/charts/ccsm-helm/test/golden/curator-configmap.golden.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/name: ccsm-helm
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/part-of: camunda-cloud-self-managed
+    app.kubernetes.io/version: "1.3.4"
 data:
   action_file.yml: |-
     ---

--- a/charts/ccsm-helm/test/golden/curator-cronjob.golden.yaml
+++ b/charts/ccsm-helm/test/golden/curator-cronjob.golden.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/name: ccsm-helm
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/part-of: camunda-cloud-self-managed
+    app.kubernetes.io/version: "1.3.4"
 spec:
   schedule: "0 0 * * *"
   successfulJobsHistoryLimit: 1

--- a/charts/ccsm-helm/test/golden/service-monitor.golden.yaml
+++ b/charts/ccsm-helm/test/golden/service-monitor.golden.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/name: ccsm-helm
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/part-of: camunda-cloud-self-managed
+    app.kubernetes.io/version: "1.3.4"
     release: metrics
 spec:
   selector:

--- a/charts/ccsm-helm/test/operate/golden/configmap-elastic-url.golden.yaml
+++ b/charts/ccsm-helm/test/operate/golden/configmap-elastic-url.golden.yaml
@@ -8,8 +8,8 @@ metadata:
     app.kubernetes.io/name: operate
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/part-of: camunda-cloud-self-managed
+    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/component: operate
 apiVersion: v1
 data:

--- a/charts/ccsm-helm/test/operate/golden/configmap.golden.yaml
+++ b/charts/ccsm-helm/test/operate/golden/configmap.golden.yaml
@@ -8,8 +8,8 @@ metadata:
     app.kubernetes.io/name: operate
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/part-of: camunda-cloud-self-managed
+    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/component: operate
 apiVersion: v1
 data:

--- a/charts/ccsm-helm/test/operate/golden/deployment.golden.yaml
+++ b/charts/ccsm-helm/test/operate/golden/deployment.golden.yaml
@@ -23,7 +23,6 @@ spec:
       app.kubernetes.io/instance: ccsm-helm-test
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-cloud-self-managed
-      app.kubernetes.io/version: "1.3.4"
       app.kubernetes.io/component: operate
   template:
     metadata:

--- a/charts/ccsm-helm/test/operate/golden/deployment.golden.yaml
+++ b/charts/ccsm-helm/test/operate/golden/deployment.golden.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/name: operate
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/part-of: camunda-cloud-self-managed
+    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/component: operate
   annotations:
     {}
@@ -22,8 +22,8 @@ spec:
       app.kubernetes.io/name: operate
       app.kubernetes.io/instance: ccsm-helm-test
       app.kubernetes.io/managed-by: Helm
-      app.kubernetes.io/version: "1.3.4"
       app.kubernetes.io/part-of: camunda-cloud-self-managed
+      app.kubernetes.io/version: "1.3.4"
       app.kubernetes.io/component: operate
   template:
     metadata:
@@ -32,8 +32,8 @@ spec:
         app.kubernetes.io/name: operate
         app.kubernetes.io/instance: ccsm-helm-test
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/version: "1.3.4"
         app.kubernetes.io/part-of: camunda-cloud-self-managed
+        app.kubernetes.io/version: "1.3.4"
         app.kubernetes.io/component: operate
     spec:
       containers:

--- a/charts/ccsm-helm/test/operate/golden/ingress-all-enabled.golden.yaml
+++ b/charts/ccsm-helm/test/operate/golden/ingress-all-enabled.golden.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/name: operate
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/part-of: camunda-cloud-self-managed
+    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/component: operate
   annotations: 
     ingress.kubernetes.io/rewrite-target: /

--- a/charts/ccsm-helm/test/operate/golden/ingress.golden.yaml
+++ b/charts/ccsm-helm/test/operate/golden/ingress.golden.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/name: operate
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/part-of: camunda-cloud-self-managed
+    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/component: operate
   annotations: 
     ingress.kubernetes.io/rewrite-target: /

--- a/charts/ccsm-helm/test/operate/golden/service.golden.yaml
+++ b/charts/ccsm-helm/test/operate/golden/service.golden.yaml
@@ -26,5 +26,4 @@ spec:
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-cloud-self-managed
-    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/component: operate

--- a/charts/ccsm-helm/test/operate/golden/service.golden.yaml
+++ b/charts/ccsm-helm/test/operate/golden/service.golden.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/name: operate
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/part-of: camunda-cloud-self-managed
+    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/component: operate
   annotations:
 spec:
@@ -25,6 +25,6 @@ spec:
     app.kubernetes.io/name: operate
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/part-of: camunda-cloud-self-managed
+    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/component: operate

--- a/charts/ccsm-helm/test/operate/golden/serviceaccount.golden.yaml
+++ b/charts/ccsm-helm/test/operate/golden/serviceaccount.golden.yaml
@@ -9,6 +9,6 @@ metadata:
     app.kubernetes.io/name: operate
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/part-of: camunda-cloud-self-managed
+    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/component: operate

--- a/charts/ccsm-helm/test/tasklist/golden/configmap.golden.yaml
+++ b/charts/ccsm-helm/test/tasklist/golden/configmap.golden.yaml
@@ -8,8 +8,8 @@ metadata:
     app.kubernetes.io/name: tasklist
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/part-of: camunda-cloud-self-managed
+    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/component: tasklist
 apiVersion: v1
 data:

--- a/charts/ccsm-helm/test/tasklist/golden/deployment.golden.yaml
+++ b/charts/ccsm-helm/test/tasklist/golden/deployment.golden.yaml
@@ -23,7 +23,6 @@ spec:
       app.kubernetes.io/instance: ccsm-helm-test
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-cloud-self-managed
-      app.kubernetes.io/version: "1.3.4"
       app.kubernetes.io/component: tasklist
   template:
     metadata:

--- a/charts/ccsm-helm/test/tasklist/golden/deployment.golden.yaml
+++ b/charts/ccsm-helm/test/tasklist/golden/deployment.golden.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/name: tasklist
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/part-of: camunda-cloud-self-managed
+    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/component: tasklist
   annotations:
     {}
@@ -22,8 +22,8 @@ spec:
       app.kubernetes.io/name: tasklist
       app.kubernetes.io/instance: ccsm-helm-test
       app.kubernetes.io/managed-by: Helm
-      app.kubernetes.io/version: "1.3.4"
       app.kubernetes.io/part-of: camunda-cloud-self-managed
+      app.kubernetes.io/version: "1.3.4"
       app.kubernetes.io/component: tasklist
   template:
     metadata:
@@ -32,8 +32,8 @@ spec:
         app.kubernetes.io/name: tasklist
         app.kubernetes.io/instance: ccsm-helm-test
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/version: "1.3.4"
         app.kubernetes.io/part-of: camunda-cloud-self-managed
+        app.kubernetes.io/version: "1.3.4"
         app.kubernetes.io/component: tasklist
     spec:
       containers:

--- a/charts/ccsm-helm/test/tasklist/golden/service.golden.yaml
+++ b/charts/ccsm-helm/test/tasklist/golden/service.golden.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/name: tasklist
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/part-of: camunda-cloud-self-managed
+    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/component: tasklist
 spec:
   type: ClusterIP
@@ -24,6 +24,6 @@ spec:
     app.kubernetes.io/name: tasklist
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/part-of: camunda-cloud-self-managed
+    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/component: tasklist

--- a/charts/ccsm-helm/test/tasklist/golden/service.golden.yaml
+++ b/charts/ccsm-helm/test/tasklist/golden/service.golden.yaml
@@ -25,5 +25,4 @@ spec:
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-cloud-self-managed
-    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/component: tasklist

--- a/charts/ccsm-helm/test/zeebe-gateway/golden/configmap-log4j2.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe-gateway/golden/configmap-log4j2.golden.yaml
@@ -8,8 +8,8 @@ metadata:
     app.kubernetes.io/name: zeebe-gateway
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/part-of: camunda-cloud-self-managed
+    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/component: zeebe-gateway
 apiVersion: v1
 data:

--- a/charts/ccsm-helm/test/zeebe-gateway/golden/configmap.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe-gateway/golden/configmap.golden.yaml
@@ -8,8 +8,8 @@ metadata:
     app.kubernetes.io/name: zeebe-gateway
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/part-of: camunda-cloud-self-managed
+    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/component: zeebe-gateway
 apiVersion: v1
 data:

--- a/charts/ccsm-helm/test/zeebe-gateway/golden/gateway-deployment.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe-gateway/golden/gateway-deployment.golden.yaml
@@ -23,7 +23,6 @@ spec:
       app.kubernetes.io/instance: ccsm-helm-test
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-cloud-self-managed
-      app.kubernetes.io/version: "1.3.4"
       app.kubernetes.io/component: zeebe-gateway
   template:
     metadata:

--- a/charts/ccsm-helm/test/zeebe-gateway/golden/gateway-deployment.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe-gateway/golden/gateway-deployment.golden.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/name: zeebe-gateway
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/part-of: camunda-cloud-self-managed
+    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/component: zeebe-gateway
   annotations:
     {}
@@ -22,8 +22,8 @@ spec:
       app.kubernetes.io/name: zeebe-gateway
       app.kubernetes.io/instance: ccsm-helm-test
       app.kubernetes.io/managed-by: Helm
-      app.kubernetes.io/version: "1.3.4"
       app.kubernetes.io/part-of: camunda-cloud-self-managed
+      app.kubernetes.io/version: "1.3.4"
       app.kubernetes.io/component: zeebe-gateway
   template:
     metadata:
@@ -32,8 +32,8 @@ spec:
         app.kubernetes.io/name: zeebe-gateway
         app.kubernetes.io/instance: ccsm-helm-test
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/version: "1.3.4"
         app.kubernetes.io/part-of: camunda-cloud-self-managed
+        app.kubernetes.io/version: "1.3.4"
         app.kubernetes.io/component: zeebe-gateway
       annotations:
         {}

--- a/charts/ccsm-helm/test/zeebe-gateway/golden/gateway-service.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe-gateway/golden/gateway-service.golden.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/name: zeebe-gateway
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/part-of: camunda-cloud-self-managed
+    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/component: zeebe-gateway
   annotations:
 spec:
@@ -20,8 +20,8 @@ spec:
       app.kubernetes.io/name: zeebe-gateway
       app.kubernetes.io/instance: ccsm-helm-test
       app.kubernetes.io/managed-by: Helm
-      app.kubernetes.io/version: "1.3.4"
       app.kubernetes.io/part-of: camunda-cloud-self-managed
+      app.kubernetes.io/version: "1.3.4"
       app.kubernetes.io/component: zeebe-gateway
   ports:
     - port: 9600

--- a/charts/ccsm-helm/test/zeebe-gateway/golden/gateway-service.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe-gateway/golden/gateway-service.golden.yaml
@@ -21,7 +21,6 @@ spec:
       app.kubernetes.io/instance: ccsm-helm-test
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-cloud-self-managed
-      app.kubernetes.io/version: "1.3.4"
       app.kubernetes.io/component: zeebe-gateway
   ports:
     - port: 9600

--- a/charts/ccsm-helm/test/zeebe-gateway/golden/gateway-serviceaccount.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe-gateway/golden/gateway-serviceaccount.golden.yaml
@@ -9,6 +9,6 @@ metadata:
     app.kubernetes.io/name: zeebe-gateway
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/part-of: camunda-cloud-self-managed
+    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/component: zeebe-gateway

--- a/charts/ccsm-helm/test/zeebe-gateway/golden/poddisruptionbudget.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe-gateway/golden/poddisruptionbudget.golden.yaml
@@ -21,5 +21,4 @@ spec:
       app.kubernetes.io/instance: ccsm-helm-test
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-cloud-self-managed
-      app.kubernetes.io/version: "1.3.4"
       app.kubernetes.io/component: zeebe-gateway

--- a/charts/ccsm-helm/test/zeebe-gateway/golden/poddisruptionbudget.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe-gateway/golden/poddisruptionbudget.golden.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/name: zeebe-gateway
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/part-of: camunda-cloud-self-managed
+    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/component: zeebe-gateway
 spec:
   minAvailable: 1
@@ -20,6 +20,6 @@ spec:
       app.kubernetes.io/name: zeebe-gateway
       app.kubernetes.io/instance: ccsm-helm-test
       app.kubernetes.io/managed-by: Helm
-      app.kubernetes.io/version: "1.3.4"
       app.kubernetes.io/part-of: camunda-cloud-self-managed
+      app.kubernetes.io/version: "1.3.4"
       app.kubernetes.io/component: zeebe-gateway

--- a/charts/ccsm-helm/test/zeebe-gateway/golden/serviceaccount-annotations.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe-gateway/golden/serviceaccount-annotations.golden.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/name: zeebe-gateway
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/part-of: camunda-cloud-self-managed
+    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/component: zeebe-gateway
   annotations:
     foo: bar

--- a/charts/ccsm-helm/test/zeebe/golden/configmap-log4j2.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe/golden/configmap-log4j2.golden.yaml
@@ -8,8 +8,8 @@ metadata:
     app.kubernetes.io/name: zeebe
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/part-of: camunda-cloud-self-managed
+    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/component: zeebe-broker
 apiVersion: v1
 data:

--- a/charts/ccsm-helm/test/zeebe/golden/configmap.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe/golden/configmap.golden.yaml
@@ -8,8 +8,8 @@ metadata:
     app.kubernetes.io/name: zeebe
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/part-of: camunda-cloud-self-managed
+    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/component: zeebe-broker
 apiVersion: v1
 data:

--- a/charts/ccsm-helm/test/zeebe/golden/poddisruptionbudget.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe/golden/poddisruptionbudget.golden.yaml
@@ -21,5 +21,4 @@ spec:
       app.kubernetes.io/instance: ccsm-helm-test
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-cloud-self-managed
-      app.kubernetes.io/version: "1.3.4"
       app.kubernetes.io/component: zeebe-broker

--- a/charts/ccsm-helm/test/zeebe/golden/poddisruptionbudget.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe/golden/poddisruptionbudget.golden.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/name: zeebe
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/part-of: camunda-cloud-self-managed
+    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/component: zeebe-broker
 spec:
   maxUnavailable: 1
@@ -20,6 +20,6 @@ spec:
       app.kubernetes.io/name: zeebe
       app.kubernetes.io/instance: ccsm-helm-test
       app.kubernetes.io/managed-by: Helm
-      app.kubernetes.io/version: "1.3.4"
       app.kubernetes.io/part-of: camunda-cloud-self-managed
+      app.kubernetes.io/version: "1.3.4"
       app.kubernetes.io/component: zeebe-broker

--- a/charts/ccsm-helm/test/zeebe/golden/service.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe/golden/service.golden.yaml
@@ -34,5 +34,4 @@ spec:
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-cloud-self-managed
-    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/component: zeebe-broker

--- a/charts/ccsm-helm/test/zeebe/golden/service.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe/golden/service.golden.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/name: zeebe
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/part-of: camunda-cloud-self-managed
+    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/component: zeebe-broker
   annotations:
     {}
@@ -33,6 +33,6 @@ spec:
     app.kubernetes.io/name: zeebe
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/part-of: camunda-cloud-self-managed
+    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/component: zeebe-broker

--- a/charts/ccsm-helm/test/zeebe/golden/serviceaccount.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe/golden/serviceaccount.golden.yaml
@@ -9,6 +9,6 @@ metadata:
     app.kubernetes.io/name: zeebe
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/part-of: camunda-cloud-self-managed
+    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/component: zeebe-broker

--- a/charts/ccsm-helm/test/zeebe/golden/statefulset.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe/golden/statefulset.golden.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/name: zeebe
     app.kubernetes.io/instance: ccsm-helm-test
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/part-of: camunda-cloud-self-managed
+    app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/component: zeebe-broker
   annotations:
 spec:
@@ -21,8 +21,8 @@ spec:
       app.kubernetes.io/name: zeebe
       app.kubernetes.io/instance: ccsm-helm-test
       app.kubernetes.io/managed-by: Helm
-      app.kubernetes.io/version: "1.3.4"
       app.kubernetes.io/part-of: camunda-cloud-self-managed
+      app.kubernetes.io/version: "1.3.4"
       app.kubernetes.io/component: zeebe-broker
   serviceName: "ccsm-helm-test-zeebe"
   updateStrategy:
@@ -35,8 +35,8 @@ spec:
         app.kubernetes.io/name: zeebe
         app.kubernetes.io/instance: ccsm-helm-test
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/version: "1.3.4"
         app.kubernetes.io/part-of: camunda-cloud-self-managed
+        app.kubernetes.io/version: "1.3.4"
         app.kubernetes.io/component: zeebe-broker
       annotations:
     spec:

--- a/charts/ccsm-helm/test/zeebe/golden/statefulset.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe/golden/statefulset.golden.yaml
@@ -22,7 +22,6 @@ spec:
       app.kubernetes.io/instance: ccsm-helm-test
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-cloud-self-managed
-      app.kubernetes.io/version: "1.3.4"
       app.kubernetes.io/component: zeebe-broker
   serviceName: "ccsm-helm-test-zeebe"
   updateStrategy:


### PR DESCRIPTION
Introduce ccsm.matchLabels template
This allows to distinguish between the common labels and the match labels which can be used in selectors.

The common labels, combining the match labels and transient labels, which might change on updating
(version depending). These labels shouldn't be used on matchLabels selector, since the selectors are immutable.

Update all sub-charts with using the new named templates and introduce own templates to extend them. Use the matchLabels templates in the selectors.

Alternative:
We could also just drop the support for the version label, since it is marked as optional here https://helm.sh/docs/chart_best_practices/labels/#standard-labels. Personally i like the label so I tried to kept it for now.

closes https://github.com/camunda/camunda-platform-helm/issues/247