### PR TITLE
refactor: using bitnami oci chart repository

### DIFF
--- a/charts/camunda-platform-8.2/Chart.yaml
+++ b/charts/camunda-platform-8.2/Chart.yaml
@@ -50,12 +50,12 @@ dependencies:
     version: 7.17.3
     condition: "elasticsearch.enabled"
   - name: postgresql
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     version: 11.x.x
     condition: "postgresql.enabled"
   # Helpers charts.
   - name: common
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     version: 2.x.x
 maintainers:
   - name: Zelldon

--- a/charts/camunda-platform-8.2/charts/identity/Chart.yaml
+++ b/charts/camunda-platform-8.2/charts/identity/Chart.yaml
@@ -6,6 +6,6 @@ type: application
 icon: https://helm.camunda.io/imgs/camunda.svg
 dependencies:
   - name: keycloak
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     version: 12.3.0
     condition: keycloak.enabled

--- a/charts/camunda-platform-8.3/Chart.yaml
+++ b/charts/camunda-platform-8.3/Chart.yaml
@@ -31,16 +31,16 @@ dependencies:
         parent: global.identity.image
   # Dependency charts.
   - name: elasticsearch
-    repository: "oci://registry-1.docker.io/bitnamicharts"
+    repository: oci://registry-1.docker.io/bitnamicharts
     version: 19.13.13
     condition: elasticsearch.enabled
   - name: postgresql
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     version: 11.x.x
     condition: postgresql.enabled
   # Helpers charts.
   - name: common
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     version: 2.x.x
 maintainers:
   - name: Zelldon

--- a/charts/camunda-platform-8.3/charts/identity/Chart.yaml
+++ b/charts/camunda-platform-8.3/charts/identity/Chart.yaml
@@ -6,10 +6,10 @@ type: application
 icon: https://helm.camunda.io/imgs/camunda.svg
 dependencies:
   - name: keycloak
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     version: 16.1.7
     condition: keycloak.enabled
   - name: postgresql
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     version: 12.x.x
     condition: postgresql.enabled

--- a/charts/camunda-platform-8.4/Chart.yaml
+++ b/charts/camunda-platform-8.4/Chart.yaml
@@ -33,16 +33,16 @@ dependencies:
         parent: global.identity.image
   # Dependency charts.
   - name: elasticsearch
-    repository: "oci://registry-1.docker.io/bitnamicharts"
+    repository: oci://registry-1.docker.io/bitnamicharts
     version: 19.19.4
     condition: "elasticsearch.enabled"
   - name: postgresql
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     version: 11.x.x
     condition: "postgresql.enabled"
   # Helpers charts.
   - name: common
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     version: 2.x.x
 maintainers:
   - name: Zelldon

--- a/charts/camunda-platform-8.4/charts/identity/Chart.yaml
+++ b/charts/camunda-platform-8.4/charts/identity/Chart.yaml
@@ -6,10 +6,10 @@ type: application
 icon: https://helm.camunda.io/imgs/camunda.svg
 dependencies:
   - name: keycloak
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     version: 17.3.6
     condition: keycloak.enabled
   - name: postgresql
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     version: 12.x.x
     condition: postgresql.enabled

--- a/charts/camunda-platform-alpha/Chart.yaml
+++ b/charts/camunda-platform-alpha/Chart.yaml
@@ -22,12 +22,12 @@ dependencies:
   # Identity Dependencies.
   - name: keycloak
     alias: identityKeycloak
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     version: 22.2.3
     condition: "identity.keycloak.enabled,identityKeycloak.enabled"
   - name: postgresql
     alias: identityPostgresql
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     version: 15.x.x
     condition: "identity.postgresql.enabled,identityPostgresql.enabled"
   # WebModeler Dependencies.
@@ -38,12 +38,12 @@ dependencies:
     condition: "postgresql.enabled"
   # Shared Dependencies.
   - name: elasticsearch
-    repository: "oci://registry-1.docker.io/bitnamicharts"
+    repository: oci://registry-1.docker.io/bitnamicharts
     version: 21.3.16
     condition: "elasticsearch.enabled"
   # Helpers.
   - name: common
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     version: 2.x.x
 maintainers:
   - name: aabouzaid

