### PR TITLE
fix: refactor unit tests in 8.6/test/unit/console to new style

### DIFF
--- a/charts/camunda-platform-8.6/test/unit/console/deployment_test.go
+++ b/charts/camunda-platform-8.6/test/unit/console/deployment_test.go
@@ -130,630 +130,506 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 				// then
 				s.Require().Equal("SecretName", deployment.Spec.Template.Spec.ImagePullSecrets[0].Name)
 			},
+		}, {
+			Name: "TestContainerSetImagePullSecretsSubChart",
+
+			Values: map[string]string{
+				"console.enabled":                   "true",
+				"global.image.pullSecrets[0].name":  "SecretName",
+				"console.image.pullSecrets[0].name": "SecretNameSubChart",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				s.Require().Equal("SecretNameSubChart", deployment.Spec.Template.Spec.ImagePullSecrets[0].Name)
+			},
+		}, {
+			Name: "TestContainerOverwriteImageTag",
+
+			Values: map[string]string{
+				"console.enabled":   "true",
+				"console.image.tag": "a.b.c",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				containers := deployment.Spec.Template.Spec.Containers
+				s.Require().Equal(1, len(containers))
+				s.Require().Equal("camunda/console:a.b.c", containers[0].Image)
+			},
+		}, {
+			Name: "TestContainerOverwriteGlobalImageTag",
+
+			Values: map[string]string{
+				"console.enabled":   "true",
+				"global.image.tag":  "a.b.c",
+				"console.image.tag": "",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				containers := deployment.Spec.Template.Spec.Containers
+				s.Require().Equal(1, len(containers))
+				s.Require().Equal("camunda/console:a.b.c", containers[0].Image)
+			},
+		}, {
+			Name: "TestContainerOverwriteImageTagWithChartDirectSetting",
+			Values: map[string]string{
+				"console.enabled":   "true",
+				"global.image.tag":  "x.y.z",
+				"console.image.tag": "a.b.c",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				expectedContainerImage := "camunda/console:a.b.c"
+				containers := deployment.Spec.Template.Spec.Containers
+				s.Require().Equal(1, len(containers))
+				s.Require().Equal(expectedContainerImage, containers[0].Image)
+			},
+		}, {
+			Name:                 "TestContainerSetContainerCommand",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values: map[string]string{
+				"console.enabled":    "true",
+				"console.command[0]": "printenv",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				containers := deployment.Spec.Template.Spec.Containers
+				s.Require().Equal(1, len(containers))
+				s.Require().Equal(1, len(containers[0].Command))
+				s.Require().Equal("printenv", containers[0].Command[0])
+			},
+		}, {
+			Name:                 "TestContainerSetExtraVolumes",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values: map[string]string{
+				"console.enabled":                               "true",
+				"console.extraVolumes[0].name":                  "extraVolume",
+				"console.extraVolumes[0].configMap.name":        "otherConfigMap",
+				"console.extraVolumes[0].configMap.defaultMode": "744",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				// finding out the length of volumes array before addition of new volume
+				beforeOptions := &helm.Options{
+					SetValues: map[string]string{
+						"console.enabled": "true",
+					},
+					KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+					ExtraArgs:      map[string][]string{"install": {"--debug"}},
+				}
+				var deploymentBefore appsv1.Deployment
+				before := helm.RenderTemplate(s.T(), beforeOptions, s.chartPath, s.release, s.templates)
+				helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
+				volumeLenBefore := len(deploymentBefore.Spec.Template.Spec.Volumes)
+
+				// when
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				volumes := deployment.Spec.Template.Spec.Volumes
+				s.Require().Equal(volumeLenBefore+1, len(volumes))
+
+				extraVolume := volumes[volumeLenBefore]
+				s.Require().Equal("extraVolume", extraVolume.Name)
+				s.Require().NotNil(*extraVolume.ConfigMap)
+				s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
+				s.Require().EqualValues(744, *extraVolume.ConfigMap.DefaultMode)
+			},
+		}, {
+			Name:                 "TestContainerSetExtraVolumeMounts",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values: map[string]string{
+				"console.enabled":                        "true",
+				"console.extraVolumeMounts[0].name":      "otherConfigMap",
+				"console.extraVolumeMounts[0].mountPath": "/usr/local/config",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				// finding out the length of containers and volumeMounts array before addition of new volumeMount
+				beforeOptions := &helm.Options{
+					SetValues: map[string]string{
+						"console.enabled": "true",
+					},
+					KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+					ExtraArgs:      map[string][]string{"install": {"--debug"}},
+				}
+				var deploymentBefore appsv1.Deployment
+				before := helm.RenderTemplate(s.T(), beforeOptions, s.chartPath, s.release, s.templates)
+				helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
+				containerLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers)
+				volumeMountLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
+
+				// when
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				containers := deployment.Spec.Template.Spec.Containers
+				s.Require().Equal(containerLenBefore, len(containers))
+
+				volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
+				s.Require().Equal(volumeMountLenBefore+1, len(volumeMounts))
+				extraVolumeMount := volumeMounts[volumeMountLenBefore]
+				s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
+				s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
+			},
+		}, {
+			Name:                 "TestContainerSetExtraVolumesAndMounts",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values: map[string]string{
+				"console.enabled":                               "true",
+				"console.extraVolumeMounts[0].name":             "otherConfigMap",
+				"console.extraVolumeMounts[0].mountPath":        "/usr/local/config",
+				"console.extraVolumes[0].name":                  "extraVolume",
+				"console.extraVolumes[0].configMap.name":        "otherConfigMap",
+				"console.extraVolumes[0].configMap.defaultMode": "744",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				// finding out the length of volumes, volumemounts array before addition of new volume
+				beforeOptions := &helm.Options{
+					SetValues: map[string]string{
+						"console.enabled": "true",
+					},
+					KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+					ExtraArgs:      map[string][]string{"install": {"--debug"}},
+				}
+				var deploymentBefore appsv1.Deployment
+				before := helm.RenderTemplate(s.T(), beforeOptions, s.chartPath, s.release, s.templates)
+				helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
+				volumeLenBefore := len(deploymentBefore.Spec.Template.Spec.Volumes)
+				volumeMountLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
+				containerLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers)
+
+				// given
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				volumes := deployment.Spec.Template.Spec.Volumes
+				s.Require().Equal(volumeLenBefore+1, len(volumes))
+
+				extraVolume := volumes[volumeLenBefore]
+				s.Require().Equal("extraVolume", extraVolume.Name)
+				s.Require().NotNil(*extraVolume.ConfigMap)
+				s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
+				s.Require().EqualValues(744, *extraVolume.ConfigMap.DefaultMode)
+
+				containers := deployment.Spec.Template.Spec.Containers
+				s.Require().Equal(containerLenBefore, len(containers))
+
+				volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
+				s.Require().Equal(volumeMountLenBefore+1, len(volumeMounts))
+				extraVolumeMount := volumeMounts[volumeMountLenBefore]
+				s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
+				s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
+			},
+		}, {
+			Name:                 "TestContainerSetServiceAccountName",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values: map[string]string{
+				"console.enabled":             "true",
+				"console.serviceAccount.name": "accName",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				serviceAccName := deployment.Spec.Template.Spec.ServiceAccountName
+				s.Require().Equal("accName", serviceAccName)
+			},
+		}, {
+			Name: "TestPodSetSecurityContext",
+			Values: map[string]string{
+				"console.enabled":                      "true",
+				"console.podSecurityContext.runAsUser": "1000",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				securityContext := deployment.Spec.Template.Spec.SecurityContext
+				s.Require().EqualValues(1000, *securityContext.RunAsUser)
+			},
+		}, {
+			Name: "TestContainerSetSecurityContext",
+			Values: map[string]string{
+				"console.enabled": "true",
+				"console.containerSecurityContext.privileged": "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				securityContext := deployment.Spec.Template.Spec.Containers[0].SecurityContext
+				s.Require().True(*securityContext.Privileged)
+			},
+		}, {
+			// https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+			Name: "TestContainerSetNodeSelector",
+			Values: map[string]string{
+				"console.enabled":               "true",
+				"console.nodeSelector.disktype": "ssd",
+				"console.nodeSelector.cputype":  "arm",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				s.Require().Equal("ssd", deployment.Spec.Template.Spec.NodeSelector["disktype"])
+				s.Require().Equal("arm", deployment.Spec.Template.Spec.NodeSelector["cputype"])
+			},
+		}, {
+			// https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+			// affinity:
+			//	nodeAffinity:
+			//	 requiredDuringSchedulingIgnoredDuringExecution:
+			//	   nodeSelectorTerms:
+			//	   - matchExpressions:
+			//		 - key: kubernetes.io/e2e-az-name
+			//		   operator: In
+			//		   values:
+			//		   - e2e-az1
+			//		   - e2e-az2
+			//	 preferredDuringSchedulingIgnoredDuringExecution:
+			//	 - weight: 1
+			//	   preference:
+			//		 matchExpressions:
+			//		 - key: another-node-label-key
+			//		   operator: In
+			//		   values:
+			//		   - another-node-label-value
+			Name: "TestContainerSetAffinity",
+			Values: map[string]string{
+				"console.enabled": "true",
+				"console.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].key":       "kubernetes.io/e2e-az-name",
+				"console.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].operator":  "In",
+				"console.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].values[0]": "e2e-a1",
+				"console.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].values[1]": "e2e-a2",
+				"console.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight":                                         "1",
+				"console.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].key":             "another-node-label-key",
+				"console.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].operator":        "In",
+				"console.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].values[0]":       "another-node-label-value",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				nodeAffinity := deployment.Spec.Template.Spec.Affinity.NodeAffinity
+				s.Require().NotNil(nodeAffinity)
+
+				nodeSelectorTerm := nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0]
+				s.Require().NotNil(nodeSelectorTerm)
+				matchExpression := nodeSelectorTerm.MatchExpressions[0]
+				s.Require().NotNil(matchExpression)
+				s.Require().Equal("kubernetes.io/e2e-az-name", matchExpression.Key)
+				s.Require().EqualValues("In", matchExpression.Operator)
+				s.Require().Equal([]string{"e2e-a1", "e2e-a2"}, matchExpression.Values)
+
+				preferredSchedulingTerm := nodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0]
+				s.Require().NotNil(preferredSchedulingTerm)
+
+				matchExpression = preferredSchedulingTerm.Preference.MatchExpressions[0]
+				s.Require().NotNil(matchExpression)
+				s.Require().Equal("another-node-label-key", matchExpression.Key)
+				s.Require().EqualValues("In", matchExpression.Operator)
+				s.Require().Equal([]string{"another-node-label-value"}, matchExpression.Values)
+			},
+		}, {
+			// https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration
+			//tolerations:
+			//- key: "key1"
+			//  operator: "Equal"
+			//  value: "value1"
+			//  effect: "NoSchedule"
+			Name: "TestContainerSetTolerations",
+			Values: map[string]string{
+				"console.enabled":                 "true",
+				"console.tolerations[0].key":      "key1",
+				"console.tolerations[0].operator": "Equal",
+				"console.tolerations[0].value":    "Value1",
+				"console.tolerations[0].effect":   "NoSchedule",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				tolerations := deployment.Spec.Template.Spec.Tolerations
+				s.Require().Equal(1, len(tolerations))
+
+				toleration := tolerations[0]
+				s.Require().Equal("key1", toleration.Key)
+				s.Require().EqualValues("Equal", toleration.Operator)
+				s.Require().Equal("Value1", toleration.Value)
+				s.Require().EqualValues("NoSchedule", toleration.Effect)
+			},
+		}, {
+			Name: "TestContainerShouldOverwriteGlobalImagePullPolicy",
+			Values: map[string]string{
+				"console.enabled":         "true",
+				"global.image.pullPolicy": "Always",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				expectedPullPolicy := corev1.PullAlways
+				containers := deployment.Spec.Template.Spec.Containers
+				s.Require().Equal(1, len(containers))
+				pullPolicy := containers[0].ImagePullPolicy
+				s.Require().Equal(expectedPullPolicy, pullPolicy)
+			},
+		}, {
+			Name: "TestContainerStartupProbe",
+			Values: map[string]string{
+				"console.enabled":                          "true",
+				"console.startupProbe.enabled":             "true",
+				"console.startupProbe.probePath":           "/healthz",
+				"console.startupProbe.initialDelaySeconds": "5",
+				"console.startupProbe.periodSeconds":       "10",
+				"console.startupProbe.successThreshold":    "1",
+				"console.startupProbe.failureThreshold":    "5",
+				"console.startupProbe.timeoutSeconds":      "1",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				probe := deployment.Spec.Template.Spec.Containers[0].StartupProbe
+
+				s.Require().Equal("/healthz", probe.HTTPGet.Path)
+				s.Require().EqualValues(5, probe.InitialDelaySeconds)
+				s.Require().EqualValues(10, probe.PeriodSeconds)
+				s.Require().EqualValues(1, probe.SuccessThreshold)
+				s.Require().EqualValues(5, probe.FailureThreshold)
+				s.Require().EqualValues(1, probe.TimeoutSeconds)
+			},
+		}, {
+			// readinessProbe is enabled by default so it's tested by golden files.
+			Name: "TestContainerLivenessProbe",
+			Values: map[string]string{
+				"console.enabled":                           "true",
+				"console.livenessProbe.enabled":             "true",
+				"console.livenessProbe.probePath":           "/healthz",
+				"console.livenessProbe.initialDelaySeconds": "5",
+				"console.livenessProbe.periodSeconds":       "10",
+				"console.livenessProbe.successThreshold":    "1",
+				"console.livenessProbe.failureThreshold":    "5",
+				"console.livenessProbe.timeoutSeconds":      "1",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				probe := deployment.Spec.Template.Spec.Containers[0].LivenessProbe
+
+				s.Require().EqualValues("/healthz", probe.HTTPGet.Path)
+				s.Require().EqualValues(5, probe.InitialDelaySeconds)
+				s.Require().EqualValues(10, probe.PeriodSeconds)
+				s.Require().EqualValues(1, probe.SuccessThreshold)
+				s.Require().EqualValues(5, probe.FailureThreshold)
+				s.Require().EqualValues(1, probe.TimeoutSeconds)
+			},
+		}, {
+			Name: "TestContainerSetSidecar",
+			Values: map[string]string{
+				"console.enabled":                            "true",
+				"console.sidecars[0].name":                   "nginx",
+				"console.sidecars[0].image":                  "nginx:latest",
+				"console.sidecars[0].ports[0].containerPort": "80",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				podContainers := deployment.Spec.Template.Spec.Containers
+				expectedContainer := corev1.Container{
+					Name:  "nginx",
+					Image: "nginx:latest",
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: 80,
+						},
+					},
+				}
+
+				s.Require().Contains(podContainers, expectedContainer)
+			},
+		}, {
+			Name: "TestInitContainers",
+			Values: map[string]string{
+				"console.enabled":                                  "true",
+				"console.initContainers[0].name":                   "nginx",
+				"console.initContainers[0].image":                  "nginx:latest",
+				"console.initContainers[0].ports[0].containerPort": "80",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				podContainers := deployment.Spec.Template.Spec.InitContainers
+				expectedContainer := corev1.Container{
+					Name:  "nginx",
+					Image: "nginx:latest",
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: 80,
+						},
+					},
+				}
+
+				s.Require().Contains(podContainers, expectedContainer)
+			},
+		}, {
+			Name: "TestSetDnsPolicyAndDnsConfig",
+			Values: map[string]string{
+				"console.enabled":                  "true",
+				"console.dnsPolicy":                "ClusterFirst",
+				"console.dnsConfig.nameservers[0]": "8.8.8.8",
+				"console.dnsConfig.searches[0]":    "example.com",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				// Check if dnsPolicy is set
+				require.NotEmpty(s.T(), deployment.Spec.Template.Spec.DNSPolicy, "dnsPolicy should not be empty")
+
+				// Check if dnsConfig is set
+				require.NotNil(s.T(), deployment.Spec.Template.Spec.DNSConfig, "dnsConfig should not be nil")
+
+				expectedDNSConfig := &corev1.PodDNSConfig{
+					Nameservers: []string{"8.8.8.8"},
+					Searches:    []string{"example.com"},
+				}
+
+				require.Equal(s.T(), expectedDNSConfig, deployment.Spec.Template.Spec.DNSConfig, "dnsConfig should match the expected configuration")
+			},
 		},
 	}
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
-}
-
-func (s *DeploymentTemplateTest) TestContainerSetImagePullSecretsSubChart() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"console.enabled":                   "true",
-			"global.image.pullSecrets[0].name":  "SecretName",
-			"console.image.pullSecrets[0].name": "SecretNameSubChart",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	s.Require().Equal("SecretNameSubChart", deployment.Spec.Template.Spec.ImagePullSecrets[0].Name)
-}
-
-func (s *DeploymentTemplateTest) TestContainerOverwriteImageTag() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"console.enabled":   "true",
-			"console.image.tag": "a.b.c",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
-	s.Require().Equal("camunda/console:a.b.c", containers[0].Image)
-}
-
-func (s *DeploymentTemplateTest) TestContainerOverwriteGlobalImageTag() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"console.enabled":   "true",
-			"global.image.tag":  "a.b.c",
-			"console.image.tag": "",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
-	s.Require().Equal("camunda/console:a.b.c", containers[0].Image)
-}
-
-func (s *DeploymentTemplateTest) TestContainerOverwriteImageTagWithChartDirectSetting() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"console.enabled":   "true",
-			"global.image.tag":  "x.y.z",
-			"console.image.tag": "a.b.c",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	expectedContainerImage := "camunda/console:a.b.c"
-	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
-	s.Require().Equal(expectedContainerImage, containers[0].Image)
-}
-
-func (s *DeploymentTemplateTest) TestContainerSetContainerCommand() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"console.enabled":    "true",
-			"console.command[0]": "printenv",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
-	s.Require().Equal(1, len(containers[0].Command))
-	s.Require().Equal("printenv", containers[0].Command[0])
-}
-
-func (s *DeploymentTemplateTest) TestContainerSetExtraVolumes() {
-	// finding out the length of volumes array before addition of new volume
-	beforeOptions := &helm.Options{
-		SetValues: map[string]string{
-			"console.enabled": "true",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-	var deploymentBefore appsv1.Deployment
-	before := helm.RenderTemplate(s.T(), beforeOptions, s.chartPath, s.release, s.templates)
-	helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
-	volumeLenBefore := len(deploymentBefore.Spec.Template.Spec.Volumes)
-
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"console.enabled":                               "true",
-			"console.extraVolumes[0].name":                  "extraVolume",
-			"console.extraVolumes[0].configMap.name":        "otherConfigMap",
-			"console.extraVolumes[0].configMap.defaultMode": "744",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	volumes := deployment.Spec.Template.Spec.Volumes
-	s.Require().Equal(volumeLenBefore+1, len(volumes))
-
-	extraVolume := volumes[volumeLenBefore]
-	s.Require().Equal("extraVolume", extraVolume.Name)
-	s.Require().NotNil(*extraVolume.ConfigMap)
-	s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
-	s.Require().EqualValues(744, *extraVolume.ConfigMap.DefaultMode)
-}
-
-func (s *DeploymentTemplateTest) TestContainerSetExtraVolumeMounts() {
-	// finding out the length of containers and volumeMounts array before addition of new volumeMount
-	beforeOptions := &helm.Options{
-		SetValues: map[string]string{
-			"console.enabled": "true",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-	var deploymentBefore appsv1.Deployment
-	before := helm.RenderTemplate(s.T(), beforeOptions, s.chartPath, s.release, s.templates)
-	helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
-	containerLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers)
-	volumeMountLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
-
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"console.enabled":                        "true",
-			"console.extraVolumeMounts[0].name":      "otherConfigMap",
-			"console.extraVolumeMounts[0].mountPath": "/usr/local/config",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(containerLenBefore, len(containers))
-
-	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(volumeMountLenBefore+1, len(volumeMounts))
-	extraVolumeMount := volumeMounts[volumeMountLenBefore]
-	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
-	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
-}
-
-func (s *DeploymentTemplateTest) TestContainerSetExtraVolumesAndMounts() {
-	// finding out the length of volumes, volumemounts array before addition of new volume
-	beforeOptions := &helm.Options{
-		SetValues: map[string]string{
-			"console.enabled": "true",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-	var deploymentBefore appsv1.Deployment
-	before := helm.RenderTemplate(s.T(), beforeOptions, s.chartPath, s.release, s.templates)
-	helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
-	volumeLenBefore := len(deploymentBefore.Spec.Template.Spec.Volumes)
-	volumeMountLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
-	containerLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers)
-
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"console.enabled":                               "true",
-			"console.extraVolumeMounts[0].name":             "otherConfigMap",
-			"console.extraVolumeMounts[0].mountPath":        "/usr/local/config",
-			"console.extraVolumes[0].name":                  "extraVolume",
-			"console.extraVolumes[0].configMap.name":        "otherConfigMap",
-			"console.extraVolumes[0].configMap.defaultMode": "744",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	volumes := deployment.Spec.Template.Spec.Volumes
-	s.Require().Equal(volumeLenBefore+1, len(volumes))
-
-	extraVolume := volumes[volumeLenBefore]
-	s.Require().Equal("extraVolume", extraVolume.Name)
-	s.Require().NotNil(*extraVolume.ConfigMap)
-	s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
-	s.Require().EqualValues(744, *extraVolume.ConfigMap.DefaultMode)
-
-	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(containerLenBefore, len(containers))
-
-	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(volumeMountLenBefore+1, len(volumeMounts))
-	extraVolumeMount := volumeMounts[volumeMountLenBefore]
-	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
-	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
-}
-
-func (s *DeploymentTemplateTest) TestContainerSetServiceAccountName() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"console.enabled":             "true",
-			"console.serviceAccount.name": "accName",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	serviceAccName := deployment.Spec.Template.Spec.ServiceAccountName
-	s.Require().Equal("accName", serviceAccName)
-}
-
-func (s *DeploymentTemplateTest) TestPodSetSecurityContext() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"console.enabled":                      "true",
-			"console.podSecurityContext.runAsUser": "1000",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	securityContext := deployment.Spec.Template.Spec.SecurityContext
-	s.Require().EqualValues(1000, *securityContext.RunAsUser)
-}
-
-func (s *DeploymentTemplateTest) TestContainerSetSecurityContext() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"console.enabled": "true",
-			"console.containerSecurityContext.privileged": "true",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	securityContext := deployment.Spec.Template.Spec.Containers[0].SecurityContext
-	s.Require().True(*securityContext.Privileged)
-}
-
-// https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
-func (s *DeploymentTemplateTest) TestContainerSetNodeSelector() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"console.enabled":               "true",
-			"console.nodeSelector.disktype": "ssd",
-			"console.nodeSelector.cputype":  "arm",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	s.Require().Equal("ssd", deployment.Spec.Template.Spec.NodeSelector["disktype"])
-	s.Require().Equal("arm", deployment.Spec.Template.Spec.NodeSelector["cputype"])
-}
-
-// https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
-func (s *DeploymentTemplateTest) TestContainerSetAffinity() {
-	// given
-
-	// affinity:
-	//	nodeAffinity:
-	//	 requiredDuringSchedulingIgnoredDuringExecution:
-	//	   nodeSelectorTerms:
-	//	   - matchExpressions:
-	//		 - key: kubernetes.io/e2e-az-name
-	//		   operator: In
-	//		   values:
-	//		   - e2e-az1
-	//		   - e2e-az2
-	//	 preferredDuringSchedulingIgnoredDuringExecution:
-	//	 - weight: 1
-	//	   preference:
-	//		 matchExpressions:
-	//		 - key: another-node-label-key
-	//		   operator: In
-	//		   values:
-	//		   - another-node-label-value
-
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"console.enabled": "true",
-			"console.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].key":       "kubernetes.io/e2e-az-name",
-			"console.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].operator":  "In",
-			"console.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].values[0]": "e2e-a1",
-			"console.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].values[1]": "e2e-a2",
-			"console.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight":                                         "1",
-			"console.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].key":             "another-node-label-key",
-			"console.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].operator":        "In",
-			"console.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].values[0]":       "another-node-label-value",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	nodeAffinity := deployment.Spec.Template.Spec.Affinity.NodeAffinity
-	s.Require().NotNil(nodeAffinity)
-
-	nodeSelectorTerm := nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0]
-	s.Require().NotNil(nodeSelectorTerm)
-	matchExpression := nodeSelectorTerm.MatchExpressions[0]
-	s.Require().NotNil(matchExpression)
-	s.Require().Equal("kubernetes.io/e2e-az-name", matchExpression.Key)
-	s.Require().EqualValues("In", matchExpression.Operator)
-	s.Require().Equal([]string{"e2e-a1", "e2e-a2"}, matchExpression.Values)
-
-	preferredSchedulingTerm := nodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0]
-	s.Require().NotNil(preferredSchedulingTerm)
-
-	matchExpression = preferredSchedulingTerm.Preference.MatchExpressions[0]
-	s.Require().NotNil(matchExpression)
-	s.Require().Equal("another-node-label-key", matchExpression.Key)
-	s.Require().EqualValues("In", matchExpression.Operator)
-	s.Require().Equal([]string{"another-node-label-value"}, matchExpression.Values)
-}
-
-// https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration
-func (s *DeploymentTemplateTest) TestContainerSetTolerations() {
-	// given
-
-	//tolerations:
-	//- key: "key1"
-	//  operator: "Equal"
-	//  value: "value1"
-	//  effect: "NoSchedule"
-
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"console.enabled":                 "true",
-			"console.tolerations[0].key":      "key1",
-			"console.tolerations[0].operator": "Equal",
-			"console.tolerations[0].value":    "Value1",
-			"console.tolerations[0].effect":   "NoSchedule",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	tolerations := deployment.Spec.Template.Spec.Tolerations
-	s.Require().Equal(1, len(tolerations))
-
-	toleration := tolerations[0]
-	s.Require().Equal("key1", toleration.Key)
-	s.Require().EqualValues("Equal", toleration.Operator)
-	s.Require().Equal("Value1", toleration.Value)
-	s.Require().EqualValues("NoSchedule", toleration.Effect)
-}
-
-func (s *DeploymentTemplateTest) TestContainerShouldOverwriteGlobalImagePullPolicy() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"console.enabled":         "true",
-			"global.image.pullPolicy": "Always",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	expectedPullPolicy := corev1.PullAlways
-	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
-	pullPolicy := containers[0].ImagePullPolicy
-	s.Require().Equal(expectedPullPolicy, pullPolicy)
-}
-
-// readinessProbe is enabled by default so it's tested by golden files.
-
-func (s *DeploymentTemplateTest) TestContainerStartupProbe() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"console.enabled":                          "true",
-			"console.startupProbe.enabled":             "true",
-			"console.startupProbe.probePath":           "/healthz",
-			"console.startupProbe.initialDelaySeconds": "5",
-			"console.startupProbe.periodSeconds":       "10",
-			"console.startupProbe.successThreshold":    "1",
-			"console.startupProbe.failureThreshold":    "5",
-			"console.startupProbe.timeoutSeconds":      "1",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	probe := deployment.Spec.Template.Spec.Containers[0].StartupProbe
-
-	s.Require().Equal("/healthz", probe.HTTPGet.Path)
-	s.Require().EqualValues(5, probe.InitialDelaySeconds)
-	s.Require().EqualValues(10, probe.PeriodSeconds)
-	s.Require().EqualValues(1, probe.SuccessThreshold)
-	s.Require().EqualValues(5, probe.FailureThreshold)
-	s.Require().EqualValues(1, probe.TimeoutSeconds)
-}
-
-func (s *DeploymentTemplateTest) TestContainerLivenessProbe() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"console.enabled":                           "true",
-			"console.livenessProbe.enabled":             "true",
-			"console.livenessProbe.probePath":           "/healthz",
-			"console.livenessProbe.initialDelaySeconds": "5",
-			"console.livenessProbe.periodSeconds":       "10",
-			"console.livenessProbe.successThreshold":    "1",
-			"console.livenessProbe.failureThreshold":    "5",
-			"console.livenessProbe.timeoutSeconds":      "1",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	probe := deployment.Spec.Template.Spec.Containers[0].LivenessProbe
-
-	s.Require().EqualValues("/healthz", probe.HTTPGet.Path)
-	s.Require().EqualValues(5, probe.InitialDelaySeconds)
-	s.Require().EqualValues(10, probe.PeriodSeconds)
-	s.Require().EqualValues(1, probe.SuccessThreshold)
-	s.Require().EqualValues(5, probe.FailureThreshold)
-	s.Require().EqualValues(1, probe.TimeoutSeconds)
-}
-
-func (s *DeploymentTemplateTest) TestContainerSetSidecar() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"console.enabled":                            "true",
-			"console.sidecars[0].name":                   "nginx",
-			"console.sidecars[0].image":                  "nginx:latest",
-			"console.sidecars[0].ports[0].containerPort": "80",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	podContainers := deployment.Spec.Template.Spec.Containers
-	expectedContainer := corev1.Container{
-		Name:  "nginx",
-		Image: "nginx:latest",
-		Ports: []corev1.ContainerPort{
-			{
-				ContainerPort: 80,
-			},
-		},
-	}
-
-	s.Require().Contains(podContainers, expectedContainer)
-}
-
-func (s *DeploymentTemplateTest) TestInitContainers() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"console.enabled":                                  "true",
-			"console.initContainers[0].name":                   "nginx",
-			"console.initContainers[0].image":                  "nginx:latest",
-			"console.initContainers[0].ports[0].containerPort": "80",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	podContainers := deployment.Spec.Template.Spec.InitContainers
-	expectedContainer := corev1.Container{
-		Name:  "nginx",
-		Image: "nginx:latest",
-		Ports: []corev1.ContainerPort{
-			{
-				ContainerPort: 80,
-			},
-		},
-	}
-
-	s.Require().Contains(podContainers, expectedContainer)
-}
-
-func (s *DeploymentTemplateTest) TestSetDnsPolicyAndDnsConfig() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"console.enabled":                  "true",
-			"console.dnsPolicy":                "ClusterFirst",
-			"console.dnsConfig.nameservers[0]": "8.8.8.8",
-			"console.dnsConfig.searches[0]":    "example.com",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	// Check if dnsPolicy is set
-	require.NotEmpty(s.T(), deployment.Spec.Template.Spec.DNSPolicy, "dnsPolicy should not be empty")
-
-	// Check if dnsConfig is set
-	require.NotNil(s.T(), deployment.Spec.Template.Spec.DNSConfig, "dnsConfig should not be nil")
-
-	expectedDNSConfig := &corev1.PodDNSConfig{
-		Nameservers: []string{"8.8.8.8"},
-		Searches:    []string{"example.com"},
-	}
-
-	require.Equal(s.T(), expectedDNSConfig, deployment.Spec.Template.Spec.DNSConfig, "dnsConfig should match the expected configuration")
 }

