### PR TITLE
feat: configure basic auth for connectors

### DIFF
--- a/charts/camunda-platform-alpha-8.8/templates/connectors/configmap.yaml
+++ b/charts/camunda-platform-alpha-8.8/templates/connectors/configmap.yaml
@@ -45,12 +45,19 @@ data:
             worker-threads: 10
             max-jobs-active: 32
             stream-enabled: true          
+        mode: {{ .Values.global.security.authentication.method }}
+        {{- if eq .Values.global.security.authentication.method "basic" }}
+        auth:
+          {{- $user := first .Values.global.security.initialization.users }}
+          username: {{ $user.username | quote }}
+          password: {{ $user.password | quote }}
+        {{- else }}
         auth:
           token-url: {{ include "camundaPlatform.authIssuerBackendUrlTokenEndpoint" . }}
           client-id: {{ include "connectors.authClientId" . | quote }}
           client-secret: ${VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET}
           audience: {{ include "core.authAudience" . | quote }}
-        mode: self-managed
+        {{- end }}
 
     logging:
 {{- with .Values.connectors.logging }}

--- a/charts/camunda-platform-alpha-8.8/templates/connectors/configmap.yaml
+++ b/charts/camunda-platform-alpha-8.8/templates/connectors/configmap.yaml
@@ -36,22 +36,20 @@ data:
 
     camunda:
       client:
-        zeebe:
-          {{-  $proto := (lower .Values.core.readinessProbe.scheme) -}}
-          {{- $baseURLInternal := printf "%s://%s" $proto (include "core.fullname" . | trimAll "\"") }}
-          rest-address: {{ printf "%s:%v%s" $baseURLInternal .Values.core.service.httpPort .Values.core.contextPath }}
-          grpc-address: {{ printf "%s:%v" $baseURLInternal .Values.core.service.grpcPort }}
+        {{-  $proto := (lower .Values.core.readinessProbe.scheme) -}}
+        {{- $baseURLInternal := printf "%s://%s" $proto (include "core.fullname" . | trimAll "\"") }}
+        rest-address: {{ printf "%s:%v%s" $baseURLInternal .Values.core.service.httpPort .Values.core.contextPath }}
+        grpc-address: {{ printf "%s:%v" $baseURLInternal .Values.core.service.grpcPort }}
+        worker:
           defaults:
             worker-threads: 10
             max-jobs-active: 32
-            stream-enabled: true
-        identity:
-          base-url: {{ include "camundaPlatform.identityURL" . | quote }}
-          audience: {{ include "core.authAudience" . | quote }}
+            stream-enabled: true          
         auth:
-          issuer: {{ include "camundaPlatform.authIssuerBackendUrlTokenEndpoint" . }}
+          token-url: {{ include "camundaPlatform.authIssuerBackendUrlTokenEndpoint" . }}
           client-id: {{ include "connectors.authClientId" . | quote }}
           client-secret: ${VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET}
+          audience: {{ include "core.authAudience" . | quote }}
         mode: self-managed
 
     logging:

--- a/charts/camunda-platform-alpha-8.8/templates/connectors/configmap.yaml
+++ b/charts/camunda-platform-alpha-8.8/templates/connectors/configmap.yaml
@@ -42,7 +42,6 @@ data:
         grpc-address: {{ printf "%s:%v" $baseURLInternal .Values.core.service.grpcPort }}
         worker:
           defaults:
-            worker-threads: 10
             max-jobs-active: 32
             stream-enabled: true          
         mode: {{ .Values.global.security.authentication.method }}

--- a/charts/camunda-platform-alpha-8.8/test/unit/connectors/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-alpha-8.8/test/unit/connectors/golden/configmap.golden.yaml
@@ -39,7 +39,6 @@ data:
         grpc-address: http://camunda-platform-test-core:26500
         worker:
           defaults:
-            worker-threads: 10
             max-jobs-active: 32
             stream-enabled: true          
         mode: basic

--- a/charts/camunda-platform-alpha-8.8/test/unit/connectors/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-alpha-8.8/test/unit/connectors/golden/configmap.golden.yaml
@@ -42,11 +42,10 @@ data:
             worker-threads: 10
             max-jobs-active: 32
             stream-enabled: true          
+        mode: basic
         auth:
-          token-endpoint: http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/token
-          client-id: "connectors"
-          audience: "core-api"
-        mode: self-managed
+          username: "demo"
+          password: "demo"
 
     logging:
       level:

--- a/charts/camunda-platform-alpha-8.8/test/unit/connectors/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-alpha-8.8/test/unit/connectors/golden/configmap.golden.yaml
@@ -35,19 +35,17 @@ data:
 
     camunda:
       client:
-        zeebe:
-          rest-address: http://camunda-platform-test-core:8080
-          grpc-address: http://camunda-platform-test-core:26500
+        rest-address: http://camunda-platform-test-core:8080
+        grpc-address: http://camunda-platform-test-core:26500
+        worker:
           defaults:
             worker-threads: 10
             max-jobs-active: 32
-            stream-enabled: true
-        identity:
-          base-url: "http://camunda-platform-test-identity:80"
-          audience: "core-api"
+            stream-enabled: true          
         auth:
-          issuer: http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/token
+          token-endpoint: http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/token
           client-id: "connectors"
+          audience: "core-api"
         mode: self-managed
 
     logging:


### PR DESCRIPTION
### What's in this PR?

It adds the config needed for connectors to authenticate via basic credentials in case the helm chart is run with basic `authentication.method: basic` see https://github.com/camunda/camunda/issues/28664.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
