### PR TITLE
chore: fix gha expressions substitution in ci workflow

### DIFF
--- a/.github/config/test-integration-matrix.yaml
+++ b/.github/config/test-integration-matrix.yaml
@@ -8,7 +8,7 @@ matrix:
         cluster-location: DISTRO_CI_GCP_GKE_CLUSTER_LOCATION
         workload-identity-provider: DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER
         service-account: DISTRO_CI_GCP_SERVICE_ACCOUNT
-      if: ${{ contains(inputs.platforms, 'gke') }}
+      if: $INPUTS_PLATFORMS_GKE
     - name: OpenShift
       type: openshift
       platform: rosa
@@ -16,16 +16,16 @@ matrix:
         server-url: DISTRO_CI_OPENSHIFT_CLUSTER_URL
         username: DISTRO_CI_OPENSHIFT_CLUSTER_USERNAME
         password: DISTRO_CI_OPENSHIFT_CLUSTER_PASSWORD
-      if: ${{ contains(inputs.platforms, 'rosa') }}
+      if: $INPUTS_PLATFORMS_ROSA
   scenario:
     - name: Chart Setup
       desc: Setup chart in production-like setup with Ingress and TLS.
       flow: install
-      if: ${{ contains(inputs.flows, 'install') }}
+      if: $INPUTS_FLOWS_INSTALL
     - name: Chart Upgrade
       desc: Upgrade chart from the latest released version to the current branch.
       flow: upgrade
-      if: ${{ contains(inputs.flows, 'upgrade') }}
+      if: $INPUTS_FLOWS_UPGRADE
   exclude:
     - distro:
         if: false

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -82,22 +82,31 @@ jobs:
     outputs:
       matrix: ${{ steps.generate-workflow-matrix.outputs.matrix }}
     steps:
-    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-      with:
-        # This is needed if the workflow is triggered by workflow_call.
-        repository: camunda/camunda-platform-helm
-        ref: ${{ inputs.camunda-helm-git-ref }}
-    - name: Generate workflow matrix
-      id: generate-workflow-matrix
-      env:
-          CI_MATRIX_FILE: ".github/config/test-integration-matrix.yaml"
-          # Use GH env to safly load JSON matrix input.
-          CI_MATRIX_INPUT: "${{ inputs.matrix-data }}"
-      run: |
-        matrix_defult="$(yq '.matrix' --indent=0 --output-format json ${CI_MATRIX_FILE})"
-        matrix="${CI_MATRIX_INPUT:-${matrix_defult}}"
-        echo "${matrix}" | jq
-        echo "matrix=$(echo ${matrix} | jq -c)" > "$GITHUB_OUTPUT"
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        with:
+          # This is needed if the workflow is triggered by workflow_call.
+          repository: camunda/camunda-platform-helm
+          ref: ${{ inputs.camunda-helm-git-ref }}
+      - name: Generate workflow matrix
+        id: generate-workflow-matrix
+        env:
+            CI_MATRIX_FILE: ".github/config/test-integration-matrix.yaml"
+            # Use GH env to safly load JSON matrix input.
+            CI_MATRIX_INPUT: "${{ inputs.matrix-data }}"
+        run: |
+          # TODO: Find a better way to handle GitHub Actions expressions substitution.
+          # Substitute vars.
+          export INPUTS_PLATFORMS_GKE=${{ contains(inputs.platforms, 'gke') }}
+          export INPUTS_PLATFORMS_ROSA=${{ contains(inputs.platforms, 'rosa') }}
+          export INPUTS_FLOWS_INSTALL=${{ contains(inputs.flows, 'install') }}
+          export INPUTS_FLOWS_UPGRADE=${{ contains(inputs.flows, 'upgrade') }}
+          cat ${CI_MATRIX_FILE} | envsubst | tee /tmp/matrix.yaml
+          # Read matrix YAML file.
+          matrix_defult="$(yq '.matrix' --indent=0 --output-format json /tmp/matrix.yaml)"
+          matrix="${CI_MATRIX_INPUT:-${matrix_defult}}"
+          # Print and set matrix JSON object as an output.
+          echo "${matrix}" | jq
+          echo "matrix=$(echo ${matrix} | jq -c)" > "$GITHUB_OUTPUT"
 
   test:
     if: github.event.action != 'closed'


### PR DESCRIPTION
### What's in this PR?

The GHA expression substitution doesn't work as expected when loaded from a file (it was introduced in https://github.com/camunda/camunda-platform-helm/pull/2118)

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
