### PR TITLE
fix: Include opensearch env vars in operate initContainer

### DIFF
--- a/charts/camunda-platform-latest/templates/operate/deployment.yaml
+++ b/charts/camunda-platform-latest/templates/operate/deployment.yaml
@@ -53,7 +53,7 @@ spec:
                   name: {{ include "elasticsearch.authExistingSecret" . | quote }}
                   key: {{ include "elasticsearch.authExistingSecretKey" . | quote }}
             {{- end }}
-            {{- if and .Values.global.opensearch.enabled .Values.global.opensearch.auth.password}}
+            {{- if and .Values.global.opensearch.enabled (or .Values.global.opensearch.auth.existingSecret .Values.global.opensearch.auth.password) }}
             - name: CAMUNDA_OPERATE_ZEEBE_OPENSEARCH_PASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
Fixing if statement in operate initContainer so the OpenSearch env vars for the password are included
### What's in this PR?
closes: https://github.com/camunda/camunda-platform-helm/issues/2360
support-ticket: https://jira.camunda.com/browse/SUPPORT-23690?atlLinkOrigin=c2xhY2staW50ZWdyYXRpb258aXNzdWU%3D
<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
