### PR TITLE
fix: tasklist auth config

### DIFF
--- a/charts/camunda-platform-8.5/templates/tasklist/configmap.yaml
+++ b/charts/camunda-platform-8.5/templates/tasklist/configmap.yaml
@@ -49,8 +49,7 @@ data:
 
       identity:
         redirectRootUrl: {{ tpl .Values.global.identity.auth.tasklist.redirectUrl $ | trimSuffix .Values.tasklist.contextPath | quote }}
-        userAccessRestrictions:
-          enabled: {{ .Values.tasklist.identity.userAccessRestrictions.enabled | quote }}
+        userAccessRestrictionsEnabled: {{ .Values.tasklist.identity.userAccessRestrictions.enabled }}
 
       # Set Tasklist username and password.
       # If user with <username> does not exists it will be created.

--- a/charts/camunda-platform-8.5/test/unit/tasklist/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.5/test/unit/tasklist/golden/configmap.golden.yaml
@@ -35,8 +35,7 @@ data:
 
       identity:
         redirectRootUrl: "http://localhost:8082"
-        userAccessRestrictions:
-          enabled: "true"
+        userAccessRestrictionsEnabled: true
 
       # Set Tasklist username and password.
       # If user with <username> does not exists it will be created.

--- a/charts/camunda-platform-8.6/templates/tasklist/configmap.yaml
+++ b/charts/camunda-platform-8.6/templates/tasklist/configmap.yaml
@@ -71,8 +71,7 @@ data:
 
       identity:
         redirectRootUrl: {{ tpl .Values.global.identity.auth.tasklist.redirectUrl $ | trimSuffix .Values.tasklist.contextPath | quote }}
-        userAccessRestrictions:
-          enabled: {{ .Values.tasklist.identity.userAccessRestrictions.enabled }}
+        userAccessRestrictionsEnabled: {{ .Values.tasklist.identity.userAccessRestrictions.enabled }}
 
       # Set Tasklist username and password.
       # If user with <username> does not exists it will be created.

--- a/charts/camunda-platform-8.6/templates/tasklist/configmap.yaml
+++ b/charts/camunda-platform-8.6/templates/tasklist/configmap.yaml
@@ -72,7 +72,7 @@ data:
       identity:
         redirectRootUrl: {{ tpl .Values.global.identity.auth.tasklist.redirectUrl $ | trimSuffix .Values.tasklist.contextPath | quote }}
         userAccessRestrictions:
-          enabled: {{ .Values.tasklist.identity.userAccessRestrictions.enabled | quote }}
+          enabled: {{ .Values.tasklist.identity.userAccessRestrictions.enabled }}
 
       # Set Tasklist username and password.
       # If user with <username> does not exists it will be created.

--- a/charts/camunda-platform-8.6/test/unit/tasklist/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.6/test/unit/tasklist/golden/configmap.golden.yaml
@@ -42,8 +42,7 @@ data:
 
       identity:
         redirectRootUrl: "http://localhost:8082"
-        userAccessRestrictions:
-          enabled: "true"
+        userAccessRestrictionsEnabled: true
 
       # Set Tasklist username and password.
       # If user with <username> does not exists it will be created.


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

closes #2523 

### What's in this PR?

The user task access restrictions are a boolean, but are defined as a string. To fix this, the quote pipe has been removed.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
