### PR TITLE
fix: unify imagePullPolicy across components

### DIFF
--- a/charts/camunda-platform/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/identity/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         {{- else }}
         image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
         {{- end }}
+        imagePullPolicy: {{ .Values.global.image.pullPolicy }}
         env:
           - name: KEYCLOAK_USERS_0_USERNAME
             value: {{ .Values.firstUser.username | quote }}

--- a/charts/camunda-platform/charts/operate/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/operate/templates/deployment.yaml
@@ -29,6 +29,7 @@ spec:
         {{- else }}
         image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
         {{- end }}
+        imagePullPolicy: {{ .Values.global.image.pullPolicy }}
         env:
           {{- if .Values.global.identity.auth.enabled }}
           - name: SPRING_PROFILES_ACTIVE

--- a/charts/camunda-platform/charts/optimize/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/optimize/templates/deployment.yaml
@@ -30,6 +30,7 @@ spec:
         {{- else }}
         image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
         {{- end }}
+        imagePullPolicy: {{ .Values.global.image.pullPolicy }}
         env:
           - name: CAMUNDA_OPTIMIZE_ZEEBE_ENABLED
             value: "true"

--- a/charts/camunda-platform/charts/tasklist/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/tasklist/templates/deployment.yaml
@@ -30,6 +30,7 @@ spec:
         {{- else }}
         image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
         {{- end }}
+        imagePullPolicy: {{ .Values.global.image.pullPolicy }}
         env:
           {{- if .Values.global.identity.auth.enabled }}
           - name: SPRING_PROFILES_ACTIVE

--- a/charts/camunda-platform/test/identity/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/identity/golden/deployment.golden.yaml
@@ -40,6 +40,7 @@ spec:
       containers:
       - name: identity
         image: "camunda/identity:8.0.0"
+        imagePullPolicy: IfNotPresent
         env:
           - name: KEYCLOAK_USERS_0_USERNAME
             value: "demo"

--- a/charts/camunda-platform/test/operate/deployment_test.go
+++ b/charts/camunda-platform/test/operate/deployment_test.go
@@ -596,3 +596,25 @@ func (s *deploymentTemplateTest) TestContainerShouldSetTheRightKeycloakServiceUr
 			Value: "http://keycloak:80/auth/realms/camunda-platform",
 		})
 }
+
+func (s *deploymentTemplateTest) TestContainerOverwriteGlobalImagePullPolicy() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.image.pullPolicy": "Always",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	expectedPullPolicy := v12.PullAlways
+	containers := deployment.Spec.Template.Spec.Containers
+	s.Require().Equal(1, len(containers))
+	pullPolicy := containers[0].ImagePullPolicy
+	s.Require().Equal(expectedPullPolicy, pullPolicy)
+}

--- a/charts/camunda-platform/test/operate/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/operate/golden/deployment.golden.yaml
@@ -40,6 +40,7 @@ spec:
       containers:
       - name: operate
         image: "camunda/operate:8.0.0"
+        imagePullPolicy: IfNotPresent
         env:
           - name: SPRING_PROFILES_ACTIVE
             value: "identity-auth"

--- a/charts/camunda-platform/test/optimize/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/optimize/golden/deployment.golden.yaml
@@ -40,6 +40,7 @@ spec:
       containers:
       - name: optimize
         image: "camunda/optimize:3.9.0-preview-2"
+        imagePullPolicy: IfNotPresent
         env:
           - name: CAMUNDA_OPTIMIZE_ZEEBE_ENABLED
             value: "true"

--- a/charts/camunda-platform/test/tasklist/deployment_test.go
+++ b/charts/camunda-platform/test/tasklist/deployment_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
 	v12 "k8s.io/api/core/v1"
 )
 
@@ -594,4 +595,26 @@ func (s *deploymentTemplateTest) TestContainerShouldSetTheRightKeycloakServiceUr
 			Name:  "CAMUNDA_TASKLIST_IDENTITY_ISSUER_BACKEND_URL",
 			Value: "http://keycloak:80/auth/realms/camunda-platform",
 		})
+}
+
+func (s *deploymentTemplateTest) TestContainerOverwriteGlobalImagePullPolicy() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.image.pullPolicy": "Always",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment v1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	expectedPullPolicy := v12.PullAlways
+	containers := deployment.Spec.Template.Spec.Containers
+	s.Require().Equal(1, len(containers))
+	pullPolicy := containers[0].ImagePullPolicy
+	s.Require().Equal(expectedPullPolicy, pullPolicy)
 }

--- a/charts/camunda-platform/test/tasklist/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/tasklist/golden/deployment.golden.yaml
@@ -40,6 +40,7 @@ spec:
       containers:
       - name: tasklist
         image: "camunda/tasklist:8.0.0"
+        imagePullPolicy: IfNotPresent
         env:
           - name: SPRING_PROFILES_ACTIVE
             value: "identity-auth"

--- a/charts/camunda-platform/test/zeebe-gateway/deployment_test.go
+++ b/charts/camunda-platform/test/zeebe-gateway/deployment_test.go
@@ -558,3 +558,25 @@ func (s *deploymentTemplateTest) TestContainerSetExtraInitContainers() {
 	s.Require().Equal("busybox:1.28", initContainer.Image)
 	s.Require().Equal([]string{"sh", "-c", "top"}, initContainer.Command)
 }
+
+func (s *deploymentTemplateTest) TestContainerOverwriteGlobalImagePullPolicy() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.image.pullPolicy": "Always",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	expectedPullPolicy := v12.PullAlways
+	containers := deployment.Spec.Template.Spec.Containers
+	s.Require().Equal(1, len(containers))
+	pullPolicy := containers[0].ImagePullPolicy
+	s.Require().Equal(expectedPullPolicy, pullPolicy)
+}


### PR DESCRIPTION
added imagePullPolicy to tasklist, operate, optimize and identity and added tests

### Related issues
 #396 

### What's in this PR?
added global imagePullPolicy to templates to match zeebe and zeebegateway
added tests to all for testing override using global pullPolicy

### Which problem does the PR fix?

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls)
      for the same update/change.
- [ ] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added.
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?
