### PR TITLE
fix: resolve issues with web modeler deployment when using OIDC

### DIFF
--- a/charts/camunda-platform/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform/templates/web-modeler/deployment-restapi.yaml
@@ -34,8 +34,10 @@ spec:
           env:
             - name: JAVA_OPTIONS
               value: "-Xmx1536m"
+            {{- if .Values.identity.enabled }}
             - name: CAMUNDA_IDENTITY_BASEURL
               value: {{ include "webModeler.identityBaseUrl" . | quote }}
+            {{- end }}
             - name: CAMUNDA_IDENTITY_TYPE
               value: {{ include "camundaPlatform.authType" . | quote }}
             - name: CAMUNDA_MODELER_SECURITY_JWT_AUDIENCE_PUBLIC_API

--- a/charts/camunda-platform/templates/web-modeler/deployment-webapp.yaml
+++ b/charts/camunda-platform/templates/web-modeler/deployment-webapp.yaml
@@ -92,8 +92,10 @@ spec:
                 configMapKeyRef:
                   name: {{ include "webModeler.fullname" . }}
                   key: pusher-app-key
+            {{- if .Values.identity.enabled }}
             - name: IDENTITY_BASE_URL
               value: {{ include "webModeler.identityBaseUrl" . | quote }}
+            {{- end }}
             {{- with .Values.webModeler.webapp.env }}
               {{- tpl (toYaml .) $ | nindent 12 }}
             {{- end }}

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -1398,7 +1398,7 @@ optimize:
 identity:
   ## @param identity.enabled if true, the identity deployment and its related resources are deployed via a helm release
   #
-  # Note: Identity is required by Optimize and Web Modeler. If Identity is disabled, both Optimize and Web Modeler will be unusable.
+  # Note: If using Keycloak, Identity is required by Optimize and Web Modeler.
   #       If you need neither Optimize nor Web Modeler, make sure to disable both the Identity authentication and the applications by setting:
   #         global.identity.auth.enabled=false
   #         optimize.enabled=false


### PR DESCRIPTION
### What's in this PR?

When installing the platform via helm using local charts for unrelated reasons I noticed an issue with getting Web Modeler to use Microsoft as the auth provider. 

The Identity component for a first iteration will not have a UI when using something other than Keycloak, therefore the Identity component will not be created and currently leads to an error when resolving the `webModeler.identityBaseUrl` helper.

This PR includes some defensive logic to only set the Identity specific value for Web Modeler when required.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
