### PR TITLE
fix: re-added the postgresql secret

### DIFF
--- a/charts/camunda-platform/templates/identity/postgresql-secret.yaml
+++ b/charts/camunda-platform/templates/identity/postgresql-secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.identity.enabled -}}
+{{- if and .Values.identity.externalDatabase.enabled (not .Values.identity.externalDatabase.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "identity.postgresql.secretName" . }}
+  labels:
+    {{- include "identity.labels" . | nindent 4 }}
+type: Opaque
+data:
+  password: {{ include "identity.postgresql.secretPassword" . | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/charts/camunda-platform/test/unit/identity/secret_test.go
+++ b/charts/camunda-platform/test/unit/identity/secret_test.go
@@ -1,0 +1,78 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package identity
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	coreV1 "k8s.io/api/core/v1"
+)
+
+type secretTest struct {
+	suite.Suite
+	chartPath  string
+	release    string
+	namespace  string
+	templates  []string
+	secretName []string
+}
+
+func TestSecretTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../")
+	require.NoError(t, err)
+
+	suite.Run(t, &secretTest{
+		chartPath:  chartPath,
+		release:    "camunda-platform-test",
+		namespace:  "camunda-platform-" + strings.ToLower(random.UniqueId()),
+		templates:  []string{},
+		secretName: []string{},
+	})
+}
+
+func (s *secretTest) TestSecretExternalDatabaseEnabledWithDefinedPassword() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"identityPostgresql.enabled":         "false",
+			"identity.externalDatabase.enabled":  "true",
+			"identity.externalDatabase.password": "super-secure-ext",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	s.templates = []string{
+		"templates/identity/postgresql-secret.yaml",
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var secret coreV1.Secret
+	helm.UnmarshalK8SYaml(s.T(), output, &secret)
+
+	// then
+	s.NotEmpty(secret.Data)
+	s.Require().Equal("super-secure-ext", string(secret.Data["password"]))
+}
+

--- a/charts/camunda-platform/test/unit/identity/secret_test.go
+++ b/charts/camunda-platform/test/unit/identity/secret_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	appsv1 "k8s.io/api/apps/v1"
 	coreV1 "k8s.io/api/core/v1"
 )
 
@@ -76,3 +77,60 @@ func (s *secretTest) TestSecretExternalDatabaseEnabledWithDefinedPassword() {
 	s.Require().Equal("super-secure-ext", string(secret.Data["password"]))
 }
 
+func (s *secretTest) TestSupport21601() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"identity.postgresql.enabled":       "true",
+			"identity.externalDatabase.enabled": "false",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// There are 2 possible ways for this secret to be rendered:
+	// 1. through charts/identityPostgresql/templates/secrets.yaml for situations when identityPostgresql is enabled
+	// 2. through templates/identity/postgresql-secret.yaml for situations when identityPostgresql is disabled but
+	//    there is an externalDatabase configured
+	postgresqlSubchartSecretTemplatePath := []string{
+		"charts/identityPostgresql/templates/secrets.yaml",
+	}
+
+	identityPostgresqlMainChartSecretTemplatePath := []string{
+		"templates/identity/postgresql-secret.yaml",
+	}
+
+	deploymentTemplateName := []string{
+		"templates/identity/deployment.yaml",
+	}
+
+	// when
+	postgresqlSubchartSecret := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, postgresqlSubchartSecretTemplatePath)
+	_, mainChartSecretError := helm.RenderTemplateE(s.T(), options, s.chartPath, s.release, identityPostgresqlMainChartSecretTemplatePath)
+	deploymentTemplate := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, deploymentTemplateName)
+	var secret coreV1.Secret
+	var deployment appsv1.Deployment
+
+	helm.UnmarshalK8SYaml(s.T(), postgresqlSubchartSecret, &secret)
+	helm.UnmarshalK8SYaml(s.T(), deploymentTemplate, &deployment)
+
+	envVars := deployment.Spec.Template.Spec.Containers[0].Env
+	var identityDatabasePassword coreV1.EnvVar
+	for _, envVar := range envVars {
+		if envVar.Name == "IDENTITY_DATABASE_PASSWORD" {
+			identityDatabasePassword = envVar
+		}
+	}
+
+	// then
+
+	// I expect Deployment to be rendered
+	// I expect Secret to NOT be rendered via charts/identityPostgresql/templates/secrets.yaml
+	// I expect Secret to be rendered via templates/identity/postgresql-secret.yaml
+	// I expect Deployment NOT to have a referenced password?
+	// I expect Deployment environment variable to reference the secret that is rendered
+	s.Require().ErrorContains(mainChartSecretError, "could not find template templates/identity/postgresql-secret.yaml in chart")
+	s.Require().Equal("IDENTITY_DATABASE_PASSWORD", identityDatabasePassword.Name)
+	s.Require().Equal("camunda-platform-test-identity-postgresql", identityDatabasePassword.ValueFrom.SecretKeyRef.Name)
+	s.Require().Equal("camunda-platform-test-identity-postgresql", secret.ObjectMeta.Name)
+	s.Require().NotEmpty(string(secret.Data["password"]))
+}

