### PR TITLE
fix: renovate web-modeler and console  no longer does faulty minor upgrades

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -242,5 +242,14 @@
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
     }
+  ],
+
+  "hostRules": [
+    {
+      "hostType": "docker",
+      "matchHost": "https://registry.camunda.cloud",
+      "username": "ci-distribution",
+      "password": "{{ secrets.DISTRO_CAMUNDA_DOCKER_REGISTRY_PASSWORD }}"
+    }
   ]
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -141,7 +141,7 @@
     {
       // Disable app minor version update in the previous Camunda Helm charts.
       "enabled": false,
-      "matchPackageNames": ["/.*camunda\/.*/"],
+      "matchPackageNames": ["/.*camunda\/[.-]*/", "registry.camunda.cloud/console/console-sm"],
       "matchFileNames": [
         "charts/camunda-platform-8.*/values.yaml",
         "charts/camunda-platform-8.*/values-latest.yaml",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -242,14 +242,5 @@
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
     }
-  ],
-
-  "hostRules": [
-    {
-      "hostType": "docker",
-      "matchHost": "https://registry.camunda.cloud",
-      "username": "ci-distribution",
-      "password": "{{ secrets.DISTRO_CAMUNDA_DOCKER_REGISTRY_PASSWORD }}"
-    }
   ]
 }


### PR DESCRIPTION
### Which problem does the PR fix?

In renovate we encountered a problem where console and web modeler are doing minor upgrades unnecessarily. the cause this time was that the period does not match dashes in regexes in renovate.  This PR introduces dashes as part of the packageName query.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

Renovate tweaks

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
