### PR TITLE
Fix so that `global.identity.keycloak.realm` value is used correctly

### DIFF
--- a/charts/camunda-platform/templates/_helpers.tpl
+++ b/charts/camunda-platform/templates/_helpers.tpl
@@ -129,7 +129,7 @@ Set imagePullSecrets according the values of global, subchart, or empty.
 */}}
 
 {{- define "camundaPlatform.issuerBackendUrl" -}}
-    {{- include "camundaPlatform.keycloakURL" . -}}{{- .Values.global.identity.keycloak.realm -}}
+    {{- include "camundaPlatform.keycloakURL" . -}}{{ .Values.global.identity.keycloak.realm }}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
### Which problem does the PR fix?

Addresses issue #537

### What's in this PR?

Small fix to allow the `global.identity.keycloak.realm` value to have an effect. 

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
