### PR TITLE
fix(alpha): add missing auth for grpc api

### DIFF
--- a/charts/camunda-platform-alpha/templates/core/configmap.yaml
+++ b/charts/camunda-platform-alpha/templates/core/configmap.yaml
@@ -38,7 +38,6 @@ data:
                 redirect-uri: "{{ tpl .Values.global.identity.auth.core.redirectUrl $ | default $redirectURIDefault }}/login/oauth2/code/core"
                 provider: oidcclient
                 scope: openid,profile
-
     {{- else }}
     spring:
       profiles:
@@ -70,6 +69,18 @@ data:
         # zeebe.broker.gateway
         gateway:
           enable: true
+          # zeebe.broker.gateway.security
+          security:
+            authentication:
+            {{- if .Values.global.identity.auth.enabled }}
+              mode: identity
+              {{- $issuerURIDefault := (include "camundaPlatform.authIssuerBackendUrl" . | replace ":80" "") }}
+              issuerBackendUrl: {{ (include "camundaPlatform.authIssuerUrl" .) | default $issuerURIDefault | quote }}
+              audience: {{ include "core.authAudience" . | quote }}
+              type: {{ lower .Values.global.identity.auth.type | default "keycloak" }}
+            {{- else }}
+              mode: none
+            {{- end }}
           network:
             host: 0.0.0.0
             port: {{ .Values.core.service.grpcPort }}

--- a/charts/camunda-platform-alpha/test/unit/core/golden/configmap-authorizations.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/core/golden/configmap-authorizations.golden.yaml
@@ -58,6 +58,13 @@ data:
         # zeebe.broker.gateway
         gateway:
           enable: true
+          # zeebe.broker.gateway.security
+          security:
+            authentication:
+              mode: identity
+              issuerBackendUrl: "http://localhost:18080/auth/realms/camunda-platform"
+              audience: "core-api"
+              type: keycloak
           network:
             host: 0.0.0.0
             port: 26500

--- a/charts/camunda-platform-alpha/test/unit/core/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/core/golden/configmap-log4j2.golden.yaml
@@ -58,6 +58,13 @@ data:
         # zeebe.broker.gateway
         gateway:
           enable: true
+          # zeebe.broker.gateway.security
+          security:
+            authentication:
+              mode: identity
+              issuerBackendUrl: "http://localhost:18080/auth/realms/camunda-platform"
+              audience: "core-api"
+              type: keycloak
           network:
             host: 0.0.0.0
             port: 26500

--- a/charts/camunda-platform-alpha/test/unit/core/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/core/golden/configmap.golden.yaml
@@ -58,6 +58,13 @@ data:
         # zeebe.broker.gateway
         gateway:
           enable: true
+          # zeebe.broker.gateway.security
+          security:
+            authentication:
+              mode: identity
+              issuerBackendUrl: "http://localhost:18080/auth/realms/camunda-platform"
+              audience: "core-api"
+              type: keycloak
           network:
             host: 0.0.0.0
             port: 26500


### PR DESCRIPTION
### Which problem does the PR fix?

Task: https://github.com/camunda/camunda-platform-helm/issues/2525

### What's in this PR?

Add missing auth for gRPC API as it doesn't use the unified auth (yet).

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
