### PR TITLE
fix(follow-up): add contextPath to startup/readiness/liveness probes

### DIFF
--- a/charts/camunda-platform/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/identity/templates/deployment.yaml
@@ -168,7 +168,8 @@ spec:
         {{- if .Values.startupProbe.enabled }}
         startupProbe:
           httpGet:
-            path: {{ .Values.contextPath }}{{ .Values.startupProbe.probePath }}
+            # NOTE: Identity doesn't support contextPath for health endpoints.
+            path: {{ .Values.startupProbe.probePath }}
             port: metrics
           initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.startupProbe.periodSeconds }}
@@ -179,7 +180,8 @@ spec:
         {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.contextPath }}{{ .Values.readinessProbe.probePath }}
+            # NOTE: Identity doesn't support contextPath for health endpoints.
+            path: {{ .Values.readinessProbe.probePath }}
             port: metrics
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
@@ -190,7 +192,8 @@ spec:
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.contextPath }}{{ .Values.livenessProbe.probePath }}
+            # NOTE: Identity doesn't support contextPath for health endpoints.
+            path: {{ .Values.livenessProbe.probePath }}
             port: metrics
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}

--- a/charts/camunda-platform/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform/templates/web-modeler/deployment-restapi.yaml
@@ -111,7 +111,7 @@ spec:
         {{- if .Values.webModeler.restapi.startupProbe.enabled }}
         startupProbe:
           httpGet:
-            path: {{ .Values.webModeler.contextPath }}{{ .Values.webModeler.restapi.startupProbe.probePath }}
+            path: {{ .Values.webModeler.restapi.startupProbe.probePath }}
             port: http-management
           initialDelaySeconds: {{ .Values.webModeler.restapi.startupProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.webModeler.restapi.startupProbe.periodSeconds }}
@@ -122,7 +122,7 @@ spec:
         {{- if .Values.webModeler.restapi.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.webModeler.contextPath }}{{ .Values.webModeler.restapi.readinessProbe.probePath }}
+            path: {{ .Values.webModeler.restapi.readinessProbe.probePath }}
             port: http-management
           initialDelaySeconds: {{ .Values.webModeler.restapi.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.webModeler.restapi.readinessProbe.periodSeconds }}
@@ -133,7 +133,7 @@ spec:
         {{- if .Values.webModeler.restapi.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.webModeler.contextPath }}{{ .Values.webModeler.restapi.livenessProbe.probePath }}
+            path: {{ .Values.webModeler.restapi.livenessProbe.probePath }}
             port: http-management
           initialDelaySeconds: {{ .Values.webModeler.restapi.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.webModeler.restapi.livenessProbe.periodSeconds }}

--- a/charts/camunda-platform/templates/web-modeler/deployment-webapp.yaml
+++ b/charts/camunda-platform/templates/web-modeler/deployment-webapp.yaml
@@ -114,7 +114,8 @@ spec:
         {{- if .Values.webModeler.webapp.startupProbe.enabled }}
         startupProbe:
           httpGet:
-            path: {{ .Values.webModeler.contextPath }}{{ .Values.webModeler.webapp.startupProbe.probePath }}
+            # NOTE: WebApp doesn't support contextPath for health endpoints.
+            path: {{ .Values.webModeler.webapp.startupProbe.probePath }}
             port: http-management
           initialDelaySeconds: {{ .Values.webModeler.webapp.startupProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.webModeler.webapp.startupProbe.periodSeconds }}
@@ -125,7 +126,8 @@ spec:
         {{- if .Values.webModeler.webapp.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.webModeler.contextPath }}{{ .Values.webModeler.webapp.readinessProbe.probePath }}
+            # NOTE: WebApp doesn't support contextPath for health endpoints.
+            path: {{ .Values.webModeler.webapp.readinessProbe.probePath }}
             port: http-management
           initialDelaySeconds: {{ .Values.webModeler.webapp.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.webModeler.webapp.readinessProbe.periodSeconds }}
