### PR TITLE
chore: update values-latest for 8.6

### DIFF
--- a/charts/camunda-platform-8.6/values-latest.yaml
+++ b/charts/camunda-platform-8.6/values-latest.yaml
@@ -12,7 +12,7 @@ console:
   # Camunda Enterprise repository.
   # https://hub.docker.com/r/camunda/console/tags
   image:
-    tag: 8.6.0
+    tag: 8.6.10
 
 connectors:
   # https://hub.docker.com/r/camunda/connectors-bundle/tags
@@ -23,7 +23,7 @@ connectors:
 operate:
   # https://hub.docker.com/r/camunda/operate/tags
   image:
-    tag: 8.6.0
+    tag: 8.6.3
 
 optimize:
   # https://hub.docker.com/r/camunda/optimize/tags
@@ -69,7 +69,7 @@ identityKeycloak:
   # https://hub.docker.com/r/bitnami/keycloak/tags
   image:
     repository: bitnami/keycloak
-    tag: 23.0.7
+    tag: 25.0.6
   postgresql:
     # https://hub.docker.com/r/bitnami/postgresql/tags
     image:


### PR DESCRIPTION
### Which problem does the PR fix?
values-latest.yaml has not been updated renovate. the next time this changes renovate should update it automatically.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?
Correct `image.tags` for components
<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
