### PR TITLE
fix: remove identity/optimize vars when auth is disabled

### DIFF
--- a/charts/camunda-platform/charts/optimize/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/optimize/templates/deployment.yaml
@@ -47,6 +47,7 @@ spec:
             value: {{ .Values.global.elasticsearch.host | quote }}
           - name: OPTIMIZE_ELASTICSEARCH_HTTP_PORT
             value: {{ .Values.global.elasticsearch.port | quote }}
+          {{- if .Values.global.identity.auth.enabled }}
           - name: SPRING_PROFILES_ACTIVE
             value: "ccsm"
           - name: CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL
@@ -74,6 +75,7 @@ spec:
             {{- end }}
           - name: CAMUNDA_OPTIMIZE_IDENTITY_AUDIENCE
             value: "optimize-api"
+          {{- end }}
           - name: CAMUNDA_OPTIMIZE_SECURITY_AUTH_COOKIE_SAME_SITE_ENABLED
             value: "false"
           - name: CAMUNDA_OPTIMIZE_UI_LOGOUT_HIDDEN

--- a/charts/camunda-platform/test/global_deployment_test.go
+++ b/charts/camunda-platform/test/global_deployment_test.go
@@ -104,7 +104,6 @@ func (s *deploymentTemplateTest) TestContainerShouldNotRenderIdentityIfDisabled(
 		SetValues: map[string]string{
 			"identity.enabled":             "false",
 			"global.identity.auth.enabled": "false",
-			"optimize.enabled":             "false",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes: #419

### What's in this PR?

Add an if condition to disable Identity vars in Optimize when the auth is disabled.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added.
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?
