### PR TITLE
docs: use correct parameter for extraPorts

### DIFF
--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -130,7 +130,7 @@ Information about Zeebe you can find [here](https://docs.camunda.io/docs/compone
 | | `service.commandName` | Defines the name of the Command API endpoint, where the broker commands are sent to | `command` |
 | | `service.internalPort` | Defines the port of the Internal API endpoint, which is used for internal communication | `26502` |
 | | `service.internalName` | Defines the name of the Internal API endpoint, which is used for internal communication | `internal` |
-| | `service.extraPort` |  Exposes any other [ports](https://kubernetes.io/docs/concepts/services-networking/service/#multi-port-services) which are required. Can be useful for exporters | `[]` |
+| | `service.extraPorts` |  Exposes any other [ports](https://kubernetes.io/docs/concepts/services-networking/service/#multi-port-services) which are required. Can be useful for exporters | `[]` |
 | | `serviceAccount.enabled` | If true, enables the broker service account | `true` |
 | | `serviceAccount.name` | Can be used to set the name of the broker service account | `""` |
 | | `serviceAccount.annotations` | Can be used to set the annotations of the broker service account | `{ }` |


### PR DESCRIPTION
### Which problem does the PR fix?

In the readme the configuration parameter for extra ports is missing the **s** in **extraPorts**.
Getting started with the helm chart is easier, e.g. when setting up a custom exporter.
https://github.com/camunda/camunda-platform-helm/blob/main/charts/camunda-platform/charts/zeebe/templates/service.yaml 

e.g.
```
  service:
    extraPorts:
    - port: 5701
      name: hazelcast
```

### What's in this PR?

- Changed parameter in readme.md from extraPort to **extraPorts**.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

