### PR TITLE
ci: support multi openshift clusters

### DIFF
--- a/.github/workflows/test-integration-main.yaml
+++ b/.github/workflows/test-integration-main.yaml
@@ -45,17 +45,30 @@ jobs:
             cluster-location: GKE_ZONE
             workload-identity-provider: GCP_AUTH_WORKLOAD_IDENTITY_PROVIDER
             service-account: GCP_AUTH_SERVICE_ACCOUNT
-        - name: OpenShift 4.10
+          if: true
+        - name: OpenShift 4.13
           type: openshift
+          version: 4.13
           platform: rosa
-          secret:
-            server: OPENSHIFT_URL_410
-            token: OPENSHIFT_TOKEN_410
+          if: true
+        - name: OpenShift 4.12
+          type: openshift
+          version: 4.12
+          platform: rosa
+          if: ${{ contains(github.event.*.labels.*.name, 'test-release') }}
+        - name: OpenShift 4.11
+          type: openshift
+          version: 4.11
+          platform: rosa
+          if: ${{ contains(github.event.*.labels.*.name, 'test-release') }}
+        exclude:
+        - test:
+            if: false
     env:
       TEST_CLUSTER_TYPE: "${{ matrix.test.type }}"
     steps:
     - uses: actions/checkout@v3
-    # TODO: Later, find a way to abstract the auth to different platforms.
+    # TODO: Later, find a way to abstract the auth for different platforms.
     - name: Authenticate to GKE
       if: matrix.test.platform == 'gke'
       uses: ./.github/actions/gke-login
@@ -64,12 +77,20 @@ jobs:
         cluster-location: ${{ secrets[matrix.test.secret.cluster-location] }}
         workload-identity-provider: ${{ secrets[matrix.test.secret.workload-identity-provider] }}
         service-account: ${{ secrets[matrix.test.secret.service-account] }}
+    - name: Set OpenShift authentication vars
+      if: matrix.test.type == 'openshift'
+      run: |
+        OPENSHIFT_CLUSTER_VERSION="$(echo ${{ matrix.test.version }} | tr -d '.')"
+        echo "OPENSHIFT_CLUSTER_URL=OPENSHIFT_CLUSTER_URL_${OPENSHIFT_CLUSTER_VERSION}" >> $GITHUB_ENV
+        echo "OPENSHIFT_CLUSTER_USERNAME=OPENSHIFT_CLUSTER_USERNAME_${OPENSHIFT_CLUSTER_VERSION}" >> $GITHUB_ENV
+        echo "OPENSHIFT_CLUSTER_PASSWORD=OPENSHIFT_CLUSTER_PASSWORD_${OPENSHIFT_CLUSTER_VERSION}" >> $GITHUB_ENV
     - name: Authenticate to OpenShift
       if: matrix.test.platform == 'rosa'
       uses: redhat-actions/oc-login@v1
       with:
-        openshift_server_url: ${{ secrets[matrix.test.secret.server] }}
-        openshift_token: ${{ secrets[matrix.test.secret.token] }}
+        openshift_server_url: ${{ secrets[env.OPENSHIFT_CLUSTER_URL] }}
+        openshift_username: ${{ secrets[env.OPENSHIFT_CLUSTER_USERNAME] }}
+        openshift_password: ${{ secrets[env.OPENSHIFT_CLUSTER_PASSWORD] }}
     - name: Set PR vars
       uses: ./.github/actions/pr-vars
     - name: Install env dependencies


### PR DESCRIPTION
### Which problem does the PR fix?

Part of: distribution/issues/87

### What's in this PR?

Support multi OpenShift clusters and switch to the new CI cluster with OpenShift v4.13.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added (if needed).
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
