### PR TITLE
ci: add test-integration-cleanup-template.yaml

### DIFF
--- a/.github/workflows/test-integration-cleanup-template.yaml
+++ b/.github/workflows/test-integration-cleanup-template.yaml
@@ -1,0 +1,80 @@
+name: "Test - Integration Cleanup - Template"
+
+on:
+  workflow_call:
+    inputs:
+      platforms:
+        default: gke
+        type: string
+      github-run-id:
+        description: |
+          The GitHub Action run that deployed Helm chart
+          which will be used to delete the deployment namespace.
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.github-run-id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup:
+    name: Cleanup Namespace
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      deployments: write
+    strategy:
+      fail-fast: false
+      matrix:
+        distro:
+        - name: Kubernetes 1.27
+          type: kubernetes
+          platform: gke
+          secret:
+            cluster-name: DISTRO_CI_GCP_GKE_CLUSTER_NAME
+            cluster-location: DISTRO_CI_GCP_GKE_CLUSTER_LOCATION
+            workload-identity-provider: DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER
+            service-account: DISTRO_CI_GCP_SERVICE_ACCOUNT
+          if: ${{ contains(inputs.platforms, 'gke') }}
+        - name: OpenShift 4.14
+          type: openshift
+          version: 4.14
+          platform: rosa
+          secret:
+            server-url: DISTRO_CI_OPENSHIFT_CLUSTER_URL
+            username: DISTRO_CI_OPENSHIFT_CLUSTER_USERNAME
+            password: DISTRO_CI_OPENSHIFT_CLUSTER_PASSWORD
+          if: ${{ contains(inputs.platforms, 'rosa') }}
+        exclude:
+        - distro:
+            if: false
+    steps:
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      with:
+        # This is needed to load repo GH composite actions if the workflow triggered by workflow_call.
+        repository: camunda/camunda-platform-helm
+    # TODO: Later, find a way to abstract the auth for different platforms.
+    - name: Authenticate to GKE
+      if: matrix.distro.platform == 'gke'
+      uses: ./.github/actions/gke-login
+      with:
+        cluster-name: ${{ secrets[matrix.distro.secret.cluster-name] }}
+        cluster-location: ${{ secrets[matrix.distro.secret.cluster-location] }}
+        workload-identity-provider: ${{ secrets[matrix.distro.secret.workload-identity-provider] }}
+        service-account: ${{ secrets[matrix.distro.secret.service-account] }}
+    - name: Authenticate to OpenShift
+      if: matrix.distro.platform == 'rosa'
+      uses: redhat-actions/oc-login@56d1810bbb29d7a0ea9783f8b3ee790c15de7bde # v1
+      with:
+        openshift_server_url: ${{ secrets[matrix.distro.secret.server-url] }}
+        openshift_username: ${{ secrets[matrix.distro.secret.username] }}
+        openshift_password: ${{ secrets[matrix.distro.secret.password] }}
+    - name: Delete Namespace on ${{ matrix.distro.name }}
+      run: |
+        kubectl delete ns --ignore-not-found=true \
+          -l github-run-id="${{ inputs.github-run-id }}"


### PR DESCRIPTION
Fixes: https://github.com/camunda/camunda-platform-helm/issues/1348

### What's in this PR?

Added a new GHA workflow that allows to deletion of the Helm deployment namespace based on the GHA run ID which is already used as a label for the namespace.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
