### PR TITLE
ci: re-enable service monitor tests

### DIFF
--- a/charts/camunda-platform/test/integration/testsuites/core/testsuites/core.yaml
+++ b/charts/camunda-platform/test/integration/testsuites/core/testsuites/core.yaml
@@ -253,24 +253,23 @@ testcases:
     assertions:
     - result.statuscode ShouldEqual 200
 
-# TODO: Enable when Prometheus issue is fixed in the CI cluster.
-# - name: TEST - Check ServiceMonitor
-#   steps:
-#   - name: Check prometheus could query containers
-#     type: http
-#     method: GET
-#     url: "http://{{ .coreVars.baseURLs.prometheus }}/api/v1/query?query=system_cpu_count%7Bnamespace%3D%22{{ .coreVars.testNamespace }}%22%7D"
-#     retry: 4
-#     delay: 15
-#     # info: |
-#     #   = Request Body: {{ .result.request.body }}
-#     #   = Response Body: {{ .result.body }}
-#     assertions:
-#     - result.body ShouldContainSubstring connectors
-#     - result.body ShouldContainSubstring identity
-#     - result.body ShouldContainSubstring operate
-#     - result.body ShouldContainSubstring optimize
-#     - result.body ShouldContainSubstring tasklist
-#     - result.body ShouldContainSubstring web-modeler-restapi
-#     - result.body ShouldContainSubstring zeebe
-#     - result.body ShouldContainSubstring zeebe-gateway
+- name: TEST - Check ServiceMonitor
+  steps:
+  - name: Check prometheus could query containers
+    type: http
+    method: GET
+    url: "http://{{ .coreVars.baseURLs.prometheus }}/api/v1/query?query=system_cpu_count%7Bnamespace%3D%22{{ .coreVars.testNamespace }}%22%7D"
+    retry: 4
+    delay: 15
+    # info: |
+    #   = Request Body: {{ .result.request.body }}
+    #   = Response Body: {{ .result.body }}
+    assertions:
+    - result.body ShouldContainSubstring connectors
+    - result.body ShouldContainSubstring identity
+    - result.body ShouldContainSubstring operate
+    - result.body ShouldContainSubstring optimize
+    - result.body ShouldContainSubstring tasklist
+    - result.body ShouldContainSubstring web-modeler-restapi
+    - result.body ShouldContainSubstring zeebe
+    - result.body ShouldContainSubstring zeebe-gateway


### PR DESCRIPTION
### Which problem does the PR fix?

The problem with our prometheus deployment is now resolved, and it should now be safe to re-enable the tests. For more details about what was wrong in our deployment, look here: https://github.com/camunda/distribution/pull/100

<!-- Which GitHub issues related to or fixed by this PR, if any. -->
Related to https://github.com/camunda/camunda-platform-helm/issues/733

### What's in this PR?

Just uncommenting a test that was previously disabled.

<!--
  Explain the contents of the PR.
  Give an overview about the implementation, which decisions were made and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] The commits follow our [Commit Guidelines](../blob/main/CONTRIBUTING.md#commit-guidelines).
- [x] Tests for charts are added (if needed).
- [x] The main Helm chart and sub-chart are updated (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
