### PR TITLE
update elastic image to 8.8.2

### DIFF
--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -2957,7 +2957,7 @@ elasticsearch:
     ## @param elasticsearch.image.repository
     repository: bitnami/elasticsearch
     ## @param elasticsearch.image.tag
-    tag: 8.7.1
+    tag: 8.8.2
   ## @param elasticsearch.extraVolumes[0].name
   ## @param elasticsearch.extraVolumes[0].emptyDir
   ## @param elasticsearch.extraVolumes[1].name

--- a/charts/camunda-platform/values/values-latest.yaml
+++ b/charts/camunda-platform/values/values-latest.yaml
@@ -47,4 +47,4 @@ webModeler:
 elasticsearch:
   # https://hub.docker.com/r/bitnami/elasticsearch/tags
   image: bitnami/elasticsearch
-  tag: 8.7.1
+  tag: 8.8.2


### PR DESCRIPTION
### Which problem does the PR fix?

In the newest values.yaml, for 8.3 we have elasticsearch image tag set to 8.7.1, but we only support 8.8.x
https://github.com/camunda/camunda-platform-helm/blob/9c31ca4c9948d858ed844ffaaa0f7f93990989c4/charts/camunda-platform/values.yaml#L2960
https://docs.camunda.io/docs/reference/supported-environments/#camunda-8-self-managed
### What's in this PR?

update elastic search image to 8.8.2 (the most recent supported version)

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).


**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [ ] Tests for charts are added (if needed).
- [ ] The main Helm chart and sub-chart are updated (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?


I'm pretty sure I updated this everywhere, but please double check me.