### PR TITLE
chore: add keycloak defaults

### DIFF
--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -849,6 +849,16 @@ identity:
   keycloak:
     # Keycloak.enabled is used incorporate with "global.identity.keycloak" to use your own Keycloak instead of the one comes with Camunda Platform Helm chart.
     enabled: true
+    # KEYCLOAK_PROXY_ADDRESS_FORWARDING is set to "true" to make it work with Ingress (if it's enabled).
+    extraEnvVars:
+    - name: KEYCLOAK_PROXY_ADDRESS_FORWARDING
+      value: "true"
+    # Keycloak.ingress configuration, to setup a separated Ingress for Keycloak if needed.
+    # It's disabled by default and just added here for visibility.
+    ingress:
+      enabled: false
+      ingressClassName: ""
+      hostname: ""
     # Keycloak.service configuration, to configure the service which is deployed along with keycloak
     service:
       # Keycloak.service.type can be set to change the service type.


### PR DESCRIPTION
### Which problem does the PR fix?

Simplify the Ingress step for both combined and separated [Ingress](https://docs.camunda.io/docs/next/self-managed/platform-deployment/helm-kubernetes/guides/ingress-setup/).

### What's in this PR?

Adding:
- `KEYCLOAK_PROXY_ADDRESS_FORWARDING` to simplify the Ingress setup.
- `keycloak.ingress` for visibility.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added.
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?