### PR TITLE
fix: ensure app configs rendered correctly in ConfigMap

### DIFF
--- a/charts/camunda-platform-8.3/templates/zeebe/configmap.yaml
+++ b/charts/camunda-platform-8.3/templates/zeebe/configmap.yaml
@@ -9,7 +9,7 @@ data:
   startup.sh: |
     #!/usr/bin/env bash
     set -eux -o pipefail
-    
+
 {{- if eq .Values.global.multiregion.installationType "failOver" }}
     export ZEEBE_BROKER_CLUSTER_NODEID=${ZEEBE_BROKER_CLUSTER_NODEID:-$[${K8S_NAME##*-} * 2 * {{.Values.global.multiregion.regions}} + {{.Values.global.multiregion.regionId}}]}
 {{- else }}

--- a/charts/camunda-platform-8.4/templates/zeebe/configmap.yaml
+++ b/charts/camunda-platform-8.4/templates/zeebe/configmap.yaml
@@ -9,7 +9,7 @@ data:
   startup.sh: |
     #!/usr/bin/env bash
     set -eux -o pipefail
-    
+
 {{- if eq .Values.global.multiregion.installationType "failOver" }}
     export ZEEBE_BROKER_CLUSTER_NODEID=${ZEEBE_BROKER_CLUSTER_NODEID:-$[${K8S_NAME##*-} * 2 * {{.Values.global.multiregion.regions}} + {{.Values.global.multiregion.regionId}}]}
 {{- else }}

--- a/charts/camunda-platform-8.5/templates/operate/configmap.yaml
+++ b/charts/camunda-platform-8.5/templates/operate/configmap.yaml
@@ -37,7 +37,7 @@ data:
       profiles:
         active: "auth"
     {{- end }}
-    
+
     # Operate configuration file
     camunda.operate:
       {{- if .Values.global.opensearch.enabled }}
@@ -51,7 +51,7 @@ data:
       identity:
         redirectRootUrl: {{ tpl .Values.global.identity.auth.operate.redirectUrl $ | trimSuffix .Values.operate.contextPath | quote }}
       {{- end }}
-    
+
       # ELS instance to store Operate data
       {{- if .Values.global.elasticsearch.enabled }}
       elasticsearch:

--- a/charts/camunda-platform-8.5/templates/tasklist/configmap.yaml
+++ b/charts/camunda-platform-8.5/templates/tasklist/configmap.yaml
@@ -16,7 +16,7 @@ data:
       servlet:
         contextPath: {{ .Values.tasklist.contextPath | quote }}
     {{- end }}
-  
+
     {{- if .Values.global.identity.auth.enabled }}
     spring:
       profiles:

--- a/charts/camunda-platform-8.5/templates/zeebe/configmap.yaml
+++ b/charts/camunda-platform-8.5/templates/zeebe/configmap.yaml
@@ -81,7 +81,7 @@ data:
   startup.sh: |
     #!/usr/bin/env bash
     set -eux -o pipefail
-    
+
 {{- if eq .Values.global.multiregion.installationType "failOver" }}
     export ZEEBE_BROKER_CLUSTER_NODEID=${ZEEBE_BROKER_CLUSTER_NODEID:-$[${K8S_NAME##*-} * 2 * {{.Values.global.multiregion.regions}} + {{.Values.global.multiregion.regionId}}]}
 {{- else }}

--- a/charts/camunda-platform-8.5/test/unit/operate/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.5/test/unit/operate/golden/configmap.golden.yaml
@@ -29,12 +29,12 @@ data:
         clientId: "operate"
         audience: "operate-api"
         baseUrl: "http://camunda-platform-test-identity:80"
-    
+
     # Operate configuration file
     camunda.operate:
       identity:
         redirectRootUrl: "http://localhost:8081"
-    
+
       # ELS instance to store Operate data
       elasticsearch:
         # Cluster name

--- a/charts/camunda-platform-8.6/templates/operate/configmap.yaml
+++ b/charts/camunda-platform-8.6/templates/operate/configmap.yaml
@@ -75,7 +75,7 @@ data:
       identity:
         redirectRootUrl: {{ tpl .Values.global.identity.auth.operate.redirectUrl $ | trimSuffix .Values.operate.contextPath | quote }}
       {{- end }}
-    
+
       # ELS instance to store Operate data
       {{- if .Values.global.elasticsearch.enabled }}
       elasticsearch:

--- a/charts/camunda-platform-8.6/templates/tasklist/configmap.yaml
+++ b/charts/camunda-platform-8.6/templates/tasklist/configmap.yaml
@@ -19,7 +19,7 @@ data:
       server:
         base-path: {{ .Values.tasklist.contextPath | quote }}
     {{- end }}
-  
+
     {{- if .Values.global.identity.auth.enabled }}
     spring:
       profiles:

--- a/charts/camunda-platform-8.6/templates/zeebe/configmap.yaml
+++ b/charts/camunda-platform-8.6/templates/zeebe/configmap.yaml
@@ -103,7 +103,7 @@ data:
   startup.sh: |
     #!/usr/bin/env bash
     set -eux -o pipefail
-    
+
 {{- if eq .Values.global.multiregion.installationType "failOver" }}
     export ZEEBE_BROKER_CLUSTER_NODEID=${ZEEBE_BROKER_CLUSTER_NODEID:-$[${K8S_NAME##*-} * 2 * {{.Values.global.multiregion.regions}} + {{.Values.global.multiregion.regionId}}]}
 {{- else }}

--- a/charts/camunda-platform-8.6/test/unit/operate/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.6/test/unit/operate/golden/configmap.golden.yaml
@@ -41,7 +41,7 @@ data:
     camunda.operate:
       identity:
         redirectRootUrl: "http://localhost:8081"
-    
+
       # ELS instance to store Operate data
       elasticsearch:
         # Cluster name

--- a/charts/camunda-platform-alpha/templates/console/configmap.yaml
+++ b/charts/camunda-platform-alpha/templates/console/configmap.yaml
@@ -29,6 +29,6 @@ data:
   application-override.yaml: |-
     {{- if .Values.console.overrideConfiguration }}
       {{- include "common.tplvalues.render" ( dict "value" .Values.console.overrideConfiguration "context" $ ) | nindent 4 }}
-    {{- end }}       
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/camunda-platform-alpha/templates/operate/configmap.yaml
+++ b/charts/camunda-platform-alpha/templates/operate/configmap.yaml
@@ -75,7 +75,7 @@ data:
       identity:
         redirectRootUrl: {{ tpl .Values.global.identity.auth.operate.redirectUrl $ | trimSuffix .Values.operate.contextPath | quote }}
       {{- end }}
-    
+
       # ELS instance to store Operate data
       {{- if .Values.global.elasticsearch.enabled }}
       elasticsearch:

--- a/charts/camunda-platform-alpha/templates/tasklist/configmap.yaml
+++ b/charts/camunda-platform-alpha/templates/tasklist/configmap.yaml
@@ -19,7 +19,7 @@ data:
       server:
         base-path: {{ .Values.tasklist.contextPath | quote }}
     {{- end }}
-  
+
     {{- if .Values.global.identity.auth.enabled }}
     spring:
       profiles:

--- a/charts/camunda-platform-alpha/templates/zeebe/configmap.yaml
+++ b/charts/camunda-platform-alpha/templates/zeebe/configmap.yaml
@@ -103,7 +103,7 @@ data:
   startup.sh: |
     #!/usr/bin/env bash
     set -eux -o pipefail
-    
+
 {{- if eq .Values.global.multiregion.installationType "failOver" }}
     export ZEEBE_BROKER_CLUSTER_NODEID=${ZEEBE_BROKER_CLUSTER_NODEID:-$[${K8S_NAME##*-} * 2 * {{.Values.global.multiregion.regions}} + {{.Values.global.multiregion.regionId}}]}
 {{- else }}

--- a/charts/camunda-platform-alpha/test/unit/operate/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-alpha/test/unit/operate/golden/configmap.golden.yaml
@@ -41,7 +41,7 @@ data:
     camunda.operate:
       identity:
         redirectRootUrl: "http://localhost:8081"
-    
+
       # ELS instance to store Operate data
       elasticsearch:
         # Cluster name


### PR DESCRIPTION
### Which problem does the PR fix?

Task: https://github.com/camunda/camunda-platform-helm/issues/3070

### What's in this PR?

Remove all extra spaces in the app configs so that they are rendered as YAML in ConfigMap instead of a quoted string.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
