### PR TITLE
chore(web-modeler): adjust env variables for OIDC configuration scheme

### DIFF
--- a/charts/camunda-platform/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform/templates/web-modeler/deployment-restapi.yaml
@@ -34,6 +34,8 @@ spec:
           env:
             - name: JAVA_OPTIONS
               value: "-Xmx1536m"
+            - name: CAMUNDA_IDENTITY_BASE_URL
+              value: {{ include "webModeler.identityBaseUrl" . | quote }}
             - name: SPRING_DATASOURCE_URL
               value: {{ include "webModeler.restapi.databaseUrl" . | quote }}
             - name: SPRING_DATASOURCE_USERNAME
@@ -89,8 +91,6 @@ spec:
               value: {{ include "camundaPlatform.authIssuerUrl" . | quote }}
             - name: RESTAPI_OAUTH2_TOKEN_ISSUER_BACKEND_URL
               value: {{ include "camundaPlatform.authIssuerBackendUrl" . | quote }}
-            - name: RESTAPI_IDENTITY_BASE_URL
-              value: {{ include "webModeler.identityBaseUrl" . | quote }}
             - name: ZEEBE_CLIENT_CONFIG_PATH
               value: /tmp/zeebe_client_cache.txt
           {{- with .Values.webModeler.restapi.env }}

--- a/charts/camunda-platform/templates/web-modeler/deployment-webapp.yaml
+++ b/charts/camunda-platform/templates/web-modeler/deployment-webapp.yaml
@@ -50,18 +50,12 @@ spec:
               value: {{ hasPrefix "https://" (tpl .Values.global.identity.auth.webModeler.redirectUrl $) | quote }}
             - name: OAUTH2_CLIENT_ID
               value: "web-modeler"
+            - name: OAUTH2_JWKS_URL
+              value: {{ include "camundaPlatform.authIssuerBackendUrlCertsEndpoint" . | quote }}
             - name: OAUTH2_TOKEN_AUDIENCE
               value: "web-modeler"
             - name: OAUTH2_TOKEN_ISSUER
               value: {{ include "camundaPlatform.authIssuerUrl" . | quote }}
-            - name: KEYCLOAK_BASE_URL
-              value: {{ include "camundaPlatform.authIssuerUrl" . | trimSuffix (print (.Values.global.identity.keycloak.contextPath | trimSuffix "/") .Values.global.identity.keycloak.realm) | quote }}
-            - name: KEYCLOAK_CONTEXT_PATH
-              value: {{ .Values.global.identity.keycloak.contextPath | quote }}
-            - name: KEYCLOAK_REALM
-              value: {{ .Values.global.identity.keycloak.realm | trimPrefix "/realms/" | quote }}
-            - name: KEYCLOAK_JWKS_URL
-              value: {{ include "camundaPlatform.authIssuerBackendUrlCertsEndpoint" . | quote }}
             - name: PUSHER_HOST
               value: {{ include "webModeler.websockets.fullname" . | quote }}
             - name: PUSHER_PORT

--- a/charts/camunda-platform/test/unit/web-modeler/deployment_restapi_test.go
+++ b/charts/camunda-platform/test/unit/web-modeler/deployment_restapi_test.go
@@ -124,7 +124,7 @@ func (s *restapiDeploymentTemplateTest) TestContainerShouldSetCorrectIdentitySer
 	// then
 	env := deployment.Spec.Template.Spec.Containers[0].Env
 	s.Require().Contains(env,
-		corev1.EnvVar{Name: "RESTAPI_IDENTITY_BASE_URL", Value: "http://custom-identity-fullname:80"})
+		corev1.EnvVar{Name: "CAMUNDA_IDENTITY_BASE_URL", Value: "http://custom-identity-fullname:80"})
 }
 
 func (s *restapiDeploymentTemplateTest) TestContainerShouldSetCorrectIdentityServiceUrlWithNameOverride() {
@@ -146,7 +146,7 @@ func (s *restapiDeploymentTemplateTest) TestContainerShouldSetCorrectIdentitySer
 	// then
 	env := deployment.Spec.Template.Spec.Containers[0].Env
 	s.Require().Contains(env,
-		corev1.EnvVar{Name: "RESTAPI_IDENTITY_BASE_URL", Value: "http://camunda-platform-test-custom-identity:80"})
+		corev1.EnvVar{Name: "CAMUNDA_IDENTITY_BASE_URL", Value: "http://camunda-platform-test-custom-identity:80"})
 }
 
 func (s *restapiDeploymentTemplateTest) TestContainerShouldSetExternalDatabaseConfiguration() {

--- a/charts/camunda-platform/test/unit/web-modeler/deployment_webapp_test.go
+++ b/charts/camunda-platform/test/unit/web-modeler/deployment_webapp_test.go
@@ -51,78 +51,6 @@ func TestWebappDeploymentTemplate(t *testing.T) {
 	})
 }
 
