### PR TITLE
feat: Add resource and limits to curator-cronjob for 8.2

### DIFF
--- a/charts/camunda-platform/templates/curator-cronjob.yaml
+++ b/charts/camunda-platform/templates/curator-cronjob.yaml
@@ -20,6 +20,7 @@ spec:
             - image: {{ include "camundaPlatform.imageByParams" $curatorImageParams | quote }}
               name: curator
               args: ["--config", "/etc/config/config.yml", "/etc/config/action_file.yml"]
+              resources: {{ toYaml .Values.retentionPolicy.resources | nindent 16 }}
               volumeMounts:
                 - name: config
                   mountPath: /etc/config

--- a/charts/camunda-platform/test/unit/golden/curator-cronjob.golden.yaml
+++ b/charts/camunda-platform/test/unit/golden/curator-cronjob.golden.yaml
@@ -25,6 +25,13 @@ spec:
             - image: "bitnami/elasticsearch-curator-archived:5.8.4"
               name: curator
               args: ["--config", "/etc/config/config.yml", "/etc/config/action_file.yml"]
+              resources: 
+                limits:
+                  cpu: 2000m
+                  memory: 2Gi
+                requests:
+                  cpu: 600m
+                  memory: 1Gi
               volumeMounts:
                 - name: config
                   mountPath: /etc/config

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -2453,6 +2453,14 @@ retentionPolicy:
   operateIndexTTL: 30
   # RetentionPolicy.tasklistIndexTTL defines after how many days a tasklist index can be deleted
   tasklistIndexTTL: 30
+  # Resources configuration to set request and limit configuration for the retentionPolicy container https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
+  resources:
+    requests:
+      cpu: 600m
+      memory: 1Gi
+    limits:
+      cpu: 2000m
+      memory: 2Gi
 
   # Image configuration for the elasticsearch curator cronjob
   # https://hub.docker.com/r/bitnami/elasticsearch-curator-archived/tags


### PR DESCRIPTION
### Which problem does the PR fix?
Related to https://github.com/camunda/camunda-platform-helm/issues/1224 and https://github.com/camunda/camunda-platform-helm/issues/354
<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?
Adding the ability to define resources and limitations to the curator-cronjob for 8.2
<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
