### PR TITLE
fix: optimize to use consistent versioning with other 8.3 components

### DIFF
--- a/charts/camunda-platform/test/unit/optimize/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/optimize/golden/deployment.golden.yaml
@@ -39,7 +39,7 @@ spec:
         []
       initContainers:
         - name: migration
-          image: camunda/optimize:3.11.1
+          image: camunda/optimize:8.3.1
           command: ['./upgrade/upgrade.sh', '--skip-warning']
           securityContext:
             allowPrivilegeEscalation: false
@@ -62,7 +62,7 @@ spec:
               name: camunda
       containers:
         - name: optimize
-          image: camunda/optimize:3.11.1
+          image: camunda/optimize:8.3.1
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -1146,7 +1146,8 @@ optimize:
     ## @param optimize.image.repository defines which image repository to use
     repository: camunda/optimize
     ## @param optimize.image.tag can be set to overwrite the global tag, which should be used in that chart
-    tag: 3.11.1
+    # renovate: datasource=docker depName=camunda/optimize
+    tag: 8.3.1
     ## @param optimize.image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
     pullSecrets: []
 

--- a/charts/camunda-platform/values/values-latest.yaml
+++ b/charts/camunda-platform/values/values-latest.yaml
@@ -31,7 +31,8 @@ optimize:
   # https://hub.docker.com/r/camunda/optimize/tags
   image:
     repository: camunda/optimize
-    tag: 3.11.1
+    # renovate: datasource=docker depName=camunda/optimize
+    tag: 8.3.1
 
 webModeler:
   # Camunda Enterprise repository.


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues related to or fixed by this PR, if any. -->

Optimize now releases under the 8.3.x image tag rather than the 3.11.x image tag.  I believe they are using 3.11.1 for compatibility reasons for the time being, but I suspect they will want to drop support for the 3.11.x numbering scheme at some point.

### What's in this PR?

This PR will change the optimize versions with 8.3.x for values.yaml and values-latest.yaml.  This change also configures renovate for camunda/optimize.

<!--
  Explain the contents of the PR.
  Give an overview about the implementation, which decisions were made and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added (if needed). - not needed
- [x] The main Helm chart and sub-chart are updated (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
