### PR TITLE
fix: add contextPath to startup/readiness/liveness probes

### DIFF
--- a/charts/camunda-platform/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/identity/templates/deployment.yaml
@@ -168,7 +168,7 @@ spec:
         {{- if .Values.startupProbe.enabled }}
         startupProbe:
           httpGet:
-            path: {{ .Values.startupProbe.probePath }}
+            path: {{ .Values.contextPath }}{{ .Values.startupProbe.probePath }}
             port: metrics
           initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.startupProbe.periodSeconds }}
@@ -179,7 +179,7 @@ spec:
         {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.readinessProbe.probePath }}
+            path: {{ .Values.contextPath }}{{ .Values.readinessProbe.probePath }}
             port: metrics
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
@@ -190,7 +190,7 @@ spec:
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.livenessProbe.probePath }}
+            path: {{ .Values.contextPath }}{{ .Values.livenessProbe.probePath }}
             port: metrics
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}

--- a/charts/camunda-platform/charts/operate/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/operate/templates/deployment.yaml
@@ -92,7 +92,7 @@ spec:
         {{- if .Values.startupProbe.enabled }}
         startupProbe:
           httpGet:
-            path: {{ .Values.startupProbe.probePath }}
+            path: {{ .Values.contextPath }}{{ .Values.startupProbe.probePath }}
             port: http
           initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.startupProbe.periodSeconds }}
@@ -103,7 +103,7 @@ spec:
         {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.readinessProbe.probePath }}
+            path: {{ .Values.contextPath }}{{ .Values.readinessProbe.probePath }}
             port: http
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
@@ -114,7 +114,7 @@ spec:
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.livenessProbe.probePath }}
+            path: {{ .Values.contextPath }}{{ .Values.livenessProbe.probePath }}
             port: http
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}

--- a/charts/camunda-platform/charts/optimize/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/optimize/templates/deployment.yaml
@@ -96,7 +96,7 @@ spec:
         {{- if .Values.startupProbe.enabled }}
         startupProbe:
           httpGet:
-            path: {{ .Values.startupProbe.probePath }}
+            path: {{ .Values.contextPath }}{{ .Values.startupProbe.probePath }}
             port: http
           initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.startupProbe.periodSeconds }}
@@ -107,7 +107,7 @@ spec:
         {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.readinessProbe.probePath }}
+            path: {{ .Values.contextPath }}{{ .Values.readinessProbe.probePath }}
             port: http
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
@@ -118,7 +118,7 @@ spec:
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.livenessProbe.probePath }}
+            path: {{ .Values.contextPath }}{{ .Values.livenessProbe.probePath }}
             port: http
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}

--- a/charts/camunda-platform/charts/tasklist/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/tasklist/templates/deployment.yaml
@@ -92,7 +92,7 @@ spec:
         {{- if .Values.startupProbe.enabled }}
         startupProbe:
           httpGet:
-            path: {{ .Values.startupProbe.probePath }}
+            path: {{ .Values.contextPath }}{{ .Values.startupProbe.probePath }}
             port: http
           initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.startupProbe.periodSeconds }}
@@ -103,7 +103,7 @@ spec:
         {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.readinessProbe.probePath }}
+            path: {{ .Values.contextPath }}{{ .Values.readinessProbe.probePath }}
             port: http
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
@@ -114,7 +114,7 @@ spec:
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.livenessProbe.probePath }}
+            path: {{ .Values.contextPath }}{{ .Values.livenessProbe.probePath }}
             port: http
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}

--- a/charts/camunda-platform/charts/zeebe-gateway/templates/gateway-deployment.yaml
+++ b/charts/camunda-platform/charts/zeebe-gateway/templates/gateway-deployment.yaml
@@ -92,7 +92,7 @@ spec:
           {{- if .Values.startupProbe.enabled }}
           startupProbe:
             httpGet:
-              path: {{ .Values.startupProbe.probePath }}
+              path: {{ .Values.contextPath }}{{ .Values.startupProbe.probePath }}
               port: {{ .Values.service.httpPort }}
             initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.startupProbe.periodSeconds }}
