### PR TITLE
fix: refactor unit tests in webmodeller of 8.6 to new style

### DIFF
--- a/charts/camunda-platform-8.6/test/unit/web-modeler/configmap_shared_test.go
+++ b/charts/camunda-platform-8.6/test/unit/web-modeler/configmap_shared_test.go
@@ -15,19 +15,19 @@
 package web_modeler
 
 import (
+	"camunda-platform/test/unit/testhelpers"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	coreV1 "k8s.io/api/core/v1"
 )
 
-type configmapTest struct {
+type ConfigmapTest struct {
 	suite.Suite
 	chartPath string
 	release   string
@@ -41,7 +41,7 @@ func TestConfigmapTemplate(t *testing.T) {
 	chartPath, err := filepath.Abs("../../../")
 	require.NoError(t, err)
 
-	suite.Run(t, &configmapTest{
+	suite.Run(t, &ConfigmapTest{
 		chartPath: chartPath,
 		release:   "camunda-platform-test",
 		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
@@ -49,22 +49,24 @@ func TestConfigmapTemplate(t *testing.T) {
 	})
 }
 
-func (s *configmapTest) TestContainerGenerateRandomPusherAppKey() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                  "true",
-			"webModeler.restapi.mail.fromAddress": "example@example.com",
+func (s *ConfigmapTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestContainerGenerateRandomPusherAppKey",
+			Values: map[string]string{
+				"webModeler.enabled":                  "true",
+				"webModeler.restapi.mail.fromAddress": "example@example.com",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configMap coreV1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configMap)
+
+				// then
+				s.Require().NotNil(configMap.Data)
+				s.Require().Regexp("^[a-zA-Z0-9]{20}$", configMap.Data["pusher-app-key"])
+			},
 		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 	}
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var configMap coreV1.ConfigMap
-	helm.UnmarshalK8SYaml(s.T(), output, &configMap)
-
-	// then
-	s.Require().NotNil(configMap.Data)
-	s.Require().Regexp("^[a-zA-Z0-9]{20}$", configMap.Data["pusher-app-key"])
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }

--- a/charts/camunda-platform-8.6/test/unit/web-modeler/configmap_webapp_test.go
+++ b/charts/camunda-platform-8.6/test/unit/web-modeler/configmap_webapp_test.go
@@ -1,19 +1,20 @@
 package web_modeler
 
 import (
+	"camunda-platform/test/unit/testhelpers"
+	"path/filepath"
+	"strings"
+	"testing"
+
 	"github.com/BurntSushi/toml"
 	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	corev1 "k8s.io/api/core/v1"
-	"path/filepath"
-	"strings"
-	"testing"
 )
 
-type configmapWebAppTemplateTest struct {
+type ConfigmapWebAppTemplateTest struct {
 	suite.Suite
 	chartPath string
 	release   string
@@ -27,309 +28,262 @@ func TestWebAppConfigmapTemplate(t *testing.T) {
 	chartPath, err := filepath.Abs("../../../")
 	require.NoError(t, err)
 
-	suite.Run(t, &configmapWebAppTemplateTest{
+	suite.Run(t, &ConfigmapWebAppTemplateTest{
 		chartPath: chartPath,
 		release:   "camunda-platform-test",
 		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
 		templates: []string{"templates/web-modeler/configmap-webapp.yaml"},
 	})
 }
-func (s *configmapWebAppTemplateTest) TestContainerShouldSetCorrectAuthClientApiAudience() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                                "true",
-			"webModeler.restapi.mail.fromAddress":               "example@example.com",
-			"global.identity.auth.webModeler.clientApiAudience": "custom-audience",
+
+func (s *ConfigmapWebAppTemplateTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestContainerShouldSetCorrectAuthClientApiAudience",
+			Values: map[string]string{
+				"webModeler.enabled":                                "true",
+				"webModeler.restapi.mail.fromAddress":               "example@example.com",
+				"global.identity.auth.webModeler.clientApiAudience": "custom-audience",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				var configmapApplication WebModelerWebAppTOML
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				e := toml.Unmarshal([]byte(configmap.Data["application.toml"]), &configmapApplication)
+				if e != nil {
+					s.Fail("Failed to unmarshal yaml. error=", e)
+				}
+				// then
+				s.Require().Equal("custom-audience", configmapApplication.OAuth2.Token.Audience)
+			},
+		}, {
+			Name: "TestContainerShouldSetCorrectAuthClientId",
+			Values: map[string]string{
+				"webModeler.enabled":                       "true",
+				"webModeler.restapi.mail.fromAddress":      "example@example.com",
+				"global.identity.auth.webModeler.clientId": "custom-clientId",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				var configmapApplication WebModelerWebAppTOML
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				e := toml.Unmarshal([]byte(configmap.Data["application.toml"]), &configmapApplication)
+				if e != nil {
+					s.Fail("Failed to unmarshal yaml. error=", e)
+				}
+
+				// then
+				s.Require().Equal("custom-clientId", configmapApplication.OAuth2.ClientId)
+			},
+		}, {
+			Name: "TestContainerShouldSetCorrectClientPusherConfigurationWithGlobalIngressTlsDisabled",
+			Values: map[string]string{
+				"webModeler.enabled":                  "true",
+				"webModeler.restapi.mail.fromAddress": "example@example.com",
+				"webModeler.ingress.enabled":          "false",
+				"webModeler.contextPath":              "/modeler",
+				"global.ingress.enabled":              "true",
+				"global.ingress.host":                 "c8.example.com",
+				"global.ingress.tls.enabled":          "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				var configmapApplication WebModelerWebAppTOML
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				e := toml.Unmarshal([]byte(configmap.Data["application.toml"]), &configmapApplication)
+				if e != nil {
+					s.Fail("Failed to unmarshal yaml. error=", e)
+				}
+
+				// then
+				s.Require().Equal("c8.example.com", configmapApplication.Client.Pusher.Host)
+				s.Require().Equal("80", configmapApplication.Client.Pusher.Port)
+				s.Require().Equal("/modeler-ws", configmapApplication.Client.Pusher.Path)
+				s.Require().Equal("false", configmapApplication.Client.Pusher.ForceTLS)
+			},
+		}, {
+			Name: "TestContainerShouldSetCorrectClientPusherConfigurationWithGlobalIngressTlsEnabled",
+			Values: map[string]string{
+				"webModeler.enabled":                  "true",
+				"webModeler.restapi.mail.fromAddress": "example@example.com",
+				"webModeler.ingress.enabled":          "false",
+				"webModeler.contextPath":              "/modeler",
+				"global.ingress.enabled":              "true",
+				"global.ingress.host":                 "c8.example.com",
+				"global.ingress.tls.enabled":          "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				var configmapApplication WebModelerWebAppTOML
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				e := toml.Unmarshal([]byte(configmap.Data["application.toml"]), &configmapApplication)
+				if e != nil {
+					s.Fail("Failed to unmarshal yaml. error=", e)
+				}
+
+				// then
+				s.Require().Equal("c8.example.com", configmapApplication.Client.Pusher.Host)
+				s.Require().Equal("443", configmapApplication.Client.Pusher.Port)
+				s.Require().Equal("/modeler-ws", configmapApplication.Client.Pusher.Path)
+				s.Require().Equal("true", configmapApplication.Client.Pusher.ForceTLS)
+			},
+		}, {
+			Name: "TestContainerShouldSetCorrectClientPusherConfigurationWithIngressTlsEnabled",
+			Values: map[string]string{
+				"webModeler.enabled":                        "true",
+				"webModeler.restapi.mail.fromAddress":       "example@example.com",
+				"webModeler.ingress.enabled":                "true",
+				"webModeler.ingress.websockets.host":        "modeler-ws.example.com",
+				"webModeler.ingress.websockets.tls.enabled": "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				var configmapApplication WebModelerWebAppTOML
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				e := toml.Unmarshal([]byte(configmap.Data["application.toml"]), &configmapApplication)
+				if e != nil {
+					s.Fail("Failed to unmarshal yaml. error=", e)
+				}
+
+				// then
+				s.Require().Equal("modeler-ws.example.com", configmapApplication.Client.Pusher.Host)
+				s.Require().Equal("443", configmapApplication.Client.Pusher.Port)
+				s.Require().Equal("true", configmapApplication.Client.Pusher.ForceTLS)
+			},
+		}, {
+			Name: "TestContainerShouldSetCorrectClientPusherConfigurationWithIngressTlsDisabled",
+			Values: map[string]string{
+				"webModeler.enabled":                        "true",
+				"webModeler.restapi.mail.fromAddress":       "example@example.com",
+				"webModeler.ingress.enabled":                "true",
+				"webModeler.ingress.websockets.host":        "modeler-ws.example.com",
+				"webModeler.ingress.websockets.tls.enabled": "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				var configmapApplication WebModelerWebAppTOML
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				e := toml.Unmarshal([]byte(configmap.Data["application.toml"]), &configmapApplication)
+				if e != nil {
+					s.Fail("Failed to unmarshal yaml. error=", e)
+				}
+
+				// then
+				s.Require().Equal("modeler-ws.example.com", configmapApplication.Client.Pusher.Host)
+				s.Require().Equal("80", configmapApplication.Client.Pusher.Port)
+				s.Require().Equal("false", configmapApplication.Client.Pusher.ForceTLS)
+			},
+		}, {
+			Name: "TestContainerShouldSetCorrectIdentityServiceUrlWithFullnameOverride",
+			Values: map[string]string{
+				"webModeler.enabled":                  "true",
+				"webModeler.restapi.mail.fromAddress": "example@example.com",
+				"identity.fullnameOverride":           "custom-identity-fullname",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				var configmapApplication WebModelerWebAppTOML
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				e := toml.Unmarshal([]byte(configmap.Data["application.toml"]), &configmapApplication)
+				if e != nil {
+					s.Fail("Failed to unmarshal yaml. error=", e)
+				}
+
+				// then
+				s.Require().Equal("http://custom-identity-fullname:80", configmapApplication.Identity.BaseUrl)
+			},
+		}, {
+			Name: "TestContainerShouldSetCorrectIdentityServiceUrlWithNameOverride",
+			Values: map[string]string{
+				"webModeler.enabled":                  "true",
+				"webModeler.restapi.mail.fromAddress": "example@example.com",
+				"identity.nameOverride":               "custom-identity",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				var configmapApplication WebModelerWebAppTOML
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				e := toml.Unmarshal([]byte(configmap.Data["application.toml"]), &configmapApplication)
+				if e != nil {
+					s.Fail("Failed to unmarshal yaml. error=", e)
+				}
+
+				// then
+				s.Require().Equal("http://camunda-platform-test-custom-identity:80", configmapApplication.Identity.BaseUrl)
+			},
+		}, {
+			Name: "TestContainerShouldSetServerHttpsOnly",
+			Values: map[string]string{
+				"webModeler.enabled":                          "true",
+				"webModeler.restapi.mail.fromAddress":         "example@example.com",
+				"global.identity.auth.webModeler.redirectUrl": "https://modeler.example.com",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				var configmapApplication WebModelerWebAppTOML
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				e := toml.Unmarshal([]byte(configmap.Data["application.toml"]), &configmapApplication)
+				if e != nil {
+					s.Fail("Failed to unmarshal yaml. error=", e)
+				}
+
+				// then
+				s.Require().Equal("true", configmapApplication.Server.HttpsOnly)
+			},
+		}, {
+			Name: "TestContainerShouldSetCorrectKeycloakServiceUrl",
+			Values: map[string]string{
+				"webModeler.enabled":                    "true",
+				"webModeler.restapi.mail.fromAddress":   "example@example.com",
+				"global.identity.keycloak.url.protocol": "http",
+				"global.identity.keycloak.url.host":     "keycloak",
+				"global.identity.keycloak.url.port":     "80",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				var configmapApplication WebModelerWebAppTOML
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				e := toml.Unmarshal([]byte(configmap.Data["application.toml"]), &configmapApplication)
+				if e != nil {
+					s.Fail("Failed to unmarshal yaml. error=", e)
+				}
+
+				// then
+				s.Require().Equal("http://keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/certs", configmapApplication.OAuth2.Token.JwksUrl)
+			},
+		}, {
+			Name: "TestContainerShouldSetCorrectIdentityType",
+			Values: map[string]string{
+				"webModeler.enabled":                    "true",
+				"webModeler.restapi.mail.fromAddress":   "example@example.com",
+				"global.identity.auth.type":             "MICROSOFT",
+				"global.identity.auth.issuerBackendUrl": "https://example.com",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				var configmapApplication WebModelerWebAppTOML
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				e := toml.Unmarshal([]byte(configmap.Data["application.toml"]), &configmapApplication)
+				if e != nil {
+					s.Fail("Failed to unmarshal yaml. error=", e)
+				}
+
+				// then
+				s.Require().Equal("MICROSOFT", configmapApplication.OAuth2.Type)
+			},
 		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 	}
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var configmap corev1.ConfigMap
-	var configmapApplication WebModelerWebAppTOML
-	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-	err := toml.Unmarshal([]byte(configmap.Data["application.toml"]), &configmapApplication)
-	if err != nil {
-		s.Fail("Failed to unmarshal yaml. error=", err)
-	}
-	// then
-	s.Require().Equal("custom-audience", configmapApplication.OAuth2.Token.Audience)
-}
-func (s *configmapWebAppTemplateTest) TestContainerShouldSetCorrectAuthClientId() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                       "true",
-			"webModeler.restapi.mail.fromAddress":      "example@example.com",
-			"global.identity.auth.webModeler.clientId": "custom-clientId",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var configmap corev1.ConfigMap
-	var configmapApplication WebModelerWebAppTOML
-	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-	err := toml.Unmarshal([]byte(configmap.Data["application.toml"]), &configmapApplication)
-	if err != nil {
-		s.Fail("Failed to unmarshal yaml. error=", err)
-	}
-
-	// then
-	s.Require().Equal("custom-clientId", configmapApplication.OAuth2.ClientId)
-}
-func (s *configmapWebAppTemplateTest) TestContainerShouldSetCorrectClientPusherConfigurationWithGlobalIngressTlsDisabled() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                  "true",
-			"webModeler.restapi.mail.fromAddress": "example@example.com",
-			"webModeler.ingress.enabled":          "false",
-			"webModeler.contextPath":              "/modeler",
-			"global.ingress.enabled":              "true",
-			"global.ingress.host":                 "c8.example.com",
-			"global.ingress.tls.enabled":          "false",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var configmap corev1.ConfigMap
-	var configmapApplication WebModelerWebAppTOML
-	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-	err := toml.Unmarshal([]byte(configmap.Data["application.toml"]), &configmapApplication)
-	if err != nil {
-		s.Fail("Failed to unmarshal yaml. error=", err)
-	}
-
-	// then
-	s.Require().Equal("c8.example.com", configmapApplication.Client.Pusher.Host)
-	s.Require().Equal("80", configmapApplication.Client.Pusher.Port)
-	s.Require().Equal("/modeler-ws", configmapApplication.Client.Pusher.Path)
-	s.Require().Equal("false", configmapApplication.Client.Pusher.ForceTLS)
-}
-func (s *configmapWebAppTemplateTest) TestContainerShouldSetCorrectClientPusherConfigurationWithGlobalIngressTlsEnabled() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                  "true",
-			"webModeler.restapi.mail.fromAddress": "example@example.com",
-			"webModeler.ingress.enabled":          "false",
-			"webModeler.contextPath":              "/modeler",
-			"global.ingress.enabled":              "true",
-			"global.ingress.host":                 "c8.example.com",
-			"global.ingress.tls.enabled":          "true",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var configmap corev1.ConfigMap
-	var configmapApplication WebModelerWebAppTOML
-	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-	err := toml.Unmarshal([]byte(configmap.Data["application.toml"]), &configmapApplication)
-	if err != nil {
-		s.Fail("Failed to unmarshal yaml. error=", err)
-	}
-
-	// then
-	s.Require().Equal("c8.example.com", configmapApplication.Client.Pusher.Host)
-	s.Require().Equal("443", configmapApplication.Client.Pusher.Port)
-	s.Require().Equal("/modeler-ws", configmapApplication.Client.Pusher.Path)
-	s.Require().Equal("true", configmapApplication.Client.Pusher.ForceTLS)
-}
-func (s *configmapWebAppTemplateTest) TestContainerShouldSetCorrectClientPusherConfigurationWithIngressTlsEnabled() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                        "true",
-			"webModeler.restapi.mail.fromAddress":       "example@example.com",
-			"webModeler.ingress.enabled":                "true",
-			"webModeler.ingress.websockets.host":        "modeler-ws.example.com",
-			"webModeler.ingress.websockets.tls.enabled": "true",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var configmap corev1.ConfigMap
-	var configmapApplication WebModelerWebAppTOML
-	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-	err := toml.Unmarshal([]byte(configmap.Data["application.toml"]), &configmapApplication)
-	if err != nil {
-		s.Fail("Failed to unmarshal yaml. error=", err)
-	}
-
-	// then
-	s.Require().Equal("modeler-ws.example.com", configmapApplication.Client.Pusher.Host)
-	s.Require().Equal("443", configmapApplication.Client.Pusher.Port)
-	s.Require().Equal("true", configmapApplication.Client.Pusher.ForceTLS)
-}
-func (s *configmapWebAppTemplateTest) TestContainerShouldSetCorrectClientPusherConfigurationWithIngressTlsDisabled() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                        "true",
-			"webModeler.restapi.mail.fromAddress":       "example@example.com",
-			"webModeler.ingress.enabled":                "true",
-			"webModeler.ingress.websockets.host":        "modeler-ws.example.com",
-			"webModeler.ingress.websockets.tls.enabled": "false",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var configmap corev1.ConfigMap
-	var configmapApplication WebModelerWebAppTOML
-	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-	err := toml.Unmarshal([]byte(configmap.Data["application.toml"]), &configmapApplication)
-	if err != nil {
-		s.Fail("Failed to unmarshal yaml. error=", err)
-	}
-
-	// then
-	s.Require().Equal("modeler-ws.example.com", configmapApplication.Client.Pusher.Host)
-	s.Require().Equal("80", configmapApplication.Client.Pusher.Port)
-	s.Require().Equal("false", configmapApplication.Client.Pusher.ForceTLS)
-}
-func (s *configmapWebAppTemplateTest) TestContainerShouldSetCorrectIdentityServiceUrlWithFullnameOverride() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                  "true",
-			"webModeler.restapi.mail.fromAddress": "example@example.com",
-			"identity.fullnameOverride":           "custom-identity-fullname",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var configmap corev1.ConfigMap
-	var configmapApplication WebModelerWebAppTOML
-	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-	err := toml.Unmarshal([]byte(configmap.Data["application.toml"]), &configmapApplication)
-	if err != nil {
-		s.Fail("Failed to unmarshal yaml. error=", err)
-	}
-
-	// then
-	s.Require().Equal("http://custom-identity-fullname:80", configmapApplication.Identity.BaseUrl)
-}
-func (s *configmapWebAppTemplateTest) TestContainerShouldSetCorrectIdentityServiceUrlWithNameOverride() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                  "true",
-			"webModeler.restapi.mail.fromAddress": "example@example.com",
-			"identity.nameOverride":               "custom-identity",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var configmap corev1.ConfigMap
-	var configmapApplication WebModelerWebAppTOML
-	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-	err := toml.Unmarshal([]byte(configmap.Data["application.toml"]), &configmapApplication)
-	if err != nil {
-		s.Fail("Failed to unmarshal yaml. error=", err)
-	}
-
-	// then
-	s.Require().Equal("http://camunda-platform-test-custom-identity:80", configmapApplication.Identity.BaseUrl)
-}
-func (s *configmapWebAppTemplateTest) TestContainerShouldSetServerHttpsOnly() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                          "true",
-			"webModeler.restapi.mail.fromAddress":         "example@example.com",
-			"global.identity.auth.webModeler.redirectUrl": "https://modeler.example.com",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var configmap corev1.ConfigMap
-	var configmapApplication WebModelerWebAppTOML
-	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-	err := toml.Unmarshal([]byte(configmap.Data["application.toml"]), &configmapApplication)
-	if err != nil {
-		s.Fail("Failed to unmarshal yaml. error=", err)
-	}
-
-	// then
-	s.Require().Equal("true", configmapApplication.Server.HttpsOnly)
-}
-func (s *configmapWebAppTemplateTest) TestContainerShouldSetCorrectKeycloakServiceUrl() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                    "true",
-			"webModeler.restapi.mail.fromAddress":   "example@example.com",
-			"global.identity.keycloak.url.protocol": "http",
-			"global.identity.keycloak.url.host":     "keycloak",
-			"global.identity.keycloak.url.port":     "80",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var configmap corev1.ConfigMap
-	var configmapApplication WebModelerWebAppTOML
-	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-	err := toml.Unmarshal([]byte(configmap.Data["application.toml"]), &configmapApplication)
-	if err != nil {
-		s.Fail("Failed to unmarshal yaml. error=", err)
-	}
-
-	// then
-	s.Require().Equal("http://keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/certs", configmapApplication.OAuth2.Token.JwksUrl)
-}
-func (s *configmapWebAppTemplateTest) TestContainerShouldSetCorrectIdentityType() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                    "true",
-			"webModeler.restapi.mail.fromAddress":   "example@example.com",
-			"global.identity.auth.type":             "MICROSOFT",
-			"global.identity.auth.issuerBackendUrl": "https://example.com",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var configmap corev1.ConfigMap
-	var configmapApplication WebModelerWebAppTOML
-	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-	err := toml.Unmarshal([]byte(configmap.Data["application.toml"]), &configmapApplication)
-	if err != nil {
-		s.Fail("Failed to unmarshal yaml. error=", err)
-	}
-
-	// then
-	s.Require().Equal("MICROSOFT", configmapApplication.OAuth2.Type)
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }

