### PR TITLE
fix make verify-components-version error

### DIFF
--- a/scripts/verify-components-version.sh
+++ b/scripts/verify-components-version.sh
@@ -10,7 +10,10 @@ helm repo update
 
 chart_main_dir=$(ls -d1 charts/camunda-platform-8* | tail -n1)
 chart_main_version="$(yq '.version' ${chart_main_dir}/Chart.yaml)"
-components_versions="$(helm template camunda/camunda-platform | grep -Po '(?<=helm.sh/chart: ).+' | sort | uniq)"
+components_versions=$(helm template camunda/camunda-platform | \
+  awk -F'helm.sh/chart: ' '/helm.sh\/chart:/ {print $2}' | \
+  sort | uniq)
+
 components_count=2
 
 print_components_versions() {

--- a/scripts/verify-components-version.sh
+++ b/scripts/verify-components-version.sh
@@ -10,9 +10,7 @@ helm repo update
 
 chart_main_dir=$(ls -d1 charts/camunda-platform-8* | tail -n1)
 chart_main_version="$(yq '.version' ${chart_main_dir}/Chart.yaml)"
-components_versions=$(helm template camunda/camunda-platform | \
-  awk -F'helm.sh/chart: ' '/helm.sh\/chart:/ {print $2}' | \
-  sort | uniq)
+components_versions=$(helm template camunda/camunda-platform | awk -F'helm.sh/chart: ' '/helm.sh\/chart:/ {print $2}' | sort | uniq)
 
 components_count=2
 


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

fix #3095 

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

```sh
➜  camunda-platform-helm git:(fix/make-target-error) make release.verify-components-version
"camunda" already exists with the same configuration, skipping
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "elastic" chart repository
...Successfully got an update from the "kusionstack" chart repository
...Successfully got an update from the "ingress-nginx" chart repository
...Unable to get an update from the "loft-sh" chart repository (https://charts.loft.sh):
        Get "https://charts.loft.sh/index.yaml": dial tcp: lookup charts.loft.sh: no such host
...Successfully got an update from the "camunda" chart repository
Update Complete. ⎈Happy Helming!⎈
[INFO] All Camunda components are updated.
Current versions from Camunda Helm repo:
- camunda-platform-11.2.1
- elasticsearch-21.4.5
- identity-11.2.1
- identityKeycloak-22.2.6
- postgresql-15.5.32
```

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