@@ -103,7 +103,7 @@ spec:
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: {{ .Values.readinessProbe.probePath }}
+              path: {{ .Values.contextPath }}{{ .Values.readinessProbe.probePath }}
               port: {{ .Values.service.httpPort }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
@@ -114,7 +114,7 @@ spec:
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: {{ .Values.livenessProbe.probePath }}
+              path: {{ .Values.contextPath }}{{ .Values.livenessProbe.probePath }}
               port: {{ .Values.service.httpPort }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}

--- a/charts/camunda-platform/charts/zeebe/templates/statefulset.yaml
+++ b/charts/camunda-platform/charts/zeebe/templates/statefulset.yaml
@@ -116,7 +116,7 @@ spec:
         {{- if .Values.startupProbe.enabled }}
         startupProbe:
           httpGet:
-            path: {{ .Values.startupProbe.probePath }}
+            path: {{ .Values.contextPath }}{{ .Values.startupProbe.probePath }}
             port: {{ .Values.service.httpPort  }}
           initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.startupProbe.periodSeconds }}
@@ -127,7 +127,7 @@ spec:
         {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.readinessProbe.probePath }}
+            path: {{ .Values.contextPath }}{{ .Values.readinessProbe.probePath }}
             port: {{ .Values.service.httpPort  }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
@@ -138,7 +138,7 @@ spec:
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.livenessProbe.probePath }}
+            path: {{ .Values.contextPath }}{{ .Values.livenessProbe.probePath }}
             port: {{ .Values.service.httpPort  }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}

--- a/charts/camunda-platform/templates/_helpers.tpl
+++ b/charts/camunda-platform/templates/_helpers.tpl
@@ -139,5 +139,6 @@ Set imagePullSecrets according the values of global, subchart, or empty.
 {{ define "camundaPlatform.operateURL" }}
   {{- if .Values.operate.enabled -}}
     {{- print "http://" -}}{{- include "operate.fullname" .Subcharts.operate -}}:{{- .Values.operate.service.port -}}
+    {{- .Values.operate.contextPath -}}
   {{- end -}}
 {{- end -}}

--- a/charts/camunda-platform/templates/connectors/deployment.yaml
+++ b/charts/camunda-platform/templates/connectors/deployment.yaml
@@ -100,7 +100,7 @@ spec:
           {{- if .Values.connectors.startupProbe.enabled }}
           startupProbe:
             httpGet:
-              path: {{ .Values.connectors.startupProbe.probePath }}
+              path: {{ .Values.connectors.contextPath }}{{ .Values.connectors.startupProbe.probePath }}
               port: {{ .Values.connectors.service.serverName }}
             initialDelaySeconds: {{ .Values.connectors.startupProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.connectors.startupProbe.periodSeconds }}
