### PR TITLE
fix: adding back override to release-candidate workflow

### DIFF
--- a/.github/workflows/chart-release-candidate.yaml
+++ b/.github/workflows/chart-release-candidate.yaml
@@ -18,30 +18,36 @@ jobs:
             "name": "Helm Chart 8.2",
             "directory": "charts/camunda-platform-8.2",
             "versionSuffix": "rc-8.2",
+            "override": false
           },
           {
             "name": "Helm Chart 8.3",
             "directory": "charts/camunda-platform-8.3",
             "versionSuffix": "rc-8.3",
+            "override": false
           },
           {
             "name": "Helm Chart 8.4",
             "directory": "charts/camunda-platform-8.4",
             "versionSuffix": "rc-8.4",
+            "override": false
           },
           {
             "name": "Helm Chart 8.5",
             "directory": "charts/camunda-platform-8.5",
             "versionSuffix": "rc-8.5",
+            "override": false
           },
           {
             "name": "Helm Chart 8.6",
             "directory": "charts/camunda-platform-8.6",
             "versionSuffix": "rc-8.6",
+            "override": false
           },
           {
             "name": "Helm Chart Alpha",
             "directory": "charts/camunda-platform-alpha",
             "versionSuffix": "rc-alpha",
+            "override": false
           }
         ]


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
