### PR TITLE
fix(zeebe): no longer overwrites default entrypoint

### DIFF
--- a/charts/camunda-platform/charts/zeebe/templates/configmap.yaml
+++ b/charts/camunda-platform/charts/zeebe/templates/configmap.yaml
@@ -4,26 +4,6 @@ metadata:
   labels: {{- include "zeebe.labels.broker" . | nindent 4 }}
 apiVersion: v1
 data:
-  startup.sh: |
-    #!/usr/bin/env bash
-    set -eux -o pipefail
-
-    export ZEEBE_BROKER_CLUSTER_NODEID=${ZEEBE_BROKER_CLUSTER_NODEID:-${K8S_NAME##*-}}
-
-    if [ "$(ls -A /exporters/)" ]; then
-      mkdir /usr/local/zeebe/exporters/
-      cp -a /exporters/*.jar /usr/local/zeebe/exporters/
-    else
-      echo "No exporters available."
-    fi
-
-    {{- if .Values.debug }}
-
-    env
-    {{- end }}
-
-    exec /usr/local/zeebe/bin/broker
-
   broker-log4j2.xml: |
 {{- if .Values.log4j2 }}
     {{ .Values.log4j2 | indent 4 | trim }}

--- a/charts/camunda-platform/charts/zeebe/templates/statefulset.yaml
+++ b/charts/camunda-platform/charts/zeebe/templates/statefulset.yaml
@@ -152,15 +152,12 @@ spec:
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         volumeMounts:
-        - name: config
-          mountPath: /usr/local/bin/startup.sh
-          subPath: startup.sh
         {{- if not ( eq .Values.persistenceType "local" ) }}
         - name: data
           mountPath: /usr/local/zeebe/data
         {{- end }}
         - name: exporters
-          mountPath: /exporters
+          mountPath: /usr/local/zeebe/exporters
         {{- if .Values.log4j2 }}
         - name: config
           mountPath: /usr/local/zeebe/config/log4j2.xml
@@ -178,10 +175,6 @@ spec:
           emptyDir:
             medium: "Memory"
         {{- end }}
-        - name: config
-          configMap:
-            name: {{ include "zeebe.fullname" . }}
-            defaultMode: {{ .Values.configMap.defaultMode }}
         - name: exporters
           emptyDir: {}
         {{- if .Values.extraVolumes}}

--- a/charts/camunda-platform/test/unit/zeebe/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/configmap-log4j2.golden.yaml
@@ -13,21 +13,6 @@ metadata:
     app.kubernetes.io/component: zeebe-broker
 apiVersion: v1
 data:
-  startup.sh: |
-    #!/usr/bin/env bash
-    set -eux -o pipefail
-
-    export ZEEBE_BROKER_CLUSTER_NODEID=${ZEEBE_BROKER_CLUSTER_NODEID:-${K8S_NAME##*-}}
-
-    if [ "$(ls -A /exporters/)" ]; then
-      mkdir /usr/local/zeebe/exporters/
-      cp -a /exporters/*.jar /usr/local/zeebe/exporters/
-    else
-      echo "No exporters available."
-    fi
-
-    exec /usr/local/zeebe/bin/broker
-
   broker-log4j2.xml: |
     <xml>
     </xml>

--- a/charts/camunda-platform/test/unit/zeebe/golden/configmap.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/configmap.golden.yaml
@@ -13,19 +13,4 @@ metadata:
     app.kubernetes.io/component: zeebe-broker
 apiVersion: v1
 data:
-  startup.sh: |
-    #!/usr/bin/env bash
-    set -eux -o pipefail
-
-    export ZEEBE_BROKER_CLUSTER_NODEID=${ZEEBE_BROKER_CLUSTER_NODEID:-${K8S_NAME##*-}}
-
-    if [ "$(ls -A /exporters/)" ]; then
-      mkdir /usr/local/zeebe/exporters/
-      cp -a /exporters/*.jar /usr/local/zeebe/exporters/
-    else
-      echo "No exporters available."
-    fi
-
-    exec /usr/local/zeebe/bin/broker
-
   broker-log4j2.xml: |

--- a/charts/camunda-platform/test/unit/zeebe/golden/statefulset.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/statefulset.golden.yaml
@@ -131,18 +131,11 @@ spec:
             cpu: 800m
             memory: 1200Mi
         volumeMounts:
-        - name: config
-          mountPath: /usr/local/bin/startup.sh
-          subPath: startup.sh
         - name: data
           mountPath: /usr/local/zeebe/data
         - name: exporters
-          mountPath: /exporters
+          mountPath: /usr/local/zeebe/exporters
       volumes:
-        - name: config
-          configMap:
-            name: camunda-platform-test-zeebe
-            defaultMode: 492
         - name: exporters
           emptyDir: {}
       affinity:

--- a/charts/camunda-platform/test/unit/zeebe/statefulset_test.go
+++ b/charts/camunda-platform/test/unit/zeebe/statefulset_test.go
@@ -371,9 +371,9 @@ func (s *statefulSetTest) TestContainerSetLog4j2() {
 	// then
 	volumeMounts := statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts
 	s.Require().Equal(3, len(volumeMounts))
-	s.Require().Equal("config", volumeMounts[3].Name)
-	s.Require().Equal("/usr/local/zeebe/config/log4j2.xml", volumeMounts[3].MountPath)
-	s.Require().Equal("broker-log4j2.xml", volumeMounts[3].SubPath)
+	s.Require().Equal("config", volumeMounts[2].Name)
+	s.Require().Equal("/usr/local/zeebe/config/log4j2.xml", volumeMounts[2].MountPath)
+	s.Require().Equal("broker-log4j2.xml", volumeMounts[2].SubPath)
 }
 
 func (s *statefulSetTest) TestContainerSetExtraVolumes() {
@@ -397,7 +397,7 @@ func (s *statefulSetTest) TestContainerSetExtraVolumes() {
 	volumes := statefulSet.Spec.Template.Spec.Volumes
 	s.Require().Equal(2, len(volumes))
 
-	extraVolume := volumes[2]
+	extraVolume := volumes[1]
 	s.Require().Equal("extraVolume", extraVolume.Name)
 	s.Require().NotNil(*extraVolume.ConfigMap)
 	s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
@@ -423,7 +423,7 @@ func (s *statefulSetTest) TestContainerSetExtraVolumeMounts() {
 	// then
 	volumeMounts := statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts
 	s.Require().Equal(3, len(volumeMounts))
-	extraVolumeMount := volumeMounts[3]
+	extraVolumeMount := volumeMounts[2]
 	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
 	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
 }
@@ -450,15 +450,15 @@ func (s *statefulSetTest) TestContainerSetExtraVolumesAndMounts() {
 	volumes := statefulSet.Spec.Template.Spec.Volumes
 	s.Require().Equal(2, len(volumes))
 
-	extraVolume := volumes[2]
+	extraVolume := volumes[1]
 	s.Require().Equal("extraVolume", extraVolume.Name)
 	s.Require().NotNil(*extraVolume.ConfigMap)
 	s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
 	s.Require().EqualValues(744, *extraVolume.ConfigMap.DefaultMode)
 
 	volumeMounts := statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(4, len(volumeMounts))
-	extraVolumeMount := volumeMounts[3]
+	s.Require().Equal(3, len(volumeMounts))
+	extraVolumeMount := volumeMounts[2]
 	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
 	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
 }
@@ -660,7 +660,7 @@ func (s *statefulSetTest) TestContainerSetPersistenceTypeRam() {
 	// then
 	volumeMounts := statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts
 	s.Require().Equal(2, len(volumeMounts))
-	dataVolumeMount := volumeMounts[1]
+	dataVolumeMount := volumeMounts[0]
 	s.Require().Equal("data", dataVolumeMount.Name)
 	s.Require().Equal("/usr/local/zeebe/data", dataVolumeMount.MountPath)
 
@@ -697,7 +697,7 @@ func (s *statefulSetTest) TestContainerSetPersistenceTypeLocal() {
 	}
 
 	volumes := statefulSet.Spec.Template.Spec.Volumes
-	s.Require().Equal(2, len(volumes))
+	s.Require().Equal(1, len(volumes))
 	for _, volumeMount := range volumeMounts {
 		s.Require().NotEqual("data", volumeMount.Name)
 	}

--- a/charts/camunda-platform/test/unit/zeebe/statefulset_test.go
+++ b/charts/camunda-platform/test/unit/zeebe/statefulset_test.go
@@ -370,7 +370,7 @@ func (s *statefulSetTest) TestContainerSetLog4j2() {
 
 	// then
 	volumeMounts := statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(4, len(volumeMounts))
+	s.Require().Equal(3, len(volumeMounts))
 	s.Require().Equal("config", volumeMounts[3].Name)
 	s.Require().Equal("/usr/local/zeebe/config/log4j2.xml", volumeMounts[3].MountPath)
 	s.Require().Equal("broker-log4j2.xml", volumeMounts[3].SubPath)
@@ -395,7 +395,7 @@ func (s *statefulSetTest) TestContainerSetExtraVolumes() {
 
 	// then
 	volumes := statefulSet.Spec.Template.Spec.Volumes
-	s.Require().Equal(3, len(volumes))
+	s.Require().Equal(2, len(volumes))
 
 	extraVolume := volumes[2]
 	s.Require().Equal("extraVolume", extraVolume.Name)
@@ -422,7 +422,7 @@ func (s *statefulSetTest) TestContainerSetExtraVolumeMounts() {
 
 	// then
 	volumeMounts := statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(4, len(volumeMounts))
+	s.Require().Equal(3, len(volumeMounts))
 	extraVolumeMount := volumeMounts[3]
 	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
 	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
@@ -448,7 +448,7 @@ func (s *statefulSetTest) TestContainerSetExtraVolumesAndMounts() {
 
 	// then
 	volumes := statefulSet.Spec.Template.Spec.Volumes
-	s.Require().Equal(3, len(volumes))
+	s.Require().Equal(2, len(volumes))
 
 	extraVolume := volumes[2]
 	s.Require().Equal("extraVolume", extraVolume.Name)
@@ -659,13 +659,13 @@ func (s *statefulSetTest) TestContainerSetPersistenceTypeRam() {
 
 	// then
 	volumeMounts := statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(3, len(volumeMounts))
+	s.Require().Equal(2, len(volumeMounts))
 	dataVolumeMount := volumeMounts[1]
 	s.Require().Equal("data", dataVolumeMount.Name)
 	s.Require().Equal("/usr/local/zeebe/data", dataVolumeMount.MountPath)
 
 	volumes := statefulSet.Spec.Template.Spec.Volumes
-	s.Require().Equal(3, len(volumes))
+	s.Require().Equal(2, len(volumes))
 	dataVolume := volumes[0]
 	s.Require().Equal("data", dataVolume.Name)
 	s.Require().NotEmpty(dataVolume.EmptyDir)
@@ -691,7 +691,7 @@ func (s *statefulSetTest) TestContainerSetPersistenceTypeLocal() {
 
 	// then
 	volumeMounts := statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(2, len(volumeMounts))
+	s.Require().Equal(1, len(volumeMounts))
 	for _, volumeMount := range volumeMounts {
 		s.Require().NotEqual("data", volumeMount.Name)
 	}


### PR DESCRIPTION
### Which problem does the PR fix?

Our Zeebe subchart currently overwrites the the zeebe docker images entrypoint.  This is confusing, unnecessary, and occasionally causes issues with customers who try to have a more secure configuration.  This PR removes this overwritten entrypoint, and replicates the meaningful behavior, while dropping behavior that is unnecessary.

This issue is related to this [draft PR](https://github.com/camunda/camunda-platform-helm/pull/778) because while testing that PR, I was having file permission errors on this entrypoint file.  There are ways to workaround that, but still, I'd prefer if this was merged instead.


### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview about the implementation, which decisions were made and why.
-->

In terms of how I implemented this PR, I went line by line down the startup.sh file and reasoned about whether it makes sense whether we  have this custom entrypoint or not. If theres a way to replicate it's functionality in some other way, I moved that logic to statefulset.yaml.  

Starting with the following line,
```
-    export ZEEBE_BROKER_CLUSTER_NODEID=${ZEEBE_BROKER_CLUSTER_NODEID:-${K8S_NAME##*-}}
```
I see theres this ZEEBE_BROKER_CLUSTER_NODEID environment variable.  I went to my current deployment of Zeebe, and replaced the command in the statefulset with `export ZEEBE_BROKER_CLUSTER_NODEID=${ZEEBE_BROKER_CLUSTER_NODEID:-${K8S_NAME##*-}} && echo $ZEEBE_BROKER_CLUSTER_NODEID  &&  sleep 999`.

To my surprise, I found that this environment variable ends up getting set to `0`. To me, this means this environment variable is not being used.


Next, the following code block copies a volume's files to a different directory.
```
-    if [ "$(ls -A /exporters/)" ]; then
-      mkdir /usr/local/zeebe/exporters/
-      cp -a /exporters/*.jar /usr/local/zeebe/exporters/
-    else
-      echo "No exporters available."
-    fi
```

This could be avoided by simply bindmounting the exporters volume to `/usr/local/zeebe/exporters/`  with the following patch in statefulset.yaml
```
         - name: exporters
-          mountPath: /exporters
+          mountPath: /usr/local/zeebe/exporters
```

Finally, the last part of this overwritten entrypoint is 

```
-    {{- if .Values.debug }}
-    env
-    {{- end }}
```
This functionality is not provided in other components and could simply be removed. Theres also a thing called "kubectl describe" and "kubectl exec  ... -- env " for debugging purposes.



### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [ ] Tests for charts are added (if needed).
- [ ] The main Helm chart and sub-chart are updated (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
