### PR TITLE
feat(optimize): add management port to reach backup API

### DIFF
--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -331,6 +331,7 @@ Information about Optimize you can find [here](https://docs.camunda.io/docs/comp
 | | `service` |  Configuration for the Optimize service. | |
 | | `service.type` | Defines the [type of the service](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) | `ClusterIP` |
 | | `service.port` | Defines the port of the service, where the Optimize web application will be available | `80` |
+| | `service.managementPort` | Defines the management port, where actuator and the backupAPI will be available | `8092` |
 | | `service.annotations` |  Can be used to define annotations, which will be applied to the Optimize service | `{}` |
 | | `podSecurityContext` | Defines the security options the Optimize pod should be run with | `{ }` |
 | | `containerSecurityContext` | Defines the security options the Optimize container should be run with | `{ }` |

--- a/charts/camunda-platform/charts/optimize/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/optimize/templates/deployment.yaml
@@ -96,6 +96,9 @@ spec:
         - containerPort: 8090
           name: http
           protocol: TCP
+        - containerPort: 8092
+          name: management
+          protocol: TCP
         volumeMounts:
         {{- if .Values.extraVolumeMounts}}
           {{- .Values.extraVolumeMounts | toYaml | nindent 8 }}

--- a/charts/camunda-platform/charts/optimize/templates/service.yaml
+++ b/charts/camunda-platform/charts/optimize/templates/service.yaml
@@ -17,5 +17,9 @@ spec:
     name: http
     targetPort: 8090
     protocol: TCP
+  - port: {{ .Values.service.managementPort }}
+    name: management
+    targetPort: 8092
+    protocol: TCP
   selector:
     {{- include "optimize.matchLabels" . | nindent 4 }}

--- a/charts/camunda-platform/test/optimize/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/optimize/golden/deployment.golden.yaml
@@ -84,5 +84,8 @@ spec:
         - containerPort: 8090
           name: http
           protocol: TCP
+        - containerPort: 8092
+          name: management
+          protocol: TCP
         volumeMounts:
       volumes:

--- a/charts/camunda-platform/test/optimize/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/optimize/golden/service.golden.yaml
@@ -20,6 +20,10 @@ spec:
     name: http
     targetPort: 8090
     protocol: TCP
+  - port: 8092
+    name: management
+    targetPort: 8092
+    protocol: TCP
   selector:
     app: camunda-platform
     app.kubernetes.io/name: optimize

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -678,6 +678,8 @@ optimize:
     port: 80
     # Service.annotations can be used to define annotations, which will be applied to the Optimize service
     annotations: {}
+    # Service.managementPort defines the port where actuator will be available. Also required to reach backup API
+    managementPort: 8092
 
   # PodSecurityContext defines the security options the Optimize pod should be run with
   podSecurityContext: {}


### PR DESCRIPTION
related to OPT-6499

### Which problem does the PR fix?

https://jira.camunda.com/browse/OPT-6499

### What's in this PR?

Adds the default management port 8092 for Optimize to enable users to reach the new hot backup API.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added.
- [ ] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?
