### PR TITLE
chore: update zeebe gatway readiness probe tests

### DIFF
--- a/charts/camunda-platform-8.2/test/integration/testsuites/vars/files/testsuite-preflight.yaml
+++ b/charts/camunda-platform-8.2/test/integration/testsuites/vars/files/testsuite-preflight.yaml
@@ -31,14 +31,14 @@ testcases:
     - component: Connectors
       url: "{{ .preflightVars.baseURLs.connectors }}/actuator/health/readiness"
     - component: ZeebeGateway
-      url: "{{ .preflightVars.baseURLs.zeebeGateway }}/health"
+      url: "{{ .preflightVars.baseURLs.zeebeGateway }}/actuator/health/readiness"
     method: GET
     url: "{{ .value.url }}"
     retry: 3
     delay: 10
-    # info: |
-    #   {{ .value.component }} URL: {{ .value.url }}
-    #   Response Body: {{ .result.body }}
+    info: |
+      {{ .value.component }} URL: {{ .value.url }}
+      Response Body: {{ .result.body }}
     assertions:
     - result.statuscode ShouldEqual 200
   - name: "WebModeler - {{ .value.component }}"
@@ -54,9 +54,9 @@ testcases:
     url: "{{ .value.url }}"
     retry: 3
     delay: 10
-    # info: |
-    #   {{ .value.component }} URL: {{ .value.url }}
-    #   Response Body: {{ .result.body }}
+    info: |
+      {{ .value.component }} URL: {{ .value.url }}
+      Response Body: {{ .result.body }}
     assertions:
     - result.statuscode ShouldEqual 200
 
@@ -87,9 +87,9 @@ testcases:
     url: "{{ .value.url }}"
     retry: 3
     delay: 10
-    # info: |
-    #   {{ .value.component }} URL: {{ .value.url }}
-    #   Response Body: {{ .result.body }}
+    info: |
+      {{ .value.component }} URL: {{ .value.url }}
+      Response Body: {{ .result.body }}
     assertions:
     - result.statuscode ShouldEqual 200
   - name: "WebModeler - {{ .value.component }}"
@@ -105,9 +105,9 @@ testcases:
     url: "{{ .value.url }}"
     retry: 3
     delay: 10
-    # info: |
-    #   {{ .value.component }} URL: {{ .value.url }}
-    #   Response Body: {{ .result.body }}
+    info: |
+      {{ .value.component }} URL: {{ .value.url }}
+      Response Body: {{ .result.body }}
     assertions:
     - result.statuscode ShouldEqual 200
 

--- a/charts/camunda-platform-8.3/test/integration/testsuites/vars/files/testsuite-preflight.yaml
+++ b/charts/camunda-platform-8.3/test/integration/testsuites/vars/files/testsuite-preflight.yaml
@@ -31,14 +31,14 @@ testcases:
     - component: Connectors
       url: "{{ .preflightVars.baseURLs.connectors }}/actuator/health/readiness"
     - component: ZeebeGateway
-      url: "{{ .preflightVars.baseURLs.zeebeGateway }}/actuator/health"
+      url: "{{ .preflightVars.baseURLs.zeebeGateway }}/actuator/health/readiness"
     method: GET
     url: "{{ .value.url }}"
     retry: 3
     delay: 10
-    # info: |
-    #   {{ .value.component }} URL: {{ .value.url }}
-    #   Response Body: {{ .result.body }}
+    info: |
+      {{ .value.component }} URL: {{ .value.url }}
+      Response Body: {{ .result.body }}
     assertions:
     - result.statuscode ShouldEqual 200
 
@@ -55,9 +55,9 @@ testcases:
     url: "{{ .value.url }}"
     retry: 3
     delay: 10
-    # info: |
-    #   {{ .value.component }} URL: {{ .value.url }}
-    #   Response Body: {{ .result.body }}
+    info: |
+      {{ .value.component }} URL: {{ .value.url }}
+      Response Body: {{ .result.body }}
     assertions:
     - result.statuscode ShouldEqual 200
 
@@ -88,9 +88,9 @@ testcases:
     url: "{{ .value.url }}"
     retry: 3
     delay: 10
