### PR TITLE
chore: disable minor version update for camunda-platform-latest

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -71,6 +71,13 @@
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
     },
     {
+      "matchPackageNames": ["/.*camunda.*/"],
+      "matchFileNames": [
+        "charts/camunda-platform-latest/values*.yaml",
+      ],
+      "matchUpdateTypes": ["patch", "pin", "digest"],
+    },
+    {
       "groupName": "camunda-platform-alpha",
       "addLabels": ["version/8.6", "deps/charts"],
       "matchFileNames": [


### PR DESCRIPTION
### Which problem does the PR fix?

Related to: https://github.com/camunda/camunda-platform-helm/issues/2404

### What's in this PR?

Disable minor version update for `camunda-platform-latest` so the Camunda apps in the latest don't get a bump when the new minor version is released.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
