### PR TITLE
fix: handle type of es url correctly

### DIFF
--- a/charts/camunda-platform/templates/zeebe/1/2/3/4/5/6/7/8/z_compatibility_helpers.tpl
+++ b/charts/camunda-platform/templates/zeebe/1/2/3/4/5/6/7/8/z_compatibility_helpers.tpl
@@ -80,7 +80,7 @@ New:
 Notes:
 - Helm CLI will show a warning like "cannot overwrite table with non table for", but the old syntax will still work.
 */}}
-{{- if or (not .Values.global.elasticsearch.url) (empty .Values.global.elasticsearch.url) -}}
+{{- if or (not .Values.global.elasticsearch.url) (not ((.Values.global.elasticsearch).url | default "")) -}}
     {{- $esProtocol := .Values.global.elasticsearch.protocol | default "http" -}}
     {{- $esHost := .Values.global.elasticsearch.host | default (print .Release.Name "-elasticsearch") -}}
     {{- $esPort := .Values.global.elasticsearch.port | default "9200" -}}
@@ -91,9 +91,4 @@ Notes:
     {{- $esHost := ($esURL.host | splitList ":" | first) | default .Values.global.elasticsearch.host | default (print .Release.Name "-elasticsearch") -}}
     {{- $esPort := ($esURL.host | splitList ":" | last) | default .Values.global.elasticsearch.port | default "9200" -}}
     {{- $_ := set .Values.global.elasticsearch "url" (dict "protocol" $esProtocol "host" $esHost "port" $esPort) -}}
-{{- else }}
-    {{- /* Handle unexpected type with a default or error message */}}
-    {{- $_ := set .Values.global.elasticsearch "url" (dict "protocol" "http" "host" (print .Release.Name "-elasticsearch") "port" "9200") -}}
-    {{- /* Optionally, log a warning or error */}}
-    {{/* WARNING: .Values.global.elasticsearch.url is not a string as expected. Using default settings. */}}
 {{- end -}}


### PR DESCRIPTION
### Which problem does the PR fix?

Fix: https://github.com/camunda/camunda-platform-helm/issues/1734

### What's in this PR?

The old format of the key `global.elasticsearch.url` was a string that could be: `defined` (`url: xyz`), `empty` (`url: ""`), or `null` (`url:`) so using `not` and `empty` is redundant and it goes to the `else` clue.

In this PR the if condition is updated and else section is removed.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
