### PR TITLE
fix: use keycloak 7.1.6 from camunda repo index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ tools.zbctl-topology:
 # helm.repos-add: add Helm repos needed by the charts
 .PHONY: helm.repos-add
 helm.repos-add:
+	helm repo add camunda https://helm.camunda.io
 	helm repo add elastic https://helm.elastic.co
 	helm repo add bitnami https://charts.bitnami.com/bitnami
 	helm repo update

--- a/charts/camunda-platform/charts/identity/Chart.yaml
+++ b/charts/camunda-platform/charts/identity/Chart.yaml
@@ -10,6 +10,6 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
 dependencies:
   - name: keycloak
-    repository: "https://charts.bitnami.com/bitnami"
+    repository: "https://helm.camunda.io"
     version: 7.1.6
     condition: "keycloak.enabled"


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes: #511

### What's in this PR?

Use the Camunda Helm repo index instead of the Bitnami Helm repo index because Bitnami truncates the index every 6 months (more details bitnami/charts#10833)

The Camunda Helm repo index was updated by [1b3d2da](https://github.com/camunda/camunda-platform-helm/commit/1b3d2daa3a42eb32f9200eea112ba6111223aec8)

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added (if needed).
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?