### PR TITLE
chore: use new tag name for snapshots

### DIFF
--- a/.github/workflows/chart-release-snapshot.yaml
+++ b/.github/workflows/chart-release-snapshot.yaml
@@ -23,10 +23,10 @@ jobs:
         chart:
         - name: Helm Chart Latest rolling
           directory: charts/camunda-platform-latest
-          versionSuffix: main-snapshot
+          versionSuffix: snapshot-latest
         - name: Helm Chart Alpha rolling
           directory: charts/camunda-platform-alpha
-          versionSuffix: main-alpha
+          versionSuffix: snapshot-alpha
         - name: Helm Chart Alpha versioned
           directory: charts/camunda-platform-alpha
           versionSuffix: ""
@@ -46,7 +46,7 @@ jobs:
           fetch-depth: 0
       - name: Set vars
         run: |
-          # NOTE: Helm CLI only accepts SemVer so we need to use something like "0.0.0-main-snapshot".
+          # NOTE: Helm CLI only accepts SemVer so we need to use something like "0.0.0-snapshot-latest".
           CHART_VERSION_SUFFIX="${{ matrix.chart.versionSuffix }}"
           CHART_VERSION_SUFFIX_DEFAULT="$(yq '.version' Chart.yaml)"
           echo "CHART_VERSION=0.0.0-${CHART_VERSION_SUFFIX:-${CHART_VERSION_SUFFIX_DEFAULT}}" | tee -a $GITHUB_ENV

--- a/docs/release.md
+++ b/docs/release.md
@@ -9,12 +9,36 @@ created. The charts are hosted via GitHub pages and use the release artifacts. W
 
 For debugging and advanced testing purposes, we provide a snapshot chart from the unreleased changes on the `main` branch (never use it in production or stable environments).
 
-It will be always updated with the fixed version name `0.0.0-main-snapshot` (the tag needed to start with SemVer because Helm requires it).
+It will be always updated with the fixed version name like `0.0.0-snapshot-latest` (the tag needed to start with SemVer because Helm requires it).
+
+### Latest
+
+The latest unreleased changes version has rolling version `0.0.0-snapshot-latest`:
 
 ```shell
 helm template my-camunda-devel \
   oci://ghcr.io/camunda/helm/camunda-platform \
-  --version 0.0.0-main-snapshot
+  --version 0.0.0-snapshot-latest
+```
+
+### Alpha
+
+The Alpha version is available in two flavors:
+
+Rolling version `0.0.0-snapshot-alpha` (always pointing to the Camunda latest alpha release):
+
+```shell
+helm template my-camunda-devel \
+  oci://ghcr.io/camunda/helm/camunda-platform \
+  --version 0.0.0-snapshot-alpha
+```
+
+Fixed version like `0.0.0-8.6.0-alpha2` (it will be updated according to the Camunda latest alpha release):
+
+```shell
+helm template my-camunda-devel \
+  oci://ghcr.io/camunda/helm/camunda-platform \
+  --version 0.0.0-8.6.0-alpha2
 ```
 
 ## Process


### PR DESCRIPTION
### What's in this PR?

Because now we use the directory-based structure and all chart versions in the same branch, we rename the snapshot docker tag to match the new style.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
