### PR TITLE
fix: correct command value

### DIFF
--- a/charts/camunda-platform/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/identity/templates/deployment.yaml
@@ -212,7 +212,7 @@ spec:
             {{- tpl (toYaml .) $ | nindent 10 }}
         {{- end }}
         {{- if .Values.command}}
-        command: {{ .Values.command }}
+        command: {{ toYaml .Values.command | nindent 10 }}
         {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}

--- a/charts/camunda-platform/charts/operate/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/operate/templates/deployment.yaml
@@ -109,7 +109,7 @@ spec:
             {{- tpl (toYaml .) $ | nindent 10 }}
         {{- end }}
         {{- if .Values.command}}
-        command: {{ .Values.command }}
+        command: {{ toYaml .Values.command | nindent 10 }}
         {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}

--- a/charts/camunda-platform/charts/optimize/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/optimize/templates/deployment.yaml
@@ -36,7 +36,9 @@ spec:
           value: {{ .Values.global.elasticsearch.host | quote }}
         - name: OPTIMIZE_ELASTICSEARCH_HTTP_PORT
           value: {{ .Values.global.elasticsearch.port | quote }}
+      {{- if .Values.initContainers }}
         {{- tpl (.Values.initContainers | toYaml | nindent 6) $ }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: {{ include "camundaPlatform.image" . | quote }}
@@ -87,6 +89,8 @@ spec:
             {{- end }}
           - name: CAMUNDA_OPTIMIZE_IDENTITY_AUDIENCE
             value: "optimize-api"
+          - name: CAMUNDA_OPTIMIZE_IDENTITY_BASE_URL
+            value: "http://{{ .Release.Name }}-identity:80"
           - name: CAMUNDA_OPTIMIZE_API_AUDIENCE
             value: "optimize-api"
           - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI
@@ -94,6 +98,14 @@ spec:
           {{- end }}
           - name: CAMUNDA_OPTIMIZE_SECURITY_AUTH_COOKIE_SAME_SITE_ENABLED
             value: "false"
+          {{- if .Values.global.multitenancy.enabled }}
+          - name: CAMUNDA_OPTIMIZE_MULTITENANCY_ENABLED
+            value: "true"
+          - name: CAMUNDA_OPTIMIZE_CACHES_CLOUD_TENANT_AUTHORIZATIONS_MAX_SIZE
+            value: "10000"
+          - name: CAMUNDA_OPTIMIZE_CACHES_CLOUD_TENANT_AUTHORIZATIONS_MIN_FETCH_INTERVAL_SECONDS
+            value: "600000"
+          {{- end }}
         {{- with .Values.env }}
             {{- tpl (toYaml .) $ | nindent 10 }}
         {{- end }}

--- a/charts/camunda-platform/charts/optimize/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/optimize/templates/deployment.yaml
@@ -110,7 +110,7 @@ spec:
             {{- tpl (toYaml .) $ | nindent 10 }}
         {{- end }}
         {{- if .Values.command}}
-        command: {{ .Values.command }}
+        command: {{ toYaml .Values.command | nindent 10 }}
         {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}

--- a/charts/camunda-platform/charts/tasklist/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/tasklist/templates/deployment.yaml
@@ -109,7 +109,7 @@ spec:
             {{- tpl (toYaml .) $ | nindent 10 }}
           {{- end }}
         {{- if .Values.command}}
-        command: {{ .Values.command }}
+        command: {{ toYaml .Values.command | nindent 10 }}
         {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}

--- a/charts/camunda-platform/charts/zeebe-gateway/templates/gateway-deployment.yaml
+++ b/charts/camunda-platform/charts/zeebe-gateway/templates/gateway-deployment.yaml
@@ -87,7 +87,7 @@ spec:
               {{- tpl (toYaml .) $ | nindent 12 }}
             {{- end }}
           {{- if .Values.command}}
-          command: {{ .Values.command }}
+          command: {{ toYaml .Values.command | nindent 12 }}
           {{- end }}
           volumeMounts:
             {{- if .Values.log4j2 }}

--- a/charts/camunda-platform/charts/zeebe/templates/statefulset.yaml
+++ b/charts/camunda-platform/charts/zeebe/templates/statefulset.yaml
@@ -102,7 +102,7 @@ spec:
           {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
         {{- if .Values.command}}
-        command: {{ .Values.command }}
+        command: {{ toYaml .Values.command | nindent 10 }}
         {{- end }}
         ports:
         - containerPort: {{ .Values.service.httpPort  }}

--- a/charts/camunda-platform/templates/connectors/deployment.yaml
+++ b/charts/camunda-platform/templates/connectors/deployment.yaml
@@ -107,7 +107,7 @@ spec:
           {{- if .Values.connectors.env}}
             {{ .Values.connectors.env | toYaml | nindent 12 }}
           {{- end }}
-          command: {{ .Values.connectors.command }}
+          command: {{ toYaml .Values.connectors.command | nindent 12 }}
           resources: {{- toYaml .Values.connectors.resources | nindent 12 }}
           {{- if .Values.connectors.startupProbe.enabled }}
           startupProbe:

--- a/charts/camunda-platform/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform/templates/web-modeler/deployment-restapi.yaml
@@ -99,7 +99,7 @@ spec:
             {{- tpl (toYaml .) $ | nindent 10 }}
         {{- end }}
         {{- if .Values.webModeler.restapi.command }}
-        command: {{ .Values.webModeler.restapi.command }}
+        command: {{ toYaml .Values.webModeler.restapi.command | nindent 10 }}
         {{- end }}
         resources:
           {{- toYaml .Values.webModeler.restapi.resources | nindent 10 }}

--- a/charts/camunda-platform/templates/web-modeler/deployment-webapp.yaml
+++ b/charts/camunda-platform/templates/web-modeler/deployment-webapp.yaml
@@ -102,7 +102,7 @@ spec:
             {{- tpl (toYaml .) $ | nindent 10 }}
         {{- end }}
         {{- if .Values.webModeler.webapp.command }}
-        command: {{ .Values.webModeler.webapp.command }}
+        command: {{ toYaml .Values.webModeler.webapp.command | nindent 10 }}
         {{- end }}
         resources:
           {{- toYaml .Values.webModeler.webapp.resources | nindent 10 }}

--- a/charts/camunda-platform/templates/web-modeler/deployment-websockets.yaml
+++ b/charts/camunda-platform/templates/web-modeler/deployment-websockets.yaml
@@ -59,7 +59,7 @@ spec:
             {{- tpl (toYaml .) $ | nindent 10 }}
         {{- end }}
         {{- if .Values.webModeler.websockets.command}}
-        command: {{ .Values.webModeler.websockets.command }}
+        command: {{ toYaml .Values.webModeler.websockets.command | nindent 10 }}
         {{- end }}
         resources:
           {{- toYaml .Values.webModeler.websockets.resources | nindent 10 }}

--- a/charts/camunda-platform/test/unit/connectors/deployment_test.go
+++ b/charts/camunda-platform/test/unit/connectors/deployment_test.go
@@ -270,8 +270,8 @@ func (s *deploymentTemplateTest) TestContainerSetContainerCommand() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"connectors.enabled": "true",
-			"connectors.command": "[printenv]",
+			"connectors.enabled":    "true",
+			"connectors.command[0]": "printenv",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 	}

--- a/charts/camunda-platform/test/unit/connectors/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/connectors/golden/deployment.golden.yaml
@@ -78,7 +78,8 @@ spec:
               value: "http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/token"
             - name: ZEEBE_TOKEN_AUDIENCE
               value: zeebe-api
-          command: []
+          command: 
+            []
           resources:
             limits:
               cpu: 2

--- a/charts/camunda-platform/test/unit/identity/deployment_test.go
+++ b/charts/camunda-platform/test/unit/identity/deployment_test.go
@@ -280,7 +280,7 @@ func (s *deploymentTemplateTest) TestContainerSetContainerCommand() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"identity.command": "[printenv]",
+			"identity.command[0]": "printenv",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 	}

