### PR TITLE
feat(web-modeler): add support for startup/readiness/liveness probes

### DIFF
--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -750,6 +750,30 @@ You can configure a separate Ingress resource for Web Modeler though using the v
 | | `restapi.extraVolumeMounts` | Can be used to mount extra volumes for the restapi pods, useful for TLS and self-signed certificates | `[]` |
 | | `restapi.podSecurityContext` | Can be used to define the security options the restapi pod should be run with | `{}` |
 | | `restapi.containerSecurityContext` | Can be used to define the security options the restapi container should be run with | `{}` |
+| | `restapi.startupProbe` | Configuration of the restapi startup probe | |
+| | `restapi.startupProbe.enabled` | If true, the startup probe will be enabled for the restapi container | |
+| | `restapi.startupProbe.probePath` | Defines the HTTP endpoint used for the startup probe | |
+| | `restapi.startupProbe.initialDelaySeconds` | Defines the number of seconds after the container has started before the probe is initiated | |
+| | `restapi.startupProbe.periodSeconds` | Defines how often the probe is executed | |
+| | `restapi.startupProbe.successThreshold` | Defines how often the probe needs to succeed to be considered successful after having failed | |
+| | `restapi.startupProbe.failureThreshold` | Defines when the probe is considered failed so the container will be restarted | |
+| | `restapi.startupProbe.timeoutSeconds` | Defines the number of seconds after which the probe times out | |
+| | `restapi.readinessProbe` | Configuration of the restapi readiness probe | |
+| | `restapi.readinessProbe.enabled` | If true, the readiness probe will be enabled for the restapi container | |
+| | `restapi.readinessProbe.probePath` | Defines the HTTP endpoint used for the readiness probe | |
+| | `restapi.readinessProbe.initialDelaySeconds` | Defines the number of seconds after the container has started before the probe is initiated | |
+| | `restapi.readinessProbe.periodSeconds` | Defines how often the probe is executed | |
+| | `restapi.readinessProbe.successThreshold` | Defines how often the probe needs to succeed to be considered successful after having failed | |
+| | `restapi.readinessProbe.failureThreshold` | Defines when the probe is considered failed so the Pod will be marked unready | |
+| | `restapi.readinessProbe.timeoutSeconds` | Defines the number of seconds after which the probe times out | |
+| | `restapi.livenessProbe` | Configuration of the restapi liveness probe | |
+| | `restapi.livenessProbe.enabled` | If true, the liveness probe will be enabled for the restapi container | |
+| | `restapi.livenessProbe.probePath` | Defines the HTTP endpoint used for the liveness probe | |
+| | `restapi.livenessProbe.initialDelaySeconds` | Defines the number of seconds after the container has started before the probe is initiated | |
+| | `restapi.livenessProbe.periodSeconds` | Defines how often the probe is executed | |
+| | `restapi.livenessProbe.successThreshold` | Defines how often the probe needs to succeed to be considered successful after having failed | |
+| | `restapi.livenessProbe.failureThreshold` | Defines when the probe is considered failed so the container will be restarted | |
+| | `restapi.livenessProbe.timeoutSeconds` | Defines the number of seconds after which the probe times out | |
 | | `restapi.nodeSelector` | Can be used to select the nodes the restapi pods should run on | `{}` |
 | | `restapi.tolerations` | Can be used to define [pod tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) | `[]` |
 | | `restapi.affinity` | Can be used to define [pod affinity or anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) | `{}` |
@@ -770,6 +794,30 @@ You can configure a separate Ingress resource for Web Modeler though using the v
 | | `webapp.extraVolumeMounts` | Can be used to mount extra volumes for the webapp pods, useful for TLS and self-signed certificates | `[]` |
 | | `webapp.podSecurityContext` | Can be used to define the security options the webapp pod should be run with | `{}` |
 | | `webapp.containerSecurityContext` | Can be used to define the security options the webapp container should be run with | `{}` |
