### PR TITLE
ci: backport console confmap unit test to 8.5 and 8.6

### DIFF
--- a/charts/camunda-platform-8.5/test/unit/console/configmap_test.go
+++ b/charts/camunda-platform-8.5/test/unit/console/configmap_test.go
@@ -15,17 +15,14 @@
 package console
 
 import (
+	"camunda-platform/test/unit/testhelpers"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"gopkg.in/yaml.v3"
-	corev1 "k8s.io/api/core/v1"
 )
 
 type configMapTemplateTest struct {
@@ -50,29 +47,21 @@ func TestConfigMapTemplate(t *testing.T) {
 	})
 }
 
-func (s *configMapTemplateTest) TestContainerShouldSetCorrectIdentityType() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"console.enabled":                       "true",
-			"global.identity.auth.type":             "MICROSOFT",
-			"global.identity.auth.issuer":           "https://example.com",
-			"global.identity.auth.issuerBackendUrl": "https://example.com",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var configmap corev1.ConfigMap
-	var configmapApplication ConsoleYAML
-	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
-	if err != nil {
-		s.Fail("Failed to unmarshal yaml. error=", err)
-	}
-
-	// then
-	s.Require().Equal("MICROSOFT", configmapApplication.Camunda.Console.OAuth.Type)
+func (s *configMapTemplateTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+        {
+            Name: "Container should set correct identity type",
+            Values: map[string]string{
+                "console.enabled":                       "true",
+                "global.identity.auth.type":             "MICROSOFT",
+                "global.identity.auth.issuer":           "https://example.com",
+                "global.identity.auth.issuerBackendUrl": "https://example.com",
+            },
+            Expected: map[string]string{
+                "configmapApplication.camunda.console.oAuth.type": "MICROSOFT",
+            },
+        },
+    }
+		
+	testhelpers.RunTestCases(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }

--- a/charts/camunda-platform-8.5/test/unit/testhelpers/testhelpers.go
+++ b/charts/camunda-platform-8.5/test/unit/testhelpers/testhelpers.go
@@ -1,0 +1,91 @@
+package testhelpers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type TestCase struct {
+	Name     string
+	Values   map[string]string
+	Expected map[string]string
+}
+
+// RenderTemplate renders the specified Helm templates into a Kubernetes ConfigMap
+func RenderTemplate(t *testing.T, chartPath, release string, namespace string, templates []string, values map[string]string) corev1.ConfigMap {
+	options := &helm.Options{
+		SetValues:      values,
+		KubectlOptions: k8s.NewKubectlOptions("", "", namespace),
+	}
+
+	output := helm.RenderTemplate(t, options, chartPath, release, templates)
+	var configmap corev1.ConfigMap
+	helm.UnmarshalK8SYaml(t, output, &configmap)
+	return configmap
+}
+
+// VerifyConfigMap checks whether the generated ConfigMap contains the expected key-value pairs
+func VerifyConfigMap(t *testing.T, testCase string, configmap corev1.ConfigMap, expectedValues map[string]string) {
+	for keyPath, expectedValue := range expectedValues {
+		var actualValue string
+		if strings.HasPrefix(keyPath, "configmapApplication.") {
+            var configmapApplication map[string]interface{}
+            err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+            require.NoError(t, err)
+            actualValue = getConfigMapFieldValue(configmapApplication, strings.Split(keyPath, ".")[1:])
+        } else {
+            actualValue = strings.TrimSpace(configmap.Data[keyPath])
+        }
+		require.Equal(t, expectedValue, actualValue, "Test case '%s': Expected key '%s' to have value '%s', but got '%s'", testCase, keyPath, expectedValue, actualValue)
+	}
+}
+
+// RunTestCases executes multiple test cases using the provided Helm chart and ConfigMap validation
+func RunTestCases(t *testing.T, chartPath, release, namespace string, templates []string, testCases []TestCase) {
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			configmap := RenderTemplate(t, chartPath, release, namespace, templates, tc.Values)
+			VerifyConfigMap(t, tc.Name, configmap, tc.Expected)
+		})
+	}
+}
+
+// getConfigMapFieldValue function traverses a nested map structure based on a given key path.
+// It handles maps with both interface{} and string keys, converting them as necessary to retrieve the desired value.
+// If the key is not found or the final value is not a string, the function returns an empty string.
+func getConfigMapFieldValue(configmapApplication map[string]interface{}, keyPath []string) string {
+	var current interface{} = configmapApplication
+
+	for _, key := range keyPath {
+        if nestedMap, ok := current.(map[interface{}]interface{}); ok {
+            // Convert map[interface{}]interface{} to map[string]interface{}
+            stringMap := make(map[string]interface{})
+            for k, v := range nestedMap {
+                if strKey, isString := k.(string); isString {
+                    stringMap[strKey] = v
+                }
+            }
+            // Move to the next level in the map
+            current = stringMap[key]
+        } else if nestedMap, ok := current.(map[string]interface{}); ok {
+            // If the current level is already a map with string keys, move to the next level
+            current = nestedMap[key]
+        } else {
+            // If the key is not found, return an empty string
+            return ""
+        }
+    }
+
+    // If the final value is a string, return it
+    if value, ok := current.(string); ok {
+        return value
+    }
+    // If the final value is not a string, return an empty string
+    return ""
+}

