### PR TITLE
chore(deps): correct value-latest of console and operate tag

### DIFF
--- a/charts/camunda-platform-8.3/values-latest.yaml
+++ b/charts/camunda-platform-8.3/values-latest.yaml
@@ -17,6 +17,7 @@ connectors:
 operate:
   # https://hub.docker.com/r/camunda/operate/tags?page=&page_size=&ordering=&name=8.3
   image:
+    repository: camunda/operate
     tag: 8.3.13
 
 optimize:
@@ -28,6 +29,7 @@ optimize:
 tasklist:
   # https://hub.docker.com/r/camunda/tasklist/tags?page=&page_size=&ordering=&name=8.3
   image:
+    repository: camunda/tasklist
     tag: 8.3.12
 
 webModeler:
@@ -40,11 +42,13 @@ webModeler:
 zeebe:
   # https://hub.docker.com/r/camunda/zeebe/tags?page=&page_size=&ordering=&name=8.3
   image:
+    repository: camunda/zeebe
     tag: 8.3.13
 
 zeebe-gateway:
   # https://hub.docker.com/r/camunda/zeebe/tags?page=&page_size=&ordering=&name=8.3
   image:
+    repository: camunda/zeebe
     tag: 8.3.13
 
 #

--- a/charts/camunda-platform-8.4/values-latest.yaml
+++ b/charts/camunda-platform-8.4/values-latest.yaml
@@ -24,6 +24,7 @@ connectors:
 operate:
   # https://hub.docker.com/r/camunda/operate/tags?page=&page_size=&ordering=&name=8.4
   image:
+    repository: camunda/operate
     tag: 8.4.10
 
 optimize:
@@ -35,6 +36,7 @@ optimize:
 tasklist:
   # https://hub.docker.com/r/camunda/tasklist/tags?page=&page_size=&ordering=&name=8.4
   image:
+    repository: camunda/tasklist
     tag: 8.4.8
 
 webModeler:
@@ -47,11 +49,13 @@ webModeler:
 zeebe:
   # https://hub.docker.com/r/camunda/zeebe/tags?page=&page_size=&ordering=&name=8.4
   image:
+    repository: camunda/zeebe
     tag: 8.4.9
 
 zeebe-gateway:
   # https://hub.docker.com/r/camunda/zeebe/tags?page=&page_size=&ordering=&name=8.4
   image:
+    repository: camunda/zeebe
     tag: 8.4.9
 
 #

--- a/charts/camunda-platform-8.5/values-latest.yaml
+++ b/charts/camunda-platform-8.5/values-latest.yaml
@@ -29,6 +29,7 @@ connectors:
 operate:
   # https://hub.docker.com/r/camunda/operate/tags
   image:
+    repository: camunda/operate
     tag: 8.5.4
 
 optimize:
@@ -40,6 +41,7 @@ optimize:
 tasklist:
   # https://hub.docker.com/r/camunda/tasklist/tags
   image:
+    repository: camunda/tasklist
     tag: 8.5.2
 
 webModeler:
@@ -52,11 +54,13 @@ webModeler:
 zeebe:
   # https://hub.docker.com/r/camunda/zeebe/tags
   image:
+    repository: camunda/zeebe
     tag: 8.5.3
 
 zeebeGateway:
   # https://hub.docker.com/r/camunda/zeebe/tags
   image:
+    repository: camunda/zeebe
     tag: 8.5.3
 
 #
@@ -66,6 +70,7 @@ zeebeGateway:
 identity:
   # https://hub.docker.com/r/camunda/identity/tags
   image:
+    repository: camunda/identity
     tag: 8.5.5
 
 identityKeycloak:

--- a/charts/camunda-platform-8.6/values-latest.yaml
+++ b/charts/camunda-platform-8.6/values-latest.yaml
@@ -12,7 +12,7 @@ console:
   # Camunda Enterprise repository.
   # https://hub.docker.com/r/camunda/console/tags
   image:
-    tag: 8.6.10
+    tag: 8.6.36
 
 connectors:
   # https://hub.docker.com/r/camunda/connectors-bundle/tags
@@ -23,7 +23,7 @@ connectors:
 operate:
   # https://hub.docker.com/r/camunda/operate/tags
   image:
-    tag: 8.6.3
+    tag: 8.6.6
 
 optimize:
   # https://hub.docker.com/r/camunda/optimize/tags

--- a/charts/camunda-platform-8.6/values-latest.yaml
+++ b/charts/camunda-platform-8.6/values-latest.yaml
@@ -12,6 +12,7 @@ console:
   # Camunda Enterprise repository.
   # https://hub.docker.com/r/camunda/console/tags
   image:
+    repository: camunda/console
     tag: 8.6.36
 
 connectors:
@@ -23,6 +24,7 @@ connectors:
 operate:
   # https://hub.docker.com/r/camunda/operate/tags
   image:
+    repository: camunda/operate
     tag: 8.6.6
 
 optimize:

--- a/charts/camunda-platform-alpha/values-latest.yaml
+++ b/charts/camunda-platform-alpha/values-latest.yaml
@@ -12,17 +12,13 @@ console:
   # Camunda Enterprise repository.
   # https://hub.docker.com/r/camunda/console/tags
   image:
+    repository: camunda/console
     tag: SNAPSHOT
 
 connectors:
   # https://hub.docker.com/r/camunda/connectors-bundle/tags
   image:
     repository: camunda/connectors-bundle
-    tag: SNAPSHOT
-
-operate:
-  # https://hub.docker.com/r/camunda/operate/tags
-  image:
     tag: SNAPSHOT
 
 optimize:
@@ -43,17 +39,12 @@ webModeler:
     # renovate: datasource=docker depName=camunda/web-modeler-restapi
     tag: SNAPSHOT
 
-zeebe:
-  # https://hub.docker.com/r/camunda/zeebe/tags
+core:
+  # https://hub.docker.com/r/camunda/camunda/tags
   image:
-    repository: camunda/zeebe
+    repository: camunda/camunda
     tag: SNAPSHOT
 
-zeebeGateway:
-  # https://hub.docker.com/r/camunda/zeebe/tags
-  image:
-    repository: camunda/zeebe
-    tag: SNAPSHOT
 
 #
 # Identity


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

Bump tags in value-latest of console and operate, as they are not correct (see [HC version matrix](https://helm.camunda.io/camunda-platform/version-matrix/camunda-8.6/#helm-chart-1104)) 

It was reported [internally in slack](https://camunda.slack.com/archives/C03UR0V2R2M/p1733472707272259) & we have a [support ticket](https://camunda.slack.com/archives/C084RV21ZKJ).

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
