### PR TITLE
fix: label app.kubernetes.io/version does not change when updating Zeebe

### DIFF
--- a/charts/camunda-platform/templates/camunda/_helpers.tpl
+++ b/charts/camunda-platform/templates/camunda/_helpers.tpl
@@ -51,16 +51,15 @@ Define common labels, combining the match labels and transient labels, which mig
 {{- define "camundaPlatform.labels" -}}
 {{- template "camundaPlatform.matchLabels" . }}
 helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-{{- if .Values.image }}
-    {{- if .Values.image.tag }}
+  {{- if .Values.zeebe.image.tag }}
+app.kubernetes.io/version: {{ .Values.zeebe.image.tag | quote }}
+  {{- else if .Values.image.tag }}
 app.kubernetes.io/version: {{ .Values.image.tag | quote }}
-    {{- else }}
+  {{- else }}
 app.kubernetes.io/version: {{ .Values.global.image.tag | quote }}
-    {{- end }}
-{{- else }}
-app.kubernetes.io/version: {{ .Values.global.image.tag | quote }}
+  {{- end }}
 {{- end }}
-{{- end }}
+
 
 {{/*
 Common match labels, which are extended by sub-charts and should be used in matchLabels selectors.

--- a/charts/camunda-platform/templates/camunda/_helpers.tpl
+++ b/charts/camunda-platform/templates/camunda/_helpers.tpl
@@ -49,11 +49,16 @@ Get the app version label according to the values of "component" or "global" val
 Usage: {{ include "camundaPlatform.appVersionLabel" (dict "component" "zeebe" "context" $) }}
 */}}
 {{- define "camundaPlatform.appVersionLabel" -}}
-  {{- $componentValue := (index $.context.Values .component "image" "tag") -}}
-  {{- $globalValue := (index $.context.Values.global "image" "tag") -}}
-  {{- $version := $componentValue | default $globalValue -}}
-  {{- if $version }}
-  app.kubernetes.io/version: {{ $version | quote }}
+  {{- $globalTag := index $.context.Values.global.image "tag" -}}  
+  {{- $version := $globalTag -}}  
+  {{- if and .component (hasKey $.context.Values .component) -}} 
+    {{- $componentImageTag := index (index $.context.Values .component "image") "tag" -}}
+    {{- if $componentImageTag -}}
+      {{- $version = $componentImageTag -}} 
+    {{- end }}
+  {{- end }}
+  {{- if $version -}}
+    app.kubernetes.io/version: {{ $version | quote }}
   {{- end }}
 {{- end -}}
 

--- a/charts/camunda-platform/templates/connectors/deployment.yaml
+++ b/charts/camunda-platform/templates/connectors/deployment.yaml
@@ -3,7 +3,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "connectors.fullname" . }}
-  labels: {{- include "connectors.labels" . | nindent 4 }}
+  labels: 
+    {{- include "connectors.labels" . | nindent 4 }}
+    {{- include "camundaPlatform.appVersionLabel" (dict "component" "connectors" "context" $) | nindent 4 }}
   annotations: {{- toYaml .Values.global.annotations | nindent 4 }}
 spec:
   replicas: {{ .Values.connectors.replicas }}
@@ -12,6 +14,7 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "camundaPlatform.appVersionLabel" (dict "component" "connectors" "context" $) | nindent 8 }}
         {{- include "connectors.labels" . | nindent 8 }}
         {{- if .Values.connectors.podLabels }}
         {{- toYaml .Values.connectors.podLabels | nindent 8 }}

--- a/charts/camunda-platform/templates/console/deployment.yaml
+++ b/charts/camunda-platform/templates/console/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "console.fullname" . }}
   labels:
     {{- include "console.labels" . | nindent 4 }}
+    {{- include "camundaPlatform.appVersionLabel" (dict "component" "console" "context" $) | nindent 4 }}
   annotations:
     {{- toYaml .Values.global.annotations | nindent 4 }}
 spec:
@@ -19,6 +20,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
+        {{- include "camundaPlatform.appVersionLabel" (dict "component" "console" "context" $) | nindent 8 }}
         {{- include "console.matchLabels" . | nindent 8 }}
         {{- if .Values.console.podLabels }}
           {{- toYaml .Values.console.podLabels | nindent 8 }}

