### PR TITLE
[Helm Charts] Connectors MVP - without keycloak

### DIFF
--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -917,7 +917,8 @@ For more information, visit [Introduction to Connectors](https://docs.camunda.io
 | | `serviceAccount.annotations` |  Can be used to set the annotations of the Connectors service account | `{}` |
 | | `service` |  Configuration for the Connectors service. | |
 | | `service.type` | Defines the [type of the service](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) | `ClusterIP` |
-| | `service.port` | Defines the port of the service, where the Connectors web application will be available | `8080` |
+| | `service.serverPort` | Defines the port number where the Connector web application will be available | `8080` |
+| | `service.serverName` | Defines the port name where the Connector web application will be available | `http` |
 | | `service.annotations` |  Can be used to define annotations, which will be applied to the Optimize service | `{}` |
 | | `podSecurityContext` | Defines the security options the Connectors pod should be run with | `{ }` |
 | | `containerSecurityContext` | Defines the security options the Connectors container should be run with | `{ }` |

--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -22,6 +22,7 @@
   - [Optimize](#optimize)
   - [Identity](#identity)
   - [Web Modeler (Beta)](#web-modeler-beta)
+  - [Connectors](#connectors)
   - [Elasticsearch](#elasticsearch)
   - [Keycloak](#keycloak)
 - [Guides](#guides)
@@ -891,6 +892,60 @@ You can configure a separate Ingress resource for Web Modeler though using the v
 | | `postgresql.auth.username` | Defines the name of the database user to be created for Web Modeler | `web-modeler` |
 | | `postgresql.auth.password` | Defines the database user's password; a random password will be generated if left empty | |
 | | `postgresql.auth.database` | Defines the name of the database to be created for Web Modeler | `web-modeler` |
+
+### Connectors
+
+For more information, visit [Introduction to Connectors](https://docs.camunda.io/docs/components/connectors/introduction-to-connectors/).
+
+| Section | Parameter | Description | Default |
+|-|-|-|-|
+| `connectors` | |  Configuration for the Connectors. | |
+| | `enabled` |  If true, the Connectors deployment and its related resources are deployed via a helm release | `false` |
+| | `inbound.mode` | (Experimental) Controls inbound mode for webhook or polling. Acceptable values are `disabled`, `credentials`, or `oauth` | `disabled` |
+| | `image` |  Configuration for the Connectors image specifics | |
+| | `image.registry` | Can be used to set container image registry. | `""` |
+| | `image.repository` |  Defines which image repository to use | `camunda/connectors-bundle` |
+| | `image.tag` |  Can be set to overwrite the global tag, which should be used in that chart | `0.16.1` |
+| | `image.pullSecrets` | Can be set to overwrite the global.image.pullSecrets | `{{ global.image.pullSecrets }}` |
+| | `podAnnotations` | Can be used to define extra Connectors pod annotations | `{ }` |
+| | `podLabels` |  Can be used to define extra Connectors pod labels | `{ }` |
+| | `env` |  Can be used to set extra environment variables in each Connectors container | `[]` |
+| | `command` | Can be used to [override the default command provided by the container image](https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/) | `[]` |
+| | `serviceAccount` |  Configuration for the service account where the Connectors pods are assigned to | |
+| | `serviceAccount.enabled` |  If true, enables the Connectors service account | `true` |
+| | `serviceAccount.name` |  Can be used to set the name of the Connectors service account | `""` |
+| | `serviceAccount.annotations` |  Can be used to set the annotations of the Connectors service account | `{}` |
+| | `service` |  Configuration for the Connectors service. | |
+| | `service.type` | Defines the [type of the service](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) | `ClusterIP` |
+| | `service.port` | Defines the port of the service, where the Connectors web application will be available | `8080` |
+| | `service.annotations` |  Can be used to define annotations, which will be applied to the Optimize service | `{}` |
+| | `podSecurityContext` | Defines the security options the Connectors pod should be run with | `{ }` |
+| | `containerSecurityContext` | Defines the security options the Connectors container should be run with | `{ }` |
+| | `nodeSelector` |  Can be used to define on which nodes the Connectors pods should run | `{}` |
+| | `tolerations` |  Can be used to define [pod toleration's](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) | `[ ]` |
+| | `affinity` |  Can be used to define [pod affinity or anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) | `{ }` |
+| | `resources` | Configuration to set [request and limit configuration for the container](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits) | `requests:`<br>`  cpu: 1`<br> `  memory: 1Gi`<br>`limits:`<br> ` cpu: 2`<br> ` memory: 2Gi` |
+
+#### Outbound Connectors
+
+To learn more about outbound connectors, visit [related documentation article](https://docs.camunda.io/docs/components/connectors/use-connectors/#outbound-connector).
+
+#### Using Connector Secrets
+
+Connector secrets are generally configured via environment variables.
+
+You can set them via `values.yaml`, or command line. For example, if you need to set a Slack token, you should configure the following:
+
+```yaml
+connectors:
+  env:
+    - name: SLACK_TOKEN
+      value: <your actual token value>
+```
+
+After that, a Modeler user can set in their BPMN diagram a value `secrets.SLACK_TOKEN` without ever knowing the actual token.
+
+Visit [using secrets in manual installation](https://docs.camunda.io/docs/8.0/self-managed/connectors-deployment/connectors-configuration/#secrets-in-manual-installations) to learn more.
 
 ### Elasticsearch
 

--- a/charts/camunda-platform/templates/NOTES.txt
+++ b/charts/camunda-platform/templates/NOTES.txt
@@ -45,6 +45,11 @@
   - Docker Image used for Optimize: {{ .Values.optimize.image.repository }}:{{ .Values.global.image.tag }}
     {{- end }}
   {{- end }}
+- Connectors:
+  - Enabled: {{ .Values.connectors.enabled }}
+  {{- if .Values.connectors.enabled }}
+  - Docker Image used for Connectors: {{ .Values.connectors.image.repository }}:{{ .Values.connectors.image.tag }}
+  {{- end }}
 - Identity:
   - Enabled: {{ .Values.identity.enabled }}
   {{- if .Values.identity.enabled }}

--- a/charts/camunda-platform/templates/connectors/_helpers.tpl
+++ b/charts/camunda-platform/templates/connectors/_helpers.tpl
@@ -1,0 +1,58 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+
+{{/*Pre-validate that inbound mode contains correct values*/}}
+{{- $inboundMode := .Values.connectors.inbound.mode -}}
+{{- if not (has $inboundMode (list "disabled" "credentials" "oauth")) }}
+  {{ fail "Not supported inbound mode" }}
+{{- end -}}
+
+{{ define "connectors.zeebeEndpoint" }}
+  {{- include "zeebe.names.gateway" . | replace "\"" "" -}}:{{- index .Values "zeebe-gateway" "service" "gatewayPort" -}}
+{{- end -}}
+
+{{- define "connectors.fullname" -}}
+{{/* TODO: Refactor this when more sub-charts are flatten and moved to the main chart. */}}
+    {{- $connectorsValues := deepCopy . -}}
+    {{- $_ := set $connectorsValues.Values "nameOverride" "connectors" -}}
+    {{- include "camundaPlatform.fullname" $connectorsValues -}}
+{{- end -}}
+
+{{/*
+Defines extra labels for connectors.
+*/}}
+{{- define "connectors.extraLabels" -}}
+app.kubernetes.io/component: connectors
+{{- end -}}
+
+{{/*
+Define common labels for connectors, combining the match labels and transient labels, which might change on updating
+(version depending). These labels shouldn't be used on matchLabels selector, since the selectors are immutable.
+*/}}
+{{- define "connectors.labels" -}}
+{{- template "camundaPlatform.labels" . }}
+{{ template "connectors.extraLabels" . }}
+{{- end -}}
+{{/*
+Defines match labels for connectors, which are extended by sub-charts and should be used in matchLabels selectors.
+*/}}
+{{- define "connectors.matchLabels" -}}
+{{- template "camundaPlatform.matchLabels" . }}
+{{ template "connectors.extraLabels" . }}
+{{- end -}}
+{{/*
+[connectors] Create the name of the service account to use
+*/}}
+{{- define "connectors.serviceAccountName" -}}
+{{- if .Values.connectors.serviceAccount.enabled }}
+{{- default (include "connectors.fullname" .) .Values.connectors.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.connectors.serviceAccount.name }}
+{{- end }}
+
+{{- end }}

--- a/charts/camunda-platform/templates/connectors/deployment.yaml
+++ b/charts/camunda-platform/templates/connectors/deployment.yaml
@@ -1,0 +1,95 @@
+{{- if .Values.connectors.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "connectors.fullname" . }}
+  labels: {{- include "connectors.labels" . | nindent 4 }}
+  annotations: {{- toYaml .Values.global.annotations | nindent 4 }}
+spec:
+  replicas: {{ .Values.connectors.replicas }}
+  selector:
+    matchLabels: {{- include "connectors.matchLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "connectors.labels" . | nindent 8 }}
+        {{- if .Values.connectors.podLabels }}
+        {{- toYaml .Values.connectors.podLabels | nindent 8 }}
+        {{- end }}
+        {{- if .Values.connectors.podAnnotations }}
+        annotations: {{- toYaml  .Values.connectors.podAnnotations | nindent 8 }}
+        {{- end }}
+    spec:
+{{/*      imagePullSecrets:*/}}
+{{/*        {{- include "camundaPlatform.imagePullSecrets" . | nindent 8 }}*/}}
+      containers:
+        - name: connectors
+          image: {{ include "camundaPlatform.imageByParams" (dict "base" .Values.global "overlay" .Values.connectors) }}
+          imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+          {{- if .Values.connectors.containerSecurityContext }}
+          securityContext: {{- toYaml .Values.connectors.containerSecurityContext | nindent 10 }}
+          {{- end }}
+          ports:
+            - containerPort: {{ .Values.connectors.serverPort }}
+              name: http
+              protocol: TCP
+          env:
+            - name: SERVER_PORT
+              value: {{ .Values.connectors.serverPort | quote }}
+          {{- if eq .Values.connectors.inbound.mode "disabled" }}
+            - name: ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS
+              value: {{ include "connectors.zeebeEndpoint" . | quote }}
+            - name: ZEEBE_CLIENT_SECURITY_PLAINTEXT
+              value: "true"
+            - name: CAMUNDA_CONNECTOR_POLLING_ENABLED
+              value: "false"
+            - name: CAMUNDA_CONNECTOR_WEBHOOK_ENABLED
+              value: "false"
+            - name: SPRING_MAIN_WEB-APPLICATION-TYPE
+              value: "NONE"
+          {{- end }}
+          {{- if eq .Values.connectors.inbound.mode "credentials" }} # Not implemented yet
+            - name: ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS
+              value: {{ include "connectors.zeebeEndpoint" . | quote }}
+            - name: ZEEBE_CLIENT_SECURITY_PLAINTEXT
+              value: "true"
+            - name: CAMUNDA_CONNECTOR_POLLING_ENABLED
+              value: "false"
+            - name: CAMUNDA_CONNECTOR_WEBHOOK_ENABLED
+              value: "false"
+            - name: SPRING_MAIN_WEB-APPLICATION-TYPE
+              value: "NONE"
+          {{- end }}
+          {{- if eq .Values.connectors.inbound.mode "oauth" }} # Not implemented yet
+            - name: ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS
+              value: {{ include "connectors.zeebeEndpoint" . | quote }}
+            - name: ZEEBE_CLIENT_SECURITY_PLAINTEXT
+              value: "true"
+            - name: CAMUNDA_CONNECTOR_POLLING_ENABLED
+              value: "false"
+            - name: CAMUNDA_CONNECTOR_WEBHOOK_ENABLED
+              value: "false"
+            - name: SPRING_MAIN_WEB-APPLICATION-TYPE
+              value: "NONE"
+          {{- end }}
+          {{- if .Values.connectors.env}}
+            {{ .Values.connectors.env | toYaml | nindent 12 }}
+          {{- end }}
+          command: {{ .Values.connectors.command }}
+          resources: {{- toYaml .Values.connectors.resources | nindent 12 }}
+      {{- if .Values.connectors.serviceAccount.name}}
+      serviceAccountName: {{ .Values.connectors.serviceAccount.name }}
+      {{- end }}
+      {{- if .Values.connectors.podSecurityContext }}
+      securityContext: {{- toYaml .Values.connectors.podSecurityContext | nindent 8 }}
+      {{- end }}
+      {{- with .Values.connectors.nodeSelector }}
+      nodeSelector: {{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.connectors.affinity }}
+      affinity: {{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.connectors.tolerations }}
+      tolerations: {{ toYaml . | indent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/camunda-platform/templates/connectors/deployment.yaml
+++ b/charts/camunda-platform/templates/connectors/deployment.yaml
@@ -30,8 +30,8 @@ spec:
           securityContext: {{- toYaml .Values.connectors.containerSecurityContext | nindent 10 }}
           {{- end }}
           ports:
-            - containerPort: {{ .Values.connectors.serverPort }}
-              name: http
+            - containerPort: {{ .Values.connectors.service.serverPort }}
+              name: {{ .Values.connectors.service.serverName }}
               protocol: TCP
           env:
             - name: SERVER_PORT

--- a/charts/camunda-platform/templates/connectors/service.yaml
+++ b/charts/camunda-platform/templates/connectors/service.yaml
@@ -14,9 +14,9 @@ metadata:
 spec:
   type: {{ .Values.connectors.service.type }}
   ports:
-    - name: http
-      port: {{ .Values.connectors.service.port }}
-      targetPort: 8080
+    - name: {{ .Values.connectors.service.serverName }}
+      port: {{ .Values.connectors.service.serverPort }}
+      targetPort: {{ .Values.connectors.service.serverPort }}
       protocol: TCP
   selector:
     {{- include "connectors.matchLabels" . | nindent 4 }}

--- a/charts/camunda-platform/templates/connectors/service.yaml
+++ b/charts/camunda-platform/templates/connectors/service.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.connectors.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "connectors.fullname" . }}
+  labels: {{- include "connectors.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.global.annotations}}
+    {{- toYaml .Values.global.annotations | nindent 4 }}
+    {{- end }}
+    {{- if .Values.connectors.service.annotations}}
+    {{- toYaml .Values.connectors.service.annotations | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ .Values.connectors.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.connectors.service.port }}
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    {{- include "connectors.matchLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/camunda-platform/templates/connectors/serviceaccount.yaml
+++ b/charts/camunda-platform/templates/connectors/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.connectors.enabled -}}
+{{- if .Values.connectors.serviceAccount.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "connectors.serviceAccountName" . }}
+  labels: {{- include "connectors.labels" . | nindent 4 }}
+  {{- with .Values.connectors.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -1756,8 +1756,6 @@ connectors:
     # Acceptable values: disabled, credentials, or oauth
     mode: disabled
 
-  serverPort: 8080
-
   # Image configuration to configure the Connectors image specifics
   image:
     # Image.registry can be used to set container image registry.
@@ -1787,10 +1785,12 @@ connectors:
   service:
     # Service.type defines the type of the service https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
     type: ClusterIP
-    # Service.port defines the port of the service, where the Connector web application will be available
-    port: 8080
     # Service.annotations can be used to define annotations, which will be applied to the Connectors service
     annotations: {}
+    # Service.serverPort defines the port number where the Connector web application will be available
+    serverPort: 8080
+    # Service.serverName defines the port name where the Connector web application will be available
+    serverName: http
 
   # Resources configuration to set request and limit configuration for the container https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
   resources:

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -1746,6 +1746,110 @@ web-modeler:
       # Postgresql.auth.database defines the name of the database to be created for Web Modeler
       database: web-modeler
 
+# Connectors configuration for the Connectors.
+connectors:
+  # Enabled if true, the Connectors deployment and its related resources are deployed via a helm release
+  enabled: false
+
+  # Switch for inbound mode (e.g., for webhook or polling)
+  inbound:
+    # Acceptable values: disabled, credentials, or oauth
+    mode: disabled
+
+  serverPort: 8080
+
+  # Image configuration to configure the Connectors image specifics
+  image:
+    # Image.registry can be used to set container image registry.
+    registry: ""
+    # Image.repository defines which image repository to use
+    repository: camunda/connectors-bundle
+    # Image.tag can be set to overwrite the global tag, which should be used in that chart
+    tag: 0.16.1
+    # Image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+    pullSecrets: []
+
+  # Number of Connectors replicas
+  replicas: 1
+
+  # PodAnnotations can be used to define extra Connectors pod annotations
+  podAnnotations: {}
+  # PodLabels can be used to define extra Connectors pod labels
+  podLabels: {}
+
+  # Logging configuration for the Connectors logging. This template will be directly included in the Operate configuration yaml file
+  logging:
+    level:
+      ROOT: INFO
+      io.camunda.connector: DEBUG
+
+  # Service configuration to configure the Connectors service.
+  service:
+    # Service.type defines the type of the service https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+    type: ClusterIP
+    # Service.port defines the port of the service, where the Connector web application will be available
+    port: 8080
+    # Service.annotations can be used to define annotations, which will be applied to the Connectors service
+    annotations: {}
+
+  # Resources configuration to set request and limit configuration for the container https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
+  resources:
+    requests:
+      cpu: 1
+      memory: 1Gi
+    limits:
+      cpu: 2
+      memory: 2Gi
+
+  # Env can be used to set extra environment variables in each Connector container
+  env: []
+  # Command can be used to override the default command provided by the container image. See https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/
+  command: []
+
+  # ServiceAccount configuration for the service account where the Connectors pods are assigned to
+  serviceAccount:
+    # ServiceAccount.enabled if true, enables the Connectors service account
+    enabled: true
+    # ServiceAccount.name can be used to set the name of the Connectors service account
+    name: ""
+    # ServiceAccount.annotations can be used to set the annotations of the Operate service account
+    annotations: {}
+
+  # Ingress configuration to configure the ingress resource
+  ingress:
+    # Ingress.enabled if true, an ingress resource is deployed with the Operate deployment. Only useful if an ingress controller is available, like nginx.
+    enabled: false
+    # Ingress.className defines the class or configuration of ingress which should be used by the controller
+    className: nginx
+    # Ingress.annotations defines the ingress related annotations, consumed mostly by the ingress controller
+    annotations:
+      ingress.kubernetes.io/rewrite-target: "/"
+      nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    # Ingress.path defines the path which is associated with the Operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
+    path: /
+    # Ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
+    # If not specified the rules applies to all inbound http traffic, if specified the rule applies to that host.
+    host: ""
+    # Ingress.tls configuration for tls on the ingress resource https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+    tls:
+      # Ingress.tls.enabled if true, then tls is configured on the ingress resource. If enabled the Ingress.host need to be defined.
+      enabled: false
+      # Ingress.tls.secretName defines the secret name which contains the TLS private key and certificate
+      secretName: ""
+
+  # PodSecurityContext defines the security options the Connectors pod should be run with
+  podSecurityContext: {}
+
+  # ContainerSecurityContext defines the security options the Connectors container should be run with
+  containerSecurityContext: {}
+
+  # NodeSelector can be used to define on which nodes the Connectors pods should run
+  nodeSelector: {}
+  # Tolerations can be used to define pod toleration's https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+  tolerations: []
+  # Affinity can be used to define pod affinity or anti-affinity https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+  affinity: {}
+
 elasticsearch:
   enabled: true
   extraEnvs:

--- a/kind/camunda-platform-core-kind-values.yaml
+++ b/kind/camunda-platform-core-kind-values.yaml
@@ -23,6 +23,11 @@ zeebe:
 zeebe-gateway:
   replicas: 1
 
+connectors:
+  enabled: true
+  inbound:
+    mode: disabled
+
 # Configure elastic search to make it running for local development
 elasticsearch:
   imageTag: 7.17.3

--- a/test/integration/scenarios/chart-with-custom-values/values-custom.yaml
+++ b/test/integration/scenarios/chart-with-custom-values/values-custom.yaml
@@ -10,3 +10,6 @@ zeebe-gateway:
 
 retentionPolicy:
   enabled: true
+
+connectors:
+  enabled: true

--- a/test/integration/scenarios/chart-with-web-modeler/values-web-modeler-enabled.yaml
+++ b/test/integration/scenarios/chart-with-web-modeler/values-web-modeler-enabled.yaml
@@ -18,3 +18,6 @@ web-modeler:
   websockets:
     readinessProbe:
       enabled: true
+
+connectors:
+  enabled: true


### PR DESCRIPTION
Same as https://github.com/camunda/camunda-platform-helm/pull/501, but minimal version without security.

The following k8s configs work without helm charts:

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: connectors
spec:
  selector:
    matchLabels:
      app: connectors
  template:
    metadata:
      labels:
        app: connectors
    spec:
      containers:
      - name: connectors
        image: camunda/connectors-bundle:0.16.0
        imagePullPolicy: IfNotPresent
        resources:
          limits:
            memory: "1024Mi"
            cpu: "500m"
        ports:
        - containerPort: 8080
        env:
          - name: ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS
            value: 127.0.0.1:26500
          - name: ZEEBE_CLIENT_SECURITY_PLAINTEXT
            value: "true"
          - name: CAMUNDA_CONNECTOR_POLLING_ENABLED
            value: "false"
          - name: CAMUNDA_CONNECTOR_WEBHOOK_ENABLED
            value: "false"
          - name: SPRING_MAIN_WEB-APPLICATION-TYPE
            value: none
```

---

```
apiVersion: v1
kind: Service
metadata:
  name: connectors-service
spec:
  type: ClusterIP
  selector:
    app: connectors
  ports:
  - port: 8088
    targetPort: 8080
```