--- a/charts/camunda-platform/test/unit/operate/deployment_test.go
+++ b/charts/camunda-platform/test/unit/operate/deployment_test.go
@@ -238,7 +238,7 @@ func (s *deploymentTemplateTest) TestContainerSetContainerCommand() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"operate.command": "[printenv]",
+			"operate.command[0]": "printenv",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 		ExtraArgs:      map[string][]string{"install": {"--debug"}},

--- a/charts/camunda-platform/test/unit/optimize/deployment_test.go
+++ b/charts/camunda-platform/test/unit/optimize/deployment_test.go
@@ -819,3 +819,22 @@ func (s *deploymentTemplateTest) TestInitContainers() {
 
 	s.Require().Contains(podContainers, expectedContainer)
 }
+
+func (s *deploymentTemplateTest) TestOptimizeMultiTenancyEnabled() {
+ 	// given
+ 	options := &helm.Options{
+ 		SetValues: map[string]string{
+ 			"global.multitenancy.enabled": "true",
+ 		},
+ 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+ 	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+	// then
+	env := deployment.Spec.Template.Spec.Containers[0].Env
+	s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_OPTIMIZE_MULTITENANCY_ENABLED", Value: "true"})
+}

--- a/charts/camunda-platform/test/unit/optimize/deployment_test.go
+++ b/charts/camunda-platform/test/unit/optimize/deployment_test.go
@@ -239,7 +239,7 @@ func (s *deploymentTemplateTest) TestContainerSetContainerCommand() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"optimize.command": "[printenv]",
+			"optimize.command[0]": "printenv",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 		ExtraArgs:      map[string][]string{"install": {"--debug"}},

--- a/charts/camunda-platform/test/unit/optimize/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/optimize/golden/deployment.golden.yaml
@@ -38,7 +38,18 @@ spec:
       imagePullSecrets:
         []
       initContainers:
-        []
+      - name: migration
+        image: "camunda/optimize:3.10.5"
+        command: ['./upgrade/upgrade.sh', '--skip-warning']
+        env:
+        - name: CAMUNDA_OPTIMIZE_ZEEBE_ENABLED
+          value: "true"
+        - name: CAMUNDA_OPTIMIZE_ZEEBE_PARTITION_COUNT
+          value: "3"
+        - name: OPTIMIZE_ELASTICSEARCH_HOST
+          value: "elasticsearch-master"
+        - name: OPTIMIZE_ELASTICSEARCH_HTTP_PORT
+          value: "9200"
       containers:
       - name: optimize
         image: "camunda/optimize:3.10.5"
@@ -69,6 +80,8 @@ spec:
                 key: optimize-secret
           - name: CAMUNDA_OPTIMIZE_IDENTITY_AUDIENCE
             value: "optimize-api"
+          - name: CAMUNDA_OPTIMIZE_IDENTITY_BASE_URL
+            value: "http://camunda-platform-test-identity:80"
           - name: CAMUNDA_OPTIMIZE_API_AUDIENCE
             value: "optimize-api"
           - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI
@@ -101,16 +114,3 @@ spec:
           timeoutSeconds: 1
         volumeMounts:
       volumes:
-      initContainers:
-      - name: migration
-        image: "camunda/optimize:3.10.5"
-        command: ['./upgrade/upgrade.sh', '--skip-warning']
-        env:
-        - name: CAMUNDA_OPTIMIZE_ZEEBE_ENABLED
-          value: "true"
-        - name: CAMUNDA_OPTIMIZE_ZEEBE_PARTITION_COUNT
-          value: "3"
-        - name: OPTIMIZE_ELASTICSEARCH_HOST
-          value: "elasticsearch-master"
-        - name: OPTIMIZE_ELASTICSEARCH_HTTP_PORT
-          value: "9200"

--- a/charts/camunda-platform/test/unit/tasklist/deployment_test.go
+++ b/charts/camunda-platform/test/unit/tasklist/deployment_test.go
@@ -295,7 +295,7 @@ func (s *deploymentTemplateTest) TestContainerSetContainerCommand() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"tasklist.command": "[printenv]",
+			"tasklist.command[0]": "printenv",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 	}

