### PR TITLE
fix: mismatch errors during installation z_compatibility_helpers.tpl

### DIFF
--- a/charts/camunda-platform/templates/zeebe/z_compatibility_helpers.tpl
+++ b/charts/camunda-platform/templates/zeebe/z_compatibility_helpers.tpl
@@ -65,17 +65,20 @@ New:
 Notes:
 - Helm CLI will show a warning like "cannot overwrite table with non table for", but the old syntax will still work.
 */}}
-{{- if or (empty .Values.global.elasticsearch.url) (eq .Values.global.elasticsearch.url nil) -}}
+{{- if or (not .Values.global.elasticsearch.url) (empty .Values.global.elasticsearch.url) -}}
     {{- $esProtocol := .Values.global.elasticsearch.protocol | default "http" -}}
-    {{- $esHost := .Values.global.elasticsearch.host | default "{{ .Release.Name }}-elasticsearch" -}}
+    {{- $esHost := .Values.global.elasticsearch.host | default (print .Release.Name "-elasticsearch") -}}
     {{- $esPort := .Values.global.elasticsearch.port | default "9200" -}}
-    {{- $_ := set .Values.global.elasticsearch "url" (dict "protocol" $esProtocol "host" (tpl $esHost .) "port" $esPort) -}}
-
-{{- else if (typeIs "string" .Values.global.elasticsearch.url) -}}
+    {{- $_ := set .Values.global.elasticsearch "url" (dict "protocol" $esProtocol "host" $esHost "port" $esPort) -}}
+{{- else if eq (kindOf .Values.global.elasticsearch.url) "string" -}}
     {{- $esURL := urlParse .Values.global.elasticsearch.url -}}
     {{- $esProtocol := $esURL.scheme | default .Values.global.elasticsearch.protocol | default "http" -}}
-    {{- $esHost := ($esURL.host | splitList ":" | first) | default .Values.global.elasticsearch.host | default "{{ .Release.Name }}-elasticsearch" -}}
+    {{- $esHost := ($esURL.host | splitList ":" | first) | default .Values.global.elasticsearch.host | default (print .Release.Name "-elasticsearch") -}}
     {{- $esPort := ($esURL.host | splitList ":" | last) | default .Values.global.elasticsearch.port | default "9200" -}}
-    {{- $_ := set .Values.global.elasticsearch "url" (dict "protocol" $esProtocol "host" (tpl $esHost .) "port" $esPort) -}}
-
+    {{- $_ := set .Values.global.elasticsearch "url" (dict "protocol" $esProtocol "host" $esHost "port" $esPort) -}}
+{{- else }}
+    {{- /* Handle unexpected type with a default or error message */}}
+    {{- $_ := set .Values.global.elasticsearch "url" (dict "protocol" "http" "host" (print .Release.Name "-elasticsearch") "port" "9200") -}}
+    {{- /* Optionally, log a warning or error */}}
+    {{/* WARNING: .Values.global.elasticsearch.url is not a string as expected. Using default settings. */}}
 {{- end -}}

--- a/charts/camunda-platform/test/unit/console/golden/configmap.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/configmap.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: console
-    app.kubernetes.io/version: "8.5.5"
+    app.kubernetes.io/version: "8.5.10"
 data:
   application.yaml: |-
     # https://docs.camunda.io/docs/self-managed/console-deployment/configuration/
@@ -26,7 +26,7 @@ data:
             components:
             - name: Console
               id: console
-              version: 8.5.5
+              version: 8.5.10
               url: 
               readiness: http://camunda-platform-test-console.camunda-platform:9100/health/readiness
               metrics: http://camunda-platform-test-console.camunda-platform:9100/prometheus

--- a/charts/camunda-platform/test/unit/console/golden/configmap.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/configmap.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: console
-    app.kubernetes.io/version: "8.5.10"
+    app.kubernetes.io/version: "8.5.11"
 data:
   application.yaml: |-
     # https://docs.camunda.io/docs/self-managed/console-deployment/configuration/
@@ -26,7 +26,7 @@ data:
             components:
             - name: Console
               id: console
