### PR TITLE
fix: add constraint for contextPath and rest path to be the same for zeebe gateway

### DIFF
--- a/charts/camunda-platform-alpha/templates/camunda/constraints.tpl
+++ b/charts/camunda-platform-alpha/templates/camunda/constraints.tpl
@@ -60,6 +60,14 @@ Fail with a message if Identity is disabled and identityKeycloak is enabled.
   {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}
 
+{{/*
+Fail with a message if zeebeGateway.contextPath and zeebeGateway.ingress.rest.path are not the same
+*/}}
+{{- if and .Values.zeebeGateway.ingress.rest.enabled (ne .Values.zeebeGateway.ingress.rest.path .Values.zeebeGateway.contextPath) }}
+  {{- $errorMessage := "[camunda][error] zeebeGateway.ingress.rest.path and zeebeGateway.contextPath must have the same value."
+  -}}
+  {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
+{{- end }}
 
 {{- define "camunda.constraints.warnings" }}
   {{- if .Values.global.testDeprecationFlags.existingSecretsMustBeSet }}

--- a/charts/camunda-platform-alpha/test/unit/camunda/constraints_test.go
+++ b/charts/camunda-platform-alpha/test/unit/camunda/constraints_test.go
@@ -127,6 +127,6 @@ func (s *ConstraintsTemplateTest) TestContextPathAndRestPathForZeebeGatewayConst
 
 	_, err := helm.RenderTemplateE(s.T(), options, s.chartPath, s.release, s.templates)
 
-	s.Require().Error(err, "[camunda][error] zeebeGateway.ingress.rest.path and zeebeGateway.contextPath must have the same value.")
+	s.Require().ErrorContains(err, "[camunda][error]")
 
 }

--- a/charts/camunda-platform-alpha/test/unit/camunda/constraints_test.go
+++ b/charts/camunda-platform-alpha/test/unit/camunda/constraints_test.go
@@ -114,3 +114,19 @@ func (s *constraintTemplateTest) TestExistingSecretConstraintInWarningModeDoesNo
 	// then
 	s.Require().Nil(err)
 }
+
+func (s *ConstraintsTemplateTest) TestContextPathAndRestPathForZeebeGatewayConstraintBothValuesShouldBeTheSame() {
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"zeebeGateway.ingress.rest.enabled": "true",
+			"zeebeGateway.ingress.rest.path":    "/zeebe",
+			"zeebeGateway.contextPath":          "/zeebeRest",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	_, err := helm.RenderTemplateE(s.T(), options, s.chartPath, s.release, s.templates)
+
+	s.Require().Error(err, "[camunda][error] zeebeGateway.ingress.rest.path and zeebeGateway.contextPath must have the same value.")
+
+}

--- a/charts/camunda-platform-latest/templates/camunda/constraints.tpl
+++ b/charts/camunda-platform-latest/templates/camunda/constraints.tpl
@@ -60,6 +60,14 @@ Fail with a message if Identity is disabled and identityKeycloak is enabled.
   {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}
 
+{{/*
+Fail with a message if zeebeGateway.contextPath and zeebeGateway.ingress.rest.path are not the same
+*/}}
+{{- if and .Values.zeebeGateway.ingress.rest.enabled (ne .Values.zeebeGateway.ingress.rest.path .Values.zeebeGateway.contextPath) }}
+  {{- $errorMessage := "[camunda][error] zeebeGateway.ingress.rest.path and zeebeGateway.contextPath must have the same value."
+  -}}
+  {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
+{{- end }}
 
 {{- define "camunda.constraints.warnings" }}
   {{- if .Values.global.testDeprecationFlags.existingSecretsMustBeSet }}

--- a/charts/camunda-platform-latest/test/unit/camunda/constraints_test.go
+++ b/charts/camunda-platform-latest/test/unit/camunda/constraints_test.go
@@ -127,6 +127,6 @@ func (s *ConstraintsTemplateTest) TestContextPathAndRestPathForZeebeGatewayConst
 
 	_, err := helm.RenderTemplateE(s.T(), options, s.chartPath, s.release, s.templates)
 
-	s.Require().Error(err, "[camunda][error] zeebeGateway.ingress.rest.path and zeebeGateway.contextPath must have the same value.")
+	s.Require().ErrorContains(err, "[camunda][error]")
 
 }

--- a/charts/camunda-platform-latest/test/unit/camunda/constraints_test.go
+++ b/charts/camunda-platform-latest/test/unit/camunda/constraints_test.go
@@ -114,3 +114,19 @@ func (s *constraintTemplateTest) TestExistingSecretConstraintInWarningModeDoesNo
 	// then
 	s.Require().Nil(err)
 }
+
+func (s *ConstraintsTemplateTest) TestContextPathAndRestPathForZeebeGatewayConstraintBothValuesShouldBeTheSame() {
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"zeebeGateway.ingress.rest.enabled": "true",
+			"zeebeGateway.ingress.rest.path":    "/zeebe",
+			"zeebeGateway.contextPath":          "/zeebeRest",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	_, err := helm.RenderTemplateE(s.T(), options, s.chartPath, s.release, s.templates)
+
+	s.Require().Error(err, "[camunda][error] zeebeGateway.ingress.rest.path and zeebeGateway.contextPath must have the same value.")
+
+}


### PR DESCRIPTION

### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
closes: https://github.com/camunda/camunda-platform-helm/issues/1755

### What's in this PR?

I added a constraint to make sure that `zeebeGateway.ingress.rest.path` and `zeebeGateway.contextPath` have the same value when the rest endpoint is enabled for zeebe gateway.
<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
