### PR TITLE
fix(zeebe-grpc-ingress): class check for openshift was not checked

### DIFF
--- a/charts/camunda-platform-8.6/templates/camunda/ingress.yaml
+++ b/charts/camunda-platform-8.6/templates/camunda/ingress.yaml
@@ -111,8 +111,7 @@ spec:
           {{- end }}
   {{- if .Values.global.ingress.tls.enabled }}
   {{- if and (not .Values.global.ingress.tls.secretName) (contains "openshift-"  (default "" .Values.global.ingress.className)) }}
-    # The tls block is not applied because .Values.global.ingress.tls.secretName is empty
-    # and .Values.global.ingress.className contains "openshift-".
+    # The tls block is not applied because secretName is empty and className contains "openshift-".
     # This is necessary to use the certificate managed by the OpenShift Ingress operator,
     # which will automatically convert this Ingress into a Route (https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/security_and_compliance/configuring-certificates#replacing-default-ingress_replacing-default-ingress).
   {{- else }}

--- a/charts/camunda-platform-8.6/templates/connectors/ingress.yaml
+++ b/charts/camunda-platform-8.6/templates/connectors/ingress.yaml
@@ -29,8 +29,7 @@ spec:
                   number: 8080
   {{- if .Values.connectors.ingress.tls.enabled }}
   {{- if and (not .Values.connectors.ingress.tls.secretName) (contains "openshift-"  (default "" .Values.connectors.ingress.className)) }}
-    # The tls block is not applied because .Values.connectors.ingress.tls.secretName is empty
-    # and .Values.connectors.ingress.className contains "openshift-".
+    # The tls block is not applied because secretName is empty and className contains "openshift-".
     # This is necessary to use the certificate managed by the OpenShift Ingress operator,
     # which will automatically convert this Ingress into a Route (https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/security_and_compliance/configuring-certificates#replacing-default-ingress_replacing-default-ingress).
   {{- else }}

--- a/charts/camunda-platform-8.6/templates/console/ingress.yaml
+++ b/charts/camunda-platform-8.6/templates/console/ingress.yaml
@@ -28,8 +28,7 @@ spec:
                   number: 80
   {{- if .Values.console.ingress.tls.enabled }}
   {{- if and (not .Values.console.ingress.tls.secretName) (contains "openshift-"  (default "" .Values.console.ingress.className)) }}
-    # The tls block is not applied because .Values.console.ingress.tls.secretName is empty
-    # and .Values.console.ingress.className contains "openshift-".
+    # The tls block is not applied because secretName is empty and className contains "openshift-".
     # This is necessary to use the certificate managed by the OpenShift Ingress operator,
     # which will automatically convert this Ingress into a Route (https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/security_and_compliance/configuring-certificates#replacing-default-ingress_replacing-default-ingress).
   {{- else }}

--- a/charts/camunda-platform-8.6/templates/execution-identity/ingress.yaml
+++ b/charts/camunda-platform-8.6/templates/execution-identity/ingress.yaml
@@ -28,8 +28,7 @@ spec:
                   number: 80
   {{- if .Values.executionIdentity.ingress.tls.enabled }}
   {{- if and (not .Values.executionIdentity.ingress.tls.secretName) (contains "openshift-"  (default "" .Values.executionIdentity.ingress.className)) }}
-    # The tls block is not applied because .Values.executionIdentity.ingress.tls.secretName is empty
-    # and .Values.executionIdentity.ingress.className contains "openshift-".
+    # The tls block is not applied because secretName is empty and className contains "openshift-".
     # This is necessary to use the certificate managed by the OpenShift Ingress operator,
     # which will automatically convert this Ingress into a Route (https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/security_and_compliance/configuring-certificates#replacing-default-ingress_replacing-default-ingress).
   {{- else }}

--- a/charts/camunda-platform-8.6/templates/identity/ingress.yaml
+++ b/charts/camunda-platform-8.6/templates/identity/ingress.yaml
@@ -29,8 +29,7 @@ spec:
                   number: 80
   {{- if .Values.identity.ingress.tls.enabled }}
   {{- if and (not .Values.identity.ingress.tls.secretName) (contains "openshift-"  (default "" .Values.identity.ingress.className)) }}
