### PR TITLE
chore: add CAMUNDA_TASKLIST_IDENTITY_USER_ACCESS_RESTRICTIONS_ENABLED as true

### DIFF
--- a/charts/camunda-platform/templates/tasklist/deployment.yaml
+++ b/charts/camunda-platform/templates/tasklist/deployment.yaml
@@ -75,6 +75,8 @@ spec:
               {{- end }}
             - name: CAMUNDA_TASKLIST_IDENTITY_AUDIENCE
               value: "tasklist-api"
+            - name: CAMUNDA_TASKLIST_IDENTITY_USER_ACCESS_RESTRICTIONS_ENABLED
+              value: "true"
             {{- /*
               TODO: Remove the trimSuffix when it's fixed in Tasklist.
               https://github.com/camunda/camunda-platform-helm/issues/714


### PR DESCRIPTION
### Which problem does the PR fix?

User Group management flag

### What's in this PR?

- We set to true the env variable  CAMUNDA_TASKLIST_IDENTITY_USER_ACCESS_RESTRICTIONS_ENABLED as default to turn on the User Access Restrictions on Self Managed

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [ ] Tests for charts are added (if needed).
- [ ] The main Helm chart and sub-chart are updated (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
