### PR TITLE
fix: use correct type

### DIFF
--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -127,8 +127,8 @@ Information about Zeebe you can find [here](https://docs.camunda.io/docs/compone
 | | `pvcSize` | Defines the [persistent volume claim](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims) size, which is used by each broker pod | `32Gi` |
 | | `pvcAccessModes` | Can be used to configure the [persistent volume claim access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) | `[ "ReadWriteOnce" ]` |
 | | `pvcStorageClassName` | Can be used to set the storage class name which should be used by the persistent volume claim. It is recommended to use a storage class, which is backed with a SSD. | ` ` |
-| | `extraVolumes` | Can be used to define extra volumes for the broker pods, useful for additional exporters | `{ }`|
-| | `extraVolumeMounts` | Can be used to mount extra volumes for the broker pods, useful for additional exporters | `{ }` |
+| | `extraVolumes` | Can be used to define extra volumes for the broker pods, useful for additional exporters | `[ ]`|
+| | `extraVolumeMounts` | Can be used to mount extra volumes for the broker pods, useful for additional exporters | `[ ]` |
 | | `extraInitContainers` | Can be used to set up extra init containers for the broker pods, useful for additional exporters | `[ ]` |
 | | `podAnnotations` | Can be used to define extra broker pod annotations | `{ }` |
 | | `podLabels` | Can be used to define extra broker pod labels | `{ }` |
@@ -176,8 +176,8 @@ Information about the Zeebe Gateway you can find [here](https://docs.camunda.io/
 | | `nodeSelector` | Can be used to define on which nodes the gateway pods should run | `{ } ` |
 | | `tolerations` | Can be used to define [pod toleration's](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) | `[ ]` |
 | | `affinity` | Can be used to define [pod affinity or anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity). The default defined PodAntiAffinity allows constraining on which nodes the [Zeebe gateway pods are scheduled on](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity). It uses a hard requirement for scheduling and works based on the Zeebe gateway pod labels. | `podAntiAffinity:</br>  requiredDuringSchedulingIgnoredDuringExecution:</br>  - labelSelector: </br>    matchExpressions:</br>    - key: "app.kubernetes.io/component"</br>    operator: In</br>    values:</br>    - zeebe-gatway</br>  topologyKey: "kubernetes.io/hostname"` |
-| | `extraVolumeMounts` | Can be used to mount extra volumes for the gateway pods, useful for enabling TLS between gateway and broker | `{ }` |
-| | `extraVolumes` | Can be used to define extra volumes for the gateway pods, useful for enabling TLS between gateway and broker | `{ }` |
+| | `extraVolumeMounts` | Can be used to mount extra volumes for the gateway pods, useful for enabling TLS between gateway and broker | `[ ]` |
+| | `extraVolumes` | Can be used to define extra volumes for the gateway pods, useful for enabling TLS between gateway and broker | `[ ]` |
 | | `extraInitContainers` | Can be used to set up extra init containers for the gateway pods, useful for adding interceptors | `[ ]` |
 | | `service` | Configuration for the gateway service | |
 | | `service.type` | Defines the [type of the service](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) | `ClusterIP` |

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -206,9 +206,9 @@ zeebe:
   pvcStorageClassName: ''
 
   # ExtraVolumes can be used to define extra volumes for the broker pods, useful for additional exporters
-  extraVolumes: { }
+  extraVolumes: [ ]
   # ExtraVolumeMounts can be used to mount extra volumes for the broker pods, useful for additional exporters
-  extraVolumeMounts: { }
+  extraVolumeMounts: [ ]
   # ExtraInitContainers can be used to set up extra init containers for the broker pods, useful for additional exporters
   extraInitContainers: [ ]
 
@@ -333,9 +333,9 @@ zeebe-gateway:
           topologyKey: "kubernetes.io/hostname"
 
   # ExtraVolumeMounts can be used to mount extra volumes for the gateway pods, useful for enabling tls between gateway and broker
-  extraVolumeMounts: { }
+  extraVolumeMounts: [ ]
   # ExtraVolumes can be used to define extra volumes for the gateway pods, useful for enabling tls between gateway and broker
-  extraVolumes: { }
+  extraVolumes: [ ]
   # ExtraInitContainers can be used to set up extra init containers for the gateway pods, useful for adding interceptors
   extraInitContainers: [ ]
 


### PR DESCRIPTION
Hi,
I was trying to add
```
  # ExtraVolumeMounts can be used to mount extra volumes for the gateway pods, useful for enabling tls between gateway and broker
  extraVolumeMounts:
    - mountPath: "/etc/zeebe"
      name: zeebe-ssl
      readOnly: true
  # ExtraVolumes can be used to define extra volumes for the gateway pods, useful for enabling tls between gateway and broker
  extraVolumes:
    - name: zeebe-ssl
      secret:
        secretName: zeebe-ssl
```
to my YAML but both are defined as empty objects and thus not mergeable:
_coalesce.go:199: warning: cannot overwrite table with non table for extraVolumeMounts (map[])
coalesce.go:199: warning: cannot overwrite table with non table for extraVolumes (map[])_