### PR TITLE
ci: mange integration tests clean-up via ttl

### DIFF
--- a/.github/actions/workflow-vars/action.yml
+++ b/.github/actions/workflow-vars/action.yml
@@ -8,9 +8,9 @@ inputs:
     description: The base of the Ingress hostname.
   platform:
     description: The deployment cloud platform like GKE or ROSA.
-  ttl:
+  deployment-ttl:
     description: |
-      Define a ttl for the lifespan of the workflow
+      Define a ttl for the lifespan of the deployment
     required: false
     default: ""
     type: string
@@ -63,7 +63,7 @@ runs:
       TRIGGER_KEY=$(is_pr && echo "pr" || echo "id")
       TEST_NAMESPACE="$(echo camunda-${TRIGGER_KEY}-${{ inputs.identifier-base }} | sed 's/\./-/g')"
 
-      if [[ "${{ inputs.ttl }}" == '' ]]; then
+      if [[ "${{ inputs.deployment-ttl }}" == '' ]]; then
       TEST_NAMESPACE="${TEST_NAMESPACE}-run-${{ github.run_id }}-sfx-${GITHUB_WORKFLOW_JOB_ID}"
       fi
 
@@ -84,7 +84,7 @@ runs:
 
       # Ingress hostname.
       TEST_INGRESS_HOST="${TEST_IDENTIFIER}.${{ inputs.ingress-hostname-base }}"
-      if [[ "${{ inputs.ttl }}" == "" ]] && is_pr; then
+      if [[ "${{ inputs.deployment-ttl }}" == "" ]] && is_pr; then
         TEST_INGRESS_HOST="${GITHUB_WORKFLOW_JOB_ID}-${TEST_INGRESS_HOST}"
       fi
       # The var is needed in some non-shell steps.

--- a/.github/actions/workflow-vars/action.yml
+++ b/.github/actions/workflow-vars/action.yml
@@ -12,6 +12,18 @@ inputs:
     description: The base of the Ingress hostname.
   platform:
     description: The deployment cloud platform like GKE or ROSA.
+  ttl:
+    description: |
+      Define a ttl for the lifespan of the workflow
+    required: false
+    default: ""
+    type: string
+  repo:
+    description: |
+      Specifies what github repository has called this workflow
+    required: false
+    default: ""
+    type: string
   identifier-base:
     description: The fixed string in the identifier of the deployment it could be PR number or another specified name.
   chart-dir:

--- a/.github/actions/workflow-vars/action.yml
+++ b/.github/actions/workflow-vars/action.yml
@@ -64,7 +64,7 @@ runs:
       TEST_NAMESPACE="$(echo camunda-${TRIGGER_KEY}-${{ inputs.identifier-base }} | sed 's/\./-/g')"
 
       if [[ "${{ inputs.deployment-ttl }}" == '' ]]; then
-      TEST_NAMESPACE="${TEST_NAMESPACE}-run-${{ github.run_id }}-sfx-${GITHUB_WORKFLOW_JOB_ID}"
+        TEST_NAMESPACE="${TEST_NAMESPACE}-run-${{ github.run_id }}-sfx-${GITHUB_WORKFLOW_JOB_ID}"
       fi
 
       if [[ "${{ inputs.setup-flow }}" == 'upgrade' ]]; then

--- a/.github/actions/workflow-vars/action.yml
+++ b/.github/actions/workflow-vars/action.yml
@@ -1,10 +1,6 @@
 name: Workflow vars
 description: Set common vars for workflow
 inputs:
-  # persistent:
-  #   description: Don't use changing vars like SHA commit
-  #   # TODO: Change that to real bool when it's supported in GHA.
-  #   default: "false"
   setup-flow:
     description: The chart setup flow either "install" or "upgrade".
     default: "install"
@@ -67,9 +63,9 @@ runs:
       TRIGGER_KEY=$(is_pr && echo "pr" || echo "id")
       TEST_NAMESPACE="$(echo camunda-${TRIGGER_KEY}-${{ inputs.identifier-base }} | sed 's/\./-/g')"
 
-      # if [[ "${{ inputs.persistent }}" == 'false' ]]; then
+      if [[ "${{ inputs.ttl }}" == '' ]]; then
       TEST_NAMESPACE="${TEST_NAMESPACE}-run-${{ github.run_id }}-sfx-${GITHUB_WORKFLOW_JOB_ID}"
-      # fi
+      fi
 
       if [[ "${{ inputs.setup-flow }}" == 'upgrade' ]]; then
         TEST_NAMESPACE="${TEST_NAMESPACE}-upgrade"
@@ -88,9 +84,9 @@ runs:
 
       # Ingress hostname.
       TEST_INGRESS_HOST="${TEST_IDENTIFIER}.${{ inputs.ingress-hostname-base }}"
-      # if [[ "${{ inputs.persistent }}" == "false" ]] && is_pr; then
-      #   TEST_INGRESS_HOST="${GITHUB_WORKFLOW_JOB_ID}-${TEST_INGRESS_HOST}"
-      # fi
+      if [[ "${{ inputs.ttl }}" == "" ]] && is_pr; then
+        TEST_INGRESS_HOST="${GITHUB_WORKFLOW_JOB_ID}-${TEST_INGRESS_HOST}"
+      fi
       # The var is needed in some non-shell steps.
       echo "ingress-host=${TEST_INGRESS_HOST}" | tee -a $GITHUB_OUTPUT
 

--- a/.github/actions/workflow-vars/action.yml
+++ b/.github/actions/workflow-vars/action.yml
@@ -14,12 +14,6 @@ inputs:
     required: false
     default: ""
     type: string
-  repo:
-    description: |
-      Specifies what github repository has called this workflow
-    required: false
-    default: ""
-    type: string
   identifier-base:
     description: The fixed string in the identifier of the deployment it could be PR number or another specified name.
   chart-dir:

--- a/.github/workflows/dispatch-integration-backport.yaml
+++ b/.github/workflows/dispatch-integration-backport.yaml
@@ -7,6 +7,7 @@ on:
         description: |
           Define a ttl for the lifespan of the workflow
         required: false
+        default: ""
         type: string
       repo:
         description: |
@@ -43,5 +44,5 @@ jobs:
       identifier: ${{ github.event.inputs.identifier }}
       extra-values: ${{ github.event.inputs.extra-values }}
       platforms: ${{ github.event.inputs.platforms }}
-      # ??
-      # persistent: ${{ github.event.inputs.persistent == 'true' }}
+      ttl: ${{ github.event.inputs.ttl == "1w" }}
+      repo: ${{ github.event.inputs.repo }}

--- a/.github/workflows/dispatch-integration-backport.yaml
+++ b/.github/workflows/dispatch-integration-backport.yaml
@@ -9,11 +9,6 @@ on:
         required: false
         default: ""
         type: string
-      repo:
-        description: |
-          Specifies what github repository has called this workflow
-        required: false
-        type: string
       platforms:
         description: platform to test on
         required: false
@@ -45,4 +40,3 @@ jobs:
       extra-values: ${{ github.event.inputs.extra-values }}
       platforms: ${{ github.event.inputs.platforms }}
       ttl: ${{ github.event.inputs.ttl == "1w" }}
-      repo: ${{ github.event.inputs.repo }}

--- a/.github/workflows/dispatch-integration-backport.yaml
+++ b/.github/workflows/dispatch-integration-backport.yaml
@@ -3,13 +3,16 @@ name: "Dispatch Backport - Integration - Main"
 on:
   workflow_dispatch:
     inputs:
-      persistent:
+      ttl:
         description: |
-          Keep test deployment after the workflow is done.
-          NOTE: All persistent deployments will be deleted frequently to save costs!
+          Define a ttl for the lifespan of the workflow
         required: false
-        default: false
-        type: boolean
+        type: string
+      repo:
+        description: |
+          Specifies what github repository has called this workflow
+        required: false
+        type: string
       platforms:
         description: platform to test on
         required: false
@@ -40,4 +43,5 @@ jobs:
       identifier: ${{ github.event.inputs.identifier }}
       extra-values: ${{ github.event.inputs.extra-values }}
       platforms: ${{ github.event.inputs.platforms }}
-      persistent: ${{ github.event.inputs.persistent == 'true' }}
+      # ??
+      # persistent: ${{ github.event.inputs.persistent == 'true' }}

--- a/.github/workflows/dispatch-integration-backport.yaml
+++ b/.github/workflows/dispatch-integration-backport.yaml
@@ -3,9 +3,9 @@ name: "Dispatch Backport - Integration - Main"
 on:
   workflow_dispatch:
     inputs:
-      ttl:
+      deployment-ttl:
         description: |
-          Define a ttl for the lifespan of the workflow
+          Define a ttl for the lifespan of the deployment
         required: false
         default: ""
         type: string
@@ -39,4 +39,4 @@ jobs:
       identifier: ${{ github.event.inputs.identifier }}
       extra-values: ${{ github.event.inputs.extra-values }}
       platforms: ${{ github.event.inputs.platforms }}
-      ttl: ${{ github.event.inputs.ttl == "1w" }}
+      deployment-ttl: ${{ github.event.inputs.deployment-ttl == "1w" }}

--- a/.github/workflows/dispatch-integration.yaml
+++ b/.github/workflows/dispatch-integration.yaml
@@ -17,9 +17,9 @@ on:
         required: false
         default: main
         type: string
-      ttl:
+      deployment-ttl:
         description: |
-          Define a ttl for the lifespan of the workflow
+          Define a ttl for the lifespan of the deployment
         required: false
         default: ""
         type: string
