### PR TITLE
feat: configure camunda database to be used by v2 API

### DIFF
--- a/charts/camunda-platform-alpha/templates/operate/configmap.yaml
+++ b/charts/camunda-platform-alpha/templates/operate/configmap.yaml
@@ -40,7 +40,28 @@ data:
       profiles:
         active: "auth"
     {{- end }}
-    
+
+    # Camunda Database configuration
+    {{- if .Values.global.elasticsearch.enabled }}
+    camunda.database:
+      type: elasticsearch
+      # Cluster name
+      clusterName: {{ .Values.global.elasticsearch.clusterName }}
+      {{- if .Values.global.elasticsearch.external }}
+      username: {{ .Values.global.elasticsearch.auth.username | quote }}
+      {{- end }}
+      # Elasticsearch full url
+      url: {{ include "camundaPlatform.elasticsearchURL" . | quote }}
+    {{- end }}
+    {{- if .Values.global.opensearch.enabled }}
+    camunda.database:
+      type: opensearch
+      url: {{ include "camundaPlatform.opensearchURL" . | quote }}
+      {{- if .Values.global.opensearch.auth.username }}
+      username: {{ .Values.global.opensearch.auth.username | quote }}
+      {{- end }}
+    {{- end }}
+
     # Operate configuration file
     camunda.operate:
       {{- if .Values.global.opensearch.enabled }}

--- a/charts/camunda-platform-alpha/templates/operate/deployment.yaml
+++ b/charts/camunda-platform-alpha/templates/operate/deployment.yaml
@@ -120,6 +120,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "elasticsearch.authExistingSecret" . | quote }}
                   key: {{ include "elasticsearch.authExistingSecretKey" . | quote }}
+            - name: CAMUNDA_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "elasticsearch.authExistingSecret" . | quote }}
+                  key: {{ include "elasticsearch.authExistingSecretKey" . | quote }}
             {{- end }}
             {{- if and .Values.global.opensearch.enabled .Values.global.opensearch.auth.password}}
             - name: CAMUNDA_OPERATE_ZEEBE_OPENSEARCH_PASSWORD
@@ -128,6 +133,11 @@ spec:
                   name: {{ include "opensearch.authExistingSecret" . | quote }}
                   key: {{ include "opensearch.authExistingSecretKey" . | quote }}
             - name: CAMUNDA_OPERATE_OPENSEARCH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "opensearch.authExistingSecret" . | quote }}
+                  key: {{ include "opensearch.authExistingSecretKey" . | quote }}
+            - name: CAMUNDA_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "opensearch.authExistingSecret" . | quote }}

--- a/charts/camunda-platform-alpha/templates/tasklist/configmap.yaml
+++ b/charts/camunda-platform-alpha/templates/tasklist/configmap.yaml
@@ -41,6 +41,27 @@ data:
         active: auth
     {{- end }}
 
+    # Camunda Database configuration
+    {{- if .Values.global.elasticsearch.enabled }}
+    camunda.database:
+      type: elasticsearch
+      # Cluster name
+      clusterName: {{ .Values.global.elasticsearch.clusterName }}
+      {{- if .Values.global.elasticsearch.external }}
+      username: {{ .Values.global.elasticsearch.auth.username | quote }}
+      {{- end }}
+      # Elasticsearch full url
+      url: {{ include "camundaPlatform.elasticsearchURL" . | quote }}
+    {{- end }}
+    {{- if .Values.global.opensearch.enabled }}
+    camunda.database:
+      type: opensearch
+      url: {{ include "camundaPlatform.opensearchURL" . | quote }}
+      {{- if .Values.global.opensearch.auth.username }}
+      username: {{ .Values.global.opensearch.auth.username | quote }}
+      {{- end }}
+    {{- end }}
+
     # Tasklist configuration file
     camunda.tasklist:
       {{- if .Values.global.multitenancy.enabled }}

--- a/charts/camunda-platform-alpha/templates/tasklist/deployment.yaml
+++ b/charts/camunda-platform-alpha/templates/tasklist/deployment.yaml
@@ -59,6 +59,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "elasticsearch.authExistingSecret" . | quote }}
                   key: {{ include "elasticsearch.authExistingSecretKey" . | quote }}
+            - name: CAMUNDA_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "elasticsearch.authExistingSecret" . | quote }}
+                  key: {{ include "elasticsearch.authExistingSecretKey" . | quote }}
             {{- end }}
             {{- if and .Values.global.opensearch.enabled .Values.global.opensearch.auth.password}}
             - name: CAMUNDA_TASKLIST_OPENSEARCH_PASSWORD
@@ -67,6 +72,11 @@ spec:
                   name: {{ include "opensearch.authExistingSecret" . | quote }}
                   key: {{ include "opensearch.authExistingSecretKey" . | quote }}
             - name: CAMUNDA_TASKLIST_ZEEBEOPENSEARCH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "opensearch.authExistingSecret" . | quote }}
