### PR TITLE
test: fixes username / password for openshift tests

### DIFF
--- a/.github/workflows/dispatch-integration-backport.yaml
+++ b/.github/workflows/dispatch-integration-backport.yaml
@@ -1,0 +1,35 @@
+name: "Dispatch Backport - Integration - Main"
+
+on:
+  workflow_dispatch:
+    inputs:
+      persistent:
+        description: |
+          Keep test deployment after the workflow is done.
+          NOTE: All persistent deployments will be deleted frequently to save costs!
+        required: false
+        default: false
+        type: boolean
+      platforms:
+        description: platform to test on
+        required: false
+        default: gke
+        type: string
+      identifier:
+        description: The unique identifier of used in the deployment hostname.
+        required: true
+        type: string
+      extra-values:
+        description: Pass extra values to the Helm chart.
+        required: false
+        type: string
+jobs:
+  helm-deploy:
+    name: Helm chart Integration Tests
+    uses: ./.github/workflows/test-integration-main.yaml
+    secrets: inherit
+    with:
+      identifier: ${{ github.event.inputs.identifier }}
+      extra-values: ${{ github.event.inputs.extra-values }}
+      platforms: ${{ github.event.inputs.platforms }}
+      persistent: ${{ github.event.inputs.persistent }}

--- a/.github/workflows/dispatch-integration-backport.yaml
+++ b/.github/workflows/dispatch-integration-backport.yaml
@@ -32,4 +32,4 @@ jobs:
       identifier: ${{ github.event.inputs.identifier }}
       extra-values: ${{ github.event.inputs.extra-values }}
       platforms: ${{ github.event.inputs.platforms }}
-      persistent: ${{ github.event.inputs.persistent }}
+      persistent: ${{ github.event.inputs.persistent == 'true' }}

--- a/.github/workflows/dispatch-integration.yaml
+++ b/.github/workflows/dispatch-integration.yaml
@@ -1,0 +1,52 @@
+name: "Dispatch - Integration - Main"
+
+on:
+  workflow_dispatch:
+    inputs:
+      identifier:
+        description: The unique identifier of used in the deployment hostname.
+        required: true
+        type: string
+      git-ref:
+        description: Git ref
+        required: false
+        default: main
+        type: string
+      persistent:
+        description: |
+          Keep test deployment after the workflow is done.
+          NOTE: All persistent deployments will be deleted frequently to save costs!
+        required: false
+        default: false
+        type: boolean
+      platforms:
+        description: platforms
+        default: gke
+        type: string
+      flows:
+        description: flows
+        required: false
+        default: install
+        type: string
+      test-enabled:
+        description: test enabled
+        required: false
+        default: true
+        type: boolean
+      extra-values:
+        description: Pass extra values to the Helm chart.
+        required: false
+        type: string
+jobs:
+  helm-deploy:
+    name: Helm chart Integration Tests
+    uses: ./.github/workflows/test-integration-template.yaml
+    secrets: inherit
+    with:
+      identifier: ${{ github.event.inputs.identifier }}
+      git-ref: ${{ github.event.inputs.git-ref }}
+      persistent: ${{ github.event.inputs.persistent }}
+      platforms: ${{ github.event.inputs.platforms }}
+      flows: ${{ github.event.inputs.flows }}
+      test-enabled: ${{ github.event.inputs.test-enabled }}
+      extra-values: ${{ github.event.inputs.extra-values }}

--- a/.github/workflows/test-integration-main.yaml
+++ b/.github/workflows/test-integration-main.yaml
@@ -67,10 +67,14 @@ jobs:
             workload-identity-provider: DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER
             service-account: DISTRO_CI_GCP_SERVICE_ACCOUNT
           if: ${{ github.event.pull_request.number || contains(inputs.platforms, 'gke') }}
-        - name: OpenShift 4.13
+        - name: OpenShift 4.14
           type: openshift
-          version: 4.13
+          version: 4.14
           platform: rosa
+          secret:
+            server-url: DISTRO_CI_OPENSHIFT_CLUSTER_URL
+            username: DISTRO_CI_OPENSHIFT_CLUSTER_USERNAME
+            password: DISTRO_CI_OPENSHIFT_CLUSTER_PASSWORD
           if: ${{ github.event.pull_request.number || contains(inputs.platforms, 'rosa') }}
         exclude:
         - test:
