### PR TITLE
feat(security): read-only root filesystems for all containers

### DIFF
--- a/charts/camunda-platform/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/identity/templates/deployment.yaml
@@ -277,6 +277,8 @@ spec:
         {{- end }}
         {{- if .Values.extraVolumeMounts}}
         volumeMounts:
+        - mountPath: /tmp
+          name: tmp
         {{- .Values.extraVolumeMounts | toYaml | nindent 8 }}
         {{- end }}
       {{- if .Values.sidecars }}
@@ -285,6 +287,8 @@ spec:
 
       {{- if .Values.extraVolumes}}
       volumes:
+        - name: tmp
+          emptyDir: {}
       {{- .Values.extraVolumes | toYaml | nindent 6 }}
       {{- end }}
       {{- if .Values.serviceAccount.name}}

--- a/charts/camunda-platform/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/identity/templates/deployment.yaml
@@ -275,10 +275,10 @@ spec:
           failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
         {{- end }}
-        {{- if .Values.extraVolumeMounts}}
         volumeMounts:
         - mountPath: /tmp
           name: tmp
+        {{- if .Values.extraVolumeMounts}}
         {{- .Values.extraVolumeMounts | toYaml | nindent 8 }}
         {{- end }}
       {{- if .Values.sidecars }}

--- a/charts/camunda-platform/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/identity/templates/deployment.yaml
@@ -276,10 +276,10 @@ spec:
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
         {{- end }}
         volumeMounts:
-          - mountPath: /tmp
-            name: tmp
+        - mountPath: /tmp
+          name: tmp
         {{- if .Values.extraVolumeMounts}}
-        {{- .Values.extraVolumeMounts | toYaml | nindent 8 }}
+          {{- .Values.extraVolumeMounts | toYaml | nindent 8 }}
         {{- end }}
       {{- if .Values.sidecars }}
       {{- .Values.sidecars | toYaml | nindent 6 }}

--- a/charts/camunda-platform/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/identity/templates/deployment.yaml
@@ -276,8 +276,8 @@ spec:
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
         {{- end }}
         volumeMounts:
-        - mountPath: /tmp
-          name: tmp
+          - mountPath: /tmp
+            name: tmp
         {{- if .Values.extraVolumeMounts}}
         {{- .Values.extraVolumeMounts | toYaml | nindent 8 }}
         {{- end }}
@@ -285,10 +285,10 @@ spec:
       {{- .Values.sidecars | toYaml | nindent 6 }}
       {{- end }}
 
-      {{- if .Values.extraVolumes}}
       volumes:
-        - name: tmp
-          emptyDir: {}
+      - name: tmp
+        emptyDir: {}
+      {{- if .Values.extraVolumes}}
       {{- .Values.extraVolumes | toYaml | nindent 6 }}
       {{- end }}
       {{- if .Values.serviceAccount.name}}

--- a/charts/camunda-platform/charts/operate/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/operate/templates/deployment.yaml
@@ -158,6 +158,10 @@ spec:
         - name: config
           mountPath: /usr/local/operate/config/application.yml
           subPath: application.yml
+        - name: tmp
+          mountPath: /tmp
+        - name: camunda
+          mountPath: /camunda
         {{- if .Values.extraVolumeMounts}}
         {{- .Values.extraVolumeMounts | toYaml | nindent 8 }}
         {{- end }}
@@ -169,6 +173,10 @@ spec:
         configMap:
           name: {{ include "operate.fullname" . }}
           defaultMode: {{ .Values.configMap.defaultMode }}
+      - name: tmp
+        emptyDir: {}
+      - name: camunda
+        emptyDir: {}
       {{- if .Values.extraVolumes}}
       {{- .Values.extraVolumes | toYaml | nindent 6 }}
       {{- end }}

--- a/charts/camunda-platform/charts/optimize/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/optimize/templates/deployment.yaml
@@ -158,6 +158,10 @@ spec:
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
         {{- end }}
         volumeMounts:
+        - mountPath: /tmp
+          name: tmp
+        - mountPath: /camunda
+          name: camunda
         {{- if .Values.extraVolumeMounts}}
           {{- .Values.extraVolumeMounts | toYaml | nindent 8 }}
         {{- end }}
@@ -165,6 +169,10 @@ spec:
       {{- .Values.sidecars | toYaml | nindent 6 }}
       {{- end }}
       volumes:
+      - name: tmp
+        emptyDir: {}
+      - name: camunda
+        emptyDir: {}
       {{- if .Values.extraVolumes}}
       {{- .Values.extraVolumes | toYaml | nindent 6 }}
       {{- end }}

--- a/charts/camunda-platform/charts/optimize/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/optimize/templates/deployment.yaml
@@ -39,6 +39,11 @@ spec:
       {{- if .Values.initContainers }}
         {{- tpl (.Values.initContainers | toYaml | nindent 6) $ }}
       {{- end }}
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp
+        - mountPath: /camunda
+          name: camunda
       containers:
       - name: {{ .Chart.Name }}
         image: {{ include "camundaPlatform.image" . | quote }}

--- a/charts/camunda-platform/charts/optimize/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/optimize/templates/deployment.yaml
@@ -24,6 +24,9 @@ spec:
       imagePullSecrets:
         {{- include "camundaPlatform.imagePullSecrets" . | nindent 8 }}
       initContainers:
+      {{- if .Values.initContainers }}
+        {{- tpl (.Values.initContainers | toYaml | nindent 6) $ }}
+      {{- end }}
       - name: migration
         image: {{ include "camundaPlatform.image" . | quote }}
         command: ['./upgrade/upgrade.sh', '--skip-warning']
@@ -36,9 +39,6 @@ spec:
           value: {{ include "camundaPlatform.elasticsearchHost" . | quote }}
         - name: OPTIMIZE_ELASTICSEARCH_HTTP_PORT
           value: {{ .Values.global.elasticsearch.port | quote }}
-      {{- if .Values.initContainers }}
-        {{- tpl (.Values.initContainers | toYaml | nindent 6) $ }}
-      {{- end }}
         volumeMounts:
         - mountPath: /tmp
           name: tmp

--- a/charts/camunda-platform/charts/optimize/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/optimize/templates/deployment.yaml
@@ -44,6 +44,9 @@ spec:
           name: tmp
         - mountPath: /camunda
           name: camunda
