### PR TITLE
chore(optimize): correct spring uri env var name

### DIFF
--- a/charts/camunda-platform/charts/optimize/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/optimize/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
             value: "optimize-api"
           - name: CAMUNDA_OPTIMIZE_API_AUDIENCE
             value: "optimize-api"
-          - name: CAMUNDA_OPTIMIZE_API_JWTSETURI
+          - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI
             value: {{ printf "%s%s" (include "camundaPlatform.issuerBackendUrl" .) "/protocol/openid-connect/certs" | quote }}
           {{- end }}
           - name: CAMUNDA_OPTIMIZE_SECURITY_AUTH_COOKIE_SAME_SITE_ENABLED

--- a/charts/camunda-platform/test/optimize/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/optimize/golden/deployment.golden.yaml
@@ -67,7 +67,7 @@ spec:
             value: "optimize-api"
           - name: CAMUNDA_OPTIMIZE_API_AUDIENCE
             value: "optimize-api"
-          - name: CAMUNDA_OPTIMIZE_API_JWTSETURI
+          - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI
             value: "http://camunda-platform-tes:80/auth/realms/camunda-platform/protocol/openid-connect/certs"
           - name: CAMUNDA_OPTIMIZE_SECURITY_AUTH_COOKIE_SAME_SITE_ENABLED
             value: "false"


### PR DESCRIPTION
### Which problem does the PR fix?

-

### What's in this PR?

The environment variable `CAMUNDA_OPTIMIZE_API_JWTSETURI` should actually be `SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI`

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added (if needed).
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
