### PR TITLE
fix(alpha): move core sts command to correct location

### DIFF
--- a/charts/camunda-platform-alpha/templates/core/statefulset.yaml
+++ b/charts/camunda-platform-alpha/templates/core/statefulset.yaml
@@ -45,7 +45,11 @@ spec:
           {{- if .Values.core.containerSecurityContext }}
           securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" $.Values.core.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}
+          {{- if .Values.core.command }}
+          command: {{ toYaml .Values.core.command | nindent 10 }}
+          {{- else }}
           command: ["bash", "/usr/local/bin/startup.sh"]
+          {{- end }}
           env:
             - name: CAMUNDA_LICENSE_KEY
               valueFrom:
@@ -88,9 +92,6 @@ spec:
           {{- if .Values.core.envFrom }}
           envFrom:
             {{- .Values.core.envFrom | toYaml | nindent 12 }}
-          {{- end }}
-          {{- if .Values.core.command }}
-          command: {{ toYaml .Values.core.command | nindent 10 }}
           {{- end }}
           ports:
             - containerPort: {{ .Values.core.service.httpPort }}


### PR DESCRIPTION
### What's in this PR?

We had the container `command` key duplicated in the core sts.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
