### PR TITLE
refactor: mount tasklist-configmap volume on a new path [Backport to 8.2]

### DIFF
--- a/charts/camunda-platform/charts/tasklist/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/tasklist/templates/deployment.yaml
@@ -151,6 +151,9 @@ spec:
         - name: config
           mountPath: /app/resources/application.yml
           subPath: application.yml
+        - name: config
+          mountPath: /usr/local/tasklist/config/application.yml
+          subPath: application.yml
         {{- if .Values.extraVolumeMounts}}
         {{- .Values.extraVolumeMounts | toYaml | nindent 8 }}
         {{- end }}

--- a/charts/camunda-platform/test/unit/tasklist/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/tasklist/golden/deployment.golden.yaml
@@ -103,6 +103,9 @@ spec:
         - name: config
           mountPath: /app/resources/application.yml
           subPath: application.yml
+        - name: config
+          mountPath: /usr/local/tasklist/config/application.yml
+          subPath: application.yml
       volumes:
       - name: config
         configMap:


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?
backports https://github.com/camunda/camunda-platform-helm/pull/1101 to 8.2

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
