### PR TITLE
fix: configure identity base url

### DIFF
--- a/charts/camunda-platform/templates/_helpers.tpl
+++ b/charts/camunda-platform/templates/_helpers.tpl
@@ -179,10 +179,26 @@ Usage:
     {{- end -}}
 {{- end -}}
 
+{{/*
+[camunda-platform] Operate internal URL.
+*/}}
 {{ define "camundaPlatform.operateURL" }}
   {{- if .Values.operate.enabled -}}
     {{- print "http://" -}}{{- include "operate.fullname" . -}}:{{- .Values.operate.service.port -}}
     {{- .Values.operate.contextPath -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+[camunda-platform] Identity internal URL.
+*/}}
+{{ define "camundaPlatform.identityURL" }}
+  {{- if .Values.identity.enabled -}}
+    {{- printf "http://%s:%v%s"
+        (include "identity.fullname" .Subcharts.identity)
+        .Values.identity.service.port
+        (.Values.identity.contextPath | default "")
+    -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/camunda-platform/templates/operate/deployment.yaml
+++ b/charts/camunda-platform/templates/operate/deployment.yaml
@@ -48,6 +48,8 @@ spec:
             value: {{ include "camundaPlatform.issuerBackendUrl" . | quote }}
           - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWKSETURI
             value: {{ printf "%s%s" (include "camundaPlatform.issuerBackendUrl" .) "/protocol/openid-connect/certs" | quote }}
+          - name: CAMUNDA_OPERATE_IDENTITY_BASEURL
+            value: {{ include "camundaPlatform.identityURL" . | quote }}
           - name: CAMUNDA_OPERATE_IDENTITY_ISSUER_URL
             value: {{ tpl .Values.global.identity.auth.publicIssuerUrl $ | quote }}
           - name: CAMUNDA_OPERATE_IDENTITY_ISSUER_BACKEND_URL

--- a/charts/camunda-platform/templates/optimize/deployment.yaml
+++ b/charts/camunda-platform/templates/optimize/deployment.yaml
@@ -101,7 +101,7 @@ spec:
           - name: CAMUNDA_OPTIMIZE_IDENTITY_AUDIENCE
             value: "optimize-api"
           - name: CAMUNDA_OPTIMIZE_IDENTITY_BASE_URL
-            value: "http://{{ .Release.Name }}-identity:80"
+            value: {{ include "webModeler.identityBaseUrl" . | quote }}
           - name: CAMUNDA_OPTIMIZE_API_AUDIENCE
             value: "optimize-api"
           - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI

--- a/charts/camunda-platform/templates/tasklist/deployment.yaml
+++ b/charts/camunda-platform/templates/tasklist/deployment.yaml
@@ -48,6 +48,8 @@ spec:
             value: {{ include "camundaPlatform.issuerBackendUrl" . | quote }}
           - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWKSETURI
             value: {{ printf "%s%s" (include "camundaPlatform.issuerBackendUrl" .) "/protocol/openid-connect/certs" | quote }}
+          - name: CAMUNDA_TASKLIST_IDENTITY_BASEURL
+            value: {{ include "camundaPlatform.identityURL" . | quote }}
           - name: CAMUNDA_TASKLIST_IDENTITY_ISSUER_URL
             value: {{ tpl .Values.global.identity.auth.publicIssuerUrl $ | quote }}
           - name: CAMUNDA_TASKLIST_IDENTITY_ISSUER_BACKEND_URL

--- a/charts/camunda-platform/templates/zeebe-gateway/deployment.yaml
+++ b/charts/camunda-platform/templates/zeebe-gateway/deployment.yaml
@@ -87,6 +87,8 @@ spec:
               value: "true"
             - name: ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_BASEURL
               value: {{ include "camundaPlatform.identityURL" . | quote }}
+            - name: ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_BASEURL
+              value: {{ include "camundaPlatform.identityURL" . | quote }}
             {{- end }}
             {{- with .Values.zeebeGateway.env }}
               {{- tpl (toYaml .) $ | nindent 12 }}

--- a/charts/camunda-platform/templates/zeebe-gateway/deployment.yaml
+++ b/charts/camunda-platform/templates/zeebe-gateway/deployment.yaml
@@ -85,6 +85,8 @@ spec:
               value: "true"
             - name: ZEEBE_BROKER_GATEWAY_MULTITENANCY_ENABLED
               value: "true"
+            - name: ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_BASEURL
+              value: {{ include "camundaPlatform.identityURL" . | quote }}
             {{- end }}
             {{- with .Values.zeebeGateway.env }}
               {{- tpl (toYaml .) $ | nindent 12 }}

--- a/charts/camunda-platform/test/integration/scenarios/lib/chart-upgrade-taskfile.yaml
+++ b/charts/camunda-platform/test/integration/scenarios/lib/chart-upgrade-taskfile.yaml
@@ -63,5 +63,6 @@ tasks:
         --set global.identity.auth.console.existingSecret=$CONSOLE_SECRET \
         --set identity.keycloak.auth.adminPassword=$KEYCLOAK_ADMIN_SECRET \
         --set identity.keycloak.postgresql.auth.password=$KEYCLOAK_POSTGRESQL_SECRET \
+        --set identity.postgresql.auth.password=dummy \
         --timeout 20m0s \
         --wait {{ .TEST_HELM_EXTRA_ARGS }}

--- a/charts/camunda-platform/test/unit/operate/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/operate/golden/deployment.golden.yaml
@@ -57,6 +57,8 @@ spec:
             value: "http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform"
           - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWKSETURI
             value: "http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/certs"
+          - name: CAMUNDA_OPERATE_IDENTITY_BASEURL
+            value: "http://camunda-platform-test-identity:80"
           - name: CAMUNDA_OPERATE_IDENTITY_ISSUER_URL
             value: "http://localhost:18080/auth/realms/camunda-platform"
           - name: CAMUNDA_OPERATE_IDENTITY_ISSUER_BACKEND_URL

--- a/charts/camunda-platform/test/unit/tasklist/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/tasklist/golden/deployment.golden.yaml
@@ -57,6 +57,8 @@ spec:
             value: "http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform"
           - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWKSETURI
             value: "http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/certs"
+          - name: CAMUNDA_TASKLIST_IDENTITY_BASEURL
+            value: "http://camunda-platform-test-identity:80"
           - name: CAMUNDA_TASKLIST_IDENTITY_ISSUER_URL
             value: "http://localhost:18080/auth/realms/camunda-platform"
           - name: CAMUNDA_TASKLIST_IDENTITY_ISSUER_BACKEND_URL


### PR DESCRIPTION
### Which problem does the PR fix?

#961 

Depends on:
- [x] https://github.com/camunda/camunda-platform-helm/issues/966
- [x] https://github.com/camunda/camunda-platform-helm/issues/967
- [x] https://github.com/camunda/camunda-platform-helm/issues/969
- [x] https://github.com/camunda/camunda-platform-helm/issues/972

### What's in this PR?

Configures the identity base url on the zeebe gateway needed for the gateway to retrieve authorized tenants.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [ ] Tests for charts are added (if needed).
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
