### PR TITLE
refactor: remove support for global.multiregion.installationType

### DIFF
--- a/charts/camunda-platform-alpha/templates/camunda/constraints.tpl
+++ b/charts/camunda-platform-alpha/templates/camunda/constraints.tpl
@@ -197,24 +197,20 @@ The following values inside your values.yaml need to be set but were not:
       {{- end }}
     {{- end }}
   {{- end }}
-  {{- if .Values.global.multiregion.installationType }}
-    {{- $installationTypeMessage := "[camunda][warning]\nDEPRECATION NOTICE: Starting from appVersion 8.7, the Camunda Helm chart will no longer support the global.multiregion.installationType option. This is replaced with a new procedure for managing multi-region installations documented here:\nhttps://docs.camunda.io/docs/self-managed/operational-guides/multi-region/dual-region-operational-procedure/\nPlease unset this option to remove the warning.\n" }}
-    {{ printf "\n%s" $installationTypeMessage }}
-  {{- end }}
 {{- end }}
 
-
 {{/*
-TODO: Enable for 8.7 cycle.
+Camunda 8.7 cycle deprecated keys.
 
 Fail with a message when old values syntax is used.
 Chart Version: 12.0.0
+*/}}
 
-{{- if (TBA) }}
-  {{- $errorMessage := printf "[camunda][error] %s %s"
-      "TBA"
-      "TBA"
+{{- if hasKey .Values.global.multiregion "installationType" }}
+  {{- $errorMessage := printf "[camunda][error] %s %s %s"
+      "The option \"global.multiregion.installationType\" has been removed."
+      "Use application API's for multi-region failover/failback operations."
+      "More details: https://docs.camunda.io/docs/self-managed/operational-guides/multi-region/dual-region-operational-procedure/"
   -}}
   {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}
-*/}}

--- a/charts/camunda-platform-alpha/templates/core/statefulset.yaml
+++ b/charts/camunda-platform-alpha/templates/core/statefulset.yaml
@@ -10,12 +10,7 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
-  {{- if eq .Values.global.multiregion.installationType "failOver" }}
-  replicas: {{ div (div .Values.core.clusterSize .Values.global.multiregion.regions) 2 }}
-  {{- end }}
-  {{- if ne .Values.global.multiregion.installationType "failOver" }}
   replicas: {{ div .Values.core.clusterSize .Values.global.multiregion.regions }}
-  {{- end }}
   selector:
     matchLabels:
       {{- include "core.matchLabels" . | nindent 6 }}

--- a/charts/camunda-platform-alpha/test/unit/core/configmap_test.go
+++ b/charts/camunda-platform-alpha/test/unit/core/configmap_test.go
@@ -68,66 +68,6 @@ func TestGoldenConfigmapWithLog4j2(t *testing.T) {
 	})
 }
 
-func TestGoldenConfigmapWithMultiregionNormal(t *testing.T) {
-	t.Parallel()
-
-	chartPath, err := filepath.Abs("../../../")
-	require.NoError(t, err)
-
-	suite.Run(t, &utils.TemplateGoldenTest{
-		ChartPath:      chartPath,
-		Release:        "camunda-platform-test",
-		Namespace:      "camunda-platform-" + strings.ToLower(random.UniqueId()),
-		GoldenFileName: "configmap",
-		Templates:      []string{"templates/core/configmap.yaml"},
-		SetValues: map[string]string{
-			"global.multiregion.regions":          "1",
-			"global.multiregion.regionId":         "0",
-			"global.multiregion.installationType": "normal",
-		},
-	})
-}
-
-func TestGoldenConfigmapWithMultiregionFailOver(t *testing.T) {
-	t.Parallel()
-
-	chartPath, err := filepath.Abs("../../../")
-	require.NoError(t, err)
-
-	suite.Run(t, &utils.TemplateGoldenTest{
-		ChartPath:      chartPath,
-		Release:        "camunda-platform-test",
-		Namespace:      "camunda-platform-" + strings.ToLower(random.UniqueId()),
-		GoldenFileName: "configmap-multiregion-failOver",
-		Templates:      []string{"templates/core/configmap.yaml"},
-		SetValues: map[string]string{
-			"global.multiregion.regions":          "1",
-			"global.multiregion.regionId":         "0",
-			"global.multiregion.installationType": "failOver",
-		},
-	})
-}
-
-func TestGoldenConfigmapWithMultiregionFailBack(t *testing.T) {
-	t.Parallel()
-
-	chartPath, err := filepath.Abs("../../../")
-	require.NoError(t, err)
-
-	suite.Run(t, &utils.TemplateGoldenTest{
-		ChartPath:      chartPath,
-		Release:        "camunda-platform-test",
-		Namespace:      "camunda-platform-" + strings.ToLower(random.UniqueId()),
-		GoldenFileName: "configmap-multiregion-failBack",
-		Templates:      []string{"templates/core/configmap.yaml"},
-		SetValues: map[string]string{
-			"global.multiregion.regions":          "1",
-			"global.multiregion.regionId":         "0",
-			"global.multiregion.installationType": "failBack",
-		},
-	})
-}
-
 func (s *configmapTemplateTest) TestContainerShouldContainExporterClassPerDefault() {
 	// given
 	options := &helm.Options{

--- a/charts/camunda-platform-alpha/values.yaml
+++ b/charts/camunda-platform-alpha/values.yaml
@@ -365,8 +365,6 @@ global:
     regions: 1
     ## @skip global.multiregion.regionId unique id of the region. MUST start at 0 for the computation to work correctly. With 2 regions, you would have region 0 and 1.
     regionId: 0
-    ## @skip global.multiregion.installationType mode of installation for multi-region disaster recovery: normal, failOver, failBack
-    installationType: normal
 
 
 #------------------------------------------------------------------------------------------------------------------------------------------#


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes: https://github.com/camunda/camunda-platform-helm/issues/2380

### What's in this PR?

In Camunda 8.7 release, the Multi-Region setup doesn't need Helm config anymore via `global.multiregion.installationType`.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
