### PR TITLE
Add optimize to helm charts

### DIFF
--- a/charts/camunda-platform/Chart.yaml
+++ b/charts/camunda-platform/Chart.yaml
@@ -22,6 +22,9 @@ dependencies:
 - name: tasklist
   version: 8.0.4
   condition: "tasklist.enabled"
+- name: optimize
+  version: 8.0.4
+  condition: "global.identity.auth.enabled"
 - name: identity
   version: 8.0.4
   condition: "identity.enabled"

--- a/charts/camunda-platform/charts/identity/templates/_helpers.tpl
+++ b/charts/camunda-platform/charts/identity/templates/_helpers.tpl
@@ -68,3 +68,11 @@ Defines match labels for identity, which are extended by sub-charts and should b
 {{- $name := .Release.Name -}}
 {{- printf "%s-tasklist-identity-secret" $name | trunc 63 | trimSuffix "-" | quote -}}
 {{- end }}
+
+{{/*
+[identity] Create the name of the optimize-identity secret
+*/}}
+{{- define "identity.secretNameOptimizeIdentity" -}}
+{{- $name := .Release.Name -}}
+{{- printf "%s-optimize-identity-secret" $name | trunc 63 | trimSuffix "-" | quote -}}
+{{- end }}

--- a/charts/camunda-platform/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/identity/templates/deployment.yaml
@@ -77,6 +77,29 @@ spec:
             {{- end }}
           - name: KEYCLOAK_INIT_TASKLIST_ROOT_URL
             value: {{ .Values.global.identity.auth.tasklist.redirectUrl | quote }}
+
+
+          - name: KEYCLOAK_USERS_0_ROLES_3
+            value: "Optimize"
+          - name: KEYCLOAK_INIT_OPTIMIZE_SECRET
+            {{- if .Values.global.identity.auth.optimize.existingSecret }}
+            valueFrom:
+              secretKeyRef:
+                {{- /*
+                    Helper: https://github.com/bitnami/charts/blob/master/bitnami/common/templates/_secrets.tpl
+                    Usage in keycloak secrets https://github.com/bitnami/charts/blob/master/bitnami/keycloak/templates/secrets.yaml
+                    and in statefulset https://github.com/bitnami/charts/blob/master/bitnami/keycloak/templates/statefulset.yaml
+                */}}
+                name: {{ include "common.secrets.name" (dict "existingSecret" .Values.global.identity.auth.optimize.existingSecret "context" $) }}
+                key: optimize-secret
+            {{- else }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "identity.secretNameOptimizeIdentity" . }}
+                key: optimize-secret
+          {{- end }}
+          - name: KEYCLOAK_INIT_OPTIMIZE_ROOT_URL
+            value: {{ .Values.global.identity.auth.optimize.redirectUrl | quote }}
           {{- end }}
           - name: SERVER_PORT
             value: "8080"

