### PR TITLE
fix(core-values): disable operate to match connectors inbound mode

### DIFF
--- a/kind/camunda-platform-core-kind-values.yaml
+++ b/kind/camunda-platform-core-kind-values.yaml
@@ -26,7 +26,13 @@ zeebe-gateway:
 connectors:
   enabled: true
   inbound:
-    mode: disabled
+    mode: "disabled"
+  # Remove the following env vars after the next release (current 8.2.8)
+  env:
+  - name: SPRING_MAIN_WEB-APPLICATION-TYPE
+    value: ""
+  - name: OPERATE_CLIENT_ENABLED
+    value: "false"
 
 # Configure elastic search to make it running for local development
 elasticsearch:


### PR DESCRIPTION
### Which problem does the PR fix?

On existing HC releases, when a customer follows [this guide to set up a local k8s cluster](https://docs.camunda.io/docs/self-managed/platform-deployment/helm-kubernetes/guides/local-kubernetes-cluster/), They get the following error:

```
2023-07-24T20:36:56.479Z  WARN 1 --- [ult-executor-26] io.camunda.zeebe.client.job.poller       : Failed to activate jobs for worker SENDGRID and job type io.camunda:sendgrid:1                 │
│                                                                                                                                                                                                  
│ io.grpc.StatusRuntimeException: UNAVAILABLE: io exception                                                                                                                                        
│     at io.grpc.Status.asRuntimeException(Status.java:539)                                                                                                                                        
│     at io.grpc.stub.ClientCalls$StreamObserverToCallListenerAdapter.onClose(ClientCalls.java:487)                                                                                                
│     at io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:567)                                                                                                                    
│     at io.grpc.internal.ClientCallImpl.access$300(ClientCallImpl.java:71)                                                                                                                        
│     at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInternal(ClientCallImpl.java:735)                                                                               
│     at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInContext(ClientCallImpl.java:716)                                                                              
│     at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)                                                                                                                             
│     at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)                                                                                                                    
│     at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)                                                                                                               
│     at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)                                                                                                              
│     at java.base/java.lang.Thread.run(Unknown Source)                                                                                                                                            │
│ Caused by: io.netty.channel.AbstractChannel$AnnotatedConnectException: Connection refused: dev-zeebe-gateway/10.96.203.76:26500                                                                  │
│ Caused by: java.net.ConnectException: Connection refused                                                                                                                                        
│     at java.base/sun.nio.ch.Net.pollConnect(Native Method)                                                                                                                                      
│     at java.base/sun.nio.ch.Net.pollConnectNow(Unknown Source)                                                                                                                                  
│     at java.base/sun.nio.ch.SocketChannelImpl.finishConnect(Unknown Source)                                                                                                                     
│     at io.netty.channel.socket.nio.NioSocketChannel.doFinishConnect(NioSocketChannel.java:337)                                                                                                  
│     at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.finishConnect(AbstractNioChannel.java:334)                                                                                     
│     at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:776)                                                                                                              
│     at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)                                                                                                    
│     at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)                                                                                                              
│     at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)                                                                                                                              
│     at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)                                                                                              
│     at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)                                                                                                                 
│     at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)                                                                                                     
│     at java.base/java.lang.Thread.run(Unknown Source)
```

This issue is currently fixed on main, but customers have to either use our main branch, or update their values.yaml with the changes made in this PR.  

<!-- Which GitHub issues related to or fixed by this PR, if any. -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview about the implementation, which decisions were made and why.
-->

This PR adds a couple environment variables that will turn off the Connectors connection to Operate.  It's essentially the values.yaml equivalent of [this change](https://github.com/camunda/camunda-platform-helm/pull/756).

These changes should be reverted after the next release.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [ ] Tests for charts are added (if needed).
- [ ] The main Helm chart and sub-chart are updated (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
