### PR TITLE
fix: remove local storage unit test for doc handling

### DIFF
--- a/.github/workflows/test-version-alpha.yaml
+++ b/.github/workflows/test-version-alpha.yaml
@@ -32,13 +32,13 @@ jobs:
       camunda-helm-dir: "camunda-platform-alpha"
       camunda-helm-git-ref: "${{ github.event.pull_request.head.sha }}"
 
-  # unit:
-  #   name: Unit Test - Camunda Alpha
-  #   uses: ./.github/workflows/test-unit-template.yml
-  #   with:
-  #     identifier: "${{ github.event.pull_request.number }}-unit-alpha"
-  #     camunda-helm-dir: "camunda-platform-alpha"
-  #     camunda-helm-git-ref: "${{ github.event.pull_request.head.sha }}"
+  unit:
+    name: Unit Test - Camunda Alpha
+    uses: ./.github/workflows/test-unit-template.yml
+    with:
+      identifier: "${{ github.event.pull_request.number }}-unit-alpha"
+      camunda-helm-dir: "camunda-platform-alpha"
+      camunda-helm-git-ref: "${{ github.event.pull_request.head.sha }}"
 
   integration:
     name: Integration Test - Camunda Alpha

--- a/charts/camunda-platform-alpha-8.8/test/unit/camunda/documentstore_configmap_test.go
+++ b/charts/camunda-platform-alpha-8.8/test/unit/camunda/documentstore_configmap_test.go
@@ -123,27 +123,3 @@ func (s *documentStoreConfigMapTest) TestActiveDocumentStoreGCP() {
 	s.Require().Equal("io.camunda.document.store.gcp.GcpDocumentStoreProvider", strings.TrimSpace(configmap.Data["DOCUMENT_STORE_GCP_CLASS"]))
 	s.Require().Equal("my-gcp-bucket", strings.TrimSpace(configmap.Data["DOCUMENT_STORE_GCP_BUCKET"]))
 }
-
-func (s *documentStoreConfigMapTest) TestActiveDocumentStoreLocalStorage() {
-	// given: set activeStoreId to localstorage and enable LocalStorage configuration
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.documentStore.activeStoreId":             "localstorage",
-			"global.documentStore.type.localstorage.enabled": "true",
-			"global.documentStore.type.localstorage.storeId": "LOCAL",
-			"global.documentStore.type.localstorage.class":   "io.camunda.document.store.localstorage.LocalStorageDocumentStoreProvider",
-			"global.documentStore.type.localstorage.path":    "/tmp/camunda-docs",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var configmap corev1.ConfigMap
-	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-	// then: verify that active store is LocalStorage and the correct keys are present
-	s.Require().Equal("localstorage", strings.ToLower(configmap.Data["DOCUMENT_DEFAULT_STORE_ID"]))
-	s.Require().Equal("io.camunda.document.store.localstorage.LocalStorageDocumentStoreProvider", strings.TrimSpace(configmap.Data["DOCUMENT_STORE_LOCAL_CLASS"]))
-	s.Require().Equal("/tmp/camunda-docs", strings.TrimSpace(configmap.Data["DOCUMENT_STORE_LOCAL_PATH"]))
-}

--- a/charts/camunda-platform-alpha-8.8/values.schema.json
+++ b/charts/camunda-platform-alpha-8.8/values.schema.json
@@ -868,7 +868,7 @@
                         "tag": {
                             "type": "string",
                             "description": "can be set to overwrite the global tag, which should be used in that chart",
-                            "default": "8.8.0-alpha1"
+                            "default": "8.8.0-alpha2"
                         },
                         "pullSecrets": {
                             "type": "array",
@@ -4902,7 +4902,7 @@
                         "tag": {
                             "type": "string",
                             "description": "can be set to overwrite the global tag, which should be used in that chart",
-                            "default": "8.8.0-alpha1"
+                            "default": "8.8.0-alpha2"
                         },
                         "pullSecrets": {
                             "type": "array",
@@ -5422,7 +5422,7 @@
                         "tag": {
                             "type": "string",
                             "description": "",
-                            "default": "8.17.2"
+                            "default": "8.17.3"
                         }
                     }
                 },

