### PR TITLE
feat: support customizing container image registry

### DIFF
--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -114,6 +114,7 @@ Check out the default [values.yaml](values.yaml) file, which contains the same c
 | | `zeebeIndexMaxSize` | Can be set to configure the maximum allowed zeebe index size in gigabytes. After reaching that size, curator will delete that corresponding index on the next run. To benefit from that configuration the schedule needs to be configured small enough, like every 15 minutes. | `` |
 | | `operateIndexTTL` | Defines after how many days an Operate index can be deleted. | `30` |
 | | `tasklistIndexTTL` | Defines after how many days an Tasklist index can be deleted. | `30` |
+| | `image.registry` | Can be used to set container image registry. | `""` |
 | | `image.repository` | Defines which image repository to use. | `bitnami/elasticsearch-curator` |
 | | `image.tag` | Defines the tag / version which should be used in the chart. | `5.8.4` |
 | `prometheusServiceMonitor` | | Configuration to configure a prometheus service monitor | |
@@ -129,6 +130,7 @@ For more information about Zeebe, visit [Zeebe Overview](https://docs.camunda.io
 |-|-|-|-|
 | `zeebe` | Configuration for the Zeebe sub chart. Contains configuration for the Zeebe broker and related resources. | |
 | | `image` | Configuration to configure the Zeebe image specifics. | |
+| | `image.registry` | Can be used to set container image registry. | `""` |
 | | `image.repository` | Defines which image repository to use. | `camunda/zeebe` |
 | | `image.tag` | Can be set to overwrite the global tag, which should be used in that chart. | ` ` |
 | | `image.pullSecrets` | Can be set to overwrite the global.image.pullSecrets | `{{ global.image.pullSecrets }}` |
@@ -190,6 +192,7 @@ For more information about Zeebe Gateway, visit
 | `zeebe-gateway`| | Configuration to define properties related to the Zeebe standalone gateway | |
 | | `replicas` | Defines how many standalone gateways are deployed | `1` |
 | | `image` | Configuration to configure the zeebe-gateway image specifics. | |
+| | `image.registry` | Can be used to set container image registry. | `""` |
 | | `image.repository` | Defines which image repository to use. | `camunda/zeebe` |
 | | `image.tag` | Can be set to overwrite the global tag, which should be used in that chart. | ` ` |
 | | `image.pullSecrets` | Can be set to overwrite the global.image.pullSecrets | `{{ global.image.pullSecrets }}` |
@@ -250,6 +253,7 @@ For more information about Operate, visit
 | `operate` | | Configuration for the Operate sub chart. | |
 | | `enabled` | If true, the Operate deployment and its related resources are deployed via a helm release | `true` |
 | | `image` | Configuration to configure the Operate image specifics. | |
+| | `image.registry` | Can be used to set container image registry. | `""` |
 | | `image.repository` | Defines which image repository to use. | `camunda/operate` |
 | | `image.tag` | Can be set to overwrite the global tag, which should be used in that chart. | `` |
 | | `image.pullSecrets` | Can be set to overwrite the global.image.pullSecrets | `{{ global.image.pullSecrets }}` |
@@ -296,6 +300,7 @@ For more information about Tasklist, visit
 | `tasklist` | | Configuration for the Tasklist sub chart. | |
 | | `enabled` | If true, the Tasklist deployment and its related resources are deployed via a helm release | `true` |
 | | `image` | Configuration to configure the Tasklist image specifics. | |
+| | `image.registry` | Can be used to set container image registry. | `""` |
 | | `image.repository` | Defines which image repository to use. | `camunda/tasklist` |
 | | `image.tag` | Can be set to overwrite the global tag, which should be used in that chart. | `` |
 | | `image.pullSecrets` | Can be set to overwrite the global.image.pullSecrets | `{{ global.image.pullSecrets }}` |
@@ -334,6 +339,7 @@ For more information, visit [Optimize Introduction](https://docs.camunda.io/opti
 | `optimize` | |  Configuration for the Optimize sub chart. | |
 | | `enabled` |  If true, the Optimize deployment and its related resources are deployed via a helm release | `true` |
 | | `image` |  Configuration for the Optimize image specifics | |
+| | `image.registry` | Can be used to set container image registry. | `""` |
 | | `image.repository` |  Defines which image repository to use | `camunda/optimize` |
 | | `image.tag` |  Can be set to overwrite the global tag, which should be used in that chart | `3.8.0` |
 | | `image.pullSecrets` | Can be set to overwrite the global.image.pullSecrets | `{{ global.image.pullSecrets }}` |
@@ -380,6 +386,7 @@ For more information, visit [Identity Overview](https://docs.camunda.io/docs/sel
 | | `firstUser.username` | Defines the username of the first user, needed to log in into the web applications | `demo` |
 | | `firstUser.password` | Defines the password of the first user, needed to log in into the web applications | `demo` |
 | | `image` |  Configuration to configure the Identity image specifics | |
+| | `image.registry` | Can be used to set container image registry. | `""` |
 | | `image.repository` |  Defines which image repository to use | `camunda/identity` |
 | | `image.tag` |   Can be set to overwrite the global.image.tag | |
 | | `image.pullSecrets` | Can be set to overwrite the global.image.pullSecrets | `{{ global.image.pullSecrets }}` |

--- a/charts/camunda-platform/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/identity/templates/deployment.yaml
@@ -20,11 +20,7 @@ spec:
         {{- include "camundaPlatform.imagePullSecrets" . | nindent 8 }}
       containers:
       - name: {{ .Chart.Name }}
-        {{- if .Values.image.tag }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        {{- else }}
-        image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
-        {{- end }}
+        image: {{ include "camundaPlatform.image" . | quote }}
         imagePullPolicy: {{ .Values.global.image.pullPolicy }}
         {{- if .Values.containerSecurityContext }}
         securityContext: {{- toYaml .Values.containerSecurityContext | nindent 10 }}

--- a/charts/camunda-platform/charts/operate/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/operate/templates/deployment.yaml
@@ -24,11 +24,7 @@ spec:
         {{- include "camundaPlatform.imagePullSecrets" . | nindent 8 }}
       containers:
       - name: {{ .Chart.Name }}
-        {{- if .Values.image.tag }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        {{- else }}
-        image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
-        {{- end }}
+        image: {{ include "camundaPlatform.image" . | quote }}
         imagePullPolicy: {{ .Values.global.image.pullPolicy }}
         {{- if .Values.containerSecurityContext }}
         securityContext: {{- toYaml .Values.containerSecurityContext | nindent 10 }}

--- a/charts/camunda-platform/charts/optimize/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/optimize/templates/deployment.yaml
@@ -25,11 +25,7 @@ spec:
         {{- include "camundaPlatform.imagePullSecrets" . | nindent 8 }}
       containers:
       - name: {{ .Chart.Name }}
-        {{- if .Values.image.tag }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        {{- else }}
-        image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
-        {{- end }}
+        image: {{ include "camundaPlatform.image" . | quote }}
         imagePullPolicy: {{ .Values.global.image.pullPolicy }}
         {{- if .Values.containerSecurityContext }}
         securityContext: {{- toYaml .Values.containerSecurityContext | nindent 10 }}

--- a/charts/camunda-platform/charts/tasklist/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/tasklist/templates/deployment.yaml
@@ -25,11 +25,7 @@ spec:
         {{- include "camundaPlatform.imagePullSecrets" . | nindent 8 }}
       containers:
       - name: {{ .Chart.Name }}
-        {{- if .Values.image.tag }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        {{- else }}
-        image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
-        {{- end }}
+        image: {{ include "camundaPlatform.image" . | quote }}
         imagePullPolicy: {{ .Values.global.image.pullPolicy }}
         {{- if .Values.containerSecurityContext }}
         securityContext: {{- toYaml .Values.containerSecurityContext | nindent 10 }}

--- a/charts/camunda-platform/charts/zeebe-gateway/templates/gateway-deployment.yaml
+++ b/charts/camunda-platform/charts/zeebe-gateway/templates/gateway-deployment.yaml
@@ -33,11 +33,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          {{- if .Values.image.tag }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          {{- else }}
-          image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
-          {{- end }}
+          image: {{ include "camundaPlatform.image" . | quote }}
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
           ports:
             - containerPort: {{  .Values.service.httpPort }}

--- a/charts/camunda-platform/charts/zeebe/templates/statefulset.yaml
+++ b/charts/camunda-platform/charts/zeebe/templates/statefulset.yaml
@@ -39,11 +39,7 @@ spec:
         {{- end }}
       containers:
       - name: {{ .Chart.Name }}
-        {{- if .Values.image.tag }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        {{- else }}
-        image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
-        {{- end }}
+        image: {{ include "camundaPlatform.image" . | quote }}
         imagePullPolicy: {{ .Values.global.image.pullPolicy }}
         {{- if .Values.containerSecurityContext }}
         securityContext: {{- toYaml .Values.containerSecurityContext | nindent 10 }}

--- a/charts/camunda-platform/templates/_helpers.tpl
+++ b/charts/camunda-platform/templates/_helpers.tpl
@@ -56,6 +56,19 @@ app.kubernetes.io/part-of: camunda-platform
 {{- end -}}
 
 {{/*
+Set image according the values of global or subchart value.
+*/}}
+{{- define "camundaPlatform.image" -}}
+    {{- $imageRegistry := .Values.image.registry | default .Values.global.image.registry -}}
+    {{- printf "%s%s%s:%s"
+        $imageRegistry
+        (empty $imageRegistry | ternary "" "/")
+        (.Values.image.repository | default .Values.global.image.repository)
+        (.Values.image.tag | default .Values.global.image.tag)
+    -}}
+{{- end -}}
+
+{{/*
 Set imagePullSecrets according the values of global, subchart, or empty.
 */}}
 {{- define "camundaPlatform.imagePullSecrets" -}}

--- a/charts/camunda-platform/templates/curator-cronjob.yaml
+++ b/charts/camunda-platform/templates/curator-cronjob.yaml
@@ -16,7 +16,8 @@ spec:
       template:
         spec:
           containers:
-            - image: "{{ .Values.retentionPolicy.image.repository }}:{{ .Values.retentionPolicy.image.tag }}"
+              {{- $_ := set .Values "image" .Values.retentionPolicy.image }}
+            - image: {{ include "camundaPlatform.image" . | quote }}
               name: curator
               args: ["--config", "/etc/config/config.yml", "/etc/config/action_file.yml"]
               volumeMounts:

--- a/charts/camunda-platform/test/global_deployment_test.go
+++ b/charts/camunda-platform/test/global_deployment_test.go
@@ -115,3 +115,28 @@ func (s *deploymentTemplateTest) TestContainerShouldNotRenderIdentityIfDisabled(
 	// then
 	s.Require().NotContains(output, "charts/identity")
 }
+
+func (s *deploymentTemplateTest) TestContainerSetImageNameGlobal() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.image.registry":     "global.custom.registry.io",
+			"global.image.tag":          "8.x.x",
+			"optimize.image.tag":        "3.x.x",
+			"retentionPolicy.enabled":   "true",
+			"retentionPolicy.image.tag": "5.x.x",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+
+	// then
+	s.Require().Contains(output, "image: \"global.custom.registry.io/camunda/identity:8.x.x\"")
+	s.Require().Contains(output, "image: \"global.custom.registry.io/camunda/operate:8.x.x\"")
+	s.Require().Contains(output, "image: \"global.custom.registry.io/camunda/optimize:3.x.x\"")
+	s.Require().Contains(output, "image: \"global.custom.registry.io/camunda/tasklist:8.x.x\"")
+	s.Require().Contains(output, "image: \"global.custom.registry.io/camunda/zeebe:8.x.x\"")
+	s.Require().Contains(output, "image: \"global.custom.registry.io/bitnami/elasticsearch-curator:5.x.x\"")
+}

--- a/charts/camunda-platform/test/golden/curator-configmap.golden.yaml
+++ b/charts/camunda-platform/test/golden/curator-configmap.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.1.2"
+    app.kubernetes.io/version: "5.8.4"
 data:
   action_file.yml: |-
     ---

--- a/charts/camunda-platform/test/operate/deployment_test.go
+++ b/charts/camunda-platform/test/operate/deployment_test.go
@@ -106,6 +106,29 @@ func (s *deploymentTemplateTest) TestContainerSetGlobalAnnotations() {
 	s.Require().Equal("bar", deployment.ObjectMeta.Annotations["foo"])
 }
 
+func (s *deploymentTemplateTest) TestContainerSetImageNameSubChart() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.image.registry":    "global.custom.registry.io",
+			"global.image.tag":         "8.x.x",
+			"operate.image.registry":   "subchart.custom.registry.io",
+			"operate.image.repository": "camunda/operate-test",
+			"operate.image.tag":        "snapshot",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	container := deployment.Spec.Template.Spec.Containers[0]
+	s.Require().Equal(container.Image, "subchart.custom.registry.io/camunda/operate-test:snapshot")
+}
+
 func (s *deploymentTemplateTest) TestContainerSetImagePullSecretsGlobal() {
 	// given
 	options := &helm.Options{

--- a/charts/camunda-platform/test/optimize/deployment_test.go
+++ b/charts/camunda-platform/test/optimize/deployment_test.go
@@ -107,6 +107,29 @@ func (s *deploymentTemplateTest) TestContainerSetGlobalAnnotations() {
 	s.Require().Equal("bar", deployment.ObjectMeta.Annotations["foo"])
 }
 
+func (s *deploymentTemplateTest) TestContainerSetImageNameSubChart() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.image.registry":     "global.custom.registry.io",
+			"global.image.tag":          "8.x.x",
+			"optimize.image.registry":   "subchart.custom.registry.io",
+			"optimize.image.repository": "camunda/optimize-test",
+			"optimize.image.tag":        "snapshot",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	container := deployment.Spec.Template.Spec.Containers[0]
+	s.Require().Equal(container.Image, "subchart.custom.registry.io/camunda/optimize-test:snapshot")
+}
+
 func (s *deploymentTemplateTest) TestContainerSetImagePullSecretsGlobal() {
 	// given
 	options := &helm.Options{

--- a/charts/camunda-platform/test/tasklist/deployment_test.go
+++ b/charts/camunda-platform/test/tasklist/deployment_test.go
@@ -107,6 +107,29 @@ func (s *deploymentTemplateTest) TestContainerSetGlobalAnnotations() {
 	s.Require().Equal("bar", deployment.ObjectMeta.Annotations["foo"])
 }
 
+func (s *deploymentTemplateTest) TestContainerSetImageNameSubChart() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.image.registry":     "global.custom.registry.io",
+			"global.image.tag":          "8.x.x",
+			"tasklist.image.registry":   "subchart.custom.registry.io",
+			"tasklist.image.repository": "camunda/tasklist-test",
+			"tasklist.image.tag":        "snapshot",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	container := deployment.Spec.Template.Spec.Containers[0]
+	s.Require().Equal(container.Image, "subchart.custom.registry.io/camunda/tasklist-test:snapshot")
+}
+
 func (s *deploymentTemplateTest) TestContainerSetImagePullSecretsGlobal() {
 	// given
 	options := &helm.Options{

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -32,6 +32,8 @@ global:
 
   # Image configuration to be used in each sub chart
   image:
+    # Image.registry can be used to set container image registry.
+    registry: ""
     # Image.tag defines the tag / version which should be used in the chart
     # Don't change the comment after the value, it's needed due to a bug yq. Check Makefile for more details.
     tag: 8.1.2  # global.image.tag
@@ -150,6 +152,8 @@ zeebe:
 
   # Image configuration to configure the zeebe image specifics
   image:
+    # Image.registry can be used to set container image registry.
+    registry: ""
     # Image.repository defines which image repository to use
     repository: camunda/zeebe
     # Image.tag can be set to overwrite the global tag, which should be used in that chart
@@ -311,6 +315,8 @@ zeebe-gateway:
   replicas: 2
   # Image configuration to configure the zeebe-gateway image specifics
   image:
+    # Image.registry can be used to set container image registry.
+    registry: ""
     # Image.repository defines which image repository to use
     repository: camunda/zeebe
     # Image.tag can be set to overwrite the global tag, which should be used in that chart
@@ -454,6 +460,8 @@ operate:
 
   # Image configuration to configure the Operate image specifics
   image:
+    # Image.registry can be used to set container image registry.
+    registry: ""
     # Image.repository defines which image repository to use
     repository: camunda/operate
     # Image.tag can be set to overwrite the global tag, which should be used in that chart
@@ -558,6 +566,8 @@ tasklist:
 
   # Image configuration to configure the tasklist image specifics
   image:
+    # Image.registry can be used to set container image registry.
+    registry: ""
     # Image.repository defines which image repository to use
     repository: camunda/tasklist
     # Image.tag can be set to overwrite the global tag, which should be used in that chart
@@ -650,6 +660,8 @@ optimize:
 
   # Image configuration to configure the Optimize image specifics
   image:
+    # Image.registry can be used to set container image registry.
+    registry: ""
     # Image.repository defines which image repository to use
     repository: camunda/optimize
     # Image.tag can be set to overwrite the global tag, which should be used in that chart
@@ -760,6 +772,8 @@ retentionPolicy:
 
   # Image configuration for the elasticsearch curator cronjob
   image:
+    # Image.registry can be used to set container image registry.
+    registry: ""
     # Image.repository defines which image repository to use
     repository: bitnami/elasticsearch-curator
     # Image.tag defines the tag / version which should be used in the chart
@@ -795,6 +809,8 @@ identity:
 
   # Image configuration to configure the identity image specifics
   image:
+    # Image.registry can be used to set container image registry.
+    registry: ""
     # Image.repository defines which image repository to use
     repository: camunda/identity
     # Image.tag can be set to overwrite the global tag, which should be used in that chart


### PR DESCRIPTION
### Which problem does the PR fix?

Currently, it's hard to just change the registry for all components, and it needs to override each component image repo name.

### What's in this PR?

Support customizing container image registry for all components globally and also allow to set registry per component.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added.
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?