+                  key: {{ include "opensearch.authExistingSecretKey" . | quote }}
+            - name: CAMUNDA_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "opensearch.authExistingSecret" . | quote }}

--- a/charts/camunda-platform-alpha/templates/zeebe-gateway/configmap.yaml
+++ b/charts/camunda-platform-alpha/templates/zeebe-gateway/configmap.yaml
@@ -27,6 +27,27 @@ data:
         base-path: {{ .Values.zeebeGateway.contextPath | quote }}
     {{- end }}
 
+    # Camunda Database configuration
+    {{- if .Values.global.elasticsearch.enabled }}
+    camunda.database:
+      type: elasticsearch
+      # Cluster name
+      clusterName: {{ .Values.global.elasticsearch.clusterName }}
+      {{- if .Values.global.elasticsearch.external }}
+      username: {{ .Values.global.elasticsearch.auth.username | quote }}
+      {{- end }}
+      # Elasticsearch full url
+      url: {{ include "camundaPlatform.elasticsearchURL" . | quote }}
+    {{- end }}
+    {{- if .Values.global.opensearch.enabled }}
+    camunda.database:
+      type: opensearch
+      url: {{ include "camundaPlatform.opensearchURL" . | quote }}
+      {{- if .Values.global.opensearch.auth.username }}
+      username: {{ .Values.global.opensearch.auth.username | quote }}
+      {{- end }}
+    {{- end }}
+
     server:
       address: "0.0.0.0"
       port: {{  .Values.zeebeGateway.service.restPort | quote }}

--- a/charts/camunda-platform-alpha/templates/zeebe-gateway/deployment.yaml
+++ b/charts/camunda-platform-alpha/templates/zeebe-gateway/deployment.yaml
@@ -69,6 +69,20 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            {{- if and .Values.global.elasticsearch.external (include "elasticsearch.passwordIsDefined" .) }}
+            - name: CAMUNDA_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "elasticsearch.authExistingSecret" . | quote }}
+                  key: {{ include "elasticsearch.authExistingSecretKey" . | quote }}
+            {{- end }}
+            {{- if and .Values.global.opensearch.enabled .Values.global.opensearch.auth.password}}
+            - name: CAMUNDA_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "opensearch.authExistingSecret" . | quote }}
+                  key: {{ include "opensearch.authExistingSecretKey" . | quote }}
+            {{- end}}
             {{- with .Values.zeebeGateway.env }}
               {{- tpl (toYaml .) $ | nindent 12 }}
             {{- end }}

--- a/charts/camunda-platform-alpha/templates/zeebe/configmap.yaml
+++ b/charts/camunda-platform-alpha/templates/zeebe/configmap.yaml
@@ -71,7 +71,29 @@ data:
         threads:
           cpuThreadCount: {{ .Values.zeebe.cpuThreadCount  | quote }}
           ioThreadCount: {{ .Values.zeebe.ioThreadCount  | quote }}
+
+    # Camunda Database configuration
+    {{- if .Values.global.elasticsearch.enabled }}
+    camunda.database:
+      type: elasticsearch
+      # Cluster name
+      clusterName: {{ .Values.global.elasticsearch.clusterName }}
+      {{- if .Values.global.elasticsearch.external }}
+      username: {{ .Values.global.elasticsearch.auth.username | quote }}
+      {{- end }}
+      # Elasticsearch full url
+      url: {{ include "camundaPlatform.elasticsearchURL" . | quote }}
+    {{- end }}
+    {{- if .Values.global.opensearch.enabled }}
+    camunda.database:
+      type: opensearch
+      url: {{ include "camundaPlatform.opensearchURL" . | quote }}
+      {{- if .Values.global.opensearch.auth.username }}
+      username: {{ .Values.global.opensearch.auth.username | quote }}
+      {{- end }}
+    {{- end }}
   {{- end }}
+
   startup.sh: |
     #!/usr/bin/env bash
     set -eux -o pipefail

--- a/charts/camunda-platform-alpha/templates/zeebe/statefulset.yaml
+++ b/charts/camunda-platform-alpha/templates/zeebe/statefulset.yaml
@@ -85,9 +85,19 @@ spec:
                 secretKeyRef:
                   name: {{ include "elasticsearch.authExistingSecret" . | quote }}
                   key: {{ include "elasticsearch.authExistingSecretKey" . | quote }}
+            - name: CAMUNDA_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "elasticsearch.authExistingSecret" . | quote }}
+                  key: {{ include "elasticsearch.authExistingSecretKey" . | quote }}
             {{- end }}
             {{- if and .Values.global.opensearch.enabled .Values.global.opensearch.auth.password}}
             - name: ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_AUTHENTICATION_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "opensearch.authExistingSecret" . | quote }}
+                  key: {{ include "opensearch.authExistingSecretKey" . | quote }}
+            - name: CAMUNDA_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "opensearch.authExistingSecret" . | quote }}

--- a/charts/camunda-platform-alpha/test/unit/operate/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/operate/golden/configmap.golden.yaml
@@ -28,7 +28,15 @@ data:
       identity:
         clientId: "operate"
         audience: "operate-api"