@@ -58,7 +58,7 @@ jobs:
       identifier: ${{ github.event.inputs.identifier }}
       caller-git-ref: ${{ github.event.inputs.caller-git-ref }}
       camunda-helm-git-ref: ${{ github.event.inputs.camunda-helm-git-ref }}
-      ttl: ${{ github.event.inputs.ttl == "1w" }}
+      deployment-ttl: ${{ github.event.inputs.deployment-ttl == "1w" }}
       platforms: ${{ github.event.inputs.platforms }}
       flows: ${{ github.event.inputs.flows }}
       test-enabled: ${{ github.event.inputs.test-enabled == 'true' }}

--- a/.github/workflows/dispatch-integration.yaml
+++ b/.github/workflows/dispatch-integration.yaml
@@ -17,13 +17,18 @@ on:
         required: false
         default: main
         type: string
-      persistent:
+      ttl:
         description: |
-          Keep test deployment after the workflow is done.
-          NOTE: All persistent deployments will be deleted frequently to save costs!
+          Define a ttl for the lifespan of the workflow
         required: false
-        default: false
-        type: boolean
+        default: ""
+        type: string
+      repo:
+        description: |
+          Specifies what github repository has called this workflow
+        required: false
+        default: ""
+        type: string
       platforms:
         description: platforms
         default: gke
@@ -59,7 +64,8 @@ jobs:
       identifier: ${{ github.event.inputs.identifier }}
       caller-git-ref: ${{ github.event.inputs.caller-git-ref }}
       camunda-helm-git-ref: ${{ github.event.inputs.camunda-helm-git-ref }}
-      persistent: ${{ github.event.inputs.persistent == 'true' }}
+      # ??
+      # persistent: ${{ github.event.inputs.persistent == 'true' }}
       platforms: ${{ github.event.inputs.platforms }}
       flows: ${{ github.event.inputs.flows }}
       test-enabled: ${{ github.event.inputs.test-enabled == 'true' }}

--- a/.github/workflows/dispatch-integration.yaml
+++ b/.github/workflows/dispatch-integration.yaml
@@ -64,8 +64,8 @@ jobs:
       identifier: ${{ github.event.inputs.identifier }}
       caller-git-ref: ${{ github.event.inputs.caller-git-ref }}
       camunda-helm-git-ref: ${{ github.event.inputs.camunda-helm-git-ref }}
-      # ??
-      # persistent: ${{ github.event.inputs.persistent == 'true' }}
+      ttl: ${{ github.event.inputs.ttl == "1w" }}
+      repo: ${{ github.event.inputs.repo }}
       platforms: ${{ github.event.inputs.platforms }}
       flows: ${{ github.event.inputs.flows }}
       test-enabled: ${{ github.event.inputs.test-enabled == 'true' }}

--- a/.github/workflows/dispatch-integration.yaml
+++ b/.github/workflows/dispatch-integration.yaml
@@ -23,12 +23,6 @@ on:
         required: false
         default: ""
         type: string
-      repo:
-        description: |
-          Specifies what github repository has called this workflow
-        required: false
-        default: ""
-        type: string
       platforms:
         description: platforms
         default: gke
@@ -65,7 +59,6 @@ jobs:
       caller-git-ref: ${{ github.event.inputs.caller-git-ref }}
       camunda-helm-git-ref: ${{ github.event.inputs.camunda-helm-git-ref }}
       ttl: ${{ github.event.inputs.ttl == "1w" }}
-      repo: ${{ github.event.inputs.repo }}
       platforms: ${{ github.event.inputs.platforms }}
       flows: ${{ github.event.inputs.flows }}
       test-enabled: ${{ github.event.inputs.test-enabled == 'true' }}

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -200,6 +200,8 @@ jobs:
         kubectl label ns $TEST_NAMESPACE github-job-id=$GITHUB_WORKFLOW_JOB_ID
         kubectl label ns $TEST_NAMESPACE github-id=${{ steps.vars.outputs.identifier }}
         kubectl label ns $TEST_NAMESPACE test-flow=${{ matrix.scenario.flow }}
+        kubectl label ns $TEST_NAMESPACE repo=${{ env.REPO }}
+        kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${{ env.CI_TTL }}
     - name: Copy PRs wildcard certificate
       run: |
         kubectl apply -n $TEST_NAMESPACE -f .github/config/external-secret.yaml
@@ -270,7 +272,7 @@ jobs:
       if: failure()
       uses: ./.github/actions/failed-pods-info
     - name: Cleanup GitHub deployment
-      if: always() && (matrix.distro.type != 'kubernetes')
+      if: always() && (env.CI_TTL != "" || matrix.distro.type != 'kubernetes')
       uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1
       with:
         step: delete-env
@@ -278,7 +280,7 @@ jobs:
         env: ${{ steps.vars.outputs.identifier }}
         ref: ${{ inputs.caller-git-ref }}
     - name: Cleanup test namespace
-      if: always() && (matrix.distro.type != 'kubernetes')
+      if: always() && (env.CI_TTL != "" || matrix.distro.type != 'kubernetes')
       run: |
         kubectl delete ns --ignore-not-found=true \
           -l github-run-id=$GITHUB_WORKFLOW_RUN_ID \

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -56,7 +56,7 @@ concurrency:
 env:
   # Vars with "CI_" prefix are used in the CI workflow only.
   # Vars with "TEST_" prefix are used in the test runner tool (Task).
-  CI_TTL: ${{ inputs.deployment-ttl }}
+  CI_DEPLOYMENT_TTL: ${{ inputs.deployment-ttl }}
   CI_REPO: $(basename ${{ github.event.repository.full_name }})
   CI_HOSTNAME_BASE: ci.distro.ultrawombat.com
   # Docker Hub auth to avoid image pull rate limit.
@@ -165,7 +165,7 @@ jobs:
       id: vars
       uses: ./.github/actions/workflow-vars
       with:
-        deployment-ttl: ${{ env.CI_TTL }}
+        deployment-ttl: ${{ env.CI_DEPLOYMENT_TTL }}
         repo: ${{ env.CI_REPO }}
         setup-flow: ${{ matrix.scenario.flow }}
         platform: ${{ matrix.distro.platform }}
@@ -195,7 +195,7 @@ jobs:
         kubectl label ns $TEST_NAMESPACE github-id=${{ steps.vars.outputs.identifier }}
         kubectl label ns $TEST_NAMESPACE test-flow=${{ matrix.scenario.flow }}
         kubectl label ns $TEST_NAMESPACE repo=${{ env.CI_REPO }}
-        kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${{ env.CI_TTL }}
+        kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${{ env.CI_DEPLOYMENT_TTL }}
     - name: Copy PRs wildcard certificate
       run: |
         kubectl apply -n $TEST_NAMESPACE -f .github/config/external-secret.yaml
@@ -266,7 +266,7 @@ jobs:
       if: failure()
       uses: ./.github/actions/failed-pods-info
     - name: Cleanup test namespace
-      if: always() && (env.CI_TTL == '' || matrix.distro.type != 'kubernetes')
+      if: always() && (env.CI_DEPLOYMENT_TTL == '' || matrix.distro.type != 'kubernetes')
       run: |
         kubectl delete ns --ignore-not-found=true \
           -l github-run-id=$GITHUB_WORKFLOW_RUN_ID \

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -274,7 +274,7 @@ jobs:
         env: ${{ steps.vars.outputs.identifier }}
         ref: ${{ inputs.caller-git-ref }}
     - name: Cleanup test namespace
-      if: always() && (env.CI_DEPLOYMENT_TTL == '' || matrix.distro.type != 'kubernetes')
+      if: always() && (matrix.distro.type != 'kubernetes')
       run: |
         # the if statement ensures that only the input from the user is taken and not the default value.
         if [ -n "${CI_DEPLOYMENT_TTL}" ]; then

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -274,6 +274,7 @@ jobs:
         env: ${{ steps.vars.outputs.identifier }}
         ref: ${{ inputs.caller-git-ref }}
     - name: Cleanup test namespace
+      if: always()
       run: |
         if [ "${{ env.CI_DEPLOYMENT_TTL }}" != "" ]; then
           if [ "${{ matrix.distro.type }}" == "kubernetes" ]; then

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -274,6 +274,6 @@ jobs:
         env: ${{ steps.vars.outputs.identifier }}
         ref: ${{ inputs.caller-git-ref }}
     - name: Cleanup test namespace
-      if: always() && (env.CI_DEPLOYMENT_TTL == "43200s" || matrix.distro.type != 'kubernetes')
+      if: always() && (env.CI_DEPLOYMENT_TTL == '' || matrix.distro.type != 'kubernetes')
       run: |
         kubectl annotate ns $TEST_NAMESPACE cleaner/ttl="1s"

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -62,6 +62,8 @@ concurrency:
 env:
   # Vars with "CI_" prefix are used in the CI workflow only.
   # Vars with "TEST_" prefix are used in the test runner tool (Task).
+  CI_TTL: ${{ inputs.ttl }}
+  CI_REPO: ${{ inputs.repo }}
   CI_HOSTNAME_BASE: ci.distro.ultrawombat.com
   # Docker Hub auth to avoid image pull rate limit.
   TEST_CREATE_DOCKER_LOGIN_SECRET: "TRUE"

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -63,7 +63,7 @@ env:
   # Vars with "CI_" prefix are used in the CI workflow only.
   # Vars with "TEST_" prefix are used in the test runner tool (Task).
   CI_TTL: ${{ inputs.ttl }}
