### PR TITLE
chore: update rosa actions

### DIFF
--- a/.github/workflows/test-integration-rosa-template.yaml
+++ b/.github/workflows/test-integration-rosa-template.yaml
@@ -112,7 +112,7 @@ jobs:
           aws configure set aws_access_key_id ${{ secrets.DISTRO_CI_AWS_ACCESS_KEY }} --profile=${{ secrets.DISTRO_CI_AWS_PROFILE }}
 
       - name: Create ROSA cluster and login
-        uses: camunda/camunda-tf-rosa/.github/actions/rosa-create-cluster@408ad133d0da2362b84b144774ef0e5866aa2e61 # main
+        uses: camunda/camunda-tf-rosa/.github/actions/rosa-create-cluster@60c139db8ef7779183bb9d20e89820648019ea02 # main
         timeout-minutes: 125
         env:
           AWS_PROFILE: ${{ secrets.DISTRO_CI_AWS_PROFILE }}
@@ -274,7 +274,7 @@ jobs:
           aws configure set aws_access_key_id ${{ secrets.DISTRO_CI_AWS_ACCESS_KEY }} --profile=${{ secrets.DISTRO_CI_AWS_PROFILE }}
 
       - name: Delete on-demand ROSA HCP Cluster
-        uses: camunda/camunda-tf-rosa/.github/actions/rosa-delete-cluster@408ad133d0da2362b84b144774ef0e5866aa2e61 # main
+        uses: camunda/camunda-tf-rosa/.github/actions/rosa-delete-cluster@60c139db8ef7779183bb9d20e89820648019ea02 # main
         if: always()
         timeout-minutes: 125
         env:


### PR DESCRIPTION
### Which problem does the PR fix?

pinned version didn't work with a behaviour change at RedHat.
RedHat changed the download server and the curl command didn't follow redirects.
Not what your Renovate schedule is, so I thought I would proactively create the PR to not have you run into OpenShift cluster creation issues.

### What's in this PR?

Just digest updates from tf-rosa repo to not have the cluster creation fail for OpenShift tests.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
