### PR TITLE
Deprecating ccsm

### DIFF
--- a/charts/ccsm-helm/Chart.yaml
+++ b/charts/ccsm-helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ccsm-helm
-version: 0.0.28
+version: 0.0.29
 appVersion: "1.3.4"
 description: Camunda Cloud Self-Managed Helm Chart for Kubernetes
 type: application
@@ -9,21 +9,22 @@ home: https://docs.camunda.io/docs/self-managed/overview/
 sources:
   - https://github.com/camunda/camunda-platform-helm
   - https://github.com/camunda/zeebe
+deprecated: true
 dependencies:
 - name: zeebe
-  version: 0.0.28
+  version: 0.0.29
   condition: "zeebe.enabled"
 - name: zeebe-gateway
-  version: 0.0.28
+  version: 0.0.29
   condition: "zeebe.enabled"
 - name: operate
-  version: 0.0.28
+  version: 0.0.29
   condition: "operate.enabled"
 - name: tasklist
-  version: 0.0.28
+  version: 0.0.29
   condition: "tasklist.enabled"
 - name: identity
-  version: 0.0.28
+  version: 0.0.29
   condition: "identity.enabled"
 - name: elasticsearch
   repository: "https://helm.elastic.co"
@@ -34,5 +35,5 @@ maintainers:
     email: christopher.zell@camunda.com
 annotations:
   artifacthub.io/changes: |
-    - add missing dependencies
+    - deprecating ccsm-helm -> use camunda-platform instead
   artifacthub.io/containsSecurityUpdates: "false"

--- a/charts/ccsm-helm/charts/identity/Chart.yaml
+++ b/charts/ccsm-helm/charts/identity/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Identity Helm Chart for Kubernetes
 name: identity
-version: 0.0.28
+version: 0.0.29
 type: application
 icon: https://raw.githubusercontent.com/camunda-cloud/camunda-cloud-documentation/master/static/img/iam.png
 annotations:

--- a/charts/ccsm-helm/charts/operate/Chart.yaml
+++ b/charts/ccsm-helm/charts/operate/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Operate Helm Chart for Kubernetes
 name: operate
-version: 0.0.28
+version: 0.0.29
 type: application
 icon: https://raw.githubusercontent.com/camunda-cloud/camunda-cloud-documentation/master/static/img/camunda-operate-gradient.png
 annotations:

--- a/charts/ccsm-helm/charts/tasklist/Chart.yaml
+++ b/charts/ccsm-helm/charts/tasklist/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Zeebe TaskList Helm Chart for Kubernetes
 name: tasklist
-version: 0.0.28
+version: 0.0.29
 icon: https://helm.camunda.io/imgs/zeebe-logo.png
 annotations:
   artifacthub.io/changes: |

--- a/charts/ccsm-helm/charts/zeebe-gateway/Chart.yaml
+++ b/charts/ccsm-helm/charts/zeebe-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Zeebe Gateway Helm Chart for Kubernetes
 name: zeebe-gateway
 type: application
-version: 0.0.28
+version: 0.0.29
 icon: https://helm.camunda.io/imgs/zeebe-logo.png
 annotations:
   artifacthub.io/changes: |

--- a/charts/ccsm-helm/charts/zeebe/Chart.yaml
+++ b/charts/ccsm-helm/charts/zeebe/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Zeebe Helm Chart for Kubernetes
 name: zeebe
 type: application
-version: 0.0.28
+version: 0.0.29
 icon: https://helm.camunda.io/imgs/zeebe-logo.png
 annotations:
   artifacthub.io/changes: |

--- a/charts/ccsm-helm/templates/NOTES.txt
+++ b/charts/ccsm-helm/templates/NOTES.txt
@@ -88,3 +88,17 @@ Now you can point your browser to `http://localhost:8080`. Identity will forward
 
 Default user and password: "demo/demo"
 {{- end }}
+
+
+  _____    ______   _____    _____    ______    _____              _______   ______   _____
+ |  __ \  |  ____| |  __ \  |  __ \  |  ____|  / ____|     /\     |__   __| |  ____| |  __ \
+ | |  | | | |__    | |__) | | |__) | | |__    | |         /  \       | |    | |__    | |  | |
+ | |  | | |  __|   |  ___/  |  _  /  |  __|   | |        / /\ \      | |    |  __|   | |  | |
+ | |__| | | |____  | |      | | \ \  | |____  | |____   / ____ \     | |    | |____  | |__| |
+ |_____/  |______| |_|      |_|  \_\ |______|  \_____| /_/    \_\    |_|    |______| |_____/
+
+
+Please be aware that this helm chart has been renamed to camunda-platform.
+
+This helm chart "ccsm-helm" is as of now deprecated and will no longer receive any updates.
+Please use: helm install <release> <reponame>/camunda-platform instead.


### PR DESCRIPTION
Merging this PR will cause the last release and mark the chart as deprecated.
Furthermore it adds a note to the release notes that the chart is deprecated and camunda-platform should be used instead



:warning: Shouldn't be merged before #261 