--- a/charts/camunda-platform-8.6/test/unit/web-modeler/deployment_restapi_test.go
+++ b/charts/camunda-platform-8.6/test/unit/web-modeler/deployment_restapi_test.go
@@ -15,6 +15,7 @@
 package web_modeler
 
 import (
+	"camunda-platform/test/unit/testhelpers"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -22,14 +23,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	appsv1 "k8s.io/api/apps/v1"
 )
 
-type restapiDeploymentTemplateTest struct {
+type RestapiDeploymentTemplateTest struct {
 	suite.Suite
 	chartPath string
 	release   string
@@ -43,7 +43,7 @@ func TestRestapiDeploymentTemplate(t *testing.T) {
 	chartPath, err := filepath.Abs("../../../")
 	require.NoError(t, err)
 
-	suite.Run(t, &restapiDeploymentTemplateTest{
+	suite.Run(t, &RestapiDeploymentTemplateTest{
 		chartPath: chartPath,
 		release:   "camunda-platform-test",
 		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
@@ -51,493 +51,407 @@ func TestRestapiDeploymentTemplate(t *testing.T) {
 	})
 }
 
-func (s *restapiDeploymentTemplateTest) TestContainerExternalDatabasePasswordSecretRefForGivenPassword() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                           "true",
-			"webModeler.restapi.mail.fromAddress":          "example@example.com",
-			"postgresql.enabled":                           "false",
-			"webModeler.restapi.externalDatabase.url":      "jdbc:postgresql://postgres.example.com:65432/modeler-database",
-			"webModeler.restapi.externalDatabase.user":     "modeler-user",
-			"webModeler.restapi.externalDatabase.password": "modeler-password",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-	s.Require().Contains(env,
-		corev1.EnvVar{
-			Name: "SPRING_DATASOURCE_PASSWORD",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "camunda-platform-test-web-modeler-restapi"},
-					Key:                  "database-password",
-				},
+func (s *RestapiDeploymentTemplateTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestContainerExternalDatabasePasswordSecretRefForGivenPassword",
+			Values: map[string]string{
+				"webModeler.enabled":                           "true",
+				"webModeler.restapi.mail.fromAddress":          "example@example.com",
+				"postgresql.enabled":                           "false",
+				"webModeler.restapi.externalDatabase.url":      "jdbc:postgresql://postgres.example.com:65432/modeler-database",
+				"webModeler.restapi.externalDatabase.user":     "modeler-user",
+				"webModeler.restapi.externalDatabase.password": "modeler-password",
 			},
-		})
-}
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-func (s *restapiDeploymentTemplateTest) TestContainerExternalDatabasePasswordSecretRefForExistingSecretAndDefaultKey() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                                      "true",
-			"webModeler.restapi.mail.fromAddress":                     "example@example.com",
-			"postgresql.enabled":                                      "false",
-			"webModeler.restapi.externalDatabase.url":                 "jdbc:postgresql://postgres.example.com:65432/modeler-database",
-			"webModeler.restapi.externalDatabase.user":                "modeler-user",
-			"webModeler.restapi.externalDatabase.existingSecret.name": "my-secret",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-	s.Require().Contains(env,
-		corev1.EnvVar{
-			Name: "SPRING_DATASOURCE_PASSWORD",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"},
-					Key:                  "database-password",
-				},
+				// then
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env,
+					corev1.EnvVar{
+						Name: "SPRING_DATASOURCE_PASSWORD",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "camunda-platform-test-web-modeler-restapi"},
+								Key:                  "database-password",
+							},
+						},
+					})
 			},
-		})
-}
-
-func (s *restapiDeploymentTemplateTest) TestContainerExternalDatabasePasswordSecretRefForExistingSecretAndCustomKey() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                                            "true",
-			"webModeler.restapi.mail.fromAddress":                           "example@example.com",
-			"postgresql.enabled":                                            "false",
-			"webModeler.restapi.externalDatabase.url":                       "jdbc:postgresql://postgres.example.com:65432/modeler-database",
-			"webModeler.restapi.externalDatabase.user":                      "modeler-user",
-			"webModeler.restapi.externalDatabase.existingSecret.name":       "my-secret",
-			"webModeler.restapi.externalDatabase.existingSecretPasswordKey": "my-database-password-key",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-	s.Require().Contains(env,
-		corev1.EnvVar{
-			Name: "SPRING_DATASOURCE_PASSWORD",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"},
-					Key:                  "my-database-password-key",
-				},
+		}, {
+			Name: "TestContainerExternalDatabasePasswordSecretRefForExistingSecretAndDefaultKey",
+			Values: map[string]string{
+				"webModeler.enabled":                                      "true",
+				"webModeler.restapi.mail.fromAddress":                     "example@example.com",
+				"postgresql.enabled":                                      "false",
+				"webModeler.restapi.externalDatabase.url":                 "jdbc:postgresql://postgres.example.com:65432/modeler-database",
+				"webModeler.restapi.externalDatabase.user":                "modeler-user",
+				"webModeler.restapi.externalDatabase.existingSecret.name": "my-secret",
 			},
-		})
-}
-func (s *restapiDeploymentTemplateTest) TestContainerExternalDatabasePasswordExplicitlyDefinedStillReferencesInternalSecret() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                                 "true",
-			"webModeler.restapi.mail.fromAddress":                "example@example.com",
-			"postgresql.enabled":                                 "false",
-			"webModeler.restapi.externalDatabase.url":            "jdbc:postgresql://postgres.example.com:65432/modeler-database",
-			"webModeler.restapi.externalDatabase.user":           "modeler-user",
-			"webModeler.restapi.externalDatabase.existingSecret": "password1234",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-
-	s.Require().Contains(env,
-		corev1.EnvVar{
-			Name: "SPRING_DATASOURCE_PASSWORD",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "camunda-platform-test-web-modeler-restapi"},
-					Key:                  "database-password",
-				},
+				// then
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env,
+					corev1.EnvVar{
+						Name: "SPRING_DATASOURCE_PASSWORD",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"},
+								Key:                  "database-password",
+							},
+						},
+					})
 			},
-		})
-}
-
-func (s *restapiDeploymentTemplateTest) TestContainerInternalDatabasePasswordSecretRefForExistingSecretAndDefaultKey() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                  "true",
-			"webModeler.restapi.mail.fromAddress": "example@example.com",
-			"postgresql.enabled":                  "true",
-			"postgresql.auth.existingSecret":      "my-secret",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-	s.Require().Contains(env,
-		corev1.EnvVar{
-			Name: "SPRING_DATASOURCE_PASSWORD",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"},
-					Key:                  "password",
-				},
+		}, {
+			Name: "TestContainerExternalDatabasePasswordSecretRefForExistingSecretAndCustomKey",
+			Values: map[string]string{
+				"webModeler.enabled":                                            "true",
+				"webModeler.restapi.mail.fromAddress":                           "example@example.com",
+				"postgresql.enabled":                                            "false",
+				"webModeler.restapi.externalDatabase.url":                       "jdbc:postgresql://postgres.example.com:65432/modeler-database",
+				"webModeler.restapi.externalDatabase.user":                      "modeler-user",
+				"webModeler.restapi.externalDatabase.existingSecret.name":       "my-secret",
+				"webModeler.restapi.externalDatabase.existingSecretPasswordKey": "my-database-password-key",
 			},
-		})
-}
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-func (s *restapiDeploymentTemplateTest) TestContainerInternalDatabasePasswordSecretRefForExistingSecretAndCustomKey() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                         "true",
-			"webModeler.restapi.mail.fromAddress":        "example@example.com",
-			"postgresql.enabled":                         "true",
-			"postgresql.auth.existingSecret":             "my-secret",
-			"postgresql.auth.secretKeys.userPasswordKey": "my-database-password-key",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-	s.Require().Contains(env,
-		corev1.EnvVar{
-			Name: "SPRING_DATASOURCE_PASSWORD",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"},
-					Key:                  "my-database-password-key",
-				},
+				// then
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env,
+					corev1.EnvVar{
+						Name: "SPRING_DATASOURCE_PASSWORD",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"},
+								Key:                  "my-database-password-key",
+							},
+						},
+					})
 			},