--- a/charts/camunda-platform-alpha/test/unit/camunda/documentstore_configmap_test.go
+++ b/charts/camunda-platform-alpha/test/unit/camunda/documentstore_configmap_test.go
@@ -123,27 +123,3 @@ func (s *documentStoreConfigMapTest) TestActiveDocumentStoreGCP() {
 	s.Require().Equal("io.camunda.document.store.gcp.GcpDocumentStoreProvider", strings.TrimSpace(configmap.Data["DOCUMENT_STORE_GCP_CLASS"]))
 	s.Require().Equal("my-gcp-bucket", strings.TrimSpace(configmap.Data["DOCUMENT_STORE_GCP_BUCKET"]))
 }
-
-func (s *documentStoreConfigMapTest) TestActiveDocumentStoreLocalStorage() {
-	// given: set activeStoreId to localstorage and enable LocalStorage configuration
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.documentStore.activeStoreId":             "localstorage",
-			"global.documentStore.type.localstorage.enabled": "true",
-			"global.documentStore.type.localstorage.storeId": "LOCAL",
-			"global.documentStore.type.localstorage.class":   "io.camunda.document.store.localstorage.LocalStorageDocumentStoreProvider",
-			"global.documentStore.type.localstorage.path":    "/tmp/camunda-docs",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var configmap corev1.ConfigMap
-	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-	// then: verify that active store is LocalStorage and the correct keys are present
-	s.Require().Equal("localstorage", strings.ToLower(configmap.Data["DOCUMENT_DEFAULT_STORE_ID"]))
-	s.Require().Equal("io.camunda.document.store.localstorage.LocalStorageDocumentStoreProvider", strings.TrimSpace(configmap.Data["DOCUMENT_STORE_LOCAL_CLASS"]))
-	s.Require().Equal("/tmp/camunda-docs", strings.TrimSpace(configmap.Data["DOCUMENT_STORE_LOCAL_PATH"]))
-}

--- a/charts/camunda-platform-alpha/test/unit/connectors/configmap_test.go
+++ b/charts/camunda-platform-alpha/test/unit/connectors/configmap_test.go
@@ -1,6 +1,10 @@
 package connectors
 
 import (
+	"path/filepath"
+	"strings"
+	"testing"
+
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
@@ -8,9 +12,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
-	"path/filepath"
-	"strings"
-	"testing"
 )
 
 type configMapTemplateTest struct {
@@ -34,6 +35,7 @@ func TestConfigMapTemplate(t *testing.T) {
 		templates: []string{"templates/connectors/configmap.yaml"},
 	})
 }