+| | `webapp.startupProbe` | Configuration of the webapp startup probe | |
+| | `webapp.startupProbe.enabled` | If true, the startup probe will be enabled for the webapp container | |
+| | `webapp.startupProbe.probePath` | Defines the HTTP endpoint used for the startup probe | |
+| | `webapp.startupProbe.initialDelaySeconds` | Defines the number of seconds after the container has started before the probe is initiated | |
+| | `webapp.startupProbe.periodSeconds` | Defines how often the probe is executed | |
+| | `webapp.startupProbe.successThreshold` | Defines how often the probe needs to succeed to be considered successful after having failed | |
+| | `webapp.startupProbe.failureThreshold` | Defines when the probe is considered failed so the container will be restarted | |
+| | `webapp.startupProbe.timeoutSeconds` | Defines the number of seconds after which the probe times out | |
+| | `webapp.readinessProbe` | Configuration of the webapp readiness probe | |
+| | `webapp.readinessProbe.enabled` | If true, the readiness probe will be enabled for the webapp container | |
+| | `webapp.readinessProbe.probePath` | Defines the HTTP endpoint used for the readiness probe | |
+| | `webapp.readinessProbe.initialDelaySeconds` | Defines the number of seconds after the container has started before the probe is initiated | |
+| | `webapp.readinessProbe.periodSeconds` | Defines how often the probe is executed | |
+| | `webapp.readinessProbe.successThreshold` | Defines how often the probe needs to succeed to be considered successful after having failed | |
+| | `webapp.readinessProbe.failureThreshold` | Defines when the probe is considered failed so the Pod will be marked unready | |
+| | `webapp.readinessProbe.timeoutSeconds` | Defines the number of seconds after which the probe times out | |
+| | `webapp.livenessProbe` | Configuration of the webapp liveness probe | |
+| | `webapp.livenessProbe.enabled` | If true, the liveness probe will be enabled for the webapp container | |
+| | `webapp.livenessProbe.probePath` | Defines the HTTP endpoint used for the liveness probe | |
+| | `webapp.livenessProbe.initialDelaySeconds` | Defines the number of seconds after the container has started before the probe is initiated | |
+| | `webapp.livenessProbe.periodSeconds` | Defines how often the probe is executed | |
+| | `webapp.livenessProbe.successThreshold` | Defines how often the probe needs to succeed to be considered successful after having failed | |
+| | `webapp.livenessProbe.failureThreshold` | Defines when the probe is considered failed so the container will be restarted | |
+| | `webapp.livenessProbe.timeoutSeconds` | Defines the number of seconds after which the probe times out | |
 | | `webapp.nodeSelector` | Can be used to select the nodes the webapp pods should run on | `{}` |
 | | `webapp.tolerations` | Can be used to define [pod tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) | `[]` |
 | | `webapp.affinity` | Can be used to define [pod affinity or anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) | `{}` |
