### PR TITLE
fix: use correct keycloak var for connectors

### DIFF
--- a/charts/camunda-platform/charts/identity/templates/_helpers.tpl
+++ b/charts/camunda-platform/charts/identity/templates/_helpers.tpl
@@ -207,27 +207,15 @@ This is mainly used to access the external Keycloak service in the global Ingres
 {{- end -}}
 
 {{/*
-[identity] Get Keycloak based URL: protocol, host, and port (without contextPath).
-Because some apps need the base without the context path.
-*/}}
-{{- define "identity.keycloak.urlBase" -}}
-    {{- include "identity.keycloak.isConfigured" . -}}
-    {{-
-      printf "%s://%s:%s"
-        (include "identity.keycloak.protocol" .)
-        (include "identity.keycloak.host" .)
-        (include "identity.keycloak.port" .)
-    -}}
-{{- end -}}
-
-{{/*
 [identity] Get Keycloak full URL (protocol, host, port, and contextPath).
 */}}
 {{- define "identity.keycloak.url" -}}
     {{- include "identity.keycloak.isConfigured" . -}}
     {{-
-      printf "%s%s"
-        (include "identity.keycloak.urlBase" .)
+      printf "%s://%s:%s%s"
+        (include "identity.keycloak.protocol" .)
+        (include "identity.keycloak.host" .)
+        (include "identity.keycloak.port" .)
         (include "identity.keycloak.contextPath" .)
     -}}
 {{- end -}}

--- a/charts/camunda-platform/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/identity/templates/deployment.yaml
@@ -186,7 +186,7 @@ spec:
           - name: KEYCLOAK_URL
             value: {{ include "identity.keycloak.url" . | quote }}
           - name: IDENTITY_AUTH_PROVIDER_ISSUER_URL
-            value: {{ tpl .Values.global.identity.auth.publicIssuerUrl $ | quote }}
+            value: {{ include "camundaPlatform.authIssuerUrl" . | quote }}
           - name: IDENTITY_AUTH_PROVIDER_BACKEND_URL
             value: {{ include "identity.issuerBackendUrl" . | quote }}
           - name: KEYCLOAK_SETUP_USER

--- a/charts/camunda-platform/templates/_helpers.tpl
+++ b/charts/camunda-platform/templates/_helpers.tpl
@@ -123,18 +123,32 @@ Usage:
 {{- end -}}
 
 {{/*
+[camunda-platform] Keycloak issuer public URL which used externally for Camunda apps.
+*/}}
+{{- define "camundaPlatform.authIssuerUrl" -}}
+    {{- tpl .Values.global.identity.auth.publicIssuerUrl . -}}
+{{- end -}}
+
+
+{{/*
 [camunda-platform] Keycloak issuer backend URL which used internally for Camunda apps.
 */}}
-{{- define "camundaPlatform.issuerBackendUrl" -}}
+{{- define "camundaPlatform.authIssuerBackendUrl" -}}
     {{- include "identity.keycloak.url" .Subcharts.identity -}}{{- .Values.global.identity.keycloak.realm -}}
 {{- end -}}
 
 {{/*
 [camunda-platform] Keycloak auth token URL which used internally for Camunda apps.
 */}}
+{{- define "camundaPlatform.authIssuerBackendUrlTokenEndpoint" -}}
+    {{- include "camundaPlatform.authIssuerBackendUrl" . -}}/protocol/openid-connect/token
+{{- end -}}
 
-{{- define "camundaPlatform.authTokenUrl" -}}
-    {{- include "camundaPlatform.issuerBackendUrl" . -}}/protocol/openid-connect/token
+{{/*
+[camunda-platform] Keycloak auth certs URL which used internally for Camunda apps.
+*/}}
+{{- define "camundaPlatform.authIssuerBackendUrlCertsEndpoint" -}}
+    {{- include "camundaPlatform.authIssuerBackendUrl" . -}}/protocol/openid-connect/certs
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform/templates/connectors/deployment.yaml
+++ b/charts/camunda-platform/templates/connectors/deployment.yaml
@@ -59,8 +59,8 @@ spec:
                   key: connectors-secret
           {{- end }}
           {{- if and .Values.global.identity.auth.enabled (eq .Values.connectors.inbound.mode "oauth") }}
