### PR TITLE
docs: add multiregion CI badge in footer of release-please PR

### DIFF
--- a/.github/config/release-please/release-please-config.json
+++ b/.github/config/release-please/release-please-config.json
@@ -111,5 +111,6 @@
       "hidden": false
     }
   ],
+  "pull-request-footer": "MultiRegion CI Status: ![multiregion workflow](https://github.com/camunda/c8-multi-region/actions/workflows/nightly_aws_operational_procedure.yml/badge.svg)\nThis PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).",
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
 }


### PR DESCRIPTION
### Which problem does the PR fix?

#2236 

This PR adds a badge to the footer of release-please PRs that looks like this:

![multiregion workflow](https://github.com/camunda/c8-multi-region/actions/workflows/nightly_aws_operational_procedure.yml/badge.svg)

This will help us know at-a-glance if a release is capable of being ran with multiregion enabled.

However, this is limited. the CI that gives the badge status will only run nightly on weekdays, and tests against the snapshot images/helm charts. not specifically the helm package from the release PR.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
