### PR TITLE
chore: unify make targets

### DIFF
--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -47,10 +47,10 @@ jobs:
         uses: asdf-vm/actions/install@v1
       - name: Add Helm repos
         run: |
-          make helm-repos-add
+          make helm.repos-add
       - name: Update Helm dependency
         run: |
-          make helm-dependency-update
+          make helm.dependency-update
       - name: Run Chart Releaser
         uses: helm/chart-releaser-action@v1.3.0
         with:

--- a/.github/workflows/chart-update-image-tag.yaml
+++ b/.github/workflows/chart-update-image-tag.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Update values file image tag
         run: |
           make update-values-file-image-tag
-          make golden
+          make go.test-golden-updated
       - name: Make sure all Docker image tags are available
         run: |
           make helm.repos-add

--- a/.github/workflows/chart-update-image-tag.yaml
+++ b/.github/workflows/chart-update-image-tag.yaml
@@ -37,7 +37,7 @@ jobs:
           make golden
       - name: Make sure all Docker image tags are available
         run: |
-          make helm-repos-add
+          make helm.repos-add
           camunda_docker_images="$(helm template charts/camunda-platform --skip-tests | awk '/image:.+camunda/ {gsub(/"/, "", $2); print $2}' | sort | uniq)"
           for image_name in ${camunda_docker_images}; do
               echo -e "\n\nImage: ${image_name}"

--- a/.github/workflows/chart-update-image-tag.yaml
+++ b/.github/workflows/chart-update-image-tag.yaml
@@ -33,7 +33,7 @@ jobs:
           echo "OPTIMIZE_IMAGE_TAG=${{ github.event.inputs.optimize-image-tag }}" >> "$GITHUB_ENV"
       - name: Update values file image tag
         run: |
-          make update-values-file-image-tag
+          make tools.update-values-file-image-tag
           make go.test-golden-updated
       - name: Make sure all Docker image tags are available
         run: |

--- a/.github/workflows/chart-validate.yaml
+++ b/.github/workflows/chart-validate.yaml
@@ -25,10 +25,10 @@ jobs:
         uses: asdf-vm/actions/install@v1
       - name: Add helm repos
         run: |
-          make helm-repos-add
+          make helm.repos-add
       - name: Get Helm dependency
         run: |
