### PR TITLE
fix: task 448 backport and refactor Camunda unit test refactor from 8.6 to 8.4

### DIFF
--- a/charts/camunda-platform-8.4/test/unit/camunda/global_deployment_test.go
+++ b/charts/camunda-platform-8.4/test/unit/camunda/global_deployment_test.go
@@ -15,18 +15,17 @@
 package camunda
 
 import (
+	"camunda-platform/test/unit/testhelpers"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
-type deploymentTemplateTest struct {
+type DeploymentTemplateTest struct {
 	suite.Suite
 	chartPath string
 	release   string
@@ -40,125 +39,91 @@ func TestDeploymentTemplate(t *testing.T) {
 	chartPath, err := filepath.Abs("../../../")
 	require.NoError(t, err)
 
-	suite.Run(t, &deploymentTemplateTest{
+	suite.Run(t, &DeploymentTemplateTest{
 		chartPath: chartPath,
 		release:   "camunda-platform-test",
 		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
 	})
 }
 
-func (s *deploymentTemplateTest) TestContainerShouldNotRenderOptimizeIfDisabled() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"optimize.enabled": "false",
+func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name:                 "TestContainerShouldNotRenderOptimizeIfDisabled",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values: map[string]string{
+				"optimize.enabled": "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				// then
+				s.Require().NotContains(output, "charts/optimize")
+			},
+		}, {
+			Name:                 "TestContainerShouldNotRenderOperateIfDisabled",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values: map[string]string{
+				"operate.enabled": "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				// then
+				s.Require().NotContains(output, "charts/operate")
+			},
+		}, {
+			Name:                 "TestContainerShouldNotRenderTasklistIfDisabled",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values: map[string]string{
+				"tasklist.enabled": "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				// then
+				s.Require().NotContains(output, "charts/tasklist")
+			},
+		}, {
+			Name:                 "TestContainerShouldNotRenderIdentityIfDisabled",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values: map[string]string{
+				"optimize.enabled":             "true",
+				"identity.enabled":             "false",
+				"global.identity.auth.enabled": "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				// then
+				s.Require().NotContains(output, "charts/identity")
+			},
+		}, {
+			Name:                 "TestContainerShouldNotRenderWebModelerIfDisabled",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values: map[string]string{
+				"webModeler.enabled": "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				// then
+				s.Require().NotContains(output, "templates/web-modeler")
+			},
+		}, {
+			Name: "TestContainerSetImageNameGlobal",
+			Values: map[string]string{
+				"global.image.registry":  "global.custom.registry.io",
+				"global.image.tag":       "8.x.x",
+				"connectors.image.tag":   "",
+				"identity.image.tag":     "",
+				"operate.image.tag":      "",
+				"optimize.image.tag":     "",
+				"tasklist.image.tag":     "",
+				"zeebe.image.tag":        "",
+				"zeebeGateway.image.tag": "",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				// then
+				s.Require().Contains(output, "image: global.custom.registry.io/camunda/connectors-bundle:8.x.x")
+				s.Require().Contains(output, "image: global.custom.registry.io/camunda/identity:8.x.x")
+				s.Require().Contains(output, "image: global.custom.registry.io/camunda/operate:8.x.x")
+				s.Require().Contains(output, "image: global.custom.registry.io/camunda/optimize:8.x.x")
+				s.Require().Contains(output, "image: global.custom.registry.io/camunda/tasklist:8.x.x")
+				s.Require().Contains(output, "image: global.custom.registry.io/camunda/zeebe:8.x.x")
+			},
 		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
 	}
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-
-	// then
-	s.Require().NotContains(output, "charts/optimize")
-}
-
-func (s *deploymentTemplateTest) TestContainerShouldNotRenderOperateIfDisabled() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"operate.enabled": "false",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-
-	// then
-	s.Require().NotContains(output, "charts/operate")
-}
-
-func (s *deploymentTemplateTest) TestContainerShouldNotRenderTasklistIfDisabled() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"tasklist.enabled": "false",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-
-	// then
-	s.Require().NotContains(output, "charts/tasklist")
-}
-
-func (s *deploymentTemplateTest) TestContainerShouldNotRenderIdentityIfDisabled() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"optimize.enabled":             "true",
-			"identity.enabled":             "false",
-			"global.identity.auth.enabled": "false",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output, _ := helm.RenderTemplateE(s.T(), options, s.chartPath, s.release, s.templates)
-
-	// then
-	s.Require().NotContains(output, "charts/identity")
-}
-
-func (s *deploymentTemplateTest) TestContainerShouldNotRenderWebModelerIfDisabled() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled": "false",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-
-	// then
-	s.Require().NotContains(output, "templates/web-modeler")
-}
-
-func (s *deploymentTemplateTest) TestContainerSetImageNameGlobal() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.image.registry":  "global.custom.registry.io",
-			"global.image.tag":       "8.x.x",
-			"connectors.image.tag":   "",
-			"identity.image.tag":     "",
-			"operate.image.tag":      "",
-			"optimize.image.tag":     "",
-			"tasklist.image.tag":     "",
-			"zeebe.image.tag":        "",
-			"zeebeGateway.image.tag": "",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-
-	// then
-	s.Require().Contains(output, "image: global.custom.registry.io/camunda/connectors-bundle:8.x.x")
-	s.Require().Contains(output, "image: global.custom.registry.io/camunda/identity:8.x.x")
-	s.Require().Contains(output, "image: global.custom.registry.io/camunda/operate:8.x.x")
-	s.Require().Contains(output, "image: global.custom.registry.io/camunda/optimize:8.x.x")
-	s.Require().Contains(output, "image: global.custom.registry.io/camunda/tasklist:8.x.x")
-	s.Require().Contains(output, "image: global.custom.registry.io/camunda/zeebe:8.x.x")
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }

