### PR TITLE
fix: use integration-test-credentials for web modeler secret

### DIFF
--- a/charts/camunda-platform-8.3/test/integration/scenarios/chart-full-setup/values-integration-test-ingress.yaml
+++ b/charts/camunda-platform-8.3/test/integration/scenarios/chart-full-setup/values-integration-test-ingress.yaml
@@ -88,12 +88,12 @@ webModeler:
 # database used by Web Modeler
 postgresql:
   enabled: true
-  auth:
-    existingSecret: "integration-test-credentials"
-    # Should be set to have a different name of Identity Keycloak PostgreSQL.
-    secretKeys:
-      adminPasswordKey: "webmodeler-postgresql-admin-password"
-      userPasswordKey: "webmodeler-postgresql-user-password"
+#   auth:
+#     existingSecret: "integration-test-credentials"
+#     # Should be set to have a different name of Identity Keycloak PostgreSQL.
+#     secretKeys:
+#       adminPasswordKey: "webmodeler-postgresql-admin-password"
+#       userPasswordKey: "webmodeler-postgresql-user-password"
 
 zeebe-gateway:
   ingress:


### PR DESCRIPTION
### Which problem does the PR fix?

I made a mistake with https://github.com/camunda/camunda-platform-helm/pull/2742
where web modeler will not run due to improperly set up secret name in test values.yaml

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
