### PR TITLE
fix: template grpc url in console config

### DIFF
--- a/charts/camunda-platform-alpha/templates/camunda/_helpers.tpl
+++ b/charts/camunda-platform-alpha/templates/camunda/_helpers.tpl
@@ -514,7 +514,7 @@ Zeebe templates.
 */}}
 {{- define "camundaPlatform.zeebeGatewayGRPCExternalURL" -}}
   {{ $proto := ternary "https" "http" .Values.zeebeGateway.ingress.grpc.tls.enabled -}}
-  {{- printf "%s://%s" $proto .Values.zeebeGateway.ingress.grpc.host -}}
+  {{- printf "%s://%s" $proto (tpl .Values.zeebeGateway.ingress.grpc.host .) -}}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform-latest/templates/camunda/_helpers.tpl
+++ b/charts/camunda-platform-latest/templates/camunda/_helpers.tpl
@@ -498,7 +498,7 @@ Zeebe templates.
 */}}
 {{- define "camundaPlatform.zeebeGatewayGRPCExternalURL" -}}
   {{ $proto := ternary "https" "http" .Values.zeebeGateway.ingress.grpc.tls.enabled -}}
-  {{- printf "%s://%s" $proto .Values.zeebeGateway.ingress.grpc.host -}}
+  {{- printf "%s://%s" $proto (tpl .Values.zeebeGateway.ingress.grpc.host .) -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes: https://github.com/camunda/camunda-platform-helm/issues/2164

### What's in this PR?

The value of `zeebeGateway.ingress.grpc.host` wasn't templated in the Console config as we do in Ingress object.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
