### PR TITLE
fix: add gateway enabled

### DIFF
--- a/charts/camunda-platform-8.6/templates/zeebe-gateway/configmap.yaml
+++ b/charts/camunda-platform-8.6/templates/zeebe-gateway/configmap.yaml
@@ -65,6 +65,7 @@ data:
     {{- end }}
     zeebe:
       gateway:
+        enable: true
         {{- if .Values.global.identity.auth.enabled }}
         security:
           authentication:

--- a/charts/camunda-platform-8.7/templates/zeebe-gateway/configmap.yaml
+++ b/charts/camunda-platform-8.7/templates/zeebe-gateway/configmap.yaml
@@ -69,6 +69,7 @@ data:
     {{- end }}
     zeebe:
       gateway:
+        enable: true
         {{- if .Values.global.identity.auth.enabled }}
         security:
           authentication:


### PR DESCRIPTION
### Which problem does the PR fix?

During a support ticket we learned that 11.2.2 and later requires setting this extra option in the zeebe gateway, otherwise the REST api endpoints will not work for deploying a model and creating a process instance.

In the context of the support ticket, this was in a multitenancy-enabled environment, but I'm not sure that part was relevant.

related to : https://github.com/camunda/camunda/issues/30635
[SUPPORT-26426](https://jira.camunda.com/browse/SUPPORT-26426)

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
