### PR TITLE
Add Pod annotations to all sub charts

### DIFF
--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -209,6 +209,7 @@ Information about Operate you can find [here](https://docs.camunda.io/docs/compo
 | | `image.repository` | Defines which image repository to use. | `camunda/operate` |
 | | `image.tag` | Can be set to overwrite the global tag, which should be used in that chart. | `` |
 | | `image.pullSecrets` | Can be set to overwrite the global.image.pullSecrets | `{{ global.image.pullSecrets }}` |
+| | `podAnnotations` | Can be used to define extra Operate pod annotations | `{ }` |
 | | `podLabels` |  Can be used to define extra Operate pod labels | `{ }` |
 | | `logging` | Configuration for the Operate logging. This template will be directly included in the Operate configuration yaml file | `level:` <br/> `ROOT: INFO` <br/> `org.camunda.operate: DEBUG` |
 | | `service` | Configuration to configure the Operate service. | |
@@ -251,6 +252,7 @@ Information about Tasklist you can find [here](https://docs.camunda.io/docs/comp
 | | `image.repository` | Defines which image repository to use. | `camunda/tasklist` |
 | | `image.tag` | Can be set to overwrite the global tag, which should be used in that chart. | `` |
 | | `image.pullSecrets` | Can be set to overwrite the global.image.pullSecrets | `{{ global.image.pullSecrets }}` |
+| | `podAnnotations` | Can be used to define extra Tasklist pod annotations | `{ }` |
 | | `podLabels` |  Can be used to define extra Tasklist pod labels | `{ }` |
 | | `configMap.defaultMode` | Can be used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. See [Api docs](https://github.com/kubernetes/api/blob/master/core/v1/types.go#L1615-L1623) for more details. It is useful to configure it if you want to run the helm charts in OpenShift. | [`0744`](https://chmodcommand.com/chmod-744/) |
 | | `command` | Can be used to [override the default command provided by the container image](https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/) | `[]` |
@@ -284,6 +286,7 @@ Information about Optimize you can find [here](https://docs.camunda.io/docs/comp
 | | `image.repository` |  Defines which image repository to use | `camunda/optimize` |
 | | `image.tag` |  Can be set to overwrite the global tag, which should be used in that chart | `3.8.0` |
 | | `image.pullSecrets` | Can be set to overwrite the global.image.pullSecrets | `{{ global.image.pullSecrets }}` |
+| | `podAnnotations` | Can be used to define extra Optimize pod annotations | `{ }` |
 | | `podLabels` |  Can be used to define extra Optimize pod labels | `{ }` |
 | | `partitionCount` |  Defines how many Zeebe partitions are set up in the cluster and which should be imported by Optimize | `"3"` |
 | | `env` |  Can be used to set extra environment variables in each Optimize container | `[]` |
@@ -323,6 +326,7 @@ Information about Identity you can find [here](https://docs.camunda.io/docs/self
 | | `image.repository` |  Defines which image repository to use | `camunda/identity` |
 | | `image.tag` |   Can be set to overwrite the global.image.tag | |
 | | `image.pullSecrets` | Can be set to overwrite the global.image.pullSecrets | `{{ global.image.pullSecrets }}` |
+| | `podAnnotations` | Can be used to define extra Identity pod annotations | `{ }` |
 | | `service` |  Configuration to configure the Identity service. | |
 | | `service.type` | Defines the [type of the service](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) | `ClusterIP` |
 | | `service.port` |  Defines the port of the service, where the Identity web application will be available | `80` |

--- a/charts/camunda-platform/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/identity/templates/deployment.yaml
@@ -11,6 +11,10 @@ spec:
   template:
     metadata:
       labels: {{- include "identity.labels" . | nindent 8 }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+        {{- toYaml  .Values.podAnnotations | nindent 8 }}
+      {{- end }}
     spec:
       imagePullSecrets:
         {{- include "camundaPlatform.imagePullSecrets" . | nindent 8 }}

--- a/charts/camunda-platform/charts/operate/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/operate/templates/deployment.yaml
@@ -15,6 +15,10 @@ spec:
         {{- if .Values.podLabels }}
         {{- toYaml .Values.podLabels | nindent 8 }}
         {{- end }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+        {{- toYaml  .Values.podAnnotations | nindent 8 }}
+      {{- end }}
     spec:
       imagePullSecrets:
         {{- include "camundaPlatform.imagePullSecrets" . | nindent 8 }}

--- a/charts/camunda-platform/charts/optimize/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/optimize/templates/deployment.yaml
@@ -16,6 +16,10 @@ spec:
         {{- if .Values.podLabels }}
         {{- toYaml .Values.podLabels | nindent 8 }}
         {{- end }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+        {{- toYaml  .Values.podAnnotations | nindent 8 }}
+      {{- end }}
     spec:
       imagePullSecrets:
         {{- include "camundaPlatform.imagePullSecrets" . | nindent 8 }}

--- a/charts/camunda-platform/charts/tasklist/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/tasklist/templates/deployment.yaml
@@ -16,6 +16,10 @@ spec:
         {{- if .Values.podLabels }}
         {{- toYaml .Values.podLabels | nindent 8 }}
         {{- end }}
+      {{- if .Values.podAnnotations }}
+      annotations:
+        {{- toYaml  .Values.podAnnotations | nindent 8 }}
+      {{- end }}
     spec:
       imagePullSecrets:
         {{- include "camundaPlatform.imagePullSecrets" . | nindent 8 }}

--- a/charts/camunda-platform/test/identity/deployment_test.go
+++ b/charts/camunda-platform/test/identity/deployment_test.go
@@ -50,6 +50,26 @@ func TestDeploymentTemplate(t *testing.T) {
 	})
 }
 
+func (s *deploymentTemplateTest) TestContainerSetPodAnnotations() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"identity.podAnnotations.foo": "bar",
+			"identity.podAnnotations.foz": "baz",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	s.Require().Equal("bar", deployment.Spec.Template.Annotations["foo"])
+	s.Require().Equal("baz", deployment.Spec.Template.Annotations["foz"])
+}
+
 func (s *deploymentTemplateTest) TestContainerSetGlobalAnnotations() {
 	// given
 	options := &helm.Options{

--- a/charts/camunda-platform/test/operate/deployment_test.go
+++ b/charts/camunda-platform/test/operate/deployment_test.go
@@ -68,6 +68,26 @@ func (s *deploymentTemplateTest) TestContainerSetPodLabels() {
 	s.Require().Equal("bar", deployment.Spec.Template.Labels["foo"])
 }
 
+func (s *deploymentTemplateTest) TestContainerSetPodAnnotations() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"operate.podAnnotations.foo": "bar",
+			"operate.podAnnotations.foz": "baz",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	s.Require().Equal("bar", deployment.Spec.Template.Annotations["foo"])
+	s.Require().Equal("baz", deployment.Spec.Template.Annotations["foz"])
+}
+
 func (s *deploymentTemplateTest) TestContainerSetGlobalAnnotations() {
 	// given
 	options := &helm.Options{

--- a/charts/camunda-platform/test/optimize/deployment_test.go
+++ b/charts/camunda-platform/test/optimize/deployment_test.go
@@ -68,6 +68,26 @@ func (s *deploymentTemplateTest) TestContainerSetPodLabels() {
 	s.Require().Equal("bar", deployment.Spec.Template.Labels["foo"])
 }
 
+func (s *deploymentTemplateTest) TestContainerSetPodAnnotations() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"optimize.podAnnotations.foo": "bar",
+			"optimize.podAnnotations.foz": "baz",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	s.Require().Equal("bar", deployment.Spec.Template.Annotations["foo"])
+	s.Require().Equal("baz", deployment.Spec.Template.Annotations["foz"])
+}
+
 func (s *deploymentTemplateTest) TestContainerSetGlobalAnnotations() {
 	// given
 	options := &helm.Options{

--- a/charts/camunda-platform/test/tasklist/deployment_test.go
+++ b/charts/camunda-platform/test/tasklist/deployment_test.go
@@ -68,6 +68,26 @@ func (s *deploymentTemplateTest) TestContainerSetPodLabels() {
 	s.Require().Equal("bar", deployment.Spec.Template.Labels["foo"])
 }
 
+func (s *deploymentTemplateTest) TestContainerSetPodAnnotations() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"tasklist.podAnnotations.foo": "bar",
+			"tasklist.podAnnotations.foz": "baz",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	s.Require().Equal("bar", deployment.Spec.Template.Annotations["foo"])
+	s.Require().Equal("baz", deployment.Spec.Template.Annotations["foz"])
+}
+
 func (s *deploymentTemplateTest) TestContainerSetGlobalAnnotations() {
 	// given
 	options := &helm.Options{

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -691,6 +691,9 @@ identity:
     # Image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
     pullSecrets: []
 
+  # PodAnnotations can be used to define extra operate pod annotations
+  podAnnotations: { }
+
   # Service configuration to configure the identity service.
   service:
     # Service.type defines the type of the service https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -561,6 +561,8 @@ optimize:
     # Image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
     pullSecrets: []
 
+  # PodAnnotations can be used to define extra operate pod annotations
+  podAnnotations: { }
   # PodLabels can be used to define extra Optimize pod labels
   podLabels: { }
 

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -490,6 +490,8 @@ tasklist:
   # Env can be used to set extra environment variables on each Tasklist container
   env: [ ]
 
+  # PodAnnotations can be used to define extra operate pod annotations
+  podAnnotations: { }
   # PodLabels can be used to define extra tasklist pod labels
   podLabels: { }
 

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -490,7 +490,7 @@ tasklist:
   # Env can be used to set extra environment variables on each Tasklist container
   env: [ ]
 
-  # PodAnnotations can be used to define extra operate pod annotations
+  # PodAnnotations can be used to define extra Tasklist pod annotations
   podAnnotations: { }
   # PodLabels can be used to define extra tasklist pod labels
   podLabels: { }
@@ -563,7 +563,7 @@ optimize:
     # Image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
     pullSecrets: []
 
-  # PodAnnotations can be used to define extra operate pod annotations
+  # PodAnnotations can be used to define extra Optimize pod annotations
   podAnnotations: { }
   # PodLabels can be used to define extra Optimize pod labels
   podLabels: { }
@@ -691,7 +691,7 @@ identity:
     # Image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
     pullSecrets: []
 
-  # PodAnnotations can be used to define extra operate pod annotations
+  # PodAnnotations can be used to define extra Identity pod annotations
   podAnnotations: { }
 
   # Service configuration to configure the identity service.

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -389,6 +389,8 @@ operate:
     # Image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
     pullSecrets: []
 
+  # PodAnnotations can be used to define extra operate pod annotations
+  podAnnotations: { }
   # PodLabels can be used to define extra operate pod labels
   podLabels: { }
   

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -375,12 +375,12 @@ zeebe-gateway:
     # ServiceAccount.annotations can be used to set the annotations of the gateway service account
     annotations: { }
 
-# Operate configuration for the operate sub chart.
+# Operate configuration for the Operate sub chart.
 operate:
-  # Enabled if true, the operate deployment and its related resources are deployed via a helm release
+  # Enabled if true, the Operate deployment and its related resources are deployed via a helm release
   enabled: true
 
-  # Image configuration to configure the operate image specifics
+  # Image configuration to configure the Operate image specifics
   image:
     # Image.repository defines which image repository to use
     repository: camunda/operate
@@ -389,24 +389,24 @@ operate:
     # Image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
     pullSecrets: []
 
-  # PodAnnotations can be used to define extra operate pod annotations
+  # PodAnnotations can be used to define extra Operate pod annotations
   podAnnotations: { }
-  # PodLabels can be used to define extra operate pod labels
+  # PodLabels can be used to define extra Operate pod labels
   podLabels: { }
-  
-  # Logging configuration for the operate logging. This template will be directly included in the operate configuration yaml file
+
+  # Logging configuration for the Operate logging. This template will be directly included in the Operate configuration yaml file
   logging:
     level:
       ROOT: INFO
       org.camunda.operate: DEBUG
 
-  # Service configuration to configure the operate service.
+  # Service configuration to configure the Operate service.
   service:
     # Service.type defines the type of the service https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
     type: ClusterIP
-    # Service.port defines the port of the service, where the operate web application will be available
+    # Service.port defines the port of the service, where the Operate web application will be available
     port: 80
-    # Service.annotations can be used to define annotations, which will be applied to the operate service
+    # Service.annotations can be used to define annotations, which will be applied to the Operate service
     annotations: {}
 
   # Resources configuration to set request and limit configuration for the container https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
@@ -418,7 +418,7 @@ operate:
       cpu: 2000m
       memory: 2Gi
 
-  # Env can be used to set extra environment variables in each operate container
+  # Env can be used to set extra environment variables in each Operate container
   env: []
   # ConfigMap configuration which will be applied to the mounted config map.
   configMap:
@@ -427,23 +427,23 @@ operate:
     defaultMode: 0744
   # Command can be used to override the default command provided by the container image. See https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/
   command: []
-  # ExtraVolumes can be used to define extra volumes for the operate pods, useful for tls and self-signed certificates
+  # ExtraVolumes can be used to define extra volumes for the Operate pods, useful for tls and self-signed certificates
   extraVolumes: []
-  # ExtraVolumeMounts can be used to mount extra volumes for the operate pods, useful for tls and self-signed certificates
+  # ExtraVolumeMounts can be used to mount extra volumes for the Operate pods, useful for tls and self-signed certificates
   extraVolumeMounts: []
 
-  # ServiceAccount configuration for the service account where the operate pods are assigned to
+  # ServiceAccount configuration for the service account where the Operate pods are assigned to
   serviceAccount:
-    # ServiceAccount.enabled if true, enables the operate service account
+    # ServiceAccount.enabled if true, enables the Operate service account
     enabled: true
-    # ServiceAccount.name can be used to set the name of the operate service account
+    # ServiceAccount.name can be used to set the name of the Operate service account
     name: ""
-    # ServiceAccount.annotations can be used to set the annotations of the operate service account
+    # ServiceAccount.annotations can be used to set the annotations of the Operate service account
     annotations: { }
 
   # Ingress configuration to configure the ingress resource
   ingress:
-    # Ingress.enabled if true, an ingress resource is deployed with the operate deployment. Only useful if an ingress controller is available, like nginx.
+    # Ingress.enabled if true, an ingress resource is deployed with the Operate deployment. Only useful if an ingress controller is available, like nginx.
     enabled: false
     # Ingress.className defines the class or configuration of ingress which should be used by the controller
     className: nginx
@@ -451,7 +451,7 @@ operate:
     annotations:
       ingress.kubernetes.io/rewrite-target: "/"
       nginx.ingress.kubernetes.io/ssl-redirect: "false"
-    # Ingress.path defines the path which is associated with the operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
+    # Ingress.path defines the path which is associated with the Operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     # Ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     # If not specified the rules applies to all inbound http traffic, if specified the rule applies to that host.
@@ -463,10 +463,10 @@ operate:
       # Ingress.tls.secretName defines the secret name which contains the TLS private key and certificate
       secretName: ""
 
-  # PodSecurityContext defines the security options the operate container should be run with
+  # PodSecurityContext defines the security options the Operate container should be run with
   podSecurityContext: {}
 
-  # NodeSelector can be used to define on which nodes the operate pods should run
+  # NodeSelector can be used to define on which nodes the Operate pods should run
   nodeSelector: { }
   # Tolerations can be used to define pod toleration's https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
   tolerations: [ ]


### PR DESCRIPTION
Adds the possibility to configure pod annotations on all subcharts.


Added for:

 * Operate
 * Optimize
 * Tasklist
 * Identity


Already available in Zeebe and Zeebe Gateway.

closes #327 