### PR TITLE
fix: decouples renovate from camunda-platform

### DIFF
--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -53,7 +53,7 @@ global:
     ## @param global.image.registry Can be used to set container image registry.
     registry: ""
     ## @param global.image.tag defines the tag / version which should be used in the most of the apps.
-    # renovate: datasource=github-releases depName=camunda/camunda-platform
+    # renovate: datasource=docker depName=camunda/zeebe
     tag: 8.4.1
     ## @param global.image.pullPolicy defines the image pull policy which should be used https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
     pullPolicy: IfNotPresent

--- a/charts/camunda-platform/values/values-latest.yaml
+++ b/charts/camunda-platform/values/values-latest.yaml
@@ -6,7 +6,7 @@ global:
   # https://github.com/camunda/camunda-platform/releases
   # https://hub.docker.com/u/camunda
   image:
-    # renovate: datasource=github-releases depName=camunda/camunda-platform
+    # renovate: datasource=docker depName=camunda/zeebe
     tag: 8.4.1
 
 connectors:

--- a/charts/camunda-platform/values/values-latest.yaml
+++ b/charts/camunda-platform/values/values-latest.yaml
@@ -9,6 +9,27 @@ global:
     # renovate: datasource=docker depName=camunda/zeebe
     tag: 8.4.1
 
+zeebe:
+  # https://github.com/camunda/zeebe/releases
+  # https://hub.docker.com/r/camunda/zeebe
+  image:
+    # renovate: datasource=docker depName=camunda/zeebe
+    tag: 8.4.1
+    
+operate:
+  # https://github.com/camunda/operate/releases
+  # https://hub.docker.com/r/camunda/operate
+  image:
+    # renovate: datasource=docker depName=camunda/operate
+    tag: 8.4.1
+
+tasklist:
+  # https://github.com/camunda/tasklist/blob/master/CHANGELOG.md
+  # https://hub.docker.com/r/camunda/tasklist
+  image:
+    # renovate: datasource=docker depName=camunda/tasklist
+    tag: 8.4.1
+
 connectors:
   # https://hub.docker.com/r/camunda/connectors-bundle/tags
   image:
@@ -16,6 +37,12 @@ connectors:
     tag: 8.4.3
 
 identity:
+  # https://github.com/camunda-cloud/identity/releases
+  # https://hub.docker.com/r/camunda/identity
+  image:
+    # renovate: datasource=docker depName=camunda/identity
+    tag: 8.4.3
+
   keycloak:
     # https://hub.docker.com/r/bitnami/keycloak/tags
     image:

--- a/charts/camunda-platform/values/values-v8.0-eol.yaml
+++ b/charts/camunda-platform/values/values-v8.0-eol.yaml
@@ -6,7 +6,7 @@ global:
   # https://github.com/camunda/camunda-platform/releases
   # https://hub.docker.com/u/camunda
   image:
-    # renovate: datasource=github-releases depName=camunda/camunda-platform
+    # renovate: datasource=docker depName=camunda/zeebe
     tag: 8.0.21
 
 identity:

--- a/charts/camunda-platform/values/values-v8.1.yaml
+++ b/charts/camunda-platform/values/values-v8.1.yaml
@@ -10,6 +10,28 @@ global:
     # renovate: datasource=docker depName=camunda/zeebe
     tag: 8.1.22
 
+zeebe:
+  # https://github.com/camunda/zeebe/releases
+  # https://hub.docker.com/r/camunda/zeebe
+  image:
+    # renovate: datasource=docker depName=camunda/zeebe
+    tag: 8.1.22
+    
+operate:
+  # https://github.com/camunda/operate/releases
+  # https://hub.docker.com/r/camunda/operate
+  image:
+    # renovate: datasource=docker depName=camunda/operate
+    tag: 8.1.22
+
+tasklist:
+  # https://github.com/camunda/tasklist/blob/master/CHANGELOG.md
+  # https://hub.docker.com/r/camunda/tasklist
+  image:
+    # renovate: datasource=docker depName=camunda/tasklist
+    tag: 8.1.22
+
+
 connectors:
   # https://hub.docker.com/r/camunda/connectors-bundle/tags
   image:
@@ -17,6 +39,12 @@ connectors:
     tag: 0.16.1
 
 identity:
+  # https://github.com/camunda-cloud/identity/releases
+  # https://hub.docker.com/r/camunda/identity
+  image:
+    # renovate: datasource=docker depName=camunda/identity
+    tag: 8.1.22
+
   keycloak:
     # https://hub.docker.com/r/bitnami/keycloak/tags
     image:

