### PR TITLE
docs: add prerelease annotation to alpha charts

### DIFF
--- a/charts/camunda-platform-alpha-8.8/Chart.yaml
+++ b/charts/camunda-platform-alpha-8.8/Chart.yaml
@@ -54,6 +54,7 @@ maintainers:
   - name: jessesimpson36
     email: jesse.simpson@camunda.com
 annotations:
+  artifacthub.io/prerelease: "true"
   camunda.io/helmCLIVersion: "3.16.3"
   artifacthub.io/links: |
     - name: Camunda 8 docs

--- a/charts/camunda-platform-alpha-8.8/values.schema.json
+++ b/charts/camunda-platform-alpha-8.8/values.schema.json
@@ -1822,7 +1822,7 @@
                         "tag": {
                             "type": "string",
                             "description": "can be used to set the Docker image tag for the Console image (overwrites global.image.tag)",
-                            "default": "8.8.0-alpha1"
+                            "default": "8.8.0-alpha2"
                         },
                         "pullSecrets": {
                             "type": "array",

--- a/charts/camunda-platform-alpha/Chart.yaml
+++ b/charts/camunda-platform-alpha/Chart.yaml
@@ -54,6 +54,7 @@ maintainers:
   - name: jessesimpson36
     email: jesse.simpson@camunda.com
 annotations:
+  artifacthub.io/prerelease: "true"
   camunda.io/helmCLIVersion: "3.17.0"
   artifacthub.io/links: |
     - name: Camunda 8 docs


### PR DESCRIPTION
### Which problem does the PR fix?

The pre-release annotation in artifacthub will avoid placing the latest label ontop of alpha chart builds. We are adding this into Chart.yaml so that it will propogate into the index.yaml in `gh-pages` during the chart-releaser step of our release process.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

A new annotation for the alpha charts

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
