### PR TITLE
fix(ci): updates regression test to reflect that 8.0 is eol and 8.2 i…

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_template.md
@@ -9,3 +9,6 @@
 - [ ] Make sure that all checks in the PR passed
 - [ ] If everything in place, add `release` label to the PR
 - [ ] Follow up the release workflow and make sure it succeeded (double-check the [releases page](https://github.com/camunda/camunda-platform-helm/releases))
+
+If the release is a minor version bump:
+- [ ] Make sure the regression test matrix is updated: located at [.github/workflows/test-regression.yaml](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/test-regression.yaml#L33-L36)

--- a/.github/workflows/test-regression.yaml
+++ b/.github/workflows/test-regression.yaml
@@ -32,8 +32,8 @@ jobs:
       fail-fast: false
       matrix:
         camundaChart:
+        - "8.2"
         - "8.1"
-        - "8.0"
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
     - name: Login to GKE


### PR DESCRIPTION
…s a previous version

### Which problem does the PR fix?

Turns out our regression / upgrade tests are not testing the path between 8.2 to 8.3.   And those tests are also trying to test 8.0 to 8.1 , which references a values.yaml for 8.0 that is marked as EOL. Causing this failure: 
https://github.com/camunda/camunda-platform-helm/actions/runs/6774431973/job/18411462355?pr=1015

<!-- Which GitHub issues related to or fixed by this PR, if any. -->

### What's in this PR?

This PR will remove 8.0 from the upgrade tests and adds in 8.2

<!--
  Explain the contents of the PR.
  Give an overview about the implementation, which decisions were made and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [ ] Tests for charts are added (if needed).
- [ ] The main Helm chart and sub-chart are updated (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
