### PR TITLE
Support single domain setup

### DIFF
--- a/.github/workflows/charttesting.yml
+++ b/.github/workflows/charttesting.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
 env:
-  HELM_VERSION: 3.6.3
+  HELM_VERSION: 3.9.3
 
 jobs:
   release:

--- a/.github/workflows/go-it.yaml
+++ b/.github/workflows/go-it.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch: { }
 
 env:
-  HELM_VERSION: 3.6.3
+  HELM_VERSION: 3.9.3
   KUBECTL_VERSION: 'latest'
   KUBECTX: 'gke_zeebe-io_europe-west1-b_zeebe-cluster'
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,9 +4,10 @@ on:
   push:
     branches: [ main ]
   pull_request: { }
+  workflow_dispatch: { }
 
 env:
-  HELM_VERSION: 3.6.3
+  HELM_VERSION: 3.9.3
 
 jobs:
   build:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,7 +8,7 @@ on:
       - main
   pull_request: { }
 env:
-  HELM_VERSION: 3.6.3
+  HELM_VERSION: 3.9.3
 
 jobs:
   release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ on:
       - main
 
 env:
-  HELM_VERSION: 3.6.3
+  HELM_VERSION: 3.9.3
 
 jobs:
   generate-charts-release-notes:

--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -33,7 +33,7 @@
 
 ## Installing
 
