### PR TITLE
fix: references to grpc:// protocol removed

### DIFF
--- a/charts/camunda-platform/templates/NOTES.txt
+++ b/charts/camunda-platform/templates/NOTES.txt
@@ -222,7 +222,7 @@ Default user and password: "{{ .Values.identity.firstUser.username -}}/{{ .Value
 {{- end }}
 
 {{- if .Values.zeebeGateway.ingress.grpc.enabled }}
-- Zeebe Gateway gRPC: grpc://{{ tpl .Values.zeebeGateway.ingress.grpc.host $ }}
+- Zeebe Gateway gRPC: {{  include "camundaPlatform.zeebeGatewayGRPCExternalURL" . }}
 {{- end }}
 
 {{- if .Values.zeebeGateway.ingress.rest.enabled }}

--- a/charts/camunda-platform/templates/camunda/_helpers.tpl
+++ b/charts/camunda-platform/templates/camunda/_helpers.tpl
@@ -491,7 +491,7 @@ Zeebe templates.
 */}}
 {{- define "camundaPlatform.zeebeGatewayGRPCExternalURL" }}
   {{ $proto := ternary "https" "http" .Values.zeebeGateway.ingress.grpc.tls.enabled -}}
-  {{- printf "%s://%s%s" $proto .Values.zeebeGateway.ingress.grpc.host .Values.zeebeGateway.contextPath -}}
+  {{- printf "%s://%s" $proto .Values.zeebeGateway.ingress.grpc.host -}}
 {{- end -}}
 
 

--- a/charts/camunda-platform/templates/camunda/_helpers.tpl
+++ b/charts/camunda-platform/templates/camunda/_helpers.tpl
@@ -489,7 +489,7 @@ Zeebe templates.
 {{/*
 [camunda-platform] Zeebe Gateway GRPC external URL.
 */}}
-{{- define "camundaPlatform.zeebeGatewayGRPCExternalURL" }}
+{{- define "camundaPlatform.zeebeGatewayGRPCExternalURL" -}}
   {{ $proto := ternary "https" "http" .Values.zeebeGateway.ingress.grpc.tls.enabled -}}
   {{- printf "%s://%s" $proto .Values.zeebeGateway.ingress.grpc.host -}}
 {{- end -}}

--- a/charts/camunda-platform/templates/camunda/_helpers.tpl
+++ b/charts/camunda-platform/templates/camunda/_helpers.tpl
@@ -486,6 +486,14 @@ Zeebe templates.
   {{- end -}}
 {{- end -}}
 
+{{/*
+[camunda-platform] Zeebe Gateway GRPC external URL.
+*/}}
+{{- define "camundaPlatform.zeebeGatewayGRPCExternalURL" }}
+  {{ $proto := ternary "https" "http" .Values.zeebeGateway.ingress.grpc.tls.enabled -}}
+  {{- printf "%s://%s%s" $proto .Values.zeebeGateway.ingress.grpc.host .Values.zeebeGateway.contextPath -}}
+{{- end -}}
+
 
 {{/*
 ********************************************************************************
@@ -570,7 +578,7 @@ Release templates.
     id: zeebeGateway
     version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.zeebe) }}
     urls:
-      grpc: grpc://{{ tpl .Values.zeebeGateway.ingress.grpc.host $ }}
+      grpc: {{ include "camundaPlatform.zeebeGatewayGRPCExternalURL" . }}
       http: {{ include "camundaPlatform.zeebeGatewayExternalURL" . }}
     readiness: {{ printf "%s%s" $baseURLInternal .Values.zeebeGateway.readinessProbe.probePath }}
     metrics: {{ printf "%s%s" $baseURLInternal .Values.zeebeGateway.metrics.prometheus }}

--- a/charts/camunda-platform/test/unit/console/golden/configmap.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/configmap.golden.yaml
@@ -26,7 +26,7 @@ data:
             components:
             - name: Console
               id: console
-              version: 8.4.60
+              version: 8.5.0
               url: 
               readiness: http://camunda-platform-test-console.camunda-platform:9100/health/readiness
               metrics: http://camunda-platform-test-console.camunda-platform:9100/prometheus
@@ -62,7 +62,7 @@ data:
               id: zeebeGateway
               version: 8.5.0-RC2
               urls:
-                grpc: grpc://
+                grpc: http://
                 http: http://
               readiness: http://camunda-platform-test-zeebe-gateway.camunda-platform:9600/actuator/health/readiness
               metrics: http://camunda-platform-test-zeebe-gateway.camunda-platform:9600/actuator/prometheus

--- a/charts/camunda-platform/test/unit/console/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/deployment.golden.yaml
@@ -44,7 +44,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: camunda-platform
-          image: registry.camunda.cloud/console/console-sm:8.4.60
+          image: registry.camunda.cloud/console/console-sm:8.5.0
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
### Which problem does the PR fix?

closes #1520 

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

References to `grpc://` protocol are replaced with `http://` or `https://`

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