--- a/charts/camunda-platform/templates/identity/deployment.yaml
+++ b/charts/camunda-platform/templates/identity/deployment.yaml
@@ -3,7 +3,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "identity.fullname" . }}
-  labels: {{- include "identity.labels" . | nindent 4 }}
+  labels: 
+    {{- include "identity.labels" . | nindent 4 }}
+    {{- include "camundaPlatform.appVersionLabel" (dict "component" "identity" "context" $) | nindent 4 }}
   annotations: {{- toYaml .Values.global.annotations | nindent 4 }}
 spec:
   replicas: 1
@@ -12,6 +14,7 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "camundaPlatform.appVersionLabel" (dict "component" "identity" "context" $) | nindent 8 }}
         {{- include "identity.labels" . | nindent 8 }}
         {{- if .Values.identity.podLabels }}
         {{- toYaml .Values.identity.podLabels | nindent 8 }}

--- a/charts/camunda-platform/templates/operate/deployment.yaml
+++ b/charts/camunda-platform/templates/operate/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "operate.fullname" . }}
   labels:
     {{- include "operate.labels" . | nindent 4 }}
+    {{- include "camundaPlatform.appVersionLabel" (dict "component" "operate" "context" $) | nindent 4 }}
   annotations:
     {{- toYaml .Values.global.annotations | nindent 4 }}
 spec:
@@ -15,6 +16,7 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "camundaPlatform.appVersionLabel" (dict "component" "operate" "context" $) | nindent 8 }}
         {{- include "operate.labels" . | nindent 8 }}
         {{- if .Values.operate.podLabels }}
           {{- toYaml .Values.operate.podLabels | nindent 8 }}

--- a/charts/camunda-platform/templates/optimize/deployment.yaml
+++ b/charts/camunda-platform/templates/optimize/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "optimize.fullname" . }}
   labels:
     {{- include "optimize.labels" . | nindent 4 }}
+    {{- include "camundaPlatform.appVersionLabel" (dict "component" "optimize" "context" $) | nindent 4 }}
   annotations:
     {{- toYaml .Values.global.annotations | nindent 4 }}
 spec:
@@ -14,7 +15,8 @@ spec:
       {{- include "optimize.matchLabels" . | nindent 6 }}
   template:
     metadata:
-      labels: 
+      labels:
+        {{- include "camundaPlatform.appVersionLabel" (dict "component" "optimize" "context" $) | nindent 8 }} 
         {{- include "optimize.labels" . | nindent 8 }}
         {{- if .Values.optimize.podLabels }}
         {{- toYaml .Values.optimize.podLabels | nindent 8 }}

--- a/charts/camunda-platform/templates/tasklist/deployment.yaml
+++ b/charts/camunda-platform/templates/tasklist/deployment.yaml
@@ -4,6 +4,7 @@ kind: Deployment
 metadata:
   name: {{ include "tasklist.fullname" . }}
   labels:
+    {{- include "camundaPlatform.appVersionLabel" (dict "component" "tasklist" "context" $) | nindent 4 }}
     {{- include "tasklist.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.global.annotations | nindent 4 }}
@@ -15,6 +16,7 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "camundaPlatform.appVersionLabel" (dict "component" "tasklist" "context" $) | nindent 8 }}
         {{- include "tasklist.labels" . | nindent 8 }}
         {{- if .Values.tasklist.podLabels }}
           {{- toYaml .Values.tasklist.podLabels | nindent 8 }}

--- a/charts/camunda-platform/templates/web-modeler/configmap-shared.yaml
+++ b/charts/camunda-platform/templates/web-modeler/configmap-shared.yaml
@@ -3,7 +3,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "webModeler.fullname" . }}
-  labels: {{- include "webModeler.labels" . | nindent 4 }}
+  labels: 
+    {{- include "webModeler.labels" . | nindent 4 }}
+    {{- include "camundaPlatform.appVersionLabel" (dict "component" "webModler" "context" $) | nindent 4 }}
   annotations: {{- toYaml .Values.global.annotations | nindent 4 }}
 data:
   pusher-app-id: web-modeler

