### PR TITLE
ci: add missing tool in chart-release-chores.yml

### DIFF
--- a/.github/workflows/chart-release-chores.yml
+++ b/.github/workflows/chart-release-chores.yml
@@ -45,6 +45,7 @@ jobs:
         uses: ./.github/actions/install-tool-versions
         with:
           tools: |
+            git-cliff
             golang
             helm
             helm-ct


### PR DESCRIPTION
### What's in this PR?

Related to the change in https://github.com/camunda/distribution/issues/432

Add missing tool for the workflow .github/workflows/chart-release-chores.yml

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
