### PR TITLE
chore: add a note about camunda helm github repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 [![Test - Unit](https://github.com/camunda/camunda-platform-helm/actions/workflows/test-unit.yml/badge.svg)](https://github.com/camunda/camunda-platform-helm/actions/workflows/test-unit.yml)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/camunda)](https://artifacthub.io/packages/search?repo=camunda)
 
+> [!CAUTION]
+>
+> This GitHub repository is mainly for development, don't use it directly to deploy Camunda. End users should use the [official documentation](https://docs.camunda.io/docs/self-managed/about-self-managed/) for [installation](https://docs.camunda.io/docs/self-managed/setup/install/), [upgrade](https://docs.camunda.io/docs/self-managed/setup/upgrade/), etc.
 
 - [Overview](#overview)
 - [Documentation](#documentation)


### PR DESCRIPTION
### Which problem does the PR fix?

Sometimes end users try to install Camunda from this GitHub repo which is not meant for that (the final Helm chart artifacts should be used).

### What's in this PR?

Add a note about this GitHub repo.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?
