### PR TITLE
fix(zeebe-gateway): set correct identity conf env vars for zeebe

### DIFF
--- a/charts/camunda-platform/templates/zeebe-gateway/deployment.yaml
+++ b/charts/camunda-platform/templates/zeebe-gateway/deployment.yaml
@@ -75,7 +75,7 @@ spec:
               value: {{ include "camundaPlatform.authType" . | quote }}
             - name: ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_MODE
               value: "identity"
-            - name: CAMUNDA_IDENTITY_ISSUERBACKENDURL
+            - name: CAMUNDA_IDENTITY_ISSUER_BACKEND_URL
               value: {{ include "camundaPlatform.authIssuerBackendUrl" . | quote }}
             - name: CAMUNDA_IDENTITY_AUDIENCE
               value: {{ include "zeebe.audience" . | quote }}
@@ -85,9 +85,7 @@ spec:
               value: "true"
             - name: ZEEBE_BROKER_GATEWAY_MULTITENANCY_ENABLED
               value: "true"
-            - name: ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_BASEURL
-              value: {{ include "camundaPlatform.identityURL" . | quote }}
-            - name: ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_BASEURL
+            - name: CAMUNDA_IDENTITY_BASE_URL
               value: {{ include "camundaPlatform.identityURL" . | quote }}
             {{- end }}
             {{- with .Values.zeebeGateway.env }}

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/deployment.golden.yaml
@@ -85,7 +85,7 @@ spec:
               value: "KEYCLOAK"
             - name: ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_MODE
               value: "identity"
-            - name: CAMUNDA_IDENTITY_ISSUERBACKENDURL
+            - name: CAMUNDA_IDENTITY_ISSUER_BACKEND_URL
               value: "http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform"
             - name: CAMUNDA_IDENTITY_AUDIENCE
               value: "zeebe-api"


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
closes #1250 

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->
Set the correct names for the Identity configuration environment variables so that they can be correctly picked up by the Zeebe Gateway.
* Replace `ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_IDENTITY_ISSUERBACKENDURL` with `CAMUNDA_IDENTITY_BASE_URL`.
* Replace `CAMUNDA_IDENTITY_ISSUERBACKENDURL` with `CAMUNDA_IDENTITY_ISSUER_BACKEND_URL`
* Update the `deployment.golden.yaml` with the corresponding env var changes.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