@@ -91,20 +95,13 @@ jobs:
         cluster-location: ${{ secrets[matrix.test.secret.cluster-location] }}
         workload-identity-provider: ${{ secrets[matrix.test.secret.workload-identity-provider] }}
         service-account: ${{ secrets[matrix.test.secret.service-account] }}
-    - name: Set OpenShift authentication vars
-      if: matrix.test.type == 'openshift'
-      run: |
-        OPENSHIFT_CLUSTER_VERSION="$(echo ${{ matrix.test.version }} | tr -d '.')"
-        echo "OPENSHIFT_CLUSTER_URL=OPENSHIFT_CLUSTER_URL_${OPENSHIFT_CLUSTER_VERSION}" >> $GITHUB_ENV
-        echo "OPENSHIFT_CLUSTER_USERNAME=OPENSHIFT_CLUSTER_USERNAME_${OPENSHIFT_CLUSTER_VERSION}" >> $GITHUB_ENV
-        echo "OPENSHIFT_CLUSTER_PASSWORD=OPENSHIFT_CLUSTER_PASSWORD_${OPENSHIFT_CLUSTER_VERSION}" >> $GITHUB_ENV
     - name: Authenticate to OpenShift
       if: matrix.test.platform == 'rosa'
       uses: redhat-actions/oc-login@v1
       with:
-        openshift_server_url: ${{ secrets[env.DISTRO_CI_OPENSHIFT_CLUSTER_URL] }}
-        openshift_username: ${{ secrets[env.DISTRO_CI_OPENSHIFT_CLUSTER_USERNAME] }}
-        openshift_password: ${{ secrets[env.DISTRO_CI_OPENSHIFT_CLUSTER_PASSWORD] }}
+        openshift_server_url: ${{ secrets[matrix.distro.secret.server-url] }}
+        openshift_username: ${{ secrets[matrix.distro.secret.username] }}
+        openshift_password: ${{ secrets[matrix.distro.secret.password] }}
     - name: Set workflow vars
       id: vars
       uses: ./.github/actions/workflow-vars

--- a/.github/workflows/test-integration-main.yaml
+++ b/.github/workflows/test-integration-main.yaml
@@ -102,9 +102,9 @@ jobs:
       if: matrix.test.platform == 'rosa'
       uses: redhat-actions/oc-login@v1
       with:
-        openshift_server_url: ${{ secrets[env.OPENSHIFT_CLUSTER_URL] }}
-        openshift_username: ${{ secrets[env.OPENSHIFT_CLUSTER_USERNAME] }}
-        openshift_password: ${{ secrets[env.OPENSHIFT_CLUSTER_PASSWORD] }}
+        openshift_server_url: ${{ secrets[env.DISTRO_CI_OPENSHIFT_CLUSTER_URL] }}
+        openshift_username: ${{ secrets[env.DISTRO_CI_OPENSHIFT_CLUSTER_USERNAME] }}
+        openshift_password: ${{ secrets[env.DISTRO_CI_OPENSHIFT_CLUSTER_PASSWORD] }}
     - name: Set workflow vars
       id: vars
       uses: ./.github/actions/workflow-vars

--- a/.github/workflows/test-integration-main.yaml
+++ b/.github/workflows/test-integration-main.yaml
@@ -99,9 +99,9 @@ jobs:
       if: matrix.test.platform == 'rosa'
       uses: redhat-actions/oc-login@v1
       with:
-        openshift_server_url: ${{ secrets[matrix.distro.secret.server-url] }}
-        openshift_username: ${{ secrets[matrix.distro.secret.username] }}
-        openshift_password: ${{ secrets[matrix.distro.secret.password] }}
+        openshift_server_url: ${{ secrets[matrix.test.secret.server-url] }}
+        openshift_username: ${{ secrets[matrix.test.secret.username] }}
+        openshift_password: ${{ secrets[matrix.test.secret.password] }}
     - name: Set workflow vars
       id: vars
       uses: ./.github/actions/workflow-vars


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

Turns out openshift tests are failing because of username/passwords referencing secrets that don't exist.

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