-    # info: |
-    #   {{ .value.component }} URL: {{ .value.url }}
-    #   Response Body: {{ .result.body }}
+    info: |
+      {{ .value.component }} URL: {{ .value.url }}
+      Response Body: {{ .result.body }}
     assertions:
     - result.statuscode ShouldEqual 200
   - name: "WebModeler - {{ .value.component }}"
@@ -106,9 +106,9 @@ testcases:
     url: "{{ .value.url }}"
     retry: 3
     delay: 10
-    # info: |
-    #   {{ .value.component }} URL: {{ .value.url }}
-    #   Response Body: {{ .result.body }}
+    info: |
+      {{ .value.component }} URL: {{ .value.url }}
+      Response Body: {{ .result.body }}
     assertions:
     - result.statuscode ShouldEqual 200
 

--- a/charts/camunda-platform-8.4/test/integration/testsuites/vars/files/testsuite-preflight.yaml
+++ b/charts/camunda-platform-8.4/test/integration/testsuites/vars/files/testsuite-preflight.yaml
@@ -31,14 +31,14 @@ testcases:
     - component: Connectors
       url: "{{ .preflightVars.baseURLs.connectors }}/actuator/health/readiness"
     - component: ZeebeGateway
-      url: "{{ .preflightVars.baseURLs.zeebeGateway }}/actuator/health"
+      url: "{{ .preflightVars.baseURLs.zeebeGateway }}/actuator/health/readiness"
     method: GET
     url: "{{ .value.url }}"
     retry: 3
     delay: 10
-    # info: |
-    #   {{ .value.component }} URL: {{ .value.url }}
-    #   Response Body: {{ .result.body }}
+    info: |
+      {{ .value.component }} URL: {{ .value.url }}
+      Response Body: {{ .result.body }}
     assertions:
     - result.statuscode ShouldEqual 200
 
@@ -55,9 +55,9 @@ testcases:
     url: "{{ .value.url }}"
     retry: 3
     delay: 10
-    # info: |
-    #   {{ .value.component }} URL: {{ .value.url }}
-    #   Response Body: {{ .result.body }}
+    info: |
+      {{ .value.component }} URL: {{ .value.url }}
+      Response Body: {{ .result.body }}
     assertions:
     - result.statuscode ShouldEqual 200
 
@@ -88,9 +88,9 @@ testcases:
     url: "{{ .value.url }}"
     retry: 3
     delay: 10
-    # info: |
-    #   {{ .value.component }} URL: {{ .value.url }}
-    #   Response Body: {{ .result.body }}
+    info: |
+      {{ .value.component }} URL: {{ .value.url }}
+      Response Body: {{ .result.body }}
     assertions:
     - result.statuscode ShouldEqual 200
   - name: "WebModeler - {{ .value.component }}"
@@ -106,9 +106,9 @@ testcases:
     url: "{{ .value.url }}"
     retry: 3
     delay: 10
-    # info: |
-    #   {{ .value.component }} URL: {{ .value.url }}
-    #   Response Body: {{ .result.body }}
+    info: |
+      {{ .value.component }} URL: {{ .value.url }}
+      Response Body: {{ .result.body }}
     assertions:
     - result.statuscode ShouldEqual 200
 

--- a/charts/camunda-platform-alpha/test/integration/testsuites/vars/files/testsuite-preflight.yaml
+++ b/charts/camunda-platform-alpha/test/integration/testsuites/vars/files/testsuite-preflight.yaml
@@ -31,14 +31,14 @@ testcases:
     - component: Connectors
       url: "{{ .preflightVars.baseURLs.connectors }}/actuator/health/readiness"
     - component: ZeebeGateway
-      url: "{{ .preflightVars.baseURLs.zeebeGateway }}/actuator/health"
+      url: "{{ .preflightVars.baseURLs.zeebeGateway }}/actuator/health/readiness"
     method: GET
     url: "{{ .value.url }}"
     retry: 3
     delay: 10
-    # info: |
-    #   {{ .value.component }} URL: {{ .value.url }}
-    #   Response Body: {{ .result.body }}
+    info: |
+      {{ .value.component }} URL: {{ .value.url }}
+      Response Body: {{ .result.body }}
     assertions:
     - result.statuscode ShouldEqual 200
   - name: "WebModeler - {{ .value.component }}"
