### PR TITLE
fix: correct ingress nginx annotation to activate proxy buffering by default

### DIFF
--- a/charts/camunda-platform-8.2/test/unit/connectors/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-8.2/test/unit/connectors/golden/ingress-all-enabled.golden.yaml
@@ -14,6 +14,8 @@ metadata:
     app.kubernetes.io/component: connectors
   annotations: 
     ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.2/test/unit/connectors/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-8.2/test/unit/connectors/golden/ingress.golden.yaml
@@ -14,6 +14,8 @@ metadata:
     app.kubernetes.io/component: connectors
   annotations: 
     ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.2/test/unit/identity/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-8.2/test/unit/identity/golden/ingress-all-enabled.golden.yaml
@@ -14,6 +14,8 @@ metadata:
     app.kubernetes.io/component: identity
   annotations: 
     ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.2/test/unit/identity/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-8.2/test/unit/identity/golden/ingress.golden.yaml
@@ -14,6 +14,8 @@ metadata:
     app.kubernetes.io/component: identity
   annotations: 
     ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.2/test/unit/operate/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-8.2/test/unit/operate/golden/ingress-all-enabled.golden.yaml
@@ -14,6 +14,8 @@ metadata:
     app.kubernetes.io/component: operate
   annotations: 
     ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.2/test/unit/operate/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-8.2/test/unit/operate/golden/ingress.golden.yaml
@@ -14,6 +14,8 @@ metadata:
     app.kubernetes.io/component: operate
   annotations: 
     ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.2/test/unit/optimize/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-8.2/test/unit/optimize/golden/ingress-all-enabled.golden.yaml
@@ -14,6 +14,8 @@ metadata:
     app.kubernetes.io/component: optimize
   annotations: 
     ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.2/test/unit/optimize/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-8.2/test/unit/optimize/golden/ingress.golden.yaml
@@ -14,6 +14,8 @@ metadata:
     app.kubernetes.io/component: optimize
   annotations: 
     ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.2/test/unit/tasklist/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-8.2/test/unit/tasklist/golden/ingress-all-enabled.golden.yaml
@@ -14,6 +14,8 @@ metadata:
     app.kubernetes.io/component: tasklist
   annotations: 
     ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.2/test/unit/tasklist/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-8.2/test/unit/tasklist/golden/ingress.golden.yaml
@@ -14,6 +14,8 @@ metadata:
     app.kubernetes.io/component: tasklist
   annotations: 
     ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.2/test/unit/web-modeler/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-8.2/test/unit/web-modeler/golden/ingress-all-enabled.golden.yaml
@@ -14,6 +14,8 @@ metadata:
     app.kubernetes.io/component: web-modeler
   annotations:
     ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.2/test/unit/web-modeler/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-8.2/test/unit/web-modeler/golden/ingress.golden.yaml
@@ -14,6 +14,8 @@ metadata:
     app.kubernetes.io/component: web-modeler
   annotations:
     ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.2/values.yaml
+++ b/charts/camunda-platform-8.2/values.yaml
@@ -61,8 +61,10 @@ global:
     className: nginx
     # Ingress.annotations defines the ingress related annotations, consumed mostly by the ingress controller
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
     # Ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     # If not specified the rules applies to all inbound http traffic, if specified the rule applies to that host.
     host: ""
@@ -617,9 +619,9 @@ zeebe-gateway:
     className: nginx
     # Ingress.annotations defines the ingress related annotations, consumed mostly by the ingress controller
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/backend-protocol: 'GRPC'
     # Ingress.path defines the path which is associated with the operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     # Ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
@@ -725,8 +727,10 @@ operate:
     className: nginx
     # Ingress.annotations defines the ingress related annotations, consumed mostly by the ingress controller
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
     # Ingress.path defines the path which is associated with the Operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     # Ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
@@ -976,8 +980,10 @@ tasklist:
     className: nginx
     # Ingress.annotations defines the ingress related annotations, consumed mostly by the ingress controller
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
     # Ingress.path defines the path which is associated with the operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     # Ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
