### PR TITLE
refactor: allow more flexible keycloak config

### DIFF
--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -83,7 +83,11 @@ Check out the default [values.yaml](values.yaml) file, which contains the same c
 | | `identity.auth.optimize.existingSecret` |  Can be used to reference an existing secret. If not set, a random secret is generated. The existing secret should contain an `optimize-secret` field, which will be used as secret for the Identity-Optimize communication. | ` ` |
 | | `identity.auth.optimize.redirectUrl` |  Defines the redirect URL, which is used by Keycloak to access Optimize. Should be public accessible, the default value works if port-forward to Optimize is created to 8083. Can be overwritten if, an Ingress is in use and an external IP is available. | `"http://localhost:8083"` |
 | | `identity.keycloak.fullname` |    Can be used to change the referenced Keycloak service name inside the sub-charts, like operate, optimize, etc. Subcharts can't access values from other sub-charts or the parent, global only. This is useful if the `identity.keycloak.fullnameOverride` is set, and specifies a different name for the Keycloak service | `""` |
-| | `identity.keycloak.url` |    Used incorporate with "identity.keycloak.enabled: false" set exitsing Keycloak URL instead of the one comes with Camunda Platform Helm chart | `""` |
+| | `identity.keycloak.url` |    Can be used to customize the Identity Keycloak chart URL when "identity.keycloak.enabled: true", or to use already existing Keycloak instead of the one comes with Camunda Platform Helm chart when "identity.keycloak.enabled: false" | `{}` |
+| | `identity.keycloak.url.protocol` |    Can be used to set existing Keycloak URL protocol | `` |
+| | `identity.keycloak.url.host` |    Can be used to set existing Keycloak URL host | `` |
+| | `identity.keycloak.url.port` |    Can be used to set existing Keycloak URL port | `` |
+| | `identity.keycloak.auth` |   Can be used incorporate with "global.identity.keycloak.url" and "identity.keycloak.enabled: false" set existing Keycloak URL instead of the one comes with Camunda Platform Helm chart | `{}"` |
 | | `identity.keycloak.auth.adminUser` |    Can be used to configure admin user to access existing Keycloak | `""` |
 | | `identity.keycloak.auth.existingSecret` |    Can be used to configure admin user password by using existing secret with key `admin-password` to access existing Keycloak | `""` |
 | `elasticsearch`| `enabled` | Enable Elasticsearch deployment as part of the Camunda Platform Cluster | `true` |

--- a/charts/camunda-platform/charts/identity/templates/constraints.tpl
+++ b/charts/camunda-platform/charts/identity/templates/constraints.tpl
@@ -3,12 +3,14 @@ A template to handel constraints.
 */}}
 
 {{/*
-Keycloak chart and external Keycloak URL cannot be enabled at the same time.
+Show deprecation messages for using ".global.identity.keycloak.fullname".
 */}}