--- a/charts/camunda-platform/charts/identity/templates/optimize-secret.yaml
+++ b/charts/camunda-platform/charts/identity/templates/optimize-secret.yaml
@@ -1,0 +1,11 @@
+{{- if and (.Values.global.identity.auth.enabled) (not .Values.global.identity.auth.optimize.existingSecret) }}
+{{- $secretName := include "identity.secretNameOptimizeIdentity" . }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels: {{- include "identity.labels" . | nindent 4 }}
+type: Opaque
+data:
+  optimize-secret: {{ include "common.secrets.passwords.manage" (dict "secret" $secretName "key" "optimize-secret" "length" 10 "providedValues" (list "global.identity.auth.optimize.existingSecret") "context" $) }}
+{{- end }}

--- a/charts/camunda-platform/charts/optimize/.helmignore
+++ b/charts/camunda-platform/charts/optimize/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/camunda-platform/charts/optimize/Chart.yaml
+++ b/charts/camunda-platform/charts/optimize/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+description: Optimize Helm Chart for Kubernetes
+name: optimize
+version: 8.0.4
+icon: https://helm.camunda.io/imgs/zeebe-logo.png
+annotations:
+  artifacthub.io/changes: |
+    - create optimize sub chart
+  artifacthub.io/containsSecurityUpdates: "true"

--- a/charts/camunda-platform/charts/optimize/README.md
+++ b/charts/camunda-platform/charts/optimize/README.md
@@ -1,0 +1,3 @@
+# Optimize Helm Chart
+
+Contains the Optimize subchart, which is part of Camunda Platform Helm chart. For more details please take a look at [Configuration#Optimize](../../README#optimize).

--- a/charts/camunda-platform/charts/optimize/templates/_helpers.tpl
+++ b/charts/camunda-platform/charts/optimize/templates/_helpers.tpl
@@ -1,0 +1,54 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "optimize.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Defines extra labels for optimize.
+*/}}
+{{- define "optimize.extraLabels" -}}
+app.kubernetes.io/component: optimize
+{{- end -}}
+
+{{/*
+Define common labels for Optimize, combining the match labels and transient labels, which might change on updating
+(version depending). These labels shouldn't be used on matchLabels selector, since the selectors are immutable.
+*/}}
+{{- define "optimize.labels" -}}
+{{- template "camundaPlatform.labels" . }}
+{{ template "optimize.extraLabels" . }}
+{{- end -}}
+
+{{/*
+Defines match labels for tasklist, which are extended by sub-charts and should be used in matchLabels selectors.
+*/}}
+{{- define "optimize.matchLabels" -}}
+{{- template "camundaPlatform.matchLabels" . }}
+{{ template "optimize.extraLabels" . }}
+{{- end -}}
+
+{{/*
+[optimize] Create the name of the service account to use
+*/}}
+{{- define "optimize.serviceAccountName" -}}
+{{- if .Values.serviceAccount.enabled }}
+{{- default (include "optimize.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/camunda-platform/charts/optimize/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/optimize/templates/deployment.yaml
@@ -60,6 +60,8 @@ spec:
             value: "optimize-api"
           - name: CAMUNDA_OPTIMIZE_SECURITY_AUTH_COOKIE_SAME_SITE_ENABLED
             value: "false"
+          - name: CAMUNDA_OPTIMIZE_UI_LOGOUT_HIDDEN
+            value: "true"
           {{- if .Values.env}}
           {{ .Values.env | toYaml | nindent 10 }}
           {{- end }}

--- a/charts/camunda-platform/charts/optimize/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/optimize/templates/deployment.yaml
@@ -1,0 +1,100 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "optimize.fullname" . }}
+  labels: {{- include "optimize.labels" . | nindent 4 }}
+  annotations: {{- toYaml  .Values.global.annotations | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "optimize.matchLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels: 
+        {{- include "optimize.labels" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        {{- if .Values.image.tag }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- else }}
+        image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
+        {{- end }}
+        env:
+          - name: CAMUNDA_OPTIMIZE_ZEEBE_ENABLED
+            value: "true"
+          - name: OPTIMIZE_ELASTICSEARCH_HOST
+            value: {{ .Values.global.elasticsearch.host | quote }}
+          - name: OPTIMIZE_ELASTICSEARCH_HTTP_PORT
+            value: {{ .Values.global.elasticsearch.port | quote }}
+          - name: SPRING_PROFILES_ACTIVE
+            value: "ccsm"
+          - name: CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL
+            value: {{ .Values.global.identity.auth.publicIssuerUrl | quote }}
+          - name: CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_BACKEND_URL
+            value: "http://{{ include "common.names.dependency.fullname" (dict "chartName" "keycloak" "chartValues" . "context" $) | trunc 20 | trimSuffix "-" }}:80/auth/realms/camunda-platform"
+          - name: CAMUNDA_OPTIMIZE_IDENTITY_CLIENTID
+            value: "optimize"
+          - name: CAMUNDA_OPTIMIZE_IDENTITY_CLIENTSECRET
+            {{- if .Values.global.identity.auth.optimize.existingSecret }}
+            valueFrom:
+              secretKeyRef:
+                {{- /*
+                    Helper: https://github.com/bitnami/charts/blob/master/bitnami/common/templates/_secrets.tpl
+                    Usage in keycloak secrets https://github.com/bitnami/charts/blob/master/bitnami/keycloak/templates/secrets.yaml
+                    and in statefulset https://github.com/bitnami/charts/blob/master/bitnami/keycloak/templates/statefulset.yaml
+                */}}
+                name: {{ include "common.secrets.name" (dict "existingSecret" .Values.global.identity.auth.optimize.existingSecret "context" $) }}
+                key: optimize-secret
+            {{- else }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ include "identity.secretNameOptimizeIdentity" . }}
+                key: optimize-secret
+            {{- end }}
+          - name: CAMUNDA_OPTIMIZE_IDENTITY_AUDIENCE
+            value: "optimize-api"
+          - name: CAMUNDA_OPTIMIZE_SECURITY_AUTH_COOKIE_SAME_SITE_ENABLED
+            value: "false"
+          {{- if .Values.env}}
+          {{ .Values.env | toYaml | nindent 10 }}
+          {{- end }}
+        {{- if .Values.command}}
+        command: {{ .Values.command }}
+        {{- end }}
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+        ports:
+        - containerPort: 8090
+          name: http
+          protocol: TCP
+        volumeMounts:
+        {{- if .Values.extraVolumeMounts}}
+          {{- .Values.extraVolumeMounts | toYaml | nindent 8 }}
+        {{- end }}
+      volumes:
+      {{- if .Values.extraVolumes}}
+      {{- .Values.extraVolumes | toYaml | nindent 6 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.name}}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}
+      {{- if .Values.podSecurityContext }}
+      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
+{{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}

--- a/charts/camunda-platform/charts/optimize/templates/ingress.yaml
+++ b/charts/camunda-platform/charts/optimize/templates/ingress.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "optimize.fullname" . }}
+  labels: {{ include "optimize.labels" . | nindent 4 }}
+{{- with .Values.ingress.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+{{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            pathType: Prefix
+            backend:
+              service:
+                name:  {{ include "optimize.fullname" . }}
+                port:
+                  number: 80
+{{- end }}

--- a/charts/camunda-platform/charts/optimize/templates/service.yaml
+++ b/charts/camunda-platform/charts/optimize/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "optimize.fullname" . }}
+  labels: {{- include "optimize.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.global.annotations}}
+    {{- toYaml .Values.global.annotations | nindent 4 }}
+    {{- end }}
+    {{- if .Values.service.annotations}}
+    {{- toYaml .Values.service.annotations | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.port }}
+    name: http
+    targetPort: 8090
+    protocol: TCP
+  selector:
+    {{- include "optimize.matchLabels" . | nindent 4 }}

--- a/charts/camunda-platform/charts/optimize/templates/serviceaccount.yaml
+++ b/charts/camunda-platform/charts/optimize/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "optimize.serviceAccountName" . }}
+  labels: {{- include "optimize.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/camunda-platform/charts/optimize/templates/tests/test-connection.yaml
+++ b/charts/camunda-platform/charts/optimize/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "tasklist.fullname" . }}-test-connection"
+  labels:
+{{ include "tasklist.labels" . | indent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args:  ['{{ include "tasklist.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/camunda-platform/charts/optimize/templates/tests/test-connection.yaml
+++ b/charts/camunda-platform/charts/optimize/templates/tests/test-connection.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ include "tasklist.fullname" . }}-test-connection"
+  name: "{{ include "optimize.fullname" . }}-test-connection"
   labels:
-{{ include "tasklist.labels" . | indent 4 }}
+{{ include "optimize.labels" . | indent 4 }}
   annotations:
     "helm.sh/hook": test-success
 spec:
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args:  ['{{ include "tasklist.fullname" . }}:{{ .Values.service.port }}']
+      args:  ['{{ include "optimize.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never

--- a/charts/camunda-platform/templates/NOTES.txt
+++ b/charts/camunda-platform/templates/NOTES.txt
@@ -59,6 +59,9 @@ Operate:  kubectl port-forward svc/{{ .Release.Name }}-operate  8081:80
 {{ if .Values.tasklist.enabled -}}
 Tasklist: kubectl port-forward svc/{{ .Release.Name }}-tasklist 8082:80
 {{- end }}
+{{ if .Values.optimize.enabled -}}
+Optimize: kubectl port-forward svc/{{ .Release.Name }}-optimize 8083:80
+{{- end }}
 
     {{- if and .Values.global.identity.auth.enabled .Values.identity.enabled }}
 

--- a/charts/camunda-platform/test/curator_test.go
+++ b/charts/camunda-platform/test/curator_test.go
@@ -1,4 +1,4 @@
-package zeebe
+package test
 
 import (
 	"camunda-platform-helm/charts/camunda-platform/test/golden"

--- a/charts/camunda-platform/test/global_deployment_test.go
+++ b/charts/camunda-platform/test/global_deployment_test.go
@@ -1,0 +1,66 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type deploymentTemplateTest struct {
+	suite.Suite
+	chartPath string
+	release   string
+	namespace string
+	templates []string
+}
+
+func TestDeploymentTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../")
+	require.NoError(t, err)
+
+	suite.Run(t, &deploymentTemplateTest{
+		chartPath: chartPath,
+		release:   "camunda-platform-test",
+		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
+	})
+}
+
+func (s *deploymentTemplateTest) TestContainerShouldDisableOperateIfIdentityIntegrationIsDisabled() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.identity.auth.enabled": "false",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+
+	// then
+	s.Require().NotContains("optimize", output)
+	s.Require().NotContains("OPTIMIZE", output)
+}

--- a/charts/camunda-platform/test/global_deployment_test.go
+++ b/charts/camunda-platform/test/global_deployment_test.go
@@ -47,7 +47,7 @@ func TestDeploymentTemplate(t *testing.T) {
 	})
 }
 
-func (s *deploymentTemplateTest) TestContainerShouldDisableOperateIfIdentityIntegrationIsDisabled() {
+func (s *deploymentTemplateTest) TestContainerShouldDisableOptimizeIfIdentityIntegrationIsDisabled() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{

--- a/charts/camunda-platform/test/identity/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/identity/golden/deployment.golden.yaml
@@ -64,6 +64,17 @@ spec:
                 key: tasklist-secret
           - name: KEYCLOAK_INIT_TASKLIST_ROOT_URL
             value: "http://localhost:8082"
+
+
+          - name: KEYCLOAK_USERS_0_ROLES_3
+            value: "Optimize"
+          - name: KEYCLOAK_INIT_OPTIMIZE_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: "camunda-platform-test-optimize-identity-secret"
+                key: optimize-secret
+          - name: KEYCLOAK_INIT_OPTIMIZE_ROOT_URL
+            value: "http://localhost:8083"
           - name: SERVER_PORT
             value: "8080"
           - name: KEYCLOAK_URL

--- a/charts/camunda-platform/test/optimize/deployment_test.go
+++ b/charts/camunda-platform/test/optimize/deployment_test.go
@@ -460,31 +460,3 @@ func (s *deploymentTemplateTest) TestContainerShouldSetOptimizeIdentitySecret() 
 			},
 		})
 }
