### PR TITLE
feat(optimize): added ability to specify environment-config.yaml opti…

### DIFF
--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -616,6 +616,7 @@ For more information, visit [Optimize Introduction](https://docs.camunda.io/opti
 | | `podLabels` |  Can be used to define extra Optimize pod labels | `{ }` |
 | | `partitionCount` |  Defines how many Zeebe partitions are set up in the cluster and which should be imported by Optimize | `"3"` |
 | | `env` |  Can be used to set extra environment variables in each Optimize container. Environment variables listed here may appear twice in `kubectl describe` but the variable listed in this option will have precedence. | `[]` |
+| | `environmentConfig` |  can be used to set options in optimize's environment-config.yaml file | `{}` |
 | | `command` | Can be used to [override the default command provided by the container image](https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/) | `[]` |
 | | `extraVolumes` |  Can be used to define extra volumes for the Optimize pods, useful for tls and self-signed certificates | `[]` |
 | | `extraVolumeMounts` |  Can be used to mount extra volumes for the Optimize pods, useful for tls and self-signed certificates | `[]` |

--- a/charts/camunda-platform/charts/optimize/templates/configmap.yaml
+++ b/charts/camunda-platform/charts/optimize/templates/configmap.yaml
@@ -1,0 +1,10 @@
+kind: ConfigMap
+metadata:
+  name: {{ include "optimize.fullname" . }}
+  labels: {{- include "optimize.labels" . | nindent 4 }}
+apiVersion: v1
+data:
+  environment-config.yaml: |
+{{- with .Values.environmentConfig }}
+{{ . | toYaml | indent 4 }}
+{{- end }}

--- a/charts/camunda-platform/charts/optimize/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/optimize/templates/deployment.yaml
@@ -132,6 +132,9 @@ spec:
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
         {{- end }}
         volumeMounts:
+        - name: config
+          mountPath: /optimize/config/environment-config.yaml
+          subPath: environment-config.yaml
         {{- if .Values.extraVolumeMounts}}
           {{- .Values.extraVolumeMounts | toYaml | nindent 8 }}
         {{- end }}
@@ -139,6 +142,10 @@ spec:
       {{- .Values.sidecars | toYaml | nindent 6 }}
       {{- end }}
       volumes:
+      - name: config
+        configMap:
+          name: {{ include "optimize.fullname" . }}
+          defaultMode: {{ .Values.configMap.defaultMode }}
       {{- if .Values.extraVolumes}}
       {{- .Values.extraVolumes | toYaml | nindent 6 }}
       {{- end }}

--- a/charts/camunda-platform/openshift/values-patch.yaml
+++ b/charts/camunda-platform/openshift/values-patch.yaml
@@ -45,6 +45,11 @@ identity:
           fsGroup: "@@null@@"
           runAsUser: "@@null@@"
 
+# omit the values below if optimize.enabled is false
+optimize:
+  podSecurityContext:
+    fsGroup: "@@null@@"
+
 # omit the values below if elasticsearch.enabled is false
 elasticsearch:
   # test resources are disabled as they aren't pass on to the post-renderer, meaning they will not be deploy-able. this

--- a/charts/camunda-platform/test/unit/optimize/configmap_test.go
+++ b/charts/camunda-platform/test/unit/optimize/configmap_test.go
@@ -1,0 +1,42 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package optimize
+
+import (
+	"camunda-platform-helm/charts/camunda-platform/test/unit/golden"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestGoldenConfigmapWithEnvironmentConfig(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../")
+	require.NoError(t, err)
+
+	suite.Run(t, &golden.TemplateGoldenTest{
+		ChartPath:      chartPath,
+		Release:        "camunda-platform-test",
+		Namespace:      "camunda-platform-" + strings.ToLower(random.UniqueId()),
+		GoldenFileName: "configmap-environment-config",
+		Templates:      []string{"charts/optimize/templates/configmap.yaml"},
+		SetValues:      map[string]string{"optimize.environmentConfig": "sharing.enabled: true"},
+	})
+}

--- a/charts/camunda-platform/test/unit/optimize/deployment_test.go
+++ b/charts/camunda-platform/test/unit/optimize/deployment_test.go
@@ -276,9 +276,9 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumes() {
 
 	// then
 	volumes := deployment.Spec.Template.Spec.Volumes
-	s.Require().Equal(1, len(volumes))
+	s.Require().Equal(2, len(volumes))
 
-	extraVolume := volumes[0]
+	extraVolume := volumes[1]
 	s.Require().Equal("extraVolume", extraVolume.Name)
 	s.Require().NotNil(*extraVolume.ConfigMap)
 	s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
@@ -306,8 +306,8 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumeMounts() {
 	s.Require().Equal(1, len(containers))
 
 	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(1, len(volumeMounts))
-	extraVolumeMount := volumeMounts[0]
+	s.Require().Equal(2, len(volumeMounts))
+	extraVolumeMount := volumeMounts[1]
 	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
 	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
 }
@@ -333,9 +333,9 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumesAndMounts() {
 
 	// then
 	volumes := deployment.Spec.Template.Spec.Volumes
-	s.Require().Equal(1, len(volumes))
+	s.Require().Equal(2, len(volumes))
 
-	extraVolume := volumes[0]
+	extraVolume := volumes[1]
 	s.Require().Equal("extraVolume", extraVolume.Name)
 	s.Require().NotNil(*extraVolume.ConfigMap)
 	s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
@@ -345,8 +345,8 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumesAndMounts() {
 	s.Require().Equal(1, len(containers))
 
 	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(1, len(volumeMounts))
-	extraVolumeMount := volumeMounts[0]
+	s.Require().Equal(2, len(volumeMounts))
+	extraVolumeMount := volumeMounts[1]
 	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
 	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
 }

--- a/charts/camunda-platform/test/unit/optimize/golden/configmap-environment-config.golden.yaml
+++ b/charts/camunda-platform/test/unit/optimize/golden/configmap-environment-config.golden.yaml
@@ -1,0 +1,17 @@
+---
+# Source: camunda-platform/charts/optimize/templates/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: camunda-platform-test-optimize
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: optimize
+    app.kubernetes.io/instance: camunda-platform-test
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/version: "3.10.3"
+    app.kubernetes.io/component: optimize
+apiVersion: v1
+data:
+  environment-config.yaml: |
+    'sharing.enabled: true'

--- a/charts/camunda-platform/test/unit/optimize/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/optimize/golden/deployment.golden.yaml
@@ -98,4 +98,13 @@ spec:
           failureThreshold: 5
           timeoutSeconds: 1
         volumeMounts:
+        - name: config
+          mountPath: /optimize/config/environment-config.yaml
+          subPath: environment-config.yaml
       volumes:
+      - name: config
+        configMap:
+          name: camunda-platform-test-optimize
+          defaultMode: 256
+      securityContext:
+        fsGroup: 101

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -957,6 +957,13 @@ optimize:
   partitionCount: "3"
   # Env can be used to set extra environment variables in each Optimize container
   env: []
+  # EnvironmentConfig can be used to set options in optimize's environment-config.yaml file
+  environmentConfig: {}
+  # ConfigMap configuration which will be applied to the mounted config map.
+  configMap:
+    # ConfigMap.defaultMode can be used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+    # See https://github.com/kubernetes/api/blob/master/core/v1/types.go#L1615-L1623
+    defaultMode: 0400
   # Command can be used to override the default command provided by the container image. See https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/
   command: []
   # ExtraVolumes can be used to define extra volumes for the Optimize pods, useful for tls and self-signed certificates
@@ -985,7 +992,8 @@ optimize:
     managementPort: 8092
 
   # PodSecurityContext defines the security options the Optimize pod should be run with
-  podSecurityContext: {}
+  podSecurityContext:
+    fsGroup: 101
 
   # ContainerSecurityContext defines the security options the Optimize container should be run with
   containerSecurityContext: {}


### PR DESCRIPTION
…ons in optimize

### Which problem does the PR fix?

This PR comes as a incident followup item. The issue was that the customer wanted to be able to set their `es.settings.index.number_of_shards` option. This is an option in optimize that can be specified in environment-config.yaml.  The configuration options in environment-config.yaml are documented on our [Optimize Configuration documentation](https://docs.camunda.io/optimize/self-managed/optimize-deployment/configuration/system-configuration/). 

The problem is that we do not have an environment-config.yaml file when we exec into our optimize pod, so there's no way to pass in options unless customers specify their volumes / extra mounts directly in values.yaml.  

#787 

### What's in this PR?

This PR will create a configmap of the file environment-config.yaml and will set options to pass that file into optimize in the particular directory it gets read from.  This PR also includes a basic unit test that ensures that the option will pass into the configmap.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).


**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added (if needed).
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
