### PR TITLE
refactor(follow-up): ensure that 8.5 keys refactoring is backward compatible

### DIFF
--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -171,7 +171,6 @@ jobs:
         token: ${{ steps.generate-github-token.outputs.token }}
         env: ${{ steps.vars.outputs.identifier }}
         ref: ${{ inputs.caller-git-ref }}
-    # TODO: Remove all logic for extra-values-file-setup-only.yaml after Camunda 8.5 cycle is done.
     - name: Pre setup
       timeout-minutes: 5
       env:

--- a/charts/camunda-platform/templates/camunda/_helpers.tpl
+++ b/charts/camunda-platform/templates/camunda/_helpers.tpl
@@ -125,7 +125,6 @@ Usage:
 
 {{/*
 [camunda-platform] Create labels for secrets shared between Identity and other components.
-TODO: Should be removed and use "camundaPlatform.labels" before 8.4 release.
 */}}
 {{- define "camundaPlatform.identityLabels" -}}
 {{- if .Values.global.labels -}}
@@ -159,8 +158,7 @@ Keycloak templates.
 
 {{/*
 [camunda-platform] Keycloak issuer backend URL which used internally for Camunda apps.
-TODO: Refactor the Keycloak config once Console is production ready.
-      Most of the Keycloak config is handeled in Identity sub-chart, but it should be in the main chart.
+TODO: Most of the Keycloak config is handeled in Identity sub-chart, but it should be in the main chart.
 */}}
 {{- define "camundaPlatform.authIssuerBackendUrl" -}}
   {{- if .Values.global.identity.auth.issuerBackendUrl -}}

--- a/charts/camunda-platform/templates/camunda/constraints.tpl
+++ b/charts/camunda-platform/templates/camunda/constraints.tpl
@@ -40,10 +40,11 @@ Fail with a message if the auth type is set to non-Keycloak and its requirements
 {{- end }}
 
 {{/*
+TODO: Enable for 8.6 cycle.
+
 Fail with a message if global.zeebePort is set since now it's used from Zeebe Gateway values:
 "zeebeGateway.service.grpcPort".
 Chart Version: 10.0.0
-*/}}
 {{- if (.Values.global.zeebePort) }}
   {{- $errorMessage := printf "[camunda][error] %s %s"
       "The global Zeebe Gateway port \"global.zeebePort\" is deprecated. Please remove it."
@@ -51,8 +52,11 @@ Chart Version: 10.0.0
   -}}
   {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}
+*/}}
 
 {{/*
+TODO: Enable for 8.6 cycle.
+
 ********************************************************************************
 elasticsearch and opensearch constraints
 ********************************************************************************
@@ -60,61 +64,60 @@ elasticsearch and opensearch constraints
 
 {{/*
 ensuring external elasticsearch and external opensearch to be mutually exclusive
-*/}}
 {{- if and .Values.global.elasticsearch.enabled .Values.global.opensearch.enabled }}
   {{- $errorMessage := "[camunda][error] global.elasticsearch.enabled and global.opensearch.enabled cannot both be true." -}}
   {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}
+*/}}
 
 
 {{/*
 when external elasticsearch is enabled then global elasticsearch should be enabled
-*/}}
 {{- if and .Values.global.elasticsearch.external ( not .Values.global.elasticsearch.enabled ) }}
   {{- $errorMessage := "[camunda][error] global.elasticsearch should be enabled with global.elasticsearch.external" -}}
   {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}
+*/}}
 
 
 {{/*
 ensuring internal and external elasticsearch to be mutually exclusive
-*/}}
 {{- if and .Values.global.elasticsearch.external .Values.elasticsearch.enabled }}
   {{- $errorMessage := "[camunda][error] global.elasticsearch.external and elasticsearch.enabled cannot both be true." -}}
   {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}
+*/}}
 
 {{/*
 ensuring internal and external opensearch to be mutually exclusive
-*/}}
 {{- if and .Values.global.opensearch.enabled .Values.elasticsearch.enabled }}
   {{- $errorMessage := "[camunda][error] global.opensearch.enabled and elasticsearch.enabled cannot both be true." -}}
   {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}
+*/}}
 
 {{/*
 when global elasticsearch is enabled then either external elasticsearch should be enabled or internal elasticsearch should be enabled
-*/}}
 {{- if .Values.global.elasticsearch.enabled -}}
   {{- if and (not .Values.global.elasticsearch.external) (not .Values.elasticsearch.enabled) -}}
   {{- $errorMessage := "[camunda][error] global.elasticsearch.enabled is true, but neither global.elasticsearch.external.enabled nor elasticsearch.enabled is true" -}}
   {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
   {{- end -}}
 {{- end -}}
+*/}}
 
 {{/*
 [elasticsearch] when existingSecret is provided for elasticsearch then password field should be empty
-*/}}
 {{- if and .Values.global.elasticsearch.auth.existingSecret .Values.global.elasticsearch.auth.password }}
   {{- $errorMessage := "[camunda][error] global.elasticsearch.auth.existingSecret and global.elasticsearch.auth.password cannot both be set." -}}
   {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}
