### PR TITLE
improve(operate): provide an ability to extend Operate config file

### DIFF
--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -169,7 +169,7 @@ For more details, follow the Camunda 8
 
 ### OpenShift
 
-Check out [OpenShift Support](openshift/README.md) to get started with deploying the charts on Red Hat OpenShift. 
+Check out [OpenShift Support](openshift/README.md) to get started with deploying the charts on Red Hat OpenShift.
 
 ## Backporting
 
@@ -378,7 +378,7 @@ To do this you can run the following:
 
  * `--debug enable verbose output`
 
-To generate the resources/manifests without really installing them, you can use: 
+To generate the resources/manifests without really installing them, you can use:
 
  * `--dry-run simulate an install`
 
@@ -719,6 +719,7 @@ Please see the corresponding [release guide](../../RELEASE.md) to find out how t
 | `operate.contextPath`                                       | can be used to make Operate web application works on a custom sub-path. This is mainly used to run Camunda web applications under a single domain.                           | `""`                         |
 | `operate.podAnnotations`                                    | can be used to define extra Operate pod annotations                                                                                                                          | `{}`                         |
 | `operate.podLabels`                                         | can be used to define extra Operate pod labels                                                                                                                               | `{}`                         |
+| `operate.extraConfig`                                       | additional configuration for the Operate. This template will be directly included in the Operate configuration yaml file                                                        | `[]`                         |
 | `operate.logging`                                           | configuration for the Operate logging. This template will be directly included in the Operate configuration yaml file                                                        |                              |
 | `operate.logging.level.ROOT`                                |                                                                                                                                                                              | `INFO`                       |
 | `operate.logging.level.io.camunda.operate`                  |                                                                                                                                                                              | `INFO`                       |

--- a/charts/camunda-platform/templates/operate/configmap.yaml
+++ b/charts/camunda-platform/templates/operate/configmap.yaml
@@ -44,6 +44,9 @@ data:
         ilmEnabled: true
         ilmMinAgeForDeleteArchivedIndices: {{ .Values.operate.retention.minimumAge }}
       {{- end }}
+{{- with .Values.operate.extraConfig }}
+{{ . | toYaml | indent 6 }}
+{{- end }}
     logging:
 {{- with .Values.operate.logging }}
 {{ . | toYaml | indent 6 }}

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -798,6 +798,9 @@ operate:
   ## @param operate.podLabels can be used to define extra Operate pod labels
   podLabels: {}
 
+  ## @extra operate.extraConfig additional configuration for the Operate. This template will be directly included in the Operate configuration yaml file
+  extraConfig: []
+
   ## @extra operate.logging configuration for the Operate logging. This template will be directly included in the Operate configuration yaml file
   ## @param operate.logging.level.ROOT
   ## @param operate.logging.level.io.camunda.operate


### PR DESCRIPTION
### Which problem does the PR fix?


### What's in this PR?

Provide an ability to change default Operate configuration, like add userId, displayName and password:
```
# Operate configuration file

camunda.operate:
  # Set operate userId, displayName and password.
  # If user with <userId> does not exists it will be created.
  # Default: demo/demo/demo
  userId: anUserId
  displayName: nameShownInWebpage
  password: aPassword
  roles:
    - OWNER
    - USER
...
```
using YAML.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
