### PR TITLE
fix: unit tests in tasklist on 8.6 have been refactored to the new style

### DIFF
--- a/charts/camunda-platform-8.6/test/unit/tasklist/service_test.go
+++ b/charts/camunda-platform-8.6/test/unit/tasklist/service_test.go
@@ -15,19 +15,19 @@
 package tasklist
 
 import (
+	"camunda-platform/test/unit/testhelpers"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	coreV1 "k8s.io/api/core/v1"
 )
 
-type serviceTest struct {
+type ServiceTest struct {
 	suite.Suite
 	chartPath string
 	release   string
@@ -41,7 +41,7 @@ func TestServiceTemplate(t *testing.T) {
 	chartPath, err := filepath.Abs("../../../")
 	require.NoError(t, err)
 
-	suite.Run(t, &serviceTest{
+	suite.Run(t, &ServiceTest{
 		chartPath: chartPath,
 		release:   "camunda-platform-test",
 		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
@@ -49,38 +49,34 @@ func TestServiceTemplate(t *testing.T) {
 	})
 }
 
-func (s *serviceTest) TestContainerSetGlobalAnnotations() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.annotations.foo": "bar",
+func (s *ServiceTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestContainerSetGlobalAnnotations",
+			Values: map[string]string{
+				"global.annotations.foo": "bar",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var service coreV1.Service
+				helm.UnmarshalK8SYaml(s.T(), output, &service)
+
+				// then
+				s.Require().Equal("bar", service.ObjectMeta.Annotations["foo"])
+			},
+		}, {
+			Name: "TestContainerServiceAnnotations",
+			Values: map[string]string{
+				"tasklist.service.annotations.foo": "bar",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var service coreV1.Service
+				helm.UnmarshalK8SYaml(s.T(), output, &service)
+
+				// then
+				s.Require().Equal("bar", service.ObjectMeta.Annotations["foo"])
+			},
 		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 	}
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var service coreV1.Service
-	helm.UnmarshalK8SYaml(s.T(), output, &service)
-
-	// then
-	s.Require().Equal("bar", service.ObjectMeta.Annotations["foo"])
-}
-
-func (s *serviceTest) TestContainerServiceAnnotations() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"tasklist.service.annotations.foo": "bar",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var service coreV1.Service
-	helm.UnmarshalK8SYaml(s.T(), output, &service)
-
-	// then
-	s.Require().Equal("bar", service.ObjectMeta.Annotations["foo"])
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }


### PR DESCRIPTION
### Which problem does the PR fix?

https://github.com/camunda/team-distribution/issues/448

### What's in this PR?

The tasklist unit tests have been refactored to the new style in 8.6

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
