### PR TITLE
fix: add missing components when identity disabled.

### DIFF
--- a/charts/camunda-platform-alpha/templates/core/configmap.yaml
+++ b/charts/camunda-platform-alpha/templates/core/configmap.yaml
@@ -42,7 +42,7 @@ data:
     {{- else }}
     spring:
       profiles:
-        active: auth
+        active: "operate,tasklist,broker,auth"
     {{- end }}
 
     management:


### PR DESCRIPTION
### Which problem does the PR fix?

When identity auth is disabled the only profile that's set is auth. This means it doesn't start the other components.

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
