### PR TITLE
Identity-operate integration

### DIFF
--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -63,7 +63,7 @@ Check out the default [values.yaml](values.yaml) file, which contains the same c
 | | `zeebePort` | Defines the port which is used for the Zeebe Gateway. This port accepts the GRPC Client messages and forwards them to the Zeebe Brokers. | 26500 |
 | `elasticsearch`| `enabled` | Enable Elasticsearch deployment as part of the Zeebe Cluster | `true` |
 | | `operate.auth.identity.enabled` |  If true, enables the authentication on Operate with Identity, otherwise basic-auth will be used. | `true` |
-| | `operate.auth.identity.existingSecret` |  can be used to use an own existing secret. If not set a random secret is generated. Secret should contain an operate-secret field | `` |
+| | `operate.auth.identity.existingSecret` |  Can be used to reference an existing secret. If not set, a random secret is generated. The existing secret should contain an `operate-secret` field, which will be used as secret for the Identity-Operate communication. | `` |
 | | `operate.auth.identity.operateRootUrl` |  Defines the root (or redirect) URL, which is used by Keycloak to access Operate. Should be public accessible, the default value works if port-forward to operate is created to 8080. Can be overwritten if, ingress is in use and an external IP is available. | `"http://localhost:8080"` |
 | | `operate.auth.identity.publicIssuerUrl` | Defines the token issuer (Keycloak) URL, where to request JWT tokens. Should be public accessible, per default we assume a port-forward to Keycloak (18080) is created before login. Can be overwritten if, ingress is in use and an external IP is available. | `"http://localhost:18080/auth/realms/camunda-platform"` |
 

--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -62,6 +62,10 @@ Check out the default [values.yaml](values.yaml) file, which contains the same c
 | | `zeebeClusterName` | Defines the cluster name for the Zeebe cluster. All pods get this prefix in their name. | `{{ .Release.Name }}-zeebe` |
 | | `zeebePort` | Defines the port which is used for the Zeebe Gateway. This port accepts the GRPC Client messages and forwards them to the Zeebe Brokers. | 26500 |
 | `elasticsearch`| `enabled` | Enable Elasticsearch deployment as part of the Zeebe Cluster | `true` |
+| | `operate.auth.identity.enabled` |  If true, enables the authentication on Operate with Identity, otherwise basic-auth will be used. | `true` |
+| | `operate.auth.identity.existingSecret` |  can be used to use an own existing secret. If not set a random secret is generated. Secret should contain an operate-secret field | `` |
+| | `operate.auth.identity.operateRootUrl` |  Defines the root (or redirect) URL, which is used by Keycloak to access Operate. Should be public accessible, the default value works if port-forward to operate is created to 8080. Can be overwritten if, ingress is in use and an external IP is available. | `"http://localhost:8080"` |
+| | `operate.auth.identity.publicIssuerUrl` | Defines the token issuer (Keycloak) URL, where to request JWT tokens. Should be public accessible, per default we assume a port-forward to Keycloak (18080) is created before login. Can be overwritten if, ingress is in use and an external IP is available. | `"http://localhost:18080/auth/realms/camunda-platform"` |
 
 ### Camunda Platform
 

--- a/charts/camunda-platform/charts/identity/templates/_helpers.tpl
+++ b/charts/camunda-platform/charts/identity/templates/_helpers.tpl
@@ -52,3 +52,11 @@ Defines match labels for identity, which are extended by sub-charts and should b
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+[identity] Create the name of the operate-identity secret
+*/}}
+{{- define "identity.secretNameOperateIdentity" -}}
+{{- $name := .Release.Name -}}
+{{- printf "%s-operate-identity-secret" $name | trunc 63 | trimSuffix "-" | quote -}}
+{{- end }}

--- a/charts/camunda-platform/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/identity/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
 
           {{- end }}
           - name: KEYCLOAK_INIT_OPERATE_ROOT_URL
-            value: "http://localhost:8080"
+            value: {{ .Values.global.operate.auth.identity.initRootUrl | quote }}
           - name: SERVER_PORT
             value: "8080"
           - name: KEYCLOAK_URL

--- a/charts/camunda-platform/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/identity/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
 
           {{- end }}
           - name: KEYCLOAK_INIT_OPERATE_ROOT_URL
-            value: {{ .Values.global.operate.auth.identity.initRootUrl | quote }}
+            value: {{ .Values.global.operate.auth.identity.operateRootUrl | quote }}
           - name: SERVER_PORT
             value: "8080"
           - name: KEYCLOAK_URL

--- a/charts/camunda-platform/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/identity/templates/deployment.yaml
@@ -26,10 +26,35 @@ spec:
             value: "demo"
           - name: KEYCLOAK_USERS_0_ROLES_0
             value: "Identity"
+
+
+          {{- if .Values.global.operate.auth.identity.enabled }}
           - name: KEYCLOAK_USERS_0_ROLES_1
             value: "Operate"
           - name: KEYCLOAK_INIT_OPERATE_SECRET
