### PR TITLE
fix: apply password key from subchart

### DIFF
--- a/charts/camunda-platform-8.6/templates/identity/_helpers.tpl
+++ b/charts/camunda-platform-8.6/templates/identity/_helpers.tpl
@@ -263,8 +263,9 @@ https://docs.bitnami.com/kubernetes/apps/keycloak/configuration/manage-passwords
 
 {{- define "identity.postgresql.secretKey" -}}
     {{- $defaultSecretKey := "password" -}}
+    {{- $authExistingSecretKey := (.Values.identityPostgresql.auth.secretKeys.userPasswordKey | default $defaultSecretKey) -}}
     {{- $externalDatabaseSecretKey := (.Values.identity.externalDatabase.existingSecretPasswordKey | default $defaultSecretKey) -}}
-    {{- .Values.identity.externalDatabase.enabled | ternary $externalDatabaseSecretKey $defaultSecretKey }}
+    {{- .Values.identity.externalDatabase.enabled | ternary $externalDatabaseSecretKey $authExistingSecretKey }}
 {{- end -}}
 
 {{- define "identity.postgresql.secretPassword" -}}

--- a/charts/camunda-platform-alpha-8.8/templates/identity/_helpers.tpl
+++ b/charts/camunda-platform-alpha-8.8/templates/identity/_helpers.tpl
@@ -259,6 +259,7 @@ https://docs.bitnami.com/kubernetes/apps/keycloak/configuration/manage-passwords
 
 {{- define "identity.postgresql.secretKey" -}}
     {{- $defaultSecretKey := "password" -}}
+    {{- $authExistingSecretKey := (.Values.identityPostgresql.auth.secretKeys.userPasswordKey | default $defaultSecretKey) -}}
     {{- $externalDatabaseSecretKey := (.Values.identity.externalDatabase.existingSecretPasswordKey | default $defaultSecretKey) -}}
     {{- .Values.identity.externalDatabase.enabled | ternary $externalDatabaseSecretKey $authExistingSecretKey }}
 {{- end -}}

--- a/charts/camunda-platform-alpha-8.8/templates/identity/_helpers.tpl
+++ b/charts/camunda-platform-alpha-8.8/templates/identity/_helpers.tpl
@@ -260,7 +260,7 @@ https://docs.bitnami.com/kubernetes/apps/keycloak/configuration/manage-passwords
 {{- define "identity.postgresql.secretKey" -}}
     {{- $defaultSecretKey := "password" -}}
     {{- $externalDatabaseSecretKey := (.Values.identity.externalDatabase.existingSecretPasswordKey | default $defaultSecretKey) -}}
-    {{- .Values.identity.externalDatabase.enabled | ternary $externalDatabaseSecretKey $defaultSecretKey }}
+    {{- .Values.identity.externalDatabase.enabled | ternary $externalDatabaseSecretKey $authExistingSecretKey }}
 {{- end -}}
 
 {{- define "identity.postgresql.secretPassword" -}}

--- a/charts/camunda-platform-alpha-8.8/values.schema.json
+++ b/charts/camunda-platform-alpha-8.8/values.schema.json
@@ -1297,7 +1297,7 @@
                         "tag": {
                             "type": "string",
                             "description": "image tag",
-                            "default": "25.0.4"
+                            "default": "25.0.6"
                         }
                     }
                 },
@@ -2111,7 +2111,7 @@
                         "tag": {
                             "type": "string",
                             "description": "can be used to set the Docker image tag for the WebModeler images (overwrites global.image.tag)",
-                            "default": "8.7.0-alpha3"
+                            "default": "8.7.0-alpha3-rc1"
                         },
                         "pullSecrets": {
                             "type": "array",
@@ -5162,7 +5162,7 @@
                         "tag": {
                             "type": "string",
                             "description": "",
-                            "default": "8.17.0"
+                            "default": "8.17.1"
                         }
                     }
                 },

--- a/charts/camunda-platform-alpha/templates/identity/_helpers.tpl
+++ b/charts/camunda-platform-alpha/templates/identity/_helpers.tpl
@@ -263,6 +263,7 @@ https://docs.bitnami.com/kubernetes/apps/keycloak/configuration/manage-passwords
 
 {{- define "identity.postgresql.secretKey" -}}
     {{- $defaultSecretKey := "password" -}}
+    {{- $authExistingSecretKey := (.Values.identityPostgresql.auth.secretKeys.userPasswordKey | default $defaultSecretKey) -}}
     {{- $externalDatabaseSecretKey := (.Values.identity.externalDatabase.existingSecretPasswordKey | default $defaultSecretKey) -}}
     {{- .Values.identity.externalDatabase.enabled | ternary $externalDatabaseSecretKey $authExistingSecretKey }}
 {{- end -}}

--- a/charts/camunda-platform-alpha/templates/identity/_helpers.tpl
+++ b/charts/camunda-platform-alpha/templates/identity/_helpers.tpl
@@ -264,7 +264,7 @@ https://docs.bitnami.com/kubernetes/apps/keycloak/configuration/manage-passwords
 {{- define "identity.postgresql.secretKey" -}}
     {{- $defaultSecretKey := "password" -}}
     {{- $externalDatabaseSecretKey := (.Values.identity.externalDatabase.existingSecretPasswordKey | default $defaultSecretKey) -}}
-    {{- .Values.identity.externalDatabase.enabled | ternary $externalDatabaseSecretKey $defaultSecretKey }}
+    {{- .Values.identity.externalDatabase.enabled | ternary $externalDatabaseSecretKey $authExistingSecretKey }}
 {{- end -}}
 
 {{- define "identity.postgresql.secretPassword" -}}


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

The helper does currently not respect the property `auth.secretKeys.userPasswordKey`, but references it indirectly as the defaults match.

If one changes the secret key, identity will not be able to resolve the password secret.

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

This is a simple adjustment that should not cause a breaking change.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
