### PR TITLE
Release Camunda Platform Helm Chart v8.3.10

### DIFF
--- a/charts/camunda-platform/Chart.yaml
+++ b/charts/camunda-platform/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: camunda-platform
-version: 8.3.9
+version: 8.3.10
 appVersion: 8.3.x
 description: |
   Camunda 8 Self-Managed Helm charts.
@@ -20,7 +20,7 @@ keywords:
 dependencies:
   # Camunda charts.
   - name: identity
-    version: 8.3.9
+    version: 8.3.10
     condition: "identity.enabled"
     import-values:
       # NOTE: This is used to share Identity image details with its subchart Keycloak.

--- a/charts/camunda-platform/RELEASE-NOTES.md
+++ b/charts/camunda-platform/RELEASE-NOTES.md
@@ -2,20 +2,16 @@ The changelog is automatically generated using [git-chglog](https://github.com/g
 and it follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
 
 
-<a name="camunda-platform-8.3.9"></a>
-## [camunda-platform-8.3.9](https://github.com/camunda/camunda-platform-helm/compare/camunda-platform-8.3.8...camunda-platform-8.3.9) (2024-03-08)
-
-### Reverts
-
-* Release Camunda Platform Helm Chart v8.3.9 ([#1415](https://github.com/camunda/camunda-platform-helm/issues/1415))
+<a name="camunda-platform-8.3.10"></a>
+## [camunda-platform-8.3.10](https://github.com/camunda/camunda-platform-helm/compare/camunda-platform-8.3.9...camunda-platform-8.3.10) (2024-03-12)
 
 ### Verification
 
 To verify integrity of the Helm chart using [Cosign](https://docs.sigstore.dev/signing/quickstart/):
 
 ```shell
-cosign verify-blob camunda-platform-8.3.9.tgz \
-  --bundle camunda-platform-8.3.9.cosign.bundle \
+cosign verify-blob camunda-platform-8.3.10.tgz \
+  --bundle camunda-platform-8.3.10.cosign.bundle \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
   --certificate-identity "https://github.com/_GITHUB_WORKFLOW_REF_"
 ```

--- a/charts/camunda-platform/RELEASE-NOTES.md
+++ b/charts/camunda-platform/RELEASE-NOTES.md
@@ -5,6 +5,10 @@ and it follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.
 <a name="camunda-platform-8.3.10"></a>
 ## [camunda-platform-8.3.10](https://github.com/camunda/camunda-platform-helm/compare/camunda-platform-8.3.9...camunda-platform-8.3.10) (2024-03-12)
 
+### Fix
+
+* multiregion: add missing newline in start script ([#1436](https://github.com/camunda/camunda-platform-helm/pull/1436))
+
 ### Verification
 
 To verify integrity of the Helm chart using [Cosign](https://docs.sigstore.dev/signing/quickstart/):

--- a/charts/camunda-platform/charts/identity/Chart.yaml
+++ b/charts/camunda-platform/charts/identity/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Identity Helm Chart for Kubernetes
 name: identity
-version: 8.3.9
+version: 8.3.10
 type: application
 icon: https://helm.camunda.io/imgs/camunda.svg
 dependencies:

--- a/charts/camunda-platform/test/unit/identity/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/deployment.golden.yaml
@@ -35,7 +35,7 @@ spec:
         app.kubernetes.io/version: "8.3.9"
         app.kubernetes.io/component: identity
       annotations:
-        checksum/configmap-env-vars: dc5a7e53601346c61971db048d5abb3993e588e4ba12610a256f5adb93d269c0
+        checksum/configmap-env-vars: e5dea65d6f33042cdec01b230b010d055ae4c7efc7a0d8d8c02d3ac0d09ff94f
     spec:
       imagePullSecrets:
         []

--- a/charts/camunda-platform/test/unit/operate/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/operate/golden/deployment.golden.yaml
@@ -35,7 +35,7 @@ spec:
         app.kubernetes.io/version: "8.3.9"
         app.kubernetes.io/component: operate
       annotations:
-        checksum/config: 0b2ef1c7afd7a1728f9a3d3bb99f9359085900ec0181b66e217a28dbd002f379
+        checksum/config: 7ebf677d03a9580b12a479716b22814df0eff3e9947c5217999c622f882d170e
     spec:
       imagePullSecrets:
         []

--- a/charts/camunda-platform/test/unit/tasklist/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/tasklist/golden/deployment.golden.yaml
@@ -35,7 +35,7 @@ spec:
         app.kubernetes.io/version: "8.3.9"
         app.kubernetes.io/component: tasklist
       annotations:
-        checksum/config: fb8b027bb369163f9a8c7c53a7f9e63a5abff80e913a99db2dc8ea611d521827
+        checksum/config: ccda394e69a61ff812cfafdb4eaf9c5e0b5dc0f897c85004da46cfa938ac1158
     spec:
       imagePullSecrets:
         []


### PR DESCRIPTION
**Before opening the PR:**

- [x] Run `make release.chores`
- [x] Create a PR with the printed URL
- [x] [Trigger Renovate](https://developer.mend.io/github/camunda/camunda-platform-helm) to ensure that all deps are updated (to avoid any delayed sync from Renovate service).

**After opening the PR:**

- [x] Take a final look at the release commits (version bump and release notes)
- [ ] Make sure that all checks in the PR passed
- [x] If everything in place, add `release` label to the PR
- [ ] Follow up the release workflow and make sure it succeeded (double-check the [releases page](https://github.com/camunda/camunda-platform-helm/releases))

If the release is a minor version bump (e.g. from 8.2.x to 8.3.0):
- [ ] Make sure the regression test matrix is updated: located at [.github/workflows/test-regression.yaml](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/test-regression.yaml#L33-L36)