-              version: 8.5.10
+              version: 8.5.11
               url: 
               readiness: http://camunda-platform-test-console.camunda-platform:9100/health/readiness
               metrics: http://camunda-platform-test-console.camunda-platform:9100/prometheus

--- a/charts/camunda-platform/test/unit/console/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/deployment.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: console
-    app.kubernetes.io/version: "8.5.10"
+    app.kubernetes.io/version: "8.5.11"
   annotations:
     {}
 spec:
@@ -27,7 +27,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 134c8a92042deaa7e42f5ba599debb59fa4a2b5bab7ef7af8dcbf92061171bdf
+        checksum/config: 1c65e1c8db562b2603d6c55b98d8a29f32d56fcf6e4849a0f6bc7ec2c91e1b44
       labels:
         app: camunda-platform
         app.kubernetes.io/name: camunda-platform
@@ -46,7 +46,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: camunda-platform
-          image: registry.camunda.cloud/console/console-sm:8.5.10
+          image: registry.camunda.cloud/console/console-sm:8.5.11
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/camunda-platform/test/unit/console/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/deployment.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: console
-    app.kubernetes.io/version: "8.5.5"
+    app.kubernetes.io/version: "8.5.10"
   annotations:
     {}
 spec:
@@ -27,7 +27,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5089444292121cb2789e1361c513a00d8ef2cd03f3435369863fc655cd5c6421
+        checksum/config: 134c8a92042deaa7e42f5ba599debb59fa4a2b5bab7ef7af8dcbf92061171bdf
       labels:
         app: camunda-platform
         app.kubernetes.io/name: camunda-platform
@@ -46,7 +46,7 @@ spec:
         runAsNonRoot: true
       containers:
         - name: camunda-platform
-          image: registry.camunda.cloud/console/console-sm:8.5.5
+          image: registry.camunda.cloud/console/console-sm:8.5.10
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/camunda-platform/test/unit/console/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/ingress-all-enabled.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: console
-    app.kubernetes.io/version: "8.5.10"
+    app.kubernetes.io/version: "8.5.11"
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/console/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/ingress-all-enabled.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: console
-    app.kubernetes.io/version: "8.5.5"
+    app.kubernetes.io/version: "8.5.10"
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/console/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/ingress.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: console
-    app.kubernetes.io/version: "8.5.10"
+    app.kubernetes.io/version: "8.5.11"
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/console/golden/ingress.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/ingress.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: console
-    app.kubernetes.io/version: "8.5.5"
+    app.kubernetes.io/version: "8.5.10"
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k

--- a/charts/camunda-platform/test/unit/console/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/service.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: console
-    app.kubernetes.io/version: "8.5.5"
+    app.kubernetes.io/version: "8.5.10"
   annotations:
 spec:
   type: ClusterIP

--- a/charts/camunda-platform/test/unit/console/golden/service.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/service.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: console
-    app.kubernetes.io/version: "8.5.10"
+    app.kubernetes.io/version: "8.5.11"
   annotations:
 spec:
   type: ClusterIP

--- a/charts/camunda-platform/test/unit/console/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/serviceaccount.golden.yaml
@@ -11,5 +11,5 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: console
-    app.kubernetes.io/version: "8.5.5"
+    app.kubernetes.io/version: "8.5.10"
 automountServiceAccountToken: false

--- a/charts/camunda-platform/test/unit/console/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/serviceaccount.golden.yaml
@@ -11,5 +11,5 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: console
-    app.kubernetes.io/version: "8.5.10"
+    app.kubernetes.io/version: "8.5.11"
 automountServiceAccountToken: false


### PR DESCRIPTION
### Which problem does the PR fix?
https://github.com/camunda/camunda-platform-helm/issues/1633

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?
Anyone with an older version of helm cli are encountering errors during installation. 

`Error: INSTALLATION FAILED: template: camunda-platform/templates/zeebe/z_compatibility_helpers.tpl:68:52: executing "camunda-platform/templates/zeebe/z_compatibility_helpers.tpl" at <eq .Values.global.elasticsearch.url nil>: error calling eq: uncomparable type map[string]interface {}: map[host:{{ .Release.Name }}-elasticsearch port:9200 protocol:http]`
<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
