### PR TITLE
Release Camunda Platform Helm Chart v10.1.1

### DIFF
--- a/.github/workflows/chart-release-snapshot.yaml
+++ b/.github/workflows/chart-release-snapshot.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - 265-aa-follow-up
 
 jobs:
   release:

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -12,6 +12,9 @@ on:
   pull_request:
     types:
       - labeled
+  push:
+    branches:
+      - release
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -21,141 +24,141 @@ permissions:
   contents: read
   
 jobs:
-  release:
-    if: ${{ contains(github.event.*.labels.*.name, 'release') || github.event.inputs.trigger }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      id-token: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-        with:
-          fetch-depth: 0
-      - name: Install env dependencies
-        uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # v3
-      - name: Remove Dev Comments
-        run: |
-          TARGET_FILES=(
-            "charts/camunda-platform*/values*.yaml"
-            "charts/camunda-platform*/Chart.yaml"
-          )
-          for FILE in "${TARGET_FILES[@]}"; do
-            sed -i '/# START DEV COMMENT/,/# END DEV COMMENT/d' $FILE
-          done
-          echo "Dev comments removed:"
-          git --no-pager diff
-      - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-      - name: Install Chart Releaser
-        uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
-        with:
-          install_only: true
-        env:
-          CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-          CR_SKIP_EXISTING: 'true'
-      - name: Add Helm repos
-        run: |
-          make helm.repos-add
-      - name: Update Helm dependency
-        run: |
-          chartPath="$(ct list-changed | tr '\n' ' ')" \
-            make helm.dependency-update
-      - name: cosign-installer
-        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # v3.5.0
-      # TODO: Move this step to pre-release workflow when we have it.
-      - name: Generate release note footer
-        run: |
-          make release.generate-notes-footer
-      - name: Tidy up
-        run: |
-          # Clean up badges from readme to avoid showing them in Artifact Hub.
-          sed -ri '/Badge .+/d' charts/camunda-platform-latest/README.md
-          mkdir release-packages
+  # release:
+  #   if: ${{ contains(github.event.*.labels.*.name, 'release') || github.event.inputs.trigger }}
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     contents: write
+  #     id-token: write
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+  #       with:
+  #         fetch-depth: 0
+  #     - name: Install env dependencies
+  #       uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # v3
+  #     - name: Remove Dev Comments
+  #       run: |
+  #         TARGET_FILES=(
+  #           "charts/camunda-platform*/values*.yaml"
+  #           "charts/camunda-platform*/Chart.yaml"
+  #         )
+  #         for FILE in "${TARGET_FILES[@]}"; do
+  #           sed -i '/# START DEV COMMENT/,/# END DEV COMMENT/d' $FILE
+  #         done
+  #         echo "Dev comments removed:"
+  #         git --no-pager diff
+  #     - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+  #       with:
+  #         path: |
+  #           ~/.cache/go-build
+  #           ~/go/pkg/mod
+  #         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-go-
+  #     - name: Configure Git
+  #       run: |
+  #         git config user.name "$GITHUB_ACTOR"
+  #         git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+  #     - name: Install Chart Releaser
+  #       uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
+  #       with:
+  #         install_only: true
+  #       env:
+  #         CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+  #         CR_SKIP_EXISTING: 'true'
+  #     - name: Add Helm repos
+  #       run: |
+  #         make helm.repos-add
+  #     - name: Update Helm dependency
+  #       run: |
+  #         chartPath="$(ct list-changed | tr '\n' ' ')" \
+  #           make helm.dependency-update
+  #     - name: cosign-installer
+  #       uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # v3.5.0
+  #     # TODO: Move this step to pre-release workflow when we have it.
+  #     - name: Generate release note footer
+  #       run: |
+  #         make release.generate-notes-footer
+  #     - name: Tidy up
+  #       run: |
+  #         # Clean up badges from readme to avoid showing them in Artifact Hub.
+  #         sed -ri '/Badge .+/d' charts/camunda-platform-latest/README.md
+  #         mkdir release-packages
 
-      #
-      # We run Chart Releaser twice as a workaround because it's not possible to control the release order.
-      # CR by default will release "camunda-platform-10.x.x" first then "camunda-platform-8.x.x",
-      # however, we want the latest version to show as the latest release in GitHub releases.
-      #
+  #     #
+  #     # We run Chart Releaser twice as a workaround because it's not possible to control the release order.
+  #     # CR by default will release "camunda-platform-10.x.x" first then "camunda-platform-8.x.x",
+  #     # however, we want the latest version to show as the latest release in GitHub releases.
+  #     #
 
-      # Release previous versions.
-      - name: Pre-Release - Previous versions
-        run: |
-          rm -rf charts/camunda-platform-latest
-      - name: Run Chart Releaser - Previous versions
-        uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
-        with:
-          config: .github/config/chart-releaser.yaml
-        env:
-          CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-          CR_SKIP_EXISTING: 'true'
-      - name: Post-Release - Previous versions
-        run: |
-          mv .cr-release-packages/* release-packages/
-          git checkout :/
+  #     # Release previous versions.
+  #     - name: Pre-Release - Previous versions
+  #       run: |
+  #         rm -rf charts/camunda-platform-latest
+  #     - name: Run Chart Releaser - Previous versions
+  #       uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
+  #       with:
+  #         config: .github/config/chart-releaser.yaml
+  #       env:
+  #         CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+  #         CR_SKIP_EXISTING: 'true'
+  #     - name: Post-Release - Previous versions
+  #       run: |
+  #         mv .cr-release-packages/* release-packages/
+  #         git checkout :/
 
-      # Release the latest version.
-      - name: Pre-Release - Latest version
-        run: |
-          rm -rf charts/camunda-platform-8*
-      - name: Run Chart Releaser - Latest version
-        uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
-        with:
-          config: .github/config/chart-releaser.yaml
-        env:
-          CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-          CR_SKIP_EXISTING: 'true'
-      - name: Post-Release - Latest version
-        run: |
-          mv .cr-release-packages/* release-packages/
-          git checkout :/
+  #     # Release the latest version.
+  #     - name: Pre-Release - Latest version
+  #       run: |
+  #         rm -rf charts/camunda-platform-8*
+  #     - name: Run Chart Releaser - Latest version
+  #       uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
+  #       with:
+  #         config: .github/config/chart-releaser.yaml
+  #       env:
+  #         CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+  #         CR_SKIP_EXISTING: 'true'
+  #     - name: Post-Release - Latest version
+  #       run: |
+  #         mv .cr-release-packages/* release-packages/
+  #         git checkout :/
 
-      # Sign and upload the signature of the chart package.
-      - name: Set Helm chart vars
-        run: |
-          CHART_PACKAGES="$(find release-packages -maxdepth 1 -name "camunda-platform*.tgz" \
-            -exec basename {} \; | xargs)"
-          echo "CHART_PACKAGES=${CHART_PACKAGES}" | tee -a $GITHUB_ENV
-      - name: Sign Helm chart with Cosign
-        run: |
-          for chart_package in ${CHART_PACKAGES}; do
-            echo "Package: ${chart_package}"
-            cosign sign-blob -y release-packages/${chart_package} \
-              --bundle "${chart_package%.*}.cosign.bundle"
-          done
-      - name: Verify signed Helm chart with Cosign
-        run: |
-          for chart_package in ${CHART_PACKAGES}; do
-            echo "Package: ${chart_package}"
-            cosign verify-blob release-packages/${chart_package} \
-              --bundle "${chart_package%.*}.cosign.bundle" \
-              --certificate-identity "https://github.com/${GITHUB_WORKFLOW_REF}" \
-              --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
-          done
-      - name: Upload Helm chart signature bundle
-        run: |
-          for chart_package in ${CHART_PACKAGES}; do
-            echo "Package: ${chart_package}"
-            gh release upload "${chart_package%.*}" \
-              "${chart_package%.*}.cosign.bundle" \
-              --repo "${GITHUB_REPOSITORY}"
-          done
-        env:
-          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+  #     # Sign and upload the signature of the chart package.
+  #     - name: Set Helm chart vars
+  #       run: |
+  #         CHART_PACKAGES="$(find release-packages -maxdepth 1 -name "camunda-platform*.tgz" \
+  #           -exec basename {} \; | xargs)"
+  #         echo "CHART_PACKAGES=${CHART_PACKAGES}" | tee -a $GITHUB_ENV
+  #     - name: Sign Helm chart with Cosign
+  #       run: |
+  #         for chart_package in ${CHART_PACKAGES}; do
+  #           echo "Package: ${chart_package}"
+  #           cosign sign-blob -y release-packages/${chart_package} \
+  #             --bundle "${chart_package%.*}.cosign.bundle"
+  #         done
+  #     - name: Verify signed Helm chart with Cosign
+  #       run: |
+  #         for chart_package in ${CHART_PACKAGES}; do
+  #           echo "Package: ${chart_package}"
+  #           cosign verify-blob release-packages/${chart_package} \
+  #             --bundle "${chart_package%.*}.cosign.bundle" \
+  #             --certificate-identity "https://github.com/${GITHUB_WORKFLOW_REF}" \
+  #             --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+  #         done
+  #     - name: Upload Helm chart signature bundle
+  #       run: |
+  #         for chart_package in ${CHART_PACKAGES}; do
+  #           echo "Package: ${chart_package}"
+  #           gh release upload "${chart_package%.*}" \
+  #             "${chart_package%.*}.cosign.bundle" \
+  #             --repo "${GITHUB_REPOSITORY}"
+  #         done
+  #       env:
+  #         GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
 
   post-release:
-    needs: release
+    # needs: release
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -12,9 +12,6 @@ on:
   pull_request:
     types:
       - labeled
-  push:
-    branches:
-      - release
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -24,141 +21,141 @@ permissions:
   contents: read
   
 jobs:
-  # release:
-  #   if: ${{ contains(github.event.*.labels.*.name, 'release') || github.event.inputs.trigger }}
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     contents: write
-  #     id-token: write
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-  #       with:
-  #         fetch-depth: 0
-  #     - name: Install env dependencies
-  #       uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # v3
-  #     - name: Remove Dev Comments
-  #       run: |
-  #         TARGET_FILES=(
-  #           "charts/camunda-platform*/values*.yaml"
-  #           "charts/camunda-platform*/Chart.yaml"
-  #         )
-  #         for FILE in "${TARGET_FILES[@]}"; do
-  #           sed -i '/# START DEV COMMENT/,/# END DEV COMMENT/d' $FILE
-  #         done
-  #         echo "Dev comments removed:"
-  #         git --no-pager diff
-  #     - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
-  #       with:
-  #         path: |
-  #           ~/.cache/go-build
-  #           ~/go/pkg/mod
-  #         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-go-
-  #     - name: Configure Git
-  #       run: |
-  #         git config user.name "$GITHUB_ACTOR"
-  #         git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-  #     - name: Install Chart Releaser
-  #       uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
-  #       with:
-  #         install_only: true
-  #       env:
-  #         CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-  #         CR_SKIP_EXISTING: 'true'
-  #     - name: Add Helm repos
-  #       run: |
-  #         make helm.repos-add
-  #     - name: Update Helm dependency
-  #       run: |
-  #         chartPath="$(ct list-changed | tr '\n' ' ')" \
-  #           make helm.dependency-update
-  #     - name: cosign-installer
-  #       uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # v3.5.0
-  #     # TODO: Move this step to pre-release workflow when we have it.
-  #     - name: Generate release note footer
-  #       run: |
-  #         make release.generate-notes-footer
-  #     - name: Tidy up
-  #       run: |
-  #         # Clean up badges from readme to avoid showing them in Artifact Hub.
-  #         sed -ri '/Badge .+/d' charts/camunda-platform-latest/README.md
-  #         mkdir release-packages
+  release:
+    if: ${{ contains(github.event.*.labels.*.name, 'release') || github.event.inputs.trigger }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        with:
+          fetch-depth: 0
+      - name: Install env dependencies
+        uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # v3
+      - name: Remove Dev Comments
+        run: |
+          TARGET_FILES=(
+            "charts/camunda-platform*/values*.yaml"
+            "charts/camunda-platform*/Chart.yaml"
+          )
+          for FILE in "${TARGET_FILES[@]}"; do
+            sed -i '/# START DEV COMMENT/,/# END DEV COMMENT/d' $FILE
+          done
+          echo "Dev comments removed:"
+          git --no-pager diff
+      - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Install Chart Releaser
+        uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
+        with:
+          install_only: true
+        env:
+          CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          CR_SKIP_EXISTING: 'true'
+      - name: Add Helm repos
+        run: |
+          make helm.repos-add
+      - name: Update Helm dependency
+        run: |
+          chartPath="$(ct list-changed | tr '\n' ' ')" \
+            make helm.dependency-update
+      - name: cosign-installer
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # v3.5.0
+      # TODO: Move this step to pre-release workflow when we have it.
+      - name: Generate release note footer
+        run: |
+          make release.generate-notes-footer
+      - name: Tidy up
+        run: |
+          # Clean up badges from readme to avoid showing them in Artifact Hub.
+          sed -ri '/Badge .+/d' charts/camunda-platform-latest/README.md
+          mkdir release-packages
 
-  #     #
-  #     # We run Chart Releaser twice as a workaround because it's not possible to control the release order.
-  #     # CR by default will release "camunda-platform-10.x.x" first then "camunda-platform-8.x.x",
-  #     # however, we want the latest version to show as the latest release in GitHub releases.
-  #     #
+      #
+      # We run Chart Releaser twice as a workaround because it's not possible to control the release order.
+      # CR by default will release "camunda-platform-10.x.x" first then "camunda-platform-8.x.x",
+      # however, we want the latest version to show as the latest release in GitHub releases.
+      #
 
-  #     # Release previous versions.
-  #     - name: Pre-Release - Previous versions
-  #       run: |
-  #         rm -rf charts/camunda-platform-latest
-  #     - name: Run Chart Releaser - Previous versions
-  #       uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
-  #       with:
-  #         config: .github/config/chart-releaser.yaml
-  #       env:
-  #         CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-  #         CR_SKIP_EXISTING: 'true'
-  #     - name: Post-Release - Previous versions
-  #       run: |
-  #         mv .cr-release-packages/* release-packages/
-  #         git checkout :/
+      # Release previous versions.
+      - name: Pre-Release - Previous versions
+        run: |
+          rm -rf charts/camunda-platform-latest
+      - name: Run Chart Releaser - Previous versions
+        uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
+        with:
+          config: .github/config/chart-releaser.yaml
+        env:
+          CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          CR_SKIP_EXISTING: 'true'
+      - name: Post-Release - Previous versions
+        run: |
+          mv .cr-release-packages/* release-packages/
+          git checkout :/
 
-  #     # Release the latest version.
-  #     - name: Pre-Release - Latest version
-  #       run: |
-  #         rm -rf charts/camunda-platform-8*
-  #     - name: Run Chart Releaser - Latest version
-  #       uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
-  #       with:
-  #         config: .github/config/chart-releaser.yaml
-  #       env:
-  #         CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-  #         CR_SKIP_EXISTING: 'true'
-  #     - name: Post-Release - Latest version
-  #       run: |
-  #         mv .cr-release-packages/* release-packages/
-  #         git checkout :/
+      # Release the latest version.
+      - name: Pre-Release - Latest version
+        run: |
+          rm -rf charts/camunda-platform-8*
+      - name: Run Chart Releaser - Latest version
+        uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
+        with:
+          config: .github/config/chart-releaser.yaml
+        env:
+          CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          CR_SKIP_EXISTING: 'true'
+      - name: Post-Release - Latest version
+        run: |
+          mv .cr-release-packages/* release-packages/
+          git checkout :/
 
-  #     # Sign and upload the signature of the chart package.
-  #     - name: Set Helm chart vars
-  #       run: |
-  #         CHART_PACKAGES="$(find release-packages -maxdepth 1 -name "camunda-platform*.tgz" \
-  #           -exec basename {} \; | xargs)"
-  #         echo "CHART_PACKAGES=${CHART_PACKAGES}" | tee -a $GITHUB_ENV
-  #     - name: Sign Helm chart with Cosign
-  #       run: |
-  #         for chart_package in ${CHART_PACKAGES}; do
-  #           echo "Package: ${chart_package}"
-  #           cosign sign-blob -y release-packages/${chart_package} \
-  #             --bundle "${chart_package%.*}.cosign.bundle"
-  #         done
-  #     - name: Verify signed Helm chart with Cosign
-  #       run: |
-  #         for chart_package in ${CHART_PACKAGES}; do
-  #           echo "Package: ${chart_package}"
-  #           cosign verify-blob release-packages/${chart_package} \
-  #             --bundle "${chart_package%.*}.cosign.bundle" \
-  #             --certificate-identity "https://github.com/${GITHUB_WORKFLOW_REF}" \
-  #             --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
-  #         done
-  #     - name: Upload Helm chart signature bundle
-  #       run: |
-  #         for chart_package in ${CHART_PACKAGES}; do
-  #           echo "Package: ${chart_package}"
-  #           gh release upload "${chart_package%.*}" \
-  #             "${chart_package%.*}.cosign.bundle" \
-  #             --repo "${GITHUB_REPOSITORY}"
-  #         done
-  #       env:
-  #         GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+      # Sign and upload the signature of the chart package.
+      - name: Set Helm chart vars
+        run: |
+          CHART_PACKAGES="$(find release-packages -maxdepth 1 -name "camunda-platform*.tgz" \
+            -exec basename {} \; | xargs)"
+          echo "CHART_PACKAGES=${CHART_PACKAGES}" | tee -a $GITHUB_ENV
+      - name: Sign Helm chart with Cosign
+        run: |
+          for chart_package in ${CHART_PACKAGES}; do
+            echo "Package: ${chart_package}"
+            cosign sign-blob -y release-packages/${chart_package} \
+              --bundle "${chart_package%.*}.cosign.bundle"
+          done
+      - name: Verify signed Helm chart with Cosign
+        run: |
+          for chart_package in ${CHART_PACKAGES}; do
+            echo "Package: ${chart_package}"
+            cosign verify-blob release-packages/${chart_package} \
+              --bundle "${chart_package%.*}.cosign.bundle" \
+              --certificate-identity "https://github.com/${GITHUB_WORKFLOW_REF}" \
+              --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+          done
+      - name: Upload Helm chart signature bundle
+        run: |
+          for chart_package in ${CHART_PACKAGES}; do
+            echo "Package: ${chart_package}"
+            gh release upload "${chart_package%.*}" \
+              "${chart_package%.*}.cosign.bundle" \
+              --repo "${GITHUB_REPOSITORY}"
+          done
+        env:
+          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
 
   post-release:
-    # needs: release
+    needs: release
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/charts/camunda-platform-latest/Chart.yaml
+++ b/charts/camunda-platform-latest/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: camunda-platform
-version: 10.1.0
+version: 10.1.1
 appVersion: 8.5.x
 description: |
   Camunda 8 Self-Managed Helm charts.

--- a/charts/camunda-platform-latest/Chart.yaml
+++ b/charts/camunda-platform-latest/Chart.yaml
@@ -61,28 +61,4 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
     - kind: added
-      description: "warning and error for not setting existingSecrets for all components"
-    - kind: added
-      description: "support envFrom reference in all components"
-    - kind: added
-      description: "adding a constraint for identity existingSecret"
-    - kind: fixed
-      description: "release info did not respect the context path"
-    - kind: fixed
-      description: "update livenessProbe endpoint of zeebe"
-    - kind: fixed
-      description: "re-added the postgresql secret"
-    - kind: fixed
-      description: "Delete multi-region review comment in values.yaml"
-    - kind: fixed
-      description: "use component service account"
-    - kind: fixed
-      description: "handle type of es url correctly"
-    - kind: fixed
-      description: "set zeebe exporters empty map when disabled"
-    - kind: fixed
-      description: "add constraints for when identity is disabled and keycloak is enabled"
-    - kind: changed
-      description: "add support for seccomp profiles in all components"
-    - kind: changed
-      description: "update identity application yaml to match upstream"
+      description: "add console auth vars"

--- a/charts/camunda-platform-latest/RELEASE-NOTES.md
+++ b/charts/camunda-platform-latest/RELEASE-NOTES.md
@@ -2,36 +2,18 @@ The changelog is automatically generated using [git-chglog](https://github.com/g
 and it follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
 
 
-<a name="camunda-platform-10.1.0"></a>
-## [camunda-platform-10.1.0](https://github.com/camunda/camunda-platform-helm/compare/camunda-platform-10.0.4...camunda-platform-10.1.0) (2024-06-10)
-
-### Ci
-
-* enrich release notes and version matrix ([#1716](https://github.com/camunda/camunda-platform-helm/issues/1716))
-
-### Docs
-
-* enhance version matrix structure ([#1742](https://github.com/camunda/camunda-platform-helm/issues/1742))
+<a name="camunda-platform-10.1.1"></a>
+## [camunda-platform-10.1.1](https://github.com/camunda/camunda-platform-helm/compare/camunda-platform-9.3.6...camunda-platform-10.1.1) (2024-06-17)
 
 ### Feat
 
-* warning and error for not setting existingSecrets for all components ([#1876](https://github.com/camunda/camunda-platform-helm/issues/1876))
-* support envFrom reference in all components ([#1949](https://github.com/camunda/camunda-platform-helm/issues/1949))
-* adding a constraint for identity existingSecret ([#1969](https://github.com/camunda/camunda-platform-helm/issues/1969))
+* add console auth vars ([#1782](https://github.com/camunda/camunda-platform-helm/issues/1782))
 
-### Fix
 
-* release info did not respect the context path ([#1908](https://github.com/camunda/camunda-platform-helm/issues/1908))
-* update livenessProbe endpoint of zeebe ([#1858](https://github.com/camunda/camunda-platform-helm/issues/1858))
-* re-added the postgresql secret ([#1845](https://github.com/camunda/camunda-platform-helm/issues/1845))
-* Delete multi-region review comment in values.yaml ([#1819](https://github.com/camunda/camunda-platform-helm/issues/1819))
-* use component service account ([#1753](https://github.com/camunda/camunda-platform-helm/issues/1753))
-* handle type of es url correctly ([#1752](https://github.com/camunda/camunda-platform-helm/issues/1752))
-* set zeebe exporters empty map when disabled ([#1743](https://github.com/camunda/camunda-platform-helm/issues/1743))
-* add constraints for when identity is disabled and keycloak is enabled ([#1717](https://github.com/camunda/camunda-platform-helm/issues/1717))
+<a name="camunda-platform-9.3.6"></a>
+## [camunda-platform-9.3.6](https://github.com/camunda/camunda-platform-helm/compare/camunda-platform-10.1.0...camunda-platform-9.3.6) (2024-06-11)
 
-### Refactor
 
-* add support for seccomp profiles in all components ([#1973](https://github.com/camunda/camunda-platform-helm/issues/1973))
-* update identity application yaml to match upstream ([#1737](https://github.com/camunda/camunda-platform-helm/issues/1737))
+<a name="camunda-platform-10.1.0"></a>
+## [camunda-platform-10.1.0](https://github.com/camunda/camunda-platform-helm/compare/camunda-platform-8.2.28...camunda-platform-10.1.0) (2024-06-11)
 

--- a/charts/camunda-platform-latest/values-latest.yaml
+++ b/charts/camunda-platform-latest/values-latest.yaml
@@ -26,7 +26,7 @@ operate:
   # https://hub.docker.com/r/camunda/operate/tags
   image:
     # renovate: datasource=docker depName=camunda/operate
-    tag: 8.5.2
+    tag: 8.5.3
 
 optimize:
   # https://hub.docker.com/r/camunda/optimize/tags
@@ -40,6 +40,16 @@ webModeler:
   # registry.camunda.cloud/web-modeler-ee
   image:
     # renovate: datasource=docker depName=camunda/web-modeler lookupName=registry.camunda.cloud/web-modeler-ee/modeler-restapi
+    tag: 8.5.3
+
+zeebe:
+  # https://hub.docker.com/r/camunda/zeebe/tags
+  image:
+    tag: 8.5.3
+
+zeebeGateway:
+  # https://hub.docker.com/r/camunda/zeebe/tags
+  image:
     tag: 8.5.3
 
 #

--- a/scripts/generate-version-matrix.sh
+++ b/scripts/generate-version-matrix.sh
@@ -43,7 +43,7 @@ get_versions_filtered () {
 get_chart_images () {
     chart_version="${1}"
     helm template --skip-tests camunda "${CHART_SOURCE}" --version "${chart_version}" \
-      --values "charts/${CHART_NAME}/test/integration/scenarios/chart-full-setup/values-integration-test-ingress.yaml" 2> /dev/null |
+      --values "test/integration/scenarios/chart-full-setup/values-integration-test-ingress.yaml" 2> /dev/null |
     tr -d "\"'" | awk '/image:/{gsub(/^(camunda|bitnami)/, "docker.io/&", $2); printf "- %s\n", $2}' |
     sort | uniq
 }
@@ -89,12 +89,12 @@ generate_version_matrix_released () {
 
 # Generate a version matrix from the unreleased chart using the local git repo.
 generate_version_matrix_unreleased () {
-    export CHART_SOURCE="charts/${CHART_NAME}"
+    export CHART_SOURCE="charts/${CHART_NAME}-latest"
     export CHART_REF_NAME="$(git branch --show-current)"
     CHART_VERSION_LOCAL="{
-      \"app\": \"$(yq '.appVersion | sub("\..$", "")' "charts/${CHART_NAME}/Chart.yaml")\",
+      \"app\": \"$(yq '.appVersion | sub("\..$", "")' "charts/${CHART_NAME}-latest/Chart.yaml")\",
       \"charts\": [
-        \"$(yq '.version' "charts/${CHART_NAME}/Chart.yaml")\"
+        \"$(yq '.version' "charts/${CHART_NAME}-latest/Chart.yaml")\"
       ]
     }"
     generate_version_matrix_single "${CHART_VERSION_LOCAL}"

--- a/version-matrix/README.md
+++ b/version-matrix/README.md
@@ -20,6 +20,7 @@ For the best experience, please remember:
 
 ## Camunda 8.5
 
+### [Helm chart 10.1.1](./camunda-8.5/#helm-chart-1011)
 ### [Helm chart 10.1.0](./camunda-8.5/#helm-chart-1010)
 ### [Helm chart 10.0.5](./camunda-8.5/#helm-chart-1005)
 ### [Helm chart 10.0.4](./camunda-8.5/#helm-chart-1004)

--- a/version-matrix/camunda-8.5/README.md
+++ b/version-matrix/camunda-8.5/README.md
@@ -1,6 +1,37 @@
 <!-- THIS FILE IS AUTO-GENERATED, DO NOT EDIT IT MANUALLY! -->
 # Camunda 8.5 Helm Chart Version Matrix
 
+## Helm chart 10.1.1
+
+Supported versions:
+
+- Camunda applications: [8.5](https://github.com/camunda/camunda-platform/releases?q=tag%3A8.5&expanded=true)
+- Helm values: [10.1.1](https://artifacthub.io/packages/helm/camunda/camunda-platform/10.1.1#parameters)
+- Helm CLI: [3.15.1](https://github.com/helm/helm/releases/tag/v3.15.1)
+
+Camunda images:
+
+- docker.io/camunda/connectors-bundle:8.5.3
+- docker.io/camunda/identity:8.5.2
+- docker.io/camunda/identity:latest
+- docker.io/camunda/operate:8.5.3
+- docker.io/camunda/optimize:8.5.2
+- docker.io/camunda/tasklist:8.5.2
+- docker.io/camunda/zeebe:8.5.3
+- registry.camunda.cloud/console/console-sm:8.5.52
+- registry.camunda.cloud/web-modeler-ee/modeler-restapi:8.5.3
+- registry.camunda.cloud/web-modeler-ee/modeler-webapp:8.5.3
+- registry.camunda.cloud/web-modeler-ee/modeler-websockets:8.5.3
+
+Non-Camunda images:
+
+- docker.io/bitnami/elasticsearch:8.12.2
+- docker.io/bitnami/keycloak:23.0.7
+- docker.io/bitnami/os-shell:12-debian-12-r16
+- docker.io/bitnami/postgresql:14.12.0
+- docker.io/bitnami/postgresql:15.7.0
+
+
 ## Helm chart 10.1.0
 
 Supported versions:


### PR DESCRIPTION
**Before opening the PR:**

- [x] Run `make release.chores`
- [x] Create a PR with the printed URL
- [x] [Trigger Renovate](https://developer.mend.io/github/camunda/camunda-platform-helm) to ensure that all deps are updated (to avoid any delayed sync from Renovate service).

**After opening the PR:**

- [x] Take a final look at the release commits (version bump and release notes)
- [x] Make sure that all checks in the PR passed
- [x] If everything in place, add `release` label to the PR
- [ ] Follow up the release workflow and make sure it succeeded (double-check the [releases page](https://github.com/camunda/camunda-platform-helm/releases))
- [ ] Ensure that all fixed [issues with support label](https://github.com/camunda/camunda-platform-helm/issues?q=is%3Aissue+label%3Asupport+is%3Aclosed) has the release version like `version:10.0.0` (this will be automated later).

If the release is a minor version bump (e.g. from 8.2.x to 8.3.0):
- [ ] Make sure the regression test matrix is updated: located at [.github/workflows/test-regression.yaml](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/test-regression.yaml#L33-L36)