--- a/charts/camunda-platform-8.4/test/unit/camunda/ingress_test.go
+++ b/charts/camunda-platform-8.4/test/unit/camunda/ingress_test.go
@@ -15,12 +15,12 @@
 package camunda
 
 import (
+	"camunda-platform/test/unit/testhelpers"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -29,7 +29,7 @@ import (
 	netv1 "k8s.io/api/networking/v1"
 )
 
-type ingressTemplateTest struct {
+type IngressTemplateTest struct {
 	suite.Suite
 	chartPath string
 	release   string
@@ -44,7 +44,7 @@ func TestIngressTemplate(t *testing.T) {
 	chartPath, err := filepath.Abs("../../../")
 	require.NoError(t, err)
 
-	suite.Run(t, &ingressTemplateTest{
+	suite.Run(t, &IngressTemplateTest{
 		chartPath: chartPath,
 		release:   "camunda-platform-test",
 		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
@@ -52,188 +52,167 @@ func TestIngressTemplate(t *testing.T) {
 	})
 }
 
-func (s *ingressTemplateTest) TestIngressEnabledAndKeycloakChartProxyForwardingEnabled() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.ingress.tls.enabled": "true",
-			"identity.contextPath":       "/identity",
-			"identity.keycloak.enabled":  "true",
+func (s *IngressTemplateTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name:                 "TestIngressEnabledAndKeycloakChartProxyForwardingEnabled",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			// NOTE: helm.Options.ExtraArgs doesn't support passing args to Helm "template" command.
+			// TODO: Remove "template" from all helm.Options.ExtraArgs since it doesn't have any effect.
+			RenderTemplateExtraArgs: []string{"--show-only", "charts/identity/charts/keycloak/templates/statefulset.yaml"},
+			CaseTemplates: &testhelpers.CaseTemplate{
+				Templates: nil,
+			},
+			Values: map[string]string{
+				"global.ingress.tls.enabled": "true",
+				"identity.contextPath":       "/identity",
+				"identity.keycloak.enabled":  "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var statefulSet appsv1.StatefulSet
+				helm.UnmarshalK8SYaml(s.T(), output, &statefulSet)
+
+				// then
+				env := statefulSet.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env,
+					corev1.EnvVar{
+						Name:  "KEYCLOAK_PROXY_ADDRESS_FORWARDING",
+						Value: "true",
+					})
+			},
+		}, {
+			Name:                 "TestIngressEnabledWithKeycloakCustomContextPath",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values: map[string]string{
+				"global.ingress.enabled":               "true",
+				"global.identity.keycloak.contextPath": "/custom",
+				"identity.keycloak.enabled":            "true",
+				"identity.keycloak.httpRelativePath":   "/custom",
+				"identity.contextPath":                 "/identity",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var ingress netv1.Ingress
+				helm.UnmarshalK8SYaml(s.T(), output, &ingress)
+
+				// then
+				path := ingress.Spec.Rules[0].HTTP.Paths[0]
+				s.Require().Equal("/custom", path.Path)
+				s.Require().Equal("camunda-platform-test-keycloak", path.Backend.Service.Name)
+			},
+		}, {
+			Name:                 "TestIngressEnabledWithKeycloakCustomContextPathStatefulSetsOnly",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values: map[string]string{
+				"global.ingress.enabled":               "true",
+				"global.identity.keycloak.contextPath": "/custom",
+				"identity.keycloak.enabled":            "true",
+				"identity.keycloak.httpRelativePath":   "/custom",
+				"identity.contextPath":                 "/identity",
+			},
+			RenderTemplateExtraArgs: []string{"--show-only", "charts/identity/charts/keycloak/templates/statefulset.yaml"},
+			CaseTemplates: &testhelpers.CaseTemplate{
+				Templates: nil,
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var statefulSet appsv1.StatefulSet
+				helm.UnmarshalK8SYaml(s.T(), output, &statefulSet)
+
+				// then
+				env := statefulSet.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env,
+					corev1.EnvVar{
+						Name:  "KEYCLOAK_HTTP_RELATIVE_PATH",
+						Value: "/custom",
+					})
+			},
+		}, {
+			Name: "TestIngressWithKeycloakChartIsDisabled",
+			Values: map[string]string{
+				"global.ingress.enabled": "true",
+				"identity.contextPath":   "/identity",
+				// Disable Identity Keycloak chart.
+				"identity.keycloak.enabled": "false",
+				// Set vars to use existing Keycloak.
+				"global.identity.keycloak.url.protocol": "https",
+				"global.identity.keycloak.url.host":     "keycloak.prod.svc.cluster.local",
+				"global.identity.keycloak.url.port":     "8443",
+			},
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Verifier: func(t *testing.T, output string, err error) {
+				// then
+				// TODO: Instead of using plain text search, unmarshal the output in an ingress struct and assert the values.
+				s.Require().NotContains(output, "keycloak")
+				s.Require().NotContains(output, "path: /auth")
+				s.Require().NotContains(output, "number: 8443")
+			},
+		}, {
+			Name: "TestIngressWithContextPath",
+			Values: map[string]string{
+				"global.ingress.enabled":              "true",
+				"identity.contextPath":                "/identity",
+				"operate.contextPath":                 "/operate",
+				"optimize.contextPath":                "/optimize",
+				"tasklist.contextPath":                "/tasklist",
+				"webModeler.enabled":                  "true",
+				"webModeler.restapi.mail.fromAddress": "example@example.com",
+				"webModeler.contextPath":              "/modeler",
+			},
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Verifier: func(t *testing.T, output string, err error) {
+				// then
+				s.Require().Contains(output, "kind: Ingress")
+				s.Require().Contains(output, "path: /auth")
+				s.Require().Contains(output, "path: /identity")
+				s.Require().Contains(output, "path: /operate")
+				s.Require().Contains(output, "path: /optimize")
+				s.Require().Contains(output, "path: /tasklist")
+				s.Require().Contains(output, "path: /modeler")
+				s.Require().Contains(output, "path: /modeler-ws")
+			},
+		}, {
+			Name: "TestIngressComponentWithNoContextPath",
+			Values: map[string]string{
+				"global.ingress.enabled":              "true",
+				"identity.contextPath":                "",
+				"operate.contextPath":                 "",
+				"optimize.contextPath":                "",
+				"tasklist.contextPath":                "",
+				"webModeler.enabled":                  "true",
+				"webModeler.restapi.mail.fromAddress": "example@example.com",
+				"webModeler.contextPath":              "",
+			},
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Verifier: func(t *testing.T, output string, err error) {
+				// then
+				s.Require().NotContains(output, "name: camunda-platform-test-identity")
+				s.Require().NotContains(output, "name: camunda-platform-test-operate")
+				s.Require().NotContains(output, "name: camunda-platform-test-optimize")
+				s.Require().NotContains(output, "name: camunda-platform-test-tasklist")
+				s.Require().NotContains(output, "name: camunda-platform-test-web-modeler-webapp")
+				s.Require().NotContains(output, "name: camunda-platform-test-web-modeler-websockets")
+			},
+		}, {
+			Name: "TestIngressComponentDisabled",
+			Values: map[string]string{
+				"global.ingress.enabled": "true",
+				"operate.identity":       "false",
+				"operate.enabled":        "false",
+				"optimize.enabled":       "false",
+				"tasklist.enabled":       "false",
+				"webModeler.enabled":     "false",
+			},
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Verifier: func(t *testing.T, output string, err error) {
+				// then
+				s.Require().NotContains(output, "name: camunda-platform-test-identity")
+				s.Require().NotContains(output, "name: camunda-platform-test-operate")
+				s.Require().NotContains(output, "name: camunda-platform-test-optimize")
+				s.Require().NotContains(output, "name: camunda-platform-test-tasklist")
+				s.Require().NotContains(output, "name: camunda-platform-test-web-modeler-webapp")
+				s.Require().NotContains(output, "name: camunda-platform-test-web-modeler-websockets")
+			},
 		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
 	}
 
-	// NOTE: helm.Options.ExtraArgs doesn't support passing args to Helm "template" command.
-	// TODO: Remove "template" from all helm.Options.ExtraArgs since it doesn't have any effect.
-	s.extraArgs = []string{"--show-only", "charts/identity/charts/keycloak/templates/statefulset.yaml"}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, nil, s.extraArgs...)
-
-	var statefulSet appsv1.StatefulSet
-	helm.UnmarshalK8SYaml(s.T(), output, &statefulSet)
-
-	// then
-	env := statefulSet.Spec.Template.Spec.Containers[0].Env
-	s.Require().Contains(env,
-		corev1.EnvVar{
-			Name:  "KEYCLOAK_PROXY_ADDRESS_FORWARDING",
-			Value: "true",
-		})
-}
-
-func (s *ingressTemplateTest) TestIngressEnabledWithKeycloakCustomContextPath() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.ingress.enabled":               "true",
-			"global.identity.keycloak.contextPath": "/custom",
-			"identity.keycloak.enabled":            "true",
-			"identity.keycloak.httpRelativePath":   "/custom",
-			"identity.contextPath":                 "/identity",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	ingressOutput := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-
-	var ingress netv1.Ingress
-	helm.UnmarshalK8SYaml(s.T(), ingressOutput, &ingress)
-
-	// then
-	path := ingress.Spec.Rules[0].HTTP.Paths[0]
-	s.Require().Equal("/custom", path.Path)
-	s.Require().Equal("camunda-platform-test-keycloak", path.Backend.Service.Name)
-
-	// when
-	extraArgs := []string{"--show-only", "charts/identity/charts/keycloak/templates/statefulset.yaml"}
-	stsOutput := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, nil, extraArgs...)
-
-	var statefulSet appsv1.StatefulSet
-	helm.UnmarshalK8SYaml(s.T(), stsOutput, &statefulSet)
-
-	// then
-	env := statefulSet.Spec.Template.Spec.Containers[0].Env
-	s.Require().Contains(env,
-		corev1.EnvVar{
-			Name:  "KEYCLOAK_HTTP_RELATIVE_PATH",
-			Value: "/custom",
-		})
-}
-
-func (s *ingressTemplateTest) TestIngressWithKeycloakChartIsDisabled() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.ingress.enabled": "true",
-			"identity.contextPath":   "/identity",
-			// Disable Identity Keycloak chart.
-			"identity.keycloak.enabled": "false",
-			// Set vars to use existing Keycloak.
-			"global.identity.keycloak.url.protocol": "https",
-			"global.identity.keycloak.url.host":     "keycloak.prod.svc.cluster.local",
-			"global.identity.keycloak.url.port":     "8443",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-
-	// then
-	// TODO: Instead of using plain text search, unmarshal the output in an ingress struct and assert the values.
-	s.Require().NotContains(output, "keycloak")
-	s.Require().NotContains(output, "path: /auth")
-	s.Require().NotContains(output, "number: 8443")
-}
-
-func (s *ingressTemplateTest) TestIngressWithContextPath() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.ingress.enabled":              "true",
-			"identity.contextPath":                "/identity",
-			"operate.contextPath":                 "/operate",
-			"optimize.contextPath":                "/optimize",
-			"tasklist.contextPath":                "/tasklist",
-			"webModeler.enabled":                  "true",
-			"webModeler.restapi.mail.fromAddress": "example@example.com",
-			"webModeler.contextPath":              "/modeler",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-
-	// then
-	s.Require().Contains(output, "kind: Ingress")
-	s.Require().Contains(output, "path: /auth")
-	s.Require().Contains(output, "path: /identity")
-	s.Require().Contains(output, "path: /operate")
-	s.Require().Contains(output, "path: /optimize")
-	s.Require().Contains(output, "path: /tasklist")
-	s.Require().Contains(output, "path: /modeler")
-	s.Require().Contains(output, "path: /modeler-ws")
-}
-
-func (s *ingressTemplateTest) TestIngressComponentWithNoContextPath() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.ingress.enabled":              "true",
-			"identity.contextPath":                "",
-			"operate.contextPath":                 "",
-			"optimize.contextPath":                "",
-			"tasklist.contextPath":                "",
-			"webModeler.enabled":                  "true",
-			"webModeler.restapi.mail.fromAddress": "example@example.com",
-			"webModeler.contextPath":              "",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-
-	// then
-	s.Require().NotContains(output, "name: camunda-platform-test-identity")
-	s.Require().NotContains(output, "name: camunda-platform-test-operate")
-	s.Require().NotContains(output, "name: camunda-platform-test-optimize")
-	s.Require().NotContains(output, "name: camunda-platform-test-tasklist")
-	s.Require().NotContains(output, "name: camunda-platform-test-web-modeler-webapp")
-	s.Require().NotContains(output, "name: camunda-platform-test-web-modeler-websockets")
-}
-
-func (s *ingressTemplateTest) TestIngressComponentDisabled() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.ingress.enabled": "true",
-			"operate.identity":       "false",
-			"operate.enabled":        "false",
-			"optimize.enabled":       "false",
-			"tasklist.enabled":       "false",
-			"webModeler.enabled":     "false",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-
-	// then
-	s.Require().NotContains(output, "name: camunda-platform-test-identity")
-	s.Require().NotContains(output, "name: camunda-platform-test-operate")
-	s.Require().NotContains(output, "name: camunda-platform-test-optimize")
-	s.Require().NotContains(output, "name: camunda-platform-test-tasklist")
-	s.Require().NotContains(output, "name: camunda-platform-test-web-modeler-webapp")
-	s.Require().NotContains(output, "name: camunda-platform-test-web-modeler-websockets")
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }

