### PR TITLE
fix: drop namespace from zeebe advertisedHost and initialContactPoints

### DIFF
--- a/charts/camunda-platform-alpha/templates/zeebe/statefulset.yaml
+++ b/charts/camunda-platform-alpha/templates/zeebe/statefulset.yaml
@@ -69,11 +69,11 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: ZEEBE_BROKER_NETWORK_ADVERTISEDHOST
-              value: "$(K8S_NAME).$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc"
+              value: "$(K8S_NAME).$(K8S_SERVICE_NAME)"
             - name: ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS
               value:
               {{- range (untilStep 0 (int .Values.zeebe.clusterSize) 1) }}
-                $(K8S_SERVICE_NAME)-{{ . }}.$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc:{{$.Values.zeebe.service.internalPort}},
+                $(K8S_SERVICE_NAME)-{{ . }}.$(K8S_SERVICE_NAME):{{$.Values.zeebe.service.internalPort}},
               {{- end }}
             - name: ZEEBE_LOG_LEVEL
               value: {{ .Values.zeebe.logLevel | quote }}

--- a/charts/camunda-platform-alpha/test/unit/zeebe/golden/statefulset.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/zeebe/golden/statefulset.golden.yaml
@@ -74,12 +74,12 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: ZEEBE_BROKER_NETWORK_ADVERTISEDHOST
-              value: "$(K8S_NAME).$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc"
+              value: "$(K8S_NAME).$(K8S_SERVICE_NAME)"
             - name: ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS
               value:
-                $(K8S_SERVICE_NAME)-0.$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc:26502,
-                $(K8S_SERVICE_NAME)-1.$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc:26502,
-                $(K8S_SERVICE_NAME)-2.$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc:26502,
+                $(K8S_SERVICE_NAME)-0.$(K8S_SERVICE_NAME):26502,
+                $(K8S_SERVICE_NAME)-1.$(K8S_SERVICE_NAME):26502,
+                $(K8S_SERVICE_NAME)-2.$(K8S_SERVICE_NAME):26502,
             - name: ZEEBE_LOG_LEVEL
               value: "info"
             - name: ZEEBE_BROKER_GATEWAY_ENABLE

--- a/charts/camunda-platform-latest/templates/zeebe/statefulset.yaml
+++ b/charts/camunda-platform-latest/templates/zeebe/statefulset.yaml
@@ -64,11 +64,11 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: ZEEBE_BROKER_NETWORK_ADVERTISEDHOST
-              value: "$(K8S_NAME).$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc"
+              value: "$(K8S_NAME).$(K8S_SERVICE_NAME)"
             - name: ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS
               value:
               {{- range (untilStep 0 (int .Values.zeebe.clusterSize) 1) }}
-                $(K8S_SERVICE_NAME)-{{ . }}.$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc:{{$.Values.zeebe.service.internalPort}},
+                $(K8S_SERVICE_NAME)-{{ . }}.$(K8S_SERVICE_NAME):{{$.Values.zeebe.service.internalPort}},
               {{- end }}
             - name: ZEEBE_LOG_LEVEL
               value: {{ .Values.zeebe.logLevel | quote }}

--- a/charts/camunda-platform-latest/test/unit/zeebe/golden/statefulset.golden.yaml
+++ b/charts/camunda-platform-latest/test/unit/zeebe/golden/statefulset.golden.yaml
@@ -69,12 +69,12 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: ZEEBE_BROKER_NETWORK_ADVERTISEDHOST
-              value: "$(K8S_NAME).$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc"
+              value: "$(K8S_NAME).$(K8S_SERVICE_NAME)"
             - name: ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS
               value:
-                $(K8S_SERVICE_NAME)-0.$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc:26502,
-                $(K8S_SERVICE_NAME)-1.$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc:26502,
-                $(K8S_SERVICE_NAME)-2.$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc:26502,
+                $(K8S_SERVICE_NAME)-0.$(K8S_SERVICE_NAME):26502,
+                $(K8S_SERVICE_NAME)-1.$(K8S_SERVICE_NAME):26502,
+                $(K8S_SERVICE_NAME)-2.$(K8S_SERVICE_NAME):26502,
             - name: ZEEBE_LOG_LEVEL
               value: "info"
             - name: ZEEBE_BROKER_GATEWAY_ENABLE


### PR DESCRIPTION
### Which problem does the PR fix?

closes #1754 

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

This change drops the namespace and svc from the initialcontactpoints and advertised host.

The idea behind this change is that since most kubernetes deployments will do this in their dns resolv.conf 
```
search default.svc.cluster.local svc.cluster.local cluster.local
``` 
That the first and second dns search will result in a failure since the namespace and svc will be duplicated.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
