### PR TITLE
fix(console): whitespace issue in configmap

### DIFF
--- a/.github/config/yamllint.yaml
+++ b/.github/config/yamllint.yaml
@@ -33,6 +33,6 @@ rules:
   new-line-at-end-of-file: disable
   new-lines:
     type: unix
-  trailing-spaces: enable
+  trailing-spaces: disable
   truthy:
     level: warning

--- a/charts/camunda-platform/templates/camunda/_helpers.tpl
+++ b/charts/camunda-platform/templates/camunda/_helpers.tpl
@@ -437,7 +437,7 @@ Release templates.
   - name: Console
     id: console
     version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.console) }}
-    url: {{- include "camundaPlatform.consoleExternalURL" . }}
+    url: {{ include "camundaPlatform.consoleExternalURL" . }}
     readiness: {{ printf "%s%s" $baseURLInternal .Values.console.readinessProbe.probePath }}
     metrics: {{ printf "%s%s" $baseURLInternal .Values.console.metrics.prometheus }}
   {{- end }}
@@ -446,11 +446,11 @@ Release templates.
   - name: Keycloak
     id: keycloak
     version: {{ .Values.identity.keycloak.image.tag }}
-    url: {{- include "camundaPlatform.keycloakExternalURL" . }}
+    url: {{ include "camundaPlatform.keycloakExternalURL" . }}
   - name: Identity
     id: identity
     version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.identity) }}
-    url: {{- include "camundaPlatform.identityExternalURL" . }}
+    url: {{ include "camundaPlatform.identityExternalURL" . }}
     readiness: {{ printf "%s%s" $baseURLInternal .Values.identity.readinessProbe.probePath }}
     metrics: {{ printf "%s%s" $baseURLInternal .Values.identity.metrics.prometheus }}
   {{- end }}
@@ -460,7 +460,7 @@ Release templates.
   - name: Operate
     id: operate
     version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.operate) }}
-    url: {{- include "camundaPlatform.operateExternalURL" . }}
+    url: {{ include "camundaPlatform.operateExternalURL" . }}
     readiness: {{ printf "%s%s%s" $baseURLInternal .Values.operate.contextPath .Values.operate.readinessProbe.probePath }}
     metrics: {{ printf "%s%s%s" $baseURLInternal .Values.operate.contextPath .Values.operate.metrics.prometheus }}
   {{- end }}
@@ -470,7 +470,7 @@ Release templates.
   - name: Optimize
     id: optimize
     version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.optimize) }}
-    url: {{- include "camundaPlatform.optimizeExternalURL" . }}
+    url: {{ include "camundaPlatform.optimizeExternalURL" . }}
     readiness: {{ printf "%s:%v%s%s" $baseURLInternal .Values.optimize.service.port .Values.optimize.contextPath .Values.optimize.readinessProbe.probePath }}
     metrics: {{ printf "%s:%v%s" $baseURLInternal .Values.optimize.service.managementPort .Values.optimize.metrics.prometheus }}
   {{- end }}
@@ -480,7 +480,7 @@ Release templates.
   - name: Tasklist
     id: tasklist
     version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.tasklist) }}
-    url: {{- include "camundaPlatform.tasklistExternalURL" . }}
+    url: {{ include "camundaPlatform.tasklistExternalURL" . }}
     readiness: {{ printf "%s%s%s" $baseURLInternal .Values.tasklist.contextPath .Values.tasklist.readinessProbe.probePath }}
     metrics: {{ printf "%s%s%s" $baseURLInternal .Values.tasklist.contextPath .Values.tasklist.metrics.prometheus }}
   {{- end }}
@@ -490,7 +490,7 @@ Release templates.
   - name: WebModeler WebApp
     id: webModelerWebApp
     version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.webModeler) }}
-    url: {{- include "camundaPlatform.webModelerWebAppExternalURL" . }}
+    url: {{ include "camundaPlatform.webModelerWebAppExternalURL" . }}
     readiness: {{ printf "%s%s" $baseURLInternal  .Values.webModeler.webapp.readinessProbe.probePath }}
     metrics: {{ printf "%s%s" $baseURLInternal .Values.webModeler.webapp.metrics.prometheus }}
   {{- end }}

--- a/charts/camunda-platform/test/unit/console/golden/configmap.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/configmap.golden.yaml
@@ -27,35 +27,35 @@ data:
             - name: Console
               id: console
               version: SNAPSHOT
-              url:
+              url: 
               readiness: http://camunda-platform-test-console.camunda-platform:9100/health/readiness
               metrics: http://camunda-platform-test-console.camunda-platform:9100/prometheus
             - name: Keycloak
               id: keycloak
               version: 22.0.5
-              url:http:///auth
+              url: http:///auth
             - name: Identity
               id: identity
               version: 8.4.4
-              url:
+              url: 
               readiness: http://camunda-platform-test.camunda-platform:82/actuator/health
               metrics: http://camunda-platform-test.camunda-platform:82/actuator/prometheus
             - name: Operate
               id: operate
               version: 8.4.4
-              url:
+              url: 
               readiness: http://camunda-platform-test-operate.camunda-platform:80/actuator/health/readiness
               metrics: http://camunda-platform-test-operate.camunda-platform:80/actuator/prometheus
             - name: Optimize
               id: optimize
               version: 8.4.2
-              url:
+              url: 
               readiness: http://camunda-platform-test-optimize.camunda-platform:80/api/readyz
               metrics: http://camunda-platform-test-optimize.camunda-platform:8092/actuator/prometheus
             - name: Tasklist
               id: tasklist
               version: 8.4.4
-              url:
+              url: 
               readiness: http://camunda-platform-test-tasklist.camunda-platform:80/actuator/health/readiness
               metrics: http://camunda-platform-test-tasklist.camunda-platform:80/actuator/prometheus
             - name: Zeebe Gateway


### PR DESCRIPTION
### Which problem does the PR fix?

Console has issues because of a change I made recently  in hopes of fixing a linting error :sadpanda:

This PR will undo that change.

in the console configmap, sometimes the url part will remove the preceding whitespace like this:
```
url:https://optimize.jlscode.com
```
instead of 
```
url: https://optimize.jlscode.com
```

And the reason we tried to remove that whitespace was because it threw a linting error.

Part of this PR is removing the trailing-whitespace linting rule since it'll fail.  

I considered doing some special logic in helm to include the whitespace conditionally, however, that would look uglier than just having the whitespace unnecessarily.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
