### PR TITLE
fix: refactor unit tests in zeebe-gateway to new style on 8.6

### DIFF
--- a/charts/camunda-platform-8.6/test/unit/zeebe-gateway/deployment_test.go
+++ b/charts/camunda-platform-8.6/test/unit/zeebe-gateway/deployment_test.go
@@ -15,12 +15,12 @@
 package gateway
 
 import (
+	"camunda-platform/test/unit/testhelpers"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -28,7 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-type deploymentTemplateTest struct {
+type DeploymentTemplateTest struct {
 	suite.Suite
 	chartPath string
 	release   string
@@ -42,7 +42,7 @@ func TestGatewayDeploymentTemplate(t *testing.T) {
 	chartPath, err := filepath.Abs("../../../")
 	require.NoError(t, err)
 
-	suite.Run(t, &deploymentTemplateTest{
+	suite.Run(t, &DeploymentTemplateTest{
 		chartPath: chartPath,
 		release:   "camunda-platform-test",
 		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
@@ -50,863 +50,663 @@ func TestGatewayDeploymentTemplate(t *testing.T) {
 	})
 }
 
-func (s *deploymentTemplateTest) TestContainerSetPodLabels() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"zeebeGateway.podLabels.foo": "bar",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	s.Require().Equal("bar", deployment.Spec.Template.Labels["foo"])
-}
-
-func (s *deploymentTemplateTest) TestContainerSetPodAnnotations() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"zeebeGateway.podAnnotations.foo": "bar",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	s.Require().Equal("bar", deployment.Spec.Template.Annotations["foo"])
-}
-
-func (s *deploymentTemplateTest) TestContainerSetGlobalAnnotations() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.annotations.foo": "bar",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	s.Require().Equal("bar", deployment.ObjectMeta.Annotations["foo"])
-}
-
-func (s *deploymentTemplateTest) TestContainerSetPriorityClassName() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"zeebeGateway.priorityClassName": "PRIO",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	s.Require().Equal("PRIO", deployment.Spec.Template.Spec.PriorityClassName)
-}
-
-func (s *deploymentTemplateTest) TestContainerSetImageNameSubChart() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.image.registry":         "global.custom.registry.io",
-			"global.image.tag":              "8.x.x",
-			"zeebeGateway.image.registry":   "subchart.custom.registry.io",
-			"zeebeGateway.image.repository": "camunda/zeebe-test",
-			"zeebeGateway.image.tag":        "snapshot",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	container := deployment.Spec.Template.Spec.Containers[0]
-	s.Require().Equal(container.Image, "subchart.custom.registry.io/camunda/zeebe-test:snapshot")
-}
-
-func (s *deploymentTemplateTest) TestContainerSetImagePullSecretsGlobal() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.image.pullSecrets[0].name": "SecretName",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	s.Require().Equal("SecretName", deployment.Spec.Template.Spec.ImagePullSecrets[0].Name)
-}
-
-func (s *deploymentTemplateTest) TestContainerSetImagePullSecretsSubChart() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.image.pullSecrets[0].name":       "SecretName",
-			"zeebeGateway.image.pullSecrets[0].name": "SecretNameSubChart",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	s.Require().Equal("SecretNameSubChart", deployment.Spec.Template.Spec.ImagePullSecrets[0].Name)
-}
-
-func (s *deploymentTemplateTest) TestContainerOverwriteImageTag() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"zeebeGateway.image.tag": "a.b.c",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	expectedContainerImage := "camunda/zeebe:a.b.c"
-	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
-	s.Require().Equal(expectedContainerImage, containers[0].Image)
-}
-
-func (s *deploymentTemplateTest) TestContainerOverwriteGlobalImageTag() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.image.tag":       "a.b.c",
-			"zeebeGateway.image.tag": "",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	expectedContainerImage := "camunda/zeebe:a.b.c"
-	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
-	s.Require().Equal(expectedContainerImage, containers[0].Image)
-}
-
-func (s *deploymentTemplateTest) TestContainerOverwriteImageTagWithChartDirectSetting() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.image.tag":       "x.y.z",
-			"zeebeGateway.image.tag": "a.b.c",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	expectedContainerImage := "camunda/zeebe:a.b.c"
-	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
-	s.Require().Equal(expectedContainerImage, containers[0].Image)
-}
-
-func (s *deploymentTemplateTest) TestContainerShouldSetTemplateEnvVars() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"zeebeGateway.env[0].name":  "RELEASE_NAME",
-			"zeebeGateway.env[0].value": "test-{{ .Release.Name }}",
-			"zeebeGateway.env[1].name":  "OTHER_ENV",
-			"zeebeGateway.env[1].value": "nothingToSeeHere",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-	s.Require().Contains(env, corev1.EnvVar{Name: "RELEASE_NAME", Value: "test-camunda-platform-test"})
-	s.Require().Contains(env, corev1.EnvVar{Name: "OTHER_ENV", Value: "nothingToSeeHere"})
-}
-
-func (s *deploymentTemplateTest) TestContainerSetContainerCommand() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"zeebeGateway.command[0]": "printenv",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
-	s.Require().Equal(1, len(containers[0].Command))
-	s.Require().Equal("printenv", containers[0].Command[0])
-}
-
-func (s *deploymentTemplateTest) TestContainerSetLog4j2() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"zeebeGateway.log4j2": "<xml>\n</xml>",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(3, len(volumeMounts))
-	s.Require().Equal("config", volumeMounts[1].Name)
-	s.Require().Equal("/usr/local/zeebe/config/log4j2.xml", volumeMounts[1].MountPath)
-	s.Require().Equal("gateway-log4j2.xml", volumeMounts[1].SubPath)
-}
-
-func (s *deploymentTemplateTest) TestContainerSetExtraVolumes() {
-	//finding out the length of volumes, volumemounts array before addition of new volume
-	var deploymentBefore appsv1.Deployment
-	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
-	helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
-	volumeLenBefore := len(deploymentBefore.Spec.Template.Spec.Volumes)
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"zeebeGateway.extraVolumes[0].name":                  "extraVolume",
-			"zeebeGateway.extraVolumes[0].configMap.name":        "otherConfigMap",
-			"zeebeGateway.extraVolumes[0].configMap.defaultMode": "744",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	volumes := deployment.Spec.Template.Spec.Volumes
-	s.Require().Equal(volumeLenBefore+1, len(volumes))
-
-	extraVolume := volumes[volumeLenBefore]
-	s.Require().Equal("extraVolume", extraVolume.Name)
-	s.Require().NotNil(*extraVolume.ConfigMap)
-	s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
-	s.Require().EqualValues(744, *extraVolume.ConfigMap.DefaultMode)
-}
-
-func (s *deploymentTemplateTest) TestContainerSetExtraVolumeMounts() {
-	//finding out the length of containers and volumeMounts array before addition of new volumeMount
-	var deploymentBefore appsv1.Deployment
-	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
-	helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
-	volumeMountLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"zeebeGateway.extraVolumeMounts[0].name":      "otherConfigMap",
-			"zeebeGateway.extraVolumeMounts[0].mountPath": "/usr/local/config",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(volumeMountLenBefore+1, len(volumeMounts))
-	extraVolumeMount := volumeMounts[volumeMountLenBefore]
-	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
-	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
-}
-
-func (s *deploymentTemplateTest) TestContainerSetExtraVolumesAndMounts() {
-	//finding out the length of volumes, volumemounts array before addition of new volume
-	var deploymentBefore appsv1.Deployment
-	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
-	helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
-	volumeLenBefore := len(deploymentBefore.Spec.Template.Spec.Volumes)
-	volumeMountLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"zeebeGateway.extraVolumeMounts[0].name":             "otherConfigMap",
-			"zeebeGateway.extraVolumeMounts[0].mountPath":        "/usr/local/config",
-			"zeebeGateway.extraVolumes[0].name":                  "extraVolume",
-			"zeebeGateway.extraVolumes[0].configMap.name":        "otherConfigMap",
-			"zeebeGateway.extraVolumes[0].configMap.defaultMode": "744",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	volumes := deployment.Spec.Template.Spec.Volumes
-	s.Require().Equal(volumeLenBefore+1, len(volumes))
-
-	extraVolume := volumes[volumeLenBefore]
-	s.Require().Equal("extraVolume", extraVolume.Name)
-	s.Require().NotNil(*extraVolume.ConfigMap)
-	s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
-	s.Require().EqualValues(744, *extraVolume.ConfigMap.DefaultMode)
-
-	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(volumeMountLenBefore+1, len(volumeMounts))
-	extraVolumeMount := volumeMounts[volumeMountLenBefore]
-	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
-	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
-}
-
-func (s *deploymentTemplateTest) TestPodSetSecurityContext() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"zeebeGateway.podSecurityContext.runAsUser": "1000",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	securityContext := deployment.Spec.Template.Spec.SecurityContext
-	s.Require().EqualValues(1000, *securityContext.RunAsUser)
-}
-
-func (s *deploymentTemplateTest) TestContainerSetSecurityContext() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"zeebeGateway.containerSecurityContext.privileged": "true",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	securityContext := deployment.Spec.Template.Spec.Containers[0].SecurityContext
-	s.Require().True(*securityContext.Privileged)
-}
-
-func (s *deploymentTemplateTest) TestContainerSetServiceAccountName() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"zeebeGateway.serviceAccount.name": "serviceaccount",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	s.Require().Equal("serviceaccount", deployment.Spec.Template.Spec.ServiceAccountName)
-}
-
-// https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
-func (s *deploymentTemplateTest) TestContainerSetNodeSelector() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"zeebeGateway.nodeSelector.disktype": "ssd",
-			"zeebeGateway.nodeSelector.cputype":  "arm",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	s.Require().Equal("ssd", deployment.Spec.Template.Spec.NodeSelector["disktype"])
-	s.Require().Equal("arm", deployment.Spec.Template.Spec.NodeSelector["cputype"])
-}
-
-// https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
-func (s *deploymentTemplateTest) TestContainerSetAffinity() {
-	// given
-
-	//affinity:
-	//	nodeAffinity:
-	//	 requiredDuringSchedulingIgnoredDuringExecution:
-	//	   nodeSelectorTerms:
-	//	   - matchExpressions:
-	//		 - key: kubernetes.io/e2e-az-name
-	//		   operator: In
-	//		   values:
-	//		   - e2e-az1
-	//		   - e2e-az2
-	//	 preferredDuringSchedulingIgnoredDuringExecution:
-	//	 - weight: 1
-	//	   preference:
-	//		 matchExpressions:
-	//		 - key: another-node-label-key
-	//		   operator: In
-	//		   values:
-	//		   - another-node-label-value
-
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"zeebeGateway.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].key":       "kubernetes.io/e2e-az-name",
-			"zeebeGateway.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].operator":  "In",
-			"zeebeGateway.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].values[0]": "e2e-a1",
-			"zeebeGateway.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].values[1]": "e2e-a2",
-			"zeebeGateway.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight":                                         "1",
-			"zeebeGateway.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].key":             "another-node-label-key",
-			"zeebeGateway.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].operator":        "In",
-			"zeebeGateway.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].values[0]":       "another-node-label-value",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	nodeAffinity := deployment.Spec.Template.Spec.Affinity.NodeAffinity
-	s.Require().NotNil(nodeAffinity)
-
-	nodeSelectorTerm := nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0]
-	s.Require().NotNil(nodeSelectorTerm)
-	matchExpression := nodeSelectorTerm.MatchExpressions[0]
-	s.Require().NotNil(matchExpression)
-	s.Require().Equal("kubernetes.io/e2e-az-name", matchExpression.Key)
-	s.Require().EqualValues("In", matchExpression.Operator)
-	s.Require().Equal([]string{"e2e-a1", "e2e-a2"}, matchExpression.Values)
-
-	preferredSchedulingTerm := nodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0]
-	s.Require().NotNil(preferredSchedulingTerm)
-
-	matchExpression = preferredSchedulingTerm.Preference.MatchExpressions[0]
-	s.Require().NotNil(matchExpression)
-	s.Require().Equal("another-node-label-key", matchExpression.Key)
-	s.Require().EqualValues("In", matchExpression.Operator)
-	s.Require().Equal([]string{"another-node-label-value"}, matchExpression.Values)
-}
-
-// https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration
-func (s *deploymentTemplateTest) TestContainerSetTolerations() {
-	// given
-
-	//tolerations:
-	//- key: "key1"
-	//  operator: "Equal"
-	//  value: "value1"
-	//  effect: "NoSchedule"
-
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"zeebeGateway.tolerations[0].key":      "key1",
-			"zeebeGateway.tolerations[0].operator": "Equal",
-			"zeebeGateway.tolerations[0].value":    "Value1",
-			"zeebeGateway.tolerations[0].effect":   "NoSchedule",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	tolerations := deployment.Spec.Template.Spec.Tolerations
-	s.Require().Equal(1, len(tolerations))
-
-	toleration := tolerations[0]
-	s.Require().Equal("key1", toleration.Key)
-	s.Require().EqualValues("Equal", toleration.Operator)
-	s.Require().Equal("Value1", toleration.Value)
-	s.Require().EqualValues("NoSchedule", toleration.Effect)
-}
-
-func (s *deploymentTemplateTest) TestContainerSetExtraInitContainers() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"zeebeGateway.extraInitContainers[0].name":       "init-container-{{ .Release.Name }}",
-			"zeebeGateway.extraInitContainers[0].image":      "busybox:1.28",
-			"zeebeGateway.extraInitContainers[0].command[0]": "sh",
-			"zeebeGateway.extraInitContainers[0].command[1]": "-c",
-			"zeebeGateway.extraInitContainers[0].command[2]": "top",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	initContainer := deployment.Spec.Template.Spec.InitContainers[0]
-	s.Require().Equal("init-container-camunda-platform-test", initContainer.Name)
-	s.Require().Equal("busybox:1.28", initContainer.Image)
-	s.Require().Equal([]string{"sh", "-c", "top"}, initContainer.Command)
-}
-
-func (s *deploymentTemplateTest) TestInitContainers() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"zeebeGateway.initContainers[0].name":                   "nginx",
-			"zeebeGateway.initContainers[0].image":                  "nginx:latest",
-			"zeebeGateway.initContainers[0].ports[0].containerPort": "80",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	podContainers := deployment.Spec.Template.Spec.InitContainers
-	expectedContainer := corev1.Container{
-		Name:  "nginx",
-		Image: "nginx:latest",
-		Ports: []corev1.ContainerPort{
-			{
-				ContainerPort: 80,
+func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestContainerSetPodLabels",
+			Values: map[string]string{
+				"zeebeGateway.podLabels.foo": "bar",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				s.Require().Equal("bar", deployment.Spec.Template.Labels["foo"])
+			},
+		}, {
+			Name: "TestContainerSetPodAnnotations",
+			Values: map[string]string{
+				"zeebeGateway.podAnnotations.foo": "bar",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				s.Require().Equal("bar", deployment.Spec.Template.Annotations["foo"])
+			},
+		}, {
+			Name: "TestContainerSetGlobalAnnotations",
+			Values: map[string]string{
+				"global.annotations.foo": "bar",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				s.Require().Equal("bar", deployment.ObjectMeta.Annotations["foo"])
+			},
+		}, {
+			Name: "TestContainerSetPriorityClassName",
+			Values: map[string]string{
+				"zeebeGateway.priorityClassName": "PRIO",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				s.Require().Equal("PRIO", deployment.Spec.Template.Spec.PriorityClassName)
+			},
+		}, {
+			Name: "TestContainerSetImageNameSubChart",
+			Values: map[string]string{
+				"global.image.registry":         "global.custom.registry.io",
+				"global.image.tag":              "8.x.x",
+				"zeebeGateway.image.registry":   "subchart.custom.registry.io",
+				"zeebeGateway.image.repository": "camunda/zeebe-test",
+				"zeebeGateway.image.tag":        "snapshot",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				container := deployment.Spec.Template.Spec.Containers[0]
+				s.Require().Equal(container.Image, "subchart.custom.registry.io/camunda/zeebe-test:snapshot")
+			},
+		}, {
+			Name: "TestContainerSetImagePullSecretsGlobal",
+			Values: map[string]string{
+				"global.image.pullSecrets[0].name": "SecretName",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				s.Require().Equal("SecretName", deployment.Spec.Template.Spec.ImagePullSecrets[0].Name)
+			},
+		}, {
+			Name: "TestContainerSetImagePullSecretsSubChart",
+			Values: map[string]string{
+				"global.image.pullSecrets[0].name":       "SecretName",
+				"zeebeGateway.image.pullSecrets[0].name": "SecretNameSubChart",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				s.Require().Equal("SecretNameSubChart", deployment.Spec.Template.Spec.ImagePullSecrets[0].Name)
+			},
+		}, {
+			Name: "TestContainerOverwriteImageTag",
+			Values: map[string]string{
+				"zeebeGateway.image.tag": "a.b.c",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				expectedContainerImage := "camunda/zeebe:a.b.c"
+				containers := deployment.Spec.Template.Spec.Containers
+				s.Require().Equal(1, len(containers))
+				s.Require().Equal(expectedContainerImage, containers[0].Image)
+			},
+		}, {
+			Name: "TestContainerOverwriteGlobalImageTag",
+			Values: map[string]string{
+				"global.image.tag":       "a.b.c",
+				"zeebeGateway.image.tag": "",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				expectedContainerImage := "camunda/zeebe:a.b.c"
+				containers := deployment.Spec.Template.Spec.Containers
+				s.Require().Equal(1, len(containers))
+				s.Require().Equal(expectedContainerImage, containers[0].Image)
+			},
+		}, {
+			Name: "TestContainerOverwriteImageTagWithChartDirectSetting",
+			Values: map[string]string{
+				"global.image.tag":       "x.y.z",
+				"zeebeGateway.image.tag": "a.b.c",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				expectedContainerImage := "camunda/zeebe:a.b.c"
+				containers := deployment.Spec.Template.Spec.Containers
+				s.Require().Equal(1, len(containers))
+				s.Require().Equal(expectedContainerImage, containers[0].Image)
+			},
+		}, {
+			Name: "TestContainerShouldSetTemplateEnvVars",
+			Values: map[string]string{
+				"zeebeGateway.env[0].name":  "RELEASE_NAME",
+				"zeebeGateway.env[0].value": "test-{{ .Release.Name }}",
+				"zeebeGateway.env[1].name":  "OTHER_ENV",
+				"zeebeGateway.env[1].value": "nothingToSeeHere",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env, corev1.EnvVar{Name: "RELEASE_NAME", Value: "test-camunda-platform-test"})
+				s.Require().Contains(env, corev1.EnvVar{Name: "OTHER_ENV", Value: "nothingToSeeHere"})
+			},
+		}, {
+			Name: "TestContainerSetContainerCommand",
+			Values: map[string]string{
+				"zeebeGateway.command[0]": "printenv",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				containers := deployment.Spec.Template.Spec.Containers
+				s.Require().Equal(1, len(containers))
+				s.Require().Equal(1, len(containers[0].Command))
+				s.Require().Equal("printenv", containers[0].Command[0])
+			},
+		}, {
+			Name: "TestContainerSetLog4j2",
+			Values: map[string]string{
+				"zeebeGateway.log4j2": "<xml>\n</xml>",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
+				s.Require().Equal(3, len(volumeMounts))
+				s.Require().Equal("config", volumeMounts[1].Name)
+				s.Require().Equal("/usr/local/zeebe/config/log4j2.xml", volumeMounts[1].MountPath)
+				s.Require().Equal("gateway-log4j2.xml", volumeMounts[1].SubPath)
+			},
+		}, {
+			Name: "TestContainerSetExtraVolumes",
+			Values: map[string]string{
+				"zeebeGateway.extraVolumes[0].name":                  "extraVolume",
+				"zeebeGateway.extraVolumes[0].configMap.name":        "otherConfigMap",
+				"zeebeGateway.extraVolumes[0].configMap.defaultMode": "744",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				// finding out the length of volumes, volumemounts array before addition of new volume
+				var deploymentBefore appsv1.Deployment
+				before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
+				helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
+				volumeLenBefore := len(deploymentBefore.Spec.Template.Spec.Volumes)
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				volumes := deployment.Spec.Template.Spec.Volumes
+				s.Require().Equal(volumeLenBefore+1, len(volumes))
+
+				extraVolume := volumes[volumeLenBefore]
+				s.Require().Equal("extraVolume", extraVolume.Name)
+				s.Require().NotNil(*extraVolume.ConfigMap)
+				s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
+				s.Require().EqualValues(744, *extraVolume.ConfigMap.DefaultMode)
+			},
+		}, {
+			Name: "TestContainerSetExtraVolumeMounts",
+			Values: map[string]string{
+				"zeebeGateway.extraVolumeMounts[0].name":      "otherConfigMap",
+				"zeebeGateway.extraVolumeMounts[0].mountPath": "/usr/local/config",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				// finding out the length of containers and volumeMounts array before addition of new volumeMount
+				var deploymentBefore appsv1.Deployment
+				before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
+				helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
+
+				volumeMountLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
+				s.Require().Equal(volumeMountLenBefore+1, len(volumeMounts))
+				extraVolumeMount := volumeMounts[volumeMountLenBefore]
+				s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
+				s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
+			},
+		}, {
+			Name: "TestContainerSetExtraVolumesAndMounts",
+			Values: map[string]string{
+				"zeebeGateway.extraVolumeMounts[0].name":             "otherConfigMap",
+				"zeebeGateway.extraVolumeMounts[0].mountPath":        "/usr/local/config",
+				"zeebeGateway.extraVolumes[0].name":                  "extraVolume",
+				"zeebeGateway.extraVolumes[0].configMap.name":        "otherConfigMap",
+				"zeebeGateway.extraVolumes[0].configMap.defaultMode": "744",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				// finding out the length of volumes, volumemounts array before addition of new volume
+				var deploymentBefore appsv1.Deployment
+				before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
+				helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
+				volumeLenBefore := len(deploymentBefore.Spec.Template.Spec.Volumes)
+				volumeMountLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				volumes := deployment.Spec.Template.Spec.Volumes
+				s.Require().Equal(volumeLenBefore+1, len(volumes))
+
+				extraVolume := volumes[volumeLenBefore]
+				s.Require().Equal("extraVolume", extraVolume.Name)
+				s.Require().NotNil(*extraVolume.ConfigMap)
+				s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
+				s.Require().EqualValues(744, *extraVolume.ConfigMap.DefaultMode)
+
+				volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
+				s.Require().Equal(volumeMountLenBefore+1, len(volumeMounts))
+				extraVolumeMount := volumeMounts[volumeMountLenBefore]
+				s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
+				s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
+			},
+		}, {
+			Name: "TestPodSetSecurityContext",
+			Values: map[string]string{
+				"zeebeGateway.podSecurityContext.runAsUser": "1000",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				securityContext := deployment.Spec.Template.Spec.SecurityContext
+				s.Require().EqualValues(1000, *securityContext.RunAsUser)
+			},
+		}, {
+			Name: "TestContainerSetSecurityContext",
+			Values: map[string]string{
+				"zeebeGateway.containerSecurityContext.privileged": "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				securityContext := deployment.Spec.Template.Spec.Containers[0].SecurityContext
+				s.Require().True(*securityContext.Privileged)
+			},
+		}, {
+			Name: "TestContainerSetServiceAccountName",
+			Values: map[string]string{
+				"zeebeGateway.serviceAccount.name": "serviceaccount",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				s.Require().Equal("serviceaccount", deployment.Spec.Template.Spec.ServiceAccountName)
+			},
+		}, {
+			// https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+			Name: "TestContainerSetNodeSelector",
+			Values: map[string]string{
+				"zeebeGateway.nodeSelector.disktype": "ssd",
+				"zeebeGateway.nodeSelector.cputype":  "arm",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				s.Require().Equal("ssd", deployment.Spec.Template.Spec.NodeSelector["disktype"])
+				s.Require().Equal("arm", deployment.Spec.Template.Spec.NodeSelector["cputype"])
+			},
+		}, {
+			// https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+			// affinity:
+			//	nodeAffinity:
+			//	 requiredDuringSchedulingIgnoredDuringExecution:
+			//	   nodeSelectorTerms:
+			//	   - matchExpressions:
+			//		 - key: kubernetes.io/e2e-az-name
+			//		   operator: In
+			//		   values:
+			//		   - e2e-az1
+			//		   - e2e-az2
+			//	 preferredDuringSchedulingIgnoredDuringExecution:
+			//	 - weight: 1
+			//	   preference:
+			//		 matchExpressions:
+			//		 - key: another-node-label-key
+			//		   operator: In
+			//		   values:
+			//		   - another-node-label-value
+			Name: "TestContainerSetAffinity",
+			Values: map[string]string{
+				"zeebeGateway.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].key":       "kubernetes.io/e2e-az-name",
+				"zeebeGateway.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].operator":  "In",
+				"zeebeGateway.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].values[0]": "e2e-a1",
+				"zeebeGateway.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].values[1]": "e2e-a2",
+				"zeebeGateway.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight":                                         "1",
+				"zeebeGateway.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].key":             "another-node-label-key",
+				"zeebeGateway.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].operator":        "In",
+				"zeebeGateway.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].values[0]":       "another-node-label-value",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+				// then
+				nodeAffinity := deployment.Spec.Template.Spec.Affinity.NodeAffinity
+				s.Require().NotNil(nodeAffinity)
+
+				nodeSelectorTerm := nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0]
+				s.Require().NotNil(nodeSelectorTerm)
+				matchExpression := nodeSelectorTerm.MatchExpressions[0]
+				s.Require().NotNil(matchExpression)
+				s.Require().Equal("kubernetes.io/e2e-az-name", matchExpression.Key)
+				s.Require().EqualValues("In", matchExpression.Operator)
+				s.Require().Equal([]string{"e2e-a1", "e2e-a2"}, matchExpression.Values)
+
+				preferredSchedulingTerm := nodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0]
+				s.Require().NotNil(preferredSchedulingTerm)
+
+				matchExpression = preferredSchedulingTerm.Preference.MatchExpressions[0]
+				s.Require().NotNil(matchExpression)
+				s.Require().Equal("another-node-label-key", matchExpression.Key)
+				s.Require().EqualValues("In", matchExpression.Operator)
+				s.Require().Equal([]string{"another-node-label-value"}, matchExpression.Values)
+			},
+		}, {
+			// https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration
+			Name: "TestContainerSetTolerations",
+			Values: map[string]string{
+				"zeebeGateway.tolerations[0].key":      "key1",
+				"zeebeGateway.tolerations[0].operator": "Equal",
+				"zeebeGateway.tolerations[0].value":    "Value1",
+				"zeebeGateway.tolerations[0].effect":   "NoSchedule",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				tolerations := deployment.Spec.Template.Spec.Tolerations
+				s.Require().Equal(1, len(tolerations))
+
+				toleration := tolerations[0]
+				s.Require().Equal("key1", toleration.Key)
+				s.Require().EqualValues("Equal", toleration.Operator)
+				s.Require().Equal("Value1", toleration.Value)
+				s.Require().EqualValues("NoSchedule", toleration.Effect)
+			},
+		}, {
+			Name: "TestContainerSetExtraInitContainers",
+			Values: map[string]string{
+				"zeebeGateway.extraInitContainers[0].name":       "init-container-{{ .Release.Name }}",
+				"zeebeGateway.extraInitContainers[0].image":      "busybox:1.28",
+				"zeebeGateway.extraInitContainers[0].command[0]": "sh",
+				"zeebeGateway.extraInitContainers[0].command[1]": "-c",
+				"zeebeGateway.extraInitContainers[0].command[2]": "top",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				initContainer := deployment.Spec.Template.Spec.InitContainers[0]
+				s.Require().Equal("init-container-camunda-platform-test", initContainer.Name)
+				s.Require().Equal("busybox:1.28", initContainer.Image)
+				s.Require().Equal([]string{"sh", "-c", "top"}, initContainer.Command)
+			},
+		}, {
+			Name: "TestInitContainers",
+			Values: map[string]string{
+				"zeebeGateway.initContainers[0].name":                   "nginx",
+				"zeebeGateway.initContainers[0].image":                  "nginx:latest",
+				"zeebeGateway.initContainers[0].ports[0].containerPort": "80",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				podContainers := deployment.Spec.Template.Spec.InitContainers
+				expectedContainer := corev1.Container{
+					Name:  "nginx",
+					Image: "nginx:latest",
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: 80,
+						},
+					},
+				}
+
+				s.Require().Contains(podContainers, expectedContainer)
+			},
+		}, {
+			Name: "TestContainerShouldOverwriteGlobalImagePullPolicy",
+			Values: map[string]string{
+				"global.image.pullPolicy": "Always",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				expectedPullPolicy := corev1.PullAlways
+				containers := deployment.Spec.Template.Spec.Containers
+				s.Require().Equal(1, len(containers))
+				pullPolicy := containers[0].ImagePullPolicy
+				s.Require().Equal(expectedPullPolicy, pullPolicy)
+			},
+		}, {
+			// readinessProbe is enabled by default so it's tested by golden files.
+			Name: "TestContainerStartupProbe",
+			Values: map[string]string{
+				"zeebeGateway.startupProbe.enabled":             "true",
+				"zeebeGateway.startupProbe.probePath":           "/healthz",
+				"zeebeGateway.startupProbe.initialDelaySeconds": "5",
+				"zeebeGateway.startupProbe.periodSeconds":       "10",
+				"zeebeGateway.startupProbe.successThreshold":    "1",
+				"zeebeGateway.startupProbe.failureThreshold":    "5",
+				"zeebeGateway.startupProbe.timeoutSeconds":      "1",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				probe := deployment.Spec.Template.Spec.Containers[0].StartupProbe
+
+				s.Require().Equal("/healthz", probe.HTTPGet.Path)
+				s.Require().EqualValues(5, probe.InitialDelaySeconds)
+				s.Require().EqualValues(10, probe.PeriodSeconds)
+				s.Require().EqualValues(1, probe.SuccessThreshold)
+				s.Require().EqualValues(5, probe.FailureThreshold)
+				s.Require().EqualValues(1, probe.TimeoutSeconds)
+			},
+		}, {
+			Name: "TestContainerLivenessProbe",
+			Values: map[string]string{
+				"zeebeGateway.livenessProbe.enabled":             "true",
+				"zeebeGateway.livenessProbe.probePath":           "/healthz",
+				"zeebeGateway.livenessProbe.initialDelaySeconds": "5",
+				"zeebeGateway.livenessProbe.periodSeconds":       "10",
+				"zeebeGateway.livenessProbe.successThreshold":    "1",
+				"zeebeGateway.livenessProbe.failureThreshold":    "5",
+				"zeebeGateway.livenessProbe.timeoutSeconds":      "1",
+			},
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				probe := deployment.Spec.Template.Spec.Containers[0].LivenessProbe
+
+				s.Require().EqualValues("/healthz", probe.HTTPGet.Path)
+				s.Require().EqualValues(5, probe.InitialDelaySeconds)
+				s.Require().EqualValues(10, probe.PeriodSeconds)
+				s.Require().EqualValues(1, probe.SuccessThreshold)
+				s.Require().EqualValues(5, probe.FailureThreshold)
+				s.Require().EqualValues(1, probe.TimeoutSeconds)
+			},
+		}, {
+			Name: "TestContainerProbesWithContextPath",
+			Values: map[string]string{
+				"zeebeGateway.contextPath":              "/test",
+				"zeebeGateway.startupProbe.enabled":     "true",
+				"zeebeGateway.startupProbe.probePath":   "/start",
+				"zeebeGateway.readinessProbe.enabled":   "true",
+				"zeebeGateway.readinessProbe.probePath": "/ready",
+				"zeebeGateway.livenessProbe.enabled":    "true",
+				"zeebeGateway.livenessProbe.probePath":  "/live",
+			},
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				probe := deployment.Spec.Template.Spec.Containers[0]
+
+				s.Require().Equal("/test/start", probe.StartupProbe.HTTPGet.Path)
+				s.Require().Equal("/test/ready", probe.ReadinessProbe.HTTPGet.Path)
+				s.Require().Equal("/test/live", probe.LivenessProbe.HTTPGet.Path)
+			},
+		}, {
+			Name: "TestContainerSetSidecar",
+			Values: map[string]string{
+				"zeebeGateway.sidecars[0].name":                   "nginx",
+				"zeebeGateway.sidecars[0].image":                  "nginx:latest",
+				"zeebeGateway.sidecars[0].ports[0].containerPort": "80",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				podContainers := deployment.Spec.Template.Spec.Containers
+				expectedContainer := corev1.Container{
+					Name:  "nginx",
+					Image: "nginx:latest",
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: 80,
+						},
+					},
+				}
+
+				s.Require().Contains(podContainers, expectedContainer)
+			},
+		}, {
+			Name: "TestSetDnsPolicyAndDnsConfig",
+			Values: map[string]string{
+				"zeebeGateway.dnsPolicy":                "ClusterFirst",
+				"zeebeGateway.dnsConfig.nameservers[0]": "8.8.8.8",
+				"zeebeGateway.dnsConfig.searches[0]":    "example.com",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				// Check if dnsPolicy is set
+				require.NotEmpty(s.T(), deployment.Spec.Template.Spec.DNSPolicy, "dnsPolicy should not be empty")
+
+				// Check if dnsConfig is set
+				require.NotNil(s.T(), deployment.Spec.Template.Spec.DNSConfig, "dnsConfig should not be nil")
+
+				expectedDNSConfig := &corev1.PodDNSConfig{
+					Nameservers: []string{"8.8.8.8"},
+					Searches:    []string{"example.com"},
+				}
+
+				require.Equal(s.T(), expectedDNSConfig, deployment.Spec.Template.Spec.DNSConfig, "dnsConfig should match the expected configuration")
+			},
+		}, {
+			Name: "TestReadinessProbeWithContextPathAndIngressEnabled",
+			Values: map[string]string{
+				"zeebeGateway.contextPath":            "/test",
+				"zeebeGateway.readinessProbe.enabled": "true",
+				"zeebeGateway.ingress.rest.path":      "/test",
+				// Ensure ingress is enabled
+				"zeebeGateway.ingress.rest.enabled": "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				container := deployment.Spec.Template.Spec.Containers[0]
+				s.Require().Equal("/test/actuator/health/readiness", container.ReadinessProbe.HTTPGet.Path)
+			},
+		}, {
+			Name: "TestReadinessProbeWithRootContextPathAndIngressEnabled",
+			Values: map[string]string{
+				"zeebeGateway.contextPath":            "/",
+				"zeebeGateway.readinessProbe.enabled": "true",
+				"zeebeGateway.ingress.rest.path":      "/",
+				// Ensure ingress is enabled
+				"zeebeGateway.ingress.rest.enabled": "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				container := deployment.Spec.Template.Spec.Containers[0]
+				s.Require().Equal("/actuator/health/readiness", container.ReadinessProbe.HTTPGet.Path)
+			},
+		}, {
+			Name: "TestReadinessProbeWithEmptyContextPathAndIngressEnabled",
+			Values: map[string]string{
+				"zeebeGateway.contextPath":            "",
+				"zeebeGateway.readinessProbe.enabled": "true",
+				"zeebeGateway.ingress.rest.path":      "/",
+				// Ensure ingress is enabled
+				"zeebeGateway.ingress.rest.enabled": "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				container := deployment.Spec.Template.Spec.Containers[0]
+				s.Require().Equal("/actuator/health/readiness", container.ReadinessProbe.HTTPGet.Path)
+			},
+		}, {
+			Name: "TestReadinessProbeWithTrailingSlashInContextPath",
+			Values: map[string]string{
+				"zeebeGateway.contextPath":            "/test/", // Context path with trailing slash
+				"zeebeGateway.readinessProbe.enabled": "true",
+				"zeebeGateway.ingress.rest.path":      "/test/",
+				// Ensure ingress is enabled
+				"zeebeGateway.ingress.rest.enabled": "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				container := deployment.Spec.Template.Spec.Containers[0]
+				s.Require().Equal("/test/actuator/health/readiness", container.ReadinessProbe.HTTPGet.Path)
 			},
 		},
 	}
 