@@ -1154,8 +1160,10 @@ optimize:
     className: nginx
     # Ingress.annotations defines the ingress related annotations, consumed mostly by the ingress controller
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
     # Ingress.path defines the path which is associated with the operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     # Ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
@@ -1365,8 +1373,10 @@ identity:
     className: nginx
     # Ingress.annotations defines the ingress related annotations, consumed mostly by the ingress controller
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
     # Ingress.path defines the path which is associated with the operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     # Ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
@@ -1929,8 +1939,10 @@ webModeler:
     className: nginx
     # Ingress.annotations defines the ingress related annotations, consumed mostly by the ingress controller
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
     # Ingress.webapp configuration of the webapp ingress
     webapp:
       # Ingress.webapp.host defines the host of the ingress rule, see https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules; this is the host name on which the Web Modeler web application will be available
@@ -2141,8 +2153,10 @@ connectors:
     className: nginx
     # Ingress.annotations defines the ingress related annotations, consumed mostly by the ingress controller
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
     # Ingress.path defines the path which is associated with the Connectors service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     # Ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
@@ -2375,8 +2389,10 @@ console:
     className: nginx
     # Ingress.annotations defines the ingress related annotations, consumed mostly by the ingress controller
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
     # Ingress.path defines the path which is associated with the Console service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     # Ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules

--- a/charts/camunda-platform-8.3/test/unit/connectors/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-8.3/test/unit/connectors/golden/ingress-all-enabled.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.3/test/unit/connectors/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-8.3/test/unit/connectors/golden/ingress.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.3/test/unit/identity/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-8.3/test/unit/identity/golden/ingress-all-enabled.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.3/test/unit/identity/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-8.3/test/unit/identity/golden/ingress.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.3/test/unit/operate/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-8.3/test/unit/operate/golden/ingress-all-enabled.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.3/test/unit/operate/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-8.3/test/unit/operate/golden/ingress.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.3/test/unit/optimize/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-8.3/test/unit/optimize/golden/ingress-all-enabled.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.3/test/unit/optimize/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-8.3/test/unit/optimize/golden/ingress.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.3/test/unit/tasklist/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-8.3/test/unit/tasklist/golden/ingress-all-enabled.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.3/test/unit/tasklist/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-8.3/test/unit/tasklist/golden/ingress.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.3/test/unit/web-modeler/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-8.3/test/unit/web-modeler/golden/ingress-all-enabled.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.3/test/unit/web-modeler/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-8.3/test/unit/web-modeler/golden/ingress.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.3/values.yaml
+++ b/charts/camunda-platform-8.3/values.yaml
@@ -67,9 +67,10 @@ global:
     className: nginx
     ## @param global.ingress.annotations [object] defines the ingress related annotations, consumed mostly by the ingress controller
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     # Ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     ## @param global.ingress.host If not specified the rules applies to all inbound http traffic, if specified the rule applies to that host.
     host: ""
@@ -715,10 +716,10 @@ zeebe-gateway:
     ## @skip zeebe-gateway.ingress.annotations.nginx.ingress.kubernetes.io/backend-protocol
     ## @skip zeebe-gateway.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/backend-protocol: 'GRPC'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
     ## @param zeebe-gateway.ingress.path defines the path which is associated with the operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     ## @param zeebe-gateway.ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
@@ -834,9 +835,10 @@ operate:
     ## @skip operate.ingress.annotations.nginx.ingress.kubernetes.io/ssl-redirect
     ## @skip operate.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     ## @param operate.ingress.path defines the path which is associated with the Operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     ## @param operate.ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
@@ -1132,9 +1134,10 @@ tasklist:
     ## @skip tasklist.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
 
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     ## @param tasklist.ingress.path defines the path which is associated with the operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     ## @param tasklist.ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
@@ -1339,9 +1342,10 @@ optimize:
     ## @skip optimize.ingress.annotations.nginx.ingress.kubernetes.io/ssl-redirect
     ## @skip optimize.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     ## @param optimize.ingress.path defines the path which is associated with the operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     ## @param optimize.ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
