### PR TITLE
ci: make Generate workflow matrix job support trigger from another wo…

### DIFF
--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -83,6 +83,10 @@ jobs:
       matrix: ${{ steps.generate-workflow-matrix.outputs.matrix }}
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      with:
+        # This is needed if the workflow is triggered by workflow_call.
+        repository: camunda/camunda-platform-helm
+        ref: ${{ inputs.camunda-helm-git-ref }}
     - name: Generate workflow matrix
       id: generate-workflow-matrix
       env:


### PR DESCRIPTION
…rkflow

### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
Helm chart intergration test is broken in the mono-repo  https://github.com/camunda/camunda/actions/runs/9933989942/job/27437635093
```
Error: open .github/config/test-integration-matrix.yaml: no such file or directory
```

### What's in this PR?
Updating the checkout step to support the case when the workflow is triggered from outside this repository

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