-            - name: CAMUNDA_OPERATE_CLIENT_KEYCLOAK-URL
-              value: {{ include "identity.keycloak.urlBase" .Subcharts.identity | quote }}
+            - name: CAMUNDA_OPERATE_CLIENT_KEYCLOAK-TOKEN-URL
+              value: {{ include "camundaPlatform.authIssuerBackendUrlTokenEndpoint" . | quote }}
             - name: CAMUNDA_OPERATE_CLIENT_CLIENT-ID
               value: connectors
             - name: CAMUNDA_OPERATE_CLIENT_CLIENT-SECRET
@@ -75,8 +75,6 @@ spec:
                   name: {{ include "identity.secretNameConnectorsIdentity" . }}
                   key: connectors-secret
               {{- end }}
-            - name: CAMUNDA_OPERATE_CLIENT_KEYCLOAK-REALM
-              value: {{ .Values.global.identity.keycloak.realm | replace "/realms/" "" }}
             - name: CAMUNDA_OPERATE_CLIENT_URL
               value: {{ include "camundaPlatform.operateURL" . | quote }}
           {{- end }}
@@ -100,7 +98,7 @@ spec:
                   key: zeebe-secret
               {{- end }}
             - name: ZEEBE_AUTHORIZATION_SERVER_URL
-              value: {{ include "camundaPlatform.authTokenUrl" . | quote }}
+              value: {{ include "camundaPlatform.authIssuerBackendUrlTokenEndpoint" . | quote }}
             - name: ZEEBE_TOKEN_AUDIENCE
               value: zeebe-api
           {{- end }}

--- a/charts/camunda-platform/templates/console/deployment.yaml
+++ b/charts/camunda-platform/templates/console/deployment.yaml
@@ -36,9 +36,9 @@ spec:
             - name: NODE_ENV
               value: production
             - name: IDENTITY_BASE
-              value: {{ tpl .Values.global.identity.auth.publicIssuerUrl $ | quote }}
+              value: {{ include "camundaPlatform.authIssuerUrl" . | quote }}
             - name: IDENTITY_ISSUER_URL
-              value: {{ tpl .Values.global.identity.auth.publicIssuerUrl $ | quote }}
+              value: {{ include "camundaPlatform.authIssuerUrl" . | quote }}
             - name: IDENTITY_REALM
               value: camunda-platform
             - name: IDENTITY_AUDIENCE

--- a/charts/camunda-platform/templates/operate/deployment.yaml
+++ b/charts/camunda-platform/templates/operate/deployment.yaml
@@ -45,15 +45,15 @@ spec:
           - name: SPRING_PROFILES_ACTIVE
             value: "identity-auth"
           - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUERURI
-            value: {{ include "camundaPlatform.issuerBackendUrl" . | quote }}
+            value: {{ include "camundaPlatform.authIssuerBackendUrl" . | quote }}
           - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWKSETURI
-            value: {{ printf "%s%s" (include "camundaPlatform.issuerBackendUrl" .) "/protocol/openid-connect/certs" | quote }}
+            value: {{ include "camundaPlatform.authIssuerBackendUrlCertsEndpoint" . | quote }}
           - name: CAMUNDA_OPERATE_IDENTITY_BASEURL
             value: {{ include "camundaPlatform.identityURL" . | quote }}
           - name: CAMUNDA_OPERATE_IDENTITY_ISSUER_URL
-            value: {{ tpl .Values.global.identity.auth.publicIssuerUrl $ | quote }}
+            value: {{ include "camundaPlatform.authIssuerUrl" . | quote }}
           - name: CAMUNDA_OPERATE_IDENTITY_ISSUER_BACKEND_URL