+        {{- if .Values.containerSecurityContext }}
+        securityContext: {{- toYaml .Values.containerSecurityContext | nindent 10 }}
+        {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: {{ include "camundaPlatform.image" . | quote }}

--- a/charts/camunda-platform/charts/tasklist/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/tasklist/templates/deployment.yaml
@@ -106,6 +106,8 @@ spec:
             value: {{ default "true" .Values.graphqlPlaygroundEnabled | quote }}
           - name: GRAPHQL_PLAYGROUND_SETTINGS_REQUEST_CREDENTIALS
             value: {{ default "include" .Values.graphqlPlaygroundRequestCredentials | quote }}
+          - name: HOME
+            value: /parent
           {{- with .Values.env }}
             {{- tpl (toYaml .) $ | nindent 10 }}
           {{- end }}
@@ -158,6 +160,10 @@ spec:
         - name: config
           mountPath: /app/resources/application.yml
           subPath: application.yml
+        - mountPath: /tmp
+          name: tmp
+        - mountPath: /camunda
+          name: camunda
         {{- if .Values.extraVolumeMounts}}
         {{- .Values.extraVolumeMounts | toYaml | nindent 8 }}
         {{- end }}
@@ -169,6 +175,10 @@ spec:
         configMap:
           name: {{ include "tasklist.fullname" . }}
           defaultMode: {{ .Values.configMap.defaultMode }}
+      - name: tmp
+        emptyDir: {}
+      - name: camunda
+        emptyDir: {}
       {{- if .Values.extraVolumes}}
       {{- .Values.extraVolumes | toYaml | nindent 6 }}
       {{- end }}

--- a/charts/camunda-platform/charts/zeebe-gateway/templates/gateway-deployment.yaml
+++ b/charts/camunda-platform/charts/zeebe-gateway/templates/gateway-deployment.yaml
@@ -90,6 +90,8 @@ spec:
           command: {{ toYaml .Values.command | nindent 12 }}
           {{- end }}
           volumeMounts:
+            - mountPath: /tmp
+              name: tmp
             {{- if .Values.log4j2 }}
             - name: config
               mountPath: /usr/local/zeebe/config/log4j2.xml
@@ -145,6 +147,8 @@ spec:
       {{- .Values.sidecars | toYaml | nindent 8 }}
       {{- end }}
       volumes:
+        - name: tmp
+          emptyDir: {}
         - name: config
           configMap:
             name: {{ include "zeebe-gateway.fullname" . }}

--- a/charts/camunda-platform/charts/zeebe/templates/statefulset.yaml
+++ b/charts/camunda-platform/charts/zeebe/templates/statefulset.yaml
@@ -167,12 +167,12 @@ spec:
         {{- end }}
         - name: exporters
           mountPath: /exporters
+        - mountPath: /tmp
+          name: tmp
         {{- if .Values.log4j2 }}
         - name: config
           mountPath: /usr/local/zeebe/config/log4j2.xml
           subPath: broker-log4j2.xml
-        - mountPath: /tmp
-          name: tmp
         {{- end }}
         {{- if .Values.extraVolumeMounts}}
         {{ .Values.extraVolumeMounts | toYaml | nindent 8 }}

--- a/charts/camunda-platform/charts/zeebe/templates/statefulset.yaml
+++ b/charts/camunda-platform/charts/zeebe/templates/statefulset.yaml
@@ -171,6 +171,8 @@ spec:
         - name: config
           mountPath: /usr/local/zeebe/config/log4j2.xml
           subPath: broker-log4j2.xml
+        - mountPath: /tmp
+          name: tmp
         {{- end }}
         {{- if .Values.extraVolumeMounts}}
         {{ .Values.extraVolumeMounts | toYaml | nindent 8 }}
@@ -189,6 +191,8 @@ spec:
             name: {{ include "zeebe.fullname" . }}
             defaultMode: {{ .Values.configMap.defaultMode }}
         - name: exporters
+          emptyDir: {}
+        - name: tmp
           emptyDir: {}
         {{- if .Values.extraVolumes}}
           {{ .Values.extraVolumes | toYaml | nindent 8 }}

--- a/charts/camunda-platform/templates/connectors/deployment.yaml
+++ b/charts/camunda-platform/templates/connectors/deployment.yaml
@@ -142,10 +142,10 @@ spec:
             failureThreshold: {{ .Values.connectors.livenessProbe.failureThreshold }}
             timeoutSeconds: {{ .Values.connectors.livenessProbe.timeoutSeconds }}
           {{- end }}
-          {{- if .Values.connectors.extraVolumeMounts }}
           volumeMounts: 
             - mountPath: /tmp
               name: tmp
+          {{- if .Values.connectors.extraVolumeMounts }}
             {{- .Values.connectors.extraVolumeMounts | toYaml | nindent 12 }}
           {{- end }}
         {{- if .Values.connectors.sidecars }}

--- a/charts/camunda-platform/templates/connectors/deployment.yaml
+++ b/charts/camunda-platform/templates/connectors/deployment.yaml
@@ -151,10 +151,10 @@ spec:
         {{- if .Values.connectors.sidecars }}
         {{- .Values.connectors.sidecars | toYaml | nindent 8 }}
         {{- end }}
-      {{- if .Values.connectors.extraVolumes }}
       volumes:
         - name: tmp
           emptyDir: {}
+      {{- if .Values.connectors.extraVolumes }}
         {{- .Values.connectors.extraVolumes | toYaml | nindent 8 }}
       {{- end }}
       {{- if .Values.connectors.serviceAccount.name}}

--- a/charts/camunda-platform/templates/connectors/deployment.yaml
+++ b/charts/camunda-platform/templates/connectors/deployment.yaml
@@ -143,13 +143,18 @@ spec:
             timeoutSeconds: {{ .Values.connectors.livenessProbe.timeoutSeconds }}
           {{- end }}
           {{- if .Values.connectors.extraVolumeMounts }}
-          volumeMounts: {{- .Values.connectors.extraVolumeMounts | toYaml | nindent 12 }}
+          volumeMounts: 
+            - mountPath: /tmp
+              name: tmp
+            {{- .Values.connectors.extraVolumeMounts | toYaml | nindent 12 }}
           {{- end }}
         {{- if .Values.connectors.sidecars }}
         {{- .Values.connectors.sidecars | toYaml | nindent 8 }}
         {{- end }}
       {{- if .Values.connectors.extraVolumes }}
       volumes:
+        - name: tmp
+          emptyDir: {}
         {{- .Values.connectors.extraVolumes | toYaml | nindent 8 }}
       {{- end }}
       {{- if .Values.connectors.serviceAccount.name}}

--- a/charts/camunda-platform/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform/templates/web-modeler/deployment-restapi.yaml
@@ -91,6 +91,8 @@ spec:
             value: {{ include "camundaPlatform.issuerBackendUrl" . | quote }}
           - name: RESTAPI_IDENTITY_BASE_URL
             value: {{ include "webModeler.identityBaseUrl" . | quote }}
+          - name: ZEEBE_CLIENT_CONFIG_PATH
+            value: /tmp/zeebe_client_cache.txt
         {{- with .Values.webModeler.restapi.env }}
             {{- tpl (toYaml .) $ | nindent 10 }}
         {{- end }}
@@ -141,6 +143,8 @@ spec:
         {{- end }}
         {{- if .Values.webModeler.restapi.extraVolumeMounts }}
         volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         {{- .Values.webModeler.restapi.extraVolumeMounts | toYaml | nindent 8 }}
         {{- end }}
       {{- if .Values.webModeler.restapi.sidecars }}
@@ -148,6 +152,8 @@ spec:
       {{- end }}
       {{- if .Values.webModeler.restapi.extraVolumes }}
       volumes:
+      - name: tmp
+        emptyDir: {}
       {{- .Values.webModeler.restapi.extraVolumes | toYaml | nindent 6 }}
       {{- end }}
       {{- if .Values.webModeler.serviceAccount.name }}

--- a/charts/camunda-platform/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform/templates/web-modeler/deployment-restapi.yaml
@@ -141,19 +141,19 @@ spec:
           failureThreshold: {{ .Values.webModeler.restapi.livenessProbe.failureThreshold }}
           timeoutSeconds: {{ .Values.webModeler.restapi.livenessProbe.timeoutSeconds }}
         {{- end }}
-        {{- if .Values.webModeler.restapi.extraVolumeMounts }}
         volumeMounts:
         - name: tmp
           mountPath: /tmp
+        {{- if .Values.webModeler.restapi.extraVolumeMounts }}
         {{- .Values.webModeler.restapi.extraVolumeMounts | toYaml | nindent 8 }}
         {{- end }}
       {{- if .Values.webModeler.restapi.sidecars }}
       {{- .Values.webModeler.restapi.sidecars | toYaml | nindent 6 }}
       {{- end }}
-      {{- if .Values.webModeler.restapi.extraVolumes }}
       volumes:
       - name: tmp
         emptyDir: {}
+      {{- if .Values.webModeler.restapi.extraVolumes }}
       {{- .Values.webModeler.restapi.extraVolumes | toYaml | nindent 6 }}
       {{- end }}
       {{- if .Values.webModeler.serviceAccount.name }}

--- a/charts/camunda-platform/test/unit/connectors/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/connectors/golden/deployment.golden.yaml
@@ -43,6 +43,12 @@ spec:
         - name: connectors
           image: camunda/connectors-bundle:0.23.2
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1003
           ports:
             - containerPort: 8080
               name: http
@@ -96,3 +102,11 @@ spec:
             successThreshold: 1
             failureThreshold: 5
             timeoutSeconds: 1
+          volumeMounts: 
+            - mountPath: /tmp
+              name: tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      securityContext:
+        fsGroup: 1003

--- a/charts/camunda-platform/test/unit/golden/keycloak-statefulset.golden.yaml
+++ b/charts/camunda-platform/test/unit/golden/keycloak-statefulset.golden.yaml
@@ -56,18 +56,39 @@ spec:
         - command:
           - sh
           - -c
-          - cp -a /app/keycloak-theme/* /mnt
+          - 'cp -a /app/keycloak-theme/* /mnt '
           image: 'camunda/identity:8.2.15'
           imagePullPolicy: 'IfNotPresent'
           name: copy-camunda-theme
           volumeMounts:
           - mountPath: /mnt
             name: camunda-theme
+        - command:
+          - sh
+          - -c
+          - cp -ar /opt/bitnami/keycloak/conf/* /config  && cp -a /opt/bitnami/keycloak/lib/quarkus/*
+            /quarkus
+          image: bitnami/keycloak:22.0.4
+          imagePullPolicy: Always
+          name: copy-configs
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          volumeMounts:
+          - mountPath: /config
+            name: config
+          - mountPath: /quarkus
+            name: quarkus
       containers:
         - name: keycloak
           image: docker.io/bitnami/keycloak:22.0.4
           imagePullPolicy: IfNotPresent
           securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 1001
           env:
@@ -124,9 +145,21 @@ spec:
               path: /auth/realms/master
               port: http
           volumeMounts:
+            - mountPath: /opt/bitnami/keycloak/conf/
+              name: config
+            - mountPath: /opt/bitnami/keycloak/lib/quarkus
+              name: quarkus
             - mountPath: /opt/bitnami/keycloak/themes/identity
               name: camunda-theme
+            - mountPath: /tmp
+              name: tmp
       volumes:
+        - emptyDir: {}
+          name: config
+        - emptyDir: {}
+          name: quarkus
+        - emptyDir: {}
+          name: tmp
         - emptyDir:
             sizeLimit: 10Mi
           name: camunda-theme

--- a/charts/camunda-platform/test/unit/identity/deployment_test.go
+++ b/charts/camunda-platform/test/unit/identity/deployment_test.go
@@ -298,6 +298,11 @@ func (s *deploymentTemplateTest) TestContainerSetContainerCommand() {
 }
 
 func (s *deploymentTemplateTest) TestContainerSetExtraVolumes() {
+	//finding out the length of volumes array before addition of new volume
+	var deploymentBefore appsv1.Deployment
+	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
+	helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
+	volumeLenBefore := len(deploymentBefore.Spec.Template.Spec.Volumes)
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
@@ -315,9 +320,9 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumes() {
 
 	// then
 	volumes := deployment.Spec.Template.Spec.Volumes
-	s.Require().Equal(1, len(volumes))
+	s.Require().Equal(volumeLenBefore+1, len(volumes))
 
-	extraVolume := volumes[0]
+	extraVolume := volumes[volumeLenBefore]
 	s.Require().Equal("extraVolume", extraVolume.Name)
 	s.Require().NotNil(*extraVolume.ConfigMap)
 	s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
@@ -325,6 +330,12 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumes() {
 }
 
 func (s *deploymentTemplateTest) TestContainerSetExtraVolumeMounts() {
+	//finding out the length of containers and volumeMounts array before addition of new volumeMount
+	var deploymentBefore appsv1.Deployment
+	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
+	helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
+	containerLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers)
+	volumeMountLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
@@ -341,16 +352,23 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumeMounts() {
 
 	// then
 	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
+	s.Require().Equal(containerLenBefore, len(containers))
 
 	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(1, len(volumeMounts))
-	extraVolumeMount := volumeMounts[0]
+	s.Require().Equal(volumeMountLenBefore+1, len(volumeMounts))
+	extraVolumeMount := volumeMounts[volumeMountLenBefore]
 	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
 	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
 }
 
 func (s *deploymentTemplateTest) TestContainerSetExtraVolumesAndMounts() {
+	//finding out the length of volumes, volumemounts array before addition of new volume
+	var deploymentBefore appsv1.Deployment
+	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
+	helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
+	volumeLenBefore := len(deploymentBefore.Spec.Template.Spec.Volumes)
+	volumeMountLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
+	containerLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers)
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
@@ -371,20 +389,20 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumesAndMounts() {
 
 	// then
 	volumes := deployment.Spec.Template.Spec.Volumes
-	s.Require().Equal(1, len(volumes))
+	s.Require().Equal(volumeLenBefore+1, len(volumes))
 
-	extraVolume := volumes[0]
+	extraVolume := volumes[volumeLenBefore]
 	s.Require().Equal("extraVolume", extraVolume.Name)
 	s.Require().NotNil(*extraVolume.ConfigMap)
 	s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
 	s.Require().EqualValues(744, *extraVolume.ConfigMap.DefaultMode)
 
 	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
+	s.Require().Equal(containerLenBefore, len(containers))
 
 	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(1, len(volumeMounts))
-	extraVolumeMount := volumeMounts[0]
+	s.Require().Equal(volumeMountLenBefore+1, len(volumeMounts))
+	extraVolumeMount := volumeMounts[volumeMountLenBefore]
 	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
 	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
 }

--- a/charts/camunda-platform/test/unit/identity/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/deployment.golden.yaml
@@ -172,5 +172,12 @@ spec:
           successThreshold: 1
           failureThreshold: 5
           timeoutSeconds: 1
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp
+
+      volumes:
+      - name: tmp
+        emptyDir: {}
       securityContext:
         fsGroup: 1005

--- a/charts/camunda-platform/test/unit/identity/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/deployment.golden.yaml
@@ -45,6 +45,12 @@ spec:
       - name: identity
         image: "camunda/identity:8.2.15"
         imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1005
         env:
           - name: KEYCLOAK_INIT_OPERATE_SECRET
             valueFrom:
@@ -166,3 +172,5 @@ spec:
           successThreshold: 1
           failureThreshold: 5
           timeoutSeconds: 1
+      securityContext:
+        fsGroup: 1005

--- a/charts/camunda-platform/test/unit/operate/deployment_test.go
+++ b/charts/camunda-platform/test/unit/operate/deployment_test.go
@@ -257,6 +257,11 @@ func (s *deploymentTemplateTest) TestContainerSetContainerCommand() {
 }
 
 func (s *deploymentTemplateTest) TestContainerSetExtraVolumes() {
+	//finding out the length of volumes array before addition of new volume
+	var deploymentBefore appsv1.Deployment
+	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
+	helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
+	volumeLenBefore := len(deploymentBefore.Spec.Template.Spec.Volumes)
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
@@ -275,9 +280,9 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumes() {
 
 	// then
 	volumes := deployment.Spec.Template.Spec.Volumes
-	s.Require().Equal(2, len(volumes))
+	s.Require().Equal(volumeLenBefore+1, len(volumes))
 
-	extraVolume := volumes[1]
+	extraVolume := volumes[volumeLenBefore]
 	s.Require().Equal("extraVolume", extraVolume.Name)
 	s.Require().NotNil(*extraVolume.ConfigMap)
 	s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
@@ -285,6 +290,12 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumes() {
 }
 
 func (s *deploymentTemplateTest) TestContainerSetExtraVolumeMounts() {
+	//finding out the length of containers and volumeMounts array before addition of new volumeMount
+	var deploymentBefore appsv1.Deployment
+	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
+	helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
+	containerLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers)
+	volumeMountLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
@@ -302,16 +313,23 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumeMounts() {
 
 	// then
 	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
+	s.Require().Equal(containerLenBefore, len(containers))
 
 	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(2, len(volumeMounts))
-	extraVolumeMount := volumeMounts[1]
+	s.Require().Equal(volumeMountLenBefore+1, len(volumeMounts))
+	extraVolumeMount := volumeMounts[volumeMountLenBefore]
 	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
 	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
 }
 
 func (s *deploymentTemplateTest) TestContainerSetExtraVolumesAndMounts() {
+	//finding out the length of volumes, volumemounts array before addition of new volume
+	var deploymentBefore appsv1.Deployment
+	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
+	helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
+	volumeLenBefore := len(deploymentBefore.Spec.Template.Spec.Volumes)
+	volumeMountLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
+	containerLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers)
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
@@ -332,20 +350,20 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumesAndMounts() {
 
 	// then
 	volumes := deployment.Spec.Template.Spec.Volumes
-	s.Require().Equal(2, len(volumes))
+	s.Require().Equal(volumeLenBefore+1, len(volumes))
 
-	extraVolume := volumes[1]
+	extraVolume := volumes[volumeLenBefore]
 	s.Require().Equal("extraVolume", extraVolume.Name)
 	s.Require().NotNil(*extraVolume.ConfigMap)
 	s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
 	s.Require().EqualValues(744, *extraVolume.ConfigMap.DefaultMode)
 
 	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
+	s.Require().Equal(containerLenBefore, len(containers))
 
 	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(2, len(volumeMounts))
-	extraVolumeMount := volumeMounts[1]
+	s.Require().Equal(volumeMountLenBefore+1, len(volumeMounts))
+	extraVolumeMount := volumeMounts[volumeMountLenBefore]
 	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
 	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
 }

--- a/charts/camunda-platform/test/unit/operate/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/operate/golden/deployment.golden.yaml
@@ -45,6 +45,11 @@ spec:
       - name: operate
         image: "camunda/operate:8.2.15"
         imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsUser: 1004
         env:
           - name: SPRING_PROFILES_ACTIVE
             value: "identity-auth"
@@ -103,8 +108,19 @@ spec:
         - name: config
           mountPath: /usr/local/operate/config/application.yml
           subPath: application.yml
+        - name: tmp
+          mountPath: /tmp
+        - name: camunda
+          mountPath: /camunda
       volumes:
       - name: config
         configMap:
           name: camunda-platform-test-operate
           defaultMode: 484
+      - name: tmp
+        emptyDir: {}
+      - name: camunda
+        emptyDir: {}
+      securityContext:
+        fsGroup: 1000
+        runAsNonRoot: true

--- a/charts/camunda-platform/test/unit/optimize/deployment_test.go
+++ b/charts/camunda-platform/test/unit/optimize/deployment_test.go
@@ -258,6 +258,11 @@ func (s *deploymentTemplateTest) TestContainerSetContainerCommand() {
 }
 
 func (s *deploymentTemplateTest) TestContainerSetExtraVolumes() {
+	//finding out the length of volumes array before addition of new volume
+	var deploymentBefore appsv1.Deployment
+	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
+	helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
+	volumeLenBefore := len(deploymentBefore.Spec.Template.Spec.Volumes)
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
@@ -276,9 +281,9 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumes() {
 
 	// then
 	volumes := deployment.Spec.Template.Spec.Volumes
-	s.Require().Equal(1, len(volumes))
+	s.Require().Equal(volumeLenBefore+1, len(volumes))
 
-	extraVolume := volumes[0]
+	extraVolume := volumes[volumeLenBefore]
 	s.Require().Equal("extraVolume", extraVolume.Name)
 	s.Require().NotNil(*extraVolume.ConfigMap)
 	s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
@@ -286,6 +291,12 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumes() {
 }
 
 func (s *deploymentTemplateTest) TestContainerSetExtraVolumeMounts() {
+	//finding out the length of containers and volumeMounts array before addition of new volumeMount
+	var deploymentBefore appsv1.Deployment
+	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
+	helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
+	containerLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers)
+	volumeMountLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
@@ -303,16 +314,23 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumeMounts() {
 
 	// then
 	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
+	s.Require().Equal(containerLenBefore, len(containers))
 
 	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(1, len(volumeMounts))
-	extraVolumeMount := volumeMounts[0]
+	s.Require().Equal(volumeMountLenBefore+1, len(volumeMounts))
+	extraVolumeMount := volumeMounts[volumeMountLenBefore]
 	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
 	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
 }
 
 func (s *deploymentTemplateTest) TestContainerSetExtraVolumesAndMounts() {
+	//finding out the length of volumes, volumemounts array before addition of new volume
+	var deploymentBefore appsv1.Deployment
+	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
+	helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
+	volumeLenBefore := len(deploymentBefore.Spec.Template.Spec.Volumes)
+	volumeMountLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
+	containerLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers)
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
@@ -333,20 +351,20 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumesAndMounts() {
 
 	// then
 	volumes := deployment.Spec.Template.Spec.Volumes
-	s.Require().Equal(1, len(volumes))
+	s.Require().Equal(volumeLenBefore+1, len(volumes))
 
-	extraVolume := volumes[0]
+	extraVolume := volumes[volumeLenBefore]
 	s.Require().Equal("extraVolume", extraVolume.Name)
 	s.Require().NotNil(*extraVolume.ConfigMap)
 	s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
 	s.Require().EqualValues(744, *extraVolume.ConfigMap.DefaultMode)
 
 	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
+	s.Require().Equal(containerLenBefore, len(containers))
 
 	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(1, len(volumeMounts))
-	extraVolumeMount := volumeMounts[0]
+	s.Require().Equal(volumeMountLenBefore+1, len(volumeMounts))
+	extraVolumeMount := volumeMounts[volumeMountLenBefore]
 	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
 	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
 }

--- a/charts/camunda-platform/test/unit/optimize/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/optimize/golden/deployment.golden.yaml
@@ -50,10 +50,25 @@ spec:
           value: "camunda-platform-test-elasticsearch"
         - name: OPTIMIZE_ELASTICSEARCH_HTTP_PORT
           value: "9200"
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp
+        - mountPath: /camunda
+          name: camunda
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsUser: 100
       containers:
       - name: optimize
         image: "camunda/optimize:3.10.5"
         imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsUser: 100
         env:
           - name: CAMUNDA_OPTIMIZE_ZEEBE_ENABLED
             value: "true"
@@ -113,4 +128,15 @@ spec:
           failureThreshold: 5
           timeoutSeconds: 1
         volumeMounts:
+        - mountPath: /tmp
+          name: tmp
+        - mountPath: /camunda
+          name: camunda
       volumes:
+      - name: tmp
+        emptyDir: {}
+      - name: camunda
+        emptyDir: {}
+      securityContext:
+        fsGroup: 100
+        runAsNonRoot: true

--- a/charts/camunda-platform/test/unit/tasklist/deployment_test.go
+++ b/charts/camunda-platform/test/unit/tasklist/deployment_test.go
@@ -313,6 +313,11 @@ func (s *deploymentTemplateTest) TestContainerSetContainerCommand() {
 }
 
 func (s *deploymentTemplateTest) TestContainerSetExtraVolumes() {
+	//finding out the length of volumes array before addition of new volume
+	var deploymentBefore appsv1.Deployment
+	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
+	helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
+	volumeLenBefore := len(deploymentBefore.Spec.Template.Spec.Volumes)
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
@@ -331,9 +336,9 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumes() {
 
 	// then
 	volumes := deployment.Spec.Template.Spec.Volumes
-	s.Require().Equal(2, len(volumes))
+	s.Require().Equal(volumeLenBefore+1, len(volumes))
 
-	extraVolume := volumes[1]
+	extraVolume := volumes[volumeLenBefore]
 	s.Require().Equal("extraVolume", extraVolume.Name)
 	s.Require().NotNil(*extraVolume.ConfigMap)
 	s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
@@ -341,6 +346,12 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumes() {
 }
 
 func (s *deploymentTemplateTest) TestContainerSetExtraVolumeMounts() {
+	//finding out the length of volumes, volumemounts array before addition of new volume
+	var deploymentBefore appsv1.Deployment
+	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
+	helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
+	volumeMountLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
+	containerLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers)
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
@@ -358,16 +369,23 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumeMounts() {
 
 	// then
 	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
+	s.Require().Equal(containerLenBefore, len(containers))
 
 	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(2, len(volumeMounts))
-	extraVolumeMount := volumeMounts[1]
+	s.Require().Equal(volumeMountLenBefore+1, len(volumeMounts))
+	extraVolumeMount := volumeMounts[volumeMountLenBefore]
 	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
 	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
 }
 
 func (s *deploymentTemplateTest) TestContainerSetExtraVolumesAndMounts() {
+	//finding out the length of volumes, volumemounts array before addition of new volume
+	var deploymentBefore appsv1.Deployment
+	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
+	helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
+	volumeLenBefore := len(deploymentBefore.Spec.Template.Spec.Volumes)
+	volumeMountLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
+	containerLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers)
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
@@ -388,20 +406,20 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumesAndMounts() {
 
 	// then
 	volumes := deployment.Spec.Template.Spec.Volumes
-	s.Require().Equal(2, len(volumes))
+	s.Require().Equal(volumeLenBefore+1, len(volumes))
 
-	extraVolume := volumes[1]
+	extraVolume := volumes[volumeLenBefore]
 	s.Require().Equal("extraVolume", extraVolume.Name)
 	s.Require().NotNil(*extraVolume.ConfigMap)
 	s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
 	s.Require().EqualValues(744, *extraVolume.ConfigMap.DefaultMode)
 
 	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
+	s.Require().Equal(containerLenBefore, len(containers))
 
 	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(2, len(volumeMounts))
-	extraVolumeMount := volumeMounts[1]
+	s.Require().Equal(volumeMountLenBefore+1, len(volumeMounts))
+	extraVolumeMount := volumeMounts[volumeMountLenBefore]
 	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
 	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
 }

--- a/charts/camunda-platform/test/unit/tasklist/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/tasklist/golden/deployment.golden.yaml
@@ -45,6 +45,11 @@ spec:
       - name: tasklist
         image: "camunda/tasklist:8.2.15"
         imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsUser: 1002
         env:
           - name: SPRING_PROFILES_ACTIVE
             value: "identity-auth"
@@ -82,6 +87,8 @@ spec:
             value: "true"
           - name: GRAPHQL_PLAYGROUND_SETTINGS_REQUEST_CREDENTIALS
             value: "include"
+          - name: HOME
+            value: /parent
         resources:
           limits:
             cpu: 1000m
@@ -107,8 +114,19 @@ spec:
         - name: config
           mountPath: /app/resources/application.yml
           subPath: application.yml
+        - mountPath: /tmp
+          name: tmp
+        - mountPath: /camunda
+          name: camunda
       volumes:
       - name: config
         configMap:
           name: camunda-platform-test-tasklist
           defaultMode: 484
+      - name: tmp
+        emptyDir: {}
+      - name: camunda
+        emptyDir: {}
+      securityContext:
+        fsGroup: 1002
+        runAsNonRoot: true

--- a/charts/camunda-platform/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -43,6 +43,12 @@ spec:
       - name: web-modeler-restapi
         image: "registry.camunda.cloud/web-modeler-ee/modeler-restapi:8.2.6"
         imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         env:
           - name: JAVA_OPTIONS
             value: "-Xmx1536m"
@@ -92,6 +98,8 @@ spec:
             value: "http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform"
           - name: RESTAPI_IDENTITY_BASE_URL
             value: "http://camunda-platform-test-identity:80"
+          - name: ZEEBE_CLIENT_CONFIG_PATH
+            value: /tmp/zeebe_client_cache.txt
         resources:
           limits:
             cpu: 1000m
@@ -115,3 +123,12 @@ spec:
           successThreshold: 1
           failureThreshold: 5
           timeoutSeconds: 1
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      securityContext:
+        fsGroup: 1000
+        runAsNonRoot: true

--- a/charts/camunda-platform/test/unit/web-modeler/golden/deployment-webapp.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/deployment-webapp.golden.yaml
@@ -43,6 +43,12 @@ spec:
       - name: web-modeler-webapp
         image: "registry.camunda.cloud/web-modeler-ee/modeler-webapp:8.2.6"
         imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         env:
           - name: NODE_ENV
             value: "production"
@@ -130,3 +136,6 @@ spec:
           successThreshold: 1
           failureThreshold: 5
           timeoutSeconds: 1
+      securityContext:
+        fsGroup: 1000
+        runAsNonRoot: true

--- a/charts/camunda-platform/test/unit/web-modeler/golden/deployment-websockets.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/deployment-websockets.golden.yaml
@@ -43,6 +43,12 @@ spec:
       - name: web-modeler-websockets
         image: "registry.camunda.cloud/web-modeler-ee/modeler-websockets:8.2.6"
         imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         env:
           - name: APP_NAME
             value: "Web Modeler WebSockets"
@@ -82,3 +88,6 @@ spec:
           successThreshold: 1
           failureThreshold: 5
           timeoutSeconds: 1
+      securityContext:
+        fsGroup: 1000
+        runAsNonRoot: true

--- a/charts/camunda-platform/test/unit/zeebe-gateway/deployment_test.go
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/deployment_test.go
@@ -307,13 +307,18 @@ func (s *deploymentTemplateTest) TestContainerSetLog4j2() {
 
 	// then
 	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(1, len(volumeMounts))
-	s.Require().Equal("config", volumeMounts[0].Name)
-	s.Require().Equal("/usr/local/zeebe/config/log4j2.xml", volumeMounts[0].MountPath)
-	s.Require().Equal("gateway-log4j2.xml", volumeMounts[0].SubPath)
+	s.Require().Equal(2, len(volumeMounts))
+	s.Require().Equal("config", volumeMounts[1].Name)
+	s.Require().Equal("/usr/local/zeebe/config/log4j2.xml", volumeMounts[1].MountPath)
+	s.Require().Equal("gateway-log4j2.xml", volumeMounts[1].SubPath)
 }
 
 func (s *deploymentTemplateTest) TestContainerSetExtraVolumes() {
+	//finding out the length of volumes, volumemounts array before addition of new volume
+	var deploymentBefore appsv1.Deployment
+	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
+	helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
+	volumeLenBefore := len(deploymentBefore.Spec.Template.Spec.Volumes)
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
@@ -331,9 +336,9 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumes() {
 
 	// then
 	volumes := deployment.Spec.Template.Spec.Volumes
-	s.Require().Equal(2, len(volumes))
+	s.Require().Equal(volumeLenBefore+1, len(volumes))
 
-	extraVolume := volumes[1]
+	extraVolume := volumes[volumeLenBefore]
 	s.Require().Equal("extraVolume", extraVolume.Name)
 	s.Require().NotNil(*extraVolume.ConfigMap)
 	s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
@@ -341,6 +346,11 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumes() {
 }
 
 func (s *deploymentTemplateTest) TestContainerSetExtraVolumeMounts() {
+	//finding out the length of containers and volumeMounts array before addition of new volumeMount
+	var deploymentBefore appsv1.Deployment
+	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
+	helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
+	volumeMountLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
@@ -357,13 +367,19 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumeMounts() {
 
 	// then
 	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(1, len(volumeMounts))
-	extraVolumeMount := volumeMounts[0]
+	s.Require().Equal(volumeMountLenBefore+1, len(volumeMounts))
+	extraVolumeMount := volumeMounts[volumeMountLenBefore]
 	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
 	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
 }
 
 func (s *deploymentTemplateTest) TestContainerSetExtraVolumesAndMounts() {
+	//finding out the length of volumes, volumemounts array before addition of new volume
+	var deploymentBefore appsv1.Deployment
+	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
+	helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
+	volumeLenBefore := len(deploymentBefore.Spec.Template.Spec.Volumes)
+	volumeMountLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
@@ -383,17 +399,17 @@ func (s *deploymentTemplateTest) TestContainerSetExtraVolumesAndMounts() {
 
 	// then
 	volumes := deployment.Spec.Template.Spec.Volumes
-	s.Require().Equal(2, len(volumes))
+	s.Require().Equal(volumeLenBefore+1, len(volumes))
 
-	extraVolume := volumes[1]
+	extraVolume := volumes[volumeLenBefore]
 	s.Require().Equal("extraVolume", extraVolume.Name)
 	s.Require().NotNil(*extraVolume.ConfigMap)
 	s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
 	s.Require().EqualValues(744, *extraVolume.ConfigMap.DefaultMode)
 
 	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(1, len(volumeMounts))
-	extraVolumeMount := volumeMounts[0]
+	s.Require().Equal(volumeMountLenBefore+1, len(volumeMounts))
+	extraVolumeMount := volumeMounts[volumeMountLenBefore]
 	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
 	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
 }

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/gateway-deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/gateway-deployment.golden.yaml
@@ -90,6 +90,12 @@ spec:
             - name: ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_AUDIENCE
               value: "zeebe-api"
           volumeMounts:
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
           readinessProbe:
             httpGet:
               path: /actuator/health
@@ -112,6 +118,9 @@ spec:
           configMap:
             name: camunda-platform-test-zeebe-gateway-gateway
             defaultMode: 484
+      securityContext:
+        fsGroup: 1000
+        runAsNonRoot: true
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/gateway-deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/gateway-deployment.golden.yaml
@@ -90,6 +90,8 @@ spec:
             - name: ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_AUDIENCE
               value: "zeebe-api"
           volumeMounts:
+            - mountPath: /tmp
+              name: tmp
           securityContext:
             allowPrivilegeEscalation: false
             privileged: false
@@ -114,6 +116,8 @@ spec:
               cpu: 400m
               memory: 450Mi
       volumes:
+        - name: tmp
+          emptyDir: {}
         - name: config
           configMap:
             name: camunda-platform-test-zeebe-gateway-gateway

--- a/charts/camunda-platform/test/unit/zeebe/golden/statefulset.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/statefulset.golden.yaml
@@ -144,6 +144,8 @@ spec:
           mountPath: /usr/local/zeebe/data
         - name: exporters
           mountPath: /exporters
+        - mountPath: /tmp
+          name: tmp
       volumes:
         - name: config
           configMap:

--- a/charts/camunda-platform/test/unit/zeebe/golden/statefulset.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/statefulset.golden.yaml
@@ -47,6 +47,11 @@ spec:
       - name: zeebe
         image: "camunda/zeebe:8.2.15"
         imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsUser: 1000
         env:
         - name: LC_ALL
           value: C.UTF-8
@@ -146,8 +151,11 @@ spec:
             defaultMode: 492
         - name: exporters
           emptyDir: {}
+        - name: tmp
+          emptyDir: {}
       securityContext:
         fsGroup: 1000
+        runAsNonRoot: true
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/charts/camunda-platform/test/unit/zeebe/statefulset_test.go
+++ b/charts/camunda-platform/test/unit/zeebe/statefulset_test.go
@@ -399,10 +399,10 @@ func (s *statefulSetTest) TestContainerSetLog4j2() {
 
 	// then
 	volumeMounts := statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(volumeMountLenBefore+2, len(volumeMounts))
-	s.Require().Equal("config", volumeMounts[3].Name)
-	s.Require().Equal("/usr/local/zeebe/config/log4j2.xml", volumeMounts[3].MountPath)
-	s.Require().Equal("broker-log4j2.xml", volumeMounts[3].SubPath)
+	s.Require().Equal(volumeMountLenBefore+1, len(volumeMounts))
+	s.Require().Equal("config", volumeMounts[4].Name)
+	s.Require().Equal("/usr/local/zeebe/config/log4j2.xml", volumeMounts[4].MountPath)
+	s.Require().Equal("broker-log4j2.xml", volumeMounts[4].SubPath)
 }
 
 func (s *statefulSetTest) TestContainerSetExtraVolumes() {

--- a/charts/camunda-platform/test/unit/zeebe/statefulset_test.go
+++ b/charts/camunda-platform/test/unit/zeebe/statefulset_test.go
@@ -379,6 +379,11 @@ func (s *statefulSetTest) TestContainerSetContainerCommand() {
 }
 
 func (s *statefulSetTest) TestContainerSetLog4j2() {
+	//finding out the length of containers and volumeMounts array before addition of new volumeMount
+	var statefulSetBefore appsv1.StatefulSet
+	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
+	helm.UnmarshalK8SYaml(s.T(), before, &statefulSetBefore)
+	volumeMountLenBefore := len(statefulSetBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
@@ -394,13 +399,18 @@ func (s *statefulSetTest) TestContainerSetLog4j2() {
 
 	// then
 	volumeMounts := statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(4, len(volumeMounts))
+	s.Require().Equal(volumeMountLenBefore+2, len(volumeMounts))
 	s.Require().Equal("config", volumeMounts[3].Name)
 	s.Require().Equal("/usr/local/zeebe/config/log4j2.xml", volumeMounts[3].MountPath)
 	s.Require().Equal("broker-log4j2.xml", volumeMounts[3].SubPath)
 }
 
 func (s *statefulSetTest) TestContainerSetExtraVolumes() {
+	//finding out the length of containers and volumeMounts array before addition of new volumeMount
+	var statefulSetBefore appsv1.StatefulSet
+	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
+	helm.UnmarshalK8SYaml(s.T(), before, &statefulSetBefore)
+	volumeLenBefore := len(statefulSetBefore.Spec.Template.Spec.Volumes)
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
@@ -419,9 +429,9 @@ func (s *statefulSetTest) TestContainerSetExtraVolumes() {
 
 	// then
 	volumes := statefulSet.Spec.Template.Spec.Volumes
-	s.Require().Equal(3, len(volumes))
+	s.Require().Equal(volumeLenBefore+1, len(volumes))
 
-	extraVolume := volumes[2]
+	extraVolume := volumes[volumeLenBefore]
 	s.Require().Equal("extraVolume", extraVolume.Name)
 	s.Require().NotNil(*extraVolume.ConfigMap)
 	s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
@@ -429,6 +439,11 @@ func (s *statefulSetTest) TestContainerSetExtraVolumes() {
 }
 
 func (s *statefulSetTest) TestContainerSetExtraVolumeMounts() {
+	//finding out the length of containers and volumeMounts array before addition of new volumeMount
+	var statefulSetBefore appsv1.StatefulSet
+	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
+	helm.UnmarshalK8SYaml(s.T(), before, &statefulSetBefore)
+	volumeMountLenBefore := len(statefulSetBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
@@ -446,13 +461,20 @@ func (s *statefulSetTest) TestContainerSetExtraVolumeMounts() {
 
 	// then
 	volumeMounts := statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(4, len(volumeMounts))
-	extraVolumeMount := volumeMounts[3]
+	s.Require().Equal(volumeMountLenBefore+1, len(volumeMounts))
+	extraVolumeMount := volumeMounts[volumeMountLenBefore]
 	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
 	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
 }
 
 func (s *statefulSetTest) TestContainerSetExtraVolumesAndMounts() {
+	//finding out the length of containers and volumeMounts array before addition of new volumeMount
+	var statefulSetBefore appsv1.StatefulSet
+	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
+	helm.UnmarshalK8SYaml(s.T(), before, &statefulSetBefore)
+	volumeMountLenBefore := len(statefulSetBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
+	volumeLenBefore := len(statefulSetBefore.Spec.Template.Spec.Volumes)
+
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
@@ -472,17 +494,17 @@ func (s *statefulSetTest) TestContainerSetExtraVolumesAndMounts() {
 
 	// then
 	volumes := statefulSet.Spec.Template.Spec.Volumes
-	s.Require().Equal(3, len(volumes))
+	s.Require().Equal(volumeLenBefore+1, len(volumes))
 
-	extraVolume := volumes[2]
+	extraVolume := volumes[volumeLenBefore]
 	s.Require().Equal("extraVolume", extraVolume.Name)
 	s.Require().NotNil(*extraVolume.ConfigMap)
 	s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
 	s.Require().EqualValues(744, *extraVolume.ConfigMap.DefaultMode)
 
 	volumeMounts := statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(4, len(volumeMounts))
-	extraVolumeMount := volumeMounts[3]
+	s.Require().Equal(volumeMountLenBefore+1, len(volumeMounts))
+	extraVolumeMount := volumeMounts[volumeMountLenBefore]
 	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
 	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
 }
@@ -667,6 +689,12 @@ func (s *statefulSetTest) TestContainerSetTolerations() {
 }
 
 func (s *statefulSetTest) TestContainerSetPersistenceTypeRam() {
+	//finding out the length of containers and volumeMounts array before addition of new volumeMount
+	var statefulSetBefore appsv1.StatefulSet
+	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
+	helm.UnmarshalK8SYaml(s.T(), before, &statefulSetBefore)
+	volumeMountLenBefore := len(statefulSetBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
+	volumeLenBefore := len(statefulSetBefore.Spec.Template.Spec.Volumes)
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
@@ -683,13 +711,13 @@ func (s *statefulSetTest) TestContainerSetPersistenceTypeRam() {
 
 	// then
 	volumeMounts := statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(3, len(volumeMounts))
+	s.Require().Equal(volumeMountLenBefore, len(volumeMounts))
 	dataVolumeMount := volumeMounts[1]
 	s.Require().Equal("data", dataVolumeMount.Name)
 	s.Require().Equal("/usr/local/zeebe/data", dataVolumeMount.MountPath)
 
 	volumes := statefulSet.Spec.Template.Spec.Volumes
-	s.Require().Equal(3, len(volumes))
+	s.Require().Equal(volumeLenBefore+1, len(volumes))
 	dataVolume := volumes[0]
 	s.Require().Equal("data", dataVolume.Name)
 	s.Require().NotEmpty(dataVolume.EmptyDir)
@@ -699,6 +727,12 @@ func (s *statefulSetTest) TestContainerSetPersistenceTypeRam() {
 }
 
 func (s *statefulSetTest) TestContainerSetPersistenceTypeLocal() {
+	//finding out the length of containers and volumeMounts array before addition of new volumeMount
+	var statefulSetBefore appsv1.StatefulSet
+	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
+	helm.UnmarshalK8SYaml(s.T(), before, &statefulSetBefore)
+	volumeMountLenBefore := len(statefulSetBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
+	volumeLenBefore := len(statefulSetBefore.Spec.Template.Spec.Volumes)
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
@@ -715,13 +749,13 @@ func (s *statefulSetTest) TestContainerSetPersistenceTypeLocal() {
 
 	// then
 	volumeMounts := statefulSet.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(2, len(volumeMounts))
+	s.Require().Equal(volumeMountLenBefore-1, len(volumeMounts))
 	for _, volumeMount := range volumeMounts {
 		s.Require().NotEqual("data", volumeMount.Name)
 	}
 
 	volumes := statefulSet.Spec.Template.Spec.Volumes
-	s.Require().Equal(2, len(volumes))
+	s.Require().Equal(volumeLenBefore, len(volumes))
 	for _, volumeMount := range volumeMounts {
 		s.Require().NotEqual("data", volumeMount.Name)
 	}

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -1585,7 +1585,7 @@ identity:
       - name: camunda-theme
         mountPath: /mnt
     - name: copy-configs
-      image: bitnami/keycloak:22.0.4
+      image: bitnami/keycloak:{{ .Values.image.tag }}
       imagePullPolicy: "Always"
       command: ["sh", "-c", "cp -ar /opt/bitnami/keycloak/conf/* /config  && cp -a /opt/bitnami/keycloak/lib/quarkus/* /quarkus"]
       securityContext:

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -1584,10 +1584,6 @@ identity:
       volumeMounts:
       - name: camunda-theme
         mountPath: /mnt
-      - name: config
-        mountPath: /config
-      - name: quarkus
-        mountPath: /quarkus
     - name: copy-configs
       image: bitnami/keycloak:19.0.3
       imagePullPolicy: "Always"
@@ -1597,6 +1593,11 @@ identity:
         readOnlyRootFilesystem: true
         allowPrivilegeEscalation: false
         runAsNonRoot: true
+      volumeMounts:
+      - name: config
+        mountPath: /config
+      - name: quarkus
+        mountPath: /quarkus
 
     extraVolumeMounts:
     - mountPath: /opt/bitnami/keycloak/conf/

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -1518,7 +1518,7 @@ identity:
         tag: 15.4.0
 
       primary:
-        extraVolumes: 
+        extraVolumes:
         - name: tmp
           emptyDir: {}
         - name: config
@@ -1532,7 +1532,7 @@ identity:
           name: config
         - mountPath: /opt/bitnami/postgresql/tmp
           name: postgresqltmp
-        containerSecurityContext: 
+        containerSecurityContext:
           enabled: true
           privileged: false
           readOnlyRootFilesystem: true
@@ -1588,7 +1588,7 @@ identity:
       image: bitnami/keycloak:19.0.3
       imagePullPolicy: "Always"
       command: ["sh", "-c", "cp -ar /opt/bitnami/keycloak/conf/* /config  && cp -a /opt/bitnami/keycloak/lib/quarkus/* /quarkus"]
-      securityContext: 
+      securityContext:
         privileged: false
         readOnlyRootFilesystem: true
         allowPrivilegeEscalation: false
@@ -2180,7 +2180,7 @@ postgresql:
     # Postgresql.auth.database defines the name of the database to be created for Web Modeler
     database: web-modeler
   primary:
-    extraVolumes: 
+    extraVolumes:
     - name: tmp
       emptyDir: {}
     - name: config
@@ -2194,7 +2194,7 @@ postgresql:
       name: config
     - mountPath: /opt/bitnami/postgresql/tmp
       name: postgresqltmp
-    containerSecurityContext: 
+    containerSecurityContext:
       enabled: true
       privileged: false
       readOnlyRootFilesystem: true
@@ -2679,13 +2679,13 @@ elasticsearch:
     replicaCount: 0
   ingest:
     enabled: false
-  securityContext: 
+  securityContext:
     privileged: false
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
     runAsNonRoot: true
     runAsUser: 1000
-  extraVolumes: 
+  extraVolumes:
   - name: tmp
     emptyDir: {}
   - name: logs
@@ -2699,7 +2699,6 @@ elasticsearch:
     name: logs
   - mountPath: /usr/share/elasticsearch/config
     name: config
- 
 
 
 #####################################################################

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -1584,7 +1584,10 @@ identity:
       volumeMounts:
       - name: camunda-theme
         mountPath: /mnt
-
+      - name: config
+        mountPath: /config
+      - name: quarkus
+        mountPath: /quarkus
     - name: copy-configs
       image: bitnami/keycloak:19.0.3
       imagePullPolicy: "Always"

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -781,7 +781,7 @@ operate:
     allowPrivilegeEscalation: false
     privileged: false
     readOnlyRootFilesystem: true
-    runAsUser: 1000
+    runAsUser: 1004
 
   # StartupProbe configuration
   startupProbe:
@@ -935,14 +935,14 @@ tasklist:
   # PodSecurityContext defines the security options the Tasklist pod should be run with
   podSecurityContext:
     runAsNonRoot: true
-    fsGroup: 1000 # TODO jesse
+    fsGroup: 1002
 
   # ContainerSecurityContext defines the security options the Tasklist container should be run with
   containerSecurityContext:
     allowPrivilegeEscalation: false
     privileged: false
     readOnlyRootFilesystem: true
-    runAsUser: 1000
+    runAsUser: 1002
 
   # StartupProbe configuration
   startupProbe:
@@ -1122,14 +1122,14 @@ optimize:
   # PodSecurityContext defines the security options the Optimize pod should be run with
   podSecurityContext:
     runAsNonRoot: true
-    fsGroup: 1000 # TODO jesse
+    fsGroup: 100
 
   # ContainerSecurityContext defines the security options the Optimize container should be run with
   containerSecurityContext:
     allowPrivilegeEscalation: false
     privileged: false
     readOnlyRootFilesystem: true
-    runAsUser: 1000
+    runAsUser: 100
 
   # StartupProbe configuration
   startupProbe:
@@ -1322,7 +1322,7 @@ identity:
 
   # PodSecurityContext defines the security options the Identity pod should be run with
   podSecurityContext:
-    fsGroup: 1000 # TODO jesse: change to user uid in connectors container 
+    fsGroup: 1005
 
   # ContainerSecurityContext defines the security options the Identity container should be run with
   containerSecurityContext:
@@ -1330,7 +1330,7 @@ identity:
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
     runAsNonRoot: true
-    runAsUser: 1000
+    runAsUser: 1005
 
   # StartupProbe configuration
   startupProbe:
@@ -1538,11 +1538,11 @@ identity:
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
           runAsNonRoot: true
-          runAsUser: 1000
+          runAsUser: 1001
         podSecurityContext:
           enabled: true
           runAsNonRoot: true
-          fsGroup: 1000 # TODO jesse: change to user uid in connectors container 
+          fsGroup: 1001
 
     # Keycloak.enabled is used incorporate with "global.identity.keycloak" to use your own Keycloak instead of the one comes with Camunda Platform Helm chart.
     enabled: true
@@ -1614,10 +1614,10 @@ identity:
       readOnlyRootFilesystem: true
       allowPrivilegeEscalation: false
       runAsNonRoot: true
-      runAsUser: 1000 # TODO jesse: change to user uid in connectors container 
+      runAsUser: 1001
 
     podSecurityContext:
-      fsGroup: 1000 # TODO jesse: change to user uid in connectors container 
+      fsGroup: 1001
 
     # Keycloak.httpRelativePath defines the context for Keycloak. This config is valid for Keycloak v19.x.x only
     # where in Keycloak v16.x.x it's hard-coded as '/auth', but in v19.x.x it's configurable.
@@ -1764,7 +1764,7 @@ webModeler:
     # Restapi.podSecurityContext can be used to define the security options the restapi pod should be run with
     podSecurityContext:
       runAsNonRoot: true
-      fsGroup: 1000 #TODO: jesse
+      fsGroup: 1000
     # Restapi.containerSecurityContext can be used to define the security options the restapi container should be run with
     containerSecurityContext:
       privileged: false
@@ -2200,11 +2200,11 @@ postgresql:
       readOnlyRootFilesystem: true
       allowPrivilegeEscalation: false
       runAsNonRoot: true
-      runAsUser: 1000
+      runAsUser: 1001
     podSecurityContext:
       enabled: true
       runAsNonRoot: true
-      fsGroup: 1000
+      fsGroup: 1001
 
 #####################################################################
  #####
@@ -2387,7 +2387,7 @@ connectors:
 
   # PodSecurityContext defines the security options the Connectors pod should be run with
   podSecurityContext:
-    fsGroup: 1000
+    fsGroup: 1003
 
   # ContainerSecurityContext defines the security options the Connectors container should be run with
   containerSecurityContext:
@@ -2395,7 +2395,7 @@ connectors:
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
     runAsNonRoot: true
-    runAsUser: 1000 # TODO jesse: change to user uid in connectors container 
+    runAsUser: 1003
 
   # NodeSelector can be used to define on which nodes the Connectors pods should run
   nodeSelector: {}

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -1585,7 +1585,7 @@ identity:
       - name: camunda-theme
         mountPath: /mnt
     - name: copy-configs
-      image: bitnami/keycloak:19.0.3
+      image: bitnami/keycloak:22.0.4
       imagePullPolicy: "Always"
       command: ["sh", "-c", "cp -ar /opt/bitnami/keycloak/conf/* /config  && cp -a /opt/bitnami/keycloak/lib/quarkus/* /quarkus"]
       securityContext:

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -336,10 +336,15 @@ zeebe:
 
   # PodSecurityContext defines the security options the Zeebe broker pod should be run with
   podSecurityContext:
+    runAsNonRoot: true
     fsGroup: 1000
 
   # ContainerSecurityContext defines the security options the Zeebe broker container should be run with
-  containerSecurityContext: {}
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    privileged: false
+    readOnlyRootFilesystem: true
+    runAsUser: 1000
 
   # StartupProbe configuration
   startupProbe:
@@ -502,10 +507,17 @@ zeebe-gateway:
   priorityClassName: ""
 
   # PodSecurityContext defines the security options the gateway pod should be run with
-  podSecurityContext: {}
+  podSecurityContext:
+    runAsNonRoot: true
+    fsGroup: 1000
 
   # ContainerSecurityContext defines the security options the gateway container should be run with
-  containerSecurityContext: {}
+  containerSecurityContext:
+    privileged: false
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    runAsUser: 1000
 
   # StartupProbe configuration
   startupProbe:
@@ -760,10 +772,16 @@ operate:
       secretName: camunda-platform-operate
 
   # PodSecurityContext defines the security options the Operate pod should be run with
-  podSecurityContext: {}
+  podSecurityContext:
+    runAsNonRoot: true
+    fsGroup: 1000
 
   # ContainerSecurityContext defines the security options the Operate container should be run with
-  containerSecurityContext: {}
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    privileged: false
+    readOnlyRootFilesystem: true
+    runAsUser: 1000
 
   # StartupProbe configuration
   startupProbe:
@@ -915,10 +933,16 @@ tasklist:
     annotations: {}
 
   # PodSecurityContext defines the security options the Tasklist pod should be run with
-  podSecurityContext: {}
+  podSecurityContext:
+    runAsNonRoot: true
+    fsGroup: 1000 # TODO jesse
 
   # ContainerSecurityContext defines the security options the Tasklist container should be run with
-  containerSecurityContext: {}
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    privileged: false
+    readOnlyRootFilesystem: true
+    runAsUser: 1000
 
   # StartupProbe configuration
   startupProbe:
@@ -1096,10 +1120,16 @@ optimize:
     managementPort: 8092
 
   # PodSecurityContext defines the security options the Optimize pod should be run with
-  podSecurityContext: {}
+  podSecurityContext:
+    runAsNonRoot: true
+    fsGroup: 1000 # TODO jesse
 
   # ContainerSecurityContext defines the security options the Optimize container should be run with
-  containerSecurityContext: {}
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    privileged: false
+    readOnlyRootFilesystem: true
+    runAsUser: 1000
 
   # StartupProbe configuration
   startupProbe:
@@ -1291,10 +1321,16 @@ identity:
     metricsName: metrics
 
   # PodSecurityContext defines the security options the Identity pod should be run with
-  podSecurityContext: {}
+  podSecurityContext:
+    fsGroup: 1000 # TODO jesse: change to user uid in connectors container 
 
   # ContainerSecurityContext defines the security options the Identity container should be run with
-  containerSecurityContext: {}
+  containerSecurityContext:
+    privileged: false
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    runAsUser: 1000
 
   # StartupProbe configuration
   startupProbe:
@@ -1481,6 +1517,33 @@ identity:
         repository: bitnami/postgresql
         tag: 15.4.0
 
+      primary:
+        extraVolumes: 
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          emptyDir: {}
+        - name: postgresqltmp
+          emptyDir: {}
+        extraVolumeMounts:
+        - mountPath: /tmp
+          name: tmp
+        - mountPath: /opt/bitnami/postgresql/conf
+          name: config
+        - mountPath: /opt/bitnami/postgresql/tmp
+          name: postgresqltmp
+        containerSecurityContext: 
+          enabled: true
+          privileged: false
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 1000
+        podSecurityContext:
+          enabled: true
+          runAsNonRoot: true
+          fsGroup: 1000 # TODO jesse: change to user uid in connectors container 
+
     # Keycloak.enabled is used incorporate with "global.identity.keycloak" to use your own Keycloak instead of the one comes with Camunda Platform Helm chart.
     enabled: true
 
@@ -1501,6 +1564,12 @@ identity:
     # NOTE: Since Helm v3 (latest checked 3.10.x) doesn't merge lists with custom values files, then you will need to
     # add this to your own values file if you override any of "extraVolumes", "initContainers", or "extraVolumeMounts".
     extraVolumes:
+    - name: config
+      emptyDir: {}
+    - name: quarkus
+      emptyDir: {}
+    - name: tmp
+      emptyDir: {}
     - name: camunda-theme
       emptyDir:
         sizeLimit: 10Mi
@@ -1511,14 +1580,40 @@ identity:
         {{- $identityImageParams := (dict "base" .Values.global "overlay" .Values.global.identity) -}}
         {{- include "camundaPlatform.imageByParams" $identityImageParams }}
       imagePullPolicy: "{{ .Values.global.image.pullPolicy }}"
-      command: ["sh", "-c", "cp -a /app/keycloak-theme/* /mnt"]
+      command: ["sh", "-c", "cp -a /app/keycloak-theme/* /mnt "]
       volumeMounts:
       - name: camunda-theme
         mountPath: /mnt
 
+    - name: copy-configs
+      image: bitnami/keycloak:19.0.3
+      imagePullPolicy: "Always"
+      command: ["sh", "-c", "cp -ar /opt/bitnami/keycloak/conf/* /config  && cp -a /opt/bitnami/keycloak/lib/quarkus/* /quarkus"]
+      securityContext: 
+        privileged: false
+        readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
+
     extraVolumeMounts:
+    - mountPath: /opt/bitnami/keycloak/conf/
+      name: config
+    - mountPath: /opt/bitnami/keycloak/lib/quarkus
+      name: quarkus
     - name: camunda-theme
       mountPath: /opt/bitnami/keycloak/themes/identity
+    - mountPath: /tmp
+      name: tmp
+
+    containerSecurityContext:
+      privileged: false
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      runAsUser: 1000 # TODO jesse: change to user uid in connectors container 
+
+    podSecurityContext:
+      fsGroup: 1000 # TODO jesse: change to user uid in connectors container 
 
     # Keycloak.httpRelativePath defines the context for Keycloak. This config is valid for Keycloak v19.x.x only
     # where in Keycloak v16.x.x it's hard-coded as '/auth', but in v19.x.x it's configurable.
@@ -1663,9 +1758,16 @@ webModeler:
     extraVolumeMounts: []
 
     # Restapi.podSecurityContext can be used to define the security options the restapi pod should be run with
-    podSecurityContext: {}
+    podSecurityContext:
+      runAsNonRoot: true
+      fsGroup: 1000 #TODO: jesse
     # Restapi.containerSecurityContext can be used to define the security options the restapi container should be run with
-    containerSecurityContext: {}
+    containerSecurityContext:
+      privileged: false
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      runAsUser: 1000
 
     # Restapi.startupProbe configuration of the restapi startup probe
     startupProbe:
@@ -1786,9 +1888,16 @@ webModeler:
     extraVolumeMounts: []
 
     # Webapp.podSecurityContext can be used to define the security options the webapp pod should be run with
-    podSecurityContext: {}
+    podSecurityContext:
+      runAsNonRoot: true
+      fsGroup: 1000
     # Webapp.containerSecurityContext can be used to define the security options the webapp container should be run with
-    containerSecurityContext: {}
+    containerSecurityContext:
+      privileged: false
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      runAsUser: 1000
 
     # Webapp.startupProbe configuration of the webapp startup probe
     startupProbe:
@@ -1918,9 +2027,16 @@ webModeler:
     extraVolumeMounts: []
 
     # Websockets.podSecurityContext can be used to define the security options the websockets pod should be run with
-    podSecurityContext: {}
+    podSecurityContext:
+      runAsNonRoot: true
+      fsGroup: 1000
     # Websockets.containerSecurityContext can be used to define the security options the websockets container should be run with
-    containerSecurityContext: {}
+    containerSecurityContext:
+      privileged: false
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      runAsUser: 1000
 
     # Websockets.startupProbe configuration of the websockets startup probe
     startupProbe:
@@ -2059,6 +2175,32 @@ postgresql:
     password: ""
     # Postgresql.auth.database defines the name of the database to be created for Web Modeler
     database: web-modeler
+  primary:
+    extraVolumes: 
+    - name: tmp
+      emptyDir: {}
+    - name: config
+      emptyDir: {}
+    - name: postgresqltmp
+      emptyDir: {}
+    extraVolumeMounts:
+    - mountPath: /tmp
+      name: tmp
+    - mountPath: /opt/bitnami/postgresql/conf
+      name: config
+    - mountPath: /opt/bitnami/postgresql/tmp
+      name: postgresqltmp
+    containerSecurityContext: 
+      enabled: true
+      privileged: false
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      runAsUser: 1000
+    podSecurityContext:
+      enabled: true
+      runAsNonRoot: true
+      fsGroup: 1000
 
 #####################################################################
  #####
@@ -2240,10 +2382,16 @@ connectors:
       secretName: camunda-platform-connectors
 
   # PodSecurityContext defines the security options the Connectors pod should be run with
-  podSecurityContext: {}
+  podSecurityContext:
+    fsGroup: 1000
 
   # ContainerSecurityContext defines the security options the Connectors container should be run with
-  containerSecurityContext: {}
+  containerSecurityContext:
+    privileged: false
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    runAsUser: 1000 # TODO jesse: change to user uid in connectors container 
 
   # NodeSelector can be used to define on which nodes the Connectors pods should run
   nodeSelector: {}
@@ -2527,6 +2675,27 @@ elasticsearch:
     replicaCount: 0
   ingest:
     enabled: false
+  securityContext: 
+    privileged: false
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    runAsUser: 1000
+  extraVolumes: 
+  - name: tmp
+    emptyDir: {}
+  - name: logs
+    emptyDir: {}
+  - name: config
+    emptyDir: {}
+  extraVolumeMounts:
+  - mountPath: /tmp
+    name: tmp
+  - mountPath: /usr/share/elasticsearch/logs
+    name: logs
+  - mountPath: /usr/share/elasticsearch/config
+    name: config
+ 
 
 
 #####################################################################


### PR DESCRIPTION
### Which problem does the PR fix?

This change takes the read-only root filesystem changes from my values.yaml configuration and pushes them into the templates of the helm chart.

More work needs to be done on this PR, like setting the UID's to match the parent image. And testing.

[readonly_minimal.yaml.txt](https://github.com/camunda/camunda-platform-helm/files/12500753/readonly_minimal.yaml.txt)


<!-- Which GitHub issues related to or fixed by this PR, if any. -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview about the implementation, which decisions were made and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added (if needed).
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
