### PR TITLE
fix(alpha): move identity admin client to presets

### DIFF
--- a/charts/camunda-platform-alpha/templates/identity/configmap.yaml
+++ b/charts/camunda-platform-alpha/templates/identity/configmap.yaml
@@ -229,7 +229,11 @@ data:
             root-url: {{ include "identity.externalUrl" . | quote }}
             redirect-uris:
               - "/auth/login-callback"
-          {{- if .Values.global.identity.auth.admin.enabled }}
+      # The presets key should be removed when 8.6.0 of the applications are released
+      presets:
+        {{- if .Values.global.identity.auth.admin.enabled }}
+        admin:
+          clients:
           - name: {{ .Values.global.identity.auth.admin.clientId | title | default "Admin" | quote }}
             id: {{ .Values.global.identity.auth.admin.clientId | default "admin" | quote }}
             type: CONFIDENTIAL
@@ -250,9 +254,7 @@ data:
                 definition: "write:*"
               - resourceServerId: {{ include "optimize.authAudience" . | quote }}
                 definition: "write:*"
-          {{- end }}
-      # The presets key should be removed when 8.6.0 of the applications are released
-      presets:
+        {{- end }}
         core:
           clients:
             - name: Core

--- a/charts/camunda-platform-alpha/values.schema.json
+++ b/charts/camunda-platform-alpha/values.schema.json
@@ -3780,7 +3780,7 @@
                         "enabled": {
                             "type": "boolean",
                             "description": "if true, the readiness probe is enabled in app container",
-                            "default": false
+                            "default": true
                         },
                         "scheme": {
                             "type": "string",


### PR DESCRIPTION
### Which problem does the PR fix?

Task: https://github.com/camunda/camunda-platform-helm/issues/2525

### What's in this PR?

Move the Identity admin client to presets as `environment` is initialized first, then the `presets.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
