### PR TITLE
fix(multi-region failback): add missing newline in start script

### DIFF
--- a/charts/camunda-platform/templates/zeebe/configmap.yaml
+++ b/charts/camunda-platform/templates/zeebe/configmap.yaml
@@ -32,7 +32,8 @@ data:
     then
       trap : TERM INT; sleep infinity & wait
     else
-      exec /usr/local/zeebe/bin/broker    fi
+      exec /usr/local/zeebe/bin/broker
+    fi
 {{- else }}
     exec /usr/local/zeebe/bin/broker
 {{- end }}


### PR DESCRIPTION
### Which problem does the PR fix?

fixes #1247

### What's in this PR?

a missing newline ;-)

### Checklist

I did the same change manually in an actual installation and the brokers started correctly.

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
