### PR TITLE
test: set console to false for openshift test

### DIFF
--- a/charts/camunda-platform/test/integration/scenarios/chart-full-setup/values-integration-test-ingress.yaml
+++ b/charts/camunda-platform/test/integration/scenarios/chart-full-setup/values-integration-test-ingress.yaml
@@ -74,7 +74,7 @@ zeebe-gateway:
       external-dns.alpha.kubernetes.io/ttl: "60"
 
 console:
-  enabled: true
+  enabled: false
   contextPath: "/"
   image:
     pullSecrets:


### PR DESCRIPTION
### Which problem does the PR fix?
Openshift test are failing due to console being enabled.
<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?
Setting console to disabled. 
<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
