### PR TITLE
fix: adding limit on elasticsearch helm chart

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -186,6 +186,16 @@
       // https://docs.camunda.io/docs/reference/supported-environments/#camunda-8-self-managed
       "matchDatasources": ["docker"],
       "matchFileNames": [
+        "charts/camunda-platform-8.3/chart.yaml"
+      ],
+      "matchPackageNames": ["/.*elasticsearch.*/"],
+      "allowedVersions": "~19.21.2"
+    },
+    {
+      // Limit Elasticsearch version to latest supported version in Camunda 8.5 chart.
+      // https://docs.camunda.io/docs/reference/supported-environments/#camunda-8-self-managed
+      "matchDatasources": ["docker"],
+      "matchFileNames": [
         "charts/camunda-platform-8.4/values.yaml",
         "charts/camunda-platform-8.4/values-latest.yaml"
       ],


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
https://camunda.slack.com/archives/C06BN4SRB6C/p1740997970682169
### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

 This change is causing an issue for 8.3 chart: https://github.com/camunda/camunda-platform-helm/commit/3fcadb0ab91b830e9442fd5cd5170de2da64f460
The 8.8.2 ES image is not working the 19.21.2 ES helm chart. So I need to add a limit to the ES helm chart to not update passed 19.13.15

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
