### PR TITLE
fix(operate): use overridden JWKS URL if present

### DIFF
--- a/charts/camunda-platform/templates/operate/deployment.yaml
+++ b/charts/camunda-platform/templates/operate/deployment.yaml
@@ -46,6 +46,10 @@ spec:
               value: "identity-auth"
             - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUERURI
               value: {{ include "camundaPlatform.authIssuerBackendUrl" . | quote }}
+            {{- if .Values.global.identity.auth.jwksUrl }}
+            - name: CAMUNDA_OPERATE_USE_SPRING_SECURITY_JWK_URI
+              value: "true"
+            {{- end }}
             - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWKSETURI
               value: {{ include "camundaPlatform.authIssuerBackendUrlCertsEndpoint" . | quote }}
             - name: CAMUNDA_IDENTITY_CLIENT_ID


### PR DESCRIPTION
### Which problem does the PR fix?

#1283 

### What's in this PR?

This PR adds an environment variable that enables Operate to consume JWKS URL from Identity config. See #1283 for more details.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
