### PR TITLE
fix: add default webModler url when ingress is disabled

### DIFF
--- a/charts/camunda-platform-8.6/templates/camunda/_helpers.tpl
+++ b/charts/camunda-platform-8.6/templates/camunda/_helpers.tpl
@@ -441,11 +441,11 @@ Web Modeler templates.
       {{- else -}}
         {{- printf "%s://%s%s" $proto .context.Values.global.ingress.host (index .context.Values.webModeler "contextPath") -}} 
       {{- end -}}
-    {{- if eq .component "websockets" }}
-            {{- printf "http://localhost:8085" -}}
-    {{- else -}}
-            {{- printf "http://localhost:8084" -}}
-    {{- end -}}
+      {{- if eq .component "websockets" }}
+              {{- printf "http://localhost:8085" -}}
+      {{- else -}}
+              {{- printf "http://localhost:8084" -}}
+      {{- end -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/camunda-platform-8.6/templates/camunda/_helpers.tpl
+++ b/charts/camunda-platform-8.6/templates/camunda/_helpers.tpl
@@ -441,11 +441,13 @@ Web Modeler templates.
       {{- else -}}
         {{- printf "%s://%s%s" $proto .context.Values.global.ingress.host (index .context.Values.webModeler "contextPath") -}} 
       {{- end -}}
-      {{- if eq .component "websockets" }}
-              {{- printf "http://localhost:8085" -}}
+    {{- else -}}
+      {{- if eq .component "websockets" -}}
+        {{- printf "http://localhost:8085" -}}
       {{- else -}}
-              {{- printf "http://localhost:8084" -}}
+        {{- printf "http://localhost:8084" -}}
       {{- end -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/camunda-platform-8.6/templates/camunda/_helpers.tpl
+++ b/charts/camunda-platform-8.6/templates/camunda/_helpers.tpl
@@ -441,11 +441,11 @@ Web Modeler templates.
       {{- else -}}
         {{- printf "%s://%s%s" $proto .context.Values.global.ingress.host (index .context.Values.webModeler "contextPath") -}} 
       {{- end -}}
-      {{- if eq .component "websockets" }}
-              {{- printf "http://localhost:8085" -}}
-      {{- else -}}
-              {{- printf "http://localhost:8084" -}}
-      {{- end -}}
+    {{- if eq .component "websockets" }}
+            {{- printf "http://localhost:8085" -}}
+    {{- else -}}
+            {{- printf "http://localhost:8084" -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/camunda-platform-8.6/templates/camunda/_helpers.tpl
+++ b/charts/camunda-platform-8.6/templates/camunda/_helpers.tpl
@@ -441,9 +441,11 @@ Web Modeler templates.
       {{- else -}}
         {{- printf "%s://%s%s" $proto .context.Values.global.ingress.host (index .context.Values.webModeler "contextPath") -}} 
       {{- end -}}
-    {{- else -}}
-      {{- printf "http://localhost:8084" -}}
-    {{- end -}}
+      {{- if eq .component "websockets" }}
+              {{- printf "http://localhost:8085" -}}
+      {{- else -}}
+              {{- printf "http://localhost:8084" -}}
+      {{- end -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/camunda-platform-8.6/templates/camunda/_helpers.tpl
+++ b/charts/camunda-platform-8.6/templates/camunda/_helpers.tpl
@@ -441,6 +441,8 @@ Web Modeler templates.
       {{- else -}}
         {{- printf "%s://%s%s" $proto .context.Values.global.ingress.host (index .context.Values.webModeler "contextPath") -}} 
       {{- end -}}
+    {{- else -}}
+      {{- printf "http://localhost:8084" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/charts/camunda-platform-alpha/templates/camunda/_helpers.tpl
+++ b/charts/camunda-platform-alpha/templates/camunda/_helpers.tpl
@@ -452,10 +452,12 @@ Web Modeler templates.
       {{- else -}}
         {{- printf "%s://%s%s" $proto .context.Values.global.ingress.host (index .context.Values.webModeler "contextPath") -}}
       {{- end -}}
-    {{- if eq .component "websockets" }}
-            {{- printf "http://localhost:8085" -}}
     {{- else -}}
-            {{- printf "http://localhost:8084" -}}
+      {{- if eq .component "websockets" -}}
+        {{- printf "http://localhost:8085" -}}
+      {{- else -}}
+        {{- printf "http://localhost:8084" -}}
+      {{- end -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/charts/camunda-platform-alpha/templates/camunda/_helpers.tpl
+++ b/charts/camunda-platform-alpha/templates/camunda/_helpers.tpl
@@ -452,6 +452,10 @@ Web Modeler templates.
       {{- else -}}
         {{- printf "%s://%s%s" $proto .context.Values.global.ingress.host (index .context.Values.webModeler "contextPath") -}}
       {{- end -}}
+    {{- if eq .component "websockets" }}
+            {{- printf "http://localhost:8085" -}}
+    {{- else -}}
+            {{- printf "http://localhost:8084" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
### Which problem does the PR fix?
Console configmap will not read the url if not set in the helpers when there is no ingress. This quickfix will resolve the default static localhost for webModeler. 
<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