-{{/*
+*/}}
 
 {{/*
 [opensearch] when existingSecret is provided for opensearch then password field should be empty
-*/}}
 {{- if and .Values.global.opensearch.auth.existingSecret .Values.global.opensearch.auth.password }}
   {{- $errorMessage := "[camunda][error] global.opensearch.auth.existingSecret and global.opensearch.auth.password cannot both be set." -}}
   {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}
+*/}}

--- a/charts/camunda-platform/templates/connectors/_helpers.tpl
+++ b/charts/camunda-platform/templates/connectors/_helpers.tpl
@@ -17,10 +17,11 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{- define "connectors.fullname" -}}
-{{- /* TODO: Refactor this when more sub-charts are flatten and moved to the main chart. */}}
-    {{- $connectorsValues := deepCopy . -}}
-    {{- $_ := set $connectorsValues.Values "nameOverride" "connectors" -}}
-    {{- include "camundaPlatform.fullname" $connectorsValues -}}
+    {{- include "camundaPlatform.componentFullname" (dict
+        "componentName" "connectors"
+        "componentValues" .Values.connectors
+        "context" $
+    ) -}}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform/templates/console/_helpers.tpl
+++ b/charts/camunda-platform/templates/console/_helpers.tpl
@@ -6,10 +6,11 @@ Expand the name of the chart.
 {{- end }}
 
 {{- define "console.fullname" -}}
-{{- /* TODO: Refactor this when more sub-charts are flatten and moved to the main chart. */}}
-    {{- $consoleValues := deepCopy . -}}
-    {{- $_ := set $consoleValues.Values "nameOverride" "console" -}}
-    {{- include "camundaPlatform.fullname" $consoleValues -}}
+    {{- include "camundaPlatform.componentFullname" (dict
+        "componentName" "console"
+        "componentValues" .Values.console
+        "context" $
+    ) -}}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform/templates/identity/constraints.tpl
+++ b/charts/camunda-platform/templates/identity/constraints.tpl
@@ -30,9 +30,10 @@ Show an error message if both internal and external databases are enabled at the
 {{- end }}
 
 {{/*
+TODO: Enable for 8.6 cycle.
+
 Fail with a message if the old refactored keys are still used and the new keys are not used.
 Chart Version: 10.0.0
-*/}}
 {{- if (.Values.identity.keycloak) }}
     {{- $errorMessage := printf "[identity][error] %s %s %s"
         "The Keycloak key changed from \"identity.keycloak\" to \"identityKeycloak\"."
@@ -50,5 +51,6 @@ Chart Version: 10.0.0
     -}}
     {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}
+*/}}
 
 {{- end }}

--- a/charts/camunda-platform/templates/web-modeler/constraints.tpl
+++ b/charts/camunda-platform/templates/web-modeler/constraints.tpl
@@ -5,10 +5,10 @@ A template to handel constraints.
 */}}
 
 {{/*
+TODO: Enable for 8.6 cycle.
+
 Fail with a message if the old refactored keys are still used and the new keys are not used.
 Chart Version: 10.0.0
-*/}}
-
 {{- if (.Values.postgresql) }}
     {{- $errorMessage := printf "[web-modeler][error] %s %s %s"
         "The PostgreSQL key changed from \"postgresql\" to \"webModelerPostgresql\"."
@@ -17,5 +17,6 @@ Chart Version: 10.0.0
     -}}
     {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}
+*/}}
 
 {{- end }}

--- a/charts/camunda-platform/templates/zeebe-gateway/constraints.tpl
+++ b/charts/camunda-platform/templates/zeebe-gateway/constraints.tpl
@@ -5,9 +5,10 @@ A template to handel constraints.
 */}}
 
 {{/*
+TODO: Enable for 8.6 cycle.
+
 Fail with a message if the old refactored keys are still used and the new keys are not used.
 Chart Version: 10.0.0
-*/}}
 {{- if (index .Values "zeebe-gateway") }}
     {{- $errorMessage := printf "[zeebe-gateway] %s %s %s"
         "The Zeebe Gatway key changed from \"zeebe-gateway\" to \"zeebeGateway\"."
@@ -25,5 +26,6 @@ Chart Version: 10.0.0
     -}}
     {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}
+*/}}
 
 {{- end }}

