### PR TITLE
fix: renovate anything to registry.camunda.cloud should disable minor…

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -141,7 +141,7 @@
     {
       // Disable app minor version update in the previous Camunda Helm charts.
       "enabled": false,
-      "matchPackageNames": ["/.*camunda\/[.-]*/", "registry.camunda.cloud/console/console-sm"],
+      "matchPackageNames": ["/.*camunda\/[.-]*/", "/registry.camunda.cloud/[.-\/]*/"],
       "matchFileNames": [
         "charts/camunda-platform-8.*/values.yaml",
         "charts/camunda-platform-8.*/values-latest.yaml",


### PR DESCRIPTION
… version bumps

### Which problem does the PR fix?

In a previous renovate fix, I explicitly disabled minor version bumps to registry.camunda.cloud/console-sm , and my reasoning was that we've already moved over the web-modeler docker image to DockerHub . However, I forgot about the stable releases still referencing registry.camunda.cloud.

Because of this mistake, a faulty PR got recommended:
https://github.com/camunda/camunda-platform-helm/pull/2539

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

This change converts the registry.camunda.cloud/console-sm package rule to match against a regex so that it also will work for the web-modeler docker image.  I have tested this regex by running renovate locally against a forked branch validating that I could reproduce the faulty recommended PR
https://github.com/camunda/camunda-platform-helm/pull/2539

and then that it would get closed after my patch, and it did.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
