### PR TITLE
chore: update kind values.yaml with new elasticsearch values

### DIFF
--- a/kind/camunda-platform-core-kind-values.yaml
+++ b/kind/camunda-platform-core-kind-values.yaml
@@ -28,17 +28,9 @@ connectors:
   inbound:
     mode: disabled
 
-# Configure elastic search to make it running for local development
 elasticsearch:
-  replicas: 1
-  # Allow no backup for single node setups
-  clusterHealthCheckParams: "wait_for_status=yellow&timeout=1s"
-
-  # Request smaller persistent volumes.
-  volumeClaimTemplate:
-    accessModes: [ "ReadWriteOnce" ]
-    storageClassName: "standard"
-    resources:
-      requests:
-        storage: 15Gi
-
+  master:
+    replicaCount: 1
+    # Request smaller persistent volumes.
+    persistence:
+      size: 15Gi


### PR DESCRIPTION
### Which problem does the PR fix?

closes #1148 

While the core values.yaml technically runs, most of the options do not actually exist with the new bitnami helm chart version (since we upgraded to elasticsearch 8).  This PR fixes that.

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

Functionally equivalent values.yaml to the old kind/core values.yaml .

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
