### PR TITLE
chore(ci): test keycloak v19 with venom

### DIFF
--- a/.github/workflows/test-integration-kubernetes.yaml
+++ b/.github/workflows/test-integration-kubernetes.yaml
@@ -39,6 +39,21 @@ jobs:
           preSetup: ""
           setup: "helm install integration ./charts/camunda-platform --namespace=$TEST_NAMESPACE --timeout 15m0s --wait"
           postSetup: ""
+          # No need to write a full TestSuite for it since it will be removed in the next minor released
+          # when Keycloak v19 is the default version.
+        - name: ChartWithKeycloakV19
+          description: Test Camunda Platform Helm chart with next supported Keycloak version
+          preSetup: |
+            yq --inplace \
+                '.dependencies[0] |= (.version = "12.2.0", .repository = "https://charts.bitnami.com/bitnami")' \
+                charts/camunda-platform/charts/identity/Chart.yaml
+            helm dependency update charts/camunda-platform/charts/identity
+          setup: |
+            helm install integration ./charts/camunda-platform --namespace=$TEST_NAMESPACE --timeout 15m0s --wait
+          postSetup: |
+            sleep 10
+            kubectl -n $TEST_NAMESPACE get pod integration-keycloak-0 -o jsonpath='{.spec.containers[0].image}' |
+              grep "docker.io/bitnami/keycloak:19"
     steps:
     - name: Set test vars
       id: vars
@@ -70,10 +85,18 @@ jobs:
         kubectl create ns $TEST_NAMESPACE
         kubectl label ns $TEST_NAMESPACE github-run-id=$GITHUB_WORKFLOW_RUN_ID
         kubectl label ns $TEST_NAMESPACE github-job-id=$GITHUB_WORKFLOW_JOB_ID
-    - name: Deploy Camunda Platform
+    - name: Pre setup
+      if: matrix.test.preSetup
+      timeout-minutes: 5
       run: |
         ${{ matrix.test.preSetup }}
+    - name: Setup Camunda Platform
+      run: |
         ${{ matrix.test.setup }}
+    - name: Post setup
+      if: matrix.test.postSetup
+      timeout-minutes: 5
+      run: |
         ${{ matrix.test.postSetup }}
     - name: ⭐️ Run Preflight TestSuite ⭐️
       uses: ./.github/actions/venom-deploy-testsuite


### PR DESCRIPTION
### What's in this PR?

Test Camunda Platform 8 Helm chart with Keycloak v19 in Venom pipeline.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added (if needed).
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR? (failed pipelines are not related to the change)

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