+
 func (s *configMapTemplateTest) TestContainerSetContextPath() {
 	// given
 	options := &helm.Options{
@@ -58,6 +60,7 @@ func (s *configMapTemplateTest) TestContainerSetContextPath() {
 	// then
 	s.Require().Equal("/connectors", configmapApplication.Server.Servlet.ContextPath)
 }
+
 func (s *configMapTemplateTest) TestContainerConfigMapSetInboundModeCredentials() {
 	// given
 	options := &helm.Options{
@@ -83,13 +86,12 @@ func (s *configMapTemplateTest) TestContainerConfigMapSetInboundModeCredentials(
 	// then
 	s.Require().Empty(configmapApplication.Camunda.Connector.Polling.Enabled)
 	s.Require().Empty(configmapApplication.Camunda.Connector.WebHook.Enabled)
-	s.Require().Empty(configmapApplication.Camunda.Operate.Client.KeycloakTokenURL)
-	s.Require().Empty(configmapApplication.Camunda.Operate.Client.ClientId)
+	s.Require().Empty(configmapApplication.Operate.Client.KeycloakTokenURL)
+	s.Require().Empty(configmapApplication.Operate.Client.ClientId)
 
-	s.Require().Equal("camunda-platform-test-zeebe-gateway:26500", configmapApplication.Zeebe.Client.Broker.GatewayAddress)
-	s.Require().Equal("true", configmapApplication.Zeebe.Client.Security.Plaintext)
-	s.Require().Equal("http://camunda-platform-test-operate:80", configmapApplication.Camunda.Operate.Client.Url)
-	s.Require().Equal("connectors", configmapApplication.Camunda.Operate.Client.Username)
+	s.Require().Equal("http://camunda-platform-test-zeebe-gateway:26500", configmapApplication.Camunda.Client.Zeebe.GRPCAddress)
+	s.Require().Equal("http://camunda-platform-test-operate:80", configmapApplication.Operate.Client.BaseURL)
+	s.Require().Equal("connectors", configmapApplication.Operate.Client.Username)
 }
 
 func (s *configMapTemplateTest) TestContainerConfigMapSetInboundModeDisabled() {
@@ -114,13 +116,12 @@ func (s *configMapTemplateTest) TestContainerConfigMapSetInboundModeDisabled() {
 	}
 
 	// then
-	s.Require().Empty(configmapApplication.Camunda.Operate.Client.KeycloakTokenURL)
-	s.Require().Empty(configmapApplication.Camunda.Operate.Client.Url)
-	s.Require().Empty(configmapApplication.Camunda.Operate.Client.Username)
-	s.Require().Empty(configmapApplication.Camunda.Operate.Client.ClientId)
+	s.Require().Empty(configmapApplication.Operate.Client.KeycloakTokenURL)
+	s.Require().Empty(configmapApplication.Operate.Client.BaseURL)
+	s.Require().Empty(configmapApplication.Operate.Client.Username)
+	s.Require().Empty(configmapApplication.Operate.Client.ClientId)
 
-	s.Require().Equal("camunda-platform-test-zeebe-gateway:26500", configmapApplication.Zeebe.Client.Broker.GatewayAddress)
-	s.Require().Equal("true", configmapApplication.Zeebe.Client.Security.Plaintext)
+	s.Require().Equal("http://camunda-platform-test-zeebe-gateway:26500", configmapApplication.Camunda.Client.Zeebe.GRPCAddress)
 	s.Require().Equal("false", configmapApplication.Camunda.Connector.Polling.Enabled)
 	s.Require().Equal("false", configmapApplication.Camunda.Connector.WebHook.Enabled)
 }
@@ -150,11 +151,10 @@ func (s *configMapTemplateTest) TestContainerConfigMapSetInboundModeOauthIdentit
 	// then
 	s.Require().Empty(configmapApplication.Camunda.Connector.Polling.Enabled)
 	s.Require().Empty(configmapApplication.Camunda.Connector.WebHook.Enabled)
-	s.Require().Empty(configmapApplication.Camunda.Operate.Client.Username)
+	s.Require().Empty(configmapApplication.Operate.Client.Username)
 
-	s.Require().Equal("camunda-platform-test-zeebe-gateway:26500", configmapApplication.Zeebe.Client.Broker.GatewayAddress)
-	s.Require().Equal("true", configmapApplication.Zeebe.Client.Security.Plaintext)
-	s.Require().Equal("http://camunda-platform-test-operate:80", configmapApplication.Camunda.Operate.Client.Url)
+	s.Require().Equal("http://camunda-platform-test-zeebe-gateway:26500", configmapApplication.Camunda.Client.Zeebe.GRPCAddress)
+	s.Require().Equal("http://camunda-platform-test-operate:80", configmapApplication.Operate.Client.BaseURL)
 	s.Require().Equal("operate-api", configmapApplication.Camunda.Identity.Audience)
 	s.Require().Equal("connectors", configmapApplication.Camunda.Identity.ClientId)
 }

--- a/charts/camunda-platform-alpha/test/unit/connectors/deployment_test.go
+++ b/charts/camunda-platform-alpha/test/unit/connectors/deployment_test.go
@@ -731,7 +731,7 @@ func (s *deploymentTemplateTest) TestContainerSetInboundModeCredentials() {
 	s.Require().Contains(
 		env,
 		corev1.EnvVar{
-			Name:      "CAMUNDA_OPERATE_CLIENT_PASSWORD",
+			Name:      "OPERATE_CLIENT_PASSWORD",
 			ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "camunda-platform-test-connectors-auth-credentials"}, Key: "connectors-secret"}}})
 }
 
