### PR TITLE
fix: downgrade elasticsearch due to incompatibility with v8.9.2 elast…

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -66,6 +66,12 @@
       "matchPackageNames": ["bitnami/elasticsearch"],
       "allowedVersions": "~8.9.0"
     },
+    {
+      // Disable helm chart upgrades from bitnami/elasticsearch
+      "matchPackageNames": ["elasticsearch"],
+      "matchPaths": ["charts/camunda-platform/Chart.yaml"],
+      "enabled": false
+    },
     // Limit tools and libs versions to the actual Distro CI Kubernetes cluster.
     {
       "matchPackagePatterns": ["kubectl"],

--- a/charts/camunda-platform/Chart.yaml
+++ b/charts/camunda-platform/Chart.yaml
@@ -34,7 +34,7 @@ dependencies:
   # Dependency charts.
   - name: elasticsearch
     repository: "oci://registry-1.docker.io/bitnamicharts"
-    version: 19.21.0
+    version: 19.19.4
     condition: "elasticsearch.enabled"
   - name: postgresql
     repository: https://charts.bitnami.com/bitnami

--- a/charts/camunda-platform/templates/camunda/_helpers.tpl
+++ b/charts/camunda-platform/templates/camunda/_helpers.tpl
@@ -437,7 +437,7 @@ Release templates.
   - name: Console
     id: console
     version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.console) }}
-    url: {{ include "camundaPlatform.consoleExternalURL" . }}
+    url: {{- include "camundaPlatform.consoleExternalURL" . }}
     readiness: {{ printf "%s%s" $baseURLInternal .Values.console.readinessProbe.probePath }}
     metrics: {{ printf "%s%s" $baseURLInternal .Values.console.metrics.prometheus }}
   {{- end }}
@@ -446,11 +446,11 @@ Release templates.
   - name: Keycloak
     id: keycloak
     version: {{ .Values.identity.keycloak.image.tag }}
-    url: {{ include "camundaPlatform.keycloakExternalURL" . }}
+    url: {{- include "camundaPlatform.keycloakExternalURL" . }}
   - name: Identity
     id: identity
     version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.identity) }}
-    url: {{ include "camundaPlatform.identityExternalURL" . }}
+    url: {{- include "camundaPlatform.identityExternalURL" . }}
     readiness: {{ printf "%s%s" $baseURLInternal .Values.identity.readinessProbe.probePath }}
     metrics: {{ printf "%s%s" $baseURLInternal .Values.identity.metrics.prometheus }}
   {{- end }}
@@ -460,7 +460,7 @@ Release templates.
   - name: Operate
     id: operate
     version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.operate) }}
-    url: {{ include "camundaPlatform.operateExternalURL" . }}
+    url: {{- include "camundaPlatform.operateExternalURL" . }}
     readiness: {{ printf "%s%s%s" $baseURLInternal .Values.operate.contextPath .Values.operate.readinessProbe.probePath }}
     metrics: {{ printf "%s%s%s" $baseURLInternal .Values.operate.contextPath .Values.operate.metrics.prometheus }}
   {{- end }}
@@ -470,7 +470,7 @@ Release templates.
   - name: Optimize
     id: optimize
     version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.optimize) }}
-    url: {{ include "camundaPlatform.optimizeExternalURL" . }}
+    url: {{- include "camundaPlatform.optimizeExternalURL" . }}
     readiness: {{ printf "%s:%v%s%s" $baseURLInternal .Values.optimize.service.port .Values.optimize.contextPath .Values.optimize.readinessProbe.probePath }}
     metrics: {{ printf "%s:%v%s" $baseURLInternal .Values.optimize.service.managementPort .Values.optimize.metrics.prometheus }}
   {{- end }}
@@ -480,7 +480,7 @@ Release templates.
   - name: Tasklist
     id: tasklist
     version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.tasklist) }}
-    url: {{ include "camundaPlatform.tasklistExternalURL" . }}
+    url: {{- include "camundaPlatform.tasklistExternalURL" . }}
     readiness: {{ printf "%s%s%s" $baseURLInternal .Values.tasklist.contextPath .Values.tasklist.readinessProbe.probePath }}
     metrics: {{ printf "%s%s%s" $baseURLInternal .Values.tasklist.contextPath .Values.tasklist.metrics.prometheus }}
   {{- end }}
@@ -490,7 +490,7 @@ Release templates.
   - name: WebModeler WebApp
     id: webModelerWebApp
     version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.webModeler) }}
-    url: {{ include "camundaPlatform.webModelerWebAppExternalURL" . }}
+    url: {{- include "camundaPlatform.webModelerWebAppExternalURL" . }}
     readiness: {{ printf "%s%s" $baseURLInternal  .Values.webModeler.webapp.readinessProbe.probePath }}
     metrics: {{ printf "%s%s" $baseURLInternal .Values.webModeler.webapp.metrics.prometheus }}
   {{- end }}

--- a/charts/camunda-platform/test/unit/connectors/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/connectors/golden/deployment.golden.yaml
@@ -41,7 +41,7 @@ spec:
         []
       containers:
         - name: connectors
-          image: camunda/connectors-bundle:8.4.4
+          image: camunda/connectors-bundle:8.4.5
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/camunda-platform/test/unit/console/golden/configmap.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/configmap.golden.yaml
@@ -27,35 +27,35 @@ data:
             - name: Console
               id: console
               version: SNAPSHOT
-              url: 
+              url:
               readiness: http://camunda-platform-test-console.camunda-platform:9100/health/readiness
               metrics: http://camunda-platform-test-console.camunda-platform:9100/prometheus
             - name: Keycloak
               id: keycloak
               version: 22.0.5
