### PR TITLE
ci: delete namespace with a completed deployment only after 24 hours

### DIFF
--- a/.github/workflows/test-integration-cleanup-template.yaml
+++ b/.github/workflows/test-integration-cleanup-template.yaml
@@ -85,6 +85,7 @@ jobs:
             diffInSeconds=$(($(date -u -d "$currentTimestamp" +"%s") - $(date -u -d "$creationTimestamp" +"%s")))
             # If the namespace is older than 24 hours (86400 seconds), delete it
             if [ "$diffInSeconds" -gt 86400 ]; then
+              # TODO: uncomment below and remove echo command when PR is approved
               # kubectl delete ns --ignore-not-found=true "$ns"
               echo "can delete $ns"
             fi

--- a/.github/workflows/test-integration-cleanup-template.yaml
+++ b/.github/workflows/test-integration-cleanup-template.yaml
@@ -76,7 +76,7 @@ jobs:
         openshift_password: ${{ secrets[matrix.distro.secret.password] }}
     - name: Check Namespace in ${{ matrix.distro.name }} and Delete if Older than 24 hours
       run: |
-          for ns in $(kubectl get ns -l github-run-id --output=jsonpath='{.items[*].metadata.name}'); do
+          for ns in $(kubectl get ns -l github-run-id -l test-persistent=false --output=jsonpath='{.items[*].metadata.name}'); do
             # Get the creation timestamp of the namespace
             creationTimestamp=$(kubectl get ns "$ns" -o jsonpath='{.metadata.creationTimestamp}')
             # Get the current date and time

--- a/.github/workflows/test-integration-cleanup-template.yaml
+++ b/.github/workflows/test-integration-cleanup-template.yaml
@@ -77,15 +77,15 @@ jobs:
     - name: Check Namespace in ${{ matrix.distro.name }} and Delete if Older than 24 hours
       run: |
           for ns in $(kubectl get ns -l github-run-id --output=jsonpath='{.items[*].metadata.name}'); do
-            # # Get the creation timestamp of the namespace
-            # creationTimestamp=$(kubectl get ns "$ns" -o jsonpath='{.metadata.creationTimestamp}')
-            # # Get the current date and time
-            # currentTimestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-            # # Calculate the difference in seconds between the current time and the creation time
-            # diffInSeconds=$(($(date -u -d "$currentTimestamp" +"%s") - $(date -u -d "$creationTimestamp" +"%s")))
-            # # If the namespace is older than 24 hours (86400 seconds), delete it
-            # if [ "$diffInSeconds" -gt 86400 ]; then
-            #   kubectl delete ns --ignore-not-found=true "$ns"
-            # fi
-            echo "hi"
+            # Get the creation timestamp of the namespace
+            creationTimestamp=$(kubectl get ns "$ns" -o jsonpath='{.metadata.creationTimestamp}')
+            # Get the current date and time
+            currentTimestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+            # Calculate the difference in seconds between the current time and the creation time
+            diffInSeconds=$(($(date -u -d "$currentTimestamp" +"%s") - $(date -u -d "$creationTimestamp" +"%s")))
+            # If the namespace is older than 24 hours (86400 seconds), delete it
+            if [ "$diffInSeconds" -gt 86400 ]; then
+              # kubectl delete ns --ignore-not-found=true "$ns"
+              echo "can delete $ns"
+            fi
           done

--- a/.github/workflows/test-integration-cleanup-template.yaml
+++ b/.github/workflows/test-integration-cleanup-template.yaml
@@ -76,16 +76,16 @@ jobs:
         openshift_password: ${{ secrets[matrix.distro.secret.password] }}
     - name: Check Namespace in ${{ matrix.distro.name }} and Delete if Older than 24 hours
       run: |
-        # Get the creation timestamp of the namespace
-        creationTimestamp=$(kubectl get ns -l github-run-id="${{ inputs.github-run-id }}" -o jsonpath='{.items[0].metadata.creationTimestamp}')
-
-        # Get the current date and time
-        currentTimestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-
-        # Calculate the difference in seconds between the current time and the creation time
-        diffInSeconds=$(date -u -d "$currentTimestamp" +"%s" - date -u -d "$creationTimestamp" +"%s")
-
-        # If the namespace is older than 24 hours (86400 seconds), delete it
-        if [ $diffInSeconds -gt 86400 ]; then
-          kubectl delete ns --ignore-not-found=true -l github-run-id="${{ inputs.github-run-id }}"
-        fi
+          for ns in $(kubectl get ns -l github-run-id --output=jsonpath='{.items[*].metadata.name}'); do
+            # # Get the creation timestamp of the namespace
+            # creationTimestamp=$(kubectl get ns "$ns" -o jsonpath='{.metadata.creationTimestamp}')
+            # # Get the current date and time
+            # currentTimestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+            # # Calculate the difference in seconds between the current time and the creation time
+            # diffInSeconds=$(($(date -u -d "$currentTimestamp" +"%s") - $(date -u -d "$creationTimestamp" +"%s")))
+            # # If the namespace is older than 24 hours (86400 seconds), delete it
+            # if [ "$diffInSeconds" -gt 86400 ]; then
+            #   kubectl delete ns --ignore-not-found=true "$ns"
+            # fi
+            echo "hi"
+          done

--- a/.github/workflows/test-integration-cleanup-template.yaml
+++ b/.github/workflows/test-integration-cleanup-template.yaml
@@ -85,8 +85,6 @@ jobs:
             diffInSeconds=$(($(date -u -d "$currentTimestamp" +"%s") - $(date -u -d "$creationTimestamp" +"%s")))
             # If the namespace is older than 24 hours (86400 seconds), delete it
             if [ "$diffInSeconds" -gt 86400 ]; then
-              # TODO: uncomment below and remove echo command when PR is approved
-              # kubectl delete ns --ignore-not-found=true "$ns"
-              echo "can delete $ns"
+              kubectl delete ns --ignore-not-found=true "$ns"
             fi
           done

--- a/.github/workflows/test-integration-cleanup-template.yaml
+++ b/.github/workflows/test-integration-cleanup-template.yaml
@@ -74,7 +74,18 @@ jobs:
         openshift_server_url: ${{ secrets[matrix.distro.secret.server-url] }}
         openshift_username: ${{ secrets[matrix.distro.secret.username] }}
         openshift_password: ${{ secrets[matrix.distro.secret.password] }}
-    - name: Delete Namespace on ${{ matrix.distro.name }}
+    - name: Check Namespace in ${{ matrix.distro.name }} and Delete if Older than 24 hours
       run: |
-        kubectl delete ns --ignore-not-found=true \
-          -l github-run-id="${{ inputs.github-run-id }}"
+        # Get the creation timestamp of the namespace
+        creationTimestamp=$(kubectl get ns -l github-run-id="${{ inputs.github-run-id }}" -o jsonpath='{.items[0].metadata.creationTimestamp}')
+
+        # Get the current date and time
+        currentTimestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+        # Calculate the difference in seconds between the current time and the creation time
+        diffInSeconds=$(date -u -d "$currentTimestamp" +"%s" - date -u -d "$creationTimestamp" +"%s")
+
+        # If the namespace is older than 24 hours (86400 seconds), delete it
+        if [ $diffInSeconds -gt 86400 ]; then
+          kubectl delete ns --ignore-not-found=true -l github-run-id="${{ inputs.github-run-id }}"
+        fi


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?
Related to: https://github.com/camunda/distribution/issues/216
<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->
Within the CI, instead of deleting the namespace immediately, we now wait 24 hours before deletion.
### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
