### PR TITLE
fix: backport 8.6 refactoring on test/unit/camunda to 8.5

### DIFF
--- a/charts/camunda-platform-8.5/test/unit/camunda/configmap_test.go
+++ b/charts/camunda-platform-8.5/test/unit/camunda/configmap_test.go
@@ -15,19 +15,17 @@
 package camunda
 
 import (
+	"camunda-platform/test/unit/testhelpers"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	corev1 "k8s.io/api/core/v1"
 )
 
-type configMapTemplateTest struct {
+type ConfigMapTemplateTest struct {
 	suite.Suite
 	chartPath string
 	release   string
@@ -41,7 +39,7 @@ func TestConfigMapTemplate(t *testing.T) {
 	chartPath, err := filepath.Abs("../../../")
 	require.NoError(t, err)
 
-	suite.Run(t, &configMapTemplateTest{
+	suite.Run(t, &ConfigMapTemplateTest{
 		chartPath: chartPath,
 		release:   "camunda-platform-test",
 		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
@@ -49,42 +47,31 @@ func TestConfigMapTemplate(t *testing.T) {
 	})
 }
 
-func (s *configMapTemplateTest) TestConfigMapIdentityIssuerURL() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.identity.auth.issuerBackendUrl": "http://keycloak:80/auth/realms/camunda-platform",
+func (c *ConfigMapTemplateTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "Identity Provider URL",
+			Values: map[string]string{
+				"global.identity.auth.issuerBackendUrl": "http://foo-keycloak:80/auth/realms/camunda-platform",
+			},
+			Expected: map[string]string{
+				"CAMUNDA_IDENTITY_ISSUER_BACKEND_URL": "http://foo-keycloak:80/auth/realms/camunda-platform",
+			},
 		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+		{
+			Name: "Identity Provider URL with Keycloak URL syntax",
+			Values: map[string]string{
+				"global.identity.keycloak.url.protocol": "http",
+				"global.identity.keycloak.url.host":     "keycloak",
+				"global.identity.keycloak.url.port":     "80",
+				"global.identity.keycloak.contextPath":  "/auth/realms/",
+				"global.identity.keycloak.realm":        "camunda-platform",
+			},
+			Expected: map[string]string{
+				"CAMUNDA_IDENTITY_ISSUER_BACKEND_URL": "http://keycloak:80/auth/realms/camunda-platform",
+			},
+		},
 	}
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var configmap corev1.ConfigMap
-	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-	// then
-	s.Require().Equal("http://keycloak:80/auth/realms/camunda-platform", configmap.Data["CAMUNDA_IDENTITY_ISSUER_BACKEND_URL"])
-}
-
-func (s *configMapTemplateTest) TestConfigMapIdentityIssuerURLWithKeycloakURLSyntax() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.identity.keycloak.url.protocol": "http",
-			"global.identity.keycloak.url.host":     "keycloak",
-			"global.identity.keycloak.url.port":     "80",
-			"global.identity.keycloak.contextPath":  "/auth/realms/",
-			"global.identity.keycloak.realm":        "camunda-platform",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var configmap corev1.ConfigMap
-	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-	// then
-	s.Require().Equal("http://keycloak:80/auth/realms/camunda-platform", configmap.Data["CAMUNDA_IDENTITY_ISSUER_BACKEND_URL"])
+	testhelpers.RunTestCases(c.T(), c.chartPath, c.release, c.namespace, c.templates, testCases)
 }

--- a/charts/camunda-platform-8.5/test/unit/camunda/global_deployment_test.go
+++ b/charts/camunda-platform-8.5/test/unit/camunda/global_deployment_test.go
@@ -15,18 +15,17 @@
 package camunda
 
 import (
+	"camunda-platform/test/unit/testhelpers"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
-type deploymentTemplateTest struct {
+type DeploymentTemplateTest struct {
 	suite.Suite
 	chartPath string
 	release   string
@@ -40,125 +39,80 @@ func TestDeploymentTemplate(t *testing.T) {
 	chartPath, err := filepath.Abs("../../../")
 	require.NoError(t, err)
 
-	suite.Run(t, &deploymentTemplateTest{
+	suite.Run(t, &DeploymentTemplateTest{
 		chartPath: chartPath,
 		release:   "camunda-platform-test",
 		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
+		templates: []string{},
 	})
 }
 
-func (s *deploymentTemplateTest) TestContainerShouldNotRenderOptimizeIfDisabled() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"optimize.enabled": "false",
+func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name:                 "TestContainerShouldNotRenderOptimizeIfDisabled",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values:               map[string]string{"optimize.enabled": "false"},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NotContains(t, output, "charts/optimize")
+			},
+		}, {
+			Name:                 "TestContainerShouldNotRenderOperateIfDisabled",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values:               map[string]string{"operate.enabled": "false"},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NotContains(t, output, "charts/operate")
+			},
+		}, {
+			Name:                 "TestContainerShouldNotRenderTasklistIfDisabled",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values:               map[string]string{"tasklist.enabled": "false"},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NotContains(t, output, "charts/tasklist")
+			},
+		}, {
+			Name:                 "TestContainerShouldNotRenderIdentityIfDisabled",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values: map[string]string{
+				"optimize.enabled":             "true",
+				"identity.enabled":             "false",
+				"global.identity.auth.enabled": "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NotContains(t, output, "charts/identity")
+			},
+		}, {
+			Name:                 "ContainerShouldNotRenderWebModelerIfDisabled",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values: map[string]string{
+				"webModeler.enabled": "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NotContains(t, output, "templates/web-modeler")
+			},
+		}, {
+			Name: "TestContainerSetImageNameGlobal",
+			Values: map[string]string{
+				"global.image.registry":  "global.custom.registry.io",
+				"global.image.tag":       "8.x.x",
+				"connectors.image.tag":   "",
+				"identity.image.tag":     "",
+				"operate.image.tag":      "",
+				"optimize.image.tag":     "",
+				"tasklist.image.tag":     "",
+				"zeebe.image.tag":        "",
+				"zeebeGateway.image.tag": "",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.Contains(t, output, "image: global.custom.registry.io/camunda/connectors-bundle:8.x.x")
+				require.Contains(t, output, "image: global.custom.registry.io/camunda/identity:8.x.x")
+				require.Contains(t, output, "image: global.custom.registry.io/camunda/operate:8.x.x")
+				require.Contains(t, output, "image: global.custom.registry.io/camunda/optimize:8.x.x")
+				require.Contains(t, output, "image: global.custom.registry.io/camunda/tasklist:8.x.x")
+				require.Contains(t, output, "image: global.custom.registry.io/camunda/zeebe:8.x.x")
+			},
 		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
 	}
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-
-	// then
-	s.Require().NotContains(output, "charts/optimize")
-}
-
-func (s *deploymentTemplateTest) TestContainerShouldNotRenderOperateIfDisabled() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"operate.enabled": "false",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-
-	// then
-	s.Require().NotContains(output, "charts/operate")
-}
-
-func (s *deploymentTemplateTest) TestContainerShouldNotRenderTasklistIfDisabled() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"tasklist.enabled": "false",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-
-	// then
-	s.Require().NotContains(output, "charts/tasklist")
-}
-
-func (s *deploymentTemplateTest) TestContainerShouldNotRenderIdentityIfDisabled() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"optimize.enabled":             "true",
-			"identity.enabled":             "false",
-			"global.identity.auth.enabled": "false",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output, _ := helm.RenderTemplateE(s.T(), options, s.chartPath, s.release, s.templates)
-
-	// then
-	s.Require().NotContains(output, "/templates/identity/")
-}
-
-func (s *deploymentTemplateTest) TestContainerShouldNotRenderWebModelerIfDisabled() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled": "false",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-
-	// then
-	s.Require().NotContains(output, "templates/web-modeler")
-}
-
-func (s *deploymentTemplateTest) TestContainerSetImageNameGlobal() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.image.registry":  "global.custom.registry.io",
-			"global.image.tag":       "8.x.x",
-			"connectors.image.tag":   "",
-			"identity.image.tag":     "",
-			"operate.image.tag":      "",
-			"optimize.image.tag":     "",
-			"tasklist.image.tag":     "",
-			"zeebe.image.tag":        "",
-			"zeebeGateway.image.tag": "",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-
-	// then
-	s.Require().Contains(output, "image: global.custom.registry.io/camunda/connectors-bundle:8.x.x")
-	s.Require().Contains(output, "image: global.custom.registry.io/camunda/identity:8.x.x")
-	s.Require().Contains(output, "image: global.custom.registry.io/camunda/operate:8.x.x")
-	s.Require().Contains(output, "image: global.custom.registry.io/camunda/optimize:8.x.x")
-	s.Require().Contains(output, "image: global.custom.registry.io/camunda/tasklist:8.x.x")
-	s.Require().Contains(output, "image: global.custom.registry.io/camunda/zeebe:8.x.x")
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }

--- a/charts/camunda-platform-8.5/test/unit/camunda/identitykeycloak_constraints_test.go
+++ b/charts/camunda-platform-8.5/test/unit/camunda/identitykeycloak_constraints_test.go
@@ -1,16 +1,14 @@
 package camunda
 
 import (
+	"camunda-platform/test/unit/testhelpers"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	appsv1 "k8s.io/api/apps/v1"
 )
 
 type ConstraintsTemplateTest struct {
@@ -35,39 +33,30 @@ func TestConstraintsTemplate(t *testing.T) {
 	})
 }
 
-func (s *ConstraintsTemplateTest) TestIdentityKeycloakConstraintFailure() {
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"identity.enabled":         "false",
-			"identityKeycloak.enabled": "true",
+func (s *ConstraintsTemplateTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestIdentityKeycloakConstraintFailure",
+			Values: map[string]string{
+				"identity.enabled":         "false",
+				"identityKeycloak.enabled": "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.Error(t, err, "[camunda][error] Identity is disabled but identityKeycloak is enabled")
+			},
+		}, {
+			Name: "TestIdentityKeycloakConstraintSuccess",
+			Values: map[string]string{
+				"identity.enabled":                      "true",
+				"identityKeycloak.enabled":              "false",
+				"global.identity.keycloak.url.protocol": "https",
+				"global.identity.keycloak.url.host":     "keycloak.prod.svc.cluster.local",
+				"global.identity.keycloak.url.port":     "8443",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err, "[camunda][error] Identity is disabled but identityKeycloak is enabled")
+			},
 		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 	}