--- a/charts/camunda-platform-latest/Chart.yaml
+++ b/charts/camunda-platform-latest/Chart.yaml
@@ -21,12 +21,12 @@ dependencies:
   # Identity Dependencies.
   - name: keycloak
     alias: identityKeycloak
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     version: 19.4.1
     condition: "identity.keycloak.enabled,identityKeycloak.enabled"
   - name: postgresql
     alias: identityPostgresql
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     version: 12.x.x
     condition: "identity.postgresql.enabled,identityPostgresql.enabled"
   # WebModeler Dependencies.
@@ -37,12 +37,12 @@ dependencies:
     condition: "postgresql.enabled"
   # Shared Dependencies.
   - name: elasticsearch
-    repository: "oci://registry-1.docker.io/bitnamicharts"
+    repository: oci://registry-1.docker.io/bitnamicharts
     version: 20.0.4
     condition: "elasticsearch.enabled"
   # Helpers.
   - name: common
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     version: 2.x.x
 maintainers:
   - name: Zelldon

--- a/charts/web-modeler-postgresql/Chart.yaml
+++ b/charts/web-modeler-postgresql/Chart.yaml
@@ -8,7 +8,7 @@ apiVersion: v2
 appVersion: 14.5.0
 dependencies:
   - name: common
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     tags:
       - bitnami-common
     version: 2.x.x

--- a/charts/web-modeler-postgresql/README.md
+++ b/charts/web-modeler-postgresql/README.md
@@ -78,7 +78,6 @@ kubectl delete pvc -l release=my-release
 | `global.postgresql.auth.secretKeys.replicationPasswordKey` | Name of key in existing secret to use for PostgreSQL credentials (overrides `auth.secretKeys.replicationPasswordKey`). Only used when `global.postgresql.auth.existingSecret` is set. | `""`  |
 | `global.postgresql.service.ports.postgresql`               | PostgreSQL service port (overrides `service.ports.postgresql`)                                                                                                                        | `""`  |
 
-
 ### Common parameters
 
 | Name                     | Description                                                                                  | Value           |
@@ -94,14 +93,13 @@ kubectl delete pvc -l release=my-release
 | `diagnosticMode.command` | Command to override all containers in the statefulset                                        | `["sleep"]`     |
 | `diagnosticMode.args`    | Args to override all containers in the statefulset                                           | `["infinity"]`  |
 
-
 ### PostgreSQL common parameters
 
 | Name                                     | Description                                                                                                                                                                                                                                                                                                                                   | Value                      |
 | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
 | `image.registry`                         | PostgreSQL image registry                                                                                                                                                                                                                                                                                                                     | `docker.io`                |
 | `image.repository`                       | PostgreSQL image repository                                                                                                                                                                                                                                                                                                                   | `bitnami/postgresql`       |
-| `image.tag`                              | PostgreSQL image tag (immutable tags are recommended)                                                                                                                                                                                                                                                                                         | `14.5.0-debian-11-r35`     |
+| `image.tag`                              | PostgreSQL image tag (immutable tags are recommended)                                                                                                                                                                                                                                                                                         | `14.13.0`                  |
 | `image.digest`                           | PostgreSQL image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                                                                                                                                                                                                                                    | `""`                       |
 | `image.pullPolicy`                       | PostgreSQL image pull policy                                                                                                                                                                                                                                                                                                                  | `IfNotPresent`             |
 | `image.pullSecrets`                      | Specify image pull secrets                                                                                                                                                                                                                                                                                                                    | `[]`                       |
@@ -156,7 +154,6 @@ kubectl delete pvc -l release=my-release
 | `tls.certKeyFilename`                    | Certificate key filename                                                                                                                                                                                                                                                                                                                      | `""`                       |
 | `tls.certCAFilename`                     | CA Certificate filename                                                                                                                                                                                                                                                                                                                       | `""`                       |
 | `tls.crlFilename`                        | File containing a Certificate Revocation List                                                                                                                                                                                                                                                                                                 | `""`                       |
-
 
 ### PostgreSQL Primary parameters
 
@@ -261,7 +258,6 @@ kubectl delete pvc -l release=my-release
 | `primary.persistence.selector`               | Selector to match an existing Persistent Volume (this value is evaluated as a template)                                  | `{}`                  |
 | `primary.persistence.dataSource`             | Custom PVC data source                                                                                                   | `{}`                  |
 
-
 ### PostgreSQL read only replica parameters (only used when `architecture` is set to `replication`)
 
 | Name                                              | Description                                                                                                              | Value                 |
