### PR TITLE
fix: by default use 8.8 but without the symlink

### DIFF
--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -15,7 +15,7 @@ on:
         type: string
       camunda-helm-dir:
         required: false
-        default: camunda-platform-alpha
+        default: camunda-platform-8.8
         type: string
       camunda-helm-git-ref:
         required: false


### PR DESCRIPTION
### Which problem does the PR fix?

after switching our helm chart to using camunda-platform-8.8 in addition to camunda-platform-alpha via symlink, some users reported that the symlink is not working as intended when running "helm dependency update".

https://camunda.slack.com/archives/C03UR0V2R2M/p1743501024241029

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
