### PR TITLE
issue #1116 Invalid Redirect URI in Camunda Platform 8.3.3

### DIFF
--- a/charts/camunda-platform/templates/operate/deployment.yaml
+++ b/charts/camunda-platform/templates/operate/deployment.yaml
@@ -14,7 +14,7 @@ spec:
       {{- include "operate.matchLabels" . | nindent 6 }}
   template:
     metadata:
-      labels: 
+      labels:
         {{- include "operate.labels" . | nindent 8 }}
         {{- if .Values.operate.podLabels }}
           {{- toYaml .Values.operate.podLabels | nindent 8 }}
@@ -85,7 +85,7 @@ spec:
               https://github.com/camunda/camunda-platform-helm/issues/714
             */}}
             - name: CAMUNDA_OPERATE_IDENTITY_REDIRECT_ROOT_URL
-              value: {{ tpl .Values.global.identity.auth.operate.redirectUrl $ | trimSuffix "/operate" | quote }}
+              value: {{ tpl .Values.global.identity.auth.operate.redirectUrl $ | trimSuffix .Values.operate.contextPath | quote }}
             - name: ZEEBE_CLIENT_ID
               value: zeebe
             - name: ZEEBE_CLIENT_SECRET

--- a/charts/camunda-platform/templates/tasklist/deployment.yaml
+++ b/charts/camunda-platform/templates/tasklist/deployment.yaml
@@ -14,7 +14,7 @@ spec:
       {{- include "tasklist.matchLabels" . | nindent 6 }}
   template:
     metadata:
-      labels: 
+      labels:
         {{- include "tasklist.labels" . | nindent 8 }}
         {{- if .Values.tasklist.podLabels }}
           {{- toYaml .Values.tasklist.podLabels | nindent 8 }}
@@ -82,7 +82,7 @@ spec:
               https://github.com/camunda/camunda-platform-helm/issues/714
             */}}
             - name: CAMUNDA_TASKLIST_IDENTITY_REDIRECT_ROOT_URL
-              value: {{ tpl .Values.global.identity.auth.tasklist.redirectUrl $ | trimSuffix "/tasklist" | quote }}
+              value: {{ tpl .Values.global.identity.auth.tasklist.redirectUrl $ | trimSuffix .Values.tasklist.contextPath | quote }}
             - name: ZEEBE_CLIENT_ID
               value: zeebe
             - name: ZEEBE_CLIENT_SECRET


### PR DESCRIPTION
fixed the trimSuffix-Expression of the *IDENTITY_REDIRECT_ROOT_URL-env-variable in tasklist and operate

### Which problem does the PR fix?

issue #1116

### What's in this PR?

in the deployment-helmcharts for operate and tasklist the static trimming of "/operate" and "/tasklist" was replaced by trimming the contextPath-Variable in the CAMUNDA_*_IDENTITY_REDIRECT_ROOT_URL