--- a/charts/camunda-platform/templates/zeebe-gateway/deployment.yaml
+++ b/charts/camunda-platform/templates/zeebe-gateway/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "zeebe.names.gateway" . }}
   labels:
     {{- include "zeebe.labels.gateway" . | nindent 4 }}
+    {{- include "camundaPlatform.appVersionLabel" (dict "component" "zeebeGateway" "context" $) | nindent 4 }}
   annotations:
     {{- toYaml .Values.global.annotations | nindent 4 }}
 spec:
@@ -15,6 +16,7 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "camundaPlatform.appVersionLabel" (dict "component" "zeebeGateway" "context" $) | nindent 8 }}
         {{- include "zeebe.labels.gateway" . | nindent 8 }}
         {{- if .Values.zeebeGateway.podLabels }}
           {{- toYaml .Values.zeebeGateway.podLabels | nindent 8 }}

--- a/charts/camunda-platform/templates/zeebe/statefulset.yaml
+++ b/charts/camunda-platform/templates/zeebe/statefulset.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "zeebe.names.broker" . }}
   labels:
     {{- include "zeebe.labels.broker" . | nindent 4 }}
+    {{- include "camundaPlatform.appVersionLabel" (dict "component" "zeebe" "context" $) | nindent 4 }}
   annotations:
     {{- range $key, $value := .Values.global.annotations }}
     {{ $key }}: {{ $value | quote }}
@@ -26,6 +27,7 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "camundaPlatform.appVersionLabel" (dict "component" "zeebe" "context" $) | nindent 8 }}
         {{- include "zeebe.labels.broker" . | nindent 8 }}
         {{- if .Values.zeebe.podLabels }}
         {{- toYaml .Values.zeebe.podLabels | nindent 8 }}

--- a/charts/camunda-platform/test/unit/camunda/golden/connectors-service-monitor.golden.yaml
+++ b/charts/camunda-platform/test/unit/camunda/golden/connectors-service-monitor.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     release: metrics
 spec:
   selector:

--- a/charts/camunda-platform/test/unit/camunda/golden/identity-service-monitor.golden.yaml
+++ b/charts/camunda-platform/test/unit/camunda/golden/identity-service-monitor.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     release: metrics
 spec:
   selector:

--- a/charts/camunda-platform/test/unit/camunda/golden/operate-service-monitor.golden.yaml
+++ b/charts/camunda-platform/test/unit/camunda/golden/operate-service-monitor.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     release: metrics
 spec:
   selector:

--- a/charts/camunda-platform/test/unit/camunda/golden/optimize-service-monitor.golden.yaml
+++ b/charts/camunda-platform/test/unit/camunda/golden/optimize-service-monitor.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     release: metrics
 spec:
   selector:

--- a/charts/camunda-platform/test/unit/camunda/golden/tasklist-service-monitor.golden.yaml
+++ b/charts/camunda-platform/test/unit/camunda/golden/tasklist-service-monitor.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     release: metrics
 spec:
   selector:

--- a/charts/camunda-platform/test/unit/camunda/golden/web-modeler-service-monitor.golden.yaml
+++ b/charts/camunda-platform/test/unit/camunda/golden/web-modeler-service-monitor.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     release: metrics
 spec:
   selector:
@@ -34,7 +34,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     release: metrics
 spec:
   selector:

--- a/charts/camunda-platform/test/unit/camunda/golden/zeebe-gateway-service-monitor.golden.yaml
+++ b/charts/camunda-platform/test/unit/camunda/golden/zeebe-gateway-service-monitor.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     release: metrics
 spec:
   selector:

--- a/charts/camunda-platform/test/unit/camunda/golden/zeebe-service-monitor.golden.yaml
+++ b/charts/camunda-platform/test/unit/camunda/golden/zeebe-service-monitor.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     release: metrics
 spec:
   selector:

--- a/charts/camunda-platform/test/unit/connectors/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/connectors/golden/deployment.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: connectors
   annotations:
     {}
@@ -32,7 +32,7 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "8.5.0-alpha2"
+        app.kubernetes.io/version: "8.5.0-RC2"
         app.kubernetes.io/component: connectors
     spec:
       imagePullSecrets:

--- a/charts/camunda-platform/test/unit/connectors/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/connectors/golden/ingress-all-enabled.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: connectors
   annotations:
     ingress.kubernetes.io/rewrite-target: /