@@ -789,6 +837,27 @@ You can configure a separate Ingress resource for Web Modeler though using the v
 | | `websockets.command` | Can be used to [override the default command](ttps://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/) provided by the container image | `[]` |
 | | `websockets.podSecurityContext` | Can be used to define the security options the websockets pod should be run with | `{}` |
 | | `websockets.containerSecurityContext` | Can be used to define the security options the websockets container should be run with | `{}` |
+| | `websockets.startupProbe` | Configuration of the websockets startup probe | |
+| | `websockets.startupProbe.enabled` | If true, the startup probe will be enabled for the websockets container | |
+| | `websockets.startupProbe.initialDelaySeconds` | Defines the number of seconds after the container has started before the probe is initiated | |
+| | `websockets.startupProbe.periodSeconds` | Defines how often the probe is executed | |
+| | `websockets.startupProbe.successThreshold` | Defines how often the probe needs to succeed to be considered successful after having failed | |
+| | `websockets.startupProbe.failureThreshold` | Defines when the probe is considered failed so the container will be restarted | |
+| | `websockets.startupProbe.timeoutSeconds` | Defines the number of seconds after which the probe times out | |
+| | `websockets.readinessProbe` | Configuration of the websockets readiness probe | |
+| | `websockets.readinessProbe.enabled` | If true, the readiness probe will be enabled for the websockets container | |
+| | `websockets.readinessProbe.initialDelaySeconds` | Defines the number of seconds after the container has started before the probe is initiated | |
+| | `websockets.readinessProbe.periodSeconds` | Defines how often the probe is executed | |
+| | `websockets.readinessProbe.successThreshold` | Defines how often the probe needs to succeed to be considered successful after having failed | |
+| | `websockets.readinessProbe.failureThreshold` | Defines when the probe is considered failed so the Pod will be marked unready | |
+| | `websockets.readinessProbe.timeoutSeconds` | Defines the number of seconds after which the probe times out | |
+| | `websockets.livenessProbe` | Configuration of the websockets liveness probe | |
+| | `websockets.livenessProbe.enabled` | If true, the liveness probe will be enabled for the websockets container | |
+| | `websockets.livenessProbe.initialDelaySeconds` | Defines the number of seconds after the container has started before the probe is initiated | |
+| | `websockets.livenessProbe.periodSeconds` | Defines how often the probe is executed | |
+| | `websockets.livenessProbe.successThreshold` | Defines how often the probe needs to succeed to be considered successful after having failed | |
+| | `websockets.livenessProbe.failureThreshold` | Defines when the probe is considered failed so the container will be restarted | |
+| | `websockets.livenessProbe.timeoutSeconds` | Defines the number of seconds after which the probe times out | |
 | | `websockets.nodeSelector` | Can be used to select the nodes the websockets pods should run on | `{}` |
 | | `websockets.tolerations` | Can be used to define [pod tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) | `[]` |
 | | `websockets.affinity` | Can be used to define [pod affinity or anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) | `{}` |

--- a/charts/camunda-platform/charts/web-modeler/templates/deployment-restapi.yaml
+++ b/charts/camunda-platform/charts/web-modeler/templates/deployment-restapi.yaml
@@ -110,6 +110,39 @@ spec:
         - containerPort: 8091
           name: http-management
           protocol: TCP
+        {{- if .Values.restapi.startupProbe.enabled }}
+        startupProbe:
+          httpGet:
+            path: {{ .Values.restapi.startupProbe.probePath }}
+            port: http-management
+          initialDelaySeconds: {{ .Values.restapi.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.restapi.startupProbe.periodSeconds }}
+          successThreshold: {{ .Values.restapi.startupProbe.successThreshold }}
+          failureThreshold: {{ .Values.restapi.startupProbe.failureThreshold }}
+          timeoutSeconds: {{ .Values.restapi.startupProbe.timeoutSeconds }}
+        {{- end }}
+        {{- if .Values.restapi.readinessProbe.enabled }}
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.restapi.readinessProbe.probePath }}
+            port: http-management
+          initialDelaySeconds: {{ .Values.restapi.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.restapi.readinessProbe.periodSeconds }}
+          successThreshold: {{ .Values.restapi.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.restapi.readinessProbe.failureThreshold }}
+          timeoutSeconds: {{ .Values.restapi.readinessProbe.timeoutSeconds }}
+        {{- end }}
+        {{- if .Values.restapi.livenessProbe.enabled }}
+        livenessProbe:
+          httpGet:
+            path: {{ .Values.restapi.livenessProbe.probePath }}
+            port: http-management
+          initialDelaySeconds: {{ .Values.restapi.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.restapi.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.restapi.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.restapi.livenessProbe.failureThreshold }}
+          timeoutSeconds: {{ .Values.restapi.livenessProbe.timeoutSeconds }}
+        {{- end }}
         {{- if .Values.restapi.extraVolumeMounts }}
         volumeMounts:
         {{- .Values.restapi.extraVolumeMounts | toYaml | nindent 8 }}

--- a/charts/camunda-platform/charts/web-modeler/templates/deployment-webapp.yaml
+++ b/charts/camunda-platform/charts/web-modeler/templates/deployment-webapp.yaml
@@ -105,6 +105,42 @@ spec:
         - containerPort: 8070
           name: http
           protocol: TCP
