### PR TITLE
fix: do not set prefix

### DIFF
--- a/charts/camunda-platform-alpha/templates/zeebe/configmap.yaml
+++ b/charts/camunda-platform-alpha/templates/zeebe/configmap.yaml
@@ -61,10 +61,6 @@ data:
               {{- if or .Values.global.elasticsearch.auth.username .Values.global.opensearch.auth.username }}
                 username: {{ if .Values.global.elasticsearch.auth.username }}{{ .Values.global.elasticsearch.auth.username | quote }}{{ else }}{{ .Values.global.opensearch.auth.username | quote }}{{- end }}
               {{- end }}
-              {{- if .Values.global.elasticsearch.enabled }}
-              index:
-                prefix: {{ .Values.global.elasticsearch.prefix | quote }}
-              {{- end }}
               {{- if .Values.zeebe.retention.enabled }}
               retention:
                 enabled: true

--- a/charts/camunda-platform-alpha/test/unit/zeebe/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/zeebe/golden/configmap-log4j2.golden.yaml
@@ -29,8 +29,6 @@ data:
               connect:
                 type: elasticsearch
                 url: "http://camunda-platform-test-elasticsearch:9200"
-              index:
-                prefix: "zeebe-record"
               createSchema: true
         gateway:
           enable: true

--- a/charts/camunda-platform-alpha/test/unit/zeebe/golden/configmap-multiregion-failBack.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/zeebe/golden/configmap-multiregion-failBack.golden.yaml
@@ -29,8 +29,6 @@ data:
               connect:
                 type: elasticsearch
                 url: "http://camunda-platform-test-elasticsearch:9200"
-              index:
-                prefix: "zeebe-record"
               createSchema: true
         gateway:
           enable: true

--- a/charts/camunda-platform-alpha/test/unit/zeebe/golden/configmap-multiregion-failOver.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/zeebe/golden/configmap-multiregion-failOver.golden.yaml
@@ -29,8 +29,6 @@ data:
               connect:
                 type: elasticsearch
                 url: "http://camunda-platform-test-elasticsearch:9200"
-              index:
-                prefix: "zeebe-record"
               createSchema: true
         gateway:
           enable: true

--- a/charts/camunda-platform-alpha/test/unit/zeebe/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/zeebe/golden/configmap.golden.yaml
@@ -29,8 +29,6 @@ data:
               connect:
                 type: elasticsearch
                 url: "http://camunda-platform-test-elasticsearch:9200"
-              index:
-                prefix: "zeebe-record"
               createSchema: true
         gateway:
           enable: true


### PR DESCRIPTION

### Which problem does the PR fix?

For now we shouldn't set a prefix to indices, especially not the same as we use for the ES exporter.

Right now we don't support a global prefix everywhere, Operate will not able to find data.


![mvp-wrong-prefix](https://github.com/user-attachments/assets/ca2d414e-9fb5-4d90-bd2d-e23380d81b6f)
![mvp-no-data-operate](https://github.com/user-attachments/assets/15cf664f-642f-4a24-aa32-7d5565db80ab)


This needs https://github.com/camunda/camunda/issues/23807

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

Removing the setting of a prefix for the Camunda Exporter
<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
