### PR TITLE
fix: defaulting values to 'none' #695

### DIFF
--- a/charts/camunda-platform/charts/zeebe-gateway/templates/gateway-deployment.yaml
+++ b/charts/camunda-platform/charts/zeebe-gateway/templates/gateway-deployment.yaml
@@ -75,7 +75,7 @@ spec:
             - name: ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_TYPE
               value: "keycloak"
             - name: ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_MODE
-              value: "identity"
+              value: "none"
             - name: ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_ISSUERBACKENDURL
               value: {{ include "camundaPlatform.issuerBackendUrl" . | quote }}
             - name: ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_AUDIENCE

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/gateway-deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/gateway-deployment.golden.yaml
@@ -82,7 +82,7 @@ spec:
             - name: ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_TYPE
               value: "keycloak"
             - name: ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_MODE
-              value: "identity"
+              value: "none"
             - name: ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_ISSUERBACKENDURL
               value: "http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform"
             - name: ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_AUDIENCE


### PR DESCRIPTION
### Which problem does the PR fix?

#695 

### What's in this PR?

Defaulting zeebe-gateway to 'none' to meet standards

### Checklist

**Before opening the PR:**

- [x ] There is no other open [pull request](../pulls) for the same update/change.
- [ x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
