### PR TITLE
fix: rearranged env vars necessary for oidc to work with console

### DIFF
--- a/charts/camunda-platform-alpha/templates/console/deployment.yaml
+++ b/charts/camunda-platform-alpha/templates/console/deployment.yaml
@@ -54,16 +54,18 @@ spec:
                   key: {{ include "camundaPlatform.licenseSecretKey" . }}
             - name: NODE_ENV
               value: prod
+            {{- if eq .Values.global.identity.auth.type "KEYCLOAK"}}
             - name: KEYCLOAK_INTERNAL_BASE_URL
               value: {{ mustRegexReplaceAllLiteral "/realms/.+" (include "camundaPlatform.authIssuerBackendUrl" .) "" | quote }}
             - name: KEYCLOAK_BASE_URL
               value: {{ mustRegexReplaceAllLiteral "/realms/.+" (include "camundaPlatform.authIssuerUrl" .) "" | quote }}
             - name: KEYCLOAK_REALM
               value: {{ .Values.console.keycloak.realm | quote }}
+            {{- end }}
             - name: CAMUNDA_IDENTITY_AUDIENCE
-              value: console-api
+              value: {{ .Values.global.identity.auth.console.audience | default "console-api" }}
             - name: CAMUNDA_IDENTITY_CLIENT_ID
-              value: console
+              value: {{ .Values.global.identity.auth.console.clientId | default "console" }}
             - name: CAMUNDA_CONSOLE_CONTEXT_PATH
               value: {{ .Values.console.contextPath | quote }}
           {{- if .Values.console.env}}


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #2373 

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

OIDC with Console is currently broken as there are still references to KEYCLOAK variables within console, and there are some hardcoded scopes / audiences that need to be set to their configured values.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
