### PR TITLE
docs: update of outdated url in the local kubernetes  section

### DIFF
--- a/charts/camunda-platform-8.3/README.md
+++ b/charts/camunda-platform-8.3/README.md
@@ -161,7 +161,7 @@ We recommend using Helm on KIND for local environments, as the Helm configuratio
 and much closer to production systems.
 
 For more details, follow the Camunda 8
-[local Kubernetes cluster guide](https://docs.camunda.io/docs/self-managed/setup/guides/local-kubernetes-cluster/).
+[local Kubernetes cluster guide](https://docs.camunda.io/docs/self-managed/setup/deploy/local/local-kubernetes-cluster/).
 
 ### OpenShift
 

--- a/charts/camunda-platform-8.4/README.md
+++ b/charts/camunda-platform-8.4/README.md
@@ -136,7 +136,7 @@ We recommend using Helm on KIND for local environments, as the Helm configuratio
 and much closer to production systems.
 
 For more details, follow the Camunda 8
-[local Kubernetes cluster guide](https://docs.camunda.io/docs/self-managed/setup/guides/local-kubernetes-cluster/).
+[local Kubernetes cluster guide](https://docs.camunda.io/docs/self-managed/setup/deploy/local/local-kubernetes-cluster/).
 
 ### OpenShift
 

--- a/charts/camunda-platform-alpha/README.md
+++ b/charts/camunda-platform-alpha/README.md
@@ -137,7 +137,7 @@ We recommend using Helm on KIND for local environments, as the Helm configuratio
 and much closer to production systems.
 
 For more details, follow the Camunda 8
-[local Kubernetes cluster guide](https://docs.camunda.io/docs/self-managed/setup/guides/local-kubernetes-cluster/).
+[local Kubernetes cluster guide](https://docs.camunda.io/docs/self-managed/setup/deploy/local/local-kubernetes-cluster/).
 
 ### OpenShift
 

--- a/charts/camunda-platform-latest/README.md
+++ b/charts/camunda-platform-latest/README.md
@@ -137,7 +137,7 @@ We recommend using Helm on KIND for local environments, as the Helm configuratio
 and much closer to production systems.
 
 For more details, follow the Camunda 8
-[local Kubernetes cluster guide](https://docs.camunda.io/docs/self-managed/setup/guides/local-kubernetes-cluster/).
+[local Kubernetes cluster guide](https://docs.camunda.io/docs/self-managed/setup/deploy/local/local-kubernetes-cluster/).
 
 ### OpenShift
 


### PR DESCRIPTION
### What's in this PR?

While browsing through the readme, I notice that the following URL 
`https://docs.camunda.io/docs/self-managed/setup/guides/local-kubernetes-cluster/` 
does not exits anymore I updated it to the current one 
`https://docs.camunda.io/docs/self-managed/setup/deploy/local/local-kubernetes-cluster/`

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
