### PR TITLE
test: introduce retry within the integration tests

### DIFF
--- a/.github/workflows/test-integration-kubernetes.yaml
+++ b/.github/workflows/test-integration-kubernetes.yaml
@@ -30,7 +30,6 @@ env:
   TEST_DOCKER_USERNAME_CAMUNDA_CLOUD: ${{ secrets.CAMUNDA_REGISTRY_USER }}
   TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD: ${{ secrets.CAMUNDA_REGISTRY_PASSWORD }}
 
-
 jobs:
   test:
     name: ${{ matrix.test.title }}
@@ -99,11 +98,11 @@ jobs:
       run: |
         task -d $TEST_SCENARIOS_DIR/${{ matrix.test.dir }} setup.post
     - name: ⭐️ Run Preflight TestSuite ⭐️
-      timeout-minutes: 5
+      timeout-minutes: 10
       run: |
         task -d $TEST_SCENARIOS_DIR/${{ matrix.test.dir }} test.preflight
     - name: ⭐️ Run Core TestSuite ⭐️
-      timeout-minutes: 15
+      timeout-minutes: 20
       run: |
         task -d $TEST_SCENARIOS_DIR/${{ matrix.test.dir }} test.core
     - name: Get Pods info on failure

--- a/.github/workflows/test-integration-openshift.yaml
+++ b/.github/workflows/test-integration-openshift.yaml
@@ -93,11 +93,11 @@ jobs:
       run: |
         task -d $TEST_SCENARIOS_DIR/${{ matrix.test.dir }} setup.post
     - name: ⭐️ Run Preflight TestSuite ⭐️
-      timeout-minutes: 5
+      timeout-minutes: 10
       run: |
         task -d $TEST_SCENARIOS_DIR/${{ matrix.test.dir }} test.preflight
     - name: ⭐️ Run Core TestSuite ⭐️
-      timeout-minutes: 15
+      timeout-minutes: 20
       run: |
         task -d $TEST_SCENARIOS_DIR/${{ matrix.test.dir }} test.core
     - name: Get Pods info on failure

--- a/charts/camunda-platform/test/integration/scenarios/lib/testsuite-deploy-taskfile.yaml
+++ b/charts/camunda-platform/test/integration/scenarios/lib/testsuite-deploy-taskfile.yaml
@@ -6,7 +6,7 @@ vars:
 env:
   TEST_NAMESPACE: '{{ env "TEST_NAMESPACE" | default "camunda-platform" }}'
   TEST_PREFIX: integration-venom
-  TEST_TIMEOUT: 5m
+  TEST_TIMEOUT: 15m
   TEST_PARENT: "../../testsuites"
   TEST_DIR: "{{ .TEST_PARENT }}/{{ .testID }}"
   TEST_NAME: "{{ .TEST_PREFIX }}-{{ .testID }}"

--- a/charts/camunda-platform/test/integration/testsuites/base/job.yaml
+++ b/charts/camunda-platform/test/integration/testsuites/base/job.yaml
@@ -34,11 +34,28 @@ spec:
         command:
         - sh
         - -c
-        # TODO: Debug why envs from "envFrom" are not exported by default.
         - |
+          # TODO: Debug why envs from "envFrom" are not exported by default.
           export $(env | grep VENOM_VAR_);
-          /usr/local/venom run ./tests/${VENOM_RUN_ARGS:-*.y*ml} ||
-          (cat ./results/venom.log; exit 1)
+
+          # NOTE: That loop will be replaced once we use Testkube.
+          try=0
+          limit=3
+          delay=30s
+
+          until [ ${try} -ge ${limit} ]; do
+            try=$((try + 1))
+            echo "[INFO] Venom exec no. ${try}..."
+            /usr/local/venom run ./tests/${VENOM_RUN_ARGS:-*.y*ml}
+            exit_code=$?
+            test ${exit_code} == 0 && break
+            sleep ${delay}
+          done
+
+          if [[ ${exit_code} != 0 ]]; then
+            cat ./results/venom.log
+            exit 1
+          fi
         env:
         # Used to access get token from Keycloak to access Camunda APIs.
         - name: VENOM_VAR_TEST_CLIENT_SECRET

--- a/charts/camunda-platform/test/integration/testsuites/core/testsuites/core.yaml
+++ b/charts/camunda-platform/test/integration/testsuites/core/testsuites/core.yaml
@@ -146,7 +146,7 @@ testcases:
     method: GET
     url: http://{{ .releaseName }}-operate/actuator/health/readiness
     retry: 6
-    delay: 20
+    delay: 15
     info: |
       Response Body: {{ .result.body }}
     assertions:
@@ -165,7 +165,7 @@ testcases:
       Authorization: "Bearer {{ .helperVenomToken.jwt }}"
     body: '{}'
     retry: 6
-    delay: 20
+    delay: 15
     # info: |
     #   - Request Body: {{ .result.request.body }}
     #   - Response Body: {{ .result.body }}
@@ -185,7 +185,7 @@ testcases:
       Authorization: "Bearer {{ .helperVenomToken.jwt }}"
     body: '{"webhookDataKey":"webhookDataValue"}'
     retry: 6
-    delay: 60
+    delay: 15
     # info: |
     #   - Request Body: {{ .result.request.body }}
     #   - Response Body: {{ .result.body }}


### PR DESCRIPTION
### Which problem does the PR fix?

Sometimes the CP8 deployment pods fail because we are using GKE spot instances which leads the test to fail.

### What's in this PR?

Loop the Venom integration tests 3 times instead of rerunning the whole job from scratch.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added (if needed).
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
