### PR TITLE
feat: allow using external/existing keycloak

### DIFF
--- a/charts/camunda-platform/Chart.yaml
+++ b/charts/camunda-platform/Chart.yaml
@@ -18,31 +18,34 @@ keywords:
   - process-engine
   - workflow
 dependencies:
-  - name: common
-    repository: https://charts.bitnami.com/bitnami
-    version: 2.x.x
+  # Camunda Platform charts.
   - name: identity
     version: 8.0.14
     condition: "identity.enabled"
+  - name: operate
+    version: 8.0.14
+    condition: "operate.enabled"
+  - name: optimize
+    version: 8.0.14
+    condition: "optimize.enabled"
+  - name: tasklist
+    version: 8.0.14
+    condition: "tasklist.enabled"
   - name: zeebe
     version: 8.0.14
     condition: "zeebe.enabled"
   - name: zeebe-gateway
     version: 8.0.14
     condition: "zeebe.enabled"
-  - name: operate
-    version: 8.0.14
-    condition: "operate.enabled"
-  - name: tasklist
-    version: 8.0.14
-    condition: "tasklist.enabled"
-  - name: optimize
-    version: 8.0.14
-    condition: "optimize.enabled"
+  # Dependency charts.
   - name: elasticsearch
     repository: "https://helm.elastic.co"
     version: 7.17.1
     condition: "elasticsearch.enabled"
+  # Helpers charts.
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    version: 2.x.x
 maintainers:
   - name: Zelldon
     email: christopher.zell@camunda.com

--- a/charts/camunda-platform/Chart.yaml
+++ b/charts/camunda-platform/Chart.yaml
@@ -18,6 +18,12 @@ keywords:
   - process-engine
   - workflow
 dependencies:
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    version: 2.x.x
+  - name: identity
+    version: 8.0.14
+    condition: "identity.enabled"
   - name: zeebe
     version: 8.0.14
     condition: "zeebe.enabled"
@@ -33,9 +39,6 @@ dependencies:
   - name: optimize
     version: 8.0.14
     condition: "optimize.enabled"
-  - name: identity
-    version: 8.0.14
-    condition: "identity.enabled"
   - name: elasticsearch
     repository: "https://helm.elastic.co"
     version: 7.17.1

--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -83,6 +83,9 @@ Check out the default [values.yaml](values.yaml) file, which contains the same c
 | | `identity.auth.optimize.existingSecret` |  Can be used to reference an existing secret. If not set, a random secret is generated. The existing secret should contain an `optimize-secret` field, which will be used as secret for the Identity-Optimize communication. | ` ` |
 | | `identity.auth.optimize.redirectUrl` |  Defines the redirect URL, which is used by Keycloak to access Optimize. Should be public accessible, the default value works if port-forward to Optimize is created to 8083. Can be overwritten if, an Ingress is in use and an external IP is available. | `"http://localhost:8083"` |
 | | `identity.keycloak.fullname` |    Can be used to change the referenced Keycloak service name inside the sub-charts, like operate, optimize, etc. Subcharts can't access values from other sub-charts or the parent, global only. This is useful if the `identity.keycloak.fullnameOverride` is set, and specifies a different name for the Keycloak service | `""` |
+| | `identity.keycloak.url` |    Used incorporate with "identity.keycloak.enabled: false" set exitsing Keycloak URL instead of the one comes with Camunda Platform Helm chart | `""` |
+| | `identity.keycloak.auth.adminUser` |    Can be used to configure admin user to access existing Keycloak | `""` |
+| | `identity.keycloak.auth.existingSecret` |    Can be used to configure admin user password by using existing secret with key `admin-password` to access existing Keycloak | `""` |
 | `elasticsearch`| `enabled` | Enable Elasticsearch deployment as part of the Camunda Platform Cluster | `true` |
 
 ### Camunda Platform

--- a/charts/camunda-platform/charts/identity/Chart.yaml
+++ b/charts/camunda-platform/charts/identity/Chart.yaml
@@ -12,3 +12,4 @@ dependencies:
   - name: keycloak
     repository: "https://charts.bitnami.com/bitnami"
     version: 7.1.6