-    
+
+    # Camunda Database configuration
+    camunda.database:
+      type: elasticsearch
+      # Cluster name
+      clusterName: elasticsearch
+      # Elasticsearch full url
+      url: "http://camunda-platform-test-elasticsearch:9200"
+
     # Operate configuration file
     camunda.operate:
       identity:

--- a/charts/camunda-platform-alpha/test/unit/tasklist/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/tasklist/golden/configmap.golden.yaml
@@ -29,6 +29,14 @@ data:
         clientId: "tasklist"
         audience: "tasklist-api"
 
+    # Camunda Database configuration
+    camunda.database:
+      type: elasticsearch
+      # Cluster name
+      clusterName: elasticsearch
+      # Elasticsearch full url
+      url: "http://camunda-platform-test-elasticsearch:9200"
+
     # Tasklist configuration file
     camunda.tasklist:
 

--- a/charts/camunda-platform-alpha/test/unit/zeebe-gateway/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/zeebe-gateway/golden/configmap-log4j2.golden.yaml
@@ -21,6 +21,14 @@ data:
       profiles:
         active: "identity-auth"
 
+    # Camunda Database configuration
+    camunda.database:
+      type: elasticsearch
+      # Cluster name
+      clusterName: elasticsearch
+      # Elasticsearch full url
+      url: "http://camunda-platform-test-elasticsearch:9200"
+
     server:
       address: "0.0.0.0"
       port: "8080"

--- a/charts/camunda-platform-alpha/test/unit/zeebe-gateway/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/zeebe-gateway/golden/configmap.golden.yaml
@@ -19,6 +19,14 @@ data:
       profiles:
         active: "identity-auth"
 
+    # Camunda Database configuration
+    camunda.database:
+      type: elasticsearch
+      # Cluster name
+      clusterName: elasticsearch
+      # Elasticsearch full url
+      url: "http://camunda-platform-test-elasticsearch:9200"
+
     server:
       address: "0.0.0.0"
       port: "8080"

--- a/charts/camunda-platform-alpha/test/unit/zeebe/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/zeebe/golden/configmap-log4j2.golden.yaml
@@ -47,6 +47,15 @@ data:
         threads:
           cpuThreadCount: "3"
           ioThreadCount: "3"
+
+    # Camunda Database configuration
+    camunda.database:
+      type: elasticsearch
+      # Cluster name
+      clusterName: elasticsearch
+      # Elasticsearch full url
+      url: "http://camunda-platform-test-elasticsearch:9200"
+
   startup.sh: |
     #!/usr/bin/env bash
     set -eux -o pipefail

--- a/charts/camunda-platform-alpha/test/unit/zeebe/golden/configmap-multiregion-failBack.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/zeebe/golden/configmap-multiregion-failBack.golden.yaml
@@ -47,6 +47,15 @@ data:
         threads:
           cpuThreadCount: "3"
           ioThreadCount: "3"
+
+    # Camunda Database configuration
+    camunda.database:
+      type: elasticsearch
+      # Cluster name
+      clusterName: elasticsearch
+      # Elasticsearch full url
+      url: "http://camunda-platform-test-elasticsearch:9200"
+
   startup.sh: |
     #!/usr/bin/env bash
     set -eux -o pipefail

--- a/charts/camunda-platform-alpha/test/unit/zeebe/golden/configmap-multiregion-failOver.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/zeebe/golden/configmap-multiregion-failOver.golden.yaml
@@ -47,6 +47,15 @@ data:
         threads:
           cpuThreadCount: "3"
           ioThreadCount: "3"
+
+    # Camunda Database configuration
+    camunda.database:
+      type: elasticsearch
+      # Cluster name
+      clusterName: elasticsearch
+      # Elasticsearch full url
+      url: "http://camunda-platform-test-elasticsearch:9200"
+
   startup.sh: |
     #!/usr/bin/env bash
     set -eux -o pipefail

--- a/charts/camunda-platform-alpha/test/unit/zeebe/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/zeebe/golden/configmap.golden.yaml
@@ -47,6 +47,15 @@ data:
         threads:
           cpuThreadCount: "3"
           ioThreadCount: "3"
+
+    # Camunda Database configuration
+    camunda.database:
+      type: elasticsearch
+      # Cluster name
+      clusterName: elasticsearch
+      # Elasticsearch full url
+      url: "http://camunda-platform-test-elasticsearch:9200"
+
   startup.sh: |
     #!/usr/bin/env bash
     set -eux -o pipefail


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->
Configuring the new Database properties `camunda.database.*` used in v2 stack.
These properties are added to the configmaps used by:
- operate deployment
- tasklist deployment
- zeebe gateway deployment
- zeebe statefulset

The new properties use the same values as the existing ones (like `camunda.tasklist.elasticsearch` ...) . The old properties are meant to be deprecated and removed in future releases

Relates to https://github.com/camunda/camunda/issues/19076

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
