### PR TITLE
ci: standardize identity test client naming for multi-team support

### DIFF
--- a/charts/camunda-platform-8.2/test/integration/scenarios/common/values-integration-test.yaml
+++ b/charts/camunda-platform-8.2/test/integration/scenarios/common/values-integration-test.yaml
@@ -2,9 +2,9 @@ identity:
   # Keycloak client seed which is used to query Camunda Platform APIs. 
   env:
   - name: KEYCLOAK_CLIENTS_2_ID
-    value: venom
+    value: test
   - name: KEYCLOAK_CLIENTS_2_NAME
-    value: Venom
+    value: Test
   - name: KEYCLOAK_CLIENTS_2_SECRET
     valueFrom:
       secretKeyRef:

--- a/charts/camunda-platform-8.2/test/integration/testsuites/vars/files/testsuite-core.yaml
+++ b/charts/camunda-platform-8.2/test/integration/testsuites/vars/files/testsuite-core.yaml
@@ -5,7 +5,7 @@ name: Test core functionality of Camunda Platform
 # Vars without defaults are passed as a Venom var, e.g. "VENOM_VAR_TEST_CLIENT_SECRET".
 vars:
   releaseName: integration
-  venomClientID: '{{ .TEST_CLIENT_ID | default "venom" }}'
+  venomClientID: '{{ .TEST_CLIENT_ID | default "test" }}'
   venomClientSecret: '{{ .TEST_CLIENT_SECRET }}'
   skipTestIngress: '{{ .SKIP_TEST_INGRESS }}'
   skipTestWebModeler: '{{ .SKIP_TEST_WEBMODELER }}'

--- a/charts/camunda-platform-8.3/test/integration/scenarios/common/values-integration-test.yaml
+++ b/charts/camunda-platform-8.3/test/integration/scenarios/common/values-integration-test.yaml
@@ -2,9 +2,9 @@ identity:
   # Keycloak client seed which is used to query Camunda APIs. 
   env:
   - name: KEYCLOAK_CLIENTS_2_ID
-    value: venom
+    value: test
   - name: KEYCLOAK_CLIENTS_2_NAME
-    value: Venom
+    value: Test
   - name: KEYCLOAK_CLIENTS_2_SECRET
     valueFrom:
       secretKeyRef:

--- a/charts/camunda-platform-8.3/test/integration/testsuites/vars/files/testsuite-core.yaml
+++ b/charts/camunda-platform-8.3/test/integration/testsuites/vars/files/testsuite-core.yaml
@@ -5,7 +5,7 @@ name: Test core functionality of Camunda
 # Vars without defaults are passed as a Venom var, e.g. "VENOM_VAR_TEST_CLIENT_SECRET".
 vars:
   releaseName: integration
-  venomClientID: '{{ .TEST_CLIENT_ID | default "venom" }}'
+  venomClientID: '{{ .TEST_CLIENT_ID | default "test" }}'
   venomClientSecret: '{{ .TEST_CLIENT_SECRET }}'
   skipTestIngress: '{{ .SKIP_TEST_INGRESS }}'
   skipTestWebModeler: '{{ .SKIP_TEST_WEBMODELER }}'

--- a/charts/camunda-platform-8.4/test/integration/scenarios/common/values-integration-test.yaml
+++ b/charts/camunda-platform-8.4/test/integration/scenarios/common/values-integration-test.yaml
@@ -2,9 +2,9 @@ identity:
   # Keycloak client seed which is used to query Camunda APIs.
   env:
   - name: KEYCLOAK_CLIENTS_2_ID
-    value: venom
+    value: test
   - name: KEYCLOAK_CLIENTS_2_NAME
-    value: Venom
+    value: Test
   - name: KEYCLOAK_CLIENTS_2_SECRET
     valueFrom:
       secretKeyRef:

--- a/charts/camunda-platform-8.4/test/integration/testsuites/vars/files/testsuite-core.yaml
+++ b/charts/camunda-platform-8.4/test/integration/testsuites/vars/files/testsuite-core.yaml
@@ -5,7 +5,7 @@ name: Test core functionality of Camunda
 # Vars without defaults are passed as a Venom var, e.g. "VENOM_VAR_TEST_CLIENT_SECRET".
 vars:
   releaseName: integration
-  venomClientID: '{{ .TEST_CLIENT_ID | default "venom" }}'
+  venomClientID: '{{ .TEST_CLIENT_ID | default "test" }}'
   venomClientSecret: '{{ .TEST_CLIENT_SECRET }}'
   skipTestIngress: '{{ .SKIP_TEST_INGRESS }}'
   skipTestWebModeler: '{{ .SKIP_TEST_WEBMODELER }}'

--- a/charts/camunda-platform-8.5/test/integration/scenarios/common/values-integration-test.yaml
+++ b/charts/camunda-platform-8.5/test/integration/scenarios/common/values-integration-test.yaml
@@ -2,9 +2,9 @@ identity:
   # Keycloak client seed which is used to query Camunda APIs.
   env:
   - name: KEYCLOAK_CLIENTS_2_ID
-    value: venom
+    value: test
   - name: KEYCLOAK_CLIENTS_2_NAME
-    value: Venom
+    value: Test
   - name: KEYCLOAK_CLIENTS_2_SECRET
     valueFrom:
       secretKeyRef:

