### PR TITLE
fix(core): disable core client secret if identity is disabled

### DIFF
--- a/charts/camunda-platform-alpha/templates/core/statefulset.yaml
+++ b/charts/camunda-platform-alpha/templates/core/statefulset.yaml
@@ -69,11 +69,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- if .Values.global.identity.auth.enabled }}
             - name: VALUES_CAMUNDA_CORE_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ include "core.authClientSecretName" . }}
                   key: {{ include "core.authClientSecretKey" . }}
+            {{- end }}
             {{- if or .Values.global.elasticsearch.tls.existingSecret .Values.global.opensearch.tls.existingSecret }}
             - name: JAVA_TOOL_OPTIONS
               value: {{ .Values.core.javaOpts }} -Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/externaldb.jks


### PR DESCRIPTION
### Which problem does the PR fix?

Related to: https://github.com/camunda/camunda-platform-helm/issues/2525

### What's in this PR?

Disable core client secret en var if identity is disabled.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
