### PR TITLE
fix: existingSecret for OpenSearch password can be used without defining password literal

### DIFF
--- a/charts/camunda-platform-alpha/templates/camunda/_helpers.tpl
+++ b/charts/camunda-platform-alpha/templates/camunda/_helpers.tpl
@@ -284,7 +284,7 @@ Elasticsearch and Opensearch templates.
 {{- end -}}
 
 {{/*
-[elasticsearch] Get name of elasticsearch auth existing secret. For more details:
+[elasticsearch] Get name of opensearch auth existing secret. For more details:
 https://docs.bitnami.com/kubernetes/apps/keycloak/configuration/manage-passwords/
 */}}
 {{- define "elasticsearch.authExistingSecret" -}}

--- a/charts/camunda-platform-alpha/templates/camunda/_helpers.tpl
+++ b/charts/camunda-platform-alpha/templates/camunda/_helpers.tpl
@@ -284,7 +284,7 @@ Elasticsearch and Opensearch templates.
 {{- end -}}
 
 {{/*
-[elasticsearch] Get name of opensearch auth existing secret. For more details:
+[elasticsearch] Get name of elasticsearch auth existing secret. For more details:
 https://docs.bitnami.com/kubernetes/apps/keycloak/configuration/manage-passwords/
 */}}
 {{- define "elasticsearch.authExistingSecret" -}}

--- a/charts/camunda-platform-alpha/templates/camunda/constraints.tpl
+++ b/charts/camunda-platform-alpha/templates/camunda/constraints.tpl
@@ -69,6 +69,15 @@ Fail with a message if zeebeGateway.contextPath and zeebeGateway.ingress.rest.pa
   {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}
 
+
+{{/*
+[opensearch] when existingSecret is provided for opensearch then password field should be empty
+*/}}
+{{- if and .Values.global.opensearch.auth.existingSecret .Values.global.opensearch.auth.password }}
+  {{- $errorMessage := "[camunda][error] global.opensearch.auth.existingSecret and global.opensearch.auth.password cannot both be set." -}}
+  {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
+{{- end }}
+
 {{- define "camunda.constraints.warnings" }}
   {{- if .Values.global.testDeprecationFlags.existingSecretsMustBeSet }}
     {{/* TODO: Check if there are more existingSecrets to check */}}
@@ -278,10 +287,3 @@ when global elasticsearch is enabled then either external elasticsearch should b
 {{- end }}
 */}}
 
-{{/*
-[opensearch] when existingSecret is provided for opensearch then password field should be empty
-{{- if and .Values.global.opensearch.auth.existingSecret .Values.global.opensearch.auth.password }}
-  {{- $errorMessage := "[camunda][error] global.opensearch.auth.existingSecret and global.opensearch.auth.password cannot both be set." -}}
-  {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
-{{- end }}
-*/}}

--- a/charts/camunda-platform-alpha/templates/operate/deployment.yaml
+++ b/charts/camunda-platform-alpha/templates/operate/deployment.yaml
@@ -121,7 +121,7 @@ spec:
                   name: {{ include "elasticsearch.authExistingSecret" . | quote }}
                   key: {{ include "elasticsearch.authExistingSecretKey" . | quote }}
             {{- end }}
-            {{- if and .Values.global.opensearch.enabled .Values.global.opensearch.auth.password}}
+            {{- if and .Values.global.opensearch.enabled (or .Values.global.opensearch.auth.existingSecret .Values.global.opensearch.auth.password) }}
             - name: CAMUNDA_OPERATE_ZEEBE_OPENSEARCH_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/camunda-platform-alpha/templates/optimize/deployment.yaml
+++ b/charts/camunda-platform-alpha/templates/optimize/deployment.yaml
@@ -66,7 +66,7 @@ spec:
               value: {{ include "camundaPlatform.opensearchHost" . | quote }}
             - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SECURITY_USERNAME
               value: {{ .Values.global.opensearch.auth.username | quote }}
-            {{- if .Values.global.opensearch.auth.password}}
+            {{- if or .Values.global.opensearch.auth.existingSecret .Values.global.opensearch.auth.password }}
             - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SECURITY_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -149,7 +149,7 @@ spec:
               value: {{ include "camundaPlatform.opensearchHost" . | quote }}
             - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SECURITY_USERNAME
               value: {{ .Values.global.opensearch.auth.username | quote }}
-            {{- if .Values.global.opensearch.auth.password}}
+            {{- if or .Values.global.opensearch.auth.existingSecret .Values.global.opensearch.auth.password }}
             - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SECURITY_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/camunda-platform-alpha/templates/tasklist/deployment.yaml
+++ b/charts/camunda-platform-alpha/templates/tasklist/deployment.yaml
@@ -60,7 +60,7 @@ spec:
                   name: {{ include "elasticsearch.authExistingSecret" . | quote }}
                   key: {{ include "elasticsearch.authExistingSecretKey" . | quote }}
             {{- end }}
-            {{- if and .Values.global.opensearch.enabled .Values.global.opensearch.auth.password}}
+            {{- if and .Values.global.opensearch.enabled (or .Values.global.opensearch.auth.existingSecret .Values.global.opensearch.auth.password) }}
             - name: CAMUNDA_TASKLIST_OPENSEARCH_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/camunda-platform-alpha/templates/zeebe/statefulset.yaml
+++ b/charts/camunda-platform-alpha/templates/zeebe/statefulset.yaml
@@ -86,7 +86,7 @@ spec:
                   name: {{ include "elasticsearch.authExistingSecret" . | quote }}
                   key: {{ include "elasticsearch.authExistingSecretKey" . | quote }}
             {{- end }}
