### PR TITLE
fix(test): correct the order of expected and actual parameters

### DIFF
--- a/charts/camunda-platform/test/identity/deployment_test.go
+++ b/charts/camunda-platform/test/identity/deployment_test.go
@@ -205,7 +205,7 @@ func (s *deploymentTemplateTest) TestContainerSetContainerCommand() {
 
 	// then
 	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(len(containers), 1)
+	s.Require().Equal(1, len(containers))
 	s.Require().Equal(1, len(containers[0].Command))
 	s.Require().Equal("printenv", containers[0].Command[0])
 }
@@ -228,7 +228,7 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumes() {
 
 	// then
 	volumes := deployment.Spec.Template.Spec.Volumes
-	s.Require().Equal(len(volumes), 1)
+	s.Require().Equal(1, len(volumes))
 
 	extraVolume := volumes[0]
 	s.Require().Equal("extraVolume", extraVolume.Name)
@@ -254,10 +254,10 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumeMounts() {
 
 	// then
 	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(len(containers), 1)
+	s.Require().Equal(1, len(containers))
 
 	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(len(volumeMounts), 1)
+	s.Require().Equal(1, len(volumeMounts))
 	extraVolumeMount := volumeMounts[0]
 	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
 	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
@@ -284,7 +284,7 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumesAndMounts() {
 
 	// then
 	volumes := deployment.Spec.Template.Spec.Volumes
-	s.Require().Equal(len(volumes), 1)
+	s.Require().Equal(1, len(volumes))
 
 	extraVolume := volumes[0]
 	s.Require().Equal("extraVolume", extraVolume.Name)
@@ -293,10 +293,10 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumesAndMounts() {
 	s.Require().EqualValues(744, *extraVolume.ConfigMap.DefaultMode)
 
 	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(len(containers), 1)
+	s.Require().Equal(1, len(containers))
 
 	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(len(volumeMounts), 1)
+	s.Require().Equal(1, len(volumeMounts))
 	extraVolumeMount := volumeMounts[0]
 	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
 	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)

--- a/charts/camunda-platform/test/identity/secret_test.go
+++ b/charts/camunda-platform/test/identity/secret_test.go
@@ -58,7 +58,7 @@ func (s *secretTest) TestContainerGenerateSecret() {
 	}
 
 	// when
-	s.Require().GreaterOrEqual(len(s.templates), 1)
+	s.Require().GreaterOrEqual(2, len(s.templates))
 	for idx, template := range s.templates {
 		output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, []string{template})
 		var secret coreV1.Secret

--- a/charts/camunda-platform/test/integration/integration_suite.go
+++ b/charts/camunda-platform/test/integration/integration_suite.go
@@ -18,12 +18,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/suite"
 	"net/http"
 	"strings"
 	"time"
 
+	"github.com/stretchr/testify/suite"
+
 	"context"
+
 	"github.com/camunda-cloud/zeebe/clients/go/pkg/pb"
 	"github.com/camunda-cloud/zeebe/clients/go/pkg/zbc"
 	"github.com/gruntwork-io/terratest/modules/k8s"
@@ -64,7 +66,7 @@ func (s *integrationSuite) assertProcessDefinitionFromOperate() {
 			}
 
 			total := objectMap["total"].(float64)
-			s.Require().GreaterOrEqual(total, float64(1))
+			s.Require().GreaterOrEqual(float64(1), total)
 
 			s.Require().Contains(jsonString, "it-test-process")
 
@@ -92,7 +94,7 @@ func (s *integrationSuite) assertTasksFromTasklist() {
 
 			data := objectMap["data"].(map[string]interface{})
 			tasks := data["tasks"].([]interface{})
-			s.Require().GreaterOrEqual(len(tasks), 1)
+			s.Require().GreaterOrEqual(1, len(tasks))
 			task := tasks[0].(map[string]interface{})
 			s.Require().Equal("It Test", task["name"])
 

--- a/charts/camunda-platform/test/operate/deployment_test.go
+++ b/charts/camunda-platform/test/operate/deployment_test.go
@@ -227,7 +227,7 @@ func (s *deploymentTemplateTest) TestContainerSetContainerCommand() {
 
 	// then
 	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(len(containers), 1)
+	s.Require().Equal(1, len(containers))
 	s.Require().Equal(1, len(containers[0].Command))
 	s.Require().Equal("printenv", containers[0].Command[0])
 }
@@ -251,7 +251,7 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumes() {
 
 	// then
 	volumes := deployment.Spec.Template.Spec.Volumes
-	s.Require().Equal(len(volumes), 2)
+	s.Require().Equal(2, len(volumes))
 
 	extraVolume := volumes[1]
 	s.Require().Equal("extraVolume", extraVolume.Name)
@@ -278,10 +278,10 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumeMounts() {
 
 	// then
 	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(len(containers), 1)
+	s.Require().Equal(1, len(containers))
 
 	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(len(volumeMounts), 2)
+	s.Require().Equal(2, len(volumeMounts))
 	extraVolumeMount := volumeMounts[1]
 	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
 	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
@@ -308,7 +308,7 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumesAndMounts() {
 
 	// then
 	volumes := deployment.Spec.Template.Spec.Volumes
-	s.Require().Equal(len(volumes), 2)
+	s.Require().Equal(2, len(volumes))
 
 	extraVolume := volumes[1]
 	s.Require().Equal("extraVolume", extraVolume.Name)
@@ -317,10 +317,10 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumesAndMounts() {
 	s.Require().EqualValues(744, *extraVolume.ConfigMap.DefaultMode)
 
 	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(len(containers), 1)
+	s.Require().Equal(1, len(containers))
 
 	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(len(volumeMounts), 2)
+	s.Require().Equal(2, len(volumeMounts))
 	extraVolumeMount := volumeMounts[1]
 	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
 	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)

--- a/charts/camunda-platform/test/optimize/deployment_test.go
+++ b/charts/camunda-platform/test/optimize/deployment_test.go
@@ -230,7 +230,7 @@ func (s *deploymentTemplateTest) TestContainerSetContainerCommand() {
 
 	// then
 	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(len(containers), 1)
+	s.Require().Equal(1, len(containers))
 	s.Require().Equal(1, len(containers[0].Command))
 	s.Require().Equal("printenv", containers[0].Command[0])
 }
@@ -254,7 +254,7 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumes() {
 
 	// then
 	volumes := deployment.Spec.Template.Spec.Volumes
-	s.Require().Equal(len(volumes), 1)
+	s.Require().Equal(1, len(volumes))
 
 	extraVolume := volumes[0]
 	s.Require().Equal("extraVolume", extraVolume.Name)
@@ -281,10 +281,10 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumeMounts() {
 
 	// then
 	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(len(containers), 1)
+	s.Require().Equal(1, len(containers))
 
 	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(len(volumeMounts), 1)
+	s.Require().Equal(1, len(volumeMounts))
 	extraVolumeMount := volumeMounts[0]
 	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
 	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
@@ -311,7 +311,7 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumesAndMounts() {
 
 	// then
 	volumes := deployment.Spec.Template.Spec.Volumes
-	s.Require().Equal(len(volumes), 1)
+	s.Require().Equal(1, len(volumes))
 
 	extraVolume := volumes[0]
 	s.Require().Equal("extraVolume", extraVolume.Name)
@@ -320,10 +320,10 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumesAndMounts() {
 	s.Require().EqualValues(744, *extraVolume.ConfigMap.DefaultMode)
 
 	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(len(containers), 1)
+	s.Require().Equal(1, len(containers))
 
 	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(len(volumeMounts), 1)
+	s.Require().Equal(1, len(volumeMounts))
 	extraVolumeMount := volumeMounts[0]
 	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
 	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)

--- a/charts/camunda-platform/test/tasklist/deployment_test.go
+++ b/charts/camunda-platform/test/tasklist/deployment_test.go
@@ -243,7 +243,7 @@ func (s *deploymentTemplateTest) TestContainerSetContainerCommand() {
 
 	// then
 	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(len(containers), 1)
+	s.Require().Equal(1, len(containers))
 	s.Require().Equal(1, len(containers[0].Command))
 	s.Require().Equal("printenv", containers[0].Command[0])
 }

--- a/charts/camunda-platform/test/zeebe-gateway/deployment_test.go
+++ b/charts/camunda-platform/test/zeebe-gateway/deployment_test.go
@@ -262,7 +262,7 @@ func (s *deploymentTemplateTest) TestContainerSetContainerCommand() {
 
 	// then
 	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(len(containers), 1)
+	s.Require().Equal(1, len(containers))
 	s.Require().Equal(1, len(containers[0].Command))
 	s.Require().Equal("printenv", containers[0].Command[0])
 }
@@ -307,7 +307,7 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumes() {
 
 	// then
 	volumes := deployment.Spec.Template.Spec.Volumes
-	s.Require().Equal(len(volumes), 2)
+	s.Require().Equal(2, len(volumes))
 
 	extraVolume := volumes[1]
 	s.Require().Equal("extraVolume", extraVolume.Name)
@@ -333,7 +333,7 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumeMounts() {
 
 	// then
 	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(len(volumeMounts), 1)
+	s.Require().Equal(1, len(volumeMounts))
 	extraVolumeMount := volumeMounts[0]
 	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
 	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
@@ -359,7 +359,7 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumesAndMounts() {
 
 	// then
 	volumes := deployment.Spec.Template.Spec.Volumes
-	s.Require().Equal(len(volumes), 2)
+	s.Require().Equal(2, len(volumes))
 
 	extraVolume := volumes[1]
 	s.Require().Equal("extraVolume", extraVolume.Name)
@@ -368,7 +368,7 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumesAndMounts() {
 	s.Require().EqualValues(744, *extraVolume.ConfigMap.DefaultMode)
 
 	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(len(volumeMounts), 1)
+	s.Require().Equal(1, len(volumeMounts))
 	extraVolumeMount := volumeMounts[0]
 	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
 	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)

--- a/charts/camunda-platform/test/zeebe/statefulset_test.go
+++ b/charts/camunda-platform/test/zeebe/statefulset_test.go
@@ -326,7 +326,7 @@ func (s *statefulSetTest) TestContainerSetContainerCommand() {
 
 	// then
 	containers := statefulSet.Spec.Template.Spec.Containers
-	s.Require().Equal(len(containers), 1)
+	s.Require().Equal(1, len(containers))
 	s.Require().Equal(1, len(containers[0].Command))
 	s.Require().Equal("printenv", containers[0].Command[0])
 }
@@ -372,7 +372,7 @@ func (s *statefulSetTest) TestContainerSetExtraVolumes() {
 
 	// then
 	volumes := statefulSet.Spec.Template.Spec.Volumes
-	s.Require().Equal(len(volumes), 3)
+	s.Require().Equal(3, len(volumes))
 
 	extraVolume := volumes[2]
 	s.Require().Equal("extraVolume", extraVolume.Name)
@@ -399,7 +399,7 @@ func (s *statefulSetTest) TestContainerSetExtraVolumeMounts() {
 
 	// then
 	volumeMounts := statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(len(volumeMounts), 4)
+	s.Require().Equal(4, len(volumeMounts))
 	extraVolumeMount := volumeMounts[3]
 	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
 	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
@@ -425,7 +425,7 @@ func (s *statefulSetTest) TestContainerSetExtraVolumesAndMounts() {
 
 	// then
 	volumes := statefulSet.Spec.Template.Spec.Volumes
-	s.Require().Equal(len(volumes), 3)
+	s.Require().Equal(3, len(volumes))
 
 	extraVolume := volumes[2]
 	s.Require().Equal("extraVolume", extraVolume.Name)
@@ -434,7 +434,7 @@ func (s *statefulSetTest) TestContainerSetExtraVolumesAndMounts() {
 	s.Require().EqualValues(744, *extraVolume.ConfigMap.DefaultMode)
 
 	volumeMounts := statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(len(volumeMounts), 4)
+	s.Require().Equal(4, len(volumeMounts))
 	extraVolumeMount := volumeMounts[3]
 	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
 	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)


### PR DESCRIPTION
### Related issues

Fixes: #386

### What's in this PR?

A fix to use the correct order of expected and actual parameters in the tests.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added.
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?
