### PR TITLE
refactor: upgrade elasticsearch from 8.9 to 8.12

### DIFF
--- a/charts/camunda-platform/Chart.yaml
+++ b/charts/camunda-platform/Chart.yaml
@@ -29,17 +29,18 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     version: 12.x.x
     condition: "identityPostgresql.enabled"
-  # Shared Dependencies.
-  - name: elasticsearch
-    repository: "oci://registry-1.docker.io/bitnamicharts"
-    version: 19.19.4
-    condition: "elasticsearch.enabled"
+  # WebModeler Dependencies.
   - name: postgresql
     alias: webModelerPostgresql
     repository: https://charts.bitnami.com/bitnami
     version: 11.x.x
     condition: "webModelerPostgresql.enabled"
-  # Helpers charts.
+  # Shared Dependencies.
+  - name: elasticsearch
+    repository: "oci://registry-1.docker.io/bitnamicharts"
+    version: 20.0.0
+    condition: "elasticsearch.enabled"
+  # Helpers.
   - name: common
     repository: https://charts.bitnami.com/bitnami
     version: 2.x.x

--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -1622,37 +1622,26 @@ Please see the corresponding [release guide](../../RELEASE.md) to find out how t
 
 ### Elasticsearch Parameters
 
-| Name                                             | Description  | Value                             |
-| ------------------------------------------------ | ------------ | --------------------------------- |
-| `elasticsearch`                                  |              |                                   |
-| `elasticsearch.enabled`                          |              | `true`                            |
-| `elasticsearch.image.repository`                 |              | `bitnami/elasticsearch`           |
-| `elasticsearch.image.tag`                        |              | `8.9.2`                           |
-| `elasticsearch.extraVolumes[0].name`             |              | `tmp`                             |
-| `elasticsearch.extraVolumes[0].emptyDir`         |              | `{}`                              |
-| `elasticsearch.extraVolumes[1].name`             |              | `logs`                            |
-| `elasticsearch.extraVolumes[1].emptyDir`         |              | `{}`                              |
-| `elasticsearch.extraVolumes[2].name`             |              | `config-dir`                      |
-| `elasticsearch.extraVolumes[2].emptyDir`         |              | `{}`                              |
-| `elasticsearch.extraVolumeMounts[0].mountPath`   |              | `/tmp`                            |
-| `elasticsearch.extraVolumeMounts[0].name`        |              | `tmp`                             |
-| `elasticsearch.extraVolumeMounts[1].mountPath`   |              | `/usr/share/elasticsearch/logs`   |
-| `elasticsearch.extraVolumeMounts[1].name`        |              | `logs`                            |
-| `elasticsearch.extraVolumeMounts[2].mountPath`   |              | `/usr/share/elasticsearch/config` |
-| `elasticsearch.extraVolumeMounts[2].name`        |              | `config-dir`                      |
-| `elasticsearch.master.masterOnly`                |              | `false`                           |
-| `elasticsearch.master.heapSize`                  |              | `1024m`                           |
-| `elasticsearch.master.persistence.size`          |              | `64Gi`                            |
-| `elasticsearch.master.resources.requests.cpu`    | cpu request  | `1`                               |
-| `elasticsearch.master.resources.requests.memory` | request      | `2Gi`                             |
-| `elasticsearch.master.resources.limits.cpu`      | cpu limit    | `2`                               |
-| `elasticsearch.master.resources.limits.memory`   | memory limit | `2Gi`                             |
-| `elasticsearch.master.extraEnvVars[0].name`      | env          | `ELASTICSEARCH_ENABLE_REST_TLS`   |
-| `elasticsearch.master.extraEnvVars[0].value`     | env value    | `false`                           |
-| `elasticsearch.sysctlImage.enabled`              |              | `true`                            |
-| `elasticsearch.data.replicaCount`                |              | `0`                               |
-| `elasticsearch.coordinating.replicaCount`        |              | `0`                               |
-| `elasticsearch.ingest.enabled`                   |              | `false`                           |
+| Name                                                                   | Description  | Value                           |
+| ---------------------------------------------------------------------- | ------------ | ------------------------------- |
+| `elasticsearch`                                                        |              |                                 |
+| `elasticsearch.enabled`                                                |              | `true`                          |
+| `elasticsearch.image.repository`                                       |              | `bitnami/elasticsearch`         |
+| `elasticsearch.image.tag`                                              |              | `8.12.2`                        |
+| `elasticsearch.master.containerSecurityContext.readOnlyRootFilesystem` |              | `true`                          |
+| `elasticsearch.master.masterOnly`                                      |              | `false`                         |
+| `elasticsearch.master.heapSize`                                        |              | `1024m`                         |
+| `elasticsearch.master.persistence.size`                                |              | `64Gi`                          |
+| `elasticsearch.master.resources.requests.cpu`                          | cpu request  | `1`                             |
+| `elasticsearch.master.resources.requests.memory`                       | request      | `2Gi`                           |
+| `elasticsearch.master.resources.limits.cpu`                            | cpu limit    | `2`                             |
+| `elasticsearch.master.resources.limits.memory`                         | memory limit | `2Gi`                           |
+| `elasticsearch.master.extraEnvVars[0].name`                            | env          | `ELASTICSEARCH_ENABLE_REST_TLS` |
+| `elasticsearch.master.extraEnvVars[0].value`                           | env value    | `false`                         |
+| `elasticsearch.sysctlImage.enabled`                                    |              | `true`                          |
+| `elasticsearch.data.replicaCount`                                      |              | `0`                             |
+| `elasticsearch.coordinating.replicaCount`                              |              | `0`                             |
+| `elasticsearch.ingest.enabled`                                         |              | `false`                         |
 
 ### Prometheus Parameters
 

