### PR TITLE
fix: added support for optimize env vars for migration initcontainer

### DIFF
--- a/charts/camunda-platform-8.6/templates/optimize/deployment.yaml
+++ b/charts/camunda-platform-8.6/templates/optimize/deployment.yaml
@@ -88,6 +88,9 @@ spec:
             - name: CAMUNDA_OPTIMIZE_OPENSEARCH_AWS_ENABLED
               value: "true"
             {{- end }}
+            {{- with .Values.optimize.env }}
+            {{- tpl (toYaml .) $ | nindent 12 }}
+            {{- end }}
             {{- with .Values.optimize.migration.env }}
             {{- tpl (toYaml .) $ | nindent 12 }}
             {{- end }}

--- a/charts/camunda-platform-alpha/templates/optimize/deployment.yaml
+++ b/charts/camunda-platform-alpha/templates/optimize/deployment.yaml
@@ -88,6 +88,9 @@ spec:
             - name: CAMUNDA_OPTIMIZE_OPENSEARCH_AWS_ENABLED
               value: "true"
             {{- end }}
+            {{- with .Values.optimize.env }}
+            {{- tpl (toYaml .) $ | nindent 12 }}
+            {{- end }}
             {{- with .Values.optimize.migration.env }}
             {{- tpl (toYaml .) $ | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
### Which problem does the PR fix?
Related to: https://github.com/camunda/camunda-platform-helm/issues/2709
<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?
modified the optimize deployment to render the optimized env vars in the migration init container. 

```
{{- with .Values.optimize.env }}
{{- tpl (toYaml .) $ | nindent 12 }}
{{- end }}
{{- with .Values.optimize.migration.env }}
{{- tpl (toYaml .) $ | nindent 12 }}
{{- end }}
```

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
