### PR TITLE
refactor: in connector disable operate client if inbound is disabled

### DIFF
--- a/charts/camunda-platform/templates/connectors/deployment.yaml
+++ b/charts/camunda-platform/templates/connectors/deployment.yaml
@@ -44,8 +44,6 @@ spec:
               value: "false"
             - name: CAMUNDA_CONNECTOR_WEBHOOK_ENABLED
               value: "false"
-            - name: SPRING_MAIN_WEB-APPLICATION-TYPE
-              value: "NONE"
             - name: OPERATE_CLIENT_ENABLED
               value: "false"
           {{- end }}

--- a/charts/camunda-platform/templates/connectors/deployment.yaml
+++ b/charts/camunda-platform/templates/connectors/deployment.yaml
@@ -46,6 +46,8 @@ spec:
               value: "false"
             - name: SPRING_MAIN_WEB-APPLICATION-TYPE
               value: "NONE"
+            - name: OPERATE_CLIENT_ENABLED
+              value: "false"
           {{- end }}
           {{- if eq .Values.connectors.inbound.mode "credentials" }}
             - name: OPERATE_CLIENT_ENABLED

--- a/charts/camunda-platform/test/unit/connectors/deployment_test.go
+++ b/charts/camunda-platform/test/unit/connectors/deployment_test.go
@@ -704,7 +704,6 @@ func (s *deploymentTemplateTest) TestContainerSetInboundModeDisabled() {
 	s.Require().Contains(env, corev1.EnvVar{Name: "ZEEBE_CLIENT_SECURITY_PLAINTEXT", Value: "true"})
 	s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_CONNECTOR_POLLING_ENABLED", Value: "false"})
 	s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_CONNECTOR_WEBHOOK_ENABLED", Value: "false"})
-	s.Require().Contains(env, corev1.EnvVar{Name: "SPRING_MAIN_WEB-APPLICATION-TYPE", Value: "NONE"})
 }
 
 func (s *deploymentTemplateTest) TestContainerSetInboundModeCredentials() {

--- a/charts/camunda-platform/test/unit/connectors/deployment_test.go
+++ b/charts/camunda-platform/test/unit/connectors/deployment_test.go
@@ -774,6 +774,7 @@ func (s *deploymentTemplateTest) TestContainerSetInboundModeOauth() {
 	s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_OPERATE_CLIENT_KEYCLOAK-REALM", Value: "camunda-platform"})
 	s.Require().Contains(env, corev1.EnvVar{Name: "OPERATE_CLIENT_ENABLED", Value: "true"})
 	s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_OPERATE_CLIENT_URL", Value: "http://camunda-platform-test-operate:80"})
+	
 }
 
 func (s *deploymentTemplateTest) TestContainerSetContextPath() {


### PR DESCRIPTION
### Which problem does the PR fix?

Related to https://camunda.slack.com/archives/C02JLRNQQ05/p1687897649481629

closes #757 

### What's in this PR?

By default, the Operate Client is enabled in the connectors-bundle. This PR will change the deployment to disable the operate client if the inbound connector is disabled.

### Checklist

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [ ] Tests for charts are added (if needed).
- [ ] The main Helm chart and sub-chart are updated (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

### Additional context

This is not the only way to solve the original issue.

It would also be possible to configure the connection to Operate just like in the other configuration options.

It should be checked whether the Operate connector relies on the Operate client used.