### PR TITLE
fix: identity postgresql and keycloak depend on identity.enabled

### DIFF
--- a/charts/camunda-platform/Chart.yaml
+++ b/charts/camunda-platform/Chart.yaml
@@ -23,12 +23,12 @@ dependencies:
     alias: identityKeycloak
     repository: https://charts.bitnami.com/bitnami
     version: 19.4.1
-    condition: "identityKeycloak.enabled"
+    condition: "identity.enabled,identityKeycloak.enabled"
   - name: postgresql
     alias: identityPostgresql
     repository: https://charts.bitnami.com/bitnami
     version: 12.x.x
-    condition: "identityPostgresql.enabled"
+    condition: "identity.enabled,identityPostgresql.enabled"
   # WebModeler Dependencies.
   - name: web-modeler-postgresql
     alias: postgresql

--- a/charts/camunda-platform/test/unit/camunda/golden/keycloak-statefulset.golden.yaml
+++ b/charts/camunda-platform/test/unit/camunda/golden/keycloak-statefulset.golden.yaml
@@ -79,6 +79,7 @@ spec:
             runAsGroup: 0
             runAsNonRoot: true
             runAsUser: 1001
+            seLinuxOptions: null
             seccompProfile:
               type: RuntimeDefault
           volumeMounts:
@@ -123,6 +124,7 @@ spec:
             runAsGroup: 0
             runAsNonRoot: true
             runAsUser: 1001
+            seLinuxOptions: null
             seccompProfile:
               type: RuntimeDefault
           env:

--- a/charts/camunda-platform/test/unit/console/golden/configmap.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/configmap.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: console
-    app.kubernetes.io/version: "8.5.5"
+    app.kubernetes.io/version: "8.5.8"
 data:
   application.yaml: |-
     # https://docs.camunda.io/docs/self-managed/console-deployment/configuration/
@@ -26,7 +26,7 @@ data:
             components:
             - name: Console
               id: console
-              version: 8.5.5
+              version: 8.5.8
               url: 
               readiness: http://camunda-platform-test-console.camunda-platform:9100/health/readiness
               metrics: http://camunda-platform-test-console.camunda-platform:9100/prometheus

--- a/charts/camunda-platform/test/unit/console/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/deployment.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: console
-    app.kubernetes.io/version: "8.5.5"
+    app.kubernetes.io/version: "8.5.8"
   annotations:
     {}
 spec:
@@ -27,7 +27,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5089444292121cb2789e1361c513a00d8ef2cd03f3435369863fc655cd5c6421
+        checksum/config: ca3fdb66d2f3d6cc992141b9c1ff5c094fc097bc72e81662cccb6f7f56298a8e
       labels:
         app: camunda-platform
         app.kubernetes.io/name: camunda-platform
@@ -46,7 +46,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: camunda-platform
-          image: registry.camunda.cloud/console/console-sm:8.5.5
+          image: registry.camunda.cloud/console/console-sm:8.5.8
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/camunda-platform/test/unit/console/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/ingress-all-enabled.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: console
-    app.kubernetes.io/version: "8.5.5"
+    app.kubernetes.io/version: "8.5.8"
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/console/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/ingress.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: console
-    app.kubernetes.io/version: "8.5.5"
+    app.kubernetes.io/version: "8.5.8"
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/console/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/service.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: console
-    app.kubernetes.io/version: "8.5.5"
+    app.kubernetes.io/version: "8.5.8"
   annotations:
 spec:
   type: ClusterIP

--- a/charts/camunda-platform/test/unit/console/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/serviceaccount.golden.yaml
@@ -11,5 +11,5 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: console
-    app.kubernetes.io/version: "8.5.5"
+    app.kubernetes.io/version: "8.5.8"
 automountServiceAccountToken: false


### PR DESCRIPTION
### Which problem does the PR fix?

#1596 

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

This PR adds a condition that will prevent keycloak and postgresql from being installed when identity is disabled.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
