### PR TITLE
ci: add github-workflow-rerun-enabled flag for rerun github actions

### DIFF
--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -380,7 +380,8 @@ jobs:
           fi
 
   # Rerun failed jobs running on self-hosted runners in case of network issues or node preemption
-  github-workflow-rerun-enabled:
+  rerun-failed-jobs:
+    name: Rerun failed jobs
     needs:
       - test
     if: failure() && inputs.github-workflow-rerun-enabled == true && fromJSON(github.run_attempt) < 3

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -345,6 +345,9 @@ jobs:
         timeout-minutes: 10
         run: |
           task -d ${CI_TASKS_BASE_DIR}/chart-full-setup test.preflight
+      - name: failure
+        if: fromJSON(github.run_attempt) < 2
+        run: exit 1
       - name: ⭐️ Run Core TestSuite ⭐️
         if: inputs.test-enabled
         timeout-minutes: 20

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -390,6 +390,7 @@ jobs:
           error-messages: |
             lost communication with the server
             The runner has received a shutdown signal
+            Process completed with exit code 1.
           run-id: ${{ github.run_id }}
           repository: ${{ github.repository }}
           vault-addr: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -390,8 +390,8 @@ jobs:
         uses: camunda/infra-global-github-actions/rerun-failed-run@main
         with:
           error-messages: |
-            lost communication with the server
-            The runner has received a shutdown signal
+            lost communication with the server.
+            The runner has received a shutdown signal.
             Process completed with exit code 1.
           run-id: ${{ github.run_id }}
           repository: ${{ github.repository }}

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -345,9 +345,6 @@ jobs:
         timeout-minutes: 10
         run: |
           task -d ${CI_TASKS_BASE_DIR}/chart-full-setup test.preflight
-      - name: failure
-        if: fromJSON(github.run_attempt) < 2
-        run: exit 1
       - name: ⭐️ Run Core TestSuite ⭐️
         if: inputs.test-enabled
         timeout-minutes: 20

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -80,7 +80,7 @@ on:
         required: false
         default: auto-generated
         type: string
-      retry-enabled:
+      rerun-failed-jobs:
         description: Flag to enable or disable retries for failed runs
         required: false
         default: true
@@ -383,7 +383,7 @@ jobs:
   rerun-failed-jobs:
     needs:
       - test
-    if: failure() && inputs.retry-enabled == true && fromJSON(github.run_attempt) < 3
+    if: failure() && inputs.rerun-failed-jobs == true && fromJSON(github.run_attempt) < 3
     runs-on: ubuntu-latest
     steps:
       - name: Retrigger job

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -387,7 +387,6 @@ jobs:
           error-messages: |
             lost communication with the server
             The runner has received a shutdown signal
-            Process completed with exit code 1.
           run-id: ${{ github.run_id }}
           repository: ${{ github.repository }}
           vault-addr: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -380,7 +380,7 @@ jobs:
           fi
 
   # Rerun failed jobs running on self-hosted runners in case of network issues or node preemption
-  rerun-failed-jobs:
+  github-workflow-rerun-enabled:
     needs:
       - test
     if: failure() && inputs.github-workflow-rerun-enabled == true && fromJSON(github.run_attempt) < 3

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -80,6 +80,11 @@ on:
         required: false
         default: auto-generated
         type: string
+      retry-enabled:
+        description: Flag to enable or disable retries for failed runs
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: read
@@ -378,7 +383,7 @@ jobs:
   rerun-failed-jobs:
     needs:
       - test
-    if: failure() && fromJSON(github.run_attempt) < 3
+    if: failure() && inputs.retry-enabled == true && fromJSON(github.run_attempt) < 3
     runs-on: ubuntu-latest
     steps:
       - name: Retrigger job

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -80,7 +80,7 @@ on:
         required: false
         default: auto-generated
         type: string
-      rerun-failed-jobs:
+      github-workflow-rerun-enabled:
         description: Flag to enable or disable retries for failed runs
         required: false
         default: true
@@ -383,7 +383,7 @@ jobs:
   rerun-failed-jobs:
     needs:
       - test
-    if: failure() && inputs.rerun-failed-jobs == true && fromJSON(github.run_attempt) < 3
+    if: failure() && inputs.github-workflow-rerun-enabled == true && fromJSON(github.run_attempt) < 3
     runs-on: ubuntu-latest
     steps:
       - name: Retrigger job


### PR DESCRIPTION
### Which problem does the PR fix?

related to: https://github.com/camunda/camunda-platform-helm/pull/2603

add github-workflow-rerun-enabled flag to enable/disable rerun github actions

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
