### PR TITLE
fix: downgrade gomplate over Not Found errors in v4

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
 git-cliff 2.5.0
 golang 1.23.3
-gomplate 4.2.0
+gomplate v3.11.7
 helm 3.16.3
 helm-ct 3.11.0
 kubectl 1.27.16 # The kubectl version depends on the K8s CI cluster version


### PR DESCRIPTION
### Which problem does the PR fix?

Gomplate repeatedly causes failures in the release chores CI in our release process due to v4 returning 404 Not Found from ASDF. v3 still lets you download the right version.

https://github.com/camunda/camunda-platform-helm/actions/runs/12197638945/job/34027709164?pr=2560

> /home/runner/.asdf/installs/gomplate/4.2.0/bin/gomplate: line 1: Not: command not found
make[1]: *** [Makefile:210: release.generate-version-matrix-unreleased] Error 127


<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
