### PR TITLE
fix: revert "downgrade gomplate over Not Found errors in v4"

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
 git-cliff 2.5.0
 golang 1.23.3
-gomplate 4.2.0
+gomplate v4.2.0
 helm 3.16.3
 helm-ct 3.11.0
 kubectl 1.27.16 # The kubectl version depends on the K8s CI cluster version

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
 git-cliff 2.5.0
 golang 1.23.3
-gomplate v3.11.7
+gomplate 4.2.0
 helm 3.16.3
 helm-ct 3.11.0
 kubectl 1.27.16 # The kubectl version depends on the K8s CI cluster version


### PR DESCRIPTION
Reverts camunda/camunda-platform-helm#2650 due to the issue actually being related to the missing v from the .tool-versions file. Renovate seems to chomp that character during upgrades.