### PR TITLE
ci: enhance k8s/gke integration tests

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -1,3 +1,5 @@
+# Based on:
+# https://docs.github.com/en/actions/deployment/deploying-to-your-cloud-provider/deploying-to-google-kubernetes-engine
 name: "Test - Integration"
 
 on:
@@ -10,15 +12,17 @@ on:
   workflow_dispatch: { }
 
 env:
-  KUBECTL_VERSION: 'latest'
-  KUBECTX: 'gke_zeebe-io_europe-west1-b_zeebe-cluster'
   GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
   GITHUB_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
   GITHUB_WORKFLOW_RUN_ID: ${{ github.run_id }}
+  # Keep the test namespace based on the input or if GHA debug mode is enabled.
+  CAMUNDA_DISTRO_TEST_DELETE_NAMESPACE: ${{ !secrets.ACTIONS_STEP_DEBUG || true }}
+  KUBECONFIG: .github/config/kubeconfig
 
 jobs:
   test:
     name: ${{ matrix.test.name }}
+    runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' || github.event.pull_request.head.repo.full_name == github.repository
     strategy:
       fail-fast: false
@@ -32,32 +36,36 @@ jobs:
           method: "TestServicesEnd2EndWithUpgrade"
         - name: "End2EndWithConfig"
           method: "TestServicesEnd2EndWithConfig"
-    runs-on: ubuntu-latest
-    env:
-      KUBECONFIG: .github/config/kubeconfig
-    # Add "id-token" with the intended permissions.
     permissions:
       contents: 'read'
       id-token: 'write'
     steps:
-    - name: Set var GITHUB_PR_HEAD_SHA_SHORT
-      run: echo "GITHUB_PR_HEAD_SHA_SHORT=$(echo $GITHUB_PR_HEAD_SHA | cut -c 1-7)" >> $GITHUB_ENV
+    - name: Set test env vars
+      run: |
+        sudo apt install -y pwgen
+        echo "GITHUB_PR_HEAD_SHA_SHORT=$(echo $GITHUB_PR_HEAD_SHA | cut -c 1-7)" >> $GITHUB_ENV
+        # NOTE: We should use the matrix job id var once it's available.
+        # https://github.com/orgs/community/discussions/40291
+        echo "GITHUB_WORKFLOW_JOB_ID=$(pwgen 6 1 -A)" >> $GITHUB_ENV
     - uses: actions/checkout@v3
-    - id: 'auth'
-      name: 'Authenticate to Google Cloud'
+    # NOTE: We will switch to workload identity when its resource added to Crossplane.
+    # https://github.com/upbound/provider-gcp/issues/66
+    # - name: 'Authenticate to Google Cloud'
+    #   uses: 'google-github-actions/auth@v0'
+    #   with:
+    #     workload_identity_provider: ${{ secrets.GCP_AUTH_WORKLOAD_IDENTITY_PROVIDER }}
+    #     service_account: ${{ secrets.GCP_AUTH_SERVICE_ACCOUNT }}
+    - name: 'Authenticate to Google Cloud'
       uses: 'google-github-actions/auth@v0'
       with:
-        workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/helm-identity-pool/providers/helm-identity-provider'
-        service_account: 'camunda-platform-helm@zeebe-io.iam.gserviceaccount.com'
-    - id: 'get-credentials'
-      name: 'Get GKE credentials'
+        credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+    - name: 'Get GKE credentials'
       uses: 'google-github-actions/get-gke-credentials@v0'
       with:
-        cluster_name: 'zeebe-cluster'
-        location: 'europe-west1-b'
+        cluster_name: ${{ secrets.GKE_CLUSTER }}
+        location: ${{ secrets.GKE_ZONE }}
     # The KUBECONFIG env var is automatically exported and picked up by kubectl.
-    - id: 'check-credentials'
-      name: 'Check credentials'
+    - name: 'Check credentials'
       run: 'kubectl auth can-i create deployment'
     - name: Set up Go
       uses: actions/setup-go@v2
@@ -68,4 +76,12 @@ jobs:
     - name: Add helm repos
       run: make helm.repos-add
     - name: Test - ${{ matrix.test.name }}
