### PR TITLE
chore: upgrade python version since 3.7 is no longer supported

### DIFF
--- a/.github/workflows/chart-validate-template.yaml
+++ b/.github/workflows/chart-validate-template.yaml
@@ -53,7 +53,7 @@ jobs:
       # Dependencies.
       - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Install dependencies
         uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # v3
       - name: Add helm repos


### PR DESCRIPTION
### Which problem does the PR fix?

closes #2735 

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

upgrades python version used by our linting / chart-testing scripts

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
