### PR TITLE
chore: add workflow to check pr checks status

### DIFF
--- a/.github/workflows/repo-pr-status.yaml
+++ b/.github/workflows/repo-pr-status.yaml
@@ -1,0 +1,20 @@
+name: Repo - PR Checks Status
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  # This check will be used in gh rules to determine that all checks passed.
+  check:
+    name: Check PR status
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure PR checks passed
+        uses: poseidon/wait-for-status-checks@6988432d64ad3f9c2608db4ca16fded1b7d36ead # v0.5.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Exclude this job itself from the check.
+          ignore: "Check PR status"


### PR DESCRIPTION
### What's in this PR?

Add workflow to check PR checks status.
This check will be used in gh rules to determine that all checks passed.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
