### PR TITLE
ci: allow using Vault instead of GitHub Secrets

### DIFF
--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -38,6 +38,11 @@ on:
         description: Pass extra values to the Helm chart.
         required: false
         type: string
+      vault-secret-mapping:
+        description: (optional) defines how to map Vault secrets to distro CI environment variables
+        required: false
+        type: string
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.identifier }}
@@ -57,7 +62,7 @@ env:
 
 permissions:
   contents: read
-  
+
 jobs:
   test:
     name: ${{ matrix.distro.name }} - ${{ matrix.scenario.name }}
@@ -111,6 +116,21 @@ jobs:
         # This is needed to load repo GH composite actions if the workflow triggered by workflow_call.
         repository: camunda/camunda-platform-helm
         ref: ${{ inputs.camunda-helm-git-ref }}
+
+    # When there is a vault-secret-mapping input given, use Vault instead of GitHub secrets
+    # and populate environment variables from Vault
+    - name: Import Vault secrets
+      id: secrets
+      uses: hashicorp/vault-action@v3.0.0
+      if: inputs.vault-secret-mapping != ''
+      with:
+        url: ${{ secrets.VAULT_ADDR }}
+        method: approle
+        roleId: ${{ secrets.VAULT_ROLE_ID }}
+        secretId: ${{ secrets.VAULT_SECRET_ID }}
+        secrets: ${{ inputs.vault-secret-mapping }}
+        exportEnv: true
+
     # Used to create/delete GitHub environment.
     # NOTE: The GH app requires "administration:write" access to be able to delete the GH environment.
     - name: Generate GitHub token


### PR DESCRIPTION
### Which problem does the PR fix?

Allow running Helm integration tests without using GitHub Secrets (see https://github.com/camunda/camunda/issues/18211 ) and instead is compatible with https://confluence.camunda.com/display/HAN/CI+Secrets+Self-Service

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
