### PR TITLE
Add ingress template to the Zeebe gateway chart

### DIFF
--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -197,6 +197,15 @@ Information about the Zeebe Gateway you can find [here](https://docs.camunda.io/
 | | `serviceAccount.enabled` | If true, enables the gateway service account | `true` |
 | | `serviceAccount.name` | Can be used to set the name of the gateway service account | `""` |
 | | `serviceAccount.annotations` | Can be used to set the annotations of the gateway service account | `{ }` |
+| | `ingress` | Configuration to configure the ingress resource | |
+| | `ingress.enabled` | If true, an ingress resource is deployed with the Zeebe gateway deployment. Only useful if an ingress controller is available, like nginx. | `false` |
+| | `ingress.className` | Defines the class or configuration of ingress which should be used by the controller | `nginx` |
+| | `ingress.annotations` | Defines the ingress related annotations, consumed mostly by the ingress controller | `ingress.kubernetes.io/rewrite-target: "/"` <br/> `nginx.ingress.kubernetes.io/ssl-redirect: "false"` <br/> `nginx.ingress.kubernetes.io/backend-protocol: "GRPC"` |
+| | `ingress.path` | Defines the path which is associated with the Operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules | `/` |
+| | `ingress.host` | Can be used to define the [host of the ingress rule.](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules) If not specified the rules applies to all inbound HTTP traffic, if specified the rule applies to that host. | `""` |
+| | `ingress.tls` | Configuration for [TLS on the ingress resource](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) | |
+| | `ingress.tls.enabled` | If true, then TLS is configured on the ingress resource. If enabled the Ingress.host need to be defined. | `false` |
+| | `ingress.tls.secretName` | Defines the secret name which contains the TLS private key and certificate | `""` |
 
 ### Operate
 

--- a/charts/camunda-platform/charts/zeebe-gateway/templates/ingress.yaml
+++ b/charts/camunda-platform/charts/zeebe-gateway/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "zeebe.names.gateway" . }}
+  labels: {{- include "zeebe.labels.gateway" . | nindent 4 }}
+{{- with .Values.ingress.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+{{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    {{- if .Values.ingress.host }}
+    - host: {{ .Values.ingress.host }}
+      http:
+    {{- else }}
+    - http:
+    {{- end }}
+        paths:
+          - path: {{ .Values.ingress.path }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "zeebe.names.gateway" . }}
+                port:
+                  number: {{ .Values.service.gatewayPort }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      {{- if .Values.ingress.tls.secretName }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+      {{- end }}
+  {{- end }}
+  {{- end }}

--- a/charts/camunda-platform/test/zeebe-gateway/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/zeebe-gateway/golden/ingress-all-enabled.golden.yaml
@@ -1,0 +1,35 @@
+---
+# Source: camunda-platform/charts/zeebe-gateway/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: "camunda-platform-test-zeebe-gateway"
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: zeebe-gateway
+    app.kubernetes.io/instance: camunda-platform-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/version: "8.0.0"
+    app.kubernetes.io/component: zeebe-gateway
+  annotations: 
+    ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/backend-protocol: GRPC
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: "camunda-platform-test-zeebe-gateway"
+                port:
+                  number: 26500
+  tls:
+    - hosts:
+        - local
+      secretName: my-secret

--- a/charts/camunda-platform/test/zeebe-gateway/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/zeebe-gateway/golden/ingress.golden.yaml
@@ -1,0 +1,30 @@
+---
+# Source: camunda-platform/charts/zeebe-gateway/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: "camunda-platform-test-zeebe-gateway"
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: zeebe-gateway
+    app.kubernetes.io/instance: camunda-platform-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/version: "8.0.0"
+    app.kubernetes.io/component: zeebe-gateway
+  annotations: 
+    ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/backend-protocol: GRPC
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  ingressClassName: nginx
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: "camunda-platform-test-zeebe-gateway"
+                port:
+                  number: 26500

--- a/charts/camunda-platform/test/zeebe-gateway/ingress_test.go
+++ b/charts/camunda-platform/test/zeebe-gateway/ingress_test.go
@@ -1,0 +1,64 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gateway
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"camunda-platform-helm/charts/camunda-platform/test/golden"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestGoldenIngressDefaultTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../")
+	require.NoError(t, err)
+
+	suite.Run(t, &golden.TemplateGoldenTest{
+		ChartPath:      chartPath,
+		Release:        "camunda-platform-test",
+		Namespace:      "camunda-platform-" + strings.ToLower(random.UniqueId()),
+		GoldenFileName: "ingress",
+		Templates:      []string{"charts/zeebe-gateway/templates/ingress.yaml"},
+		SetValues:      map[string]string{"zeebe-gateway.ingress.enabled": "true"},
+	})
+}
+
+func TestGoldenIngressAllEnabledTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../")
+	require.NoError(t, err)
+
+	suite.Run(t, &golden.TemplateGoldenTest{
+		ChartPath:      chartPath,
+		Release:        "camunda-platform-test",
+		Namespace:      "camunda-platform-" + strings.ToLower(random.UniqueId()),
+		GoldenFileName: "ingress-all-enabled",
+		Templates:      []string{"charts/zeebe-gateway/templates/ingress.yaml"},
+		SetValues: map[string]string{
+			"zeebe-gateway.ingress.enabled":        "true",
+			"zeebe-gateway.ingress.host":           "local",
+			"zeebe-gateway.ingress.tls.enabled":    "true",
+			"zeebe-gateway.ingress.tls.secretName": "my-secret",
+		},
+	})
+}

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -380,6 +380,29 @@ zeebe-gateway:
     # ServiceAccount.annotations can be used to set the annotations of the gateway service account
     annotations: { }
 
+  # Ingress configuration to configure the ingress resource
+  ingress:
+    # Ingress.enabled if true, an ingress resource is deployed with the Zeebe gateway deployment. Only useful if an ingress controller is available, like nginx.
+    enabled: false
+    # Ingress.className defines the class or configuration of ingress which should be used by the controller
+    className: nginx
+    # Ingress.annotations defines the ingress related annotations, consumed mostly by the ingress controller
+    annotations:
+      ingress.kubernetes.io/rewrite-target: "/"
+      nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+    # Ingress.path defines the path which is associated with the operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
+    path: /
+    # Ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
+    # If not specified the rules applies to all inbound http traffic, if specified the rule applies to that host.
+    host: ""
+    # Ingress.tls configuration for tls on the ingress resource https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+    tls:
+      # Ingress.tls.enabled if true, then tls is configured on the ingress resource. If enabled the Ingress.host need to be defined.
+      enabled: false
+      # Ingress.tls.secretName defines the secret name which contains the TLS private key and certificate
+      secretName: ""
+
 # Operate configuration for the Operate sub chart.
 operate:
   # Enabled if true, the Operate deployment and its related resources are deployed via a helm release


### PR DESCRIPTION
**Description**

This PR adds a new ingress template to the Zeebe gateway chart. It's configurable much like the ingresses for Operate, Tasklist, and Identity. It only exposes the gRPC port of the Zeebe gateway.

Testing is limited to golden files for now, as the current integration tests in general do not use any ingress. I would propose to investigate this separately, e.g. use the built-in ingress controller from GKE for our tests (though that makes the test less portable, of course).

**Related issues**

closes #343 