### PR TITLE
chore: rename camunda-platform-latest internally

### DIFF
--- a/.github/workflows/chart-release-snapshot.yaml
+++ b/.github/workflows/chart-release-snapshot.yaml
@@ -7,7 +7,6 @@ on:
       - main
     paths:
       - .github/workflows/chart-release-snapshot.yaml
-      - charts/camunda-platform-latest/**
       - charts/camunda-platform-alpha/**
 
 jobs:
@@ -54,15 +53,35 @@ jobs:
       fail-fast: false
       matrix:
         chart:
-        - name: Helm Chart Latest rolling
-          directory: charts/camunda-platform-latest
+        - name: Helm Chart rolling - 8.2
+          directory: charts/camunda-platform-8.2
+          versionSuffix: snapshot-8.2
+          override: true
+        - name: Helm Chart rolling - 8.3
+          directory: charts/camunda-platform-8.3
+          versionSuffix: snapshot-8.3
+          override: true
+        - name: Helm Chart rolling - 8.4
+          directory: charts/camunda-platform-8.4
+          versionSuffix: snapshot-8.4
+          override: true
+        - name: Helm Chart rolling - 8.5
+          directory: charts/camunda-platform-8.5
+          versionSuffix: snapshot-8.5
+          override: true
+        - name: Helm Chart rolling - 8.6
+          directory: charts/camunda-platform-8.6
+          versionSuffix: snapshot-8.6
+          override: true
+        - name: Helm Chart rolling - Latest
+          directory: charts/camunda-platform-8.6
           versionSuffix: snapshot-latest
           override: true
-        - name: Helm Chart Alpha rolling
+        - name: Helm Chart rolling - Alpha
           directory: charts/camunda-platform-alpha
           versionSuffix: snapshot-alpha
           override: true
-        - name: Helm Chart Alpha versioned
+        - name: Helm Chart versioned - Alpha
           directory: charts/camunda-platform-alpha
           versionSuffix: ""
           override: false
@@ -109,8 +128,8 @@ jobs:
             "false")
               # If the artfact exists, then it will not republished.
               helm pull oci://ghcr.io/${{ env.REPOSITORY_NAME }}/${{ env.CHART_NAME }} \
-                --version ${{ env.CHART_VERSION }} 2> /dev/null
-              test $? -eq 0 && PUBLISH_ARTIFACT="false" || PUBLISH_ARTIFACT="true"
+                --version ${{ env.CHART_VERSION }} 2> /dev/null && EXIT_CODE=0 || EXIT_CODE=1
+              test ${EXIT_CODE} -eq 0 && PUBLISH_ARTIFACT="false" || PUBLISH_ARTIFACT="true"
               ;;
             *)
               echo "Unsupported value."
@@ -119,13 +138,17 @@ jobs:
           esac
           # Add the var to GH vars.
           echo "PUBLISH_ARTIFACT=${PUBLISH_ARTIFACT}" | tee -a $GITHUB_ENV
+      - name: Helm dependency update
+        if: env.PUBLISH_ARTIFACT == 'true'
+        run: |
+          make -C ../.. helm.dependency-update \
+            chartPath=${{ matrix.chart.directory }}
       - name: Package and push Helm chart
         if: env.PUBLISH_ARTIFACT == 'true'
         env:
           HELM_EXPERIMENTAL_OCI: 1
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | helm registry login -u ${{ github.actor }} --password-stdin ghcr.io
-          helm dependency update
           helm package --version ${{ env.CHART_VERSION }} .
           helm push ${{ env.CHART_NAME }}-${{ env.CHART_VERSION }}.tgz oci://ghcr.io/${{ env.REPOSITORY_NAME }}
           helm registry logout ghcr.io

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Tidy up
         run: |
           # Clean up badges from readme to avoid showing them in Artifact Hub.
-          sed -ri '/Badge .+/d' charts/camunda-platform-latest/README.md
+          sed -ri '/Badge .+/d' charts/camunda-platform-8*/README.md
           mkdir release-packages
   
       #
@@ -85,11 +85,16 @@ jobs:
       # CR by default will release "camunda-platform-10.x.x" first then "camunda-platform-8.x.x",
       # however, we want the latest version to show as the latest release in GitHub releases.
       #
-  
+
+      - name: Get latest version name
+        run: |
+          latest_chart_version_dir="$(ls -d1 charts/camunda-platform-8* | tail -n1)"
+          echo "LATEST_CHART_VERSION_DIR=${latest_chart_version_dir}" | tee -a $GITHUB_ENV
+
       # Release previous versions.
       - name: Pre-Release - Previous versions
         run: |
-          rm -rf charts/camunda-platform-latest
+          rm -rf ${LATEST_CHART_VERSION_DIR}
           rm -rf charts/camunda-platform-alpha
       - name: Run Chart Releaser - Previous versions
         uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
@@ -106,7 +111,7 @@ jobs:
       # Release the latest version.
       - name: Pre-Release - Latest version
         run: |