--- a/charts/camunda-platform/values/values-v8.1.yaml
+++ b/charts/camunda-platform/values/values-v8.1.yaml
@@ -7,7 +7,7 @@ global:
   # https://github.com/camunda/camunda-platform/releases
   # https://hub.docker.com/u/camunda
   image:
-    # renovate: datasource=github-releases depName=camunda/camunda-platform
+    # renovate: datasource=docker depName=camunda/zeebe
     tag: 8.1.22
 
 connectors:

--- a/charts/camunda-platform/values/values-v8.2.yaml
+++ b/charts/camunda-platform/values/values-v8.2.yaml
@@ -7,7 +7,28 @@ global:
   # https://github.com/camunda/camunda-platform/releases
   # https://hub.docker.com/u/camunda
   image:
-    # renovate: datasource=github-releases depName=camunda/camunda-platform
+    # renovate: datasource=docker depName=camunda/zeebe
+    tag: 8.2.20
+
+zeebe:
+  # https://github.com/camunda/zeebe/releases
+  # https://hub.docker.com/r/camunda/zeebe
+  image:
+    # renovate: datasource=docker depName=camunda/zeebe
+    tag: 8.2.20
+    
+operate:
+  # https://github.com/camunda/operate/releases
+  # https://hub.docker.com/r/camunda/operate
+  image:
+    # renovate: datasource=docker depName=camunda/operate
+    tag: 8.2.20
+
+tasklist:
+  # https://github.com/camunda/tasklist/blob/master/CHANGELOG.md
+  # https://hub.docker.com/r/camunda/tasklist
+  image:
+    # renovate: datasource=docker depName=camunda/tasklist
     tag: 8.2.20
 
 connectors:
@@ -17,6 +38,12 @@ connectors:
     tag: 0.23.2
 
 identity:
+  # https://github.com/camunda-cloud/identity/releases
+  # https://hub.docker.com/r/camunda/identity
+  image:
+    # renovate: datasource=docker depName=camunda/identity
+    tag: 8.2.20
+
   keycloak:
     # https://hub.docker.com/r/bitnami/keycloak/tags
     image:

--- a/charts/camunda-platform/values/values-v8.3.yaml
+++ b/charts/camunda-platform/values/values-v8.3.yaml
@@ -10,6 +10,27 @@ global:
     # renovate: datasource=docker depName=camunda/zeebe
     tag: 8.3.5
 
+zeebe:
+  # https://github.com/camunda/zeebe/releases
+  # https://hub.docker.com/r/camunda/zeebe
+  image:
+    # renovate: datasource=docker depName=camunda/zeebe
+    tag: 8.3.5
+    
+operate:
+  # https://github.com/camunda/operate/releases
+  # https://hub.docker.com/r/camunda/operate
+  image:
+    # renovate: datasource=docker depName=camunda/operate
+    tag: 8.3.5
+
+tasklist:
+  # https://github.com/camunda/tasklist/blob/master/CHANGELOG.md
+  # https://hub.docker.com/r/camunda/tasklist
+  image:
+    # renovate: datasource=docker depName=camunda/tasklist
+    tag: 8.3.5
+
 connectors:
   # https://hub.docker.com/r/camunda/connectors-bundle/tags
   image:
@@ -17,6 +38,12 @@ connectors:
     tag: 8.3.6
 
 identity:
+  # https://github.com/camunda-cloud/identity/releases
+  # https://hub.docker.com/r/camunda/identity
+  image:
+    # renovate: datasource=docker depName=camunda/identity
+    tag: 8.3.5
+
   keycloak:
     # https://hub.docker.com/r/bitnami/keycloak/tags
     image:

--- a/charts/camunda-platform/values/values-v8.3.yaml
+++ b/charts/camunda-platform/values/values-v8.3.yaml
@@ -7,7 +7,7 @@ global:
   # https://github.com/camunda/camunda-platform/releases
   # https://hub.docker.com/u/camunda
   image:
-    # renovate: datasource=github-releases depName=camunda/camunda-platform
+    # renovate: datasource=docker depName=camunda/zeebe
     tag: 8.3.5
 
 connectors:


### PR DESCRIPTION
### Which problem does the PR fix?

camunda-platform is a bad source of truth when it comes to application components.  the intention of the camunda-platform repo is soley to provide release notes, and we have done multiple failed releases as result of trying to release something before the release notes properly generated.  This change will make renovate trigger prior to release notes being generated.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
