### PR TITLE
fix: application configurations for Operate + Tasklist

### DIFF
--- a/charts/camunda-platform-latest/templates/operate/configmap.yaml
+++ b/charts/camunda-platform-latest/templates/operate/configmap.yaml
@@ -7,10 +7,10 @@ metadata:
     {{- include "operate.labels" . | nindent 4 }}
 data:
   {{- if .Values.operate.configuration }}
-  application.yml: |
+  application.yaml: |
     {{ .Values.operate.configuration | indent 4 | trim }}
   {{- else }}
-  application.yml: |
+  application.yaml: |
     {{- if .Values.operate.contextPath }}
     server:
       servlet:

--- a/charts/camunda-platform-latest/templates/operate/deployment.yaml
+++ b/charts/camunda-platform-latest/templates/operate/deployment.yaml
@@ -173,8 +173,8 @@ spec:
           {{- end }}
           volumeMounts:
             - name: config
-              mountPath: /usr/local/operate/config/application.yml
-              subPath: application.yml
+              mountPath: /usr/local/operate/config/application.yaml
+              subPath: application.yaml
             - name: tmp
               mountPath: /tmp
             - name: camunda

--- a/charts/camunda-platform-latest/templates/tasklist/configmap.yaml
+++ b/charts/camunda-platform-latest/templates/tasklist/configmap.yaml
@@ -7,10 +7,10 @@ metadata:
     {{- include "tasklist.labels" . | nindent 4 }}
 data:
   {{- if .Values.tasklist.configuration }}
-  application.yml: |
+  application.yaml: |
     {{ .Values.tasklist.configuration | indent 4 | trim }}
   {{- else }}
-  application.yml: |
+  application.yaml: |
     {{- if .Values.tasklist.contextPath }}
     server:
       servlet:

--- a/charts/camunda-platform-latest/templates/tasklist/deployment.yaml
+++ b/charts/camunda-platform-latest/templates/tasklist/deployment.yaml
@@ -174,11 +174,11 @@ spec:
           {{- end }}
           volumeMounts:
             - name: config
-              mountPath: /app/resources/application.yml
-              subPath: application.yml
+              mountPath: /app/resources/application.yaml
+              subPath: application.yaml
             - name: config
-              mountPath: /usr/local/tasklist/config/application.yml
-              subPath: application.yml
+              mountPath: /usr/local/tasklist/config/application.yaml
+              subPath: application.yaml
             - mountPath: /tmp
               name: tmp
             - mountPath: /camunda