-            value: {{ include "camundaPlatform.issuerBackendUrl" . | quote }}
+            value: {{ include "camundaPlatform.authIssuerBackendUrl" . | quote }}
           - name: CAMUNDA_OPERATE_IDENTITY_CLIENT_ID
             value: "operate"
           - name: CAMUNDA_OPERATE_IDENTITY_CLIENT_SECRET
@@ -101,7 +101,7 @@ spec:
                 key: zeebe-secret
             {{- end }}
           - name: ZEEBE_AUTHORIZATION_SERVER_URL
-            value: {{ include "camundaPlatform.authTokenUrl" . | quote }}
+            value: {{ include "camundaPlatform.authIssuerBackendUrlTokenEndpoint" . | quote }}
           - name: ZEEBE_TOKEN_AUDIENCE
             value: zeebe-api
           {{- else }}

--- a/charts/camunda-platform/templates/optimize/deployment.yaml
+++ b/charts/camunda-platform/templates/optimize/deployment.yaml
@@ -79,9 +79,9 @@ spec:
           - name: SPRING_PROFILES_ACTIVE
             value: "ccsm"
           - name: CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_URL
-            value: {{ tpl .Values.global.identity.auth.publicIssuerUrl $ | quote }}
+            value: {{ include "camundaPlatform.authIssuerUrl" . | quote }}
           - name: CAMUNDA_OPTIMIZE_IDENTITY_ISSUER_BACKEND_URL
-            value: {{ include "camundaPlatform.issuerBackendUrl" . | quote }}
+            value: {{ include "camundaPlatform.authIssuerBackendUrl" . | quote }}
           - name: CAMUNDA_OPTIMIZE_IDENTITY_REDIRECT_ROOT_URL
             value: {{ tpl .Values.global.identity.auth.optimize.redirectUrl $ | quote }}
           - name: CAMUNDA_OPTIMIZE_IDENTITY_CLIENTID
@@ -110,7 +110,7 @@ spec:
           - name: CAMUNDA_OPTIMIZE_API_AUDIENCE
             value: "optimize-api"
           - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI
-            value: {{ printf "%s%s" (include "camundaPlatform.issuerBackendUrl" .) "/protocol/openid-connect/certs" | quote }}
+            value: {{ include "camundaPlatform.authIssuerBackendUrlCertsEndpoint" . | quote }}
           {{- end }}
           - name: CAMUNDA_OPTIMIZE_SECURITY_AUTH_COOKIE_SAME_SITE_ENABLED
             value: "false"

--- a/charts/camunda-platform/templates/tasklist/deployment.yaml
+++ b/charts/camunda-platform/templates/tasklist/deployment.yaml
@@ -45,15 +45,15 @@ spec:
           - name: SPRING_PROFILES_ACTIVE
             value: "identity-auth"
           - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUERURI
-            value: {{ include "camundaPlatform.issuerBackendUrl" . | quote }}
+            value: {{ include "camundaPlatform.authIssuerBackendUrl" . | quote }}
           - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWKSETURI
-            value: {{ printf "%s%s" (include "camundaPlatform.issuerBackendUrl" .) "/protocol/openid-connect/certs" | quote }}
+            value: {{ include "camundaPlatform.authIssuerBackendUrlCertsEndpoint" . | quote }}
           - name: CAMUNDA_TASKLIST_IDENTITY_BASEURL
             value: {{ include "camundaPlatform.identityURL" . | quote }}
           - name: CAMUNDA_TASKLIST_IDENTITY_ISSUER_URL
-            value: {{ tpl .Values.global.identity.auth.publicIssuerUrl $ | quote }}
+            value: {{ include "camundaPlatform.authIssuerUrl" . | quote }}
           - name: CAMUNDA_TASKLIST_IDENTITY_ISSUER_BACKEND_URL