--- a/charts/camunda-platform/templates/zeebe/z_compatibility_helpers.tpl
+++ b/charts/camunda-platform/templates/zeebe/z_compatibility_helpers.tpl
@@ -1,0 +1,87 @@
+{{/*
+NOTE: According to how Helm order the templates, this helper file should be the last file in the Zeebe dir,
+      so Helm will process it first, and all migration steps will be applied to all templates in the chart implicitly.
+*/}}
+
+{{/*
+TODO: Remove after 8.6 cycle.
+********************************************************************************
+* Camunda 8.5 backward compatibility.
+
+Overview:
+    Backward compatibility with values syntax before Camunda Helm chart v10.0.0 (Camunda 8.5 cycle).
+
+Approach:
+    Using deep copy and deep merge functions to override new keys using the old key.
+    https://helm.sh/docs/chart_template_guide/function_list/#mergeoverwrite-mustmergeoverwrite
+********************************************************************************
+*/}}
+
+{{/*
+Identity.
+*/}}
+{{- if .Values.identity.keycloak -}}
+    {{- $_ := set .Values "identityKeycloak" (deepCopy .Values.identity.keycloak | mergeOverwrite .Values.identityKeycloak) -}}
+{{- end -}}
+
+{{- if .Values.identity.postgresql -}}
+    {{- $_ := set .Values "identityPostgresql" (deepCopy .Values.identity.postgresql | mergeOverwrite .Values.identityPostgresql) -}}
+{{- end -}}
+
+
+{{/*
+Web Modeler.
+*/}}
+{{- if .Values.postgresql -}}
+    {{- $_ := set .Values "webModelerPostgresql" (deepCopy .Values.postgresql | mergeOverwrite .Values.webModelerPostgresql) -}}
+{{- end -}}
+
+{{/*
+Zeebe Gateway.
+*/}}
+
+{{- if (index .Values "zeebe-gateway") -}}
+    {{- $_ := set .Values "zeebeGateway" (deepCopy (index .Values "zeebe-gateway") | mergeOverwrite .Values.zeebeGateway) -}}
+{{- end -}}
+
+{{- if .Values.zeebeGateway.service.gatewayName -}}
+    {{- $_ := set .Values.zeebeGateway.service "grpcName" .Values.zeebeGateway.service.gatewayName -}}
+{{- end -}}
+
+{{- if .Values.zeebeGateway.service.gatewayPort -}}
+    {{- $_ := set .Values.zeebeGateway.service "grpcPort" .Values.zeebeGateway.service.gatewayPort -}}
+{{- end -}}
+
+{{- if .Values.zeebeGateway.ingress.enabled -}}
+    {{- $zgIngress := omit .Values.zeebeGateway.ingress "rest" -}}
+    {{- $_ := set .Values.zeebeGateway.ingress "grpc" (deepCopy $zgIngress | mergeOverwrite .Values.zeebeGateway.ingress.grpc) -}}
+{{- end -}}
+
+
+{{/*
+Elasticsearch.
+
+Old:
+- "global.elasticsearch.url" is a string (had priority over global.elasticsearch.{protocol, host, port})
+- "global.elasticsearch.protocol", "global.elasticsearch.host, "global.elasticsearch.port".
+
+New:
+- "global.elasticsearch.url.protocol", "global.elasticsearch.url.host, "global.url.elasticsearch.port".
+
+Notes:
+- Helm CLI will show a warning like "cannot overwrite table with non table for", but the old syntax will still work.
+*/}}
+{{- if or (empty .Values.global.elasticsearch.url) (eq .Values.global.elasticsearch.url nil) -}}
+    {{- $esProtocol := .Values.global.elasticsearch.protocol | default "http" -}}
+    {{- $esHost := .Values.global.elasticsearch.host | default "{{ .Release.Name }}-elasticsearch" -}}
+    {{- $esPort := .Values.global.elasticsearch.port | default "9200" -}}
+    {{- $_ := set .Values.global.elasticsearch "url" (dict "protocol" $esProtocol "host" (tpl $esHost .) "port" $esPort) -}}
+
+{{- else if (typeIs "string" .Values.global.elasticsearch.url) -}}
+    {{- $esURL := urlParse .Values.global.elasticsearch.url -}}
+    {{- $esProtocol := $esURL.scheme | default .Values.global.elasticsearch.protocol | default "http" -}}
+    {{- $esHost := ($esURL.host | splitList ":" | first) | default .Values.global.elasticsearch.host | default "{{ .Release.Name }}-elasticsearch" -}}
+    {{- $esPort := ($esURL.host | splitList ":" | last) | default .Values.global.elasticsearch.port | default "9200" -}}
+    {{- $_ := set .Values.global.elasticsearch "url" (dict "protocol" $esProtocol "host" (tpl $esHost .) "port" $esPort) -}}
+
+{{- end -}}


### PR DESCRIPTION
### Which problem does the PR fix?

Task: https://github.com/camunda/distribution/issues/232

### What's in this PR?

Ensure that 8.5 keys refactoring is backward compatible also disable the force check for the refactored keys for the 8.6 cycle.

**Note:** There are 2 areas that are not related to `keys` refactoring that should be migrated manually by the user before the upgrade process:
* Identity label as shown here: https://docs.camunda.io/docs/next/self-managed/platform-deployment/helm-kubernetes/upgrade/#identity
* Keycloak default values should be reviewed if the user makes a copy of the whole values file instead of relying on the default values (which is a common practice I saw many of our customers do), we have no control over this since that change happened in the upstream Keyloak chart and must to be done anyway.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?