### PR TITLE
feat: allow more configuration of LoadBalancer

### DIFF
--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -181,6 +181,8 @@ Information about the Zeebe Gateway you can find [here](https://docs.camunda.io/
 | | `extraInitContainers` | Can be used to set up extra init containers for the gateway pods, useful for adding interceptors | `[ ]` |
 | | `service` | Configuration for the gateway service | |
 | | `service.type` | Defines the [type of the service](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) | `ClusterIP` |
+| | `service.loadBalancerIP` | Can be used to set [ip address](https://cloud.google.com/kubernetes-engine/docs/how-to/service-parameters#lb_ip) if service.type is LoadBalancer | `""` |
+| | `service.loadBalancerSourceRanges` | Can be used to set list of allowed [source ip ranges](https://cloud.google.com/kubernetes-engine/docs/how-to/service-parameters#lb_source_ranges) if service.type is LoadBalancer | `[ ]` |
 | | `service.httpPort` | Defines the port of the HTTP endpoint, where for example metrics are provided | `9600` |
 | | `service.httpName` | Defines the name of the HTTP endpoint, where for example metrics are provided | `http` |
 | | `service.gatewayPort` | Defines the port of the gateway endpoint, where client commands (gRPC) are sent to | `26500` |

--- a/charts/camunda-platform/charts/zeebe-gateway/templates/gateway-service.yaml
+++ b/charts/camunda-platform/charts/zeebe-gateway/templates/gateway-service.yaml
@@ -12,6 +12,13 @@ metadata:
     {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP}}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges}}
+  loadBalancerSourceRanges:
+    {{- toYaml .Values.service.loadBalancerSourceRanges | nindent 6 }}
+  {{- end }}
   selector:
     {{- include "zeebe.matchLabels.gateway" . | nindent 6 }}
   ports:

--- a/charts/camunda-platform/test/zeebe-gateway/service_test.go
+++ b/charts/camunda-platform/test/zeebe-gateway/service_test.go
@@ -84,3 +84,40 @@ func (s *serviceTest) TestContainerServiceAnnotations() {
 	// then
 	s.Require().Equal("bar", service.ObjectMeta.Annotations["foo"])
 }
+
+func (s *serviceTest) TestContainerShouldSetServiceLoadBalancerIp() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"zeebe-gateway.service.loadBalancerIP": "bar",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var service coreV1.Service
+	helm.UnmarshalK8SYaml(s.T(), output, &service)
+
+	// then
+	s.Require().Equal("bar", service.Spec.LoadBalancerIP)
+}
+
+func (s *serviceTest) TestContainerShouldSetServiceLoadBalancerSourceRanges() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"zeebe-gateway.service.loadBalancerSourceRanges[0]": "foo",
+			"zeebe-gateway.service.loadBalancerSourceRanges[1]": "bar",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var service coreV1.Service
+	helm.UnmarshalK8SYaml(s.T(), output, &service)
+
+	// then
+	s.Require().Equal([]string{"foo", "bar"}, service.Spec.LoadBalancerSourceRanges)
+}

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -343,6 +343,10 @@ zeebe-gateway:
   service:
     # Service.type defines the type of the service https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
     type: ClusterIP
+    # Service.loadBalancerIP defines public ip of the load balancer if the type is LoadBalancer
+    loadBalancerIP: ""
+    # Service.loadBalancerSourceRanges defines list of allowed source ip address ranges if the type is LoadBalancer
+    loadBalancerSourceRanges: [ ]
     # Service.httpPort defines the port of the http endpoint, where for example metrics are provided
     httpPort: 9600
     # Service.httpName defines the name of the http endpoint, where for example metrics are provided


### PR DESCRIPTION
Allow configuration of loadBalancerIP and loadBalancerSourceRanges
which are useful in case of service.type: LoadBalancer