### PR TITLE
test: disable prometheus tests until prometheus Completed issue is re…

### DIFF
--- a/charts/camunda-platform/test/integration/testsuites/core/testsuites/core.yaml
+++ b/charts/camunda-platform/test/integration/testsuites/core/testsuites/core.yaml
@@ -269,23 +269,23 @@ testcases:
     assertions:
     - result.statuscode ShouldEqual 200
 
-- name: TEST - Check ServiceMonitor
-  steps:
-  - name: Check prometheus could query containers
-    type: http
-    method: GET
-    url: "http://{{ .coreVars.baseURLs.prometheus }}/api/v1/query?query=system_cpu_count%7Bnamespace%3D%22{{ .coreVars.testNamespace }}%22%7D"
-    retry: 4
-    delay: 15
-    # info: |
-    #   = Request Body: {{ .result.request.body }}
-    #   = Response Body: {{ .result.body }}
-    assertions:
-    - result.body ShouldContainSubstring connectors
-    - result.body ShouldContainSubstring identity
-    - result.body ShouldContainSubstring operate
-    - result.body ShouldContainSubstring optimize
-    - result.body ShouldContainSubstring tasklist
-    - result.body ShouldContainSubstring web-modeler-restapi
-    - result.body ShouldContainSubstring zeebe
-    - result.body ShouldContainSubstring zeebe-gateway
+# - name: TEST - Check ServiceMonitor
+#   steps:
+#   - name: Check prometheus could query containers
+#     type: http
+#     method: GET
+#     url: "http://{{ .coreVars.baseURLs.prometheus }}/api/v1/query?query=system_cpu_count%7Bnamespace%3D%22{{ .coreVars.testNamespace }}%22%7D"
+#     retry: 4
+#     delay: 15
+#     # info: |
+#     #   = Request Body: {{ .result.request.body }}
+#     #   = Response Body: {{ .result.body }}
+#     assertions:
+#     - result.body ShouldContainSubstring connectors
+#     - result.body ShouldContainSubstring identity
+#     - result.body ShouldContainSubstring operate
+#     - result.body ShouldContainSubstring optimize
+#     - result.body ShouldContainSubstring tasklist
+#     - result.body ShouldContainSubstring web-modeler-restapi
+#     - result.body ShouldContainSubstring zeebe
+#     - result.body ShouldContainSubstring zeebe-gateway


### PR DESCRIPTION
…solved

### Which problem does the PR fix?

Disables the prometheus test due to this bug:
https://github.com/prometheus-community/helm-charts/issues/4166

We will re-enable the prometheus test when the bug is fixed.  This issue has caused a lot of integration tests to fail intermittently and need to be restarted.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

Disables the prometheus test

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
