### PR TITLE
fix: add camundaPlatform.imageTagByParams to component helpers.tpl

### DIFF
--- a/charts/camunda-platform/templates/camunda/_helpers.tpl
+++ b/charts/camunda-platform/templates/camunda/_helpers.tpl
@@ -51,15 +51,6 @@ Define common labels, combining the match labels and transient labels, which mig
 {{- define "camundaPlatform.labels" -}}
 {{- template "camundaPlatform.matchLabels" . }}
 helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-{{- if .Values.image }}
-    {{- if .Values.image.tag }}
-app.kubernetes.io/version: {{ .Values.image.tag | quote }}
-    {{- else }}
-app.kubernetes.io/version: {{ .Values.global.image.tag | quote }}
-    {{- end }}
-{{- else }}
-app.kubernetes.io/version: {{ .Values.global.image.tag | quote }}
-{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/camunda-platform/templates/camunda/_helpers.tpl
+++ b/charts/camunda-platform/templates/camunda/_helpers.tpl
@@ -136,15 +136,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: camunda-platform
 helm.sh/chart: identity-{{ .Chart.Version | replace "+" "_" }}
-{{- if .Values.identity.image }}
-{{- if .Values.identity.image.tag }}
-app.kubernetes.io/version: {{ .Values.identity.image.tag | quote }}
-{{- else }}
-app.kubernetes.io/version: {{ .Values.global.image.tag | quote }}
-{{- end }}
-{{- else }}
-app.kubernetes.io/version: {{ .Values.global.image.tag | quote }}
-{{- end }}
 app.kubernetes.io/component: identity
 {{- end }}
 

--- a/charts/camunda-platform/templates/connectors/_helpers.tpl
+++ b/charts/camunda-platform/templates/connectors/_helpers.tpl
@@ -28,6 +28,7 @@ Defines extra labels for connectors.
 */}}
 {{- define "connectors.extraLabels" -}}
 app.kubernetes.io/component: connectors
+app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.connectors) }}
 {{- end -}}
 
 {{/*
@@ -37,7 +38,6 @@ Define common labels for connectors, combining the match labels and transient la
 {{- define "connectors.labels" -}}
 {{- template "camundaPlatform.labels" . }}
 {{ template "connectors.extraLabels" . }}
-{{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.connectors) }}
 {{- end -}}
 {{/*
 Defines match labels for connectors, which are extended by sub-charts and should be used in matchLabels selectors.

--- a/charts/camunda-platform/templates/connectors/_helpers.tpl
+++ b/charts/camunda-platform/templates/connectors/_helpers.tpl
@@ -37,6 +37,7 @@ Define common labels for connectors, combining the match labels and transient la
 {{- define "connectors.labels" -}}
 {{- template "camundaPlatform.labels" . }}
 {{ template "connectors.extraLabels" . }}
+{{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.connectors) }}
 {{- end -}}
 {{/*
 Defines match labels for connectors, which are extended by sub-charts and should be used in matchLabels selectors.

--- a/charts/camunda-platform/templates/connectors/_helpers.tpl
+++ b/charts/camunda-platform/templates/connectors/_helpers.tpl
@@ -28,7 +28,7 @@ Defines extra labels for connectors.
 */}}
 {{- define "connectors.extraLabels" -}}
 app.kubernetes.io/component: connectors
-app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.connectors) }}
+app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.connectors) | quote }}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform/templates/console/_helpers.tpl
+++ b/charts/camunda-platform/templates/console/_helpers.tpl
@@ -24,7 +24,7 @@ Defines extra labels for console.
 */}}
 {{- define "console.extraLabels" -}}
 app.kubernetes.io/component: console
-app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.console) }}
+app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.console) | quote }}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform/templates/console/_helpers.tpl
+++ b/charts/camunda-platform/templates/console/_helpers.tpl
@@ -24,6 +24,7 @@ Defines extra labels for console.
 */}}
 {{- define "console.extraLabels" -}}
 app.kubernetes.io/component: console
+app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.console) }}
 {{- end -}}
 
 {{/*
@@ -32,7 +33,6 @@ Common labels
 {{- define "console.labels" -}}
 {{- template "camundaPlatform.labels" . }}
 {{ template "console.extraLabels" . }}
-{{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.console) }}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform/templates/console/_helpers.tpl
+++ b/charts/camunda-platform/templates/console/_helpers.tpl
@@ -32,6 +32,7 @@ Common labels
 {{- define "console.labels" -}}
 {{- template "camundaPlatform.labels" . }}
 {{ template "console.extraLabels" . }}
+{{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.console) }}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform/templates/identity/_helpers.tpl
+++ b/charts/camunda-platform/templates/identity/_helpers.tpl
@@ -47,7 +47,7 @@ Defines extra labels for identity.
 */}}
 {{- define "identity.extraLabels" -}}
 app.kubernetes.io/component: identity
-app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.identity) }}
+app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.identity) | quote }}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform/templates/identity/_helpers.tpl
+++ b/charts/camunda-platform/templates/identity/_helpers.tpl
@@ -56,6 +56,7 @@ Define common labels for identity, combining the match labels and transient labe
 {{- define "identity.labels" -}}
 {{- template "camundaPlatform.labels" . }}
 {{ template "identity.extraLabels" . }}
+{{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.identity) }}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform/templates/identity/_helpers.tpl
+++ b/charts/camunda-platform/templates/identity/_helpers.tpl
@@ -47,6 +47,7 @@ Defines extra labels for identity.
 */}}
 {{- define "identity.extraLabels" -}}
 app.kubernetes.io/component: identity
+app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.identity) }}
 {{- end -}}
 
 {{/*
@@ -56,7 +57,6 @@ Define common labels for identity, combining the match labels and transient labe
 {{- define "identity.labels" -}}
 {{- template "camundaPlatform.labels" . }}
 {{ template "identity.extraLabels" . }}
-{{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.identity) }}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform/templates/operate/_helpers.tpl
+++ b/charts/camunda-platform/templates/operate/_helpers.tpl
@@ -26,6 +26,7 @@ Define common labels for operate, combining the match labels and transient label
     {{- include "camundaPlatform.labels" . }}
     {{- "\n" }}
     {{- include "operate.extraLabels" . }}
+    {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.operate) }}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform/templates/operate/_helpers.tpl
+++ b/charts/camunda-platform/templates/operate/_helpers.tpl
@@ -16,7 +16,7 @@ Defines extra labels for operate.
 */}}
 {{ define "operate.extraLabels" -}}
 app.kubernetes.io/component: operate
-app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.identity) }}
+app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.identity) | quote }}
 {{- end }}
 
 {{/*

--- a/charts/camunda-platform/templates/operate/_helpers.tpl
+++ b/charts/camunda-platform/templates/operate/_helpers.tpl
@@ -16,6 +16,7 @@ Defines extra labels for operate.
 */}}
 {{ define "operate.extraLabels" -}}
 app.kubernetes.io/component: operate
+app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.identity) }}
 {{- end }}
 
 {{/*
@@ -26,7 +27,6 @@ Define common labels for operate, combining the match labels and transient label
     {{- include "camundaPlatform.labels" . }}
     {{- "\n" }}
     {{- include "operate.extraLabels" . }}
-    {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.operate) }}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform/templates/optimize/_helpers.tpl
+++ b/charts/camunda-platform/templates/optimize/_helpers.tpl
@@ -17,6 +17,7 @@ Defines extra labels for optimize.
 */}}
 {{ define "optimize.extraLabels" -}}
 app.kubernetes.io/component: optimize
