### PR TITLE
feat: configure securityContext for pod and container

### DIFF
--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -150,7 +150,8 @@ Information about Zeebe you can find [here](https://docs.camunda.io/docs/compone
 | | `podDisruptionBudget.enabled` | If true a pod disruption budget is defined for the brokers | `false` |
 | | `podDisruptionBudget.minAvailable` | Can be used to set how many pods should be available. Be aware that if minAvailable is set, maxUnavailable will not be set (they are mutually exclusive). | `` |
 | | `podDisruptionBudget.maxUnavailable` | Can be used to set how many pods should be at max. unavailable | `1` |
-| | `containerSecurityContext` | Defines the security options the broker container should be run with | |
+| | `podSecurityContext` | Defines the security options the Zeebe broker pod should be run with | `{ }` |
+| | `containerSecurityContext` | Defines the security options the Zeebe broker container should be run with | `{ }` |
 | | `nodeSelector` | Can be used to define on which nodes the broker pods should run | `{ } ` |
 | | `tolerations` | Can be used to define [pod toleration's](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) | `[ ]` |
 | | `affinity` | Can be used to define [pod affinity or anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity). The default defined PodAntiAffinity allows constraining on which nodes the [Zeebe pods are scheduled on](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity). It uses a hard requirement for scheduling and works based on the Zeebe pod labels. To disable the default rule set `podAntiAffinity: null`. | `podAntiAffinity:`</br>`  requiredDuringSchedulingIgnoredDuringExecution:`</br>`  - labelSelector: `</br>`    matchExpressions:`</br>`    - key: "app.kubernetes.io/component"`</br>`    operator: In`</br>`    values:`</br>`    - zeebe-broker`</br>`  topologyKey: "kubernetes.io/hostname"` |
@@ -181,7 +182,8 @@ Information about the Zeebe Gateway you can find [here](https://docs.camunda.io/
 | | `env` | Can be used to set extra environment variables in each gateway container | `[ ]` |
 | | `configMap.defaultMode` | Can be used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. See [Api docs](https://github.com/kubernetes/api/blob/master/core/v1/types.go#L1615-L1623) for more details. It is useful to configure it if you want to run the helm charts in OpenShift. | [`0744`](https://chmodcommand.com/chmod-744/) |
 | | `command` | Can be used to [override the default command provided by the container image](https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/) | `[]` |
-| | `containerSecurityContext` | Defines the security options the gateway container should be run with | `{ } `|
+| | `podSecurityContext` | Defines the security options the Zeebe Gateway pod should be run with | `{ }` |
+| | `containerSecurityContext` | Defines the security options the Zeebe Gateway container should be run with | `{ }` |
 | | `podDisruptionBudget` | Configuration to configure a [pod disruption budget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) for the broker pods. | |
 | | `podDisruptionBudget.enabled` | If true a pod disruption budget is defined for the brokers | `false` |
 | | `podDisruptionBudget.minAvailable` | Can be used to set how many pods should be available. Be aware that if minAvailable is set, maxUnavailable will not be set (they are mutually exclusive). | `` |
@@ -258,7 +260,8 @@ Information about Operate you can find [here](https://docs.camunda.io/docs/compo
 | | `ingress.tls` | Configuration for [TLS on the ingress resource](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) | |
 | | `ingress.tls.enabled` | If true, then TLS is configured on the ingress resource. If enabled the Ingress.host needs to be defined. | `false` |
 | | `ingress.tls.secretName` | Defines the secret name which contains the TLS private key and certificate | `""` |
-| | `podSecurityContext` | Defines the security options the Operate container should be run with | `{ }` |
+| | `podSecurityContext` | Defines the security options the Operate pod should be run with | `{ }` |
+| | `containerSecurityContext` | Defines the security options the Operate container should be run with | `{ }` |
 | | `nodeSelector` |  Can be used to define on which nodes the Operate pods should run | `{ }` |
 | | `tolerations` |  Can be used to define [pod toleration's](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) | `[ ] ` |
 | | `affinity` |  Can be used to define [pod affinity or anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) | `{ }` |
@@ -287,7 +290,8 @@ Information about Tasklist you can find [here](https://docs.camunda.io/docs/comp
 | | `graphqlPlaygroundEnabled` | Can be set to include the credentials in each request, should be set to "include" if GraphQl playground is enabled | `""` |
 | | `extraVolumes` | Can be used to define extra volumes for the Tasklist pods, useful for tls and self-signed certificates | `[]` |
 | | `extraVolumeMounts` | Can be used to mount extra volumes for the Tasklist pods, useful for tls and self-signed certificates | `[]` |
-| | `podSecurityContext` | Defines the security options the Tasklist container should be run with | `{ }` |
+| | `podSecurityContext` | Defines the security options the Tasklist pod should be run with | `{ }` |
+| | `containerSecurityContext` | Defines the security options the Tasklist container should be run with | `{ }` |
 | | `nodeSelector` |  Can be used to define on which nodes the Tasklist pods should run | `{ }` |
 | | `tolerations` |  Can be used to define [pod toleration's](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) | `[ ]` |
 | | `affinity` |  Can be used to define [pod affinity or anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) | `{ }` |
@@ -328,7 +332,8 @@ Information about Optimize you can find [here](https://docs.camunda.io/docs/comp
 | | `service.type` | Defines the [type of the service](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) | `ClusterIP` |
 | | `service.port` | Defines the port of the service, where the Optimize web application will be available | `80` |
 | | `service.annotations` |  Can be used to define annotations, which will be applied to the Optimize service | `{}` |
-| | `podSecurityContext` |  Defines the security options the operate container should be run with | `{}` |
+| | `podSecurityContext` | Defines the security options the Optimize pod should be run with | `{ }` |
+| | `containerSecurityContext` | Defines the security options the Optimize container should be run with | `{ }` |
 | | `nodeSelector` |  Can be used to define on which nodes the Optimize pods should run | `{}` |
 | | `tolerations` |  Can be used to define [pod toleration's](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) | `[ ]` |
 | | `affinity` |  Can be used to define [pod affinity or anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) | `{ }` |
@@ -387,7 +392,8 @@ Information about Identity you can find [here](https://docs.camunda.io/docs/self
 | | `ingress.tls` | Configuration for [TLS on the ingress resource](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) | |
 | | `ingress.tls.enabled` | If true, then TLS is configured on the ingress resource. If enabled the Ingress.host needs to be defined. | `false` |
 | | `ingress.tls.secretName` | Defines the secret name which contains the TLS private key and certificate | `""` |
-| | `podSecurityContext` | Defines the security options the Identity container should be run with | `{ }` |
+| | `podSecurityContext` | Defines the security options the Identity pod should be run with | `{ }` |
+| | `containerSecurityContext` | Defines the security options the Identity container should be run with | `{ }` |
 
 ### Elasticsearch
 

--- a/charts/camunda-platform/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/identity/templates/deployment.yaml
@@ -26,6 +26,9 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
         {{- end }}
         imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+        {{- if .Values.containerSecurityContext }}
+        securityContext: {{- toYaml .Values.containerSecurityContext | nindent 10 }}
+        {{- end }}
         env:
           {{- if .Values.fullURL }}
           - name: IDENTITY_URL
@@ -164,8 +167,7 @@ spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- end }}
       {{- if .Values.podSecurityContext }}
-      securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/camunda-platform/charts/operate/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/operate/templates/deployment.yaml
@@ -30,6 +30,9 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
         {{- end }}
         imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+        {{- if .Values.containerSecurityContext }}
+        securityContext: {{- toYaml .Values.containerSecurityContext | nindent 10 }}
+        {{- end }}
         env:
           {{- if .Values.contextPath }}
           - name: SERVER_SERVLET_CONTEXT_PATH
@@ -103,8 +106,7 @@ spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- end }}
       {{- if .Values.podSecurityContext }}
-      securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- end }}
 {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/camunda-platform/charts/optimize/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/optimize/templates/deployment.yaml
@@ -31,6 +31,9 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
         {{- end }}
         imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+        {{- if .Values.containerSecurityContext }}
+        securityContext: {{- toYaml .Values.containerSecurityContext | nindent 10 }}
+        {{- end }}
         env:
           {{- if .Values.contextPath }}
           - name: CAMUNDA_OPTIMIZE_CONTEXT_PATH

--- a/charts/camunda-platform/charts/tasklist/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/tasklist/templates/deployment.yaml
@@ -31,6 +31,9 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
         {{- end }}
         imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+        {{- if .Values.containerSecurityContext }}
+        securityContext: {{- toYaml .Values.containerSecurityContext | nindent 10 }}
+        {{- end }}
         env:
           {{- if .Values.contextPath }}
           - name: SERVER_SERVLET_CONTEXT_PATH

--- a/charts/camunda-platform/charts/zeebe-gateway/templates/gateway-deployment.yaml
+++ b/charts/camunda-platform/charts/zeebe-gateway/templates/gateway-deployment.yaml
@@ -91,7 +91,7 @@ spec:
             {{ .Values.extraVolumeMounts | toYaml | nindent 12 }}
             {{- end }}
           {{- if .Values.containerSecurityContext }}
-          securityContext: {{ .Values.containerSecurityContext | toYaml | nindent 12  }}
+          securityContext: {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           {{- end }}
           readinessProbe:
             tcpSocket:
@@ -112,6 +112,9 @@ spec:
         {{- end }}
       {{- if .Values.serviceAccount.name}}
       serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}
+      {{- if .Values.podSecurityContext }}
+      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- end }}
 {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/camunda-platform/charts/zeebe/templates/statefulset.yaml
+++ b/charts/camunda-platform/charts/zeebe/templates/statefulset.yaml
@@ -45,6 +45,9 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
         {{- end }}
         imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+        {{- if .Values.containerSecurityContext }}
+        securityContext: {{- toYaml .Values.containerSecurityContext | nindent 10 }}
+        {{- end }}
         env:
         - name: LC_ALL
           value: C.UTF-8
@@ -144,9 +147,6 @@ spec:
         {{- if .Values.extraVolumeMounts}}
         {{ .Values.extraVolumeMounts | toYaml | nindent 8 }}
         {{- end }}
-        {{- if .Values.containerSecurityContext }}
-        securityContext: {{ .Values.containerSecurityContext | toYaml | nindent 10 }}
-        {{- end }}
       volumes:
         {{- if eq .Values.persistenceType "memory" }}
         - name: data
@@ -164,6 +164,9 @@ spec:
         {{- end }}
       {{- if .Values.serviceAccount.name }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}
+      {{- if .Values.podSecurityContext }}
+      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- end }}
 {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/camunda-platform/test/operate/deployment_test.go
+++ b/charts/camunda-platform/test/operate/deployment_test.go
@@ -346,14 +346,13 @@ func (s *deploymentTemplateTest) TestContainerSetServiceAccountName() {
 	s.Require().Equal("accName", serviceAccName)
 }
 
-func (s *deploymentTemplateTest) TestContainerSetSecurityContext() {
+func (s *deploymentTemplateTest) TestPodSetSecurityContext() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
 			"operate.podSecurityContext.runAsUser": "1000",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},
 	}
 
 	// when
@@ -364,6 +363,27 @@ func (s *deploymentTemplateTest) TestContainerSetSecurityContext() {
 	// then
 	securityContext := deployment.Spec.Template.Spec.SecurityContext
 	s.Require().EqualValues(1000, *securityContext.RunAsUser)
+}
+
+func (s *deploymentTemplateTest) TestContainerSetSecurityContext() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"operate.containerSecurityContext.privileged":          "true",
+			"operate.containerSecurityContext.capabilities.add[0]": "NET_ADMIN",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	securityContext := deployment.Spec.Template.Spec.Containers[0].SecurityContext
+	s.Require().True(*securityContext.Privileged)
+	s.Require().EqualValues("NET_ADMIN", securityContext.Capabilities.Add[0])
 }
 
 // https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector

--- a/charts/camunda-platform/test/optimize/deployment_test.go
+++ b/charts/camunda-platform/test/optimize/deployment_test.go
@@ -349,14 +349,13 @@ func (s *deploymentTemplateTest) TestContainerSetServiceAccountName() {
 	s.Require().Equal("accName", serviceAccName)
 }
 
-func (s *deploymentTemplateTest) TestContainerSetSecurityContext() {
+func (s *deploymentTemplateTest) TestPodSetSecurityContext() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
 			"optimize.podSecurityContext.runAsUser": "1000",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},
 	}
 
 	// when
@@ -367,6 +366,27 @@ func (s *deploymentTemplateTest) TestContainerSetSecurityContext() {
 	// then
 	securityContext := deployment.Spec.Template.Spec.SecurityContext
 	s.Require().EqualValues(1000, *securityContext.RunAsUser)
+}
+
+func (s *deploymentTemplateTest) TestContainerSetSecurityContext() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"optimize.containerSecurityContext.privileged":          "true",
+			"optimize.containerSecurityContext.capabilities.add[0]": "NET_ADMIN",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	securityContext := deployment.Spec.Template.Spec.Containers[0].SecurityContext
+	s.Require().True(*securityContext.Privileged)
+	s.Require().EqualValues("NET_ADMIN", securityContext.Capabilities.Add[0])
 }
 
 // https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector

