### PR TITLE
fix: moves ccsm spring profile outside of conditional

### DIFF
--- a/charts/camunda-platform/templates/optimize/deployment.yaml
+++ b/charts/camunda-platform/templates/optimize/deployment.yaml
@@ -78,9 +78,9 @@ spec:
               value: {{ include "camundaPlatform.elasticsearchHost" . | quote }}
             - name: OPTIMIZE_ELASTICSEARCH_HTTP_PORT
               value: {{ .Values.global.elasticsearch.port | quote }}
-            {{- if .Values.global.identity.auth.enabled }}
             - name: SPRING_PROFILES_ACTIVE
               value: "ccsm"
+            {{- if .Values.global.identity.auth.enabled }}
             - name: CAMUNDA_OPTIMIZE_IDENTITY_REDIRECT_ROOT_URL
               value: {{ tpl .Values.global.identity.auth.optimize.redirectUrl $ | quote }}
             - name: CAMUNDA_IDENTITY_CLIENT_ID


### PR DESCRIPTION
### Which problem does the PR fix?

https://github.com/camunda/camunda-platform-helm/issues/1100

C7 error messages in C8 is pretty confusing.  After this PR, you'll at least get a C8 error message about Optimize not having an issuer url (in situations where you deploy with identity disabled, no oidc configuration, AND optimize enabled).

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

The `SPRING_ACTIVE_PROFILES` is not set to `ccsm` if identity is disabled. This has a consequence of optimize booting into C7 mode. The purpose of this PR is not to get optimize working with identity disabled, it's just to clear up confusion around a confusing error message and possibly prevent issues with persistent data in a situation where optimize booting into C7 mode tries to "migrate" the data backwards.


### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