+        - containerPort: 8071
+          name: http-management
+          protocol: TCP
+        {{- if .Values.webapp.startupProbe.enabled }}
+        startupProbe:
+          httpGet:
+            path: {{ .Values.webapp.startupProbe.probePath }}
+            port: http-management
+          initialDelaySeconds: {{ .Values.webapp.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.webapp.startupProbe.periodSeconds }}
+          successThreshold: {{ .Values.webapp.startupProbe.successThreshold }}
+          failureThreshold: {{ .Values.webapp.startupProbe.failureThreshold }}
+          timeoutSeconds: {{ .Values.webapp.startupProbe.timeoutSeconds }}
+        {{- end }}
+        {{- if .Values.webapp.readinessProbe.enabled }}
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.webapp.readinessProbe.probePath }}
+            port: http-management
+          initialDelaySeconds: {{ .Values.webapp.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.webapp.readinessProbe.periodSeconds }}
+          successThreshold: {{ .Values.webapp.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.webapp.readinessProbe.failureThreshold }}
+          timeoutSeconds: {{ .Values.webapp.readinessProbe.timeoutSeconds }}
+        {{- end }}
+        {{- if .Values.webapp.livenessProbe.enabled }}
+        livenessProbe:
+          httpGet:
+            path: {{ .Values.webapp.livenessProbe.probePath }}
+            port: http-management
+          initialDelaySeconds: {{ .Values.webapp.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.webapp.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.webapp.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.webapp.livenessProbe.failureThreshold }}
+          timeoutSeconds: {{ .Values.webapp.livenessProbe.timeoutSeconds }}
+        {{- end }}
         {{- if .Values.webapp.extraVolumeMounts }}
         volumeMounts:
         {{- .Values.webapp.extraVolumeMounts | toYaml | nindent 8 }}

--- a/charts/camunda-platform/charts/web-modeler/templates/deployment-websockets.yaml
+++ b/charts/camunda-platform/charts/web-modeler/templates/deployment-websockets.yaml
@@ -60,6 +60,36 @@ spec:
         - containerPort: 8060
           name: http
           protocol: TCP
+        {{- if .Values.websockets.startupProbe.enabled }}
+        startupProbe:
+          tcpSocket:
+            port: http
+          initialDelaySeconds: {{ .Values.websockets.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.websockets.startupProbe.periodSeconds }}
+          successThreshold: {{ .Values.websockets.startupProbe.successThreshold }}
+          failureThreshold: {{ .Values.websockets.startupProbe.failureThreshold }}
+          timeoutSeconds: {{ .Values.websockets.startupProbe.timeoutSeconds }}
+        {{- end }}
+        {{- if .Values.websockets.readinessProbe.enabled }}
+        readinessProbe:
+          tcpSocket:
+            port: http
+          initialDelaySeconds: {{ .Values.websockets.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.websockets.readinessProbe.periodSeconds }}
+          successThreshold: {{ .Values.websockets.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.websockets.readinessProbe.failureThreshold }}
+          timeoutSeconds: {{ .Values.websockets.readinessProbe.timeoutSeconds }}
+        {{- end }}
+        {{- if .Values.websockets.livenessProbe.enabled }}
+        livenessProbe:
+          tcpSocket:
+            port: http
+          initialDelaySeconds: {{ .Values.websockets.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.websockets.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.websockets.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.websockets.livenessProbe.failureThreshold }}
+          timeoutSeconds: {{ .Values.websockets.livenessProbe.timeoutSeconds }}
+        {{- end }}
       {{- if .Values.serviceAccount.name}}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- end }}

--- a/charts/camunda-platform/test/web-modeler/deployment_test.go
+++ b/charts/camunda-platform/test/web-modeler/deployment_test.go
@@ -498,3 +498,93 @@ func (s *deploymentTemplateTest) TestContainerShouldOverwriteGlobalImagePullPoli
 	pullPolicy := containers[0].ImagePullPolicy
 	s.Require().Equal(expectedPullPolicy, pullPolicy)
 }
