### PR TITLE
ci: add a script to estimate unit test coverage

### DIFF
--- a/charts/camunda-platform-alpha/test/unit-test-coverage-calc.go
+++ b/charts/camunda-platform-alpha/test/unit-test-coverage-calc.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+// extractParamPaths reads values.yaml and extracts unique @param and @skip paths.
+func extractParamPaths(filename string) (map[string]bool, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	paramPaths := make(map[string]bool)
+	paramRegex := regexp.MustCompile(`## @(param|skip) ([\w\.]+)`) // Matches both @param and @skip
+	scanner := bufio.NewScanner(file)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		matches := paramRegex.FindStringSubmatch(line)
+		if len(matches) > 2 {
+			paramPaths[matches[2]] = true // Ensure uniqueness
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return paramPaths, nil
+}
+
+// extractSetValues scans .go files and extracts any map keys in SetValues or testCase values.
+func extractSetValues(folder string) (map[string]bool, error) {
+	setValues := make(map[string]bool)
+	mapKeyRegex := regexp.MustCompile(`"([\w\.]+)"\s*:`) // Matches "some.key":
+    
+	err := filepath.Walk(folder, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || filepath.Ext(path) != ".go" {
+			return nil
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		scanner := bufio.NewScanner(file)
+		inSetValues := false
+		inValuesMap := false
+
+		for scanner.Scan() {
+			line := scanner.Text()
+
+			// Detect start of SetValues or values maps
+			if regexp.MustCompile(`SetValues:\s*map\[string\]string{`).MatchString(line) {
+				inSetValues = true
+			}
+			if regexp.MustCompile(`values:\s*map\[string\]string{`).MatchString(line) {
+				inValuesMap = true
+			}
+
+			// Extract keys inside the detected maps
+			if inSetValues || inValuesMap {
+				matches := mapKeyRegex.FindAllStringSubmatch(line, -1)
+				for _, match := range matches {
+					if _, exists := setValues[match[1]]; !exists {
+						setValues[match[1]] = true // Ensure uniqueness
+					}
+				}
+			}
+
+			// Detect end of the maps
+			if inSetValues && regexp.MustCompile(`},`).MatchString(line) {
+				inSetValues = false
+			}
+			if inValuesMap && regexp.MustCompile(`},`).MatchString(line) {
+				inValuesMap = false
+			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return setValues, nil
+}
+
+// removeDuplicates removes matching entries and returns remaining unmatched items.
+func removeDuplicates(paramPaths, setValues map[string]bool) (map[string]bool, map[string]bool, int) {
+	removedCount := 0
+
+	// Remove exact matches
+	for path := range setValues {
+		if paramPaths[path] {
+			delete(setValues, path)
+			delete(paramPaths, path)
+			removedCount++
+		}
+	}
+
+	return paramPaths, setValues, removedCount
+}
+
+// calculateCoverage computes the percentage of tested params.
+func calculateCoverage(setValuesCount, paramCount int) float64 {
+	if paramCount == 0 {
+		return 0.0 // Avoid division by zero
+	}
+	return (float64(setValuesCount) / float64(paramCount)) * 100
+}
+
+func main() {
+	valuesFile := "values.yaml" // Change if needed
+	unitFolder := "test/unit"        // Folder containing .go test filesz
+
+	// Extract unique @param and @skip paths from values.yaml
+	paramPaths, err := extractParamPaths(valuesFile)
+	if err != nil {
+		fmt.Println("Error reading values.yaml:", err)
+		return
+	}
+
+	// Extract unique SetValues and testCase values from Go files
+	setValues, err := extractSetValues(unitFolder)
+	if err != nil {
+		fmt.Println("Error reading Go files:", err)
+		return
+	}
+
+	// Remove duplicates and validate
+	remainingParamPaths, remainingSetValues, removedCount := removeDuplicates(paramPaths, setValues)
+	
+	// Calculate coverage
+	coverage := calculateCoverage(removedCount, len(paramPaths)+removedCount)
+
+	// Print remaining paths if any
+	if len(remainingParamPaths) > 0 {
+		fmt.Println("❌ Unmatched @param + @skip paths:", keysFromMap(remainingParamPaths))
+	} else {
+		fmt.Println("✅ All @param + @skip paths are tested!")
+	}
+	
+	if len(remainingSetValues) > 0 {
+		fmt.Println("❌ Unmatched SetValues & testCase values:", keysFromMap(remainingSetValues))
+	} else {
+		fmt.Println("✅ All SetValues & testCase values are covered!")
+	}
+
+	// Output results
+	fmt.Println()
+    fmt.Println("📊 Results:")
+    fmt.Printf("📄 Total configs in values.yaml (based on @param + @skip): %d\n", len(paramPaths)+removedCount)
+    fmt.Printf("🧪 Total tested config keys in test files (unique): %d\n", len(setValues)+removedCount)
+    fmt.Printf("🔄 Matching entries: %d\n", removedCount)
+    fmt.Printf("❌ Unmatched configs in values.yaml: %d\n", len(remainingParamPaths))
+    fmt.Printf("❌ Unmatched configs in test files: %d\n", len(remainingSetValues))
+    fmt.Printf("📈 --> Unit Test Coverage: %.2f%%\n", coverage)
+}
+
+// keysFromMap converts a map's keys into a slice.
+func keysFromMap(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/charts/camunda-platform-alpha/test/unit-test-coverage-calc.go
+++ b/charts/camunda-platform-alpha/test/unit-test-coverage-calc.go
@@ -77,10 +77,17 @@ func extractSetValues(folder string) (map[string]bool, error) {
 					key := match[1]
 					if strings.HasSuffix(key, ".foo") {
 						key = strings.TrimSuffix(key, ".foo")
-						} else if strings.HasSuffix(key, ".foz") {
-							key = strings.TrimSuffix(key, ".foz")
-						}
-						if _, exists := setValues[key]; !exists {
+					} else if strings.HasSuffix(key, ".foz") {
+						key = strings.TrimSuffix(key, ".foz")
+					} else if strings.HasSuffix(key, ".cputype") {
+							key = strings.TrimSuffix(key, ".cputype")
+					} else if strings.HasSuffix(key, ".disktype") {
+						key = strings.TrimSuffix(key, ".disktype")
+					} else if strings.HasSuffix(key, ".runAsUser") {
+						key = strings.TrimSuffix(key, ".runAsUser")
+					}
+
+					if _, exists := setValues[key]; !exists {
 						setValues[key] = true // Ensure uniqueness
 					}
 				}

--- a/charts/camunda-platform-alpha/test/unit-test-coverage-calc.go
+++ b/charts/camunda-platform-alpha/test/unit-test-coverage-calc.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 )
 
 // extractParamPaths reads values.yaml and extracts unique @param and @skip paths.
@@ -73,8 +74,14 @@ func extractSetValues(folder string) (map[string]bool, error) {
 			if inSetValues || inValuesMap {
 				matches := mapKeyRegex.FindAllStringSubmatch(line, -1)
 				for _, match := range matches {
-					if _, exists := setValues[match[1]]; !exists {
-						setValues[match[1]] = true // Ensure uniqueness
+					key := match[1]
+					if strings.HasSuffix(key, ".foo") {
+						key = strings.TrimSuffix(key, ".foo")
+						} else if strings.HasSuffix(key, ".foz") {
+							key = strings.TrimSuffix(key, ".foz")
+						}
+						if _, exists := setValues[key]; !exists {
+						setValues[key] = true // Ensure uniqueness
 					}
 				}
 			}
@@ -128,7 +135,7 @@ func calculateCoverage(setValuesCount, paramCount int) float64 {
 
 func main() {
 	valuesFile := "values.yaml" // Change if needed
-	unitFolder := "test/unit"        // Folder containing .go test filesz
+	unitFolder := "test/unit"        // Folder containing .go test files
 
 	// Extract unique @param and @skip paths from values.yaml
 	paramPaths, err := extractParamPaths(valuesFile)


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

Trying to estimate our unit test coverage by a self-made script (used heavily copilot 🎉 ):
- It takes all config options from the values.yaml that are flagged with @params or @extra
- It takes all config options set in our unit tests
- Matches the 2 lists 
- Generate an output:
   - print out unmatched values of the values.yaml
   - print out unmatched values of the unit test
   - Calculates test scores:

<img width="1286" alt="image" src="https://github.com/user-attachments/assets/c7df1132-d749-45a2-894e-138b4b91e52f" />
 

The result looks like follows:



### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
