### PR TITLE
ci: test chart upgrade by default in the ci pipeline

### DIFF
--- a/.github/workflows/test-integration-main.yaml
+++ b/.github/workflows/test-integration-main.yaml
@@ -47,7 +47,7 @@ env:
 
 jobs:
   test:
-    name: Chart full setup - ${{ matrix.test.name }}
+    name: ${{ matrix.distro.name }} - ${{ matrix.scenario.name }}
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     permissions:
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test:
+        distro:
         - name: Kubernetes 1.24
           type: kubernetes
           platform: gke
@@ -72,11 +72,18 @@ jobs:
           version: 4.13
           platform: rosa
           if: ${{ github.event.pull_request.number || contains(inputs.platforms, 'rosa') }}
+        scenario:
+        - name: Chart Setup
+          desc: Setup chart in production-like setup with Ingress and TLS.
+          action: install
+        - name: Chart Upgrade
+          desc: Upgrade chart from the latest released version to the current branch.
+          action: upgrade
         exclude:
-        - test:
+        - distro:
             if: false
     env:
-      TEST_CLUSTER_TYPE: ${{ matrix.test.type }}
+      TEST_CLUSTER_TYPE: ${{ matrix.distro.type }}
     steps:
     - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
       with:
@@ -84,22 +91,22 @@ jobs:
         repository: camunda/camunda-platform-helm
     # TODO: Later, find a way to abstract the auth for different platforms.
     - name: Authenticate to GKE
-      if: matrix.test.platform == 'gke'
+      if: matrix.distro.platform == 'gke'
       uses: ./.github/actions/gke-login
       with:
-        cluster-name: ${{ secrets[matrix.test.secret.cluster-name] }}
-        cluster-location: ${{ secrets[matrix.test.secret.cluster-location] }}
-        workload-identity-provider: ${{ secrets[matrix.test.secret.workload-identity-provider] }}
-        service-account: ${{ secrets[matrix.test.secret.service-account] }}
+        cluster-name: ${{ secrets[matrix.distro.secret.cluster-name] }}
+        cluster-location: ${{ secrets[matrix.distro.secret.cluster-location] }}
+        workload-identity-provider: ${{ secrets[matrix.distro.secret.workload-identity-provider] }}
+        service-account: ${{ secrets[matrix.distro.secret.service-account] }}
     - name: Set OpenShift authentication vars
-      if: matrix.test.type == 'openshift'
+      if: matrix.distro.type == 'openshift'
       run: |
-        OPENSHIFT_CLUSTER_VERSION="$(echo ${{ matrix.test.version }} | tr -d '.')"
+        OPENSHIFT_CLUSTER_VERSION="$(echo ${{ matrix.distro.version }} | tr -d '.')"
         echo "OPENSHIFT_CLUSTER_URL=OPENSHIFT_CLUSTER_URL_${OPENSHIFT_CLUSTER_VERSION}" >> $GITHUB_ENV
         echo "OPENSHIFT_CLUSTER_USERNAME=OPENSHIFT_CLUSTER_USERNAME_${OPENSHIFT_CLUSTER_VERSION}" >> $GITHUB_ENV
         echo "OPENSHIFT_CLUSTER_PASSWORD=OPENSHIFT_CLUSTER_PASSWORD_${OPENSHIFT_CLUSTER_VERSION}" >> $GITHUB_ENV
     - name: Authenticate to OpenShift
-      if: matrix.test.platform == 'rosa'
+      if: matrix.distro.platform == 'rosa'
       uses: redhat-actions/oc-login@v1
       with:
         openshift_server_url: ${{ secrets[env.OPENSHIFT_CLUSTER_URL] }}
@@ -110,7 +117,7 @@ jobs:
       uses: ./.github/actions/workflow-vars
       with:
         persistent: ${{ env.TEST_PERSISTENT }}
-        platform: ${{ matrix.test.platform }}
+        platform: ${{ matrix.distro.platform }}
         identifier-base: ${{ github.event.pull_request.number || inputs.identifier }}
         ingress-hostname-base: ${{ env.TEST_HOSTNAME_BASE }}
     - name: Install env dependencies
@@ -150,7 +157,7 @@ jobs:
         echo "Extra values from workflow:"
         echo "${{ inputs.extra-values }}" > /tmp/extra-values-file.yaml
         cat /tmp/extra-values-file.yaml
-    - name: Setup Camunda Platform
+    - name: 🌟 Setup Camunda Platform chart 🌟
       env:
         TEST_HELM_EXTRA_ARGS: >-
           --set global.ingress.host=${{ steps.vars.outputs.ingress-host }}
@@ -161,6 +168,14 @@ jobs:
       timeout-minutes: 5
       run: |
         task -d $TEST_SCENARIOS_DIR/chart-full-setup setup.post