-
-	output, err := helm.RenderTemplateE(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	s.Require().Error(err, "[camunda][error] Identity is disabled but identityKeycloak is enabled")
-
-}
-
-func (s *ConstraintsTemplateTest) TestIdentityKeycloakConstraintSuccess() {
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"identity.enabled":                      "true",
-			"identityKeycloak.enabled":              "false",
-			"global.identity.keycloak.url.protocol": "https",
-			"global.identity.keycloak.url.host":     "keycloak.prod.svc.cluster.local",
-			"global.identity.keycloak.url.port":     "8443",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	output, err := helm.RenderTemplateE(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	s.Require().NoError(err, "[camunda][error] Identity is disabled but identityKeycloak is enabled")
-
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }

--- a/charts/camunda-platform-8.5/test/unit/camunda/secret_test.go
+++ b/charts/camunda-platform-8.5/test/unit/camunda/secret_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -96,42 +95,4 @@ func (s *SecretTest) verifySecretData(t *testing.T, output string, secretName st
 	require.NotNil(t, secret.Data)
 	require.NotNil(t, secret.Data[secretName])
 	require.NotEmpty(t, secret.Data[secretName])
-}
-
-func (s *SecretTest) TestContainerGenerateSecret() {
-	// given
-	options := &helm.Options{
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	s.templates = []string{
-		"templates/camunda/secret-connectors.yaml",
-		"templates/camunda/secret-console.yaml",
-		"templates/camunda/secret-operate.yaml",
-		"templates/camunda/secret-optimize.yaml",
-		"templates/camunda/secret-tasklist.yaml",
-		"templates/camunda/secret-zeebe.yaml",
-	}
-
-	s.secretName = []string{
-		"connectors-secret",
-		"console-secret",
-		"operate-secret",
-		"optimize-secret",
-		"tasklist-secret",
-		"zeebe-secret",
-	}
-
-	s.Require().GreaterOrEqual(6, len(s.templates))
-	for idx, template := range s.templates {
-		// when
-		output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, []string{template})
-		var secret coreV1.Secret
-		helm.UnmarshalK8SYaml(s.T(), output, &secret)
-
-		// then
-		s.Require().NotNil(secret.Data)
-		s.Require().NotNil(secret.Data[s.secretName[idx]])
-		s.Require().NotEmpty(secret.Data[s.secretName[idx]])
-	}
 }

--- a/charts/camunda-platform-8.5/test/unit/testhelpers/testhelpers.go
+++ b/charts/camunda-platform-8.5/test/unit/testhelpers/testhelpers.go
@@ -1,28 +1,108 @@
+// Package testhelpers provides utilities for testing Helm charts.
+// To enable verbose logging, set the VERBOSE_TEST_LOGGING environment variable to "true".
+// Example: VERBOSE_TEST_LOGGING=true go test ./...
 package testhelpers
 
 import (
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 )
 
-type TestCase struct {
-	Name     string
-	Values   map[string]string
-	Expected map[string]string
+type CaseTemplate struct {
+	Templates []string
 }
 
-// RenderTemplate renders the specified Helm templates into a Kubernetes ConfigMap
-func RenderTemplate(t *testing.T, chartPath, release string, namespace string, templates []string, values map[string]string) corev1.ConfigMap {
+// TestCase represents a single test scenario for Helm chart testing.
+// It encapsulates all the necessary configuration and validation logic for a test.
+type TestCase struct {
+	// Name is the descriptive name of the test case, used for identification in test output
+	Name string
+
+	// HelmOptionsExtraArgs contains additional arguments to pass to the Helm command
+	// The key spaecifies the Helm command (e.g., "install", "upgrade"), and the value is a slice of arguments
+	// This allows customizing the Helm command behavior for specific test cases
+	HelmOptionsExtraArgs map[string][]string
+
+	// RenderTemplateExtraArgs contains additional arguments for template rendering
+	// These are passed to the template rendering process
+	RenderTemplateExtraArgs []string
+
+	// When provided, this function is called to get the templates to render. This overrides the
+	// templates set in the test suite
+	CaseTemplates *CaseTemplate
+
+	// Values represents the Helm chart values to set for this test case
+	// These are equivalent to values passed with --set flag in Helm CLI
+	Values map[string]string
+
+	// Expected contains key-value pairs that should be present in the rendered output
+	// For error tests, it should contain an "ERROR" key with the expected error message
+	// For ConfigMap tests, keys can be direct data keys or dot-notation paths into application.yaml
+	Expected map[string]string
+
+	// Verifier is a custom function for complex validation scenarios
+	// When provided, it overrides the default validation logic
+	// It receives the rendered output and any error that occurred during rendering
+	Verifier func(t *testing.T, output string, err error)
+}
+
+// quietLogger returns a logger that only logs errors
+func quietLogger() *logger.Logger {
+	// Check if verbose logging is enabled via environment variable
+	if os.Getenv("VERBOSE_TEST_LOGGING") == "true" {
+		return logger.Default
+	}
+	// Create a logger that discards all output
+	return logger.Discard
+}
+
+func setupHelmOptions(namespace string, values map[string]string, helmOptionsExtraArgs map[string][]string) *helm.Options {
 	options := &helm.Options{
 		SetValues:      values,
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespace),
+		Logger:         quietLogger(), // Use quiet logger to reduce verbosity
+		ExtraArgs:      helmOptionsExtraArgs,
 	}
+	return options
+}
+
+func renderTemplateE(t *testing.T, chartPath, release string, namespace string, templates []string, values map[string]string, extraArgs map[string][]string, renderTemplateExtraArgs []string) (string, error) {
+	options := setupHelmOptions(namespace, values, extraArgs)
+
+	output, err := helm.RenderTemplateE(t, options, chartPath, release, templates, renderTemplateExtraArgs...)
+	return output, err
+}
+
+func RunTestCasesE(t *testing.T, chartPath, release, namespace string, templates []string, testCases []TestCase) {
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			var caseTemplates []string
+			if tc.CaseTemplates != nil {
+				caseTemplates = tc.CaseTemplates.Templates
+			} else {
+				caseTemplates = templates
+			}
+			output, err := renderTemplateE(t, chartPath, release, namespace, caseTemplates, tc.Values, tc.HelmOptionsExtraArgs, tc.RenderTemplateExtraArgs)
+			if tc.Verifier != nil {
+				tc.Verifier(t, output, err)
+			} else {
+				require.ErrorContains(t, err, tc.Expected["ERROR"])
+			}
+		})
+	}
+}
+
+// renderTemplate renders the specified Helm templates into a Kubernetes ConfigMap
+func renderTemplate(t *testing.T, chartPath, release string, namespace string, templates []string, values map[string]string) corev1.ConfigMap {
+	options := setupHelmOptions(namespace, values, nil)
 
 	output := helm.RenderTemplate(t, options, chartPath, release, templates)
 	var configmap corev1.ConfigMap
@@ -30,62 +110,63 @@ func RenderTemplate(t *testing.T, chartPath, release string, namespace string, t
 	return configmap
 }
 
-// VerifyConfigMap checks whether the generated ConfigMap contains the expected key-value pairs
-func VerifyConfigMap(t *testing.T, testCase string, configmap corev1.ConfigMap, expectedValues map[string]string) {
-	for keyPath, expectedValue := range expectedValues {
-		var actualValue string
-		if strings.HasPrefix(keyPath, "configmapApplication.") {
-            var configmapApplication map[string]interface{}
-            err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
-            require.NoError(t, err)
-            actualValue = getConfigMapFieldValue(configmapApplication, strings.Split(keyPath, ".")[1:])
-        } else {
-            actualValue = strings.TrimSpace(configmap.Data[keyPath])
-        }
-		require.Equal(t, expectedValue, actualValue, "Test case '%s': Expected key '%s' to have value '%s', but got '%s'", testCase, keyPath, expectedValue, actualValue)
-	}
-}
-
 // RunTestCases executes multiple test cases using the provided Helm chart and ConfigMap validation
 func RunTestCases(t *testing.T, chartPath, release, namespace string, templates []string, testCases []TestCase) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			configmap := RenderTemplate(t, chartPath, release, namespace, templates, tc.Values)
-			VerifyConfigMap(t, tc.Name, configmap, tc.Expected)
+			configmap := renderTemplate(t, chartPath, release, namespace, templates, tc.Values)
+			verifyConfigMap(t, tc.Name, configmap, tc.Expected)
 		})
