### PR TITLE
fix: regenerate 8.6 release matrix

### DIFF
--- a/version-matrix/README.md
+++ b/version-matrix/README.md
@@ -29,6 +29,7 @@ For the best experience, please remember:
 
 ## [Camunda 8.6](./camunda-8.6)
 
+### [Helm chart 11.3.0](./camunda-8.6/#helm-chart-1130)
 ### [Helm chart 11.2.2](./camunda-8.6/#helm-chart-1122)
 ### [Helm chart 11.2.1](./camunda-8.6/#helm-chart-1121)
 ### [Helm chart 11.2.0](./camunda-8.6/#helm-chart-1120)

--- a/version-matrix/camunda-8.6/README.md
+++ b/version-matrix/camunda-8.6/README.md
@@ -3,6 +3,7 @@
 
 # Camunda 8.6 Helm Chart Version Matrix
 
+- [Helm chart 11.3.0](#helm-chart-1130)
 - [Helm chart 11.2.2](#helm-chart-1122)
 - [Helm chart 11.2.1](#helm-chart-1121)
 - [Helm chart 11.2.0](#helm-chart-1120)
@@ -13,6 +14,36 @@
 - [Helm chart 11.0.2](#helm-chart-1102)
 - [Helm chart 11.0.1](#helm-chart-1101)
 - [Helm chart 11.0.0](#helm-chart-1100)
+
+## Helm chart 11.3.0
+
+Supported versions:
+
+- Camunda applications: [8.6](https://github.com/camunda/camunda-platform/releases?q=tag%3A8.6&expanded=true)
+- Helm values: [11.3.0](https://artifacthub.io/packages/helm/camunda/camunda-platform/11.3.0#parameters)
+- Helm CLI: [3.17.2](https://github.com/helm/helm/releases/tag/v3.17.2)
+
+Camunda images:
+
+- docker.io/camunda/connectors-bundle:8.6.9
+- docker.io/camunda/console:8.6.74
+- docker.io/camunda/identity:8.6.9
+- docker.io/camunda/keycloak:25.0.6
+- docker.io/camunda/operate:8.6.12
+- docker.io/camunda/optimize:8.6.6
+- docker.io/camunda/tasklist:8.6.12
+- docker.io/camunda/web-modeler-restapi:8.6.8
+- docker.io/camunda/web-modeler-webapp:8.6.8
+- docker.io/camunda/web-modeler-websockets:8.6.8
+- docker.io/camunda/zeebe:8.6.12
+
+Non-Camunda images:
+
+- docker.io/bitnami/elasticsearch:8.15.4
+- docker.io/bitnami/os-shell:12-debian-12-r39
+- docker.io/bitnami/postgresql:14.17.0-debian-12-r6
+- docker.io/bitnami/postgresql:15.10.0-debian-12-r2
+
 
 ## Helm chart 11.2.2
 


### PR DESCRIPTION
### Which problem does the PR fix?

The 11.3.0 release was missing an entry on helm.camunda.io, this PR adds it.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