-            value: "the-cake-is-alive" # should be generated
+            {{- if .Values.global.operate.auth.identity.existingSecret }}
+            valueFrom:
+              secretKeyRef:
+                {{- /*
+                    Helper: https://github.com/bitnami/charts/blob/master/bitnami/common/templates/_secrets.tpl
+                    Usage in keycloak secrets https://github.com/bitnami/charts/blob/master/bitnami/keycloak/templates/secrets.yaml
+                    and in statefulset https://github.com/bitnami/charts/blob/master/bitnami/keycloak/templates/statefulset.yaml
+                */}}
+                name: {{ include "common.secrets.name" (dict "existingSecret" .Values.global.operate.auth.identity.existingSecret "context" $) }}
+                key: operate-secret
+            {{- else }}
+            valueFrom:
+              secretKeyRef:
+                {{- /*
+                    Helper: https://github.com/bitnami/charts/blob/master/bitnami/common/templates/_secrets.tpl
+                    Usage in keycloak secrets https://github.com/bitnami/charts/blob/master/bitnami/keycloak/templates/secrets.yaml
+                    and in statefulset https://github.com/bitnami/charts/blob/master/bitnami/keycloak/templates/statefulset.yaml
+                */}}
+                name: {{ include "identity.secretNameOperateIdentity" . }}
+                key: operate-secret
+            {{- end }}
+
+          {{- end }}
           - name: KEYCLOAK_INIT_OPERATE_ROOT_URL
             value: "http://localhost:8080"
           - name: SERVER_PORT

--- a/charts/camunda-platform/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/identity/templates/deployment.yaml
@@ -26,6 +26,12 @@ spec:
             value: "demo"
           - name: KEYCLOAK_USERS_0_ROLES_0
             value: "Identity"
+          - name: KEYCLOAK_USERS_0_ROLES_1
+            value: "Operate"
+          - name: KEYCLOAK_INIT_OPERATE_SECRET
+            value: "the-cake-is-alive" # should be generated
+          - name: KEYCLOAK_INIT_OPERATE_ROOT_URL
+            value: "http://localhost:8080"
           - name: SERVER_PORT
             value: "8080"
           - name: KEYCLOAK_URL

--- a/charts/camunda-platform/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/identity/templates/deployment.yaml
@@ -53,10 +53,9 @@ spec:
                 name: {{ include "identity.secretNameOperateIdentity" . }}
                 key: operate-secret
             {{- end }}
-
-          {{- end }}
           - name: KEYCLOAK_INIT_OPERATE_ROOT_URL
             value: {{ .Values.global.operate.auth.identity.operateRootUrl | quote }}
+          {{- end }}
           - name: SERVER_PORT
             value: "8080"
           - name: KEYCLOAK_URL