-
-func (s *deploymentTemplateTest) TestContainerShouldDisableOperateIntegration() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.identity.auth.enabled": "false",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-
-	for _, envvar := range env {
-		s.Require().NotEqual("CAMUNDA_OPERATE_IDENTITY_ISSUER_URL", envvar.Name)
-		s.Require().NotEqual("CAMUNDA_OPERATE_IDENTITY_ISSUER_BACKEND_URL", envvar.Name)
-		s.Require().NotEqual("CAMUNDA_OPERATE_IDENTITY_CLIENT_ID", envvar.Name)
-		s.Require().NotEqual("CAMUNDA_OPERATE_IDENTITY_CLIENT_SECRET", envvar.Name)
-	}
-
-	s.Require().Contains(env, v12.EnvVar{Name: "SPRING_PROFILES_ACTIVE", Value: "auth"})
-}

--- a/charts/camunda-platform/test/optimize/deployment_test.go
+++ b/charts/camunda-platform/test/optimize/deployment_test.go
@@ -1,0 +1,490 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package optimize
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	appsv1 "k8s.io/api/apps/v1"
+	v12 "k8s.io/api/core/v1"
+)
+
+type deploymentTemplateTest struct {
+	suite.Suite
+	chartPath string
+	release   string
+	namespace string
+	templates []string
+}
+
+func TestDeploymentTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../")
+	require.NoError(t, err)
+
+	suite.Run(t, &deploymentTemplateTest{
+		chartPath: chartPath,
+		release:   "camunda-platform-test",
+		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
+		templates: []string{"charts/optimize/templates/deployment.yaml"},
+	})
+}
+
+func (s *deploymentTemplateTest) TestContainerSetPodLabels() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"optimize.podLabels.foo": "bar",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	s.Require().Equal("bar", deployment.Spec.Template.Labels["foo"])
+}
+
+func (s *deploymentTemplateTest) TestContainerSetGlobalAnnotations() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.annotations.foo": "bar",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	s.Require().Equal("bar", deployment.ObjectMeta.Annotations["foo"])
+}
+
+func (s *deploymentTemplateTest) TestContainerOverwriteImageTag() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"optimize.image.tag": "a.b.c",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	expectedContainerImage := "camunda/optimize:a.b.c"
+	containers := deployment.Spec.Template.Spec.Containers
+	s.Require().Equal(1, len(containers))
+	s.Require().Equal(expectedContainerImage, containers[0].Image)
+}
+
+func (s *deploymentTemplateTest) TestContainerNotOverwriteGlobalImageTag() {
+	// optimize uses a different version schema which means we shouldn't overwrite the tag via the global value
+
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.image.tag": "a.b.c",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	expectedContainerImage := "camunda/optimize:a.b.c"
+	containers := deployment.Spec.Template.Spec.Containers
+	s.Require().Equal(1, len(containers))
+	s.Require().NotEqual(expectedContainerImage, containers[0].Image)
+}
+
+func (s *deploymentTemplateTest) TestContainerOverwriteImageTagWithChartDirectSetting() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.image.tag":   "x.y.z",
+			"optimize.image.tag": "a.b.c",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	expectedContainerImage := "camunda/optimize:a.b.c"
+	containers := deployment.Spec.Template.Spec.Containers
+	s.Require().Equal(1, len(containers))
+	s.Require().Equal(expectedContainerImage, containers[0].Image)
+}
+
+func (s *deploymentTemplateTest) TestContainerSetContainerCommand() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"optimize.command": "[printenv]",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	containers := deployment.Spec.Template.Spec.Containers
+	s.Require().Equal(len(containers), 1)
+	s.Require().Equal(1, len(containers[0].Command))
+	s.Require().Equal("printenv", containers[0].Command[0])
+}
+
+func (s *deploymentTemplateTest) TestContainerSetExtraVolumes() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"optimize.extraVolumes[0].name":                  "extraVolume",
+			"optimize.extraVolumes[0].configMap.name":        "otherConfigMap",
+			"optimize.extraVolumes[0].configMap.defaultMode": "744",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	volumes := deployment.Spec.Template.Spec.Volumes
+	s.Require().Equal(len(volumes), 1)
+
+	extraVolume := volumes[0]
+	s.Require().Equal("extraVolume", extraVolume.Name)
+	s.Require().NotNil(*extraVolume.ConfigMap)
+	s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
+	s.Require().EqualValues(744, *extraVolume.ConfigMap.DefaultMode)
+}
+
+func (s *deploymentTemplateTest) TestContainerSetExtraVolumeMounts() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"optimize.extraVolumeMounts[0].name":      "otherConfigMap",
+			"optimize.extraVolumeMounts[0].mountPath": "/usr/local/config",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	containers := deployment.Spec.Template.Spec.Containers
+	s.Require().Equal(len(containers), 1)
+
+	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
+	s.Require().Equal(len(volumeMounts), 1)
+	extraVolumeMount := volumeMounts[0]
+	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
+	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
+}
+
+func (s *deploymentTemplateTest) TestContainerSetExtraVolumesAndMounts() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"optimize.extraVolumeMounts[0].name":             "otherConfigMap",
+			"optimize.extraVolumeMounts[0].mountPath":        "/usr/local/config",
+			"optimize.extraVolumes[0].name":                  "extraVolume",
+			"optimize.extraVolumes[0].configMap.name":        "otherConfigMap",
+			"optimize.extraVolumes[0].configMap.defaultMode": "744",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	volumes := deployment.Spec.Template.Spec.Volumes
+	s.Require().Equal(len(volumes), 1)
+
+	extraVolume := volumes[0]
+	s.Require().Equal("extraVolume", extraVolume.Name)
+	s.Require().NotNil(*extraVolume.ConfigMap)
+	s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
+	s.Require().EqualValues(744, *extraVolume.ConfigMap.DefaultMode)
+
+	containers := deployment.Spec.Template.Spec.Containers
+	s.Require().Equal(len(containers), 1)
+
+	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
+	s.Require().Equal(len(volumeMounts), 1)
+	extraVolumeMount := volumeMounts[0]
+	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
+	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
+}
+
+func (s *deploymentTemplateTest) TestContainerSetServiceAccountName() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"optimize.serviceAccount.name": "accName",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	serviceAccName := deployment.Spec.Template.Spec.ServiceAccountName
+	s.Require().Equal("accName", serviceAccName)
+}
+
+func (s *deploymentTemplateTest) TestContainerSetSecurityContext() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"optimize.podSecurityContext.runAsUser": "1000",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	securityContext := deployment.Spec.Template.Spec.SecurityContext
+	s.Require().EqualValues(1000, *securityContext.RunAsUser)
+}
+
+// https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+func (s *deploymentTemplateTest) TestContainerSetNodeSelector() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"optimize.nodeSelector.disktype": "ssd",
+			"optimize.nodeSelector.cputype":  "arm",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	s.Require().Equal("ssd", deployment.Spec.Template.Spec.NodeSelector["disktype"])
+	s.Require().Equal("arm", deployment.Spec.Template.Spec.NodeSelector["cputype"])
+}
+
+// https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+func (s *deploymentTemplateTest) TestContainerSetAffinity() {
+	// given
+
+	//affinity:
+	//	nodeAffinity:
+	//	 requiredDuringSchedulingIgnoredDuringExecution:
+	//	   nodeSelectorTerms:
+	//	   - matchExpressions:
+	//		 - key: kubernetes.io/e2e-az-name
+	//		   operator: In
+	//		   values:
+	//		   - e2e-az1
+	//		   - e2e-az2
+	//	 preferredDuringSchedulingIgnoredDuringExecution:
+	//	 - weight: 1
+	//	   preference:
+	//		 matchExpressions:
+	//		 - key: another-node-label-key
+	//		   operator: In
+	//		   values:
+	//		   - another-node-label-value
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"optimize.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].key":       "kubernetes.io/e2e-az-name",
+			"optimize.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].operator":  "In",
+			"optimize.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].values[0]": "e2e-a1",
+			"optimize.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].values[1]": "e2e-a2",
+			"optimize.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight":                                         "1",
+			"optimize.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].key":             "another-node-label-key",
+			"optimize.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].operator":        "In",
+			"optimize.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].values[0]":       "another-node-label-value",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	nodeAffinity := deployment.Spec.Template.Spec.Affinity.NodeAffinity
+	s.Require().NotNil(nodeAffinity)
+
+	nodeSelectorTerm := nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0]
+	s.Require().NotNil(nodeSelectorTerm)
+	matchExpression := nodeSelectorTerm.MatchExpressions[0]
+	s.Require().NotNil(matchExpression)
+	s.Require().Equal("kubernetes.io/e2e-az-name", matchExpression.Key)
+	s.Require().EqualValues("In", matchExpression.Operator)
+	s.Require().Equal([]string{"e2e-a1", "e2e-a2"}, matchExpression.Values)
+
+	preferredSchedulingTerm := nodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0]
+	s.Require().NotNil(preferredSchedulingTerm)
+
+	matchExpression = preferredSchedulingTerm.Preference.MatchExpressions[0]
+	s.Require().NotNil(matchExpression)
+	s.Require().Equal("another-node-label-key", matchExpression.Key)
+	s.Require().EqualValues("In", matchExpression.Operator)
+	s.Require().Equal([]string{"another-node-label-value"}, matchExpression.Values)
+}
+
+// https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration
+func (s *deploymentTemplateTest) TestContainerSetTolerations() {
+	// given
+
+	//tolerations:
+	//- key: "key1"
+	//  operator: "Equal"
+	//  value: "value1"
+	//  effect: "NoSchedule"
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"optimize.tolerations[0].key":      "key1",
+			"optimize.tolerations[0].operator": "Equal",
+			"optimize.tolerations[0].value":    "Value1",
+			"optimize.tolerations[0].effect":   "NoSchedule",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	tolerations := deployment.Spec.Template.Spec.Tolerations
+	s.Require().Equal(1, len(tolerations))
+
+	toleration := tolerations[0]
+	s.Require().Equal("key1", toleration.Key)
+	s.Require().EqualValues("Equal", toleration.Operator)
+	s.Require().Equal("Value1", toleration.Value)
+	s.Require().EqualValues("NoSchedule", toleration.Effect)
+}
+
+func (s *deploymentTemplateTest) TestContainerShouldSetOptimizeIdentitySecret() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.identity.auth.optimize.existingSecret": "ownExistingSecret",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	env := deployment.Spec.Template.Spec.Containers[0].Env
+	s.Require().Contains(env,
+		v12.EnvVar{
+			Name: "CAMUNDA_OPTIMIZE_IDENTITY_CLIENTSECRET",
+			ValueFrom: &v12.EnvVarSource{
+				SecretKeyRef: &v12.SecretKeySelector{
+					LocalObjectReference: v12.LocalObjectReference{Name: "ownExistingSecret"},
+					Key:                  "optimize-secret",
+				},
+			},
+		})
+}
+
+func (s *deploymentTemplateTest) TestContainerShouldDisableOperateIntegration() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.identity.auth.enabled": "false",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	env := deployment.Spec.Template.Spec.Containers[0].Env
+
+	for _, envvar := range env {
+		s.Require().NotEqual("CAMUNDA_OPERATE_IDENTITY_ISSUER_URL", envvar.Name)
+		s.Require().NotEqual("CAMUNDA_OPERATE_IDENTITY_ISSUER_BACKEND_URL", envvar.Name)
+		s.Require().NotEqual("CAMUNDA_OPERATE_IDENTITY_CLIENT_ID", envvar.Name)
+		s.Require().NotEqual("CAMUNDA_OPERATE_IDENTITY_CLIENT_SECRET", envvar.Name)
+	}
+
+	s.Require().Contains(env, v12.EnvVar{Name: "SPRING_PROFILES_ACTIVE", Value: "auth"})
+}