-func (s *webappDeploymentTemplateTest) TestContainerShouldSetCorrectKeycloakClientConfigWithRootPath() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                   "true",
-			"webModeler.restapi.mail.fromAddress":  "example@example.com",
-			"global.identity.auth.publicIssuerUrl": "http://localhost:18080/realms/test-realm",
-			"global.identity.keycloak.contextPath": "/",
-			"global.identity.keycloak.realm":       "/realms/test-realm",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-	s.Require().Contains(env,
-		corev1.EnvVar{
-			Name:  "KEYCLOAK_BASE_URL",
-			Value: "http://localhost:18080",
-		},
-		corev1.EnvVar{
-			Name:  "KEYCLOAK_CONTEXT_PATH",
-			Value: "/",
-		},
-		corev1.EnvVar{
-			Name:  "KEYCLOAK_REALM",
-			Value: "test-realm",
-		},
-	)
-}
-
-func (s *webappDeploymentTemplateTest) TestContainerShouldSetCorrectKeycloakClientConfigWithCustomPath() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                   "true",
-			"webModeler.restapi.mail.fromAddress":  "example@example.com",
-			"global.identity.auth.publicIssuerUrl": "http://localhost:18080/test-path/realms/test-realm",
-			"global.identity.keycloak.contextPath": "/test-path",
-			"global.identity.keycloak.realm":       "/realms/test-realm",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-	s.Require().Contains(env,
-		corev1.EnvVar{
-			Name:  "KEYCLOAK_BASE_URL",
-			Value: "http://localhost:18080",
-		},
-		corev1.EnvVar{
-			Name:  "KEYCLOAK_CONTEXT_PATH",
-			Value: "/test-path",
-		},
-		corev1.EnvVar{
-			Name:  "KEYCLOAK_REALM",
-			Value: "test-realm",
-		},
-	)
-}
-
 func (s *webappDeploymentTemplateTest) TestContainerShouldSetCorrectKeycloakServiceUrl() {
 	// given
 	options := &helm.Options{
@@ -145,7 +73,7 @@ func (s *webappDeploymentTemplateTest) TestContainerShouldSetCorrectKeycloakServ
 	env := deployment.Spec.Template.Spec.Containers[0].Env
 	s.Require().Contains(env,
 		corev1.EnvVar{
-			Name:  "KEYCLOAK_JWKS_URL",
+			Name:  "OAUTH2_JWKS_URL",
 			Value: "http://keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/certs",
 		})
 }

--- a/charts/camunda-platform/test/unit/web-modeler/golden/configmap-shared.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/configmap-shared.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.3.2"
+    app.kubernetes.io/version: "8.4.0-alpha2"
     app.kubernetes.io/component: web-modeler
   annotations:
     {}

--- a/charts/camunda-platform/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -52,6 +52,8 @@ spec:
           env:
             - name: JAVA_OPTIONS
               value: "-Xmx1536m"
+            - name: CAMUNDA_IDENTITY_BASE_URL
+              value: "http://camunda-platform-test-identity:80"
             - name: SPRING_DATASOURCE_URL
               value: "jdbc:postgresql://camunda-platform-test-postgresql-web-modeler:5432/web-modeler"
             - name: SPRING_DATASOURCE_USERNAME
@@ -96,8 +98,6 @@ spec:
               value: "http://localhost:18080/auth/realms/camunda-platform"
             - name: RESTAPI_OAUTH2_TOKEN_ISSUER_BACKEND_URL
               value: "http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform"
-            - name: RESTAPI_IDENTITY_BASE_URL
-              value: "http://camunda-platform-test-identity:80"
             - name: ZEEBE_CLIENT_CONFIG_PATH
               value: /tmp/zeebe_client_cache.txt
           resources:

--- a/charts/camunda-platform/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.3.2"
+    app.kubernetes.io/version: "8.4.0-alpha2"
     app.kubernetes.io/component: restapi
   annotations:
     {}
@@ -32,7 +32,7 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "8.3.2"
+        app.kubernetes.io/version: "8.4.0-alpha2"
         app.kubernetes.io/component: restapi
     spec:
       imagePullSecrets:
@@ -41,7 +41,7 @@ spec:
         []
       containers:
         - name: web-modeler-restapi
-          image: "registry.camunda.cloud/web-modeler-ee/modeler-restapi:8.3.2"
+          image: "registry.camunda.cloud/web-modeler-ee/modeler-restapi:8.4.0-alpha2"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/camunda-platform/test/unit/web-modeler/golden/deployment-webapp.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/deployment-webapp.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.3.2"
+    app.kubernetes.io/version: "8.4.0-alpha2"
     app.kubernetes.io/component: webapp
   annotations:
     {}
@@ -32,7 +32,7 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "8.3.2"
+        app.kubernetes.io/version: "8.4.0-alpha2"
         app.kubernetes.io/component: webapp
     spec:
       imagePullSecrets:
@@ -41,7 +41,7 @@ spec:
         []
       containers:
         - name: web-modeler-webapp
-          image: "registry.camunda.cloud/web-modeler-ee/modeler-webapp:8.3.2"
+          image: "registry.camunda.cloud/web-modeler-ee/modeler-webapp:8.4.0-alpha2"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/camunda-platform/test/unit/web-modeler/golden/deployment-webapp.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/deployment-webapp.golden.yaml
@@ -68,18 +68,12 @@ spec:
               value: "false"
             - name: OAUTH2_CLIENT_ID
               value: "web-modeler"
+            - name: OAUTH2_JWKS_URL
+              value: "http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/certs"
             - name: OAUTH2_TOKEN_AUDIENCE
               value: "web-modeler"
             - name: OAUTH2_TOKEN_ISSUER
               value: "http://localhost:18080/auth/realms/camunda-platform"
-            - name: KEYCLOAK_BASE_URL
-              value: "http://localhost:18080"
-            - name: KEYCLOAK_CONTEXT_PATH
-              value: "/auth"
-            - name: KEYCLOAK_REALM
-              value: "camunda-platform"
-            - name: KEYCLOAK_JWKS_URL
-              value: "http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/certs"
             - name: PUSHER_HOST
               value: "camunda-platform-test-web-modeler-websockets"
             - name: PUSHER_PORT

--- a/charts/camunda-platform/test/unit/web-modeler/golden/deployment-websockets.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/deployment-websockets.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.3.2"
+    app.kubernetes.io/version: "8.4.0-alpha2"
     app.kubernetes.io/component: websockets
   annotations:
     {}
@@ -32,7 +32,7 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "8.3.2"
+        app.kubernetes.io/version: "8.4.0-alpha2"
         app.kubernetes.io/component: websockets
     spec:
       imagePullSecrets:
@@ -41,7 +41,7 @@ spec:
         []
       containers:
         - name: web-modeler-websockets
-          image: "registry.camunda.cloud/web-modeler-ee/modeler-websockets:8.3.2"
+          image: "registry.camunda.cloud/web-modeler-ee/modeler-websockets:8.4.0-alpha2"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/camunda-platform/test/unit/web-modeler/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/ingress-all-enabled.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.3.2"
+    app.kubernetes.io/version: "8.4.0-alpha2"
     app.kubernetes.io/component: web-modeler
   annotations:
     ingress.kubernetes.io/rewrite-target: /

--- a/charts/camunda-platform/test/unit/web-modeler/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/ingress.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.3.2"
+    app.kubernetes.io/version: "8.4.0-alpha2"
     app.kubernetes.io/component: web-modeler
   annotations:
     ingress.kubernetes.io/rewrite-target: /

--- a/charts/camunda-platform/test/unit/web-modeler/golden/secret-shared.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/secret-shared.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.3.2"
+    app.kubernetes.io/version: "8.4.0-alpha2"
     app.kubernetes.io/component: web-modeler
   annotations:
     {}

--- a/charts/camunda-platform/test/unit/web-modeler/golden/service-restapi.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/service-restapi.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.3.2"
+    app.kubernetes.io/version: "8.4.0-alpha2"
     app.kubernetes.io/component: restapi
   annotations:
 spec:

--- a/charts/camunda-platform/test/unit/web-modeler/golden/service-webapp.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/service-webapp.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.3.2"
+    app.kubernetes.io/version: "8.4.0-alpha2"
     app.kubernetes.io/component: webapp
   annotations:
 spec:

--- a/charts/camunda-platform/test/unit/web-modeler/golden/service-websockets.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/service-websockets.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.3.2"
+    app.kubernetes.io/version: "8.4.0-alpha2"
     app.kubernetes.io/component: websockets
   annotations:
 spec:

--- a/charts/camunda-platform/test/unit/web-modeler/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/serviceaccount.golden.yaml
@@ -10,5 +10,5 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.3.2"
+    app.kubernetes.io/version: "8.4.0-alpha2"
     app.kubernetes.io/component: web-modeler

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -1939,7 +1939,7 @@ webModeler:
     registry: registry.camunda.cloud
     ## @param webModeler.image.tag can be used to set the Docker image tag for the Web Modeler images (overwrites global.image.tag)
     # renovate: datasource=docker depName=camunda/web-modeler lookupName=registry.camunda.cloud/web-modeler-ee/modeler-restapi
-    tag: 8.3.2
+    tag: 8.4.0-alpha2
     ## @param webModeler.image.pullSecrets can be used to configure image pull secrets, see https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
     # Note: A secret will be required, if the Web Modeler images are pulled directly from Camunda's private registry.
     #


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

Relates to https://github.com/camunda/web-modeler/issues/7077

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

Removes some unused environment variables after Web Modeler implemented custom OIDC support and adjusts the naming to use the newer scheme.

**Note:** These changes are backwards compatible. Using the old environment variables still works with newer versions of Web Modeler.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
