### PR TITLE
ci: use the latest released  chart in the upgrade

### DIFF
--- a/.github/workflows/test-integration-main.yaml
+++ b/.github/workflows/test-integration-main.yaml
@@ -75,10 +75,10 @@ jobs:
         scenario:
         - name: Chart Setup
           desc: Setup chart in production-like setup with Ingress and TLS.
-          action: install
+          flow: install
         - name: Chart Upgrade
           desc: Upgrade chart from the latest released version to the current branch.
-          action: upgrade
+          flow: upgrade
         exclude:
         - distro:
             if: false
@@ -159,6 +159,7 @@ jobs:
         cat /tmp/extra-values-file.yaml
     - name: 🌟 Setup Camunda Platform chart 🌟
       env:
+        TEST_CHART_FLOW: ${{ matrix.scenario.flow }}
         TEST_HELM_EXTRA_ARGS: >-
           --set global.ingress.host=${{ steps.vars.outputs.ingress-host }}
           --values /tmp/extra-values-file.yaml
@@ -169,7 +170,7 @@ jobs:
       run: |
         task -d $TEST_SCENARIOS_DIR/chart-full-setup setup.post
     - name: 🌟 Upgrade Camunda Platform chart 🌟
-      if: matrix.scenario.action == 'upgrade'
+      if: matrix.scenario.flow == 'upgrade'
       env:
         TEST_HELM_EXTRA_ARGS: >-
           --set global.ingress.host=${{ steps.vars.outputs.ingress-host }}

--- a/charts/camunda-platform/test/integration/scenarios/chart-full-setup/Taskfile.yaml
+++ b/charts/camunda-platform/test/integration/scenarios/chart-full-setup/Taskfile.yaml
@@ -48,7 +48,7 @@ tasks:
   setup.exec:
     deps: [init.seed]
     cmds:
-    - helm install integration {{ .CHART_DIR }}
+    - helm install integration {{ .TEST_CHART }}
         --namespace {{ .TEST_NAMESPACE }}
         --values {{ .FIXTURES_DIR }}/values-integration-test.yaml
         --values ./values-integration-test-ingress.yaml

--- a/charts/camunda-platform/test/integration/scenarios/chart-with-custom-values/Taskfile.yaml
+++ b/charts/camunda-platform/test/integration/scenarios/chart-with-custom-values/Taskfile.yaml
@@ -28,7 +28,7 @@ tasks:
   setup.exec:
     deps: [init.seed]
     cmds:
-    - helm install integration {{ .CHART_DIR }}
+    - helm install integration {{ .TEST_CHART }}
         --namespace {{ .TEST_NAMESPACE }}
         --values {{ .FIXTURES_DIR }}/values-integration-test.yaml
         --values ./values-custom.yaml

--- a/charts/camunda-platform/test/integration/scenarios/chart-with-default-values/Taskfile.yaml
+++ b/charts/camunda-platform/test/integration/scenarios/chart-with-default-values/Taskfile.yaml
@@ -28,7 +28,7 @@ tasks:
   setup.exec:
     deps: [init.seed]
     cmds:
-    - helm install integration {{ .CHART_DIR }}
+    - helm install integration {{ .TEST_CHART }}
         --namespace {{ .TEST_NAMESPACE }}
         --values {{ .FIXTURES_DIR }}/values-integration-test.yaml
         --timeout 20m0s

--- a/charts/camunda-platform/test/integration/scenarios/chart-with-web-modeler/Taskfile.yaml
+++ b/charts/camunda-platform/test/integration/scenarios/chart-with-web-modeler/Taskfile.yaml
@@ -37,7 +37,7 @@ tasks:
   setup.exec:
     deps: [init.seed]
     cmds:
-    - helm install integration {{ .CHART_DIR }}
+    - helm install integration {{ .TEST_CHART }}
         --namespace {{ .TEST_NAMESPACE }}
         --values {{ .FIXTURES_DIR }}/values-integration-test.yaml
         --values ./values-web-modeler-enabled.yaml

--- a/charts/camunda-platform/test/integration/scenarios/lib/chart-upgrade.yaml
+++ b/charts/camunda-platform/test/integration/scenarios/lib/chart-upgrade.yaml
@@ -26,7 +26,7 @@ tasks:
       export POSTGRESQL_SECRET=$(kubectl get secret "integration-postgresql" \
         -n $TEST_NAMESPACE -o jsonpath="{.data.postgres-password}" | base64 --decode)
 
-      helm upgrade integration {{ .CHART_DIR }} \
+      helm upgrade integration {{ .TEST_CHART }} \
         --namespace {{ .TEST_NAMESPACE }} \
         --values {{ .FIXTURES_DIR }}/values-integration-test.yaml \
         --set test.existingSecret=$TEST_SECRET \

--- a/charts/camunda-platform/test/integration/scenarios/vars/common.env
+++ b/charts/camunda-platform/test/integration/scenarios/vars/common.env
@@ -1,2 +1,4 @@
-CHART_DIR=../../../../
 FIXTURES_DIR=../fixtures
+TEST_CHART_DIR=../../../../
+TEST_CHART_REPO=camunda/camunda-platform
+TEST_CHART={{ eq .TEST_CHART_FLOW "upgrade" | ternary .TEST_CHART_REPO .TEST_CHART_DIR }}

--- a/charts/camunda-platform/test/integration/scenarios/vars/openshift.env
+++ b/charts/camunda-platform/test/integration/scenarios/vars/openshift.env
@@ -1,1 +1,1 @@
-TEST_OPENSHIFT_ARGS=--values {{ .CHART_DIR }}/openshift/values.yaml --values {{ .CHART_DIR }}/openshift/values-patch.yaml --post-renderer {{ .CHART_DIR }}/openshift/patch.sh
+TEST_OPENSHIFT_ARGS=--values {{ .TEST_CHART_DIR }}openshift/values.yaml --values {{ .TEST_CHART_DIR }}openshift/values-patch.yaml --post-renderer {{ .TEST_CHART_DIR }}openshift/patch.sh


### PR DESCRIPTION
### Which problem does the PR fix?

Part of: #913

### What's in this PR?

Use the use the latest released chart in the upgrade pipeline.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added (if needed).
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