--- a/charts/camunda-platform/test/optimize/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/optimize/golden/deployment.golden.yaml
@@ -1,0 +1,76 @@
+---
+# Source: camunda-platform/charts/operate/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: camunda-platform-test-operate
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: operate
+    app.kubernetes.io/instance: camunda-platform-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/version: "8.0.0"
+    app.kubernetes.io/component: operate
+  annotations:
+    {}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: operate
+      app.kubernetes.io/instance: camunda-platform-test
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: operate
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: operate
+        app.kubernetes.io/instance: camunda-platform-test
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        app.kubernetes.io/version: "8.0.0"
+        app.kubernetes.io/component: operate
+    spec:
+      containers:
+      - name: operate
+        image: "camunda/operate:8.0.0"
+        env:
+          - name: SPRING_PROFILES_ACTIVE
+            value: "identity-auth"
+          - name: CAMUNDA_OPERATE_IDENTITY_ISSUER_URL
+            value: "http://localhost:18080/auth/realms/camunda-platform"
+          - name: CAMUNDA_OPERATE_IDENTITY_ISSUER_BACKEND_URL
+            value: "http://camunda-platform-tes:80/auth/realms/camunda-platform"
+          - name: CAMUNDA_OPERATE_IDENTITY_CLIENT_ID
+            value: "operate"
+          - name: CAMUNDA_OPERATE_IDENTITY_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: "camunda-platform-test-operate-identity-secret"
+                key: operate-secret
+          - name: CAMUNDA_OPERATE_IDENTITY_AUDIENCE
+            value: "operate-api"
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 2Gi
+          requests:
+            cpu: 600m
+            memory: 400Mi
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        volumeMounts:
+        - name: config
+          mountPath: /usr/local/operate/config/application.yml
+          subPath: application.yml
+      volumes:
+      - name: config
+        configMap:
+          name: camunda-platform-test-operate
+          defaultMode: 484

