### PR TITLE
Release Camunda Platform Helm Chart v8.2.15

### DIFF
--- a/charts/camunda-platform/Chart.yaml
+++ b/charts/camunda-platform/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: camunda-platform
-version: 8.2.14
+version: 8.2.15
 appVersion: 8.2.x
 description: |
   Camunda Platform 8 Self-Managed Helm charts.
@@ -20,7 +20,7 @@ keywords:
 dependencies:
   # Camunda Platform charts.
   - name: identity
-    version: 8.2.14
+    version: 8.2.15
     condition: "identity.enabled"
     import-values:
       # NOTE: This is used to share Identity image details with its subchart Keycloak.
@@ -30,19 +30,19 @@ dependencies:
       - child: image
         parent: global.identity.image
   - name: operate
-    version: 8.2.14
+    version: 8.2.15
     condition: "operate.enabled"
   - name: optimize
-    version: 8.2.14
+    version: 8.2.15
     condition: "optimize.enabled"
   - name: tasklist
-    version: 8.2.14
+    version: 8.2.15
     condition: "tasklist.enabled"
   - name: zeebe
-    version: 8.2.14
+    version: 8.2.15
     condition: "zeebe.enabled"
   - name: zeebe-gateway
-    version: 8.2.14
+    version: 8.2.15
     condition: "zeebe.enabled"
   # Dependency charts.
   - name: elasticsearch

--- a/charts/camunda-platform/RELEASE-NOTES.md
+++ b/charts/camunda-platform/RELEASE-NOTES.md
@@ -2,10 +2,6 @@ The changelog is automatically generated using [git-chglog](https://github.com/g
 and it follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
 
 
-<a name="camunda-platform-8.2.13"></a>
-## [camunda-platform-8.2.13](https://github.com/camunda/camunda-platform-helm/compare/camunda-platform-8.2.12...camunda-platform-8.2.13) (2023-09-12)
-
-### Ci
-
-* fix renovate es docker matching ([#877](https://github.com/camunda/camunda-platform-helm/issues/877))
+<a name="camunda-platform-8.2.15"></a>
+## [camunda-platform-8.2.15](https://github.com/camunda/camunda-platform-helm/compare/camunda-platform-8.2.13...camunda-platform-8.2.15) (2023-09-29)
 

--- a/charts/camunda-platform/charts/identity/Chart.yaml
+++ b/charts/camunda-platform/charts/identity/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Identity Helm Chart for Kubernetes
 name: identity
-version: 8.2.14
+version: 8.2.15
 type: application
 icon: https://helm.camunda.io/imgs/camunda.svg
 dependencies:

--- a/charts/camunda-platform/charts/operate/Chart.yaml
+++ b/charts/camunda-platform/charts/operate/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 description: Operate Helm Chart for Kubernetes
 name: operate
-version: 8.2.14
+version: 8.2.15
 type: application
 icon: https://helm.camunda.io/imgs/camunda.svg

--- a/charts/camunda-platform/charts/optimize/Chart.yaml
+++ b/charts/camunda-platform/charts/optimize/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 description: Optimize Helm Chart for Kubernetes
 name: optimize
-version: 8.2.14
+version: 8.2.15
 icon: https://helm.camunda.io/imgs/camunda.svg

--- a/charts/camunda-platform/charts/tasklist/Chart.yaml
+++ b/charts/camunda-platform/charts/tasklist/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 description: Zeebe TaskList Helm Chart for Kubernetes
 name: tasklist
-version: 8.2.14
+version: 8.2.15
 icon: https://helm.camunda.io/imgs/camunda.svg

--- a/charts/camunda-platform/charts/zeebe-gateway/Chart.yaml
+++ b/charts/camunda-platform/charts/zeebe-gateway/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 description: Zeebe Gateway Helm Chart for Kubernetes
 name: zeebe-gateway
 type: application
-version: 8.2.14
+version: 8.2.15
 icon: https://helm.camunda.io/imgs/camunda.svg

--- a/charts/camunda-platform/charts/zeebe/Chart.yaml
+++ b/charts/camunda-platform/charts/zeebe/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 description: Zeebe Helm Chart for Kubernetes
 name: zeebe
 type: application
-version: 8.2.14
+version: 8.2.15
 icon: https://helm.camunda.io/imgs/camunda.svg


### PR DESCRIPTION
Note:  v8.2.14 has been skipped in [camunda-platform](https://github.com/camunda/camunda-platform).

**Before opening the PR:**

- [x] Run `make release.chores`
- [x] Create a PR with the printed URL

**After opening the PR:**

- [x] Take a final look at the release commits (version bump and release notes)
- [x] Make sure that all checks in the PR passed
- [x] If everything in place, add `release` label to the PR
- [x] Follow up the release workflow and make sure it succeeded (double-check the [releases page](https://github.com/camunda/camunda-platform-helm/releases))