-		})
-}
-
-func (s *restapiDeploymentTemplateTest) TestContainerSmtpPasswordSecretRefForGivenPassword() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                   "true",
-			"webModeler.restapi.mail.fromAddress":  "example@example.com",
-			"webModeler.restapi.mail.smtpUser":     "modeler-user",
-			"webModeler.restapi.mail.smtpPassword": "modeler-password",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-	s.Require().Contains(env,
-		corev1.EnvVar{
-			Name: "RESTAPI_MAIL_PASSWORD",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "camunda-platform-test-web-modeler-restapi"},
-					Key:                  "smtp-password",
-				},
+		}, {
+			Name: "TestContainerExternalDatabasePasswordExplicitlyDefinedStillReferencesInternalSecret",
+			Values: map[string]string{
+				"webModeler.enabled":                                 "true",
+				"webModeler.restapi.mail.fromAddress":                "example@example.com",
+				"postgresql.enabled":                                 "false",
+				"webModeler.restapi.externalDatabase.url":            "jdbc:postgresql://postgres.example.com:65432/modeler-database",
+				"webModeler.restapi.externalDatabase.user":           "modeler-user",
+				"webModeler.restapi.externalDatabase.existingSecret": "password1234",
 			},
-		})
-}
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-func (s *restapiDeploymentTemplateTest) TestContainerSmtpPasswordSecretRefForExistingSecretAndDefaultKey() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                          "true",
-			"webModeler.restapi.mail.fromAddress":         "example@example.com",
-			"webModeler.restapi.mail.smtpUser":            "modeler-user",
-			"webModeler.restapi.mail.existingSecret.name": "my-secret",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
+				// then
+				env := deployment.Spec.Template.Spec.Containers[0].Env
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-	s.Require().Contains(env,
-		corev1.EnvVar{
-			Name: "RESTAPI_MAIL_PASSWORD",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"},
-					Key:                  "smtp-password",
-				},
+				s.Require().Contains(env,
+					corev1.EnvVar{
+						Name: "SPRING_DATASOURCE_PASSWORD",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "camunda-platform-test-web-modeler-restapi"},
+								Key:                  "database-password",
+							},
+						},
+					})
 			},
-		})
-}
-
-func (s *restapiDeploymentTemplateTest) TestContainerSmtpPasswordSecretRefForExistingSecretAndCustomKey() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                                "true",
-			"webModeler.restapi.mail.fromAddress":               "example@example.com",
-			"webModeler.restapi.mail.smtpUser":                  "modeler-user",
-			"webModeler.restapi.mail.existingSecret.name":       "my-secret",
-			"webModeler.restapi.mail.existingSecretPasswordKey": "my-smtp-password-key",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-	s.Require().Contains(env,
-		corev1.EnvVar{
-			Name: "RESTAPI_MAIL_PASSWORD",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"},
-					Key:                  "my-smtp-password-key",
-				},
+		}, {
+			Name: "TestContainerInternalDatabasePasswordSecretRefForExistingSecretAndDefaultKey",
+			Values: map[string]string{
+				"webModeler.enabled":                  "true",
+				"webModeler.restapi.mail.fromAddress": "example@example.com",
+				"postgresql.enabled":                  "true",
+				"postgresql.auth.existingSecret":      "my-secret",
 			},
-		})
-}
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-func (s *restapiDeploymentTemplateTest) TestContainerStartupProbe() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                        "true",
-			"webModeler.restapi.mail.fromAddress":       "example@example.com",
-			"webModeler.restapi.startupProbe.enabled":   "true",
-			"webModeler.restapi.startupProbe.probePath": "/healthz",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
+				// then
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env,
+					corev1.EnvVar{
+						Name: "SPRING_DATASOURCE_PASSWORD",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"},
+								Key:                  "password",
+							},
+						},
+					})
+			},
+		}, {
+			Name: "TestContainerInternalDatabasePasswordSecretRefForExistingSecretAndCustomKey",
+			Values: map[string]string{
+				"webModeler.enabled":                         "true",
+				"webModeler.restapi.mail.fromAddress":        "example@example.com",
+				"postgresql.enabled":                         "true",
+				"postgresql.auth.existingSecret":             "my-secret",
+				"postgresql.auth.secretKeys.userPasswordKey": "my-database-password-key",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+				// then
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env,
+					corev1.EnvVar{
+						Name: "SPRING_DATASOURCE_PASSWORD",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"},
+								Key:                  "my-database-password-key",
+							},
+						},
+					})
+			},
+		}, {
+			Name: "TestContainerSmtpPasswordSecretRefForGivenPassword",
+			Values: map[string]string{
+				"webModeler.enabled":                   "true",
+				"webModeler.restapi.mail.fromAddress":  "example@example.com",
+				"webModeler.restapi.mail.smtpUser":     "modeler-user",
+				"webModeler.restapi.mail.smtpPassword": "modeler-password",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	// then
-	probe := deployment.Spec.Template.Spec.Containers[0].StartupProbe
+				// then
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env,
+					corev1.EnvVar{
+						Name: "RESTAPI_MAIL_PASSWORD",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "camunda-platform-test-web-modeler-restapi"},
+								Key:                  "smtp-password",
+							},
+						},
+					})
+			},
+		}, {
+			Name: "TestContainerSmtpPasswordSecretRefForExistingSecretAndDefaultKey",
+			Values: map[string]string{
+				"webModeler.enabled":                          "true",
+				"webModeler.restapi.mail.fromAddress":         "example@example.com",
+				"webModeler.restapi.mail.smtpUser":            "modeler-user",
+				"webModeler.restapi.mail.existingSecret.name": "my-secret",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	s.Require().Equal("/healthz", probe.HTTPGet.Path)
-	s.Require().Equal("http-management", probe.HTTPGet.Port.StrVal)
-}
+				// then
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env,
+					corev1.EnvVar{
+						Name: "RESTAPI_MAIL_PASSWORD",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"},
+								Key:                  "smtp-password",
+							},
+						},
+					})
+			},
+		}, {
+			Name: "TestContainerSmtpPasswordSecretRefForExistingSecretAndCustomKey",
+			Values: map[string]string{
+				"webModeler.enabled":                                "true",
+				"webModeler.restapi.mail.fromAddress":               "example@example.com",
+				"webModeler.restapi.mail.smtpUser":                  "modeler-user",
+				"webModeler.restapi.mail.existingSecret.name":       "my-secret",
+				"webModeler.restapi.mail.existingSecretPasswordKey": "my-smtp-password-key",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-func (s *restapiDeploymentTemplateTest) TestContainerReadinessProbe() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                          "true",
-			"webModeler.restapi.mail.fromAddress":         "example@example.com",
-			"webModeler.restapi.readinessProbe.enabled":   "true",
-			"webModeler.restapi.readinessProbe.probePath": "/healthz",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
+				// then
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env,
+					corev1.EnvVar{
+						Name: "RESTAPI_MAIL_PASSWORD",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "my-secret"},
+								Key:                  "my-smtp-password-key",
+							},
+						},
+					})
+			},
+		}, {
+			Name: "TestContainerStartupProbe",
+			Values: map[string]string{
+				"webModeler.enabled":                        "true",
+				"webModeler.restapi.mail.fromAddress":       "example@example.com",
+				"webModeler.restapi.startupProbe.enabled":   "true",
+				"webModeler.restapi.startupProbe.probePath": "/healthz",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+				// then
+				probe := deployment.Spec.Template.Spec.Containers[0].StartupProbe
 
-	// then
-	probe := deployment.Spec.Template.Spec.Containers[0].ReadinessProbe
+				s.Require().Equal("/healthz", probe.HTTPGet.Path)
+				s.Require().Equal("http-management", probe.HTTPGet.Port.StrVal)
+			},
+		}, {
+			Name: "TestContainerReadinessProbe",
+			Values: map[string]string{
+				"webModeler.enabled":                          "true",
+				"webModeler.restapi.mail.fromAddress":         "example@example.com",
+				"webModeler.restapi.readinessProbe.enabled":   "true",
+				"webModeler.restapi.readinessProbe.probePath": "/healthz",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	s.Require().Equal("/healthz", probe.HTTPGet.Path)
-	s.Require().Equal("http-management", probe.HTTPGet.Port.StrVal)
-}
+				// then
+				probe := deployment.Spec.Template.Spec.Containers[0].ReadinessProbe
 
-func (s *restapiDeploymentTemplateTest) TestContainerLivenessProbe() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                         "true",
-			"webModeler.restapi.mail.fromAddress":        "example@example.com",
-			"webModeler.restapi.livenessProbe.enabled":   "true",
-			"webModeler.restapi.livenessProbe.probePath": "/healthz",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
+				s.Require().Equal("/healthz", probe.HTTPGet.Path)
+				s.Require().Equal("http-management", probe.HTTPGet.Port.StrVal)
+			},
+		}, {
+			Name: "TestContainerLivenessProbe",
+			Values: map[string]string{
+				"webModeler.enabled":                         "true",
+				"webModeler.restapi.mail.fromAddress":        "example@example.com",
+				"webModeler.restapi.livenessProbe.enabled":   "true",
+				"webModeler.restapi.livenessProbe.probePath": "/healthz",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+				// then
+				probe := deployment.Spec.Template.Spec.Containers[0].LivenessProbe
 
-	// then
-	probe := deployment.Spec.Template.Spec.Containers[0].LivenessProbe
+				s.Require().Equal("/healthz", probe.HTTPGet.Path)
+				s.Require().Equal("http-management", probe.HTTPGet.Port.StrVal)
+			},
+		}, {
+			Name: "TestContainerProbesWithContextPath",
+			Values: map[string]string{
+				"webModeler.enabled":                          "true",
+				"webModeler.restapi.mail.fromAddress":         "example@example.com",
+				"webModeler.contextPath":                      "/test",
+				"webModeler.restapi.startupProbe.enabled":     "true",
+				"webModeler.restapi.startupProbe.probePath":   "/start",
+				"webModeler.restapi.readinessProbe.enabled":   "true",
+				"webModeler.restapi.readinessProbe.probePath": "/ready",
+				"webModeler.restapi.livenessProbe.enabled":    "true",
+				"webModeler.restapi.livenessProbe.probePath":  "/live",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	s.Require().Equal("/healthz", probe.HTTPGet.Path)
-	s.Require().Equal("http-management", probe.HTTPGet.Port.StrVal)
-}
+				// then
+				probe := deployment.Spec.Template.Spec.Containers[0]
 
-// Web-Modeler REST API doesn't use contextPath for health endpoints.
-func (s *restapiDeploymentTemplateTest) TestContainerProbesWithContextPath() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                          "true",
-			"webModeler.restapi.mail.fromAddress":         "example@example.com",
-			"webModeler.contextPath":                      "/test",
-			"webModeler.restapi.startupProbe.enabled":     "true",
-			"webModeler.restapi.startupProbe.probePath":   "/start",
-			"webModeler.restapi.readinessProbe.enabled":   "true",
-			"webModeler.restapi.readinessProbe.probePath": "/ready",
-			"webModeler.restapi.livenessProbe.enabled":    "true",
-			"webModeler.restapi.livenessProbe.probePath":  "/live",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
+				s.Require().Equal("/start", probe.StartupProbe.HTTPGet.Path)
+				s.Require().Equal("/ready", probe.ReadinessProbe.HTTPGet.Path)
+				s.Require().Equal("/live", probe.LivenessProbe.HTTPGet.Path)
+			},
+		}, {
+			Name: "TestContainerSetSidecar",
+			Values: map[string]string{
+				"webModeler.enabled":                                    "true",
+				"webModeler.restapi.mail.fromAddress":                   "example@example.com",
+				"webModeler.restapi.sidecars[0].name":                   "nginx",
+				"webModeler.restapi.sidecars[0].image":                  "nginx:latest",
+				"webModeler.restapi.sidecars[0].ports[0].containerPort": "80",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+				// then
+				podContainers := deployment.Spec.Template.Spec.Containers
+				expectedContainer := corev1.Container{
+					Name:  "nginx",
+					Image: "nginx:latest",
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: 80,
+						},
+					},
+				}
 
-	// then
-	probe := deployment.Spec.Template.Spec.Containers[0]
+				s.Require().Contains(podContainers, expectedContainer)
+			},
+		}, {
+			// Web-Modeler REST API doesn't use contextPath for health endpoints.
+			Name: "TestContainerSetInitContainer",
+			Values: map[string]string{
+				"webModeler.enabled":                                          "true",
+				"webModeler.restapi.mail.fromAddress":                         "example@example.com",
+				"webModeler.restapi.initContainers[0].name":                   "nginx",
+				"webModeler.restapi.initContainers[0].image":                  "nginx:latest",
+				"webModeler.restapi.initContainers[0].ports[0].containerPort": "80",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	s.Require().Equal("/start", probe.StartupProbe.HTTPGet.Path)
-	s.Require().Equal("/ready", probe.ReadinessProbe.HTTPGet.Path)
-	s.Require().Equal("/live", probe.LivenessProbe.HTTPGet.Path)
-}
+				// then
+				podContainers := deployment.Spec.Template.Spec.InitContainers
+				expectedContainer := corev1.Container{
+					Name:  "nginx",
+					Image: "nginx:latest",
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: 80,
+						},
+					},
+				}
 