--- a/charts/camunda-platform/charts/identity/templates/operate-secret.yaml
+++ b/charts/camunda-platform/charts/identity/templates/operate-secret.yaml
@@ -1,0 +1,11 @@
+{{- if and (.Values.global.operate.auth.identity.enabled) (not .Values.global.operate.auth.identity.existingSecret) }}
+{{- $secretName := include "identity.secretNameOperateIdentity" . }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels: {{- include "identity.labels" . | nindent 4 }}
+type: Opaque
+data:
+  operate-secret: {{ include "common.secrets.passwords.manage" (dict "secret" $secretName "key" "operate-secret" "length" 10 "providedValues" (list "global.operate.auth.identity.operateSecret") "context" $) }}
+{{- end }}

--- a/charts/camunda-platform/charts/operate/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/operate/templates/deployment.yaml
@@ -19,8 +19,20 @@ spec:
         {{- else }}
         image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
         {{- end }}
-        {{- if .Values.env}}
         env:
+          - name: SPRING_PROFILES_ACTIVE
+            value: {{ default "identity-auth" .Values.springProfilesActive | quote }}
+          - name: CAMUNDA_OPERATE_IDENTITY_ISSUER_URL
+            value: "http://localhost:18080/auth/realms/camunda-platform"
+          - name: CAMUNDA_OPERATE_IDENTITY_ISSUER_BACKEND_URL
+            value: "http://{{ include "common.names.dependency.fullname" (dict "chartName" "keycloak" "chartValues" . "context" $) | trunc 20 | trimSuffix "-" }}:80/auth/realms/camunda-platform"
+          - name: CAMUNDA_OPERATE_IDENTITY_CLIENT_ID
+            value: "operate"
+          - name: CAMUNDA_OPERATE_IDENTITY_CLIENT_SECRET
+            value: "the-cake-is-alive"
+          - name: CAMUNDA_OPERATE_IDENTITY_AUDIENCE
+            value: "operate-api"
+        {{- if .Values.env}}
         {{ .Values.env | toYaml | nindent 10 }}
         {{- end }}
         {{- if .Values.command}}

--- a/charts/camunda-platform/charts/operate/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/operate/templates/deployment.yaml
@@ -29,7 +29,27 @@ spec:
           - name: CAMUNDA_OPERATE_IDENTITY_CLIENT_ID
             value: "operate"
           - name: CAMUNDA_OPERATE_IDENTITY_CLIENT_SECRET
-            value: "the-cake-is-alive"
+            {{- if .Values.global.operate.auth.identity.existingSecret }}
+            valueFrom:
+              secretKeyRef:
+                {{- /*
+                    Helper: https://github.com/bitnami/charts/blob/master/bitnami/common/templates/_secrets.tpl
+                    Usage in keycloak secrets https://github.com/bitnami/charts/blob/master/bitnami/keycloak/templates/secrets.yaml
+                    and in statefulset https://github.com/bitnami/charts/blob/master/bitnami/keycloak/templates/statefulset.yaml
+                */}}
+                name: {{ include "common.secrets.name" (dict "existingSecret" .Values.global.operate.auth.identity.existingSecret "context" $) }}
+                key: operate-secret
+            {{- else }}
+            valueFrom:
+              secretKeyRef:
+                {{- /*
+                    Helper: https://github.com/bitnami/charts/blob/master/bitnami/common/templates/_secrets.tpl
+                    Usage in keycloak secrets https://github.com/bitnami/charts/blob/master/bitnami/keycloak/templates/secrets.yaml
+                    and in statefulset https://github.com/bitnami/charts/blob/master/bitnami/keycloak/templates/statefulset.yaml
+                */}}
+                name: {{ include "identity.secretNameOperateIdentity" . }}
+                key: operate-secret
+            {{- end }}
           - name: CAMUNDA_OPERATE_IDENTITY_AUDIENCE
             value: "operate-api"
         {{- if .Values.env}}

--- a/charts/camunda-platform/charts/operate/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/operate/templates/deployment.yaml
@@ -20,8 +20,9 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
         {{- end }}
         env:
+          {{- if .Values.global.operate.auth.identity.enabled }}
           - name: SPRING_PROFILES_ACTIVE
-            value: {{ default "identity-auth" .Values.springProfilesActive | quote }}
+            value: "identity-auth"
           - name: CAMUNDA_OPERATE_IDENTITY_ISSUER_URL
             value: "http://localhost:18080/auth/realms/camunda-platform"
           - name: CAMUNDA_OPERATE_IDENTITY_ISSUER_BACKEND_URL
@@ -52,6 +53,10 @@ spec:
             {{- end }}
           - name: CAMUNDA_OPERATE_IDENTITY_AUDIENCE
             value: "operate-api"
+          {{- else }}
+          - name: SPRING_PROFILES_ACTIVE
+            value: "auth"
+          {{- end }}
         {{- if .Values.env}}
         {{ .Values.env | toYaml | nindent 10 }}
         {{- end }}

--- a/charts/camunda-platform/charts/operate/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/operate/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
           - name: SPRING_PROFILES_ACTIVE
             value: "identity-auth"
           - name: CAMUNDA_OPERATE_IDENTITY_ISSUER_URL
-            value: "http://localhost:18080/auth/realms/camunda-platform"
+            value: {{ .Values.global.operate.auth.identity.publicIssuerUrl | quote }}
           - name: CAMUNDA_OPERATE_IDENTITY_ISSUER_BACKEND_URL
             value: "http://{{ include "common.names.dependency.fullname" (dict "chartName" "keycloak" "chartValues" . "context" $) | trunc 20 | trimSuffix "-" }}:80/auth/realms/camunda-platform"
           - name: CAMUNDA_OPERATE_IDENTITY_CLIENT_ID

--- a/charts/camunda-platform/templates/NOTES.txt
+++ b/charts/camunda-platform/templates/NOTES.txt
@@ -52,6 +52,14 @@ If you don't have an Ingress Controller you can use kubectl port-forward to acce
 
 > kubectl port-forward svc/{{ .Release.Name }}-operate 8080:80
 
+    {{- if .Values.global.operate.auth.identity.enabled }}
+
+Per default authentication via Identity/Keycloak is enabled. In order to login into Operate please port-forward to Keycloak
+as well, otherwise a login will not be possible. Make sure you use `18080` as port.
+
+> kubectl port-forward svc/{{ include "common.names.dependency.fullname" (dict "chartName" "keycloak" "chartValues" .Values.identity.keycloak "context" $) | trunc 20 | trimSuffix "-" }} 18080:80
+    {{- end }}
+
 Now you can point your browser to `http://localhost:8080`
 
 Default user and password: "demo/demo"
@@ -78,10 +86,10 @@ Default user and password: "demo/demo"
 As part of Identity an ingress definition can be deployed, but you require to have an Ingress Contoller for that Ingress to be Exposed.
 In order to deploy the ingress manifest, set `identity.ingress.enabled` to `true`.
 
-If you don't have an ingress controller you can use kubectl port-forward to access identity from outside the cluster:
+If you don't have an ingress controller you can use kubectl port-forward to access Identity from outside the cluster:
 
 > kubectl port-forward svc/{{ .Release.Name }}-identity 8080:80
-> kubectl port-forward svc/{{ .Release.Name }}-keycl 18080:80
+> kubectl port-forward svc/{{ include "common.names.dependency.fullname" (dict "chartName" "keycloak" "chartValues" .Values.identity.keycloak "context" $) | trunc 20 | trimSuffix "-" }} 18080:80
 
 Now you can point your browser to `http://localhost:8080`. Identity will forward requests to keycloak (listening under `18080`).
 

--- a/charts/camunda-platform/templates/NOTES.txt
+++ b/charts/camunda-platform/templates/NOTES.txt
@@ -54,7 +54,7 @@ If you don't have an Ingress Controller you can use kubectl port-forward to acce
 
     {{- if .Values.global.operate.auth.identity.enabled }}
 
-Per default authentication via Identity/Keycloak is enabled. In order to login into Operate please port-forward to Keycloak
+Authentication via Identity/Keycloak is enabled. In order to login into Operate please port-forward to Keycloak
 as well, otherwise a login will not be possible. Make sure you use `18080` as port.
 
 > kubectl port-forward svc/{{ include "common.names.dependency.fullname" (dict "chartName" "keycloak" "chartValues" .Values.identity.keycloak "context" $) | trunc 20 | trimSuffix "-" }} 18080:80

--- a/charts/camunda-platform/test/golden/curator-configmap.golden.yaml
+++ b/charts/camunda-platform/test/golden/curator-configmap.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "1.3.4"
+    app.kubernetes.io/version: "8.0.0-rc1"
 data:
   action_file.yml: |-
     ---

--- a/charts/camunda-platform/test/golden/curator-cronjob.golden.yaml
+++ b/charts/camunda-platform/test/golden/curator-cronjob.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "1.3.4"
+    app.kubernetes.io/version: "8.0.0-rc1"
 spec:
   schedule: "0 0 * * *"
   successfulJobsHistoryLimit: 1

--- a/charts/camunda-platform/test/golden/service-monitor.golden.yaml
+++ b/charts/camunda-platform/test/golden/service-monitor.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "1.3.4"
+    app.kubernetes.io/version: "8.0.0-rc1"
     release: metrics
 spec:
   selector:

--- a/charts/camunda-platform/test/identity/deployment_test.go
+++ b/charts/camunda-platform/test/identity/deployment_test.go
@@ -336,3 +336,56 @@ func (s *deploymentTemplateTest) TestContainerShouldSetCorrectSecret() {
 			},
 		})
 }
