### PR TITLE
fix: use service for keycloak instead of host

### DIFF
--- a/charts/camunda-platform/charts/identity/templates/_helpers.tpl
+++ b/charts/camunda-platform/charts/identity/templates/_helpers.tpl
@@ -125,7 +125,7 @@ For more details, please check Camunda Platform Helm chart documentation.
 [identity] Get Keycloak URL protocol based on global value or Keycloak subchart.
 */}}
 {{- define "identity.keycloak.protocol" -}}
-    {{- if .Values.global.identity.keycloak.url -}}
+    {{- if and .Values.global.identity.keycloak.url .Values.global.identity.keycloak.url.protocol -}}
         {{- .Values.global.identity.keycloak.url.protocol -}}
     {{- else -}}
         {{- ternary "https" "http" (.Values.keycloak.auth.tls.enabled) -}}
@@ -133,11 +133,12 @@ For more details, please check Camunda Platform Helm chart documentation.
 {{- end -}}
 
 {{/*
-[identity] Get Keycloak URL host based on global value or Keycloak subchart.
+[identity] Get Keycloak URL service name based on global value or Keycloak subchart.
+This is mainly used for cases where the external Keycloak is used.
 */}}
-{{- define "identity.keycloak.host" -}}
-    {{- if .Values.global.identity.keycloak.url -}}
-        {{- .Values.global.identity.keycloak.url.host -}}
+{{- define "identity.keycloak.service" -}}
+    {{- if and .Values.global.identity.keycloak.url .Values.global.identity.keycloak.url.host -}}
+        {{- printf "%s-keycloak-custom" .Release.Name | trunc 63 -}}
     {{- else -}}
         {{ include "common.names.dependency.fullname" (dict "chartName" "keycloak" "chartValues" . "context" $) | trunc 20 | trimSuffix "-" }}
     {{- end -}}
@@ -147,7 +148,7 @@ For more details, please check Camunda Platform Helm chart documentation.
 [identity] Get Keycloak URL port based on global value or Keycloak subchart.
 */}}
 {{- define "identity.keycloak.port" -}}
-    {{- if .Values.global.identity.keycloak.url -}}
+    {{- if and .Values.global.identity.keycloak.url .Values.global.identity.keycloak.url.port -}}
         {{- .Values.global.identity.keycloak.url.port -}}
     {{- else -}}
         {{- $keycloakProtocol := (include "identity.keycloak.protocol" .) -}}
@@ -163,7 +164,7 @@ For more details, please check Camunda Platform Helm chart documentation.
     {{-
       printf "%s://%s:%s"
         (include "identity.keycloak.protocol" .)
-        (include "identity.keycloak.host" .)
+        (include "identity.keycloak.service" .)
         (include "identity.keycloak.port" .)
     -}}
 {{- end -}}

--- a/charts/camunda-platform/charts/identity/templates/keycloak-service.yaml
+++ b/charts/camunda-platform/charts/identity/templates/keycloak-service.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.global.identity.keycloak.url .Values.global.identity.keycloak.url.host -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "identity.keycloak.service" . }}
+  labels: {{- include "identity.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.global.annotations}}
+    {{- toYaml .Values.global.annotations | nindent 4 }}
+    {{- end }}
+    {{- if .Values.service.annotations}}
+    {{- toYaml .Values.service.annotations | nindent 4 }}
+    {{- end }}
+spec:
+  type: ExternalName
+  externalName: {{ .Values.global.identity.keycloak.url.host }}
+{{- end -}}

--- a/charts/camunda-platform/templates/ingress.yaml
+++ b/charts/camunda-platform/templates/ingress.yaml
@@ -21,7 +21,7 @@ spec:
           {{- if and .Values.identity.enabled .Values.identity.contextPath }}
           - backend:
               service:
-                name: {{ include "identity.keycloak.host" .Subcharts.identity }}
+                name: {{ include "identity.keycloak.service" .Subcharts.identity }}
                 port:
                   number: {{ include "identity.keycloak.port" .Subcharts.identity }}
             # It's complex to change the context path in Keycloak v16.x.x, so it's hard-coded.

--- a/charts/camunda-platform/test/identity/deployment_test.go
+++ b/charts/camunda-platform/test/identity/deployment_test.go
@@ -50,7 +50,7 @@ func TestDeploymentTemplate(t *testing.T) {
 	})
 }
 