-func (s *restapiDeploymentTemplateTest) TestContainerSetSidecar() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                                    "true",
-			"webModeler.restapi.mail.fromAddress":                   "example@example.com",
-			"webModeler.restapi.sidecars[0].name":                   "nginx",
-			"webModeler.restapi.sidecars[0].image":                  "nginx:latest",
-			"webModeler.restapi.sidecars[0].ports[0].containerPort": "80",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
+				s.Require().Contains(podContainers, expectedContainer)
+			},
+		}, {
+			Name: "TestSetDnsPolicyAndDnsConfig",
+			Values: map[string]string{
+				"webModeler.enabled":                          "true",
+				"webModeler.restapi.mail.fromAddress":         "example@example.com",
+				"webModeler.restapi.dnsPolicy":                "ClusterFirst",
+				"webModeler.restapi.dnsConfig.nameservers[0]": "8.8.8.8",
+				"webModeler.restapi.dnsConfig.searches[0]":    "example.com",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+				// then
+				// Check if dnsPolicy is set
+				require.NotEmpty(s.T(), deployment.Spec.Template.Spec.DNSPolicy, "dnsPolicy should not be empty")
 
-	// then
-	podContainers := deployment.Spec.Template.Spec.Containers
-	expectedContainer := corev1.Container{
-		Name:  "nginx",
-		Image: "nginx:latest",
-		Ports: []corev1.ContainerPort{
-			{
-				ContainerPort: 80,
+				// Check if dnsConfig is set
+				require.NotNil(s.T(), deployment.Spec.Template.Spec.DNSConfig, "dnsConfig should not be nil")
+
+				expectedDNSConfig := &corev1.PodDNSConfig{
+					Nameservers: []string{"8.8.8.8"},
+					Searches:    []string{"example.com"},
+				}
+
+				require.Equal(s.T(), expectedDNSConfig, deployment.Spec.Template.Spec.DNSConfig, "dnsConfig should match the expected configuration")
 			},
 		},
 	}
 
-	s.Require().Contains(podContainers, expectedContainer)
-}
-
-func (s *restapiDeploymentTemplateTest) TestContainerSetInitContainer() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                                          "true",
-			"webModeler.restapi.mail.fromAddress":                         "example@example.com",
-			"webModeler.restapi.initContainers[0].name":                   "nginx",
-			"webModeler.restapi.initContainers[0].image":                  "nginx:latest",
-			"webModeler.restapi.initContainers[0].ports[0].containerPort": "80",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	podContainers := deployment.Spec.Template.Spec.InitContainers
-	expectedContainer := corev1.Container{
-		Name:  "nginx",
-		Image: "nginx:latest",
-		Ports: []corev1.ContainerPort{
-			{
-				ContainerPort: 80,
-			},
-		},
-	}
-
-	s.Require().Contains(podContainers, expectedContainer)
-}
-func (s *restapiDeploymentTemplateTest) TestSetDnsPolicyAndDnsConfig() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                          "true",
-			"webModeler.restapi.mail.fromAddress":         "example@example.com",
-			"webModeler.restapi.dnsPolicy":                "ClusterFirst",
-			"webModeler.restapi.dnsConfig.nameservers[0]": "8.8.8.8",
-			"webModeler.restapi.dnsConfig.searches[0]":    "example.com",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	// Check if dnsPolicy is set
-	require.NotEmpty(s.T(), deployment.Spec.Template.Spec.DNSPolicy, "dnsPolicy should not be empty")
-
-	// Check if dnsConfig is set
-	require.NotNil(s.T(), deployment.Spec.Template.Spec.DNSConfig, "dnsConfig should not be nil")
-
-	expectedDNSConfig := &corev1.PodDNSConfig{
-		Nameservers: []string{"8.8.8.8"},
-		Searches:    []string{"example.com"},
-	}
-
-	require.Equal(s.T(), expectedDNSConfig, deployment.Spec.Template.Spec.DNSConfig, "dnsConfig should match the expected configuration")
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }

--- a/charts/camunda-platform-8.6/test/unit/web-modeler/deployment_test.go
+++ b/charts/camunda-platform-8.6/test/unit/web-modeler/deployment_test.go
@@ -15,6 +15,7 @@
 package web_modeler
 
 import (
+	"camunda-platform/test/unit/testhelpers"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -29,7 +30,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 )
 
