### PR TITLE
fix: set zeebe exporters empty map when disabled

### DIFF
--- a/charts/camunda-platform/templates/zeebe/configmap.yaml
+++ b/charts/camunda-platform/templates/zeebe/configmap.yaml
@@ -31,6 +31,8 @@ data:
                 minimumAge: {{ .Values.zeebe.retention.minimumAge | quote }}
                 policyName: {{ .Values.zeebe.retention.policyName | quote }}
               {{- end }}
+        {{- else -}}
+          {{ " {}" }}
         {{- end }}
         {{- if .Values.global.opensearch.enabled }}
           opensearch:


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes: https://github.com/camunda/camunda-platform-helm/issues/1697

### What's in this PR?

Set empty map in Zeebe config when exporters are disabled to avoid interpreting it as a string.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
