### PR TITLE
feat: allow to exclude components in combined the ingress

### DIFF
--- a/charts/camunda-platform/templates/ingress.yaml
+++ b/charts/camunda-platform/templates/ingress.yaml
@@ -18,6 +18,7 @@ spec:
     - http:
     {{- end }}
         paths:
+          {{- if and .Values.identity.enabled .Values.identity.contextPath }}
           - backend:
               service:
                 name: {{ include "keycloak.fullname" .Subcharts.identity.Subcharts.keycloak }}
@@ -33,6 +34,8 @@ spec:
                   number: {{ .Values.identity.service.port }}
             path: {{ .Values.identity.contextPath }}
             pathType: Prefix
+          {{- end }}
+          {{- if and .Values.operate.enabled .Values.operate.contextPath }}
           - backend:
               service:
                 name: {{ template "operate.fullname" .Subcharts.operate }}
@@ -40,6 +43,8 @@ spec:
                   number: {{ .Values.operate.service.port }}
             path: {{ .Values.operate.contextPath }}
             pathType: Prefix
+          {{- end }}
+          {{- if and .Values.optimize.enabled .Values.optimize.contextPath }}
           - backend:
               service:
                 name: {{ template "optimize.fullname" .Subcharts.optimize }}
@@ -47,6 +52,8 @@ spec:
                   number: {{ .Values.optimize.service.port }}
             path: {{ .Values.optimize.contextPath }}
             pathType: Prefix
+          {{- end }}
+          {{- if and .Values.tasklist.enabled .Values.tasklist.contextPath }}
           - backend:
               service:
                 name: {{ template "tasklist.fullname" .Subcharts.tasklist }}
@@ -54,6 +61,7 @@ spec:
                   number: {{ .Values.tasklist.service.port }}
             path: {{ .Values.tasklist.contextPath }}
             pathType: Prefix
+          {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
   tls:
     - hosts:

--- a/charts/camunda-platform/test/ingress_test.go
+++ b/charts/camunda-platform/test/ingress_test.go
@@ -34,7 +34,7 @@ func TestIngressTemplate(t *testing.T) {
 	})
 }
 
-func (s *ingressTemplateTest) TestIngress() {
+func (s *ingressTemplateTest) TestIngressWithContextPath() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
@@ -58,4 +58,52 @@ func (s *ingressTemplateTest) TestIngress() {
 	s.Require().Contains(output, "path: /operate")
 	s.Require().Contains(output, "path: /optimize")
 	s.Require().Contains(output, "path: /tasklist")
+}
+
+func (s *ingressTemplateTest) TestIngressComponentWithNoContextPath() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.ingress.enabled": "true",
+			"identity.contextPath":   "",
+			"operate.contextPath":    "",
+			"optimize.contextPath":   "",
+			"tasklist.contextPath":   "",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+
+	// then
+	s.Require().NotContains(output, "name: camunda-platform-test-identity")
+	s.Require().NotContains(output, "name: camunda-platform-test-operate")
+	s.Require().NotContains(output, "name: camunda-platform-test-optimize")
+	s.Require().NotContains(output, "name: camunda-platform-test-tasklist")
+}
+
+func (s *ingressTemplateTest) TestIngressComponentDisabled() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.ingress.enabled": "true",
+			"operate.identity":       "false",
+			"operate.enabled":        "false",
+			"optimize.enabled":       "false",
+			"tasklist.enabled":       "false",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+
+	// then
+	s.Require().NotContains(output, "name: camunda-platform-test-identity")
+	s.Require().NotContains(output, "name: camunda-platform-test-operate")
+	s.Require().NotContains(output, "name: camunda-platform-test-optimize")
+	s.Require().NotContains(output, "name: camunda-platform-test-tasklist")
 }


### PR DESCRIPTION
### Which problem does the PR fix?

Currently there is no way to deploy the combined Ingress with any of the Camunda Platform disabled.
So this PR allows excluding components in combined the Ingress.

### What's in this PR?

If the component is not enabled or the contextPath is not set, the component endpoint in the Ingress will not be present.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added.
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?
