### PR TITLE
fix: bump core and connectors to 8.8.0-alpha3

### DIFF
--- a/charts/camunda-platform-8.8/values.yaml
+++ b/charts/camunda-platform-8.8/values.yaml
@@ -1929,7 +1929,7 @@ connectors:
     ## @param connectors.image.repository defines which image repository to use
     repository: camunda/connectors-bundle
     ## @param connectors.image.tag can be set to overwrite the global tag, which should be used in that chart
-    tag: 8.8.0-alpha3-rc1
+    tag: 8.8.0-alpha3
     ## @param connectors.image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
     pullSecrets: []
 
@@ -2136,7 +2136,7 @@ core:
      ## @param core.image.repository defines which image repository to use
     repository: camunda/camunda
      ## @param core.image.tag can be set to overwrite the global tag, which should be used in that chart
-    tag: 8.8.0-alpha2-rc1
+    tag: 8.8.0-alpha3
      ## @param core.image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
     pullSecrets: []
 


### PR DESCRIPTION
### Which problem does the PR fix?

renovate will not properly handle versions of format -alphaX-rcY

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
