### PR TITLE
refactor: Update Tasklist identity env variable names

### DIFF
--- a/charts/camunda-platform/templates/tasklist/deployment.yaml
+++ b/charts/camunda-platform/templates/tasklist/deployment.yaml
@@ -48,15 +48,15 @@ spec:
               value: {{ include "camundaPlatform.authIssuerBackendUrl" . | quote }}
             - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWKSETURI
               value: {{ include "camundaPlatform.authIssuerBackendUrlCertsEndpoint" . | quote }}
-            - name: CAMUNDA_TASKLIST_IDENTITY_BASEURL
+            - name: CAMUNDA_IDENTITY_BASE_URL
               value: {{ include "camundaPlatform.identityURL" . | quote }}
-            - name: CAMUNDA_TASKLIST_IDENTITY_ISSUER_URL
+            - name: CAMUNDA_IDENTITY_ISSUER
               value: {{ include "camundaPlatform.authIssuerUrl" . | quote }}
-            - name: CAMUNDA_TASKLIST_IDENTITY_ISSUER_BACKEND_URL
+            - name: CAMUNDA_IDENTITY_ISSUER_BACKEND_URL
               value: {{ include "camundaPlatform.authIssuerBackendUrl" . | quote }}
-            - name: CAMUNDA_TASKLIST_IDENTITY_CLIENT_ID
+            - name: CAMUNDA_IDENTITY_CLIENT_ID
               value: "tasklist"
-            - name: CAMUNDA_TASKLIST_IDENTITY_CLIENT_SECRET
+            - name: CAMUNDA_IDENTITY_CLIENT_SECRET
               {{- if and .Values.global.identity.auth.tasklist.existingSecret (not (typeIs "string" .Values.global.identity.auth.tasklist.existingSecret)) }}
               valueFrom:
                 secretKeyRef:
@@ -73,7 +73,7 @@ spec:
                   name: {{ include "camundaPlatform.identitySecretName" (dict "context" . "component" "tasklist") }}
                   key: tasklist-secret
               {{- end }}
-            - name: CAMUNDA_TASKLIST_IDENTITY_AUDIENCE
+            - name: CAMUNDA_IDENTITY_AUDIENCE
               value: "tasklist-api"
             - name: CAMUNDA_TASKLIST_IDENTITY_USER_ACCESS_RESTRICTIONS_ENABLED
               value: {{ .Values.tasklist.identity.userAccessRestrictions.enabled | quote }}

--- a/charts/camunda-platform/test/unit/tasklist/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/tasklist/golden/deployment.golden.yaml
@@ -57,20 +57,20 @@ spec:
               value: "http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform"
             - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWKSETURI
               value: "http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/certs"
-            - name: CAMUNDA_TASKLIST_IDENTITY_BASEURL
+            - name: CAMUNDA_IDENTITY_BASE_URL
               value: "http://camunda-platform-test-identity:80"
-            - name: CAMUNDA_TASKLIST_IDENTITY_ISSUER_URL
+            - name: CAMUNDA_IDENTITY_ISSUER
               value: "http://localhost:18080/auth/realms/camunda-platform"
-            - name: CAMUNDA_TASKLIST_IDENTITY_ISSUER_BACKEND_URL
+            - name: CAMUNDA_IDENTITY_ISSUER_BACKEND_URL
               value: "http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform"
-            - name: CAMUNDA_TASKLIST_IDENTITY_CLIENT_ID
+            - name: CAMUNDA_IDENTITY_CLIENT_ID
               value: "tasklist"
-            - name: CAMUNDA_TASKLIST_IDENTITY_CLIENT_SECRET
+            - name: CAMUNDA_IDENTITY_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: camunda-platform-test-tasklist-identity-secret
                   key: tasklist-secret
-            - name: CAMUNDA_TASKLIST_IDENTITY_AUDIENCE
+            - name: CAMUNDA_IDENTITY_AUDIENCE
               value: "tasklist-api"
             - name: CAMUNDA_TASKLIST_IDENTITY_USER_ACCESS_RESTRICTIONS_ENABLED
               value: "true"


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
closes https://github.com/camunda/tasklist/issues/3973
in scope of https://github.com/camunda-cloud/identity/issues/2331 , the Tasklist env variables names used for identity has changed
The old variable names are kept working for backward compatibility. But it is better though to use the official env variable names in the helm charts

> [!WARNING]  
> The new environment variables are applicable for >= 8.4.0 versions so this pull request should be merged after the creation of camunda-platform 8.4.

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
