### PR TITLE
fix: adding output to the clean job in rc-prep workflow

### DIFF
--- a/.github/workflows/prepare-chart-release-candidate.yaml
+++ b/.github/workflows/prepare-chart-release-candidate.yaml
@@ -44,6 +44,8 @@ jobs:
             gh api --method DELETE -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
               "/orgs/camunda/packages/container/helm%2Fcamunda-platform/versions/${container_id}"
           done
+      outputs:
+      should-run: ${{ steps.conditions.outputs.should-run }}
   reset:
     needs: [clean]
     if: needs.clean.outputs.should-run == 'true'

--- a/.github/workflows/prepare-chart-release-candidate.yaml
+++ b/.github/workflows/prepare-chart-release-candidate.yaml
@@ -44,11 +44,8 @@ jobs:
             gh api --method DELETE -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
               "/orgs/camunda/packages/container/helm%2Fcamunda-platform/versions/${container_id}"
           done
-      outputs:
-      should-run: ${{ steps.conditions.outputs.should-run }}
   reset:
     needs: [clean]
-    if: needs.clean.outputs.should-run == 'true'
     name: reset release-candidate branch
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

I was using an output in the `reset` job that was missing in the `clean` job of the `prepare-release-candidate.yaml` workflow.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