--- a/charts/camunda-platform-8.6/test/unit/console/service_test.go
+++ b/charts/camunda-platform-8.6/test/unit/console/service_test.go
@@ -15,19 +15,19 @@
 package console
 
 import (
+	"camunda-platform/test/unit/testhelpers"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	coreV1 "k8s.io/api/core/v1"
 )
 
-type serviceTest struct {
+type ServiceTest struct {
 	suite.Suite
 	chartPath string
 	release   string
@@ -41,7 +41,7 @@ func TestServiceTemplate(t *testing.T) {
 	chartPath, err := filepath.Abs("../../../")
 	require.NoError(t, err)
 
-	suite.Run(t, &serviceTest{
+	suite.Run(t, &ServiceTest{
 		chartPath: chartPath,
 		release:   "camunda-platform-test",
 		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
@@ -49,40 +49,36 @@ func TestServiceTemplate(t *testing.T) {
 	})
 }
 
-func (s *serviceTest) TestContainerSetGlobalAnnotations() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"console.enabled":        "true",
-			"global.annotations.foo": "bar",
+func (s *ServiceTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestContainerSetGlobalAnnotations",
+			Values: map[string]string{
+				"console.enabled":        "true",
+				"global.annotations.foo": "bar",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var service coreV1.Service
+				helm.UnmarshalK8SYaml(s.T(), output, &service)
+
+				// then
+				s.Require().Equal("bar", service.Annotations["foo"])
+			},
+		}, {
+			Name: "TestContainerServiceAnnotations",
+			Values: map[string]string{
+				"console.enabled":                 "true",
+				"console.service.annotations.foo": "bar",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var service coreV1.Service
+				helm.UnmarshalK8SYaml(s.T(), output, &service)
+
+				// then
+				s.Require().Equal("bar", service.Annotations["foo"])
+			},
 		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 	}
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var service coreV1.Service
-	helm.UnmarshalK8SYaml(s.T(), output, &service)
-
-	// then
-	s.Require().Equal("bar", service.ObjectMeta.Annotations["foo"])
-}
-
-func (s *serviceTest) TestContainerServiceAnnotations() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"console.enabled":                 "true",
-			"console.service.annotations.foo": "bar",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var service coreV1.Service
-	helm.UnmarshalK8SYaml(s.T(), output, &service)
-
-	// then
-	s.Require().Equal("bar", service.ObjectMeta.Annotations["foo"])
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }


### PR DESCRIPTION
### Which problem does the PR fix?

https://github.com/camunda/team-distribution/issues/448

### What's in this PR?

This PR refactors the unit tests in console on 8.6 into the new style

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