+app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.optimize) }}
 {{- end }}
 
 {{/*
@@ -27,7 +28,6 @@ Define common labels for optimize, combining the match labels and transient labe
     {{- include "camundaPlatform.labels" . }}
     {{- "\n" }}
     {{- include "optimize.extraLabels" . }}
-    {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.optimize) }}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform/templates/optimize/_helpers.tpl
+++ b/charts/camunda-platform/templates/optimize/_helpers.tpl
@@ -17,7 +17,7 @@ Defines extra labels for optimize.
 */}}
 {{ define "optimize.extraLabels" -}}
 app.kubernetes.io/component: optimize
-app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.optimize) }}
+app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.optimize) | quote }}
 {{- end }}
 
 {{/*

--- a/charts/camunda-platform/templates/optimize/_helpers.tpl
+++ b/charts/camunda-platform/templates/optimize/_helpers.tpl
@@ -27,6 +27,7 @@ Define common labels for optimize, combining the match labels and transient labe
     {{- include "camundaPlatform.labels" . }}
     {{- "\n" }}
     {{- include "optimize.extraLabels" . }}
+    {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.optimize) }}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform/templates/tasklist/_helpers.tpl
+++ b/charts/camunda-platform/templates/tasklist/_helpers.tpl
@@ -19,6 +19,7 @@ Defines extra labels for tasklist.
 */}}
 {{ define "tasklist.extraLabels" -}}
 app.kubernetes.io/component: tasklist
+app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.tasklist) }}
 {{- end }}
 
 {{/*
@@ -29,7 +30,6 @@ Define common labels for tasklist, combining the match labels and transient labe
     {{- include "camundaPlatform.labels" . }}
     {{- "\n" }}
     {{- include "tasklist.extraLabels" . }}
-    {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.tasklist) }}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform/templates/tasklist/_helpers.tpl
+++ b/charts/camunda-platform/templates/tasklist/_helpers.tpl
@@ -29,6 +29,7 @@ Define common labels for tasklist, combining the match labels and transient labe
     {{- include "camundaPlatform.labels" . }}
     {{- "\n" }}
     {{- include "tasklist.extraLabels" . }}
+    {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.tasklist) }}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform/templates/tasklist/_helpers.tpl
+++ b/charts/camunda-platform/templates/tasklist/_helpers.tpl
@@ -19,7 +19,7 @@ Defines extra labels for tasklist.
 */}}
 {{ define "tasklist.extraLabels" -}}
 app.kubernetes.io/component: tasklist
-app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.tasklist) }}
+app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.tasklist) | quote }}
 {{- end }}
 
 {{/*

--- a/charts/camunda-platform/templates/web-modeler/_helpers.tpl
+++ b/charts/camunda-platform/templates/web-modeler/_helpers.tpl
@@ -90,6 +90,7 @@ Define common labels for Web Modeler, combining the match labels and transient l
 {{- define "webModeler.labels" -}}
 {{ template "webModeler.commonLabels" . }}
 {{ template "webModeler.extraLabels" . }}
+{{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.webModeler) }}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform/templates/web-modeler/_helpers.tpl
+++ b/charts/camunda-platform/templates/web-modeler/_helpers.tpl
@@ -44,6 +44,7 @@ Define extra labels for Web Modeler.
 */}}
 {{- define "webModeler.extraLabels" -}}
 app.kubernetes.io/component: web-modeler
+app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.webModeler) }}
 {{- end -}}
 
 {{/*
@@ -90,7 +91,6 @@ Define common labels for Web Modeler, combining the match labels and transient l
 {{- define "webModeler.labels" -}}
 {{ template "webModeler.commonLabels" . }}
 {{ template "webModeler.extraLabels" . }}
-{{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.webModeler) }}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform/templates/web-modeler/_helpers.tpl
+++ b/charts/camunda-platform/templates/web-modeler/_helpers.tpl
@@ -44,7 +44,7 @@ Define extra labels for Web Modeler.
 */}}
 {{- define "webModeler.extraLabels" -}}
 app.kubernetes.io/component: web-modeler
-app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.webModeler) }}
+app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.webModeler) | quote }}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform/templates/zeebe-gateway/_helpers.tpl
+++ b/charts/camunda-platform/templates/zeebe-gateway/_helpers.tpl
@@ -24,6 +24,7 @@
 */}}
 {{ define "zeebe.extraLabels.gateway" -}}
 app.kubernetes.io/component: zeebe-gateway
+app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.zeebeGateway) }}
 {{- end }}
 
 {{/*
@@ -34,7 +35,6 @@ app.kubernetes.io/component: zeebe-gateway
     {{- include "camundaPlatform.labels" . }}
     {{- "\n" }}
     {{- include "zeebe.extraLabels.gateway" . }}
-    {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.zeebeGateway) }}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform/templates/zeebe-gateway/_helpers.tpl
+++ b/charts/camunda-platform/templates/zeebe-gateway/_helpers.tpl
@@ -24,7 +24,7 @@
 */}}
 {{ define "zeebe.extraLabels.gateway" -}}
 app.kubernetes.io/component: zeebe-gateway
-app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.zeebeGateway) }}
+app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.zeebeGateway) | quote }}
 {{- end }}
 
 {{/*

--- a/charts/camunda-platform/templates/zeebe-gateway/_helpers.tpl
+++ b/charts/camunda-platform/templates/zeebe-gateway/_helpers.tpl
@@ -34,6 +34,7 @@ app.kubernetes.io/component: zeebe-gateway
     {{- include "camundaPlatform.labels" . }}
     {{- "\n" }}
     {{- include "zeebe.extraLabels.gateway" . }}
+    {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.zeebeGateway) }}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform/templates/zeebe/_helpers.tpl
+++ b/charts/camunda-platform/templates/zeebe/_helpers.tpl
@@ -27,7 +27,7 @@
 */}}
 {{ define "zeebe.extraLabels.broker" -}}
 app.kubernetes.io/component: zeebe-broker
-app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.zeebe) }}
+app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.zeebe) | quote }}
 {{- end }}
 
 {{/*

--- a/charts/camunda-platform/templates/zeebe/_helpers.tpl
+++ b/charts/camunda-platform/templates/zeebe/_helpers.tpl
@@ -37,6 +37,7 @@ app.kubernetes.io/component: zeebe-broker
     {{- include "camundaPlatform.labels" . }}
     {{- "\n" }}
     {{- include "zeebe.extraLabels.broker" . }}
+    {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.zeebe) }}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform/templates/zeebe/_helpers.tpl
+++ b/charts/camunda-platform/templates/zeebe/_helpers.tpl
@@ -27,6 +27,7 @@
 */}}
 {{ define "zeebe.extraLabels.broker" -}}
 app.kubernetes.io/component: zeebe-broker