+
+func (s *deploymentTemplateTest) TestContainerStartupProbe() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"web-modeler.enabled": "true",
+			"web-modeler." + s.component + ".startupProbe.enabled":             "true",
+			"web-modeler." + s.component + ".startupProbe.initialDelaySeconds": "5",
+			"web-modeler." + s.component + ".startupProbe.periodSeconds":       "10",
+			"web-modeler." + s.component + ".startupProbe.successThreshold":    "1",
+			"web-modeler." + s.component + ".startupProbe.failureThreshold":    "5",
+			"web-modeler." + s.component + ".startupProbe.timeoutSeconds":      "1",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	probe := deployment.Spec.Template.Spec.Containers[0].StartupProbe
+
+	s.Require().EqualValues(5, probe.InitialDelaySeconds)
+	s.Require().EqualValues(10, probe.PeriodSeconds)
+	s.Require().EqualValues(1, probe.SuccessThreshold)
+	s.Require().EqualValues(5, probe.FailureThreshold)
+	s.Require().EqualValues(1, probe.TimeoutSeconds)
+}
+
+func (s *deploymentTemplateTest) TestContainerReadinessProbe() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"web-modeler.enabled": "true",
+			"web-modeler." + s.component + ".readinessProbe.enabled":             "true",
+			"web-modeler." + s.component + ".readinessProbe.initialDelaySeconds": "5",
+			"web-modeler." + s.component + ".readinessProbe.periodSeconds":       "10",
+			"web-modeler." + s.component + ".readinessProbe.successThreshold":    "1",
+			"web-modeler." + s.component + ".readinessProbe.failureThreshold":    "5",
+			"web-modeler." + s.component + ".readinessProbe.timeoutSeconds":      "1",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	probe := deployment.Spec.Template.Spec.Containers[0].ReadinessProbe
+
+	s.Require().EqualValues(5, probe.InitialDelaySeconds)
+	s.Require().EqualValues(10, probe.PeriodSeconds)
+	s.Require().EqualValues(1, probe.SuccessThreshold)
+	s.Require().EqualValues(5, probe.FailureThreshold)
+	s.Require().EqualValues(1, probe.TimeoutSeconds)
+}
+
+func (s *deploymentTemplateTest) TestContainerLivenessProbe() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"web-modeler.enabled": "true",
+			"web-modeler." + s.component + ".livenessProbe.enabled":             "true",
+			"web-modeler." + s.component + ".livenessProbe.initialDelaySeconds": "5",
+			"web-modeler." + s.component + ".livenessProbe.periodSeconds":       "10",
+			"web-modeler." + s.component + ".livenessProbe.successThreshold":    "1",
+			"web-modeler." + s.component + ".livenessProbe.failureThreshold":    "5",
+			"web-modeler." + s.component + ".livenessProbe.timeoutSeconds":      "1",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	probe := deployment.Spec.Template.Spec.Containers[0].LivenessProbe
+
+	s.Require().EqualValues(5, probe.InitialDelaySeconds)
+	s.Require().EqualValues(10, probe.PeriodSeconds)
+	s.Require().EqualValues(1, probe.SuccessThreshold)
+	s.Require().EqualValues(5, probe.FailureThreshold)
+	s.Require().EqualValues(1, probe.TimeoutSeconds)
+}

