### PR TITLE
Optimize TLS termination on ingress

### DIFF
--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -321,6 +321,9 @@ Information about Optimize you can find [here](https://docs.camunda.io/docs/comp
 | | `ingress.annotations` | Defines the ingress related annotations, consumed mostly by the ingress controller | `ingress.kubernetes.io/rewrite-target: "/"` <br/> `nginx.ingress.kubernetes.io/ssl-redirect: "false"` |
 | | `ingress.path` | Defines the path which is associated with the Optimize [service and port](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules) | `/` |
 | | `ingress.host` | Can be used to define the [host of the ingress rule.](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules) If not specified the rules applies to all inbound HTTP traffic, if specified the rule applies to that host. | `""` |
+| | `ingress.tls` | Configuration for [TLS on the ingress resource](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) | |
+| | `ingress.tls.enabled` | If true, then TLS is configured on the ingress resource. If enabled the Ingress.host need to be defined. | `false` |
+| | `ingress.tls.secretName` | Defines the secret name which contains the TLS private key and certificate | `""` |
 
 ### Identity
 

--- a/charts/camunda-platform/charts/optimize/templates/ingress.yaml
+++ b/charts/camunda-platform/charts/optimize/templates/ingress.yaml
@@ -20,4 +20,12 @@ spec:
                 name:  {{ include "optimize.fullname" . }}
                 port:
                   number: 80
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      {{- if .Values.ingress.tls.secretName }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+      {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/camunda-platform/test/optimize/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/optimize/golden/ingress-all-enabled.golden.yaml
@@ -28,3 +28,7 @@ spec:
                 name:  camunda-platform-test-optimize
                 port:
                   number: 80
+  tls:
+    - hosts:
+        - local
+      secretName: my-secret

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -659,6 +659,12 @@ optimize:
     # Ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     # If not specified the rules applies to all inbound http traffic, if specified the rule applies to that host.
     host:
+    # Ingress.tls configuration for tls on the ingress resource https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+    tls:
+      # Ingress.tls.enabled if true, then tls is configured on the ingress resource. If enabled the Ingress.host need to be defined.
+      enabled: false
+      # Ingress.tls.secretName defines the secret name which contains the TLS private key and certificate
+      secretName: ""
 
 # RetentionPolicy configuration to configure the elasticsearch index retention policies
 retentionPolicy:


### PR DESCRIPTION
Fixes the issue that Optimize uses http in the redirect url instead of https.

Background here is that the redirect URL is determined from the request and with tls terminating before the ingress it always used http.