+
+func (s *deploymentTemplateTest) TestContainerShouldDisableOperateIntegration() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.operate.auth.identity.enabled":  "false",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	env := deployment.Spec.Template.Spec.Containers[0].Env
+
+	for _, envvar := range env {
+		s.Require().NotEqual("KEYCLOAK_INIT_OPERATE_ROOT_URL", envvar.Name)
+		s.Require().NotEqual("KEYCLOAK_INIT_OPERATE_SECRET", envvar.Name)
+	}
+}
+
+func (s *deploymentTemplateTest) TestContainerShouldSetOperateIdentitySecret() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.operate.auth.identity.existingSecret": "ownExistingSecret",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	env := deployment.Spec.Template.Spec.Containers[0].Env
+	s.Require().Contains(env,
+		v12.EnvVar{
+			Name: "KEYCLOAK_INIT_OPERATE_SECRET",
+			ValueFrom: &v12.EnvVarSource{
+				SecretKeyRef: &v12.SecretKeySelector{
+					LocalObjectReference: v12.LocalObjectReference{Name: "ownExistingSecret"},
+					Key:                  "operate-secret",
+				},
+			},
+		})
+}

--- a/charts/camunda-platform/test/identity/deployment_test.go
+++ b/charts/camunda-platform/test/identity/deployment_test.go
@@ -341,7 +341,7 @@ func (s *deploymentTemplateTest) TestContainerShouldDisableOperateIntegration() 
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"global.operate.auth.identity.enabled":  "false",
+			"global.operate.auth.identity.enabled": "false",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},

--- a/charts/camunda-platform/test/identity/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/identity/golden/deployment.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "SNAPSHOT"
+    app.kubernetes.io/version: "8.0.0-rc1"
     app.kubernetes.io/component: identity
   annotations:
     {}
@@ -32,12 +32,12 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "SNAPSHOT"
+        app.kubernetes.io/version: "8.0.0-rc1"
         app.kubernetes.io/component: identity
     spec:
       containers:
       - name: identity
-        image: "camunda/identity:SNAPSHOT"
+        image: "camunda/identity:8.0.0-rc1"
         env:
           - name: KEYCLOAK_USERS_0_USERNAME
             value: "demo"
@@ -45,6 +45,15 @@ spec:
             value: "demo"
           - name: KEYCLOAK_USERS_0_ROLES_0
             value: "Identity"