-          make helm-dependency-update
+          make helm.dependency-update
       - name: Run Helm lint 
         run: |
           helm lint --strict charts/*

--- a/.github/workflows/go-it-os.yaml
+++ b/.github/workflows/go-it-os.yaml
@@ -55,5 +55,5 @@ jobs:
       - name: Add helm repos
         run: make helm.repos-add
       - name: Test - ${{ matrix.test.name }}
-        run: make it-os GO_TEST_IT_OS_ARGS="-testify.m ${{ matrix.test.method }}"
+        run: make go.test-it-os GO_TEST_IT_OS_ARGS="-testify.m ${{ matrix.test.method }}"
 

--- a/.github/workflows/go-it-os.yaml
+++ b/.github/workflows/go-it-os.yaml
@@ -53,7 +53,7 @@ jobs:
         with:
           go-version: 1.17
       - name: Add helm repos
-        run: make helm-repos-add
+        run: make helm.repos-add
       - name: Test - ${{ matrix.test.name }}
         run: make it-os GO_TEST_IT_OS_ARGS="-testify.m ${{ matrix.test.method }}"
 

--- a/.github/workflows/go-it.yaml
+++ b/.github/workflows/go-it.yaml
@@ -70,4 +70,4 @@ jobs:
     - name: Add helm repos
       run: make helm.repos-add
     - name: Test - ${{ matrix.test.name }}
-      run: make it GO_TEST_IT_ARGS="-testify.m ${{ matrix.test.method }}"
+      run: make go.test-it GO_TEST_IT_ARGS="-testify.m ${{ matrix.test.method }}"

--- a/.github/workflows/go-it.yaml
+++ b/.github/workflows/go-it.yaml
@@ -68,6 +68,6 @@ jobs:
     - name: Install Helm
       uses: asdf-vm/actions/install@v1
     - name: Add helm repos
-      run: make helm-repos-add
+      run: make helm.repos-add
     - name: Test - ${{ matrix.test.name }}
       run: make it GO_TEST_IT_ARGS="-testify.m ${{ matrix.test.method }}"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,8 +38,8 @@ jobs:
       uses: asdf-vm/actions/install@v1
     - name: Add helm repos
       run: |
-        make helm-repos-add
+        make helm.repos-add
     - name: Get Helm dependency
-      run: make helm-dependency-update
+      run: make helm.dependency-update
     - name: Test
       run: make test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,7 +23,7 @@ jobs:
         go-version: 1.17
     - name: Format
       run: |
-        make fmt
+        make go.fmt
         diff=$(git status --porcelain)
         if [ -n "$diff" ]
         then
@@ -31,9 +31,9 @@ jobs:
           exit 1
         fi
     - name: Install License Tool
-      run: make installLicense
+      run: make go.addlicense-install
     - name: Check License
-      run: make checkLicense
+      run: make go.addlicense-check
     - name: Install Helm
       uses: asdf-vm/actions/install@v1
     - name: Add helm repos
@@ -42,4 +42,4 @@ jobs:
     - name: Get Helm dependency
       run: make helm.dependency-update
     - name: Test
-      run: make test
+      run: make go.test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,9 +35,9 @@ Please feel free to fork this repository and open a pull request to fix an issue
 Make sure that your provided PR's works via:
 
  * `helm lint` to run the linting
- * `make fmt` to run the gofmt
- * `make checkLicense` to run the license check
- * `make test` to run the go tests
+ * `make go.fmt` to run the gofmt
+ * `make go.addlicense-check` to run the license check
+ * `make go.test` to run the go tests
  * `helm install <releasename> chartPath/` to install a Helm release in your K8s cluster (e.g. kind)
 
 We have the following expectation on PR's:
@@ -110,7 +110,7 @@ We separate our tests in two parts, with different targets and goals.
 Tests can be found in the `charts/camunda-platform` directory under `test/`. For each sub-chart we have a sub-directory 
 in the `test/` directory. For example [test/zeebe](charts/camunda-platform/test/zeebe).
 
-In order to run the tests, execute `make test` on the root repository level.
+In order to run the tests, execute `make go.test` on the root repository level.
 
 #### Unit Tests
 
@@ -124,7 +124,7 @@ For an example see [zeebe/goldenfiles_test.go](charts/camunda-platform/test/zeeb
 
 If the complete manifest can be enabled by a toggle, we also write a golden file test. This test is part of `<manifestFileName>_test.go` file. The `<manifestFileName>` corresponds to the template filename we have in the sub-chart `templates` dir. For example, the prometheus [servicemonitor](charts/camunda-platform/templates/service-monitor.yaml) can be enabled by a toggle. This means we write a golden file test in [servicemonitor_test.go](charts/camunda-platform/test/servicemonitor_test.go).
 
-In order to generate the golden files run `make golden` on the root level of the repository. This will add a new golden file in a `golden` sub-dir and run the corresponding test. The golden files should also be named related to the manifest.
+In order to generate the golden files run `go.test-with-updated-golden-files` on the root level of the repository. This will add a new golden file in a `golden` sub-dir and run the corresponding test. The golden files should also be named related to the manifest.
 
 ##### Properties Test
 
@@ -136,7 +136,7 @@ It is always helpful to check already existing tests to get a better understandi
 
 #### Test License Headers
 
-Make sure that new go tests contain the apache license headers, otherwise the CI license check will fail. For adding and checking the license we use [addlicense](https://github.com/google/addlicense). In order to install it locally, simply run `make installLicense`. Afterwards you can run `make addlicense` to add the missing license header to a new go file.
+Make sure that new go tests contain the apache license headers, otherwise the CI license check will fail. For adding and checking the license we use [addlicense](https://github.com/google/addlicense). In order to install it locally, simply run `make go.addlicense-install`. Afterwards you can run `make go.addlicense-run` to add the missing license header to a new go file.
 
 #### OpenShift
 

--- a/Makefile
+++ b/Makefile
@@ -122,39 +122,39 @@ topology:
 ######### Release
 #########################################################
 
-.PHONY: .bump-chart-version
-.bump-chart-version:
+.PHONY: .release.bump-chart-version
+.release.bump-chart-version:
 	@bash scripts/bump-chart-version.sh
 
-.PHONY: bump-chart-version-and-commit
-bump-chart-version-and-commit: .bump-chart-version
+.PHONY: .release.bump-chart-version-and-commit
+.release.bump-chart-version-and-commit: .release.bump-chart-version
 	git add $(chartPath);\
 	git commit -m "chore: bump camunda-platform chart version to $(chartVersion)"
 
-.PHONY: .generate-release-notes
-.generate-release-notes:
+.PHONY: .release.generate-notes
+.release.generate-notes:
 	docker run --rm -w /data -v `pwd`:/data --entrypoint sh $(gitChglog) \
 		-c "apk add bash grep yq; bash scripts/generate-release-notes.sh"
 
-.PHONY: generate-release-notes-and-commit
-generate-release-notes-and-commit: .generate-release-notes
+.PHONY: release.generate-notes-and-commit
+release.generate-notes-and-commit: .release.generate-notes
 	git add $(chartPath);\
 	git commit -m "chore: add release notes for camunda-platform $(chartVersion)"
 
-.PHONY: generate-release-pr-url
-generate-release-pr-url:
+.PHONY: release.generate-pr-url
+release.generate-pr-url:
 	@echo "\n\n###################################\n"
 	@echo "Open the release PR using this URL:"
 	@echo "https://github.com/camunda/camunda-platform-helm/compare/release?expand=1&template=release_template.md&title=Release%20Camunda%20Platform%20Helm%20Chart%20v$(chartVersion)"
 	@echo "\n###################################\n\n"
 
-.PHONY: release-chores
-release-chores:
+.PHONY: release.chores
+release.chores:
 	git checkout main
-	git pull
+	git pull --tags
 	git switch -C release
-	@$(MAKE) bump-chart-version-and-commit
-	@$(MAKE) generate-release-notes-and-commit
+	@$(MAKE) release.bump-chart-version-and-commit
+	@$(MAKE) release.generate-notes-and-commit
 	git push -fu origin release
-	@$(MAKE) generate-release-pr-url
+	@$(MAKE) release.generate-pr-url
 	git checkout main

--- a/Makefile
+++ b/Makefile
@@ -5,45 +5,55 @@ chartVersion=$(shell grep -Po '(?<=^version: ).+' $(chartPath)/Chart.yaml)
 releaseName=camunda-platform-test
 gitChglog=quay.io/git-chglog/git-chglog:0.15.1
 
-# test: runs the tests without updating the golden files (runs checks against golden files)
-.PHONY: test
-test:	helm.dependency-update
+#########################################################
+######### Go.
+#########################################################
+
+#
+# Tests.
+
+# go.test: runs the tests without updating the golden files (runs checks against golden files)
+.PHONY: go.test
+go.test: helm.dependency-update
 	go test ./...
 
-# it: runs the integration tests against the current kube context
-.PHONY: it
-it:	helm.dependency-update
-	go test -p 1 -timeout 1h -tags integration ./.../integration ${GO_TEST_IT_ARGS}
-
-# it-os: runs a subset of the integration tests against the current Openshift cluster
-.PHONY: it-os
-it-os: helm.dependency-update
-	go test -p 1 -timeout 1h -tags integration,openshift ./.../integration ${GO_TEST_IT_OS_ARGS}
-
-# golden: runs the tests with updating the golden files
-.PHONY: golden
-golden:	helm.dependency-update
+# go.test-golden-updated: runs the tests with updating the golden files
+.PHONY: go.test-golden-updated
+go.test-golden-updated: helm.dependency-update
 	go test ./... -args -update-golden 
 
-# fmt: runs the gofmt in order to format all go files
-.PHONY: fmt
-fmt:
+# go.test-it: runs the integration tests against the current kube context
+.PHONY: go.test-it
+go.test-it: helm.dependency-update
+	go test -p 1 -timeout 1h -tags integration ./.../integration ${GO_TEST_IT_ARGS}
+
+# go.it-os: runs a subset of the integration tests against the current Openshift cluster
+.PHONY: go.test-it-os
+go.test-it-os: helm.dependency-update
+	go test -p 1 -timeout 1h -tags integration,openshift ./.../integration ${GO_TEST_IT_OS_ARGS}
+
+# go.fmt: runs the gofmt in order to format all go files
+.PHONY: go.fmt
+go.fmt:
 	go fmt ./... 
 
-# addlicense: add license headers to go files
-.PHONY: addlicense
-addlicense:
+#
+# Helpers.
+
+# go.addlicense-install: installs the addlicense tool
+.PHONY: go.addlicense-install
+go.addlicense-install:
+	go install github.com/google/addlicense@v1.0.0
+
+# go.addlicense-run: adds license headers to go files
+.PHONY: go.addlicense-run
+go.addlicense-run:
 	addlicense -c 'Camunda Services GmbH' -l apache charts/camunda-platform/test/**/*.go
 
