### PR TITLE
fix: re-adds necessary permissions GH deployments: write

### DIFF
--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -65,6 +65,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      deployments: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      deployments: write
     secrets: inherit
     uses: ./.github/workflows/test-integration-template.yaml
     with:


### PR DESCRIPTION
### Which problem does the PR fix?

We learned recently that integration tests were not getting ran due to necessary permissions not being applied on the github actions job:
https://github.com/camunda/camunda-platform-helm/actions/runs/8543837528/workflow

![2024-04-03-145517_grim](https://github.com/camunda/camunda-platform-helm/assets/19277629/d4fe028d-7cc9-4183-b374-d1680ed38698)

> The workflow is not valid. .github/workflows/test-integration.yaml (Line: 18, Col: 3): Error calling workflow 'camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@0170911a741cdfddf3a814a98d0631215159c8cc'. The nested job 'clean' is requesting 'deployments: write', but is only allowed 'deployments: none'.

PR that dropped the permission
https://github.com/camunda/camunda-platform-helm/pull/1523


<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