--- a/charts/camunda-platform-8.4/test/unit/camunda/secret_test.go
+++ b/charts/camunda-platform-8.4/test/unit/camunda/secret_test.go
@@ -15,19 +15,19 @@
 package camunda
 
 import (
+	"camunda-platform/test/unit/testhelpers"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	coreV1 "k8s.io/api/core/v1"
 )
 
-type secretTest struct {
+type SecretTest struct {
 	suite.Suite
 	chartPath  string
 	release    string
@@ -42,7 +42,7 @@ func TestSecretTemplate(t *testing.T) {
 	chartPath, err := filepath.Abs("../../../")
 	require.NoError(t, err)
 
-	suite.Run(t, &secretTest{
+	suite.Run(t, &SecretTest{
 		chartPath:  chartPath,
 		release:    "camunda-platform-test",
 		namespace:  "camunda-platform-" + strings.ToLower(random.UniqueId()),
@@ -51,40 +51,48 @@ func TestSecretTemplate(t *testing.T) {
 	})
 }
 
-func (s *secretTest) TestContainerGenerateSecret() {
-	// given
-	options := &helm.Options{
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+func (s *SecretTest) TestDifferentValuesInputs() {
+	// Define components that need secret tests
+	components := []string{
+		"Connectors",
+		"Console",
+		"Operate",
+		"Optimize",
+		"TaskList",
+		"Zeebe",
 	}
 
-	s.templates = []string{
-		"templates/camunda/secret-connectors.yaml",
-		"templates/camunda/secret-console.yaml",
-		"templates/camunda/secret-operate.yaml",
-		"templates/camunda/secret-optimize.yaml",
-		"templates/camunda/secret-tasklist.yaml",
-		"templates/camunda/secret-zeebe.yaml",
+	require.Equal(s.T(), len(components), 6, "Expected 6 components to be tested")
+
+	// Create test cases for each component
+	testCases := make([]testhelpers.TestCase, 0, len(components)+1)
+	for _, component := range components {
+		testCases = append(testCases, s.createSecretTestCase(component))
 	}
 
-	s.secretName = []string{
-		"connectors-secret",
-		"console-secret",
-		"operate-secret",
-		"optimize-secret",
-		"tasklist-secret",
-		"zeebe-secret",
-	}
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
 
-	s.Require().GreaterOrEqual(6, len(s.templates))
-	for idx, template := range s.templates {
-		// when
-		output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, []string{template})
-		var secret coreV1.Secret
-		helm.UnmarshalK8SYaml(s.T(), output, &secret)
+func (s *SecretTest) createSecretTestCase(componentName string) testhelpers.TestCase {
+	secretKey := strings.ToLower(componentName) + "-secret"
+	templatePath := "templates/camunda/secret-" + strings.ToLower(componentName) + ".yaml"
 
-		// then
-		s.Require().NotNil(secret.Data)
-		s.Require().NotNil(secret.Data[s.secretName[idx]])
-		s.Require().NotEmpty(secret.Data[s.secretName[idx]])
+	return testhelpers.TestCase{
+		Name: "TestContainerGenerateSecret" + componentName,
+		CaseTemplates: &testhelpers.CaseTemplate{
+			Templates: []string{templatePath},
+		},
+		Verifier: func(t *testing.T, output string, err error) {
+			s.verifySecretData(t, output, secretKey)
+		},
 	}
+}
+
+func (s *SecretTest) verifySecretData(t *testing.T, output string, secretName string) {
+	var secret coreV1.Secret
+	helm.UnmarshalK8SYaml(t, output, &secret)
+
+	require.NotNil(t, secret.Data)
+	require.NotNil(t, secret.Data[secretName])
+	require.NotEmpty(t, secret.Data[secretName])
 }

--- a/charts/camunda-platform-8.4/test/unit/testhelpers/testhelpers.go
+++ b/charts/camunda-platform-8.4/test/unit/testhelpers/testhelpers.go
@@ -1,0 +1,171 @@
+// Package testhelpers provides utilities for testing Helm charts.
+// To enable verbose logging, set the VERBOSE_TEST_LOGGING environment variable to "true".
+// Example: VERBOSE_TEST_LOGGING=true go test ./...
+package testhelpers
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type CaseTemplate struct {
+	Templates []string
+}
+
+// TestCase represents a single test scenario for Helm chart testing.
+// It encapsulates all the necessary configuration and validation logic for a test.
+type TestCase struct {
+	// Name is the descriptive name of the test case, used for identification in test output
+	Name string
+
+	// HelmOptionsExtraArgs contains additional arguments to pass to the Helm command
+	// The key spaecifies the Helm command (e.g., "install", "upgrade"), and the value is a slice of arguments
+	// This allows customizing the Helm command behavior for specific test cases
+	HelmOptionsExtraArgs map[string][]string
+
+	// RenderTemplateExtraArgs contains additional arguments for template rendering
+	// These are passed to the template rendering process
+	RenderTemplateExtraArgs []string
+
+	// When provided, this function is called to get the templates to render. This overrides the
+	// templates set in the test suite
+	CaseTemplates *CaseTemplate
+
+	// Values represents the Helm chart values to set for this test case
+	// These are equivalent to values passed with --set flag in Helm CLI
+	Values map[string]string
+
+	// Expected contains key-value pairs that should be present in the rendered output
+	// For error tests, it should contain an "ERROR" key with the expected error message
+	// For ConfigMap tests, keys can be direct data keys or dot-notation paths into application.yaml
+	Expected map[string]string
+
+	// Verifier is a custom function for complex validation scenarios
+	// When provided, it overrides the default validation logic
+	// It receives the rendered output and any error that occurred during rendering
+	Verifier func(t *testing.T, output string, err error)
+}
+
+// quietLogger returns a logger that only logs errors
+func quietLogger() *logger.Logger {
+	// Check if verbose logging is enabled via environment variable
+	if os.Getenv("VERBOSE_TEST_LOGGING") == "true" {
+		return logger.Default
+	}
+	// Create a logger that discards all output
+	return logger.Discard
+}
+
+func setupHelmOptions(namespace string, values map[string]string, helmOptionsExtraArgs map[string][]string) *helm.Options {
+	options := &helm.Options{
+		SetValues:      values,
+		KubectlOptions: k8s.NewKubectlOptions("", "", namespace),
+		Logger:         quietLogger(), // Use quiet logger to reduce verbosity
+		ExtraArgs:      helmOptionsExtraArgs,
+	}
+	return options
+}
+
+func renderTemplateE(t *testing.T, chartPath, release string, namespace string, templates []string, values map[string]string, extraArgs map[string][]string, renderTemplateExtraArgs []string) (string, error) {
+	options := setupHelmOptions(namespace, values, extraArgs)
+
+	output, err := helm.RenderTemplateE(t, options, chartPath, release, templates, renderTemplateExtraArgs...)
+	return output, err
+}
+
+func RunTestCasesE(t *testing.T, chartPath, release, namespace string, templates []string, testCases []TestCase) {
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			var caseTemplates []string
+			if tc.CaseTemplates != nil {
+				caseTemplates = tc.CaseTemplates.Templates
+			} else {
+				caseTemplates = templates
+			}
+			output, err := renderTemplateE(t, chartPath, release, namespace, caseTemplates, tc.Values, tc.HelmOptionsExtraArgs, tc.RenderTemplateExtraArgs)
+			if tc.Verifier != nil {
+				tc.Verifier(t, output, err)
+			} else {
+				require.ErrorContains(t, err, tc.Expected["ERROR"])
+			}
+		})
+	}
+}
+
+// renderTemplate renders the specified Helm templates into a Kubernetes ConfigMap
+func renderTemplate(t *testing.T, chartPath, release string, namespace string, templates []string, values map[string]string) corev1.ConfigMap {
+	options := setupHelmOptions(namespace, values, nil)
+
+	output := helm.RenderTemplate(t, options, chartPath, release, templates)
+	var configmap corev1.ConfigMap
+	helm.UnmarshalK8SYaml(t, output, &configmap)
+	return configmap
+}
+
+// RunTestCases executes multiple test cases using the provided Helm chart and ConfigMap validation
+func RunTestCases(t *testing.T, chartPath, release, namespace string, templates []string, testCases []TestCase) {
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			configmap := renderTemplate(t, chartPath, release, namespace, templates, tc.Values)
+			verifyConfigMap(t, tc.Name, configmap, tc.Expected)
+		})
+	}
+}
+
+// verifyConfigMap checks whether the generated ConfigMap contains the expected key-value pairs
+func verifyConfigMap(t *testing.T, testCase string, configmap corev1.ConfigMap, expectedValues map[string]string) {
+	for keyPath, expectedValue := range expectedValues {
+		var actualValue string
+		if strings.HasPrefix(keyPath, "configmapApplication.") {
+			var configmapApplication map[string]any
+			err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+			require.NoError(t, err)
+			actualValue = getConfigMapFieldValue(configmapApplication, strings.Split(keyPath, ".")[1:])
+		} else {
+			actualValue = strings.TrimSpace(configmap.Data[keyPath])
+		}
+		require.Equal(t, expectedValue, actualValue, "Test case '%s': Expected key '%s' to have value '%s', but got '%s'", testCase, keyPath, expectedValue, actualValue)
+	}
+}
+
+// getConfigMapFieldValue function traverses a nested map structure based on a given key path.
+// It handles maps with both interface{} and string keys, converting them as necessary to retrieve the desired value.
+// If the key is not found or the final value is not a string, the function returns an empty string.
+func getConfigMapFieldValue(configmapApplication map[string]any, keyPath []string) string {
+	var current any = configmapApplication
+
+	for _, key := range keyPath {
+		if nestedMap, ok := current.(map[any]any); ok {
+			// Convert map[interface{}]any to map[string]any
+			stringMap := make(map[string]any)
+			for k, v := range nestedMap {
+				if strKey, isString := k.(string); isString {
+					stringMap[strKey] = v
+				}
+			}
+			// Move to the next level in the map
+			current = stringMap[key]
+		} else if nestedMap, ok := current.(map[string]any); ok {
+			// If the current level is already a map with string keys, move to the next level
+			current = nestedMap[key]
+		} else {
+			// If the key is not found, return an empty string
+			return ""
+		}
+	}
+
+	// If the final value is a string, return it
+	if value, ok := current.(string); ok {
+		return value
+	}
+	// If the final value is not a string, return an empty string
+	return ""
+}


### PR DESCRIPTION
### Which problem does the PR fix?

https://github.com/camunda/team-distribution/issues/448

### What's in this PR?

- unit tests under camunda in 8.4 have been refactored

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
