### PR TITLE
fix: dynamically set advertisedHosts based on multiregion

### DIFF
--- a/charts/camunda-platform-alpha/templates/zeebe/statefulset.yaml
+++ b/charts/camunda-platform-alpha/templates/zeebe/statefulset.yaml
@@ -69,7 +69,11 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: ZEEBE_BROKER_NETWORK_ADVERTISEDHOST
+              {{- if .Values.global.multiregion.enabled }}
+              value: "$(K8S_NAME).$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc"
+              {{- else }}
               value: "$(K8S_NAME).$(K8S_SERVICE_NAME)"
+              {{- end }}
             - name: ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS
               value:
               {{- range (untilStep 0 (int .Values.zeebe.clusterSize) 1) }}

--- a/charts/camunda-platform-latest/templates/zeebe/statefulset.yaml
+++ b/charts/camunda-platform-latest/templates/zeebe/statefulset.yaml
@@ -64,7 +64,11 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: ZEEBE_BROKER_NETWORK_ADVERTISEDHOST
+              {{- if .Values.global.multiregion.enabled }}
               value: "$(K8S_NAME).$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc"
+              {{- else }}
+              value: "$(K8S_NAME).$(K8S_SERVICE_NAME)"
+              {{- end }}
             - name: ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS
               value:
               {{- range (untilStep 0 (int .Values.zeebe.clusterSize) 1) }}

--- a/charts/camunda-platform-latest/test/unit/zeebe/golden/statefulset.golden.yaml
+++ b/charts/camunda-platform-latest/test/unit/zeebe/golden/statefulset.golden.yaml
@@ -69,7 +69,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: ZEEBE_BROKER_NETWORK_ADVERTISEDHOST
-              value: "$(K8S_NAME).$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc"
+              value: "$(K8S_NAME).$(K8S_SERVICE_NAME)"
             - name: ZEEBE_BROKER_CLUSTER_INITIALCONTACTPOINTS
               value:
                 $(K8S_SERVICE_NAME)-0.$(K8S_SERVICE_NAME).$(K8S_NAMESPACE).svc:26502,


### PR DESCRIPTION
### Which problem does the PR fix?

closes #2216 

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

This change will allow us to use short DNS names in zeebe for non-multiregion environments, while using the long DNS names for multiregion environments. This gives us the best of both worlds,
1. zeebe team will get fewer DNS misses
2. Multiregion deployments won't break due to the namespace being missing.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