@@ -54,9 +54,9 @@ testcases:
     url: "{{ .value.url }}"
     retry: 3
     delay: 10
-    # info: |
-    #   {{ .value.component }} URL: {{ .value.url }}
-    #   Response Body: {{ .result.body }}
+    info: |
+      {{ .value.component }} URL: {{ .value.url }}
+      Response Body: {{ .result.body }}
     assertions:
     - result.statuscode ShouldEqual 200
 
@@ -87,9 +87,9 @@ testcases:
     url: "{{ .value.url }}"
     retry: 3
     delay: 10
-    # info: |
-    #   {{ .value.component }} URL: {{ .value.url }}
-    #   Response Body: {{ .result.body }}
+    info: |
+      {{ .value.component }} URL: {{ .value.url }}
+      Response Body: {{ .result.body }}
     assertions:
     - result.statuscode ShouldEqual 200
   - name: "WebModeler - {{ .value.component }}"
@@ -105,9 +105,9 @@ testcases:
     url: "{{ .value.url }}"
     retry: 3
     delay: 10
-    # info: |
-    #   {{ .value.component }} URL: {{ .value.url }}
-    #   Response Body: {{ .result.body }}
+    info: |
+      {{ .value.component }} URL: {{ .value.url }}
+      Response Body: {{ .result.body }}
     assertions:
     - result.statuscode ShouldEqual 200
 

--- a/charts/camunda-platform-latest/test/integration/testsuites/vars/files/testsuite-preflight.yaml
+++ b/charts/camunda-platform-latest/test/integration/testsuites/vars/files/testsuite-preflight.yaml
@@ -31,14 +31,14 @@ testcases:
     - component: Connectors
       url: "{{ .preflightVars.baseURLs.connectors }}/actuator/health/readiness"
     - component: ZeebeGateway
-      url: "{{ .preflightVars.baseURLs.zeebeGateway }}/actuator/health"
+      url: "{{ .preflightVars.baseURLs.zeebeGateway }}/actuator/health/readiness"
     method: GET
     url: "{{ .value.url }}"
     retry: 3
     delay: 10
-    # info: |
-    #   {{ .value.component }} URL: {{ .value.url }}
-    #   Response Body: {{ .result.body }}
+    info: |
+      {{ .value.component }} URL: {{ .value.url }}
+      Response Body: {{ .result.body }}
     assertions:
     - result.statuscode ShouldEqual 200
   - name: "WebModeler - {{ .value.component }}"
@@ -54,9 +54,9 @@ testcases:
     url: "{{ .value.url }}"
     retry: 3
     delay: 10
-    # info: |
-    #   {{ .value.component }} URL: {{ .value.url }}
-    #   Response Body: {{ .result.body }}
+    info: |
+      {{ .value.component }} URL: {{ .value.url }}
+      Response Body: {{ .result.body }}
     assertions:
     - result.statuscode ShouldEqual 200
 
@@ -87,9 +87,9 @@ testcases:
     url: "{{ .value.url }}"
     retry: 3
     delay: 10
-    # info: |
-    #   {{ .value.component }} URL: {{ .value.url }}
-    #   Response Body: {{ .result.body }}
+    info: |
+      {{ .value.component }} URL: {{ .value.url }}
+      Response Body: {{ .result.body }}
     assertions:
     - result.statuscode ShouldEqual 200
   - name: "WebModeler - {{ .value.component }}"
@@ -105,9 +105,9 @@ testcases:
     url: "{{ .value.url }}"
     retry: 3
     delay: 10
-    # info: |
-    #   {{ .value.component }} URL: {{ .value.url }}
-    #   Response Body: {{ .result.body }}
+    info: |
+      {{ .value.component }} URL: {{ .value.url }}
+      Response Body: {{ .result.body }}
     assertions:
     - result.statuscode ShouldEqual 200
 


### PR DESCRIPTION
### What's in this PR?

In the tests, we used the health endpoint for readiness even though there is already a dedicated endpoint for readiness.

So updating the tests to use the correct probe in test. 

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
