### PR TITLE
refactor: remove unused web-modeler config map entries

### DIFF
--- a/charts/camunda-platform-8.5/templates/web-modeler/configmap-restapi.yaml
+++ b/charts/camunda-platform-8.5/templates/web-modeler/configmap-restapi.yaml
@@ -6,8 +6,6 @@ metadata:
   labels: {{- include "webModeler.labels" . | nindent 4 }}
   annotations: {{- toYaml .Values.global.annotations | nindent 4 }}
 data:
-  pusher-app-id: web-modeler
-  pusher-app-key: {{ randAlphaNum 20 }}
   {{- if .Values.webModeler.restapi.configuration }}
   application.yaml: |
     {{ .Values.webModeler.restapi.configuration | indent 4 | trim }}
@@ -26,7 +24,7 @@ data:
         pusher:
           host: {{ include "webModeler.websockets.fullname" . | quote }}
           port: {{ .Values.webModeler.websockets.service.port }}
-    
+
         security:
           jwt:
             issuer:

--- a/charts/camunda-platform-8.5/templates/web-modeler/configmap-webapp.yaml
+++ b/charts/camunda-platform-8.5/templates/web-modeler/configmap-webapp.yaml
@@ -6,8 +6,6 @@ metadata:
   labels: {{- include "webModeler.labels" . | nindent 4 }}
   annotations: {{- toYaml .Values.global.annotations | nindent 4 }}
 data:
-  pusher-app-id: web-modeler
-  pusher-app-key: {{ randAlphaNum 20 }}
   {{- if .Values.webModeler.webapp.configuration }}
   application.toml: |
     {{ .Values.webModeler.webapp.configuration | indent 4 | trim }}

--- a/charts/camunda-platform-8.6/templates/web-modeler/configmap-restapi.yaml
+++ b/charts/camunda-platform-8.6/templates/web-modeler/configmap-restapi.yaml
@@ -6,8 +6,6 @@ metadata:
   labels: {{- include "webModeler.labels" . | nindent 4 }}
   annotations: {{- toYaml .Values.global.annotations | nindent 4 }}
 data:
-  pusher-app-id: web-modeler
-  pusher-app-key: {{ randAlphaNum 20 }}
   {{- if .Values.webModeler.restapi.configuration }}
   application.yaml: |
     {{ .Values.webModeler.restapi.configuration | indent 4 | trim }}
@@ -26,7 +24,7 @@ data:
         pusher:
           host: {{ include "webModeler.websockets.fullname" . | quote }}
           port: {{ .Values.webModeler.websockets.service.port }}
-    
+
         security:
           jwt:
             issuer:

--- a/charts/camunda-platform-8.6/templates/web-modeler/configmap-webapp.yaml
+++ b/charts/camunda-platform-8.6/templates/web-modeler/configmap-webapp.yaml
@@ -6,8 +6,6 @@ metadata:
   labels: {{- include "webModeler.labels" . | nindent 4 }}
   annotations: {{- toYaml .Values.global.annotations | nindent 4 }}
 data:
-  pusher-app-id: web-modeler
-  pusher-app-key: {{ randAlphaNum 20 }}
   {{- if .Values.webModeler.webapp.configuration }}
   application.toml: |
     {{ .Values.webModeler.webapp.configuration | indent 4 | trim }}

--- a/charts/camunda-platform-alpha/templates/web-modeler/configmap-restapi.yaml
+++ b/charts/camunda-platform-alpha/templates/web-modeler/configmap-restapi.yaml
@@ -6,8 +6,6 @@ metadata:
   labels: {{- include "webModeler.labels" . | nindent 4 }}
   annotations: {{- toYaml .Values.global.annotations | nindent 4 }}
 data:
-  pusher-app-id: web-modeler
-  pusher-app-key: {{ randAlphaNum 20 }}
   {{- if .Values.webModeler.restapi.configuration }}
   application.yaml: |
     {{ .Values.webModeler.restapi.configuration | indent 4 | trim }}

--- a/charts/camunda-platform-alpha/templates/web-modeler/configmap-webapp.yaml
+++ b/charts/camunda-platform-alpha/templates/web-modeler/configmap-webapp.yaml
@@ -6,8 +6,6 @@ metadata:
   labels: {{- include "webModeler.labels" . | nindent 4 }}
   annotations: {{- toYaml .Values.global.annotations | nindent 4 }}
 data:
-  pusher-app-id: web-modeler
-  pusher-app-key: {{ randAlphaNum 20 }}
   {{- if .Values.webModeler.webapp.configuration }}
   application.toml: |
     {{ .Values.webModeler.webapp.configuration | indent 4 | trim }}


### PR DESCRIPTION
### Which problem does the PR fix?
-- no issue exists --

### What's in this PR?
Removes `pusher-app-id` and `pusher-app-key` from `configmap-restapi.yaml` and `configmap-webapp.yaml`. Both values are defined in `configmap-shared.yaml` and read from there by all three Web Modeler components.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?