### PR TITLE
refactor: enable readinessProbe by default for all components

### DIFF
--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -357,7 +357,7 @@ For more information about Zeebe Gateway, visit
 | | `startupProbe.failureThreshold` | Defines when the probe is considered as failed so the Pod will be marked Unready | `5` |
 | | `startupProbe.timeoutSeconds` | Defines the seconds after the probe times out | `1` |
 | | `readinessProbe` | ReadinessProbe configuration | |
-| | `readinessProbe.enabled` | If true, the readiness probe is enabled in app container | `false` |
+| | `readinessProbe.enabled` | If true, the readiness probe is enabled in app container | `true` |
 | | `readinessProbe.probePath` | Defines the readiness probe route used on the app | `/actuator/health` |
 | | `readinessProbe.initialDelaySeconds` | Defines the number of seconds after the container has started before the probe is initiated | `30` |
 | | `readinessProbe.periodSeconds` | Defines how often the probe is executed | `30` |
@@ -455,7 +455,7 @@ For more information about Operate, visit
 | | `startupProbe.failureThreshold` | Defines when the probe is considered as failed so the Pod will be marked Unready | `5` |
 | | `startupProbe.timeoutSeconds` | Defines the seconds after the probe times out | `1` |
 | | `readinessProbe` | ReadinessProbe configuration | |
-| | `readinessProbe.enabled` | If true, the readiness probe is enabled in app container | `false` |
+| | `readinessProbe.enabled` | If true, the readiness probe is enabled in app container | `true` |
 | | `readinessProbe.probePath` | Defines the readiness probe route used on the app | `/actuator/health/readiness` |
 | | `readinessProbe.initialDelaySeconds` | Defines the number of seconds after the container has started before the probe is initiated | `30` |
 | | `readinessProbe.periodSeconds` | Defines how often the probe is executed | `30` |
@@ -511,7 +511,7 @@ For more information about Tasklist, visit
 | | `startupProbe.failureThreshold` | Defines when the probe is considered as failed so the Pod will be marked Unready | `5` |
 | | `startupProbe.timeoutSeconds` | Defines the seconds after the probe times out | `1` |
 | | `readinessProbe` | ReadinessProbe configuration | |
-| | `readinessProbe.enabled` | If true, the readiness probe is enabled in app container | `false` |
+| | `readinessProbe.enabled` | If true, the readiness probe is enabled in app container | `true` |
 | | `readinessProbe.probePath` | Defines the readiness probe route used on the app | `/actuator/health/readiness` |
 | | `readinessProbe.initialDelaySeconds` | Defines the number of seconds after the container has started before the probe is initiated | `30` |
 | | `readinessProbe.periodSeconds` | Defines how often the probe is executed | `30` |
