### PR TITLE
fix: correctly intend operate migration envs

### DIFF
--- a/charts/camunda-platform-alpha/templates/operate/deployment.yaml
+++ b/charts/camunda-platform-alpha/templates/operate/deployment.yaml
@@ -70,7 +70,7 @@ spec:
               value: -Djavax.net.ssl.trustStore=/usr/local/operate/certificates/externaldb.jks
             {{- end }}
             {{- with .Values.operate.migration.env }}
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           resources:
             {{- toYaml .Values.operate.migration.resources | nindent 12 }}

--- a/charts/camunda-platform-latest/templates/operate/deployment.yaml
+++ b/charts/camunda-platform-latest/templates/operate/deployment.yaml
@@ -76,7 +76,7 @@ spec:
               value: {{ .Values.global.elasticsearch.url.port | quote }}
             {{- end }}
             {{- with .Values.operate.migration.env }}
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           resources:
             {{- toYaml .Values.operate.migration.resources | nindent 12 }}


### PR DESCRIPTION
### Which problem does the PR fix?

Small fix that corrects the indentation of the operate migration envs when configuring those to e.g. overwrite the Elasticsearch URL.
Otherwise it will be interpreted as additional init container.

Example:

```
helm template camunda camunda/camunda-platform --set-string 'operate.migration.env[0].name=test' --set-string 'operate.migration.env[0].value=test'
```

will result in the following with `latest` and `alpha`:
```
      initContainers:
        - name: migration
          image: camunda/operate:8.5.5
          command: ['/bin/sh', '/usr/local/operate/bin/migrate']
          securityContext:
            allowPrivilegeEscalation: false
            privileged: false
            readOnlyRootFilesystem: true
            runAsNonRoot: true
            runAsUser: 1001
            seccompProfile:
              type: RuntimeDefault
          env:
            - name: CAMUNDA_OPERATE_ELASTICSEARCH_HOST
              value: "camunda-elasticsearch"
            - name: CAMUNDA_OPERATE_ELASTICSEARCH_HTTP_PORT
              value: "9200"
        - name: test
          value: test
```

The proposed fix will correctly align it to:
```
          env:
            - name: CAMUNDA_OPERATE_ELASTICSEARCH_HOST
              value: "camunda-elasticsearch"
            - name: CAMUNDA_OPERATE_ELASTICSEARCH_HTTP_PORT
              value: "9200"
            - name: test
              value: test
```

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

This PR contains a small fix to correctly align the environment variables of the new migration initcontainer in Operate.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
