### PR TITLE
Add identity IT

### DIFF
--- a/charts/ccsm-helm/charts/identity/templates/deployment.yaml
+++ b/charts/ccsm-helm/charts/identity/templates/deployment.yaml
@@ -20,6 +20,14 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
         {{- end }}
         env:
+          - name: KEYCLOAK_USERS_0_USERNAME
+            value: "demo"
+          - name: KEYCLOAK_USERS_0_PASSWORD
+            value: "demo"
+          - name: KEYCLOAK_USERS_0_ROLES_0
+            value: "Identity"
+          - name: KEYCLOAK_USERS_0_ROLES_1
+            value: "Operate"
           - name: SERVER_PORT
             value: "8080"
           - name: KEYCLOAK_URL

--- a/charts/ccsm-helm/charts/identity/templates/deployment.yaml
+++ b/charts/ccsm-helm/charts/identity/templates/deployment.yaml
@@ -20,10 +20,6 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
         {{- end }}
         env:
-          - name: KEYCLOAK_INIT_OPERATE_SECRET
-            value: "the-cake-is-alive"
-          - name: KEYCLOAK_INIT_OPERATE_ROOT_URL
-            value: "http://localhost:8080"
           - name: KEYCLOAK_USERS_0_USERNAME
             value: "demo"
           - name: KEYCLOAK_USERS_0_PASSWORD

--- a/charts/ccsm-helm/charts/identity/templates/deployment.yaml
+++ b/charts/ccsm-helm/charts/identity/templates/deployment.yaml
@@ -26,8 +26,6 @@ spec:
             value: "demo"
           - name: KEYCLOAK_USERS_0_ROLES_0
             value: "Identity"
-          - name: KEYCLOAK_USERS_0_ROLES_1
-            value: "Operate"
           - name: SERVER_PORT
             value: "8080"
           - name: KEYCLOAK_URL

--- a/charts/ccsm-helm/charts/identity/templates/deployment.yaml
+++ b/charts/ccsm-helm/charts/identity/templates/deployment.yaml
@@ -20,6 +20,10 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
         {{- end }}
         env:
+          - name: KEYCLOAK_INIT_OPERATE_SECRET
+            value: "the-cake-is-alive"
+          - name: KEYCLOAK_INIT_OPERATE_ROOT_URL
+            value: "http://localhost:8080"
           - name: KEYCLOAK_USERS_0_USERNAME
             value: "demo"
           - name: KEYCLOAK_USERS_0_PASSWORD

--- a/charts/ccsm-helm/test/identity/golden/deployment.golden.yaml
+++ b/charts/ccsm-helm/test/identity/golden/deployment.golden.yaml
@@ -39,6 +39,18 @@ spec:
       - name: identity
         image: "camunda/identity:SNAPSHOT"
         env:
+          - name: KEYCLOAK_INIT_OPERATE_SECRET
+            value: "the-cake-is-alive"
+          - name: KEYCLOAK_INIT_OPERATE_ROOT_URL
+            value: "http://localhost:8080"
+          - name: KEYCLOAK_USERS_0_USERNAME
+            value: "demo"
+          - name: KEYCLOAK_USERS_0_PASSWORD
+            value: "demo"
+          - name: KEYCLOAK_USERS_0_ROLES_0
+            value: "Identity"
+          - name: KEYCLOAK_USERS_0_ROLES_1
+            value: "Operate"
           - name: SERVER_PORT
             value: "8080"
           - name: KEYCLOAK_URL

--- a/charts/ccsm-helm/test/identity/golden/deployment.golden.yaml
+++ b/charts/ccsm-helm/test/identity/golden/deployment.golden.yaml
@@ -39,18 +39,12 @@ spec:
       - name: identity
         image: "camunda/identity:SNAPSHOT"
         env:
-          - name: KEYCLOAK_INIT_OPERATE_SECRET
-            value: "the-cake-is-alive"
-          - name: KEYCLOAK_INIT_OPERATE_ROOT_URL
-            value: "http://localhost:8080"
           - name: KEYCLOAK_USERS_0_USERNAME
             value: "demo"
           - name: KEYCLOAK_USERS_0_PASSWORD
             value: "demo"
           - name: KEYCLOAK_USERS_0_ROLES_0
             value: "Identity"
-          - name: KEYCLOAK_USERS_0_ROLES_1
-            value: "Operate"
           - name: SERVER_PORT
             value: "8080"
           - name: KEYCLOAK_URL

--- a/charts/ccsm-helm/test/integration/integration_test.go
+++ b/charts/ccsm-helm/test/integration/integration_test.go
@@ -281,8 +281,10 @@ func (s *integrationTest) assertLoginToIdentity() error {
 	if err != nil {
 		return err
 	}
+	s.T().Logf("Extracted following JWT token from cookie jar '%s'.", jwtToken)
 
-	getRequest, err := http.NewRequest("GET", "http://"+identityEndpoint+"/api/clients", nil)
+	verificationUrl := "http://" + identityEndpoint + "/api/clients"
+	getRequest, err := http.NewRequest("GET", verificationUrl, nil)
 	if err != nil {
 		return err
 	}

--- a/charts/ccsm-helm/test/integration/integration_test.go
+++ b/charts/ccsm-helm/test/integration/integration_test.go
@@ -72,7 +72,9 @@ func TestIntegration(t *testing.T) {
 }
 
 func (s *integrationTest) SetupTest() {
-	k8s.CreateNamespace(s.T(), s.kubeOptions, s.namespace)
+	if _, err := k8s.GetNamespaceE(s.T(), s.kubeOptions, s.namespace); err != nil {
+		k8s.CreateNamespace(s.T(), s.kubeOptions, s.namespace)
+	}
 }
 
 func (s *integrationTest) TearDownTest() {

--- a/charts/ccsm-helm/test/integration/integration_test.go
+++ b/charts/ccsm-helm/test/integration/integration_test.go
@@ -90,7 +90,9 @@ func (s *integrationTest) TestServicesEnd2End() {
 	}
 
 	// when
-	helm.Install(s.T(), options, s.chartPath, s.release)
+	if _, err := k8s.GetPodE(s.T(), s.kubeOptions, s.release+"-zeebe-0"); err != nil {
+		helm.Install(s.T(), options, s.chartPath, s.release)
+	}
 
 	// then
 	s.awaitCCSMPods()


### PR DESCRIPTION
Integrate in the current IT test identity, to verify whether the services are coming up and we can log in to identity/keycloak. This is later also necessary to access operate and tasklist.


Details:

 *  In order to log in we need to port-forward to identity (:8080) and keycloak (:18080)
 * We need to get the log in URL from identity (GET /auth/login to resolve url with session code)
 * Login with session URL and demo:demo user
 * After log in we get a JWT, which we verify on a identity resource
 
Since all of this can be quite flaky, due to the properties of distributed systems (many dependency's and fragile environment) we retry the log in.

Dear reviewers:

@oleschoenburg just check whether you understand what is happening. I will later do some more refactoring to split the functions in separate files etc.
@dlavrenuek just check whether it makes sense how we do the log in (it should be like we discussed)
@menski no need to review it, just for you if you want to check it out (since you were interested)