+          - name: KEYCLOAK_USERS_0_ROLES_1
+            value: "Operate"
+          - name: KEYCLOAK_INIT_OPERATE_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: "camunda-platform-test-operate-identity-secret"
+                key: operate-secret
+          - name: KEYCLOAK_INIT_OPERATE_ROOT_URL
+            value: "http://localhost:8080"
           - name: SERVER_PORT
             value: "8080"
           - name: KEYCLOAK_URL

--- a/charts/camunda-platform/test/identity/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/identity/golden/ingress-all-enabled.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "SNAPSHOT"
+    app.kubernetes.io/version: "8.0.0-rc1"
     app.kubernetes.io/component: identity
   annotations: 
     ingress.kubernetes.io/rewrite-target: /

--- a/charts/camunda-platform/test/identity/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/identity/golden/ingress.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "SNAPSHOT"
+    app.kubernetes.io/version: "8.0.0-rc1"
     app.kubernetes.io/component: identity
   annotations: 
     ingress.kubernetes.io/rewrite-target: /

--- a/charts/camunda-platform/test/identity/golden/operate-secret.golden.yaml
+++ b/charts/camunda-platform/test/identity/golden/operate-secret.golden.yaml
@@ -1,0 +1,17 @@
+---
+# Source: camunda-platform/charts/identity/templates/operate-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "camunda-platform-test-operate-identity-secret"
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: identity
+    app.kubernetes.io/instance: camunda-platform-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/version: "8.0.0-rc1"
+    app.kubernetes.io/component: identity
+type: Opaque
+data:
+  operate-secret: "OEJkaXo4ZFZNRA=="

--- a/charts/camunda-platform/test/identity/golden/operate-secret.golden.yaml
+++ b/charts/camunda-platform/test/identity/golden/operate-secret.golden.yaml
@@ -14,4 +14,3 @@ metadata:
     app.kubernetes.io/component: identity
 type: Opaque
 data:
-  operate-secret: "OEJkaXo4ZFZNRA=="

--- a/charts/camunda-platform/test/identity/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/identity/golden/service.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "SNAPSHOT"
+    app.kubernetes.io/version: "8.0.0-rc1"
     app.kubernetes.io/component: identity
   annotations:
 spec:

--- a/charts/camunda-platform/test/identity/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/identity/golden/serviceaccount.golden.yaml
@@ -10,5 +10,5 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "SNAPSHOT"
+    app.kubernetes.io/version: "8.0.0-rc1"
     app.kubernetes.io/component: identity

--- a/charts/camunda-platform/test/identity/goldenfiles_test.go
+++ b/charts/camunda-platform/test/identity/goldenfiles_test.go
@@ -39,6 +39,7 @@ func TestGoldenDefaultsTemplate(t *testing.T) {
 			Release:        "camunda-platform-test",
 			Namespace:      "camunda-platform-" + strings.ToLower(random.UniqueId()),
 			GoldenFileName: name,
+			IgnoredLines:   []string{`\s+operate-secret:\s+.*`}, // secrets are auto-generated and need to be ignored
 			Templates:      []string{"charts/identity/templates/" + name + ".yaml"},
 		})
 	}

