### PR TITLE
 Allow configuring imagePullSecrets separately for subcharts

### DIFF
--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -3,21 +3,21 @@
 # Camunda Platform Helm Chart
 
 - [Camunda Platform Helm Chart](#camunda-platform-helm-chart)
-  * [Requirements](#requirements)
-  * [Installing](#installing)
-  * [Configuration](#configuration)
-    + [Global](#global)
-    + [Camunda Platform](#camunda-platform)
-    + [Zeebe](#zeebe)
-    + [Zeebe Gateway](#zeebe-gateway)
-    + [Operate](#operate)
-    + [Tasklist](#tasklist)
-    + [Optimize](#optimize)
-    + [Identity](#identity)
-    + [Elasticsearch](#elasticsearch)
-  * [Adding dynamic exporters to Zeebe Brokers](#adding-dynamic-exporters-to-zeebe-brokers)
-  * [Development](#development)
-  * [Releasing the Charts](#releasing-the-charts)
+  - [Requirements](#requirements)
+  - [Installing](#installing)
+  - [Configuration](#configuration)
+    - [Global](#global)
+    - [Camunda Platform](#camunda-platform)
+    - [Zeebe](#zeebe)
+    - [Zeebe Gateway](#zeebe-gateway)
+    - [Operate](#operate)
+    - [Tasklist](#tasklist)
+    - [Optimize](#optimize)
+    - [Identity](#identity)
+    - [Elasticsearch](#elasticsearch)
+  - [Adding dynamic exporters to Zeebe Brokers](#adding-dynamic-exporters-to-zeebe-brokers)
+  - [Development](#development)
+  - [Releasing the Charts](#releasing-the-charts)
 
 <small><i><a href='http://ecotrust-canada.github.io/markdown-toc/'>Table of contents generated with markdown-toc</a></i></small>
 
@@ -53,7 +53,7 @@ Check out the default [values.yaml](values.yaml) file, which contains the same c
 | | `labels` | Can be used to define common labels, which should be applied to all deployments | |
 | | `image.tag` | Defines the tag / version which should be used in the chart. | |
 | | `image.pullPolicy` | Defines the [image pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy) which should be used. | IfNotPresent |
-| | `image.pullSecrets` | Can be used to configure [image pull secrets](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod) which should be used. | `[]` |
+| | `image.pullSecrets` | Can be used to configure [image pull secrets](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod). Also it could be configured per component separately. | `[]` |
 | | `elasticsearch.disableExporter` | If true, disables the [Elasticsearch Exporter](https://github.com/camunda-cloud/zeebe/tree/develop/exporters/elasticsearch-exporter) in Zeebe | `false` |
 | | `elasticsearch.url` | Can be used to configure the URL to access Elasticsearch. When not set, services fallback to host and port configuration. | |
 | | `elasticsearch.host` | Defines the Elasticsearch host, ideally the service name inside the namespace. | `elasticsearch-master` |
@@ -100,6 +100,7 @@ Information about Zeebe you can find [here](https://docs.camunda.io/docs/compone
 | | `image` | Configuration to configure the Zeebe image specifics. | |
 | | `image.repository` | Defines which image repository to use. | `camunda/zeebe` |
 | | `image.tag` | Can be set to overwrite the global tag, which should be used in that chart. | ` ` |
+| | `image.pullSecrets` | Can be set to overwrite the global.image.pullSecrets | `{{ global.image.pullSecrets }}` |
 | | `clusterSize` | Defines the amount of brokers (=replicas), which are deployed via helm | `3` |
 | | `partitionCount` | Defines how many Zeebe partitions are set up in the cluster | `3` |
 | | `replicationFactor` | Defines how each partition is replicated, the value defines the number of nodes | `3` |
@@ -158,6 +159,7 @@ Information about the Zeebe Gateway you can find [here](https://docs.camunda.io/
 | | `image` | Configuration to configure the zeebe-gateway image specifics. | |
 | | `image.repository` | Defines which image repository to use. | `camunda/zeebe` |
 | | `image.tag` | Can be set to overwrite the global tag, which should be used in that chart. | ` ` |
+| | `image.pullSecrets` | Can be set to overwrite the global.image.pullSecrets | `{{ global.image.pullSecrets }}` |
 | | `podAnnotations` | Can be used to define extra gateway pod annotations | `{ }` |
 | | `podLabels` | Can be used to define extra gateway pod labels | `{ }` |
 | | `logLevel` | Defines the log level which is used by the gateway | `info` |
@@ -206,6 +208,7 @@ Information about Operate you can find [here](https://docs.camunda.io/docs/compo
 | | `image` | Configuration to configure the Operate image specifics. | |
 | | `image.repository` | Defines which image repository to use. | `camunda/operate` |
 | | `image.tag` | Can be set to overwrite the global tag, which should be used in that chart. | `` |
+| | `image.pullSecrets` | Can be set to overwrite the global.image.pullSecrets | `{{ global.image.pullSecrets }}` |
 | | `podLabels` |  Can be used to define extra Operate pod labels | `{ }` |
 | | `logging` | Configuration for the Operate logging. This template will be directly included in the Operate configuration yaml file | `level:` <br/> `ROOT: INFO` <br/> `org.camunda.operate: DEBUG` |
 | | `service` | Configuration to configure the Operate service. | |
@@ -247,6 +250,7 @@ Information about Tasklist you can find [here](https://docs.camunda.io/docs/comp
 | | `image` | Configuration to configure the Tasklist image specifics. | |
 | | `image.repository` | Defines which image repository to use. | `camunda/tasklist` |
 | | `image.tag` | Can be set to overwrite the global tag, which should be used in that chart. | `` |
+| | `image.pullSecrets` | Can be set to overwrite the global.image.pullSecrets | `{{ global.image.pullSecrets }}` |
 | | `podLabels` |  Can be used to define extra Tasklist pod labels | `{ }` |
 | | `configMap.defaultMode` | Can be used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. See [Api docs](https://github.com/kubernetes/api/blob/master/core/v1/types.go#L1615-L1623) for more details. It is useful to configure it if you want to run the helm charts in OpenShift. | [`0744`](https://chmodcommand.com/chmod-744/) |
 | | `command` | Can be used to [override the default command provided by the container image](https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/) | `[]` |
@@ -279,6 +283,7 @@ Information about Optimize you can find [here](https://docs.camunda.io/docs/comp
 | | `image` |  Configuration for the Optimize image specifics | |
 | | `image.repository` |  Defines which image repository to use | `camunda/optimize` |
 | | `image.tag` |  Can be set to overwrite the global tag, which should be used in that chart | `3.8.0` |
+| | `image.pullSecrets` | Can be set to overwrite the global.image.pullSecrets | `{{ global.image.pullSecrets }}` |
 | | `podLabels` |  Can be used to define extra Optimize pod labels | `{ }` |
 | | `partitionCount` |  Defines how many Zeebe partitions are set up in the cluster and which should be imported by Optimize | `"3"` |
 | | `env` |  Can be used to set extra environment variables in each Optimize container | `[]` |
@@ -317,6 +322,7 @@ Information about Identity you can find [here](https://docs.camunda.io/docs/self
 | | `image` |  Configuration to configure the Identity image specifics | |
 | | `image.repository` |  Defines which image repository to use | `camunda/identity` |
 | | `image.tag` |   Can be set to overwrite the global.image.tag | |
+| | `image.pullSecrets` | Can be set to overwrite the global.image.pullSecrets | `{{ global.image.pullSecrets }}` |
 | | `service` |  Configuration to configure the Identity service. | |
 | | `service.type` | Defines the [type of the service](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) | `ClusterIP` |
 | | `service.port` |  Defines the port of the service, where the Identity web application will be available | `80` |

--- a/charts/camunda-platform/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/identity/templates/deployment.yaml
@@ -12,6 +12,8 @@ spec:
     metadata:
       labels: {{- include "identity.labels" . | nindent 8 }}
     spec:
+      imagePullSecrets:
+        {{- include "camundaPlatform.imagePullSecrets" . | nindent 8 }}
       containers:
       - name: {{ .Chart.Name }}
         {{- if .Values.image.tag }}

--- a/charts/camunda-platform/charts/operate/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/operate/templates/deployment.yaml
@@ -16,6 +16,8 @@ spec:
         {{- toYaml .Values.podLabels | nindent 8 }}
         {{- end }}
     spec:
+      imagePullSecrets:
+        {{- include "camundaPlatform.imagePullSecrets" . | nindent 8 }}
       containers:
       - name: {{ .Chart.Name }}
         {{- if .Values.image.tag }}

--- a/charts/camunda-platform/charts/optimize/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/optimize/templates/deployment.yaml
@@ -17,6 +17,8 @@ spec:
         {{- toYaml .Values.podLabels | nindent 8 }}
         {{- end }}
     spec:
+      imagePullSecrets:
+        {{- include "camundaPlatform.imagePullSecrets" . | nindent 8 }}
       containers:
       - name: {{ .Chart.Name }}
         {{- if .Values.image.tag }}

--- a/charts/camunda-platform/charts/tasklist/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/tasklist/templates/deployment.yaml
@@ -17,6 +17,8 @@ spec:
         {{- toYaml .Values.podLabels | nindent 8 }}
         {{- end }}
     spec:
+      imagePullSecrets:
+        {{- include "camundaPlatform.imagePullSecrets" . | nindent 8 }}
       containers:
       - name: {{ .Chart.Name }}
         {{- if .Values.image.tag }}

--- a/charts/camunda-platform/charts/zeebe-gateway/templates/gateway-deployment.yaml
+++ b/charts/camunda-platform/charts/zeebe-gateway/templates/gateway-deployment.yaml
@@ -23,10 +23,8 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}
-      {{- if .Values.global.image.pullSecrets }}
       imagePullSecrets:
-        {{ toYaml .Values.global.image.pullSecrets | indent 8 | trim }}
-      {{- end }}
+        {{- include "camundaPlatform.imagePullSecrets" . | nindent 8 }}
       {{- if .Values.extraInitContainers }}
       initContainers:
         {{- with .Values.extraInitContainers }}

--- a/charts/camunda-platform/charts/zeebe/templates/statefulset.yaml
+++ b/charts/camunda-platform/charts/zeebe/templates/statefulset.yaml
@@ -31,10 +31,8 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}
-      {{- if .Values.global.image.pullSecrets }}
       imagePullSecrets:
-        {{ toYaml .Values.global.image.pullSecrets | indent 8 | trim }}
-      {{- end }}
+        {{- include "camundaPlatform.imagePullSecrets" . | nindent 8 }}
       initContainers:
         {{- with .Values.extraInitContainers }}
         {{- tpl (toYaml . ) $ | nindent 8  }}

--- a/charts/camunda-platform/templates/_helpers.tpl
+++ b/charts/camunda-platform/templates/_helpers.tpl
@@ -36,3 +36,16 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: camunda-platform
 {{- end -}}
+
+{{/*
+Set imagePullSecrets according the values of global, subchart, or empty.
+*/}}
+{{- define "camundaPlatform.imagePullSecrets" -}}
+{{- if (.Values.image.pullSecrets) -}}
+{{ .Values.image.pullSecrets | toYaml }}
+{{- else if (.Values.global.image.pullSecrets) -}}
+{{ .Values.global.image.pullSecrets | toYaml }}
+{{- else -}}
+[]
+{{- end -}}
+{{- end -}}

--- a/charts/camunda-platform/test/identity/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/identity/golden/deployment.golden.yaml
@@ -35,6 +35,8 @@ spec:
         app.kubernetes.io/version: "8.0.0"
         app.kubernetes.io/component: identity
     spec:
+      imagePullSecrets:
+        []
       containers:
       - name: identity
         image: "camunda/identity:8.0.0"

--- a/charts/camunda-platform/test/operate/deployment_test.go
+++ b/charts/camunda-platform/test/operate/deployment_test.go
@@ -86,6 +86,43 @@ func (s *deploymentTemplateTest) TestContainerSetGlobalAnnotations() {
 	s.Require().Equal("bar", deployment.ObjectMeta.Annotations["foo"])
 }
 
+func (s *deploymentTemplateTest) TestContainerSetImagePullSecretsGlobal() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.image.pullSecrets[0].name": "SecretName",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	s.Require().Equal("SecretName", deployment.Spec.Template.Spec.ImagePullSecrets[0].Name)
+}
+
+func (s *deploymentTemplateTest) TestContainerSetImagePullSecretsSubChart() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.image.pullSecrets[0].name":  "SecretName",
+			"operate.image.pullSecrets[0].name": "SecretNameSubChart",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	s.Require().Equal("SecretNameSubChart", deployment.Spec.Template.Spec.ImagePullSecrets[0].Name)
+}
+
 func (s *deploymentTemplateTest) TestContainerOverwriteImageTag() {
 	// given
 	options := &helm.Options{

--- a/charts/camunda-platform/test/operate/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/operate/golden/deployment.golden.yaml
@@ -35,6 +35,8 @@ spec:
         app.kubernetes.io/version: "8.0.0"
         app.kubernetes.io/component: operate
     spec:
+      imagePullSecrets:
+        []
       containers:
       - name: operate
         image: "camunda/operate:8.0.0"

--- a/charts/camunda-platform/test/optimize/deployment_test.go
+++ b/charts/camunda-platform/test/optimize/deployment_test.go
@@ -86,6 +86,43 @@ func (s *deploymentTemplateTest) TestContainerSetGlobalAnnotations() {
 	s.Require().Equal("bar", deployment.ObjectMeta.Annotations["foo"])
 }
 
+func (s *deploymentTemplateTest) TestContainerSetImagePullSecretsGlobal() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.image.pullSecrets[0].name": "SecretName",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	s.Require().Equal("SecretName", deployment.Spec.Template.Spec.ImagePullSecrets[0].Name)
+}
+
+func (s *deploymentTemplateTest) TestContainerSetImagePullSecretsSubChart() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.image.pullSecrets[0].name":   "SecretName",
+			"optimize.image.pullSecrets[0].name": "SecretNameSubChart",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	s.Require().Equal("SecretNameSubChart", deployment.Spec.Template.Spec.ImagePullSecrets[0].Name)
+}
+
 func (s *deploymentTemplateTest) TestContainerOverwriteImageTag() {
 	// given
 	options := &helm.Options{

--- a/charts/camunda-platform/test/optimize/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/optimize/golden/deployment.golden.yaml
@@ -35,6 +35,8 @@ spec:
         app.kubernetes.io/version: "3.8.0"
         app.kubernetes.io/component: optimize
     spec:
+      imagePullSecrets:
+        []
       containers:
       - name: optimize
         image: "camunda/optimize:3.8.0"

--- a/charts/camunda-platform/test/tasklist/deployment_test.go
+++ b/charts/camunda-platform/test/tasklist/deployment_test.go
@@ -86,6 +86,43 @@ func (s *deploymentTemplateTest) TestContainerSetGlobalAnnotations() {
 	s.Require().Equal("bar", deployment.ObjectMeta.Annotations["foo"])
 }
 
+func (s *deploymentTemplateTest) TestContainerSetImagePullSecretsGlobal() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.image.pullSecrets[0].name": "SecretName",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	s.Require().Equal("SecretName", deployment.Spec.Template.Spec.ImagePullSecrets[0].Name)
+}
+
+func (s *deploymentTemplateTest) TestContainerSetImagePullSecretsSubChart() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.image.pullSecrets[0].name":   "SecretName",
+			"tasklist.image.pullSecrets[0].name": "SecretNameSubChart",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	s.Require().Equal("SecretNameSubChart", deployment.Spec.Template.Spec.ImagePullSecrets[0].Name)
+}
+
 func (s *deploymentTemplateTest) TestContainerOverwriteImageTag() {
 	// given
 	options := &helm.Options{

--- a/charts/camunda-platform/test/tasklist/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/tasklist/golden/deployment.golden.yaml
@@ -35,6 +35,8 @@ spec:
         app.kubernetes.io/version: "8.0.0"
         app.kubernetes.io/component: tasklist
     spec:
+      imagePullSecrets:
+        []
       containers:
       - name: tasklist
         image: "camunda/tasklist:8.0.0"

--- a/charts/camunda-platform/test/zeebe-gateway/golden/gateway-deployment.golden.yaml
+++ b/charts/camunda-platform/test/zeebe-gateway/golden/gateway-deployment.golden.yaml
@@ -37,6 +37,8 @@ spec:
       annotations:
         {}
     spec:
+      imagePullSecrets:
+        []
       containers:
         - name: zeebe-gateway
           image: "camunda/zeebe:8.0.0"

--- a/charts/camunda-platform/test/zeebe/golden/statefulset.golden.yaml
+++ b/charts/camunda-platform/test/zeebe/golden/statefulset.golden.yaml
@@ -39,6 +39,8 @@ spec:
         app.kubernetes.io/component: zeebe-broker
       annotations:
     spec:
+      imagePullSecrets:
+        []
       initContainers:
       containers:
       - name: zeebe

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -38,7 +38,7 @@ global:
     # Image.pullPolicy defines the image pull policy which should be used https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
     pullPolicy: IfNotPresent
     # Image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
-    pullSecrets: [ ]
+    pullSecrets: []
 
   # Elasticsearch configuration which is shared between the sub charts  
   elasticsearch:
@@ -113,6 +113,8 @@ zeebe:
     repository: camunda/zeebe
     # Image.tag can be set to overwrite the global tag, which should be used in that chart
     tag:
+    # Image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+    pullSecrets: []
 
   # ClusterSize defines the amount of brokers (=replicas), which are deployed via helm
   clusterSize: "3"
@@ -269,6 +271,8 @@ zeebe-gateway:
     repository: camunda/zeebe
     # Image.tag can be set to overwrite the global tag, which should be used in that chart
     tag:
+    # Image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+    pullSecrets: []
   # PodAnnotations can be used to define extra gateway pod annotations
   podAnnotations: { }
   # PodLabels can be used to define extra gateway pod labels
@@ -382,6 +386,8 @@ operate:
     repository: camunda/operate
     # Image.tag can be set to overwrite the global tag, which should be used in that chart
     tag:
+    # Image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+    pullSecrets: []
 
   # PodLabels can be used to define extra operate pod labels
   podLabels: { }
@@ -476,6 +482,8 @@ tasklist:
     repository: camunda/tasklist
     # Image.tag can be set to overwrite the global tag, which should be used in that chart
     tag:
+    # Image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+    pullSecrets: []
 
   # Env can be used to set extra environment variables on each Tasklist container
   env: [ ]
@@ -548,6 +556,8 @@ optimize:
     repository: camunda/optimize
     # Image.tag can be set to overwrite the global tag, which should be used in that chart
     tag: 3.8.0
+    # Image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+    pullSecrets: []
 
   # PodLabels can be used to define extra Optimize pod labels
   podLabels: { }
@@ -672,6 +682,8 @@ identity:
     repository: camunda/identity
     # Image.tag can be set to overwrite the global tag, which should be used in that chart
     tag:
+    # Image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+    pullSecrets: []
 
   # Service configuration to configure the identity service.
   service:


### PR DESCRIPTION
This PR allows configuring `imagePullSecrets` separately for subcharts.

The value of `global.image.pullSecrets` will be used for all subcharts which has the default value of an empy list `[]`.
If the subchart configured `image.pullSecrets` it will overwrite the global value.

Fixes: #302