### PR TITLE
fix: revert "test: disable tests for disabled components (#3151)"

### DIFF
--- a/charts/camunda-platform-alpha/test/integration/testsuites/vars/files/testsuite-core.yaml
+++ b/charts/camunda-platform-alpha/test/integration/testsuites/vars/files/testsuite-core.yaml
@@ -31,9 +31,9 @@ testcases:
     - component: Operate
       clientID: operate
       clientSecret: "{{ .OPERATE_CLIENT_SECRET }}"
-#     - component: Optimize
-#       clientID: optimize
-#       clientSecret: "{{ .OPTIMIZE_CLIENT_SECRET }}"
+    - component: Optimize
+      clientID: optimize
+      clientSecret: "{{ .OPTIMIZE_CLIENT_SECRET }}"
     - component: Zeebe
       clientID: zeebe
       clientSecret: "{{ .ZEEBE_CLIENT_SECRET }}"
@@ -74,20 +74,20 @@ testcases:
     - skiptestingress ShouldBeFalse
     type: http
     range:
-#     - component: Console
-#       url: "{{ .coreVars.baseURLs.console }}"
-#     - component: Keycloak
-#       url: "{{ .coreVars.baseURLs.keycloak }}"
+    - component: Console
+      url: "{{ .coreVars.baseURLs.console }}"
+    - component: Keycloak
+      url: "{{ .coreVars.baseURLs.keycloak }}"
     - component: Identity
       url: "{{ .coreVars.baseURLs.identity }}"
     - component: Operate
       url: "{{ .coreVars.baseURLs.operate }}"
-#     - component: Optimize
-#       url: "{{ .coreVars.baseURLs.optimize }}"
+    - component: Optimize
+      url: "{{ .coreVars.baseURLs.optimize }}"
     - component: Tasklist
       url: "{{ .coreVars.baseURLs.tasklist }}"
-#     - component: WebModeler
-#       url: "{{ .coreVars.baseURLs.webModeler }}"
+    - component: WebModeler
+      url: "{{ .coreVars.baseURLs.webModeler }}"
     method: GET
     url: "{{ .value.url }}"
     retry: 3
@@ -179,23 +179,23 @@ testcases:
   #   assertions:
   #   - result.statuscode ShouldEqual 200
   #   - result.bodyjson.version ShouldNotBeEmpty
-#   - name: Check WebModeler login page
-#     skip:
-#     - skiptestingress ShouldBeFalse
-#     - skipTestWebModeler ShouldBeFalse
-#     type: http
-#     method: GET
-#     url: "{{ .coreVars.baseURLs.webModeler }}"
-#     retry: 3
-#     delay: 15
-#     # info: |
-#     #   Component: {{ .value.component }}
-#     #   = Request Method: {{ .value.method }}
-#     #   = Request Body: {{ .result.request.body }}
-#     #   = Response Body: {{ .result.body }}
-#     assertions:
-#     - result.statuscode ShouldEqual 200
-#     - result.body ShouldNotContainSubstring error
+  - name: Check WebModeler login page
+    skip:
+    - skiptestingress ShouldBeFalse
+    - skipTestWebModeler ShouldBeFalse
+    type: http
+    method: GET
+    url: "{{ .coreVars.baseURLs.webModeler }}"
+    retry: 3
+    delay: 15
+    # info: |
+    #   Component: {{ .value.component }}
+    #   = Request Method: {{ .value.method }}
+    #   = Request Body: {{ .result.request.body }}
+    #   = Response Body: {{ .result.body }}
+    assertions:
+    - result.statuscode ShouldEqual 200
+    - result.body ShouldNotContainSubstring error
 
 - name: TEST - Interacting with Zeebe Gateway
   steps:


### PR DESCRIPTION
This reverts commit 56528b98320e3a5823f9ff184a251401d110bc46.

### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

reverting disabling of 8.7 test (aim was to disable 8.8) 

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
