### PR TITLE
fix: gomplate now upgrades with the v

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -125,9 +125,10 @@
     {
       "matchFileNames": [".tool-versions"],
       "matchPackageNames": [
+        "hairyhenderson/gomplate",
         "gomplate",
       ],
-      "extractVersion": "^v(?<version>.*)$",
+      "extractVersion": "^(?<version>v.*)$",
     },
 
     //


### PR DESCRIPTION
### Which problem does the PR fix?

Our renovate configuration had a problem which was causing it to not process any packageRules for gomplate, because the packageName is actually `hairyhenderson/gomplate` and not just `gomplate`. Furthermore, the v has to be inside the named regex named "currentVersion" for it to be recognized as necessary for the new version.

Here's my evidence of it working:
https://github.com/jessesimpson36/renovate-gomplate-test/pull/3

![2025-01-16-184955_grim](https://github.com/user-attachments/assets/61aeb2bc-ca57-4890-8bef-bf31ff4c8132)


<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?



<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