-{{- $keycloakFailMessage := `
-[identity] Keycloak chart and external Keycloak URL are mutually exclusive.
-Either enable the Keycloak chart (identity.keycloak.enabled) OR set the external Keycloak URL (global.identity.keycloak.url).
+
+{{- if (.Values.global.identity.keycloak.fullname) }}
+{{- $globalIdentityKeycloakFullnameMessage := `
+[identity][deprecation] The var ".global.identity.keycloak.fullname" is deprecated in favour of
+".global.identity.keycloak.url".
+For more details, please check Camunda Platform Helm chart documentation.
 ` -}}
-{{- if and .Values.keycloak.enabled .Values.global.identity.keycloak.url }}
-    {{ printf "\n%s" $keycloakFailMessage | trimSuffix "\n" | fail }}
+    {{ printf "\n%s" $globalIdentityKeycloakFullnameMessage | trimSuffix "\n"| fail }}
 {{- end }}

--- a/charts/camunda-platform/templates/_helpers.tpl
+++ b/charts/camunda-platform/templates/_helpers.tpl
@@ -75,13 +75,10 @@ Subcharts can't access values from other sub-charts or the parent, global only. 
 */}}
 
 {{- define "camundaPlatform.issuerBackendUrl" -}}
-{{- $keycloakRealmPath := "/auth/realms/camunda-platform" -}}
-
-{{- if (.Values.global.identity.keycloak.url) -}}
-    {{ .Values.global.identity.keycloak.url }}{{ $keycloakRealmPath }}
-{{- else if (.Values.global.identity.keycloak.fullname) -}}
-    http://{{ .Values.global.identity.keycloak.fullname | trunc 20 | trimSuffix "-" }}:80{{ $keycloakRealmPath }}
-{{- else -}}
-    http://{{ include "common.names.dependency.fullname" (dict "chartName" "keycloak" "chartValues" . "context" $) | trunc 20 | trimSuffix "-" }}:80{{ $keycloakRealmPath }}
-{{- end -}}
+    {{- $keycloakRealmPath := "/auth/realms/camunda-platform" -}}
+    {{- if .Values.global.identity.keycloak.url -}}
+        {{- include "identity.keycloak.url" . -}}{{- $keycloakRealmPath -}}
+    {{- else -}}
+        http://{{ include "common.names.dependency.fullname" (dict "chartName" "keycloak" "chartValues" . "context" $) | trunc 20 | trimSuffix "-" }}:80{{ $keycloakRealmPath }}
+    {{- end -}}
 {{- end -}}

--- a/charts/camunda-platform/templates/ingress.yaml
+++ b/charts/camunda-platform/templates/ingress.yaml
@@ -21,9 +21,9 @@ spec:
           {{- if and .Values.identity.enabled .Values.identity.contextPath }}
           - backend:
               service:
-                name: {{ include "keycloak.fullname" .Subcharts.identity.Subcharts.keycloak }}
+                name: {{ include "identity.keycloak.host" .Subcharts.identity }}
                 port:
-                  number: {{ .Values.identity.keycloak.service.ports.http }}
+                  number: {{ include "identity.keycloak.port" .Subcharts.identity }}
             # It's complex to change the context path in Keycloak v16.x.x, so it's hard-coded.
             path: /auth
             pathType: Prefix

--- a/charts/camunda-platform/test/identity/deployment_test.go
+++ b/charts/camunda-platform/test/identity/deployment_test.go
@@ -50,14 +50,16 @@ func TestDeploymentTemplate(t *testing.T) {
 	})
 }
 
-func (s *deploymentTemplateTest) TestContainerWithExternalKeycloak() {
+func (s *deploymentTemplateTest) TestContainerWithExistingKeycloak() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
 			"identity.keycloak.enabled":                    "false",
-			"global.identity.keycloak.url":                 "https://keycloak.prod.svc.cluster.local:8443",
+			"global.identity.keycloak.url.protocol":        "https",
+			"global.identity.keycloak.url.host":            "keycloak.prod.svc.cluster.local",
+			"global.identity.keycloak.url.port":            "8443",
 			"global.identity.keycloak.auth.adminUser":      "testAdmin",
-			"global.identity.keycloak.auth.existingSecret": "ownExistingSecretExternal",
+			"global.identity.keycloak.auth.existingSecret": "ownExistingSecretKeycloak",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},
@@ -85,7 +87,7 @@ func (s *deploymentTemplateTest) TestContainerWithExternalKeycloak() {
 			Name: "KEYCLOAK_SETUP_PASSWORD",
 			ValueFrom: &v12.EnvVarSource{
 				SecretKeyRef: &v12.SecretKeySelector{
-					LocalObjectReference: v12.LocalObjectReference{Name: "ownExistingSecretExternal"},
+					LocalObjectReference: v12.LocalObjectReference{Name: "ownExistingSecretKeycloak"},
 					Key:                  "admin-password",
 				},
 			},

--- a/charts/camunda-platform/test/operate/deployment_test.go
+++ b/charts/camunda-platform/test/operate/deployment_test.go
@@ -597,7 +597,9 @@ func (s *deploymentTemplateTest) TestContainerShouldSetTheRightKeycloakServiceUr
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"global.identity.keycloak.fullname": "keycloak",
+			"global.identity.keycloak.url.protocol": "http",
+			"global.identity.keycloak.url.host":     "keycloak",
+			"global.identity.keycloak.url.port":     "80",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},

--- a/charts/camunda-platform/test/optimize/deployment_test.go
+++ b/charts/camunda-platform/test/optimize/deployment_test.go
@@ -572,7 +572,9 @@ func (s *deploymentTemplateTest) TestContainerShouldSetTheRightKeycloakServiceUr
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"global.identity.keycloak.fullname": "keycloak",
+			"global.identity.keycloak.url.protocol": "http",
+			"global.identity.keycloak.url.host":     "keycloak",
+			"global.identity.keycloak.url.port":     "80",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},

--- a/charts/camunda-platform/test/tasklist/deployment_test.go
+++ b/charts/camunda-platform/test/tasklist/deployment_test.go
@@ -598,7 +598,9 @@ func (s *deploymentTemplateTest) TestContainerShouldSetTheRightKeycloakServiceUr
 
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"global.identity.keycloak.fullname": "keycloak",
+			"global.identity.keycloak.url.protocol": "http",
+			"global.identity.keycloak.url.host":     "keycloak",
+			"global.identity.keycloak.url.port":     "80",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -82,19 +82,19 @@ global:
   # Identity configuration to configure identity specifics on global level, which can be accessed by other sub-charts
   identity:
     keycloak:
-      # Identity.keycloak.fullname can be used to change the referenced Keycloak service name inside the sub-charts, like operate, optimize, etc.
-      # Subcharts can't access values from other sub-charts or the parent, global only.
-      # This is useful if the identity.keycloak.fullnameOverride is set, and specifies a different name for the Keycloak service.
-      fullname: ""
-      # Identity.keycloak.url is used incorporate with "identity.keycloak.enabled: false" to use your own Keycloak instead of the one comes with Camunda Platform Helm chart. Example:
-      # url: "https://keycloak.prod.svc.cluster.local:8443"
-      url: ""
-      # Identity.keycloak.auth same as "identity.keycloak.auth" but it's used for existing Keycloak.
-      auth:
+      # Identity.keycloak.url is can be used incorporate with "identity.keycloak.enabled: false" to use your own Keycloak instead of the one comes with Camunda Platform Helm chart.
+      url: {}
+        # Example to produce the following URL "https://keycloak.prod.svc.cluster.local:8443":
+        # url:
+        #   protocol: "https"
+        #   host: "keycloak.prod.svc.cluster.local"
+        #   port: "8443"
+        # Identity.keycloak.auth same as "identity.keycloak.auth" but it's used for existing Keycloak.
+      auth: {}
         # Identity.keycloak.auth.adminUser can be used to configure admin user to access existing Keycloak.
-        adminUser: ""
+        # adminUser: ""
         # Identity.keycloak.auth.existingSecret can be used to configure admin user password by using existing secret with key `admin-password` to access existing Keycloak.
-        existingSecret: ""
+        # existingSecret: ""
 
     # Identity.auth configuration, to configure Identity authentication setup
     auth:


### PR DESCRIPTION
### Which problem does the PR fix?

Keycloak has 2 patterns, private (container-to-container auth) and public (end-user auth).
This change allows:
- Customizing the Identity Keycloak chart URL (which deprecates the host customization via "global.identity.keycloak.fullname").
- Using the existing Keycloak with more fine-grain vars.
- Using the existing Keycloak in the external access via Ingress.

### What's in this PR?

Use the existing Keycloak vars in the combined ingress.
Added a test to ensure the Keycloak access worked as expected.
Also fix a bug related to #458 

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added.
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
