### PR TITLE
Use keycloakURL instead of keycloakURLBase

### DIFF
--- a/charts/camunda-platform/templates/connectors/deployment.yaml
+++ b/charts/camunda-platform/templates/connectors/deployment.yaml
@@ -62,7 +62,7 @@ spec:
           {{- end }}
           {{- if and .Values.global.identity.auth.enabled (eq .Values.connectors.inbound.mode "oauth") }}
             - name: CAMUNDA_OPERATE_CLIENT_KEYCLOAK-URL
-              value: {{ include "camundaPlatform.keycloakURLBase" . }}
+              value: {{ include "camundaPlatform.keycloakURL" . }}
             - name: CAMUNDA_OPERATE_CLIENT_CLIENT-ID
               value: connectors
             - name: CAMUNDA_OPERATE_CLIENT_CLIENT-SECRET


### PR DESCRIPTION
### Which problem does the PR fix?

self-managed connectors configuration

### What's in this PR?

In self-managed setup with existing keycloak, even though the values `global.identity.keycloak.url` is present, the connectors will connect to the wrong host `camunda-keycloak`.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added (if needed).
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
