### PR TITLE
Add TLS configuration to tasklist ingress

### DIFF
--- a/charts/camunda-platform/charts/tasklist/templates/ingress.yaml
+++ b/charts/camunda-platform/charts/tasklist/templates/ingress.yaml
@@ -10,14 +10,26 @@ metadata:
 spec:
   ingressClassName: {{ .Values.ingress.className }}
   rules:
+    {{- if .Values.ingress.host }}
     - host: {{ .Values.ingress.host }}
       http:
+    {{- else }}
+    - http:
+    {{- end }}
         paths:
           - path: {{ .Values.ingress.path }}
             pathType: Prefix
             backend:
               service:
-                name:  {{ include "tasklist.fullname" . }}
+                name: {{ include "tasklist.fullname" . }}
                 port:
                   number: 80
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      {{- if .Values.ingress.tls.secretName }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+      {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/camunda-platform/test/tasklist/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/tasklist/golden/ingress-all-enabled.golden.yaml
@@ -1,0 +1,34 @@
+---
+# Source: camunda-platform/charts/tasklist/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: camunda-platform-test-tasklist
+  labels: 
+    app: camunda-platform
+    app.kubernetes.io/name: tasklist
+    app.kubernetes.io/instance: camunda-platform-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/version: "8.0.0"
+    app.kubernetes.io/component: tasklist
+  annotations: 
+    ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: camunda-platform-test-tasklist
+                port:
+                  number: 80
+  tls:
+    - hosts:
+        - local
+      secretName: my-secret

--- a/charts/camunda-platform/test/tasklist/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/tasklist/golden/ingress.golden.yaml
@@ -1,0 +1,29 @@
+---
+# Source: camunda-platform/charts/tasklist/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: camunda-platform-test-tasklist
+  labels: 
+    app: camunda-platform
+    app.kubernetes.io/name: tasklist
+    app.kubernetes.io/instance: camunda-platform-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/version: "8.0.0"
+    app.kubernetes.io/component: tasklist
+  annotations: 
+    ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  ingressClassName: nginx
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: camunda-platform-test-tasklist
+                port:
+                  number: 80

--- a/charts/camunda-platform/test/tasklist/ingress_test.go
+++ b/charts/camunda-platform/test/tasklist/ingress_test.go
@@ -1,0 +1,64 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tasklist
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"camunda-platform-helm/charts/camunda-platform/test/golden"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestGoldenIngressDefaultTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../")
+	require.NoError(t, err)
+
+	suite.Run(t, &golden.TemplateGoldenTest{
+		ChartPath:      chartPath,
+		Release:        "camunda-platform-test",
+		Namespace:      "camunda-platform-" + strings.ToLower(random.UniqueId()),
+		GoldenFileName: "ingress",
+		Templates:      []string{"charts/tasklist/templates/ingress.yaml"},
+		SetValues:      map[string]string{"tasklist.ingress.enabled": "true"},
+	})
+}
+
+func TestGoldenIngressAllEnabledTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../")
+	require.NoError(t, err)
+
+	suite.Run(t, &golden.TemplateGoldenTest{
+		ChartPath:      chartPath,
+		Release:        "camunda-platform-test",
+		Namespace:      "camunda-platform-" + strings.ToLower(random.UniqueId()),
+		GoldenFileName: "ingress-all-enabled",
+		Templates:      []string{"charts/tasklist/templates/ingress.yaml"},
+		SetValues: map[string]string{
+			"tasklist.ingress.enabled":        "true",
+			"tasklist.ingress.host":           "local",
+			"tasklist.ingress.tls.enabled":    "true",
+			"tasklist.ingress.tls.secretName": "my-secret",
+		},
+	})
+}

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -581,6 +581,11 @@ tasklist:
     # Ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     # If not specified the rules applies to all inbound http traffic, if specified the rule applies to that host.
     host:
+    tls:
+      # Ingress.tls.enabled if true, then tls is configured on the ingress resource. If enabled the Ingress.host need to be defined.
+      enabled: false
+      # Ingress.tls.secretName defines the secret name which contains the TLS private key and certificate
+      secretName: ""
 
 # Optimize configuration for the Optimize sub chart.
 optimize:


### PR DESCRIPTION
For whatever reason, tasklist does not allow you to configure TLS on the ingress like the rest of the camunda components.  These changes address the issue by simply following the same pattern as all of the other camunda ingress templates.  