--- a/charts/camunda-platform-8.6/test/unit/console/configmap_test.go
+++ b/charts/camunda-platform-8.6/test/unit/console/configmap_test.go
@@ -15,17 +15,14 @@
 package console
 
 import (
+	"camunda-platform/test/unit/testhelpers"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"gopkg.in/yaml.v3"
-	corev1 "k8s.io/api/core/v1"
 )
 
 type configMapTemplateTest struct {
@@ -50,29 +47,21 @@ func TestConfigMapTemplate(t *testing.T) {
 	})
 }
 
-func (s *configMapTemplateTest) TestContainerShouldSetCorrectIdentityType() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"console.enabled":                       "true",
-			"global.identity.auth.type":             "MICROSOFT",
-			"global.identity.auth.issuer":           "https://example.com",
-			"global.identity.auth.issuerBackendUrl": "https://example.com",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var configmap corev1.ConfigMap
-	var configmapApplication ConsoleYAML
-	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
-	if err != nil {
-		s.Fail("Failed to unmarshal yaml. error=", err)
-	}
-
-	// then
-	s.Require().Equal("MICROSOFT", configmapApplication.Camunda.Console.OAuth.Type)
+func (s *configMapTemplateTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+        {
+            Name: "Container should set correct identity type",
+            Values: map[string]string{
+                "console.enabled":                       "true",
+                "global.identity.auth.type":             "MICROSOFT",
+                "global.identity.auth.issuer":           "https://example.com",
+                "global.identity.auth.issuerBackendUrl": "https://example.com",
+            },
+            Expected: map[string]string{
+                "configmapApplication.camunda.console.oAuth.type": "MICROSOFT",
+            },
+        },
+    }
+		
+	testhelpers.RunTestCases(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }

--- a/charts/camunda-platform-8.6/test/unit/testhelpers/testhelpers.go
+++ b/charts/camunda-platform-8.6/test/unit/testhelpers/testhelpers.go
@@ -1,0 +1,91 @@
+package testhelpers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type TestCase struct {
+	Name     string
+	Values   map[string]string
+	Expected map[string]string
+}
+
+// RenderTemplate renders the specified Helm templates into a Kubernetes ConfigMap
+func RenderTemplate(t *testing.T, chartPath, release string, namespace string, templates []string, values map[string]string) corev1.ConfigMap {
+	options := &helm.Options{
+		SetValues:      values,
+		KubectlOptions: k8s.NewKubectlOptions("", "", namespace),
+	}
+
+	output := helm.RenderTemplate(t, options, chartPath, release, templates)
+	var configmap corev1.ConfigMap
+	helm.UnmarshalK8SYaml(t, output, &configmap)
+	return configmap
+}
+
+// VerifyConfigMap checks whether the generated ConfigMap contains the expected key-value pairs
+func VerifyConfigMap(t *testing.T, testCase string, configmap corev1.ConfigMap, expectedValues map[string]string) {
+	for keyPath, expectedValue := range expectedValues {
+		var actualValue string
+		if strings.HasPrefix(keyPath, "configmapApplication.") {
+            var configmapApplication map[string]interface{}
+            err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+            require.NoError(t, err)
+            actualValue = getConfigMapFieldValue(configmapApplication, strings.Split(keyPath, ".")[1:])
+        } else {
+            actualValue = strings.TrimSpace(configmap.Data[keyPath])
+        }
+		require.Equal(t, expectedValue, actualValue, "Test case '%s': Expected key '%s' to have value '%s', but got '%s'", testCase, keyPath, expectedValue, actualValue)
+	}
+}
+
+// RunTestCases executes multiple test cases using the provided Helm chart and ConfigMap validation
+func RunTestCases(t *testing.T, chartPath, release, namespace string, templates []string, testCases []TestCase) {
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			configmap := RenderTemplate(t, chartPath, release, namespace, templates, tc.Values)
+			VerifyConfigMap(t, tc.Name, configmap, tc.Expected)
+		})
+	}
+}
+
+// getConfigMapFieldValue function traverses a nested map structure based on a given key path.
+// It handles maps with both interface{} and string keys, converting them as necessary to retrieve the desired value.
+// If the key is not found or the final value is not a string, the function returns an empty string.
+func getConfigMapFieldValue(configmapApplication map[string]interface{}, keyPath []string) string {
+	var current interface{} = configmapApplication
+
+	for _, key := range keyPath {
+        if nestedMap, ok := current.(map[interface{}]interface{}); ok {
+            // Convert map[interface{}]interface{} to map[string]interface{}
+            stringMap := make(map[string]interface{})
+            for k, v := range nestedMap {
+                if strKey, isString := k.(string); isString {
+                    stringMap[strKey] = v
+                }
+            }
+            // Move to the next level in the map
+            current = stringMap[key]
+        } else if nestedMap, ok := current.(map[string]interface{}); ok {
+            // If the current level is already a map with string keys, move to the next level
+            current = nestedMap[key]
+        } else {
+            // If the key is not found, return an empty string
+            return ""
+        }
+    }
+
+    // If the final value is a string, return it
+    if value, ok := current.(string); ok {
+        return value
+    }
+    // If the final value is not a string, return an empty string
+    return ""
+}


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

Backports the refactoring of the unit test for consoles configmap back to 8.5 and 8.6, see [backport for 8.8](https://github.com/camunda/camunda-platform-helm/pull/3179)

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
