### PR TITLE
fix: kind values.yaml file disable keycloak

### DIFF
--- a/kind/camunda-platform-core-kind-values.yaml
+++ b/kind/camunda-platform-core-kind-values.yaml
@@ -9,6 +9,10 @@ global:
 identity:
   enabled: false
 
+# Disable keycloak
+identityKeycloak:
+  enabled: false
+
 optimize:
   enabled: false
 


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?
This is a fix for the kind file. I am also disabling keycloak since identity is disabled.
Related: https://github.com/camunda/camunda-platform-helm/issues/1832
<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
