### PR TITLE
refactor: add volume mounts for optimize migration init container

### DIFF
--- a/charts/camunda-platform/templates/optimize/deployment.yaml
+++ b/charts/camunda-platform/templates/optimize/deployment.yaml
@@ -54,7 +54,7 @@ spec:
               name: tmp
             - mountPath: /camunda
               name: camunda
-            {{- if .Values.optimize.extraVolumeMounts}}
+            {{- if .Values.optimize.extraVolumeMounts }}
             {{- .Values.optimize.extraVolumeMounts | toYaml | nindent 12 }}
             {{- end }}
         {{- end }}
@@ -128,7 +128,7 @@ spec:
           {{- with .Values.optimize.env }}
             {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
-          {{- if .Values.optimize.command}}
+          {{- if .Values.optimize.command }}
           command: {{ toYaml .Values.optimize.command | nindent 10 }}
           {{- end }}
           resources:
@@ -181,7 +181,7 @@ spec:
               name: tmp
             - mountPath: /camunda
               name: camunda
-            {{- if .Values.optimize.extraVolumeMounts}}
+            {{- if .Values.optimize.extraVolumeMounts }}
             {{- .Values.optimize.extraVolumeMounts | toYaml | nindent 12 }}
             {{- end }}
         {{- if .Values.optimize.sidecars }}
@@ -192,10 +192,10 @@ spec:
           emptyDir: {}
         - name: camunda
           emptyDir: {}
-        {{- if .Values.optimize.extraVolumes}}
+        {{- if .Values.optimize.extraVolumes }}
         {{- .Values.optimize.extraVolumes | toYaml | nindent 8 }}
         {{- end }}
-      {{- if .Values.optimize.serviceAccount.name}}
+      {{- if .Values.optimize.serviceAccount.name }}
       serviceAccountName: {{ .Values.optimize.serviceAccount.name }}
       {{- end }}
       {{- if .Values.optimize.podSecurityContext }}

--- a/charts/camunda-platform/templates/optimize/deployment.yaml
+++ b/charts/camunda-platform/templates/optimize/deployment.yaml
@@ -54,6 +54,9 @@ spec:
               name: tmp
             - mountPath: /camunda
               name: camunda
+            {{- if .Values.optimize.extraVolumeMounts}}
+            {{- .Values.optimize.extraVolumeMounts | toYaml | nindent 12 }}
+            {{- end }}
         {{- end }}
       containers:
         - name: optimize

--- a/charts/camunda-platform/templates/optimize/deployment.yaml
+++ b/charts/camunda-platform/templates/optimize/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "optimize.labels" . | nindent 4 }}
   annotations:
-    {{- toYaml  .Values.global.annotations | nindent 4 }}
+    {{- toYaml .Values.global.annotations | nindent 4 }}
 spec:
   replicas: 1
   selector:
@@ -21,7 +21,7 @@ spec:
         {{- end }}
       {{- if .Values.optimize.podAnnotations }}
       annotations:
-        {{- toYaml  .Values.optimize.podAnnotations | nindent 8 }}
+        {{- toYaml .Values.optimize.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
       imagePullSecrets:


### PR DESCRIPTION

### Which problem does the PR fix?
#953 and #1036

<!-- Which GitHub issues related to or fixed by this PR, if any. -->

### What's in this PR?
Previously optimize migration container couldnt use volume mounts defined for the optimize container. 
PR adds support to mount the extraVolumeMounts from optimize to the migration container.
<!--
  Explain the contents of the PR.
  Give an overview about the implementation, which decisions were made and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [ ] Tests for charts are added (if needed).
- [ ] The main Helm chart and sub-chart are updated (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
