### PR TITLE
fix: identity baseUrl supplied regardless of multitenancy

### DIFF
--- a/charts/camunda-platform-alpha/templates/zeebe-gateway/configmap.yaml
+++ b/charts/camunda-platform-alpha/templates/zeebe-gateway/configmap.yaml
@@ -55,17 +55,13 @@ data:
       servlet:
         context-path: {{ .Values.zeebeGateway.contextPath | quote }}
       {{- end }}
-    {{- if or .Values.global.identity.auth.enabled .Values.global.multitenancy.enabled }}
+    {{- if .Values.global.identity.auth.enabled }}
     camunda:
       identity:
-        {{- if .Values.global.identity.auth.enabled }}
         type: {{ include "camundaPlatform.authType" . | quote }}
         issuerBackendUrl: {{ include "camundaPlatform.authIssuerBackendUrl" . | quote }}
         audience: {{ include "zeebe.audience" . | quote }}
-        {{- end }}
-        {{- if .Values.global.multitenancy.enabled }}
         baseUrl: {{ include "camundaPlatform.identityURL" . | quote }}
-        {{- end }}
     {{- end }}
     zeebe:
       gateway:

--- a/charts/camunda-platform-alpha/test/unit/zeebe-gateway/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/zeebe-gateway/golden/configmap-log4j2.golden.yaml
@@ -37,6 +37,7 @@ data:
         type: "KEYCLOAK"
         issuerBackendUrl: "http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform"
         audience: "zeebe-api"
+        baseUrl: "http://camunda-platform-test-identity:80"
     zeebe:
       gateway:
         security:

--- a/charts/camunda-platform-alpha/test/unit/zeebe-gateway/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/zeebe-gateway/golden/configmap.golden.yaml
@@ -35,6 +35,7 @@ data:
         type: "KEYCLOAK"
         issuerBackendUrl: "http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform"
         audience: "zeebe-api"
+        baseUrl: "http://camunda-platform-test-identity:80"
     zeebe:
       gateway:
         security:


### PR DESCRIPTION
### Which problem does the PR fix?

#2385 

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

This PR contains a change that supplies the baseUrl to the identity sdk. in previous versions, this was done for the sake of multitenancy so that other components could make a request to identity to ask "what resources does this user have access to?" but this is now a requirement in 8.6-alpha builds especially in situations where OIDC is enabled.  

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