-	s.Require().Contains(podContainers, expectedContainer)
-}
-
-func (s *deploymentTemplateTest) TestContainerShouldOverwriteGlobalImagePullPolicy() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.image.pullPolicy": "Always",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	expectedPullPolicy := corev1.PullAlways
-	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
-	pullPolicy := containers[0].ImagePullPolicy
-	s.Require().Equal(expectedPullPolicy, pullPolicy)
-}
-
-// readinessProbe is enabled by default so it's tested by golden files.
-
-func (s *deploymentTemplateTest) TestContainerStartupProbe() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"zeebeGateway.startupProbe.enabled":             "true",
-			"zeebeGateway.startupProbe.probePath":           "/healthz",
-			"zeebeGateway.startupProbe.initialDelaySeconds": "5",
-			"zeebeGateway.startupProbe.periodSeconds":       "10",
-			"zeebeGateway.startupProbe.successThreshold":    "1",
-			"zeebeGateway.startupProbe.failureThreshold":    "5",
-			"zeebeGateway.startupProbe.timeoutSeconds":      "1",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	probe := deployment.Spec.Template.Spec.Containers[0].StartupProbe
-
-	s.Require().Equal("/healthz", probe.HTTPGet.Path)
-	s.Require().EqualValues(5, probe.InitialDelaySeconds)
-	s.Require().EqualValues(10, probe.PeriodSeconds)
-	s.Require().EqualValues(1, probe.SuccessThreshold)
-	s.Require().EqualValues(5, probe.FailureThreshold)
-	s.Require().EqualValues(1, probe.TimeoutSeconds)
-}
-
-func (s *deploymentTemplateTest) TestContainerLivenessProbe() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"zeebeGateway.livenessProbe.enabled":             "true",
-			"zeebeGateway.livenessProbe.probePath":           "/healthz",
-			"zeebeGateway.livenessProbe.initialDelaySeconds": "5",
-			"zeebeGateway.livenessProbe.periodSeconds":       "10",
-			"zeebeGateway.livenessProbe.successThreshold":    "1",
-			"zeebeGateway.livenessProbe.failureThreshold":    "5",
-			"zeebeGateway.livenessProbe.timeoutSeconds":      "1",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	probe := deployment.Spec.Template.Spec.Containers[0].LivenessProbe
-
-	s.Require().EqualValues("/healthz", probe.HTTPGet.Path)
-	s.Require().EqualValues(5, probe.InitialDelaySeconds)
-	s.Require().EqualValues(10, probe.PeriodSeconds)
-	s.Require().EqualValues(1, probe.SuccessThreshold)
-	s.Require().EqualValues(5, probe.FailureThreshold)
-	s.Require().EqualValues(1, probe.TimeoutSeconds)
-}
-
-func (s *deploymentTemplateTest) TestContainerProbesWithContextPath() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"zeebeGateway.contextPath":              "/test",
-			"zeebeGateway.startupProbe.enabled":     "true",
-			"zeebeGateway.startupProbe.probePath":   "/start",
-			"zeebeGateway.readinessProbe.enabled":   "true",
-			"zeebeGateway.readinessProbe.probePath": "/ready",
-			"zeebeGateway.livenessProbe.enabled":    "true",
-			"zeebeGateway.livenessProbe.probePath":  "/live",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	probe := deployment.Spec.Template.Spec.Containers[0]
-
-	s.Require().Equal("/test/start", probe.StartupProbe.HTTPGet.Path)
-	s.Require().Equal("/test/ready", probe.ReadinessProbe.HTTPGet.Path)
-	s.Require().Equal("/test/live", probe.LivenessProbe.HTTPGet.Path)
-}
-
-func (s *deploymentTemplateTest) TestContainerSetSidecar() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"zeebeGateway.sidecars[0].name":                   "nginx",
-			"zeebeGateway.sidecars[0].image":                  "nginx:latest",
-			"zeebeGateway.sidecars[0].ports[0].containerPort": "80",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	podContainers := deployment.Spec.Template.Spec.Containers
-	expectedContainer := corev1.Container{
-		Name:  "nginx",
-		Image: "nginx:latest",
-		Ports: []corev1.ContainerPort{
-			{
-				ContainerPort: 80,
-			},
-		},
-	}
-
-	s.Require().Contains(podContainers, expectedContainer)
-}
-func (s *deploymentTemplateTest) TestSetDnsPolicyAndDnsConfig() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"zeebeGateway.dnsPolicy":                "ClusterFirst",
-			"zeebeGateway.dnsConfig.nameservers[0]": "8.8.8.8",
-			"zeebeGateway.dnsConfig.searches[0]":    "example.com",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	// Check if dnsPolicy is set
-	require.NotEmpty(s.T(), deployment.Spec.Template.Spec.DNSPolicy, "dnsPolicy should not be empty")
-
-	// Check if dnsConfig is set
-	require.NotNil(s.T(), deployment.Spec.Template.Spec.DNSConfig, "dnsConfig should not be nil")
-
-	expectedDNSConfig := &corev1.PodDNSConfig{
-		Nameservers: []string{"8.8.8.8"},
-		Searches:    []string{"example.com"},
-	}
-
-	require.Equal(s.T(), expectedDNSConfig, deployment.Spec.Template.Spec.DNSConfig, "dnsConfig should match the expected configuration")
-}
-func (s *deploymentTemplateTest) TestReadinessProbeWithContextPathAndIngressEnabled() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"zeebeGateway.contextPath":            "/test",
-			"zeebeGateway.readinessProbe.enabled": "true",
-			"zeebeGateway.ingress.rest.path":      "/test",
-			"zeebeGateway.ingress.rest.enabled":   "true", // Ensure ingress is enabled
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	container := deployment.Spec.Template.Spec.Containers[0]
-	s.Require().Equal("/test/actuator/health/readiness", container.ReadinessProbe.HTTPGet.Path)
-}
-
-func (s *deploymentTemplateTest) TestReadinessProbeWithRootContextPathAndIngressEnabled() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"zeebeGateway.contextPath":            "/",
-			"zeebeGateway.readinessProbe.enabled": "true",
-			"zeebeGateway.ingress.rest.path":      "/",
-			"zeebeGateway.ingress.rest.enabled":   "true", // Ensure ingress is enabled
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	container := deployment.Spec.Template.Spec.Containers[0]
-	s.Require().Equal("/actuator/health/readiness", container.ReadinessProbe.HTTPGet.Path)
-}
-
-func (s *deploymentTemplateTest) TestReadinessProbeWithEmptyContextPathAndIngressEnabled() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"zeebeGateway.contextPath":            "",
-			"zeebeGateway.readinessProbe.enabled": "true",
-			"zeebeGateway.ingress.rest.path":      "/",
-			"zeebeGateway.ingress.rest.enabled":   "true", // Ensure ingress is enabled
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	container := deployment.Spec.Template.Spec.Containers[0]
-	s.Require().Equal("/actuator/health/readiness", container.ReadinessProbe.HTTPGet.Path)
-}
-func (s *deploymentTemplateTest) TestReadinessProbeWithTrailingSlashInContextPath() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"zeebeGateway.contextPath":            "/test/", // Context path with trailing slash
-			"zeebeGateway.readinessProbe.enabled": "true",
-			"zeebeGateway.ingress.rest.path":      "/test/",
-			"zeebeGateway.ingress.rest.enabled":   "true", // Ensure ingress is enabled
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	container := deployment.Spec.Template.Spec.Containers[0]
-	s.Require().Equal("/test/actuator/health/readiness", container.ReadinessProbe.HTTPGet.Path)
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }

