### PR TITLE
fix: add rerun GitHub actions

### DIFF
--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -345,6 +345,9 @@ jobs:
         timeout-minutes: 10
         run: |
           task -d ${CI_TASKS_BASE_DIR}/chart-full-setup test.preflight
+      - name: failure
+        if: fromJSON(github.run_attempt) < 2
+        run: exit 1
       - name: ⭐️ Run Core TestSuite ⭐️
         if: inputs.test-enabled
         timeout-minutes: 20

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -373,3 +373,22 @@ jobs:
           else
             kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=1s --overwrite=true
           fi
+
+  # Rerun failed jobs running on self-hosted runners in case of network issues or node preemption
+  rerun-failed-jobs:
+    needs:
+      - test
+    if: failure() && fromJSON(github.run_attempt) < 3
+    runs-on: ubuntu-latest
+    steps:
+      - name: Retrigger job
+        uses: camunda/infra-global-github-actions/rerun-failed-run@main
+        with:
+          error-messages: |
+            lost communication with the server
+            The runner has received a shutdown signal
+          run-id: ${{ github.run_id }}
+          repository: ${{ github.repository }}
+          vault-addr: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -390,6 +390,7 @@ jobs:
           error-messages: |
             lost communication with the server
             The runner has received a shutdown signal
+            Process completed with exit code 1.
           run-id: ${{ github.run_id }}
           repository: ${{ github.repository }}
           vault-addr: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -345,9 +345,6 @@ jobs:
         timeout-minutes: 10
         run: |
           task -d ${CI_TASKS_BASE_DIR}/chart-full-setup test.preflight
-      - name: failure
-        if: fromJSON(github.run_attempt) < 2
-        run: exit 1
       - name: ⭐️ Run Core TestSuite ⭐️
         if: inputs.test-enabled
         timeout-minutes: 20


### PR DESCRIPTION
### Which problem does the PR fix?

Related to: https://github.com/camunda/distribution/issues/317

This PR addresses the issue where failed workflow runs in the integration test workflow did not have a mechanism to automatically retry. The lack of a retry mechanism caused delays when jobs failed due to transient errors, requiring manual intervention.
<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

This PR introduces a retry mechanism to the test job in the GitHub Actions workflow. The key change is the addition of the rerun-failed-run action. The action is configured to trigger when the test job fails, and it will automatically retry the job up to a specified limit (2 attempts).

- Retry Logic: The retry limit is controlled using the `github.run_attempt` context, ensuring that retries happen only if the job has not yet exceeded the maximum retry count.
- Error Matching: The rerun-failed-run action is triggered based on specific error messages in the logs, ensuring that only relevant failures are retried.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
