### PR TITLE
Add support for Multi-Region Active-Active setups

### DIFF
--- a/charts/camunda-platform/templates/zeebe/configmap.yaml
+++ b/charts/camunda-platform/templates/zeebe/configmap.yaml
@@ -9,8 +9,12 @@ data:
   startup.sh: |
     #!/usr/bin/env bash
     set -eux -o pipefail
-
-    export ZEEBE_BROKER_CLUSTER_NODEID=${ZEEBE_BROKER_CLUSTER_NODEID:-${K8S_NAME##*-}}
+    
+{{- if eq .Values.global.installationType "failOver" }}
+    export ZEEBE_BROKER_CLUSTER_NODEID=${ZEEBE_BROKER_CLUSTER_NODEID:-$[${K8S_NAME##*-} * 2 * {{.Values.global.regions}} + {{.Values.global.regionId}}]}
+{{- else }}
+    export ZEEBE_BROKER_CLUSTER_NODEID=${ZEEBE_BROKER_CLUSTER_NODEID:-$[${K8S_NAME##*-} * {{.Values.global.regions}} + {{.Values.global.regionId}}]}
+{{- end }}
 
     if [ "$(ls -A /exporters/)" ]; then
       mkdir /usr/local/zeebe/exporters/
@@ -23,8 +27,15 @@ data:
 
     env
     {{- end }}
-
+{{- if eq .Values.global.installationType "failBack" }}
+    if [ $[${K8S_NAME##*-} % 2] -eq 0 ]
+    then
+      trap : TERM INT; sleep infinity & wait
+    else
+      exec /usr/local/zeebe/bin/broker    fi
+{{- else }}
     exec /usr/local/zeebe/bin/broker
+{{- end }}
 
   broker-log4j2.xml: |
 {{- if .Values.zeebe.log4j2 }}

--- a/charts/camunda-platform/templates/zeebe/statefulset.yaml
+++ b/charts/camunda-platform/templates/zeebe/statefulset.yaml
@@ -11,9 +11,9 @@ metadata:
     {{- end }}
 spec:
   replicas: {{- if eq .Values.global.installationType "failOver" }}
-                {{ div (div .Values.clusterSize .Values.global.regions) 2 }}
+                {{ div (div .Values.zeebe.clusterSize .Values.global.regions) 2 }}
             {{- else }}
-                {{ div .Values.clusterSize .Values.global.regions }}
+                {{ div .Values.zeebe.clusterSize .Values.global.regions }}
             {{- end }}
   selector:
     matchLabels:

--- a/charts/camunda-platform/templates/zeebe/statefulset.yaml
+++ b/charts/camunda-platform/templates/zeebe/statefulset.yaml
@@ -10,7 +10,11 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
-  replicas: {{ .Values.zeebe.clusterSize  }}
+  replicas: {{- if eq .Values.global.installationType "failOver" }}
+                {{ div (div .Values.clusterSize .Values.global.regions) 2 }}
+            {{- else }}
+                {{ div .Values.clusterSize .Values.global.regions }}
+            {{- end }}
   selector:
     matchLabels:
       {{- include "zeebe.matchLabels.broker" . | nindent 6 }}

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -37,6 +37,12 @@
 ## @section Global parameters
 ## @extra global
 global:
+  # number of regions that this Camunda Platform instance is stretched across
+  regions: 1
+  # unique id of the region. Should start at 0 for easy computation. With 2 regions, you would have region 0 and 1.
+  regionId: 0
+  # mode of installation for multi-region disaster recovery: normal, failOver, failBack
+  installationType: normal
   ## Multitenancy configuration.
   ## @extra global.multitenancy
   multitenancy:


### PR DESCRIPTION
### Which problem does the PR fix?

Add support for Multi-Region Active-Active setups

### What's in this PR?

Creates partial Zeebe clusters in order to form stretch clusters across multiple k8s clusters.

This is accompanied by a [Helm profile containing chart values and Makefiles to automate operations procedures](https://github.com/camunda-community-hub/camunda-8-helm-profiles/tree/activeactive/google/multi-region/active-active).

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [ ] Tests for charts are added (if needed).
- [ ] The main Helm chart and sub-chart are updated (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