--- a/charts/camunda-platform/test/unit/console/golden/configmap.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/configmap.golden.yaml
@@ -26,7 +26,7 @@ data:
             components:
             - name: Console
               id: console
-              version: 8.4.54
+              version: 8.4.57
               url: 
               readiness: http://camunda-platform-test-console.camunda-platform:9100/health/readiness
               metrics: http://camunda-platform-test-console.camunda-platform:9100/prometheus

--- a/charts/camunda-platform/test/unit/console/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/deployment.golden.yaml
@@ -44,7 +44,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: camunda-platform
-          image: registry.camunda.cloud/console/console-sm:8.4.54
+          image: registry.camunda.cloud/console/console-sm:8.4.57
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -3113,34 +3113,11 @@ elasticsearch:
     ## @param elasticsearch.image.repository
     repository: bitnami/elasticsearch
     ## @param elasticsearch.image.tag
-    tag: 8.9.2
-  ## @param elasticsearch.extraVolumes[0].name
-  ## @param elasticsearch.extraVolumes[0].emptyDir
-  ## @param elasticsearch.extraVolumes[1].name
-  ## @param elasticsearch.extraVolumes[1].emptyDir
-  ## @param elasticsearch.extraVolumes[2].name
-  ## @param elasticsearch.extraVolumes[2].emptyDir
-  extraVolumes:
-  - name: tmp
-    emptyDir: {}
-  - name: logs
-    emptyDir: {}
-  - name: config-dir
-    emptyDir: {}
-  ## @param elasticsearch.extraVolumeMounts[0].mountPath
-  ## @param elasticsearch.extraVolumeMounts[0].name
-  ## @param elasticsearch.extraVolumeMounts[1].mountPath
-  ## @param elasticsearch.extraVolumeMounts[1].name
-  ## @param elasticsearch.extraVolumeMounts[2].mountPath
-  ## @param elasticsearch.extraVolumeMounts[2].name
-  extraVolumeMounts:
-  - mountPath: /tmp
-    name: tmp
-  - mountPath: /usr/share/elasticsearch/logs
-    name: logs
-  - mountPath: /usr/share/elasticsearch/config
-    name: config-dir
+    tag: 8.12.2
   master:
+    containerSecurityContext:
+    ## @param elasticsearch.master.containerSecurityContext.readOnlyRootFilesystem
+      readOnlyRootFilesystem: true
     ## @param elasticsearch.master.masterOnly
     masterOnly: false
     ## @param elasticsearch.master.heapSize


### PR DESCRIPTION
### Which problem does the PR fix?

Task: https://github.com/camunda/distribution/issues/229

### What's in this PR?

Upgrade Elasticsearch from 8.9 to 8.12 to have the latest ES app and latest chart.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?
