### PR TITLE
chore(web-modeler): dynamically set heap space size

### DIFF
--- a/charts/camunda-platform/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform/templates/web-modeler/deployment-restapi.yaml
@@ -33,7 +33,7 @@ spec:
           {{- end }}
           env:
             - name: JAVA_OPTIONS
-              value: "-Xmx1536m"
+              value: "-XX:MaxRAMPercentage=80.0"
             - name: SPRING_DATASOURCE_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/camunda-platform/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -49,7 +49,7 @@ spec:
             runAsUser: 1001
           env:
             - name: JAVA_OPTIONS
-              value: "-Xmx1536m"
+              value: "-XX:MaxRAMPercentage=80.0"
             - name: SPRING_DATASOURCE_PASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

Dynamically sets the heap space size of Web Modeler's `restapi` instead of using an absolute value. Mirrors the changes made in https://github.com/camunda/web-modeler/pull/8952.

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
