### PR TITLE
fix: added recreate strategy to all Operate deployments

### DIFF
--- a/charts/camunda-platform-8.2/charts/operate/templates/deployment.yaml
+++ b/charts/camunda-platform-8.2/charts/operate/templates/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   labels: {{- include "operate.labels" . | nindent 4 }}
   annotations: {{- toYaml  .Values.global.annotations | nindent 4 }}
 spec:
+  strategy:
+    type: Recreate
   replicas: 1
   selector:
     matchLabels: {{- include "operate.matchLabels" . | nindent 6 }}

--- a/charts/camunda-platform-8.2/test/unit/operate/golden/deployment.golden.yaml
+++ b/charts/camunda-platform-8.2/test/unit/operate/golden/deployment.golden.yaml
@@ -15,6 +15,8 @@ metadata:
   annotations:
     {}
 spec:
+  strategy:
+    type: Recreate
   replicas: 1
   selector:
     matchLabels:

--- a/charts/camunda-platform-8.3/templates/operate/deployment.yaml
+++ b/charts/camunda-platform-8.3/templates/operate/deployment.yaml
@@ -8,6 +8,8 @@ metadata:
   annotations:
     {{- toYaml .Values.global.annotations | nindent 4 }}
 spec:
+  strategy:
+    type: Recreate
   replicas: 1
   selector:
     matchLabels:

--- a/charts/camunda-platform-8.3/test/unit/operate/golden/deployment.golden.yaml
+++ b/charts/camunda-platform-8.3/test/unit/operate/golden/deployment.golden.yaml
@@ -15,6 +15,8 @@ metadata:
   annotations:
     {}
 spec:
+  strategy:
+    type: Recreate
   replicas: 1
   selector:
     matchLabels:

--- a/charts/camunda-platform-8.4/templates/operate/deployment.yaml
+++ b/charts/camunda-platform-8.4/templates/operate/deployment.yaml
@@ -8,6 +8,8 @@ metadata:
   annotations:
     {{- toYaml .Values.global.annotations | nindent 4 }}
 spec:
+  strategy:
+    type: Recreate
   replicas: 1
   selector:
     matchLabels:

--- a/charts/camunda-platform-8.4/test/unit/operate/golden/deployment.golden.yaml
+++ b/charts/camunda-platform-8.4/test/unit/operate/golden/deployment.golden.yaml
@@ -15,6 +15,8 @@ metadata:
   annotations:
     {}
 spec:
+  strategy:
+    type: Recreate
   replicas: 1
   selector:
     matchLabels:

--- a/charts/camunda-platform-alpha/templates/operate/deployment.yaml
+++ b/charts/camunda-platform-alpha/templates/operate/deployment.yaml
@@ -8,6 +8,8 @@ metadata:
   annotations:
     {{- toYaml .Values.global.annotations | nindent 4 }}
 spec:
+  strategy:
+    type: Recreate
   replicas: 1
   {{- if .Values.operate.strategy }}
   strategy:

--- a/charts/camunda-platform-alpha/test/unit/operate/deployment_test.go
+++ b/charts/camunda-platform-alpha/test/unit/operate/deployment_test.go
@@ -1012,7 +1012,7 @@ func (s *deploymentTemplateTest) TestSetDnsPolicyAndDnsConfig() {
 	require.Equal(s.T(), expectedDNSConfig, deployment.Spec.Template.Spec.DNSConfig, "dnsConfig should match the expected configuration")
 }
 
-func (s *deploymentTemplateTest) TestDefaultStrategy() {
+func (s *deploymentTemplateTest) TestRecreateStrategy() {
 	// given
 	options := &helm.Options{
 		SetValues:      map[string]string{},
@@ -1027,7 +1027,7 @@ func (s *deploymentTemplateTest) TestDefaultStrategy() {
 	// then
 	strategy := deployment.Spec.Strategy
 
-	s.Require().Equal(string(strategy.Type), "")
+	s.Require().Equal(string(strategy.Type), "Recreate")
 }
 
 func (s *deploymentTemplateTest) TestDefinedStrategy() {

--- a/charts/camunda-platform-alpha/test/unit/operate/golden/deployment.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/operate/golden/deployment.golden.yaml
@@ -15,6 +15,8 @@ metadata:
   annotations:
     {}
 spec:
+  strategy:
+    type: Recreate
   replicas: 1
   selector:
     matchLabels:

--- a/charts/camunda-platform-latest/templates/operate/deployment.yaml
+++ b/charts/camunda-platform-latest/templates/operate/deployment.yaml
@@ -8,6 +8,8 @@ metadata:
   annotations:
     {{- toYaml .Values.global.annotations | nindent 4 }}
 spec:
+  strategy:
+    type: Recreate
   replicas: 1
   {{- if .Values.operate.strategy }}
   strategy:

--- a/charts/camunda-platform-latest/test/unit/operate/deployment_test.go
+++ b/charts/camunda-platform-latest/test/unit/operate/deployment_test.go
@@ -1012,7 +1012,7 @@ func (s *deploymentTemplateTest) TestSetDnsPolicyAndDnsConfig() {
 	require.Equal(s.T(), expectedDNSConfig, deployment.Spec.Template.Spec.DNSConfig, "dnsConfig should match the expected configuration")
 }
 
-func (s *deploymentTemplateTest) TestDefaultStrategy() {
+func (s *deploymentTemplateTest) TestRecreateStrategy() {
 	// given
 	options := &helm.Options{
 		SetValues:      map[string]string{},
@@ -1027,7 +1027,7 @@ func (s *deploymentTemplateTest) TestDefaultStrategy() {
 	// then
 	strategy := deployment.Spec.Strategy
 
-	s.Require().Equal(string(strategy.Type), "")
+	s.Require().Equal(string(strategy.Type), "Recreate")
 }
 
 func (s *deploymentTemplateTest) TestDefinedStrategy() {

--- a/charts/camunda-platform-latest/test/unit/operate/golden/deployment.golden.yaml
+++ b/charts/camunda-platform-latest/test/unit/operate/golden/deployment.golden.yaml
@@ -15,6 +15,8 @@ metadata:
   annotations:
     {}
 spec:
+  strategy:
+    type: Recreate
   replicas: 1
   selector:
     matchLabels:


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
related issue: https://github.com/camunda/camunda-platform-helm/issues/2142
### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->
I added a recreate strategy to all operate deployments, instead of rolling update. 
### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