@@ -1568,9 +1572,10 @@ identity:
     ## @skip identity.ingress.annotations.nginx.ingress.kubernetes.io/ssl-redirect
     ## @skip identity.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     ## @param identity.ingress.path defines the path which is associated with the operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     ## @param identity.ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
@@ -1889,7 +1894,8 @@ identity:
       ## @param identity.keycloak.ingress.annotations [object] configures annotations to be applied to the ingress record.
       annotations:
       ## @skip identity.keycloak.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
-        nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+        nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+        nginx.ingress.kubernetes.io/proxy-buffering: 'on'
 
     ## @extra identity.keycloak.service configuration, to configure the service which is deployed along with keycloak
     service:
@@ -2432,9 +2438,10 @@ webModeler:
     ## @skip webModeler.ingress.annotations.nginx.ingress.kubernetes.io/ssl-redirect
     ## @skip webModeler.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     ## @extra webModeler.ingress.webapp configuration of the webapp ingress
     webapp:
       ## @param webModeler.ingress.webapp.host defines the host of the ingress rule, see https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules; this is the host name on which the Web Modeler web application will be available
@@ -2708,9 +2715,10 @@ connectors:
     ## @skip connectors.ingress.annotations.nginx.ingress.kubernetes.io/ssl-redirect
     ## @skip connectors.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     ## @param connectors.ingress.path defines the path which is associated with the Connectors service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     ## @param connectors.ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
@@ -2963,9 +2971,10 @@ console:
     ## @skip console.ingress.annotations.nginx.ingress.kubernetes.io/ssl-redirect
     ## @skip console.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     ## @skip console.ingress.path defines the path which is associated with the Console service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     ## @skip console.ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules

--- a/charts/camunda-platform-8.4/test/integration/scenarios/chart-full-setup/values-integration-test-ingress.yaml
+++ b/charts/camunda-platform-8.4/test/integration/scenarios/chart-full-setup/values-integration-test-ingress.yaml
@@ -88,12 +88,13 @@ webModeler:
 # database used by Web Modeler
 postgresql:
   enabled: true
-  auth:
-    existingSecret: "integration-test-credentials"
-    # Should be set to have a different name of Identity Keycloak PostgreSQL.
-    secretKeys:
-      adminPasswordKey: "webmodeler-postgresql-admin-password"
-      userPasswordKey: "webmodeler-postgresql-user-password"
+  # TODO: Uncomment after Camunda chart 9.4.0 release.
+  # auth:
+  #   existingSecret: "integration-test-credentials"
+  #   # Should be set to have a different name of Identity Keycloak PostgreSQL.
+  #   secretKeys:
+  #     adminPasswordKey: "webmodeler-postgresql-admin-password"
+  #     userPasswordKey: "webmodeler-postgresql-user-password"
 
 zeebe-gateway:
   ingress:

--- a/charts/camunda-platform-8.4/test/unit/connectors/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-8.4/test/unit/connectors/golden/ingress-all-enabled.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.4/test/unit/connectors/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-8.4/test/unit/connectors/golden/ingress.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.4/test/unit/console/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-8.4/test/unit/console/golden/ingress-all-enabled.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.4/test/unit/console/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-8.4/test/unit/console/golden/ingress.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.4/test/unit/identity/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-8.4/test/unit/identity/golden/ingress-all-enabled.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.4/test/unit/identity/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-8.4/test/unit/identity/golden/ingress.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.4/test/unit/operate/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-8.4/test/unit/operate/golden/ingress-all-enabled.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.4/test/unit/operate/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-8.4/test/unit/operate/golden/ingress.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.4/test/unit/optimize/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-8.4/test/unit/optimize/golden/ingress-all-enabled.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.4/test/unit/optimize/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-8.4/test/unit/optimize/golden/ingress.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.4/test/unit/tasklist/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-8.4/test/unit/tasklist/golden/ingress-all-enabled.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.4/test/unit/tasklist/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-8.4/test/unit/tasklist/golden/ingress.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.4/test/unit/web-modeler/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-8.4/test/unit/web-modeler/golden/ingress-all-enabled.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.4/test/unit/web-modeler/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-8.4/test/unit/web-modeler/golden/ingress.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-8.4/values.yaml
+++ b/charts/camunda-platform-8.4/values.yaml
@@ -83,9 +83,10 @@ global:
     className: nginx
     ## @param global.ingress.annotations [object] defines the ingress related annotations, consumed mostly by the ingress controller
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     # Ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     ## @param global.ingress.host If not specified the rules applies to all inbound http traffic, if specified the rule applies to that host.
     host: ""
