### PR TITLE
chore(ci): use clear namespace name for integration tests

### DIFF
--- a/.github/workflows/go-it-os.yaml
+++ b/.github/workflows/go-it-os.yaml
@@ -9,6 +9,10 @@ on:
     - 'go.*'
   workflow_dispatch: { }
 
+env:
+  GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
+  GITHUB_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+
 jobs:
   build:
     if: github.ref == 'refs/heads/main' || github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/go-it.yaml
+++ b/.github/workflows/go-it.yaml
@@ -12,6 +12,8 @@ on:
 env:
   KUBECTL_VERSION: 'latest'
   KUBECTX: 'gke_zeebe-io_europe-west1-b_zeebe-cluster'
+  GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
+  GITHUB_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
 jobs:  
   build:

--- a/charts/camunda-platform/test/integration/setup.go
+++ b/charts/camunda-platform/test/integration/setup.go
@@ -32,11 +32,17 @@ func truncateString(str string, num int) string {
 func createNamespaceName() string {
 	// if triggered by a github action the environment variable is set
 	// we use it to better identify the test
-	commitSHA, exist := os.LookupEnv("GITHUB_SHA")
-	namespace := "camunda-platform-" + strings.ToLower(random.UniqueId())
-	if exist {
-		namespace += "-" + commitSHA
+
+	namespace := "camunda-platform"
+	if prNumber, exist := os.LookupEnv("GITHUB_PR_NUMBER"); exist {
+		namespace += "-pr-" + prNumber
 	}
+	// In PRs the GITHUB_SHA refers to the PR commit ID not the actual head ID.
+	// So we need to use a custom env var.
+	if commitSHA, exist := os.LookupEnv("GITHUB_PR_HEAD_SHA"); exist {
+		namespace += "-commit-" + commitSHA[0:8]
+	}
+	namespace += "-rand-" + strings.ToLower(random.UniqueId())
 
 	// max namespace length is 63 characters
 	// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names


### PR DESCRIPTION
### Which problem does the PR fix?

Using a clear namespaces name for integration tests so it's easy to debug failed tests.

### What's in this PR?

Set the integration test namespace using pr num, short commit hash, and a random number.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added.
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
