### PR TITLE
refactor(console): add zeebe broker to the release configmap

### DIFF
--- a/charts/camunda-platform/templates/camunda/_helpers.tpl
+++ b/charts/camunda-platform/templates/camunda/_helpers.tpl
@@ -311,13 +311,13 @@ Release templates.
 {{- "" }}
   {{- with dict "Release" .Release "Chart" (dict "Name" "identity") "Values" .Values.identity }}
   {{ if .Values.enabled -}}
-  {{- $baseURLInternal := printf "http://%s.%s:%v" (include "identity.fullname" .) .Release.Namespace .Values.service.port -}}
+  {{- $baseURLInternal := printf "http://%s.%s" (include "identity.fullname" .) .Release.Namespace -}}
   - name: Keycloak
     url: {{ $baseURL }}{{ .Values.global.identity.keycloak.contextPath }}
   - name: Identity
     url: {{ $baseURL }}{{ .Values.contextPath }}
-    readiness: {{ printf "%s%s" $baseURLInternal .Values.readinessProbe.probePath }}
-    metrics: {{ printf "%s%s" $baseURLInternal .Values.metrics.prometheus }}
+    readiness: {{ printf "%s:%v%s" $baseURLInternal .Values.service.port .Values.readinessProbe.probePath }}
+    metrics: {{ printf "%s:%v%s" $baseURLInternal .Values.service.metricsPort .Values.metrics.prometheus }}
   {{- end }}
   {{- end }}
 {{- "" }}
@@ -330,11 +330,11 @@ Release templates.
   {{- end }}
 {{- "" }}
   {{ if .Values.optimize.enabled -}}
-  {{- $baseURLInternal := printf "http://%s.%s:%v" (include "optimize.fullname" .) .Release.Namespace .Values.optimize.service.port -}}
+  {{- $baseURLInternal := printf "http://%s.%s" (include "optimize.fullname" .) .Release.Namespace -}}
   - name: Optimize
     url: {{ $baseURL }}{{ .Values.optimize.contextPath }}
-    readiness: {{ printf "%s%s%s" $baseURLInternal .Values.optimize.contextPath .Values.optimize.readinessProbe.probePath }}
-    metrics: {{ printf "%s%s" $baseURLInternal .Values.optimize.metrics.prometheus }}
+    readiness: {{ printf "%s:%v%s%s" $baseURLInternal .Values.optimize.service.port .Values.optimize.contextPath .Values.optimize.readinessProbe.probePath }}
+    metrics: {{ printf "%s:%v%s" $baseURLInternal .Values.optimize.service.managementPort .Values.optimize.metrics.prometheus }}
   {{- end }}
 {{- "" }}
   {{ if .Values.tasklist.enabled -}}
@@ -359,5 +359,9 @@ Release templates.
     url: grpc://{{ tpl .Values.zeebeGateway.ingress.host $ }}
     readiness: {{ printf "%s%s" $baseURLInternal .Values.zeebeGateway.readinessProbe.probePath }}
     metrics: {{ printf "%s%s" $baseURLInternal .Values.zeebeGateway.metrics.prometheus }}
+  {{- $baseURLInternal := printf "http://%s.%s:%v" (include "zeebe.names.broker" . | trimAll "\"") .Release.Namespace .Values.zeebe.service.httpPort }}
+  - name: Zeebe
+    readiness: {{ printf "%s%s" $baseURLInternal .Values.zeebe.readinessProbe.probePath }}
+    metrics: {{ printf "%s%s" $baseURLInternal .Values.zeebe.metrics.prometheus }}
   {{- end }}
 {{- end -}}


### PR DESCRIPTION
### What's in this PR?

Add zeebe broker to the info and fix identity and optimize port.

Related to: https://github.com/camunda/camunda-platform-helm/issues/1223

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?


