### PR TITLE
fix: allow existing zeebe exporters dir

### DIFF
--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -23,8 +23,6 @@ Please also refer to the [documentation](https://docs.camunda.io/docs/self-manag
   - [Web Modeler](#web-modeler)
   - [Elasticsearch](#elasticsearch)
   - [Keycloak](#keycloak)
-- [Guides](#guides)
-  - [Adding dynamic exporters to Zeebe Brokers](#adding-dynamic-exporters-to-zeebe-brokers)
 - [Development](#development)
 - [Releasing the Charts](#releasing-the-charts)
 - [Parameters](#parameters)
@@ -366,46 +364,6 @@ identity:
     - name: camunda-theme
       mountPath: /opt/bitnami/keycloak/themes/identity
 ```
-
-## Guides
-
-> **Note**
->
-> For full list of guides list, please visit
-> [Helm/Kubernetes Guides](https://docs.camunda.io/docs/next/self-managed/platform-deployment/helm-kubernetes/overview/)
-
-### Adding dynamic exporters to Zeebe Brokers
-
-This chart supports the addition of Zeebe Exporters by using `initContainer` as shown in the following example:
-
-```
-extraInitContainers:
-  - name: init-exporters-hazelcast
-    image: busybox:1.35
-    command: ['/bin/sh', '-c']
-    args: ['wget --no-check-certificate https://repo1.maven.org/maven2/io/zeebe/hazelcast/zeebe-hazelcast-exporter/0.8.0-alpha1/zeebe-hazelcast-exporter-0.8.0-alpha1-jar-with-dependencies.jar -O /exporters/zeebe-hazelcast-exporter.jar; ls -al /exporters']
-    volumeMounts:
-    - name: exporters
-      mountPath: /exporters/
-  - name: init-exporters-kafka
-    image: busybox:1.35
-    command: ['/bin/sh', '-c']
-    args: ['wget --no-check-certificate https://github.com/zeebe-io/zeebe-kafka-exporter/releases/download/1.1.0/zeebe-kafka-exporter-1.1.0-uber.jar -O /exporters/zeebe-kafka-exporter.jar; ls -al /exporters']
-    volumeMounts:
-    - name: exporters
-      mountPath: /exporters/
-env:
-  - name: ZEEBE_BROKER_EXPORTERS_HAZELCAST_JARPATH
-    value: /exporters/zeebe-hazelcast-exporter.jar
-  - name: ZEEBE_BROKER_EXPORTERS_HAZELCAST_CLASSNAME
-    value: io.zeebe.hazelcast.exporter.HazelcastExporter
-  - name: ZEEBE_HAZELCAST_REMOTE_ADDRESS
-    value: "{{ .Release.Name }}-hazelcast"
-```
-
-This example is downloading the exporters' Jar from a URL and adding the Jars to the `exporters` directory,
-which will be scanned for jars and added to the Zeebe broker classpath. Then with `environment variables`,
-you can configure the exporter parameters.
 
 ## Development
 

--- a/charts/camunda-platform/templates/zeebe/configmap.yaml
+++ b/charts/camunda-platform/templates/zeebe/configmap.yaml
@@ -17,7 +17,7 @@ data:
 {{- end }}
 
     if [ "$(ls -A /exporters/)" ]; then
-      mkdir /usr/local/zeebe/exporters/
+      mkdir -p /usr/local/zeebe/exporters/
       cp -a /exporters/*.jar /usr/local/zeebe/exporters/
     else
       echo "No exporters available."

--- a/charts/camunda-platform/test/unit/zeebe/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/configmap-log4j2.golden.yaml
@@ -19,7 +19,7 @@ data:
     export ZEEBE_BROKER_CLUSTER_NODEID=${ZEEBE_BROKER_CLUSTER_NODEID:-$[${K8S_NAME##*-} * 1 + 0]}
 
     if [ "$(ls -A /exporters/)" ]; then
-      mkdir /usr/local/zeebe/exporters/
+      mkdir -p /usr/local/zeebe/exporters/
       cp -a /exporters/*.jar /usr/local/zeebe/exporters/
     else
       echo "No exporters available."

--- a/charts/camunda-platform/test/unit/zeebe/golden/configmap.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/configmap.golden.yaml
@@ -19,7 +19,7 @@ data:
     export ZEEBE_BROKER_CLUSTER_NODEID=${ZEEBE_BROKER_CLUSTER_NODEID:-$[${K8S_NAME##*-} * 1 + 0]}
 
     if [ "$(ls -A /exporters/)" ]; then
-      mkdir /usr/local/zeebe/exporters/
+      mkdir -p /usr/local/zeebe/exporters/
       cp -a /exporters/*.jar /usr/local/zeebe/exporters/
     else
       echo "No exporters available."


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes: #1011

### What's in this PR?

Allow mounting Zeebe exporters dir as an extra volume:

```
zeebe:
...
  extraVolumes
  - name: exporters-zeebe
    emptyDir: {}
  extraVolumeMounts:
  - name: exporters-zeebe
    mountPath: /usr/local/zeebe/exporters
```

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added (if needed).
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