@@ -136,7 +138,8 @@ spec:
         {{- if .Values.webModeler.webapp.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: {{ .Values.webModeler.contextPath }}{{ .Values.webModeler.webapp.livenessProbe.probePath }}
+            # NOTE: WebApp doesn't support contextPath for health endpoints.
+            path: {{ .Values.webModeler.webapp.livenessProbe.probePath }}
             port: http-management
           initialDelaySeconds: {{ .Values.webModeler.webapp.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.webModeler.webapp.livenessProbe.periodSeconds }}

--- a/charts/camunda-platform/test/unit/identity/deployment_test.go
+++ b/charts/camunda-platform/test/unit/identity/deployment_test.go
@@ -925,6 +925,7 @@ func (s *deploymentTemplateTest) TestContainerLivenessProbe() {
 	s.Require().EqualValues(1, probe.TimeoutSeconds)
 }
 
+// Identity doesn't support contextPath for health endpoints.
 func (s *deploymentTemplateTest) TestContainerProbesWithContextPath() {
 	// given
 	options := &helm.Options{
@@ -949,7 +950,7 @@ func (s *deploymentTemplateTest) TestContainerProbesWithContextPath() {
 	// then
 	probe := deployment.Spec.Template.Spec.Containers[0]
 
-	s.Require().Equal("/test/start", probe.StartupProbe.HTTPGet.Path)
-	s.Require().Equal("/test/ready", probe.ReadinessProbe.HTTPGet.Path)
-	s.Require().Equal("/test/live", probe.LivenessProbe.HTTPGet.Path)
+	s.Require().Equal("/start", probe.StartupProbe.HTTPGet.Path)
+	s.Require().Equal("/ready", probe.ReadinessProbe.HTTPGet.Path)
+	s.Require().Equal("/live", probe.LivenessProbe.HTTPGet.Path)
 }

--- a/charts/camunda-platform/test/unit/identity/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/deployment.golden.yaml
@@ -136,6 +136,7 @@ spec:
           protocol: TCP
         readinessProbe:
           httpGet:
+            # NOTE: Identity doesn't support contextPath for health endpoints.
             path: /actuator/health
             port: metrics
           initialDelaySeconds: 30

--- a/charts/camunda-platform/test/unit/web-modeler/deployment_restapi_test.go
+++ b/charts/camunda-platform/test/unit/web-modeler/deployment_restapi_test.go
@@ -338,6 +338,7 @@ func (s *restapiDeploymentTemplateTest) TestContainerLivenessProbe() {
 	s.Require().Equal("http-management", probe.HTTPGet.Port.StrVal)
 }
 
+// Web-Modeler REST API doesn't use contextPath for health endpoints.
 func (s *restapiDeploymentTemplateTest) TestContainerProbesWithContextPath() {
 	// given
 	options := &helm.Options{
@@ -362,7 +363,7 @@ func (s *restapiDeploymentTemplateTest) TestContainerProbesWithContextPath() {
 	// then
 	probe := deployment.Spec.Template.Spec.Containers[0]
 
-	s.Require().Equal("/test/start", probe.StartupProbe.HTTPGet.Path)
-	s.Require().Equal("/test/ready", probe.ReadinessProbe.HTTPGet.Path)
-	s.Require().Equal("/test/live", probe.LivenessProbe.HTTPGet.Path)
+	s.Require().Equal("/start", probe.StartupProbe.HTTPGet.Path)
+	s.Require().Equal("/ready", probe.ReadinessProbe.HTTPGet.Path)
+	s.Require().Equal("/live", probe.LivenessProbe.HTTPGet.Path)
 }

--- a/charts/camunda-platform/test/unit/web-modeler/deployment_test.go
+++ b/charts/camunda-platform/test/unit/web-modeler/deployment_test.go
@@ -627,38 +627,3 @@ func (s *deploymentTemplateTest) TestContainerLivenessProbe() {
 	s.Require().EqualValues(5, probe.FailureThreshold)
 	s.Require().EqualValues(1, probe.TimeoutSeconds)
 }
-
-func (s *deploymentTemplateTest) TestContainerProbesWithContextPath() {
-
-	// WebModeler websockets uses tcpSocket, hence, it doesn't use any path in the probs.
-	if s.component == "websockets" {
-		return
-	}
-
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                                      "true",
-			"webModeler.contextPath":                                  "/test",
-			"webModeler." + s.component + ".startupProbe.enabled":     "true",
-			"webModeler." + s.component + ".startupProbe.probePath":   "/start",
-			"webModeler." + s.component + ".readinessProbe.enabled":   "true",
-			"webModeler." + s.component + ".readinessProbe.probePath": "/ready",
-			"webModeler." + s.component + ".livenessProbe.enabled":    "true",
-			"webModeler." + s.component + ".livenessProbe.probePath":  "/live",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	probe := deployment.Spec.Template.Spec.Containers[0]
-
-	s.Require().Equal("/test/start", probe.StartupProbe.HTTPGet.Path)
-	s.Require().Equal("/test/ready", probe.ReadinessProbe.HTTPGet.Path)
-	s.Require().Equal("/test/live", probe.LivenessProbe.HTTPGet.Path)
-}

--- a/charts/camunda-platform/test/unit/web-modeler/deployment_webapp_test.go
+++ b/charts/camunda-platform/test/unit/web-modeler/deployment_webapp_test.go
@@ -434,6 +434,7 @@ func (s *webappDeploymentTemplateTest) TestContainerLivenessProbe() {
 	s.Require().Equal("http-management", probe.HTTPGet.Port.StrVal)
 }
 
+// Web-Modeler WebApp doesn't support contextPath for health endpoints.
 func (s *webappDeploymentTemplateTest) TestContainerProbesWithContextPath() {
 	// given
 	options := &helm.Options{
@@ -459,7 +460,7 @@ func (s *webappDeploymentTemplateTest) TestContainerProbesWithContextPath() {
 	// then
 	probe := deployment.Spec.Template.Spec.Containers[0]
 
-	s.Require().Equal("/test/start", probe.StartupProbe.HTTPGet.Path)
-	s.Require().Equal("/test/ready", probe.ReadinessProbe.HTTPGet.Path)
-	s.Require().Equal("/test/live", probe.LivenessProbe.HTTPGet.Path)
+	s.Require().Equal("/start", probe.StartupProbe.HTTPGet.Path)
+	s.Require().Equal("/ready", probe.ReadinessProbe.HTTPGet.Path)
+	s.Require().Equal("/live", probe.LivenessProbe.HTTPGet.Path)
 }

--- a/charts/camunda-platform/test/unit/web-modeler/golden/deployment-webapp.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/deployment-webapp.golden.yaml
@@ -120,6 +120,7 @@ spec:
           protocol: TCP
         readinessProbe:
           httpGet:
+            # NOTE: WebApp doesn't support contextPath for health endpoints.
             path: /health/readiness
             port: http-management
           initialDelaySeconds: 15


### PR DESCRIPTION
### Which problem does the PR fix?

Follow-up for: #629

### What's in this PR?

Add contextPath to components URL that will fix the failing readiness when contextPath is enabled

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added (if needed).
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?