--- a/charts/camunda-platform-latest/test/unit/operate/configmap_test.go
+++ b/charts/camunda-platform-latest/test/unit/operate/configmap_test.go
@@ -17,7 +17,6 @@ package operate
 import (
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
-	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	"path/filepath"
 	"strings"
@@ -66,7 +65,7 @@ func (s *configMapTemplateTest) TestContainerShouldAddContextPath() {
 	var configmapApplication OperateConfigYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -91,7 +90,7 @@ func (s *configMapTemplateTest) TestContainerShouldDisableOperateIntegration() {
 	var configmapApplication OperateConfigYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -115,7 +114,7 @@ func (s *configMapTemplateTest) TestOperateMultiTenancyEnabled() {
 	var configmapApplication OperateConfigYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -139,7 +138,7 @@ func (s *configMapTemplateTest) TestRedirectRootUrlTrimsComplexSuffixes() {
 	var configmapApplication OperateConfigYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}

--- a/charts/camunda-platform-latest/test/unit/operate/deployment_test.go
+++ b/charts/camunda-platform-latest/test/unit/operate/deployment_test.go
@@ -826,8 +826,8 @@ camunda.operate:
 		}
 	}
 	s.Require().Equal("config", volumeMount.Name)
-	s.Require().Equal("/usr/local/operate/config/application.yml", volumeMount.MountPath)
-	s.Require().Equal("application.yml", volumeMount.SubPath)
+	s.Require().Equal("/usr/local/operate/config/application.yaml", volumeMount.MountPath)
+	s.Require().Equal("application.yaml", volumeMount.SubPath)
 
 	s.Require().Equal("config", volume.Name)
 	s.Require().Equal("camunda-platform-test-operate-configuration", volume.ConfigMap.Name)

--- a/charts/camunda-platform-latest/test/unit/operate/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-latest/test/unit/operate/golden/configmap.golden.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/component: operate
     app.kubernetes.io/version: "8.5.4"
 data:
-  application.yml: |
+  application.yaml: |
     spring:
       profiles:
         active: "identity-auth"

--- a/charts/camunda-platform-latest/test/unit/operate/golden/deployment.golden.yaml
+++ b/charts/camunda-platform-latest/test/unit/operate/golden/deployment.golden.yaml
@@ -99,8 +99,8 @@ spec:
             timeoutSeconds: 1
           volumeMounts:
             - name: config
-              mountPath: /usr/local/operate/config/application.yml
-              subPath: application.yml
+              mountPath: /usr/local/operate/config/application.yaml
+              subPath: application.yaml
             - name: tmp
               mountPath: /tmp
             - name: camunda

--- a/charts/camunda-platform-latest/test/unit/tasklist/configmap_test.go
+++ b/charts/camunda-platform-latest/test/unit/tasklist/configmap_test.go
@@ -17,7 +17,6 @@ package tasklist
 import (
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
-	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	"path/filepath"
 	"strings"
@@ -66,7 +65,7 @@ func (s *configMapTemplateTest) TestContainerShouldAddContextPath() {
 	var configmapApplication TasklistConfigYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -90,7 +89,7 @@ func (s *configMapTemplateTest) TestContainerShouldDisableOperateIntegration() {
 	var configmapApplication TasklistConfigYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -117,7 +116,7 @@ func (s *configMapTemplateTest) TestRedirectRootUrlTrimsComplexSuffixes() {
 	var configmapApplication TasklistConfigYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -141,7 +140,7 @@ func (s *configMapTemplateTest) TestTasklistMultiTenancyEnabled() {
 	var configmapApplication TasklistConfigYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}

--- a/charts/camunda-platform-latest/test/unit/tasklist/deployment_test.go
+++ b/charts/camunda-platform-latest/test/unit/tasklist/deployment_test.go
@@ -868,8 +868,8 @@ camunda.tasklist:
 		}
 	}
 	s.Require().Equal("config", volumeMount.Name)
-	s.Require().Equal("/usr/local/tasklist/config/application.yml", volumeMount.MountPath)
-	s.Require().Equal("application.yml", volumeMount.SubPath)
+	s.Require().Equal("/usr/local/tasklist/config/application.yaml", volumeMount.MountPath)
+	s.Require().Equal("application.yaml", volumeMount.SubPath)
 
 	s.Require().Equal("config", volume.Name)
 	s.Require().Equal("camunda-platform-test-tasklist-configuration", volume.ConfigMap.Name)

--- a/charts/camunda-platform-latest/test/unit/tasklist/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-latest/test/unit/tasklist/golden/configmap.golden.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/component: tasklist
     app.kubernetes.io/version: "8.5.3"
 data:
-  application.yml: |
+  application.yaml: |
     spring:
       profiles:
         active: identity-auth

--- a/charts/camunda-platform-latest/test/unit/tasklist/golden/deployment.golden.yaml
+++ b/charts/camunda-platform-latest/test/unit/tasklist/golden/deployment.golden.yaml
@@ -101,11 +101,11 @@ spec:
             timeoutSeconds: 1
           volumeMounts:
             - name: config
-              mountPath: /app/resources/application.yml
-              subPath: application.yml
+              mountPath: /app/resources/application.yaml
+              subPath: application.yaml
             - name: config
-              mountPath: /usr/local/tasklist/config/application.yml
-              subPath: application.yml
+              mountPath: /usr/local/tasklist/config/application.yaml
+              subPath: application.yaml
             - mountPath: /tmp
               name: tmp
             - mountPath: /camunda


### PR DESCRIPTION
### Which problem does the PR fix?

The Operate and Tasklist application file has been renamed on the way to a single application. It is now called `application.yaml`, instead of `application.yml`.

If we still use the old name, we would create a separate file and
not overwrite the existing one. This causes Spring to load multiple configs,
Spring will handle them in a way that the `yaml` overrides several configs
from the `yml` file.

See related investigation for more details https://github.com/camunda/camunda/issues/21033#issuecomment-2288476572

This causes the application to load defaults unexpectedly, like URL to ES will be
localhost:9200, that of course doesn't work in the K8 environment.
<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

In this PR I change the file names to the new expected names. This will override the default application.yaml files.

> [!NOTE]
> As the helm charts are overriding default application files (happened already since a while), this needs to be done carefully. We might want to think about a different approach, as application teams might add specific values in the `application.yaml` files as defaults which are then simply overridden. 
<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

closes https://github.com/camunda/camunda/issues/21033

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