@@ -756,14 +756,14 @@ func (s *deploymentTemplateTest) TestContainerSetInboundModeOauthIdentity() {
 
 	for _, envvar := range env {
 		s.Require().NotEqual("SPRING_MAIN_WEB-APPLICATION-TYPE", envvar.Name)
-		s.Require().NotEqual("CAMUNDA_OPERATE_CLIENT_PASSWORD", envvar.Name)
+		s.Require().NotEqual("OPERATE_CLIENT_PASSWORD", envvar.Name)
 	}
 
-	s.Require().Contains(env, corev1.EnvVar{Name: "ZEEBE_CLIENT_ID", Value: "zeebe"})
+	s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_CLIENT_AUTH_CLIENT_ID", Value: "zeebe"})
 	s.Require().Contains(
 		env,
 		corev1.EnvVar{
-			Name: "ZEEBE_CLIENT_SECRET",
+			Name: "CAMUNDA_CLIENT_AUTH_CLIENT_SECRET",
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{Name: "camunda-platform-test-zeebe-identity-secret"},
@@ -771,8 +771,8 @@ func (s *deploymentTemplateTest) TestContainerSetInboundModeOauthIdentity() {
 				},
 			},
 		})
-	s.Require().Contains(env, corev1.EnvVar{Name: "ZEEBE_AUTHORIZATION_SERVER_URL", Value: "http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/token"})
-	s.Require().Contains(env, corev1.EnvVar{Name: "ZEEBE_TOKEN_AUDIENCE", Value: "zeebe-api"})
+	s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_CLIENT_AUTH_ISSUER", Value: "http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/token"})
+	s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_CLIENT_ZEEBE_AUDIENCE", Value: "zeebe-api"})
 	s.Require().Contains(
 		env,
 		corev1.EnvVar{

--- a/charts/camunda-platform-alpha/test/unit/connectors/types.go
+++ b/charts/camunda-platform-alpha/test/unit/connectors/types.go
@@ -3,13 +3,7 @@ package connectors
 type ConnectorsConfigYAML struct {
 	Server  ServerYAML  `yaml:"server"`
 	Camunda CamundaYAML `yaml:"camunda"`
-	Zeebe   ZeebeYAML   `yaml:"zeebe"`
-}
-
-type IdentityYAML struct {
-	Url      string `yaml:"url"`
-	Audience string `yaml:"audience"`
-	ClientId string `yaml:"client-id"`
+	Operate OperateYAML `yaml:"operate"`
 }
 
 type ServerYAML struct {
@@ -21,14 +15,21 @@ type ServletYAML struct {
 }
 
 type CamundaYAML struct {
-	Connector ConnectorYAML `yaml:"connector"`
-	Operate   OperateYAML   `yaml:"operate"`
-	Identity  IdentityYAML  `yaml:"identity"`
-}
-
-type ConnectorYAML struct {
-	Polling PollingYAML `yaml:"polling"`
-	WebHook WebHookYAML `yaml:"webhook"`
+	Connector struct {
+		Polling PollingYAML `yaml:"polling"`
+		WebHook WebHookYAML `yaml:"webhook"`
+	} `yaml:"connector"`
+	Identity struct {
+		Url      string `yaml:"url"`
+		Audience string `yaml:"audience"`
+		ClientId string `yaml:"client-id"`
+	} `yaml:"identity"`
+	Client struct {
+		Zeebe struct {
+			RESTAddress string `yaml:"rest-address"`
+			GRPCAddress string `yaml:"grpc-address"`
+		} `yaml:"zeebe"`
+	} `yaml:"client"`
 }
 
 type PollingYAML struct {
@@ -40,18 +41,12 @@ type WebHookYAML struct {
 }
 
 type OperateYAML struct {
-	Client ClientYAML `yaml:"client"`
-}
-
-type ClientYAML struct {
-	KeycloakTokenURL string `yaml:"keycloakTokenUrl"`
-	ClientId         string `yaml:"clientId"`
-	Url              string `yaml:"url"`
-	Username         string `yaml:"username"`
-}
-
-type ZeebeYAML struct {
-	Client ZeebeClientYAML `yaml:"client"`
+	Client struct {
+		KeycloakTokenURL string `yaml:"keycloakTokenUrl"`
+		ClientId         string `yaml:"clientId"`
+		BaseURL          string `yaml:"base-url"`
+		Username         string `yaml:"username"`
+	} `yaml:"client"`
 }
 
 type ZeebeClientYAML struct {


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

The local option was removed and can therefore also be removed from the unit test.

related to https://github.com/camunda/camunda-platform-helm/pull/3013

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