-# checkLicense: checks that the go files contain license header
-.PHONY: checkLicense
-checkLicense:
+# go.addlicense-check: checks that the go files contain license header
+.PHONY: go.addlicense-check
+go.addlicense-check:
 	addlicense -check -l apache charts/camunda-platform/test/**/*.go
-
-# installLicense: installs the addlicense tool
-.PHONY: installLicense
-installLicense:
-	go install github.com/google/addlicense@v1.0.0
 
 #########################################################
 ######### Tools
@@ -90,7 +100,7 @@ helm.dependency-update:
 
 # helm.install: install the local chart into the current kubernetes cluster/namespace
 .PHONY: helm.install
-helm.install:	helm.dependency-update
+helm.install: helm.dependency-update
 	helm install $(releaseName) $(chartPath)
 
 # helm.uninstall: uninstall the chart and removes all related pvc's
@@ -107,7 +117,7 @@ helm.dry-run: helm.dependency-update
 
 # helm.template: show all rendered templates for the local chart
 .PHONY: helm.template
-helm.template:	helm.dependency-update
+helm.template: helm.dependency-update
 	helm template $(releaseName) $(chartPath)
 
 #########################################################

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ go.addlicense-check:
 #########################################################
 
 # Add asdf plugins.
-.asdf-plugins-add:
+.tools.asdf-plugins-add:
 	@# Add plugins from .tool-versions file within the repo.
 	@# If the plugin is already installed asdf exits with 2, so grep is used to handle that.
 	@for plugin in $$(awk '{print $$1}' .tool-versions); do \
