### PR TITLE
fix: changed name of zeebegateway in console configmap

### DIFF
--- a/charts/camunda-platform-8.8/templates/NOTES.txt
+++ b/charts/camunda-platform-8.8/templates/NOTES.txt
@@ -143,7 +143,7 @@ Default user and password: "{{ .Values.identity.firstUser.username -}}/{{ .Value
 {{- end }}
 
 {{- if .Values.core.ingress.grpc.enabled }}
-- Camunda gRPC API: {{  include "camundaPlatform.zeebeGatewayGRPCExternalURL" . }}
+- Camunda gRPC API: {{  include "camundaPlatform.coreGRPCExternalURL" . }}
 {{- end }}
 
 {{- if .Values.global.ingress.enabled }}

--- a/charts/camunda-platform-8.8/templates/camunda/_helpers.tpl
+++ b/charts/camunda-platform-8.8/templates/camunda/_helpers.tpl
@@ -572,7 +572,7 @@ Zeebe templates.
 {{/*
 [camunda-platform] Zeebe Gateway GRPC external URL.
 */}}
-{{- define "camundaPlatform.zeebeGatewayGRPCExternalURL" -}}
+{{- define "camundaPlatform.coreGRPCExternalURL" -}}
   {{ $proto := ternary "https" "http" .Values.core.ingress.grpc.tls.enabled -}}
   {{- printf "%s://%s" $proto (tpl .Values.core.ingress.grpc.host . | default "localhost:26500") -}}
 {{- end -}}
@@ -687,11 +687,12 @@ Release templates.
     url: {{ include "camundaPlatform.coreIdentityExternalURL" . }}
     readiness: {{ printf "%s%s%s" $baseURLInternal .Values.core.contextPath .Values.core.readinessProbe.probePath }}
     metrics: {{ printf "%s%s%s" $baseURLInternal .Values.core.contextPath .Values.core.metrics.prometheus }}
-  - name: Zeebe Gateway
-    id: zeebeGateway
+
+  - name: Orchestration Core
+    id: core
     version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.core) }}
     urls:
-      grpc: {{ include "camundaPlatform.zeebeGatewayGRPCExternalURL" . }}
+      grpc: {{ include "camundaPlatform.coreGRPCExternalURL" . }}
       http: {{ include "camundaPlatform.coreExternalURL" . }}
     readiness: {{ printf "%s%s%s" $baseURLInternal .Values.core.contextPath .Values.core.readinessProbe.probePath }}
     metrics: {{ printf "%s%s%s" $baseURLInternal .Values.core.contextPath .Values.core.metrics.prometheus }}

--- a/charts/camunda-platform-8.8/test/unit/console/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/console/golden/configmap.golden.yaml
@@ -59,8 +59,9 @@ data:
               url: http://localhost:8088/identity
               readiness: http://camunda-platform-test-core.camunda-platform:9600/actuator/health/readiness
               metrics: http://camunda-platform-test-core.camunda-platform:9600/actuator/prometheus
-            - name: Zeebe Gateway
-              id: zeebeGateway
+          
+            - name: Orchestration Core
+              id: core
               urls:
                 grpc: http://localhost:26500
                 http: http://localhost:8088


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
fixes: https://github.com/camunda/distribution/issues/348

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->
Zeebe Gateway is no more! Long live Camudna core!

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
