### PR TITLE
fix(web-modeler): use correct config property for OAuth2 client id

### DIFF
--- a/charts/camunda-platform/templates/web-modeler/configmap-webapp.yaml
+++ b/charts/camunda-platform/templates/web-modeler/configmap-webapp.yaml
@@ -26,7 +26,9 @@ data:
 
     [oAuth2]
     type = {{ include "camundaPlatform.authType" . | quote }}
-    clientId = {{ include "webModeler.authClientId" . | quote }}
+
+    [oAuth2.client]
+    id = {{ include "webModeler.authClientId" . | quote }}
 
     [oAuth2.token]
     jwksUrl = {{ include "camundaPlatform.authIssuerBackendUrlCertsEndpoint" . | quote }}

--- a/charts/camunda-platform/test/unit/web-modeler/configmap_webapp_test.go
+++ b/charts/camunda-platform/test/unit/web-modeler/configmap_webapp_test.go
@@ -81,7 +81,7 @@ func (s *configmapWebAppTemplateTest) TestContainerShouldSetCorrectAuthClientId(
 	}
 
 	// then
-	s.Require().Equal("custom-clientId", configmapApplication.OAuth2.ClientId)
+	s.Require().Equal("custom-clientId", configmapApplication.OAuth2.Client.Id)
 }
 func (s *configmapWebAppTemplateTest) TestContainerShouldSetCorrectClientPusherConfigurationWithGlobalIngressTlsDisabled() {
 	// given

--- a/charts/camunda-platform/test/unit/web-modeler/types.go
+++ b/charts/camunda-platform/test/unit/web-modeler/types.go
@@ -77,12 +77,16 @@ type PusherConfig struct {
 }
 
 type OAuth2Config struct {
-	Token    TokenConfig `toml:"token"`
-	ClientId string      `toml:"clientId"`
-	Type     string      `toml:"type"`
+	Client OAuth2ClientConfig `toml:"client"`
+	Token  OAuth2TokenConfig  `toml:"token"`
+	Type   string             `toml:"type"`
 }
 
-type TokenConfig struct {
+type OAuth2ClientConfig struct {
+	Id string `toml:"id"`
+}
+
+type OAuth2TokenConfig struct {
 	Audience string `toml:"audience"`
 	JwksUrl  string `toml:"jwksUrl"`
 }


### PR DESCRIPTION
### Which problem does the PR fix?
The property for the OAuth2 client id used by Web Modeler was changed from `[oAuth2].clientId` to `[oAuth2.client].id` (see https://github.com/camunda/web-modeler/pull/9483). This change was not reflected yet in the Helm chart.

### What's in this PR?
In the webapp configuration, `[oAuth2].clientId` is changed to `[oAuth2.client].id`.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/CONTRIBUTING.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
  - _Note_: I ran the command, but it would update a lot of unrelated files. So I think it should be done in a separate PR.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/CONTRIBUTING.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?