@@ -69,17 +69,17 @@ go.addlicense-check:
 	done
 
 # Install tools via asdf.
-asdf-tools-install: .asdf-plugins-add
+tools.asdf-install: .tools.asdf-plugins-add
 	asdf install
 
-#########################################################
-######### Helpers
-#########################################################
-
 # This target will be mainly used in the CI to update the images tag from camunda-platform repo
-.PHONY: update-values-file-image-tag
-update-values-file-image-tag:
+.PHONY: tools.update-values-file-image-tag
+tools.update-values-file-image-tag:
 	@bash scripts/update-values-file-image-tag.sh
+
+.PHONY: tools.zbctl-topology
+tools.zbctl-topology:
+	kubectl exec svc/$(releaseName)-zeebe-gateway -- zbctl --insecure status
 
 #########################################################
 ######### HELM
@@ -119,14 +119,6 @@ helm.dry-run: helm.dependency-update
 .PHONY: helm.template
 helm.template: helm.dependency-update
 	helm template $(releaseName) $(chartPath)
-
-#########################################################
-######### Testing
-#########################################################
-
-.PHONY: topology
-topology:
-	kubectl exec svc/$(releaseName)-zeebe-gateway -- zbctl --insecure status
 
 #########################################################
 ######### Release

--- a/Makefile
+++ b/Makefile
@@ -7,22 +7,22 @@ gitChglog=quay.io/git-chglog/git-chglog:0.15.1
 
 # test: runs the tests without updating the golden files (runs checks against golden files)
 .PHONY: test
