### PR TITLE
cd: show release PR opened by release-please workflow

### DIFF
--- a/.github/workflows/chart-release-pr.yml
+++ b/.github/workflows/chart-release-pr.yml
@@ -41,11 +41,11 @@ jobs:
           chart_dir_id_input="${{ inputs.id }}"
           chart_dir_id_fallback="$(echo "${{ github.ref_name }}" | sed 's/release-candidate-//')"
           chart_dir_id="${chart_dir_id_input:-$chart_dir_id_fallback}"
-          echo "CHART_PATH=charts/camunda-platform-${chart_dir_id}" >> $GITHUB_ENV
+          echo "CHART_PATH=charts/camunda-platform-${chart_dir_id}" | tee -a $GITHUB_ENV
       - name: Install release-please
         run: |
           npm i release-please -g
-      - name: Run release-please
+      - name: ⭐ Run release-please ⭐
         run: |
           release-please release-pr \
             --token="${{ steps.generate-github-token.outputs.token }}" \
@@ -54,4 +54,12 @@ jobs:
             --path="${{ env.CHART_PATH }}" \
             --config-file="${{ env.RELEASE_PLEASE_CONFIG_FILE }}" \
             --manifest-file="${{ env.RELEASE_PLEASE_MANIFEST_FILE }}" \
-            --debug
+            --debug | tee release-please.log
+      - name: Get release PR number
+        run: |
+          release_pr_number="$(grep "Successfully opened pull request:" release-please.log | grep -Po "\d+" || true)"
+          echo="release_pr_number=${release_pr_number}" | tee -a $GITHUB_ENV
+      - name: Add release PR number to workflow summary
+        if: env.release_pr_number
+        run: |
+          echo "⭐ Release PR URL: https://github.com/${{ github.repository }}/pull/${{ env.release_pr_number }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
### Which problem does the PR fix?

Related to: https://github.com/camunda/team-distribution/issues/360

### What's in this PR?

A tiny enhancement for the release workflow to show the release PR opened by the release-please workflow.
It makes it easier for the release manager to go directly to the release PR without any search.

How it looks like in the workflow summary:

![release-pr-summary](https://github.com/user-attachments/assets/32ea91c5-65d3-4961-80ed-0e5ff3054992)
