### PR TITLE
fix: keycloak realm in console component is hardcoded

### DIFF
--- a/charts/camunda-platform/templates/console/deployment.yaml
+++ b/charts/camunda-platform/templates/console/deployment.yaml
@@ -48,7 +48,7 @@ spec:
             - name: KEYCLOAK_BASE_URL
               value: {{ mustRegexReplaceAllLiteral "/realms/.+" (include "camundaPlatform.authIssuerUrl" .) "" | quote }}
             - name: KEYCLOAK_REALM
-              value: camunda-platform
+              value: {{ .Values.console.keycloak.realm | quote }}
             - name: CAMUNDA_IDENTITY_AUDIENCE
               value: console-api
             - name: CAMUNDA_IDENTITY_CLIENT_ID

--- a/charts/camunda-platform/test/unit/console/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/console/golden/deployment.golden.yaml
@@ -62,7 +62,7 @@ spec:
             - name: KEYCLOAK_BASE_URL
               value: "http://localhost:18080/auth"
             - name: KEYCLOAK_REALM
-              value: camunda-platform
+              value: "camunda-platform"
             - name: CAMUNDA_IDENTITY_AUDIENCE
               value: console-api
             - name: CAMUNDA_IDENTITY_CLIENT_ID

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -371,6 +371,13 @@ console:
 
   ## @param console.replicas Number of Console replicas
   replicas: 1
+  console:
+    ## @param console.keycloak Keycloak authentication settings for the Console.
+    keycloak:
+      ## @param console.keycloak.realm Specifies the Keycloak realm used for authentication.
+      realm: "camunda-platform"
+
+
 
   ## @param console.contextPath can be used to make Console web application works on a custom sub-path. This is mainly used to run Camunda web applications under a single domain.
   contextPath: ""

--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -371,13 +371,11 @@ console:
 
   ## @param console.replicas Number of Console replicas
   replicas: 1
-  console:
-    ## @param console.keycloak Keycloak authentication settings for the Console.
-    keycloak:
-      ## @param console.keycloak.realm Specifies the Keycloak realm used for authentication.
-      realm: "camunda-platform"
 
-
+  ## @param console.keycloak Keycloak authentication settings for the Console.
+  keycloak:
+    ## @param console.keycloak.realm Specifies the Keycloak realm used for authentication.
+    realm: "camunda-platform"
 
   ## @param console.contextPath can be used to make Console web application works on a custom sub-path. This is mainly used to run Camunda web applications under a single domain.
   contextPath: ""


### PR DESCRIPTION
### Which problem does the PR fix?
Related to https://github.com/camunda/camunda-platform-helm/issues/1625
KEYCLOAK_REALM is hard corded in the console deployment.yaml 
<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?
Added dynamic configuration via values.yaml
<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