--- a/charts/camunda-platform/test/unit/identity/secret_test.go
+++ b/charts/camunda-platform/test/unit/identity/secret_test.go
@@ -77,10 +77,11 @@ func (s *secretTest) TestSecretExternalDatabaseEnabledWithDefinedPassword() {
 	s.Require().Equal("super-secure-ext", string(secret.Data["password"]))
 }
 
-func (s *secretTest) TestSupport21601() {
+func (s *secretTest) TestExternalIdentityPostgresqlSecretRenderedOnCompatibilityPostgresqlEnabled() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
+			// note how it's not identityPostgresql.enabled so we can reproduce SUPPORT-21601
 			"identity.postgresql.enabled":       "true",
 			"identity.externalDatabase.enabled": "false",
 		},
@@ -123,14 +124,12 @@ func (s *secretTest) TestSupport21601() {
 
 	// then
 
-	// I expect Deployment to be rendered
 	// I expect Secret to NOT be rendered via charts/identityPostgresql/templates/secrets.yaml
-	// I expect Secret to be rendered via templates/identity/postgresql-secret.yaml
-	// I expect Deployment NOT to have a referenced password?
-	// I expect Deployment environment variable to reference the secret that is rendered
 	s.Require().ErrorContains(mainChartSecretError, "could not find template templates/identity/postgresql-secret.yaml in chart")
 	s.Require().Equal("IDENTITY_DATABASE_PASSWORD", identityDatabasePassword.Name)
+	// I expect Deployment environment variable to reference the secret that is rendered
 	s.Require().Equal("camunda-platform-test-identity-postgresql", identityDatabasePassword.ValueFrom.SecretKeyRef.Name)
+	// I expect Secret to be rendered via templates/identity/postgresql-secret.yaml
 	s.Require().Equal("camunda-platform-test-identity-postgresql", secret.ObjectMeta.Name)
 	s.Require().NotEmpty(string(secret.Data["password"]))
 }


### PR DESCRIPTION
### Which problem does the PR fix?

In #1707 , I removed a postgresql secret because I thought the secret would be created by the postgresql helm chart.

This is true, but only for the scenario where `identityPostgresql.enabled` is true.  For situations where you use an externalDatabase, you need to have the postgresql secret because that secret is referenced from the `IDENTITY_DATABASE_PASSWORD` environment variable.

This PR also adds a unit test for the problem in #1707 to ensure that re-adding this secret does not re-add the issue that I previously fixed.

Related to 

closes https://github.com/camunda/camunda-platform-helm/issues/1846


<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

The postgresql secret is re-added, the test I removed is re-added, and I created a new unit test to cover scenario related to #1707 

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