-  CI_REPO: ${{ github.event.repository.full_name }}
+  CI_REPO: ${{ github.event.repository.full_name.split('/')[1] }}
   CI_HOSTNAME_BASE: ci.distro.ultrawombat.com
   # Docker Hub auth to avoid image pull rate limit.
   TEST_CREATE_DOCKER_LOGIN_SECRET: "TRUE"

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -63,7 +63,7 @@ env:
   # Vars with "CI_" prefix are used in the CI workflow only.
   # Vars with "TEST_" prefix are used in the test runner tool (Task).
   CI_TTL: ${{ inputs.ttl }}
-  CI_REPO: ${{ github.event.repository.full_name#camunda/ }}
+  CI_REPO: ${{ github.event.repository.full_name.split('/')[1] }}
   CI_HOSTNAME_BASE: ci.distro.ultrawombat.com
   # Docker Hub auth to avoid image pull rate limit.
   TEST_CREATE_DOCKER_LOGIN_SECRET: "TRUE"

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -218,55 +218,8 @@ jobs:
         echo "Extra values from workflow:"
         echo "${{ inputs.extra-values }}" > /tmp/extra-values-file.yaml
         cat /tmp/extra-values-file.yaml
-    - name: 🌟 Setup Camunda chart 🌟
-      env:
-        TEST_CHART_FLOW: ${{ matrix.scenario.flow }}
-        TEST_HELM_EXTRA_ARGS: >-
-          --set global.ingress.host=${{ steps.vars.outputs.ingress-host }}
-          --values /tmp/extra-values-file.yaml
-      run: |
-        task -d ${CI_TASKS_BASE_DIR}/chart-full-setup setup.exec
-    - name: Post setup
-      timeout-minutes: 5
-      run: |
-        task -d ${CI_TASKS_BASE_DIR}/chart-full-setup setup.post
-    - name: Pre Upgrade
-      if: matrix.scenario.flow == 'upgrade'
-      run: |
-        task -d ${CI_TASKS_BASE_DIR}/chart-full-setup upgrade.pre
-    - name: 🌟 Upgrade Camunda chart 🌟
-      if: matrix.scenario.flow == 'upgrade'
-      env:
-        TEST_HELM_EXTRA_ARGS: >-
-          --set global.ingress.host=${{ steps.vars.outputs.ingress-host }}
-          --values /tmp/extra-values-file.yaml
-      run: |
-        task -d ${CI_TASKS_BASE_DIR}/chart-full-setup upgrade.exec
-    - name: Update GitHub deployment status
-      uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1
-      with:
-        step: finish
-        token: ${{ steps.generate-github-token.outputs.token }}
-        status: ${{ job.status }}
-        deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-        env_url: https://${{ steps.vars.outputs.ingress-host }}
-        env: ${{ steps.vars.outputs.identifier }}
-        ref: ${{ inputs.caller-git-ref }}
-    - name: ⭐️ Run Preflight TestSuite ⭐️
-      if: inputs.test-enabled
-      timeout-minutes: 10
-      run: |
-        task -d ${CI_TASKS_BASE_DIR}/chart-full-setup test.preflight
-    - name: ⭐️ Run Core TestSuite ⭐️
-      if: inputs.test-enabled
-      timeout-minutes: 20
-      run: |
-        task -d ${CI_TASKS_BASE_DIR}/chart-full-setup test.core
-    - name: 🚨 Get failed Pods info 🚨
-      if: failure()
-      uses: ./.github/actions/failed-pods-info
     - name: Cleanup GitHub deployment
-      if: always() && (matrix.distro.type != 'kubernetes')
+      if: always() && (env.CI_DEPLOYMENT_TTL == '' || matrix.distro.type != 'kubernetes')
       uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1
       with:
         step: delete-env
@@ -274,7 +227,7 @@ jobs:
         env: ${{ steps.vars.outputs.identifier }}
         ref: ${{ inputs.caller-git-ref }}
     - name: Cleanup test namespace
-      if: always() && (matrix.distro.type != 'kubernetes')
+      if: always() && (env.CI_DEPLOYMENT_TTL == '' || matrix.distro.type != 'kubernetes')
       run: |
         # the if statement ensures that only the input from the user is taken and not the default value.
         if [ -n "${CI_DEPLOYMENT_TTL}" ]; then
@@ -282,3 +235,67 @@ jobs:
         else
             kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=1s --overwrite=true
         fi
+    # - name: 🌟 Setup Camunda chart 🌟
+    #   env:
+    #     TEST_CHART_FLOW: ${{ matrix.scenario.flow }}
+    #     TEST_HELM_EXTRA_ARGS: >-
+    #       --set global.ingress.host=${{ steps.vars.outputs.ingress-host }}
+    #       --values /tmp/extra-values-file.yaml
+    #   run: |
+    #     task -d ${CI_TASKS_BASE_DIR}/chart-full-setup setup.exec
+    # - name: Post setup
+    #   timeout-minutes: 5
+    #   run: |
+    #     task -d ${CI_TASKS_BASE_DIR}/chart-full-setup setup.post
+    # - name: Pre Upgrade
+    #   if: matrix.scenario.flow == 'upgrade'
+    #   run: |
+    #     task -d ${CI_TASKS_BASE_DIR}/chart-full-setup upgrade.pre
+    # - name: 🌟 Upgrade Camunda chart 🌟
+    #   if: matrix.scenario.flow == 'upgrade'
+    #   env:
+    #     TEST_HELM_EXTRA_ARGS: >-
+    #       --set global.ingress.host=${{ steps.vars.outputs.ingress-host }}
+    #       --values /tmp/extra-values-file.yaml
+    #   run: |
+    #     task -d ${CI_TASKS_BASE_DIR}/chart-full-setup upgrade.exec
+    # - name: Update GitHub deployment status
+    #   uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1
+    #   with:
+    #     step: finish
+    #     token: ${{ steps.generate-github-token.outputs.token }}
+    #     status: ${{ job.status }}
+    #     deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+    #     env_url: https://${{ steps.vars.outputs.ingress-host }}
+    #     env: ${{ steps.vars.outputs.identifier }}
+    #     ref: ${{ inputs.caller-git-ref }}
+    # - name: ⭐️ Run Preflight TestSuite ⭐️
+    #   if: inputs.test-enabled
+    #   timeout-minutes: 10
+    #   run: |
+    #     task -d ${CI_TASKS_BASE_DIR}/chart-full-setup test.preflight
+    # - name: ⭐️ Run Core TestSuite ⭐️
+    #   if: inputs.test-enabled
+    #   timeout-minutes: 20
+    #   run: |
+    #     task -d ${CI_TASKS_BASE_DIR}/chart-full-setup test.core
+    # - name: 🚨 Get failed Pods info 🚨
+    #   if: failure()
+    #   uses: ./.github/actions/failed-pods-info
+    # - name: Cleanup GitHub deployment
+    #   if: always() && (env.CI_DEPLOYMENT_TTL == '' || matrix.distro.type != 'kubernetes')
+    #   uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1
+    #   with:
+    #     step: delete-env
+    #     token: ${{ steps.generate-github-token.outputs.token }}
+    #     env: ${{ steps.vars.outputs.identifier }}
+    #     ref: ${{ inputs.caller-git-ref }}
+    # - name: Cleanup test namespace
+    #   if: always() && (env.CI_DEPLOYMENT_TTL == '' || matrix.distro.type != 'kubernetes')
+    #   run: |
+    #     # the if statement ensures that only the input from the user is taken and not the default value.
+    #     if [ -n "${CI_DEPLOYMENT_TTL}" ]; then
+    #         kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${CI_DEPLOYMENT_TTL} --overwrite=true
+    #     else
+    #         kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=1s --overwrite=true
+    #     fi

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -20,18 +20,6 @@ on:
         required: false
         default: main
         type: string
-      ttl:
-        description: |
-          Define a ttl for the lifespan of the workflow
-        required: false
-        default: ""
-        type: string
-      repo:
-        description: |
-          Specifies what github repository has called this workflow
-        required: false
-        default: ""
-        type: string
       platforms:
         default: gke
         type: string
@@ -62,8 +50,6 @@ concurrency:
 env:
   # Vars with "CI_" prefix are used in the CI workflow only.
   # Vars with "TEST_" prefix are used in the test runner tool (Task).
-  CI_TTL: ${{ inputs.ttl }}
-  REPO: ${{ inputs.repo }}
   CI_HOSTNAME_BASE: ci.distro.ultrawombat.com
   # Docker Hub auth to avoid image pull rate limit.
   TEST_CREATE_DOCKER_LOGIN_SECRET: "TRUE"
@@ -171,8 +157,6 @@ jobs:
       id: vars
       uses: ./.github/actions/workflow-vars
       with:
-        ttl: ${{ env.CI_TTL }}
-        repo: ${{ env.REPO }}
         setup-flow: ${{ matrix.scenario.flow }}
         platform: ${{ matrix.distro.platform }}
         identifier-base: ${{ inputs.identifier }}
@@ -200,8 +184,6 @@ jobs:
         kubectl label ns $TEST_NAMESPACE github-job-id=$GITHUB_WORKFLOW_JOB_ID
         kubectl label ns $TEST_NAMESPACE github-id=${{ steps.vars.outputs.identifier }}
         kubectl label ns $TEST_NAMESPACE test-flow=${{ matrix.scenario.flow }}
-        kubectl label ns $TEST_NAMESPACE repo=${{ env.REPO }}
-        kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${{ env.CI_TTL }}
     - name: Copy PRs wildcard certificate
       run: |
         kubectl apply -n $TEST_NAMESPACE -f .github/config/external-secret.yaml
@@ -272,7 +254,7 @@ jobs:
       if: failure()
       uses: ./.github/actions/failed-pods-info
     - name: Cleanup GitHub deployment
-      if: always() && (env.CI_TTL != "" || matrix.distro.type != 'kubernetes')
+      if: always() && (matrix.distro.type != 'kubernetes')
       uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1
       with:
         step: delete-env
@@ -280,7 +262,7 @@ jobs:
         env: ${{ steps.vars.outputs.identifier }}
         ref: ${{ inputs.caller-git-ref }}
     - name: Cleanup test namespace
-      if: always() && (env.CI_TTL != "" || matrix.distro.type != 'kubernetes')
+      if: always() && (matrix.distro.type != 'kubernetes')
       run: |
         kubectl delete ns --ignore-not-found=true \
           -l github-run-id=$GITHUB_WORKFLOW_RUN_ID \

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -200,6 +200,8 @@ jobs:
         kubectl label ns $TEST_NAMESPACE github-job-id=$GITHUB_WORKFLOW_JOB_ID
         kubectl label ns $TEST_NAMESPACE github-id=${{ steps.vars.outputs.identifier }}
         kubectl label ns $TEST_NAMESPACE test-flow=${{ matrix.scenario.flow }}
+        kubectl label ns $TEST_NAMESPACE repo=${{ env.REPO }}
+        kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${{ env.CI_TTL }}
     - name: Copy PRs wildcard certificate
       run: |
         kubectl apply -n $TEST_NAMESPACE -f .github/config/external-secret.yaml

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -194,7 +194,7 @@ jobs:
         kubectl label ns $TEST_NAMESPACE github-job-id=$GITHUB_WORKFLOW_JOB_ID
         kubectl label ns $TEST_NAMESPACE github-id=${{ steps.vars.outputs.identifier }}
         kubectl label ns $TEST_NAMESPACE test-flow=${{ matrix.scenario.flow }}
-        kubectl label ns $TEST_NAMESPACE repo=${{ env.CI_REPO }}
+        kubectl label ns $TEST_NAMESPACE repo=${{ GITHUB_ACTION_REPOSITORY }}
         kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${{ env.CI_DEPLOYMENT_TTL }}
     - name: Copy PRs wildcard certificate
       run: |

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -219,7 +219,7 @@ jobs:
         echo "${{ inputs.extra-values }}" > /tmp/extra-values-file.yaml
         cat /tmp/extra-values-file.yaml
     - name: Cleanup GitHub deployment
-      if: always() && (env.CI_DEPLOYMENT_TTL == '' || matrix.distro.type != 'kubernetes')
+      if: always() && (env.CI_DEPLOYMENT_TTL == '')
       uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1
       with:
         step: delete-env
@@ -227,7 +227,7 @@ jobs:
         env: ${{ steps.vars.outputs.identifier }}
         ref: ${{ inputs.caller-git-ref }}
     - name: Cleanup test namespace
-      if: always() && (env.CI_DEPLOYMENT_TTL == '' || matrix.distro.type != 'kubernetes')
+      if: always()
       run: |
         # the if statement ensures that only the input from the user is taken and not the default value.
         if [ -n "${CI_DEPLOYMENT_TTL}" ]; then

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -200,8 +200,6 @@ jobs:
         kubectl label ns $TEST_NAMESPACE github-job-id=$GITHUB_WORKFLOW_JOB_ID
         kubectl label ns $TEST_NAMESPACE github-id=${{ steps.vars.outputs.identifier }}
         kubectl label ns $TEST_NAMESPACE test-flow=${{ matrix.scenario.flow }}
-        kubectl label ns $TEST_NAMESPACE repo=${{ env.REPO }}
-        kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${{ env.CI_TTL }}
     - name: Copy PRs wildcard certificate
       run: |
         kubectl apply -n $TEST_NAMESPACE -f .github/config/external-secret.yaml
@@ -272,7 +270,7 @@ jobs:
       if: failure()
       uses: ./.github/actions/failed-pods-info
     - name: Cleanup GitHub deployment
-      if: always() && (env.CI_TTL != "" || matrix.distro.type != 'kubernetes')
+      if: always() && (matrix.distro.type != 'kubernetes')
       uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1
       with:
         step: delete-env
@@ -280,7 +278,7 @@ jobs:
         env: ${{ steps.vars.outputs.identifier }}
         ref: ${{ inputs.caller-git-ref }}
     - name: Cleanup test namespace
-      if: always() && (env.CI_TTL != "" || matrix.distro.type != 'kubernetes')
+      if: always() && (matrix.distro.type != 'kubernetes')
       run: |
         kubectl delete ns --ignore-not-found=true \
           -l github-run-id=$GITHUB_WORKFLOW_RUN_ID \

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -218,6 +218,53 @@ jobs:
         echo "Extra values from workflow:"
         echo "${{ inputs.extra-values }}" > /tmp/extra-values-file.yaml
         cat /tmp/extra-values-file.yaml
+    - name: 🌟 Setup Camunda chart 🌟
+      env:
+        TEST_CHART_FLOW: ${{ matrix.scenario.flow }}
+        TEST_HELM_EXTRA_ARGS: >-
+          --set global.ingress.host=${{ steps.vars.outputs.ingress-host }}
+          --values /tmp/extra-values-file.yaml
+      run: |
+        task -d ${CI_TASKS_BASE_DIR}/chart-full-setup setup.exec
+    - name: Post setup
+      timeout-minutes: 5
+      run: |
+        task -d ${CI_TASKS_BASE_DIR}/chart-full-setup setup.post
+    - name: Pre Upgrade
+      if: matrix.scenario.flow == 'upgrade'
+      run: |
+        task -d ${CI_TASKS_BASE_DIR}/chart-full-setup upgrade.pre
+    - name: 🌟 Upgrade Camunda chart 🌟
+      if: matrix.scenario.flow == 'upgrade'
+      env:
+        TEST_HELM_EXTRA_ARGS: >-
+          --set global.ingress.host=${{ steps.vars.outputs.ingress-host }}
+          --values /tmp/extra-values-file.yaml
+      run: |
+        task -d ${CI_TASKS_BASE_DIR}/chart-full-setup upgrade.exec
+    - name: Update GitHub deployment status
+      uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1
+      with:
+        step: finish
+        token: ${{ steps.generate-github-token.outputs.token }}
+        status: ${{ job.status }}
+        deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+        env_url: https://${{ steps.vars.outputs.ingress-host }}
+        env: ${{ steps.vars.outputs.identifier }}
+        ref: ${{ inputs.caller-git-ref }}
+    - name: ⭐️ Run Preflight TestSuite ⭐️
+      if: inputs.test-enabled
+      timeout-minutes: 10
+      run: |
+        task -d ${CI_TASKS_BASE_DIR}/chart-full-setup test.preflight
+    - name: ⭐️ Run Core TestSuite ⭐️
+      if: inputs.test-enabled
+      timeout-minutes: 20
+      run: |
+        task -d ${CI_TASKS_BASE_DIR}/chart-full-setup test.core
+    - name: 🚨 Get failed Pods info 🚨
+      if: failure()
+      uses: ./.github/actions/failed-pods-info
     - name: Cleanup GitHub deployment
       if: always() && (env.CI_DEPLOYMENT_TTL == '' || matrix.distro.type != 'kubernetes')
       uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1
@@ -227,7 +274,7 @@ jobs:
         env: ${{ steps.vars.outputs.identifier }}
         ref: ${{ inputs.caller-git-ref }}
     - name: Cleanup test namespace
-      if: always()
+      if: always() && (env.CI_DEPLOYMENT_TTL == '' || matrix.distro.type != 'kubernetes')
       run: |
         # the if statement ensures that only the input from the user is taken and not the default value.
         if [ -n "${CI_DEPLOYMENT_TTL}" ]; then
@@ -235,67 +282,3 @@ jobs:
         else
             kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=1s --overwrite=true
         fi
-    # - name: 🌟 Setup Camunda chart 🌟
-    #   env:
-    #     TEST_CHART_FLOW: ${{ matrix.scenario.flow }}
-    #     TEST_HELM_EXTRA_ARGS: >-
-    #       --set global.ingress.host=${{ steps.vars.outputs.ingress-host }}
-    #       --values /tmp/extra-values-file.yaml
-    #   run: |
-    #     task -d ${CI_TASKS_BASE_DIR}/chart-full-setup setup.exec
-    # - name: Post setup
-    #   timeout-minutes: 5
-    #   run: |
-    #     task -d ${CI_TASKS_BASE_DIR}/chart-full-setup setup.post
-    # - name: Pre Upgrade
-    #   if: matrix.scenario.flow == 'upgrade'
-    #   run: |
-    #     task -d ${CI_TASKS_BASE_DIR}/chart-full-setup upgrade.pre
-    # - name: 🌟 Upgrade Camunda chart 🌟
-    #   if: matrix.scenario.flow == 'upgrade'
-    #   env:
-    #     TEST_HELM_EXTRA_ARGS: >-
-    #       --set global.ingress.host=${{ steps.vars.outputs.ingress-host }}
-    #       --values /tmp/extra-values-file.yaml
-    #   run: |
-    #     task -d ${CI_TASKS_BASE_DIR}/chart-full-setup upgrade.exec
-    # - name: Update GitHub deployment status
-    #   uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1
-    #   with:
-    #     step: finish
-    #     token: ${{ steps.generate-github-token.outputs.token }}
-    #     status: ${{ job.status }}
-    #     deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-    #     env_url: https://${{ steps.vars.outputs.ingress-host }}
-    #     env: ${{ steps.vars.outputs.identifier }}
-    #     ref: ${{ inputs.caller-git-ref }}
-    # - name: ⭐️ Run Preflight TestSuite ⭐️
-    #   if: inputs.test-enabled
-    #   timeout-minutes: 10
-    #   run: |
-    #     task -d ${CI_TASKS_BASE_DIR}/chart-full-setup test.preflight
-    # - name: ⭐️ Run Core TestSuite ⭐️
-    #   if: inputs.test-enabled
-    #   timeout-minutes: 20
-    #   run: |
-    #     task -d ${CI_TASKS_BASE_DIR}/chart-full-setup test.core
-    # - name: 🚨 Get failed Pods info 🚨
-    #   if: failure()
-    #   uses: ./.github/actions/failed-pods-info
-    # - name: Cleanup GitHub deployment
-    #   if: always() && (env.CI_DEPLOYMENT_TTL == '' || matrix.distro.type != 'kubernetes')
-    #   uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1
-    #   with:
-    #     step: delete-env
-    #     token: ${{ steps.generate-github-token.outputs.token }}
-    #     env: ${{ steps.vars.outputs.identifier }}
-    #     ref: ${{ inputs.caller-git-ref }}
-    # - name: Cleanup test namespace
-    #   if: always() && (env.CI_DEPLOYMENT_TTL == '' || matrix.distro.type != 'kubernetes')
-    #   run: |
-    #     # the if statement ensures that only the input from the user is taken and not the default value.
-    #     if [ -n "${CI_DEPLOYMENT_TTL}" ]; then
-    #         kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${CI_DEPLOYMENT_TTL} --overwrite=true
-    #     else
-    #         kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=1s --overwrite=true
-    #     fi

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -26,12 +26,6 @@ on:
         required: false
         default: ""
         type: string
-      # repo:
-      #   description: |
-      #     Specifies what github repository has called this workflow
-      #   required: false
-      #   default: ""
-      #   type: string
       platforms:
         default: gke
         type: string

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -277,6 +277,8 @@ jobs:
       if: always() && (env.CI_DEPLOYMENT_TTL == '' || matrix.distro.type != 'kubernetes')
       run: |
         # the if statement ensures that only the input from the user is taken and not the default value.
-        if [ -n "${{ env.CI_TTL }}" ]; then
-        kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${{ env.CI_DEPLOYMENT_TTL }} --overwrite=true
+        if [ -n "${CI_TTL}" ]; then
+            kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${CI_DEPLOYMENT_TTL} --overwrite=true
+        else
+            kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=1s --overwrite=true
         fi

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -272,7 +272,7 @@ jobs:
       if: failure()
       uses: ./.github/actions/failed-pods-info
     - name: Cleanup GitHub deployment
-      if: always() && (matrix.distro.type != 'kubernetes')
+      if: always() && (env.CI_TTL == "" || matrix.distro.type != 'kubernetes')
       uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1
       with:
         step: delete-env
@@ -280,7 +280,7 @@ jobs:
         env: ${{ steps.vars.outputs.identifier }}
         ref: ${{ inputs.caller-git-ref }}
     - name: Cleanup test namespace
-      if: always() && (matrix.distro.type != 'kubernetes')
+      if: always() && (env.CI_TTL == "" || matrix.distro.type != 'kubernetes')
       run: |
         kubectl delete ns --ignore-not-found=true \
           -l github-run-id=$GITHUB_WORKFLOW_RUN_ID \

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -63,7 +63,7 @@ env:
   # Vars with "CI_" prefix are used in the CI workflow only.
   # Vars with "TEST_" prefix are used in the test runner tool (Task).
   CI_TTL: ${{ inputs.ttl }}
-  CI_REPO: ${{ github.event.repository.full_name }}
+  CI_REPO: ${{ github.event.repository.full_name#camunda/ }}
   CI_HOSTNAME_BASE: ci.distro.ultrawombat.com
   # Docker Hub auth to avoid image pull rate limit.
   TEST_CREATE_DOCKER_LOGIN_SECRET: "TRUE"

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -277,7 +277,7 @@ jobs:
       if: always() && (env.CI_DEPLOYMENT_TTL == '' || matrix.distro.type != 'kubernetes')
       run: |
         # the if statement ensures that only the input from the user is taken and not the default value.
-        if [ -n "${CI_TTL}" ]; then
+        if [ -n "${CI_DEPLOYMENT_TTL}" ]; then
             kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${CI_DEPLOYMENT_TTL} --overwrite=true
         else
             kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=1s --overwrite=true

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -274,7 +274,13 @@ jobs:
         env: ${{ steps.vars.outputs.identifier }}
         ref: ${{ inputs.caller-git-ref }}
     - name: Cleanup test namespace
-      if: always() && (env.CI_DEPLOYMENT_TTL == '' || matrix.distro.type != 'kubernetes')
       run: |
-        # the if statement ensures that only the input from the user is taken and not the default value.
-        kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${CI_DEPLOYMENT_TTL} --overwrite=true
+        if [ "${{ env.CI_DEPLOYMENT_TTL }}" != "" ]; then
+          if [ "${{ matrix.distro.type }}" == "kubernetes" ]; then
+            kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${CI_DEPLOYMENT_TTL} --overwrite=true
+          else
+            kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=1s --overwrite=true
+          fi
+        else
+          kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=1s --overwrite=true
+        fi

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -200,7 +200,7 @@ jobs:
         kubectl label ns $TEST_NAMESPACE github-job-id=$GITHUB_WORKFLOW_JOB_ID
         kubectl label ns $TEST_NAMESPACE github-id=${{ steps.vars.outputs.identifier }}
         kubectl label ns $TEST_NAMESPACE test-flow=${{ matrix.scenario.flow }}
-        kubectl label ns $TEST_NAMESPACE repo=${{ env.CI_REPO }}
+        kubectl label ns $TEST_NAMESPACE repo="${{ env.CI_REPO }}"
         kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${{ env.CI_TTL }}
     - name: Copy PRs wildcard certificate
       run: |

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -24,7 +24,7 @@ on:
         description: |
           Define a ttl for the lifespan of the deployment
         required: false
-        default: "43200s"
+        default: ""
         type: string
       platforms:
         default: gke

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -194,6 +194,7 @@ jobs:
         kubectl label ns $TEST_NAMESPACE github-job-id=$GITHUB_WORKFLOW_JOB_ID
         kubectl label ns $TEST_NAMESPACE github-id=${{ steps.vars.outputs.identifier }}
         kubectl label ns $TEST_NAMESPACE test-flow=${{ matrix.scenario.flow }}
+        kubectl label ns $TEST_NAMESPACE org=$(dirname $GITHUB_REPOSITORY)
         kubectl label ns $TEST_NAMESPACE repo=$(basename $GITHUB_REPOSITORY)
         kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${{ env.CI_DEPLOYMENT_TTL }}
     - name: Copy PRs wildcard certificate

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -194,7 +194,7 @@ jobs:
         kubectl label ns $TEST_NAMESPACE github-job-id=$GITHUB_WORKFLOW_JOB_ID
         kubectl label ns $TEST_NAMESPACE github-id=${{ steps.vars.outputs.identifier }}
         kubectl label ns $TEST_NAMESPACE test-flow=${{ matrix.scenario.flow }}
-        kubectl label ns $TEST_NAMESPACE repo=${{ env.GITHUB_REPOSITORY }}
+        kubectl label ns $TEST_NAMESPACE repo=$GITHUB_ACTION_REPOSITORY
         kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${{ env.CI_DEPLOYMENT_TTL }}
     - name: Copy PRs wildcard certificate
       run: |

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -193,7 +193,6 @@ jobs:
     - name: Create test namespace
       run: |
         echo $TEST_NAMESPACE
-        repo_name=$(echo ${{ env.CI_REPO }} | sed 's|camunda/||')')
         kubectl delete ns --ignore-not-found=true \
           -l "github-id=${{ steps.vars.outputs.identifier }},test-flow=${{ matrix.scenario.flow }}"
         kubectl create ns $TEST_NAMESPACE
@@ -201,7 +200,7 @@ jobs:
         kubectl label ns $TEST_NAMESPACE github-job-id=$GITHUB_WORKFLOW_JOB_ID
         kubectl label ns $TEST_NAMESPACE github-id=${{ steps.vars.outputs.identifier }}
         kubectl label ns $TEST_NAMESPACE test-flow=${{ matrix.scenario.flow }}
-        kubectl label ns $TEST_NAMESPACE repo=$repo_name
+        kubectl label ns $TEST_NAMESPACE repo=${{ env.CI_REPO }}
         kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${{ env.CI_TTL }}
     - name: Copy PRs wildcard certificate
       run: |

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -219,7 +219,7 @@ jobs:
         echo "${{ inputs.extra-values }}" > /tmp/extra-values-file.yaml
         cat /tmp/extra-values-file.yaml
     - name: Cleanup GitHub deployment
-      if: always() && (env.CI_DEPLOYMENT_TTL == '')
+      if: always() && (env.CI_DEPLOYMENT_TTL == '' || matrix.distro.type != 'kubernetes')
       uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1
       with:
         step: delete-env

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -24,7 +24,7 @@ on:
         description: |
           Define a ttl for the lifespan of the deployment
         required: false
-        default: ""
+        default: "43200s"
         type: string
       platforms:
         default: gke
@@ -265,9 +265,15 @@ jobs:
     - name: 🚨 Get failed Pods info 🚨
       if: failure()
       uses: ./.github/actions/failed-pods-info
+    - name: Cleanup GitHub deployment
+      if: always() && (env.CI_DEPLOYMENT_TTL == "43200s" || matrix.distro.type != 'kubernetes')
+      uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1
+      with:
+        step: delete-env
+        token: ${{ steps.generate-github-token.outputs.token }}
+        env: ${{ steps.vars.outputs.identifier }}
+        ref: ${{ inputs.caller-git-ref }}
     - name: Cleanup test namespace
-      if: always() && (env.CI_DEPLOYMENT_TTL == '' || matrix.distro.type != 'kubernetes')
+      if: always() && (env.CI_DEPLOYMENT_TTL == "43200s" || matrix.distro.type != 'kubernetes')
       run: |
-        kubectl delete ns --ignore-not-found=true \
-          -l github-run-id=$GITHUB_WORKFLOW_RUN_ID \
-          -l github-job-id=$GITHUB_WORKFLOW_JOB_ID
+        kubectl annotate ns $TEST_NAMESPACE cleaner/ttl="1s"

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -194,7 +194,7 @@ jobs:
         kubectl label ns $TEST_NAMESPACE github-job-id=$GITHUB_WORKFLOW_JOB_ID
         kubectl label ns $TEST_NAMESPACE github-id=${{ steps.vars.outputs.identifier }}
         kubectl label ns $TEST_NAMESPACE test-flow=${{ matrix.scenario.flow }}
-        kubectl label ns $TEST_NAMESPACE repo=${{ GITHUB_ACTION_REPOSITORY }}
+        kubectl label ns $TEST_NAMESPACE repo=${{ env.GITHUB_ACTION_REPOSITORY }}
         kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${{ env.CI_DEPLOYMENT_TTL }}
     - name: Copy PRs wildcard certificate
       run: |

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -194,7 +194,7 @@ jobs:
         kubectl label ns $TEST_NAMESPACE github-job-id=$GITHUB_WORKFLOW_JOB_ID
         kubectl label ns $TEST_NAMESPACE github-id=${{ steps.vars.outputs.identifier }}
         kubectl label ns $TEST_NAMESPACE test-flow=${{ matrix.scenario.flow }}
-        kubectl label ns $TEST_NAMESPACE repo=${{ env.GITHUB_ACTION_REPOSITORY }}
+        kubectl label ns $TEST_NAMESPACE repo=${{ env.GITHUB_REPOSITORY }}
         kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${{ env.CI_DEPLOYMENT_TTL }}
     - name: Copy PRs wildcard certificate
       run: |

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -194,7 +194,7 @@ jobs:
         kubectl label ns $TEST_NAMESPACE test-flow=${{ matrix.scenario.flow }}
         kubectl label ns $TEST_NAMESPACE github-org=$(dirname $GITHUB_REPOSITORY)
         kubectl label ns $TEST_NAMESPACE github-repo=$(basename $GITHUB_REPOSITORY)
-        kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${{ env.CI_DEPLOYMENT_TTL }}
+        kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=1d
         kubectl annotate ns $TEST_NAMESPACE github-workflow-run-url=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Copy PRs wildcard certificate
       run: |
@@ -276,4 +276,7 @@ jobs:
     - name: Cleanup test namespace
       if: always() && (env.CI_DEPLOYMENT_TTL == '' || matrix.distro.type != 'kubernetes')
       run: |
-        kubectl annotate ns $TEST_NAMESPACE cleaner/ttl="1s"
+        # the if statement ensures that only the input from the user is taken and not the default value.
+        if [ -n "${{ env.CI_TTL }}" ]; then
+        kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${{ env.CI_DEPLOYMENT_TTL }} --overwrite=true
+        fi

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -193,6 +193,7 @@ jobs:
     - name: Create test namespace
       run: |
         echo $TEST_NAMESPACE
+        repo_name=$(echo ${{ env.CI_REPO }} | sed 's|camunda/||')')
         kubectl delete ns --ignore-not-found=true \
           -l "github-id=${{ steps.vars.outputs.identifier }},test-flow=${{ matrix.scenario.flow }}"
         kubectl create ns $TEST_NAMESPACE
@@ -200,7 +201,7 @@ jobs:
         kubectl label ns $TEST_NAMESPACE github-job-id=$GITHUB_WORKFLOW_JOB_ID
         kubectl label ns $TEST_NAMESPACE github-id=${{ steps.vars.outputs.identifier }}
         kubectl label ns $TEST_NAMESPACE test-flow=${{ matrix.scenario.flow }}
-        kubectl label ns $TEST_NAMESPACE repo=${{ env.CI_REPO//\//- }}
+        kubectl label ns $TEST_NAMESPACE repo=$repo_name
         kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${{ env.CI_TTL }}
     - name: Copy PRs wildcard certificate
       run: |

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -266,7 +266,7 @@ jobs:
       if: failure()
       uses: ./.github/actions/failed-pods-info
     - name: Cleanup GitHub deployment
-      if: always() && (env.CI_DEPLOYMENT_TTL == '' || matrix.distro.type != 'kubernetes')
+      if: always() && (matrix.distro.type != 'kubernetes')
       uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1
       with:
         step: delete-env

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -26,12 +26,12 @@ on:
         required: false
         default: ""
         type: string
-      repo:
-        description: |
-          Specifies what github repository has called this workflow
-        required: false
-        default: ""
-        type: string
+      # repo:
+      #   description: |
+      #     Specifies what github repository has called this workflow
+      #   required: false
+      #   default: ""
+      #   type: string
       platforms:
         default: gke
         type: string
@@ -63,7 +63,7 @@ env:
   # Vars with "CI_" prefix are used in the CI workflow only.
   # Vars with "TEST_" prefix are used in the test runner tool (Task).
   CI_TTL: ${{ inputs.ttl }}
-  CI_REPO: ${{ inputs.repo }}
+  CI_REPO: ${{ github.event.repository.full_name }}
   CI_HOSTNAME_BASE: ci.distro.ultrawombat.com
   # Docker Hub auth to avoid image pull rate limit.
   TEST_CREATE_DOCKER_LOGIN_SECRET: "TRUE"

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -272,7 +272,7 @@ jobs:
       if: failure()
       uses: ./.github/actions/failed-pods-info
     - name: Cleanup GitHub deployment
-      if: always() && (env.CI_TTL == "" || matrix.distro.type != 'kubernetes')
+      if: always() && (env.CI_TTL == '' || matrix.distro.type != 'kubernetes')
       uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1
       with:
         step: delete-env
@@ -280,7 +280,7 @@ jobs:
         env: ${{ steps.vars.outputs.identifier }}
         ref: ${{ inputs.caller-git-ref }}
     - name: Cleanup test namespace
-      if: always() && (env.CI_TTL == "" || matrix.distro.type != 'kubernetes')
+      if: always() && (env.CI_TTL == '' || matrix.distro.type != 'kubernetes')
       run: |
         kubectl delete ns --ignore-not-found=true \
           -l github-run-id=$GITHUB_WORKFLOW_RUN_ID \

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -63,7 +63,7 @@ env:
   # Vars with "CI_" prefix are used in the CI workflow only.
   # Vars with "TEST_" prefix are used in the test runner tool (Task).
   CI_TTL: ${{ inputs.ttl }}
-  CI_REPO: ${{ github.event.repository.full_name.split('/')[1] }}
+  CI_REPO: ${{ github.event.repository.full_name }}
   CI_HOSTNAME_BASE: ci.distro.ultrawombat.com
   # Docker Hub auth to avoid image pull rate limit.
   TEST_CREATE_DOCKER_LOGIN_SECRET: "TRUE"

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -277,8 +277,4 @@ jobs:
       if: always() && (env.CI_DEPLOYMENT_TTL == '' || matrix.distro.type != 'kubernetes')
       run: |
         # the if statement ensures that only the input from the user is taken and not the default value.
-        if [ -n "${CI_DEPLOYMENT_TTL}" ]; then
-            kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${CI_DEPLOYMENT_TTL} --overwrite=true
-        else
-            kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=1s --overwrite=true
-        fi
+        kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${CI_DEPLOYMENT_TTL} --overwrite=true

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -172,7 +172,7 @@ jobs:
       uses: ./.github/actions/workflow-vars
       with:
         ttl: ${{ env.CI_TTL }}
-        repo: ${{ env.REPO }}
+        repo: ${{ env.CI_REPO }}
         setup-flow: ${{ matrix.scenario.flow }}
         platform: ${{ matrix.distro.platform }}
         identifier-base: ${{ inputs.identifier }}
@@ -200,7 +200,7 @@ jobs:
         kubectl label ns $TEST_NAMESPACE github-job-id=$GITHUB_WORKFLOW_JOB_ID
         kubectl label ns $TEST_NAMESPACE github-id=${{ steps.vars.outputs.identifier }}
         kubectl label ns $TEST_NAMESPACE test-flow=${{ matrix.scenario.flow }}
-        kubectl label ns $TEST_NAMESPACE repo=${{ env.REPO }}
+        kubectl label ns $TEST_NAMESPACE repo=${{ env.CI_REPO }}
         kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${{ env.CI_TTL }}
     - name: Copy PRs wildcard certificate
       run: |

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -20,9 +20,9 @@ on:
         required: false
         default: main
         type: string
-      ttl:
+      deployment-ttl:
         description: |
-          Define a ttl for the lifespan of the workflow
+          Define a ttl for the lifespan of the deployment
         required: false
         default: ""
         type: string
@@ -56,7 +56,7 @@ concurrency:
 env:
   # Vars with "CI_" prefix are used in the CI workflow only.
   # Vars with "TEST_" prefix are used in the test runner tool (Task).
-  CI_TTL: ${{ inputs.ttl }}
+  CI_TTL: ${{ inputs.deployment-ttl }}
   CI_REPO: $(basename ${{ github.event.repository.full_name }})
   CI_HOSTNAME_BASE: ci.distro.ultrawombat.com
   # Docker Hub auth to avoid image pull rate limit.
@@ -165,7 +165,7 @@ jobs:
       id: vars
       uses: ./.github/actions/workflow-vars
       with:
-        ttl: ${{ env.CI_TTL }}
+        deployment-ttl: ${{ env.CI_TTL }}
         repo: ${{ env.CI_REPO }}
         setup-flow: ${{ matrix.scenario.flow }}
         platform: ${{ matrix.distro.platform }}

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -194,7 +194,7 @@ jobs:
         kubectl label ns $TEST_NAMESPACE github-job-id=$GITHUB_WORKFLOW_JOB_ID
         kubectl label ns $TEST_NAMESPACE github-id=${{ steps.vars.outputs.identifier }}
         kubectl label ns $TEST_NAMESPACE test-flow=${{ matrix.scenario.flow }}
-        kubectl label ns $TEST_NAMESPACE repo=$GITHUB_ACTION_REPOSITORY
+        kubectl label ns $TEST_NAMESPACE repo=$GITHUB_REPOSITORY
         kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${{ env.CI_DEPLOYMENT_TTL }}
     - name: Copy PRs wildcard certificate
       run: |

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -266,7 +266,7 @@ jobs:
       if: failure()
       uses: ./.github/actions/failed-pods-info
     - name: Cleanup GitHub deployment
-      if: always() && (env.CI_DEPLOYMENT_TTL == "43200s" || matrix.distro.type != 'kubernetes')
+      if: always() && (env.CI_DEPLOYMENT_TTL == '' || matrix.distro.type != 'kubernetes')
       uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1
       with:
         step: delete-env

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -195,7 +195,7 @@ jobs:
         kubectl label ns $TEST_NAMESPACE github-org=$(dirname $GITHUB_REPOSITORY)
         kubectl label ns $TEST_NAMESPACE github-repo=$(basename $GITHUB_REPOSITORY)
         kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${{ env.CI_DEPLOYMENT_TTL }}
-        kubectl annotate ns $TEST_NAMESPACE workflow-run-url=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+        kubectl annotate ns $TEST_NAMESPACE github-workflow-run-url=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Copy PRs wildcard certificate
       run: |
         kubectl apply -n $TEST_NAMESPACE -f .github/config/external-secret.yaml

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -57,7 +57,6 @@ env:
   # Vars with "CI_" prefix are used in the CI workflow only.
   # Vars with "TEST_" prefix are used in the test runner tool (Task).
   CI_DEPLOYMENT_TTL: ${{ inputs.deployment-ttl }}
-  CI_REPO: $(basename ${{ github.event.repository.full_name }})
   CI_HOSTNAME_BASE: ci.distro.ultrawombat.com
   # Docker Hub auth to avoid image pull rate limit.
   TEST_CREATE_DOCKER_LOGIN_SECRET: "TRUE"
@@ -166,7 +165,6 @@ jobs:
       uses: ./.github/actions/workflow-vars
       with:
         deployment-ttl: ${{ env.CI_DEPLOYMENT_TTL }}
-        repo: ${{ env.CI_REPO }}
         setup-flow: ${{ matrix.scenario.flow }}
         platform: ${{ matrix.distro.platform }}
         identifier-base: ${{ inputs.identifier }}

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -192,9 +192,10 @@ jobs:
         kubectl label ns $TEST_NAMESPACE github-job-id=$GITHUB_WORKFLOW_JOB_ID
         kubectl label ns $TEST_NAMESPACE github-id=${{ steps.vars.outputs.identifier }}
         kubectl label ns $TEST_NAMESPACE test-flow=${{ matrix.scenario.flow }}
-        kubectl label ns $TEST_NAMESPACE org=$(dirname $GITHUB_REPOSITORY)
-        kubectl label ns $TEST_NAMESPACE repo=$(basename $GITHUB_REPOSITORY)
+        kubectl label ns $TEST_NAMESPACE github-org=$(dirname $GITHUB_REPOSITORY)
+        kubectl label ns $TEST_NAMESPACE github-repo=$(basename $GITHUB_REPOSITORY)
         kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${{ env.CI_DEPLOYMENT_TTL }}
+        kubectl annotate ns $TEST_NAMESPACE workflow-run-url=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
     - name: Copy PRs wildcard certificate
       run: |
         kubectl apply -n $TEST_NAMESPACE -f .github/config/external-secret.yaml

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -265,14 +265,6 @@ jobs:
     - name: 🚨 Get failed Pods info 🚨
       if: failure()
       uses: ./.github/actions/failed-pods-info
-    - name: Cleanup GitHub deployment
-      if: always() && (env.CI_TTL == '' || matrix.distro.type != 'kubernetes')
-      uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1
-      with:
-        step: delete-env
-        token: ${{ steps.generate-github-token.outputs.token }}
-        env: ${{ steps.vars.outputs.identifier }}
-        ref: ${{ inputs.caller-git-ref }}
     - name: Cleanup test namespace
       if: always() && (env.CI_TTL == '' || matrix.distro.type != 'kubernetes')
       run: |

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -63,7 +63,7 @@ env:
   # Vars with "CI_" prefix are used in the CI workflow only.
   # Vars with "TEST_" prefix are used in the test runner tool (Task).
   CI_TTL: ${{ inputs.ttl }}
-  CI_REPO: ${{ github.event.repository.full_name }}
+  CI_REPO: $(basename ${{ github.event.repository.full_name }})
   CI_HOSTNAME_BASE: ci.distro.ultrawombat.com
   # Docker Hub auth to avoid image pull rate limit.
   TEST_CREATE_DOCKER_LOGIN_SECRET: "TRUE"

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -200,7 +200,7 @@ jobs:
         kubectl label ns $TEST_NAMESPACE github-job-id=$GITHUB_WORKFLOW_JOB_ID
         kubectl label ns $TEST_NAMESPACE github-id=${{ steps.vars.outputs.identifier }}
         kubectl label ns $TEST_NAMESPACE test-flow=${{ matrix.scenario.flow }}
-        kubectl label ns $TEST_NAMESPACE repo="${{ env.CI_REPO }}"
+        kubectl label ns $TEST_NAMESPACE repo=${{ env.CI_REPO//\//- }}
         kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${{ env.CI_TTL }}
     - name: Copy PRs wildcard certificate
       run: |

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -194,7 +194,7 @@ jobs:
         kubectl label ns $TEST_NAMESPACE github-job-id=$GITHUB_WORKFLOW_JOB_ID
         kubectl label ns $TEST_NAMESPACE github-id=${{ steps.vars.outputs.identifier }}
         kubectl label ns $TEST_NAMESPACE test-flow=${{ matrix.scenario.flow }}
-        kubectl label ns $TEST_NAMESPACE repo=$GITHUB_REPOSITORY
+        kubectl label ns $TEST_NAMESPACE repo=$(basename $GITHUB_REPOSITORY)
         kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${{ env.CI_DEPLOYMENT_TTL }}
     - name: Copy PRs wildcard certificate
       run: |

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -171,6 +171,8 @@ jobs:
       id: vars
       uses: ./.github/actions/workflow-vars
       with:
+        ttl: ${{ env.CI_TTL }}
+        repo: ${{ env.REPO }}
         setup-flow: ${{ matrix.scenario.flow }}
         platform: ${{ matrix.distro.platform }}
         identifier-base: ${{ inputs.identifier }}

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -20,6 +20,18 @@ on:
         required: false
         default: main
         type: string
+      ttl:
+        description: |
+          Define a ttl for the lifespan of the workflow
+        required: false
+        default: ""
+        type: string
+      repo:
+        description: |
+          Specifies what github repository has called this workflow
+        required: false
+        default: ""
+        type: string
       platforms:
         default: gke
         type: string

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -27,7 +27,7 @@ jobs:
     with:
       identifier: "${{ github.event.pull_request.number }}"
       platforms: "gke,rosa"
-      ttl: "${{ contains(github.event.pull_request.labels.*.name, 'test-persistent') && '1w' || '' }}"
+      deployment-ttl: "${{ contains(github.event.pull_request.labels.*.name, 'test-persistent') && '1w' || '' }}"
       flows: "install,upgrade"
       caller-git-ref: ${{ github.event.pull_request.head.sha }}
       camunda-helm-git-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -27,6 +27,8 @@ jobs:
     with:
       identifier: "${{ github.event.pull_request.number }}"
       platforms: "gke,rosa"
+      repo: "camunda-platform-helm"
+      ttl: "${{ contains(github.event.pull_request.labels.*.name, 'test-persistent') && '1w' || '' }}"
       flows: "install,upgrade"
       caller-git-ref: ${{ github.event.pull_request.head.sha }}
       camunda-helm-git-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -27,7 +27,7 @@ jobs:
     with:
       identifier: "${{ github.event.pull_request.number }}"
       platforms: "gke,rosa"
-      repo: "camunda-platform-helm"
+      # repo: "camunda-platform-helm"
       ttl: "${{ contains(github.event.pull_request.labels.*.name, 'test-persistent') && '1w' || '' }}"
       flows: "install,upgrade"
       caller-git-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -27,7 +27,6 @@ jobs:
     with:
       identifier: "${{ github.event.pull_request.number }}"
       platforms: "gke,rosa"
-      # repo: "camunda-platform-helm"
       ttl: "${{ contains(github.event.pull_request.labels.*.name, 'test-persistent') && '1w' || '' }}"
       flows: "install,upgrade"
       caller-git-ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/test-regression.yaml
+++ b/.github/workflows/test-regression.yaml
@@ -80,7 +80,7 @@ jobs:
     with:
       identifier: "${{ github.event.pull_request.number }}-intg-${{ matrix.version }}"
       ttl: "${{ contains(github.event.pull_request.labels.*.name, 'test-persistent') && '1w' || '' }}"
-      repo: "camunda-platform-helm"
+      repo: "camunda-platform-helm" 
       platforms: "gke"
       flows: "install,upgrade"
       test-enabled: false

--- a/.github/workflows/test-regression.yaml
+++ b/.github/workflows/test-regression.yaml
@@ -79,7 +79,7 @@ jobs:
     uses: ./.github/workflows/test-integration-template.yaml
     with:
       identifier: "${{ github.event.pull_request.number }}-intg-${{ matrix.version }}"
-      persistent: "${{ contains(github.event.*.labels.*.name, 'test-persistent') }}"
+      ttl: "${{ contains(github.event.pull_request.labels.*.name, 'test-persistent') && '1w' || '' }}"
       platforms: "gke"
       flows: "install,upgrade"
       test-enabled: false

--- a/.github/workflows/test-regression.yaml
+++ b/.github/workflows/test-regression.yaml
@@ -80,7 +80,6 @@ jobs:
     with:
       identifier: "${{ github.event.pull_request.number }}-intg-${{ matrix.version }}"
       ttl: "${{ contains(github.event.pull_request.labels.*.name, 'test-persistent') && '1w' || '' }}"
-      repo: "camunda-platform-helm"
       platforms: "gke"
       flows: "install,upgrade"
       test-enabled: false

--- a/.github/workflows/test-regression.yaml
+++ b/.github/workflows/test-regression.yaml
@@ -79,7 +79,7 @@ jobs:
     uses: ./.github/workflows/test-integration-template.yaml
     with:
       identifier: "${{ github.event.pull_request.number }}-intg-${{ matrix.version }}"
-      ttl: "${{ contains(github.event.pull_request.labels.*.name, 'test-persistent') && '1w' || '' }}"
+      deployment-ttl: "${{ contains(github.event.pull_request.labels.*.name, 'test-persistent') && '1w' || '' }}"
       platforms: "gke"
       flows: "install,upgrade"
       test-enabled: false

--- a/.github/workflows/test-regression.yaml
+++ b/.github/workflows/test-regression.yaml
@@ -80,6 +80,7 @@ jobs:
     with:
       identifier: "${{ github.event.pull_request.number }}-intg-${{ matrix.version }}"
       ttl: "${{ contains(github.event.pull_request.labels.*.name, 'test-persistent') && '1w' || '' }}"
+      repo: "camunda-platform-helm"
       platforms: "gke"
       flows: "install,upgrade"
       test-enabled: false

--- a/.github/workflows/test-regression.yaml
+++ b/.github/workflows/test-regression.yaml
@@ -80,7 +80,7 @@ jobs:
     with:
       identifier: "${{ github.event.pull_request.number }}-intg-${{ matrix.version }}"
       ttl: "${{ contains(github.event.pull_request.labels.*.name, 'test-persistent') && '1w' || '' }}"
-      repo: "camunda-platform-helm" 
+      repo: "camunda-platform-helm"
       platforms: "gke"
       flows: "install,upgrade"
       test-enabled: false

--- a/charts/camunda-platform-latest/values.yaml
+++ b/charts/camunda-platform-latest/values.yaml
@@ -2,6 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 # test
+# test
 
 # The values file follows helm best practices https://helm.sh/docs/chart_best_practices/values/
 #

--- a/charts/camunda-platform-latest/values.yaml
+++ b/charts/camunda-platform-latest/values.yaml
@@ -1,4 +1,5 @@
 # Default values for Camunda Helm chart.
+#test
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 

--- a/charts/camunda-platform-latest/values.yaml
+++ b/charts/camunda-platform-latest/values.yaml
@@ -1,8 +1,6 @@
 # Default values for Camunda Helm chart.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-# test
-# test
 
 # The values file follows helm best practices https://helm.sh/docs/chart_best_practices/values/
 #

--- a/charts/camunda-platform-latest/values.yaml
+++ b/charts/camunda-platform-latest/values.yaml
@@ -2,8 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 # test
-# test
-# test
 
 # The values file follows helm best practices https://helm.sh/docs/chart_best_practices/values/
 #

--- a/charts/camunda-platform-latest/values.yaml
+++ b/charts/camunda-platform-latest/values.yaml
@@ -1,5 +1,4 @@
 # Default values for Camunda Helm chart.
-#test
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 

--- a/docs/gha-workflows.md
+++ b/docs/gha-workflows.md
@@ -50,7 +50,7 @@ jobs:
       # Note: All persistent deployments will be deleted frequently to save costs
       # Default: ""
       # Required: false
-      ttl:
+      deployment-ttl:
 
       # Specifies the cloud platform that is currently used
       # Default: 'gke'
@@ -86,9 +86,9 @@ jobs:
 
 > [!NOTE]
 > The default behavior in the integration tests workflow is to delete the test resources 
-> after the test is finished. To keep the deployment for at least one day, you need to set `ttl: 1d`.
-> and you need to rerun the workflow again when you need the deployment to be persistent with a defined ttl.
-Example ttl values:
+> after the test is finished. To keep the deployment for at least one day, you need to set `deployment-ttl: 1d`.
+> and you need to rerun the workflow again when you need the deployment to be persistent with a defined deployment-ttl.
+Example deployment-ttl values:
 360s: 360 seconds
 10m: 10 minutes
 24h: 24 hours
@@ -200,11 +200,11 @@ jobs:
     secrets: inherit
     with:
       identifier: dev-console-sm-${{ matrix.deployment.id }}
-      ttl: 1d
+      deployment-ttl: 1d
       extra-values: |
         ${{ matrix.deployment.extra-values }}
 ```
 
 #### Persistent deployment
 
-If you have long-running workflows with multiple jobs, you can set `ttl: 1d` which will keep the deployment namespace for 1 day and not delete it after the workflow is done.
+If you have long-running workflows with multiple jobs, you can set `deployment-ttl: 1d` which will keep the deployment namespace for 1 day and not delete it after the workflow is done.

--- a/docs/gha-workflows.md
+++ b/docs/gha-workflows.md
@@ -9,7 +9,7 @@ of the CI pipelines.
 
 ## Camunda Helm chart deployment
 
-The Distro team provides a GitHub Actions Workflow to deploy the Camunda Helm chart via GitHub Actions. This workflow is customizable and supports different patterns. For example: disabling integration tests, single namespace, multi namespace, persistent setup (not deleted after the workflow is done), and more.
+The Distro team provides a GitHub Actions Workflow to deploy the Camunda Helm chart via GitHub Actions. This workflow is customizable and supports different patterns. For example: disabling integration tests, single namespace, multi namespace, persistent setup with a defined ttl (not deleted after the workflow is done), and more.
 
 The GitHub Actions workflow is defined in the [test-integration-template.yaml](../.github/workflows/test-integration-template.yaml) within the Camunda Platform Helm repository and could be used by other repos within Camunda organizations.
 
@@ -46,11 +46,11 @@ jobs:
       # Required: false
       caller-git-ref: ''
 
-      # Whether to keep the test deployment after the workflow is completed
+      # Define a ttl for the deployment after the workflow is completed
       # Note: All persistent deployments will be deleted frequently to save costs
-      # Default: false
+      # Default: ""
       # Required: false
-      persistent:
+      ttl:
 
       # Specifies the cloud platform that is currently used
       # Default: 'gke'
@@ -86,9 +86,15 @@ jobs:
 
 > [!NOTE]
 > The default behavior in the integration tests workflow is to delete the test resources 
-> after the test is finished. To keep the deployment you need to set `persistent: true`.
-> **However**, even it's persistent, the resources will be deleted frequently to save costs
-> and you need to rerun the workflow again when you need it.
+> after the test is finished. To keep the deployment for at least one day, you need to set `ttl: 1d`.
+> and you need to rerun the workflow again when you need the deployment to be persistent with a defined ttl.
+Example ttl values:
+360s: 360 seconds
+10m: 10 minutes
+24h: 24 hours
+7d: 7 days
+2w: 2 weeks
+
 
 ### Workflow patterns
 
@@ -194,32 +200,11 @@ jobs:
     secrets: inherit
     with:
       identifier: dev-console-sm-${{ matrix.deployment.id }}
-      persistent: true
+      ttl: 1d
       extra-values: |
         ${{ matrix.deployment.extra-values }}
 ```
 
 #### Persistent deployment
 
-If you have long-running workflows with multiple jobs, you can set `persistent: true` which will keep the deployment namespace and not delete it after the workflow is done.
-
-If you need to delete the deployment afterward, you need to add the following workflow to delete the namespace once the main workflow is finished.
-
-```yaml
-name: Helm Deployment Cleanup
-
-on: 
-  workflow_run:
-    workflows: 
-      - "*"
-    types:
-      - completed
-
-jobs:
-  cleaup:
-    name: Delete Namespace
-    uses: camunda/camunda-platform-helm/.github/workflows/test-integration-cleanup-template.yaml@main
-    secrets: inherit
-    with:
-      github-run-id: "${{ github.event.workflow_run.id }}"
-```
+If you have long-running workflows with multiple jobs, you can set `ttl: 1d` which will keep the deployment namespace for 1 day and not delete it after the workflow is done.


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
related: https://github.com/camunda/distribution/issues/216
### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->
The persistent flag is now being removed in favour of deployment-ttl

You can now modify how long a deployment lasts after the integration tests have ran. It takes advantage of the k8s-cleaner operator that is already present in both CI clusters.

Example deployment-ttl values:
360s: 360 seconds
10m: 10 minutes
24h: 24 hours
7d: 7 days
2w: 2 weeks
### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