@@ -352,7 +348,6 @@ kubectl delete pvc -l release=my-release
 | `readReplicas.persistence.selector`               | Selector to match an existing Persistent Volume (this value is evaluated as a template)                                  | `{}`                  |
 | `readReplicas.persistence.dataSource`             | Custom PVC data source                                                                                                   | `{}`                  |
 
-
 ### NetworkPolicy parameters
 
 | Name                                                                      | Description                                                                                                                                        | Value   |
@@ -372,7 +367,6 @@ kubectl delete pvc -l release=my-release
 | `networkPolicy.egressRules.denyConnectionsToExternal`                     | Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).                                                     | `false` |
 | `networkPolicy.egressRules.customRules`                                   | Custom network policy rule                                                                                                                         | `{}`    |
 
-
 ### Volume Permissions parameters
 
 | Name                                                   | Description                                                                                                                       | Value                   |
@@ -380,14 +374,13 @@ kubectl delete pvc -l release=my-release
 | `volumePermissions.enabled`                            | Enable init container that changes the owner and group of the persistent volume                                                   | `false`                 |
 | `volumePermissions.image.registry`                     | Init container volume-permissions image registry                                                                                  | `docker.io`             |
 | `volumePermissions.image.repository`                   | Init container volume-permissions image repository                                                                                | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`                          | Init container volume-permissions image tag (immutable tags are recommended)                                                      | `11-debian-11-r45`      |
+| `volumePermissions.image.tag`                          | Init container volume-permissions image tag (immutable tags are recommended)                                                      | `11-debian-11-r136`     |
 | `volumePermissions.image.digest`                       | Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                    |
 | `volumePermissions.image.pullPolicy`                   | Init container volume-permissions image pull policy                                                                               | `IfNotPresent`          |
 | `volumePermissions.image.pullSecrets`                  | Init container volume-permissions image pull secrets                                                                              | `[]`                    |
 | `volumePermissions.resources.limits`                   | Init container volume-permissions resource limits                                                                                 | `{}`                    |
 | `volumePermissions.resources.requests`                 | Init container volume-permissions resource requests                                                                               | `{}`                    |
 | `volumePermissions.containerSecurityContext.runAsUser` | User ID for the init container                                                                                                    | `0`                     |
-
 
 ### Other Parameters
 
@@ -401,7 +394,6 @@ kubectl delete pvc -l release=my-release
 | `rbac.rules`                                  | Custom RBAC rules to set                                                                                                                    | `[]`    |
 | `psp.create`                                  | Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later | `false` |
 
-
 ### Metrics Parameters
 
 | Name                                            | Description                                                                                                | Value                       |
@@ -409,7 +401,7 @@ kubectl delete pvc -l release=my-release
 | `metrics.enabled`                               | Start a prometheus exporter                                                                                | `false`                     |
 | `metrics.image.registry`                        | PostgreSQL Prometheus Exporter image registry                                                              | `docker.io`                 |
 | `metrics.image.repository`                      | PostgreSQL Prometheus Exporter image repository                                                            | `bitnami/postgres-exporter` |
-| `metrics.image.tag`                             | PostgreSQL Prometheus Exporter image tag (immutable tags are recommended)                                  | `0.11.1-debian-11-r22`      |
+| `metrics.image.tag`                             | PostgreSQL Prometheus Exporter image tag (immutable tags are recommended)                                  | `0.15.0`                    |
 | `metrics.image.digest`                          | PostgreSQL image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                        |
 | `metrics.image.pullPolicy`                      | PostgreSQL Prometheus Exporter image pull policy                                                           | `IfNotPresent`              |
 | `metrics.image.pullSecrets`                     | Specify image pull secrets                                                                                 | `[]`                        |

--- a/charts/web-modeler-postgresql/charts/common/README.md
+++ b/charts/web-modeler-postgresql/charts/common/README.md
@@ -8,7 +8,7 @@ A [Helm Library Chart](https://helm.sh/docs/topics/library_charts/#helm) for gro
 dependencies:
   - name: common
     version: 1.x.x
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
 ```
 
 ```bash


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes errors show in the renovatebot dashboard https://github.com/camunda/camunda-platform-helm/issues/2314

### What's in this PR?

Using bitnami oci chart repository to avoid redirections in the old repos (related to renovatebot and dependencies update).

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
