### PR TITLE
fix bug where initContainer env has wrong indent

### DIFF
--- a/charts/camunda-platform-latest/templates/operate/deployment.yaml
+++ b/charts/camunda-platform-latest/templates/operate/deployment.yaml
@@ -76,7 +76,7 @@ spec:
               value: {{ .Values.global.elasticsearch.url.port | quote }}
             {{- end }}
             {{- with .Values.operate.migration.env }}
-            {{- toYaml . | nindent 12 }}
+            {{- toYaml . | nindent 16 }}
             {{- end }}
           resources:
             {{- toYaml .Values.operate.migration.resources | nindent 12 }}


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

Not created

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

This PR fixed this issue:

Install the helm chart using these values:

```yaml
operate:
  env: 
  - name: CAMUNDA_OPERATE_ELASTICSEARCH_INDEXPREFIX
    value: custom-operate
  migration:
    env:
    - name: CAMUNDA_OPERATE_ELASTICSEARCH_INDEXPREFIX
      value: custom-operate
```

It fails with this message:

```yaml
Error: INSTALLATION FAILED: 1 error occurred:
        * Deployment.apps "camunda-operate" is invalid: [spec.template.spec.initContainers[1].name: Invalid value: "CAMUNDA_OPERATE_ELASTICSEARCH_INDEXPREFIX": a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?'), spec.template.spec.initContainers[1].image: Required value]
```

Reason: the indent is not correct, the resulting initContainer section inside the camunda-operate deployment looks like this:

```yaml
      initContainers:
        - name: migration
          image: camunda/operate:8.5.5
          command: ['/bin/sh', '/usr/local/operate/bin/migrate']
          securityContext:
            allowPrivilegeEscalation: false
            privileged: false
            readOnlyRootFilesystem: true
            runAsNonRoot: true
            runAsUser: 1001
            seccompProfile:
              type: RuntimeDefault
          env:
            - name: CAMUNDA_OPERATE_ELASTICSEARCH_HOST
              value: "release-name-elasticsearch"
            - name: CAMUNDA_OPERATE_ELASTICSEARCH_HTTP_PORT
              value: "9200"
        - name: CAMUNDA_OPERATE_ELASTICSEARCH_INDEXPREFIX
          value: custom-operate
          resources:
            limits:
              cpu: 2000m
              memory: 2Gi
            requests:
              cpu: 600m
              memory: 1Gi
          volumeMounts:
            - name: config
              mountPath: /usr/local/operate/config/application.yml
              subPath: application.yml
            - name: tmp
              mountPath: /tmp
            - name: camunda
              mountPath: /camunda
```

You can clearly see that the manually added env is off.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