-            value: {{ include "camundaPlatform.issuerBackendUrl" . | quote }}
+            value: {{ include "camundaPlatform.authIssuerBackendUrl" . | quote }}
           - name: CAMUNDA_TASKLIST_IDENTITY_CLIENT_ID
             value: "tasklist"
           - name: CAMUNDA_TASKLIST_IDENTITY_CLIENT_SECRET
@@ -96,7 +96,7 @@ spec:
                 key: zeebe-secret
             {{- end }}
           - name: ZEEBE_AUTHORIZATION_SERVER_URL
-            value: {{ include "camundaPlatform.authTokenUrl" . | quote }}
+            value: {{ include "camundaPlatform.authIssuerBackendUrlTokenEndpoint" . | quote }}
           - name: ZEEBE_TOKEN_AUDIENCE
             value: zeebe-api
           {{- else }}

--- a/charts/camunda-platform/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform/templates/web-modeler/deployment-restapi.yaml
@@ -86,9 +86,9 @@ spec:
                 name: {{ include "webModeler.fullname" . }}
                 key: pusher-app-secret
           - name: RESTAPI_OAUTH2_TOKEN_ISSUER
-            value: {{ tpl .Values.global.identity.auth.publicIssuerUrl $ | quote }}
+            value: {{ include "camundaPlatform.authIssuerUrl" . | quote }}
           - name: RESTAPI_OAUTH2_TOKEN_ISSUER_BACKEND_URL
-            value: {{ include "camundaPlatform.issuerBackendUrl" . | quote }}
+            value: {{ include "camundaPlatform.authIssuerBackendUrl" . | quote }}
           - name: RESTAPI_IDENTITY_BASE_URL
             value: {{ include "webModeler.identityBaseUrl" . | quote }}
           - name: ZEEBE_CLIENT_CONFIG_PATH

--- a/charts/camunda-platform/templates/web-modeler/deployment-webapp.yaml
+++ b/charts/camunda-platform/templates/web-modeler/deployment-webapp.yaml
@@ -53,15 +53,15 @@ spec:
           - name: OAUTH2_TOKEN_AUDIENCE
             value: "web-modeler"
           - name: OAUTH2_TOKEN_ISSUER
-            value: {{ tpl .Values.global.identity.auth.publicIssuerUrl $ | quote }}
+            value: {{ include "camundaPlatform.authIssuerUrl" . | quote }}
           - name: KEYCLOAK_BASE_URL
-            value: {{ tpl .Values.global.identity.auth.publicIssuerUrl $ | trimSuffix (print (.Values.global.identity.keycloak.contextPath | trimSuffix "/") .Values.global.identity.keycloak.realm) | quote }}
+            value: {{ include "camundaPlatform.authIssuerUrl" . | trimSuffix (print (.Values.global.identity.keycloak.contextPath | trimSuffix "/") .Values.global.identity.keycloak.realm) | quote }}
           - name: KEYCLOAK_CONTEXT_PATH
             value: {{ .Values.global.identity.keycloak.contextPath | quote }}
           - name: KEYCLOAK_REALM
             value: {{ .Values.global.identity.keycloak.realm | trimPrefix "/realms/" | quote }}
           - name: KEYCLOAK_JWKS_URL
-            value: {{ printf "%s%s" (include "camundaPlatform.issuerBackendUrl" .) "/protocol/openid-connect/certs" | quote }}
+            value: {{ include "camundaPlatform.authIssuerBackendUrlCertsEndpoint" . | quote }}
           - name: PUSHER_HOST
             value: {{ include "webModeler.websockets.fullname" . | quote }}
           - name: PUSHER_PORT

--- a/charts/camunda-platform/templates/zeebe-gateway/deployment.yaml
+++ b/charts/camunda-platform/templates/zeebe-gateway/deployment.yaml
@@ -76,7 +76,7 @@ spec:
             - name: ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_MODE
               value: "identity"
             - name: ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_ISSUERBACKENDURL