--- a/charts/camunda-platform/test/unit/connectors/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/connectors/golden/ingress.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: connectors
   annotations:
     ingress.kubernetes.io/rewrite-target: /

--- a/charts/camunda-platform/test/unit/connectors/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/connectors/golden/service.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: connectors
   annotations:
 spec:

--- a/charts/camunda-platform/test/unit/connectors/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/unit/connectors/golden/serviceaccount.golden.yaml
@@ -10,6 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: connectors
 automountServiceAccountToken: false

--- a/charts/camunda-platform/test/unit/console/golden/configmap.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/configmap.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: console
 data:
   application.yaml: |-

--- a/charts/camunda-platform/test/unit/console/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/deployment.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: console
   annotations:
     {}

--- a/charts/camunda-platform/test/unit/console/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/ingress-all-enabled.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: console
   annotations:
     ingress.kubernetes.io/rewrite-target: /

--- a/charts/camunda-platform/test/unit/console/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/ingress.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: console
   annotations:
     ingress.kubernetes.io/rewrite-target: /

--- a/charts/camunda-platform/test/unit/console/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/service.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: console
   annotations:
 spec:

--- a/charts/camunda-platform/test/unit/console/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/serviceaccount.golden.yaml
@@ -10,6 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: console
 automountServiceAccountToken: false

--- a/charts/camunda-platform/test/unit/identity/golden/configmap-env-vars.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/configmap-env-vars.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: identity
   annotations:
     {}

--- a/charts/camunda-platform/test/unit/identity/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/deployment.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: identity
   annotations:
     {}
@@ -32,10 +32,10 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "8.5.0-alpha2"
+        app.kubernetes.io/version: "8.5.0-RC2"
         app.kubernetes.io/component: identity
       annotations:
-        checksum/configmap-env-vars: 4128f1c505cd30066686397de348f600f9fde410954338037994e4953fea5acc
+        checksum/configmap-env-vars: 1f40d5375ae6b40950a5d06d71068abed4604b41eb083a7acf101c96810ed67c
     spec:
       imagePullSecrets:
         []

--- a/charts/camunda-platform/test/unit/identity/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/ingress-all-enabled.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: identity
   annotations:
     ingress.kubernetes.io/rewrite-target: /

--- a/charts/camunda-platform/test/unit/identity/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/ingress.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: identity
   annotations:
     ingress.kubernetes.io/rewrite-target: /

--- a/charts/camunda-platform/test/unit/identity/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/service.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: identity
   annotations:
 spec:

--- a/charts/camunda-platform/test/unit/identity/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/serviceaccount.golden.yaml
@@ -10,6 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: identity
 automountServiceAccountToken: true

--- a/charts/camunda-platform/test/unit/operate/golden/configmap.golden.yaml
+++ b/charts/camunda-platform/test/unit/operate/golden/configmap.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: operate
 data:
   application.yml: |

--- a/charts/camunda-platform/test/unit/operate/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/operate/golden/deployment.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: operate
   annotations:
     {}
@@ -32,10 +32,10 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "8.5.0-alpha2"
+        app.kubernetes.io/version: "8.5.0-RC2"
         app.kubernetes.io/component: operate
       annotations:
-        checksum/config: d3181d8bbf1c416d82082f846923bc5e0c41abfa846a76e22e9b4fbee8310523
+        checksum/config: 6078389a0bf443d93c214f0f8e404710674fc4ee83270ca9bf6d193269c719b8
     spec:
       imagePullSecrets:
         []

--- a/charts/camunda-platform/test/unit/operate/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/operate/golden/ingress-all-enabled.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: operate
   annotations:
     ingress.kubernetes.io/rewrite-target: /

--- a/charts/camunda-platform/test/unit/operate/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/operate/golden/ingress.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: operate
   annotations:
     ingress.kubernetes.io/rewrite-target: /

--- a/charts/camunda-platform/test/unit/operate/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/operate/golden/service.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: operate
   annotations:
 spec:

--- a/charts/camunda-platform/test/unit/operate/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/unit/operate/golden/serviceaccount.golden.yaml
@@ -10,6 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: operate
 automountServiceAccountToken: false

