### PR TITLE
chore: refactor initialUserId to be initialClaimName and initialClaimValue to match Identity code

### DIFF
--- a/charts/camunda-platform/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform/charts/identity/templates/deployment.yaml
@@ -241,8 +241,10 @@ spec:
               value: {{ include "camundaPlatform.authIssuerUrl" . | quote }}
             - name: CAMUNDA_IDENTITY_ISSUER_BACKEND_URL
               value: {{ include "camundaPlatform.authIssuerBackendUrl" . | quote }}
-            - name: IDENTITY_INITIAL_USER_ID
-              value: {{ .Values.global.identity.auth.identity.initialUserId }}
+            - name: IDENTITY_INITIAL_CLAIM_NAME
+              value: {{ .Values.global.identity.auth.identity.initialClaimName }}
+            - name: IDENTITY_INITIAL_CLAIM_VALUE
+              value: {{ .Values.global.identity.auth.identity.initialClaimValue }}
             - name: CAMUNDA_IDENTITY_CLIENT_ID
               value: {{ include "identity.authClientId" . | quote }}
             - name: CAMUNDA_IDENTITY_CLIENT_SECRET

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -183,9 +183,11 @@ global:
         # Should be publicly accessible, the default value works if a port-forward to Identity is created to 8085.
         # Can be overwritten if ingress is in use and an external IP is available.
         redirectUrl: "http://localhost:8085"
-        ## @param global.identity.auth.identity.initialUserId defines the initial user id, which is used by Identity to configure mapping rules for the
-        # initial user.
-        initialUserId: ""
+        ## @param global.identity.auth.identity.initialClaimName defines the initial claim name, which is used by Identity to configure initial mapping rules,
+        # defaults to "oid".
+        initialClaimName: "oid"
+        ## @param global.identity.auth.identity.initialClaimValue defines the initial claim value, which is used by Identity to configure initial mapping rules.
+        initialClaimValue:
 
       ## @extra global.identity.auth.operate configuration to configure Operate authentication specifics on global level, which can be accessed by other sub-charts
       operate:


### PR DESCRIPTION
### Which problem does the PR fix?

After the merge of https://github.com/camunda-cloud/identity/pull/2632 the env vars need to be updated to reflect the improved method of mapping rule initialization in Identity.

### What's in this PR?

In this PR we remove the `initialUserId` variable and introduce `initialClaimName` and `initialClaimValue`

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