+	}
+}
+
+// verifyConfigMap checks whether the generated ConfigMap contains the expected key-value pairs
+func verifyConfigMap(t *testing.T, testCase string, configmap corev1.ConfigMap, expectedValues map[string]string) {
+	for keyPath, expectedValue := range expectedValues {
+		var actualValue string
+		if strings.HasPrefix(keyPath, "configmapApplication.") {
+			var configmapApplication map[string]any
+			err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+			require.NoError(t, err)
+			actualValue = getConfigMapFieldValue(configmapApplication, strings.Split(keyPath, ".")[1:])
+		} else {
+			actualValue = strings.TrimSpace(configmap.Data[keyPath])
+		}
+		require.Equal(t, expectedValue, actualValue, "Test case '%s': Expected key '%s' to have value '%s', but got '%s'", testCase, keyPath, expectedValue, actualValue)
 	}
 }
 
 // getConfigMapFieldValue function traverses a nested map structure based on a given key path.
 // It handles maps with both interface{} and string keys, converting them as necessary to retrieve the desired value.
 // If the key is not found or the final value is not a string, the function returns an empty string.
-func getConfigMapFieldValue(configmapApplication map[string]interface{}, keyPath []string) string {
-	var current interface{} = configmapApplication
+func getConfigMapFieldValue(configmapApplication map[string]any, keyPath []string) string {
+	var current any = configmapApplication
 
 	for _, key := range keyPath {
-        if nestedMap, ok := current.(map[interface{}]interface{}); ok {
-            // Convert map[interface{}]interface{} to map[string]interface{}
-            stringMap := make(map[string]interface{})
-            for k, v := range nestedMap {
-                if strKey, isString := k.(string); isString {
-                    stringMap[strKey] = v
-                }
-            }
-            // Move to the next level in the map
-            current = stringMap[key]
-        } else if nestedMap, ok := current.(map[string]interface{}); ok {
-            // If the current level is already a map with string keys, move to the next level
-            current = nestedMap[key]
-        } else {
-            // If the key is not found, return an empty string
-            return ""
-        }
-    }
+		if nestedMap, ok := current.(map[any]any); ok {
+			// Convert map[interface{}]any to map[string]any
+			stringMap := make(map[string]any)
+			for k, v := range nestedMap {
+				if strKey, isString := k.(string); isString {
+					stringMap[strKey] = v
+				}
+			}
+			// Move to the next level in the map
+			current = stringMap[key]
+		} else if nestedMap, ok := current.(map[string]any); ok {
+			// If the current level is already a map with string keys, move to the next level
+			current = nestedMap[key]
+		} else {
+			// If the key is not found, return an empty string
+			return ""
+		}
+	}
 
-    // If the final value is a string, return it
-    if value, ok := current.(string); ok {
-        return value
-    }
-    // If the final value is not a string, return an empty string
-    return ""
+	// If the final value is a string, return it
+	if value, ok := current.(string); ok {
+		return value
+	}
+	// If the final value is not a string, return an empty string
+	return ""
 }
+


### PR DESCRIPTION
### Which problem does the PR fix?

https://github.com/camunda/team-distribution/issues/448

### What's in this PR?

The only difference here between 8.6 and 8.5 is that there is not test on the Camunda license in 8.5

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
