### PR TITLE
Exclude ingress rule for keycloak when `identity.keycloak.enabled` is false

### DIFF
--- a/charts/camunda-platform/templates/ingress.yaml
+++ b/charts/camunda-platform/templates/ingress.yaml
@@ -18,7 +18,7 @@ spec:
     - http:
     {{- end }}
         paths:
-          {{- if and .Values.identity.enabled .Values.identity.contextPath }}
+          {{- if and .Values.identity.enabled .Values.identity.contextPath .Values.identity.keycloak.enabled }}
           - backend:
               service:
                 name: {{ include "identity.keycloak.service" .Subcharts.identity }}
@@ -26,6 +26,8 @@ spec:
                   number: {{ include "identity.keycloak.port" .Subcharts.identity }}
             path: {{ include "identity.keycloak.contextPath" .Subcharts.identity }}
             pathType: Prefix
+          {{- end }}
+          {{- if and .Values.identity.enabled .Values.identity.contextPath }}
           - backend:
               service:
                 name: {{ template "identity.fullname" .Subcharts.identity }}

--- a/charts/camunda-platform/test/ingress_test.go
+++ b/charts/camunda-platform/test/ingress_test.go
@@ -132,9 +132,9 @@ func (s *ingressTemplateTest) TestIngressWithKeycloakChartIsDisabled() {
 
 	// then
 	// TODO: Instead of using plain text search, unmarshal the output in an ingress struct and assert the values.
-	s.Require().Contains(output, "path: /auth")
-	s.Require().Contains(output, "name: camunda-platform-test-keycloak-custom")
-	s.Require().Contains(output, "number: 8443")
+	s.Require().NotContains(output, "path: /auth")
+	s.Require().NotContains(output, "name: camunda-platform-test-keycloak-custom")
+	s.Require().NotContains(output, "number: 8443")
 }
 
 func (s *ingressTemplateTest) TestIngressWithContextPath() {


### PR DESCRIPTION
### Which problem does the PR fix?

This pull requests addresses issue #530. 

### What's in this PR?

Added a if/else to prevent an ingress rule from being added for Keycloak when `identity.keycloak.enabled` is false

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines). I had to install `go` 😉 
- [x] Tests for charts are added (if needed). 
- [x] The main Helm chart and sub-chart are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
