### PR TITLE
fix: use client credentials authentication for default cluster in Web Modeler if Entra ID is used

### DIFF
--- a/charts/camunda-platform-alpha/templates/web-modeler/_helpers.tpl
+++ b/charts/camunda-platform-alpha/templates/web-modeler/_helpers.tpl
@@ -235,7 +235,7 @@ Define match labels for Web Modeler websockets to be used in matchLabels selecto
 [web-modeler] Get the name of the secret resource that contains the SMTP password.
 */}}
 {{- define "webModeler.restapi.smtpSecretName" -}}
-  {{- if or (typeIs "string" .Values.webModeler.restapi.mail.existingSecret) .Values.webModeler.restapi.mail.smtpPassword }} 
+  {{- if or (typeIs "string" .Values.webModeler.restapi.mail.existingSecret) .Values.webModeler.restapi.mail.smtpPassword }}
       {{- (include "webModeler.restapi.fullname" .) }}
   {{- else if and (typeIs "map[string]interface {}" .Values.webModeler.restapi.mail.existingSecret) .Values.webModeler.restapi.mail.existingSecret.name }}
       {{- .Values.webModeler.restapi.mail.existingSecret.name }}
@@ -267,6 +267,17 @@ Define match labels for Web Modeler websockets to be used in matchLabels selecto
     {{- end }}
   {{- end }}
   {{- $authEnabled -}}
+{{- end -}}
+
+{{/*
+[web-modeler] Get the authentication type for the configured cluster
+*/}}
+{{- define "webModeler.restapi.clusterAuthentication" -}}
+  {{- if .Values.global.identity.auth.enabled -}}
+    {{- eq (include "camundaPlatform.authType" .) "MICROSOFT" | ternary "CLIENT_CREDENTIALS" "OAUTH" -}}
+  {{- else -}}
+    NONE
+  {{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform-alpha/templates/web-modeler/configmap-restapi.yaml
+++ b/charts/camunda-platform-alpha/templates/web-modeler/configmap-restapi.yaml
@@ -47,13 +47,22 @@ data:
           - id: "default-cluster"
             name: {{ tpl .Values.global.zeebeClusterName . | quote }}
             version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.zeebe) | quote }}
-            authentication: {{ .Values.global.identity.auth.enabled | ternary "OAUTH" "NONE" | quote }}
+            authentication: {{ include "webModeler.restapi.clusterAuthentication" . | quote }}
             url:
               zeebe:
                 grpc: "grpc://{{ tpl .Values.global.zeebeClusterName . }}-gateway:{{ .Values.zeebeGateway.service.grpcPort }}"
                 rest: {{ include "camundaPlatform.zeebeGatewayRESTURL" . | quote }}
               operate: {{ include "camundaPlatform.operateURL" . | quote }}
               tasklist: {{ include "camundaPlatform.tasklistURL" . | quote }}
+            {{- if eq (include "camundaPlatform.authType" .) "MICROSOFT" }}
+            oauth:
+              url: {{ include "camundaPlatform.authIssuerBackendUrlTokenEndpoint" . | quote }}
+              scope: {{ include "zeebe.authTokenScope" . | quote }}
+              audience:
+                zeebe: {{ include "zeebe.authAudience" . | quote }}
+                operate: {{ include "operate.authAudience" . | quote }}
+                tasklist: {{ include "tasklist.authAudience" . | quote }}
+            {{- end }}
           {{- end }}
         {{- end }}
 

--- a/charts/camunda-platform-alpha/test/unit/web-modeler/types.go
+++ b/charts/camunda-platform-alpha/test/unit/web-modeler/types.go
@@ -55,25 +55,26 @@ type ModelerSecurityYAML struct {
 }
 
 type ModelerJwtYAML struct {
-	Audience AudienceYAML `yaml:"audience"`
-	Issuer   IssuerYAML   `yaml:"issuer"`
+	Audience JwtAudienceYAML `yaml:"audience"`
+	Issuer   IssuerYAML      `yaml:"issuer"`
 }
 
 type IssuerYAML struct {
 	BackendUrl string `yaml:"backend-url"`
 }
 
-type AudienceYAML struct {
+type JwtAudienceYAML struct {
 	InternalAPI string `yaml:"internal-api"`
 	PublicAPI   string `yaml:"public-api"`
 }
 
 type ClusterYAML struct {
-	Id             string  `yaml:"id"`
-	Name           string  `yaml:"name"`
-	Version        string  `yaml:"version"`
-	Authentication string  `yaml:"authentication"`
-	Url            UrlYAML `yaml:"url"`
+	Id             string    `yaml:"id"`
+	Name           string    `yaml:"name"`
+	Version        string    `yaml:"version"`
+	Authentication string    `yaml:"authentication"`
+	Url            UrlYAML   `yaml:"url"`
+	OAuth          OAuthYAML `yaml:"oauth"`
 }
 
 type UrlYAML struct {
@@ -85,6 +86,18 @@ type UrlYAML struct {
 type ZeebeUrlYAML struct {
 	Grpc string `yaml:"grpc"`
 	Rest string `yaml:"rest"`
+}
+
+type OAuthYAML struct {
+	Url      string              `yaml:"url"`
+	Scope    string              `yaml:"scope"`
+	Audience ClusterAudienceYAML `yaml:"audience"`
+}
+
+type ClusterAudienceYAML struct {
+	Zeebe    string `yaml:"zeebe"`
+	Operate  string `yaml:"operate"`
+	Tasklist string `yaml:"tasklist"`
 }
 
 // Web App ---

--- a/charts/camunda-platform-alpha/values.yaml
+++ b/charts/camunda-platform-alpha/values.yaml
@@ -2922,6 +2922,14 @@ webModeler:
     #        rest: "http://camunda-platform-zeebe-gateway:8080"
     #      operate: "http://camunda-platform-operate:80"
     #      tasklist: "http://camunda-platform-tasklist:80"
+    #    # only required for authentication type CLIENT_CREDENTIALS
+    #    oauth:
+    #      url: https://auth.example.com/token    # required (URL of the token endpoint)
+    #      scope: "custom-scope"                  # optional (default is empty)
+    #      audience:
+    #        zeebe: "custom-zeebe-audience"       # optional (default is "zeebe-api")
+    #        operate: "custom-operate-audience"   # optional (default is "operate-api")
+    #        tasklist: "custom-tasklist-audience" # optional (default is "tasklist-api")
 
     ## @param webModeler.restapi.podAnnotations can be used to define extra restapi pod annotations
     podAnnotations: {}


### PR DESCRIPTION
### Which problem does the PR fix?
Closes https://github.com/camunda/web-modeler/issues/13860

### What's in this PR?
Configure the default cluster that is available in Web Modeler for deployments with the authentication type `CLIENT_CREDENTIALS` if Entra ID is used as identity provider.

This is necessary because the default authentication method – which would just pass on the user token to the cluster – does not work with Entra ID (see details in https://github.com/camunda/web-modeler/issues/13265).

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
