### PR TITLE
fix: client-secret should only be present when string literal provided for oidc

### DIFF
--- a/charts/camunda-platform-8.5/templates/identity/configmap.yaml
+++ b/charts/camunda-platform-8.5/templates/identity/configmap.yaml
@@ -20,6 +20,8 @@ data:
 
       {{- if (tpl ( include "identity.authClientSecret" . ) .)}}
       client-id: {{ include "identity.authClientId" . | quote }}
+      {{- end }}
+      {{- if and (.Values.global.identity.auth.identity.existingSecret) (eq (typeOf .Values.global.identity.auth.identity.existingSecret) "string") }}
       client-secret: {{ include "identity.authClientSecret" . | quote }}
       {{- end }}
 

--- a/charts/camunda-platform-8.6/templates/identity/configmap.yaml
+++ b/charts/camunda-platform-8.6/templates/identity/configmap.yaml
@@ -20,6 +20,8 @@ data:
 
       {{- if (tpl ( include "identity.authClientSecret" . ) .)}}
       client-id: {{ include "identity.authClientId" . | quote }}
+      {{- end }}
+      {{- if and (.Values.global.identity.auth.identity.existingSecret) (eq (typeOf .Values.global.identity.auth.identity.existingSecret) "string") }}
       client-secret: {{ include "identity.authClientSecret" . | quote }}
       {{- end }}
 

--- a/charts/camunda-platform-alpha/templates/identity/configmap.yaml
+++ b/charts/camunda-platform-alpha/templates/identity/configmap.yaml
@@ -25,6 +25,8 @@ data:
 
       {{- if (tpl ( include "identity.authClientSecret" . ) .)}}
       client-id: {{ include "identity.authClientId" . | quote }}
+      {{- end }}
+      {{- if and (.Values.global.identity.auth.identity.existingSecret) (eq (typeOf .Values.global.identity.auth.identity.existingSecret) "string") }}
       client-secret: {{ include "identity.authClientSecret" . | quote }}
       {{- end }}
 


### PR DESCRIPTION
### Which problem does the PR fix?

closes: https://github.com/camunda/camunda-platform-helm/issues/2727

### What's in this PR?

I am fixing the `client-secret` section in identity configmap. it should render when a string literal is provided and should not render when a k8s secret is provided.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
