### PR TITLE
feat: customize Identity firstUser creation

### DIFF
--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -649,11 +649,13 @@ For more information, visit [Identity Overview](https://docs.camunda.io/docs/sel
 | | `enabled` |  If true, the Identity deployment and its related resources are deployed via a helm release. <br/> Note: Identity is required by Optimize and Web Modeler. If Identity is disabled, both Optimize and Web Modeler will be unusable. If you need neither Optimize nor Web Modeler, make sure to disable both the Identity authentication and the applications by setting:<br/>`global.identity.auth.enabled: false`<br/>`optimize.enabled: false`<br/>`webModeler.enabled: false` | `true` |
 | | `fullnameOverride` | Can be used to override the full name of the Identity resources | |
 | | `nameOverride` | Can be used to partly override the name of the Identity resources (names will still be prefixed with the release name) | |
+| | `firstUser.enabled` | If true, Identity will seed the first user in Keycloak | `true` |
 | | `firstUser.username` | Defines the username of the first user, needed to log in into the web applications | `demo` |
 | | `firstUser.password` | Defines the password of the first user, needed to log in into the web applications | `demo` |
 | | `firstUser.email` | Defines the email address of the first user; a valid email address is required to use Web Modeler | `demo@example.org` |
 | | `firstUser.firstName` | Defines the first name of the first user; a name is required to use Web Modeler | `Demo` |
 | | `firstUser.lastName` | Defines the last name of the first user; a name is required to use Web Modeler | `User` |
+| | `firstUser.existingSecret` | Can be used to use an own existing secret for Identity first user. Currently, only password field is supported via "identity-firstuser-password" key in the secret resource | `""` |
 | | `image` |  Configuration to configure the Identity image specifics | |
 | | `image.registry` | Can be used to set container image registry. | `""` |
 | | `image.repository` |  Defines which image repository to use | `camunda/identity` |

--- a/charts/camunda-platform/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/identity/templates/deployment.yaml
@@ -34,21 +34,7 @@ spec:
           - name: IDENTITY_BASE_PATH
             value: {{ .Values.contextPath | quote }}
           {{- end }}
-          - name: KEYCLOAK_USERS_0_USERNAME
-            value: {{ .Values.firstUser.username | quote }}
-          - name: KEYCLOAK_USERS_0_PASSWORD
-            value: {{ .Values.firstUser.password | quote }}
-          - name: KEYCLOAK_USERS_0_EMAIL
-            value: {{ .Values.firstUser.email | quote }}
-          - name: KEYCLOAK_USERS_0_FIRST_NAME
-            value: {{ .Values.firstUser.firstName | quote }}
-          - name: KEYCLOAK_USERS_0_LAST_NAME
-            value: {{ .Values.firstUser.lastName | quote }}
-          - name: KEYCLOAK_USERS_0_ROLES_0
-            value: "Identity"
           {{- if .Values.global.identity.auth.enabled }}
-          - name: KEYCLOAK_USERS_0_ROLES_1
-            value: "Operate"
           - name: KEYCLOAK_INIT_OPERATE_SECRET
             {{- if and .Values.global.identity.auth.operate.existingSecret (not (typeIs "string" .Values.global.identity.auth.operate.existingSecret)) }}
             valueFrom:
@@ -68,8 +54,6 @@ spec:
             {{- end }}
           - name: KEYCLOAK_INIT_OPERATE_ROOT_URL
             value: {{ tpl .Values.global.identity.auth.operate.redirectUrl $ | quote }}
-          - name: KEYCLOAK_USERS_0_ROLES_2
-            value: "Tasklist"
           - name: KEYCLOAK_INIT_TASKLIST_SECRET
             {{- if and .Values.global.identity.auth.tasklist.existingSecret (not (typeIs "string" .Values.global.identity.auth.tasklist.existingSecret)) }}
             valueFrom:
@@ -89,8 +73,6 @@ spec:
             {{- end }}
           - name: KEYCLOAK_INIT_TASKLIST_ROOT_URL
             value: {{ tpl .Values.global.identity.auth.tasklist.redirectUrl $ | quote }}
-          - name: KEYCLOAK_USERS_0_ROLES_3
-            value: "Optimize"
           - name: KEYCLOAK_INIT_OPTIMIZE_SECRET
             {{- if and .Values.global.identity.auth.optimize.existingSecret (not (typeIs "string" .Values.global.identity.auth.optimize.existingSecret)) }}
             valueFrom:
@@ -110,8 +92,6 @@ spec:
             {{- end }}
           - name: KEYCLOAK_INIT_OPTIMIZE_ROOT_URL
             value: {{ tpl .Values.global.identity.auth.optimize.redirectUrl $ | quote }}
-          - name: KEYCLOAK_USERS_0_ROLES_4
-            value: "Web Modeler"
           - name: KEYCLOAK_INIT_WEBMODELER_ROOT_URL
             value: {{ tpl .Values.global.identity.auth.webModeler.redirectUrl $ | quote }}
           - name: KEYCLOAK_INIT_ZEEBE_NAME
@@ -190,6 +170,38 @@ spec:
               secretKeyRef:
                 name: {{ include "identity.keycloak.authExistingSecret" . }}
                 key: {{ include "identity.keycloak.authExistingSecretKey" . }}
+        {{- if .Values.firstUser.enabled }}
+          - name: KEYCLOAK_USERS_0_USERNAME
+            value: {{ .Values.firstUser.username | quote }}
+        {{- if .Values.firstUser.existingSecret }}
+          - name: KEYCLOAK_USERS_0_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.firstUser.existingSecret }}
+                key: "identity-firstuser-password"
+        {{- else }}
+          - name: KEYCLOAK_USERS_0_PASSWORD
+            value: {{ .Values.firstUser.password | quote }}
+        {{- end }}
+          - name: KEYCLOAK_USERS_0_EMAIL
+            value: {{ .Values.firstUser.email | quote }}
+          - name: KEYCLOAK_USERS_0_FIRST_NAME
+            value: {{ .Values.firstUser.firstName | quote }}
+          - name: KEYCLOAK_USERS_0_LAST_NAME
+            value: {{ .Values.firstUser.lastName | quote }}
+          - name: KEYCLOAK_USERS_0_ROLES_0
+            value: "Identity"
+        {{- if .Values.global.identity.auth.enabled }}
+          - name: KEYCLOAK_USERS_0_ROLES_1
+            value: "Operate"
+          - name: KEYCLOAK_USERS_0_ROLES_2
+            value: "Tasklist"
+          - name: KEYCLOAK_USERS_0_ROLES_3
+            value: "Optimize"
+          - name: KEYCLOAK_USERS_0_ROLES_4
+            value: "Web Modeler"
+        {{- end }}
+        {{- end }}
         {{- with .Values.env }}
             {{- tpl (toYaml .) $ | nindent 10 }}
         {{- end }}