--- a/charts/camunda-platform/test/optimize/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/optimize/golden/deployment.golden.yaml
@@ -62,6 +62,8 @@ spec:
             value: "optimize-api"
           - name: CAMUNDA_OPTIMIZE_SECURITY_AUTH_COOKIE_SAME_SITE_ENABLED
             value: "false"
+          - name: CAMUNDA_OPTIMIZE_UI_LOGOUT_HIDDEN
+            value: "true"
         resources:
           limits:
             cpu: 1000m

--- a/charts/camunda-platform/test/optimize/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/optimize/golden/deployment.golden.yaml
@@ -1,17 +1,17 @@
 ---
-# Source: camunda-platform/charts/operate/templates/deployment.yaml
+# Source: camunda-platform/charts/optimize/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: camunda-platform-test-operate
+  name: camunda-platform-test-optimize
   labels:
     app: camunda-platform
-    app.kubernetes.io/name: operate
+    app.kubernetes.io/name: optimize
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.0.0"
-    app.kubernetes.io/component: operate
+    app.kubernetes.io/version: "3.8.0"
+    app.kubernetes.io/component: optimize
   annotations:
     {}
 spec:
@@ -19,58 +19,59 @@ spec:
   selector:
     matchLabels:
       app: camunda-platform
-      app.kubernetes.io/name: operate
+      app.kubernetes.io/name: optimize
       app.kubernetes.io/instance: camunda-platform-test
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
-      app.kubernetes.io/component: operate
+      app.kubernetes.io/component: optimize
   template:
     metadata:
       labels:
         app: camunda-platform
