### PR TITLE
fix: add `CAMUNDA_OPERATE_IDENTITY_REDIRECT_ROOT_URL` var

### DIFF
--- a/charts/camunda-platform/charts/operate/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/operate/templates/deployment.yaml
@@ -71,6 +71,8 @@ spec:
             {{- end }}
           - name: CAMUNDA_OPERATE_IDENTITY_AUDIENCE
             value: "operate-api"
+          - name: CAMUNDA_OPERATE_IDENTITY_REDIRECT_ROOT_URL
+            value: {{ .Values.global.identity.auth.operate.redirectUrl | quote }}
           {{- else }}
           - name: SPRING_PROFILES_ACTIVE
             value: "auth"

--- a/charts/camunda-platform/test/unit/operate/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/operate/golden/deployment.golden.yaml
@@ -61,6 +61,8 @@ spec:
                 key: operate-secret
           - name: CAMUNDA_OPERATE_IDENTITY_AUDIENCE
             value: "operate-api"
+          - name: CAMUNDA_OPERATE_IDENTITY_REDIRECT_ROOT_URL
+            value: "http://localhost:8081"
         resources:
           limits:
             cpu: 2000m


### PR DESCRIPTION
### Which problem does the PR fix?
https://github.com/camunda/operate/issues/4336

### What's in this PR?

Adding new `CAMUNDA_OPERATE_IDENTITY_REDIRECT_ROOT_URL`  that will be consumed by [operate](https://github.com/camunda/operate) application and used as a redirect host value for identity.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [ ] Tests for charts are added (if needed).
- [ ] The main Helm chart and sub-chart are updated (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