+    condition: "keycloak.enabled"

--- a/charts/camunda-platform/charts/identity/templates/constraints.tpl
+++ b/charts/camunda-platform/charts/identity/templates/constraints.tpl
@@ -1,0 +1,14 @@
+{{/*
+A template to handel constraints.
+*/}}
+
+{{/*
+Keycloak chart and external Keycloak URL cannot be enabled at the same time.
+*/}}
+{{- $keycloakFailMessage := `
+[identity] Keycloak chart and external Keycloak URL are mutually exclusive.
+Either enable the Keycloak chart (identity.keycloak.enabled) OR set the external Keycloak URL (global.identity.keycloak.url).
+` -}}
+{{- if and .Values.keycloak.enabled .Values.global.identity.keycloak.url }}
+    {{ printf "\n%s" $keycloakFailMessage | trimSuffix "\n" | fail }}
+{{- end }}

--- a/charts/camunda-platform/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/identity/templates/deployment.yaml
@@ -77,7 +77,7 @@ spec:
                     Usage in keycloak secrets https://github.com/bitnami/charts/blob/master/bitnami/keycloak/templates/secrets.yaml
                     and in statefulset https://github.com/bitnami/charts/blob/master/bitnami/keycloak/templates/statefulset.yaml
                 */}}
-                name: {{ include "common.secrets.name" (dict "existingSecret" .Values.global.identity.auth.tasklist.existingSecret "context" $) }}
+                name: "{{ include "common.secrets.name" (dict "existingSecret" .Values.global.identity.auth.tasklist.existingSecret "context" $) }}"
                 key: tasklist-secret
             {{- else }}
             valueFrom:
@@ -112,15 +112,11 @@ spec:
           - name: SERVER_PORT
             value: "8080"
           - name: KEYCLOAK_URL
-            {{- /*
-            We resolve the fullname of keycloak and trim it to 20, since this is the limitation by keycloak
-            https://github.com/bitnami/charts/blob/master/bitnami/keycloak/templates/_helpers.tpl#L2-L5
-            */}}
-            value: "http://{{ include "common.names.dependency.fullname" (dict "chartName" "keycloak" "chartValues" .Values.keycloak "context" $) | trunc 20 | trimSuffix "-" }}:{{ coalesce .Values.keycloak.service.ports.http .Values.keycloak.service.port }}/auth"
+            value: "{{ include "identity.keycloakURL" . }}/auth"
           - name: IDENTITY_AUTH_PROVIDER_ISSUER_URL
             value: {{ .Values.global.identity.auth.publicIssuerUrl | quote }}
           - name: IDENTITY_AUTH_PROVIDER_BACKEND_URL
-            value: "http://{{ include "common.names.dependency.fullname" (dict "chartName" "keycloak" "chartValues" .Values.keycloak "context" $) | trunc 20 | trimSuffix "-" }}:{{ coalesce .Values.keycloak.service.ports.http .Values.keycloak.service.port }}/auth/realms/camunda-platform"
+            value: {{ include "camundaPlatform.issuerBackendUrl" . | quote }}
           - name: KEYCLOAK_SETUP_USER
             value: {{ .Values.keycloak.auth.adminUser }}
           - name: KEYCLOAK_SETUP_PASSWORD

--- a/charts/camunda-platform/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/identity/templates/deployment.yaml
@@ -112,33 +112,18 @@ spec:
           - name: SERVER_PORT
             value: "8080"
           - name: KEYCLOAK_URL
-            value: "{{ include "identity.keycloakURL" . }}/auth"
+            value: "{{ include "identity.keycloak.url" . }}/auth"
           - name: IDENTITY_AUTH_PROVIDER_ISSUER_URL
             value: {{ .Values.global.identity.auth.publicIssuerUrl | quote }}
           - name: IDENTITY_AUTH_PROVIDER_BACKEND_URL
             value: {{ include "camundaPlatform.issuerBackendUrl" . | quote }}
           - name: KEYCLOAK_SETUP_USER
