### PR TITLE
ci: update preflightVars.baseURLs vars for Tasklist and Operate

### DIFF
--- a/test/integration/testsuites/base/files/variables-default.yaml
+++ b/test/integration/testsuites/base/files/variables-default.yaml
@@ -5,8 +5,8 @@ preflightVars:
     keycloak: http://integration-keycloak
     identity: http://integration-identity:82
     optimize: http://integration-optimize
-    operate: http://integration-operate
-    tasklist: http://integration-tasklist
+    operate: http://integration-operate:9600
+    tasklist: http://integration-tasklist:9600
     connectors: http://integration-connectors:8080
     webModelerRestapi: http://integration-web-modeler-restapi:8091
     webModelerWebapp: http://integration-web-modeler-webapp:8071

--- a/test/integration/testsuites/base/files/variables-ingress-combined.yaml
+++ b/test/integration/testsuites/base/files/variables-ingress-combined.yaml
@@ -5,8 +5,8 @@ preflightVars:
     keycloak: http://integration-keycloak
     identity: http://integration-identity:82
     optimize: http://integration-optimize/optimize
-    operate: http://integration-operate/operate
-    tasklist: http://integration-tasklist/tasklist
+    operate: http://integration-operate:9600/operate
+    tasklist: http://integration-tasklist:9600/tasklist
     connectors: http://integration-connectors:8080/connectors
     webModelerRestapi: http://integration-web-modeler-restapi:8091
     webModelerWebapp: http://integration-web-modeler-webapp:8071


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->
Updating `preflightVars.baseURLs` used by integration tests with Tasklist and Operate management port `9600`

This makes this job passing https://github.com/camunda/camunda/actions/runs/9598610686/job/26470345249?pr=18780

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