-type deploymentTemplateTest struct {
+type DeploymentTemplateTest struct {
 	suite.Suite
 	chartPath string
 	release   string
@@ -46,7 +47,7 @@ func TestDeploymentTemplate(t *testing.T) {
 	components := []string{"restapi", "webapp", "websockets"}
 
 	for _, component := range components {
-		suite.Run(t, &deploymentTemplateTest{
+		suite.Run(t, &DeploymentTemplateTest{
 			chartPath: chartPath,
 			release:   "camunda-platform-test",
 			namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
@@ -56,677 +57,508 @@ func TestDeploymentTemplate(t *testing.T) {
 	}
 }
 
-func (s *deploymentTemplateTest) TestContainerOverrideAppName() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                  "true",
-			"webModeler.restapi.mail.fromAddress": "example@example.com",
-			"webModeler.nameOverride":             "foo",
+func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestContainerOverrideAppName",
+			Values: map[string]string{
+				"webModeler.enabled":                  "true",
+				"webModeler.restapi.mail.fromAddress": "example@example.com",
+				"webModeler.nameOverride":             "foo",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				s.Require().Equal("camunda-platform-test-foo-"+s.component, deployment.ObjectMeta.Name)
+			},
+		}, {
+			Name: "TestContainerOverrideAppFullname",
+			Values: map[string]string{
+				"webModeler.enabled":                  "true",
+				"webModeler.restapi.mail.fromAddress": "example@example.com",
+				"webModeler.fullnameOverride":         "foo",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				s.Require().Equal("foo-"+s.component, deployment.ObjectMeta.Name)
+			},
+		}, {
+			Name: "TestContainerSetPodLabels",
+			Values: map[string]string{
+				"webModeler.enabled":                           "true",
+				"webModeler.restapi.mail.fromAddress":          "example@example.com",
+				"webModeler." + s.component + ".podLabels.foo": "bar",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				s.Require().Equal("bar", deployment.Spec.Template.Labels["foo"])
+			},
+		}, {
+			Name: "TestContainerSetPodAnnotations",
+			Values: map[string]string{
+				"webModeler.enabled":                                "true",
+				"webModeler.restapi.mail.fromAddress":               "example@example.com",
+				"webModeler." + s.component + ".podAnnotations.foo": "bar",
+				"webModeler." + s.component + ".podAnnotations.foz": "baz",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				s.Require().Equal("bar", deployment.Spec.Template.Annotations["foo"])
+				s.Require().Equal("baz", deployment.Spec.Template.Annotations["foz"])
+			},
+		}, {
+			Name: "TestContainerSetGlobalAnnotations",
+			Values: map[string]string{
+				"webModeler.enabled":                  "true",
+				"webModeler.restapi.mail.fromAddress": "example@example.com",
+				"global.annotations.foo":              "bar",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				s.Require().Equal("bar", deployment.ObjectMeta.Annotations["foo"])
+			},
+		}, {
+			Name: "TestContainerSetImageNameSubChart",
+			Values: map[string]string{
+				"webModeler.enabled":                              "true",
+				"webModeler.restapi.mail.fromAddress":             "example@example.com",
+				"global.image.registry":                           "global.custom.registry.io",
+				"global.image.tag":                                "8.x.x",
+				"webModeler.image.registry":                       "subchart.custom.registry.io",
+				"webModeler.image.tag":                            "snapshot",
+				"webModeler." + s.component + ".image.repository": "web-modeler/modeler-" + s.component,
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				container := deployment.Spec.Template.Spec.Containers[0]
+				s.Require().Equal("subchart.custom.registry.io/web-modeler/modeler-"+s.component+":snapshot", container.Image)
+			},
+		}, {
+			Name: "TestContainerSetImageNameGlobalRegistry",
+			Values: map[string]string{
+				"webModeler.enabled":                              "true",
+				"webModeler.restapi.mail.fromAddress":             "example@example.com",
+				"global.image.registry":                           "global.custom.registry.io",
+				"webModeler.image.registry":                       "",
+				"webModeler.image.tag":                            "snapshot",
+				"webModeler." + s.component + ".image.repository": "web-modeler/modeler-" + s.component,
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				container := deployment.Spec.Template.Spec.Containers[0]
+				s.Require().Equal("global.custom.registry.io/web-modeler/modeler-"+s.component+":snapshot", container.Image)
+			},
+		}, {
+			Name: "TestContainerSetImagePullSecretsGlobal",
+			Values: map[string]string{
+				"webModeler.enabled":                  "true",
+				"webModeler.restapi.mail.fromAddress": "example@example.com",
+				"global.image.pullSecrets[0].name":    "SecretName",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				s.Require().Equal("SecretName", deployment.Spec.Template.Spec.ImagePullSecrets[0].Name)
+			},
+		}, {
+			Name: "TestContainerSetImagePullSecretsSubChart",
+			Values: map[string]string{
+				"webModeler.enabled":                   "true",
+				"webModeler.restapi.mail.fromAddress":  "example@example.com",
+				"global.image.pullSecrets[0].name":     "SecretName",
+				"webModeler.image.pullSecrets[0].name": "SecretNameSubChart",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				s.Require().Equal("SecretNameSubChart", deployment.Spec.Template.Spec.ImagePullSecrets[0].Name)
+			},
+		}, {
+			Name: "TestContainerOverwriteImageTag",
+			Values: map[string]string{
+				"webModeler.enabled":                  "true",
+				"webModeler.restapi.mail.fromAddress": "example@example.com",
+				"webModeler.image.tag":                "a.b.c",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				expectedContainerImage := "camunda/web-modeler-" + s.component + ":a.b.c"
+				containers := deployment.Spec.Template.Spec.Containers
+				s.Require().Equal(1, len(containers))
+				s.Require().Equal(expectedContainerImage, containers[0].Image)
+			},
+		}, {
+			Name: "TestContainerOverwriteGlobalImageTag",
+			Values: map[string]string{
+				"webModeler.enabled":                  "true",
+				"webModeler.restapi.mail.fromAddress": "example@example.com",
+				"webModeler.image.tag":                "",
+				"global.image.tag":                    "a.b.c",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				expectedContainerImage := "camunda/web-modeler-" + s.component + ":a.b.c"
+				containers := deployment.Spec.Template.Spec.Containers
+				s.Require().Equal(1, len(containers))
+				s.Require().Equal(expectedContainerImage, containers[0].Image)
+			},
+		}, {
+			Name: "TestContainerOverwriteImageTagWithChartDirectSetting",
+			Values: map[string]string{
+				"webModeler.enabled":                  "true",
+				"webModeler.restapi.mail.fromAddress": "example@example.com",
+				"webModeler.image.tag":                "a.b.c",
+				"global.image.tag":                    "x.y.z",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				expectedContainerImage := "camunda/web-modeler-" + s.component + ":a.b.c"
+				containers := deployment.Spec.Template.Spec.Containers
+				s.Require().Equal(1, len(containers))
+				s.Require().Equal(expectedContainerImage, containers[0].Image)
+			},
+		}, {
+			Name: "TestContainerSetContainerCommand",
+			Values: map[string]string{
+				"webModeler.enabled":                        "true",
+				"webModeler.restapi.mail.fromAddress":       "example@example.com",
+				"webModeler." + s.component + ".command[0]": "printenv",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				containers := deployment.Spec.Template.Spec.Containers
+				s.Require().Equal(1, len(containers))
+				s.Require().Equal(1, len(containers[0].Command))
+				s.Require().Equal("printenv", containers[0].Command[0])
+			},
+		}, {
+			Name: "TestContainerSetExtraVolumes",
+			Values: map[string]string{
+				"webModeler.enabled":                                                   "true",
+				"webModeler.restapi.mail.fromAddress":                                  "example@example.com",
+				"webModeler." + s.component + ".extraVolumes[0].name":                  "extraVolume",
+				"webModeler." + s.component + ".extraVolumes[0].configMap.name":        "otherConfigMap",
+				"webModeler." + s.component + ".extraVolumes[0].configMap.defaultMode": "744",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				// finding out the length of volumes array before addition of new volume
+				optionsBefore := &helm.Options{
+					SetValues: map[string]string{
+						"webModeler.enabled":                  "true",
+						"webModeler.restapi.mail.fromAddress": "example@example.com",
+					},
+					KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+				}
+				var deploymentBefore appsv1.Deployment
+				before := helm.RenderTemplate(s.T(), optionsBefore, s.chartPath, s.release, s.templates)
+				helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
+				volumeLenBefore := len(deploymentBefore.Spec.Template.Spec.Volumes)
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				volumes := deployment.Spec.Template.Spec.Volumes
+				s.Require().Equal(volumeLenBefore+1, len(volumes))
+
+				extraVolume := volumes[volumeLenBefore]
+				s.Require().Equal("extraVolume", extraVolume.Name)
+				s.Require().NotNil(*extraVolume.ConfigMap)
+				s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
+				s.Require().EqualValues(744, *extraVolume.ConfigMap.DefaultMode)
+			},
+		}, {
+			Name: "TestContainerSetExtraVolumeMounts",
+			Values: map[string]string{
+				"webModeler.enabled":                                            "true",
+				"webModeler.restapi.mail.fromAddress":                           "example@example.com",
+				"webModeler." + s.component + ".extraVolumeMounts[0].name":      "otherConfigMap",
+				"webModeler." + s.component + ".extraVolumeMounts[0].mountPath": "/usr/local/config",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				// finding out the length of containers and volumeMounts array before addition of new volumeMount
+				optionsBefore := &helm.Options{
+					SetValues: map[string]string{
+						"webModeler.enabled":                  "true",
+						"webModeler.restapi.mail.fromAddress": "example@example.com",
+					},
+					KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+				}
+				var deploymentBefore appsv1.Deployment
+				before := helm.RenderTemplate(s.T(), optionsBefore, s.chartPath, s.release, s.templates)
+				helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
+				containerLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers)
+				volumeMountLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				containers := deployment.Spec.Template.Spec.Containers
+				s.Require().Equal(containerLenBefore, len(containers))
+
+				volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
+				s.Require().Equal(volumeMountLenBefore+1, len(volumeMounts))
+				extraVolumeMount := volumeMounts[volumeMountLenBefore]
+				s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
+				s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
+			},
+		}, {
+			Name: "TestContainerSetServiceAccountName",
+			Values: map[string]string{
+				"webModeler.enabled":                  "true",
+				"webModeler.restapi.mail.fromAddress": "example@example.com",
+				"webModeler.serviceAccount.name":      "accName",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				serviceAccName := deployment.Spec.Template.Spec.ServiceAccountName
+				s.Require().Equal("accName", serviceAccName)
+			},
+		}, {
+			Name: "TestPodSetSecurityContext",
+			Values: map[string]string{
+				"webModeler.enabled":                                          "true",
+				"webModeler.restapi.mail.fromAddress":                         "example@example.com",
+				"webModeler." + s.component + ".podSecurityContext.runAsUser": "1000",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				securityContext := deployment.Spec.Template.Spec.SecurityContext
+				s.Require().EqualValues(1000, *securityContext.RunAsUser)
+			},
+		}, {
+			Name: "TestContainerSetSecurityContext",
+			Values: map[string]string{
+				"webModeler.enabled":                                                 "true",
+				"webModeler.restapi.mail.fromAddress":                                "example@example.com",
+				"webModeler." + s.component + ".containerSecurityContext.privileged": "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				securityContext := deployment.Spec.Template.Spec.Containers[0].SecurityContext
+				s.Require().True(*securityContext.Privileged)
+			},
+		}, {
+			// https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+			Name: "TestContainerSetNodeSelector",
+			Values: map[string]string{
+				"webModeler.enabled":                                   "true",
+				"webModeler.restapi.mail.fromAddress":                  "example@example.com",
+				"webModeler." + s.component + ".nodeSelector.disktype": "ssd",
+				"webModeler." + s.component + ".nodeSelector.cputype":  "arm",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				s.Require().Equal("ssd", deployment.Spec.Template.Spec.NodeSelector["disktype"])
+				s.Require().Equal("arm", deployment.Spec.Template.Spec.NodeSelector["cputype"])
+			},
+		}, {
+			// https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+			Name: "TestContainerSetAffinity",
+			Values: map[string]string{
+				"webModeler.enabled":                  "true",
+				"webModeler.restapi.mail.fromAddress": "example@example.com",
+				"webModeler." + s.component + ".affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].key":       "kubernetes.io/e2e-az-name",
+				"webModeler." + s.component + ".affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].operator":  "In",
+				"webModeler." + s.component + ".affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].values[0]": "e2e-a1",
+				"webModeler." + s.component + ".affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].values[1]": "e2e-a2",
+				"webModeler." + s.component + ".affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight":                                         "1",
+				"webModeler." + s.component + ".affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].key":             "another-node-label-key",
+				"webModeler." + s.component + ".affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].operator":        "In",
+				"webModeler." + s.component + ".affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].values[0]":       "another-node-label-value",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				nodeAffinity := deployment.Spec.Template.Spec.Affinity.NodeAffinity
+				s.Require().NotNil(nodeAffinity)
+
+				nodeSelectorTerm := nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0]
+				s.Require().NotNil(nodeSelectorTerm)
+				matchExpression := nodeSelectorTerm.MatchExpressions[0]
+				s.Require().NotNil(matchExpression)
+				s.Require().Equal("kubernetes.io/e2e-az-name", matchExpression.Key)
+				s.Require().EqualValues("In", matchExpression.Operator)
+				s.Require().Equal([]string{"e2e-a1", "e2e-a2"}, matchExpression.Values)
+
+				preferredSchedulingTerm := nodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0]
+				s.Require().NotNil(preferredSchedulingTerm)
+
+				matchExpression = preferredSchedulingTerm.Preference.MatchExpressions[0]
+				s.Require().NotNil(matchExpression)
+				s.Require().Equal("another-node-label-key", matchExpression.Key)
+				s.Require().EqualValues("In", matchExpression.Operator)
+				s.Require().Equal([]string{"another-node-label-value"}, matchExpression.Values)
+			},
+		}, {
+			// https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration
+			Name: "TestContainerSetTolerations",
+			Values: map[string]string{
+				"webModeler.enabled":                                     "true",
+				"webModeler.restapi.mail.fromAddress":                    "example@example.com",
+				"webModeler." + s.component + ".tolerations[0].key":      "key1",
+				"webModeler." + s.component + ".tolerations[0].operator": "Equal",
+				"webModeler." + s.component + ".tolerations[0].value":    "Value1",
+				"webModeler." + s.component + ".tolerations[0].effect":   "NoSchedule",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				tolerations := deployment.Spec.Template.Spec.Tolerations
+				s.Require().Equal(1, len(tolerations))
+
+				toleration := tolerations[0]
+				s.Require().Equal("key1", toleration.Key)
+				s.Require().EqualValues("Equal", toleration.Operator)
+				s.Require().Equal("Value1", toleration.Value)
+				s.Require().EqualValues("NoSchedule", toleration.Effect)
+			},
+		}, {
+			Name: "TestContainerShouldOverwriteGlobalImagePullPolicy",
+			Values: map[string]string{
+				"webModeler.enabled":                  "true",
+				"webModeler.restapi.mail.fromAddress": "example@example.com",
+				"global.image.pullPolicy":             "Always",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				expectedPullPolicy := corev1.PullAlways
+				containers := deployment.Spec.Template.Spec.Containers
+				s.Require().Equal(1, len(containers))
+				pullPolicy := containers[0].ImagePullPolicy
+				s.Require().Equal(expectedPullPolicy, pullPolicy)
+			},
+		}, {
+			Name: "TestContainerStartupProbe",
+			Values: map[string]string{
+				"webModeler.enabled":                                              "true",
+				"webModeler.restapi.mail.fromAddress":                             "example@example.com",
+				"webModeler." + s.component + ".startupProbe.enabled":             "true",
+				"webModeler." + s.component + ".startupProbe.initialDelaySeconds": "5",
+				"webModeler." + s.component + ".startupProbe.periodSeconds":       "10",
+				"webModeler." + s.component + ".startupProbe.successThreshold":    "1",
+				"webModeler." + s.component + ".startupProbe.failureThreshold":    "5",
+				"webModeler." + s.component + ".startupProbe.timeoutSeconds":      "1",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				probe := deployment.Spec.Template.Spec.Containers[0].StartupProbe
+
+				s.Require().EqualValues(5, probe.InitialDelaySeconds)
+				s.Require().EqualValues(10, probe.PeriodSeconds)
+				s.Require().EqualValues(1, probe.SuccessThreshold)
+				s.Require().EqualValues(5, probe.FailureThreshold)
+				s.Require().EqualValues(1, probe.TimeoutSeconds)
+			},
+		}, {
+			Name: "TestContainerReadinessProbe",
+			Values: map[string]string{
+				"webModeler.enabled":                                                "true",
+				"webModeler.restapi.mail.fromAddress":                               "example@example.com",
+				"webModeler." + s.component + ".readinessProbe.enabled":             "true",
+				"webModeler." + s.component + ".readinessProbe.initialDelaySeconds": "5",
+				"webModeler." + s.component + ".readinessProbe.periodSeconds":       "10",
+				"webModeler." + s.component + ".readinessProbe.successThreshold":    "1",
+				"webModeler." + s.component + ".readinessProbe.failureThreshold":    "5",
+				"webModeler." + s.component + ".readinessProbe.timeoutSeconds":      "1",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				probe := deployment.Spec.Template.Spec.Containers[0].ReadinessProbe
+
+				s.Require().EqualValues(5, probe.InitialDelaySeconds)
+				s.Require().EqualValues(10, probe.PeriodSeconds)
+				s.Require().EqualValues(1, probe.SuccessThreshold)
+				s.Require().EqualValues(5, probe.FailureThreshold)
+				s.Require().EqualValues(1, probe.TimeoutSeconds)
+			},
+		}, {
+			Name: "TestContainerLivenessProbe",
+			Values: map[string]string{
+				"webModeler.enabled":                                               "true",
+				"webModeler.restapi.mail.fromAddress":                              "example@example.com",
+				"webModeler." + s.component + ".livenessProbe.enabled":             "true",
+				"webModeler." + s.component + ".livenessProbe.initialDelaySeconds": "5",
+				"webModeler." + s.component + ".livenessProbe.periodSeconds":       "10",
+				"webModeler." + s.component + ".livenessProbe.successThreshold":    "1",
+				"webModeler." + s.component + ".livenessProbe.failureThreshold":    "5",
+				"webModeler." + s.component + ".livenessProbe.timeoutSeconds":      "1",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				probe := deployment.Spec.Template.Spec.Containers[0].LivenessProbe
+
+				s.Require().EqualValues(5, probe.InitialDelaySeconds)
+				s.Require().EqualValues(10, probe.PeriodSeconds)
+				s.Require().EqualValues(1, probe.SuccessThreshold)
+				s.Require().EqualValues(5, probe.FailureThreshold)
+				s.Require().EqualValues(1, probe.TimeoutSeconds)
+			},
 		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 	}
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	s.Require().Equal("camunda-platform-test-foo-"+s.component, deployment.ObjectMeta.Name)
-}
-
-func (s *deploymentTemplateTest) TestContainerOverrideAppFullname() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                  "true",
-			"webModeler.restapi.mail.fromAddress": "example@example.com",
-			"webModeler.fullnameOverride":         "foo",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	s.Require().Equal("foo-"+s.component, deployment.ObjectMeta.Name)
-}
-
-func (s *deploymentTemplateTest) TestContainerSetPodLabels() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                           "true",
-			"webModeler.restapi.mail.fromAddress":          "example@example.com",
-			"webModeler." + s.component + ".podLabels.foo": "bar",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	s.Require().Equal("bar", deployment.Spec.Template.Labels["foo"])
-}
-
-func (s *deploymentTemplateTest) TestContainerSetPodAnnotations() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                                "true",
-			"webModeler.restapi.mail.fromAddress":               "example@example.com",
-			"webModeler." + s.component + ".podAnnotations.foo": "bar",
-			"webModeler." + s.component + ".podAnnotations.foz": "baz",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	s.Require().Equal("bar", deployment.Spec.Template.Annotations["foo"])
-	s.Require().Equal("baz", deployment.Spec.Template.Annotations["foz"])
-}
-
-func (s *deploymentTemplateTest) TestContainerSetGlobalAnnotations() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                  "true",
-			"webModeler.restapi.mail.fromAddress": "example@example.com",
-			"global.annotations.foo":              "bar",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	s.Require().Equal("bar", deployment.ObjectMeta.Annotations["foo"])
-}
-
-func (s *deploymentTemplateTest) TestContainerSetImageNameSubChart() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                              "true",
-			"webModeler.restapi.mail.fromAddress":             "example@example.com",
-			"global.image.registry":                           "global.custom.registry.io",
-			"global.image.tag":                                "8.x.x",
-			"webModeler.image.registry":                       "subchart.custom.registry.io",
-			"webModeler.image.tag":                            "snapshot",
-			"webModeler." + s.component + ".image.repository": "web-modeler/modeler-" + s.component,
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	container := deployment.Spec.Template.Spec.Containers[0]
-	s.Require().Equal("subchart.custom.registry.io/web-modeler/modeler-"+s.component+":snapshot", container.Image)
-}
-
-func (s *deploymentTemplateTest) TestContainerSetImageNameGlobalRegistry() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                              "true",
-			"webModeler.restapi.mail.fromAddress":             "example@example.com",
-			"global.image.registry":                           "global.custom.registry.io",
-			"webModeler.image.registry":                       "",
-			"webModeler.image.tag":                            "snapshot",
-			"webModeler." + s.component + ".image.repository": "web-modeler/modeler-" + s.component,
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	container := deployment.Spec.Template.Spec.Containers[0]
-	s.Require().Equal("global.custom.registry.io/web-modeler/modeler-"+s.component+":snapshot", container.Image)
-}
-
-func (s *deploymentTemplateTest) TestContainerSetImagePullSecretsGlobal() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                  "true",
-			"webModeler.restapi.mail.fromAddress": "example@example.com",
-			"global.image.pullSecrets[0].name":    "SecretName",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	s.Require().Equal("SecretName", deployment.Spec.Template.Spec.ImagePullSecrets[0].Name)
-}
-
-func (s *deploymentTemplateTest) TestContainerSetImagePullSecretsSubChart() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                   "true",
-			"webModeler.restapi.mail.fromAddress":  "example@example.com",
-			"global.image.pullSecrets[0].name":     "SecretName",
-			"webModeler.image.pullSecrets[0].name": "SecretNameSubChart",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	s.Require().Equal("SecretNameSubChart", deployment.Spec.Template.Spec.ImagePullSecrets[0].Name)
-}
-
-func (s *deploymentTemplateTest) TestContainerOverwriteImageTag() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                  "true",
-			"webModeler.restapi.mail.fromAddress": "example@example.com",
-			"webModeler.image.tag":                "a.b.c",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	expectedContainerImage := "camunda/web-modeler-" + s.component + ":a.b.c"
-	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
-	s.Require().Equal(expectedContainerImage, containers[0].Image)
-}
-
-func (s *deploymentTemplateTest) TestContainerOverwriteGlobalImageTag() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                  "true",
-			"webModeler.restapi.mail.fromAddress": "example@example.com",
-			"webModeler.image.tag":                "",
-			"global.image.tag":                    "a.b.c",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	expectedContainerImage := "camunda/web-modeler-" + s.component + ":a.b.c"
-	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
-	s.Require().Equal(expectedContainerImage, containers[0].Image)
-}
-
-func (s *deploymentTemplateTest) TestContainerOverwriteImageTagWithChartDirectSetting() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                  "true",
-			"webModeler.restapi.mail.fromAddress": "example@example.com",
-			"webModeler.image.tag":                "a.b.c",
-			"global.image.tag":                    "x.y.z",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	expectedContainerImage := "camunda/web-modeler-" + s.component + ":a.b.c"
-	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
-	s.Require().Equal(expectedContainerImage, containers[0].Image)
-}
-
-func (s *deploymentTemplateTest) TestContainerSetContainerCommand() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                        "true",
-			"webModeler.restapi.mail.fromAddress":       "example@example.com",
-			"webModeler." + s.component + ".command[0]": "printenv",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
-	s.Require().Equal(1, len(containers[0].Command))
-	s.Require().Equal("printenv", containers[0].Command[0])
-}
-
-func (s *deploymentTemplateTest) TestContainerSetExtraVolumes() {
-	//finding out the length of volumes array before addition of new volume
-	optionsBefore := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                  "true",
-			"webModeler.restapi.mail.fromAddress": "example@example.com",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-	var deploymentBefore appsv1.Deployment
-	before := helm.RenderTemplate(s.T(), optionsBefore, s.chartPath, s.release, s.templates)
-	helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
-	volumeLenBefore := len(deploymentBefore.Spec.Template.Spec.Volumes)
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                                                   "true",
-			"webModeler.restapi.mail.fromAddress":                                  "example@example.com",
-			"webModeler." + s.component + ".extraVolumes[0].name":                  "extraVolume",
-			"webModeler." + s.component + ".extraVolumes[0].configMap.name":        "otherConfigMap",
-			"webModeler." + s.component + ".extraVolumes[0].configMap.defaultMode": "744",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	volumes := deployment.Spec.Template.Spec.Volumes
-	s.Require().Equal(volumeLenBefore+1, len(volumes))
-
-	extraVolume := volumes[volumeLenBefore]
-	s.Require().Equal("extraVolume", extraVolume.Name)
-	s.Require().NotNil(*extraVolume.ConfigMap)
-	s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
-	s.Require().EqualValues(744, *extraVolume.ConfigMap.DefaultMode)
-}
-
-func (s *deploymentTemplateTest) TestContainerSetExtraVolumeMounts() {
-	//finding out the length of containers and volumeMounts array before addition of new volumeMount
-	optionsBefore := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                  "true",
-			"webModeler.restapi.mail.fromAddress": "example@example.com",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-	var deploymentBefore appsv1.Deployment
-	before := helm.RenderTemplate(s.T(), optionsBefore, s.chartPath, s.release, s.templates)
-	helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
-	containerLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers)
-	volumeMountLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                                            "true",
-			"webModeler.restapi.mail.fromAddress":                           "example@example.com",
-			"webModeler." + s.component + ".extraVolumeMounts[0].name":      "otherConfigMap",
-			"webModeler." + s.component + ".extraVolumeMounts[0].mountPath": "/usr/local/config",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(containerLenBefore, len(containers))
-
-	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(volumeMountLenBefore+1, len(volumeMounts))
-	extraVolumeMount := volumeMounts[volumeMountLenBefore]
-	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
-	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
-}
-
-func (s *deploymentTemplateTest) TestContainerSetServiceAccountName() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                  "true",
-			"webModeler.restapi.mail.fromAddress": "example@example.com",
-			"webModeler.serviceAccount.name":      "accName",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	serviceAccName := deployment.Spec.Template.Spec.ServiceAccountName
-	s.Require().Equal("accName", serviceAccName)
-}
-
-func (s *deploymentTemplateTest) TestPodSetSecurityContext() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                                          "true",
-			"webModeler.restapi.mail.fromAddress":                         "example@example.com",
-			"webModeler." + s.component + ".podSecurityContext.runAsUser": "1000",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	securityContext := deployment.Spec.Template.Spec.SecurityContext
-	s.Require().EqualValues(1000, *securityContext.RunAsUser)
-}
-
-func (s *deploymentTemplateTest) TestContainerSetSecurityContext() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                                                          "true",
-			"webModeler.restapi.mail.fromAddress":                                         "example@example.com",
-			"webModeler." + s.component + ".containerSecurityContext.privileged":          "true",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	securityContext := deployment.Spec.Template.Spec.Containers[0].SecurityContext
-	s.Require().True(*securityContext.Privileged)
-}
-
-// https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
-func (s *deploymentTemplateTest) TestContainerSetNodeSelector() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                                   "true",
-			"webModeler.restapi.mail.fromAddress":                  "example@example.com",
-			"webModeler." + s.component + ".nodeSelector.disktype": "ssd",
-			"webModeler." + s.component + ".nodeSelector.cputype":  "arm",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	s.Require().Equal("ssd", deployment.Spec.Template.Spec.NodeSelector["disktype"])
-	s.Require().Equal("arm", deployment.Spec.Template.Spec.NodeSelector["cputype"])
-}
-
-// https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
-func (s *deploymentTemplateTest) TestContainerSetAffinity() {
-	// given
-
-	//affinity:
-	//	nodeAffinity:
-	//	 requiredDuringSchedulingIgnoredDuringExecution:
-	//	   nodeSelectorTerms:
-	//	   - matchExpressions:
-	//		 - key: kubernetes.io/e2e-az-name
-	//		   operator: In
-	//		   values:
-	//		   - e2e-az1
-	//		   - e2e-az2
-	//	 preferredDuringSchedulingIgnoredDuringExecution:
-	//	 - weight: 1
-	//	   preference:
-	//		 matchExpressions:
-	//		 - key: another-node-label-key
-	//		   operator: In
-	//		   values:
-	//		   - another-node-label-value
-
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                  "true",
-			"webModeler.restapi.mail.fromAddress": "example@example.com",
-			"webModeler." + s.component + ".affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].key":       "kubernetes.io/e2e-az-name",
-			"webModeler." + s.component + ".affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].operator":  "In",
-			"webModeler." + s.component + ".affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].values[0]": "e2e-a1",
-			"webModeler." + s.component + ".affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].values[1]": "e2e-a2",
-			"webModeler." + s.component + ".affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight":                                         "1",
-			"webModeler." + s.component + ".affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].key":             "another-node-label-key",
-			"webModeler." + s.component + ".affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].operator":        "In",
-			"webModeler." + s.component + ".affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].values[0]":       "another-node-label-value",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	nodeAffinity := deployment.Spec.Template.Spec.Affinity.NodeAffinity
-	s.Require().NotNil(nodeAffinity)
-
-	nodeSelectorTerm := nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0]
-	s.Require().NotNil(nodeSelectorTerm)
-	matchExpression := nodeSelectorTerm.MatchExpressions[0]
-	s.Require().NotNil(matchExpression)
-	s.Require().Equal("kubernetes.io/e2e-az-name", matchExpression.Key)
-	s.Require().EqualValues("In", matchExpression.Operator)
-	s.Require().Equal([]string{"e2e-a1", "e2e-a2"}, matchExpression.Values)
-
-	preferredSchedulingTerm := nodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0]
-	s.Require().NotNil(preferredSchedulingTerm)
-
-	matchExpression = preferredSchedulingTerm.Preference.MatchExpressions[0]
-	s.Require().NotNil(matchExpression)
-	s.Require().Equal("another-node-label-key", matchExpression.Key)
-	s.Require().EqualValues("In", matchExpression.Operator)
-	s.Require().Equal([]string{"another-node-label-value"}, matchExpression.Values)
-}
-
-// https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration
-func (s *deploymentTemplateTest) TestContainerSetTolerations() {
-	// given
-
-	//tolerations:
-	//- key: "key1"
-	//  operator: "Equal"
-	//  value: "value1"
-	//  effect: "NoSchedule"
-
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                                     "true",
-			"webModeler.restapi.mail.fromAddress":                    "example@example.com",
-			"webModeler." + s.component + ".tolerations[0].key":      "key1",
-			"webModeler." + s.component + ".tolerations[0].operator": "Equal",
-			"webModeler." + s.component + ".tolerations[0].value":    "Value1",
-			"webModeler." + s.component + ".tolerations[0].effect":   "NoSchedule",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	tolerations := deployment.Spec.Template.Spec.Tolerations
-	s.Require().Equal(1, len(tolerations))
-
-	toleration := tolerations[0]
-	s.Require().Equal("key1", toleration.Key)
-	s.Require().EqualValues("Equal", toleration.Operator)
-	s.Require().Equal("Value1", toleration.Value)
-	s.Require().EqualValues("NoSchedule", toleration.Effect)
-}
-
-func (s *deploymentTemplateTest) TestContainerShouldOverwriteGlobalImagePullPolicy() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                  "true",
-			"webModeler.restapi.mail.fromAddress": "example@example.com",
-			"global.image.pullPolicy":             "Always",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	expectedPullPolicy := corev1.PullAlways
-	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
-	pullPolicy := containers[0].ImagePullPolicy
-	s.Require().Equal(expectedPullPolicy, pullPolicy)
-}
-
-func (s *deploymentTemplateTest) TestContainerStartupProbe() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                                              "true",
-			"webModeler.restapi.mail.fromAddress":                             "example@example.com",
-			"webModeler." + s.component + ".startupProbe.enabled":             "true",
-			"webModeler." + s.component + ".startupProbe.initialDelaySeconds": "5",
-			"webModeler." + s.component + ".startupProbe.periodSeconds":       "10",
-			"webModeler." + s.component + ".startupProbe.successThreshold":    "1",
-			"webModeler." + s.component + ".startupProbe.failureThreshold":    "5",
-			"webModeler." + s.component + ".startupProbe.timeoutSeconds":      "1",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	probe := deployment.Spec.Template.Spec.Containers[0].StartupProbe
-
-	s.Require().EqualValues(5, probe.InitialDelaySeconds)
-	s.Require().EqualValues(10, probe.PeriodSeconds)
-	s.Require().EqualValues(1, probe.SuccessThreshold)
-	s.Require().EqualValues(5, probe.FailureThreshold)
-	s.Require().EqualValues(1, probe.TimeoutSeconds)
-}
-
-func (s *deploymentTemplateTest) TestContainerReadinessProbe() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                                                "true",
-			"webModeler.restapi.mail.fromAddress":                               "example@example.com",
-			"webModeler." + s.component + ".readinessProbe.enabled":             "true",
-			"webModeler." + s.component + ".readinessProbe.initialDelaySeconds": "5",
-			"webModeler." + s.component + ".readinessProbe.periodSeconds":       "10",
-			"webModeler." + s.component + ".readinessProbe.successThreshold":    "1",
-			"webModeler." + s.component + ".readinessProbe.failureThreshold":    "5",
-			"webModeler." + s.component + ".readinessProbe.timeoutSeconds":      "1",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	probe := deployment.Spec.Template.Spec.Containers[0].ReadinessProbe
-
-	s.Require().EqualValues(5, probe.InitialDelaySeconds)
-	s.Require().EqualValues(10, probe.PeriodSeconds)
-	s.Require().EqualValues(1, probe.SuccessThreshold)
-	s.Require().EqualValues(5, probe.FailureThreshold)
-	s.Require().EqualValues(1, probe.TimeoutSeconds)
-}
-
-func (s *deploymentTemplateTest) TestContainerLivenessProbe() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                                               "true",
-			"webModeler.restapi.mail.fromAddress":                              "example@example.com",
-			"webModeler." + s.component + ".livenessProbe.enabled":             "true",
-			"webModeler." + s.component + ".livenessProbe.initialDelaySeconds": "5",
-			"webModeler." + s.component + ".livenessProbe.periodSeconds":       "10",
-			"webModeler." + s.component + ".livenessProbe.successThreshold":    "1",
-			"webModeler." + s.component + ".livenessProbe.failureThreshold":    "5",
-			"webModeler." + s.component + ".livenessProbe.timeoutSeconds":      "1",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	probe := deployment.Spec.Template.Spec.Containers[0].LivenessProbe
-
-	s.Require().EqualValues(5, probe.InitialDelaySeconds)
-	s.Require().EqualValues(10, probe.PeriodSeconds)
-	s.Require().EqualValues(1, probe.SuccessThreshold)
-	s.Require().EqualValues(5, probe.FailureThreshold)
-	s.Require().EqualValues(1, probe.TimeoutSeconds)
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }

--- a/charts/camunda-platform-8.6/test/unit/web-modeler/deployment_webapp_test.go
+++ b/charts/camunda-platform-8.6/test/unit/web-modeler/deployment_webapp_test.go
@@ -15,6 +15,7 @@
 package web_modeler
 
 import (
+	"camunda-platform/test/unit/testhelpers"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -22,14 +23,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	appsv1 "k8s.io/api/apps/v1"
 )
 
-type webappDeploymentTemplateTest struct {
+type WebappDeploymentTemplateTest struct {
 	suite.Suite
 	chartPath string
 	release   string
@@ -43,7 +43,7 @@ func TestWebappDeploymentTemplate(t *testing.T) {
 	chartPath, err := filepath.Abs("../../../")
 	require.NoError(t, err)
 
-	suite.Run(t, &webappDeploymentTemplateTest{
+	suite.Run(t, &WebappDeploymentTemplateTest{
 		chartPath: chartPath,
 		release:   "camunda-platform-test",
 		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
@@ -51,204 +51,169 @@ func TestWebappDeploymentTemplate(t *testing.T) {
 	})
 }
 
-func (s *webappDeploymentTemplateTest) TestContainerStartupProbe() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                       "true",
-			"webModeler.restapi.mail.fromAddress":      "example@example.com",
-			"webModeler.webapp.startupProbe.enabled":   "true",
-			"webModeler.webapp.startupProbe.probePath": "/healthz",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
+func (s *WebappDeploymentTemplateTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestContainerStartupProbe",
+			Values: map[string]string{
+				"webModeler.enabled":                       "true",
+				"webModeler.restapi.mail.fromAddress":      "example@example.com",
+				"webModeler.webapp.startupProbe.enabled":   "true",
+				"webModeler.webapp.startupProbe.probePath": "/healthz",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+				// then
+				probe := deployment.Spec.Template.Spec.Containers[0].StartupProbe
 
-	// then
-	probe := deployment.Spec.Template.Spec.Containers[0].StartupProbe
+				s.Require().Equal("/healthz", probe.HTTPGet.Path)
+				s.Require().Equal("http-management", probe.HTTPGet.Port.StrVal)
+			},
+		}, {
+			Name: "TestContainerReadinessProbe",
+			Values: map[string]string{
+				"webModeler.enabled":                         "true",
+				"webModeler.restapi.mail.fromAddress":        "example@example.com",
+				"webModeler.webapp.readinessProbe.enabled":   "true",
+				"webModeler.webapp.readinessProbe.probePath": "/healthz",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	s.Require().Equal("/healthz", probe.HTTPGet.Path)
-	s.Require().Equal("http-management", probe.HTTPGet.Port.StrVal)
-}
+				// then
+				probe := deployment.Spec.Template.Spec.Containers[0].ReadinessProbe
 
-func (s *webappDeploymentTemplateTest) TestContainerReadinessProbe() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                         "true",
-			"webModeler.restapi.mail.fromAddress":        "example@example.com",
-			"webModeler.webapp.readinessProbe.enabled":   "true",
-			"webModeler.webapp.readinessProbe.probePath": "/healthz",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
+				s.Require().Equal("/healthz", probe.HTTPGet.Path)
+				s.Require().Equal("http-management", probe.HTTPGet.Port.StrVal)
+			},
+		}, {
+			Name: "TestContainerLivenessProbe",
+			Values: map[string]string{
+				"webModeler.enabled":                        "true",
+				"webModeler.restapi.mail.fromAddress":       "example@example.com",
+				"webModeler.webapp.livenessProbe.enabled":   "true",
+				"webModeler.webapp.livenessProbe.probePath": "/healthz",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+				// then
+				probe := deployment.Spec.Template.Spec.Containers[0].LivenessProbe
 
-	// then
-	probe := deployment.Spec.Template.Spec.Containers[0].ReadinessProbe
+				s.Require().Equal("/healthz", probe.HTTPGet.Path)
+				s.Require().Equal("http-management", probe.HTTPGet.Port.StrVal)
+			},
+		}, {
+			Name: "TestContainerProbesWithContextPath",
+			Values: map[string]string{
+				"webModeler.enabled":                         "true",
+				"webModeler.restapi.mail.fromAddress":        "example@example.com",
+				"webModeler.contextPath":                     "/test",
+				"webModeler.webapp.startupProbe.enabled":     "true",
+				"webModeler.webapp.startupProbe.probePath":   "/start",
+				"webModeler.webapp.readinessProbe.enabled":   "true",
+				"webModeler.webapp.readinessProbe.probePath": "/ready",
+				"webModeler.webapp.livenessProbe.enabled":    "true",
+				"webModeler.webapp.livenessProbe.probePath":  "/live",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	s.Require().Equal("/healthz", probe.HTTPGet.Path)
-	s.Require().Equal("http-management", probe.HTTPGet.Port.StrVal)
-}
+				// then
+				probe := deployment.Spec.Template.Spec.Containers[0]
 
-func (s *webappDeploymentTemplateTest) TestContainerLivenessProbe() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                        "true",
-			"webModeler.restapi.mail.fromAddress":       "example@example.com",
-			"webModeler.webapp.livenessProbe.enabled":   "true",
-			"webModeler.webapp.livenessProbe.probePath": "/healthz",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
+				s.Require().Equal("/start", probe.StartupProbe.HTTPGet.Path)
+				s.Require().Equal("/ready", probe.ReadinessProbe.HTTPGet.Path)
+				s.Require().Equal("/live", probe.LivenessProbe.HTTPGet.Path)
+			},
+		}, {
+			Name: "TestContainerSetSidecar",
+			Values: map[string]string{
+				"webModeler.enabled":                                   "true",
+				"webModeler.restapi.mail.fromAddress":                  "example@example.com",
+				"webModeler.webapp.sidecars[0].name":                   "nginx",
+				"webModeler.webapp.sidecars[0].image":                  "nginx:latest",
+				"webModeler.webapp.sidecars[0].ports[0].containerPort": "80",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+				// then
+				podContainers := deployment.Spec.Template.Spec.Containers
+				expectedContainer := corev1.Container{
+					Name:  "nginx",
+					Image: "nginx:latest",
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: 80,
+						},
+					},
+				}
 
-	// then
-	probe := deployment.Spec.Template.Spec.Containers[0].LivenessProbe
+				s.Require().Contains(podContainers, expectedContainer)
+			},
+		}, {
+			Name: "TestContainerSetInitContainer",
+			Values: map[string]string{
+				"webModeler.enabled":                                         "true",
+				"webModeler.restapi.mail.fromAddress":                        "example@example.com",
+				"webModeler.webapp.initContainers[0].name":                   "nginx",
+				"webModeler.webapp.initContainers[0].image":                  "nginx:latest",
+				"webModeler.webapp.initContainers[0].ports[0].containerPort": "80",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	s.Require().Equal("/healthz", probe.HTTPGet.Path)
-	s.Require().Equal("http-management", probe.HTTPGet.Port.StrVal)
-}
+				// then
+				podContainers := deployment.Spec.Template.Spec.InitContainers
+				expectedContainer := corev1.Container{
+					Name:  "nginx",
+					Image: "nginx:latest",
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: 80,
+						},
+					},
+				}
 