-            value: {{ .Values.keycloak.auth.adminUser }}
+            value: {{ include "identity.keycloak.authAdminUser" . | quote }}
           - name: KEYCLOAK_SETUP_PASSWORD
-            {{- if and .Values.keycloak.auth.existingSecret (not (typeIs "string" .Values.keycloak.auth.existingSecret)) }}
             valueFrom:
               secretKeyRef:
-                {{- /*
-                    Helper: https://github.com/bitnami/charts/blob/master/bitnami/common/templates/_secrets.tpl
-                    Usage in keycloak secrets https://github.com/bitnami/charts/blob/master/bitnami/keycloak/templates/secrets.yaml
-                    and in statefulset https://github.com/bitnami/charts/blob/master/bitnami/keycloak/templates/statefulset.yaml
-                */}}
-                name: {{ include "common.secrets.name" (dict "existingSecret" .Values.keycloak.auth.existingSecret "context" $) }}
+                name: {{ include "identity.keycloak.authExistingSecret" . }}
                 key: admin-password
-            {{- else }}
-            valueFrom:
-                secretKeyRef:
-                  {{- /*
-                    https://github.com/bitnami/charts/blob/master/bitnami/common/templates/_names.tpl
-                  */}}
-                  name: {{ include "common.names.dependency.fullname" (dict "chartName" "keycloak" "chartValues" .Values.keycloak "context" $) }}
-                  key: admin-password
-            {{- end }}
         {{- with .Values.env }}
             {{- tpl (toYaml .) $ | nindent 10 }}
         {{- end }}

--- a/charts/camunda-platform/templates/NOTES.txt
+++ b/charts/camunda-platform/templates/NOTES.txt
@@ -53,6 +53,8 @@
     {{- else }}
   - Docker Image used for Identity: {{ .Values.identity.image.repository }}:{{ .Values.global.image.tag }}
     {{- end }}
+  {{- end }}
+  {{ if .Values.identity.keycloak.enabled -}}
   - Keycloak: {{ .Values.identity.keycloak.image.repository }}:{{ .Values.identity.keycloak.image.tag }}
   {{- end }}
 - Elasticsearch:
@@ -94,7 +96,9 @@ If you want to use different ports for the services, please adjust the related c
 The authentication via Identity/Keycloak is enabled. In order to login into one of the services please port-forward to Keycloak
 as well, otherwise a login will not be possible. Make sure you use `18080` as port.
 
+{{ if .Values.identity.keycloak.enabled -}}
 > kubectl port-forward svc/{{ include "common.names.dependency.fullname" (dict "chartName" "keycloak" "chartValues" .Values.identity.keycloak "context" $) | trunc 20 | trimSuffix "-" }} 18080:80
+{{- end }}
     {{- end }}
 
 Now you can point your browser to one of the service's login page. Example: http://localhost:8081 for Operate.

--- a/charts/camunda-platform/templates/_helpers.tpl
+++ b/charts/camunda-platform/templates/_helpers.tpl
@@ -75,9 +75,13 @@ Subcharts can't access values from other sub-charts or the parent, global only. 
 */}}
 
 {{- define "camundaPlatform.issuerBackendUrl" -}}
-{{- if (.Values.global.identity.keycloak.fullname) -}}
-http://{{ .Values.global.identity.keycloak.fullname | trunc 20 | trimSuffix "-" }}:80/auth/realms/camunda-platform
+{{- $keycloakRealmPath := "/auth/realms/camunda-platform" -}}
+
+{{- if (.Values.global.identity.keycloak.url) -}}
+    {{ .Values.global.identity.keycloak.url }}{{ $keycloakRealmPath }}
+{{- else if (.Values.global.identity.keycloak.fullname) -}}
+    http://{{ .Values.global.identity.keycloak.fullname | trunc 20 | trimSuffix "-" }}:80{{ $keycloakRealmPath }}
 {{- else -}}
