### PR TITLE
feat(web-modeler): add support for volume mounts

### DIFF
--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -746,6 +746,8 @@ You can configure a separate Ingress resource for Web Modeler though using the v
 | | `restapi.podLabels` | Can be used to define extra restapi pod labels | `{}` |
 | | `restapi.env` | Can be used to set extra environment variables in each restapi container | `[]` |
 | | `restapi.command` | Can be used to [override the default command](https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/) provided by the container image | `[]` |
+| | `restapi.extraVolumes` | Can be used to define extra volumes for the restapi pods, useful for TLS and self-signed certificates | `[]` |
+| | `restapi.extraVolumeMounts` | Can be used to mount extra volumes for the restapi pods, useful for TLS and self-signed certificates | `[]` |
 | | `restapi.podSecurityContext` | Can be used to define the security options the restapi pod should be run with | `{}` |
 | | `restapi.containerSecurityContext` | Can be used to define the security options the restapi container should be run with | `{}` |
 | | `restapi.nodeSelector` | Can be used to select the nodes the restapi pods should run on | `{}` |
@@ -764,6 +766,8 @@ You can configure a separate Ingress resource for Web Modeler though using the v
 | | `webapp.podLabels` | Can be used to define extra webapp pod labels | `{}` |
 | | `webapp.env` | Can be used to set extra environment variables in each webapp container | `[]` |
 | | `webapp.command` | Can be used to [override the default command](https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/) provided by the container image | `[]` |
+| | `webapp.extraVolumes` | Can be used to define extra volumes for the webapp pods, useful for TLS and self-signed certificates | `[]` |
+| | `webapp.extraVolumeMounts` | Can be used to mount extra volumes for the webapp pods, useful for TLS and self-signed certificates | `[]` |
 | | `webapp.podSecurityContext` | Can be used to define the security options the webapp pod should be run with | `{}` |
 | | `webapp.containerSecurityContext` | Can be used to define the security options the webapp container should be run with | `{}` |
 | | `webapp.nodeSelector` | Can be used to select the nodes the webapp pods should run on | `{}` |

--- a/charts/camunda-platform/charts/web-modeler/templates/deployment-restapi.yaml
+++ b/charts/camunda-platform/charts/web-modeler/templates/deployment-restapi.yaml
@@ -98,7 +98,7 @@ spec:
         {{- with .Values.restapi.env }}
             {{- tpl (toYaml .) $ | nindent 10 }}
         {{- end }}
-        {{- if .Values.restapi.command}}
+        {{- if .Values.restapi.command }}
         command: {{ .Values.restapi.command }}
         {{- end }}
         resources:
@@ -110,7 +110,15 @@ spec:
         - containerPort: 8091
           name: http-management
           protocol: TCP
-      {{- if .Values.serviceAccount.name}}
+        {{- if .Values.restapi.extraVolumeMounts }}
+        volumeMounts:
+        {{- .Values.restapi.extraVolumeMounts | toYaml | nindent 8 }}
+        {{- end }}
+      {{- if .Values.restapi.extraVolumes }}
+      volumes:
+      {{- .Values.restapi.extraVolumes | toYaml | nindent 6 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.name }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- end }}
       {{- if .Values.restapi.podSecurityContext }}

--- a/charts/camunda-platform/charts/web-modeler/templates/deployment-webapp.yaml
+++ b/charts/camunda-platform/charts/web-modeler/templates/deployment-webapp.yaml
@@ -96,7 +96,7 @@ spec:
         {{- with .Values.webapp.env }}
             {{- tpl (toYaml .) $ | nindent 10 }}
         {{- end }}
-        {{- if .Values.webapp.command}}
+        {{- if .Values.webapp.command }}
         command: {{ .Values.webapp.command }}
         {{- end }}
         resources:
@@ -105,7 +105,15 @@ spec:
         - containerPort: 8070
           name: http
           protocol: TCP
