### PR TITLE
fix: use new disk usage configs for zeebe

### DIFF
--- a/charts/camunda-platform/test/unit/zeebe/golden/statefulset.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/statefulset.golden.yaml
@@ -103,10 +103,10 @@ spec:
           value: "-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/zeebe/data -XX:ErrorFile=/usr/local/zeebe/data/zeebe_error%p.log -XX:+ExitOnOutOfMemoryError"
         - name: ZEEBE_BROKER_DATA_SNAPSHOTPERIOD
           value: 5m
-        - name: ZEEBE_BROKER_DATA_DISKUSAGECOMMANDWATERMARK
-          value: "0.85"
-        - name: ZEEBE_BROKER_DATA_DISKUSAGEREPLICATIONWATERMARK
-          value: "0.87"
+        - name: ZEEBE_BROKER_DATA_DISK_FREESPACE_REPLICATION
+          value: 2GB
+        - name: ZEEBE_BROKER_DATA_DISK_FREESPACE_PROCESSING
+          value: 3GB
         ports:
         - containerPort: 9600
           name: http

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -232,10 +232,10 @@ zeebe:
   env:
     - name: ZEEBE_BROKER_DATA_SNAPSHOTPERIOD
       value: "5m"
-    - name: ZEEBE_BROKER_DATA_DISKUSAGECOMMANDWATERMARK
-      value: "0.85"
-    - name: ZEEBE_BROKER_DATA_DISKUSAGEREPLICATIONWATERMARK
-      value: "0.87"
+    - name: ZEEBE_BROKER_DATA_DISK_FREESPACE_REPLICATION
+      value: "2GB"
+    - name: ZEEBE_BROKER_DATA_DISK_FREESPACE_PROCESSING
+      value: "3GB"
   # ConfigMap configuration which will be applied to the mounted config map.
   configMap:
     # ConfigMap.defaultMode can be used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.


### PR DESCRIPTION
### Which problem does the PR fix?

closes #926 

### What's in this PR?

Replace old deprecated Zeebe configs for disk usage with the new ones. The new config is documented in https://docs.camunda.io/docs/self-managed/zeebe-deployment/operations/disk-space/

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [ ] Tests for charts are added (if needed).
- [ ] The main Helm chart and sub-chart are updated (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