-The first command adds the official Camunda Platform Helm charts repo and the second installs the Camunda Platform chart to your current kubernetes context.
+The first command adds the official Camunda Platform Helm charts repo and the second installs the Camunda Platform chart to your current Kubernetes context.
 
 ```shell
   helm repo add camunda https://helm.camunda.io
@@ -42,7 +42,8 @@ The first command adds the official Camunda Platform Helm charts repo and the se
 
 ## Configuration
 
-The following sections contain the configuration values for the chart and each sub chart. All of them can be overwritten via a separate `values.yaml` file.
+The following sections contain the configuration values for the chart and each sub-chart. All of them can be overwritten
+via a separate `values.yaml` file.
 
 Check out the default [values.yaml](values.yaml) file, which contains the same content and documentation.
 
@@ -56,6 +57,15 @@ Check out the default [values.yaml](values.yaml) file, which contains the same c
 | | `image.tag` | Defines the tag / version which should be used in the chart. | |
 | | `image.pullPolicy` | Defines the [image pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy) which should be used. | IfNotPresent |
 | | `image.pullSecrets` | Can be used to configure [image pull secrets](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod). Also it could be configured per component separately. | `[]` |
+| | `ingress` | Configuration to configure the ingress resource | |
+| | `ingress.enabled` | If true, an ingress resource is deployed. Only useful if an ingress controller is available, like Ingress-NGINX. | `false` |
+| | `ingress.className` | Defines the class or configuration of ingress which should be used by the controller | `nginx` |
+| | `ingress.annotations` | Defines the ingress related annotations, consumed mostly by the ingress controller | `ingress.kubernetes.io/rewrite-target: "/"` <br/> `nginx.ingress.kubernetes.io/ssl-redirect: "false"` <br/> `nginx.ingress.kubernetes.io/backend-protocol: "GRPC"` |
+| | `ingress.path` | Defines the path which is used as a base for all services | `/` |
+| | `ingress.host` | Can be used to define the [host of the ingress rule.](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules) If not specified the rules applies to all inbound HTTP traffic, if specified the rule applies to that host. | `""` |
+| | `ingress.tls` | Configuration for [TLS on the ingress resource](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) | |
+| | `ingress.tls.enabled` | If true, then TLS is configured on the ingress resource. If enabled the Ingress.host needs to be defined. | `false` |
+| | `ingress.tls.secretName` | Defines the secret name which contains the TLS private key and certificate | `""` |
 | | `elasticsearch.disableExporter` | If true, disables the [Elasticsearch Exporter](https://github.com/camunda-cloud/zeebe/tree/develop/exporters/elasticsearch-exporter) in Zeebe | `false` |
 | | `elasticsearch.url` | Can be used to configure the URL to access Elasticsearch. When not set, services fallback to host and port configuration. | |
 | | `elasticsearch.host` | Defines the Elasticsearch host, ideally the service name inside the namespace. | `elasticsearch-master` |
@@ -200,13 +210,13 @@ Information about the Zeebe Gateway you can find [here](https://docs.camunda.io/
 | | `serviceAccount.name` | Can be used to set the name of the gateway service account | `""` |
 | | `serviceAccount.annotations` | Can be used to set the annotations of the gateway service account | `{ }` |
 | | `ingress` | Configuration to configure the ingress resource | |
-| | `ingress.enabled` | If true, an ingress resource is deployed with the Zeebe gateway deployment. Only useful if an ingress controller is available, like nginx. | `false` |
+| | `ingress.enabled` | If true, an ingress resource is deployed with the Zeebe gateway deployment. Only useful if an ingress controller is available, like Ingress-NGINX. | `false` |
 | | `ingress.className` | Defines the class or configuration of ingress which should be used by the controller | `nginx` |
 | | `ingress.annotations` | Defines the ingress related annotations, consumed mostly by the ingress controller | `ingress.kubernetes.io/rewrite-target: "/"` <br/> `nginx.ingress.kubernetes.io/ssl-redirect: "false"` <br/> `nginx.ingress.kubernetes.io/backend-protocol: "GRPC"` |
-| | `ingress.path` | Defines the path which is associated with the Operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules | `/` |
+| | `ingress.path` | Defines the path which is associated with the Zeebe Gateway [service and port](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules) | `/` |
 | | `ingress.host` | Can be used to define the [host of the ingress rule.](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules) If not specified the rules applies to all inbound HTTP traffic, if specified the rule applies to that host. | `""` |
 | | `ingress.tls` | Configuration for [TLS on the ingress resource](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) | |
-| | `ingress.tls.enabled` | If true, then TLS is configured on the ingress resource. If enabled the Ingress.host need to be defined. | `false` |
+| | `ingress.tls.enabled` | If true, then TLS is configured on the ingress resource. If enabled the Ingress.host needs to be defined. | `false` |
 | | `ingress.tls.secretName` | Defines the secret name which contains the TLS private key and certificate | `""` |
 
 ### Operate
@@ -221,6 +231,7 @@ Information about Operate you can find [here](https://docs.camunda.io/docs/compo
 | | `image.repository` | Defines which image repository to use. | `camunda/operate` |
 | | `image.tag` | Can be set to overwrite the global tag, which should be used in that chart. | `` |
 | | `image.pullSecrets` | Can be set to overwrite the global.image.pullSecrets | `{{ global.image.pullSecrets }}` |
+| | `contextPath` |  Can be used to make Operate web application works on a custom sub-path. This is mainly used to run Camunda Platform web applications under a single domain. | |
 | | `podAnnotations` | Can be used to define extra Operate pod annotations | `{ }` |
 | | `podLabels` |  Can be used to define extra Operate pod labels | `{ }` |
 | | `logging` | Configuration for the Operate logging. This template will be directly included in the Operate configuration yaml file | `level:` <br/> `ROOT: INFO` <br/> `org.camunda.operate: DEBUG` |
@@ -239,13 +250,13 @@ Information about Operate you can find [here](https://docs.camunda.io/docs/compo
 | | `serviceAccount.name` | Can be used to set the name of the Operate service account | `""` |
 | | `serviceAccount.annotations` | Can be used to set the annotations of the Operate service account | `{ }` |
 | | `ingress` | Configuration to configure the ingress resource | |
-| | `ingress.enabled` | If true, an ingress resource is deployed with the Operate deployment. Only useful if an ingress controller is available, like nginx. | `false` |
+| | `ingress.enabled` | If true, an ingress resource is deployed with the Operate deployment. Only useful if an ingress controller is available, like Ingress-NGINX. | `false` |
 | | `ingress.className` | Defines the class or configuration of ingress which should be used by the controller | `nginx` |
 | | `ingress.annotations` | Defines the ingress related annotations, consumed mostly by the ingress controller | `ingress.kubernetes.io/rewrite-target: "/"` <br/> `nginx.ingress.kubernetes.io/ssl-redirect: "false"` |
-| | `ingress.path` | Defines the path which is associated with the Operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules | `/` |
+| | `ingress.path` | Defines the path which is associated with the Operate [service and port](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules) | `/` |
 | | `ingress.host` | Can be used to define the [host of the ingress rule.](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules) If not specified the rules applies to all inbound HTTP traffic, if specified the rule applies to that host. | `""` |
 | | `ingress.tls` | Configuration for [TLS on the ingress resource](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) | |
-| | `ingress.tls.enabled` | If true, then TLS is configured on the ingress resource. If enabled the Ingress.host need to be defined. | `false` |
+| | `ingress.tls.enabled` | If true, then TLS is configured on the ingress resource. If enabled the Ingress.host needs to be defined. | `false` |
 | | `ingress.tls.secretName` | Defines the secret name which contains the TLS private key and certificate | `""` |
 | | `podSecurityContext` | Defines the security options the Operate container should be run with | `{ }` |
 | | `nodeSelector` |  Can be used to define on which nodes the Operate pods should run | `{ }` |
@@ -264,6 +275,7 @@ Information about Tasklist you can find [here](https://docs.camunda.io/docs/comp
 | | `image.repository` | Defines which image repository to use. | `camunda/tasklist` |
 | | `image.tag` | Can be set to overwrite the global tag, which should be used in that chart. | `` |
 | | `image.pullSecrets` | Can be set to overwrite the global.image.pullSecrets | `{{ global.image.pullSecrets }}` |
+| | `contextPath` |  Can be used to make Tasklist web application works on a custom sub-path. This is mainly used to run Camunda Platform web applications under a single domain. | |
 | | `podAnnotations` | Can be used to define extra Tasklist pod annotations | `{ }` |
 | | `podLabels` |  Can be used to define extra Tasklist pod labels | `{ }` |
 | | `configMap.defaultMode` | Can be used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. See [Api docs](https://github.com/kubernetes/api/blob/master/core/v1/types.go#L1615-L1623) for more details. It is useful to configure it if you want to run the helm charts in OpenShift. | [`0744`](https://chmodcommand.com/chmod-744/) |
@@ -281,7 +293,7 @@ Information about Tasklist you can find [here](https://docs.camunda.io/docs/comp
 | | `affinity` |  Can be used to define [pod affinity or anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) | `{ }` |
 | | `resources` | Configuration to set [request and limit configuration for the container](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits) | `requests:`<br>`  cpu: 400m`<br> `  memory: 1Gi`<br>`limits:`<br> ` cpu: 1000m`<br> ` memory: 2Gi` |
 | | `ingress` | Configuration to configure the ingress resource | |
-| | `ingress.enabled` | If true, an ingress resource is deployed with the Tasklist deployment. Only useful if an ingress controller is available, like nginx. | `false` |
+| | `ingress.enabled` | If true, an ingress resource is deployed with the Tasklist deployment. Only useful if an ingress controller is available, like Ingress-NGINX. | `false` |
 | | `ingress.className` | Defines the class or configuration of ingress which should be used by the controller | `nginx` |
 | | `ingress.annotations` | Defines the ingress related annotations, consumed mostly by the ingress controller | `ingress.kubernetes.io/rewrite-target: "/"` <br/> `nginx.ingress.kubernetes.io/ssl-redirect: "false"` |
 | | `ingress.path` | Defines the path which is associated with the Tasklist [service and port](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules) | `/` |
@@ -300,6 +312,7 @@ Information about Optimize you can find [here](https://docs.camunda.io/docs/comp
 | | `image.repository` |  Defines which image repository to use | `camunda/optimize` |
 | | `image.tag` |  Can be set to overwrite the global tag, which should be used in that chart | `3.8.0` |
 | | `image.pullSecrets` | Can be set to overwrite the global.image.pullSecrets | `{{ global.image.pullSecrets }}` |
+| | `contextPath` |  Can be used to make Optimize web application works on a custom sub-path. This is mainly used to run Camunda Platform web applications under a single domain. | |
 | | `podAnnotations` | Can be used to define extra Optimize pod annotations | `{ }` |
 | | `podLabels` |  Can be used to define extra Optimize pod labels | `{ }` |
 | | `partitionCount` |  Defines how many Zeebe partitions are set up in the cluster and which should be imported by Optimize | `"3"` |
@@ -320,13 +333,13 @@ Information about Optimize you can find [here](https://docs.camunda.io/docs/comp
 | | `tolerations` |  Can be used to define [pod toleration's](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) | `[ ]` |
 | | `affinity` |  Can be used to define [pod affinity or anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) | `{ }` |
 | | `resources` | Configuration to set [request and limit configuration for the container](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits) | `requests:`<br>`  cpu: 600m`<br> `  memory: 1Gi`<br>`limits:`<br> ` cpu: 2000m`<br> ` memory: 2Gi` || | `ingress` |  Configuration to configure the ingress resource | |
-| | `ingress.enabled` |  If true, an ingress resource is deployed with the Optimize deployment. Only useful if an ingress controller is available, like nginx. | `false` |
+| | `ingress.enabled` |  If true, an ingress resource is deployed with the Optimize deployment. Only useful if an ingress controller is available, like Ingress-NGINX. | `false` |
 | | `ingress.className` | Defines the class or configuration of ingress which should be used by the controller | `nginx` |
 | | `ingress.annotations` | Defines the ingress related annotations, consumed mostly by the ingress controller | `ingress.kubernetes.io/rewrite-target: "/"` <br/> `nginx.ingress.kubernetes.io/ssl-redirect: "false"` |
 | | `ingress.path` | Defines the path which is associated with the Optimize [service and port](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules) | `/` |
 | | `ingress.host` | Can be used to define the [host of the ingress rule.](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules) If not specified the rules applies to all inbound HTTP traffic, if specified the rule applies to that host. | `""` |
 | | `ingress.tls` | Configuration for [TLS on the ingress resource](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) | |
-| | `ingress.tls.enabled` | If true, then TLS is configured on the ingress resource. If enabled the Ingress.host need to be defined. | `false` |
+| | `ingress.tls.enabled` | If true, then TLS is configured on the ingress resource. If enabled the Ingress.host needs to be defined. | `false` |
 | | `ingress.tls.secretName` | Defines the secret name which contains the TLS private key and certificate | `""` |
 
 ### Identity
@@ -343,6 +356,8 @@ Information about Identity you can find [here](https://docs.camunda.io/docs/self
 | | `image.repository` |  Defines which image repository to use | `camunda/identity` |
 | | `image.tag` |   Can be set to overwrite the global.image.tag | |
 | | `image.pullSecrets` | Can be set to overwrite the global.image.pullSecrets | `{{ global.image.pullSecrets }}` |
+| | `fullURL` |  Can be used when Ingress is configured (for both multi and single domain setup). <br/> Note: If the `ContextPath` is configured, then value of `ContextPath` should be included in the fullURL too. | |
+| | `contextPath` |  Can be used to make Identity web application works on a custom sub-path. This is mainly used to run Camunda Platform web applications under a single domain. | |
 | | `podAnnotations` | Can be used to define extra Identity pod annotations | `{ }` |
 | | `service` |  Configuration to configure the Identity service. | |
 | | `service.type` | Defines the [type of the service](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) | `ClusterIP` |
@@ -364,19 +379,19 @@ Information about Identity you can find [here](https://docs.camunda.io/docs/self
 | | `serviceAccount.enabled` |  If true, enables the Identity service account | `true` |
 | | `serviceAccount.name` |  Can be used to set the name of the Identity service account | `` |
 | | `serviceAccount.annotations` |  Can be used to set the annotations of the Identity service account | `{}` |
-| | `ingress.enabled` | If true, an ingress resource is deployed with the Identity deployment. Only useful if an ingress controller is available, like nginx. | `false` |
+| | `ingress.enabled` | If true, an ingress resource is deployed with the Identity deployment. Only useful if an ingress controller is available, like Ingress-NGINX. | `false` |
 | | `ingress.className` | Defines the class or configuration of ingress which should be used by the controller | `nginx` |
 | | `ingress.annotations` | Defines the ingress related annotations, consumed mostly by the ingress controller | `ingress.kubernetes.io/rewrite-target: "/"` <br/> `nginx.ingress.kubernetes.io/ssl-redirect: "false"` |
 | | `ingress.path` | Defines the path which is associated with the Identity service, - see [ingress-rules](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules) | `/` |
 | | `ingress.host` | Can be used to define the [host of the ingress rule.](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules) If not specified the rules applies to all inbound HTTP traffic, if specified the rule applies to that host. | `""` |
 | | `ingress.tls` | Configuration for [TLS on the ingress resource](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) | |
-| | `ingress.tls.enabled` | If true, then TLS is configured on the ingress resource. If enabled the Ingress.host need to be defined. | `false` |
+| | `ingress.tls.enabled` | If true, then TLS is configured on the ingress resource. If enabled the Ingress.host needs to be defined. | `false` |
 | | `ingress.tls.secretName` | Defines the secret name which contains the TLS private key and certificate | `""` |
 | | `podSecurityContext` | Defines the security options the Identity container should be run with | `{ }` |
 
 ### Elasticsearch
 
-This chart has a dependency to the [Elasticsearch Helm Chart](https://github.com/elastic/helm-charts/blob/master/elasticsearch/README.md). All variables related to Elasticsearch which can be found [here](https://github.com/elastic/helm-charts/blob/main/elasticsearch/values.yaml) can be set under `elasticsearch`.
+This chart has a dependency on the [Elasticsearch Helm Chart](https://github.com/elastic/helm-charts/blob/master/elasticsearch/README.md). All variables related to Elasticsearch which can be found [here](https://github.com/elastic/helm-charts/blob/main/elasticsearch/values.yaml) can be set under `elasticsearch`.
 
 | Section | Parameter | Description | Default |
 |-|-|-|-|

--- a/charts/camunda-platform/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/identity/templates/deployment.yaml
@@ -27,14 +27,20 @@ spec:
         {{- end }}
         imagePullPolicy: {{ .Values.global.image.pullPolicy }}
         env:
+          {{- if .Values.fullURL }}
+          - name: IDENTITY_URL
+            value: {{ .Values.fullURL | quote }}
+          {{- end }}
+          {{- if .Values.contextPath }}
+          - name: IDENTITY_BASE_PATH
+            value: {{ .Values.contextPath | quote }}
+          {{- end }}
           - name: KEYCLOAK_USERS_0_USERNAME
             value: {{ .Values.firstUser.username | quote }}
           - name: KEYCLOAK_USERS_0_PASSWORD
             value: {{ .Values.firstUser.password | quote }}
           - name: KEYCLOAK_USERS_0_ROLES_0
             value: "Identity"
-
-
           {{- if .Values.global.identity.auth.enabled }}
           - name: KEYCLOAK_USERS_0_ROLES_1
             value: "Operate"
@@ -57,7 +63,6 @@ spec:
             {{- end }}
           - name: KEYCLOAK_INIT_OPERATE_ROOT_URL
             value: {{ .Values.global.identity.auth.operate.redirectUrl | quote }}
-
           - name: KEYCLOAK_USERS_0_ROLES_2
             value: "Tasklist"
           - name: KEYCLOAK_INIT_TASKLIST_SECRET
@@ -79,8 +84,6 @@ spec:
             {{- end }}
           - name: KEYCLOAK_INIT_TASKLIST_ROOT_URL
             value: {{ .Values.global.identity.auth.tasklist.redirectUrl | quote }}
-
-
           - name: KEYCLOAK_USERS_0_ROLES_3
             value: "Optimize"
           - name: KEYCLOAK_INIT_OPTIMIZE_SECRET

--- a/charts/camunda-platform/charts/operate/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/operate/templates/deployment.yaml
@@ -31,6 +31,10 @@ spec:
         {{- end }}
         imagePullPolicy: {{ .Values.global.image.pullPolicy }}
         env:
+          {{- if .Values.contextPath }}
+          - name: SERVER_SERVLET_CONTEXT_PATH
+            value: {{ .Values.contextPath | quote }}
+          {{- end }}
           {{- if .Values.global.identity.auth.enabled }}
           - name: SPRING_PROFILES_ACTIVE
             value: "identity-auth"

--- a/charts/camunda-platform/charts/optimize/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/optimize/templates/deployment.yaml
@@ -32,6 +32,10 @@ spec:
         {{- end }}
         imagePullPolicy: {{ .Values.global.image.pullPolicy }}
         env:
+          {{- if .Values.contextPath }}
+          - name: CAMUNDA_OPTIMIZE_CONTEXT_PATH
+            value: {{ .Values.contextPath | quote }}
+          {{- end }}
           - name: CAMUNDA_OPTIMIZE_ZEEBE_ENABLED
             value: "true"
           - name: CAMUNDA_OPTIMIZE_ZEEBE_PARTITION_COUNT

--- a/charts/camunda-platform/charts/tasklist/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/tasklist/templates/deployment.yaml
@@ -32,6 +32,10 @@ spec:
         {{- end }}
         imagePullPolicy: {{ .Values.global.image.pullPolicy }}
         env:
+          {{- if .Values.contextPath }}
+          - name: SERVER_SERVLET_CONTEXT_PATH
+            value: {{ .Values.contextPath | quote }}
+          {{- end }}
           {{- if .Values.global.identity.auth.enabled }}
           - name: SPRING_PROFILES_ACTIVE
             value: "identity-auth"

--- a/charts/camunda-platform/templates/_helpers.tpl
+++ b/charts/camunda-platform/templates/_helpers.tpl
@@ -7,6 +7,24 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (for example,
+by the DNS naming spec). If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "camundaPlatform.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Define common labels, combining the match labels and transient labels, which might change on updating
 (version depending). These labels shouldn't be used on matchLabels selector, since the selectors are immutable.
 */}}

--- a/charts/camunda-platform/templates/ingress.yaml
+++ b/charts/camunda-platform/templates/ingress.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.global.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "camundaPlatform.fullname" . }}
+  labels:
+    {{- include "camundaPlatform.labels" . | nindent 4 }}
+{{- with .Values.global.ingress.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+{{- end }}
+spec:
+  ingressClassName: {{ .Values.global.ingress.className }}
+  rules:
+    {{- if .Values.global.ingress.host }}
+    - host: {{ .Values.global.ingress.host }}
+      http:
+    {{- else }}
+    - http:
+    {{- end }}
+        paths:
+          - backend:
+              service:
+                name: {{ include "keycloak.fullname" .Subcharts.identity.Subcharts.keycloak }}
+                port:
+                  number: {{ .Values.identity.keycloak.service.ports.http }}
+            # It's complex to change the context path in Keycloak v16.x.x, so it's hard-coded.
+            path: /auth
+            pathType: Prefix
+          - backend:
+              service:
+                name: {{ template "identity.fullname" .Subcharts.identity }}
+                port:
+                  number: {{ .Values.identity.service.port }}
+            path: {{ .Values.identity.contextPath }}
+            pathType: Prefix
+          - backend:
+              service:
+                name: {{ template "operate.fullname" .Subcharts.operate }}
+                port:
+                  number: {{ .Values.operate.service.port }}
+            path: {{ .Values.operate.contextPath }}
+            pathType: Prefix
+          - backend:
+              service:
+                name: {{ template "optimize.fullname" .Subcharts.optimize }}
+                port:
+                  number: {{ .Values.optimize.service.port }}
+            path: {{ .Values.optimize.contextPath }}
+            pathType: Prefix
+          - backend:
+              service:
+                name: {{ template "tasklist.fullname" .Subcharts.tasklist }}
+                port:
+                  number: {{ .Values.tasklist.service.port }}
+            path: {{ .Values.tasklist.contextPath }}
+            pathType: Prefix
+  {{- if .Values.global.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.global.ingress.host }}
+      {{- if .Values.global.ingress.tls.secretName }}
+      secretName: {{ .Values.global.ingress.tls.secretName }}
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/camunda-platform/test/identity/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/identity/golden/deployment.golden.yaml
@@ -57,7 +57,6 @@ spec:
                 key: operate-secret
           - name: KEYCLOAK_INIT_OPERATE_ROOT_URL
             value: "http://localhost:8081"
-
           - name: KEYCLOAK_USERS_0_ROLES_2
             value: "Tasklist"
           - name: KEYCLOAK_INIT_TASKLIST_SECRET
@@ -67,8 +66,6 @@ spec:
                 key: tasklist-secret
           - name: KEYCLOAK_INIT_TASKLIST_ROOT_URL
             value: "http://localhost:8082"
-
-
           - name: KEYCLOAK_USERS_0_ROLES_3
             value: "Optimize"
           - name: KEYCLOAK_INIT_OPTIMIZE_SECRET

--- a/charts/camunda-platform/test/ingress_test.go
+++ b/charts/camunda-platform/test/ingress_test.go
@@ -1,0 +1,61 @@
+package test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type ingressTemplateTest struct {
+	suite.Suite
+	chartPath string
+	release   string
+	namespace string
+	templates []string
+}
+
+func TestIngressTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../")
+	require.NoError(t, err)
+
+	suite.Run(t, &ingressTemplateTest{
+		chartPath: chartPath,
+		release:   "camunda-platform-test",
+		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
+		templates: []string{"templates/ingress.yaml"},
+	})
+}
+
+func (s *ingressTemplateTest) TestIngress() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.ingress.enabled": "true",
+			"identity.contextPath":   "/identity",
+			"operate.contextPath":    "/operate",
+			"optimize.contextPath":   "/optimize",
+			"tasklist.contextPath":   "/tasklist",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+
+	// then
+	s.Require().Contains(output, "kind: Ingress")
+	s.Require().Contains(output, "path: /auth")
+	s.Require().Contains(output, "path: /identity")
+	s.Require().Contains(output, "path: /operate")
+	s.Require().Contains(output, "path: /optimize")
+	s.Require().Contains(output, "path: /tasklist")
+}

--- a/charts/camunda-platform/test/optimize/deployment_test.go
+++ b/charts/camunda-platform/test/optimize/deployment_test.go
@@ -572,7 +572,7 @@ func (s *deploymentTemplateTest) TestContainerShouldSetTheRightKeycloakServiceUr
 		})
 }
 
-func (s *deploymentTemplateTest) TestContainerOverwriteGlobalImagePullPolicy() {
+func (s *deploymentTemplateTest) TestContainerShouldOverwriteGlobalImagePullPolicy() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
@@ -592,4 +592,29 @@ func (s *deploymentTemplateTest) TestContainerOverwriteGlobalImagePullPolicy() {
 	s.Require().Equal(1, len(containers))
 	pullPolicy := containers[0].ImagePullPolicy
 	s.Require().Equal(expectedPullPolicy, pullPolicy)
+}
+
+func (s *deploymentTemplateTest) TestContainerShouldAddContextPath() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"optimize.contextPath": "/optimize",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	env := deployment.Spec.Template.Spec.Containers[0].Env
+	s.Require().Contains(env,
+		v12.EnvVar{
+			Name:  "CAMUNDA_OPTIMIZE_CONTEXT_PATH",
+			Value: "/optimize",
+		},
+	)
 }

--- a/charts/camunda-platform/test/tasklist/deployment_test.go
+++ b/charts/camunda-platform/test/tasklist/deployment_test.go
@@ -597,7 +597,7 @@ func (s *deploymentTemplateTest) TestContainerShouldSetTheRightKeycloakServiceUr
 		})
 }
 
-func (s *deploymentTemplateTest) TestContainerOverwriteGlobalImagePullPolicy() {
+func (s *deploymentTemplateTest) TestContainerShouldOverwriteGlobalImagePullPolicy() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
@@ -617,4 +617,29 @@ func (s *deploymentTemplateTest) TestContainerOverwriteGlobalImagePullPolicy() {
 	s.Require().Equal(1, len(containers))
 	pullPolicy := containers[0].ImagePullPolicy
 	s.Require().Equal(expectedPullPolicy, pullPolicy)
+}
+
+func (s *deploymentTemplateTest) TestContainerShouldAddContextPath() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"tasklist.contextPath": "/tasklist",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	env := deployment.Spec.Template.Spec.Containers[0].Env
+	s.Require().Contains(env,
+		v12.EnvVar{
+			Name:  "SERVER_SERVLET_CONTEXT_PATH",
+			Value: "/tasklist",
+		},
+	)
 }

--- a/charts/camunda-platform/test/zeebe-gateway/deployment_test.go
+++ b/charts/camunda-platform/test/zeebe-gateway/deployment_test.go
@@ -559,7 +559,7 @@ func (s *deploymentTemplateTest) TestContainerSetExtraInitContainers() {
 	s.Require().Equal([]string{"sh", "-c", "top"}, initContainer.Command)
 }
 
-func (s *deploymentTemplateTest) TestContainerOverwriteGlobalImagePullPolicy() {
+func (s *deploymentTemplateTest) TestContainerShouldOverwriteGlobalImagePullPolicy() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{

--- a/charts/camunda-platform/test/zeebe/statefulset_test.go
+++ b/charts/camunda-platform/test/zeebe/statefulset_test.go
@@ -663,7 +663,7 @@ func (s *statefulSetTest) TestContainerSetPersistenceTypeLocal() {
 	s.Require().Equal(0, len(statefulSet.Spec.VolumeClaimTemplates))
 }
 
-func (s *statefulSetTest) TestContainerOverwriteGlobalImagePullPolicy() {
+func (s *statefulSetTest) TestContainerShouldOverwriteGlobalImagePullPolicy() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -40,6 +40,26 @@ global:
     # Image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
     pullSecrets: []
 
+  # Ingress configuration to configure the ingress resource
+  ingress:
+    # Ingress.enabled if true, an ingress resource is deployed. Only useful if an ingress controller is available, like Ingress-NGINX.
+    enabled: false
+    # Ingress.className defines the class or configuration of ingress which should be used by the controller
+    className: nginx
+    # Ingress.annotations defines the ingress related annotations, consumed mostly by the ingress controller
+    annotations:
+      ingress.kubernetes.io/rewrite-target: "/"
+      nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    # Ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
+    # If not specified the rules applies to all inbound http traffic, if specified the rule applies to that host.
+    host: ""
+    # Ingress.tls configuration for tls on the ingress resource https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+    tls:
+      # Ingress.tls.enabled if true, then tls is configured on the ingress resource. If enabled the Ingress.host need to be defined.
+      enabled: false
+      # Ingress.tls.secretName defines the secret name which contains the TLS private key and certificate
+      secretName: ""
+
   # Elasticsearch configuration which is shared between the sub charts  
   elasticsearch:
     # Elasticsearch.disableExporter if true, disables the elastic exporter in zeebe
@@ -58,7 +78,6 @@ global:
   zeebeClusterName: "{{ .Release.Name }}-zeebe"
   # ZeebePort defines the port which is used for the Zeebe Gateway. This port accepts the GRPC Client messages and forwards them to the Zeebe Brokers.
   zeebePort: 26500
-
 
   # Identity configuration to configure identity specifics on global level, which can be accessed by other sub-charts
   identity:
@@ -153,7 +172,6 @@ zeebe:
     -XX:HeapDumpPath=/usr/local/zeebe/data
     -XX:ErrorFile=/usr/local/zeebe/data/zeebe_error%p.log
     -XX:+ExitOnOutOfMemoryError
-
 
  # Service configuration for the broker service
   service:
@@ -417,6 +435,9 @@ operate:
     # Image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
     pullSecrets: []
 
+  # ContextPath can be used to make Operate web application works on a custom sub-path. This is mainly used to run Camunda Platform web applications under a single domain.
+  # contextPath: "/operate"
+
   # PodAnnotations can be used to define extra Operate pod annotations
   podAnnotations: { }
   # PodLabels can be used to define extra Operate pod labels
@@ -515,6 +536,9 @@ tasklist:
     # Image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
     pullSecrets: []
 
+  # ContextPath can be used to make Tasklist web application works on a custom sub-path. This is mainly used to run Camunda Platform web applications under a single domain.
+  # contextPath: "/tasklist"
+
   # Env can be used to set extra environment variables on each Tasklist container
   env: [ ]
 
@@ -600,6 +624,9 @@ optimize:
     tag: 3.9.0-preview-2
     # Image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
     pullSecrets: []
+
+  # ContextPath can be used to make Optimize web application works on a custom sub-path. This is mainly used to run Camunda Platform web applications under a single domain.
+  # contextPath: "/optimize"
 
   # PodAnnotations can be used to define extra Optimize pod annotations
   podAnnotations: { }
@@ -736,6 +763,13 @@ identity:
     tag:
     # Image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
     pullSecrets: []
+
+  # FullURL can be used when Ingress is configured (for both multi and single domain setup).
+  # Note: If the `ContextPath` is configured, then value of `ContextPath` should be included in the URL too.
+  # fullURL: "https://camunda.example.com/identity"
+
+  # ContextPath can be used to make Identity web application works on a custom sub-path. This is mainly used to run Camunda Platform web applications under a single domain.
+  # contextPath: "/identity"
 
   # PodAnnotations can be used to define extra Identity pod annotations
   podAnnotations: { }


### PR DESCRIPTION
### Related issues

Fixes: camunda/distribution/issues/5

### What's in this PR?

Allow to Camunda Platform 8 components to work on a single domain and multi sub-paths.

### Which problem does the PR fix?

N/A

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added.
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?