-        app.kubernetes.io/name: operate
+        app.kubernetes.io/name: optimize
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "8.0.0"
-        app.kubernetes.io/component: operate
+        app.kubernetes.io/version: "3.8.0"
+        app.kubernetes.io/component: optimize
     spec:
       containers:
-      - name: operate
-        image: "camunda/operate:8.0.0"
+      - name: optimize
+        image: "camunda/optimize:3.8.0"
         env:
+          - name: CAMUNDA_OPTIMIZE_ZEEBE_ENABLED
+            value: "true"
+          - name: OPTIMIZE_ELASTICSEARCH_HOST
+            value: "elasticsearch-master"
+          - name: OPTIMIZE_ELASTICSEARCH_HTTP_PORT
+            value: "9200"
           - name: SPRING_PROFILES_ACTIVE
-            value: "identity-auth"
-          - name: CAMUNDA_OPERATE_IDENTITY_ISSUER_URL
+            value: "ccsm"
+          - name: CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL
             value: "http://localhost:18080/auth/realms/camunda-platform"
-          - name: CAMUNDA_OPERATE_IDENTITY_ISSUER_BACKEND_URL
+          - name: CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_BACKEND_URL
             value: "http://camunda-platform-tes:80/auth/realms/camunda-platform"
-          - name: CAMUNDA_OPERATE_IDENTITY_CLIENT_ID
-            value: "operate"
-          - name: CAMUNDA_OPERATE_IDENTITY_CLIENT_SECRET
+          - name: CAMUNDA_OPTIMIZE_IDENTITY_CLIENTID
+            value: "optimize"
+          - name: CAMUNDA_OPTIMIZE_IDENTITY_CLIENTSECRET
             valueFrom:
               secretKeyRef:
-                name: "camunda-platform-test-operate-identity-secret"
-                key: operate-secret
-          - name: CAMUNDA_OPERATE_IDENTITY_AUDIENCE
-            value: "operate-api"
+                name: "camunda-platform-test-optimize-identity-secret"
+                key: optimize-secret
+          - name: CAMUNDA_OPTIMIZE_IDENTITY_AUDIENCE
+            value: "optimize-api"
+          - name: CAMUNDA_OPTIMIZE_SECURITY_AUTH_COOKIE_SAME_SITE_ENABLED
+            value: "false"
         resources:
           limits:
-            cpu: 2000m
+            cpu: 1000m
             memory: 2Gi
           requests:
-            cpu: 600m
-            memory: 400Mi
+            cpu: 400m
+            memory: 1Gi
         ports:
-        - containerPort: 8080
+        - containerPort: 8090
           name: http
           protocol: TCP
         volumeMounts:
-        - name: config
-          mountPath: /usr/local/operate/config/application.yml
-          subPath: application.yml
       volumes:
-      - name: config
-        configMap:
-          name: camunda-platform-test-operate
-          defaultMode: 484

--- a/charts/camunda-platform/test/optimize/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/optimize/golden/ingress-all-enabled.golden.yaml
@@ -1,0 +1,30 @@
+---
+# Source: camunda-platform/charts/optimize/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: camunda-platform-test-optimize
+  labels: 
+    app: camunda-platform
+    app.kubernetes.io/name: optimize
+    app.kubernetes.io/instance: camunda-platform-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/version: "3.8.0"
+    app.kubernetes.io/component: optimize
+  annotations: 
+    ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name:  camunda-platform-test-optimize
+                port:
+                  number: 80

--- a/charts/camunda-platform/test/optimize/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/optimize/golden/ingress.golden.yaml
@@ -1,0 +1,30 @@
+---
+# Source: camunda-platform/charts/optimize/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: camunda-platform-test-optimize
+  labels: 
+    app: camunda-platform
+    app.kubernetes.io/name: optimize
+    app.kubernetes.io/instance: camunda-platform-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/version: "3.8.0"
+    app.kubernetes.io/component: optimize
+  annotations: 
+    ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: 
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name:  camunda-platform-test-optimize
+                port:
+                  number: 80

--- a/charts/camunda-platform/test/optimize/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/optimize/golden/service.golden.yaml
@@ -1,0 +1,29 @@
+---
+# Source: camunda-platform/charts/operate/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda-platform-test-operate
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: operate
+    app.kubernetes.io/instance: camunda-platform-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/version: "8.0.0"
+    app.kubernetes.io/component: operate
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    name: http
+    targetPort: 8080
+    protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: operate
+    app.kubernetes.io/instance: camunda-platform-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: operate

--- a/charts/camunda-platform/test/optimize/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/optimize/golden/service.golden.yaml
@@ -1,29 +1,29 @@
 ---
-# Source: camunda-platform/charts/operate/templates/service.yaml
+# Source: camunda-platform/charts/optimize/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: camunda-platform-test-operate
+  name: camunda-platform-test-optimize
   labels:
     app: camunda-platform
-    app.kubernetes.io/name: operate
+    app.kubernetes.io/name: optimize
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.0.0"
-    app.kubernetes.io/component: operate
+    app.kubernetes.io/version: "3.8.0"
+    app.kubernetes.io/component: optimize
   annotations:
 spec:
   type: ClusterIP
   ports:
   - port: 80
     name: http
-    targetPort: 8080
+    targetPort: 8090
     protocol: TCP
   selector:
     app: camunda-platform
-    app.kubernetes.io/name: operate
+    app.kubernetes.io/name: optimize
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/component: operate
+    app.kubernetes.io/component: optimize

