### PR TITLE
feat: support custom keycloak context path

### DIFF
--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -96,7 +96,8 @@ Check out the default [values.yaml](values.yaml) file, which contains the same c
 | | `identity.keycloak.url.protocol` |    Can be used to set existing Keycloak URL protocol | `` |
 | | `identity.keycloak.url.host` |    Can be used to set existing Keycloak URL host | `` |
 | | `identity.keycloak.url.port` |    Can be used to set existing Keycloak URL port | `` |
-| | `identity.keycloak.auth` |   Can be used incorporate with "global.identity.keycloak.url" and "identity.keycloak.enabled: false" set existing Keycloak URL instead of the one comes with Camunda Platform Helm chart | `{}"` |
+| | `identity.keycloak.contextPath` |   Defines the endpoint of Keycloak which varies between Keycloak versions. In Keycloak v16.x.x it's hard-coded as '/auth', but in v19.x.x it's '/' | `"/auth"` |
+| | `identity.keycloak.auth` |   Can be used incorporate with "global.identity.keycloak.url" and "identity.keycloak.enabled: false" set existing Keycloak URL instead of the one comes with Camunda Platform Helm chart | `{}` |
 | | `identity.keycloak.auth.adminUser` |    Can be used to configure admin user to access existing Keycloak | `""` |
 | | `identity.keycloak.auth.existingSecret` |    Can be used to configure admin user password by using existing secret with key `admin-password` to access existing Keycloak | `""` |
 | `elasticsearch`| `enabled` | Enable Elasticsearch deployment as part of the Camunda Platform Cluster | `true` |

--- a/charts/camunda-platform/charts/identity/templates/_helpers.tpl
+++ b/charts/camunda-platform/charts/identity/templates/_helpers.tpl
@@ -157,15 +157,23 @@ This is mainly used for cases where the external Keycloak is used.
 {{- end -}}
 
 {{/*
+[identity] Get Keycloak contextPath based on global value.
+*/}}
+{{- define "identity.keycloak.contextPath" -}}
+    {{ .Values.global.identity.keycloak.contextPath | default "/auth" }}
+{{- end -}}
+
+{{/*
 [identity] Get Keycloak full URL (protocol, host, and port).
 */}}
 {{- define "identity.keycloak.url" -}}
     {{- include "identity.keycloak.isConfigured" . -}}
     {{-
-      printf "%s://%s:%s"
+      printf "%s://%s:%s%s"
         (include "identity.keycloak.protocol" .)
         (include "identity.keycloak.service" .)
         (include "identity.keycloak.port" .)
+        (include "identity.keycloak.contextPath" .)
     -}}
 {{- end -}}
 

--- a/charts/camunda-platform/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/identity/templates/deployment.yaml
@@ -112,7 +112,7 @@ spec:
           - name: SERVER_PORT
             value: "8080"
           - name: KEYCLOAK_URL
-            value: "{{ include "identity.keycloak.url" . }}/auth"
+            value: {{ include "identity.keycloak.url" . | quote }}
           - name: IDENTITY_AUTH_PROVIDER_ISSUER_URL
             value: {{ .Values.global.identity.auth.publicIssuerUrl | quote }}
           - name: IDENTITY_AUTH_PROVIDER_BACKEND_URL

--- a/charts/camunda-platform/templates/_helpers.tpl
+++ b/charts/camunda-platform/templates/_helpers.tpl
@@ -75,10 +75,10 @@ Subcharts can't access values from other sub-charts or the parent, global only. 
 */}}
 
 {{- define "camundaPlatform.issuerBackendUrl" -}}
-    {{- $keycloakRealmPath := "/auth/realms/camunda-platform" -}}
+    {{- $keycloakRealmPath := "/realms/camunda-platform" -}}
     {{- if .Values.global.identity.keycloak.url -}}
         {{- include "identity.keycloak.url" . -}}{{- $keycloakRealmPath -}}
     {{- else -}}