-    # The tls block is not applied because .Values.identity.ingress.tls.secretName is empty
-    # and .Values.identity.ingress.className contains "openshift-".
+    # The tls block is not applied because secretName is empty and className contains "openshift-".
     # This is necessary to use the certificate managed by the OpenShift Ingress operator,
     # which will automatically convert this Ingress into a Route (https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/security_and_compliance/configuring-certificates#replacing-default-ingress_replacing-default-ingress).
   {{- else }}

--- a/charts/camunda-platform-8.6/templates/operate/ingress.yaml
+++ b/charts/camunda-platform-8.6/templates/operate/ingress.yaml
@@ -28,8 +28,7 @@ spec:
                   number: 80
   {{- if .Values.operate.ingress.tls.enabled }}
   {{- if and (not .Values.operate.ingress.tls.secretName) (contains "openshift-"  (default "" .Values.operate.ingress.className)) }}
-    # The tls block is not applied because .Values.operate.ingress.tls.secretName is empty
-    # and .Values.operate.ingress.className contains "openshift-".
+    # The tls block is not applied because secretName is empty and className contains "openshift-".
     # This is necessary to use the certificate managed by the OpenShift Ingress operator,
     # which will automatically convert this Ingress into a Route (https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/security_and_compliance/configuring-certificates#replacing-default-ingress_replacing-default-ingress).
   {{- else }}

--- a/charts/camunda-platform-8.6/templates/optimize/ingress.yaml
+++ b/charts/camunda-platform-8.6/templates/optimize/ingress.yaml
@@ -28,8 +28,7 @@ spec:
                   number: 80
   {{- if .Values.optimize.ingress.tls.enabled }}
   {{- if and (not .Values.optimize.ingress.tls.secretName) (contains "openshift-"  (default "" .Values.optimize.ingress.className)) }}
-    # The tls block is not applied because .Values.optimize.ingress.tls.secretName is empty
-    # and .Values.optimize.ingress.className contains "openshift-".
+    # The tls block is not applied because secretName is empty and className contains "openshift-".
     # This is necessary to use the certificate managed by the OpenShift Ingress operator,
     # which will automatically convert this Ingress into a Route (https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/security_and_compliance/configuring-certificates#replacing-default-ingress_replacing-default-ingress).
   {{- else }}

--- a/charts/camunda-platform-8.6/templates/tasklist/ingress.yaml
+++ b/charts/camunda-platform-8.6/templates/tasklist/ingress.yaml
@@ -28,8 +28,7 @@ spec:
                   number: 80
   {{- if .Values.tasklist.ingress.tls.enabled }}
   {{- if and (not .Values.tasklist.ingress.tls.secretName) (contains "openshift-"  (default "" .Values.tasklist.ingress.className)) }}
-    # The tls block is not applied because .Values.tasklist.ingress.tls.secretName is empty
-    # and .Values.tasklist.ingress.className contains "openshift-".
+    # The tls block is not applied because secretName is empty and className contains "openshift-".
     # This is necessary to use the certificate managed by the OpenShift Ingress operator,
     # which will automatically convert this Ingress into a Route (https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/security_and_compliance/configuring-certificates#replacing-default-ingress_replacing-default-ingress).
   {{- else }}

--- a/charts/camunda-platform-8.6/templates/web-modeler/ingress.yaml
+++ b/charts/camunda-platform-8.6/templates/web-modeler/ingress.yaml
@@ -37,8 +37,7 @@ spec:
     (not .Values.webModeler.ingress.websockets.tls.secretName) 
     (contains "openshift-"  (default "" .Values.webModeler.ingress.className)) 
   }}
-    # The tls block is not applied because both .Values.webModeler.ingress.webapp.tls.secretName and .Values.webModeler.ingress.websockets.tls.secretName are empty
-    # and .Values.webModeler.ingress.className contains "openshift-".
+    # The tls block is not applied because secretName is empty and className contains "openshift-".
     # This is necessary to use the certificate managed by the OpenShift Ingress operator,
     # which will automatically convert this Ingress into a Route (https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/security_and_compliance/configuring-certificates#replacing-default-ingress_replacing-default-ingress).
   {{- else }}

