### PR TITLE
test: disable preflight 8.8 tests for disabled components

### DIFF
--- a/charts/camunda-platform-alpha-8.8/test/integration/testsuites/vars/files/testsuite-preflight.yaml
+++ b/charts/camunda-platform-alpha-8.8/test/integration/testsuites/vars/files/testsuite-preflight.yaml
@@ -17,13 +17,13 @@ testcases:
     # Dependencies.
     - component: Elasticsearch
       url: "{{ .preflightVars.baseURLs.elasticsearch }}/_cluster/health?&timeout=1s"
-    - component: Keycloak
-      url: "{{ .preflightVars.baseURLs.keycloak }}/auth/realms/master"
+#     - component: Keycloak
+#       url: "{{ .preflightVars.baseURLs.keycloak }}/auth/realms/master"
     # Camunda.
-    - component: Identity
-      url: "{{ .preflightVars.baseURLs.identity }}/actuator/health"
-    - component: Optimize
-      url: "{{ .preflightVars.baseURLs.optimize }}/api/readyz"
+#     - component: Identity
+#       url: "{{ .preflightVars.baseURLs.identity }}/actuator/health"
+#     - component: Optimize
+#       url: "{{ .preflightVars.baseURLs.optimize }}/api/readyz"
     - component: Core
       url: "{{ .preflightVars.baseURLs.core }}/actuator/health/readiness"
     # - component: Connectors
@@ -37,24 +37,24 @@ testcases:
       Response Body: {{ .result.body }}
     assertions:
     - result.statuscode ShouldEqual 200
-  - name: "WebModeler - {{ .value.component }}"
-    skip:
-    - skipTestWebModeler ShouldBeFalse
-    type: http
-    range:
-    - component: RESTAPI
-      url: "{{ .preflightVars.baseURLs.webModelerRestapi }}/health/readiness"
-    - component: WebApp
-      url: "{{ .preflightVars.baseURLs.webModelerWebapp }}/health/readiness"
-    method: GET
-    url: "{{ .value.url }}"
-    retry: 3
-    delay: 10
-    info: |
-      {{ .value.component }} URL: {{ .value.url }}
-      Response Body: {{ .result.body }}
-    assertions:
-    - result.statuscode ShouldEqual 200
+#   - name: "WebModeler - {{ .value.component }}"
+#     skip:
+#     - skipTestWebModeler ShouldBeFalse
+#     type: http
+#     range:
+#     - component: RESTAPI
+#       url: "{{ .preflightVars.baseURLs.webModelerRestapi }}/health/readiness"
+#     - component: WebApp
+#       url: "{{ .preflightVars.baseURLs.webModelerWebapp }}/health/readiness"
+#     method: GET
+#     url: "{{ .value.url }}"
+#     retry: 3
+#     delay: 10
+#     info: |
+#       {{ .value.component }} URL: {{ .value.url }}
+#       Response Body: {{ .result.body }}
+#     assertions:
+#     - result.statuscode ShouldEqual 200
 
 - name: TEST - Liveness
   steps:
@@ -64,8 +64,8 @@ testcases:
     # Dependencies.
     - component: Elasticsearch
       url: "{{ .preflightVars.baseURLs.elasticsearch }}/_cluster/health?wait_for_status=green&timeout=1s"
-    - component: Keycloak
-      url:  "{{ .preflightVars.baseURLs.keycloak }}/auth/realms/camunda-platform"
+#     - component: Keycloak
+#       url:  "{{ .preflightVars.baseURLs.keycloak }}/auth/realms/camunda-platform"
     # Camunda.
     - component: Identity
       url: "{{ .preflightVars.baseURLs.identity }}/actuator/health"
@@ -84,23 +84,23 @@ testcases:
       Response Body: {{ .result.body }}
     assertions:
     - result.statuscode ShouldEqual 200
-  - name: "WebModeler - {{ .value.component }}"
-    skip:
-    - skipTestWebModeler ShouldBeFalse
-    type: http
-    range:
-    - component: RESTAPI
-      url:  "{{ .preflightVars.baseURLs.webModelerRestapi }}/health/liveness"
-    - component: WebApp
-      url:  "{{ .preflightVars.baseURLs.webModelerWebapp }}/health/liveness"
-    method: GET
-    url: "{{ .value.url }}"
-    retry: 3
-    delay: 10
-    info: |
-      {{ .value.component }} URL: {{ .value.url }}
-      Response Body: {{ .result.body }}
-    assertions:
-    - result.statuscode ShouldEqual 200
+#   - name: "WebModeler - {{ .value.component }}"
+#     skip:
+#     - skipTestWebModeler ShouldBeFalse
+#     type: http
+#     range:
+#     - component: RESTAPI
+#       url:  "{{ .preflightVars.baseURLs.webModelerRestapi }}/health/liveness"
+#     - component: WebApp
+#       url:  "{{ .preflightVars.baseURLs.webModelerWebapp }}/health/liveness"
+#     method: GET
+#     url: "{{ .value.url }}"
+#     retry: 3
+#     delay: 10
+#     info: |
+#       {{ .value.component }} URL: {{ .value.url }}
+#       Response Body: {{ .result.body }}
+#     assertions:
+#     - result.statuscode ShouldEqual 200
 
 # TODO: Check seed config like ES indexes.

--- a/charts/camunda-platform-alpha-8.8/values.schema.json
+++ b/charts/camunda-platform-alpha-8.8/values.schema.json
@@ -868,7 +868,7 @@
                         "tag": {
                             "type": "string",
                             "description": "can be set to overwrite the global tag, which should be used in that chart",
-                            "default": "8.8.0-alpha1"
+                            "default": "8.8.0-alpha2"
                         },
                         "pullSecrets": {
                             "type": "array",
@@ -4902,7 +4902,7 @@
                         "tag": {
                             "type": "string",
                             "description": "can be set to overwrite the global tag, which should be used in that chart",
-                            "default": "8.8.0-alpha1"
+                            "default": "8.8.0-alpha2"
                         },
                         "pullSecrets": {
                             "type": "array",
@@ -5422,7 +5422,7 @@
                         "tag": {
                             "type": "string",
                             "description": "",
-                            "default": "8.17.2"
+                            "default": "8.17.3"
                         }
                     }
                 },


### PR DESCRIPTION
### Which problem does the PR fix?

In my previous PR #3151 , I missed some of the tests that should be disabled.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

Disabled the venom tests for each disabled component in 8.8.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
