### PR TITLE
fix: define Web Modeler Admin role in identity

### DIFF
--- a/charts/camunda-platform-alpha/templates/identity/configmap.yaml
+++ b/charts/camunda-platform-alpha/templates/identity/configmap.yaml
@@ -166,6 +166,8 @@ data:
               permissions:
                 - definition: write:*
                   description: "Write permission"
+                - definition: admin:*
+                  description: "Admin permission"
             - name: Web Modeler API
               audience: {{ .Values.global.identity.auth.webModeler.publicApiAudience | default "web-modeler-public-api" | quote }}
               permissions:
@@ -185,6 +187,15 @@ data:
                   definition: write:*
                 - audience: {{ include "identity.authAudience" . | default "camunda-identity-resource-server" | quote }}
                   definition: read:users
+            - name: "Web Modeler Admin"
+              description: "Grants elevated access to Web Modeler"
+              permissions:
+                - audience: {{ include "identity.authAudience" . | default "camunda-identity-resource-server" | quote }}
+                  definition: read:users
+                - audience: {{ .Values.global.identity.auth.webModeler.clientApiAudience | default "web-modeler-api" | quote }}
+                  definition: write:*
+                - audience: {{ .Values.global.identity.auth.webModeler.clientApiAudience | default "web-modeler-api" | quote }}
+                  definition: admin:*
         zeebe:
           apis:
             - name: Zeebe API

--- a/charts/camunda-platform-alpha/test/unit/identity/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/identity/golden/configmap.golden.yaml
@@ -159,6 +159,8 @@ data:
               permissions:
                 - definition: write:*
                   description: "Write permission"
+                - definition: admin:*
+                  description: "Admin permission"
             - name: Web Modeler API
               audience: "web-modeler-public-api"
               permissions:
@@ -178,6 +180,15 @@ data:
                   definition: write:*
                 - audience: "camunda-identity-resource-server"
                   definition: read:users
+            - name: "Web Modeler Admin"
+              description: "Grants elevated access to Web Modeler"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "web-modeler-api"
+                  definition: admin:*
         zeebe:
           apis:
             - name: Zeebe API


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes: https://github.com/camunda/camunda-platform-helm/issues/2339

### What's in this PR?

Because the `Web Modeler Admin` role was missing so Identity wasn't able to assign any role to the Identity's first user.

The role was assigned to the user in PR no. https://github.com/camunda/camunda-platform-helm/pull/2326, but the role wasn't added.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
