### PR TITLE
docs(extraInitContainers): fix example

### DIFF
--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -405,7 +405,7 @@ extraInitContainers:
       mountPath: /exporters/
 env:
   - name: ZEEBE_BROKER_EXPORTERS_HAZELCAST_JARPATH
-    value: exporters/zeebe-hazelcast-exporter.jar
+    value: /exporters/zeebe-hazelcast-exporter.jar
   - name: ZEEBE_BROKER_EXPORTERS_HAZELCAST_CLASSNAME
     value: io.zeebe.hazelcast.exporter.HazelcastExporter
   - name: ZEEBE_HAZELCAST_REMOTE_ADDRESS

--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -399,7 +399,7 @@ extraInitContainers:
   - name: init-exporters-kafka
     image: busybox:1.35
     command: ['/bin/sh', '-c']
-    args: ['wget --no-check-certificate https://github.com/zeebe-io/zeebe-kafka-exporter/releases/download/1.1.0/zeebe-kafka-exporter-1.1.0-uber.jar -O /exporters/zeebe-kafka-exporter.jar; ls -al exporters']
+    args: ['wget --no-check-certificate https://github.com/zeebe-io/zeebe-kafka-exporter/releases/download/1.1.0/zeebe-kafka-exporter-1.1.0-uber.jar -O /exporters/zeebe-kafka-exporter.jar; ls -al /exporters']
     volumeMounts:
     - name: exporters
       mountPath: /exporters/

--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -392,7 +392,7 @@ extraInitContainers:
   - name: init-exporters-hazelcast
     image: busybox:1.35
     command: ['/bin/sh', '-c']
-    args: ['wget --no-check-certificate https://repo1.maven.org/maven2/io/zeebe/hazelcast/zeebe-hazelcast-exporter/0.8.0-alpha1/zeebe-hazelcast-exporter-0.8.0-alpha1-jar-with-dependencies.jar -O /exporters/zeebe-hazelcast-exporter.jar; ls -al exporters']
+    args: ['wget --no-check-certificate https://repo1.maven.org/maven2/io/zeebe/hazelcast/zeebe-hazelcast-exporter/0.8.0-alpha1/zeebe-hazelcast-exporter-0.8.0-alpha1-jar-with-dependencies.jar -O /exporters/zeebe-hazelcast-exporter.jar; ls -al /exporters']
     volumeMounts:
     - name: exporters
       mountPath: /exporters/

--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -388,25 +388,28 @@ elasticsearch:
 This chart supports the addition of Zeebe Exporters by using initContainer as shown in the following example:
 
 ```
-extraInitContainers: |
+extraInitContainers:
   - name: init-exporters-hazelcast
-    image: busybox:1.28
+    image: busybox:1.35
     command: ['/bin/sh', '-c']
-    args: ['wget --no-check-certificate https://repo1.maven.org/maven2/io/zeebe/hazelcast/zeebe-hazelcast-exporter/0.8.0-alpha1/zeebe-hazelcast-exporter-0.8.0-alpha1-jar-with-dependencies.jar -O /exporters/zeebe-hazelcast-exporter.jar; ls -al']
+    args: ['wget --no-check-certificate https://repo1.maven.org/maven2/io/zeebe/hazelcast/zeebe-hazelcast-exporter/0.8.0-alpha1/zeebe-hazelcast-exporter-0.8.0-alpha1-jar-with-dependencies.jar -O /exporters/zeebe-hazelcast-exporter.jar; ls -al exporters']
     volumeMounts:
     - name: exporters
       mountPath: /exporters/
   - name: init-exporters-kafka
-    image: busybox:1.28
+    image: busybox:1.35
     command: ['/bin/sh', '-c']
-    args: ['wget --no-check-certificate https://github.com/zeebe-io/zeebe-kafka-exporter/releases/download/1.1.0/zeebe-kafka-exporter-1.1.0-uber.jar -O /exporters/zeebe-kafka-exporter.jar; ls -al']
+    args: ['wget --no-check-certificate https://github.com/zeebe-io/zeebe-kafka-exporter/releases/download/1.1.0/zeebe-kafka-exporter-1.1.0-uber.jar -O /exporters/zeebe-kafka-exporter.jar; ls -al exporters']
     volumeMounts:
     - name: exporters
       mountPath: /exporters/
 env:
-  ZEEBE_BROKER_EXPORTERS_HAZELCAST_JARPATH: exporters/zeebe-hazelcast-exporter.jar
-  ZEEBE_BROKER_EXPORTERS_HAZELCAST_CLASSNAME: io.zeebe.hazelcast.exporter.HazelcastExporter
-  ZEEBE_HAZELCAST_REMOTE_ADDRESS: "{{ .Release.Name }}-hazelcast"
+  - name: ZEEBE_BROKER_EXPORTERS_HAZELCAST_JARPATH
+    value: exporters/zeebe-hazelcast-exporter.jar
+  - name: ZEEBE_BROKER_EXPORTERS_HAZELCAST_CLASSNAME
+    value: io.zeebe.hazelcast.exporter.HazelcastExporter
+  - name: ZEEBE_HAZELCAST_REMOTE_ADDRESS
+    value: "{{ .Release.Name }}-hazelcast"
 ```
 This example is downloading the exporters Jar from a URL and adding the Jars to the `exporters` directory that will be scanned for jars and added to the zeebe broker classpath. Then with `environment variables` you can configure the exporter parameters.
 


### PR DESCRIPTION
The example for `extraInitContainers` in the README did not work for me. My suggestion to update them is based on 
 this configuration, which I tested in a real installation: https://github.com/camunda-community-hub/in-engine-job-worker/blob/main/helm-chart-values.yaml