-test:	helm-dependency-update
+test:	helm.dependency-update
 	go test ./...
 
 # it: runs the integration tests against the current kube context
 .PHONY: it
-it:	helm-dependency-update
+it:	helm.dependency-update
 	go test -p 1 -timeout 1h -tags integration ./.../integration ${GO_TEST_IT_ARGS}
 
 # it-os: runs a subset of the integration tests against the current Openshift cluster
 .PHONY: it-os
-it-os: helm-dependency-update
+it-os: helm.dependency-update
 	go test -p 1 -timeout 1h -tags integration,openshift ./.../integration ${GO_TEST_IT_OS_ARGS}
 
 # golden: runs the tests with updating the golden files
 .PHONY: golden
-golden:	helm-dependency-update
+golden:	helm.dependency-update
 	go test ./... -args -update-golden 
 
 # fmt: runs the gofmt in order to format all go files
@@ -75,39 +75,39 @@ update-values-file-image-tag:
 ######### HELM
 #########################################################
 
-# helm-repos-add: add Helm repos needed by the charts
-.PHONY: helm-repos-add
-helm-repos-add:
+# helm.repos-add: add Helm repos needed by the charts
+.PHONY: helm.repos-add
+helm.repos-add:
 	helm repo add elastic https://helm.elastic.co
 	helm repo add bitnami https://charts.bitnami.com/bitnami
 	helm repo update
 
-# helm-dependency-update: updates and downloads the dependencies for the Helm chart
-.PHONY: helm-dependency-update
-helm-dependency-update:
+# helm.dependency-update: update and downloads the dependencies for the Helm chart
+.PHONY: helm.dependency-update
+helm.dependency-update:
 	helm dependency update $(chartPath)
 	helm dependency update $(chartPath)/charts/identity
 
-# install: install the local chart into the current kubernetes cluster/namespace
-.PHONY: install
-install:	helm-dependency-update
+# helm.install: install the local chart into the current kubernetes cluster/namespace
+.PHONY: helm.install
+helm.install:	helm.dependency-update
 	helm install $(releaseName) $(chartPath)
 
-# uninstall: uninstalls the chart and removes all related pvc's
-.PHONY: uninstall
-uninstall:
+# helm.uninstall: uninstall the chart and removes all related pvc's
+.PHONY: helm.uninstall
+helm.uninstall:
 	-helm uninstall $(releaseName)
 	-kubectl delete pvc -l app.kubernetes.io/instance=$(releaseName)
 	-kubectl delete pvc -l release=$(releaseName)
 
-# dry-run: runs an install dry-run with the local chart
-.PHONY: dry-run
-dry-run:	helm-dependency-update
+# helm.dry-run: run an install dry-run with the local chart
+.PHONY: helm.dry-run
+helm.dry-run: helm.dependency-update
 	helm install $(releaseName) $(chartPath) --dry-run
 
-# template: show all rendered templates for the local chart
-.PHONY: template
-template:	helm-dependency-update
+# helm.template: show all rendered templates for the local chart
+.PHONY: helm.template
+helm.template:	helm.dependency-update
 	helm template $(releaseName) $(chartPath)
 
 #########################################################

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -22,7 +22,7 @@ When it's time to release, just do the following steps.
 
 Locally, run:
 ```
-make release-chores
+make release.chores
 ```
 
 This action will:

--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -508,14 +508,14 @@ Then you need to download the dependencies first.
 Run the following to add resolve the dependencies:
 
 ```sh
-make helm-repos-add
+make helm.repos-add
 ```
 
-After this you can run: `make helm-dependency-update`, which will update and download the dependencies for all charts.
+After this you can run: `make helm.dependency-update`, which will update and download the dependencies for all charts.
 
 The execution should look like this:
 ```
-$ make helm-dependency-update
+$ make helm.dependency-update
 helm dependency update charts/camunda-platform
 Hang tight while we grab the latest from your chart repositories...
 ...Successfully got an update from the "camunda-platform" chart repository


### PR DESCRIPTION
### Which problem does the PR fix?

Currently, make targes don't follow the same pattern also, there are target names too short of understanding what they are doing without digging into the Make file.

### What's in this PR?

Tidy up and unify make targets.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added.
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