--- a/charts/camunda-platform/test/unit/web-modeler/deployment_test.go
+++ b/charts/camunda-platform/test/unit/web-modeler/deployment_test.go
@@ -323,9 +323,9 @@ func (s *deploymentTemplateTest) TestContainerSetContainerCommand() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"webModeler.enabled":                     "true",
-			"webModeler.restapi.mail.fromAddress":    "example@example.com",
-			"webModeler." + s.component + ".command": "[printenv]",
+			"webModeler.enabled":                        "true",
+			"webModeler.restapi.mail.fromAddress":       "example@example.com",
+			"webModeler." + s.component + ".command[0]": "printenv",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 	}

--- a/charts/camunda-platform/test/unit/zeebe-gateway/deployment_test.go
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/deployment_test.go
@@ -274,7 +274,7 @@ func (s *deploymentTemplateTest) TestContainerSetContainerCommand() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"zeebe-gateway.command": "[printenv]",
+			"zeebe-gateway.command[0]": "printenv",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 	}

--- a/charts/camunda-platform/test/unit/zeebe/statefulset_test.go
+++ b/charts/camunda-platform/test/unit/zeebe/statefulset_test.go
@@ -361,7 +361,7 @@ func (s *statefulSetTest) TestContainerSetContainerCommand() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"zeebe.command": "[printenv]",
+			"zeebe.command[0]": "printenv",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 	}


### PR DESCRIPTION
Fixing the problem with command values that get rendered as one string. 

### Which problem does the PR fix?

Fixes https://github.com/camunda/camunda-platform-helm/issues/799.

### What's in this PR?

Instead of plain value of the command value: with `toYaml` & `nindent` the correct array gets rendered in the resources.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [X] There is no other open [pull request](../pulls) for the same update/change.
- [X] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
