### PR TITLE
fix: changed restAddress in Tasklist with helper function

### DIFF
--- a/charts/camunda-platform-alpha/templates/camunda/_helpers.tpl
+++ b/charts/camunda-platform-alpha/templates/camunda/_helpers.tpl
@@ -517,6 +517,20 @@ Zeebe templates.
   {{- printf "%s://%s" $proto .Values.zeebeGateway.ingress.grpc.host -}}
 {{- end -}}
 
+{{/*
+[camunda-platform] Zeebe Gateway REST internal URL.
+*/}}
+{{ define "camundaPlatform.zeebeGatewayRESTURL" }}
+  {{- if .Values.zeebe.enabled -}}
+    {{-
+      printf "http://%s:%v%s"
+        (include "zeebe.fullname.gateway" .)
+        .Values.zeebeGateway.service.restPort
+        (.Values.zeebeGateway.contextPath | default "")
+    -}}
+  {{- end -}}
+{{- end -}}
+
 
 {{/*
 ********************************************************************************

--- a/charts/camunda-platform-alpha/templates/tasklist/configmap.yaml
+++ b/charts/camunda-platform-alpha/templates/tasklist/configmap.yaml
@@ -109,7 +109,7 @@ data:
       zeebe:
         # Gateway address
         gatewayAddress: "{{ tpl .Values.global.zeebeClusterName . }}-gateway:{{ .Values.zeebeGateway.service.grpcPort }}"
-        restAddress: "http://{{ tpl .Values.global.zeebeClusterName . }}-gateway:{{ .Values.zeebeGateway.service.restPort }}"
+        restAddress: {{ include "camundaPlatform.zeebeGatewayRESTURL" . | quote }}
       {{- if .Values.tasklist.retention.enabled }}
       archiver:
         ilmEnabled: true

--- a/charts/camunda-platform-latest/templates/camunda/_helpers.tpl
+++ b/charts/camunda-platform-latest/templates/camunda/_helpers.tpl
@@ -501,6 +501,20 @@ Zeebe templates.
   {{- printf "%s://%s" $proto .Values.zeebeGateway.ingress.grpc.host -}}
 {{- end -}}
 
+{{/*
+[camunda-platform] Zeebe Gateway REST internal URL.
+*/}}
+{{ define "camundaPlatform.zeebeGatewayRESTURL" }}
+  {{- if .Values.zeebe.enabled -}}
+    {{-
+      printf "http://%s:%v%s"
+        (include "zeebe.fullname.gateway" .)
+        .Values.zeebeGateway.service.restPort
+        (.Values.zeebeGateway.contextPath | default "")
+    -}}
+  {{- end -}}
+{{- end -}}
+
 
 {{/*
 ********************************************************************************

--- a/charts/camunda-platform-latest/templates/tasklist/configmap.yaml
+++ b/charts/camunda-platform-latest/templates/tasklist/configmap.yaml
@@ -108,7 +108,7 @@ data:
       zeebe:
         # Broker contact point
         brokerContactPoint: "{{ tpl .Values.global.zeebeClusterName . }}-gateway:{{ .Values.zeebeGateway.service.grpcPort }}"
-        restAddress: "http://{{ tpl .Values.global.zeebeClusterName . }}-gateway:{{ .Values.zeebeGateway.service.restPort }}"
+        restAddress: {{ include "camundaPlatform.zeebeGatewayRESTURL" . | quote }}
       {{- if .Values.tasklist.retention.enabled }}
       archiver:
         ilmEnabled: true


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
closes https://github.com/camunda/camunda-platform-helm/issues/2151 
closes https://github.com/camunda/tasklist/issues/4997

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->
- Define a new template `camundaPlatform.zeebeGatewayRESTURL` that takes into account `.Values.zeebeGateway.contextPath`
- Use this template in Tasklist configMap to set `zeebe.restAddress` configuration

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
