### PR TITLE
ci: add PR caller information to integration test template

### DIFF
--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -123,6 +123,17 @@ jobs:
         repository: camunda/camunda-platform-helm
         ref: ${{ inputs.camunda-helm-git-ref }}
 
+    # Print PR information when triggered by a pull request.
+    - name: Get PR information
+      if: github.event.pull_request
+      run: |
+        echo "PR Information:"
+        echo "Title: ${{ github.event.pull_request.title }}"  
+        echo "Number: ${{ github.event.pull_request.number }}"
+        echo "URL: ${{ github.event.pull_request.html_url }}"
+        echo "Head SHA: ${{ github.event.pull_request.head.sha }}"
+        echo "Base Ref: ${{ github.event.pull_request.base.ref }}"
+
     # When there is a vault-secret-mapping input given, use Vault instead of GitHub secrets
     # and populate environment variables from Vault
     - name: Import Vault secrets


### PR DESCRIPTION
### Which problem does the PR fix?
Related to task https://github.com/camunda/distribution/issues/270
Related to epic https://github.com/camunda/distribution/issues/241

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?
When teams use our integration test sometimes its hard to get the caller information. With this PR we provide a way to get this information right in the github actions workflow.
<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
