### PR TITLE
fix: replace alpha tag with 8.8 in renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -397,7 +397,7 @@
       ],
       // Ignore non-semver versions like 8.6.0-alpha3-rc3 which has a higher precedence than 8.6.0-alpha3
       // which is not the case.
-      versionCompatibility: '^(?<version>\\d+.\\d+.\\d+-alpha[1-6])(?<compatibility>.*)$',
+      versionCompatibility: '^(?<version>\\d+.\\d+.\\d+(-alpha[1-6])?)(?<compatibility>.*)$',
       // setting versioning to semver is important because by default docker versioning will
       // assume that anything after the dash is a compatibility rather than a prerelease
       // indicator. Some docker images have versions like 8.5.0-alpine but in camunda

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -373,7 +373,8 @@
         'camunda/camunda',
       ],
       matchFileNames: [
-        'charts/camunda-platform-alpha/Chart.yaml',
+        // bump these to whatever the latest alpha is
+        'charts/camunda-platform-8.8/Chart.yaml',
       ],
       versioning: 'regex:^(?<major>\\d+)(.(?<minor>\\d+))(.(?<patch>\\d+))(-(?<prerelease>alpha[1-6]))$',
     },
@@ -390,12 +391,17 @@
         'regex',
       ],
       matchFileNames: [
-        'charts/camunda-platform-alpha/Chart.yaml',
-        'charts/camunda-platform-alpha/values*.yaml',
+        // bump these to whatever the latest alpha is
+        'charts/camunda-platform-8.8/Chart.yaml',
+        'charts/camunda-platform-8.8/values*.yaml',
       ],
       // Ignore non-semver versions like 8.6.0-alpha3-rc3 which has a higher precedence than 8.6.0-alpha3
       // which is not the case.
       versionCompatibility: '^(?<version>\\d+.\\d+.\\d+-alpha[1-6])(?<compatibility>.*)$',
+      // setting versioning to semver is important because by default docker versioning will
+      // assume that anything after the dash is a compatibility rather than a prerelease
+      // indicator. Some docker images have versions like 8.5.0-alpine but in camunda
+      // images, we use 8.5.0-alpha3.
       versioning: 'semver',
     },
     {


### PR DESCRIPTION


### Which problem does the PR fix?

We recently encountered an error where 8.7.0-alpha5 did not automatically upgrade to 8.7.0, and this is because the versioning was not properly set to semver, which would account for the -alpha being a prerelease notation rather than a compatibility notation such as if the image was named 8.7.0-alpine, denoting that the image is based on alpine.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
