### PR TITLE
chore(web-modeler): update to version 0.6.0-beta

### DIFF
--- a/charts/camunda-platform/charts/web-modeler/templates/deployment-restapi.yaml
+++ b/charts/camunda-platform/charts/web-modeler/templates/deployment-restapi.yaml
@@ -89,10 +89,7 @@ spec:
           - name: RESTAPI_OAUTH2_TOKEN_ISSUER
             value: {{ .Values.global.identity.auth.publicIssuerUrl | quote }}
           - name: RESTAPI_OAUTH2_TOKEN_ISSUER_BACKEND_URL
-            # If the default HTTP port 80 is included in the URL, Spring Security will produce the following error when creating the JWT decoder:
-            # > The Issuer "http://demo-keycloak/auth/realms/camunda-platform" provided in the configuration did not match the requested issuer "http://demo-keycloak:80/auth/realms/camunda-platform"
-            # Thus, port 80 is removed from the URL. Other port numbers work just fine and don't need to be removed.
-            value: {{ include "camundaPlatform.issuerBackendUrl" . | replace ":80/" "/" | quote }}
+            value: {{ include "camundaPlatform.issuerBackendUrl" . | quote }}
           - name: RESTAPI_IDENTITY_BASE_URL
             value: {{ include "webModeler.identityBaseUrl" . | quote }}
         {{- with .Values.restapi.env }}

--- a/charts/camunda-platform/test/web-modeler/deployment_restapi_test.go
+++ b/charts/camunda-platform/test/web-modeler/deployment_restapi_test.go
@@ -72,7 +72,7 @@ func (s *restapiDeploymentTemplateTest) TestContainerShouldSetCorrectKeycloakSer
 	s.Require().Contains(env,
 		corev1.EnvVar{
 			Name:  "RESTAPI_OAUTH2_TOKEN_ISSUER_BACKEND_URL",
-			Value: "http://keycloak/auth/realms/camunda-platform",
+			Value: "http://keycloak:80/auth/realms/camunda-platform",
 		})
 }
 
@@ -295,7 +295,7 @@ func (s *restapiDeploymentTemplateTest) TestContainerReadinessProbe() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"web-modeler.enabled":                        "true",
+			"web-modeler.enabled":                          "true",
 			"web-modeler.restapi.readinessProbe.enabled":   "true",
 			"web-modeler.restapi.readinessProbe.probePath": "/healthz",
 		},

--- a/charts/camunda-platform/test/web-modeler/golden/configmap-shared.golden.yaml
+++ b/charts/camunda-platform/test/web-modeler/golden/configmap-shared.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "0.5.1-beta"
+    app.kubernetes.io/version: "0.6.0-beta"
     app.kubernetes.io/component: web-modeler
   annotations:
     {}

--- a/charts/camunda-platform/test/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform/test/web-modeler/golden/deployment-restapi.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "0.5.1-beta"
+    app.kubernetes.io/version: "0.6.0-beta"
     app.kubernetes.io/component: restapi
   annotations:
     {}
@@ -32,14 +32,14 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "0.5.1-beta"
+        app.kubernetes.io/version: "0.6.0-beta"
         app.kubernetes.io/component: restapi
     spec:
       imagePullSecrets:
         []
       containers:
       - name: web-modeler-restapi
-        image: "registry.camunda.cloud/web-modeler-ee/modeler-restapi:0.5.1-beta"
+        image: "registry.camunda.cloud/web-modeler-ee/modeler-restapi:0.6.0-beta"
         imagePullPolicy: IfNotPresent
         env:
           - name: JAVA_OPTIONS
@@ -91,10 +91,7 @@ spec:
           - name: RESTAPI_OAUTH2_TOKEN_ISSUER
             value: "http://localhost:18080/auth/realms/camunda-platform"
           - name: RESTAPI_OAUTH2_TOKEN_ISSUER_BACKEND_URL
-            # If the default HTTP port 80 is included in the URL, Spring Security will produce the following error when creating the JWT decoder:
-            # > The Issuer "http://demo-keycloak/auth/realms/camunda-platform" provided in the configuration did not match the requested issuer "http://demo-keycloak:80/auth/realms/camunda-platform"
-            # Thus, port 80 is removed from the URL. Other port numbers work just fine and don't need to be removed.
-            value: "http://camunda-platform-tes/auth/realms/camunda-platform"
+            value: "http://camunda-platform-tes:80/auth/realms/camunda-platform"
           - name: RESTAPI_IDENTITY_BASE_URL
             value: "http://camunda-platform-test-identity:80"
         resources:

--- a/charts/camunda-platform/test/web-modeler/golden/deployment-webapp.golden.yaml
+++ b/charts/camunda-platform/test/web-modeler/golden/deployment-webapp.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "0.5.1-beta"
+    app.kubernetes.io/version: "0.6.0-beta"
     app.kubernetes.io/component: webapp
   annotations:
     {}