@@ -486,9 +487,10 @@ console:
     ## @skip console.ingress.annotations.nginx.ingress.kubernetes.io/ssl-redirect
     ## @skip console.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     ## @param console.ingress.path defines the path which is associated with the Console service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     ## @param console.ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
@@ -1038,10 +1040,10 @@ zeebe-gateway:
     ## @skip zeebe-gateway.ingress.annotations.nginx.ingress.kubernetes.io/backend-protocol
     ## @skip zeebe-gateway.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/backend-protocol: 'GRPC'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
     ## @param zeebe-gateway.ingress.path defines the path which is associated with the operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     ## @param zeebe-gateway.ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
@@ -1159,9 +1161,10 @@ operate:
     ## @skip operate.ingress.annotations.nginx.ingress.kubernetes.io/ssl-redirect
     ## @skip operate.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     ## @param operate.ingress.path defines the path which is associated with the Operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     ## @param operate.ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
@@ -1466,9 +1469,10 @@ tasklist:
     ## @skip tasklist.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
 
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     ## @param tasklist.ingress.path defines the path which is associated with the operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     ## @param tasklist.ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
@@ -1680,9 +1684,10 @@ optimize:
     ## @skip optimize.ingress.annotations.nginx.ingress.kubernetes.io/ssl-redirect
     ## @skip optimize.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     ## @param optimize.ingress.path defines the path which is associated with the operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     ## @param optimize.ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
@@ -1917,9 +1922,10 @@ identity:
     ## @skip identity.ingress.annotations.nginx.ingress.kubernetes.io/ssl-redirect
     ## @skip identity.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     ## @param identity.ingress.path defines the path which is associated with the operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     ## @param identity.ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
@@ -2240,7 +2246,8 @@ identity:
       ## @param identity.keycloak.ingress.annotations [object] configures annotations to be applied to the ingress record.
       annotations:
       ## @skip identity.keycloak.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
-        nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+        nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+        nginx.ingress.kubernetes.io/proxy-buffering: 'on'
 
     ## @extra identity.keycloak.service configuration, to configure the service which is deployed along with keycloak
     service:
@@ -2797,9 +2804,10 @@ webModeler:
     ## @skip webModeler.ingress.annotations.nginx.ingress.kubernetes.io/ssl-redirect
     ## @skip webModeler.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     ## @extra webModeler.ingress.webapp configuration of the webapp ingress
     webapp:
       ## @param webModeler.ingress.webapp.host defines the host of the ingress rule, see https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules; this is the host name on which the Web Modeler web application will be available
@@ -3082,9 +3090,10 @@ connectors:
     ## @skip connectors.ingress.annotations.nginx.ingress.kubernetes.io/ssl-redirect
     ## @skip connectors.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     ## @param connectors.ingress.path defines the path which is associated with the Connectors service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     ## @param connectors.ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules

--- a/charts/camunda-platform-alpha/test/unit/connectors/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/connectors/golden/ingress-all-enabled.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-alpha/test/unit/connectors/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/connectors/golden/ingress.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-alpha/test/unit/console/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/console/golden/ingress-all-enabled.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-alpha/test/unit/console/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/console/golden/ingress.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-alpha/test/unit/identity/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/identity/golden/ingress-all-enabled.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-alpha/test/unit/identity/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/identity/golden/ingress.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-alpha/test/unit/operate/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/operate/golden/ingress-all-enabled.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-alpha/test/unit/operate/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/operate/golden/ingress.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-alpha/test/unit/optimize/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/optimize/golden/ingress-all-enabled.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-alpha/test/unit/optimize/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/optimize/golden/ingress.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-alpha/test/unit/tasklist/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/tasklist/golden/ingress-all-enabled.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-alpha/test/unit/tasklist/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/tasklist/golden/ingress.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-alpha/test/unit/web-modeler/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/web-modeler/golden/ingress-all-enabled.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-alpha/test/unit/web-modeler/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/web-modeler/golden/ingress.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-alpha/test/unit/zeebe-gateway/golden/ingress-rest-all-enabled.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/zeebe-gateway/golden/ingress-rest-all-enabled.golden.yaml
@@ -16,6 +16,7 @@ metadata:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/backend-protocol: HTTP
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-alpha/test/unit/zeebe-gateway/golden/ingress-rest.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/zeebe-gateway/golden/ingress-rest.golden.yaml
@@ -16,6 +16,7 @@ metadata:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/backend-protocol: HTTP
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-alpha/values.yaml
+++ b/charts/camunda-platform-alpha/values.yaml
@@ -107,9 +107,10 @@ global:
     className: nginx
     ## @param global.ingress.annotations [object] defines the ingress related annotations, consumed mostly by the ingress controller
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     # Ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     ## @param global.ingress.host If not specified the rules applies to all inbound http traffic, if specified the rule applies to that host.
     host: ""
@@ -557,9 +558,10 @@ console:
     ## @skip console.ingress.annotations.nginx.ingress.kubernetes.io/ssl-redirect
     ## @skip console.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     ## @param console.ingress.path defines the path which is associated with the Console service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     ## @param console.ingress.pathType can be used to define the Ingress path type. https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
@@ -1161,10 +1163,10 @@ zeebeGateway:
       ## @skip zeebeGateway.ingress.grpc.annotations.nginx.ingress.kubernetes.io/backend-protocol
       ## @skip zeebeGateway.ingress.grpc.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
       annotations:
-        ingress.kubernetes.io/rewrite-target: "/"
-        nginx.ingress.kubernetes.io/ssl-redirect: "false"
-        nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
-        nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+        ingress.kubernetes.io/rewrite-target: '/'
+        nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+        nginx.ingress.kubernetes.io/backend-protocol: 'GRPC'
+        nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
       ## @param zeebeGateway.ingress.grpc.path defines the path which is associated with the Zeebe gateway's gRPC service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
       path: /
       ## @param zeebeGateway.ingress.grpc.pathType can be used to define the Ingress path type. https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
@@ -1189,10 +1191,11 @@ zeebeGateway:
       ## @skip zeebeGateway.ingress.rest.annotations.nginx.ingress.kubernetes.io/backend-protocol
       ## @skip zeebeGateway.ingress.rest.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
       annotations:
-        ingress.kubernetes.io/rewrite-target: "/"
-        nginx.ingress.kubernetes.io/ssl-redirect: "false"
+        ingress.kubernetes.io/rewrite-target: '/'
+        nginx.ingress.kubernetes.io/ssl-redirect: 'false'
         nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
-        nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+        nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+        nginx.ingress.kubernetes.io/proxy-buffering: 'on'
       ## @param zeebeGateway.ingress.rest.path defines the path which is associated with the Zeebe gateway's REST service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
       path: /
       ## @param zeebeGateway.ingress.rest.pathType can be used to define the Ingress path type. https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
@@ -1352,9 +1355,10 @@ operate:
     ## @skip operate.ingress.annotations.nginx.ingress.kubernetes.io/ssl-redirect
     ## @skip operate.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     ## @param operate.ingress.path defines the path which is associated with the Operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     ## @param operate.ingress.pathType can be used to define the Ingress path type. https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