-              url: http:///auth
+              url:http:///auth
             - name: Identity
               id: identity
               version: 8.4.4
-              url: 
+              url:
               readiness: http://camunda-platform-test.camunda-platform:82/actuator/health
               metrics: http://camunda-platform-test.camunda-platform:82/actuator/prometheus
             - name: Operate
               id: operate
               version: 8.4.4
-              url: 
+              url:
               readiness: http://camunda-platform-test-operate.camunda-platform:80/actuator/health/readiness
               metrics: http://camunda-platform-test-operate.camunda-platform:80/actuator/prometheus
             - name: Optimize
               id: optimize
               version: 8.4.1
-              url: 
+              url:
               readiness: http://camunda-platform-test-optimize.camunda-platform:80/api/readyz
               metrics: http://camunda-platform-test-optimize.camunda-platform:8092/actuator/prometheus
             - name: Tasklist
               id: tasklist
               version: 8.4.4
-              url: 
+              url:
               readiness: http://camunda-platform-test-tasklist.camunda-platform:80/actuator/health/readiness
               metrics: http://camunda-platform-test-tasklist.camunda-platform:80/actuator/prometheus
             - name: Zeebe Gateway

--- a/charts/camunda-platform/test/unit/web-modeler/golden/configmap-shared.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/configmap-shared.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.2"
+    app.kubernetes.io/version: "8.4.3"
     app.kubernetes.io/component: web-modeler
   annotations:
     {}

--- a/charts/camunda-platform/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.2"
+    app.kubernetes.io/version: "8.4.3"
     app.kubernetes.io/component: restapi
   annotations:
     {}
@@ -32,7 +32,7 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "8.4.2"
+        app.kubernetes.io/version: "8.4.3"
         app.kubernetes.io/component: restapi
     spec:
       imagePullSecrets:
@@ -41,7 +41,7 @@ spec:
         []
       containers:
         - name: web-modeler-restapi
-          image: "registry.camunda.cloud/web-modeler-ee/modeler-restapi:8.4.2"
+          image: "registry.camunda.cloud/web-modeler-ee/modeler-restapi:8.4.3"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/camunda-platform/test/unit/web-modeler/golden/deployment-webapp.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/deployment-webapp.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.2"
+    app.kubernetes.io/version: "8.4.3"
     app.kubernetes.io/component: webapp
   annotations:
     {}
@@ -32,7 +32,7 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "8.4.2"
+        app.kubernetes.io/version: "8.4.3"
         app.kubernetes.io/component: webapp
     spec:
       imagePullSecrets:
@@ -41,7 +41,7 @@ spec:
         []
       containers:
         - name: web-modeler-webapp
-          image: "registry.camunda.cloud/web-modeler-ee/modeler-webapp:8.4.2"
+          image: "registry.camunda.cloud/web-modeler-ee/modeler-webapp:8.4.3"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/camunda-platform/test/unit/web-modeler/golden/deployment-websockets.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/deployment-websockets.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.2"
+    app.kubernetes.io/version: "8.4.3"
     app.kubernetes.io/component: websockets
   annotations:
     {}
@@ -32,7 +32,7 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "8.4.2"
+        app.kubernetes.io/version: "8.4.3"
         app.kubernetes.io/component: websockets
     spec:
       imagePullSecrets:
@@ -41,7 +41,7 @@ spec:
         []
       containers:
         - name: web-modeler-websockets
-          image: "registry.camunda.cloud/web-modeler-ee/modeler-websockets:8.4.2"
+          image: "registry.camunda.cloud/web-modeler-ee/modeler-websockets:8.4.3"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/camunda-platform/test/unit/web-modeler/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/ingress-all-enabled.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.2"
+    app.kubernetes.io/version: "8.4.3"
     app.kubernetes.io/component: web-modeler
   annotations:
     ingress.kubernetes.io/rewrite-target: /

--- a/charts/camunda-platform/test/unit/web-modeler/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/ingress.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.2"
+    app.kubernetes.io/version: "8.4.3"
     app.kubernetes.io/component: web-modeler
   annotations:
     ingress.kubernetes.io/rewrite-target: /

--- a/charts/camunda-platform/test/unit/web-modeler/golden/secret-shared.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/secret-shared.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.2"
+    app.kubernetes.io/version: "8.4.3"
     app.kubernetes.io/component: web-modeler
   annotations:
     {}

--- a/charts/camunda-platform/test/unit/web-modeler/golden/service-restapi.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/service-restapi.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.2"
+    app.kubernetes.io/version: "8.4.3"
     app.kubernetes.io/component: restapi
   annotations:
 spec:

--- a/charts/camunda-platform/test/unit/web-modeler/golden/service-webapp.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/service-webapp.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.2"
+    app.kubernetes.io/version: "8.4.3"
     app.kubernetes.io/component: webapp
   annotations:
 spec:

--- a/charts/camunda-platform/test/unit/web-modeler/golden/service-websockets.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/service-websockets.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.2"
+    app.kubernetes.io/version: "8.4.3"
     app.kubernetes.io/component: websockets
   annotations:
 spec:

--- a/charts/camunda-platform/test/unit/web-modeler/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/serviceaccount.golden.yaml
@@ -10,5 +10,5 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.2"
+    app.kubernetes.io/version: "8.4.3"
     app.kubernetes.io/component: web-modeler


### PR DESCRIPTION
…icsearch image

### Which problem does the PR fix?

v19.20.0 of the bitnami elasticsearch helm chart breaks compatibility with v8.9.2 of elasticsearch. This PR undoes the upgrade.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
https://github.com/camunda/camunda-platform-helm/issues/1411
https://github.com/camunda/camunda-platform-helm/issues/1410

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
