### PR TITLE
improve(operate): set default log level to INFO

### DIFF
--- a/charts/camunda-platform/test/unit/operate/golden/configmap.golden.yaml
+++ b/charts/camunda-platform/test/unit/operate/golden/configmap.golden.yaml
@@ -41,6 +41,6 @@ data:
     logging:
       level:
         ROOT: INFO
-        io.camunda.operate: DEBUG
+        io.camunda.operate: INFO
     #Spring Boot Actuator endpoints to be exposed
     management.endpoints.web.exposure.include: health,info,conditions,configprops,prometheus,loggers,usage-metrics,backups

--- a/charts/camunda-platform/test/unit/operate/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/operate/golden/deployment.golden.yaml
@@ -35,7 +35,7 @@ spec:
         app.kubernetes.io/version: "8.3.3"
         app.kubernetes.io/component: operate
       annotations:
-        checksum/config: 44a7e9786a324dcc0d9aee8c457bd8292ee0f01c3ae9eafa5c6af473cf47f074
+        checksum/config: 0885d7527ebdb825c27882d384756943c1591a8f06fc6f4168a4bd232f586f48
     spec:
       imagePullSecrets:
         []

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -774,7 +774,7 @@ operate:
   logging:
     level:
       ROOT: INFO
-      io.camunda.operate: DEBUG
+      io.camunda.operate: INFO
 
   ## @extra operate.service configuration to configure the Operate service.
   service:


### PR DESCRIPTION
### Which problem does the PR fix?
### What's in this PR?

I found that the default log level of Operate was DEBUG which I consider way too verbose. This changes it to INFO.