-              value: {{ include "camundaPlatform.issuerBackendUrl" . | quote }}
+              value: {{ include "camundaPlatform.authIssuerBackendUrl" . | quote }}
             - name: ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_AUDIENCE
               value: "zeebe-api"
             {{- end }}

--- a/charts/camunda-platform/test/unit/connectors/deployment_test.go
+++ b/charts/camunda-platform/test/unit/connectors/deployment_test.go
@@ -701,14 +701,12 @@ func (s *deploymentTemplateTest) TestContainerSetInboundModeDisabled() {
 	env := deployment.Spec.Template.Spec.Containers[0].Env
 
 	for _, envvar := range env {
+		s.Require().NotEqual("CAMUNDA_OPERATE_CLIENT_KEYCLOAK-TOKEN-URL", envvar.Name)
 		s.Require().NotEqual("CAMUNDA_OPERATE_CLIENT_URL", envvar.Name)
 		s.Require().NotEqual("CAMUNDA_OPERATE_CLIENT_USERNAME", envvar.Name)
 		s.Require().NotEqual("CAMUNDA_OPERATE_CLIENT_PASSWORD", envvar.Name)
-		s.Require().NotEqual("CAMUNDA_OPERATE_CLIENT_KEYCLOAK-URL", envvar.Name)
 		s.Require().NotEqual("CAMUNDA_OPERATE_CLIENT_CLIENT-ID", envvar.Name)
 		s.Require().NotEqual("CAMUNDA_OPERATE_CLIENT_CLIENT-SECRET", envvar.Name)
-		s.Require().NotEqual("CAMUNDA_OPERATE_CLIENT_KEYCLOAK-REALM", envvar.Name)
-		s.Require().NotEqual("CAMUNDA_OPERATE_CLIENT_URL", envvar.Name)
 	}
 
 	s.Require().Contains(env, corev1.EnvVar{Name: "ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS", Value: "camunda-platform-test-zeebe-gateway:26500"})
@@ -738,11 +736,10 @@ func (s *deploymentTemplateTest) TestContainerSetInboundModeCredentials() {
 	for _, envvar := range env {
 		s.Require().NotEqual("CAMUNDA_CONNECTOR_POLLING_ENABLED", envvar.Name)
 		s.Require().NotEqual("CAMUNDA_CONNECTOR_WEBHOOK_ENABLED", envvar.Name)
-		s.Require().NotEqual("SPRING_MAIN_WEB-APPLICATION-TYPE", envvar.Name)
-		s.Require().NotEqual("CAMUNDA_OPERATE_CLIENT_KEYCLOAK-URL", envvar.Name)
+		s.Require().NotEqual("CAMUNDA_OPERATE_CLIENT_KEYCLOAK-TOKEN-URL", envvar.Name)
 		s.Require().NotEqual("CAMUNDA_OPERATE_CLIENT_CLIENT-ID", envvar.Name)
 		s.Require().NotEqual("CAMUNDA_OPERATE_CLIENT_CLIENT-SECRET", envvar.Name)
-		s.Require().NotEqual("CAMUNDA_OPERATE_CLIENT_KEYCLOAK-REALM", envvar.Name)
+		s.Require().NotEqual("SPRING_MAIN_WEB-APPLICATION-TYPE", envvar.Name)
 	}
 
 	s.Require().Contains(env, corev1.EnvVar{Name: "ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS", Value: "camunda-platform-test-zeebe-gateway:26500"})
@@ -779,9 +776,8 @@ func (s *deploymentTemplateTest) TestContainerSetInboundModeOauth() {
 
 	s.Require().Contains(env, corev1.EnvVar{Name: "ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS", Value: "camunda-platform-test-zeebe-gateway:26500"})
 	s.Require().Contains(env, corev1.EnvVar{Name: "ZEEBE_CLIENT_SECURITY_PLAINTEXT", Value: "true"})
-	s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_OPERATE_CLIENT_KEYCLOAK-URL", Value: "http://camunda-platform-test-keycloak:80"})
+	s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_OPERATE_CLIENT_KEYCLOAK-TOKEN-URL", Value: "http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/token"})
 	s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_OPERATE_CLIENT_CLIENT-ID", Value: "connectors"})
-	s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_OPERATE_CLIENT_KEYCLOAK-REALM", Value: "camunda-platform"})
 	s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_OPERATE_CLIENT_URL", Value: "http://camunda-platform-test-operate:80"})
 
 }
@@ -872,10 +868,11 @@ func (s *deploymentTemplateTest) TestContainerShouldSetCorrectKeycloakServiceUrl
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"global.identity.keycloak.url.protocol":	"https",
-			"global.identity.keycloak.url.host":    	"keycloak-ext",
-			"global.identity.keycloak.url.port":    	"443",
-			"global.identity.keycloak.contextPath":		"/authz",
+			"global.identity.keycloak.url.protocol":  "https",
+			"global.identity.keycloak.url.host":      "keycloak-ext",
+			"global.identity.keycloak.url.port":      "443",
+			"global.identity.keycloak.contextPath":   "/authz",
+			"global.identity.keycloak.realm":         "/realms/camunda-platform-test",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 	}
@@ -889,7 +886,7 @@ func (s *deploymentTemplateTest) TestContainerShouldSetCorrectKeycloakServiceUrl
 	env := deployment.Spec.Template.Spec.Containers[0].Env
 	s.Require().Contains(env,
 		corev1.EnvVar{
-			Name:  "CAMUNDA_OPERATE_CLIENT_KEYCLOAK-URL",
-			Value: "https://keycloak-ext:443",
+			Name:  "CAMUNDA_OPERATE_CLIENT_KEYCLOAK-TOKEN-URL",
+			Value: "https://keycloak-ext:443/authz/realms/camunda-platform-test/protocol/openid-connect/token",
 		})
 }

