### PR TITLE
refactor: unify authorization configuration

### DIFF
--- a/charts/camunda-platform-alpha/templates/core/configmap.yaml
+++ b/charts/camunda-platform-alpha/templates/core/configmap.yaml
@@ -67,12 +67,6 @@ data:
         level: {{ .Values.core.logLevel | quote }}
 
       broker:
-        # zeebe.broker.experimental
-        experimental:
-          engine:
-            authorization:
-              enableAuthorization: {{ .Values.global.authorizations.enabled }}
-
         # zeebe.broker.gateway
         gateway:
           enable: true
@@ -235,7 +229,6 @@ data:
         {{- if .Values.global.identity.auth.enabled }}
         identity:
           redirectRootUrl: "{{ tpl .Values.global.identity.auth.core.redirectUrl $ }}/operate"
-          resourcePermissionsEnabled: {{ .Values.global.authorizations.enabled }}
         {{- end }}
       
         # ELS instance to store Operate data
@@ -310,7 +303,6 @@ data:
         {{- if .Values.global.identity.auth.enabled }}
         identity:
           redirectRootUrl: "{{ tpl .Values.global.identity.auth.core.redirectUrl $ }}/tasklist"
-          resourcePermissionsEnabled: {{ .Values.global.authorizations.enabled }}
         {{- end }}
 
         # Set Tasklist username and password.

--- a/charts/camunda-platform-alpha/test/unit/core/golden/configmap-authorizations.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/core/golden/configmap-authorizations.golden.yaml
@@ -55,12 +55,6 @@ data:
         level: "info"
 
       broker:
-        # zeebe.broker.experimental
-        experimental:
-          engine:
-            authorization:
-              enableAuthorization: true
-
         # zeebe.broker.gateway
         gateway:
           enable: true
@@ -147,7 +141,6 @@ data:
       operate:
         identity:
           redirectRootUrl: "http://localhost:8082/operate"
-          resourcePermissionsEnabled: true
       
         # ELS instance to store Operate data
         elasticsearch:
@@ -182,7 +175,6 @@ data:
       tasklist:
         identity:
           redirectRootUrl: "http://localhost:8082/tasklist"
-          resourcePermissionsEnabled: true
 
         # Set Tasklist username and password.
         # If user with <username> does not exists it will be created.

--- a/charts/camunda-platform-alpha/test/unit/core/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/core/golden/configmap-log4j2.golden.yaml
@@ -55,12 +55,6 @@ data:
         level: "info"
 
       broker:
-        # zeebe.broker.experimental
-        experimental:
-          engine:
-            authorization:
-              enableAuthorization: false
-
         # zeebe.broker.gateway
         gateway:
           enable: true
@@ -147,7 +141,6 @@ data:
       operate:
         identity:
           redirectRootUrl: "http://localhost:8082/operate"
-          resourcePermissionsEnabled: false
       
         # ELS instance to store Operate data
         elasticsearch:
@@ -182,7 +175,6 @@ data:
       tasklist:
         identity:
           redirectRootUrl: "http://localhost:8082/tasklist"
-          resourcePermissionsEnabled: false
 
         # Set Tasklist username and password.
         # If user with <username> does not exists it will be created.

--- a/charts/camunda-platform-alpha/test/unit/core/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/core/golden/configmap.golden.yaml
@@ -55,12 +55,6 @@ data:
         level: "info"
 
       broker:
-        # zeebe.broker.experimental
-        experimental:
-          engine:
-            authorization:
-              enableAuthorization: false
-
         # zeebe.broker.gateway
         gateway:
           enable: true
@@ -147,7 +141,6 @@ data:
       operate:
         identity:
           redirectRootUrl: "http://localhost:8082/operate"
-          resourcePermissionsEnabled: false
       
         # ELS instance to store Operate data
         elasticsearch:
@@ -182,7 +175,6 @@ data:
       tasklist:
         identity:
           redirectRootUrl: "http://localhost:8082/tasklist"
-          resourcePermissionsEnabled: false
 
         # Set Tasklist username and password.
         # If user with <username> does not exists it will be created.


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
With https://github.com/camunda/camunda/issues/25373, a single a parameter `camunda.security.authorizations.enabled` is used to enable authorizations. Backward compatibility will be maintained for the legacy parameters `camunda.operate.identity.resourcePermissionsEnabled` and `camunda.tasklist.identity.resourcePermissionsEnabled`

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