--- a/charts/camunda-platform-8.6/templates/zeebe-gateway/ingress-grpc.yaml
+++ b/charts/camunda-platform-8.6/templates/zeebe-gateway/ingress-grpc.yaml
@@ -31,8 +31,7 @@ spec:
     (not .Values.zeebeGateway.ingress.grpc.tls.secretName) 
     (contains "openshift-" (default "" .Values.zeebeGateway.ingress.grpc.className)) 
   }}
-    # The tls block is not applied because .Values.zeebeGateway.ingress.grpc.tls.secretName is empty
-    # and .Values.zeebeGateway.ingress.className contains "openshift-".
+    # The tls block is not applied because secretName is empty and className contains "openshift-".
     # This is necessary to use the certificate managed by the OpenShift Ingress operator,
     # which will automatically convert this Ingress into a Route (https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/security_and_compliance/configuring-certificates#replacing-default-ingress_replacing-default-ingress).
   {{- else }}

--- a/charts/camunda-platform-8.6/templates/zeebe-gateway/ingress-rest.yaml
+++ b/charts/camunda-platform-8.6/templates/zeebe-gateway/ingress-rest.yaml
@@ -31,8 +31,7 @@ spec:
     (not .Values.zeebeGateway.ingress.rest.tls.secretName) 
     (contains "openshift-"  (default "" .Values.zeebeGateway.ingress.rest.className))
   }}
-    # The tls block is not applied because .Values.zeebeGateway.ingress.rest.tls.secretName is empty
-    # and .Values.zeebeGateway.ingress.className contains "openshift-".
+    # The tls block is not applied because secretName is empty and className contains "openshift-".
     # This is necessary to use the certificate managed by the OpenShift Ingress operator,
     # which will automatically convert this Ingress into a Route (https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/security_and_compliance/configuring-certificates#replacing-default-ingress_replacing-default-ingress).
   {{- else }}

--- a/charts/camunda-platform-alpha/templates/camunda/ingress-grpc.yaml
+++ b/charts/camunda-platform-alpha/templates/camunda/ingress-grpc.yaml
@@ -29,10 +29,9 @@ spec:
   {{- if .Values.core.ingress.grpc.tls.enabled }}
   {{- if and 
     (not .Values.core.ingress.grpc.tls.secretName) 
-    (contains "openshift-"  (default "" .Values.core.ingress.className)) 
+    (contains "openshift-"  (default "" .Values.core.ingress.grpc.className)) 
   }}
-    # The tls block is not applied because .Values.core.ingress.grpc.tls.secretName is empty
-    # and .Values.core.ingress.className contains "openshift-".
+    # The tls block is not applied because secretName is empty and className contains "openshift-".
     # This is necessary to use the certificate managed by the OpenShift Ingress operator,
     # which will automatically convert this Ingress into a Route (https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/security_and_compliance/configuring-certificates#replacing-default-ingress_replacing-default-ingress).
   {{- else }}

--- a/charts/camunda-platform-alpha/templates/camunda/ingress-http.yaml
+++ b/charts/camunda-platform-alpha/templates/camunda/ingress-http.yaml
@@ -99,8 +99,7 @@ spec:
     (not .Values.global.ingress.tls.secretName) 
     (contains "openshift-"  (default "" .Values.global.ingress.className)) 
   }}
-    # The tls block is not applied because .Values.global.ingress.tls.secretName is empty
-    # and .Values.global.ingress.className contains "openshift-".
+    # The tls block is not applied because secretName is empty and className contains "openshift-".
     # This is necessary to use the certificate managed by the OpenShift Ingress operator,
     # which will automatically convert this Ingress into a Route (https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/security_and_compliance/configuring-certificates#replacing-default-ingress_replacing-default-ingress).
   {{- else }}


### PR DESCRIPTION
### Which problem does the PR fix?

Previous PR https://github.com/camunda/camunda-platform-helm/pull/2646 fixed the OpenShift route but for the GRPC an error regarding the class condition of grpc is causing this route not to be created.

### What's in this PR?

This PR use the right className (https://github.com/camunda/camunda-platform-helm/pull/2678/files#diff-48ce3b026110eded528072962fcddbf15b3106b0d500843496a323d17def1ffe)

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
