### PR TITLE
fix: identity firstuser existingsecretkey has no effect

### DIFF
--- a/charts/camunda-platform-8.4/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform-8.4/charts/identity/templates/deployment.yaml
@@ -204,7 +204,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.firstUser.existingSecret }}
-                  key: "identity-firstuser-password"
+                  key: {{ .Values.identity.firstUser.existingSecretKey }}
             {{- else }}
             - name: KEYCLOAK_USERS_0_PASSWORD
               value: {{ .Values.firstUser.password | quote }}

--- a/charts/camunda-platform-8.4/charts/identity/templates/deployment.yaml
+++ b/charts/camunda-platform-8.4/charts/identity/templates/deployment.yaml
@@ -204,7 +204,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.firstUser.existingSecret }}
-                  key: {{ .Values.identity.firstUser.existingSecretKey }}
+                  key: {{ .Values.firstUser.existingSecretKey }}
             {{- else }}
             - name: KEYCLOAK_USERS_0_PASSWORD
               value: {{ .Values.firstUser.password | quote }}

--- a/charts/camunda-platform-latest/templates/identity/deployment.yaml
+++ b/charts/camunda-platform-latest/templates/identity/deployment.yaml
@@ -185,7 +185,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.identity.firstUser.existingSecret }}
-                  key: "identity-firstuser-password"
+                  key: {{ .Values.identity.firstUser.existingSecretKey }}
             {{- else }}
             - name: KEYCLOAK_USERS_0_PASSWORD
               value: {{ .Values.identity.firstUser.password | quote }}


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
closes: https://github.com/camunda/camunda-platform-helm/issues/2366
### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->
Adding a fix for 8.4, and 8.5 to change the existingSecretKey of the firstUser through the values.yaml
### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
