### PR TITLE
ci: bring back private alpha release

### DIFF
--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -23,6 +23,21 @@ permissions:
   packages: write
 
 jobs:
+  release-alpha:
+    if: ${{ (contains(github.event.*.labels.*.name, 'release') && github.event.pull_request.merged == false) || github.event.inputs.trigger }}
+    name: Camunda Alpha
+    uses: ./.github/workflows/chart-release-template.yaml
+    with:
+      branch: ${{ github.event.pull_request.head.ref }}
+      workflow-ref: chart-release-template.yaml
+      chart-matrix: |
+        [
+          {
+            "name": "Helm Chart Alpha",
+            "directory": "charts/camunda-platform-alpha",
+            "override": false
+          }
+        ]
   release:
     if: ${{ (contains(github.event.*.labels.*.name, 'release') && github.event.pull_request.merged == false) || github.event.inputs.trigger }}
     name: Camunda Stable
@@ -98,7 +113,6 @@ jobs:
       - name: Pre-Release - Previous versions
         run: |
           rm -rf ${LATEST_CHART_VERSION_DIR}
-          rm -rf charts/camunda-platform-alpha*
       - name: Run Chart Releaser - Previous versions
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:
@@ -115,7 +129,6 @@ jobs:
       - name: Pre-Release - Latest version
         run: |
           rm -rf $(ls -d1 charts/camunda-platform-8* | head -n -1)
-          rm -rf charts/camunda-platform-alpha*
       - name: Run Chart Releaser - Latest version
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:


### PR DESCRIPTION
### Which problem does the PR fix?

forward-port of https://github.com/camunda/camunda-platform-helm/pull/2925 . 

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