--- a/charts/camunda-platform-8.6/test/unit/zeebe/statefulset_test.go
+++ b/charts/camunda-platform-8.6/test/unit/zeebe/statefulset_test.go
@@ -250,7 +250,6 @@ func (s *statefulSetTest) TestInitContainers() {
 	initContainer := statefulSet.Spec.Template.Spec.InitContainers[0]
 	s.Require().Equal("nginx", initContainer.Name)
 	s.Require().Equal("nginx:latest", initContainer.Image)
-
 }
 
 func (s *statefulSetTest) TestContainerOverwriteImageTag() {
@@ -382,7 +381,7 @@ func (s *statefulSetTest) TestContainerSetContainerCommand() {
 }
 
 func (s *statefulSetTest) TestContainerSetLog4j2() {
-	//finding out the length of containers and volumeMounts array before addition of new volumeMount
+	// finding out the length of containers and volumeMounts array before addition of new volumeMount
 	var statefulSetBefore appsv1.StatefulSet
 	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
 	helm.UnmarshalK8SYaml(s.T(), before, &statefulSetBefore)
@@ -409,7 +408,7 @@ func (s *statefulSetTest) TestContainerSetLog4j2() {
 }
 
 func (s *statefulSetTest) TestContainerSetExtraVolumes() {
-	//finding out the length of containers and volumeMounts array before addition of new volumeMount
+	// finding out the length of containers and volumeMounts array before addition of new volumeMount
 	var statefulSetBefore appsv1.StatefulSet
 	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
 	helm.UnmarshalK8SYaml(s.T(), before, &statefulSetBefore)
@@ -442,7 +441,7 @@ func (s *statefulSetTest) TestContainerSetExtraVolumes() {
 }
 
 func (s *statefulSetTest) TestContainerSetExtraVolumeMounts() {
-	//finding out the length of containers and volumeMounts array before addition of new volumeMount
+	// finding out the length of containers and volumeMounts array before addition of new volumeMount
 	var statefulSetBefore appsv1.StatefulSet
 	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
 	helm.UnmarshalK8SYaml(s.T(), before, &statefulSetBefore)
@@ -471,7 +470,7 @@ func (s *statefulSetTest) TestContainerSetExtraVolumeMounts() {
 }
 
 func (s *statefulSetTest) TestContainerSetExtraVolumesAndMounts() {
-	//finding out the length of containers and volumeMounts array before addition of new volumeMount
+	// finding out the length of containers and volumeMounts array before addition of new volumeMount
 	var statefulSetBefore appsv1.StatefulSet
 	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
 	helm.UnmarshalK8SYaml(s.T(), before, &statefulSetBefore)
@@ -535,7 +534,7 @@ func (s *statefulSetTest) TestContainerSetSecurityContext() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"zeebe.containerSecurityContext.privileged":          "true",
+			"zeebe.containerSecurityContext.privileged": "true",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 	}
@@ -593,7 +592,7 @@ func (s *statefulSetTest) TestContainerSetNodeSelector() {
 func (s *statefulSetTest) TestContainerSetAffinity() {
 	// given
 
-	//affinity:
+	// affinity:
 	//	nodeAffinity:
 	//	 requiredDuringSchedulingIgnoredDuringExecution:
 	//	   nodeSelectorTerms:
@@ -690,7 +689,7 @@ func (s *statefulSetTest) TestContainerSetTolerations() {
 }
 
 func (s *statefulSetTest) TestContainerSetPersistenceTypeRam() {
-	//finding out the length of containers and volumeMounts array before addition of new volumeMount
+	// finding out the length of containers and volumeMounts array before addition of new volumeMount
 	var statefulSetBefore appsv1.StatefulSet
 	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
 	helm.UnmarshalK8SYaml(s.T(), before, &statefulSetBefore)
@@ -728,7 +727,7 @@ func (s *statefulSetTest) TestContainerSetPersistenceTypeRam() {
 }
 
 func (s *statefulSetTest) TestContainerSetPersistenceTypeLocal() {
-	//finding out the length of containers and volumeMounts array before addition of new volumeMount
+	// finding out the length of containers and volumeMounts array before addition of new volumeMount
 	var statefulSetBefore appsv1.StatefulSet
 	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
 	helm.UnmarshalK8SYaml(s.T(), before, &statefulSetBefore)
@@ -911,6 +910,7 @@ func (s *statefulSetTest) TestContainerSetSidecar() {
 
 	s.Require().Contains(podContainers, expectedContainer)
 }
+
 func (s *statefulSetTest) TestSetDnsPolicyAndDnsConfig() {
 	// given
 	options := &helm.Options{


### PR DESCRIPTION
### Which problem does the PR fix?

https://github.com/camunda/team-distribution/issues/448

### What's in this PR?

- Zeebe gateway unit tests have been refactored the new style

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
