### PR TITLE
fix: remove empty string to get rid of warnings for zeebe and connectors

### DIFF
--- a/charts/camunda-platform/values.yaml
+++ b/charts/camunda-platform/values.yaml
@@ -220,7 +220,7 @@ global:
         clientId: connectors
         ## @param global.identity.auth.connectors.existingSecret can be used to use an own existing secret. If not set a random secret is generated.
         # The existing secret should contain an `connectors-secret` field, which will be used as secret for the identity-Connectors communication.
-        existingSecret: ""
+        existingSecret:
 
       ## @extra global.identity.auth.identity configuration to configure Identity authentication specifics on global level, which can be accessed by other sub-charts
       identity:
@@ -314,7 +314,7 @@ global:
         clientId: zeebe
         ## @param global.identity.auth.zeebe.existingSecret can be used to use an own existing secret. If not set a random secret is generated.
         # The existing secret should contain an `zeebe-secret` field, which will be used as secret for the Identity-Zeebe communication.
-        existingSecret: ""
+        existingSecret:
         ## @param global.identity.auth.zeebe.audience defines the audience, which is used by Zeebe.
         audience: zeebe-api
         ## @param global.identity.auth.zeebe.tokenScope defines the token scope, which is used by Zeebe.


### PR DESCRIPTION
### Which problem does the PR fix?
https://github.com/camunda/camunda-platform-helm/issues/1809
<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
Remove warnings for zeebe and connectors. 
### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
