### PR TITLE
feat: make first user configurable

### DIFF
--- a/charts/camunda-platform/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/identity/templates/deployment.yaml
@@ -21,9 +21,9 @@ spec:
         {{- end }}
         env:
           - name: KEYCLOAK_USERS_0_USERNAME
-            value: "demo"
+            value: {{ .Values.firstUser.username | quote }}
           - name: KEYCLOAK_USERS_0_PASSWORD
-            value: "demo"
+            value: {{ .Values.firstUser.password | quote }}
           - name: KEYCLOAK_USERS_0_ROLES_0
             value: "Identity"
 

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -514,6 +514,14 @@ identity:
   # Enabled if true, the identity deployment and its related resources are deployed via a helm release
   enabled: true
 
+  # FirstUser configuration to configure properties of the first Identity user, which can be used to access all
+  # web applications
+  firstUser:
+    # FirstUser.username defines the username of the first user, needed to log in into the web applications
+    username: demo
+    # FirstUser.name defines the password of the first user, needed to log in into the web applications
+    password: demo
+
   # Image configuration to configure the identity image specifics
   image:
     # Image.repository defines which image repository to use


### PR DESCRIPTION

Allows the user to configure the first identity user and overwrite the name and password. 

Note: In the release helm notes I decided to not print the actual set values for security reasons, so we will only print the default: demo/demo values.