### PR TITLE
fix: warning added to NOTES about installationType

### DIFF
--- a/charts/camunda-platform-alpha/templates/camunda/constraints.tpl
+++ b/charts/camunda-platform-alpha/templates/camunda/constraints.tpl
@@ -224,7 +224,7 @@ The following values inside your values.yaml need to be set but were not:
     {{- end }}
   {{- end }}
   {{- if .Values.global.multiregion.installationType }}
-    {{- $installationTypeMessage := "[camunda][warning]\nDEPRECATION NOTICE: Starting from appVersion 8.7, the Camunda Helm chart will no longer support the global.multiregion.installationType option. Please unset this to remove this warning.\n" }}
+    {{- $installationTypeMessage := "[camunda][warning]\nDEPRECATION NOTICE: Starting from appVersion 8.7, the Camunda Helm chart will no longer support the global.multiregion.installationType option. This is replaced with a new procudure for managing multi-region installations documented here:\nhttps://docs.camunda.io/docs/self-managed/operational-guides/multi-region/dual-region-operational-procedure/\nPlease unset this option to remove the warning.\n" }}
     {{ printf "\n%s" $installationTypeMessage }}
   {{- end }}
 {{- end }}

--- a/charts/camunda-platform-alpha/templates/camunda/constraints.tpl
+++ b/charts/camunda-platform-alpha/templates/camunda/constraints.tpl
@@ -223,6 +223,10 @@ The following values inside your values.yaml need to be set but were not:
       {{- end }}
     {{- end }}
   {{- end }}
+  {{- if .Values.global.multiregion.installationType }}
+    {{- $installationTypeMessage := "[camunda][warning]\nDEPRECATION NOTICE: Starting from appVersion 8.7, the Camunda Helm chart will no longer support the global.multiregion.installationType option. Please unset this to remove this warning.\n" }}
+    {{ printf "\n%s" $installationTypeMessage }}
+  {{- end }}
 {{- end }}
 
 


### PR DESCRIPTION
### Which problem does the PR fix?

Related to https://github.com/camunda/camunda-platform-helm/issues/2286

`global.multiregion.installationType` is going away, so if anyone uses this option, they should get a notice that says:


> [camunda][warning]
> DEPRECATION NOTICE: Starting from appVersion 8.7, the Camunda Helm chart will no longer support the global.multiregion.installationType option. This is replaced with a new procudure for managing multi-region installations documented here:
> https://docs.camunda.io/docs/self-managed/operational-guides/multi-region/dual-region-operational-procedure/
> Please unset this option to remove the warning.



<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

if the option is set, print the warning. 

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
