### PR TITLE
fix: unauthenticated external elasticsearch no longer forces password…

### DIFF
--- a/charts/camunda-platform-latest/templates/camunda/_helpers.tpl
+++ b/charts/camunda-platform-latest/templates/camunda/_helpers.tpl
@@ -291,6 +291,15 @@ https://docs.bitnami.com/kubernetes/apps/keycloak/configuration/manage-passwords
 {{- end -}}
 
 {{/*
+[elasticsearch] Used as a boolean to determine whether any password is defined.
+do not use this for its string value.
+*/}}
+{{- define "elasticsearch.passwordIsDefined" -}}
+{{- (cat .Values.global.elasticsearch.auth.existingSecret .Values.global.elasticsearch.auth.password) -}}
+{{- end -}}
+
+
+{{/*
 [opensearch] Get name of elasticsearch auth existing secret. For more details:
 https://docs.bitnami.com/kubernetes/apps/keycloak/configuration/manage-passwords/
 */}}

--- a/charts/camunda-platform-latest/templates/operate/deployment.yaml
+++ b/charts/camunda-platform-latest/templates/operate/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           securityContext: {{- toYaml .Values.operate.containerSecurityContext | nindent 12 }}
           {{- end }}
           env:
-            {{- if and .Values.global.elasticsearch.external (include "elasticsearch.authExistingSecret" .) }}
+            {{- if and .Values.global.elasticsearch.external (include "elasticsearch.passwordIsDefined" .) }}
             - name: CAMUNDA_OPERATE_ELASTICSEARCH_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/camunda-platform-latest/templates/operate/deployment.yaml
+++ b/charts/camunda-platform-latest/templates/operate/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           securityContext: {{- toYaml .Values.operate.containerSecurityContext | nindent 12 }}
           {{- end }}
           env:
-            {{- if .Values.global.elasticsearch.external }}
+            {{- if and .Values.global.elasticsearch.external (include "elasticsearch.authExistingSecret" .) }}
             - name: CAMUNDA_OPERATE_ELASTICSEARCH_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/camunda-platform-latest/templates/optimize/deployment.yaml
+++ b/charts/camunda-platform-latest/templates/optimize/deployment.yaml
@@ -39,7 +39,7 @@ spec:
           securityContext: {{- toYaml .Values.optimize.containerSecurityContext | nindent 12 }}
           {{- end }}
           env:
-            {{- if .Values.global.elasticsearch.external }}
+            {{- if and .Values.global.elasticsearch.external  (include "elasticsearch.authExistingSecret" .) }}
             - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SECURITY_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/camunda-platform-latest/templates/optimize/deployment.yaml
+++ b/charts/camunda-platform-latest/templates/optimize/deployment.yaml
@@ -39,7 +39,7 @@ spec:
           securityContext: {{- toYaml .Values.optimize.containerSecurityContext | nindent 12 }}
           {{- end }}
           env:
-            {{- if and .Values.global.elasticsearch.external  (include "elasticsearch.authExistingSecret" .) }}
+            {{- if and .Values.global.elasticsearch.external  (include "elasticsearch.passwordIsDefined" .) }}
             - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SECURITY_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -117,7 +117,7 @@ spec:
           securityContext: {{- toYaml .Values.optimize.containerSecurityContext | nindent 12 }}
           {{- end }}
           env:
-            {{- if .Values.global.elasticsearch.external }}
+            {{- if and .Values.global.elasticsearch.external  (include "elasticsearch.passwordIsDefined" .) }}
             - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SECURITY_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/camunda-platform-latest/templates/tasklist/deployment.yaml
+++ b/charts/camunda-platform-latest/templates/tasklist/deployment.yaml
@@ -41,7 +41,7 @@ spec:
             - name: SERVER_SERVLET_CONTEXT_PATH
               value: {{ .Values.tasklist.contextPath | quote }}
             {{- end }}
-            {{- if .Values.global.elasticsearch.external }}
+            {{- if and .Values.global.elasticsearch.external (include "elasticsearch.authExistingSecret" .) }}
             - name: CAMUNDA_TASKLIST_ELASTICSEARCH_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/camunda-platform-latest/templates/tasklist/deployment.yaml
+++ b/charts/camunda-platform-latest/templates/tasklist/deployment.yaml
@@ -41,7 +41,7 @@ spec:
             - name: SERVER_SERVLET_CONTEXT_PATH
               value: {{ .Values.tasklist.contextPath | quote }}
             {{- end }}
-            {{- if and .Values.global.elasticsearch.external (include "elasticsearch.authExistingSecret" .) }}
+            {{- if and .Values.global.elasticsearch.external (include "elasticsearch.passwordIsDefined" .) }}
             - name: CAMUNDA_TASKLIST_ELASTICSEARCH_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/camunda-platform-latest/templates/zeebe/statefulset.yaml
+++ b/charts/camunda-platform-latest/templates/zeebe/statefulset.yaml
@@ -74,7 +74,7 @@ spec:
               value: {{ .Values.zeebe.logLevel | quote }}
             - name: ZEEBE_BROKER_GATEWAY_ENABLE
               value: "false"
-            {{- if .Values.global.elasticsearch.external }}
+            {{- if and .Values.global.elasticsearch.external (include "elasticsearch.authExistingSecret" .) }}
             - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_AUTHENTICATION_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/camunda-platform-latest/templates/zeebe/statefulset.yaml
+++ b/charts/camunda-platform-latest/templates/zeebe/statefulset.yaml
@@ -74,7 +74,7 @@ spec:
               value: {{ .Values.zeebe.logLevel | quote }}
             - name: ZEEBE_BROKER_GATEWAY_ENABLE
               value: "false"
-            {{- if and .Values.global.elasticsearch.external (include "elasticsearch.authExistingSecret" .) }}
+            {{- if and .Values.global.elasticsearch.external (include "elasticsearch.passwordIsDefined" .) }}
             - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_AUTHENTICATION_PASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
…s to be configured

### Which problem does the PR fix?

#1987 

Currently external elasticsearch servers that do not require authentication, results in a camunda helm installation with `CreateContainerConfigError` due our helm chart thinking that credentials exist, when they do not.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

For each deployment or statefulset, if there is no password defined for elasticsearch, then the env vars supplying those passwords will no longer be rendered.



<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
