### PR TITLE
cd: use release-please always-bump-patch for 8.3

### DIFF
--- a/.github/config/release-please/release-please-config.json
+++ b/.github/config/release-please/release-please-config.json
@@ -51,6 +51,7 @@
     "charts/camunda-platform-8.3": {
       "pull-request-title-pattern": "chore(release): Camunda Platform Helm Chart ${version} - Camunda 8.3",
       "release-type": "helm",
+      "versioning": "always-bump-patch",
       "extra-label": "version/8.3,automation/release-please,release/pr,kind/chore,chart/camunda-platform",
       "component": "camunda-platform-8.3",
       "include-v-in-tag": false,


### PR DESCRIPTION
### Which problem does the PR fix?

Task: https://github.com/camunda/team-distribution/issues/462

### What's in this PR?

Always bump patch version as the charts got their own version starting from camunda 8.4 release.