### PR TITLE
Add publicIssuerUrl to identity chart

### DIFF
--- a/charts/camunda-platform/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/identity/templates/deployment.yaml
@@ -109,6 +109,8 @@ spec:
             https://github.com/bitnami/charts/blob/master/bitnami/keycloak/templates/_helpers.tpl#L2-L5
             */}}
             value: "http://{{ include "common.names.dependency.fullname" (dict "chartName" "keycloak" "chartValues" .Values.keycloak "context" $) | trunc 20 | trimSuffix "-" }}:{{ coalesce .Values.keycloak.service.ports.http .Values.keycloak.service.port }}/auth"
+          - name: IDENTITY_AUTH_PROVIDER_ISSUER_URL
+            value: {{ .Values.global.identity.auth.publicIssuerUrl | quote }}
           - name: IDENTITY_AUTH_PROVIDER_BACKEND_URL
             value: "http://{{ include "common.names.dependency.fullname" (dict "chartName" "keycloak" "chartValues" .Values.keycloak "context" $) | trunc 20 | trimSuffix "-" }}:{{ coalesce .Values.keycloak.service.ports.http .Values.keycloak.service.port }}/auth/realms/camunda-platform"
           - name: KEYCLOAK_SETUP_USER

--- a/charts/camunda-platform/test/identity/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/identity/golden/deployment.golden.yaml
@@ -79,6 +79,8 @@ spec:
             value: "8080"
           - name: KEYCLOAK_URL
             value: "http://camunda-platform-tes:80/auth"
+          - name: IDENTITY_AUTH_PROVIDER_ISSUER_URL
+            value: "http://localhost:18080/auth/realms/camunda-platform"
           - name: IDENTITY_AUTH_PROVIDER_BACKEND_URL
             value: "http://camunda-platform-tes:80/auth/realms/camunda-platform"
           - name: KEYCLOAK_SETUP_USER


### PR DESCRIPTION
Fixes a bug that setting `global.identity.auth.publicIssuerUrl` does not set the redirect url in Identity