### PR TITLE
refactor: show error message for optimize requirements

### DIFF
--- a/charts/camunda-platform/templates/camunda/constraints.tpl
+++ b/charts/camunda-platform/templates/camunda/constraints.tpl
@@ -4,6 +4,7 @@ A template to handle constraints.
 
 {{/*
 Show a message if Optimize is enabled but identity is disabled
+Optimize requirements: https://docs.camunda.io/docs/reference/supported-environments/#camunda-8-self-managed
 */}}
 
 {{- if (and (.Values.optimize.enabled) (not .Values.identity.enabled))}}
@@ -13,4 +14,3 @@ Show a message if Optimize is enabled but identity is disabled
     -}}
     {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}
-

--- a/charts/camunda-platform/templates/camunda/constraints.tpl
+++ b/charts/camunda-platform/templates/camunda/constraints.tpl
@@ -1,0 +1,16 @@
+{{/*
+A template to handle constraints.
+*/}}
+
+{{/*
+Show a message if Optimize is enabled but identity is disabled
+*/}}
+
+{{- if (and (.Values.optimize.enabled) (not .Values.identity.enabled))}}
+    {{- $errorMessage := printf "Error %s %s"
+        "Optimize may only be used if Identity is enabled."
+        "Please set 'identity.enabled' to true or set 'optimize.enabled' to false"
+    -}}
+    {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
+{{- end }}
+

--- a/charts/camunda-platform/test/unit/camunda/global_deployment_test.go
+++ b/charts/camunda-platform/test/unit/camunda/global_deployment_test.go
@@ -103,6 +103,7 @@ func (s *deploymentTemplateTest) TestContainerShouldNotRenderIdentityIfDisabled(
 	options := &helm.Options{
 		SetValues: map[string]string{
 			"identity.enabled":             "false",
+			"optimize.enabled":             "false",
 			"global.identity.auth.enabled": "false",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),


### PR DESCRIPTION
…ntity

### Which problem does the PR fix?

closes https://github.com/camunda/camunda-platform-helm/issues/1103

> Optimize can only run in C8SM mode with Identity. So we need to exit installation early if Optimize is enabled and Identity is disabled.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

Helm chart should not attempt installation if Optimize is enabled but Identity is disabled. This change will add an error message 

```
Error Optimize may only be used if Identity is enabled. Please set 'identity.enabled' to true or set 'optimize.enabled' to false
```

Example execution
```
helm template --values base-values.yaml \
    --set zeebe-gateway.enabled=false \
    --set optimize.enabled=true \
    --set webModeler.enabled=false \
    --set global.identity.auth.enabled=false \
    --set identity.enabled=false charts/camunda-platform  \
    --debug 
 
install.go:194: [debug] Original chart version: ""
install.go:211: [debug] CHART PATH: /home/jesse/code/camunda-platform-helm/charts/camunda-platform

coalesce.go:220: warning: cannot overwrite table with non table for camunda-platform.console.ingress.tls (map[enabled:false secretName:camunda-platform-console])
coalesce.go:220: warning: cannot overwrite table with non table for camunda-platform.console.ingress.tls (map[enabled:false secretName:camunda-platform-console])

Error: execution error at (camunda-platform/templates/camunda/constraints.tpl:14:54): 
Error Optimize may only be used if Identity is enabled. Please set 'identity.enabled' to true or set 'optimize.enabled' to false
helm.go:84: [debug] execution error at (camunda-platform/templates/camunda/constraints.tpl:14:54): 
Error Optimize may only be used if Identity is enabled. Please set 'identity.enabled' to true or set 'optimize.enabled' to false
```




<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