-      run: make go.test-it GO_TEST_IT_ARGS="-testify.m ${{ matrix.test.method }}"
+      run: make go.test-it GO_TEST_IT_ARGS="-v -testify.m ^${{ matrix.test.method }}$"
+    # This is helpful if the job is canceled and the test didn't tear down its resources.
+    - name: Cleanup test namespace
+      if: ${{ always() && env.CAMUNDA_DISTRO_TEST_DELETE_NAMESPACE }}
+      run: |
+        kubectl delete ns \
+          --ignore-not-found=true \
+          -l github-run-id=${{ env.GITHUB_WORKFLOW_RUN_ID }} \
+          -l github-job-id=${{ env.GITHUB_WORKFLOW_JOB_ID }}

--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,12 @@ go.test-golden-updated: helm.dependency-update
 # go.test-it: runs the integration tests against the current kube context
 .PHONY: go.test-it
 go.test-it: helm.dependency-update
-	go test -p 1 -timeout 1h -tags integration ./.../integration ${GO_TEST_IT_ARGS}
+	go test -p 1 -timeout 1h -tags integration ./.../integration $(value GO_TEST_IT_ARGS)
 
 # go.it-os: runs a subset of the integration tests against the current Openshift cluster
 .PHONY: go.test-it-os
 go.test-it-os: helm.dependency-update
-	go test -p 1 -timeout 1h -tags integration,openshift ./.../integration ${GO_TEST_IT_OS_ARGS}
+	go test -p 1 -timeout 1h -tags integration,openshift ./.../integration $(value GO_TEST_IT_OS_ARGS)
 
 # go.fmt: runs the gofmt in order to format all go files
 .PHONY: go.fmt

--- a/charts/camunda-platform/test/integration/integration_suite.go
+++ b/charts/camunda-platform/test/integration/integration_suite.go
@@ -33,12 +33,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+type integrationSuiteOptions struct {
+	deleteNamespace bool
+}
+
 type integrationSuite struct {
 	suite.Suite
-	chartPath   string
-	release     string
-	namespace   string
-	kubeOptions *k8s.KubectlOptions
+	chartPath         string
+	release           string
+	namespace         string
+	namespaceMetadata metav1.ObjectMeta
+	kubeOptions       *k8s.KubectlOptions
+	options           integrationSuiteOptions
 }
 
 func (s *integrationSuite) getSecret(secretSuffix string, secretKey string) string {

--- a/charts/camunda-platform/test/integration/openshift_test.go
+++ b/charts/camunda-platform/test/integration/openshift_test.go
@@ -49,7 +49,8 @@ func TestOpenShift(t *testing.T) {
 }
 
 func (s *openshiftSuite) SetupTest() {
-	s.namespace = createNamespaceName()
+	nsMetadata := createNamespaceObjectMeta()
+	s.namespace = nsMetadata.Name
 	s.kubeOptions = k8s.NewKubectlOptions("", "", s.namespace)
 
 	if !s.doesProjectExist() {

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 )
 
 require (
+	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/openshift/api v0.0.0-20220414050251-a83e6f8f1d50
 	github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3
 	k8s.io/apimachinery v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,7 @@ github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0Bsq
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/camunda-cloud/zeebe/clients/go v1.3.4 h1:P7GJybyH2wI9LbU4F7vXTocRCaFNOYQrD8TOc0MDBvQ=
 github.com/camunda-cloud/zeebe/clients/go v1.3.4/go.mod h1:Drngktd7fr05tWcPjOx6g6F8gRZVBx9T+pQWgTZUyIs=
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes: #395

### What's in this PR?

- **Tests**: Fix the retry issue where the Pods' names were used, and the test fails if the pods were removed afterward (using labels instead).
- **Tests**: Impelment `waitUntilPodAvailable` that supports backoff retry instead of [terratest/k8s/WaitUntilPodAvailable](https://pkg.go.dev/github.com/gruntwork-io/terratest@v0.40.3/modules/k8s#WaitUntilPodAvailable) which was humming the cluster with a fixed retry (also it makes a lot of noise in the logs).
- **Tests**: By default, delete the test namespace unless explicitly it needs to be kept.
- **CI**: Ensure the test namespace is deleted even if the CI job is canceled.  
- **CI**: Use the distro team GKE cluster for integration tests.
- **CI**: Fix wrong match in the matrix where `-testify.m` matches regex not fixed name.

These changes should enhance the stability of the tests, shorten test time, and help to debug failed tests.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added.
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
