### PR TITLE
Disable optimize separately 

### DIFF
--- a/charts/camunda-platform/Chart.yaml
+++ b/charts/camunda-platform/Chart.yaml
@@ -24,7 +24,7 @@ dependencies:
   condition: "tasklist.enabled"
 - name: optimize
   version: 8.0.4
-  condition: "global.identity.auth.enabled"
+  condition: "optimize.enabled"
 - name: identity
   version: 8.0.4
   condition: "identity.enabled"

--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -270,7 +270,7 @@ Information about Identity you can find [here](https://docs.camunda.io/docs/self
 | Section | Parameter | Description | Default |
 |-|-|-|-|
 | `identity`| |  Configuration for the identity sub chart. | |
-| | `enabled` |  If true, the identity deployment and its related resources are deployed via a helm release. <br/> Note: If identity is disabled it is likely that the Helm chart installation fails, if you not disable the Identity integration. Make sure to set global.identity.auth.enabled=false AND optimize.enabled=false, since Optimize is highly depending on Identity. | `true` |
+| | `enabled` |  If true, the Identity deployment and its related resources are deployed via a helm release. <br/> Note: Identity is required by Optimize. If Identity is disabled, then Optimize will be unusable. If you don't need Optimize, then make sure to disable both: set global.identity.auth.enabled=false AND optimize.enabled=false. | `true` |
 | | `firstUser.username` | Defines the username of the first user, needed to log in into the web applications | `demo` |
 | | `firstUser.password` | Defines the password of the first user, needed to log in into the web applications | `demo` |
 | | `image` |  Configuration to configure the identity image specifics | |

--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -270,7 +270,7 @@ Information about Identity you can find [here](https://docs.camunda.io/docs/self
 | Section | Parameter | Description | Default |
 |-|-|-|-|
 | `identity`| |  Configuration for the identity sub chart. | |
-| | `enabled` |  If true, the identity deployment and its related resources are deployed via a helm release | `true` |
+| | `enabled` |  If true, the identity deployment and its related resources are deployed via a helm release. <br/> Note: If identity is disabled it is likely that the Helm chart installation fails, if you not disable the Identity integration. Make sure to set global.identity.auth.enabled=false AND optimize.enabled=false, since Optimize is highly depending on Identity. | `true` |
 | | `firstUser.username` | Defines the username of the first user, needed to log in into the web applications | `demo` |
 | | `firstUser.password` | Defines the password of the first user, needed to log in into the web applications | `demo` |
 | | `image` |  Configuration to configure the identity image specifics | |

--- a/charts/camunda-platform/test/global_deployment_test.go
+++ b/charts/camunda-platform/test/global_deployment_test.go
@@ -64,8 +64,6 @@ func (s *deploymentTemplateTest) TestContainerShouldNotRenderOptimizeIfDisabled(
 	s.Require().NotContains(output, "charts/optimize")
 }
 
-
-
 func (s *deploymentTemplateTest) TestContainerShouldNotRenderOperateIfDisabled() {
 	// given
 	options := &helm.Options{
@@ -104,9 +102,9 @@ func (s *deploymentTemplateTest) TestContainerShouldNotRenderIdentityIfDisabled(
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"identity.enabled": "false",
+			"identity.enabled":             "false",
 			"global.identity.auth.enabled": "false",
-			"optimize.enabled": "false",
+			"optimize.enabled":             "false",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},

--- a/charts/camunda-platform/test/global_deployment_test.go
+++ b/charts/camunda-platform/test/global_deployment_test.go
@@ -47,11 +47,11 @@ func TestDeploymentTemplate(t *testing.T) {
 	})
 }
 
-func (s *deploymentTemplateTest) TestContainerShouldDisableOptimizeIfIdentityIntegrationIsDisabled() {
+func (s *deploymentTemplateTest) TestContainerShouldNotRenderOptimizeIfDisabled() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"global.identity.auth.enabled": "false",
+			"optimize.enabled": "false",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},
@@ -61,6 +61,5 @@ func (s *deploymentTemplateTest) TestContainerShouldDisableOptimizeIfIdentityInt
 	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
 
 	// then
-	s.Require().NotContains("optimize", output)
-	s.Require().NotContains("OPTIMIZE", output)
+	s.Require().NotContains(output, "charts/optimize")
 }

--- a/charts/camunda-platform/test/global_deployment_test.go
+++ b/charts/camunda-platform/test/global_deployment_test.go
@@ -63,3 +63,58 @@ func (s *deploymentTemplateTest) TestContainerShouldNotRenderOptimizeIfDisabled(
 	// then
 	s.Require().NotContains(output, "charts/optimize")
 }
+
+
+
+func (s *deploymentTemplateTest) TestContainerShouldNotRenderOperateIfDisabled() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"operate.enabled": "false",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+
+	// then
+	s.Require().NotContains(output, "charts/operate")
+}
+
+func (s *deploymentTemplateTest) TestContainerShouldNotRenderTasklistIfDisabled() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"tasklist.enabled": "false",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+
+	// then
+	s.Require().NotContains(output, "charts/tasklist")
+}
+
+func (s *deploymentTemplateTest) TestContainerShouldNotRenderIdentityIfDisabled() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"identity.enabled": "false",
+			"global.identity.auth.enabled": "false",
+			"optimize.enabled": "false",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+
+	// then
+	s.Require().NotContains(output, "charts/identity")
+}

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -647,8 +647,8 @@ prometheusServiceMonitor:
 identity:
   # Enabled if true, the identity deployment and its related resources are deployed via a helm release
   #
-  # Note: If identity is disabled it is likely that the Helm chart installation fails, if you not disable the Identity integration.
-  #       Make sure to set global.identity.auth.enabled=false AND optimize.enabled=false, since Optimize is highly depending on Identity.
+  # Note: Identity is required by Optimize. If Identity is disabled, then Optimize will be unusable.
+  #       If you don't need Optimize, then make sure to disable both: set global.identity.auth.enabled=false AND optimize.enabled=false.
   enabled: true
 
   # FirstUser configuration to configure properties of the first Identity user, which can be used to access all

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -646,6 +646,9 @@ prometheusServiceMonitor:
 # Identity configuration for the identity sub chart.
 identity:
   # Enabled if true, the identity deployment and its related resources are deployed via a helm release
+  #
+  # Note: If identity is disabled it is likely that the Helm chart installation fails, if you not disable the Identity integration.
+  #       Make sure to set global.identity.auth.enabled=false AND optimize.enabled=false, since Optimize is highly depending on Identity.
   enabled: true
 
   # FirstUser configuration to configure properties of the first Identity user, which can be used to access all


### PR DESCRIPTION
Based on discussion we disable optimize now via `optimize.enabled`. For more information see comment https://github.com/camunda/camunda-platform-helm/issues/289#issuecomment-1108493461

Add some more tests and a note how to disable identity. 

closes #289