### PR TITLE
Disable test resources in Elasticsearch deployment for OpenShift patch

### DIFF
--- a/openshift/values-patch.yaml
+++ b/openshift/values-patch.yaml
@@ -47,6 +47,8 @@ identity:
 
 # omit the values below if elasticsearch.enabled is false
 elasticsearch:
+  tests:
+    enabled: false
   securityContext:
     runAsUser: "@@null@@"
   podSecurityContext:

--- a/openshift/values-patch.yaml
+++ b/openshift/values-patch.yaml
@@ -47,6 +47,8 @@ identity:
 
 # omit the values below if elasticsearch.enabled is false
 elasticsearch:
+  # test resources are disabled as they aren't pass on to the post-renderer, meaning they will not be deploy-able. this
+  # has no impact on a production deployment.
   tests:
     enabled: false
   securityContext:


### PR DESCRIPTION
This PR disables the test resources for Elasticsearch when using the OpenShift patch values, as these will not be post-rendered. As they're only test values, this should be acceptable for a production deployment.