### PR TITLE
ci: release chart snapshot from main branch

### DIFF
--- a/.github/workflows/chart-release-snapshot.yaml
+++ b/.github/workflows/chart-release-snapshot.yaml
@@ -1,0 +1,80 @@
+# TODO: Convert this workflow to a template and use it for both snapshot and actual releases.
+name: "Chart - Release - Snapshot"
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    name: Helm Chart Snapshot
+    permissions:
+      packages: write
+      id-token: write
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: charts/camunda-platform
+    #
+    # Vars.
+    env:
+      REPOSITORY_NAME: "camunda/helm"
+      CHART_NAME: "camunda-platform"
+      # NOTE: Helm CLI only accepts SemVer so we need to use the "0.0.0-main-snapshot" format.
+      CHART_VERSION: "0.0.0-main-snapshot"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4
+        with:
+          ref: main
+          fetch-depth: 0
+      #
+      # Changelog.
+      - name: Generate snapshot changelog
+        run: |
+          LATEST_TAG="$(git describe --tags $(git rev-list --tags="${{ env.CHART_NAME }}-*" --max-count=1))"
+          export SNAPSHOT_DESCRIPTION="Changes since the latest release: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/compare/${LATEST_TAG}...main"
+          yq -i '.description |= strenv(SNAPSHOT_DESCRIPTION)' Chart.yaml
+      #
+      # Package.
+      - name: Install Helm CLI
+        uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # v3
+      - name: Print Helm CLI version
+        run: helm version
+      - name: Package and push Helm chart
+        env:
+          HELM_EXPERIMENTAL_OCI: 1
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | helm registry login -u ${{ github.actor }} --password-stdin ghcr.io
+          helm dependency update
+          helm package --version ${{ env.CHART_VERSION }} .
+          helm push ${{ env.CHART_NAME }}-${{ env.CHART_VERSION }}.tgz oci://ghcr.io/${{ env.REPOSITORY_NAME }}
+          helm registry logout ghcr.io
+      #
+      # Security signature.
+      - name: Install Cosign CLI
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # v3.5.0
+      - name: Sign Helm chart with Cosign
+        run: |
+          cosign sign-blob -y ${{ env.CHART_NAME }}-${{ env.CHART_VERSION }}.tgz \
+            --bundle ${{ env.CHART_NAME }}-${{ env.CHART_VERSION }}.cosign.bundle
+      - name: Verify signed Helm chart with Cosign
+        run: |
+          cosign verify-blob ${{ env.CHART_NAME }}-${{ env.CHART_VERSION }}.tgz \
+            --bundle ${{ env.CHART_NAME }}-${{ env.CHART_VERSION }}.cosign.bundle \
+            --certificate-identity "https://github.com/${GITHUB_WORKFLOW_REF}" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install ORAS CLI
+        uses: oras-project/setup-oras@ee7dbe1144cb00080a89497f937dae78f85fce29 # v1
+      - name: Upload Helm chart Cosign bundle
+        run: |
+          oras push ghcr.io/${{ env.REPOSITORY_NAME }}/${{ env.CHART_NAME }}:${{ env.CHART_VERSION }}.cosign.bundle \
+            ${{ env.CHART_NAME }}-${{ env.CHART_VERSION }}.cosign.bundle:text/plain

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ We value all feedback and contributions. To start contributing to this project, 
 
 ## Releasing
 
-Please visit the [Camunda 8 release guide](./RELEASE.md) to find out how to release the charts.
+Please visit the [Camunda 8 release guide](./docs/release.md) to find out how to release the charts.
 
 ## Deprecation
 

--- a/charts/camunda-platform/README.md
+++ b/charts/camunda-platform/README.md
@@ -412,7 +412,7 @@ Downloading common from repo https://charts.bitnami.com/bitnami
 
 ## Releasing the Charts
 
-Please see the corresponding [release guide](../../RELEASE.md) to find out how to release the chart.
+Please see the corresponding [release guide](../../docs/release.md) to find out how to release the chart.
 
 ## Parameters
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -6,4 +6,4 @@ tests, releases, etc. For the Camunda official docs, please check [Camunda 8 Sel
 
 - [GitHub Actions Workflows](./gha-workflows.md)
 - Tests (TBA).
-- Release (TBA).
+- [Release](./release.md).

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,9 +1,21 @@
 # Camunda Helm Chart Release Process
 
-The charts are build, linted and tested on every push to the main branch. If the chart version
-(in `Chart.yaml`) changes a new github release with the corresponding packaged helm chart is
-created. The charts are hosted via github pages and use the release artifacts. We use the
+The charts are built, linted, and tested on every push to the main branch. If the chart version
+(in `Chart.yaml`) changes a new GitHub release with the corresponding packaged helm chart is
+created. The charts are hosted via GitHub pages and use the release artifacts. We use the
 [chart-releaser-action](https://github.com/helm/chart-releaser-action) to release the charts.
+
+## Snapshot
+
+For debugging and advanced testing purposes, we provide a snapshot chart from the unreleased changes on the `main` branch (never use it in production or stable environments).
+
+It will be always updated with the fixed version name `0.0.0-main-snapshot` (the tag needed to start with SemVer because Helm requires it).
+
+```shell
+helm template my-camunda-devel \
+  oci://ghcr.io/camunda/helm/camunda-platform \
+  --version 0.0.0-main-snapshot
+```
 
 ## Process
 
@@ -20,14 +32,14 @@ make release.chores
 
 This action will:
 
-- Locally pull latest updates to the `main` branch.
+- Locally pull the latest updates to the `main` branch.
 - Locally create a new branch called `release` from `main` branch.
-- Bump chart version and make a commit.
+- Bump the chart version and make a commit.
 - Generate release notes and make a commit.
-- Push updated `release` branch to the repo.
+- Push the updated `release` branch to the repo.
 - Generate a link to open a PR with prefilled title and template.
 
-Next, all that you need to open the PR using the generated link and follow th checklist there.
+Next, all you need to open the PR using the generated link and follow the checklist there.
 
 > [!NOTE]
 >
@@ -38,7 +50,7 @@ the release notes.
 ## Artifact Hub
 
 [Camunda repo](https://artifacthub.io/packages/search?repo=camunda) is already configured on
-Artifact Hub. Once the release workflow is done, Artifact Hub automatically scans Camunda Helm repo
+Artifact Hub. Once the release workflow is done, Artifact Hub automatically scans the Camunda Helm repo
 and the new release will show on Artifact Hub.
 
 > [!NOTE]


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes: https://github.com/camunda/camunda-platform-helm/issues/1683

### What's in this PR?

Release Camunda Helm chart snapshot to GitHub package registry as an OCI.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

