### PR TITLE
chore: use Renovatebot new secrets syntax

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -250,9 +250,7 @@
       "hostType": "docker",
       "matchHost": "https://registry.camunda.cloud",
       "username": "ci-distribution",
-      "encrypted": {
-        "password": "wcFMA/xDdHCJBTolAQ/7BSbgiur4KfMX0vgTM9T8Rt1pTqby5bR/RW6n/Iq5+bNU8pQne1W6zxaFEagkMMMTx/JtdWl88sDlGFqdG80Oik7Wbb7UDYl39Wdvax0DhmfkT1yqXYToyYz0rXpB9BIllAkfCy9ll8SbZqVBa/NoMPo2Fb8Hj/PiT4xG1U+YoWdsyXFLXz+jKEsRIKXC28ApxqJ7TN4iO5FEWrZIB4Bgtkg+x4FOpCTaS6fwui7FRxfFSGWTFkepr6R/lhPTDCHH7u65Mroff4IjUqfJ5dkGY+49QUGW45toaHXdXV9ZaBIMm+v6cNOOw92P+bidMdhIBLurOBqig24Jj02+wb5J9eKPBP1tvXW0vz1jwhOQIqRmV95zt5JCiQ7s/DByQnUsWfsJ3Vz9rbsUPLwspAhK3ayTl0ltrSj+LaejZei6Ny0Qq4LWTW14RjgLnABRhcK9iefCqVmLbRN+NQDcP0IxjHkFdGgxNaGPkb+jTC7CYJj9TKRHBabauXxvNGrggliUKAlOh8VmpQ1ZFoxryMDQK/HEP/qUU/TmzyAuAtSfrUdOlgYVBEQ7xGH1AfC7fhFUFohAcs4OGCKjbPTCM/LwH9o9zx4hEHh1bCjdgv98Ug4UgYpXBJPJ7Jc2Xng9nCUrkEPPX85kXTlT7T96a5p6CqKBkRNPES88Nj1adP7uANjSYgFIB59DO0tlvxUgBGo+NhjSNQl4wigI0Uc6JGysDb3qXH66nlymaZFzR5jrvqXU+iCMTf/yVyOdAcYQqh1wRHOmuuy0/AK/N0m4fFE3ldsmyV61oCUPxj1sjlNYd1Bte5fy"
-      }
+      "password": "{{ secrets.CAMUNDA_DOCKER_REGISTRY }}"
     }
   ]
 }


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes: https://github.com/camunda/camunda-platform-helm/issues/2344

### What's in this PR?

Use Renovatebot's new secrets syntax.
Now, the encrypted secret is saved in the renovatebot cloud service.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
