### PR TITLE
feat: [Identity] add env configuration of the connection to keycloak

### DIFF
--- a/charts/camunda-platform/charts/identity/Chart.yaml
+++ b/charts/camunda-platform/charts/identity/Chart.yaml
@@ -12,3 +12,4 @@ dependencies:
   - name: keycloak
     repository: "https://charts.bitnami.com/bitnami"
     version: 7.1.6
+    condition: "keycloak.enabled"

--- a/charts/camunda-platform/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/identity/templates/deployment.yaml
@@ -116,11 +116,11 @@ spec:
             We resolve the fullname of keycloak and trim it to 20, since this is the limitation by keycloak
             https://github.com/bitnami/charts/blob/master/bitnami/keycloak/templates/_helpers.tpl#L2-L5
             */}}
-            value: "http://{{ include "common.names.dependency.fullname" (dict "chartName" "keycloak" "chartValues" .Values.keycloak "context" $) | trunc 20 | trimSuffix "-" }}:{{ coalesce .Values.keycloak.service.ports.http .Values.keycloak.service.port }}/auth"
+            value: {{ .Values.global.identity.keycloak.url | default "http://camunda-platform-tes:80/auth" | quote }}
           - name: IDENTITY_AUTH_PROVIDER_ISSUER_URL
-            value: {{ .Values.global.identity.auth.publicIssuerUrl | quote }}
+            value: {{ .Values.global.identity.auth.publicIssuerUrl | default "http://camunda-platform-tes:80/auth/realms/camunda-platform" | quote }}
           - name: IDENTITY_AUTH_PROVIDER_BACKEND_URL
-            value: "http://{{ include "common.names.dependency.fullname" (dict "chartName" "keycloak" "chartValues" .Values.keycloak "context" $) | trunc 20 | trimSuffix "-" }}:{{ coalesce .Values.keycloak.service.ports.http .Values.keycloak.service.port }}/auth/realms/camunda-platform"
+            value: {{ .Values.global.identity.auth.providerBackendUrl | default "http://camunda-platform-tes:80/auth/realms/camunda-platform" | quote }}
           - name: KEYCLOAK_SETUP_USER
             value: {{ .Values.keycloak.auth.adminUser }}
           - name: KEYCLOAK_SETUP_PASSWORD

--- a/charts/camunda-platform/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/identity/templates/deployment.yaml
@@ -118,7 +118,7 @@ spec:
             */}}
             value: {{ .Values.global.identity.keycloak.url | default "http://camunda-platform-tes:80/auth" | quote }}
           - name: IDENTITY_AUTH_PROVIDER_ISSUER_URL
-            value: {{ .Values.global.identity.auth.publicIssuerUrl | default "http://camunda-platform-tes:80/auth/realms/camunda-platform" | quote }}
+            value: {{ .Values.global.identity.auth.publicIssuerUrl | default "http://localhost:18080/auth/realms/camunda-platform" | quote }}
           - name: IDENTITY_AUTH_PROVIDER_BACKEND_URL
             value: {{ .Values.global.identity.auth.providerBackendUrl | default "http://camunda-platform-tes:80/auth/realms/camunda-platform" | quote }}
           - name: KEYCLOAK_SETUP_USER

--- a/charts/camunda-platform/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/identity/templates/deployment.yaml
@@ -118,7 +118,7 @@ spec:
             */}}
             value: {{ .Values.global.identity.keycloak.url | default "http://camunda-platform-tes:80/auth" | quote }}
           - name: IDENTITY_AUTH_PROVIDER_ISSUER_URL
-            value: {{ .Values.global.identity.auth.publicIssuerUrl | default "http://localhost:18080/auth/realms/camunda-platform" | quote }}
+            value: {{ .Values.global.identity.auth.publicIssuerUrl | quote }}
           - name: IDENTITY_AUTH_PROVIDER_BACKEND_URL
             value: {{ .Values.global.identity.auth.providerBackendUrl | default "http://camunda-platform-tes:80/auth/realms/camunda-platform" | quote }}
           - name: KEYCLOAK_SETUP_USER

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -82,6 +82,7 @@ global:
   # Identity configuration to configure identity specifics on global level, which can be accessed by other sub-charts
   identity:
     keycloak:
+      enabled: true
       # Identity.keycloak.fullname can be used to change the referenced Keycloak service name inside the sub-charts, like operate, optimize, etc.
       # Subcharts can't access values from other sub-charts or the parent, global only.
       # This is useful if the identity.keycloak.fullnameOverride is set, and specifies a different name for the Keycloak service.

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -96,7 +96,7 @@ global:
       # Identity.auth.publicIssuerUrl defines the token issuer (Keycloak) URL, where the services can request JWT tokens.
       # Should be public accessible, per default we assume a port-forward to Keycloak (18080) is created before login.
       # Can be overwritten if, ingress is in use and an external IP is available.
-      publicIssuerUrl: ""
+      publicIssuerUrl: "http://localhost:18080/auth/realms/camunda-platform"
 
       providerBackendUrl: ""
 

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -60,7 +60,7 @@ global:
       # Ingress.tls.secretName defines the secret name which contains the TLS private key and certificate
       secretName: ""
 
-  # Elasticsearch configuration which is shared between the sub charts  
+  # Elasticsearch configuration which is shared between the sub charts
   elasticsearch:
     # Elasticsearch.disableExporter if true, disables the elastic exporter in zeebe
     disableExporter: false
@@ -86,6 +86,8 @@ global:
       # Subcharts can't access values from other sub-charts or the parent, global only.
       # This is useful if the identity.keycloak.fullnameOverride is set, and specifies a different name for the Keycloak service.
       fullname: ""
+
+      url: ""
     # Identity.auth configuration, to configure Identity authentication setup
     auth:
       # Identity.auth.enabled if true, enables the Identity authentication otherwise basic-auth will be used on all services.
@@ -94,7 +96,9 @@ global:
       # Identity.auth.publicIssuerUrl defines the token issuer (Keycloak) URL, where the services can request JWT tokens.
       # Should be public accessible, per default we assume a port-forward to Keycloak (18080) is created before login.
       # Can be overwritten if, ingress is in use and an external IP is available.
-      publicIssuerUrl: "http://localhost:18080/auth/realms/camunda-platform"
+      publicIssuerUrl: ""
+
+      providerBackendUrl: ""
 
       # Identity.auth.operate configuration to configure Operate authentication specifics on global level, which can be accessed by other sub-charts
       operate:
@@ -192,9 +196,9 @@ zeebe:
     # extraPorts can be used to expose any other ports which are required. Can be useful for exporters
     extraPorts: []
       # - name: hazelcast
-      #   protocol: TCP 
+      #   protocol: TCP
       #   port: 5701
-      #   targetPort: 5701 
+      #   targetPort: 5701
 
   # ServiceAccount configuration for the service account where the broker pods are assigned to
   serviceAccount:


### PR DESCRIPTION
### Related issues

<!-- Which GitHub issues related to or fixed by this PR, if any. -->

### What's in this PR?

Allow to set `KEYCLOAK_URL`and `IDENTITY_AUTH_PROVIDER_BACKEND_URL` in case keycloak must be accessible through https.
<!--
  Explain the contents of the PR.
  Give an overview about the implementation, which decisions were made and why.
-->

### Which problem does the PR fix?

<!-- Which problem does the PR fix? Please remove this section if you linked an issue above -->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [ ] Tests for charts are added.
- [ ] The main Helm chart and sub-chart are updated (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

### To-Do

<!-- Please remove this section if you don't need it. -->

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
