### PR TITLE
test: adds dispatch workflow to manually trigger a gha workflow

### DIFF
--- a/.github/workflows/dispatch-integration-backport.yaml
+++ b/.github/workflows/dispatch-integration-backport.yaml
@@ -1,0 +1,35 @@
+name: "Dispatch Backport - Integration - Main"
+
+on:
+  workflow_dispatch:
+    inputs:
+      persistent:
+        description: |
+          Keep test deployment after the workflow is done.
+          NOTE: All persistent deployments will be deleted frequently to save costs!
+        required: false
+        default: false
+        type: boolean
+      platforms:
+        description: platform to test on
+        required: false
+        default: gke
+        type: string
+      identifier:
+        description: The unique identifier of used in the deployment hostname.
+        required: true
+        type: string
+      extra-values:
+        description: Pass extra values to the Helm chart.
+        required: false
+        type: string
+jobs:
+  helm-deploy:
+    name: Helm chart Integration Tests
+    uses: ./.github/workflows/test-integration-main.yaml
+    secrets: inherit
+    with:
+      identifier: ${{ github.event.inputs.identifier }}
+      extra-values: ${{ github.event.inputs.extra-values }}
+      platforms: ${{ github.event.inputs.platforms }}
+      persistent: ${{ github.event.inputs.persistent }}

--- a/.github/workflows/dispatch-integration.yaml
+++ b/.github/workflows/dispatch-integration.yaml
@@ -1,0 +1,35 @@
+name: "Dispatch - Integration - Main"
+
+on:
+  workflow_dispatch:
+    inputs:
+      persistent:
+        description: |
+          Keep test deployment after the workflow is done.
+          NOTE: All persistent deployments will be deleted frequently to save costs!
+        required: false
+        default: false
+        type: boolean
+      platforms:
+        description: platform to test on
+        required: false
+        default: gke
+        type: string
+      identifier:
+        description: The unique identifier of used in the deployment hostname.
+        required: true
+        type: string
+      extra-values:
+        description: Pass extra values to the Helm chart.
+        required: false
+        type: string
+jobs:
+  helm-deploy:
+    name: Helm chart Integration Tests
+    uses: ./.github/workflows/test-integration-template.yaml
+    secrets: inherit
+    with:
+      identifier: ${{ github.event.inputs.identifier }}
+      extra-values: ${{ github.event.inputs.extra-values }}
+      platforms: ${{ github.event.inputs.platforms }}
+      persistent: ${{ github.event.inputs.persistent }}

--- a/.github/workflows/dispatch-integration.yaml
+++ b/.github/workflows/dispatch-integration.yaml
@@ -3,6 +3,15 @@ name: "Dispatch - Integration - Main"
 on:
   workflow_dispatch:
     inputs:
+      identifier:
+        description: The unique identifier of used in the deployment hostname.
+        required: true
+        type: string
+      git-ref:
+        description: Git ref
+        required: false
+        default: main
+        type: string
       persistent:
         description: |
           Keep test deployment after the workflow is done.
@@ -11,14 +20,19 @@ on:
         default: false
         type: boolean
       platforms:
-        description: platform to test on
-        required: false
+        description: platforms
         default: gke
         type: string
-      identifier:
-        description: The unique identifier of used in the deployment hostname.
-        required: true
+      flows:
+        description: flows
+        required: false
+        default: install
         type: string
+      test-enabled:
+        description: test enabled
+        required: false
+        default: true
+        type: boolean
       extra-values:
         description: Pass extra values to the Helm chart.
         required: false
@@ -30,6 +44,9 @@ jobs:
     secrets: inherit
     with:
       identifier: ${{ github.event.inputs.identifier }}
-      extra-values: ${{ github.event.inputs.extra-values }}
-      platforms: ${{ github.event.inputs.platforms }}
+      git-ref: ${{ github.event.inputs.git-ref }}
       persistent: ${{ github.event.inputs.persistent }}
+      platforms: ${{ github.event.inputs.platforms }}
+      flows: ${{ github.event.inputs.flows }}
+      test-enabled: ${{ github.event.inputs.test-enabled }}
+      extra-values: ${{ github.event.inputs.extra-values }}


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

This is to allow manually triggering the GHA integration test workflow without needing a PR. also helps with workflows that use pull_request instead of pull_request_target.

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
