### PR TITLE
fix: added reasonable default proxy-buffer-size

### DIFF
--- a/charts/camunda-platform/test/unit/connectors/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/connectors/golden/ingress-all-enabled.golden.yaml
@@ -14,6 +14,7 @@ metadata:
     app.kubernetes.io/component: connectors
   annotations: 
     ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform/test/unit/connectors/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/connectors/golden/ingress.golden.yaml
@@ -14,6 +14,7 @@ metadata:
     app.kubernetes.io/component: connectors
   annotations: 
     ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform/test/unit/identity/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/ingress-all-enabled.golden.yaml
@@ -14,6 +14,7 @@ metadata:
     app.kubernetes.io/component: identity
   annotations: 
     ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform/test/unit/identity/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/ingress.golden.yaml
@@ -14,6 +14,7 @@ metadata:
     app.kubernetes.io/component: identity
   annotations: 
     ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform/test/unit/operate/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/operate/golden/ingress-all-enabled.golden.yaml
@@ -14,6 +14,7 @@ metadata:
     app.kubernetes.io/component: operate
   annotations: 
     ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform/test/unit/operate/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/operate/golden/ingress.golden.yaml
@@ -14,6 +14,7 @@ metadata:
     app.kubernetes.io/component: operate
   annotations: 
     ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform/test/unit/optimize/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/optimize/golden/ingress-all-enabled.golden.yaml
@@ -14,6 +14,7 @@ metadata:
     app.kubernetes.io/component: optimize
   annotations: 
     ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform/test/unit/optimize/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/optimize/golden/ingress.golden.yaml
@@ -14,6 +14,7 @@ metadata:
     app.kubernetes.io/component: optimize
   annotations: 
     ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform/test/unit/tasklist/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/tasklist/golden/ingress-all-enabled.golden.yaml
@@ -14,6 +14,7 @@ metadata:
     app.kubernetes.io/component: tasklist
   annotations: 
     ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform/test/unit/tasklist/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/tasklist/golden/ingress.golden.yaml
@@ -14,6 +14,7 @@ metadata:
     app.kubernetes.io/component: tasklist
   annotations: 
     ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform/test/unit/web-modeler/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/ingress-all-enabled.golden.yaml
@@ -14,6 +14,7 @@ metadata:
     app.kubernetes.io/component: web-modeler
   annotations:
     ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform/test/unit/web-modeler/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/ingress.golden.yaml
@@ -14,6 +14,7 @@ metadata:
     app.kubernetes.io/component: web-modeler
   annotations:
     ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/ingress-all-enabled.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations: 
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/backend-protocol: GRPC
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/ingress.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations: 
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/backend-protocol: GRPC
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -69,6 +69,7 @@ global:
     annotations:
       ingress.kubernetes.io/rewrite-target: "/"
       nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     # Ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     # If not specified the rules applies to all inbound http traffic, if specified the rule applies to that host.
     host: ""
@@ -627,6 +628,7 @@ zeebe-gateway:
       ingress.kubernetes.io/rewrite-target: "/"
       nginx.ingress.kubernetes.io/ssl-redirect: "false"
       nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     # Ingress.path defines the path which is associated with the operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     # Ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
@@ -735,6 +737,7 @@ operate:
     annotations:
       ingress.kubernetes.io/rewrite-target: "/"
       nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     # Ingress.path defines the path which is associated with the Operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     # Ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
@@ -987,6 +990,7 @@ tasklist:
     annotations:
       ingress.kubernetes.io/rewrite-target: "/"
       nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     # Ingress.path defines the path which is associated with the operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     # Ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
@@ -1161,6 +1165,7 @@ optimize:
     annotations:
       ingress.kubernetes.io/rewrite-target: "/"
       nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     # Ingress.path defines the path which is associated with the operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     # Ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
@@ -1373,6 +1378,7 @@ identity:
     annotations:
       ingress.kubernetes.io/rewrite-target: "/"
       nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     # Ingress.path defines the path which is associated with the operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     # Ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
@@ -1461,6 +1467,9 @@ identity:
       tls: false
       # Keycloak.ingress.extraTls configuration for additional hostnames to be covered with this ingress record.
       extraTls: []
+      # Keycloak.ingress.annotations configures annotations to be applied to the ingress record.
+      annotations:
+        nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
 
     # Keycloak.service configuration, to configure the service which is deployed along with keycloak
     service:
@@ -1931,6 +1940,7 @@ webModeler:
     annotations:
       ingress.kubernetes.io/rewrite-target: "/"
       nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     # Ingress.webapp configuration of the webapp ingress
     webapp:
       # Ingress.webapp.host defines the host of the ingress rule, see https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules; this is the host name on which the Web Modeler web application will be available
@@ -2145,6 +2155,7 @@ connectors:
     annotations:
       ingress.kubernetes.io/rewrite-target: "/"
       nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     # Ingress.path defines the path which is associated with the Connectors service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     # Ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
@@ -2379,6 +2390,7 @@ console:
     annotations:
       ingress.kubernetes.io/rewrite-target: "/"
       nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
     # Ingress.path defines the path which is associated with the Console service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     # Ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues related to or fixed by this PR, if any. -->

As @Ben-Sheppard  noted in #889 the default proxy-buffer-size can sometimes cause issues in our web components. This has led to some issues internally as well as a few support tickets and ask-distribution questions. @jonathanlukas @plungu  thank you for your efforts on those.

### What's in this PR?

This PR adds a default proxy-buffer-size to our default annotations as an attempt to warn users that if they want to use their own ingress, hopefully they will make sure to set this annotation. And if they happen to use ingress-nginx, it'll hopefully work out of the box.
<!--
  Explain the contents of the PR.
  Give an overview about the implementation, which decisions were made and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added (if needed).
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
