### PR TITLE
feat: expose identity metrics port

### DIFF
--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -629,6 +629,9 @@ For more information, visit [Identity Overview](https://docs.camunda.io/docs/sel
 | | `service` |  Configuration to configure the Identity service. | |
 | | `service.type` | Defines the [type of the service](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) | `ClusterIP` |
 | | `service.annotations` |  Can be used to define annotations, which will be applied to the Identity service | `{}` |
+| | `service.port` | Defines the port of the service on which the identity application will be available | `80` |
+| | `service.metricsPort` | Defines the port of the service on which the identity metrics will be available | `82` |
+| | `service.metricsName` | Defines the name of the service on which the identity metrics will be available | `metrics` |
 | | `resources` |  Configuration to set request and limit configuration for the container [request and limit configuration for the container](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits) | `requests:`<br>`  cpu: 600m`<br> `  memory: 400Mi`<br>`limits:`<br> ` cpu: 2000m`<br> ` memory: 2Gi` |
 | | `nodeSelector` |  Can be used to define on which nodes the Identity pods should run | `{ }` |
 | | `tolerations` |  Can be used to define [pod toleration's](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) | `[ ] ` |

--- a/charts/camunda-platform/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/identity/templates/deployment.yaml
@@ -142,11 +142,14 @@ spec:
         - containerPort: 8080
           name: http
           protocol: TCP
+        - containerPort: 8082
+          name: metrics
+          protocol: TCP
         {{- if .Values.startupProbe.enabled }}
         startupProbe:
           httpGet:
             path: {{ .Values.startupProbe.probePath }}
-            port: http
+            port: metrics
           initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.startupProbe.periodSeconds }}
           successThreshold: {{ .Values.startupProbe.successThreshold }}
@@ -157,7 +160,7 @@ spec:
         readinessProbe:
           httpGet:
             path: {{ .Values.readinessProbe.probePath }}
-            port: http
+            port: metrics
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           successThreshold: {{ .Values.readinessProbe.successThreshold }}
@@ -168,7 +171,7 @@ spec:
         livenessProbe:
           httpGet:
             path: {{ .Values.livenessProbe.probePath }}
-            port: http
+            port: metrics
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           successThreshold: {{ .Values.livenessProbe.successThreshold }}

--- a/charts/camunda-platform/charts/identity/templates/service.yaml
+++ b/charts/camunda-platform/charts/identity/templates/service.yaml
@@ -17,5 +17,9 @@ spec:
     name: http
     targetPort: 8080
     protocol: TCP
+  - port: {{ .Values.service.metricsPort }}
+    name: {{ .Values.service.metricsName }}
+    targetPort: 8082
+    protocol: TCP
   selector:
     {{- include "identity.matchLabels" . | nindent 4 }}

--- a/charts/camunda-platform/test/identity/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/identity/golden/deployment.golden.yaml
@@ -111,3 +111,6 @@ spec:
         - containerPort: 8080
           name: http
           protocol: TCP
+        - containerPort: 8082
+          name: metrics
+          protocol: TCP

--- a/charts/camunda-platform/test/identity/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/identity/golden/service.golden.yaml
@@ -20,6 +20,10 @@ spec:
     name: http
     targetPort: 8080
     protocol: TCP
+  - port: 82
+    name: metrics
+    targetPort: 8082
+    protocol: TCP
   selector:
     app: camunda-platform
     app.kubernetes.io/name: identity

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -1128,6 +1128,10 @@ identity:
     annotations: {}
     # Service.port defines the port of the service on which the identity application will be available
     port: 80
+    # Service.metricsPort defines the port of the service on which the identity metrics will be available
+    metricsPort: 82
+    # Service.metricsName defines the name of the service on which the identity metrics will be available
+    metricsName: metrics
 
   # PodSecurityContext defines the security options the Identity pod should be run with
   podSecurityContext: {}

--- a/test/integration/venom/preflight/testsuites/preflight.yaml
+++ b/test/integration/venom/preflight/testsuites/preflight.yaml
@@ -16,9 +16,8 @@ testcases:
     - component: Elasticsearch
       url: "http://elasticsearch-master:9200/_cluster/health?&timeout=1s"
     # Camunda.
-      # TODO: Fix this by exposing health port in Identity service.
-      # - component: Identity
-      #   url: http://{{ .releaseName }}-identity:8082/actuator/health
+    - component: Identity
+      url: http://{{ .releaseName }}-identity:82/actuator/health
     - component: Optimize
       url: http://{{ .releaseName }}-optimize/api/readyz
     - component: Operate


### PR DESCRIPTION
### Which problem does the PR fix?

Follow up on #504

### What's in this PR?

Expose the Identity metrics port, which's used in the health checks.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added (if needed).
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR? (the failed checks are not related to the change)

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
