### PR TITLE
Set partitionCount in optimize

### DIFF
--- a/charts/camunda-platform/charts/optimize/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/optimize/templates/deployment.yaml
@@ -27,6 +27,8 @@ spec:
         env:
           - name: CAMUNDA_OPTIMIZE_ZEEBE_ENABLED
             value: "true"
+          - name: CAMUNDA_OPTIMIZE_ZEEBE_PARTITION_COUNT
+            value: {{ .Values.partitionCount | quote }}
           - name: OPTIMIZE_ELASTICSEARCH_HOST
             value: {{ .Values.global.elasticsearch.host | quote }}
           - name: OPTIMIZE_ELASTICSEARCH_HTTP_PORT

--- a/charts/camunda-platform/test/optimize/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/optimize/golden/deployment.golden.yaml
@@ -41,6 +41,8 @@ spec:
         env:
           - name: CAMUNDA_OPTIMIZE_ZEEBE_ENABLED
             value: "true"
+          - name: CAMUNDA_OPTIMIZE_ZEEBE_PARTITION_COUNT
+            value: "3"
           - name: OPTIMIZE_ELASTICSEARCH_HOST
             value: "elasticsearch-master"
           - name: OPTIMIZE_ELASTICSEARCH_HTTP_PORT

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -547,6 +547,8 @@ optimize:
   # PodLabels can be used to define extra Optimize pod labels
   podLabels: { }
 
+  # PartitionCount defines how many Zeebe partitions are set up in the cluster and which should be imported by Optimize
+  partitionCount: "3"
   # Env can be used to set extra environment variables in each Optimize container
   env: []
   # Command can be used to override the default command provided by the container image. See https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/


### PR DESCRIPTION
Sets the partition count in optimize sub chart correctly. For simplicity and flexibility, we added a new property to the Optimize sub chart, see comment https://github.com/camunda/camunda-platform-helm/issues/286#issuecomment-1108503752

closes #286 