### PR TITLE
test: disable console on unsupported versions

### DIFF
--- a/charts/camunda-platform-8.2/test/integration/scenarios/chart-full-setup/values-integration-test-ingress.yaml
+++ b/charts/camunda-platform-8.2/test/integration/scenarios/chart-full-setup/values-integration-test-ingress.yaml
@@ -72,42 +72,7 @@ zeebe-gateway:
       external-dns.alpha.kubernetes.io/ttl: "60"
 
 console:
-  enabled: true
-  contextPath: "/"
-  image:
-    pullSecrets:
-    - name: index-docker-io
-    - name: registry-camunda-cloud
-  managed:
-    releases:
-    - name: camunda-platform-dev
-      namespace: camunda-dev
-      version: 8.2.10
-      components:
-      - name: Console
-        url: "https://example-dev.camunda.com/"
-      - name: Optimize
-        url: "https://example-dev.camunda.com/optimize"
-      - name: Operate
-        url: "https://example-dev.camunda.com/operate"
-      - name: WebModeler WebApp
-        url: "https://example-dev.camunda.com/modeler"
-      - name: zeebeGateway
-        url: "grpc://zeebe-example-dev.camunda.com/"
-    - name: camunda-platform-stage
-      namespace: camunda-stage
-      version: 8.2.11
-      components:
-      - name: Console
-        url: "https://example-stage.camunda.com/"
-      - name: Optimize
-        url: "https://example-stage.camunda.com/optimize"
-      - name: Operate
-        url: "https://example-stage.camunda.com/operate"
-      - name: WebModeler WebApp
-        url: "https://example-stage.camunda.com/modeler"
-      - name: zeebeGateway
-        url: "grpc://zeebe-example-stage.camunda.com/"
+  enabled: false
 
 elasticsearch:
   maxUnavailable: 0

--- a/charts/camunda-platform-8.3/test/integration/scenarios/chart-full-setup/values-integration-test-ingress.yaml
+++ b/charts/camunda-platform-8.3/test/integration/scenarios/chart-full-setup/values-integration-test-ingress.yaml
@@ -74,42 +74,7 @@ zeebe-gateway:
       external-dns.alpha.kubernetes.io/ttl: "60"
 
 console:
-  enabled: true
-  contextPath: "/"
-  image:
-    pullSecrets:
-    - name: index-docker-io
-    - name: registry-camunda-cloud
-  managed:
-    releases:
-    - name: camunda-platform-dev
-      namespace: camunda-dev
-      version: 8.2.10
-      components:
-      - name: Console
-        url: "https://example-dev.camunda.com/"
-      - name: Optimize
-        url: "https://example-dev.camunda.com/optimize"
-      - name: Operate
-        url: "https://example-dev.camunda.com/operate"
-      - name: WebModeler WebApp
-        url: "https://example-dev.camunda.com/modeler"
-      - name: zeebeGateway
-        url: "grpc://zeebe-example-dev.camunda.com/"
-    - name: camunda-platform-stage
-      namespace: camunda-stage
-      version: 8.2.11
-      components:
-      - name: Console
-        url: "https://example-stage.camunda.com/"
-      - name: Optimize
-        url: "https://example-stage.camunda.com/optimize"
-      - name: Operate
-        url: "https://example-stage.camunda.com/operate"
-      - name: WebModeler WebApp
-        url: "https://example-stage.camunda.com/modeler"
-      - name: zeebeGateway
-        url: "grpc://zeebe-example-stage.camunda.com/"
+  enabled: false
 
 elasticsearch:
   maxUnavailable: 0


### PR DESCRIPTION
### Which problem does the PR fix?

closes #2161 

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

this PR disables console for integration tests for 8.2 and 8.3 charts

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