--- a/charts/camunda-platform/test/web-modeler/deployment_websockets_test.go
+++ b/charts/camunda-platform/test/web-modeler/deployment_websockets_test.go
@@ -1,0 +1,113 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package web_modeler
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+type websocketsDeploymentTemplateTest struct {
+	suite.Suite
+	chartPath string
+	release   string
+	namespace string
+	templates []string
+}
+
+func TestWebsocketsDeploymentTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../")
+	require.NoError(t, err)
+
+	suite.Run(t, &websocketsDeploymentTemplateTest{
+		chartPath: chartPath,
+		release:   "camunda-platform-test",
+		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
+		templates: []string{"charts/web-modeler/templates/deployment-websockets.yaml"},
+	})
+}
+
+func (s *websocketsDeploymentTemplateTest) TestContainerStartupProbe() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"web-modeler.enabled":                         "true",
+			"web-modeler.websockets.startupProbe.enabled": "true",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	probe := deployment.Spec.Template.Spec.Containers[0].StartupProbe
+
+	s.Require().Equal("http", probe.TCPSocket.Port.StrVal)
+}
+
+func (s *websocketsDeploymentTemplateTest) TestContainerReadinessProbe() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"web-modeler.enabled":                           "true",
+			"web-modeler.websockets.readinessProbe.enabled": "true",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	probe := deployment.Spec.Template.Spec.Containers[0].ReadinessProbe
+
+	s.Require().Equal("http", probe.TCPSocket.Port.StrVal)
+}
+
+func (s *websocketsDeploymentTemplateTest) TestContainerLivenessProbe() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"web-modeler.enabled":                          "true",
+			"web-modeler.websockets.livenessProbe.enabled": "true",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	probe := deployment.Spec.Template.Spec.Containers[0].LivenessProbe
+
+	s.Require().Equal("http", probe.TCPSocket.Port.StrVal)
+}

--- a/charts/camunda-platform/test/web-modeler/golden/deployment-webapp.golden.yaml
+++ b/charts/camunda-platform/test/web-modeler/golden/deployment-webapp.golden.yaml
@@ -113,3 +113,6 @@ spec:
         - containerPort: 8070
           name: http
           protocol: TCP
+        - containerPort: 8071
+          name: http-management
+          protocol: TCP

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -1406,6 +1406,57 @@ web-modeler:
     # Restapi.containerSecurityContext can be used to define the security options the restapi container should be run with
     containerSecurityContext: {}
 
+    # Restapi.startupProbe configuration of the restapi startup probe
+    startupProbe:
+      # Restapi.startupProbe.enabled if true, the startup probe will be enabled for the restapi container
+      enabled: false
+      # Restapi.startupProbe.probePath defines the HTTP endpoint used for the startup probe
+      probePath: /health/liveness
+      # Restapi.startupProbe.initialDelaySeconds defines the number of seconds after the container has started before the probe is initiated
+      initialDelaySeconds: 30
+      # Restapi.startupProbe.periodSeconds defines how often the probe is executed
+      periodSeconds: 30
+      # Restapi.startupProbe.successThreshold defines how often the probe needs to succeed to be considered successful after having failed
+      successThreshold: 1
+      # Restapi.startupProbe.failureThreshold defines when the probe is considered failed so the container will be restarted
+      failureThreshold: 5
+      # Restapi.startupProbe.timeoutSeconds defines the number of seconds after which the probe times out
+      timeoutSeconds: 1
+
+    # Restapi.readinessProbe configuration of the restapi readiness probe
+    readinessProbe:
+      # Restapi.readinessProbe.enabled if true, the readiness probe will be enabled for the restapi container
+      enabled: false
+      # Restapi.readinessProbe.probePath defines the HTTP endpoint used for the readiness probe
+      probePath: /health/readiness
+      # Restapi.readinessProbe.initialDelaySeconds defines the number of seconds after the container has started before the probe is initiated
+      initialDelaySeconds: 30
+      # Restapi.readinessProbe.periodSeconds defines how often the probe is executed
+      periodSeconds: 30
+      # Restapi.readinessProbe.successThreshold defines how often the probe needs to succeed to be considered successful after having failed
+      successThreshold: 1
+      # Restapi.readinessProbe.failureThreshold defines when the probe is considered failed so the Pod will be marked unready
+      failureThreshold: 5
+      # Restapi.readinessProbe.timeoutSeconds defines the number of seconds after which the probe times out
+      timeoutSeconds: 1
+
+    # Restapi.livenessProbe configuration of the restapi liveness probe
+    livenessProbe:
+      # Restapi.livenessProbe.enabled if true, the liveness probe will be enabled for the restapi container
+      enabled: false
+      # Restapi.livenessProbe.probePath defines the HTTP endpoint used for the liveness probe
+      probePath: /health/liveness
+      # Restapi.livenessProbe.initialDelaySeconds defines the number of seconds after the container has started before the probe is initiated
+      initialDelaySeconds: 30
+      # Restapi.livenessProbe.periodSeconds defines how often the probe is executed
+      periodSeconds: 30
+      # Restapi.livenessProbe.successThreshold defines how often the probe needs to succeed to be considered successful after having failed
+      successThreshold: 1
+      # Restapi.livenessProbe.failureThreshold defines when the probe is considered failed so the container will be restarted
+      failureThreshold: 5
+      # Restapi.livenessProbe.timeoutSeconds defines the number of seconds after which the probe times out
+      timeoutSeconds: 1
+
     # Restapi.nodeSelector can be used to select the nodes the restapi pods should run on
     nodeSelector: {}
     # Restapi.tolerations can be used to define pod tolerations, see https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
