### PR TITLE
fix: use correct image object

### DIFF
--- a/charts/camunda-platform-alpha/templates/operate/_helpers.tpl
+++ b/charts/camunda-platform-alpha/templates/operate/_helpers.tpl
@@ -16,7 +16,7 @@ Defines extra labels for operate.
 */}}
 {{ define "operate.extraLabels" -}}
 app.kubernetes.io/component: operate
-app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.identity) | quote }}
+app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.operate) | quote }}
 {{- end }}
 
 {{/*

--- a/charts/camunda-platform-latest/templates/operate/_helpers.tpl
+++ b/charts/camunda-platform-latest/templates/operate/_helpers.tpl
@@ -16,7 +16,7 @@ Defines extra labels for operate.
 */}}
 {{ define "operate.extraLabels" -}}
 app.kubernetes.io/component: operate
-app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.identity) | quote }}
+app.kubernetes.io/version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.operate) | quote }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION

### Which problem does the PR fix?

Previously Operate resources used identity image map instead of the one from Operate. That causes that the deployment, and services are labeled with wrong version
<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

Using the right map/object for the labeling.
<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
