### PR TITLE
fix: disable renovate minor version bumps on 8.2-8.4

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -75,6 +75,9 @@
       "enabled": false,
       "matchPackageNames": ["/.*camunda.*/"],
       "matchFileNames": [
+        "charts/camunda-platform-8.2/values*.yaml",
+        "charts/camunda-platform-8.3/values*.yaml",
+        "charts/camunda-platform-8.4/values*.yaml",
         "charts/camunda-platform-latest/values*.yaml",
       ],
       "matchUpdateTypes": ["minor"],


### PR DESCRIPTION
### Which problem does the PR fix?

The recent renovate changes on main made it so that the 8.2 to 8.4 versions of the helm values.yaml will now upgrade to minor versions higher than what they're supposed to be. we got a number of PRs today such as 

https://github.com/camunda/camunda-platform-helm/pull/2419

How @drodriguez-305 and I tested this was with a forked camunda-platform-helm repository, with disabled private repository access, and then running the following command:

```
docker run -e LOG_LEVEL=debug -e RENOVATE_TOKEN=YOUR_PAT -it --rm -v $(pwd):/usr/src/app -w /usr/src/app renovate/renovate:38-full renovate jessesimpson36/camunda-platform-helm
```

Running it locally reduced our dependency on Mend which for some reason was very slow.  And I was able to see that the open PRs that was previously opened by renovate were now closed for being invalid.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

This PR adds a rule for  8.2, 8.3, and 8.4 values.yaml files so that minor version bumps are disabled.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