+    - name: 🌟 Upgrade Camunda Platform chart 🌟
+      if: matrix.scenario.action == 'upgrade'
+      env:
+        TEST_HELM_EXTRA_ARGS: >-
+          --set global.ingress.host=${{ steps.vars.outputs.ingress-host }}
+          --values /tmp/extra-values-file.yaml
+      run: |
+        task -d $TEST_SCENARIOS_DIR/chart-full-setup setup.upgrade
     - name: Update GitHub deployment status
       uses: bobheadxi/deployments@v1
       with:
@@ -186,7 +201,7 @@ jobs:
     # Even using GH app token with deployment write access doesn't work.
     # https://github.com/bobheadxi/deployments/issues/145
     - name: Cleanup GitHub deployment
-      if: always() && (env.TEST_PERSISTENT == 'false' || matrix.test.type != 'kubernetes')
+      if: always() && (env.TEST_PERSISTENT == 'false' || matrix.distro.type != 'kubernetes')
       uses: bobheadxi/deployments@v1
       with:
         step: deactivate-env
@@ -194,7 +209,7 @@ jobs:
         env: ${{ steps.deployment.outputs.env }}
         ref: ${{ github.event.pull_request.head.sha }}
     - name: Cleanup test namespace
-      if: always() && (env.TEST_PERSISTENT == 'false' || matrix.test.type != 'kubernetes')
+      if: always() && (env.TEST_PERSISTENT == 'false' || matrix.distro.type != 'kubernetes')
       run: |
         kubectl delete ns --ignore-not-found=true \
           -l github-run-id=$GITHUB_WORKFLOW_RUN_ID \

--- a/charts/camunda-platform/test/integration/scenarios/chart-full-setup/Taskfile.yaml
+++ b/charts/camunda-platform/test/integration/scenarios/chart-full-setup/Taskfile.yaml
@@ -11,6 +11,12 @@ dotenv:
 
 includes:
   init.seed: ../lib/init-seed-taskfile.yaml
+  setup.upgrade:
+    taskfile: ../lib/chart-upgrade.yaml
+    vars:
+      TEST_NAMESPACE: "{{ .TEST_NAMESPACE }}"
+      TEST_HELM_EXTRA_ARGS: |-
+        {{ .TEST_HELM_EXTRA_ARGS }} --values ../chart-full-setup/values-integration-test-ingress.yaml
   test.preflight:
     taskfile: ../lib/testsuite-deploy-taskfile.yaml
     vars:

--- a/charts/camunda-platform/test/integration/scenarios/lib/chart-upgrade.yaml
+++ b/charts/camunda-platform/test/integration/scenarios/lib/chart-upgrade.yaml
@@ -2,37 +2,12 @@ version: '3'
 
 vars:
   TEST_NAMESPACE: '{{ env "TEST_NAMESPACE" | default "camunda-platform" }}'
-  TEST_CLUSTER_TYPE: '{{ env "TEST_CLUSTER_TYPE" | default "kubernetes" }}'
   TEST_HELM_EXTRA_ARGS: '{{ env "TEST_HELM_EXTRA_ARGS" }} {{ .TEST_OPENSHIFT_ARGS }}'
 
-dotenv:
-- ../vars/common.env
-- ../vars/{{ .TEST_CLUSTER_TYPE }}.env
-
-includes:
-  init.seed: ../lib/init-seed-taskfile.yaml
-  test.preflight:
-    taskfile: ../lib/testsuite-deploy-taskfile.yaml
-    vars:
-      testID: preflight
-  test.core:
-    taskfile: ../lib/testsuite-deploy-taskfile.yaml
-    vars:
-      testID: core
-
 tasks:
-  setup.pre:
-    cmds:
-    - echo "No pre setup task for this test."
-
   # https://docs.camunda.io/docs/self-managed/platform-deployment/helm-kubernetes/upgrade/
-  setup.exec:
-    deps: [init.seed]
+  default:
     cmds:
-    - helm install integration {{ .CHART_DIR }}
-        --namespace {{ .TEST_NAMESPACE }}
-        --values {{ .FIXTURES_DIR }}/values-integration-test.yaml
-        {{ .TEST_HELM_EXTRA_ARGS }}
     - |
       export TEST_SECRET=$(kubectl get secret "integration-test" \
         -n $TEST_NAMESPACE -o jsonpath="{.data.client-secret}" | base64 --decode)
@@ -64,16 +39,3 @@ tasks:
         --set identity.keycloak.postgresql.auth.password=$POSTGRESQL_SECRET \
         --timeout 20m0s \
         --wait {{ .TEST_HELM_EXTRA_ARGS }}
-
-  setup.post:
-    cmds:
-    - echo "No post task for this test."
-
-  all:
-    cmds:
-    - task: init.seed
-    - task: setup.pre
-    - task: setup.exec
-    - task: setup.post
-    - task: test.preflight
-    - task: test.core


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes: #913

### What's in this PR?

Add a new job to test the upgrade in full setup to ensure that the Camunda chart is always upgradable.
 
### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added (if needed).
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
