### PR TITLE
fix: backport identity changes

### DIFF
--- a/charts/camunda-platform/charts/identity/templates/_helpers.tpl
+++ b/charts/camunda-platform/charts/identity/templates/_helpers.tpl
@@ -38,11 +38,13 @@ If release name contains chart name it will be used as a full name.
             {{ $host := .Values.global.ingress.host }}
             {{ $path := .Values.contextPath | default "" -}}
             {{- printf "%s://%s%s" $proto $host $path -}}
-        {{- else -}}
-            {{ $proto := ternary "https" "http" .Values.ingress.tls.enabled -}}
-            {{ $host := .Values.ingress.host -}}
+       {{- else if .Values.ingress.enabled -}}
+            {{- $proto := ternary "https" "http" .Values.ingress.tls.enabled -}}
+            {{- $host := .Values.ingress.host -}}
             {{- printf "%s://%s" $proto $host -}}
-        {{- end -}}
+      {{- else -}}
+        {{- "http://localhost:8080" -}}
+      {{- end -}}
     {{- end -}}
 {{- end -}}
 

--- a/charts/camunda-platform/test/unit/identity/golden/deployment.golden.yaml
+++ b/charts/camunda-platform/test/unit/identity/golden/deployment.golden.yaml
@@ -35,7 +35,7 @@ spec:
         app.kubernetes.io/version: "8.4.7"
         app.kubernetes.io/component: identity
       annotations:
-        checksum/configmap-env-vars: 02416565c87addc10b821e319f7dff8d5642313e7b1b7036f4c17d4703f4caa7
+        checksum/configmap-env-vars: 80f115d06e2487e6fd692379dacdeaaefc1f01edeef2a830245985ed10099574
     spec:
       imagePullSecrets:
         []


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
related: https://github.com/camunda/camunda-platform-helm/issues/1442
### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

This fix is to backport the change made for identity so the pod won't fail on install.
### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