@@ -1458,6 +1509,57 @@ web-modeler:
     podSecurityContext: {}
     # Webapp.containerSecurityContext can be used to define the security options the webapp container should be run with
     containerSecurityContext: {}
+
+    # Webapp.startupProbe configuration of the webapp startup probe
+    startupProbe:
+      # Webapp.startupProbe.enabled if true, the startup probe will be enabled for the webapp container
+      enabled: false
+      # Webapp.startupProbe.probePath defines the HTTP endpoint used for the startup probe
+      probePath: /health/liveness
+      # Webapp.startupProbe.initialDelaySeconds defines the number of seconds after the container has started before the probe is initiated
+      initialDelaySeconds: 15
+      # Webapp.startupProbe.periodSeconds defines how often the probe is executed
+      periodSeconds: 30
+      # Webapp.startupProbe.successThreshold defines how often the probe needs to succeed to be considered successful after having failed
+      successThreshold: 1
+      # Webapp.startupProbe.failureThreshold defines when the probe is considered failed so the container will be restarted
+      failureThreshold: 5
+      # Webapp.startupProbe.timeoutSeconds defines the number of seconds after which the probe times out
+      timeoutSeconds: 1
+
+    # Webapp.readinessProbe configuration of the webapp readiness probe
+    readinessProbe:
+      # Webapp.readinessProbe.enabled if true, the readiness probe will be enabled for the webapp container
+      enabled: false
+      # Webapp.readinessProbe.probePath defines the HTTP endpoint used for the readiness probe
+      probePath: /health/readiness
+      # Webapp.readinessProbe.initialDelaySeconds defines the number of seconds after the container has started before the probe is initiated
+      initialDelaySeconds: 15
+      # Webapp.readinessProbe.periodSeconds defines how often the probe is executed
+      periodSeconds: 30
+      # Webapp.readinessProbe.successThreshold defines how often the probe needs to succeed to be considered successful after having failed
+      successThreshold: 1
+      # Webapp.readinessProbe.failureThreshold defines when the probe is considered failed so the Pod will be marked unready
+      failureThreshold: 5
+      # Webapp.readinessProbe.timeoutSeconds defines the number of seconds after which the probe times out
+      timeoutSeconds: 1
+
+    # Webapp.livenessProbe configuration of the webapp liveness probe
+    livenessProbe:
+      # Webapp.livenessProbe.enabled if true, the liveness probe will be enabled for the webapp container
+      enabled: false
+      # Webapp.livenessProbe.probePath defines the HTTP endpoint used for the liveness probe
+      probePath: /health/liveness
+      # Webapp.livenessProbe.initialDelaySeconds defines the number of seconds after the container has started before the probe is initiated
+      initialDelaySeconds: 15
+      # Webapp.livenessProbe.periodSeconds defines how often the probe is executed
+      periodSeconds: 30
+      # Webapp.livenessProbe.successThreshold defines how often the probe needs to succeed to be considered successful after having failed
+      successThreshold: 1
+      # Webapp.livenessProbe.failureThreshold defines when the probe is considered failed so the container will be restarted
+      failureThreshold: 5
+      # Webapp.livenessProbe.timeoutSeconds defines the number of seconds after which the probe times out
+      timeoutSeconds: 1
 
     # Webapp.nodeSelector can be used to select the nodes the webapp pods should run on
     nodeSelector: {}
