### PR TITLE
Add initContainer cfg to gateway

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test:	deps
 # it: runs the integration tests agains the current kube context
 .PHONY: it
 it:	deps
-	go test -timeout 1h -tags integration ./.../integration
+	go test -p 1 -timeout 1h -tags integration ./.../integration
 
 # golden: runs the tests with updating the golden files
 .PHONY: golden

--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -121,7 +121,7 @@ Information about Zeebe you can find [here](https://docs.camunda.io/docs/compone
 | | `resources` | Configuration to set [request and limit configuration for the container](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits) | `requests:`<br>`  cpu: 800m`<br> `  memory: 1200Mi`<br>`limits:`<br>  ` cpu: 960m`<br>  ` memory: 1920Mi` |
 | | `pvcSize` | Defines the [persistent volume claim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims) size, which is used by each broker pod | `32Gi` |
 | | `pvcAccessModes` | Can be used to configure the [persistent volume claim access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) | `[ "ReadWriteOnce" ]` |
-| | `pvcStorageClassName` | Can be used to set the storage class name which should be used by the persistent volume claim. It is recommended to use a storage class, which is backed with a SSD. | `` |
+| | `pvcStorageClassName` | Can be used to set the storage class name which should be used by the persistent volume claim. It is recommended to use a storage class, which is backed with a SSD. | ` ` |
 | | `extraVolumes` | Can be used to define extra volumes for the broker pods, useful for additional exporters | `{ }`|
 | | `extraVolumeMounts` | Can be used to mount extra volumes for the broker pods, useful for additional exporters | `{ }` |
 | | `extraInitContainers` | Can be used to set up extra init containers for the broker pods, useful for additional exporters | `[ ]` |
@@ -172,6 +172,7 @@ Information about the Zeebe Gateway you can find [here](https://docs.camunda.io/
 | | `affinity` | Can be used to define [pod affinity or anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity). The default defined PodAntiAffinity allows constraining on which nodes the [Zeebe gateway pods are scheduled on](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity). It uses a hard requirement for scheduling and works based on the Zeebe gateway pod labels. | `podAntiAffinity:</br>  requiredDuringSchedulingIgnoredDuringExecution:</br>  - labelSelector: </br>    matchExpressions:</br>    - key: "app.kubernetes.io/component"</br>    operator: In</br>    values:</br>    - zeebe-gatway</br>  topologyKey: "kubernetes.io/hostname"` |
 | | `extraVolumeMounts` | Can be used to mount extra volumes for the gateway pods, useful for enabling TLS between gateway and broker | `{ }` |
 | | `extraVolumes` | Can be used to define extra volumes for the gateway pods, useful for enabling TLS between gateway and broker | `{ }` |
+| | `extraInitContainers` | Can be used to set up extra init containers for the gateway pods, useful for adding interceptors | `[ ]` |
 | | `service` | Configuration for the gateway service | |
 | | `service.type` | Defines the [type of the service](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) | `ClusterIP` |
 | | `service.httpPort` | Defines the port of the HTTP endpoint, where for example metrics are provided | `9600` |

--- a/charts/camunda-platform/charts/zeebe-gateway/templates/gateway-deployment.yaml
+++ b/charts/camunda-platform/charts/zeebe-gateway/templates/gateway-deployment.yaml
@@ -27,6 +27,12 @@ spec:
       imagePullSecrets:
         {{ toYaml .Values.global.image.pullSecrets | indent 8 | trim }}
       {{- end }}
+      {{- if .Values.extraInitContainers }}
+      initContainers:
+        {{- with .Values.extraInitContainers }}
+          {{- tpl (toYaml . ) $ | nindent 8 }}
+        {{- end }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           {{- if .Values.image.tag }}

--- a/charts/camunda-platform/test/integration/it-values.yaml
+++ b/charts/camunda-platform/test/integration/it-values.yaml
@@ -1,0 +1,7 @@
+# Gateway configuration to define properties related to the standalone gateway
+zeebe-gateway:
+  # ExtraInitContainers can be used to set up extra init containers for the gateway pods, useful for adding interceptors
+  extraInitContainers:
+    - name: "init-container"
+      image: "busybox:1.28"
+      command: ["sh", "-c" , "echo", "Hello World!"]

--- a/charts/camunda-platform/test/zeebe-gateway/deployment_test.go
+++ b/charts/camunda-platform/test/zeebe-gateway/deployment_test.go
@@ -514,3 +514,28 @@ func (s *deploymentTemplateTest) TestContainerSetTolerations() {
 	s.Require().Equal("Value1", toleration.Value)
 	s.Require().EqualValues("NoSchedule", toleration.Effect)
 }
+
+func (s *deploymentTemplateTest) TestContainerSetExtraInitContainers() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"zeebe-gateway.extraInitContainers[0].name":                      "init-container-{{ .Release.Name }}",
+			"zeebe-gateway.extraInitContainers[0].image":                     "busybox:1.28",
+			"zeebe-gateway.extraInitContainers[0].command[0]":                "sh",
+			"zeebe-gateway.extraInitContainers[0].command[1]":                "-c",
+			"zeebe-gateway.extraInitContainers[0].command[2]":                "top",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	initContainer := deployment.Spec.Template.Spec.InitContainers[0]
+	s.Require().Equal("init-container-camunda-platform-test", initContainer.Name)
+	s.Require().Equal("busybox:1.28", initContainer.Image)
+	s.Require().Equal([]string{"sh", "-c", "top"}, initContainer.Command)
+}

--- a/charts/camunda-platform/test/zeebe-gateway/deployment_test.go
+++ b/charts/camunda-platform/test/zeebe-gateway/deployment_test.go
@@ -519,11 +519,11 @@ func (s *deploymentTemplateTest) TestContainerSetExtraInitContainers() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"zeebe-gateway.extraInitContainers[0].name":                      "init-container-{{ .Release.Name }}",
-			"zeebe-gateway.extraInitContainers[0].image":                     "busybox:1.28",
-			"zeebe-gateway.extraInitContainers[0].command[0]":                "sh",
-			"zeebe-gateway.extraInitContainers[0].command[1]":                "-c",
-			"zeebe-gateway.extraInitContainers[0].command[2]":                "top",
+			"zeebe-gateway.extraInitContainers[0].name":       "init-container-{{ .Release.Name }}",
+			"zeebe-gateway.extraInitContainers[0].image":      "busybox:1.28",
+			"zeebe-gateway.extraInitContainers[0].command[0]": "sh",
+			"zeebe-gateway.extraInitContainers[0].command[1]": "-c",
+			"zeebe-gateway.extraInitContainers[0].command[2]": "top",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 	}

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -310,6 +310,8 @@ zeebe-gateway:
   extraVolumeMounts: { }
   # ExtraVolumes can be used to define extra volumes for the gateway pods, useful for enabling tls between gateway and broker
   extraVolumes: { }
+  # ExtraInitContainers can be used to set up extra init containers for the gateway pods, useful for adding interceptors
+  extraInitContainers: [ ]
 
   # Service configuration for the gateway service
   service:


### PR DESCRIPTION
Add new variable configuration to the values file to configure the initContainers for the Zeebe gateway. This allows for example to add interceptors as jar files to the lib folder.

closes #177 