### PR TITLE
fix: add bot to ignoredAuthors for renovate to automerge again

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,6 +5,8 @@
   "labels": ["dependencies"],
   "dependencyDashboard": true,
   "separateMinorPatch": true,
+  // ignore the distro-ci[bot] which adds commits for readme updates
+  "gitIgnoredAuthors": ["122795778+distro-ci[bot]@users.noreply.github.com"],
   "minor": {
     "enabled": true
   },


### PR DESCRIPTION
### Which problem does the PR fix?

Renovate no longer automerges due to the recent PR which adds commits which auto-commits readme updates https://github.com/camunda/camunda-platform-helm/pull/2108

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

This commit introduces [gitIgnoredAuthors](https://docs.renovatebot.com/configuration-options/#gitignoredauthors) so that renovate will not flag PRs as non-auto-mergeable.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