@@ -32,14 +32,14 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "0.5.1-beta"
+        app.kubernetes.io/version: "0.6.0-beta"
         app.kubernetes.io/component: webapp
     spec:
       imagePullSecrets:
         []
       containers:
       - name: web-modeler-webapp
-        image: "registry.camunda.cloud/web-modeler-ee/modeler-webapp:0.5.1-beta"
+        image: "registry.camunda.cloud/web-modeler-ee/modeler-webapp:0.6.0-beta"
         imagePullPolicy: IfNotPresent
         env:
           - name: NODE_ENV

--- a/charts/camunda-platform/test/web-modeler/golden/deployment-websockets.golden.yaml
+++ b/charts/camunda-platform/test/web-modeler/golden/deployment-websockets.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "0.5.1-beta"
+    app.kubernetes.io/version: "0.6.0-beta"
     app.kubernetes.io/component: websockets
   annotations:
     {}
@@ -32,14 +32,14 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "0.5.1-beta"
+        app.kubernetes.io/version: "0.6.0-beta"
         app.kubernetes.io/component: websockets
     spec:
       imagePullSecrets:
         []
       containers:
       - name: web-modeler-websockets
-        image: "registry.camunda.cloud/web-modeler-ee/modeler-websockets:0.5.1-beta"
+        image: "registry.camunda.cloud/web-modeler-ee/modeler-websockets:0.6.0-beta"
         imagePullPolicy: IfNotPresent
         env:
           - name: APP_NAME

--- a/charts/camunda-platform/test/web-modeler/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/web-modeler/golden/ingress-all-enabled.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "0.5.1-beta"
+    app.kubernetes.io/version: "0.6.0-beta"
     app.kubernetes.io/component: web-modeler
   annotations:
     ingress.kubernetes.io/rewrite-target: /

--- a/charts/camunda-platform/test/web-modeler/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/web-modeler/golden/ingress.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "0.5.1-beta"
+    app.kubernetes.io/version: "0.6.0-beta"
     app.kubernetes.io/component: web-modeler
   annotations:
     ingress.kubernetes.io/rewrite-target: /

--- a/charts/camunda-platform/test/web-modeler/golden/secret-shared.golden.yaml
+++ b/charts/camunda-platform/test/web-modeler/golden/secret-shared.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "0.5.1-beta"
+    app.kubernetes.io/version: "0.6.0-beta"
     app.kubernetes.io/component: web-modeler
   annotations:
     {}

--- a/charts/camunda-platform/test/web-modeler/golden/service-restapi.golden.yaml
+++ b/charts/camunda-platform/test/web-modeler/golden/service-restapi.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "0.5.1-beta"
+    app.kubernetes.io/version: "0.6.0-beta"
     app.kubernetes.io/component: restapi
   annotations:
 spec:

--- a/charts/camunda-platform/test/web-modeler/golden/service-webapp.golden.yaml
+++ b/charts/camunda-platform/test/web-modeler/golden/service-webapp.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "0.5.1-beta"
+    app.kubernetes.io/version: "0.6.0-beta"
     app.kubernetes.io/component: webapp
   annotations:
 spec:

--- a/charts/camunda-platform/test/web-modeler/golden/service-websockets.golden.yaml
+++ b/charts/camunda-platform/test/web-modeler/golden/service-websockets.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "0.5.1-beta"
+    app.kubernetes.io/version: "0.6.0-beta"
     app.kubernetes.io/component: websockets
   annotations:
 spec:

--- a/charts/camunda-platform/test/web-modeler/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/web-modeler/golden/serviceaccount.golden.yaml
@@ -10,5 +10,5 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "0.5.1-beta"
+    app.kubernetes.io/version: "0.6.0-beta"
     app.kubernetes.io/component: web-modeler

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -1338,7 +1338,7 @@ web-modeler:
     # Note: The images are not publicly available on Docker Hub, but only from Camunda's private registry.
     registry: registry.camunda.cloud
     # Image.tag can be used to set the Docker image tag for the Web Modeler images (overwrites global.image.tag)
-    tag: 0.5.1-beta
+    tag: 0.6.0-beta
     # Image.pullSecrets can be used to configure image pull secrets, see https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
     # Note: A secret will be required, if the Web Modeler images are pulled directly from Camunda's private registry.
     #


### PR DESCRIPTION
### Which problem does the PR fix?
Updates Web Modeler to the latest beta version.

### What's in this PR?
- Version update to `0.6.0-beta`.
- Workaround for `RESTAPI_OAUTH2_TOKEN_ISSUER_BACKEND_URL` is removed. The problem with the default ports has been fixed in Web Modeler itself (see https://github.com/camunda/web-modeler/issues/3993).

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added (if needed).
- [x] The main Helm chart and sub-chart are updated (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
