### PR TITLE
Add ramdisk support

### DIFF
--- a/charts/ccsm-helm/charts/zeebe/templates/statefulset.yaml
+++ b/charts/ccsm-helm/charts/zeebe/templates/statefulset.yaml
@@ -132,7 +132,7 @@ spec:
         - name: config
           mountPath: /usr/local/bin/startup.sh
           subPath: startup.sh
-        {{- if .Values.persistence.enabled }}
+        {{- if .Values.pvcEnabled }}
         - name: data
           mountPath: /usr/local/zeebe/data
         {{- end }}
@@ -174,7 +174,7 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
 {{- end }}
-{{- if .Values.persistence.enabled }}
+{{- if .Values.pvcEnabled }}
   volumeClaimTemplates:
   - metadata:
       name: data

--- a/charts/ccsm-helm/charts/zeebe/templates/statefulset.yaml
+++ b/charts/ccsm-helm/charts/zeebe/templates/statefulset.yaml
@@ -132,7 +132,7 @@ spec:
         - name: config
           mountPath: /usr/local/bin/startup.sh
           subPath: startup.sh
-        {{- if .Values.pvcEnabled }}
+        {{- if or .Values.pvcEnabled .Values.ramdiskEnabled }}
         - name: data
           mountPath: /usr/local/zeebe/data
         {{- end }}
@@ -154,6 +154,11 @@ spec:
         configMap:
           name: {{ include "zeebe.fullname" . }}
           defaultMode: 0744
+      {{- if .Values.ramdiskEnabled}}
+      - name: data
+        emptyDir:
+          medium: "Memory"
+      {{- end }}
       - name: exporters
         emptyDir: {}
       {{- if .Values.extraVolumes}}

--- a/charts/ccsm-helm/charts/zeebe/templates/statefulset.yaml
+++ b/charts/ccsm-helm/charts/zeebe/templates/statefulset.yaml
@@ -132,8 +132,10 @@ spec:
         - name: config
           mountPath: /usr/local/bin/startup.sh
           subPath: startup.sh
+        {{- if .Values.persistence.enabled }}
         - name: data
           mountPath: /usr/local/zeebe/data
+        {{- end }}
         - name: exporters
           mountPath: /exporters
         {{- if .Values.log4j2 }}
@@ -172,6 +174,7 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
 {{- end }}
+{{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:
       name: data
@@ -181,3 +184,4 @@ spec:
       resources:
         requests:
           storage: {{ .Values.pvcSize | quote }}
+{{- end -}}

--- a/charts/ccsm-helm/values.yaml
+++ b/charts/ccsm-helm/values.yaml
@@ -138,6 +138,8 @@ zeebe:
       cpu: 960m
       memory: 1920Mi
 
+  # RamdiskEnabled mounts a tmpfs (RAM-backed filesystem) for the data directory. Requires pvcEnabled: false. While tmpfs is very fast, be aware that unlike disks, tmpfs is cleared on node reboot and any files you write count against your container's memory limit.
+  ramdiskEnabled: false
   # PvcEnabled if true, a persistent volume claim (PVC) is created for each broker of the Zeebe StatefulSet. CAVE: disabling persistence WILL lead to data loss, but can be preferable in a testing situation.
   pvcEnabled: true
   # PvcSize defines the persistent volume claim size, which is used by each broker pod https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims

--- a/charts/ccsm-helm/values.yaml
+++ b/charts/ccsm-helm/values.yaml
@@ -99,10 +99,6 @@ zeebe:
     -XX:ErrorFile=/usr/local/zeebe/data/zeebe_error%p.log
     -XX:+ExitOnOutOfMemoryError
 
-  persistence:
-    # Enabled if true, a PVC is created as part of the zeebe StatefulSet. CAVE: disabling persistence WILL lead to data loss, but can be preferable in a testing situation.
-    enabled: true
-
  # Service configuration for the broker service
   service:
     # Service.type defines the type of the service https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
@@ -142,6 +138,8 @@ zeebe:
       cpu: 960m
       memory: 1920Mi
 
+  # PvcEnabled if true, a persistent volume claim (PVC) is created for each broker of the Zeebe StatefulSet. CAVE: disabling persistence WILL lead to data loss, but can be preferable in a testing situation.
+  pvcEnabled: true
   # PvcSize defines the persistent volume claim size, which is used by each broker pod https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
   pvcSize: "32Gi"
   # PvcAccessModes can be used to configure the persistent volume claim access mode https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes

--- a/charts/ccsm-helm/values.yaml
+++ b/charts/ccsm-helm/values.yaml
@@ -40,7 +40,7 @@ global:
     # Image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
     pullSecrets: [ ]
 
-  # Elasticsearch configuration which is shared between the sub charts  
+  # Elasticsearch configuration which is shared between the sub charts
   elasticsearch:
     # Elasticsearch.disableExporter if true, disables the elastic exporter in zeebe
     disableExporter: false
@@ -99,6 +99,9 @@ zeebe:
     -XX:ErrorFile=/usr/local/zeebe/data/zeebe_error%p.log
     -XX:+ExitOnOutOfMemoryError
 
+  persistence:
+    # Enabled if true, a PVC is created as part of the zeebe StatefulSet. CAVE: disabling persistence WILL lead to data loss, but can be preferable in a testing situation.
+    enabled: true
 
  # Service configuration for the broker service
   service:


### PR DESCRIPTION
Short-lived processes may not require disk persistence but instead very low cycle times, which can be achieved by using a ramdisk as a data directory.

Another use case is performance benchmarking and tuning: When an i/o bottleneck is suspected, a ramdisk can be used to test that hypothesis.

This PR is builds on top of PR #233 