### PR TITLE
fix: add zeebe opensearch retention to app config file

### DIFF
--- a/charts/camunda-platform-alpha/templates/zeebe/configmap.yaml
+++ b/charts/camunda-platform-alpha/templates/zeebe/configmap.yaml
@@ -44,6 +44,12 @@ data:
               aws:
                 enabled: true
               {{- end}}
+              {{- if .Values.zeebe.retention.enabled }}
+              retention:
+                enabled: true
+                minimumAge: {{ .Values.zeebe.retention.minimumAge | quote }}
+                policyName: {{ .Values.zeebe.retention.policyName | quote }}
+              {{- end }}
         {{- else -}}
           {{ " {}" }}
         {{- end }}

--- a/charts/camunda-platform-latest/templates/zeebe/configmap.yaml
+++ b/charts/camunda-platform-latest/templates/zeebe/configmap.yaml
@@ -44,6 +44,12 @@ data:
               aws:
                 enabled: true
               {{- end}}
+              {{- if .Values.zeebe.retention.enabled }}
+              retention:
+                enabled: true
+                minimumAge: {{ .Values.zeebe.retention.minimumAge | quote }}
+                policyName: {{ .Values.zeebe.retention.policyName | quote }}
+              {{- end }}
         {{- else -}}
           {{ " {}" }}
         {{- end }}


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes: https://github.com/camunda/camunda-platform-helm/issues/2249

### What's in this PR?

Add Zeebe OpenSearch retention to the app config file.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