--- a/charts/camunda-platform/test/zeebe-gateway/deployment_test.go
+++ b/charts/camunda-platform/test/zeebe-gateway/deployment_test.go
@@ -374,6 +374,25 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumesAndMounts() {
 	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
 }
 
+func (s *deploymentTemplateTest) TestPodSetSecurityContext() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"zeebe-gateway.podSecurityContext.runAsUser": "1000",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	securityContext := deployment.Spec.Template.Spec.SecurityContext
+	s.Require().EqualValues(1000, *securityContext.RunAsUser)
+}
+
 func (s *deploymentTemplateTest) TestContainerSetSecurityContext() {
 	// given
 	options := &helm.Options{

--- a/charts/camunda-platform/test/zeebe/statefulset_test.go
+++ b/charts/camunda-platform/test/zeebe/statefulset_test.go
@@ -440,6 +440,25 @@ func (s *statefulSetTest) TestContainerSetExtraVolumesAndMounts() {
 	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
 }
 
+func (s *statefulSetTest) TestPodSetSecurityContext() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"zeebe.podSecurityContext.runAsUser": "1000",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var statefulSet v1.StatefulSet
+	helm.UnmarshalK8SYaml(s.T(), output, &statefulSet)
+
+	// then
+	securityContext := statefulSet.Spec.Template.Spec.SecurityContext
+	s.Require().EqualValues(1000, *securityContext.RunAsUser)
+}
+
 func (s *statefulSetTest) TestContainerSetSecurityContext() {
 	// given
 	options := &helm.Options{

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -250,8 +250,12 @@ zeebe:
     # podDisruptionBudget.maxUnavailable can be used to set how many pods should be at max. unavailable
     maxUnavailable: 1
 
-  # ContainerSecurityContext defines the security options the broker container should be run with
+  # PodSecurityContext defines the security options the Zeebe broker pod should be run with
+  podSecurityContext: { }
+
+  # ContainerSecurityContext defines the security options the Zeebe broker container should be run with
   containerSecurityContext: { }
+
   # NodeSelector can be used to define on which nodes the broker pods should run
   nodeSelector: { }
   # Tolerations can be used to define pod toleration's https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
@@ -319,8 +323,6 @@ zeebe-gateway:
   # Command can be used to override the default command provided by the container image. See https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/
   command: []
 
-  # ContainerSecurityContext defines the security options the gateway container should be run with
-  containerSecurityContext: { }
   # PodDisruptionBudget configuration to configure a pod disruption budget for the gateway pods https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   podDisruptionBudget:
     # PodDisruptionBudget.enabled if true a pod disruption budget is defined for the gateways
@@ -341,6 +343,13 @@ zeebe-gateway:
 
   # PriorityClassName can be used to define the gateway pods priority https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass
   priorityClassName: ""
+
+  # PodSecurityContext defines the security options the gateway pod should be run with
+  podSecurityContext: { }
+
+  # ContainerSecurityContext defines the security options the gateway container should be run with
+  containerSecurityContext: { }
+
   # NodeSelector can be used to define on which nodes the gateway pods should run
   nodeSelector: { }
   # Tolerations can be used to define pod toleration's https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
@@ -512,8 +521,11 @@ operate:
       # Ingress.tls.secretName defines the secret name which contains the TLS private key and certificate
       secretName: ""
 
-  # PodSecurityContext defines the security options the Operate container should be run with
-  podSecurityContext: {}
+  # PodSecurityContext defines the security options the Operate pod should be run with
+  podSecurityContext: { }
+
+  # ContainerSecurityContext defines the security options the Operate container should be run with
+  containerSecurityContext: { }
 
   # NodeSelector can be used to define on which nodes the Operate pods should run
   nodeSelector: { }
@@ -571,10 +583,13 @@ tasklist:
   # ExtraVolumeMounts can be used to mount extra volumes for the Tasklist pods, useful for tls and self-signed certificates
   extraVolumeMounts: [ ]
 
-  # PodSecurityContext defines the security options the operate container should be run with
-  podSecurityContext: {}
+  # PodSecurityContext defines the security options the Tasklist pod should be run with
+  podSecurityContext: { }
 
-  # NodeSelector can be used to define on which nodes the tasklist pods should run
+  # ContainerSecurityContext defines the security options the Tasklist container should be run with
+  containerSecurityContext: { }
+
+  # NodeSelector can be used to define on which nodes the Tasklist pods should run
   nodeSelector: { }
   # Tolerations can be used to define pod toleration's https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
   tolerations: [ ]
@@ -662,8 +677,11 @@ optimize:
     # Service.annotations can be used to define annotations, which will be applied to the Optimize service
     annotations: {}
 
-  # PodSecurityContext defines the security options the operate container should be run with
-  podSecurityContext: {}
+  # PodSecurityContext defines the security options the Optimize pod should be run with
+  podSecurityContext: { }
+
+  # ContainerSecurityContext defines the security options the Optimize container should be run with
+  containerSecurityContext: { }
 
   # NodeSelector can be used to define on which nodes the Optimize pods should run
   nodeSelector: { }
@@ -783,6 +801,12 @@ identity:
     # Service.annotations can be used to define annotations, which will be applied to the identity service
     annotations: {}
 
+  # PodSecurityContext defines the security options the Identity pod should be run with
+  podSecurityContext: { }
+
+  # ContainerSecurityContext defines the security options the Identity container should be run with
+  containerSecurityContext: { }
+
   # NodeSelector can be used to define on which nodes the Identity pods should run
   nodeSelector: { }
   # Tolerations can be used to define pod toleration's https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
@@ -867,9 +891,6 @@ identity:
       enabled: false
       # Ingress.tls.secretName defines the secret name which contains the TLS private key and certificate
       secretName: ""
-
-  # PodSecurityContext defines the security options the identity container should be run with
-  podSecurityContext: {}
 
 elasticsearch:
   enabled: true


### PR DESCRIPTION
### Related issues

Fixes: #374

### What's in this PR?

Allow configuring `securityContext` for pod and container in all charts.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added.
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?