### PR TITLE
fix zeebe pvcStorageClassName 

### DIFF
--- a/charts/camunda-platform/templates/zeebe/statefulset.yaml
+++ b/charts/camunda-platform/templates/zeebe/statefulset.yaml
@@ -231,7 +231,7 @@ spec:
         name: data
       spec:
         accessModes: {{ .Values.zeebe.pvcAccessModes }}
-        {{- if .Values.zeebe.storageClassName}}
+        {{- if .Values.zeebe.pvcStorageClassName }}
         storageClassName: {{ .Values.zeebe.pvcStorageClassName }}
         {{- end }}
         resources:


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues related to or fixed by this PR, if any. -->

### What's in this PR?

A recent change has broken pvcStorageClassName in 8.3.1 as the if clause is checking for storageClassName instead of pvcStorageClassName.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [ ] Tests for charts are added (if needed).
- [ ] The main Helm chart and sub-chart are updated (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
