### PR TITLE
fix(ci): failure alerts are not triggered on ROSA schedule integration

### DIFF
--- a/.github/actions/workflow-vars/action.yml
+++ b/.github/actions/workflow-vars/action.yml
@@ -112,7 +112,15 @@ runs:
         # In the upgrade flow, the latest released chart for certain minor Camunda version will installed,
         # then upgraded from the PR branch to ensure upgradability.
         if [[ "${{ inputs.setup-flow }}" == 'upgrade' ]]; then
-          git fetch origin main:main --no-tags
+          current_branch=$(git symbolic-ref --short HEAD)
+
+          if [ "$current_branch" != "main" ]; then
+              # Perform the fetch operation
+              git fetch origin main:main --no-tags
+          else
+              echo "You are currently on the 'main' branch. Fetch operation not performed."
+          fi
+
           TEST_CHART_VERSION="$(git show main:charts/${{ inputs.chart-dir }}/Chart.yaml | yq '.version')"
           echo "TEST_CHART_VERSION=${TEST_CHART_VERSION}" | tee -a "$GITHUB_ENV" "$GITHUB_OUTPUT"
 

--- a/.github/workflows/test-integration-rosa.yaml
+++ b/.github/workflows/test-integration-rosa.yaml
@@ -389,7 +389,7 @@ jobs:
 
   report:
     name: "Report failures"
-    if: always()
+    if: failure()
     runs-on: ubuntu-latest
     needs:
       - launch-tests
@@ -397,7 +397,7 @@ jobs:
     steps:
       - name: Notify in Slack in case of failure
         id: slack-notification
-        if: failure() && github.event_name == 'schedule'
+        if: github.event_name == 'schedule'
         uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
         with:
           channel-id: ${{ secrets.SLACK_CHANNEL_ID }}


### PR DESCRIPTION
### Which problem does the PR fix?

- Alerts are not triggered
- When performing test upgrade on main, the fetch command fails due to the current already on main (this error wasn't triggered before due to the fact that integration tests were always launched from PRs).
See
https://github.com/camunda/camunda-platform-helm/actions/runs/9802466140/job/27068549929

### What's in this PR?

This fix implements the same logic as we have in
https://github.com/camunda/camunda-tf-eks-module/blob/85f9a6913e3a14c0c0ce966e9dc434762e1448b2/.github/workflows/tests.yml#L184

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
