### PR TITLE
fix(ci): runs integration on completion of unit tests (fixes communit…

### DIFF
--- a/.github/workflows/test-integration-main.yaml
+++ b/.github/workflows/test-integration-main.yaml
@@ -2,6 +2,10 @@
 name: "Test - Integration - Main"
 
 on:
+  workflow_run:
+    workflows: [Test - Unit]
+    types:
+      - completed
   pull_request:
     paths:
     - '.github/workflows/test-integration-main.yaml'


### PR DESCRIPTION
…y PRs not having secrets)

### Which problem does the PR fix?

Community PRs currently cannot have any successful run of our integration tests because forks do not have access to secrets from our repository.   The current workflow is to create a duplicate PR originating from a branch within the repository, and monitor the CI status from there.

### What's in this PR?

GitHub requires manual approval of CI runs triggered from forked repositories anyway.  So what this change will do is
1. Unit tests will trigger integration tests
2.  because the integration tests are ran from within a workflow_run call, it will be in the context of this repository with it's secrets.

<!--
  Explain the contents of the PR.
  Give an overview about the implementation, which decisions were made and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [ ] Tests for charts are added (if needed).
- [ ] The main Helm chart and sub-chart are updated (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
