### PR TITLE
Release Camunda Platform Helm Chart v8.3.12

### DIFF
--- a/charts/camunda-platform/Chart.yaml
+++ b/charts/camunda-platform/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: camunda-platform
-version: 8.3.11
+version: 8.3.12
 appVersion: 8.3.x
 description: |
   Camunda 8 Self-Managed Helm charts.
@@ -20,7 +20,7 @@ keywords:
 dependencies:
   # Camunda charts.
   - name: identity
-    version: 8.3.11
+    version: 8.3.12
     condition: "identity.enabled"
     import-values:
       # NOTE: This is used to share Identity image details with its subchart Keycloak.

--- a/charts/camunda-platform/RELEASE-NOTES.md
+++ b/charts/camunda-platform/RELEASE-NOTES.md
@@ -2,16 +2,16 @@ The changelog is automatically generated using [git-chglog](https://github.com/g
 and it follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
 
 
-<a name="camunda-platform-8.3.11"></a>
-## [camunda-platform-8.3.11](https://github.com/camunda/camunda-platform-helm/compare/camunda-platform-8.3.10...camunda-platform-8.3.11) (2024-03-12)
+<a name="camunda-platform-8.3.12"></a>
+## [camunda-platform-8.3.12](https://github.com/camunda/camunda-platform-helm/compare/camunda-platform-8.3.11...camunda-platform-8.3.12) (2024-05-13)
 
 ### Verification
 
 To verify integrity of the Helm chart using [Cosign](https://docs.sigstore.dev/signing/quickstart/):
 
 ```shell
-cosign verify-blob camunda-platform-8.3.11.tgz \
-  --bundle camunda-platform-8.3.11.cosign.bundle \
+cosign verify-blob camunda-platform-8.3.12.tgz \
+  --bundle camunda-platform-8.3.12.cosign.bundle \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
   --certificate-identity "https://github.com/_GITHUB_WORKFLOW_REF_"
 ```

--- a/charts/camunda-platform/charts/identity/Chart.yaml
+++ b/charts/camunda-platform/charts/identity/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Identity Helm Chart for Kubernetes
 name: identity
-version: 8.3.11
+version: 8.3.12
 type: application
 icon: https://helm.camunda.io/imgs/camunda.svg
 dependencies:


### PR DESCRIPTION
**Before opening the PR:**

- [x] Run `make release.chores`
- [x] Create a PR with the printed URL
- [x] [Trigger Renovate](https://developer.mend.io/github/camunda/camunda-platform-helm) to ensure that all deps are updated (to avoid any delayed sync from Renovate service).

**After opening the PR:**

- [x] Take a final look at the release commits (version bump and release notes)
- [ ] Make sure that all checks in the PR passed
- [ ] If everything in place, add `release` label to the PR
- [ ] Follow up the release workflow and make sure it succeeded (double-check the [releases page](https://github.com/camunda/camunda-platform-helm/releases))
- [ ] Ensure that all fixed [issues with support label](https://github.com/camunda/camunda-platform-helm/issues?q=is%3Aissue+label%3Asupport+is%3Aclosed) has the release version like `version:10.0.0` (this will be automated later).

If the release is a minor version bump (e.g. from 8.2.x to 8.3.0):
- [ ] Make sure the regression test matrix is updated: located at [.github/workflows/test-regression.yaml](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/test-regression.yaml#L33-L36)
