### PR TITLE
refactor: make web-modeler restapi database password secret optional

### DIFF
--- a/charts/camunda-platform-latest/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform-latest/templates/web-modeler/deployment-restapi.yaml
@@ -38,7 +38,7 @@ spec:
           env:
             - name: JAVA_OPTIONS
               value: "-XX:MaxRAMPercentage=80.0"
-            {{- if .Values.webModeler.restapi.externalDatabase.password }}
+            {{- if or (not .Values.webModeler.restapi.externalDatabase.enabled) .Values.webModeler.restapi.externalDatabase.password }}
             - name: SPRING_DATASOURCE_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/camunda-platform-latest/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform-latest/templates/web-modeler/deployment-restapi.yaml
@@ -38,6 +38,7 @@ spec:
           env:
             - name: JAVA_OPTIONS
               value: "-XX:MaxRAMPercentage=80.0"
+            {{- if .Values.webModeler.restapi.externalDatabase.password }}
             - name: SPRING_DATASOURCE_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/camunda-platform-latest/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform-latest/templates/web-modeler/deployment-restapi.yaml
@@ -44,6 +44,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "webModeler.restapi.databaseSecretName" . }}
                   key: {{ include "webModeler.restapi.databaseSecretKey" . }}
+            {{- end }}
             {{- $smtpSecretName := (include "webModeler.restapi.smtpSecretName" .) }}
             {{- if $smtpSecretName }}
             - name: RESTAPI_MAIL_PASSWORD

--- a/charts/camunda-platform-latest/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform-latest/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -52,11 +52,6 @@ spec:
           env:
             - name: JAVA_OPTIONS
               value: "-XX:MaxRAMPercentage=80.0"
-            - name: SPRING_DATASOURCE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: camunda-platform-test-postgresql-web-modeler
-                  key: password
             - name: RESTAPI_PUSHER_APP_ID
               valueFrom:
                 configMapKeyRef:

--- a/charts/camunda-platform-latest/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform-latest/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -52,6 +52,11 @@ spec:
           env:
             - name: JAVA_OPTIONS
               value: "-XX:MaxRAMPercentage=80.0"
+            - name: SPRING_DATASOURCE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-platform-test-postgresql-web-modeler
+                  key: password
             - name: RESTAPI_PUSHER_APP_ID
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
### Which problem does the PR fix?
Related to https://jira.camunda.com/browse/SUPPORT-21863

When configuring WebModeler.RestAPI to Postgres using IAM Role Base Authentication, it should not require environment variable SPRING_DATASOURCE_PASSWORD and its corresponding secret to be set

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
1. Do not specify any database password for webModeler.restapi.externalDatabase.password in values.yaml
2. Run helm install
3. webmodeler-restapi pod is unable to start up with a status of CreateContainerConfigError, with the following message: secret "<release_name>-web-modeler-restapi" not found
### What's in this PR?
It enables configuration of WebModeler.RestAPI to Postgres using IAM Role Base Authentication without requiring password secret defined and environment variable from rendering into the Kubernetes resource
<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