-http://{{ include "common.names.dependency.fullname" (dict "chartName" "keycloak" "chartValues" . "context" $) | trunc 20 | trimSuffix "-" }}:80/auth/realms/camunda-platform
+    http://{{ include "common.names.dependency.fullname" (dict "chartName" "keycloak" "chartValues" . "context" $) | trunc 20 | trimSuffix "-" }}:80{{ $keycloakRealmPath }}
 {{- end -}}
 {{- end -}}

--- a/charts/camunda-platform/test/identity/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/identity/golden/deployment.golden.yaml
@@ -84,12 +84,12 @@ spec:
           - name: IDENTITY_AUTH_PROVIDER_BACKEND_URL
             value: "http://camunda-platform-tes:80/auth/realms/camunda-platform"
           - name: KEYCLOAK_SETUP_USER
-            value: admin
+            value: "admin"
           - name: KEYCLOAK_SETUP_PASSWORD
             valueFrom:
-                secretKeyRef:
-                  name: camunda-platform-test-keycloak
-                  key: admin-password
+              secretKeyRef:
+                name: camunda-platform-test-keycloak
+                key: admin-password
         resources:
           limits:
             cpu: 2000m

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -89,6 +89,13 @@ global:
       # Identity.keycloak.url is used incorporate with "identity.keycloak.enabled: false" to use your own Keycloak instead of the one comes with Camunda Platform Helm chart. Example:
       # url: "https://keycloak.prod.svc.cluster.local:8443"
       url: ""
+      # Identity.keycloak.auth same as "identity.keycloak.auth" but it's used for existing Keycloak.
+      auth:
+        # Identity.keycloak.auth.adminUser can be used to configure admin user to access existing Keycloak.
+        adminUser: ""
+        # Identity.keycloak.auth.existingSecret can be used to configure admin user password by using existing secret with key `admin-password` to access existing Keycloak.
+        existingSecret: ""
+
     # Identity.auth configuration, to configure Identity authentication setup
     auth:
       # Identity.auth.enabled if true, enables the Identity authentication otherwise basic-auth will be used on all services.

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -24,7 +24,6 @@
 
 # Global configuration for variables which can be accessed by all sub charts
 global:
-
   # Annotations can be used to define common annotations, which should be applied to all deployments
   annotations: {}
   # Labels can be used to define common labels, which should be applied to all deployments
@@ -87,6 +86,9 @@ global:
       # Subcharts can't access values from other sub-charts or the parent, global only.
       # This is useful if the identity.keycloak.fullnameOverride is set, and specifies a different name for the Keycloak service.
       fullname: ""
+      # Identity.keycloak.url is used incorporate with "identity.keycloak.enabled: false" to use your own Keycloak instead of the one comes with Camunda Platform Helm chart. Example:
+      # url: "https://keycloak.prod.svc.cluster.local:8443"
+      url: ""
     # Identity.auth configuration, to configure Identity authentication setup
     auth:
       # Identity.auth.enabled if true, enables the Identity authentication otherwise basic-auth will be used on all services.
@@ -838,6 +840,8 @@ identity:
 
   # Keycloak configuration, for the keycloak dependency chart which is used by identity. See the chart documentation https://github.com/bitnami/charts/tree/master/bitnami/keycloak#parameters for more details.
   keycloak:
+    # Keycloak.enabled is used incorporate with "global.identity.keycloak" to use your own Keycloak instead of the one comes with Camunda Platform Helm chart.
+    enabled: true
     # Keycloak.service configuration, to configure the service which is deployed along with keycloak
     service:
       # Keycloak.service.type can be set to change the service type.


### PR DESCRIPTION
### Which problem does the PR fix?

Currently, Camunda Platform Identlty depends on Keycloak, shipped as a dependency Helm chart.
This change allows using an existing Keycloak but setting the URL for it.

### What's in this PR?
- Allow to disable Keycloak chart and set external Keycloak URL.
- Add [Bitnami common chart](https://github.com/bitnami/charts/tree/main/bitnami/common/) as a dependency because we were using it as an indirect dependency via Keycloak.
- Add constraints since Keycloak chart and the external Keycloak URL are mutually exclusive.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added.
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?
