### PR TITLE
Fix: unify sub-charts icons

### DIFF
--- a/charts/camunda-platform/charts/identity/Chart.yaml
+++ b/charts/camunda-platform/charts/identity/Chart.yaml
@@ -3,7 +3,7 @@ description: Identity Helm Chart for Kubernetes
 name: identity
 version: 8.0.13
 type: application
-icon: https://raw.githubusercontent.com/camunda-cloud/camunda-cloud-documentation/master/static/img/iam.png
+icon: https://helm.camunda.io/imgs/camunda.svg
 annotations:
   artifacthub.io/changes: |
     - create identity sub chart

--- a/charts/camunda-platform/charts/operate/Chart.yaml
+++ b/charts/camunda-platform/charts/operate/Chart.yaml
@@ -3,7 +3,7 @@ description: Operate Helm Chart for Kubernetes
 name: operate
 version: 8.0.13
 type: application
-icon: https://raw.githubusercontent.com/camunda-cloud/camunda-cloud-documentation/master/static/img/camunda-operate-gradient.png
+icon: https://helm.camunda.io/imgs/camunda.svg
 annotations:
   artifacthub.io/changes: |
     - create operate sub chart

--- a/charts/camunda-platform/charts/optimize/Chart.yaml
+++ b/charts/camunda-platform/charts/optimize/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Optimize Helm Chart for Kubernetes
 name: optimize
 version: 8.0.13
-icon: https://helm.camunda.io/imgs/zeebe-logo.png
+icon: https://helm.camunda.io/imgs/camunda.svg
 annotations:
   artifacthub.io/changes: |
     - create optimize sub chart

--- a/charts/camunda-platform/charts/tasklist/Chart.yaml
+++ b/charts/camunda-platform/charts/tasklist/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Zeebe TaskList Helm Chart for Kubernetes
 name: tasklist
 version: 8.0.13
-icon: https://helm.camunda.io/imgs/zeebe-logo.png
+icon: https://helm.camunda.io/imgs/camunda.svg
 annotations:
   artifacthub.io/changes: |
     - create tasklist sub chart

--- a/charts/camunda-platform/charts/zeebe-gateway/Chart.yaml
+++ b/charts/camunda-platform/charts/zeebe-gateway/Chart.yaml
@@ -3,7 +3,7 @@ description: Zeebe Gateway Helm Chart for Kubernetes
 name: zeebe-gateway
 type: application
 version: 8.0.13
-icon: https://helm.camunda.io/imgs/zeebe-logo.png
+icon: https://helm.camunda.io/imgs/camunda.svg
 annotations:
   artifacthub.io/changes: |
     - add zeebe-gateway sub chart

--- a/charts/camunda-platform/charts/zeebe/Chart.yaml
+++ b/charts/camunda-platform/charts/zeebe/Chart.yaml
@@ -3,7 +3,7 @@ description: Zeebe Helm Chart for Kubernetes
 name: zeebe
 type: application
 version: 8.0.13
-icon: https://helm.camunda.io/imgs/zeebe-logo.png
+icon: https://helm.camunda.io/imgs/camunda.svg
 annotations:
   artifacthub.io/changes: |
     - rewrite zeebe chart


### PR DESCRIPTION
### Related issues
Fixes: #288

### What's in this PR?

Unify sub-charts icons to use Camunda's logo because:
- The components themselves don't use their logos as a fav icon when run locally.
- In Camunda SaaS also, the components don't use their logos.
- Since we are using an umbrella chart and the sub-chart are not independent charts. 

### Which problem does the PR fix?

The wrong icons were used for sub-charts.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added (not needed).
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?
