### PR TITLE
fix(openshift): allow usage of the route with the default router

### DIFF
--- a/charts/camunda-platform-8.6/templates/camunda/ingress.yaml
+++ b/charts/camunda-platform-8.6/templates/camunda/ingress.yaml
@@ -110,7 +110,7 @@ spec:
             pathType: {{ .Values.zeebeGateway.ingress.rest.pathType | default .Values.global.ingress.pathType }}
           {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
-  {{- if and (not .Values.global.ingress.tls.secretName) (contains "openshift-" .Values.global.ingress.className) }}
+  {{- if and (not .Values.global.ingress.tls.secretName) (contains "openshift-"  (default "" .Values.global.ingress.className)) }}
     # The tls block is not applied because .Values.global.ingress.tls.secretName is empty
     # and .Values.global.ingress.className contains "openshift-".
     # This is necessary to use the certificate managed by the OpenShift Ingress operator,

--- a/charts/camunda-platform-8.6/templates/connectors/ingress.yaml
+++ b/charts/camunda-platform-8.6/templates/connectors/ingress.yaml
@@ -28,7 +28,7 @@ spec:
                 port:
                   number: 8080
   {{- if .Values.connectors.ingress.tls.enabled }}
-  {{- if and (not .Values.connectors.ingress.tls.secretName) (contains "openshift-" .Values.connectors.ingress.className) }}
+  {{- if and (not .Values.connectors.ingress.tls.secretName) (contains "openshift-"  (default "" .Values.connectors.ingress.className)) }}
     # The tls block is not applied because .Values.connectors.ingress.tls.secretName is empty
     # and .Values.connectors.ingress.className contains "openshift-".
     # This is necessary to use the certificate managed by the OpenShift Ingress operator,

--- a/charts/camunda-platform-8.6/templates/console/ingress.yaml
+++ b/charts/camunda-platform-8.6/templates/console/ingress.yaml
@@ -27,7 +27,7 @@ spec:
                 port:
                   number: 80
   {{- if .Values.console.ingress.tls.enabled }}
-  {{- if and (not .Values.console.ingress.tls.secretName) (contains "openshift-" .Values.console.ingress.className) }}
+  {{- if and (not .Values.console.ingress.tls.secretName) (contains "openshift-"  (default "" .Values.console.ingress.className)) }}
     # The tls block is not applied because .Values.console.ingress.tls.secretName is empty
     # and .Values.console.ingress.className contains "openshift-".
     # This is necessary to use the certificate managed by the OpenShift Ingress operator,

--- a/charts/camunda-platform-8.6/templates/execution-identity/ingress.yaml
+++ b/charts/camunda-platform-8.6/templates/execution-identity/ingress.yaml
@@ -27,7 +27,7 @@ spec:
                 port:
                   number: 80
   {{- if .Values.executionIdentity.ingress.tls.enabled }}
-  {{- if and (not .Values.executionIdentity.ingress.tls.secretName) (contains "openshift-" .Values.executionIdentity.ingress.className) }}
+  {{- if and (not .Values.executionIdentity.ingress.tls.secretName) (contains "openshift-"  (default "" .Values.executionIdentity.ingress.className)) }}
     # The tls block is not applied because .Values.executionIdentity.ingress.tls.secretName is empty
     # and .Values.executionIdentity.ingress.className contains "openshift-".
     # This is necessary to use the certificate managed by the OpenShift Ingress operator,

--- a/charts/camunda-platform-8.6/templates/identity/ingress.yaml
+++ b/charts/camunda-platform-8.6/templates/identity/ingress.yaml
@@ -28,7 +28,7 @@ spec:
                 port:
                   number: 80
   {{- if .Values.identity.ingress.tls.enabled }}
-  {{- if and (not .Values.identity.ingress.tls.secretName) (contains "openshift-" .Values.identity.ingress.className) }}
+  {{- if and (not .Values.identity.ingress.tls.secretName) (contains "openshift-"  (default "" .Values.identity.ingress.className)) }}
     # The tls block is not applied because .Values.identity.ingress.tls.secretName is empty
     # and .Values.identity.ingress.className contains "openshift-".
     # This is necessary to use the certificate managed by the OpenShift Ingress operator,

--- a/charts/camunda-platform-8.6/templates/operate/ingress.yaml
+++ b/charts/camunda-platform-8.6/templates/operate/ingress.yaml
@@ -27,7 +27,7 @@ spec:
                 port:
                   number: 80
   {{- if .Values.operate.ingress.tls.enabled }}
-  {{- if and (not .Values.operate.ingress.tls.secretName) (contains "openshift-" .Values.operate.ingress.className) }}
+  {{- if and (not .Values.operate.ingress.tls.secretName) (contains "openshift-"  (default "" .Values.operate.ingress.className)) }}
     # The tls block is not applied because .Values.operate.ingress.tls.secretName is empty
     # and .Values.operate.ingress.className contains "openshift-".
     # This is necessary to use the certificate managed by the OpenShift Ingress operator,

--- a/charts/camunda-platform-8.6/templates/optimize/ingress.yaml
+++ b/charts/camunda-platform-8.6/templates/optimize/ingress.yaml
@@ -27,7 +27,7 @@ spec:
                 port:
                   number: 80
   {{- if .Values.optimize.ingress.tls.enabled }}
-  {{- if and (not .Values.optimize.ingress.tls.secretName) (contains "openshift-" .Values.optimize.ingress.className) }}
+  {{- if and (not .Values.optimize.ingress.tls.secretName) (contains "openshift-"  (default "" .Values.optimize.ingress.className)) }}
     # The tls block is not applied because .Values.optimize.ingress.tls.secretName is empty
     # and .Values.optimize.ingress.className contains "openshift-".
     # This is necessary to use the certificate managed by the OpenShift Ingress operator,

--- a/charts/camunda-platform-8.6/templates/tasklist/ingress.yaml
+++ b/charts/camunda-platform-8.6/templates/tasklist/ingress.yaml
@@ -27,7 +27,7 @@ spec:
                 port:
                   number: 80
   {{- if .Values.tasklist.ingress.tls.enabled }}
-  {{- if and (not .Values.tasklist.ingress.tls.secretName) (contains "openshift-" .Values.tasklist.ingress.className) }}
+  {{- if and (not .Values.tasklist.ingress.tls.secretName) (contains "openshift-"  (default "" .Values.tasklist.ingress.className)) }}
     # The tls block is not applied because .Values.tasklist.ingress.tls.secretName is empty
     # and .Values.tasklist.ingress.className contains "openshift-".
     # This is necessary to use the certificate managed by the OpenShift Ingress operator,

--- a/charts/camunda-platform-8.6/templates/web-modeler/ingress.yaml
+++ b/charts/camunda-platform-8.6/templates/web-modeler/ingress.yaml
@@ -35,7 +35,7 @@ spec:
   {{- if and 
     (not .Values.webModeler.ingress.webapp.tls.secretName) 
     (not .Values.webModeler.ingress.websockets.tls.secretName) 
-    (contains "openshift-" .Values.webModeler.ingress.className) 
+    (contains "openshift-"  (default "" .Values.webModeler.ingress.className)) 
   }}
     # The tls block is not applied because both .Values.webModeler.ingress.webapp.tls.secretName and .Values.webModeler.ingress.websockets.tls.secretName are empty
     # and .Values.webModeler.ingress.className contains "openshift-".

--- a/charts/camunda-platform-8.6/templates/zeebe-gateway/ingress-grpc.yaml
+++ b/charts/camunda-platform-8.6/templates/zeebe-gateway/ingress-grpc.yaml
@@ -29,7 +29,7 @@ spec:
   {{- if .Values.zeebeGateway.ingress.grpc.tls.enabled }}
   {{- if and 
     (not .Values.zeebeGateway.ingress.grpc.tls.secretName) 
-    (contains "openshift-" .Values.zeebeGateway.ingress.className) 
+    (contains "openshift-" (default "" .Values.zeebeGateway.ingress.grpc.className)) 
   }}
     # The tls block is not applied because .Values.zeebeGateway.ingress.grpc.tls.secretName is empty
     # and .Values.zeebeGateway.ingress.className contains "openshift-".

--- a/charts/camunda-platform-8.6/templates/zeebe-gateway/ingress-rest.yaml
+++ b/charts/camunda-platform-8.6/templates/zeebe-gateway/ingress-rest.yaml
@@ -29,7 +29,7 @@ spec:
   {{- if .Values.zeebeGateway.ingress.rest.tls.enabled }}
   {{- if and 
     (not .Values.zeebeGateway.ingress.rest.tls.secretName) 
-    (contains "openshift-" .Values.zeebeGateway.ingress.className) 
+    (contains "openshift-"  (default "" .Values.zeebeGateway.ingress.rest.className))
   }}
     # The tls block is not applied because .Values.zeebeGateway.ingress.rest.tls.secretName is empty
     # and .Values.zeebeGateway.ingress.className contains "openshift-".

--- a/charts/camunda-platform-alpha/templates/camunda/ingress-grpc.yaml
+++ b/charts/camunda-platform-alpha/templates/camunda/ingress-grpc.yaml
@@ -29,7 +29,7 @@ spec:
   {{- if .Values.core.ingress.grpc.tls.enabled }}
   {{- if and 
     (not .Values.core.ingress.grpc.tls.secretName) 
-    (contains "openshift-" .Values.core.ingress.className) 
+    (contains "openshift-"  (default "" .Values.core.ingress.className)) 
   }}
     # The tls block is not applied because .Values.core.ingress.grpc.tls.secretName is empty
     # and .Values.core.ingress.className contains "openshift-".

--- a/charts/camunda-platform-alpha/templates/camunda/ingress-http.yaml
+++ b/charts/camunda-platform-alpha/templates/camunda/ingress-http.yaml
@@ -97,7 +97,7 @@ spec:
   {{- if .Values.global.ingress.tls.enabled }}
   {{- if and 
     (not .Values.global.ingress.tls.secretName) 
-    (contains "openshift-" .Values.global.ingress.className) 
+    (contains "openshift-"  (default "" .Values.global.ingress.className)) 
   }}
     # The tls block is not applied because .Values.global.ingress.tls.secretName is empty
     # and .Values.global.ingress.className contains "openshift-".


### PR DESCRIPTION
### Which problem does the PR fix?

This PR introduces a fix for https://github.com/camunda/camunda-platform-helm/issues/2620

### What's in this PR?

The fix is implemented by checking the className, if it contains "openshift-" and if no secret is set, then the tls block is completely removed, allowing fallback on the TLS of the Router.
It does not break the other mechanisms related to the https scheme. 

For the context, here's an example usage https://github.com/camunda/camunda-deployment-references/blob/12cfae837701d9bc1c7e583400bfd897eee60efc/aws/rosa-hcp/camunda-versions/8.7/procedure/install/helm-values/domain.yml#L12 (don't pay attention to the version, it's a 8.6 file, I've not tested it with 8.7, but it should work also)

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed). <= we don't test the default Router currently, I've tested it as part of the infraex reference arch
- [x] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed). <= The associated documentation will be updated with the introduction of ROSA specific reference arch

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