--- a/charts/camunda-platform/test/optimize/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/optimize/golden/serviceaccount.golden.yaml
@@ -1,0 +1,14 @@
+---
+# Source: camunda-platform/charts/operate/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: camunda-platform-test-operate
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: operate
+    app.kubernetes.io/instance: camunda-platform-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/version: "8.0.0"
+    app.kubernetes.io/component: operate

--- a/charts/camunda-platform/test/optimize/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/optimize/golden/serviceaccount.golden.yaml
@@ -1,14 +1,14 @@
 ---
-# Source: camunda-platform/charts/operate/templates/serviceaccount.yaml
+# Source: camunda-platform/charts/optimize/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: camunda-platform-test-operate
+  name: camunda-platform-test-optimize
   labels:
     app: camunda-platform
-    app.kubernetes.io/name: operate
+    app.kubernetes.io/name: optimize
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.0.0"
-    app.kubernetes.io/component: operate
+    app.kubernetes.io/version: "3.8.0"
+    app.kubernetes.io/component: optimize

--- a/charts/camunda-platform/test/optimize/goldenfiles_test.go
+++ b/charts/camunda-platform/test/optimize/goldenfiles_test.go
@@ -1,0 +1,45 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package optimize
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"camunda-platform-helm/charts/camunda-platform/test/golden"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestGoldenDefaultsTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../")
+	require.NoError(t, err)
+	templateNames := []string{"service", "serviceaccount", "deployment"}
+
+	for _, name := range templateNames {
+		suite.Run(t, &golden.TemplateGoldenTest{
+			ChartPath:      chartPath,
+			Release:        "camunda-platform-test",
+			Namespace:      "camunda-platform-" + strings.ToLower(random.UniqueId()),
+			GoldenFileName: name,
+			Templates:      []string{"charts/operate/templates/" + name + ".yaml"},
+		})
+	}
+}

--- a/charts/camunda-platform/test/optimize/goldenfiles_test.go
+++ b/charts/camunda-platform/test/optimize/goldenfiles_test.go
@@ -39,7 +39,7 @@ func TestGoldenDefaultsTemplate(t *testing.T) {
 			Release:        "camunda-platform-test",
 			Namespace:      "camunda-platform-" + strings.ToLower(random.UniqueId()),
 			GoldenFileName: name,
-			Templates:      []string{"charts/operate/templates/" + name + ".yaml"},
+			Templates:      []string{"charts/optimize/templates/" + name + ".yaml"},
 		})
 	}
 }

--- a/charts/camunda-platform/test/optimize/ingress_test.go
+++ b/charts/camunda-platform/test/optimize/ingress_test.go
@@ -1,0 +1,64 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package optimize
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"camunda-platform-helm/charts/camunda-platform/test/golden"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestGoldenIngressDefaultTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../")
+	require.NoError(t, err)
+
+	suite.Run(t, &golden.TemplateGoldenTest{
+		ChartPath:      chartPath,
+		Release:        "camunda-platform-test",
+		Namespace:      "camunda-platform-" + strings.ToLower(random.UniqueId()),
+		GoldenFileName: "ingress",
+		Templates:      []string{"charts/optimize/templates/ingress.yaml"},
+		SetValues:      map[string]string{"optimize.ingress.enabled": "true"},
+	})
+}
+
+func TestGoldenIngressAllEnabledTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../")
+	require.NoError(t, err)
+
+	suite.Run(t, &golden.TemplateGoldenTest{
+		ChartPath:      chartPath,
+		Release:        "camunda-platform-test",
+		Namespace:      "camunda-platform-" + strings.ToLower(random.UniqueId()),
+		GoldenFileName: "ingress-all-enabled",
+		Templates:      []string{"charts/optimize/templates/ingress.yaml"},
+		SetValues: map[string]string{
+			"optimize.ingress.enabled":        "true",
+			"optimize.ingress.host":           "local",
+			"optimize.ingress.tls.enabled":    "true",
+			"optimize.ingress.tls.secretName": "my-secret",
+		},
+	})
+}

--- a/charts/camunda-platform/test/optimize/service_test.go
+++ b/charts/camunda-platform/test/optimize/service_test.go
@@ -1,0 +1,86 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package optimize
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	coreV1 "k8s.io/api/core/v1"
+)
+
+type serviceTest struct {
+	suite.Suite
+	chartPath string
+	release   string
+	namespace string
+	templates []string
+}
+
+func TestServiceTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../")
+	require.NoError(t, err)
+
+	suite.Run(t, &serviceTest{
+		chartPath: chartPath,
+		release:   "camunda-platform-test",
+		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
+		templates: []string{"charts/optimize/templates/service.yaml"},
+	})
+}
+
+func (s *serviceTest) TestContainerSetGlobalAnnotations() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.annotations.foo": "bar",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var service coreV1.Service
+	helm.UnmarshalK8SYaml(s.T(), output, &service)
+
+	// then
+	s.Require().Equal("bar", service.ObjectMeta.Annotations["foo"])
+}
+
+func (s *serviceTest) TestContainerServiceAnnotations() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"optimize.service.annotations.foo": "bar",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var service coreV1.Service
+	helm.UnmarshalK8SYaml(s.T(), output, &service)
+
+	// then
+	s.Require().Equal("bar", service.ObjectMeta.Annotations["foo"])
+}