--- a/charts/camunda-platform-8.5/test/integration/testsuites/vars/files/testsuite-core.yaml
+++ b/charts/camunda-platform-8.5/test/integration/testsuites/vars/files/testsuite-core.yaml
@@ -5,7 +5,7 @@ name: Test core functionality of Camunda
 # Vars without defaults are passed as a Venom var, e.g. "VENOM_VAR_TEST_CLIENT_SECRET".
 vars:
   releaseName: integration
-  venomClientID: '{{ .TEST_CLIENT_ID | default "venom" }}'
+  venomClientID: '{{ .TEST_CLIENT_ID | default "test" }}'
   venomClientSecret: '{{ .TEST_CLIENT_SECRET }}'
   skipTestIngress: '{{ .SKIP_TEST_INGRESS }}'
   skipTestWebModeler: '{{ .SKIP_TEST_WEBMODELER }}'

--- a/charts/camunda-platform-8.6/test/integration/scenarios/common/values-integration-test.yaml
+++ b/charts/camunda-platform-8.6/test/integration/scenarios/common/values-integration-test.yaml
@@ -2,9 +2,9 @@ identity:
   # Keycloak client seed which is used to query Camunda APIs.
   env:
   - name: KEYCLOAK_CLIENTS_2_ID
-    value: venom
+    value: test
   - name: KEYCLOAK_CLIENTS_2_NAME
-    value: Venom
+    value: Test
   - name: KEYCLOAK_CLIENTS_2_SECRET
     valueFrom:
       secretKeyRef:

--- a/charts/camunda-platform-8.6/test/integration/testsuites/vars/files/testsuite-core.yaml
+++ b/charts/camunda-platform-8.6/test/integration/testsuites/vars/files/testsuite-core.yaml
@@ -5,7 +5,7 @@ name: Test core functionality of Camunda
 # Vars without defaults are passed as a Venom var, e.g. "VENOM_VAR_TEST_CLIENT_SECRET".
 vars:
   releaseName: integration
-  venomClientID: '{{ .TEST_CLIENT_ID | default "venom" }}'
+  venomClientID: '{{ .TEST_CLIENT_ID | default "test" }}'
   venomClientSecret: '{{ .TEST_CLIENT_SECRET }}'
   skipTestIngress: '{{ .SKIP_TEST_INGRESS }}'
   skipTestWebModeler: '{{ .SKIP_TEST_WEBMODELER }}'

--- a/charts/camunda-platform-alpha-8.8/test/integration/testsuites/vars/files/testsuite-core.yaml
+++ b/charts/camunda-platform-alpha-8.8/test/integration/testsuites/vars/files/testsuite-core.yaml
@@ -5,7 +5,7 @@ name: Test core functionality of Camunda
 # Vars without defaults are passed as a Venom var, e.g. "VENOM_VAR_TEST_CLIENT_SECRET".
 vars:
   releaseName: integration
-  venomClientID: '{{ .TEST_CLIENT_ID | default "venom" }}'
+  venomClientID: '{{ .TEST_CLIENT_ID | default "test" }}'
   venomClientSecret: '{{ .TEST_CLIENT_SECRET }}'
   skipTestIngress: '{{ .SKIP_TEST_INGRESS }}'
   skipTestWebModeler: '{{ .SKIP_TEST_WEBMODELER }}'

--- a/charts/camunda-platform-alpha/test/integration/scenarios/common/values-integration-test.yaml
+++ b/charts/camunda-platform-alpha/test/integration/scenarios/common/values-integration-test.yaml
@@ -2,9 +2,9 @@ identity:
   # Keycloak client seed which is used to query Camunda APIs.
   env:
   - name: KEYCLOAK_CLIENTS_2_ID
-    value: venom
+    value: test
   - name: KEYCLOAK_CLIENTS_2_NAME
-    value: Venom
+    value: Test
   - name: KEYCLOAK_CLIENTS_2_SECRET
     valueFrom:
       secretKeyRef:

--- a/charts/camunda-platform-alpha/test/integration/testsuites/vars/files/testsuite-core.yaml
+++ b/charts/camunda-platform-alpha/test/integration/testsuites/vars/files/testsuite-core.yaml
@@ -5,7 +5,7 @@ name: Test core functionality of Camunda
 # Vars without defaults are passed as a Venom var, e.g. "VENOM_VAR_TEST_CLIENT_SECRET".
 vars:
   releaseName: integration
-  venomClientID: '{{ .TEST_CLIENT_ID | default "venom" }}'
+  venomClientID: '{{ .TEST_CLIENT_ID | default "test" }}'
   venomClientSecret: '{{ .TEST_CLIENT_SECRET }}'
   skipTestIngress: '{{ .SKIP_TEST_INGRESS }}'
   skipTestWebModeler: '{{ .SKIP_TEST_WEBMODELER }}'


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
Related to : https://github.com/camunda/camunda-platform-helm/issues/2482
### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

- Renamed clients from `venom` to `test` for all versions. (8.8 was not included as there is no test currently)
- Made the `test` user to be the default `venomClientID` in our testsuite-core.yaml
`venomClientID: '{{ .TEST_CLIENT_ID | default "test" }}'`

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
