### PR TITLE
fix: added contextpath to 8.4 identity

### DIFF
--- a/charts/camunda-platform-8.4/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform-8.4/charts/identity/templates/deployment.yaml
@@ -50,7 +50,6 @@ spec:
               valueFrom:
                 secretKeyRef:
                   {{- /*
-                      REMOVE
                       Helper: https://github.com/bitnami/charts/blob/master/bitnami/common/templates/_secrets.tpl
                       Usage in keycloak secrets https://github.com/bitnami/charts/blob/master/bitnami/keycloak/templates/secrets.yaml
                       and in statefulset https://github.com/bitnami/charts/blob/master/bitnami/keycloak/templates/statefulset.yaml

--- a/charts/camunda-platform-8.4/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform-8.4/charts/identity/templates/deployment.yaml
@@ -50,6 +50,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   {{- /*
+                      REMOVE
                       Helper: https://github.com/bitnami/charts/blob/master/bitnami/common/templates/_secrets.tpl
                       Usage in keycloak secrets https://github.com/bitnami/charts/blob/master/bitnami/keycloak/templates/secrets.yaml
                       and in statefulset https://github.com/bitnami/charts/blob/master/bitnami/keycloak/templates/statefulset.yaml

--- a/charts/camunda-platform-8.4/test/integration/scenarios/chart-full-setup/values-integration-test-ingress.yaml
+++ b/charts/camunda-platform-8.4/test/integration/scenarios/chart-full-setup/values-integration-test-ingress.yaml
@@ -48,6 +48,7 @@ global:
           name: "integration-test-credentials"
 
 identity:
+  contextPath: "/identity"
   keycloak:
     postgresql:
       auth:

--- a/charts/camunda-platform-8.4/test/integration/testsuites/vars/files/testsuite-core.yaml
+++ b/charts/camunda-platform-8.4/test/integration/testsuites/vars/files/testsuite-core.yaml
@@ -71,8 +71,8 @@ testcases:
     - skiptestingress ShouldBeFalse
     type: http
     range:
-    - component: Console
-      url: "{{ .coreVars.baseURLs.console }}"
+    # - component: Console
+    #   url: "{{ .coreVars.baseURLs.console }}"
     - component: Keycloak
       url: "{{ .coreVars.baseURLs.keycloak }}"
     - component: Identity
@@ -124,10 +124,10 @@ testcases:
   - name: "{{ .value.component }}"
     type: http
     range:
-    - component: Console
-      url: "{{ .coreVars.baseURLs.console }}/api/clusters"
-      method: GET
-      body: ''
+    # - component: Console
+    #   url: "{{ .coreVars.baseURLs.console }}/api/clusters"
+    #   method: GET
+    #   body: ''
     - component: Identity
       url: "{{ .coreVars.baseURLs.identity }}/api/users"
       method: GET


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
I added a contextPath to 8.4 identity
and also removed console integration tests
related slack thread: https://camunda.slack.com/archives/CRQAL5A1M/p1725614202107509
### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