-func (s *deploymentTemplateTest) TestContainerWithExistingKeycloak() {
+func (s *deploymentTemplateTest) TestContainerWithExternalKeycloak() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
@@ -75,7 +75,7 @@ func (s *deploymentTemplateTest) TestContainerWithExistingKeycloak() {
 	s.Require().Contains(env,
 		v12.EnvVar{
 			Name:  "KEYCLOAK_URL",
-			Value: "https://keycloak.prod.svc.cluster.local:8443/auth",
+			Value: "https://camunda-platform-test-keycloak-custom:8443/auth",
 		})
 	s.Require().Contains(env,
 		v12.EnvVar{

--- a/charts/camunda-platform/test/ingress_test.go
+++ b/charts/camunda-platform/test/ingress_test.go
@@ -90,7 +90,7 @@ func (s *ingressTemplateTest) TestIngressWithKeycloakChartIsDisabled() {
 	// then
 	// TODO: Instead of using plain text search, unmarshal the output in an ingress struct and assert the values.
 	s.Require().Contains(output, "path: /auth")
-	s.Require().Contains(output, "name: keycloak.prod.svc.cluster.local")
+	s.Require().Contains(output, "name: camunda-platform-test-keycloak-custom")
 	s.Require().Contains(output, "number: 8443")
 }
 

--- a/charts/camunda-platform/test/operate/deployment_test.go
+++ b/charts/camunda-platform/test/operate/deployment_test.go
@@ -615,7 +615,7 @@ func (s *deploymentTemplateTest) TestContainerShouldSetTheRightKeycloakServiceUr
 	s.Require().Contains(env,
 		v12.EnvVar{
 			Name:  "CAMUNDA_OPERATE_IDENTITY_ISSUER_BACKEND_URL",
-			Value: "http://keycloak:80/auth/realms/camunda-platform",
+			Value: "http://camunda-platform-test-keycloak-custom:80/auth/realms/camunda-platform",
 		})
 }
 

--- a/charts/camunda-platform/test/optimize/deployment_test.go
+++ b/charts/camunda-platform/test/optimize/deployment_test.go
@@ -590,7 +590,7 @@ func (s *deploymentTemplateTest) TestContainerShouldSetTheRightKeycloakServiceUr
 	s.Require().Contains(env,
 		v12.EnvVar{
 			Name:  "CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_BACKEND_URL",
-			Value: "http://keycloak:80/auth/realms/camunda-platform",
+			Value: "http://camunda-platform-test-keycloak-custom:80/auth/realms/camunda-platform",
 		})
 }
 

--- a/charts/camunda-platform/test/tasklist/deployment_test.go
+++ b/charts/camunda-platform/test/tasklist/deployment_test.go
@@ -616,7 +616,7 @@ func (s *deploymentTemplateTest) TestContainerShouldSetTheRightKeycloakServiceUr
 	s.Require().Contains(env,
 		v12.EnvVar{
 			Name:  "CAMUNDA_TASKLIST_IDENTITY_ISSUER_BACKEND_URL",
-			Value: "http://keycloak:80/auth/realms/camunda-platform",
+			Value: "http://camunda-platform-test-keycloak-custom:80/auth/realms/camunda-platform",
 		})
 }
 


### PR DESCRIPTION
### Which problem does the PR fix?

If the Keycloak custom or external service is in another space, the Ingress will fail because the host is used instead of the service name. And since the Ingress is actually namespaced, so we need to setup a service with `ExternalName` type to deal with this use case.

### What's in this PR?
A new service for custom Keycloak access has been added with the type `ExternalName` which will be used as a bridge to Keycloak. Which also used to customize Keycloak URL options.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added.
- [x] The main Helm chart and sub-chart are updated (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