-          rm -rf charts/camunda-platform-8*
+          rm -rf $(ls -d1 charts/camunda-platform-8* | head -n -1)
           rm -rf charts/camunda-platform-alpha
       - name: Run Chart Releaser - Latest version
         uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0

--- a/.github/workflows/chart-validate-template.yaml
+++ b/.github/workflows/chart-validate-template.yaml
@@ -13,7 +13,7 @@ on:
         type: string
       camunda-helm-dir:
         required: false
-        default: camunda-platform-latest
+        default: camunda-platform-alpha
         type: string
 
 permissions:

--- a/.github/workflows/examples/test-helm-chart.yaml
+++ b/.github/workflows/examples/test-helm-chart.yaml
@@ -22,7 +22,7 @@ jobs:
     # https://github.com/camunda/camunda-platform-helm/blob/main/docs/gha-workflows.md#workflow-inputs
     with:
       identifier: "<USE_CASE>-${{ github.event.pull_request.number }}"
-      camunda-helm-dir: "camunda-platform-latest"
+      camunda-helm-dir: "camunda-platform-alpha"
       # For full value options (ensure to select the correct chart version from the right side):
       # https://artifacthub.io/packages/helm/camunda/camunda-platform
       extra-values: |

--- a/.github/workflows/test-integration-rosa-template.yaml
+++ b/.github/workflows/test-integration-rosa-template.yaml
@@ -11,7 +11,7 @@ on:
         type: string
       camunda-helm-dir:
         required: false
-        default: camunda-platform-latest
+        default: camunda-platform-alpha
         type: string
       camunda-helm-git-ref:
         default: main

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -15,7 +15,7 @@ on:
         type: string
       camunda-helm-dir:
         required: false
-        default: camunda-platform-latest
+        default: camunda-platform-alpha
         type: string
       camunda-helm-git-ref:
         required: false

--- a/.github/workflows/test-unit-template.yml
+++ b/.github/workflows/test-unit-template.yml
@@ -13,7 +13,7 @@ on:
         type: string
       camunda-helm-dir:
         required: false
-        default: camunda-platform-latest
+        default: camunda-platform-alpha
         type: string
 
 concurrency:

--- a/.github/workflows/test-version-latest.yaml
+++ b/.github/workflows/test-version-latest.yaml
@@ -6,7 +6,6 @@ on:
     paths:
       - '.github/workflows/test-integration-template.yaml'
       - '.github/workflows/test-version-latest.yaml'
-      - 'charts/camunda-platform-latest/**'
   workflow_dispatch: { }
 
 concurrency:
@@ -29,7 +28,7 @@ jobs:
     uses: ./.github/workflows/chart-validate-template.yaml
     with:
       identifier: "${{ github.event.pull_request.number }}-vald-latest"
-      camunda-helm-dir: "camunda-platform-latest"
+      camunda-helm-dir: "camunda-platform-8.6"
       camunda-helm-git-ref: "${{ github.event.pull_request.head.sha }}"
 
   unit:
@@ -37,7 +36,7 @@ jobs:
     uses: ./.github/workflows/test-unit-template.yml
     with:
       identifier: "${{ github.event.pull_request.number }}-unit-latest"
-      camunda-helm-dir: "camunda-platform-latest"
+      camunda-helm-dir: "camunda-platform-8.6"
       camunda-helm-git-ref: "${{ github.event.pull_request.head.sha }}"
 
   integration:
@@ -54,6 +53,6 @@ jobs:
       deployment-ttl: "${{ contains(github.event.pull_request.labels.*.name, 'test-persistent') && '1w' || '' }}"
       platforms: "gke,rosa"
       flows: "install,upgrade"
-      camunda-helm-dir: "camunda-platform-latest"
+      camunda-helm-dir: "camunda-platform-8.6"
       camunda-helm-git-ref: "${{ github.event.pull_request.head.sha }}"
       caller-git-ref: "${{ github.event.pull_request.head.sha }}"

--- a/docs/gha-workflows.md
+++ b/docs/gha-workflows.md
@@ -43,9 +43,9 @@ jobs:
       # A reference for the Camunda Helm chart directory which allows to test unreleased chagnes from Git repo.
       # The latest supported chart doesn't have a version in its directory name like `camunda-platform`.
       # The previous releases have the Camunda version in their directory name e.g. `camunda-platform-8.4`.
-      # Default: 'camunda-platform-latest'
+      # Default: 'camunda-platform-alpha'
       # Required: false
-      camunda-helm-dir: 'camunda-platform-latest'
+      camunda-helm-dir: 'camunda-platform-alpha'
 
       # Pass extra values to the Helm chart during deployment
       # Default: ''


### PR DESCRIPTION
### Which problem does the PR fix?

Related: #2404

### What's in this PR?

Rename `camunda-platform-latest` internally, as we will have all released versions with the version suffix.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
