### PR TITLE
ci: add Set Vars step to renovate config

### DIFF
--- a/.github/workflows/renovate-post-upgrade.yaml
+++ b/.github/workflows/renovate-post-upgrade.yaml
@@ -55,6 +55,9 @@ jobs:
       #
       # Post Upgrade Tasks.
       #
+      - name: Set vars
+        run: |
+          echo "CHANGED_CHARTS=$(ct list-changed | tr '\n' ' ')" | tee -a $GITHUB_ENV
       - name: Update golden files
         run: |
           chartPath="${CHANGED_CHARTS}" \


### PR DESCRIPTION
### Which problem does the PR fix?
Renovate doesn't update the README. By setting this var it will define `${CHANGED_CHARTS}`
<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