@@ -1695,9 +1699,10 @@ tasklist:
     ## @skip tasklist.ingress.annotations.nginx.ingress.kubernetes.io/ssl-redirect
     ## @skip tasklist.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     ## @param tasklist.ingress.path defines the path which is associated with the operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     ## @param tasklist.ingress.pathType can be used to define the Ingress path type. https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
@@ -1951,9 +1956,10 @@ optimize:
     ## @skip optimize.ingress.annotations.nginx.ingress.kubernetes.io/ssl-redirect
     ## @skip optimize.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     ## @param optimize.ingress.path defines the path which is associated with the operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     ## @param optimize.ingress.pathType can be used to define the Ingress path type. https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
@@ -2154,9 +2160,10 @@ executionIdentity:
     ## @skip executionIdentity.ingress.annotations.nginx.ingress.kubernetes.io/ssl-redirect
     ## @skip executionIdentity.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     ## @param executionIdentity.ingress.path defines the path which is associated with the executionIdentity service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     ## @param executionIdentity.ingress.pathType can be used to define the Ingress path type. https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
@@ -2442,9 +2449,10 @@ identity:
     ## @skip identity.ingress.annotations.nginx.ingress.kubernetes.io/ssl-redirect
     ## @skip identity.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     ## @param identity.ingress.path defines the path which is associated with the operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     ## @param identity.ingress.pathType can be used to define the Ingress path type. https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
@@ -2694,7 +2702,8 @@ identityKeycloak:
     ## @param identityKeycloak.ingress.annotations [object] configures annotations to be applied to the ingress record.
     annotations:
     ## @skip identityKeycloak.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
 
   ## @extra identityKeycloak.service configuration, to configure the service which is deployed along with keycloak
   service:
@@ -3293,9 +3302,10 @@ webModeler:
     ## @skip webModeler.ingress.annotations.nginx.ingress.kubernetes.io/ssl-redirect
     ## @skip webModeler.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     ## @extra webModeler.ingress.webapp configuration of the webapp ingress
     webapp:
       ## @param webModeler.ingress.webapp.host defines the host of the ingress rule, see https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules; this is the host name on which the WebModeler web application will be available
@@ -3581,9 +3591,10 @@ connectors:
     ## @skip connectors.ingress.annotations.nginx.ingress.kubernetes.io/ssl-redirect
     ## @skip connectors.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     ## @param connectors.ingress.path defines the path which is associated with the Connectors service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     ## @param connectors.ingress.pathType can be used to define the Ingress path type. https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types

--- a/charts/camunda-platform-latest/test/unit/connectors/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-latest/test/unit/connectors/golden/ingress-all-enabled.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-latest/test/unit/connectors/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-latest/test/unit/connectors/golden/ingress.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-latest/test/unit/console/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-latest/test/unit/console/golden/ingress-all-enabled.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-latest/test/unit/console/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-latest/test/unit/console/golden/ingress.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-latest/test/unit/identity/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-latest/test/unit/identity/golden/ingress-all-enabled.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-latest/test/unit/identity/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-latest/test/unit/identity/golden/ingress.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-latest/test/unit/operate/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-latest/test/unit/operate/golden/ingress-all-enabled.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-latest/test/unit/operate/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-latest/test/unit/operate/golden/ingress.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-latest/test/unit/optimize/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-latest/test/unit/optimize/golden/ingress-all-enabled.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-latest/test/unit/optimize/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-latest/test/unit/optimize/golden/ingress.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-latest/test/unit/tasklist/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-latest/test/unit/tasklist/golden/ingress-all-enabled.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-latest/test/unit/tasklist/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-latest/test/unit/tasklist/golden/ingress.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-latest/test/unit/web-modeler/golden/ingress-all-enabled.golden.yaml
+++ b/charts/camunda-platform-latest/test/unit/web-modeler/golden/ingress-all-enabled.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-latest/test/unit/web-modeler/golden/ingress.golden.yaml
+++ b/charts/camunda-platform-latest/test/unit/web-modeler/golden/ingress.golden.yaml
@@ -15,6 +15,7 @@ metadata:
   annotations:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-latest/test/unit/zeebe-gateway/golden/ingress-rest-all-enabled.golden.yaml
