### PR TITLE
Add support for Multi-Region Active-Active setups

### DIFF
--- a/charts/camunda-platform/Chart.yaml
+++ b/charts/camunda-platform/Chart.yaml
@@ -43,7 +43,7 @@ dependencies:
     condition: "zeebe.enabled"
   - name: zeebe-gateway
     version: 8.2.6
-    condition: "zeebe.enabled"
+    condition: "zeebe-gateway.enabled"
   # Dependency charts.
   - name: elasticsearch
     repository: "https://helm.elastic.co"

--- a/charts/camunda-platform/charts/operate/templates/configmap.yaml
+++ b/charts/camunda-platform/charts/operate/templates/configmap.yaml
@@ -42,4 +42,4 @@ data:
 {{ . | toYaml | indent 6 }}
 {{- end }}
     #Spring Boot Actuator endpoints to be exposed
-    management.endpoints.web.exposure.include: health,info,conditions,configprops,prometheus,loggers,usage-metrics,backup
+    management.endpoints.web.exposure.include: health,info,conditions,configprops,prometheus,loggers,usage-metrics,backups

--- a/charts/camunda-platform/charts/zeebe/templates/configmap.yaml
+++ b/charts/camunda-platform/charts/zeebe/templates/configmap.yaml
@@ -7,8 +7,11 @@ data:
   startup.sh: |
     #!/usr/bin/env bash
     set -eux -o pipefail