@@ -579,7 +579,7 @@ For more information, visit [Optimize Introduction](https://docs.camunda.io/opti
 | | `startupProbe.failureThreshold` | Defines when the probe is considered as failed so the Pod will be marked Unready | `5` |
 | | `startupProbe.timeoutSeconds` | Defines the seconds after the probe times out | `1` |
 | | `readinessProbe` | ReadinessProbe configuration | |
-| | `readinessProbe.enabled` | If true, the readiness probe is enabled in app container | `false` |
+| | `readinessProbe.enabled` | If true, the readiness probe is enabled in app container | `true` |
 | | `readinessProbe.probePath` | Defines the readiness probe route used on the app | `/api/readyz` |
 | | `readinessProbe.initialDelaySeconds` | Defines the number of seconds after the container has started before the probe is initiated | `30` |
 | | `readinessProbe.periodSeconds` | Defines how often the probe is executed | `30` |
@@ -671,7 +671,7 @@ For more information, visit [Identity Overview](https://docs.camunda.io/docs/sel
 | | `startupProbe.failureThreshold` | Defines when the probe is considered as failed so the Pod will be marked Unready | `5` |
 | | `startupProbe.timeoutSeconds` | Defines the seconds after the probe times out | `1` |
 | | `readinessProbe` | ReadinessProbe configuration | |
-| | `readinessProbe.enabled` | If true, the readiness probe is enabled in app container | `false` |
+| | `readinessProbe.enabled` | If true, the readiness probe is enabled in app container | `true` |
 | | `readinessProbe.probePath` | Defines the readiness probe route used on the app | `/actuator/health` |
 | | `readinessProbe.initialDelaySeconds` | Defines the number of seconds after the container has started before the probe is initiated | `30` |
 | | `readinessProbe.periodSeconds` | Defines how often the probe is executed | `30` |
@@ -954,7 +954,7 @@ For more information, visit [Introduction to Connectors](https://docs.camunda.io
 |              | `startupProbe.failureThreshold`      | Defines when the probe is considered as failed so the Pod will be marked Unready                                                                                                                                                                  | `5`                                                                                                   |
 |              | `startupProbe.timeoutSeconds`        | Defines the seconds after the probe times out                                                                                                                                                                                                     | `1`                                                                                                   |
 |              | `readinessProbe`                     | ReadinessProbe configuration                                                                                                                                                                                                                      |                                                                                                       |
-|              | `readinessProbe.enabled`             | If true, the readiness probe is enabled in app container                                                                                                                                                                                          | `false`                                                                                               |
+|              | `readinessProbe.enabled`             | If true, the readiness probe is enabled in app container                                                                                                                                                                                          | `true`                                                                                               |
 |              | `readinessProbe.probePath`           | Defines the readiness probe route used on the app                                                                                                                                                                                                 | `/actuator/health/readiness`                                                                          |
 |              | `readinessProbe.initialDelaySeconds` | Defines the number of seconds after the container has started before the probe is initiated                                                                                                                                                       | `30`                                                                                                  |
 |              | `readinessProbe.periodSeconds`       | Defines how often the probe is executed                                                                                                                                                                                                           | `30`                                                                                                  |

--- a/charts/camunda-platform/test/integration/scenarios/chart-with-web-modeler/values-web-modeler-enabled.yaml
+++ b/charts/camunda-platform/test/integration/scenarios/chart-with-web-modeler/values-web-modeler-enabled.yaml
@@ -10,14 +10,6 @@ webModeler:
     mail:
       # the value is required, otherwise the restapi pod wouldn't start
       fromAddress: noreply@example.com
-    readinessProbe:
-      enabled: true
-  webapp:
-    readinessProbe:
-      enabled: true
-  websockets:
-    readinessProbe:
-      enabled: true
 
 # database used by Web Modeler
 postgresql:

--- a/charts/camunda-platform/test/integration/scenarios/fixtures/values-integration-test.yaml
+++ b/charts/camunda-platform/test/integration/scenarios/fixtures/values-integration-test.yaml
@@ -4,30 +4,7 @@ test:
 connectors:
   enabled: true
 
-# TODO: Remove readinessProbe once it's enabled by default (planned for v8.2).
-operate:
-  readinessProbe:
-    enabled: true
-
-tasklist:
-  readinessProbe:
-    enabled: true
-
-optimize:
-  readinessProbe:
-    enabled: true
-
-zeebe:
-  readinessProbe:
-    enabled: true
-
-zeebe-gateway:
-  readinessProbe:
-    enabled: true
-
 identity:
-  readinessProbe:
-    enabled: true
   # Keycloak client seed which is used to query Camunda Platform APIs. 
   env:
   - name: KEYCLOAK_CLIENTS_1_ID

--- a/charts/camunda-platform/test/unit/identity/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/deployment.golden.yaml
@@ -134,3 +134,12 @@ spec:
         - containerPort: 8082
           name: metrics
           protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /actuator/health
+            port: metrics
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          successThreshold: 1
+          failureThreshold: 5
+          timeoutSeconds: 1

--- a/charts/camunda-platform/test/unit/operate/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/operate/golden/deployment.golden.yaml
@@ -72,6 +72,15 @@ spec:
         - containerPort: 8080
           name: http
           protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /actuator/health/readiness
+            port: http
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          successThreshold: 1
+          failureThreshold: 5
+          timeoutSeconds: 1
         volumeMounts:
         - name: config
           mountPath: /usr/local/operate/config/application.yml

--- a/charts/camunda-platform/test/unit/optimize/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/optimize/golden/deployment.golden.yaml
@@ -85,5 +85,14 @@ spec:
         - containerPort: 8092
           name: management
           protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /api/readyz
+            port: http
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          successThreshold: 1
+          failureThreshold: 5
+          timeoutSeconds: 1
         volumeMounts:
       volumes:

--- a/charts/camunda-platform/test/unit/tasklist/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/tasklist/golden/deployment.golden.yaml
@@ -76,6 +76,15 @@ spec:
         - containerPort: 8080
           name: http
           protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /actuator/health/readiness
+            port: http
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          successThreshold: 1
+          failureThreshold: 5
+          timeoutSeconds: 1
         volumeMounts:
         - name: config
           mountPath: /app/resources/application.yml

--- a/charts/camunda-platform/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -108,3 +108,12 @@ spec:
         - containerPort: 8091
           name: http-management
           protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /health/readiness
+            port: http-management
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          successThreshold: 1
+          failureThreshold: 5
+          timeoutSeconds: 1

--- a/charts/camunda-platform/test/unit/web-modeler/golden/deployment-webapp.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/deployment-webapp.golden.yaml
@@ -118,3 +118,12 @@ spec:
         - containerPort: 8071
           name: http-management
           protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /health/readiness
+            port: http-management
+          initialDelaySeconds: 15
+          periodSeconds: 30
+          successThreshold: 1
+          failureThreshold: 5
+          timeoutSeconds: 1

--- a/charts/camunda-platform/test/unit/web-modeler/golden/deployment-websockets.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/deployment-websockets.golden.yaml
@@ -72,3 +72,11 @@ spec:
         - containerPort: 8060
           name: http
           protocol: TCP
+        readinessProbe:
+          tcpSocket:
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          successThreshold: 1
+          failureThreshold: 5
+          timeoutSeconds: 1

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/gateway-deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/gateway-deployment.golden.yaml
@@ -80,6 +80,15 @@ spec:
             - name: ZEEBE_GATEWAY_MONITORING_PORT
               value: "9600"
           volumeMounts:
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 9600
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
           resources:
             limits:
               cpu: 400m

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -461,7 +461,7 @@ zeebe-gateway:
   # ReadinessProbe configuration
   readinessProbe:
     # ReadinessProbe.enabled if true, the readiness probe is enabled in app container
-    enabled: false
+    enabled: true
     # ReadinessProbe.probePath defines the readiness probe route used on the app
     probePath: /actuator/health
     # ReadinessProbe.initialDelaySeconds defines the number of seconds after the container has started before
@@ -694,7 +694,7 @@ operate:
   # ReadinessProbe configuration
   readinessProbe:
     # ReadinessProbe.enabled if true, the readiness probe is enabled in app container
-    enabled: false
+    enabled: true
     # ReadinessProbe.probePath defines the readiness probe route used on the app
     probePath: /actuator/health/readiness
     # ReadinessProbe.initialDelaySeconds defines the number of seconds after the container has started before
@@ -812,7 +812,7 @@ tasklist:
   # ReadinessProbe configuration
   readinessProbe:
     # ReadinessProbe.enabled if true, the readiness probe is enabled in app container
-    enabled: false
+    enabled: true
     # ReadinessProbe.probePath defines the readiness probe route used on the app
     probePath: /actuator/health/readiness
     # ReadinessProbe.initialDelaySeconds defines the number of seconds after the container has started before
@@ -965,7 +965,7 @@ optimize:
   # ReadinessProbe configuration
   readinessProbe:
     # ReadinessProbe.enabled if true, the readiness probe is enabled in app container
-    enabled: false
+    enabled: true
     # ReadinessProbe.probePath defines the readiness probe route used on the app
     probePath: /api/readyz
     # ReadinessProbe.initialDelaySeconds defines the number of seconds after the container has started before
@@ -1169,7 +1169,7 @@ identity:
   # ReadinessProbe configuration
   readinessProbe:
     # ReadinessProbe.enabled if true, the readiness probe is enabled in app container
-    enabled: false
+    enabled: true
     # ReadinessProbe.probePath defines the readiness probe route used on the app
     probePath: /actuator/health
     # ReadinessProbe.initialDelaySeconds defines the number of seconds after the container has started before
@@ -1441,7 +1441,7 @@ webModeler:
     # Restapi.readinessProbe configuration of the restapi readiness probe
     readinessProbe:
       # Restapi.readinessProbe.enabled if true, the readiness probe will be enabled for the restapi container
-      enabled: false
+      enabled: true
       # Restapi.readinessProbe.probePath defines the HTTP endpoint used for the readiness probe
       probePath: /health/readiness
       # Restapi.readinessProbe.initialDelaySeconds defines the number of seconds after the container has started before the probe is initiated
@@ -1545,7 +1545,7 @@ webModeler:
     # Webapp.readinessProbe configuration of the webapp readiness probe
     readinessProbe:
       # Webapp.readinessProbe.enabled if true, the readiness probe will be enabled for the webapp container
-      enabled: false
+      enabled: true
       # Webapp.readinessProbe.probePath defines the HTTP endpoint used for the readiness probe
       probePath: /health/readiness
       # Webapp.readinessProbe.initialDelaySeconds defines the number of seconds after the container has started before the probe is initiated
@@ -1650,7 +1650,7 @@ webModeler:
     # Websockets.readinessProbe configuration of the websockets readiness probe
     readinessProbe:
       # Websockets.readinessProbe.enabled if true, the readiness probe will be enabled for the websockets container
-      enabled: false
+      enabled: true
       # Websockets.readinessProbe.initialDelaySeconds defines the number of seconds after the container has started before the probe is initiated
       initialDelaySeconds: 10
       # Websockets.readinessProbe.periodSeconds defines how often the probe is executed


### PR DESCRIPTION
### What's in this PR?

Enable `readinessProbe` for all components which is the default for the next release, Camunda Platform 8.2. 

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added (if needed).
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?