--- a/charts/camunda-platform/test/identity/goldenfiles_test.go
+++ b/charts/camunda-platform/test/identity/goldenfiles_test.go
@@ -31,7 +31,7 @@ func TestGoldenDefaultsTemplate(t *testing.T) {
 
 	chartPath, err := filepath.Abs("../../")
 	require.NoError(t, err)
-	templateNames := []string{"service", "serviceaccount", "deployment"}
+	templateNames := []string{"service", "serviceaccount", "operate-secret", "deployment"}
 
 	for _, name := range templateNames {
 		suite.Run(t, &golden.TemplateGoldenTest{

--- a/charts/camunda-platform/test/identity/secret_test.go
+++ b/charts/camunda-platform/test/identity/secret_test.go
@@ -1,0 +1,67 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package identity
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	coreV1 "k8s.io/api/core/v1"
+)
+
+type secretTest struct {
+	suite.Suite
+	chartPath string
+	release   string
+	namespace string
+	templates []string
+}
+
+func TestSecretTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../")
+	require.NoError(t, err)
+
+	suite.Run(t, &secretTest{
+		chartPath: chartPath,
+		release:   "camunda-platform-test",
+		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
+		templates: []string{"charts/identity/templates/operate-secret.yaml"},
+	})
+}
+
+func (s *secretTest) TestContainerGenerateSecret() {
+	// given
+	options := &helm.Options{
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var secret coreV1.Secret
+	helm.UnmarshalK8SYaml(s.T(), output, &secret)
+
+	// then
+	s.Require().NotNil(secret.Data)
+	s.Require().NotNil(secret.Data["operate-secret"])
+	s.Require().NotEmpty(secret.Data["operate-secret"])
+}

--- a/charts/camunda-platform/test/operate/deployment_test.go
+++ b/charts/camunda-platform/test/operate/deployment_test.go
@@ -295,7 +295,7 @@ func (s *deploymentTemplateTest) TestContainerShouldDisableOperateIntegration() 
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"global.operate.auth.identity.enabled":  "false",
+			"global.operate.auth.identity.enabled": "false",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},

--- a/charts/camunda-platform/test/operate/golden/configmap-elastic-url.golden.yaml
+++ b/charts/camunda-platform/test/operate/golden/configmap-elastic-url.golden.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "1.3.4"
+    app.kubernetes.io/version: "8.0.0-rc1"
     app.kubernetes.io/component: operate
 apiVersion: v1
 data:

--- a/charts/camunda-platform/test/operate/golden/configmap.golden.yaml
+++ b/charts/camunda-platform/test/operate/golden/configmap.golden.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "1.3.4"
+    app.kubernetes.io/version: "8.0.0-rc1"
     app.kubernetes.io/component: operate
 apiVersion: v1
 data:

--- a/charts/camunda-platform/test/operate/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/operate/golden/deployment.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "1.3.4"
+    app.kubernetes.io/version: "8.0.0-rc1"
     app.kubernetes.io/component: operate
   annotations:
     {}
@@ -32,12 +32,28 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "1.3.4"
+        app.kubernetes.io/version: "8.0.0-rc1"
         app.kubernetes.io/component: operate
     spec:
       containers:
       - name: operate
-        image: "camunda/operate:1.3.4"
+        image: "camunda/operate:8.0.0-rc1"
+        env:
+          - name: SPRING_PROFILES_ACTIVE
+            value: "identity-auth"
+          - name: CAMUNDA_OPERATE_IDENTITY_ISSUER_URL
+            value: "http://localhost:18080/auth/realms/camunda-platform"
+          - name: CAMUNDA_OPERATE_IDENTITY_ISSUER_BACKEND_URL
+            value: "http://camunda-platform-tes:80/auth/realms/camunda-platform"
+          - name: CAMUNDA_OPERATE_IDENTITY_CLIENT_ID
+            value: "operate"
+          - name: CAMUNDA_OPERATE_IDENTITY_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: "camunda-platform-test-operate-identity-secret"
+                key: operate-secret
+          - name: CAMUNDA_OPERATE_IDENTITY_AUDIENCE
+            value: "operate-api"
         resources:
           limits:
             cpu: 2000m

--- a/charts/camunda-platform/test/operate/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/operate/golden/ingress-all-enabled.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "1.3.4"
+    app.kubernetes.io/version: "8.0.0-rc1"
     app.kubernetes.io/component: operate
   annotations: 
     ingress.kubernetes.io/rewrite-target: /

--- a/charts/camunda-platform/test/operate/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/operate/golden/ingress.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "1.3.4"
+    app.kubernetes.io/version: "8.0.0-rc1"
     app.kubernetes.io/component: operate
   annotations: 
     ingress.kubernetes.io/rewrite-target: /

--- a/charts/camunda-platform/test/operate/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/operate/golden/service.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "1.3.4"
+    app.kubernetes.io/version: "8.0.0-rc1"
     app.kubernetes.io/component: operate
   annotations:
 spec:

--- a/charts/camunda-platform/test/operate/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/operate/golden/serviceaccount.golden.yaml
@@ -10,5 +10,5 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "1.3.4"
+    app.kubernetes.io/version: "8.0.0-rc1"
     app.kubernetes.io/component: operate

--- a/charts/camunda-platform/test/tasklist/golden/configmap.golden.yaml
+++ b/charts/camunda-platform/test/tasklist/golden/configmap.golden.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "1.3.4"
+    app.kubernetes.io/version: "8.0.0-rc1"
     app.kubernetes.io/component: tasklist
 apiVersion: v1
 data:

--- a/charts/camunda-platform/test/tasklist/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/tasklist/golden/deployment.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "1.3.4"
+    app.kubernetes.io/version: "8.0.0-rc1"
     app.kubernetes.io/component: tasklist
   annotations:
     {}
@@ -32,12 +32,12 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "1.3.4"
+        app.kubernetes.io/version: "8.0.0-rc1"
         app.kubernetes.io/component: tasklist
     spec:
       containers:
       - name: tasklist
-        image: "camunda/tasklist:1.3.4"
+        image: "camunda/tasklist:8.0.0-rc1"
         env:
           - name: SPRING_PROFILES_ACTIVE
             value: "auth"

--- a/charts/camunda-platform/test/tasklist/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/tasklist/golden/service.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "1.3.4"
+    app.kubernetes.io/version: "8.0.0-rc1"
     app.kubernetes.io/component: tasklist
 spec:
   type: ClusterIP

--- a/charts/camunda-platform/test/zeebe-gateway/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform/test/zeebe-gateway/golden/configmap-log4j2.golden.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "1.3.4"
+    app.kubernetes.io/version: "8.0.0-rc1"
     app.kubernetes.io/component: zeebe-gateway
 apiVersion: v1
 data:

--- a/charts/camunda-platform/test/zeebe-gateway/golden/configmap.golden.yaml
+++ b/charts/camunda-platform/test/zeebe-gateway/golden/configmap.golden.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "1.3.4"
+    app.kubernetes.io/version: "8.0.0-rc1"
     app.kubernetes.io/component: zeebe-gateway
 apiVersion: v1
 data:

--- a/charts/camunda-platform/test/zeebe-gateway/golden/gateway-deployment.golden.yaml
+++ b/charts/camunda-platform/test/zeebe-gateway/golden/gateway-deployment.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "1.3.4"
+    app.kubernetes.io/version: "8.0.0-rc1"
     app.kubernetes.io/component: zeebe-gateway
   annotations:
     {}
@@ -32,14 +32,14 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "1.3.4"
+        app.kubernetes.io/version: "8.0.0-rc1"
         app.kubernetes.io/component: zeebe-gateway
       annotations:
         {}
     spec:
       containers:
         - name: zeebe-gateway
-          image: "camunda/zeebe:1.3.4"
+          image: "camunda/zeebe:8.0.0-rc1"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9600

--- a/charts/camunda-platform/test/zeebe-gateway/golden/gateway-service.golden.yaml
+++ b/charts/camunda-platform/test/zeebe-gateway/golden/gateway-service.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "1.3.4"
+    app.kubernetes.io/version: "8.0.0-rc1"
     app.kubernetes.io/component: zeebe-gateway
   annotations:
 spec:

--- a/charts/camunda-platform/test/zeebe-gateway/golden/gateway-serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/zeebe-gateway/golden/gateway-serviceaccount.golden.yaml
@@ -10,5 +10,5 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "1.3.4"
+    app.kubernetes.io/version: "8.0.0-rc1"
     app.kubernetes.io/component: zeebe-gateway

--- a/charts/camunda-platform/test/zeebe-gateway/golden/poddisruptionbudget.golden.yaml
+++ b/charts/camunda-platform/test/zeebe-gateway/golden/poddisruptionbudget.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "1.3.4"
+    app.kubernetes.io/version: "8.0.0-rc1"
     app.kubernetes.io/component: zeebe-gateway
 spec:
   minAvailable: 1

--- a/charts/camunda-platform/test/zeebe-gateway/golden/serviceaccount-annotations.golden.yaml
+++ b/charts/camunda-platform/test/zeebe-gateway/golden/serviceaccount-annotations.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "1.3.4"
+    app.kubernetes.io/version: "8.0.0-rc1"
     app.kubernetes.io/component: zeebe-gateway
   annotations:
     foo: bar

--- a/charts/camunda-platform/test/zeebe/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform/test/zeebe/golden/configmap-log4j2.golden.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "1.3.4"
+    app.kubernetes.io/version: "8.0.0-rc1"
     app.kubernetes.io/component: zeebe-broker
 apiVersion: v1
 data:

--- a/charts/camunda-platform/test/zeebe/golden/configmap.golden.yaml
+++ b/charts/camunda-platform/test/zeebe/golden/configmap.golden.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "1.3.4"
+    app.kubernetes.io/version: "8.0.0-rc1"
     app.kubernetes.io/component: zeebe-broker
 apiVersion: v1
 data:

--- a/charts/camunda-platform/test/zeebe/golden/poddisruptionbudget.golden.yaml
+++ b/charts/camunda-platform/test/zeebe/golden/poddisruptionbudget.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "1.3.4"
+    app.kubernetes.io/version: "8.0.0-rc1"
     app.kubernetes.io/component: zeebe-broker
 spec:
   maxUnavailable: 1

--- a/charts/camunda-platform/test/zeebe/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/zeebe/golden/service.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "1.3.4"
+    app.kubernetes.io/version: "8.0.0-rc1"
     app.kubernetes.io/component: zeebe-broker
   annotations:
     {}

--- a/charts/camunda-platform/test/zeebe/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/zeebe/golden/serviceaccount.golden.yaml
@@ -10,5 +10,5 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "1.3.4"
+    app.kubernetes.io/version: "8.0.0-rc1"
     app.kubernetes.io/component: zeebe-broker

--- a/charts/camunda-platform/test/zeebe/golden/statefulset.golden.yaml
+++ b/charts/camunda-platform/test/zeebe/golden/statefulset.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "1.3.4"
+    app.kubernetes.io/version: "8.0.0-rc1"
     app.kubernetes.io/component: zeebe-broker
   annotations:
 spec:
@@ -35,14 +35,14 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "1.3.4"
+        app.kubernetes.io/version: "8.0.0-rc1"
         app.kubernetes.io/component: zeebe-broker
       annotations:
     spec:
       initContainers:
       containers:
       - name: zeebe
-        image: "camunda/zeebe:1.3.4"
+        image: "camunda/zeebe:8.0.0-rc1"
         imagePullPolicy: IfNotPresent
         env:
         - name: LC_ALL

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -59,6 +59,19 @@ global:
   # ZeebePort defines the port which is used for the Zeebe Gateway. This port accepts the GRPC Client messages and forwards them to the Zeebe Brokers.
   zeebePort: 26500
 
+  # Operate configuration to configure operate on global level
+  operate:
+    # Operate.auth configuration, to configure operates authentication setup
+    auth:
+      # Operate.auth.identity configuration, to configure operate with Identity authentication
+      identity:
+        # Operate.auth.identity.enabled if true, enables the Identity authentication otherwise basic-auth will be used.
+        enabled: true
+        # Operate.auth.identity.existingSecret can be used to use an own existing secret. If not set a random secret is generated.
+        # Secret should contain an operate-secret field
+        existingSecret:
+        initRootUrl: "http://localhost:8080"
+
 # Zeebe configuration for the Zeebe sub chart. Contains configuration for the Zeebe broker and related resources.
 zeebe:
   # Enabled if true, all zeebe related resources are deployed via the helm release

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -34,7 +34,7 @@ global:
   # Image configuration to be used in each sub chart
   image:
     # Image.tag defines the tag / version which should be used in the chart
-    tag: 1.3.4
+    tag: 8.0.0-rc1
     # Image.pullPolicy defines the image pull policy which should be used https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
     pullPolicy: IfNotPresent
     # Image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
@@ -487,7 +487,7 @@ identity:
     # Image.repository defines which image repository to use
     repository: camunda/identity
     # Image.tag can be set to overwrite the global tag, which should be used in that chart
-    tag: SNAPSHOT # currently no image available
+    tag:
 
   # Service configuration to configure the identity service.
   service:

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -67,8 +67,8 @@ global:
       identity:
         # Operate.auth.identity.enabled if true, enables the Identity authentication otherwise basic-auth will be used.
         enabled: true
-        # Operate.auth.identity.existingSecret can be used to use an own existing secret. If not set a random secret is generated.
-        # Secret should contain an operate-secret field
+        # Operate.auth.identity.existingSecret can be used to reference an existing secret. If not set, a random secret is generated.
+        # The existing secret should contain an `operate-secret` field, which will be used as secret for the Identity-Operate communication.
         existingSecret:
         # Operate.auth.identity.operateRootUrl defines the root (or redirect) URL, which is used by Keycloak to access Operate.
         # Should be public accessible, the default value works if port-forward to operate is created to 8080.

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -70,7 +70,14 @@ global:
         # Operate.auth.identity.existingSecret can be used to use an own existing secret. If not set a random secret is generated.
         # Secret should contain an operate-secret field
         existingSecret:
-        initRootUrl: "http://localhost:8080"
+        # Operate.auth.identity.operateRootUrl defines the root (or redirect) URL, which is used by Keycloak to access Operate.
+        # Should be public accessible, the default value works if port-forward to operate is created to 8080.
+        # Can be overwritten if, ingress is in use and an external IP is available.
+        operateRootUrl: "http://localhost:8080"
+        # Operate.auth.identity.publicIssuerUrl defines the token issuer (Keycloak) URL, where to request JWT tokens.
+        # Should be public accessible, per default we assume a port-forward to Keycloak (18080) is created before login.
+        # Can be overwritten if, ingress is in use and an external IP is available.
+        publicIssuerUrl: "http://localhost:18080/auth/realms/camunda-platform"
 
 # Zeebe configuration for the Zeebe sub chart. Contains configuration for the Zeebe broker and related resources.
 zeebe:


### PR DESCRIPTION
Integrates Identity with Operate. 

 * uses the recent release candidate at the time (8.0.0-rc1)
 * Configure Operate and Identity to communicate with each other
 * Make it possible to disable this configuration
 * Auto generate a secret for Operate-Identity ( can be also overwritten by user and an existing secret)
 * Adjust docs, values file
 * Add notes in Helm release notes file
 * Add template tests
 * Add integration test for operate login


New notes:

```
### Operate

As part of the Operate HELM Chart an ingress definition can be deployed, but you require to have an Ingress Controller for that Ingress to be Exposed.
In order to deploy the ingress manifest, set `operate.ingress.enabled` to `true`.
If you don't have an Ingress Controller you can use kubectl port-forward to access Operate from outside the cluster:

> kubectl port-forward svc/camunda-platform-test-operate 8080:80

Per default authentication via Identity/Keycloak is enabled. In order to login into Operate please port-forward to Keycloak
as well, otherwise a login will not be possible. Make sure you use `18080` as port.

> kubectl port-forward svc/camunda-platform-tes 18080:80

Now you can point your browser to `http://localhost:8080`

Default user and password: "demo/demo"

```


@dlavrenuek maybe you can shortly check whether the config is like we discuss ( I would expect, just to be sure)
@npepinpe please do a normal review :) 