### PR TITLE
fix: elasticserach version 7.17.3

### DIFF
--- a/kind/camunda-platform-core-kind-values.yaml
+++ b/kind/camunda-platform-core-kind-values.yaml
@@ -25,7 +25,7 @@ zeebe-gateway:
 
 # Configure elastic search to make it running for local development
 elasticsearch:
-  imageTag: 7.16.1
+  imageTag: 7.17.3
   replicas: 1
   minimumMasterNodes: 1
   # Allow no backup for single node setups


### PR DESCRIPTION
Elasticsearch version 7.16.1 is not supported by Optimize.

I know that Optimize is disabled with these values, but maybe if people use this configuration as a starting point, it may be good to use a supported elasticsearch version. 

Current version of Optimize supports following Elasticsearch versions:
7.10.0+
7.11.0+
7.12.0+
7.13.0+
7.14.0+
7.15.0+
7.16.2+
7.17.0+
Your current Elasticsearch version is: 7.16.1