### PR TITLE
refactor(internal): simplify camundaPlatform.image template

### DIFF
--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -516,8 +516,8 @@ identity:
     initContainers:
     - name: copy-camunda-theme
       image: >-
-        {{- $identityImage := (dict "base" .Values.global "overlay" .Values.global.identity) -}}
-        {{- include "camundaPlatform.image" $identityImage }}
+        {{- $identityImageParams := (dict "base" .Values.global "overlay" .Values.global.identity) -}}
+        {{- include "camundaPlatform.imageByParams" $identityImageParams }}
       imagePullPolicy: "{{ .Values.global.image.pullPolicy }}"
       command: ["sh", "-c", "cp -a /app/keycloak-theme/* /mnt"]
       volumeMounts:

--- a/charts/camunda-platform/templates/_helpers.tpl
+++ b/charts/camunda-platform/templates/_helpers.tpl
@@ -26,7 +26,7 @@ by the DNS naming spec). If release name contains chart name it will be used as 
 
 {{/*
 Define common labels, combining the match labels and transient labels, which might change on updating
-(version depending). These labels shouldn't be used on matchLabels selector, since the selectors are immutable.
+(version depending). These labels should not be used on matchLabels selector, since the selectors are immutable.
 */}}
 {{- define "camundaPlatform.labels" -}}
 {{- template "camundaPlatform.matchLabels" . }}
@@ -56,27 +56,26 @@ app.kubernetes.io/part-of: camunda-platform
 {{- end -}}
 
 {{/*
-Set image according the values of base (global) or overlay (subchart) values.
+Set image according the values of "base" or "overlay" values.
 If the "overlay" values exist, they will override the "base" values, otherwise the "base" values will be used.
-Usage:
-  This template has 2 syntaxes:
-  1. Top-level values: It relies on ".Values.global.image" (base) and ".Values.image" (overlay) dicts.
-     Example: {{ include "camundaPlatform.image" . }}
-  2. Parameterized values: It relies on ".base.image" and ".overlay.image" dicts.
-     Example: {{ include "camundaPlatform.image" (dict "base" .Values.global "overlay" .Values.retentionPolicy) }}
+Usage: {{ include "camundaPlatform.imageByParams" (dict "base" .Values.global "overlay" .Values.retentionPolicy) }}
 */}}
-{{- define "camundaPlatform.image" -}}
-    {{/* Allow the template to work with top-level and parameterized values. */}}
-    {{- $baseImage := (hasKey . "base" | ternary (.base).image (.Values).global.image) -}}
-    {{- $overlayImage := (hasKey . "overlay" | ternary (.overlay).image (.Values).image) -}}
-
-    {{- $imageRegistry := $overlayImage.registry | default $baseImage.registry -}}
+{{- define "camundaPlatform.imageByParams" -}}
+    {{- $imageRegistry := .overlay.image.registry | default .base.image.registry -}}
     {{- printf "%s%s%s:%s"
         $imageRegistry
         (empty $imageRegistry | ternary "" "/")
-        ($overlayImage.repository | default $baseImage.repository)
-        ($overlayImage.tag | default $baseImage.tag)
+        (.overlay.image.repository | default .base.image.repository)
+        (.overlay.image.tag | default .base.image.tag)
     -}}
+{{- end -}}
+
+{{/*
+Set image according the values of "global" or "subchart" values.
+Usage: {{ include "camundaPlatform.image" . }}
+*/}}
+{{- define "camundaPlatform.image" -}}
+    {{ include "camundaPlatform.imageByParams" (dict "base" .Values.global "overlay" .Values) }}
 {{- end -}}
 
 {{/*
@@ -95,7 +94,7 @@ Set imagePullSecrets according the values of global, subchart, or empty.
 {{/*
 Keycloak service name should be a max of 20 char since the Keycloak Bitnami Chart is using Wildfly, the node identifier in WildFly is limited to 23 characters.
 Furthermore, this allows changing the referenced Keycloak name inside the sub-charts.
-Subcharts can't access values from other sub-charts or the parent, global only. This is the reason why we have a global value to specify the Keycloak full name.
+Subcharts can not access values from other sub-charts or the parent, global only. This is the reason why we have a global value to specify the Keycloak full name.
 */}}
 
 {{- define "camundaPlatform.issuerBackendUrl" -}}

--- a/charts/camunda-platform/templates/curator-cronjob.yaml
+++ b/charts/camunda-platform/templates/curator-cronjob.yaml
@@ -16,7 +16,8 @@ spec:
       template:
         spec:
           containers:
-            - image: {{ include "camundaPlatform.image" (dict "base" .Values.global "overlay" .Values.retentionPolicy) | quote }}
+            {{- $curatorImageParams := (dict "base" .Values.global "overlay" .Values.retentionPolicy) }}
+            - image: {{ include "camundaPlatform.imageByParams" $curatorImageParams | quote }}
               name: curator
               args: ["--config", "/etc/config/config.yml", "/etc/config/action_file.yml"]
               volumeMounts:

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -888,8 +888,8 @@ identity:
     initContainers:
     - name: copy-camunda-theme
       image: >-
-        {{- $identityImage := (dict "base" .Values.global "overlay" .Values.global.identity) -}}
-        {{- include "camundaPlatform.image" $identityImage }}
+        {{- $identityImageParams := (dict "base" .Values.global "overlay" .Values.global.identity) -}}
+        {{- include "camundaPlatform.imageByParams" $identityImageParams }}
       imagePullPolicy: "{{ .Values.global.image.pullPolicy }}"
       command: ["sh", "-c", "cp -a /app/keycloak-theme/* /mnt"]
       volumeMounts:


### PR DESCRIPTION
### What's in this PR?

Simplify the `camundaPlatform.image` template by applying SOLID principles for better readability and maintainability.

So instead of having a single template that handles 2 cases, now we have 2 templates, an abstraction that works with any input and an implementation that works with known paths like `.Values.global.image` and `.Values.image`.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added.
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