-            {{- if and .Values.global.opensearch.enabled .Values.global.opensearch.auth.password}}
+            {{- if and .Values.global.opensearch.enabled (or .Values.global.opensearch.auth.existingSecret .Values.global.opensearch.auth.password) }}
             - name: ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_AUTHENTICATION_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/camunda-platform-latest/templates/camunda/_helpers.tpl
+++ b/charts/camunda-platform-latest/templates/camunda/_helpers.tpl
@@ -300,7 +300,7 @@ do not use this for its string value.
 
 
 {{/*
-[opensearch] Get name of elasticsearch auth existing secret. For more details:
+[opensearch] Get name of opensearch auth existing secret. For more details:
 https://docs.bitnami.com/kubernetes/apps/keycloak/configuration/manage-passwords/
 */}}
 {{- define "opensearch.authExistingSecret" -}}

--- a/charts/camunda-platform-latest/templates/camunda/constraints.tpl
+++ b/charts/camunda-platform-latest/templates/camunda/constraints.tpl
@@ -69,6 +69,14 @@ Fail with a message if zeebeGateway.contextPath and zeebeGateway.ingress.rest.pa
   {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}
 
+{{/*
+[opensearch] when existingSecret is provided for opensearch then password field should be empty
+*/}}
+{{- if and .Values.global.opensearch.auth.existingSecret .Values.global.opensearch.auth.password }}
+  {{- $errorMessage := "[camunda][error] global.opensearch.auth.existingSecret and global.opensearch.auth.password cannot both be set." -}}
+  {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
+{{- end }}
+
 {{- define "camunda.constraints.warnings" }}
   {{- if .Values.global.testDeprecationFlags.existingSecretsMustBeSet }}
     {{/* TODO: Check if there are more existingSecrets to check */}}
@@ -278,10 +286,3 @@ when global elasticsearch is enabled then either external elasticsearch should b
 {{- end }}
 */}}
 
-{{/*
-[opensearch] when existingSecret is provided for opensearch then password field should be empty
-{{- if and .Values.global.opensearch.auth.existingSecret .Values.global.opensearch.auth.password }}
-  {{- $errorMessage := "[camunda][error] global.opensearch.auth.existingSecret and global.opensearch.auth.password cannot both be set." -}}
-  {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
-{{- end }}
-*/}}

--- a/charts/camunda-platform-latest/templates/operate/deployment.yaml
+++ b/charts/camunda-platform-latest/templates/operate/deployment.yaml
@@ -122,7 +122,7 @@ spec:
                   name: {{ include "elasticsearch.authExistingSecret" . | quote }}
                   key: {{ include "elasticsearch.authExistingSecretKey" . | quote }}
             {{- end }}
-            {{- if and .Values.global.opensearch.enabled .Values.global.opensearch.auth.password}}
+            {{- if and .Values.global.opensearch.enabled (or .Values.global.opensearch.auth.existingSecret .Values.global.opensearch.auth.password) }}
             - name: CAMUNDA_OPERATE_ZEEBE_OPENSEARCH_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/camunda-platform-latest/templates/optimize/deployment.yaml
+++ b/charts/camunda-platform-latest/templates/optimize/deployment.yaml
@@ -61,7 +61,7 @@ spec:
               value: {{ include "camundaPlatform.opensearchHost" . | quote }}
             - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SECURITY_USERNAME
               value: {{ .Values.global.opensearch.auth.username | quote }}
-            {{- if .Values.global.opensearch.auth.password}}
+            {{- if or .Values.global.opensearch.auth.existingSecret .Values.global.opensearch.auth.password }}
             - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SECURITY_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -139,7 +139,7 @@ spec:
               value: {{ include "camundaPlatform.opensearchHost" . | quote }}
             - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SECURITY_USERNAME
               value: {{ .Values.global.opensearch.auth.username | quote }}
-            {{- if .Values.global.opensearch.auth.password}}
+            {{- if or .Values.global.opensearch.auth.existingSecret .Values.global.opensearch.auth.password }}
             - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SECURITY_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/camunda-platform-latest/templates/tasklist/deployment.yaml
+++ b/charts/camunda-platform-latest/templates/tasklist/deployment.yaml
@@ -55,7 +55,7 @@ spec:
                   name: {{ include "elasticsearch.authExistingSecret" . | quote }}
                   key: {{ include "elasticsearch.authExistingSecretKey" . | quote }}
             {{- end }}
-            {{- if and .Values.global.opensearch.enabled .Values.global.opensearch.auth.password}}
+            {{- if and .Values.global.opensearch.enabled (or .Values.global.opensearch.auth.existingSecret .Values.global.opensearch.auth.password) }}
             - name: CAMUNDA_TASKLIST_OPENSEARCH_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/camunda-platform-latest/templates/zeebe/statefulset.yaml
+++ b/charts/camunda-platform-latest/templates/zeebe/statefulset.yaml
@@ -81,7 +81,7 @@ spec:
                   name: {{ include "elasticsearch.authExistingSecret" . | quote }}
                   key: {{ include "elasticsearch.authExistingSecretKey" . | quote }}
             {{- end }}
-            {{- if and .Values.global.opensearch.enabled .Values.global.opensearch.auth.password}}
+            {{- if and .Values.global.opensearch.enabled (or .Values.global.opensearch.auth.existingSecret .Values.global.opensearch.auth.password) }}
             - name: ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_AUTHENTICATION_PASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
closes: https://github.com/camunda/camunda-platform-helm/issues/2133
### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->
I modified the if statement to allow the user to use existingSecret without needing to specify the password literal in OpenSearch.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
