### PR TITLE
fix: upload logs to GHA

### DIFF
--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -359,7 +359,7 @@ jobs:
         run: |
           mkdir -p logs
           kubectl get pods -n "$TEST_NAMESPACE" > "logs/pod_status.txt"
-          for pod in $( kubectl get pods -n "$TEST_NAMESPACE" ); do
+          for pod in $( kubectl get pods -n "$TEST_NAMESPACE" | awk '{print $1}' | grep -v NAME ); do 
             kubectl logs -n "$TEST_NAMESPACE" "$pod" > "logs/$pod.txt"
           done
 

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -353,6 +353,22 @@ jobs:
       - name: 🚨 Get failed Pods info 🚨
         if: failure()
         uses: ./.github/actions/failed-pods-info
+
+      - name: Get pod logs
+        if: always()
+        run: |
+          mkdir -p logs
+          for pod in $( kubectl get pods -n "$TEST_NAMESPACE" ); do
+            kubectl logs -n "$TEST_NAMESPACE" "$pod" > "logs/$pod.txt"
+          done
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: pod-logs-${{ matrix.os }}
+          path: ./logs/*
+          retention-days: 1
+
       - name: Cleanup GitHub deployment
         if: always() && (env.CI_DEPLOYMENT_TTL == '' || matrix.distro.type != 'kubernetes')
         uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -366,7 +366,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: pod-logs-${{ matrix.os }}
+          name: pod-logs-${{ matrix.distro.platform }}-{{ matrix.scenario.flow }}
           path: ./logs/*
           retention-days: 1
 

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -358,6 +358,7 @@ jobs:
         if: always()
         run: |
           mkdir -p logs
+          kubectl get pods -n "$TEST_NAMESPACE" > "logs/pod_status.txt"
           for pod in $( kubectl get pods -n "$TEST_NAMESPACE" ); do
             kubectl logs -n "$TEST_NAMESPACE" "$pod" > "logs/$pod.txt"
           done


### PR DESCRIPTION
### Which problem does the PR fix?

At the end of the installation process, we should upload the logs  and pod status regardless of whether it was a successful run or not, because users of our integration test workflow may experience an error that our healthchecks don't cover. 


<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?


This PR will upload logs and pod status to GHA to help with debugging. 

One drawback to this implementation is that it gives you pod status's and logs at the end of the workflow, and not at the end of the callers workflow. this may be insufficient.  A less primitive solution may be to set up a logging provider like Splunk or ELK and provide access to it.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