-// Web-Modeler WebApp doesn't support contextPath for health endpoints.
-func (s *webappDeploymentTemplateTest) TestContainerProbesWithContextPath() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                         "true",
-			"webModeler.restapi.mail.fromAddress":        "example@example.com",
-			"webModeler.contextPath":                     "/test",
-			"webModeler.webapp.startupProbe.enabled":     "true",
-			"webModeler.webapp.startupProbe.probePath":   "/start",
-			"webModeler.webapp.readinessProbe.enabled":   "true",
-			"webModeler.webapp.readinessProbe.probePath": "/ready",
-			"webModeler.webapp.livenessProbe.enabled":    "true",
-			"webModeler.webapp.livenessProbe.probePath":  "/live",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
+				s.Require().Contains(podContainers, expectedContainer)
+			},
+		}, {
+			Name: "TestSetDnsPolicyAndDnsConfig",
+			Values: map[string]string{
+				"webModeler.enabled":                         "true",
+				"webModeler.restapi.mail.fromAddress":        "example@example.com",
+				"webModeler.webapp.dnsPolicy":                "ClusterFirst",
+				"webModeler.webapp.dnsConfig.nameservers[0]": "8.8.8.8",
+				"webModeler.webapp.dnsConfig.searches[0]":    "example.com",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+				// then
+				// Check if dnsPolicy is set
+				require.NotEmpty(s.T(), deployment.Spec.Template.Spec.DNSPolicy, "dnsPolicy should not be empty")
 
-	// then
-	probe := deployment.Spec.Template.Spec.Containers[0]
+				// Check if dnsConfig is set
+				require.NotNil(s.T(), deployment.Spec.Template.Spec.DNSConfig, "dnsConfig should not be nil")
 
-	s.Require().Equal("/start", probe.StartupProbe.HTTPGet.Path)
-	s.Require().Equal("/ready", probe.ReadinessProbe.HTTPGet.Path)
-	s.Require().Equal("/live", probe.LivenessProbe.HTTPGet.Path)
-}
+				expectedDNSConfig := &corev1.PodDNSConfig{
+					Nameservers: []string{"8.8.8.8"},
+					Searches:    []string{"example.com"},
+				}
 
-func (s *webappDeploymentTemplateTest) TestContainerSetSidecar() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                                   "true",
-			"webModeler.restapi.mail.fromAddress":                  "example@example.com",
-			"webModeler.webapp.sidecars[0].name":                   "nginx",
-			"webModeler.webapp.sidecars[0].image":                  "nginx:latest",
-			"webModeler.webapp.sidecars[0].ports[0].containerPort": "80",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	podContainers := deployment.Spec.Template.Spec.Containers
-	expectedContainer := corev1.Container{
-		Name:  "nginx",
-		Image: "nginx:latest",
-		Ports: []corev1.ContainerPort{
-			{
-				ContainerPort: 80,
+				require.Equal(s.T(), expectedDNSConfig, deployment.Spec.Template.Spec.DNSConfig, "dnsConfig should match the expected configuration")
 			},
 		},
 	}
 
-	s.Require().Contains(podContainers, expectedContainer)
-}
-
-func (s *webappDeploymentTemplateTest) TestContainerSetInitContainer() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                                         "true",
-			"webModeler.restapi.mail.fromAddress":                        "example@example.com",
-			"webModeler.webapp.initContainers[0].name":                   "nginx",
-			"webModeler.webapp.initContainers[0].image":                  "nginx:latest",
-			"webModeler.webapp.initContainers[0].ports[0].containerPort": "80",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	podContainers := deployment.Spec.Template.Spec.InitContainers
-	expectedContainer := corev1.Container{
-		Name:  "nginx",
-		Image: "nginx:latest",
-		Ports: []corev1.ContainerPort{
-			{
-				ContainerPort: 80,
-			},
-		},
-	}
-
-	s.Require().Contains(podContainers, expectedContainer)
-}
-func (s *webappDeploymentTemplateTest) TestSetDnsPolicyAndDnsConfig() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                         "true",
-			"webModeler.restapi.mail.fromAddress":        "example@example.com",
-			"webModeler.webapp.dnsPolicy":                "ClusterFirst",
-			"webModeler.webapp.dnsConfig.nameservers[0]": "8.8.8.8",
-			"webModeler.webapp.dnsConfig.searches[0]":    "example.com",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	// Check if dnsPolicy is set
-	require.NotEmpty(s.T(), deployment.Spec.Template.Spec.DNSPolicy, "dnsPolicy should not be empty")
-
-	// Check if dnsConfig is set
-	require.NotNil(s.T(), deployment.Spec.Template.Spec.DNSConfig, "dnsConfig should not be nil")
-
-	expectedDNSConfig := &corev1.PodDNSConfig{
-		Nameservers: []string{"8.8.8.8"},
-		Searches:    []string{"example.com"},
-	}
-
-	require.Equal(s.T(), expectedDNSConfig, deployment.Spec.Template.Spec.DNSConfig, "dnsConfig should match the expected configuration")
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }

--- a/charts/camunda-platform-8.6/test/unit/web-modeler/deployment_websockets_test.go
+++ b/charts/camunda-platform-8.6/test/unit/web-modeler/deployment_websockets_test.go
@@ -15,6 +15,7 @@
 package web_modeler
 
 import (
+	"camunda-platform/test/unit/testhelpers"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -22,14 +23,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	appsv1 "k8s.io/api/apps/v1"
 )
 
-type websocketsDeploymentTemplateTest struct {
+type WebsocketsDeploymentTemplateTest struct {
 	suite.Suite
 	chartPath string
 	release   string
@@ -43,7 +43,7 @@ func TestWebsocketsDeploymentTemplate(t *testing.T) {
 	chartPath, err := filepath.Abs("../../../")
 	require.NoError(t, err)
 
-	suite.Run(t, &websocketsDeploymentTemplateTest{
+	suite.Run(t, &WebsocketsDeploymentTemplateTest{
 		chartPath: chartPath,
 		release:   "camunda-platform-test",
 		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
@@ -51,191 +51,158 @@ func TestWebsocketsDeploymentTemplate(t *testing.T) {
 	})
 }
 
-func (s *websocketsDeploymentTemplateTest) TestContainerSetPusherAppPathIfGlobalIngressEnabled() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                  "true",
-			"webModeler.restapi.mail.fromAddress": "example@example.com",
-			"webModeler.ingress.enabled":          "false",
-			"webModeler.contextPath":              "/modeler",
-			"global.ingress.enabled":              "true",
-			"global.ingress.host":                 "c8.example.com",
-			"global.ingress.tls.enabled":          "false",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
+func (s *WebsocketsDeploymentTemplateTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestContainerSetPusherAppPathIfGlobalIngressEnabled",
+			Values: map[string]string{
+				"webModeler.enabled":                  "true",
+				"webModeler.restapi.mail.fromAddress": "example@example.com",
+				"webModeler.ingress.enabled":          "false",
+				"webModeler.contextPath":              "/modeler",
+				"global.ingress.enabled":              "true",
+				"global.ingress.host":                 "c8.example.com",
+				"global.ingress.tls.enabled":          "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+				// then
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env, corev1.EnvVar{Name: "PUSHER_APP_PATH", Value: "/modeler-ws"})
+			},
+		}, {
+			Name: "TestContainerStartupProbe",
+			Values: map[string]string{
+				"webModeler.enabled":                         "true",
+				"webModeler.restapi.mail.fromAddress":        "example@example.com",
+				"webModeler.websockets.startupProbe.enabled": "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-	s.Require().Contains(env, corev1.EnvVar{Name: "PUSHER_APP_PATH", Value: "/modeler-ws"})
-}
+				// then
+				probe := deployment.Spec.Template.Spec.Containers[0].StartupProbe
 
-func (s *websocketsDeploymentTemplateTest) TestContainerStartupProbe() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                         "true",
-			"webModeler.restapi.mail.fromAddress":        "example@example.com",
-			"webModeler.websockets.startupProbe.enabled": "true",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
+				s.Require().Equal("http", probe.TCPSocket.Port.StrVal)
+			},
+		}, {
+			Name: "TestContainerReadinessProbe",
+			Values: map[string]string{
+				"webModeler.enabled":                           "true",
+				"webModeler.restapi.mail.fromAddress":          "example@example.com",
+				"webModeler.websockets.readinessProbe.enabled": "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+				// then
+				probe := deployment.Spec.Template.Spec.Containers[0].ReadinessProbe
 
-	// then
-	probe := deployment.Spec.Template.Spec.Containers[0].StartupProbe
+				s.Require().Equal("http", probe.TCPSocket.Port.StrVal)
+			},
+		}, {
+			Name: "TestContainerLivenessProbe",
+			Values: map[string]string{
+				"webModeler.enabled":                          "true",
+				"webModeler.restapi.mail.fromAddress":         "example@example.com",
+				"webModeler.websockets.livenessProbe.enabled": "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	s.Require().Equal("http", probe.TCPSocket.Port.StrVal)
-}
+				// then
+				probe := deployment.Spec.Template.Spec.Containers[0].LivenessProbe
 
-func (s *websocketsDeploymentTemplateTest) TestContainerReadinessProbe() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                           "true",
-			"webModeler.restapi.mail.fromAddress":          "example@example.com",
-			"webModeler.websockets.readinessProbe.enabled": "true",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
+				s.Require().Equal("http", probe.TCPSocket.Port.StrVal)
+			},
+		}, {
+			Name: "TestContainerSetSidecar",
+			Values: map[string]string{
+				"webModeler.enabled":                                       "true",
+				"webModeler.restapi.mail.fromAddress":                      "example@example.com",
+				"webModeler.websockets.sidecars[0].name":                   "nginx",
+				"webModeler.websockets.sidecars[0].image":                  "nginx:latest",
+				"webModeler.websockets.sidecars[0].ports[0].containerPort": "80",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+				// then
+				podContainers := deployment.Spec.Template.Spec.Containers
+				expectedContainer := corev1.Container{
+					Name:  "nginx",
+					Image: "nginx:latest",
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: 80,
+						},
+					},
+				}
 
-	// then
-	probe := deployment.Spec.Template.Spec.Containers[0].ReadinessProbe
+				s.Require().Contains(podContainers, expectedContainer)
+			},
+		}, {
+			Name: "TestContainerSetInitContainer",
+			Values: map[string]string{
+				"webModeler.enabled":                                             "true",
+				"webModeler.restapi.mail.fromAddress":                            "example@example.com",
+				"webModeler.websockets.initContainers[0].name":                   "nginx",
+				"webModeler.websockets.initContainers[0].image":                  "nginx:latest",
+				"webModeler.websockets.initContainers[0].ports[0].containerPort": "80",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	s.Require().Equal("http", probe.TCPSocket.Port.StrVal)
-}
+				// then
+				podContainers := deployment.Spec.Template.Spec.InitContainers
+				expectedContainer := corev1.Container{
+					Name:  "nginx",
+					Image: "nginx:latest",
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: 80,
+						},
+					},
+				}
 