--- a/charts/camunda-platform/test/unit/connectors/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/connectors/golden/deployment.golden.yaml
@@ -56,8 +56,8 @@ spec:
           env:
             - name: SERVER_PORT
               value: "8080"
-            - name: CAMUNDA_OPERATE_CLIENT_KEYCLOAK-URL
-              value: "http://camunda-platform-test-keycloak:80"
+            - name: CAMUNDA_OPERATE_CLIENT_KEYCLOAK-TOKEN-URL
+              value: "http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/token"
             - name: CAMUNDA_OPERATE_CLIENT_CLIENT-ID
               value: connectors
             - name: CAMUNDA_OPERATE_CLIENT_CLIENT-SECRET
@@ -65,8 +65,6 @@ spec:
                 secretKeyRef:
                   name: "camunda-platform-test-connectors-identity-secret"
                   key: connectors-secret
-            - name: CAMUNDA_OPERATE_CLIENT_KEYCLOAK-REALM
-              value: camunda-platform
             - name: CAMUNDA_OPERATE_CLIENT_URL
               value: "http://camunda-platform-test-operate:80"
             - name: ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes: #978

### What's in this PR?

Allow the Keycloak URL to be fully customizable to work with external KC with a different context path.

Use `CAMUNDA_OPERATE_CLIENT_KEYCLOAK-TOKEN-URL` var in Connectors to customize the KC URL since it's not possible to set the context using `CAMUNDA_OPERATE_CLIENT_KEYCLOAK-URL` and `CAMUNDA_OPERATE_CLIENT_KEYCLOAK-REALM` (the context is hard coded in [camunda-operate-client-java](https://github.com/camunda-community-hub/camunda-operate-client-java/blob/fa38603174de3d5f18414d25386ccc5444cad52d/src/main/java/io/camunda/operate/auth/SelfManagedAuthentication.java#L71) used in Connectors code base).

Also, a couple of internal renaming for consistency.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added (if needed).
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
