### PR TITLE
Changed: Enable labels for Elasticsearch PVC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ install:	deps
 uninstall:
 	-helm uninstall $(releaseName)
 	-kubectl delete pvc -l app.kubernetes.io/instance=$(releaseName)
-	-kubectl delete pvc -l app=elasticsearch-master
+	-kubectl delete pvc -l release=$(releaseName)
 
 # dry-run: runs an install dry-run with the local chart
 .PHONY: dry-run

--- a/README.md
+++ b/README.md
@@ -93,14 +93,14 @@ In order to free up the storage you need to manually delete all the Persistent V
 
 ```sh
 kubectl get pvc -l app.kubernetes.io/instance=<YOUR HELM RELEASE NAME>
-kubectl get pvc -l app=elasticsearch-master
+kubectl get pvc -l release=<YOUR HELM RELEASE NAME>
 ```
 
 Then delete the ones that you don't want to keep:
 
 ```sh
 kubectl delete pvc -l app.kubernetes.io/instance=<YOUR HELM RELEASE NAME>
-kubectl delete pvc -l app=elasticsearch-master
+kubectl delete pvc -l release=<YOUR HELM RELEASE NAME>
 ```
 
 Or you can simply delete the related Kubernetes namespace, which contains the resources.

--- a/charts/camunda-platform/test/integration/integration_suite.go
+++ b/charts/camunda-platform/test/integration/integration_suite.go
@@ -247,7 +247,7 @@ func (s *integrationSuite) awaitAllPodsForThisRelease() {
 
 func (s *integrationSuite) awaitElasticPods() {
 	// await that all elastic related pods become ready, otherwise operate and tasklist can't answer requests
-	pods := k8s.ListPods(s.T(), s.kubeOptions, v1.ListOptions{LabelSelector: "app=elasticsearch-master"})
+	pods := k8s.ListPods(s.T(), s.kubeOptions, v1.ListOptions{LabelSelector: "release=" + s.release})
 
 	for _, pod := range pods {
 		k8s.WaitUntilPodAvailable(s.T(), s.kubeOptions, pod.Name, 10, 10*time.Second)

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -840,6 +840,10 @@ elasticsearch:
 
   replicas: 2
 
+  persistence:
+    labels:
+      enabled: true
+
   volumeClaimTemplate:
     accessModes: [ "ReadWriteOnce" ]
     resources:


### PR DESCRIPTION
Fixes: #379

Zeebe and Posgtes already use the `app.kubernetes.io/instance` label, so no action is needed for them.