### PR TITLE
feat: upgrade to ship Keycloak v22

### DIFF
--- a/charts/camunda-platform/charts/identity/Chart.yaml
+++ b/charts/camunda-platform/charts/identity/Chart.yaml
@@ -7,5 +7,5 @@ icon: https://helm.camunda.io/imgs/camunda.svg
 dependencies:
   - name: keycloak
     repository: https://charts.bitnami.com/bitnami
-    version: 12.3.0
+    version: 16.1.2
     condition: "keycloak.enabled"

--- a/charts/camunda-platform/charts/identity/Chart.yaml
+++ b/charts/camunda-platform/charts/identity/Chart.yaml
@@ -7,5 +7,5 @@ icon: https://helm.camunda.io/imgs/camunda.svg
 dependencies:
   - name: keycloak
     repository: https://charts.bitnami.com/bitnami
-    version: 16.1.2
+    version: 16.1.7
     condition: "keycloak.enabled"

--- a/charts/camunda-platform/test/unit/golden/keycloak-statefulset.golden.yaml
+++ b/charts/camunda-platform/test/unit/golden/keycloak-statefulset.golden.yaml
@@ -30,7 +30,7 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak
-        app.kubernetes.io/version: "20.0.1"
+        app.kubernetes.io/version: 22.0.3
         app.kubernetes.io/component: keycloak
     spec:
       serviceAccountName: camunda-platform-test-keycloak
@@ -51,6 +51,7 @@ spec:
           
       securityContext:
         fsGroup: 1001
+      enableServiceLinks: true
       initContainers:
         - command:
           - sh
@@ -64,7 +65,7 @@ spec:
             name: camunda-theme
       containers:
         - name: keycloak
-          image: docker.io/bitnami/keycloak:22.0.1
+          image: docker.io/bitnami/keycloak:22.0.3
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true

--- a/charts/camunda-platform/test/unit/golden/keycloak-statefulset.golden.yaml
+++ b/charts/camunda-platform/test/unit/golden/keycloak-statefulset.golden.yaml
@@ -6,10 +6,10 @@ metadata:
   name: camunda-platform-test-keycloak
   namespace: "camunda"
   labels:
-    app.kubernetes.io/name: keycloak
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/version: "20.0.1"
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/version: 22.0.3
     app.kubernetes.io/component: keycloak
 spec:
   replicas: 1
@@ -19,17 +19,17 @@ spec:
     rollingUpdate: {}
     type: RollingUpdate
   selector:
-    matchLabels: 
-      app.kubernetes.io/name: keycloak
+    matchLabels:
       app.kubernetes.io/instance: camunda-platform-test
+      app.kubernetes.io/name: keycloak
       app.kubernetes.io/component: keycloak
   template:
     metadata:
       annotations:
       labels:
-        app.kubernetes.io/name: keycloak
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: keycloak
         app.kubernetes.io/version: "20.0.1"
         app.kubernetes.io/component: keycloak
     spec:
@@ -64,7 +64,7 @@ spec:
             name: camunda-theme
       containers:
         - name: keycloak
-          image: docker.io/bitnami/keycloak:19.0.3
+          image: docker.io/bitnami/keycloak:22.0.1
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true
@@ -100,6 +100,9 @@ spec:
           ports:
             - name: http
               containerPort: 8080
+              protocol: TCP
+            - name: infinispan
+              containerPort: 7800
               protocol: TCP
           livenessProbe:
             failureThreshold: 3

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -1417,7 +1417,8 @@ identity:
     # https://hub.docker.com/r/bitnami/keycloak/tags
     image:
       repository: bitnami/keycloak
-      tag: 19.0.3
+      tag: 22.0.1
+    proxy: edge
 
     # Keycloak.tls can be used to enable TLS encryption. Required for HTTPs traffic.
     tls:

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -1417,7 +1417,10 @@ identity:
     # https://hub.docker.com/r/bitnami/keycloak/tags
     image:
       repository: bitnami/keycloak
-      tag: 22.0.1
+      tag: 22.0.3
+
+    # Keycloak.proxy defines the proxy mode depends on the TLS termination in your environment.
+    # Docs: https://www.keycloak.org/server/reverseproxy
     proxy: edge
 
     # Keycloak.tls can be used to enable TLS encryption. Required for HTTPs traffic.


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues related to or fixed by this PR, if any. -->
Closes #849 

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview about the implementation, which decisions were made and why.
-->

This PR contains a couple of smaller changes (and one larger one!), these are:
1. Upgrade the base Keycloak chart to one that supports Keycloak 22.0.1 (in prep for 8.3)
2. Updates the defaulted Keycloak version from 19.0.3 -> 22.0.1
3. Sets the `keycloak.proxy` value to `edge` (this is required to allow the Keycloak UI to load

I have tested this locally the best I can, these tests cover mainly:
1. I can deploy a clean cluster with Keycloak 22, access applications, and deploy a model
2. I can upgrade a cluster from Keycloak 19 -> 22, access applications (no model deployment testing here)

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?
