### PR TITLE
fix: envVar-identity-client-secret-not-passed

### DIFF
--- a/charts/camunda-platform-8.6/templates/identity/configmap.yaml
+++ b/charts/camunda-platform-8.6/templates/identity/configmap.yaml
@@ -218,7 +218,7 @@ data:
           - name: Identity
             id: {{  printf "%s" (include "identity.authClientId" .) | default "camunda-identity" | quote }}
             type: CONFIDENTIAL
-            secret: ${CAMUNDA_IDENTITY_CLIENT_SECRET:}
+            secret: ${CAMUNDA_IDENTITY_CLIENT_SECRET:${IDENTITY_CLIENT_SECRET}}
             root-url: {{ include "identity.externalUrl" . | quote }}
             redirect-uris:
               - "/auth/login-callback"

--- a/charts/camunda-platform-8.6/test/unit/identity/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.6/test/unit/identity/golden/configmap.golden.yaml
@@ -208,7 +208,7 @@ data:
           - name: Identity
             id: "camunda-identity"
             type: CONFIDENTIAL
-            secret: ${CAMUNDA_IDENTITY_CLIENT_SECRET:}
+            secret: ${CAMUNDA_IDENTITY_CLIENT_SECRET:${IDENTITY_CLIENT_SECRET}}
             root-url: "http://localhost:8080"
             redirect-uris:
               - "/auth/login-callback"


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

related https://github.com/camunda/camunda/issues/25904

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

Using `IDENTITY_CLIENT_SECRET` envVar in case `CAMUNDA_IDENTITY_CLIENT_SECRET` not set.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