--- a/charts/camunda-platform/templates/NOTES.txt
+++ b/charts/camunda-platform/templates/NOTES.txt
@@ -94,27 +94,32 @@ In order to deploy the ingress manifest, set `<service>.ingress.enabled` to `tru
 If you don't have an ingress controller you can use `kubectl port-forward` to access the deployed web application from outside the cluster:
 
 {{ if .Values.identity.enabled -}}
-Identity: kubectl port-forward svc/{{ .Release.Name }}-identity 8080:80
+Identity:
+> kubectl port-forward svc/{{ .Release.Name }}-identity 8080:80
 {{- end }}
 {{ if .Values.operate.enabled -}}
-Operate:  kubectl port-forward svc/{{ .Release.Name }}-operate  8081:80
+Operate:
+> kubectl port-forward svc/{{ .Release.Name }}-operate  8081:80
 {{- end }}
 {{ if .Values.tasklist.enabled -}}
-Tasklist: kubectl port-forward svc/{{ .Release.Name }}-tasklist 8082:80
+Tasklist:
+> kubectl port-forward svc/{{ .Release.Name }}-tasklist 8082:80
 {{- end }}
 {{ if .Values.optimize.enabled -}}
-Optimize: kubectl port-forward svc/{{ .Release.Name }}-optimize 8083:80
-{{- end }}
-{{ if .Values.webModeler.enabled }}
-Web Modeler:
-kubectl port-forward svc/{{ include "webModeler.webapp.fullname" . }} 8084:80
-kubectl port-forward svc/{{ include "webModeler.websockets.fullname" . }} 8085:80
+Optimize:
+> kubectl port-forward svc/{{ .Release.Name }}-optimize 8083:80
 {{- end }}
 {{ if .Values.connectors.enabled -}}
-Connectors: kubectl port-forward svc/{{ .Release.Name }}-connectors 8088:8080
+Connectors:
+> kubectl port-forward svc/{{ .Release.Name }}-connectors 8088:8080
+{{- end }}
+{{ if .Values.webModeler.enabled -}}
+Web Modeler:
+> kubectl port-forward svc/{{ include "webModeler.webapp.fullname" . }} 8084:80
+> kubectl port-forward svc/{{ include "webModeler.websockets.fullname" . }} 8085:80
 {{- end }}
 
-    {{- if and .Values.global.identity.auth.enabled .Values.identity.enabled }}
+{{- if and .Values.global.identity.auth.enabled .Values.identity.enabled }}
 
 If you want to use different ports for the services, please adjust the related configs in the values file since these ports are used as redirect URLs for Keycloak.
 
@@ -124,10 +129,16 @@ as well, otherwise, a login will not be possible. Make sure you use `18080` as a
 {{ if .Values.identity.keycloak.enabled -}}
 > kubectl port-forward svc/{{ include "common.names.dependency.fullname" (dict "chartName" "keycloak" "chartValues" .Values.identity.keycloak "context" $) | trunc 20 | trimSuffix "-" }} 18080:80
 {{- end }}
-    {{- end }}
+{{- end }}
 
 Now you can point your browser to one of the service's login pages. Example: http://localhost:8081 for Operate.
-
-Default user and password: "demo/demo"
+{{ if .Values.identity.firstUser.enabled }}
+{{- if .Values.identity.firstUser.existingSecret }}
+Default user: "{{ .Values.identity.firstUser.username }}", and for password, run:
+> kubectl get secret {{ .Values.identity.firstUser.existingSecret }} -o jsonpath='{.data.identity-firstuser-password}' | base64 -d
+{{- else }}
+Default user and password: "{{ .Values.identity.firstUser.username -}}/{{ .Values.identity.firstUser.password }}"
+{{- end }}
+{{ end }}
 
 {{- end }}

--- a/charts/camunda-platform/templates/tests/integration-test-secret.yaml
+++ b/charts/camunda-platform/templates/tests/integration-test-secret.yaml
@@ -8,4 +8,5 @@ metadata:
 type: Opaque
 data:
   client-secret: {{ include "common.secrets.passwords.manage" (dict "secret" "integration-test" "key" "client-secret" "length" 16 "providedValues" (list "test.existingSecret") "context" $) }}
+  identity-firstuser-password: {{ include "common.secrets.passwords.manage" (dict "secret" "integration-test" "key" "identity-firstuser-password" "length" 16 "providedValues" (list "") "context" $) }}
 {{- end }}

--- a/charts/camunda-platform/test/unit/identity/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/deployment.golden.yaml
@@ -42,20 +42,6 @@ spec:
         image: "camunda/identity:8.2.5"
         imagePullPolicy: IfNotPresent
         env:
-          - name: KEYCLOAK_USERS_0_USERNAME
-            value: "demo"
-          - name: KEYCLOAK_USERS_0_PASSWORD
-            value: "demo"
-          - name: KEYCLOAK_USERS_0_EMAIL
-            value: "demo@example.org"
-          - name: KEYCLOAK_USERS_0_FIRST_NAME
-            value: "Demo"
-          - name: KEYCLOAK_USERS_0_LAST_NAME
-            value: "User"
-          - name: KEYCLOAK_USERS_0_ROLES_0
-            value: "Identity"
-          - name: KEYCLOAK_USERS_0_ROLES_1
-            value: "Operate"
           - name: KEYCLOAK_INIT_OPERATE_SECRET
             valueFrom:
               secretKeyRef:
@@ -63,8 +49,6 @@ spec:
                 key: operate-secret
           - name: KEYCLOAK_INIT_OPERATE_ROOT_URL
             value: "http://localhost:8081"
-          - name: KEYCLOAK_USERS_0_ROLES_2
-            value: "Tasklist"
           - name: KEYCLOAK_INIT_TASKLIST_SECRET
             valueFrom:
               secretKeyRef:
@@ -72,8 +56,6 @@ spec:
                 key: tasklist-secret
           - name: KEYCLOAK_INIT_TASKLIST_ROOT_URL
             value: "http://localhost:8082"
-          - name: KEYCLOAK_USERS_0_ROLES_3
-            value: "Optimize"
           - name: KEYCLOAK_INIT_OPTIMIZE_SECRET
             valueFrom:
               secretKeyRef:
@@ -81,8 +63,6 @@ spec:
                 key: optimize-secret
           - name: KEYCLOAK_INIT_OPTIMIZE_ROOT_URL
             value: "http://localhost:8083"
-          - name: KEYCLOAK_USERS_0_ROLES_4
-            value: "Web Modeler"
           - name: KEYCLOAK_INIT_WEBMODELER_ROOT_URL
             value: "http://localhost:8084"
           - name: KEYCLOAK_INIT_ZEEBE_NAME
@@ -136,6 +116,26 @@ spec:
               secretKeyRef:
                 name: camunda-platform-test-keycloak
                 key: admin-password
+          - name: KEYCLOAK_USERS_0_USERNAME
+            value: "demo"
+          - name: KEYCLOAK_USERS_0_PASSWORD
+            value: "demo"
+          - name: KEYCLOAK_USERS_0_EMAIL
+            value: "demo@example.org"
+          - name: KEYCLOAK_USERS_0_FIRST_NAME
+            value: "Demo"
+          - name: KEYCLOAK_USERS_0_LAST_NAME
+            value: "User"
+          - name: KEYCLOAK_USERS_0_ROLES_0
+            value: "Identity"
+          - name: KEYCLOAK_USERS_0_ROLES_1
+            value: "Operate"
+          - name: KEYCLOAK_USERS_0_ROLES_2
+            value: "Tasklist"
+          - name: KEYCLOAK_USERS_0_ROLES_3
+            value: "Optimize"
+          - name: KEYCLOAK_USERS_0_ROLES_4
+            value: "Web Modeler"
         resources:
           limits:
             cpu: 2000m

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -1146,6 +1146,8 @@ identity:
   # FirstUser configuration to configure properties of the first Identity user, which can be used to access all
   # web applications
   firstUser:
+    # FirstUser.enabled if true, Identity will seed the first user in Keycloak.
+    enabled: true
     # FirstUser.username defines the username of the first user, needed to log in into the web applications
     username: demo
     # FirstUser.password defines the password of the first user, needed to log in into the web applications
@@ -1156,6 +1158,9 @@ identity:
     firstName: Demo
     # FirstUser.lastName defines the last name of the first user; a name is required to use Web Modeler
     lastName: User
+    # FirstUser.existingSecret can be used to use an own existing secret for Identity first user.
+    # Currently, only password field is supported via "identity-firstuser-password" key in the secret resource.
+    existingSecret: ""
 
   # Image configuration to configure the identity image specifics
   image:


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes: #645
Should be merged before: #728

### What's in this PR?

- Support disabling the creation of Identity firstUser. 
- Support using a custom secret for Identity firstUser. 

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added (if needed).
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
