### PR TITLE
ci: run release-please for a single version

### DIFF
--- a/.github/workflows/chart-release-pr.yml
+++ b/.github/workflows/chart-release-pr.yml
@@ -3,7 +3,11 @@ name: "Chart - Release - PR"
 on:
   push:
     branches:
-      - release-candidate*
+      # Must be in the format of release-candidate-VERSION,
+      # e.g. release-candidate-8.8 or release-candidate-alpha,
+      # it must match the name used in the charts dir.
+      # We rely on that format in this workflow.
+      - release-candidate-*
 
 permissions:
   contents: write
@@ -24,15 +28,21 @@ jobs:
         with:
           app_id: ${{ secrets.GH_APP_ID_DISTRO_CI }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY_DISTRO_CI }}
+      # NOTE: This is a bit fragile as it depends on the branch name,
+      # but it's the best option so far to allow release-please creates a PR for a single version.
       - name: Get chart folder from branch name
         run: |
-          chart_folder=$(echo "${{ github.ref_name }}" | sed 's/release-candidate-//')
-          echo "CHART_PATH=charts/camunda-platform-${chart_folder}" >> $GITHUB_ENV
-      - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # v4
-        with:
-          path: "${{ env.CHART_PATH }}"
-          token: '${{ steps.generate-github-token.outputs.token }}'
-          # Config docs: https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md
-          config-file: "${{ env.RELEASE_PLEASE_CONFIG_FILE }}"
-          manifest-file: "${{ env.RELEASE_PLEASE_MANIFEST_FILE }}"
-          target-branch: "${{ github.ref_name }}"
+          chart_version=$(echo "${{ github.ref_name }}" | sed 's/release-candidate-//')
+          echo "CHART_PATH=charts/camunda-platform-${chart_version}" >> $GITHUB_ENV
+      - name: Install release-please
+        run: |
+          npm i release-please -g
+      - name: Run release-please
+        run: |
+          release-please release-pr \
+            --token="${{ steps.generate-github-token.outputs.token }}" \
+            --repo-url="${{ github.repository }}" \
+            --target-branch="${{ github.ref_name }}" \
+            --config-file="${{ env.RELEASE_PLEASE_CONFIG_FILE }}" \
+            --manifest-file="${{ env.RELEASE_PLEASE_MANIFEST_FILE }}" \
+            --path="${{ env.CHART_PATH }}"


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes: https://github.com/camunda/camunda-platform-helm/issues/2918

### What's in this PR?

Switch to release-please CLI to use the `--path` where it runs the release PR for a single version instead of all chart versions.

It wasn't possible to use the GHA due to this bug:
https://github.com/googleapis/release-please-action/issues/741

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