--- a/charts/camunda-platform/test/unit/optimize/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/optimize/golden/deployment.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: optimize
   annotations:
     {}
@@ -32,7 +32,7 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "8.5.0-alpha2"
+        app.kubernetes.io/version: "8.5.0-RC2"
         app.kubernetes.io/component: optimize
     spec:
       imagePullSecrets:

--- a/charts/camunda-platform/test/unit/optimize/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/optimize/golden/ingress-all-enabled.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: optimize
   annotations:
     ingress.kubernetes.io/rewrite-target: /

--- a/charts/camunda-platform/test/unit/optimize/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/optimize/golden/ingress.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: optimize
   annotations:
     ingress.kubernetes.io/rewrite-target: /

--- a/charts/camunda-platform/test/unit/optimize/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/optimize/golden/service.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: optimize
   annotations:
 spec:

--- a/charts/camunda-platform/test/unit/optimize/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/unit/optimize/golden/serviceaccount.golden.yaml
@@ -10,6 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: optimize
 automountServiceAccountToken: false

--- a/charts/camunda-platform/test/unit/tasklist/golden/configmap.golden.yaml
+++ b/charts/camunda-platform/test/unit/tasklist/golden/configmap.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: tasklist
 data:
   application.yml: |

--- a/charts/camunda-platform/test/unit/tasklist/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/tasklist/golden/deployment.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: tasklist
   annotations:
     {}
@@ -32,10 +32,10 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "8.5.0-alpha2"
+        app.kubernetes.io/version: "8.5.0-RC2"
         app.kubernetes.io/component: tasklist
       annotations:
-        checksum/config: 3ebbabcc7c6e51a6dbf8b1deee2a2d1bfd3f3d24b0d8974bbdd95ecb0b05f7f4
+        checksum/config: 95cface481b61e2261d3b85c80253eab2a2a33531f7e1e7df6ba4e07a7a94ac0
     spec:
       imagePullSecrets:
         []

--- a/charts/camunda-platform/test/unit/tasklist/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/tasklist/golden/ingress-all-enabled.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: tasklist
   annotations:
     ingress.kubernetes.io/rewrite-target: /

--- a/charts/camunda-platform/test/unit/tasklist/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/tasklist/golden/ingress.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: tasklist
   annotations:
     ingress.kubernetes.io/rewrite-target: /

--- a/charts/camunda-platform/test/unit/tasklist/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/tasklist/golden/service.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: tasklist
   annotations:
 spec:

--- a/charts/camunda-platform/test/unit/web-modeler/golden/configmap-shared.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/configmap-shared.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.3"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: web-modeler
   annotations:
     {}

--- a/charts/camunda-platform/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.3"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: restapi
   annotations:
     {}
@@ -32,7 +32,7 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "8.4.3"
+        app.kubernetes.io/version: "8.5.0-RC2"
         app.kubernetes.io/component: restapi
     spec:
       imagePullSecrets:

--- a/charts/camunda-platform/test/unit/web-modeler/golden/deployment-webapp.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/deployment-webapp.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.3"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: webapp
   annotations:
     {}
@@ -32,7 +32,7 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "8.4.3"
+        app.kubernetes.io/version: "8.5.0-RC2"
         app.kubernetes.io/component: webapp
     spec:
       imagePullSecrets:

--- a/charts/camunda-platform/test/unit/web-modeler/golden/deployment-websockets.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/deployment-websockets.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.3"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: websockets
   annotations:
     {}
@@ -32,7 +32,7 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "8.4.3"
+        app.kubernetes.io/version: "8.5.0-RC2"
         app.kubernetes.io/component: websockets
     spec:
       imagePullSecrets:

--- a/charts/camunda-platform/test/unit/web-modeler/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/ingress-all-enabled.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.3"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: web-modeler
   annotations:
     ingress.kubernetes.io/rewrite-target: /

--- a/charts/camunda-platform/test/unit/web-modeler/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/ingress.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.3"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: web-modeler
   annotations:
     ingress.kubernetes.io/rewrite-target: /

--- a/charts/camunda-platform/test/unit/web-modeler/golden/secret-shared.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/secret-shared.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.3"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: web-modeler
   annotations:
     {}

