### PR TITLE
feat(connectors): add connectorsExternalURL and use it in a new Connectors Release Template component

### DIFF
--- a/charts/camunda-platform-alpha/templates/camunda/_helpers.tpl
+++ b/charts/camunda-platform-alpha/templates/camunda/_helpers.tpl
@@ -402,6 +402,17 @@ Optimize templates.
   {{- printf "%s" (include "camundaPlatform.getExternalURL" (dict "component" "optimize" "context" .)) -}}
 {{- end -}}
 
+{{/*
+********************************************************************************
+Connectors templates.
+********************************************************************************
+*/}}
+{{/*
+[camunda-platform] Connectors external URL.
+*/}}
+{{- define "camundaPlatform.connectorsExternalURL" }}
+  {{- printf "%s" (include "camundaPlatform.getExternalURL" (dict "component" "connectors" "context" .)) -}}
+{{- end -}}
 
 {{/*
 ********************************************************************************
@@ -643,6 +654,17 @@ Release templates.
     url: {{ include "camundaPlatform.optimizeExternalURL" . }}
     readiness: {{ printf "%s:%v%s%s" $baseURLInternal .Values.optimize.service.port .Values.optimize.contextPath .Values.optimize.readinessProbe.probePath }}
     metrics: {{ printf "%s:%v%s" $baseURLInternal .Values.optimize.service.managementPort .Values.optimize.metrics.prometheus }}
+  {{- end }}
+
+  {{- if .Values.connectors.enabled }}
+  {{-  $proto := (lower .Values.connectors.readinessProbe.scheme) -}}
+  {{- $baseURLInternal := printf "%s://%s.%s" $proto (include "connectors.fullname" .) .Release.Namespace }}
+  - name: Connectors
+    id: connectors
+    version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.connectors) }}
+    url: {{ include "camundaPlatform.connectorsExternalURL" . }}
+    readiness: {{ printf "%s:%v%s%s" $baseURLInternal .Values.connectors.service.serverPort .Values.connectors.contextPath .Values.connectors.readinessProbe.probePath }}
+    metrics: {{ printf "%s:%v%s" $baseURLInternal .Values.connectors.service.serverPort .Values.connectors.metrics.prometheus }}
   {{- end }}
 
   {{- if .Values.core.enabled }}

--- a/charts/camunda-platform-alpha/test/unit/console/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/console/golden/configmap.golden.yaml
@@ -51,6 +51,11 @@ data:
               url: http://localhost:8083
               readiness: http://camunda-platform-test-optimize.camunda-platform:80/api/readyz
               metrics: http://camunda-platform-test-optimize.camunda-platform:8092/actuator/prometheus
+            - name: Connectors
+              id: connectors
+              url: http://localhost:8086
+              readiness: http://camunda-platform-test-connectors.camunda-platform:8080/actuator/health/readiness
+              metrics: http://camunda-platform-test-connectors.camunda-platform:8080/actuator/prometheus
             - name: Operate
               id: operate
               url: http://localhost:8088/operate


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
In the context of [Manage and Run](https://github.com/camunda/product-hub/issues/1063)  we need to provide the `connectorsExternalURL` so that **Console** can consume this URL to create visuals.

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->
- new `connectorsExternalURL` variable
- new **Connectors** Release template component

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