@@ -1514,6 +1616,51 @@ web-modeler:
     podSecurityContext: {}
     # Websockets.containerSecurityContext can be used to define the security options the websockets container should be run with
     containerSecurityContext: {}
+
+    # Websockets.startupProbe configuration of the websockets startup probe
+    startupProbe:
+      # Websockets.startupProbe.enabled if true, the startup probe will be enabled for the websockets container
+      enabled: false
+      # Websockets.startupProbe.initialDelaySeconds defines the number of seconds after the container has started before the probe is initiated
+      initialDelaySeconds: 10
+      # Websockets.startupProbe.periodSeconds defines how often the probe is executed
+      periodSeconds: 30
+      # Websockets.startupProbe.successThreshold defines how often the probe needs to succeed to be considered successful after having failed
+      successThreshold: 1
+      # Websockets.startupProbe.failureThreshold defines when the probe is considered failed so the container will be restarted
+      failureThreshold: 5
+      # Websockets.startupProbe.timeoutSeconds defines the number of seconds after which the probe times out
+      timeoutSeconds: 1
+
+    # Websockets.readinessProbe configuration of the websockets readiness probe
+    readinessProbe:
+      # Websockets.readinessProbe.enabled if true, the readiness probe will be enabled for the websockets container
+      enabled: false
+      # Websockets.readinessProbe.initialDelaySeconds defines the number of seconds after the container has started before the probe is initiated
+      initialDelaySeconds: 10
+      # Websockets.readinessProbe.periodSeconds defines how often the probe is executed
+      periodSeconds: 30
+      # Websockets.readinessProbe.successThreshold defines how often the probe needs to succeed to be considered successful after having failed
+      successThreshold: 1
+      # Websockets.readinessProbe.failureThreshold defines when the probe is considered failed so the Pod will be marked unready
+      failureThreshold: 5
+      # Websockets.readinessProbe.timeoutSeconds defines the number of seconds after which the probe times out
+      timeoutSeconds: 1
+
+    # Websockets.livenessProbe configuration of the websockets liveness probe
+    livenessProbe:
+      # Websockets.livenessProbe.enabled if true, the liveness probe will be enabled for the websockets container
+      enabled: false
+      # Websockets.livenessProbe.initialDelaySeconds defines the number of seconds after the container has started before the probe is initiated
+      initialDelaySeconds: 10
+      # Websockets.livenessProbe.periodSeconds defines how often the probe is executed
+      periodSeconds: 30
+      # Websockets.livenessProbe.successThreshold defines how often the probe needs to succeed to be considered successful after having failed
+      successThreshold: 1
+      # Websockets.livenessProbe.failureThreshold defines when the probe is considered failed so the container will be restarted
+      failureThreshold: 5
+      # Websockets.livenessProbe.timeoutSeconds defines the number of seconds after which the probe times out
+      timeoutSeconds: 1
 
     # Websockets.nodeSelector can be used to select the nodes the websockets pods should run on
     nodeSelector: {}

--- a/test/integration/scenarios/chart-with-web-modeler/values-web-modeler-enabled.yaml
+++ b/test/integration/scenarios/chart-with-web-modeler/values-web-modeler-enabled.yaml
@@ -10,3 +10,11 @@ web-modeler:
     mail:
       # the value is required, otherwise the restapi pod wouldn't start
       fromAddress: noreply@example.com
+    readinessProbe:
+      enabled: true
+  webapp:
+    readinessProbe:
+      enabled: true
+  websockets:
+    readinessProbe:
+      enabled: true


### PR DESCRIPTION
### Which problem does the PR fix?
Closes https://github.com/camunda/web-modeler/issues/3180.

Relates to #392.

### What's in this PR?
Add support for startup, readiness, and liveness probes for the Web Modeler deployments.

### Checklist
Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added (if needed).
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**
- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?