-func (s *websocketsDeploymentTemplateTest) TestContainerLivenessProbe() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                          "true",
-			"webModeler.restapi.mail.fromAddress":         "example@example.com",
-			"webModeler.websockets.livenessProbe.enabled": "true",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
+				s.Require().Contains(podContainers, expectedContainer)
+			},
+		}, {
+			Name: "TestSetDnsPolicyAndDnsConfig",
+			Values: map[string]string{
+				"webModeler.enabled":                             "true",
+				"webModeler.restapi.mail.fromAddress":            "example@example.com",
+				"webModeler.websockets.dnsPolicy":                "ClusterFirst",
+				"webModeler.websockets.dnsConfig.nameservers[0]": "8.8.8.8",
+				"webModeler.websockets.dnsConfig.searches[0]":    "example.com",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+				// then
+				// Check if dnsPolicy is set
+				require.NotEmpty(s.T(), deployment.Spec.Template.Spec.DNSPolicy, "dnsPolicy should not be empty")
 
-	// then
-	probe := deployment.Spec.Template.Spec.Containers[0].LivenessProbe
+				// Check if dnsConfig is set
+				require.NotNil(s.T(), deployment.Spec.Template.Spec.DNSConfig, "dnsConfig should not be nil")
 
-	s.Require().Equal("http", probe.TCPSocket.Port.StrVal)
-}
+				expectedDNSConfig := &corev1.PodDNSConfig{
+					Nameservers: []string{"8.8.8.8"},
+					Searches:    []string{"example.com"},
+				}
 
-func (s *websocketsDeploymentTemplateTest) TestContainerSetSidecar() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                                       "true",
-			"webModeler.restapi.mail.fromAddress":                      "example@example.com",
-			"webModeler.websockets.sidecars[0].name":                   "nginx",
-			"webModeler.websockets.sidecars[0].image":                  "nginx:latest",
-			"webModeler.websockets.sidecars[0].ports[0].containerPort": "80",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	podContainers := deployment.Spec.Template.Spec.Containers
-	expectedContainer := corev1.Container{
-		Name:  "nginx",
-		Image: "nginx:latest",
-		Ports: []corev1.ContainerPort{
-			{
-				ContainerPort: 80,
+				require.Equal(s.T(), expectedDNSConfig, deployment.Spec.Template.Spec.DNSConfig, "dnsConfig should match the expected configuration")
 			},
 		},
 	}
 
-	s.Require().Contains(podContainers, expectedContainer)
-}
-
-func (s *websocketsDeploymentTemplateTest) TestContainerSetInitContainer() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                                             "true",
-			"webModeler.restapi.mail.fromAddress":                            "example@example.com",
-			"webModeler.websockets.initContainers[0].name":                   "nginx",
-			"webModeler.websockets.initContainers[0].image":                  "nginx:latest",
-			"webModeler.websockets.initContainers[0].ports[0].containerPort": "80",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	podContainers := deployment.Spec.Template.Spec.InitContainers
-	expectedContainer := corev1.Container{
-		Name:  "nginx",
-		Image: "nginx:latest",
-		Ports: []corev1.ContainerPort{
-			{
-				ContainerPort: 80,
-			},
-		},
-	}
-
-	s.Require().Contains(podContainers, expectedContainer)
-}
-func (s *websocketsDeploymentTemplateTest) TestSetDnsPolicyAndDnsConfig() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                             "true",
-			"webModeler.restapi.mail.fromAddress":            "example@example.com",
-			"webModeler.websockets.dnsPolicy":                "ClusterFirst",
-			"webModeler.websockets.dnsConfig.nameservers[0]": "8.8.8.8",
-			"webModeler.websockets.dnsConfig.searches[0]":    "example.com",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	// Check if dnsPolicy is set
-	require.NotEmpty(s.T(), deployment.Spec.Template.Spec.DNSPolicy, "dnsPolicy should not be empty")
-
-	// Check if dnsConfig is set
-	require.NotNil(s.T(), deployment.Spec.Template.Spec.DNSConfig, "dnsConfig should not be nil")
-
-	expectedDNSConfig := &corev1.PodDNSConfig{
-		Nameservers: []string{"8.8.8.8"},
-		Searches:    []string{"example.com"},
-	}
-
-	require.Equal(s.T(), expectedDNSConfig, deployment.Spec.Template.Spec.DNSConfig, "dnsConfig should match the expected configuration")
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }

--- a/charts/camunda-platform-8.6/test/unit/web-modeler/secret_restapi_test.go
+++ b/charts/camunda-platform-8.6/test/unit/web-modeler/secret_restapi_test.go
@@ -15,19 +15,19 @@
 package web_modeler
 
 import (
+	"camunda-platform/test/unit/testhelpers"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	coreV1 "k8s.io/api/core/v1"
 )
 
-type secretTest struct {
+type SecretTest struct {
 	suite.Suite
 	chartPath string
 	release   string
@@ -41,7 +41,7 @@ func TestSecretRestapiTemplate(t *testing.T) {
 	chartPath, err := filepath.Abs("../../../")
 	require.NoError(t, err)
 
-	suite.Run(t, &secretTest{
+	suite.Run(t, &SecretTest{
 		chartPath: chartPath,
 		release:   "camunda-platform-test",
 		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
@@ -49,170 +49,134 @@ func TestSecretRestapiTemplate(t *testing.T) {
 	})
 }
 
-func (s *secretTest) TestContainerCreateExternalDatabasePasswordSecret() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                           "true",
-			"webModeler.restapi.mail.fromAddress":          "example@example.com",
-			"postgresql.enabled":                           "false",
-			"webModeler.restapi.externalDatabase.password": "secret123",
+func (s *SecretTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestContainerCreateExternalDatabasePasswordSecret",
+			Values: map[string]string{
+				"webModeler.enabled":                           "true",
+				"webModeler.restapi.mail.fromAddress":          "example@example.com",
+				"postgresql.enabled":                           "false",
+				"webModeler.restapi.externalDatabase.password": "secret123",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var secret coreV1.Secret
+				helm.UnmarshalK8SYaml(s.T(), output, &secret)
+
+				// then
+				s.Require().NotNil(secret.Data)
+				s.Require().Equal("secret123", string(secret.Data["database-password"]))
+			},
+		}, {
+			Name: "TestContainerCreateSmtpPasswordSecret",
+			Values: map[string]string{
+				"webModeler.enabled":                   "true",
+				"webModeler.restapi.mail.fromAddress":  "example@example.com",
+				"webModeler.restapi.mail.smtpPassword": "secret123",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var secret coreV1.Secret
+				helm.UnmarshalK8SYaml(s.T(), output, &secret)
+
+				// then
+				s.Require().NotNil(secret.Data)
+				s.Require().Equal("secret123", string(secret.Data["smtp-password"]))
+			},
+		}, {
+			Name: "TestDatabaseSecretAddedViaName",
+			Values: map[string]string{
+				"webModeler.enabled":                                      "true",
+				"webModeler.restapi.mail.fromAddress":                     "example@example.com",
+				"webModeler.restapi.mail.smtpPassword":                    "secret123",
+				"webModeler.restapi.externalDatabase.existingSecret.name": "example-secret",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var secret coreV1.Secret
+				helm.UnmarshalK8SYaml(s.T(), output, &secret)
+
+				// then
+				s.Require().NotNil(secret.Data)
+				_, databaseSecretKeyExists := secret.Data["database-password"]
+				s.Require().False(databaseSecretKeyExists)
+			},
+		}, {
+			Name: "TestDatabaseSecretAddedViaDirectPassword",
+			Values: map[string]string{
+				"webModeler.enabled":                                 "true",
+				"webModeler.restapi.mail.fromAddress":                "example@example.com",
+				"webModeler.restapi.mail.smtpPassword":               "secret123",
+				"webModeler.restapi.externalDatabase.existingSecret": "password1234",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var secret coreV1.Secret
+				helm.UnmarshalK8SYaml(s.T(), output, &secret)
+
+				// then
+				s.Require().Equal("password1234", string(secret.Data["database-password"]))
+			},
+		}, {
+			Name: "TestDatabaseSecretAddedViaDirectPasswordUsingOldSyntax",
+			Values: map[string]string{
+				"webModeler.enabled":                           "true",
+				"webModeler.restapi.mail.fromAddress":          "example@example.com",
+				"webModeler.restapi.mail.smtpPassword":         "secret123",
+				"webModeler.restapi.externalDatabase.password": "password1234",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var secret coreV1.Secret
+				helm.UnmarshalK8SYaml(s.T(), output, &secret)
+
+				// then
+				s.Require().Equal("password1234", string(secret.Data["database-password"]))
+			},
+		}, {
+			Name: "TestSmtpSecretAddedViaDirectPassword",
+			Values: map[string]string{
+				"webModeler.enabled":                                 "true",
+				"webModeler.restapi.mail.fromAddress":                "example@example.com",
+				"webModeler.restapi.mail.existingSecret":             "password1234",
+				"webModeler.restapi.externalDatabase.existingSecret": "otherPassword1234",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var secret coreV1.Secret
+				helm.UnmarshalK8SYaml(s.T(), output, &secret)
+
+				// then
+				s.Require().Equal("password1234", string(secret.Data["smtp-password"]))
+			},
+		}, {
+			Name: "TestSmtpSecretNotAddedWhenSecretNameSpecified",
+			Values: map[string]string{
+				"webModeler.enabled":                                 "true",
+				"webModeler.restapi.mail.fromAddress":                "example@example.com",
+				"webModeler.restapi.externalDatabase.existingSecret": "password1234",
+				"webModeler.restapi.mail.existingSecret.name":        "mail-secret",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var secret coreV1.Secret
+				helm.UnmarshalK8SYaml(s.T(), output, &secret)
+
+				// then
+				_, exists := secret.Data["smtp-password"]
+				s.Require().False(exists)
+			},
+		}, {
+			Name: "TestSmtpSecretViaPasswordKeyWhenSecretNameSpecified",
+			Values: map[string]string{
+				"webModeler.enabled":                                 "true",
+				"webModeler.restapi.mail.fromAddress":                "example@example.com",
+				"webModeler.restapi.externalDatabase.existingSecret": "password1234",
+				"webModeler.restapi.mail.smtpPassword":               "password12345",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var secret coreV1.Secret
+				helm.UnmarshalK8SYaml(s.T(), output, &secret)
+
+				// then
+				s.Require().Equal("password12345", string(secret.Data["smtp-password"]))
+			},
 		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 	}
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var secret coreV1.Secret
-	helm.UnmarshalK8SYaml(s.T(), output, &secret)
-
-	// then
-	s.Require().NotNil(secret.Data)
-	s.Require().Equal("secret123", string(secret.Data["database-password"]))
-}
-
-func (s *secretTest) TestContainerCreateSmtpPasswordSecret() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                   "true",
-			"webModeler.restapi.mail.fromAddress":  "example@example.com",
-			"webModeler.restapi.mail.smtpPassword": "secret123",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var secret coreV1.Secret
-	helm.UnmarshalK8SYaml(s.T(), output, &secret)
-
-	// then
-	s.Require().NotNil(secret.Data)
-	s.Require().Equal("secret123", string(secret.Data["smtp-password"]))
-}
-func (s *secretTest) TestDatabaseSecretAddedViaName() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                                      "true",
-			"webModeler.restapi.mail.fromAddress":                     "example@example.com",
-			"webModeler.restapi.mail.smtpPassword":                    "secret123",
-			"webModeler.restapi.externalDatabase.existingSecret.name": "example-secret",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var secret coreV1.Secret
-	helm.UnmarshalK8SYaml(s.T(), output, &secret)
-
-	// then
-	s.Require().NotNil(secret.Data)
-	_, databaseSecretKeyExists := secret.Data["database-password"]
-	s.Require().False(databaseSecretKeyExists)
-}
-func (s *secretTest) TestDatabaseSecretAddedViaDirectPassword() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                                 "true",
-			"webModeler.restapi.mail.fromAddress":                "example@example.com",
-			"webModeler.restapi.mail.smtpPassword":               "secret123",
-			"webModeler.restapi.externalDatabase.existingSecret": "password1234",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var secret coreV1.Secret
-	helm.UnmarshalK8SYaml(s.T(), output, &secret)
-
-	// then
-	s.Require().Equal("password1234", string(secret.Data["database-password"]))
-}
-
-func (s *secretTest) TestDatabaseSecretAddedViaDirectPasswordUsingOldSyntax() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                           "true",
-			"webModeler.restapi.mail.fromAddress":          "example@example.com",
-			"webModeler.restapi.mail.smtpPassword":         "secret123",
-			"webModeler.restapi.externalDatabase.password": "password1234",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var secret coreV1.Secret
-	helm.UnmarshalK8SYaml(s.T(), output, &secret)
-
-	// then
-	s.Require().Equal("password1234", string(secret.Data["database-password"]))
-}
-
-func (s *secretTest) TestSmtpSecretAddedViaDirectPassword() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                                 "true",
-			"webModeler.restapi.mail.fromAddress":                "example@example.com",
-			"webModeler.restapi.mail.existingSecret":             "password1234",
-			"webModeler.restapi.externalDatabase.existingSecret": "otherPassword1234",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var secret coreV1.Secret
-	helm.UnmarshalK8SYaml(s.T(), output, &secret)
-
-	// then
-	s.Require().Equal("password1234", string(secret.Data["smtp-password"]))
-}
-func (s *secretTest) TestSmtpSecretNotAddedWhenSecretNameSpecified() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                                 "true",
-			"webModeler.restapi.mail.fromAddress":                "example@example.com",
-			"webModeler.restapi.externalDatabase.existingSecret": "password1234",
-			"webModeler.restapi.mail.existingSecret.name":        "mail-secret",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var secret coreV1.Secret
-	helm.UnmarshalK8SYaml(s.T(), output, &secret)
-
-	// then
-	_, exists := secret.Data["smtp-password"]
-	s.Require().False(exists)
-}
-func (s *secretTest) TestSmtpSecretViaPasswordKeyWhenSecretNameSpecified() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                                 "true",
-			"webModeler.restapi.mail.fromAddress":                "example@example.com",
-			"webModeler.restapi.externalDatabase.existingSecret": "password1234",
-			"webModeler.restapi.mail.smtpPassword":               "password12345",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var secret coreV1.Secret
-	helm.UnmarshalK8SYaml(s.T(), output, &secret)
-
-	// then
-	s.Require().Equal("password12345", string(secret.Data["smtp-password"]))
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }

--- a/charts/camunda-platform-8.6/test/unit/web-modeler/secret_shared_test.go
+++ b/charts/camunda-platform-8.6/test/unit/web-modeler/secret_shared_test.go
@@ -15,19 +15,19 @@
 package web_modeler
 
 import (
+	"camunda-platform/test/unit/testhelpers"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	coreV1 "k8s.io/api/core/v1"
 )
 
-type secretSharedTest struct {
+type SecretSharedTest struct {
 	suite.Suite
 	chartPath string
 	release   string
@@ -41,7 +41,7 @@ func TestSecretSharedTemplate(t *testing.T) {
 	chartPath, err := filepath.Abs("../../../")
 	require.NoError(t, err)
 
-	suite.Run(t, &secretSharedTest{
+	suite.Run(t, &SecretSharedTest{
 		chartPath: chartPath,
 		release:   "camunda-platform-test",
 		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
@@ -49,22 +49,24 @@ func TestSecretSharedTemplate(t *testing.T) {
 	})
 }
 
-func (s *secretSharedTest) TestContainerGenerateRandomPusherAppSecret() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"webModeler.enabled":                  "true",
-			"webModeler.restapi.mail.fromAddress": "example@example.com",
+func (s *SecretSharedTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestContainerGenerateRandomPusherAppSecret",
+			Values: map[string]string{
+				"webModeler.enabled":                  "true",
+				"webModeler.restapi.mail.fromAddress": "example@example.com",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var secret coreV1.Secret
+				helm.UnmarshalK8SYaml(s.T(), output, &secret)
+
+				// then
+				s.Require().NotNil(secret.Data)
+				s.Require().Regexp("^[a-zA-Z0-9]{20}$", string(secret.Data["pusher-app-secret"]))
+			},
 		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 	}
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var secret coreV1.Secret
-	helm.UnmarshalK8SYaml(s.T(), output, &secret)
-
-	// then
-	s.Require().NotNil(secret.Data)
-	s.Require().Regexp("^[a-zA-Z0-9]{20}$", string(secret.Data["pusher-app-secret"]))
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }


### PR DESCRIPTION
### Which problem does the PR fix?

https://github.com/camunda/team-distribution/issues/448

### What's in this PR?

- Webmodeler unit tests in 8.6 have been refactored to the new style

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