+app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.zeebe) }}
 {{- end }}
 
 {{/*
@@ -37,7 +38,6 @@ app.kubernetes.io/component: zeebe-broker
     {{- include "camundaPlatform.labels" . }}
     {{- "\n" }}
     {{- include "zeebe.extraLabels.broker" . }}
-    {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.zeebe) }}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform/test/unit/camunda/golden/connectors-service-monitor.golden.yaml
+++ b/charts/camunda-platform/test/unit/camunda/golden/connectors-service-monitor.golden.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     release: metrics
 spec:
   selector:

--- a/charts/camunda-platform/test/unit/camunda/golden/identity-service-monitor.golden.yaml
+++ b/charts/camunda-platform/test/unit/camunda/golden/identity-service-monitor.golden.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     release: metrics
 spec:
   selector:

--- a/charts/camunda-platform/test/unit/camunda/golden/operate-service-monitor.golden.yaml
+++ b/charts/camunda-platform/test/unit/camunda/golden/operate-service-monitor.golden.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     release: metrics
 spec:
   selector:

--- a/charts/camunda-platform/test/unit/camunda/golden/optimize-service-monitor.golden.yaml
+++ b/charts/camunda-platform/test/unit/camunda/golden/optimize-service-monitor.golden.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     release: metrics
 spec:
   selector:

--- a/charts/camunda-platform/test/unit/camunda/golden/secret-connectors.golden.yaml
+++ b/charts/camunda-platform/test/unit/camunda/golden/secret-connectors.golden.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: identity
 type: Opaque
 data:

--- a/charts/camunda-platform/test/unit/camunda/golden/secret-console.golden.yaml
+++ b/charts/camunda-platform/test/unit/camunda/golden/secret-console.golden.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: identity
 type: Opaque
 data:

--- a/charts/camunda-platform/test/unit/camunda/golden/secret-operate.golden.yaml
+++ b/charts/camunda-platform/test/unit/camunda/golden/secret-operate.golden.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: identity
 type: Opaque
 data:

--- a/charts/camunda-platform/test/unit/camunda/golden/secret-optimize.golden.yaml
+++ b/charts/camunda-platform/test/unit/camunda/golden/secret-optimize.golden.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: identity
 type: Opaque
 data:

--- a/charts/camunda-platform/test/unit/camunda/golden/secret-tasklist.golden.yaml
+++ b/charts/camunda-platform/test/unit/camunda/golden/secret-tasklist.golden.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: identity
 type: Opaque
 data:

--- a/charts/camunda-platform/test/unit/camunda/golden/secret-zeebe.golden.yaml
+++ b/charts/camunda-platform/test/unit/camunda/golden/secret-zeebe.golden.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: identity
 type: Opaque
 data:

--- a/charts/camunda-platform/test/unit/camunda/golden/tasklist-service-monitor.golden.yaml
+++ b/charts/camunda-platform/test/unit/camunda/golden/tasklist-service-monitor.golden.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     release: metrics
 spec:
   selector:

--- a/charts/camunda-platform/test/unit/camunda/golden/web-modeler-service-monitor.golden.yaml
+++ b/charts/camunda-platform/test/unit/camunda/golden/web-modeler-service-monitor.golden.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     release: metrics
 spec:
   selector:
@@ -34,7 +33,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     release: metrics
 spec:
   selector:

--- a/charts/camunda-platform/test/unit/camunda/golden/zeebe-gateway-service-monitor.golden.yaml
+++ b/charts/camunda-platform/test/unit/camunda/golden/zeebe-gateway-service-monitor.golden.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     release: metrics
 spec:
   selector:

--- a/charts/camunda-platform/test/unit/camunda/golden/zeebe-service-monitor.golden.yaml
+++ b/charts/camunda-platform/test/unit/camunda/golden/zeebe-service-monitor.golden.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     release: metrics
 spec:
   selector:

--- a/charts/camunda-platform/test/unit/connectors/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/connectors/golden/deployment.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: connectors
+    app.kubernetes.io/version: 8.4.6
   annotations:
     {}
 spec:
@@ -24,6 +24,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: connectors
+      app.kubernetes.io/version: 8.4.6
   template:
     metadata:
       labels:
@@ -32,10 +33,10 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "8.5.0-alpha2"
         app.kubernetes.io/component: connectors
+        app.kubernetes.io/version: 8.4.6
       annotations:
-        checksum/config: a4f1ef50637254d9eb25cc41a9571a3363e993b5da07b875579e8deb69a7e07d
+        checksum/config: 52e35609f0c8f26ce16cbed335eaa5626fe0eafba9e4b3d543d393ebe40cec4e
     spec:
       imagePullSecrets:
         []

--- a/charts/camunda-platform/test/unit/connectors/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/connectors/golden/deployment.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: 8.4.6
+    app.kubernetes.io/version: "8.4.6"
   annotations:
     {}
 spec:
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: connectors
-      app.kubernetes.io/version: 8.4.6
+      app.kubernetes.io/version: "8.4.6"
   template:
     metadata:
       labels:
@@ -34,9 +34,9 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
         app.kubernetes.io/component: connectors
-        app.kubernetes.io/version: 8.4.6
+        app.kubernetes.io/version: "8.4.6"
       annotations:
-        checksum/config: 52e35609f0c8f26ce16cbed335eaa5626fe0eafba9e4b3d543d393ebe40cec4e
+        checksum/config: acd5c711153206452a51a809493e907f46126aab458b48c51ca5eb0590d6c869
     spec:
       imagePullSecrets:
         []

--- a/charts/camunda-platform/test/unit/connectors/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/connectors/golden/ingress-all-enabled.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: connectors
+    app.kubernetes.io/version: 8.4.6
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/connectors/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/connectors/golden/ingress-all-enabled.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: 8.4.6
+    app.kubernetes.io/version: "8.4.6"
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/connectors/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/connectors/golden/ingress.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: connectors
+    app.kubernetes.io/version: 8.4.6
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/connectors/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/connectors/golden/ingress.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: 8.4.6
+    app.kubernetes.io/version: "8.4.6"
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/connectors/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/connectors/golden/service.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: connectors
+    app.kubernetes.io/version: 8.4.6
   annotations:
 spec:
   type: ClusterIP
@@ -27,3 +27,4 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: connectors
+    app.kubernetes.io/version: 8.4.6

--- a/charts/camunda-platform/test/unit/connectors/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/connectors/golden/service.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: 8.4.6
+    app.kubernetes.io/version: "8.4.6"
   annotations:
 spec:
   type: ClusterIP
@@ -27,4 +27,4 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: 8.4.6
+    app.kubernetes.io/version: "8.4.6"

--- a/charts/camunda-platform/test/unit/connectors/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/unit/connectors/golden/serviceaccount.golden.yaml
@@ -10,6 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: connectors
+    app.kubernetes.io/version: 8.4.6
 automountServiceAccountToken: false

--- a/charts/camunda-platform/test/unit/connectors/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/unit/connectors/golden/serviceaccount.golden.yaml
@@ -11,5 +11,5 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: 8.4.6
+    app.kubernetes.io/version: "8.4.6"
 automountServiceAccountToken: false

--- a/charts/camunda-platform/test/unit/console/golden/configmap.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/configmap.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: console
+    app.kubernetes.io/version: 8.5.0
 data:
   application.yaml: |-
     # https://docs.camunda.io/docs/self-managed/console-deployment/configuration/

--- a/charts/camunda-platform/test/unit/console/golden/configmap.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/configmap.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: console
-    app.kubernetes.io/version: 8.5.0
+    app.kubernetes.io/version: "8.5.0"
 data:
   application.yaml: |-
     # https://docs.camunda.io/docs/self-managed/console-deployment/configuration/

--- a/charts/camunda-platform/test/unit/console/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/deployment.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: console
-    app.kubernetes.io/version: 8.5.0
+    app.kubernetes.io/version: "8.5.0"
   annotations:
     {}
 spec:
@@ -24,11 +24,11 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: console
-      app.kubernetes.io/version: 8.5.0
+      app.kubernetes.io/version: "8.5.0"
   template:
     metadata:
       annotations:
-        checksum/config: be4b151386942efbd504c5d6a6a655c3690bc6451bda93126184cd1924765440
+        checksum/config: ed99b4328e57ed9adca09e18445f46880bbbb0f92fbf59a125bce33001b0e542
       labels:
         app: camunda-platform
         app.kubernetes.io/name: camunda-platform
@@ -36,7 +36,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
         app.kubernetes.io/component: console
-        app.kubernetes.io/version: 8.5.0
+        app.kubernetes.io/version: "8.5.0"
     spec:
       imagePullSecrets:
         []

--- a/charts/camunda-platform/test/unit/console/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/deployment.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: console
+    app.kubernetes.io/version: 8.5.0
   annotations:
     {}
 spec:
@@ -24,10 +24,11 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: console
+      app.kubernetes.io/version: 8.5.0
   template:
     metadata:
       annotations:
-        checksum/config: ee4f8fb96962f8257e7ebcc2159792324864a68147f7e43c43413242ff76ad39
+        checksum/config: be4b151386942efbd504c5d6a6a655c3690bc6451bda93126184cd1924765440
       labels:
         app: camunda-platform
         app.kubernetes.io/name: camunda-platform
@@ -35,6 +36,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
         app.kubernetes.io/component: console
+        app.kubernetes.io/version: 8.5.0
     spec:
       imagePullSecrets:
         []

--- a/charts/camunda-platform/test/unit/console/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/ingress-all-enabled.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: console
-    app.kubernetes.io/version: 8.5.0
+    app.kubernetes.io/version: "8.5.0"
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/console/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/ingress-all-enabled.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: console
+    app.kubernetes.io/version: 8.5.0
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/console/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/ingress.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: console
-    app.kubernetes.io/version: 8.5.0
+    app.kubernetes.io/version: "8.5.0"
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/console/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/ingress.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: console
+    app.kubernetes.io/version: 8.5.0
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/console/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/service.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: console
+    app.kubernetes.io/version: 8.5.0
   annotations:
 spec:
   type: ClusterIP
@@ -31,3 +31,4 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: console
+    app.kubernetes.io/version: 8.5.0

--- a/charts/camunda-platform/test/unit/console/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/service.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: console
-    app.kubernetes.io/version: 8.5.0
+    app.kubernetes.io/version: "8.5.0"
   annotations:
 spec:
   type: ClusterIP
@@ -31,4 +31,4 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: console
-    app.kubernetes.io/version: 8.5.0
+    app.kubernetes.io/version: "8.5.0"

--- a/charts/camunda-platform/test/unit/console/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/serviceaccount.golden.yaml
@@ -10,6 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: console
+    app.kubernetes.io/version: 8.5.0
 automountServiceAccountToken: false

--- a/charts/camunda-platform/test/unit/console/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/serviceaccount.golden.yaml
@@ -11,5 +11,5 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: console
-    app.kubernetes.io/version: 8.5.0
+    app.kubernetes.io/version: "8.5.0"
 automountServiceAccountToken: false

--- a/charts/camunda-platform/test/unit/identity/golden/configmap-env-vars.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/configmap-env-vars.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: 8.5.0-alpha2
+    app.kubernetes.io/version: "8.5.0-alpha2"
   annotations:
     {}
 data:

--- a/charts/camunda-platform/test/unit/identity/golden/configmap-env-vars.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/configmap-env-vars.golden.yaml
@@ -1,9 +1,9 @@
 ---
-# Source: camunda-platform/templates/identity/serviceaccount.yaml
+# Source: camunda-platform/templates/identity/configmap-env-vars.yaml
 apiVersion: v1
-kind: ServiceAccount
+kind: ConfigMap
 metadata:
-  name: camunda-platform-test-identity
+  name: camunda-platform-test-identity-config-env-vars
   labels:
     app: camunda-platform
     app.kubernetes.io/name: camunda-platform
@@ -12,4 +12,7 @@ metadata:
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: identity
     app.kubernetes.io/version: 8.5.0-alpha2
-automountServiceAccountToken: true
+  annotations:
+    {}
+data:
+  IDENTITY_URL: ""

--- a/charts/camunda-platform/test/unit/identity/golden/configmap.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/configmap.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: 8.5.0-alpha2
+    app.kubernetes.io/version: "8.5.0-alpha2"
   annotations:
     {}
 data:

--- a/charts/camunda-platform/test/unit/identity/golden/configmap.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/configmap.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: identity
+    app.kubernetes.io/version: 8.5.0-alpha2
   annotations:
     {}
 data:

--- a/charts/camunda-platform/test/unit/identity/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/deployment.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: identity
+    app.kubernetes.io/version: 8.5.0-alpha2
   annotations:
     {}
 spec:
@@ -24,6 +24,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: identity
+      app.kubernetes.io/version: 8.5.0-alpha2
   template:
     metadata:
       labels:
@@ -32,10 +33,10 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "8.5.0-alpha2"
         app.kubernetes.io/component: identity
+        app.kubernetes.io/version: 8.5.0-alpha2
       annotations:
-        checksum/config: 3975916697161092a2c137501fc0114d11cdc543ecd1edc63ea7507489807538
+        checksum/config: bc35e2afa17767d621db8257c529098454a385b70d194a133d3a5778d5114811
     spec:
       imagePullSecrets:
         []

--- a/charts/camunda-platform/test/unit/identity/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/deployment.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: 8.5.0-alpha2
+    app.kubernetes.io/version: "8.5.0-alpha2"
   annotations:
     {}
 spec:
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: identity
-      app.kubernetes.io/version: 8.5.0-alpha2
+      app.kubernetes.io/version: "8.5.0-alpha2"
   template:
     metadata:
       labels:
@@ -34,9 +34,9 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
         app.kubernetes.io/component: identity
-        app.kubernetes.io/version: 8.5.0-alpha2
+        app.kubernetes.io/version: "8.5.0-alpha2"
       annotations:
-        checksum/config: bc35e2afa17767d621db8257c529098454a385b70d194a133d3a5778d5114811
+        checksum/config: d47f05ffb2f81718eea8331492f8b9c4353fa3f4528d0580445d929639e3ca0a
     spec:
       imagePullSecrets:
         []

--- a/charts/camunda-platform/test/unit/identity/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/ingress-all-enabled.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: identity
+    app.kubernetes.io/version: 8.5.0-alpha2
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/identity/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/ingress-all-enabled.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: 8.5.0-alpha2
+    app.kubernetes.io/version: "8.5.0-alpha2"
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/identity/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/ingress.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: identity
+    app.kubernetes.io/version: 8.5.0-alpha2
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/identity/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/ingress.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: 8.5.0-alpha2
+    app.kubernetes.io/version: "8.5.0-alpha2"
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/identity/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/service.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: 8.5.0-alpha2
+    app.kubernetes.io/version: "8.5.0-alpha2"
   annotations:
 spec:
   type: ClusterIP
@@ -31,4 +31,4 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: 8.5.0-alpha2
+    app.kubernetes.io/version: "8.5.0-alpha2"

--- a/charts/camunda-platform/test/unit/identity/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/service.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: identity
+    app.kubernetes.io/version: 8.5.0-alpha2
   annotations:
 spec:
   type: ClusterIP
@@ -31,3 +31,4 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: identity
+    app.kubernetes.io/version: 8.5.0-alpha2

--- a/charts/camunda-platform/test/unit/identity/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/serviceaccount.golden.yaml
@@ -11,5 +11,5 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: 8.5.0-alpha2
+    app.kubernetes.io/version: "8.5.0-alpha2"
 automountServiceAccountToken: true

--- a/charts/camunda-platform/test/unit/operate/golden/configmap.golden.yaml
+++ b/charts/camunda-platform/test/unit/operate/golden/configmap.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: operate
-    app.kubernetes.io/version: 8.5.0-alpha2
+    app.kubernetes.io/version: "8.5.0-alpha2"
 data:
   application.yml: |
     spring:

--- a/charts/camunda-platform/test/unit/operate/golden/configmap.golden.yaml
+++ b/charts/camunda-platform/test/unit/operate/golden/configmap.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: operate
+    app.kubernetes.io/version: 8.5.0-alpha2
 data:
   application.yml: |
     spring:

--- a/charts/camunda-platform/test/unit/operate/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/operate/golden/deployment.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: operate
-    app.kubernetes.io/version: 8.5.0-alpha2
+    app.kubernetes.io/version: "8.5.0-alpha2"
   annotations:
     {}
 spec:
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: operate
-      app.kubernetes.io/version: 8.5.0-alpha2
+      app.kubernetes.io/version: "8.5.0-alpha2"
   template:
     metadata:
       labels:
@@ -34,9 +34,9 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
         app.kubernetes.io/component: operate
-        app.kubernetes.io/version: 8.5.0-alpha2
+        app.kubernetes.io/version: "8.5.0-alpha2"
       annotations:
-        checksum/config: d44ac21fe70f6eaffef87649a5c907768520fe4ef15d7954fc843ebdc1ac22fa
+        checksum/config: ca6403cdcba604dbc0a6cd1957e3aab6540f06a9174a2a910512c8767f889de2
     spec:
       imagePullSecrets:
         []

--- a/charts/camunda-platform/test/unit/operate/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/operate/golden/deployment.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: operate
+    app.kubernetes.io/version: 8.5.0-alpha2
   annotations:
     {}
 spec:
@@ -24,6 +24,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: operate
+      app.kubernetes.io/version: 8.5.0-alpha2
   template:
     metadata:
       labels:
@@ -32,10 +33,10 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "8.5.0-alpha2"
         app.kubernetes.io/component: operate
+        app.kubernetes.io/version: 8.5.0-alpha2
       annotations:
-        checksum/config: e1bb53ab3b1e1e9c0de2c9709eb25fbfc191d2e41eeeaeb6f299838fb2fd06c2
+        checksum/config: d44ac21fe70f6eaffef87649a5c907768520fe4ef15d7954fc843ebdc1ac22fa
     spec:
       imagePullSecrets:
         []

--- a/charts/camunda-platform/test/unit/operate/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/operate/golden/ingress-all-enabled.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: operate
-    app.kubernetes.io/version: 8.5.0-alpha2
+    app.kubernetes.io/version: "8.5.0-alpha2"
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/operate/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/operate/golden/ingress-all-enabled.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: operate
+    app.kubernetes.io/version: 8.5.0-alpha2
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/operate/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/operate/golden/ingress.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: operate
-    app.kubernetes.io/version: 8.5.0-alpha2
+    app.kubernetes.io/version: "8.5.0-alpha2"
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/operate/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/operate/golden/ingress.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: operate
+    app.kubernetes.io/version: 8.5.0-alpha2
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/operate/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/operate/golden/service.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: operate
-    app.kubernetes.io/version: 8.5.0-alpha2
+    app.kubernetes.io/version: "8.5.0-alpha2"
   annotations:
 spec:
   type: ClusterIP
@@ -27,4 +27,4 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: operate
-    app.kubernetes.io/version: 8.5.0-alpha2
+    app.kubernetes.io/version: "8.5.0-alpha2"

--- a/charts/camunda-platform/test/unit/operate/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/operate/golden/service.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: operate
+    app.kubernetes.io/version: 8.5.0-alpha2
   annotations:
 spec:
   type: ClusterIP
@@ -27,3 +27,4 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: operate
+    app.kubernetes.io/version: 8.5.0-alpha2

--- a/charts/camunda-platform/test/unit/operate/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/unit/operate/golden/serviceaccount.golden.yaml
@@ -11,5 +11,5 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: operate
-    app.kubernetes.io/version: 8.5.0-alpha2
+    app.kubernetes.io/version: "8.5.0-alpha2"
 automountServiceAccountToken: false

--- a/charts/camunda-platform/test/unit/operate/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/unit/operate/golden/serviceaccount.golden.yaml
@@ -10,6 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: operate
+    app.kubernetes.io/version: 8.5.0-alpha2
 automountServiceAccountToken: false

--- a/charts/camunda-platform/test/unit/optimize/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/optimize/golden/deployment.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: optimize
+    app.kubernetes.io/version: 8.4.2
   annotations:
     {}
 spec:
@@ -24,6 +24,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: optimize
+      app.kubernetes.io/version: 8.4.2
   template:
     metadata:
       labels:
@@ -32,10 +33,10 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "8.5.0-alpha2"
         app.kubernetes.io/component: optimize
+        app.kubernetes.io/version: 8.4.2
       annotations:
-        checksum/config: 3707c07a28696d6d5c68762f39c8a9ddd3bc7412af4597b4cd69d41c8bae7dd1
+        checksum/config: 76e2767bb226b24bca34cc7526e032f59b7f2841cbeb6fb17f6d2abd1b3bf72e
     spec:
       imagePullSecrets:
         []

--- a/charts/camunda-platform/test/unit/optimize/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/optimize/golden/deployment.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: 8.4.2
+    app.kubernetes.io/version: "8.4.2"
   annotations:
     {}
 spec:
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: optimize
-      app.kubernetes.io/version: 8.4.2
+      app.kubernetes.io/version: "8.4.2"
   template:
     metadata:
       labels:
@@ -34,9 +34,9 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
         app.kubernetes.io/component: optimize
-        app.kubernetes.io/version: 8.4.2
+        app.kubernetes.io/version: "8.4.2"
       annotations:
-        checksum/config: 76e2767bb226b24bca34cc7526e032f59b7f2841cbeb6fb17f6d2abd1b3bf72e
+        checksum/config: 5dbeb66e4cd32040926f11a7c992a87f231461c53de97c23eb1bfd7fffe2ee55
     spec:
       imagePullSecrets:
         []

--- a/charts/camunda-platform/test/unit/optimize/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/optimize/golden/ingress-all-enabled.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: 8.4.2
+    app.kubernetes.io/version: "8.4.2"
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/optimize/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/optimize/golden/ingress-all-enabled.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: optimize
+    app.kubernetes.io/version: 8.4.2
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/optimize/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/optimize/golden/ingress.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: 8.4.2
+    app.kubernetes.io/version: "8.4.2"
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/optimize/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/optimize/golden/ingress.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: optimize
+    app.kubernetes.io/version: 8.4.2
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/optimize/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/optimize/golden/service.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: 8.4.2
+    app.kubernetes.io/version: "8.4.2"
   annotations:
 spec:
   type: ClusterIP
@@ -31,4 +31,4 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: 8.4.2
+    app.kubernetes.io/version: "8.4.2"

--- a/charts/camunda-platform/test/unit/optimize/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/optimize/golden/service.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: optimize
+    app.kubernetes.io/version: 8.4.2
   annotations:
 spec:
   type: ClusterIP
@@ -31,3 +31,4 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: optimize
+    app.kubernetes.io/version: 8.4.2

--- a/charts/camunda-platform/test/unit/optimize/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/unit/optimize/golden/serviceaccount.golden.yaml
@@ -10,6 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: optimize
+    app.kubernetes.io/version: 8.4.2
 automountServiceAccountToken: false

--- a/charts/camunda-platform/test/unit/optimize/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/unit/optimize/golden/serviceaccount.golden.yaml
@@ -11,5 +11,5 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: 8.4.2
+    app.kubernetes.io/version: "8.4.2"
 automountServiceAccountToken: false

--- a/charts/camunda-platform/test/unit/tasklist/golden/configmap.golden.yaml
+++ b/charts/camunda-platform/test/unit/tasklist/golden/configmap.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: tasklist
-    app.kubernetes.io/version: 8.5.0-alpha2
+    app.kubernetes.io/version: "8.5.0-alpha2"
 data:
   application.yml: |
     spring:

--- a/charts/camunda-platform/test/unit/tasklist/golden/configmap.golden.yaml
+++ b/charts/camunda-platform/test/unit/tasklist/golden/configmap.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: tasklist
+    app.kubernetes.io/version: 8.5.0-alpha2
 data:
   application.yml: |
     spring:

--- a/charts/camunda-platform/test/unit/tasklist/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/tasklist/golden/deployment.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: tasklist
-    app.kubernetes.io/version: 8.5.0-alpha2
+    app.kubernetes.io/version: "8.5.0-alpha2"
   annotations:
     {}
 spec:
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: tasklist
-      app.kubernetes.io/version: 8.5.0-alpha2
+      app.kubernetes.io/version: "8.5.0-alpha2"
   template:
     metadata:
       labels:
@@ -34,9 +34,9 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
         app.kubernetes.io/component: tasklist
-        app.kubernetes.io/version: 8.5.0-alpha2
+        app.kubernetes.io/version: "8.5.0-alpha2"
       annotations:
-        checksum/config: 91f0aeaf26e59e8792773577343663d577565c16843fcbf061c4d50d98caeac5
+        checksum/config: 4128b4196998289d541478a198258749139eb5c7712689c0f7b15ca543434748
     spec:
       imagePullSecrets:
         []

--- a/charts/camunda-platform/test/unit/tasklist/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/tasklist/golden/deployment.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: tasklist
+    app.kubernetes.io/version: 8.5.0-alpha2
   annotations:
     {}
 spec:
@@ -24,6 +24,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: tasklist
+      app.kubernetes.io/version: 8.5.0-alpha2
   template:
     metadata:
       labels:
@@ -32,10 +33,10 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "8.5.0-alpha2"
         app.kubernetes.io/component: tasklist
+        app.kubernetes.io/version: 8.5.0-alpha2
       annotations:
-        checksum/config: 6d681528ffb55fd2c594ae55901b525512ab80bda2795447398fb1c66613fefd
+        checksum/config: 91f0aeaf26e59e8792773577343663d577565c16843fcbf061c4d50d98caeac5
     spec:
       imagePullSecrets:
         []

--- a/charts/camunda-platform/test/unit/tasklist/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/tasklist/golden/ingress-all-enabled.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: tasklist
-    app.kubernetes.io/version: 8.5.0-alpha2
+    app.kubernetes.io/version: "8.5.0-alpha2"
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/tasklist/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/tasklist/golden/ingress-all-enabled.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: tasklist
+    app.kubernetes.io/version: 8.5.0-alpha2
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/tasklist/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/tasklist/golden/ingress.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: tasklist
-    app.kubernetes.io/version: 8.5.0-alpha2
+    app.kubernetes.io/version: "8.5.0-alpha2"
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/tasklist/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/tasklist/golden/ingress.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: tasklist
+    app.kubernetes.io/version: 8.5.0-alpha2
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/tasklist/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/tasklist/golden/service.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: tasklist
-    app.kubernetes.io/version: 8.5.0-alpha2
+    app.kubernetes.io/version: "8.5.0-alpha2"
   annotations:
 spec:
   type: ClusterIP
@@ -27,4 +27,4 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: tasklist
-    app.kubernetes.io/version: 8.5.0-alpha2
+    app.kubernetes.io/version: "8.5.0-alpha2"

--- a/charts/camunda-platform/test/unit/tasklist/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/tasklist/golden/service.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: tasklist
+    app.kubernetes.io/version: 8.5.0-alpha2
   annotations:
 spec:
   type: ClusterIP
@@ -27,3 +27,4 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: tasklist
+    app.kubernetes.io/version: 8.5.0-alpha2

--- a/charts/camunda-platform/test/unit/web-modeler/golden/configmap-shared.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/configmap-shared.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: web-modeler
-    app.kubernetes.io/version: 8.4.3
+    app.kubernetes.io/version: "8.4.3"
   annotations:
     {}
 data:

--- a/charts/camunda-platform/test/unit/web-modeler/golden/configmap-shared.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/configmap-shared.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.3"
     app.kubernetes.io/component: web-modeler
+    app.kubernetes.io/version: 8.4.3
   annotations:
     {}
 data:

--- a/charts/camunda-platform/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.3"
     app.kubernetes.io/component: restapi
   annotations:
     {}
@@ -32,7 +31,6 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "8.4.3"
         app.kubernetes.io/component: restapi
     spec:
       imagePullSecrets:

--- a/charts/camunda-platform/test/unit/web-modeler/golden/deployment-webapp.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/deployment-webapp.golden.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.3"
     app.kubernetes.io/component: webapp
   annotations:
     {}
@@ -32,7 +31,6 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "8.4.3"
         app.kubernetes.io/component: webapp
     spec:
       imagePullSecrets:

--- a/charts/camunda-platform/test/unit/web-modeler/golden/deployment-websockets.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/deployment-websockets.golden.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.3"
     app.kubernetes.io/component: websockets
   annotations:
     {}
@@ -32,7 +31,6 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "8.4.3"
         app.kubernetes.io/component: websockets
     spec:
       imagePullSecrets:

--- a/charts/camunda-platform/test/unit/web-modeler/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/ingress-all-enabled.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: web-modeler
-    app.kubernetes.io/version: 8.4.3
+    app.kubernetes.io/version: "8.4.3"
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/web-modeler/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/ingress-all-enabled.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.3"
     app.kubernetes.io/component: web-modeler
+    app.kubernetes.io/version: 8.4.3
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/web-modeler/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/ingress.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: web-modeler
-    app.kubernetes.io/version: 8.4.3
+    app.kubernetes.io/version: "8.4.3"
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/web-modeler/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/ingress.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.3"
     app.kubernetes.io/component: web-modeler
+    app.kubernetes.io/version: 8.4.3
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/web-modeler/golden/secret-shared.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/secret-shared.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: web-modeler
-    app.kubernetes.io/version: 8.4.3
+    app.kubernetes.io/version: "8.4.3"
   annotations:
     {}
 type: Opaque

--- a/charts/camunda-platform/test/unit/web-modeler/golden/secret-shared.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/secret-shared.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.3"
     app.kubernetes.io/component: web-modeler
+    app.kubernetes.io/version: 8.4.3
   annotations:
     {}
 type: Opaque

--- a/charts/camunda-platform/test/unit/web-modeler/golden/service-restapi.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/service-restapi.golden.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.3"
     app.kubernetes.io/component: restapi
   annotations:
 spec:

--- a/charts/camunda-platform/test/unit/web-modeler/golden/service-webapp.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/service-webapp.golden.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.3"
     app.kubernetes.io/component: webapp
   annotations:
 spec:

--- a/charts/camunda-platform/test/unit/web-modeler/golden/service-websockets.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/service-websockets.golden.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.3"
     app.kubernetes.io/component: websockets
   annotations:
 spec:

--- a/charts/camunda-platform/test/unit/web-modeler/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/serviceaccount.golden.yaml
@@ -10,6 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.4.3"
     app.kubernetes.io/component: web-modeler
+    app.kubernetes.io/version: 8.4.3
 automountServiceAccountToken: false

--- a/charts/camunda-platform/test/unit/web-modeler/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/serviceaccount.golden.yaml
@@ -11,5 +11,5 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: web-modeler
-    app.kubernetes.io/version: 8.4.3
+    app.kubernetes.io/version: "8.4.3"
 automountServiceAccountToken: false

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/configmap-log4j2.golden.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: zeebe-gateway
+    app.kubernetes.io/version: 8.5.0-RC2
 apiVersion: v1
 data:
   gateway-log4j2.xml: |

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/configmap-log4j2.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: 8.5.0-RC2
+    app.kubernetes.io/version: "8.5.0-RC2"
 apiVersion: v1
 data:
   gateway-log4j2.xml: |

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/configmap.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/configmap.golden.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: zeebe-gateway
+    app.kubernetes.io/version: 8.5.0-RC2
 apiVersion: v1
 data:
   gateway-log4j2.xml: |

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/configmap.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/configmap.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: 8.5.0-RC2
+    app.kubernetes.io/version: "8.5.0-RC2"
 apiVersion: v1
 data:
   gateway-log4j2.xml: |

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/deployment.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: zeebe-gateway
+    app.kubernetes.io/version: 8.5.0-RC2
   annotations:
     {}
 spec:
@@ -24,6 +24,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: zeebe-gateway
+      app.kubernetes.io/version: 8.5.0-RC2
   template:
     metadata:
       labels:
@@ -32,10 +33,10 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "8.5.0-alpha2"
         app.kubernetes.io/component: zeebe-gateway
+        app.kubernetes.io/version: 8.5.0-RC2
       annotations:
-        checksum/config: 7b6069ff090cede7496a50541e97fcaa022fe198a2cfaafc16331e28596514fb
+        checksum/config: 287f371844b75f4f5cf52ba9a29b831bbca7d39d64b2739208f2e6682f253ebd
     spec:
       imagePullSecrets:
         []

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/deployment.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: 8.5.0-RC2
+    app.kubernetes.io/version: "8.5.0-RC2"
   annotations:
     {}
 spec:
@@ -24,7 +24,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: zeebe-gateway
-      app.kubernetes.io/version: 8.5.0-RC2
+      app.kubernetes.io/version: "8.5.0-RC2"
   template:
     metadata:
       labels:
@@ -34,9 +34,9 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
         app.kubernetes.io/component: zeebe-gateway
-        app.kubernetes.io/version: 8.5.0-RC2
+        app.kubernetes.io/version: "8.5.0-RC2"
       annotations:
-        checksum/config: 287f371844b75f4f5cf52ba9a29b831bbca7d39d64b2739208f2e6682f253ebd
+        checksum/config: 3f2c7590fc320576d7a20fd9fefbfc233650397c798087bbf341985e7d2261d6
     spec:
       imagePullSecrets:
         []

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/ingress-grpc-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/ingress-grpc-all-enabled.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: zeebe-gateway
+    app.kubernetes.io/version: 8.5.0-RC2
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/backend-protocol: GRPC

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/ingress-grpc-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/ingress-grpc-all-enabled.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: 8.5.0-RC2
+    app.kubernetes.io/version: "8.5.0-RC2"
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/backend-protocol: GRPC

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/ingress-grpc.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/ingress-grpc.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: zeebe-gateway
+    app.kubernetes.io/version: 8.5.0-RC2
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/backend-protocol: GRPC

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/ingress-grpc.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/ingress-grpc.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: 8.5.0-RC2
+    app.kubernetes.io/version: "8.5.0-RC2"
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/backend-protocol: GRPC

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/ingress-rest-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/ingress-rest-all-enabled.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: zeebe-gateway
+    app.kubernetes.io/version: 8.5.0-RC2
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/backend-protocol: HTTP

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/ingress-rest-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/ingress-rest-all-enabled.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: 8.5.0-RC2
+    app.kubernetes.io/version: "8.5.0-RC2"
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/backend-protocol: HTTP

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/ingress-rest.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/ingress-rest.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: zeebe-gateway
+    app.kubernetes.io/version: 8.5.0-RC2
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/backend-protocol: HTTP

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/ingress-rest.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/ingress-rest.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: 8.5.0-RC2
+    app.kubernetes.io/version: "8.5.0-RC2"
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/backend-protocol: HTTP

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/poddisruptionbudget.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/poddisruptionbudget.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: zeebe-gateway
+    app.kubernetes.io/version: 8.5.0-RC2
 spec:
   minAvailable: 1
   selector:
@@ -22,3 +22,4 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: zeebe-gateway
+      app.kubernetes.io/version: 8.5.0-RC2

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/poddisruptionbudget.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/poddisruptionbudget.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: 8.5.0-RC2
+    app.kubernetes.io/version: "8.5.0-RC2"
 spec:
   minAvailable: 1
   selector:
@@ -22,4 +22,4 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: zeebe-gateway
-      app.kubernetes.io/version: 8.5.0-RC2
+      app.kubernetes.io/version: "8.5.0-RC2"

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/service.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: 8.5.0-RC2
+    app.kubernetes.io/version: "8.5.0-RC2"
   annotations:
 spec:
   type: ClusterIP
@@ -22,7 +22,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: 8.5.0-RC2
+    app.kubernetes.io/version: "8.5.0-RC2"
   ports:
     - port: 9600
       protocol: TCP

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/service.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: zeebe-gateway
+    app.kubernetes.io/version: 8.5.0-RC2
   annotations:
 spec:
   type: ClusterIP
@@ -22,6 +22,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: zeebe-gateway
+    app.kubernetes.io/version: 8.5.0-RC2
   ports:
     - port: 9600
       protocol: TCP

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/serviceaccount-annotations.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/serviceaccount-annotations.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: 8.5.0-RC2
+    app.kubernetes.io/version: "8.5.0-RC2"
   annotations:
     foo: bar
     lulz: baz

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/serviceaccount-annotations.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/serviceaccount-annotations.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: zeebe-gateway
+    app.kubernetes.io/version: 8.5.0-RC2
   annotations:
     foo: bar
     lulz: baz

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/serviceaccount.golden.yaml
@@ -11,5 +11,5 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: 8.5.0-RC2
+    app.kubernetes.io/version: "8.5.0-RC2"
 automountServiceAccountToken: false

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/serviceaccount.golden.yaml
@@ -10,6 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: zeebe-gateway
+    app.kubernetes.io/version: 8.5.0-RC2
 automountServiceAccountToken: false

--- a/charts/camunda-platform/test/unit/zeebe/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/configmap-log4j2.golden.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: zeebe-broker
+    app.kubernetes.io/version: 8.5.0-RC2
 apiVersion: v1
 data:
   application.yaml: |

--- a/charts/camunda-platform/test/unit/zeebe/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/configmap-log4j2.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: 8.5.0-RC2
+    app.kubernetes.io/version: "8.5.0-RC2"
 apiVersion: v1
 data:
   application.yaml: |

--- a/charts/camunda-platform/test/unit/zeebe/golden/configmap-multiregion-failBack.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/configmap-multiregion-failBack.golden.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: zeebe-broker
+    app.kubernetes.io/version: 8.5.0-RC2
 apiVersion: v1
 data:
   application.yaml: |

--- a/charts/camunda-platform/test/unit/zeebe/golden/configmap-multiregion-failBack.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/configmap-multiregion-failBack.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: 8.5.0-RC2
+    app.kubernetes.io/version: "8.5.0-RC2"
 apiVersion: v1
 data:
   application.yaml: |

--- a/charts/camunda-platform/test/unit/zeebe/golden/configmap-multiregion-failOver.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/configmap-multiregion-failOver.golden.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: zeebe-broker
+    app.kubernetes.io/version: 8.5.0-RC2
 apiVersion: v1
 data:
   application.yaml: |

--- a/charts/camunda-platform/test/unit/zeebe/golden/configmap-multiregion-failOver.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/configmap-multiregion-failOver.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: 8.5.0-RC2
+    app.kubernetes.io/version: "8.5.0-RC2"
 apiVersion: v1
 data:
   application.yaml: |

--- a/charts/camunda-platform/test/unit/zeebe/golden/configmap.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/configmap.golden.yaml
@@ -9,8 +9,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: zeebe-broker
+    app.kubernetes.io/version: 8.5.0-RC2
 apiVersion: v1
 data:
   application.yaml: |

--- a/charts/camunda-platform/test/unit/zeebe/golden/configmap.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/configmap.golden.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: 8.5.0-RC2
+    app.kubernetes.io/version: "8.5.0-RC2"
 apiVersion: v1
 data:
   application.yaml: |

--- a/charts/camunda-platform/test/unit/zeebe/golden/poddisruptionbudget.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/poddisruptionbudget.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: zeebe-broker
+    app.kubernetes.io/version: 8.5.0-RC2
 spec:
   maxUnavailable: 1
   selector:
@@ -22,3 +22,4 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: zeebe-broker
+      app.kubernetes.io/version: 8.5.0-RC2

--- a/charts/camunda-platform/test/unit/zeebe/golden/poddisruptionbudget.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/poddisruptionbudget.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: 8.5.0-RC2
+    app.kubernetes.io/version: "8.5.0-RC2"
 spec:
   maxUnavailable: 1
   selector:
@@ -22,4 +22,4 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: zeebe-broker
-      app.kubernetes.io/version: 8.5.0-RC2
+      app.kubernetes.io/version: "8.5.0-RC2"

--- a/charts/camunda-platform/test/unit/zeebe/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/service.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: zeebe-broker
+    app.kubernetes.io/version: 8.5.0-RC2
   annotations:
 spec:
   clusterIP: None
@@ -34,3 +34,4 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: zeebe-broker
+    app.kubernetes.io/version: 8.5.0-RC2

--- a/charts/camunda-platform/test/unit/zeebe/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/service.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: 8.5.0-RC2
+    app.kubernetes.io/version: "8.5.0-RC2"
   annotations:
 spec:
   clusterIP: None
@@ -34,4 +34,4 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: 8.5.0-RC2
+    app.kubernetes.io/version: "8.5.0-RC2"

--- a/charts/camunda-platform/test/unit/zeebe/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/serviceaccount.golden.yaml
@@ -10,6 +10,6 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: zeebe-broker
+    app.kubernetes.io/version: 8.5.0-RC2
 automountServiceAccountToken: false

--- a/charts/camunda-platform/test/unit/zeebe/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/serviceaccount.golden.yaml
@@ -11,5 +11,5 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: 8.5.0-RC2
+    app.kubernetes.io/version: "8.5.0-RC2"
 automountServiceAccountToken: false

--- a/charts/camunda-platform/test/unit/zeebe/golden/statefulset.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/statefulset.golden.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: "8.5.0-alpha2"
     app.kubernetes.io/component: zeebe-broker
+    app.kubernetes.io/version: 8.5.0-RC2
   annotations:
 spec:
   replicas: 3
@@ -23,6 +23,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: zeebe-broker
+      app.kubernetes.io/version: 8.5.0-RC2
   serviceName: "camunda-platform-test-zeebe"
   updateStrategy:
     type: RollingUpdate
@@ -35,10 +36,10 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
-        app.kubernetes.io/version: "8.5.0-alpha2"
         app.kubernetes.io/component: zeebe-broker
+        app.kubernetes.io/version: 8.5.0-RC2
       annotations:
-        checksum/config: 3975916697161092a2c137501fc0114d11cdc543ecd1edc63ea7507489807538
+        checksum/config: bc35e2afa17767d621db8257c529098454a385b70d194a133d3a5778d5114811
     spec:
       imagePullSecrets:
         []

--- a/charts/camunda-platform/test/unit/zeebe/golden/statefulset.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/statefulset.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: 8.5.0-RC2
+    app.kubernetes.io/version: "8.5.0-RC2"
   annotations:
 spec:
   replicas: 3
@@ -23,7 +23,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: zeebe-broker
-      app.kubernetes.io/version: 8.5.0-RC2
+      app.kubernetes.io/version: "8.5.0-RC2"
   serviceName: "camunda-platform-test-zeebe"
   updateStrategy:
     type: RollingUpdate
@@ -37,9 +37,9 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
         app.kubernetes.io/component: zeebe-broker
-        app.kubernetes.io/version: 8.5.0-RC2
+        app.kubernetes.io/version: "8.5.0-RC2"
       annotations:
-        checksum/config: bc35e2afa17767d621db8257c529098454a385b70d194a133d3a5778d5114811
+        checksum/config: d47f05ffb2f81718eea8331492f8b9c4353fa3f4528d0580445d929639e3ca0a
     spec:
       imagePullSecrets:
         []


### PR DESCRIPTION
### Which problem does the PR fix?
Related to https://github.com/camunda/camunda-platform-helm/issues/1475
<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?
Updating only Zeebe by changing the value of zeebe.image.tag now updates the version label of the StatefulSet.

After the upgrade of Zeebe, the app.kubernetes.io/version label is updated to the new version.
<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
