### PR TITLE
refactor: mount tasklist-configmap volume on a new path

### DIFF
--- a/charts/camunda-platform/templates/tasklist/deployment.yaml
+++ b/charts/camunda-platform/templates/tasklist/deployment.yaml
@@ -169,6 +169,9 @@ spec:
             - name: config
               mountPath: /app/resources/application.yml
               subPath: application.yml
+            - name: config-tasklist
+              mountPath: /usr/local/tasklist/config/application.yml
+              subPath: application.yml
             - mountPath: /tmp
               name: tmp
             - mountPath: /camunda
@@ -181,6 +184,10 @@ spec:
         {{- end }}
       volumes:
         - name: config
+          configMap:
+            name: {{ include "tasklist.fullname" . }}
+            defaultMode: {{ .Values.tasklist.configMap.defaultMode }}
+        - name: config-tasklist
           configMap:
             name: {{ include "tasklist.fullname" . }}
             defaultMode: {{ .Values.tasklist.configMap.defaultMode }}

--- a/charts/camunda-platform/templates/tasklist/deployment.yaml
+++ b/charts/camunda-platform/templates/tasklist/deployment.yaml
@@ -169,7 +169,7 @@ spec:
             - name: config
               mountPath: /app/resources/application.yml
               subPath: application.yml
-            - name: config-tasklist
+            - name: config
               mountPath: /usr/local/tasklist/config/application.yml
               subPath: application.yml
             - mountPath: /tmp
@@ -184,10 +184,6 @@ spec:
         {{- end }}
       volumes:
         - name: config
-          configMap:
-            name: {{ include "tasklist.fullname" . }}
-            defaultMode: {{ .Values.tasklist.configMap.defaultMode }}
-        - name: config-tasklist
           configMap:
             name: {{ include "tasklist.fullname" . }}
             defaultMode: {{ .Values.tasklist.configMap.defaultMode }}

--- a/charts/camunda-platform/test/unit/tasklist/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/tasklist/golden/deployment.golden.yaml
@@ -120,12 +120,19 @@ spec:
             - name: config
               mountPath: /app/resources/application.yml
               subPath: application.yml
+            - name: config-tasklist
+              mountPath: /usr/local/tasklist/config/application.yml
+              subPath: application.yml
             - mountPath: /tmp
               name: tmp
             - mountPath: /camunda
               name: camunda
       volumes:
         - name: config
+          configMap:
+            name: camunda-platform-test-tasklist
+            defaultMode: 484
+        - name: config-tasklist
           configMap:
             name: camunda-platform-test-tasklist
             defaultMode: 484

--- a/charts/camunda-platform/test/unit/tasklist/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/tasklist/golden/deployment.golden.yaml
@@ -120,7 +120,7 @@ spec:
             - name: config
               mountPath: /app/resources/application.yml
               subPath: application.yml
-            - name: config-tasklist
+            - name: config
               mountPath: /usr/local/tasklist/config/application.yml
               subPath: application.yml
             - mountPath: /tmp
@@ -129,10 +129,6 @@ spec:
               name: camunda
       volumes:
         - name: config
-          configMap:
-            name: camunda-platform-test-tasklist
-            defaultMode: 484
-        - name: config-tasklist
           configMap:
             name: camunda-platform-test-tasklist
             defaultMode: 484


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues related to or fixed by this PR, if any. -->
https://github.com/camunda/tasklist/issues/3894

### What's in this PR?
<!--
  Explain the contents of the PR.
  Give an overview about the implementation, which decisions were made and why.
-->

Similar to https://github.com/camunda-cloud/camunda-operator/pull/2255

**Mount tasklist-configmap volume on a new path (required for replacement of jib maven plugin by Dockerfile))**

In Tasklist, we are aiming to replace [jib-maven-plugin](https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin) that we use to build Docker images by plain Dockerfile

jib-maven-plugin comes with some predefined paths for the classpath (like `/app/resources/` ...)
for this reason the `tasklist-configmap-webapp` (containing application.yaml to be used in SaaS) was mounted on the container at this path

With Dockerfile, we use a generated sh script (similar to what Operate is using) as an entrypoint. It is using a different classpath (uses docker user home path)

For this reason, we need to mount `tasklist-configmap` on a new path `/usr/local/tasklist/config/application.yml`
More context can be found here https://github.com/camunda/tasklist/issues/3894#issuecomment-1831709769

I think we need to keep both mount paths coexisting until we make sure no one is using a Docker image built with jib plugin. 


### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added (if needed).
- [x] The main Helm chart and sub-chart are updated (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