--- a/charts/camunda-platform/test/servicemonitor_test.go
+++ b/charts/camunda-platform/test/servicemonitor_test.go
@@ -1,4 +1,4 @@
-package zeebe
+package test
 
 import (
 	"camunda-platform-helm/charts/camunda-platform/test/golden"

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -59,6 +59,7 @@ global:
   # ZeebePort defines the port which is used for the Zeebe Gateway. This port accepts the GRPC Client messages and forwards them to the Zeebe Brokers.
   zeebePort: 26500
 
+
   # Identity configuration to configure identity specifics on global level, which can be accessed by other sub-charts
   identity:
     # Identity.auth configuration, to configure Identity authentication setup
@@ -86,10 +87,20 @@ global:
         # Identity.auth.tasklist.existingSecret can be used to use an own existing secret. If not set a random secret is generated.
         # The existing secret should contain an `tasklist-secret` field, which will be used as secret for the Identity-Tasklist communication.
         existingSecret:
-        # Tasklist.auth.identity.tasklistRootUrl defines the root (or redirect) URL, which is used by Keycloak to access Tasklist.
+        # Identity.auth.tasklist.redirectUrl defines the root (or redirect) URL, which is used by Keycloak to access Tasklist.
         # Should be public accessible, the default value works if port-forward to Tasklist is created to 8082.
         # Can be overwritten if, ingress is in use and an external IP is available.
         redirectUrl: "http://localhost:8082"
+
+      # Identity.auth.optimize configuration to configure Optimize authentication specifics on global level, which can be accessed by other sub-charts
+      optimize:
+        # Identity.auth.optimize.existingSecret can be used to use an own existing secret. If not set a random secret is generated.
+        # The existing secret should contain an `optimize-secret` field, which will be used as secret for the Identity-Optimize communication.
+        existingSecret:
+        # Identity.auth.optimize.redirectUrl defines the root (or redirect) URL, which is used by Keycloak to access Optimize.
+        # Should be public accessible, the default value works if port-forward to Optimize is created to 8082.
+        # Can be overwritten if, ingress is in use and an external IP is available.
+        redirectUrl: "http://localhost:8083"
 
 # Zeebe configuration for the Zeebe sub chart. Contains configuration for the Zeebe broker and related resources.
 zeebe:
@@ -356,7 +367,6 @@ zeebe-gateway:
     # ServiceAccount.annotations can be used to set the annotations of the gateway service account
     annotations: { }
 
-
 # Operate configuration for the operate sub chart.
 operate:
   # Enabled if true, the operate deployment and its related resources are deployed via a helm release
@@ -509,6 +519,83 @@ tasklist:
   # Ingress configuration to configure the ingress resource
   ingress:
     # Ingress.enabled if true, an ingress resource is deployed with the tasklist deployment. Only useful if an ingress controller is available, like nginx.
+    enabled: false
+    # Ingress.className defines the class or configuration of ingress which should be used by the controller
+    className: nginx
+    # Ingress.annotations defines the ingress related annotations, consumed mostly by the ingress controller
+    annotations:
+      ingress.kubernetes.io/rewrite-target: "/"
+      nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    # Ingress.path defines the path which is associated with the operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
+    path: /
+    # Ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
+    # If not specified the rules applies to all inbound http traffic, if specified the rule applies to that host.
+    host:
+
+# Optimize configuration for the Optimize sub chart.
+optimize:
+  # Enabled if true, the Optimize deployment and its related resources are deployed via a helm release
+  enabled: true
+
+  # Image configuration to configure the Optimize image specifics
+  image:
+    # Image.repository defines which image repository to use
+    repository: camunda/optimize
+    # Image.tag can be set to overwrite the global tag, which should be used in that chart
+    tag: 3.8.0
+
+  # PodLabels can be used to define extra Optimize pod labels
+  podLabels: { }
+
+  # Env can be used to set extra environment variables in each Optimize container
+  env: []
+  # Command can be used to override the default command provided by the container image. See https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/
+  command: []
+  # ExtraVolumes can be used to define extra volumes for the Optimize pods, useful for tls and self-signed certificates
+  extraVolumes: []
+  # ExtraVolumeMounts can be used to mount extra volumes for the Optimize pods, useful for tls and self-signed certificates
+  extraVolumeMounts: []
+
+  # ServiceAccount configuration for the service account where the Optimize pods are assigned to
+  serviceAccount:
+    # ServiceAccount.enabled if true, enables the Optimize service account
+    enabled: true
+    # ServiceAccount.name can be used to set the name of the Optimize service account
+    name: ""
+    # ServiceAccount.annotations can be used to set the annotations of the Optimize service account
+    annotations: { }
+
+  # Service configuration to configure the Optimize service.
+  service:
+    # Service.type defines the type of the service https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+    type: ClusterIP
+    # Service.port defines the port of the service, where the Optimize web application will be available
+    port: 80
+    # Service.annotations can be used to define annotations, which will be applied to the Optimize service
+    annotations: {}
+
+  # PodSecurityContext defines the security options the operate container should be run with
+  podSecurityContext: {}
+
+  # NodeSelector can be used to define on which nodes the Optimize pods should run
+  nodeSelector: { }
+  # Tolerations can be used to define pod toleration's https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+  tolerations: [ ]
+  # Affinity can be used to define pod affinity or anti-affinity https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+  affinity: { }
+
+  # Resources configuration to set request and limit configuration for the container https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
+  resources:
+    requests:
+      cpu: 400m
+      memory: 1Gi
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+
+  # Ingress configuration to configure the ingress resource
+  ingress:
+    # Ingress.enabled if true, an ingress resource is deployed with the Optimize deployment. Only useful if an ingress controller is available, like nginx.
     enabled: false
     # Ingress.className defines the class or configuration of ingress which should be used by the controller
     className: nginx


### PR DESCRIPTION
## This PR contains:

* Add a new sub-chart for optimize (most resources were copied from Tasklist/Operate)
* Add default values to the values.yaml file
* Integrate Optimize with Identity (add configuration on both sides)
* Disable optimize if identity authentication is disabled
* Add template tests

## Manual testing:

After installing we see:

![notes](https://user-images.githubusercontent.com/2758593/164460706-e2d556c8-448d-4273-9760-df6c20ab3c8b.png)

Doing the necessary port-forwards we can login

![optimize](https://user-images.githubusercontent.com/2758593/164460435-fa567400-c070-4866-90e6-bcd5215025e0.png)

## Next Steps:

 * We have to solve the issue with the partition count, which is necessary for Optimize #286 
   * Per default optimize will now only import for one partition
 * We will add the values documented to the README #284 
 * We will enhance our e2e/integration test - login to optimize #283 


## Reviewers:

I know it looks like an big PR, but most of the lines are due to tests and golden files, which you can skip. :)

@oleschoenburg @npepinpe whoever has more time please have a look at the PR
@RomanJRW could you please check the configuration to whether this makes sense in your opinion? 


related to #126 