### PR TITLE
ci: prepare chart release candidate

### DIFF
--- a/.github/workflows/prepare-chart-release-candidate.yaml
+++ b/.github/workflows/prepare-chart-release-candidate.yaml
@@ -1,7 +1,6 @@
 name: "Chart - Prepare - Release - Candidate"
 
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       releaseCandidateBranchName:
@@ -41,17 +40,17 @@ jobs:
           }
           # Delete the RC artifacts.
           echo -e "Deleting the old untagged artifacts IDs:\n${artifacts_ids_to_delete}"
-          # for container_id in ${artifacts_ids_to_delete}; do
-          #   gh api --method DELETE -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
-          #     "/orgs/camunda/packages/container/helm%2Fcamunda-platform/versions/${container_id}"
-          # done
-  # reset:
-  #   name: reset release-candidate branch
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Reset release-candidate branch to master
-  #       env:
-  #         RC_BRANCH: ${{ github.event.inputs.releaseCandidateBranchName }}
-  #       run: |
-  #         git checkout ${{ env.RC_BRANCH }}
-  #         git reset origin/main --hard
+          for container_id in ${artifacts_ids_to_delete}; do
+            gh api --method DELETE -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
+              "/orgs/camunda/packages/container/helm%2Fcamunda-platform/versions/${container_id}"
+          done
+  reset:
+    name: reset release-candidate branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reset release-candidate branch to master
+        env:
+          RC_BRANCH: ${{ github.event.inputs.releaseCandidateBranchName }}
+        run: |
+          git checkout ${{ env.RC_BRANCH }}
+          git reset origin/main --hard

--- a/.github/workflows/prepare-chart-release-candidate.yaml
+++ b/.github/workflows/prepare-chart-release-candidate.yaml
@@ -45,9 +45,24 @@ jobs:
               "/orgs/camunda/packages/container/helm%2Fcamunda-platform/versions/${container_id}"
           done
   reset:
+    needs: [clean]
+    if: needs.clean.outputs.should-run == 'true'
     name: reset release-candidate branch
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
+        id: generate-github-token
+        with:
+          app_id: ${{ secrets.GH_APP_ID_DISTRO_CI }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY_DISTRO_CI }}
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          token: "${{ steps.generate-github-token.outputs.token }}"
       - name: Reset release-candidate branch to master
         env:
           RC_BRANCH: ${{ github.event.inputs.releaseCandidateBranchName }}

--- a/.github/workflows/prepare-chart-release-candidate.yaml
+++ b/.github/workflows/prepare-chart-release-candidate.yaml
@@ -1,0 +1,57 @@
+name: "Chart - Prepare - Release - Candidate"
+
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      releaseCandidateBranchName:
+        description: "Branch Name of The Release Candidate"
+        required: false
+        default: "release-candidate"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  clean:
+    name: Clean RC artifacts
+    permissions:
+      packages: write
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: /tmp
+    steps:
+      - name: Delete old artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Get IDs of the artifacts that include "rc" (the sha256 digest).
+          artifacts_ids_to_delete="$(
+            gh api -H 'Accept: application/vnd.github+json' -H 'X-GitHub-Api-Version: 2022-11-28' \
+            '/orgs/camunda/packages/container/helm%2Fcamunda-platform/versions?per_page=100' | \
+            jq '.[] | select(.metadata.container.tags[] | contains("rc")) | .id'
+          )"
+          # Early exit if no artifacts to delete.
+          test -z "${artifacts_ids_to_delete}" && {
+            echo "No RC artifacts to delete ...";
+            exit 0;
+          }
+          # Delete the RC artifacts.
+          echo -e "Deleting the old untagged artifacts IDs:\n${artifacts_ids_to_delete}"
+          # for container_id in ${artifacts_ids_to_delete}; do
+          #   gh api --method DELETE -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
+          #     "/orgs/camunda/packages/container/helm%2Fcamunda-platform/versions/${container_id}"
+          # done
+  # reset:
+  #   name: reset release-candidate branch
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Reset release-candidate branch to master
+  #       env:
+  #         RC_BRANCH: ${{ github.event.inputs.releaseCandidateBranchName }}
+  #       run: |
+  #         git checkout ${{ env.RC_BRANCH }}
+  #         git reset origin/main --hard

--- a/.github/workflows/prepare-chart-release-candidate.yaml
+++ b/.github/workflows/prepare-chart-release-candidate.yaml
@@ -59,8 +59,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.inputs.releaseCandidateBranchName }}
           fetch-depth: 0
           token: "${{ steps.generate-github-token.outputs.token }}"
       - name: Reset release-candidate branch to master


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

This workflow is for pre-release prep for the release-candidate images

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
