### PR TITLE
fix: zeebe gateway incorrect rest ingress path 

### DIFF
--- a/charts/camunda-platform-8.6/templates/zeebe-gateway/ingress-rest.yaml
+++ b/charts/camunda-platform-8.6/templates/zeebe-gateway/ingress-rest.yaml
@@ -19,7 +19,7 @@ spec:
     - http:
     {{- end }}
         paths:
-          - path: {{ include "zeebe.readinessProbePath.gateway" . }}
+          - path: {{ .Values.zeebeGateway.ingress.rest.path }}
             pathType: {{ .Values.zeebeGateway.ingress.rest.pathType }}
             backend:
               service:

--- a/charts/camunda-platform-8.6/test/unit/zeebe-gateway/golden/ingress-rest-all-enabled.golden.yaml
+++ b/charts/camunda-platform-8.6/test/unit/zeebe-gateway/golden/ingress-rest-all-enabled.golden.yaml
@@ -24,7 +24,7 @@ spec:
     - host: local
       http:
         paths:
-          - path: /actuator/health/readiness
+          - path: /
             pathType: Prefix
             backend:
               service:

--- a/charts/camunda-platform-8.6/test/unit/zeebe-gateway/golden/ingress-rest.golden.yaml
+++ b/charts/camunda-platform-8.6/test/unit/zeebe-gateway/golden/ingress-rest.golden.yaml
@@ -23,7 +23,7 @@ spec:
   rules:
     - http:
         paths:
-          - path: /actuator/health/readiness
+          - path: /
             pathType: Prefix
             backend:
               service:

--- a/charts/camunda-platform-alpha/templates/zeebe-gateway/ingress-rest.yaml
+++ b/charts/camunda-platform-alpha/templates/zeebe-gateway/ingress-rest.yaml
@@ -19,7 +19,7 @@ spec:
     - http:
     {{- end }}
         paths:
-          - path: {{ include "zeebe.readinessProbePath.gateway" . }}
+          - path: {{ .Values.zeebeGateway.ingress.rest.path }}
             pathType: {{ .Values.zeebeGateway.ingress.rest.pathType }}
             backend:
               service:

--- a/charts/camunda-platform-alpha/test/unit/zeebe-gateway/golden/ingress-rest-all-enabled.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/zeebe-gateway/golden/ingress-rest-all-enabled.golden.yaml
@@ -24,7 +24,7 @@ spec:
     - host: local
       http:
         paths:
-          - path: /actuator/health/readiness
+          - path: /
             pathType: Prefix
             backend:
               service:

--- a/charts/camunda-platform-alpha/test/unit/zeebe-gateway/golden/ingress-rest.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/zeebe-gateway/golden/ingress-rest.golden.yaml
@@ -23,7 +23,7 @@ spec:
   rules:
     - http:
         paths:
-          - path: /actuator/health/readiness
+          - path: /
             pathType: Prefix
             backend:
               service:


### PR DESCRIPTION
### Which problem does the PR fix?

This [change](https://github.com/camunda/camunda-platform-helm/pull/2355/files#diff-51987be73eba2f7dd5f520408e9bd555a3526b38eb4a92814354911f73936683R22) introduced a bug where the ingress path was incorrectly set to include the readiness probe path `/actuator/health/readiness`. This resulted in the readiness probe path being exposed as an endpoint in the ingress, which inadvertently breaks the intended REST API access.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?
This PR reverts the previous change in ingress-rest.yaml to ensure that only the main service path (`ingress.rest.path`, e.g., `/zeebe`) is exposed via the ingress, without appending the readiness probe path.
<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
