### PR TITLE
fix: broken helm upgrades due to matchLabels including image version tags

### DIFF
--- a/charts/camunda-platform/templates/connectors/_helpers.tpl
+++ b/charts/camunda-platform/templates/connectors/_helpers.tpl
@@ -44,7 +44,7 @@ Defines match labels for connectors, which are extended by sub-charts and should
 */}}
 {{- define "connectors.matchLabels" -}}
 {{- template "camundaPlatform.matchLabels" . }}
-{{ template "connectors.extraLabels" . }}
+app.kubernetes.io/component: connectors
 {{- end -}}
 {{/*
 [connectors] Create the name of the service account to use

--- a/charts/camunda-platform/templates/console/_helpers.tpl
+++ b/charts/camunda-platform/templates/console/_helpers.tpl
@@ -40,7 +40,7 @@ Selector labels
 */}}
 {{- define "console.matchLabels" -}}
 {{- template "camundaPlatform.matchLabels" . }}
-{{ template "console.extraLabels" . }}
+app.kubernetes.io/component: console
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform/templates/identity/_helpers.tpl
+++ b/charts/camunda-platform/templates/identity/_helpers.tpl
@@ -64,7 +64,7 @@ Defines match labels for identity, which are extended by sub-charts and should b
 */}}
 {{- define "identity.matchLabels" -}}
 {{- template "camundaPlatform.matchLabels" . }}
-{{ template "identity.extraLabels" . }}
+app.kubernetes.io/component: identity
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform/templates/operate/_helpers.tpl
+++ b/charts/camunda-platform/templates/operate/_helpers.tpl
@@ -34,8 +34,7 @@ Defines match labels for operate, which are extended by sub-charts and should be
 */}}
 {{- define "operate.matchLabels" -}}
     {{- include "camundaPlatform.matchLabels" . }}
-    {{- "\n" }}
-    {{- include "operate.extraLabels" . }}
+app.kubernetes.io/component: operate
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform/templates/optimize/_helpers.tpl
+++ b/charts/camunda-platform/templates/optimize/_helpers.tpl
@@ -35,8 +35,7 @@ Defines match labels for optimize, which are extended by sub-charts and should b
 */}}
 {{- define "optimize.matchLabels" -}}
     {{- include "camundaPlatform.matchLabels" . }}
-    {{- "\n" }}
-    {{- include "optimize.extraLabels" . }}
+app.kubernetes.io/component: optimize
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform/templates/tasklist/_helpers.tpl
+++ b/charts/camunda-platform/templates/tasklist/_helpers.tpl
@@ -37,8 +37,7 @@ Defines match labels for tasklist, which are extended by sub-charts and should b
 */}}
 {{- define "tasklist.matchLabels" -}}
     {{- include "camundaPlatform.matchLabels" . }}
-    {{- "\n" }}
-    {{- include "tasklist.extraLabels" . }}
+app.kubernetes.io/component: tasklist
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform/templates/zeebe-gateway/_helpers.tpl
+++ b/charts/camunda-platform/templates/zeebe-gateway/_helpers.tpl
@@ -42,8 +42,7 @@ app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "
 */}}
 {{- define "zeebe.matchLabels.gateway" -}}
     {{- include "camundaPlatform.matchLabels" . }}
-    {{- "\n" }}
-    {{- include "zeebe.extraLabels.gateway" . }}
+app.kubernetes.io/component: zeebe-gateway
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform/templates/zeebe/_helpers.tpl
+++ b/charts/camunda-platform/templates/zeebe/_helpers.tpl
@@ -45,8 +45,7 @@ app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "
 */}}
 {{- define "zeebe.matchLabels.broker" -}}
     {{- include "camundaPlatform.matchLabels" . }}
