### PR TITLE
fix: Disabling Elasticsearch and enabling OpenSearch causes incorrect syntax in zeebe configmap

### DIFF
--- a/charts/camunda-platform/templates/zeebe/configmap.yaml
+++ b/charts/camunda-platform/templates/zeebe/configmap.yaml
@@ -31,10 +31,7 @@ data:
                 minimumAge: {{ .Values.zeebe.retention.minimumAge | quote }}
                 policyName: {{ .Values.zeebe.retention.policyName | quote }}
               {{- end }}
-        {{- else -}}
-          {{ " {}" }}
-        {{- end }}
-        {{- if .Values.global.opensearch.enabled }}
+        {{- else if .Values.global.opensearch.enabled }}
           opensearch:
             className: "io.camunda.zeebe.exporter.opensearch.OpensearchExporter"
             args:
@@ -43,10 +40,12 @@ data:
               authentication:
                 username: {{ .Values.global.opensearch.auth.username | quote }}
               {{- end }}
-            {{- if .Values.global.opensearch.aws.enabled }}
+              {{- if .Values.global.opensearch.aws.enabled }}
               aws:
                 enabled: true
-            {{- end}}
+              {{- end}}
+        {{- else -}}
+          {{ " {}" }}
         {{- end }}
         gateway:
           enable: true


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->
Related support issue: https://github.com/camunda/camunda-platform-helm/issues/1863

A fix for the zeebe configmap when Elasticsearch is disabled and OpenSearch is enabled.
### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