-
+{{- if eq .Values.global.installationType "failOver" }}
+    export ZEEBE_BROKER_CLUSTER_NODEID=${ZEEBE_BROKER_CLUSTER_NODEID:-$[${K8S_NAME##*-} * 2 * {{.Values.global.regions}} + {{.Values.global.regionId}}]}
+{{- else }}
     export ZEEBE_BROKER_CLUSTER_NODEID=${ZEEBE_BROKER_CLUSTER_NODEID:-$[${K8S_NAME##*-} * {{.Values.global.regions}} + {{.Values.global.regionId}}]}
+{{- end }}
 
     if [ "$(ls -A /exporters/)" ]; then
       mkdir /usr/local/zeebe/exporters/
@@ -18,11 +21,21 @@ data:
     fi
 
     {{- if .Values.debug }}
-
     env
     {{- end }}
-
+    
+{{- if eq .Values.global.installationType "failBack" }}
+    if [$[${K8S_NAME##*-} % 2] == 0]
+    then
+      export ZEEBE_BROKER_NETWORK_INTERNALAPI_PORT=26555
+      export ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS=""
+      trap : TERM INT; sleep infinity & wait
+    else
+      exec /usr/local/zeebe/bin/broker
+    fi
+{{- else }}
     exec /usr/local/zeebe/bin/broker
+{{- end }}
 
   broker-log4j2.xml: |
 {{- if .Values.log4j2 }}

--- a/charts/camunda-platform/charts/zeebe/templates/configmap.yaml
+++ b/charts/camunda-platform/charts/zeebe/templates/configmap.yaml
@@ -8,7 +8,7 @@ data:
     #!/usr/bin/env bash
     set -eux -o pipefail
 
-    export ZEEBE_BROKER_CLUSTER_NODEID=${ZEEBE_BROKER_CLUSTER_NODEID:-${K8S_NAME##*-}}
+    export ZEEBE_BROKER_CLUSTER_NODEID=${ZEEBE_BROKER_CLUSTER_NODEID:-$[${K8S_NAME##*-} * {{.Values.global.regions}} + {{.Values.global.regionId}}]}
 
     if [ "$(ls -A /exporters/)" ]; then
       mkdir /usr/local/zeebe/exporters/

--- a/charts/camunda-platform/charts/zeebe/templates/configmap.yaml
+++ b/charts/camunda-platform/charts/zeebe/templates/configmap.yaml
@@ -20,10 +20,6 @@ data:
       echo "No exporters available."
     fi
 
-    export ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH2_CLASSNAME=io.camunda.zeebe.exporter.ElasticsearchExporter
-    export ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH2_ARGS_URL=http://elasticsearch-master.europe-west1-b.svc.cluster.local:9200
-    export ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH2_ARGS_BULK_SIZE=1
-
     {{- if .Values.debug }}
     env
     {{- end }}

--- a/charts/camunda-platform/charts/zeebe/templates/configmap.yaml
+++ b/charts/camunda-platform/charts/zeebe/templates/configmap.yaml
@@ -27,8 +27,6 @@ data:
 {{- if eq .Values.global.installationType "failBack" }}
     if [ $[${K8S_NAME##*-} % 2] -eq 0 ]
     then
-      export ZEEBE_BROKER_NETWORK_INTERNALAPI_PORT=26555
-      export ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS=""
       trap : TERM INT; sleep infinity & wait
     else
       exec /usr/local/zeebe/bin/broker

--- a/charts/camunda-platform/charts/zeebe/templates/configmap.yaml
+++ b/charts/camunda-platform/charts/zeebe/templates/configmap.yaml
@@ -25,7 +25,7 @@ data:
     {{- end }}
     
 {{- if eq .Values.global.installationType "failBack" }}
-    if [$[${K8S_NAME##*-} % 2] == 0]
+    if [ $[${K8S_NAME##*-} % 2] -eq 0 ]
     then
       export ZEEBE_BROKER_NETWORK_INTERNALAPI_PORT=26555
       export ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS=""

--- a/charts/camunda-platform/charts/zeebe/templates/configmap.yaml
+++ b/charts/camunda-platform/charts/zeebe/templates/configmap.yaml
@@ -20,6 +20,10 @@ data:
       echo "No exporters available."
     fi
 
+    export ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH2_CLASSNAME=io.camunda.zeebe.exporter.ElasticsearchExporter
+    export ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH2_ARGS_URL=http://elasticsearch-master.europe-west1-b.svc.cluster.local:9200
+    export ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH2_ARGS_BULK_SIZE=1
+
     {{- if .Values.debug }}
     env
     {{- end }}

--- a/charts/camunda-platform/charts/zeebe/templates/statefulset.yaml
+++ b/charts/camunda-platform/charts/zeebe/templates/statefulset.yaml
@@ -8,7 +8,12 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
-  replicas: {{ div .Values.clusterSize .Values.global.regions }}
+
+  replicas: {{- if eq .Values.global.installationType "failOver" }}
+                {{ div (div .Values.clusterSize .Values.global.regions) 2 }}
+            {{- else }}
+                {{ div .Values.clusterSize .Values.global.regions }}
+            {{- end }}
   selector:
     matchLabels:
       {{- include "zeebe.matchLabels.broker" . | nindent 6 }}

--- a/charts/camunda-platform/charts/zeebe/templates/statefulset.yaml
+++ b/charts/camunda-platform/charts/zeebe/templates/statefulset.yaml
@@ -8,7 +8,7 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
-  replicas: {{ .Values.clusterSize  }}
+  replicas: {{ div .Values.clusterSize .Values.global.regions }}
   selector:
     matchLabels:
       {{- include "zeebe.matchLabels.broker" . | nindent 6 }}
@@ -60,7 +60,7 @@ spec:
         - name: ZEEBE_BROKER_NETWORK_ADVERTISEDHOST
           value: "$(K8S_NAME).$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc"
         - name: ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS
-          value:
+          value: 
           {{- range (untilStep 0 (int .Values.clusterSize) 1) }}
             $(K8S_SERVICE_NAME)-{{ . }}.$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc:{{$.Values.service.internalPort}},
           {{- end }}

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -216,7 +216,7 @@ zeebe:
     - name: ZEEBE_BROKER_DATA_DISKUSAGEREPLICATIONWATERMARK
       value: "0.87"
     - name: ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS
-      value: "camunda-zeebe-0.camunda-zeebe.europe-west4-b.svc.cluster.local:26502, camunda-zeebe-1.camunda-zeebe.europe-west4-b.svc.cluster.local:26502, camunda-zeebe-0.camunda-zeebe.europe-west1-b.svc.cluster.local:26502, camunda-zeebe-1.camunda-zeebe.europe-west1-b.svc.cluster.local:26502"
+      value: "camunda-zeebe-0.camunda-zeebe.europe-west4-b.svc.cluster.local:26502, camunda-zeebe-1.camunda-zeebe.europe-west4-b.svc.cluster.local:26502, camunda-zeebe-2.camunda-zeebe.europe-west4-b.svc.cluster.local:26502, camunda-zeebe-3.camunda-zeebe.europe-west4-b.svc.cluster.local:26502, camunda-zeebe-0.camunda-zeebe.europe-west1-b.svc.cluster.local:26502, camunda-zeebe-1.camunda-zeebe.europe-west1-b.svc.cluster.local:26502, camunda-zeebe-2.camunda-zeebe.europe-west1-b.svc.cluster.local:26502, camunda-zeebe-3.camunda-zeebe.europe-west1-b.svc.cluster.local:26502"
   # ConfigMap configuration which will be applied to the mounted config map.
   configMap:
     # ConfigMap.defaultMode can be used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -25,11 +25,11 @@
 # Global configuration for variables which can be accessed by all sub charts
 global:
   # number of regions that support the zeebe platform (2 for minimal multi-region setup)
-  regions: 2
-  # id of the region should start at 0 for easy computation. With 2 regions, you would have region 0 and 1.
+  regions: 1
+  # unique id of the region. Should start at 0 for easy computation. With 2 regions, you would have region 0 and 1.
   regionId: 0
-  # use that variables in case of disaster : normal, failOver, failBack
-  installationType: failBack
+  # mode of installation for multi-region disaster recovery: normal, failOver, failBack
+  installationType: normal
 
   # Annotations can be used to define common annotations, which should be applied to all deployments
   annotations: {}
@@ -215,8 +215,6 @@ zeebe:
       value: "0.85"
     - name: ZEEBE_BROKER_DATA_DISKUSAGEREPLICATIONWATERMARK
       value: "0.87"
-    - name: ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS
-      value: "camunda-zeebe-0.camunda-zeebe.europe-west4-b.svc.cluster.local:26502, camunda-zeebe-1.camunda-zeebe.europe-west4-b.svc.cluster.local:26502, camunda-zeebe-2.camunda-zeebe.europe-west4-b.svc.cluster.local:26502, camunda-zeebe-3.camunda-zeebe.europe-west4-b.svc.cluster.local:26502, camunda-zeebe-0.camunda-zeebe.europe-west1-b.svc.cluster.local:26502, camunda-zeebe-1.camunda-zeebe.europe-west1-b.svc.cluster.local:26502, camunda-zeebe-2.camunda-zeebe.europe-west1-b.svc.cluster.local:26502, camunda-zeebe-3.camunda-zeebe.europe-west1-b.svc.cluster.local:26502"
   # ConfigMap configuration which will be applied to the mounted config map.
   configMap:
     # ConfigMap.defaultMode can be used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -28,6 +28,9 @@ global:
   regions: 2
   # id of the region should start at 0 for easy computation. With 2 regions, you would have region 0 and 1.
   regionId: 0
+  # use that variables in case of disaster : normal, failOver, failBack
+  installationType: failBack
+
   # Annotations can be used to define common annotations, which should be applied to all deployments
   annotations: {}
   # Labels can be used to define common labels, which should be applied to all deployments

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -24,6 +24,10 @@
 
 # Global configuration for variables which can be accessed by all sub charts
 global:
+  # number of regions that support the zeebe platform (2 for minimal multi-region setup)
+  regions: 2
+  # id of the region should start at 0 for easy computation. With 2 regions, you would have region 0 and 1.
+  regionId: 0
   # Annotations can be used to define common annotations, which should be applied to all deployments
   annotations: {}
   # Labels can be used to define common labels, which should be applied to all deployments
@@ -208,6 +212,8 @@ zeebe:
       value: "0.85"
     - name: ZEEBE_BROKER_DATA_DISKUSAGEREPLICATIONWATERMARK
       value: "0.87"
+    - name: ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS
+      value: "camunda-zeebe-0.camunda-zeebe.region0.svc:26502, camunda-zeebe-1.camunda-zeebe.region0.svc:26502, camunda-zeebe-0.camunda-zeebe.region1.svc:26502, camunda-zeebe-1.camunda-zeebe.region1.svc:26502"
   # ConfigMap configuration which will be applied to the mounted config map.
   configMap:
     # ConfigMap.defaultMode can be used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -213,7 +213,7 @@ zeebe:
     - name: ZEEBE_BROKER_DATA_DISKUSAGEREPLICATIONWATERMARK
       value: "0.87"
     - name: ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS
-      value: "camunda-zeebe-0.camunda-zeebe.region0.svc:26502, camunda-zeebe-1.camunda-zeebe.region0.svc:26502, camunda-zeebe-0.camunda-zeebe.region1.svc:26502, camunda-zeebe-1.camunda-zeebe.region1.svc:26502"
+      value: "camunda-zeebe-0.camunda-zeebe.europe-west4-b.svc.cluster.local:26502, camunda-zeebe-1.camunda-zeebe.europe-west4-b.svc.cluster.local:26502, camunda-zeebe-0.camunda-zeebe.europe-west1-b.svc.cluster.local:26502, camunda-zeebe-1.camunda-zeebe.europe-west1-b.svc.cluster.local:26502"
   # ConfigMap configuration which will be applied to the mounted config map.
   configMap:
     # ConfigMap.defaultMode can be used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.


### PR DESCRIPTION
### Which problem does the PR fix?

Add support for Multi-Region Active-Active setups
<!-- Which GitHub issues related to or fixed by this PR, if any. -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview about the implementation, which decisions were made and why.
-->
Creates partial Zeebe clusters in order to form stretch clusters across multiple k8s clusters.

This is accompanied by a [Helm profile containing chart values and Makefiles to automate operations procedures](https://github.com/camunda-community-hub/camunda-8-helm-profiles/tree/activeactive/google/multi-region/active-active).

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [ ] Tests for charts are added (if needed).
- [ ] The main Helm chart and sub-chart are updated (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