+++ b/charts/camunda-platform-latest/test/unit/zeebe-gateway/golden/ingress-rest-all-enabled.golden.yaml
@@ -16,6 +16,7 @@ metadata:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/backend-protocol: HTTP
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-latest/test/unit/zeebe-gateway/golden/ingress-rest.golden.yaml
+++ b/charts/camunda-platform-latest/test/unit/zeebe-gateway/golden/ingress-rest.golden.yaml
@@ -16,6 +16,7 @@ metadata:
     ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/backend-protocol: HTTP
     nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   ingressClassName: nginx

--- a/charts/camunda-platform-latest/values.yaml
+++ b/charts/camunda-platform-latest/values.yaml
@@ -88,9 +88,10 @@ global:
     className: nginx
     ## @param global.ingress.annotations [object] defines the ingress related annotations, consumed mostly by the ingress controller
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     # Ingress.host can be used to define the host of the ingress rule. https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     ## @param global.ingress.host If not specified the rules applies to all inbound http traffic, if specified the rule applies to that host.
     host: ""
@@ -545,9 +546,10 @@ console:
     ## @skip console.ingress.annotations.nginx.ingress.kubernetes.io/ssl-redirect
     ## @skip console.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     ## @param console.ingress.path defines the path which is associated with the Console service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     ## @param console.ingress.pathType can be used to define the Ingress path type. https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
@@ -1149,10 +1151,10 @@ zeebeGateway:
       ## @skip zeebeGateway.ingress.grpc.annotations.nginx.ingress.kubernetes.io/backend-protocol
       ## @skip zeebeGateway.ingress.grpc.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
       annotations:
-        ingress.kubernetes.io/rewrite-target: "/"
-        nginx.ingress.kubernetes.io/ssl-redirect: "false"
-        nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
-        nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+        ingress.kubernetes.io/rewrite-target: '/'
+        nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+        nginx.ingress.kubernetes.io/backend-protocol: 'GRPC'
+        nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
       ## @param zeebeGateway.ingress.grpc.path defines the path which is associated with the Zeebe gateway's gRPC service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
       path: /
       ## @param zeebeGateway.ingress.grpc.pathType can be used to define the Ingress path type. https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
@@ -1177,10 +1179,11 @@ zeebeGateway:
       ## @skip zeebeGateway.ingress.rest.annotations.nginx.ingress.kubernetes.io/backend-protocol
       ## @skip zeebeGateway.ingress.rest.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
       annotations:
-        ingress.kubernetes.io/rewrite-target: "/"
-        nginx.ingress.kubernetes.io/ssl-redirect: "false"
+        ingress.kubernetes.io/rewrite-target: '/'
+        nginx.ingress.kubernetes.io/ssl-redirect: 'false'
         nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
-        nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+        nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+        nginx.ingress.kubernetes.io/proxy-buffering: 'on'
       ## @param zeebeGateway.ingress.rest.path defines the path which is associated with the Zeebe gateway's REST service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
       path: /
       ## @param zeebeGateway.ingress.rest.pathType can be used to define the Ingress path type. https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
@@ -1334,9 +1337,10 @@ operate:
     ## @skip operate.ingress.annotations.nginx.ingress.kubernetes.io/ssl-redirect
     ## @skip operate.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     ## @param operate.ingress.path defines the path which is associated with the Operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     ## @param operate.ingress.pathType can be used to define the Ingress path type. https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
