### PR TITLE
chore: renamed secrets for github auth token

### DIFF
--- a/.github/workflows/chart-update-readme.yaml
+++ b/.github/workflows/chart-update-readme.yaml
@@ -14,8 +14,8 @@ jobs:
         uses: tibdex/github-app-token@v2
         id: generate-github-token
         with:
-          app_id: ${{ secrets.GH_APP_ID }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          app_id: ${{ secrets.GH_APP_ID_DISTRO_CI }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY_DISTRO_CI }}
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
           token: '${{ steps.generate-github-token.outputs.token }}'

--- a/.github/workflows/chart-update-readme.yaml
+++ b/.github/workflows/chart-update-readme.yaml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'charts/camunda-platform/values.yaml'
+      - '.github/workflows/chart-update-readme.yaml'
 jobs:
   update-readme-metadata:
     runs-on: ubuntu-latest

--- a/.github/workflows/renovate-post-upgrade.yaml
+++ b/.github/workflows/renovate-post-upgrade.yaml
@@ -21,8 +21,8 @@ jobs:
       uses: tibdex/github-app-token@v2
       id: generate-github-token
       with:
-        app_id: ${{ secrets.GH_APP_ID }}
-        private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+        app_id: ${{ secrets.GH_APP_ID_DISTRO_CI }}
+        private_key: ${{ secrets.GH_APP_PRIVATE_KEY_DISTRO_CI }}
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       with:
         token: '${{ steps.generate-github-token.outputs.token }}'


### PR DESCRIPTION
### Which problem does the PR fix?
updated names on github workflows to work with GH_APP_ID_DISTRO_CI 

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
