### PR TITLE
ci: only generate releases for the helm chart being released by the candidate branch

### DIFF
--- a/.github/workflows/chart-release-pr.yml
+++ b/.github/workflows/chart-release-pr.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Get chart folder from branch name
         run: |
           chart_folder=$(echo "${{ github.ref_name }}" | sed 's/release-candidate-//')
-          echo "CHART_PATH=charts/camunda-platform-$chart_folder" >> $GITHUB_ENV
+          echo "CHART_PATH=charts/camunda-platform-${chart_folder}" >> $GITHUB_ENV
       - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # v4
         with:
           path: "${{ env.CHART_PATH }}"

--- a/.github/workflows/chart-release-pr.yml
+++ b/.github/workflows/chart-release-pr.yml
@@ -24,8 +24,13 @@ jobs:
         with:
           app_id: ${{ secrets.GH_APP_ID_DISTRO_CI }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY_DISTRO_CI }}
+      - name: get chart folder from branch name
+        run: |
+          chart_folder=$(echo "${{ github.ref_name }}" | sed 's/release-candidate-//')
+          echo "CHARTPATH=charts/camunda-platform-$chart_folder" >> $GITHUB_ENV
       - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # v4
         with:
+          path: "${{ env.CHARTPATH }}"
           token: '${{ steps.generate-github-token.outputs.token }}'
           # Config docs: https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md
           config-file: "${{ env.RELEASE_PLEASE_CONFIG_FILE }}"

--- a/.github/workflows/chart-release-pr.yml
+++ b/.github/workflows/chart-release-pr.yml
@@ -24,13 +24,13 @@ jobs:
         with:
           app_id: ${{ secrets.GH_APP_ID_DISTRO_CI }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY_DISTRO_CI }}
-      - name: get chart folder from branch name
+      - name: Get chart folder from branch name
         run: |
           chart_folder=$(echo "${{ github.ref_name }}" | sed 's/release-candidate-//')
-          echo "CHARTPATH=charts/camunda-platform-$chart_folder" >> $GITHUB_ENV
+          echo "CHART_PATH=charts/camunda-platform-$chart_folder" >> $GITHUB_ENV
       - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # v4
         with:
-          path: "${{ env.CHARTPATH }}"
+          path: "${{ env.CHART_PATH }}"
           token: '${{ steps.generate-github-token.outputs.token }}'
           # Config docs: https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md
           config-file: "${{ env.RELEASE_PLEASE_CONFIG_FILE }}"


### PR DESCRIPTION
### Which problem does the PR fix?

issue: https://github.com/camunda/camunda-platform-helm/issues/2918

We currently have 3 releases with the following name:
"chore(release): Camunda Platform Helm Chart 11.2.2 - Camunda 8.6"

In our release process, each release-candidate-8.* PR that opens triggers the release PR for ALL charts rather than just the chart that it was intended for.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

This PR adds the "path" option into release-please which will restrict release-please to only release the artifacts on that subpath, and not others. the default is "."  I get the chart path from extracting the number from branch name "release-candidate-8.x"

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