@@ -1671,9 +1675,10 @@ tasklist:
     ## @skip tasklist.ingress.annotations.nginx.ingress.kubernetes.io/ssl-redirect
     ## @skip tasklist.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     ## @param tasklist.ingress.path defines the path which is associated with the operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     ## @param tasklist.ingress.pathType can be used to define the Ingress path type. https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
@@ -1927,9 +1932,10 @@ optimize:
     ## @skip optimize.ingress.annotations.nginx.ingress.kubernetes.io/ssl-redirect
     ## @skip optimize.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     ## @param optimize.ingress.path defines the path which is associated with the operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     ## @param optimize.ingress.pathType can be used to define the Ingress path type. https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
@@ -2185,9 +2191,10 @@ identity:
     ## @skip identity.ingress.annotations.nginx.ingress.kubernetes.io/ssl-redirect
     ## @skip identity.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     ## @param identity.ingress.path defines the path which is associated with the operate service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     ## @param identity.ingress.pathType can be used to define the Ingress path type. https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
@@ -2441,7 +2448,8 @@ identityKeycloak:
     ## @param identityKeycloak.ingress.annotations [object] configures annotations to be applied to the ingress record.
     annotations:
     ## @skip identityKeycloak.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
 
   ## @extra identityKeycloak.service configuration, to configure the service which is deployed along with keycloak
   service:
@@ -3060,9 +3068,10 @@ webModeler:
     ## @skip webModeler.ingress.annotations.nginx.ingress.kubernetes.io/ssl-redirect
     ## @skip webModeler.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     ## @extra webModeler.ingress.webapp configuration of the webapp ingress
     webapp:
       ## @param webModeler.ingress.webapp.host defines the host of the ingress rule, see https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules; this is the host name on which the WebModeler web application will be available
@@ -3356,9 +3365,10 @@ connectors:
     ## @skip connectors.ingress.annotations.nginx.ingress.kubernetes.io/ssl-redirect
     ## @skip connectors.ingress.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
-      nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+      ingress.kubernetes.io/rewrite-target: '/'
+      nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+      nginx.ingress.kubernetes.io/proxy-buffer-size: '128k'
+      nginx.ingress.kubernetes.io/proxy-buffering: 'on'
     ## @param connectors.ingress.path defines the path which is associated with the Connectors service and port https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
     path: /
     ## @param connectors.ingress.pathType can be used to define the Ingress path type. https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types

--- a/test/integration/scenarios/chart-full-setup/Taskfile.yaml
+++ b/test/integration/scenarios/chart-full-setup/Taskfile.yaml
@@ -66,6 +66,12 @@ tasks:
       # Create the local chart package to install.
       pwd
       helm package {{ .TEST_CHART_DIR }}/
+    - |
+      test -f {{ .TEST_VALUES_BASE_DIR }}/pre-install/* || {
+        exit 0
+      }
+      export TEST_NAMESPACE={{ .TEST_NAMESPACE }}
+      bash -x {{ .TEST_VALUES_BASE_DIR }}/pre-install/*.sh
 
   setup.exec:
     deps: [init.seed]

--- a/test/integration/scenarios/lib/chart-upgrade-taskfile.yaml
+++ b/test/integration/scenarios/lib/chart-upgrade-taskfile.yaml
@@ -8,7 +8,13 @@ vars:
 tasks:
   pre:
     cmds:
-    - echo "No pre setup task for this test."
+    - |
+      test -f {{ .TEST_VALUES_BASE_DIR }}/pre-upgrade/* || {
+        echo "No pre setup task for this test."
+        exit 0
+      }
+      export TEST_NAMESPACE={{ .TEST_NAMESPACE }}
+      bash -x {{ .TEST_VALUES_BASE_DIR }}/pre-upgrade/*.sh
 
   # https://docs.camunda.io/docs/self-managed/setup/upgrade/
   exec:


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes: https://github.com/camunda/camunda-platform-helm/issues/2303

### What's in this PR?

Expiciltiy enables ingress nginx proxy buffering by default with default proxy buffer size.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
