### PR TITLE
refactor(follow-up): use identity old labels

### DIFF
--- a/charts/camunda-platform/templates/identity/_helpers.tpl
+++ b/charts/camunda-platform/templates/identity/_helpers.tpl
@@ -46,7 +46,6 @@ Create a default fully qualified app name.
 Defines extra labels for identity.
 */}}
 {{- define "identity.extraLabels" -}}
-app.kubernetes.io/component: identity
 app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.identity) | quote }}
 {{- end -}}
 
@@ -55,7 +54,7 @@ Define common labels for identity, combining the match labels and transient labe
 (version depending). These labels shouldn't be used on matchLabels selector, since the selectors are immutable.
 */}}
 {{- define "identity.labels" -}}
-{{- template "camundaPlatform.labels" . }}
+{{- template "camundaPlatform.identityLabels" . }}
 {{ template "identity.extraLabels" . }}
 {{- end -}}
 
@@ -63,8 +62,7 @@ Define common labels for identity, combining the match labels and transient labe
 Defines match labels for identity, which are extended by sub-charts and should be used in matchLabels selectors.
 */}}
 {{- define "identity.matchLabels" -}}
-{{- template "camundaPlatform.matchLabels" . }}
-app.kubernetes.io/component: identity
+{{- template "camundaPlatform.identityLabels" . }}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform/test/integration/scenarios/lib/chart-upgrade-taskfile.yaml
+++ b/charts/camunda-platform/test/integration/scenarios/lib/chart-upgrade-taskfile.yaml
@@ -8,10 +8,7 @@ vars:
 tasks:
   pre:
     cmds:
-    # TODO: Remove it once 8.5 cycle is done.
-    - |
-      # Identity.
-      kubectl -n {{ .TEST_NAMESPACE }} delete -l app.kubernetes.io/name=identity deployment
+    - echo "No pre setup task for this test."
 
   # https://docs.camunda.io/docs/self-managed/platform-deployment/helm-kubernetes/upgrade/
   exec:

--- a/charts/camunda-platform/test/unit/identity/golden/configmap.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/configmap.golden.yaml
@@ -6,7 +6,7 @@ metadata:
   name: camunda-platform-test-identity-configuration
   labels:
     app: camunda-platform
-    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/name: identity
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform

--- a/charts/camunda-platform/test/unit/identity/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/deployment.golden.yaml
@@ -6,7 +6,7 @@ metadata:
   name: camunda-platform-test-identity
   labels:
     app: camunda-platform
-    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/name: identity
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
@@ -19,7 +19,7 @@ spec:
   selector:
     matchLabels:
       app: camunda-platform
-      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/name: identity
       app.kubernetes.io/instance: camunda-platform-test
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
@@ -28,7 +28,7 @@ spec:
     metadata:
       labels:
         app: camunda-platform
-        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/name: identity
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/part-of: camunda-platform

--- a/charts/camunda-platform/test/unit/identity/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/ingress-all-enabled.golden.yaml
@@ -6,7 +6,7 @@ metadata:
   name: camunda-platform-test-identity
   labels:
     app: camunda-platform
-    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/name: identity
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform

--- a/charts/camunda-platform/test/unit/identity/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/ingress.golden.yaml
@@ -6,7 +6,7 @@ metadata:
   name: camunda-platform-test-identity
   labels:
     app: camunda-platform
-    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/name: identity
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform

--- a/charts/camunda-platform/test/unit/identity/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/service.golden.yaml
@@ -6,7 +6,7 @@ metadata:
   name: camunda-platform-test-identity
   labels:
     app: camunda-platform
-    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/name: identity
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
@@ -26,7 +26,7 @@ spec:
       protocol: TCP
   selector:
     app: camunda-platform
-    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/name: identity
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform

--- a/charts/camunda-platform/test/unit/identity/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/serviceaccount.golden.yaml
@@ -6,7 +6,7 @@ metadata:
   name: camunda-platform-test-identity
   labels:
     app: camunda-platform
-    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/name: identity
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform


### PR DESCRIPTION
to avoid migration steps till the end of 8.6 cycle

### Which problem does the PR fix?

Task: https://github.com/camunda/camunda-platform-helm/issues/1449

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