@@ -111,7 +111,7 @@ spec:
           {{- if .Values.connectors.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: {{ .Values.connectors.readinessProbe.probePath }}
+              path: {{ .Values.connectors.contextPath }}{{ .Values.connectors.readinessProbe.probePath }}
               port: {{ .Values.connectors.service.serverName }}
             initialDelaySeconds: {{ .Values.connectors.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.connectors.readinessProbe.periodSeconds }}
@@ -122,7 +122,7 @@ spec:
           {{- if .Values.connectors.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: {{ .Values.connectors.livenessProbe.probePath }}
+              path: {{ .Values.connectors.contextPath }}{{ .Values.connectors.livenessProbe.probePath }}
               port: {{ .Values.connectors.service.serverName }}
             initialDelaySeconds: {{ .Values.connectors.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.connectors.livenessProbe.periodSeconds }}

--- a/charts/camunda-platform/templates/ingress.yaml
+++ b/charts/camunda-platform/templates/ingress.yaml
@@ -72,7 +72,7 @@ spec:
                 name: {{ template "webModeler.webapp.fullname" . }}
                 port:
                   number: {{ .Values.webModeler.webapp.service.port }}
-            path: {{ .Values.webModeler.contextPath }}
+            path: {{ .Values.webModeler.contextPath }}{{ .Values.webModeler.contextPath }}
             pathType: Prefix
           - backend:
               service:

--- a/charts/camunda-platform/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform/templates/web-modeler/deployment-restapi.yaml
@@ -111,7 +111,7 @@ spec:
         {{- if .Values.webModeler.restapi.startupProbe.enabled }}
         startupProbe:
           httpGet:
-            path: {{ .Values.webModeler.restapi.startupProbe.probePath }}
+            path: {{ .Values.webModeler.contextPath }}{{ .Values.webModeler.restapi.startupProbe.probePath }}
             port: http-management
           initialDelaySeconds: {{ .Values.webModeler.restapi.startupProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.webModeler.restapi.startupProbe.periodSeconds }}
@@ -122,7 +122,7 @@ spec:
         {{- if .Values.webModeler.restapi.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.webModeler.restapi.readinessProbe.probePath }}
+            path: {{ .Values.webModeler.contextPath }}{{ .Values.webModeler.restapi.readinessProbe.probePath }}
             port: http-management
           initialDelaySeconds: {{ .Values.webModeler.restapi.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.webModeler.restapi.readinessProbe.periodSeconds }}
@@ -133,7 +133,7 @@ spec:
         {{- if .Values.webModeler.restapi.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.webModeler.restapi.livenessProbe.probePath }}
+            path: {{ .Values.webModeler.contextPath }}{{ .Values.webModeler.restapi.livenessProbe.probePath }}
             port: http-management
           initialDelaySeconds: {{ .Values.webModeler.restapi.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.webModeler.restapi.livenessProbe.periodSeconds }}

--- a/charts/camunda-platform/templates/web-modeler/deployment-webapp.yaml
+++ b/charts/camunda-platform/templates/web-modeler/deployment-webapp.yaml
@@ -114,7 +114,7 @@ spec:
         {{- if .Values.webModeler.webapp.startupProbe.enabled }}
         startupProbe:
           httpGet:
-            path: {{ .Values.webModeler.webapp.startupProbe.probePath }}
+            path: {{ .Values.webModeler.contextPath }}{{ .Values.webModeler.webapp.startupProbe.probePath }}
             port: http-management
           initialDelaySeconds: {{ .Values.webModeler.webapp.startupProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.webModeler.webapp.startupProbe.periodSeconds }}
@@ -125,7 +125,7 @@ spec:
         {{- if .Values.webModeler.webapp.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.webModeler.webapp.readinessProbe.probePath }}
+            path: {{ .Values.webModeler.contextPath }}{{ .Values.webModeler.webapp.readinessProbe.probePath }}
             port: http-management
           initialDelaySeconds: {{ .Values.webModeler.webapp.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.webModeler.webapp.readinessProbe.periodSeconds }}
@@ -136,7 +136,7 @@ spec:
         {{- if .Values.webModeler.webapp.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.webModeler.webapp.livenessProbe.probePath }}
+            path: {{ .Values.webModeler.contextPath }}{{ .Values.webModeler.webapp.livenessProbe.probePath }}
             port: http-management
           initialDelaySeconds: {{ .Values.webModeler.webapp.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.webModeler.webapp.livenessProbe.periodSeconds }}

--- a/charts/camunda-platform/test/unit/operate/deployment_test.go
+++ b/charts/camunda-platform/test/unit/operate/deployment_test.go
@@ -754,3 +754,32 @@ func (s *deploymentTemplateTest) TestContainerLivenessProbe() {
 	s.Require().EqualValues(5, probe.FailureThreshold)
 	s.Require().EqualValues(1, probe.TimeoutSeconds)
 }
+
+func (s *deploymentTemplateTest) TestContainerProbesWithContextPath() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"operate.contextPath":              "/test",
+			"operate.startupProbe.enabled":     "true",
+			"operate.startupProbe.probePath":   "/start",
+			"operate.readinessProbe.enabled":   "true",
+			"operate.readinessProbe.probePath": "/ready",
+			"operate.livenessProbe.enabled":    "true",
+			"operate.livenessProbe.probePath":  "/live",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	probe := deployment.Spec.Template.Spec.Containers[0]
+
+	s.Require().Equal("/test/start", probe.StartupProbe.HTTPGet.Path)
+	s.Require().Equal("/test/ready", probe.ReadinessProbe.HTTPGet.Path)
+	s.Require().Equal("/test/live", probe.LivenessProbe.HTTPGet.Path)
+}

--- a/charts/camunda-platform/test/unit/tasklist/deployment_test.go
+++ b/charts/camunda-platform/test/unit/tasklist/deployment_test.go
@@ -754,3 +754,32 @@ func (s *deploymentTemplateTest) TestContainerLivenessProbe() {
 	s.Require().EqualValues(5, probe.FailureThreshold)
 	s.Require().EqualValues(1, probe.TimeoutSeconds)
 }
+
+func (s *deploymentTemplateTest) TestContainerProbesWithContextPath() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"tasklist.contextPath":              "/test",
+			"tasklist.startupProbe.enabled":     "true",
+			"tasklist.startupProbe.probePath":   "/start",
+			"tasklist.readinessProbe.enabled":   "true",
+			"tasklist.readinessProbe.probePath": "/ready",
+			"tasklist.livenessProbe.enabled":    "true",
+			"tasklist.livenessProbe.probePath":  "/live",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	probe := deployment.Spec.Template.Spec.Containers[0]
+
+	s.Require().Equal("/test/start", probe.StartupProbe.HTTPGet.Path)
+	s.Require().Equal("/test/ready", probe.ReadinessProbe.HTTPGet.Path)
+	s.Require().Equal("/test/live", probe.LivenessProbe.HTTPGet.Path)
+}

--- a/charts/camunda-platform/test/unit/web-modeler/deployment_restapi_test.go
+++ b/charts/camunda-platform/test/unit/web-modeler/deployment_restapi_test.go
@@ -337,3 +337,32 @@ func (s *restapiDeploymentTemplateTest) TestContainerLivenessProbe() {
 	s.Require().Equal("/healthz", probe.HTTPGet.Path)
 	s.Require().Equal("http-management", probe.HTTPGet.Port.StrVal)
 }
+
+func (s *restapiDeploymentTemplateTest) TestContainerProbesWithContextPath() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"webModeler.enabled":                          "true",
+			"webModeler.contextPath":                      "/test",
+			"webModeler.restapi.startupProbe.enabled":     "true",
+			"webModeler.restapi.startupProbe.probePath":   "/start",
+			"webModeler.restapi.readinessProbe.enabled":   "true",
+			"webModeler.restapi.readinessProbe.probePath": "/ready",
+			"webModeler.restapi.livenessProbe.enabled":    "true",
+			"webModeler.restapi.livenessProbe.probePath":  "/live",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	probe := deployment.Spec.Template.Spec.Containers[0]
+
+	s.Require().Equal("/test/start", probe.StartupProbe.HTTPGet.Path)
+	s.Require().Equal("/test/ready", probe.ReadinessProbe.HTTPGet.Path)
+	s.Require().Equal("/test/live", probe.LivenessProbe.HTTPGet.Path)
+}

--- a/charts/camunda-platform/test/unit/web-modeler/deployment_test.go
+++ b/charts/camunda-platform/test/unit/web-modeler/deployment_test.go
@@ -627,3 +627,38 @@ func (s *deploymentTemplateTest) TestContainerLivenessProbe() {
 	s.Require().EqualValues(5, probe.FailureThreshold)
 	s.Require().EqualValues(1, probe.TimeoutSeconds)
 }
+
+func (s *deploymentTemplateTest) TestContainerProbesWithContextPath() {
+
+	// WebModeler websockets uses tcpSocket, hence, it doesn't use any path in the probs.
+	if s.component == "websockets" {
+		return
+	}
+
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"webModeler.enabled":                                      "true",
+			"webModeler.contextPath":                                  "/test",
+			"webModeler." + s.component + ".startupProbe.enabled":     "true",
+			"webModeler." + s.component + ".startupProbe.probePath":   "/start",
+			"webModeler." + s.component + ".readinessProbe.enabled":   "true",
+			"webModeler." + s.component + ".readinessProbe.probePath": "/ready",
+			"webModeler." + s.component + ".livenessProbe.enabled":    "true",
+			"webModeler." + s.component + ".livenessProbe.probePath":  "/live",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	probe := deployment.Spec.Template.Spec.Containers[0]
+
+	s.Require().Equal("/test/start", probe.StartupProbe.HTTPGet.Path)
+	s.Require().Equal("/test/ready", probe.ReadinessProbe.HTTPGet.Path)
+	s.Require().Equal("/test/live", probe.LivenessProbe.HTTPGet.Path)
+}

--- a/charts/camunda-platform/test/unit/zeebe-gateway/deployment_test.go
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/deployment_test.go
@@ -688,3 +688,32 @@ func (s *deploymentTemplateTest) TestContainerLivenessProbe() {
 	s.Require().EqualValues(5, probe.FailureThreshold)
 	s.Require().EqualValues(1, probe.TimeoutSeconds)
 }
+
+func (s *deploymentTemplateTest) TestContainerProbesWithContextPath() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"zeebe-gateway.contextPath":              "/test",
+			"zeebe-gateway.startupProbe.enabled":     "true",
+			"zeebe-gateway.startupProbe.probePath":   "/start",
+			"zeebe-gateway.readinessProbe.enabled":   "true",
+			"zeebe-gateway.readinessProbe.probePath": "/ready",
+			"zeebe-gateway.livenessProbe.enabled":    "true",
+			"zeebe-gateway.livenessProbe.probePath":  "/live",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	probe := deployment.Spec.Template.Spec.Containers[0]
+
+	s.Require().Equal("/test/start", probe.StartupProbe.HTTPGet.Path)
+	s.Require().Equal("/test/ready", probe.ReadinessProbe.HTTPGet.Path)
+	s.Require().Equal("/test/live", probe.LivenessProbe.HTTPGet.Path)
+}