--- a/charts/camunda-platform/test/unit/web-modeler/golden/service-restapi.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/service-restapi.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.3"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: restapi
   annotations:
 spec:

--- a/charts/camunda-platform/test/unit/web-modeler/golden/service-webapp.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/service-webapp.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.3"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: webapp
   annotations:
 spec:

--- a/charts/camunda-platform/test/unit/web-modeler/golden/service-websockets.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/service-websockets.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.3"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: websockets
   annotations:
 spec:

--- a/charts/camunda-platform/test/unit/web-modeler/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/serviceaccount.golden.yaml
@@ -10,6 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.3"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: web-modeler
 automountServiceAccountToken: false

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/configmap-log4j2.golden.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: zeebe-gateway
 apiVersion: v1
 data:

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/configmap.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/configmap.golden.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: zeebe-gateway
 apiVersion: v1
 data:

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/deployment.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: zeebe-gateway
   annotations:
     {}
@@ -32,7 +32,7 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "8.5.0-alpha2"
+        app.kubernetes.io/version: "8.5.0-RC2"
         app.kubernetes.io/component: zeebe-gateway
       annotations:
         {}

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/ingress-grpc-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/ingress-grpc-all-enabled.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: zeebe-gateway
   annotations:
     ingress.kubernetes.io/rewrite-target: /

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/ingress-grpc.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/ingress-grpc.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: zeebe-gateway
   annotations:
     ingress.kubernetes.io/rewrite-target: /

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/ingress-rest-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/ingress-rest-all-enabled.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: zeebe-gateway
   annotations:
     ingress.kubernetes.io/rewrite-target: /

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/ingress-rest.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/ingress-rest.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: zeebe-gateway
   annotations:
     ingress.kubernetes.io/rewrite-target: /

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/poddisruptionbudget.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/poddisruptionbudget.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: zeebe-gateway
 spec:
   minAvailable: 1

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/service.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: zeebe-gateway
   annotations:
 spec:

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/serviceaccount-annotations.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/serviceaccount-annotations.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: zeebe-gateway
   annotations:
     foo: bar

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/serviceaccount.golden.yaml
@@ -10,6 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: zeebe-gateway
 automountServiceAccountToken: false

--- a/charts/camunda-platform/test/unit/zeebe/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/configmap-log4j2.golden.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: zeebe-broker
 apiVersion: v1
 data:

--- a/charts/camunda-platform/test/unit/zeebe/golden/configmap-multiregion-failBack.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/configmap-multiregion-failBack.golden.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: zeebe-broker
 apiVersion: v1
 data:

--- a/charts/camunda-platform/test/unit/zeebe/golden/configmap-multiregion-failOver.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/configmap-multiregion-failOver.golden.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: zeebe-broker
 apiVersion: v1
 data:

--- a/charts/camunda-platform/test/unit/zeebe/golden/configmap.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/configmap.golden.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: zeebe-broker
 apiVersion: v1
 data:

--- a/charts/camunda-platform/test/unit/zeebe/golden/poddisruptionbudget.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/poddisruptionbudget.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: zeebe-broker
 spec:
   maxUnavailable: 1

--- a/charts/camunda-platform/test/unit/zeebe/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/service.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: zeebe-broker
   annotations:
 spec:

--- a/charts/camunda-platform/test/unit/zeebe/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/serviceaccount.golden.yaml
@@ -10,6 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: zeebe-broker
 automountServiceAccountToken: false

--- a/charts/camunda-platform/test/unit/zeebe/golden/statefulset.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/statefulset.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
+    app.kubernetes.io/version: "8.5.0-RC2"
     app.kubernetes.io/component: zeebe-broker
   annotations:
 spec:
@@ -35,7 +35,7 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "8.5.0-alpha2"
+        app.kubernetes.io/version: "8.5.0-RC2"
         app.kubernetes.io/component: zeebe-broker
       annotations:
     spec:


### PR DESCRIPTION
### Which problem does the PR fix?
https://github.com/camunda/camunda-platform-helm/issues/1475
<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?


Updating only Zeebe by changing the value of `zeebe.image.tag` now updates the version label of the StatefulSet.

After the upgrade of Zeebe, the app.kubernetes.io/version label is updated to the new version.
<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
