### PR TITLE
Use new curator image

### DIFF
--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -258,7 +258,7 @@ Check out the default [values.yaml](values.yaml) file, which contains the same c
 | | `operateIndexTTL` | Defines after how many days an Operate index can be deleted. | `30` |
 | | `tasklistIndexTTL` | Defines after how many days an Tasklist index can be deleted. | `30` |
 | | `image.registry` | Can be used to set container image registry. | `""` |
-| | `image.repository` | Defines which image repository to use. | `bitnami/elasticsearch-curator` |
+| | `image.repository` | Defines which image repository to use. | `bitnami/elasticsearch-curator-archived` |
 | | `image.tag` | Defines the tag / version which should be used in the chart. | `Check the values file` |
 | `prometheusServiceMonitor` | | Configuration to configure a prometheus service monitor | |
 | | `enabled` | If true, then a service monitor will be deployed, which allows an installed prometheus controller to scrape metrics from the deployed pods. | `false`|

--- a/charts/camunda-platform/test/unit/global_deployment_test.go
+++ b/charts/camunda-platform/test/unit/global_deployment_test.go
@@ -155,5 +155,5 @@ func (s *deploymentTemplateTest) TestContainerSetImageNameGlobal() {
 	s.Require().Contains(output, "image: \"global.custom.registry.io/camunda/optimize:3.x.x\"")
 	s.Require().Contains(output, "image: \"global.custom.registry.io/camunda/tasklist:8.x.x\"")
 	s.Require().Contains(output, "image: \"global.custom.registry.io/camunda/zeebe:8.x.x\"")
-	s.Require().Contains(output, "image: \"global.custom.registry.io/bitnami/elasticsearch-curator:5.x.x\"")
+	s.Require().Contains(output, "image: \"global.custom.registry.io/bitnami/elasticsearch-curator-archived:5.x.x\"")
 }

--- a/charts/camunda-platform/test/unit/golden/curator-cronjob.golden.yaml
+++ b/charts/camunda-platform/test/unit/golden/curator-cronjob.golden.yaml
@@ -22,7 +22,7 @@ spec:
       template:
         spec:
           containers:
-            - image: "bitnami/elasticsearch-curator:5.8.4"
+            - image: "bitnami/elasticsearch-curator-archived:5.8.4"
               name: curator
               args: ["--config", "/etc/config/config.yml", "/etc/config/action_file.yml"]
               volumeMounts:

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -1106,12 +1106,12 @@ retentionPolicy:
   tasklistIndexTTL: 30
 
   # Image configuration for the elasticsearch curator cronjob
-  # https://hub.docker.com/r/bitnami/elasticsearch-curator/tags
+  # https://hub.docker.com/r/bitnami/elasticsearch-curator-archived/tags
   image:
     # Image.registry can be used to set container image registry.
     registry: ""
     # Image.repository defines which image repository to use
-    repository: bitnami/elasticsearch-curator
+    repository: bitnami/elasticsearch-curator-archived
     # Image.tag defines the tag / version which should be used in the chart
     tag: 5.8.4
 

--- a/charts/camunda-platform/values/values-latest.yaml
+++ b/charts/camunda-platform/values/values-latest.yaml
@@ -52,5 +52,5 @@ elasticsearch:
 retentionPolicy:
   # https://hub.docker.com/r/bitnami/elasticsearch-curator/tags
   image:
-    repository: bitnami/elasticsearch-curator
+    repository: bitnami/elasticsearch-curator-archived
     tag: 5.8.4

--- a/charts/camunda-platform/values/values-v8.1.yaml
+++ b/charts/camunda-platform/values/values-v8.1.yaml
@@ -57,5 +57,5 @@ elasticsearch:
 retentionPolicy:
   # https://hub.docker.com/r/bitnami/elasticsearch-curator/tags
   image:
-    repository: bitnami/elasticsearch-curator
+    repository: bitnami/elasticsearch-curator-archived
     tag: 5.8.4


### PR DESCRIPTION
### Which problem does the PR fix?
Old bitnami curator image has been renamed to elasticsearch-curator-archived.

See related article I wrote https://medium.com/@zelldon91/looks-like-bitnami-elasticsearch-curator-is-gone-db1fa2260a97 and slack https://camunda.slack.com/archives/CSQ2E3BT4/p1687786110402069

Curator image can now be found here https://hub.docker.com/r/bitnami/elasticsearch-curator-archived/tags


<!-- Which GitHub issues related to or fixed by this PR, if any. -->

### What's in this PR?

Replaces the old/outdated image with the new one.
<!--
  Explain the contents of the PR.
  Give an overview about the implementation, which decisions were made and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [ ] Tests for charts are added (if needed).
- [ ] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