--- a/charts/camunda-platform/test/unit/zeebe/statefulset_test.go
+++ b/charts/camunda-platform/test/unit/zeebe/statefulset_test.go
@@ -792,3 +792,32 @@ func (s *statefulSetTest) TestContainerLivenessProbe() {
 	s.Require().EqualValues(5, probe.FailureThreshold)
 	s.Require().EqualValues(1, probe.TimeoutSeconds)
 }
+
+func (s *statefulSetTest) TestContainerProbesWithContextPath() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"zeebe.contextPath":              "/test",
+			"zeebe.startupProbe.enabled":     "true",
+			"zeebe.startupProbe.probePath":   "/start",
+			"zeebe.readinessProbe.enabled":   "true",
+			"zeebe.readinessProbe.probePath": "/ready",
+			"zeebe.livenessProbe.enabled":    "true",
+			"zeebe.livenessProbe.probePath":  "/live",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+		ExtraArgs:      map[string][]string{"template": {"--debug"}, "install": {"--debug"}},
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var statefulSet appsv1.StatefulSet
+	helm.UnmarshalK8SYaml(s.T(), output, &statefulSet)
+
+	// then
+	probe := statefulSet.Spec.Template.Spec.Containers[0]
+
+	s.Require().Equal("/test/start", probe.StartupProbe.HTTPGet.Path)
+	s.Require().Equal("/test/ready", probe.ReadinessProbe.HTTPGet.Path)
+	s.Require().Equal("/test/live", probe.LivenessProbe.HTTPGet.Path)
+}


### PR DESCRIPTION
### Which problem does the PR fix?

#628

### What's in this PR?

Add the `contextPath` to startup/readiness/liveness probes and add a unit test for that.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added (if needed).
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
