### PR TITLE
[ENHANCEMENT] Make templating in values.yaml possible when setting host, replicas and pvc size (different settings for different environments with same values.yaml) 

### DIFF
--- a/charts/camunda-platform/templates/camunda/_helpers.tpl
+++ b/charts/camunda-platform/templates/camunda/_helpers.tpl
@@ -168,7 +168,7 @@ TODO: Most of the Keycloak config is handeled in Identity sub-chart, but it shou
       {{-
         printf "%s://%s:%v%s%s"
           .Values.global.identity.keycloak.url.protocol
-          .Values.global.identity.keycloak.url.host
+          (tpl .Values.global.identity.keycloak.url.host . )
           .Values.global.identity.keycloak.url.port
           .Values.global.identity.keycloak.contextPath
           .Values.global.identity.keycloak.realm

--- a/charts/camunda-platform/templates/camunda/ingress.yaml
+++ b/charts/camunda-platform/templates/camunda/ingress.yaml
@@ -12,7 +12,7 @@ spec:
   ingressClassName: {{ .Values.global.ingress.className }}
   rules:
     {{- if .Values.global.ingress.host }}
-    - host: {{ .Values.global.ingress.host }}
+    - host: {{ tpl .Values.global.ingress.host . }}
       http:
     {{- else }}
     - http:

--- a/charts/camunda-platform/templates/identity/_helpers.tpl
+++ b/charts/camunda-platform/templates/identity/_helpers.tpl
@@ -157,7 +157,7 @@ This is mainly used to access the external Keycloak service in the global Ingres
 */}}
 {{- define "identity.keycloak.host" -}}
     {{- if and .Values.global.identity.keycloak.url .Values.global.identity.keycloak.url.host -}}
-        {{- .Values.global.identity.keycloak.url.host -}}
+        {{- tpl .Values.global.identity.keycloak.url.host . -}}
     {{- else -}}
         {{- include "identity.keycloak.hostDefault" . -}}
     {{- end -}}

--- a/charts/camunda-platform/templates/zeebe-gateway/deployment.yaml
+++ b/charts/camunda-platform/templates/zeebe-gateway/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     {{- toYaml .Values.global.annotations | nindent 4 }}
 spec:
-  replicas: {{ .Values.zeebeGateway.replicas  }}
+  replicas: {{ tpl .Values.zeebeGateway.replicas . }}
   selector:
     matchLabels:
       {{- include "zeebe.matchLabels.gateway" . | nindent 6 }}

--- a/charts/camunda-platform/templates/zeebe/statefulset.yaml
+++ b/charts/camunda-platform/templates/zeebe/statefulset.yaml
@@ -257,6 +257,6 @@ spec:
         {{- end }}
         resources:
           requests:
-            storage: {{ .Values.zeebe.pvcSize | quote }}
+            storage: {{ tpl .Values.zeebe.pvcSize . | quote }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
### Which problem does the PR fix?

https://github.com/camunda/camunda-platform-helm/issues/1648

### What's in this PR?

Treat the corresponding values as {{ tpl .Values.xxx . }} instead of simply {{ .Values.xxx }}
Example:
```
global.ingress.host: "{{ .Values.global.environment }}-camunda.your-domain.com"
global.identity.keycloak.url.host: "{{ .Values.global.environment }}-keycloak.your-domain.com"

connectors.replicas: "{{ if eq .Values.global.environment \"Dev\" }} 1 {{ else }} 2 {{ end }}"
zeebeGateway.replicas: "{{ if eq .Values.global.environment \"Dev\" }} 1 {{ else }} 2 {{ end }}"

zeebe.pvcSize: "{{ if eq .Values.global.environment \"Dev\")  }}5Gi{{ else }}32Gi{{ end }}"
```

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
