### PR TITLE
chore: use renovatebot new secrets syntax

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -250,7 +250,7 @@
       "hostType": "docker",
       "matchHost": "https://registry.camunda.cloud",
       "username": "ci-distribution",
-      "password": "{{ secrets.CAMUNDA_DOCKER_REGISTRY }}"
+      "password": "{{ secrets.DISTRO_CAMUNDA_DOCKER_REGISTRY_PASSWORD }}"
     }
   ]
 }


### PR DESCRIPTION
### Which problem does the PR fix?

closes: https://github.com/camunda/camunda-platform-helm/issues/2344

### What's in this PR?

Use Renovatebot's new secrets syntax.
Now, the encrypted secret is saved in the renovatebot cloud service.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
