### PR TITLE
ci: use 0.0.0-ci-snapshot as a version for ci workflows

### DIFF
--- a/.github/actions/workflow-vars/action.yml
+++ b/.github/actions/workflow-vars/action.yml
@@ -79,3 +79,9 @@ runs:
       fi
       # The var is needed in some non-shell steps.
       echo "ingress-host=${TEST_INGRESS_HOST}" | tee -a $GITHUB_OUTPUT
+    # Avoid confusion about the chart version since we only change the version during the release process
+    # as the "version" field in "Chart.yaml" file doesn't reflect the changes since the latest release.
+  - name: Set chart version
+    shell: bash
+    run: |
+      yq -i '.version = "0.0.0-ci-snapshot"' charts/camunda-platform/Chart.yaml


### PR DESCRIPTION
### What's in this PR?

Avoid confusion about the chart version since we only change the version during the release process as the "version" field in "Chart.yaml" file doesn't reflect the changes since the latest release.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
