### PR TITLE
fix(ci): use gh app to auth bot pr

### DIFF
--- a/.github/workflows/chart-update-image-tag.yaml
+++ b/.github/workflows/chart-update-image-tag.yaml
@@ -21,10 +21,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          # Needed to trigger other workflows from the bot PR. More details:
-          # https://github.com/peter-evans/create-pull-request/blob/af7c021/docs/concepts-guidelines.md#triggering-further-workflow-runs
-          ssh-key: ${{ secrets.GH_WORKFLOW_SSH_KEY_PRIVATE }}
           fetch-depth: 0
+      - name: Generate GitHub token
+        uses: tibdex/github-app-token@v1
+        id: generate-github-token
+        with:
+          app_id: ${{ secrets.GH_APP_ID }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - name: Install Helm
         uses: asdf-vm/actions/install@v1
       - name: Set images vars
@@ -58,6 +61,7 @@ jobs:
       - name: Create pull request with the changes
         uses: peter-evans/create-pull-request@v4
         with:
+          token: ${{ steps.generate-github-token.outputs.token }}
           branch: chart-update-image-tag
           commit-message: "Update Camunda Platform image tag to ${{ env.CHANGED_VERSIONS_TITLE }}"
           title: "[BOT] Update Camunda Platform image tag to ${{ env.CHANGED_VERSIONS_TITLE }}"


### PR DESCRIPTION
### Which problem does the PR fix?

This PR fixes triggering "pull_request" workflows when the PR is created by the peter-evans/create-pull-request action.

That is because pull requests created by the action using the default GITHUB_TOKEN cannot trigger other workflows.

More details:
https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs

### What's in this PR?

Use GitHub app to auth instead ssh key.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added (if needed).
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
