### PR TITLE
chore: add renovate config requiredStatusChecks

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,8 +9,16 @@
     "enabled": true
   },
   "patch": {
-    "enabled": true
+    "enabled": true,
   },
+  "requiredStatusChecks": [
+    "Custom values - Core",
+    "Custom values - Apps",
+    "Custom values - Zeebe",
+    "Custom values - WebModeler",
+    "lint-and-test",
+    "update-readme-metadata"
+  ],
   "helm-values": {
     "fileMatch": ["(^|/).*?values.*?\\.yaml$"]
   },


### PR DESCRIPTION
### Which problem does the PR fix?
Renovate pushed dependency changes even though the unit test failed. 
<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?
To prevent this happening in the future we have added `requiredStatusChecks` to the renovate config. 
<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
