### PR TITLE
chore: fix workflow inputs print

### DIFF
--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -119,7 +119,16 @@ jobs:
     - name: Print workflow inputs
       run: |
         echo "Workflow inputs:"
-        echo "${{ toJSON(inputs) }}"
+        echo "identifier: ${{ inputs.identifier }}"
+        echo "camunda-helm-dir: ${{ inputs.camunda-helm-dir }}"
+        echo "camunda-helm-git-ref: ${{ inputs.camunda-helm-git-ref }}"
+        echo "caller-git-ref: ${{ inputs.caller-git-ref }}"
+        echo "deployment-ttl: ${{ inputs.deployment-ttl }}"
+        echo "platforms: ${{ inputs.platforms }}"
+        echo "flows: ${{ inputs.flows }}"
+        echo "test-enabled: ${{ inputs.test-enabled }}"
+        echo "extra-values: ${{ inputs.extra-values }}"
+        echo "vault-secret-mapping: ${{ inputs.vault-secret-mapping }}"
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       with:
         # This is needed to load repo GH composite actions if the workflow triggered by workflow_call.


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
The new inputs print is breaking this workflow https://github.com/camunda/camunda/actions/runs/9656735771/job/26637842094 . The workflow uses `vault-secret-mapping` input which is a [multiline input including pipes](https://github.com/camunda/camunda/blob/28d412a02ec7ead43961fd674889cae31838180e/.github/workflows/camunda-helm-integration.yml#L28-L32), so it does not properly work with `toJSON` method.

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