-    {{- "\n" }}
-    {{- include "zeebe.extraLabels.broker" . }}
+app.kubernetes.io/component: zeebe-broker
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform/test/unit/camunda/ingress_test.go
+++ b/charts/camunda-platform/test/unit/camunda/ingress_test.go
@@ -58,7 +58,7 @@ func (s *ingressTemplateTest) TestIngressEnabledAndKeycloakChartProxyForwardingE
 		SetValues: map[string]string{
 			"global.ingress.tls.enabled": "true",
 			"identity.contextPath":       "/identity",
-			"identityKeycloak.enabled":  "true",
+			"identityKeycloak.enabled":   "true",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 		ExtraArgs:      map[string][]string{"install": {"--debug"}},
@@ -89,8 +89,8 @@ func (s *ingressTemplateTest) TestIngressEnabledWithKeycloakCustomContextPath() 
 		SetValues: map[string]string{
 			"global.ingress.enabled":               "true",
 			"global.identity.keycloak.contextPath": "/custom",
-			"identityKeycloak.enabled":            "true",
-			"identityKeycloak.httpRelativePath":   "/custom",
+			"identityKeycloak.enabled":             "true",
+			"identityKeycloak.httpRelativePath":    "/custom",
 			"identity.contextPath":                 "/identity",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),

--- a/charts/camunda-platform/test/unit/camunda/types.go
+++ b/charts/camunda-platform/test/unit/camunda/types.go
@@ -1,8 +1,8 @@
 package camunda
 
 type ZeebeApplicationYAML struct {
-	Zeebe ZeebeYAML `yaml:"zeebe"`
-	Spring SpringYAML `yaml:"spring"`
+	Zeebe   ZeebeYAML   `yaml:"zeebe"`
+	Spring  SpringYAML  `yaml:"spring"`
 	Camunda CamundaYAML `yaml:"camunda"`
 }
 
@@ -12,7 +12,7 @@ type ZeebeYAML struct {
 }
 
 type BrokerYAML struct {
-	Gateway GatewayYAML `yaml:"gateway"`
+	Gateway   GatewayYAML   `yaml:"gateway"`
 	Exporters ExportersYAML `yaml:"exporters"`
 }
 
@@ -26,7 +26,7 @@ type ElasticsearchYAML struct {
 
 type GatewayYAML struct {
 	MultiTenancy MultiTenancyYAML `yaml:"multitenancy"`
-	Security SecurityYAML `yaml:"security"`
+	Security     SecurityYAML     `yaml:"security"`
 }
 
 type SecurityYAML struct {
@@ -54,6 +54,6 @@ type CamundaYAML struct {
 }
 
 type IdentityYAML struct {
-	Audience string `yaml:"audience"`
+	Audience         string `yaml:"audience"`
 	IssuerBackendUrl string `yaml:"issuerBackendUrl"`
 }

--- a/charts/camunda-platform/test/unit/connectors/configmap_test.go
+++ b/charts/camunda-platform/test/unit/connectors/configmap_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	"path/filepath"
 	"strings"

--- a/charts/camunda-platform/test/unit/connectors/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/connectors/golden/deployment.golden.yaml
@@ -24,7 +24,6 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: connectors
-      app.kubernetes.io/version: "8.4.6"
   template:
     metadata:
       labels:

--- a/charts/camunda-platform/test/unit/connectors/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/connectors/golden/service.golden.yaml
@@ -27,4 +27,3 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.4.6"

--- a/charts/camunda-platform/test/unit/console/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/deployment.golden.yaml
@@ -24,7 +24,6 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: console
-      app.kubernetes.io/version: "8.5.0"
   template:
     metadata:
       annotations:
@@ -36,7 +35,6 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform
         app.kubernetes.io/component: console
-        app.kubernetes.io/version: "8.5.0"
     spec:
       imagePullSecrets:
         []

--- a/charts/camunda-platform/test/unit/console/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/service.golden.yaml
@@ -31,4 +31,3 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: console
-    app.kubernetes.io/version: "8.5.0"

--- a/charts/camunda-platform/test/unit/identity/configmap_test.go
+++ b/charts/camunda-platform/test/unit/identity/configmap_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	"path/filepath"
 	"strings"

--- a/charts/camunda-platform/test/unit/identity/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/deployment.golden.yaml
@@ -24,7 +24,6 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: identity
-      app.kubernetes.io/version: "8.5.0-alpha2"
   template:
     metadata:
       labels:

--- a/charts/camunda-platform/test/unit/identity/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/service.golden.yaml
@@ -31,4 +31,3 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.5.0-alpha2"

--- a/charts/camunda-platform/test/unit/identity/secret_test.go
+++ b/charts/camunda-platform/test/unit/identity/secret_test.go
@@ -55,7 +55,7 @@ func (s *secretTest) TestSecretExternalDatabaseEnabledWithDefinedPassword() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"identityPostgresql.enabled":        "false",
+			"identityPostgresql.enabled":         "false",
 			"identity.externalDatabase.enabled":  "true",
 			"identity.externalDatabase.password": "super-secure-ext",
 		},

--- a/charts/camunda-platform/test/unit/operate/configmap_test.go
+++ b/charts/camunda-platform/test/unit/operate/configmap_test.go
@@ -17,7 +17,7 @@ package operate
 import (
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	"path/filepath"
 	"strings"

--- a/charts/camunda-platform/test/unit/operate/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/operate/golden/deployment.golden.yaml
@@ -24,7 +24,6 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: operate
-      app.kubernetes.io/version: "8.5.0-alpha2"
   template:
     metadata:
       labels:

--- a/charts/camunda-platform/test/unit/operate/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/operate/golden/service.golden.yaml
@@ -27,4 +27,3 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: operate
-    app.kubernetes.io/version: "8.5.0-alpha2"

--- a/charts/camunda-platform/test/unit/optimize/configmap_test.go
+++ b/charts/camunda-platform/test/unit/optimize/configmap_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	"path/filepath"
 	"strings"

--- a/charts/camunda-platform/test/unit/optimize/deployment_test.go
+++ b/charts/camunda-platform/test/unit/optimize/deployment_test.go
@@ -886,7 +886,7 @@ func (s *deploymentTemplateTest) TestOptimizeWithLog4j2Configuration() {
 	// find the volumeMount named environment-config
 	var volumeMount corev1.VolumeMount
 	for _, candidateVolumeMount := range volumeMounts {
-		if candidateVolumeMount.Name == "environment-config" && candidateVolumeMount.MountPath != "/optimize/config/environment-config.yaml"  && candidateVolumeMount.MountPath != "/optimize/config/application-ccsm.yaml" {
+		if candidateVolumeMount.Name == "environment-config" && candidateVolumeMount.MountPath != "/optimize/config/environment-config.yaml" && candidateVolumeMount.MountPath != "/optimize/config/application-ccsm.yaml" {
 			volumeMount = candidateVolumeMount
 			break
 		}

--- a/charts/camunda-platform/test/unit/optimize/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/optimize/golden/deployment.golden.yaml
@@ -24,7 +24,6 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: optimize
-      app.kubernetes.io/version: "8.4.2"
   template:
     metadata:
       labels:

--- a/charts/camunda-platform/test/unit/optimize/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/optimize/golden/service.golden.yaml
@@ -31,4 +31,3 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.4.2"

--- a/charts/camunda-platform/test/unit/tasklist/configmap_test.go
+++ b/charts/camunda-platform/test/unit/tasklist/configmap_test.go
@@ -17,7 +17,7 @@ package tasklist
 import (
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	"path/filepath"
 	"strings"

--- a/charts/camunda-platform/test/unit/tasklist/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/tasklist/golden/deployment.golden.yaml
@@ -24,7 +24,6 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: tasklist
-      app.kubernetes.io/version: "8.5.0-alpha2"
   template:
     metadata:
       labels:

--- a/charts/camunda-platform/test/unit/tasklist/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/tasklist/golden/service.golden.yaml
@@ -27,4 +27,3 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: tasklist
-    app.kubernetes.io/version: "8.5.0-alpha2"

--- a/charts/camunda-platform/test/unit/web-modeler/configmap_restapi_test.go
+++ b/charts/camunda-platform/test/unit/web-modeler/configmap_restapi_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	"path/filepath"
 	"strings"

--- a/charts/camunda-platform/test/unit/zeebe-gateway/deployment_test.go
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/deployment_test.go
@@ -126,8 +126,8 @@ func (s *deploymentTemplateTest) TestContainerSetImageNameSubChart() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"global.image.registry":          "global.custom.registry.io",
-			"global.image.tag":               "8.x.x",
+			"global.image.registry":         "global.custom.registry.io",
+			"global.image.tag":              "8.x.x",
 			"zeebeGateway.image.registry":   "subchart.custom.registry.io",
 			"zeebeGateway.image.repository": "camunda/zeebe-test",
 			"zeebeGateway.image.tag":        "snapshot",
@@ -167,7 +167,7 @@ func (s *deploymentTemplateTest) TestContainerSetImagePullSecretsSubChart() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"global.image.pullSecrets[0].name":        "SecretName",
+			"global.image.pullSecrets[0].name":       "SecretName",
 			"zeebeGateway.image.pullSecrets[0].name": "SecretNameSubChart",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
@@ -207,7 +207,7 @@ func (s *deploymentTemplateTest) TestContainerOverwriteGlobalImageTag() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"global.image.tag":        "a.b.c",
+			"global.image.tag":       "a.b.c",
 			"zeebeGateway.image.tag": "",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
@@ -229,7 +229,7 @@ func (s *deploymentTemplateTest) TestContainerOverwriteImageTagWithChartDirectSe
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"global.image.tag":        "x.y.z",
+			"global.image.tag":       "x.y.z",
 			"zeebeGateway.image.tag": "a.b.c",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
@@ -796,4 +796,3 @@ func (s *deploymentTemplateTest) TestContainerSetSidecar() {
 
 	s.Require().Contains(podContainers, expectedContainer)
 }
-

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/deployment.golden.yaml
@@ -24,7 +24,6 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: zeebe-gateway
-      app.kubernetes.io/version: "8.5.0-RC2"
   template:
     metadata:
       labels:

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/poddisruptionbudget.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/poddisruptionbudget.golden.yaml
@@ -22,4 +22,3 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: zeebe-gateway
-      app.kubernetes.io/version: "8.5.0-RC2"

--- a/charts/camunda-platform/test/unit/zeebe-gateway/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe-gateway/golden/service.golden.yaml
@@ -22,7 +22,6 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: "8.5.0-RC2"
   ports:
     - port: 9600
       protocol: TCP

--- a/charts/camunda-platform/test/unit/zeebe/golden/poddisruptionbudget.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/poddisruptionbudget.golden.yaml
@@ -22,4 +22,3 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: zeebe-broker
-      app.kubernetes.io/version: "8.5.0-RC2"

--- a/charts/camunda-platform/test/unit/zeebe/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/service.golden.yaml
@@ -34,4 +34,3 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.5.0-RC2"

--- a/charts/camunda-platform/test/unit/zeebe/golden/statefulset.golden.yaml
+++ b/charts/camunda-platform/test/unit/zeebe/golden/statefulset.golden.yaml
@@ -23,7 +23,6 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: zeebe-broker
-      app.kubernetes.io/version: "8.5.0-RC2"
   serviceName: "camunda-platform-test-zeebe"
   updateStrategy:
     type: RollingUpdate

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/BurntSushi/toml v1.3.2
 	github.com/gruntwork-io/terratest v0.46.13
 	github.com/stretchr/testify v1.9.0
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.28.4
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/gruntwork-io/terratest v0.46.13
 	github.com/stretchr/testify v1.9.0
 	gopkg.in/yaml.v3 v3.0.1
-	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.28.4
 )
 
@@ -77,6 +76,7 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/client-go v0.28.4 // indirect
 	k8s.io/klog/v2 v2.100.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -73,10 +73,6 @@ github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB7
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gruntwork-io/go-commons v0.8.0 h1:k/yypwrPqSeYHevLlEDmvmgQzcyTwrlZGRaxEM6G0ro=
 github.com/gruntwork-io/go-commons v0.8.0/go.mod h1:gtp0yTtIBExIZp7vyIV9I0XQkVwiQZze678hvDXof78=
-github.com/gruntwork-io/terratest v0.46.11 h1:1Z9G18I2FNuH87Ro0YtjW4NH9ky4GDpfzE7+ivkPeB8=
-github.com/gruntwork-io/terratest v0.46.11/go.mod h1:DVZG/s7eP1u3KOQJJfE6n7FDriMWpDvnj85XIlZMEM8=
-github.com/gruntwork-io/terratest v0.46.12 h1:yz2mFk0GKnkn2Cofb587mePBkATl9HFMOlfRzZbO4D8=
-github.com/gruntwork-io/terratest v0.46.12/go.mod h1:8jNhyxN3JLlzE6rmqJZa7R7UFYtUumt0NkCeJQOtxt4=
 github.com/gruntwork-io/terratest v0.46.13 h1:FDaEoZ7DtkomV8pcwLdBV/VsytdjnPRqJkIriYEYwjs=
 github.com/gruntwork-io/terratest v0.46.13/go.mod h1:8sxu3Qup8TxtbzOHzq0MUrQffJj/G61/OwlsReaCwpo=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -239,8 +235,6 @@ google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
-google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
### Which problem does the PR fix?

Recent PR 
#1522   introduced a problem where `helm upgrades` would break due to an immutable field being altered. The immutable field is `selector.matchLabels`.    We would have expected #1522 to have a failed CI build, however, the integration tests for the CI on that PR did not run due to this PR #1530  which introduces removes the `deployments: write` permission from our integration tests, and prevents it from running.  

This change will fix the `helm upgrade` issue by making the `matchLabels`  _helper function no longer call the `extraLabels` function, and insteads adds the `component` label directly.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
