### PR TITLE
chore(web-modeler): automatically add Web Modeler admin role to first user

### DIFF
--- a/charts/camunda-platform-alpha/templates/identity/deployment.yaml
+++ b/charts/camunda-platform-alpha/templates/identity/deployment.yaml
@@ -213,6 +213,8 @@ spec:
             - name: KEYCLOAK_USERS_0_ROLES_4
               value: "Web Modeler"
             - name: KEYCLOAK_USERS_0_ROLES_5
+              value: "Web Modeler Admin"
+            - name: KEYCLOAK_USERS_0_ROLES_6
               value: "Console"
             {{- end }}
             {{- end }}

--- a/charts/camunda-platform-alpha/test/unit/identity/golden/deployment.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/identity/golden/deployment.golden.yaml
@@ -146,6 +146,8 @@ spec:
             - name: KEYCLOAK_USERS_0_ROLES_4
               value: "Web Modeler"
             - name: KEYCLOAK_USERS_0_ROLES_5
+              value: "Web Modeler Admin"
+            - name: KEYCLOAK_USERS_0_ROLES_6
               value: "Console"
           resources:
             limits:


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

Automatically adds the `Web Modeler Admin` role to the first seeded user.

Equivalent of https://github.com/camunda/camunda-platform/pull/856.

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
