### PR TITLE
fix(repo): remove minimumMasterNodes in KIND

### DIFF
--- a/kind/camunda-platform-core-kind-values.yaml
+++ b/kind/camunda-platform-core-kind-values.yaml
@@ -31,7 +31,6 @@ connectors:
 # Configure elastic search to make it running for local development
 elasticsearch:
   replicas: 1
-  minimumMasterNodes: 1
   # Allow no backup for single node setups
   clusterHealthCheckParams: "wait_for_status=yellow&timeout=1s"
 


### PR DESCRIPTION
### Which problem does the PR fix?
minimumMasterNodes is ignored in Elasticsearch versions >= 7 according to https://github.com/elastic/helm-charts/blob/main/elasticsearch/README.md#configuration

### What's in this PR?
Remove minimumMasterNodes from camunda-platform-core-kind-values.yaml

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [ ] Tests for charts are added (if needed).
- [ ] The main Helm chart and sub-chart are updated (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
