### PR TITLE
feat: use identity theme in keycloak login page

### DIFF
--- a/charts/camunda-platform/Chart.yaml
+++ b/charts/camunda-platform/Chart.yaml
@@ -22,6 +22,13 @@ dependencies:
   - name: identity
     version: 8.1.1
     condition: "identity.enabled"
+    # NOTE: This is used to share Identity image details with its subchart Keycloak.
+    #       It should be part of Identity but Helm 3 missing this option currently (v3.10.x).
+    # TODO: Move this to Identity subchart once "export-values" is implemented.
+    #       https://github.com/helm/helm/pull/10804
+    import-values:
+      - child: image
+        parent: global.identity.image
   - name: operate
     version: 8.1.1
     condition: "operate.enabled"

--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -6,6 +6,7 @@
 
 - [Architecture](#architecture)
 - [Requirements](#requirements)
+- [Dependencies](#dependencies)
 - [Installation](#installation)
 - [Configuration](#configuration)
   - [Global](#global)
@@ -40,6 +41,42 @@
 * Minimum cluster requirements include the following to run this chart with default settings. All of these settings are configurable.
   * Three Kubernetes nodes to respect the default "hard" affinity settings
   * 2GB of RAM for the JVM heap
+
+## Dependencies
+
+Camunda Platform 8 Helm chart is an umbrella chart for different components. Some of them are internal (sub-charts)
+and some are external (third-party). The dependency management is fully automated and managed by Helm itself,
+however, it's good to understand the dependency structure. This third-party dependency is reflected in the Helm chart
+as follows:
+
+```
+camunda-platform
+  |_ elasticsearch
+  |_ identity
+    |_ keycloak
+      |_ postgresql
+  |_ optimize
+  |_ operate
+  |_ tasklist
+  |_ zeebe
+```
+
+For example, Camunda Identity utilizes Keycloak and allows you to manage users, roles, and permissions
+for Camunda Platform 8 components.
+
+- Keycloak is a dependency for Camunda Identity and PostgreSQL is a dependency for Keycloak.
+- Elasticsearch is a dependency for the Camunda Platform chart which is used in Zeebe, Operate, Tasklist, and Optimize.
+
+The values for the dependencies Keycloak and PostgreSQL can be set in the same hierarchy:
+
+```yaml
+identity:
+  [identity values]
+  keycloak:
+    [keycloak values]
+    postgresql:
+      [postgresql values]
+```
 
 ## Installation
 

--- a/charts/camunda-platform/templates/curator-cronjob.yaml
+++ b/charts/camunda-platform/templates/curator-cronjob.yaml
@@ -16,8 +16,7 @@ spec:
       template:
         spec:
           containers:
-              {{- $_ := set .Values "image" .Values.retentionPolicy.image }}
-            - image: {{ include "camundaPlatform.image" . | quote }}
+            - image: {{ include "camundaPlatform.image" (dict "base" .Values.global "overlay" .Values.retentionPolicy) | quote }}
               name: curator
               args: ["--config", "/etc/config/config.yml", "/etc/config/action_file.yml"]
               volumeMounts:

--- a/charts/camunda-platform/test/golden/curator-configmap.golden.yaml
+++ b/charts/camunda-platform/test/golden/curator-configmap.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "5.8.4"
+    app.kubernetes.io/version: "8.1.2"
 data:
   action_file.yml: |-
     ---

--- a/charts/camunda-platform/test/golden/goldenfiles.go
+++ b/charts/camunda-platform/test/golden/goldenfiles.go
@@ -35,6 +35,7 @@ type TemplateGoldenTest struct {
 	Templates      []string
 	IgnoredLines   []string
 	SetValues      map[string]string
+	ExtraHelmArgs  []string
 }
 
 func (s *TemplateGoldenTest) TestContainerGoldenTestDefaults() {
@@ -42,7 +43,7 @@ func (s *TemplateGoldenTest) TestContainerGoldenTestDefaults() {
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.Namespace),
 		SetValues:      s.SetValues,
 	}
-	output := helm.RenderTemplate(s.T(), options, s.ChartPath, s.Release, s.Templates)
+	output := helm.RenderTemplate(s.T(), options, s.ChartPath, s.Release, s.Templates, s.ExtraHelmArgs...)
 
 	s.IgnoredLines = append(s.IgnoredLines, `\s+helm.sh/chart:\s+.*`)
 	bytes := []byte(output)

--- a/charts/camunda-platform/test/golden/keycloak-statefulset.golden.yaml
+++ b/charts/camunda-platform/test/golden/keycloak-statefulset.golden.yaml
@@ -1,0 +1,137 @@
+---
+# Source: camunda-platform/charts/identity/charts/keycloak/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: camunda-platform-tes
+  namespace: camunda
+  labels:
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/instance: camunda-platform-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: keycloak
+spec:
+  replicas: 1
+  podManagementPolicy: Parallel
+  serviceName: camunda-platform-tes-headless
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/instance: camunda-platform-test
+      app.kubernetes.io/component: keycloak
+  template:
+    metadata:
+      annotations:
+      labels:
+        app.kubernetes.io/name: keycloak
+        app.kubernetes.io/instance: camunda-platform-test
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: keycloak
+    spec:
+      serviceAccountName: camunda-platform-tes
+      
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: keycloak
+                    app.kubernetes.io/instance: camunda-platform-test
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      securityContext:
+        fsGroup: 1001
+      initContainers:
+        - command:
+          - sh
+          - -c
+          - cp -a /app/keycloak-theme/* /mnt
+          image: 'camunda/identity:8.1.2'
+          imagePullPolicy: 'IfNotPresent'
+          name: copy-camunda-theme
+          volumeMounts:
+          - mountPath: /mnt
+            name: camunda-theme
+      containers:
+        - name: keycloak
+          image: docker.io/bitnami/keycloak:16.1.1-debian-10-r52
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: KEYCLOAK_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-platform-test-keycloak
+                  key: admin-password
+            - name: KEYCLOAK_MANAGEMENT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-platform-test-keycloak
+                  key: management-password
+            - name: KEYCLOAK_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-platform-test-postgresql
+                  key: password
+            - name: KEYCLOAK_PROXY_ADDRESS_FORWARDING
+              value: 'false'
+            - name: KEYCLOAK_HTTP_RELATIVE_PATH
+              value: '/auth'
+          envFrom:
+            - configMapRef:
+                name: camunda-platform-tes-env-vars
+          resources:
+            limits: {}
+            requests: {}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: https
+              containerPort: 8443
+              protocol: TCP
+            - name: http-management
+              containerPort: 9990
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 300
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 5
+            httpGet:
+              path: /auth/
+              port: http
+          readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+            httpGet:
+              path: /auth/realms/master
+              port: http
+          volumeMounts:
+            - mountPath: /opt/bitnami/keycloak/themes/identity
+              name: camunda-theme
+      volumes:
+        - emptyDir:
+            sizeLimit: 10Mi
+          name: camunda-theme

--- a/charts/camunda-platform/test/ingress_test.go
+++ b/charts/camunda-platform/test/ingress_test.go
@@ -21,6 +21,7 @@ type ingressTemplateTest struct {
 	release   string
 	namespace string
 	templates []string
+	extraArgs []string
 }
 
 func TestIngressTemplate(t *testing.T) {
@@ -51,10 +52,10 @@ func (s *ingressTemplateTest) TestIngressEnabledAndKeycloakChartProxyForwardingE
 
 	// NOTE: helm.Options.ExtraArgs doesn't support passing args to Helm "template" command.
 	// TODO: Remove "template" from all helm.Options.ExtraArgs since it doesn't have any effect.
-	extraArgs := []string{"--show-only", "charts/identity/charts/keycloak/templates/statefulset.yaml"}
+	s.extraArgs = []string{"--show-only", "charts/identity/charts/keycloak/templates/statefulset.yaml"}
 
 	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, nil, extraArgs...)
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, nil, s.extraArgs...)
 
 	var statefulSet v1.StatefulSet
 	helm.UnmarshalK8SYaml(s.T(), output, &statefulSet)

--- a/charts/camunda-platform/test/keycloak_statefulset_test.go
+++ b/charts/camunda-platform/test/keycloak_statefulset_test.go
@@ -1,0 +1,51 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This is test should be part of Identity package, but it's added here because Helm 3 (v3.10.x)
+// 			 still doesn't have "export-values" option to share data between the parent (Identity) and sub-chart (Keycloak).
+//			 For more details: https://github.com/camunda/camunda-platform-helm/pull/487
+// TODO: Move this to Identity subchart once "export-values" is implemented.
+//       For more details: https://github.com/helm/helm/pull/10804
+
+package test
+
+import (
+	"camunda-platform-helm/charts/camunda-platform/test/golden"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestGoldenKeycloakDefaults(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../")
+	require.NoError(t, err)
+
+	suite.Run(t, &golden.TemplateGoldenTest{
+		ChartPath:      chartPath,
+		Release:        "camunda-platform-test",
+		Namespace:      "camunda",
+		GoldenFileName: "keycloak-statefulset",
+		// secrets are auto-generated and need to be ignored.
+		IgnoredLines: []string{
+			`\s+checksum/configmap-env-vars:\s+.*`,
+			`\s+checksum/secrets:\s+.*`,
+		},
+		// ExtraHelmArgs is used instead of Templates here because Keycloak is a dependency chart.
+		ExtraHelmArgs: []string{"--show-only", "charts/identity/charts/keycloak/templates/statefulset.yaml"},
+	})
+}

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -872,6 +872,29 @@ identity:
   keycloak:
     # Keycloak.enabled is used incorporate with "global.identity.keycloak" to use your own Keycloak instead of the one comes with Camunda Platform Helm chart.
     enabled: true
+
+    # NOTE: Since Helm v3 (latest checked 3.10.x) doesn't merge lists with custom values files, then you will need to
+    # add this to your own values file if you override any of "extraVolumes", "initContainers", or "extraVolumeMounts".
+    extraVolumes:
+    - name: camunda-theme
+      emptyDir:
+        sizeLimit: 10Mi
+
+    initContainers:
+    - name: copy-camunda-theme
+      image: >-
+        {{- $identityImage := (dict "base" .Values.global "overlay" .Values.global.identity) -}}
+        {{- include "camundaPlatform.image" $identityImage }}
+      imagePullPolicy: "{{ .Values.global.image.pullPolicy }}"
+      command: ["sh", "-c", "cp -a /app/keycloak-theme/* /mnt"]
+      volumeMounts:
+      - name: camunda-theme
+        mountPath: /mnt
+
+    extraVolumeMounts:
+    - name: camunda-theme
+      mountPath: /opt/bitnami/keycloak/themes/identity
+
     extraEnvVars:
     # KEYCLOAK_PROXY_ADDRESS_FORWARDING can be used with Ingress that has SSL Termination. It will be "true" if the TLS
     # in global Ingress is enabled, but it could be overwritten with separate Ingress setup.


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes: #448

### What's in this PR?

Copy the login page theme from Identity to Keycloak.

The implementation ensures that the Identity image version is the same as in the Identity deployment and the theme to Keycloak.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added.
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?