-      {{- if .Values.serviceAccount.name}}
+        {{- if .Values.webapp.extraVolumeMounts }}
+        volumeMounts:
+        {{- .Values.webapp.extraVolumeMounts | toYaml | nindent 8 }}
+        {{- end }}
+      {{- if .Values.webapp.extraVolumes }}
+      volumes:
+      {{- .Values.webapp.extraVolumes | toYaml | nindent 6 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.name }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- end }}
       {{- if .Values.webapp.podSecurityContext }}

--- a/charts/camunda-platform/test/web-modeler/deployment_webapp_test.go
+++ b/charts/camunda-platform/test/web-modeler/deployment_webapp_test.go
@@ -184,3 +184,58 @@ func (s *webappDeploymentTemplateTest) TestContainerShouldSetServerHttpsOnly() {
 	env := deployment.Spec.Template.Spec.Containers[0].Env
 	s.Require().Contains(env, corev1.EnvVar{Name: "SERVER_HTTPS_ONLY", Value: "true"})
 }
+
+func (s *webappDeploymentTemplateTest) TestContainerSetExtraVolumes() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"web-modeler.enabled":                                      "true",
+			"web-modeler.webapp.extraVolumes[0].name":                  "extraVolume",
+			"web-modeler.webapp.extraVolumes[0].configMap.name":        "otherConfigMap",
+			"web-modeler.webapp.extraVolumes[0].configMap.defaultMode": "744",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	volumes := deployment.Spec.Template.Spec.Volumes
+	s.Require().Equal(1, len(volumes))
+
+	extraVolume := volumes[0]
+	s.Require().Equal("extraVolume", extraVolume.Name)
+	s.Require().NotNil(*extraVolume.ConfigMap)
+	s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
+	s.Require().EqualValues(744, *extraVolume.ConfigMap.DefaultMode)
+}
+
+func (s *webappDeploymentTemplateTest) TestContainerSetExtraVolumeMounts() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"web-modeler.enabled":                               "true",
+			"web-modeler.webapp.extraVolumeMounts[0].name":      "otherConfigMap",
+			"web-modeler.webapp.extraVolumeMounts[0].mountPath": "/usr/local/config",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	containers := deployment.Spec.Template.Spec.Containers
+	s.Require().Equal(1, len(containers))
+
+	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
+	s.Require().Equal(1, len(volumeMounts))
+	extraVolumeMount := volumeMounts[0]
+	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
+	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
+}

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -1396,6 +1396,10 @@ web-modeler:
     env: []
     # Restapi.command can be used to override the default command provided by the container image, see https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/
     command: []
+    # Restapi.extraVolumes can be used to define extra volumes for the restapi pods, useful for TLS and self-signed certificates
+    extraVolumes: []
+    # Restapi.extraVolumeMounts can be used to mount extra volumes for the restapi pods, useful for TLS and self-signed certificates
+    extraVolumeMounts: []
 
     # Restapi.podSecurityContext can be used to define the security options the restapi pod should be run with
     podSecurityContext: {}
@@ -1445,6 +1449,10 @@ web-modeler:
     env: []
     # Webapp.command can be used to override the default command provided by the container image, see https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/
     command: []
+    # Webapp.extraVolumes can be used to define extra volumes for the webapp pods, useful for TLS and self-signed certificates
+    extraVolumes: []
+    # Webapp.extraVolumeMounts can be used to mount extra volumes for the webapp pods, useful for TLS and self-signed certificates
+    extraVolumeMounts: []
 
     # Webapp.podSecurityContext can be used to define the security options the webapp pod should be run with
     podSecurityContext: {}


### PR DESCRIPTION
### Which problem does the PR fix?
https://github.com/camunda/web-modeler/issues/3716

### What's in this PR?
Add support for volume mounts for the Web Modeler's `restapi` and `webapp` components. For the `websockets` component, there's no use case for volumes.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added (if needed).
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