-        http://{{ include "common.names.dependency.fullname" (dict "chartName" "keycloak" "chartValues" . "context" $) | trunc 20 | trimSuffix "-" }}:80{{ $keycloakRealmPath }}
+        http://{{ include "common.names.dependency.fullname" (dict "chartName" "keycloak" "chartValues" . "context" $) | trunc 20 | trimSuffix "-" }}:80{{- include "identity.keycloak.contextPath" . -}}{{ $keycloakRealmPath }}
     {{- end -}}
 {{- end -}}

--- a/charts/camunda-platform/templates/ingress.yaml
+++ b/charts/camunda-platform/templates/ingress.yaml
@@ -24,8 +24,7 @@ spec:
                 name: {{ include "identity.keycloak.service" .Subcharts.identity }}
                 port:
                   number: {{ include "identity.keycloak.port" .Subcharts.identity }}
-            # It's complex to change the context path in Keycloak v16.x.x, so it's hard-coded.
-            path: /auth
+            path: {{ include "identity.keycloak.contextPath" .Subcharts.identity }}
             pathType: Prefix
           - backend:
               service:

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -82,14 +82,17 @@ global:
   # Identity configuration to configure identity specifics on global level, which can be accessed by other sub-charts
   identity:
     keycloak:
-      # Identity.keycloak.url is can be used incorporate with "identity.keycloak.enabled: false" to use your own Keycloak instead of the one comes with Camunda Platform Helm chart.
+      # Identity.keycloak.url can be used incorporate with "identity.keycloak.enabled: false" to use your own Keycloak instead of the one comes with Camunda Platform Helm chart.
       url: {}
         # Example to produce the following URL "https://keycloak.prod.svc.cluster.local:8443":
         # url:
         #   protocol: "https"
         #   host: "keycloak.prod.svc.cluster.local"
         #   port: "8443"
-        # Identity.keycloak.auth same as "identity.keycloak.auth" but it's used for existing Keycloak.
+      # Identity.keycloak.contextPath defines the endpoint of Keycloak which varies between Keycloak versions.
+      # In Keycloak v16.x.x it's hard-coded as '/auth', but in v19.x.x it's '/'.
+      contextPath: "/auth"
+      # Identity.keycloak.auth same as "identity.keycloak.auth" but it's used for existing Keycloak.
       auth: {}
         # Identity.keycloak.auth.adminUser can be used to configure admin user to access existing Keycloak.
         # adminUser: ""
@@ -849,10 +852,14 @@ identity:
   keycloak:
     # Keycloak.enabled is used incorporate with "global.identity.keycloak" to use your own Keycloak instead of the one comes with Camunda Platform Helm chart.
     enabled: true
-    # KEYCLOAK_PROXY_ADDRESS_FORWARDING is set to "true" to make it work with Ingress (if it's enabled).
     extraEnvVars:
+    # KEYCLOAK_PROXY_ADDRESS_FORWARDING is set to "true" to make it work with Ingress (if it's enabled).
     - name: KEYCLOAK_PROXY_ADDRESS_FORWARDING
       value: "true"
+    # KEYCLOAK_HTTP_RELATIVE_PATH is valid for v19.x.x only and it's added for compatibility between Keycloak versions
+    # where in Keycloak v16.x.x it's hard-coded as '/auth', but in v19.x.x it's '/'.
+    - name: KEYCLOAK_HTTP_RELATIVE_PATH
+      value: "{{ .Values.global.identity.keycloak.contextPath }}"
     # Keycloak.ingress configuration, to setup a separated Ingress for Keycloak if needed.
     # It's disabled by default and just added here for visibility.
     ingress:


### PR DESCRIPTION
### Which problem does the PR fix?
It fixes #462
Also, it partially fixes #465, which allows setting the context path so the user can use Keycloak v19.x.x even Camunda Platform charts are not using the newer version yet. 

### What's in this PR?

Allow setting context path for Keycloak, which should work with `v16.x.x` and `v19.x.x`.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added.
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
