### PR TITLE
ci: sign helm chart with cosign

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -38,4 +38,15 @@ and it follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.
 {{ end }}
 {{ end -}}
 {{ end -}}
+
+### Verification
+
+To verify integrity of the Helm chart using [Cosign](https://docs.sigstore.dev/signing/quickstart/):
+
+```shell
+cosign verify-blob {{ .Tag.Name }}.tgz \
+  --bundle {{ .Tag.Name }}.cosign.bundle \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  --certificate-identity "https://github.com/_GITHUB_WORKFLOW_REF_"
+```
 {{ end -}}

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -34,12 +34,18 @@ jobs:
     needs: wait-for-release-conditions
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
           fetch-depth: 0
+      # TODO: Remove this step when we automate release chores as a pre-release workflow.
+      # Use Go Sprig Function which is supported by chglog like "{{ env GITHUB_WORKFLOW_REF }}".
+      - name: Substitute GITHUB_WORKFLOW_REF var.
+        run: |
+          sed -i "s/_GITHUB_WORKFLOW_REF_/${GITHUB_WORKFLOW_REF}/g" .chglog/CHANGELOG.tpl.md
       - name: Install env dependencies
         uses: asdf-vm/actions/install@v3
       - uses: actions/cache@v3
@@ -66,28 +72,30 @@ jobs:
         uses: helm/chart-releaser-action@v1.6.0
         with:
           config: .github/config/chart-releaser.yaml
-          install_only: true
         env:
           CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           CR_SKIP_EXISTING: 'true'
-      - name: Create Cosign bundle, verify, and upload
+      - name: Set Helm chart version var
         run: |
           CHART_VERSION="$(yq ".version" charts/camunda-platform/Chart.yaml)"
-          # Signing
+          echo "CHART_VERSION=${CHART_VERSION}" | tee -a $GITHUB_ENV
+      - name: Sign Helm chart with Cosign
+        run: |
           cosign sign-blob -y .cr-release-packages/camunda-platform-${CHART_VERSION}.tgz \
             --bundle camunda-platform-${CHART_VERSION}.cosign.bundle
-          # Verifying
+      - name: Verify signed Helm chart with Cosign
+        run: |
           cosign verify-blob .cr-release-packages/camunda-platform-${CHART_VERSION}.tgz \
             --bundle ./camunda-platform-${CHART_VERSION}.cosign.bundle \
             --certificate-identity "https://github.com/${GITHUB_WORKFLOW_REF}" \
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
-          # Uploading
-          gh release -R "${GITHUB_REPOSITORY}" upload "camunda-platform-${CHART_VERSION}" \ 
-            ./camunda-platform-${CHART_VERSION}.cosign.bundle
+      - name: Upload Helm chart signature bundle
+        run: |
+          gh release upload "camunda-platform-${CHART_VERSION}" \
+            ./camunda-platform-${CHART_VERSION}.cosign.bundle \
+            --repo "${GITHUB_REPOSITORY}"
         env:
           GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-
-
   verify:
     needs: release
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Which problem does the PR fix?
This PR is related to [Signing Helm Charts with Cosign](https://github.com/camunda/camunda-platform-helm/issues/957) 
<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?
Added Signing, verifying, and uploading bundle file of Helm Chart to the chart-releaser github action. This will add extra layer of security to our Helm Chart. 
<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
