### PR TITLE
refactor: use external keycloak host directly

### DIFF
--- a/charts/camunda-platform/charts/identity/templates/_helpers.tpl
+++ b/charts/camunda-platform/charts/identity/templates/_helpers.tpl
@@ -134,7 +134,7 @@ For more details, please check Camunda Platform Helm chart documentation.
 
 {{/*
 [identity] Get Keycloak URL service name based on global value or Keycloak subchart.
-This is mainly used for cases where the external Keycloak is used.
+This is mainly used to access the external Keycloak service in the global Ingress.
 */}}
 {{- define "identity.keycloak.service" -}}
     {{- if and .Values.global.identity.keycloak.url .Values.global.identity.keycloak.url.host -}}
@@ -143,6 +143,18 @@ This is mainly used for cases where the external Keycloak is used.
         {{ include "common.names.dependency.fullname" (dict "chartName" "keycloak" "chartValues" . "context" $) | trunc 20 | trimSuffix "-" }}
     {{- end -}}
 {{- end -}}
+
+{{/*
+[identity] Get Keycloak URL host based on global value or Keycloak subchart.
+*/}}
+{{- define "identity.keycloak.host" -}}
+    {{- if and .Values.global.identity.keycloak.url .Values.global.identity.keycloak.url.host -}}
+        {{- .Values.global.identity.keycloak.url.host -}}
+    {{- else -}}
+        {{ include "common.names.dependency.fullname" (dict "chartName" "keycloak" "chartValues" . "context" $) | trunc 20 | trimSuffix "-" }}
+    {{- end -}}
+{{- end -}}
+
 
 {{/*
 [identity] Get Keycloak URL port based on global value or Keycloak subchart.
@@ -171,7 +183,7 @@ This is mainly used for cases where the external Keycloak is used.
     {{-
       printf "%s://%s:%s%s"
         (include "identity.keycloak.protocol" .)
-        (include "identity.keycloak.service" .)
+        (include "identity.keycloak.host" .)
         (include "identity.keycloak.port" .)
         (include "identity.keycloak.contextPath" .)
     -}}

--- a/charts/camunda-platform/test/identity/deployment_test.go
+++ b/charts/camunda-platform/test/identity/deployment_test.go
@@ -76,7 +76,7 @@ func (s *deploymentTemplateTest) TestContainerWithExternalKeycloak() {
 	s.Require().Contains(env,
 		corev1.EnvVar{
 			Name:  "KEYCLOAK_URL",
-			Value: "https://camunda-platform-test-keycloak-custom:8443/auth",
+			Value: "https://keycloak.prod.svc.cluster.local:8443/auth",
 		})
 	s.Require().Contains(env,
 		corev1.EnvVar{

--- a/charts/camunda-platform/test/operate/deployment_test.go
+++ b/charts/camunda-platform/test/operate/deployment_test.go
@@ -638,7 +638,7 @@ func (s *deploymentTemplateTest) TestContainerShouldSetTheRightKeycloakServiceUr
 	s.Require().Contains(env,
 		corev1.EnvVar{
 			Name:  "CAMUNDA_OPERATE_IDENTITY_ISSUER_BACKEND_URL",
-			Value: "http://camunda-platform-test-keycloak-custom:80/auth/realms/camunda-platform",
+			Value: "http://keycloak:80/auth/realms/camunda-platform",
 		})
 }
 

--- a/charts/camunda-platform/test/optimize/deployment_test.go
+++ b/charts/camunda-platform/test/optimize/deployment_test.go
@@ -612,7 +612,7 @@ func (s *deploymentTemplateTest) TestContainerShouldSetTheRightKeycloakServiceUr
 	s.Require().Contains(env,
 		corev1.EnvVar{
 			Name:  "CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_BACKEND_URL",
-			Value: "http://camunda-platform-test-keycloak-custom:80/auth/realms/camunda-platform",
+			Value: "http://keycloak:80/auth/realms/camunda-platform",
 		})
 }
 

--- a/charts/camunda-platform/test/tasklist/deployment_test.go
+++ b/charts/camunda-platform/test/tasklist/deployment_test.go
@@ -638,7 +638,7 @@ func (s *deploymentTemplateTest) TestContainerShouldSetTheRightKeycloakServiceUr
 	s.Require().Contains(env,
 		corev1.EnvVar{
 			Name:  "CAMUNDA_TASKLIST_IDENTITY_ISSUER_BACKEND_URL",
-			Value: "http://camunda-platform-test-keycloak-custom:80/auth/realms/camunda-platform",
+			Value: "http://keycloak:80/auth/realms/camunda-platform",
 		})
 }
 


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes: SUPPORT-15345

### What's in this PR?

Use the use external Keycloak host directly in the Keycloak URL and only use the ExternalName service in the Ingress, which could be customized later if needed.

Using the host directly avoids any need to deal with TLS certificates.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added (if needed).
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?


