### PR TITLE
fix(web-modeler): pick up custom Keycloak config correctly

### DIFF
--- a/charts/camunda-platform/charts/web-modeler/templates/deployment-webapp.yaml
+++ b/charts/camunda-platform/charts/web-modeler/templates/deployment-webapp.yaml
@@ -52,9 +52,11 @@ spec:
           - name: OAUTH2_TOKEN_ISSUER
             value: {{ .Values.global.identity.auth.publicIssuerUrl | quote }}
           - name: KEYCLOAK_BASE_URL
-            value: {{ .Values.global.identity.auth.publicIssuerUrl | trimSuffix "/auth/realms/camunda-platform" | quote }}
+            value: {{ .Values.global.identity.auth.publicIssuerUrl | trimSuffix (print (.Values.global.identity.keycloak.contextPath | trimSuffix "/") .Values.global.identity.keycloak.realm) | quote }}
+          - name: KEYCLOAK_CONTEXT_PATH
+            value: {{ .Values.global.identity.keycloak.contextPath | quote }}
           - name: KEYCLOAK_REALM
-            value: "camunda-platform"
+            value: {{ .Values.global.identity.keycloak.realm | trimPrefix "/realms/" | quote }}
           - name: KEYCLOAK_JWKS_URL
             value: {{ printf "%s%s" (include "camundaPlatform.issuerBackendUrl" .) "/protocol/openid-connect/certs" | quote }}
           - name: PUSHER_HOST

--- a/charts/camunda-platform/test/web-modeler/golden/deployment-webapp.golden.yaml
+++ b/charts/camunda-platform/test/web-modeler/golden/deployment-webapp.golden.yaml
@@ -66,6 +66,8 @@ spec:
             value: "http://localhost:18080/auth/realms/camunda-platform"
           - name: KEYCLOAK_BASE_URL
             value: "http://localhost:18080"
+          - name: KEYCLOAK_CONTEXT_PATH
+            value: "/auth"
           - name: KEYCLOAK_REALM
             value: "camunda-platform"
           - name: KEYCLOAK_JWKS_URL


### PR DESCRIPTION
### Which problem does the PR fix?
Closes https://github.com/camunda/web-modeler/issues/3876

### What's in this PR?
Currently, some values are hardcoded (like the Keycloak realm), so that the Web Modeler wouldn't work with a custom Keycloak configuration. This PR fixes this problem.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added (if needed).
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?