### PR TITLE
Kubernetes API: upgrade from policy/v1beta1 to policy/v1

### DIFF
--- a/charts/camunda-platform/charts/zeebe-gateway/templates/gateway-poddisruptionbudget.yaml
+++ b/charts/camunda-platform/charts/zeebe-gateway/templates/gateway-poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.podDisruptionBudget.enabled  }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "zeebe.names.gateway" . }}

--- a/charts/camunda-platform/charts/zeebe/templates/poddisruptionbudget.yaml
+++ b/charts/camunda-platform/charts/zeebe/templates/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.podDisruptionBudget.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "zeebe.names.broker" . }}

--- a/charts/camunda-platform/templates/curator-cronjob.yaml
+++ b/charts/camunda-platform/templates/curator-cronjob.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.retentionPolicy.enabled -}}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: camunda-platform-curator

--- a/charts/camunda-platform/test/golden/curator-cronjob.golden.yaml
+++ b/charts/camunda-platform/test/golden/curator-cronjob.golden.yaml
@@ -1,6 +1,6 @@
 ---
 # Source: camunda-platform/templates/curator-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: camunda-platform-curator

--- a/charts/camunda-platform/test/integration/it-values.yaml
+++ b/charts/camunda-platform/test/integration/it-values.yaml
@@ -5,6 +5,11 @@ zeebe-gateway:
     - name: "init-container"
       image: "busybox:1.28"
       command: ["sh", "-c" , "echo", "Hello World!"]
+  podDisruptionBudget:
+    enabled: true
+
+retentionPolicy:
+  enabled: true
 
 web-modeler:
   # the Web Modeler subchart is disabled by default

--- a/charts/camunda-platform/test/zeebe-gateway/golden/poddisruptionbudget.golden.yaml
+++ b/charts/camunda-platform/test/zeebe-gateway/golden/poddisruptionbudget.golden.yaml
@@ -1,6 +1,6 @@
 ---
 # Source: camunda-platform/charts/zeebe-gateway/templates/gateway-poddisruptionbudget.yaml
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: "camunda-platform-test-zeebe-gateway"

--- a/charts/camunda-platform/test/zeebe-gateway/poddisruptionbudget_test.go
+++ b/charts/camunda-platform/test/zeebe-gateway/poddisruptionbudget_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"k8s.io/api/policy/v1beta1"
+	"k8s.io/api/policy/v1"
 )
 
 func TestGoldenPodDisruptionBudgetDefaults(t *testing.T) {
@@ -78,7 +78,7 @@ func (s *podDisruptionBudgetTest) TestContainerMinAvailableMutualExclusiveWithMa
 
 	// when
 	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var podDisruptionBudget v1beta1.PodDisruptionBudget
+	var podDisruptionBudget v1.PodDisruptionBudget
 	helm.UnmarshalK8SYaml(s.T(), output, &podDisruptionBudget)
 
 	// then

--- a/charts/camunda-platform/test/zeebe/golden/poddisruptionbudget.golden.yaml
+++ b/charts/camunda-platform/test/zeebe/golden/poddisruptionbudget.golden.yaml
@@ -1,6 +1,6 @@
 ---
 # Source: camunda-platform/charts/zeebe/templates/poddisruptionbudget.yaml
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: "camunda-platform-test-zeebe"

--- a/charts/camunda-platform/test/zeebe/poddisruptionbudget_test.go
+++ b/charts/camunda-platform/test/zeebe/poddisruptionbudget_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"k8s.io/api/policy/v1beta1"
+	v1 "k8s.io/api/policy/v1"
 )
 
 func TestGoldenPodDisruptionBudgetDefaults(t *testing.T) {
@@ -78,7 +78,7 @@ func (s *podDisruptionBudgetTest) TestContainerMinAvailableMutualExclusiveWithMa
 
 	// when
 	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var podDisruptionBudget v1beta1.PodDisruptionBudget
+	var podDisruptionBudget v1.PodDisruptionBudget
 	helm.UnmarshalK8SYaml(s.T(), output, &podDisruptionBudget)
 
 	// then


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues related to or fixed by this PR, if any. -->

https://github.com/camunda/camunda-platform-helm/issues/498

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview about the implementation, which decisions were made and why.
-->

Trying to fix outdated API-versions in:
- `PodDisruptionBudgets` from `policy/v1beta1` to `policy/v1`
-  `CronJobs` from `policy/v1beta1` to `policy/v1`

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added (if needed).
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?


### To-Do

- [ ] Update helmchart version, a bit uncertain where you would like these changes
- [x] Tested `helm install camunda .` in AKS cluster running kubernetes 1.25.4, everything started as before

