### PR TITLE
fix: add 8.8 version to renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -85,6 +85,15 @@
       ],
       "matchUpdateTypes": ["major", "minor", "patch"],
     },
+      "groupName": "camunda-platform-alpha-8.8",
+      "addLabels": ["version/8.8", "deps/charts"],
+      "matchFileNames": [
+        "charts/camunda-platform-alpha-8.8/Chart.yaml",
+        "charts/camunda-platform-alpha-8.8/values*.yaml",
+        "charts/camunda-platform-alpha-8.8/go.*"
+      ],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+    },
     // End of minor cycle chores.
 
     //
@@ -217,6 +226,27 @@
       "matchFileNames": [
         "charts/camunda-platform-alpha/Chart.yaml",
         "charts/camunda-platform-alpha/values*.yaml",
+      ],
+      // Ignore non-semver versions like 8.6.0-alpha3-rc3 which has a higher precedence than 8.6.0-alpha3
+      // which is not the case.
+      "versionCompatibility": "^(?<version>\\d+\.\\d+\.\\d+-alpha[1-6])(?<compatibility>.*)$",
+      "versioning": "semver"
+    },
+    {
+      // Limit alpha chart version to alpha tags only.
+      "enabled": true,
+      "matchDatasources": ["github-tags"],
+      "matchPackageNames": ["camunda/camunda"],
+      "matchFileNames": ["charts/camunda-platform-alpha-8.8/Chart.yaml"],
+      "versioning": "regex:^(?<major>\\d+)(\.(?<minor>\\d+))(\.(?<patch>\\d+))(-(?<prerelease>alpha[1-6]))$"
+    },
+    {
+      "enabled": true,
+      "matchPackageNames": ["/.*camunda.*/"],
+      "matchDatasources": ["helm", "docker", "regex"],
+      "matchFileNames": [
+        "charts/camunda-platform-alpha-8.8/Chart.yaml",
+        "charts/camunda-platform-alpha-8.8/values*.yaml",
       ],
       // Ignore non-semver versions like 8.6.0-alpha3-rc3 which has a higher precedence than 8.6.0-alpha3
       // which is not the case.


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

Add 8.8 version to renovate to update the 8.8 folder to the latest versions.

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
