### PR TITLE
fix: refactor of connector unit tests to new style in 8.7

### DIFF
--- a/charts/camunda-platform-8.7/test/unit/connectors/configmap_test.go
+++ b/charts/camunda-platform-8.7/test/unit/connectors/configmap_test.go
@@ -1,12 +1,12 @@
 package connectors
 
 import (
+	"camunda-platform/test/unit/testhelpers"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -14,7 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-type configMapTemplateTest struct {
+type ConfigMapTemplateTest struct {
 	suite.Suite
 	chartPath string
 	release   string
@@ -28,7 +28,7 @@ func TestConfigMapTemplate(t *testing.T) {
 	chartPath, err := filepath.Abs("../../../")
 	require.NoError(t, err)
 
-	suite.Run(t, &configMapTemplateTest{
+	suite.Run(t, &ConfigMapTemplateTest{
 		chartPath: chartPath,
 		release:   "camunda-platform-test",
 		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
@@ -36,125 +36,109 @@ func TestConfigMapTemplate(t *testing.T) {
 	})
 }
 
-func (s *configMapTemplateTest) TestContainerSetContextPath() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.enabled":     "true",
-			"connectors.contextPath": "/connectors",
+func (s *ConfigMapTemplateTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestContainerSetContextPath",
+			Values: map[string]string{
+				"connectors.enabled":     "true",
+				"connectors.contextPath": "/connectors",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				var configmapApplication ConnectorsConfigYAML
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				e := yaml.Unmarshal([]byte(configmap.Data["application.yml"]), &configmapApplication)
+				if e != nil {
+					s.Fail("Failed to unmarshal yaml. error=", e)
+				}
+
+				// then
+				s.Require().Equal("/connectors", configmapApplication.Server.Servlet.ContextPath)
+			},
+		}, {
+			Name: "TestContainerConfigMapSetInboundModeCredentials",
+			Values: map[string]string{
+				"connectors.enabled":           "true",
+				"connectors.inbound.mode":      "credentials",
+				"global.identity.auth.enabled": "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				var configmapApplication ConnectorsConfigYAML
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				e := yaml.Unmarshal([]byte(configmap.Data["application.yml"]), &configmapApplication)
+				if e != nil {
+					s.Fail("Failed to unmarshal yaml. error=", e)
+				}
+
+				// then
+				s.Require().Empty(configmapApplication.Camunda.Connector.Polling.Enabled)
+				s.Require().Empty(configmapApplication.Camunda.Connector.WebHook.Enabled)
+				s.Require().Empty(configmapApplication.Operate.Client.KeycloakTokenURL)
+				s.Require().Empty(configmapApplication.Operate.Client.ClientId)
+
+				s.Require().Equal("http://camunda-platform-test-zeebe-gateway:26500", configmapApplication.Camunda.Client.Zeebe.GRPCAddress)
+				s.Require().Equal("http://camunda-platform-test-operate:80", configmapApplication.Operate.Client.BaseURL)
+				s.Require().Equal("connectors", configmapApplication.Operate.Client.Username)
+			},
+		}, {
+			Name: "TestContainerConfigMapSetInboundModeDisabled",
+			Values: map[string]string{
+				"connectors.enabled":      "true",
+				"connectors.inbound.mode": "disabled",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				var configmapApplication ConnectorsConfigYAML
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				e := yaml.Unmarshal([]byte(configmap.Data["application.yml"]), &configmapApplication)
+				if e != nil {
+					s.Fail("Failed to unmarshal yaml. error=", e)
+				}
+
+				// then
+				s.Require().Empty(configmapApplication.Operate.Client.KeycloakTokenURL)
+				s.Require().Empty(configmapApplication.Operate.Client.BaseURL)
+				s.Require().Empty(configmapApplication.Operate.Client.Username)
+				s.Require().Empty(configmapApplication.Operate.Client.ClientId)
+
+				s.Require().Equal("http://camunda-platform-test-zeebe-gateway:26500", configmapApplication.Camunda.Client.Zeebe.GRPCAddress)
+				s.Require().Equal("false", configmapApplication.Camunda.Connector.Polling.Enabled)
+				s.Require().Equal("false", configmapApplication.Camunda.Connector.WebHook.Enabled)
+			},
+		}, {
+			Name: "TestContainerConfigMapSetInboundModeOauthIdentity",
+			Values: map[string]string{
+				"connectors.enabled":           "true",
+				"connectors.inbound.mode":      "oauth",
+				"global.identity.auth.enabled": "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				var configmapApplication ConnectorsConfigYAML
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				e := yaml.Unmarshal([]byte(configmap.Data["application.yml"]), &configmapApplication)
+				if e != nil {
+					s.Fail("Failed to unmarshal yaml. error=", e)
+				}
+
+				// then
+				s.Require().Empty(configmapApplication.Camunda.Connector.Polling.Enabled)
+				s.Require().Empty(configmapApplication.Camunda.Connector.WebHook.Enabled)
+				s.Require().Empty(configmapApplication.Operate.Client.Username)
+
+				s.Require().Equal("http://camunda-platform-test-zeebe-gateway:26500", configmapApplication.Camunda.Client.Zeebe.GRPCAddress)
+				s.Require().Equal("http://camunda-platform-test-operate:80", configmapApplication.Operate.Client.BaseURL)
+				s.Require().Equal("operate-api", configmapApplication.Camunda.Identity.Audience)
+				s.Require().Equal("connectors", configmapApplication.Camunda.Identity.ClientId)
+			},
 		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 	}
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var configmap corev1.ConfigMap
-	var configmapApplication ConnectorsConfigYAML
-	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yml"]), &configmapApplication)
-	if err != nil {
-		s.Fail("Failed to unmarshal yaml. error=", err)
-	}
-
-	// then
-	s.Require().Equal("/connectors", configmapApplication.Server.Servlet.ContextPath)
-}
-
-func (s *configMapTemplateTest) TestContainerConfigMapSetInboundModeCredentials() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.enabled":           "true",
-			"connectors.inbound.mode":      "credentials",
-			"global.identity.auth.enabled": "false",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var configmap corev1.ConfigMap
-	var configmapApplication ConnectorsConfigYAML
-	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yml"]), &configmapApplication)
-	if err != nil {
-		s.Fail("Failed to unmarshal yaml. error=", err)
-	}
-
-	// then
-	s.Require().Empty(configmapApplication.Camunda.Connector.Polling.Enabled)
-	s.Require().Empty(configmapApplication.Camunda.Connector.WebHook.Enabled)
-	s.Require().Empty(configmapApplication.Operate.Client.KeycloakTokenURL)
-	s.Require().Empty(configmapApplication.Operate.Client.ClientId)
-
-	s.Require().Equal("http://camunda-platform-test-zeebe-gateway:26500", configmapApplication.Camunda.Client.Zeebe.GRPCAddress)
-	s.Require().Equal("http://camunda-platform-test-operate:80", configmapApplication.Operate.Client.BaseURL)
-	s.Require().Equal("connectors", configmapApplication.Operate.Client.Username)
-}
-
-func (s *configMapTemplateTest) TestContainerConfigMapSetInboundModeDisabled() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.enabled":      "true",
-			"connectors.inbound.mode": "disabled",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var configmap corev1.ConfigMap
-	var configmapApplication ConnectorsConfigYAML
-	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yml"]), &configmapApplication)
-	if err != nil {
-		s.Fail("Failed to unmarshal yaml. error=", err)
-	}
-
-	// then
-	s.Require().Empty(configmapApplication.Operate.Client.KeycloakTokenURL)
-	s.Require().Empty(configmapApplication.Operate.Client.BaseURL)
-	s.Require().Empty(configmapApplication.Operate.Client.Username)
-	s.Require().Empty(configmapApplication.Operate.Client.ClientId)
-
-	s.Require().Equal("http://camunda-platform-test-zeebe-gateway:26500", configmapApplication.Camunda.Client.Zeebe.GRPCAddress)
-	s.Require().Equal("false", configmapApplication.Camunda.Connector.Polling.Enabled)
-	s.Require().Equal("false", configmapApplication.Camunda.Connector.WebHook.Enabled)
-}
-
-func (s *configMapTemplateTest) TestContainerConfigMapSetInboundModeOauthIdentity() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.enabled":           "true",
-			"connectors.inbound.mode":      "oauth",
-			"global.identity.auth.enabled": "true",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var configmap corev1.ConfigMap
-	var configmapApplication ConnectorsConfigYAML
-	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yml"]), &configmapApplication)
-	if err != nil {
-		s.Fail("Failed to unmarshal yaml. error=", err)
-	}
-
-	// then
-	s.Require().Empty(configmapApplication.Camunda.Connector.Polling.Enabled)
-	s.Require().Empty(configmapApplication.Camunda.Connector.WebHook.Enabled)
-	s.Require().Empty(configmapApplication.Operate.Client.Username)
-
-	s.Require().Equal("http://camunda-platform-test-zeebe-gateway:26500", configmapApplication.Camunda.Client.Zeebe.GRPCAddress)
-	s.Require().Equal("http://camunda-platform-test-operate:80", configmapApplication.Operate.Client.BaseURL)
-	s.Require().Equal("operate-api", configmapApplication.Camunda.Identity.Audience)
-	s.Require().Equal("connectors", configmapApplication.Camunda.Identity.ClientId)
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }

--- a/charts/camunda-platform-8.7/test/unit/connectors/deployment_test.go
+++ b/charts/camunda-platform-8.7/test/unit/connectors/deployment_test.go
@@ -15,6 +15,7 @@
 package connectors
 
 import (
+	"camunda-platform/test/unit/testhelpers"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -22,14 +23,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	appsv1 "k8s.io/api/apps/v1"
 )
 
-type deploymentTemplateTest struct {
+type DeploymentTemplateTest struct {
 	suite.Suite
 	chartPath string
 	release   string
@@ -43,7 +43,7 @@ func TestDeploymentTemplate(t *testing.T) {
 	chartPath, err := filepath.Abs("../../../")
 	require.NoError(t, err)
 
-	suite.Run(t, &deploymentTemplateTest{
+	suite.Run(t, &DeploymentTemplateTest{
 		chartPath: chartPath,
 		release:   "camunda-platform-test",
 		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
@@ -53,796 +53,626 @@ func TestDeploymentTemplate(t *testing.T) {
 
 // TODO/FIXME: currently Connectors don't support name override
 
-func (s *deploymentTemplateTest) TestContainerSetPodLabels() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.enabled":       "true",
-			"connectors.podLabels.foo": "bar",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	s.Require().Equal("bar", deployment.Spec.Template.Labels["foo"])
-}
-
-func (s *deploymentTemplateTest) TestContainerSetPodAnnotations() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.enabled":            "true",
-			"connectors.podAnnotations.foo": "bar",
-			"connectors.podAnnotations.foz": "baz",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	s.Require().Equal("bar", deployment.Spec.Template.Annotations["foo"])
-	s.Require().Equal("baz", deployment.Spec.Template.Annotations["foz"])
-}
-
-func (s *deploymentTemplateTest) TestContainerSetGlobalAnnotations() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.enabled":     "true",
-			"global.annotations.foo": "bar",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	s.Require().Equal("bar", deployment.ObjectMeta.Annotations["foo"])
-}
-
-func (s *deploymentTemplateTest) TestContainerSetImageNameSubChart() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.enabled":          "true",
-			"global.image.registry":       "global.custom.registry.io",
-			"global.image.tag":            "999.999.1",
-			"connectors.image.registry":   "subchart.custom.registry.io",
-			"connectors.image.tag":        "snapshot",
-			"connectors.image.repository": "connectors/connectors-bundle",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	container := deployment.Spec.Template.Spec.Containers[0]
-	s.Require().Equal("subchart.custom.registry.io/connectors/connectors-bundle:snapshot", container.Image)
-}
-
-func (s *deploymentTemplateTest) TestContainerSetImageNameGlobalRegistry() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.enabled":          "true",
-			"global.image.registry":       "global.custom.registry.io",
-			"connectors.image.registry":   "",
-			"connectors.image.tag":        "snapshot",
-			"connectors.image.repository": "connectors/connectors-bundle",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	container := deployment.Spec.Template.Spec.Containers[0]
-	s.Require().Equal("global.custom.registry.io/connectors/connectors-bundle:snapshot", container.Image)
-}
-
-func (s *deploymentTemplateTest) TestContainerSetImagePullSecretsGlobal() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.enabled":               "true",
-			"global.image.pullSecrets[0].name": "SecretName",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	s.Require().Equal("SecretName", deployment.Spec.Template.Spec.ImagePullSecrets[0].Name)
-}
-
-func (s *deploymentTemplateTest) TestContainerSetImagePullSecretsSubChart() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.enabled":                   "true",
-			"global.image.pullSecrets[0].name":     "SecretName",
-			"connectors.image.pullSecrets[0].name": "SecretNameSubChart",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	s.Require().Equal("SecretNameSubChart", deployment.Spec.Template.Spec.ImagePullSecrets[0].Name)
-}
-
-func (s *deploymentTemplateTest) TestContainerOverwriteImageTag() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.enabled":   "true",
-			"connectors.image.tag": "a.b.c",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	expectedContainerImage := "camunda/connectors-bundle:a.b.c"
-	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
-	s.Require().Equal(expectedContainerImage, containers[0].Image)
-}
-
-func (s *deploymentTemplateTest) TestContainerOverwriteGlobalImageTag() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.enabled":   "true",
-			"connectors.image.tag": "",
-			"global.image.tag":     "a.b.c",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	expectedContainerImage := "camunda/connectors-bundle:a.b.c"
-	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
-	s.Require().Equal(expectedContainerImage, containers[0].Image)
-}
-
-func (s *deploymentTemplateTest) TestContainerOverwriteImageTagWithChartDirectSetting() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.enabled":   "true",
-			"connectors.image.tag": "a.b.c",
-			"global.image.tag":     "x.y.z",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	expectedContainerImage := "camunda/connectors-bundle:a.b.c"
-	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
-	s.Require().Equal(expectedContainerImage, containers[0].Image)
-}
-
-func (s *deploymentTemplateTest) TestContainerSetContainerCommand() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.enabled":    "true",
-			"connectors.command[0]": "printenv",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
-	s.Require().Equal(1, len(containers[0].Command))
-	s.Require().Equal("printenv", containers[0].Command[0])
-}
-
-func (s *deploymentTemplateTest) TestContainerSetServiceAccountName() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.enabled":             "true",
-			"connectors.serviceAccount.name": "accName",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	serviceAccName := deployment.Spec.Template.Spec.ServiceAccountName
-	s.Require().Equal("accName", serviceAccName)
-}
-
-func (s *deploymentTemplateTest) TestPodSetSecurityContext() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.enabled":                      "true",
-			"connectors.podSecurityContext.runAsUser": "1000",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	securityContext := deployment.Spec.Template.Spec.SecurityContext
-	s.Require().EqualValues(1000, *securityContext.RunAsUser)
-}
-
-func (s *deploymentTemplateTest) TestContainerSetSecurityContext() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.enabled":                                      "true",
-			"connectors.containerSecurityContext.privileged":          "true",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	securityContext := deployment.Spec.Template.Spec.Containers[0].SecurityContext
-	s.Require().True(*securityContext.Privileged)
-}
-
-// https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
-func (s *deploymentTemplateTest) TestContainerSetNodeSelector() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.enabled":               "true",
-			"connectors.nodeSelector.disktype": "ssd",
-			"connectors.nodeSelector.cputype":  "arm",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	s.Require().Equal("ssd", deployment.Spec.Template.Spec.NodeSelector["disktype"])
-	s.Require().Equal("arm", deployment.Spec.Template.Spec.NodeSelector["cputype"])
-}
-
-// https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
-func (s *deploymentTemplateTest) TestContainerSetAffinity() {
-	// given
-
-	//affinity:
-	//	nodeAffinity:
-	//	 requiredDuringSchedulingIgnoredDuringExecution:
-	//	   nodeSelectorTerms:
-	//	   - matchExpressions:
-	//		 - key: kubernetes.io/e2e-az-name
-	//		   operator: In
-	//		   values:
-	//		   - e2e-az1
-	//		   - e2e-az2
-	//	 preferredDuringSchedulingIgnoredDuringExecution:
-	//	 - weight: 1
-	//	   preference:
-	//		 matchExpressions:
-	//		 - key: another-node-label-key
-	//		   operator: In
-	//		   values:
-	//		   - another-node-label-value
-
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.enabled": "true",
-			"connectors.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].key":       "kubernetes.io/e2e-az-name",
-			"connectors.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].operator":  "In",
-			"connectors.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].values[0]": "e2e-a1",
-			"connectors.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].values[1]": "e2e-a2",
-			"connectors.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight":                                         "1",
-			"connectors.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].key":             "another-node-label-key",
-			"connectors.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].operator":        "In",
-			"connectors.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].values[0]":       "another-node-label-value",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	nodeAffinity := deployment.Spec.Template.Spec.Affinity.NodeAffinity
-	s.Require().NotNil(nodeAffinity)
-
-	nodeSelectorTerm := nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0]
-	s.Require().NotNil(nodeSelectorTerm)
-	matchExpression := nodeSelectorTerm.MatchExpressions[0]
-	s.Require().NotNil(matchExpression)
-	s.Require().Equal("kubernetes.io/e2e-az-name", matchExpression.Key)
-	s.Require().EqualValues("In", matchExpression.Operator)
-	s.Require().Equal([]string{"e2e-a1", "e2e-a2"}, matchExpression.Values)
-
-	preferredSchedulingTerm := nodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0]
-	s.Require().NotNil(preferredSchedulingTerm)
-
-	matchExpression = preferredSchedulingTerm.Preference.MatchExpressions[0]
-	s.Require().NotNil(matchExpression)
-	s.Require().Equal("another-node-label-key", matchExpression.Key)
-	s.Require().EqualValues("In", matchExpression.Operator)
-	s.Require().Equal([]string{"another-node-label-value"}, matchExpression.Values)
-}
-
-// https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration
-func (s *deploymentTemplateTest) TestContainerSetTolerations() {
-	// given
-
-	//tolerations:
-	//- key: "key1"
-	//  operator: "Equal"
-	//  value: "value1"
-	//  effect: "NoSchedule"
-
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.enabled":                 "true",
-			"connectors.tolerations[0].key":      "key1",
-			"connectors.tolerations[0].operator": "Equal",
-			"connectors.tolerations[0].value":    "Value1",
-			"connectors.tolerations[0].effect":   "NoSchedule",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	tolerations := deployment.Spec.Template.Spec.Tolerations
-	s.Require().Equal(1, len(tolerations))
-
-	toleration := tolerations[0]
-	s.Require().Equal("key1", toleration.Key)
-	s.Require().EqualValues("Equal", toleration.Operator)
-	s.Require().Equal("Value1", toleration.Value)
-	s.Require().EqualValues("NoSchedule", toleration.Effect)
-}
-
-func (s *deploymentTemplateTest) TestContainerShouldOverwriteGlobalImagePullPolicy() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.enabled":      "true",
-			"global.image.pullPolicy": "Always",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	expectedPullPolicy := corev1.PullAlways
-	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
-	pullPolicy := containers[0].ImagePullPolicy
-	s.Require().Equal(expectedPullPolicy, pullPolicy)
-}
-
-func (s *deploymentTemplateTest) TestContainerStartupProbe() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.enabled":                          "true",
-			"connectors.startupProbe.enabled":             "true",
-			"connectors.startupProbe.initialDelaySeconds": "5",
-			"connectors.startupProbe.periodSeconds":       "10",
-			"connectors.startupProbe.successThreshold":    "1",
-			"connectors.startupProbe.failureThreshold":    "5",
-			"connectors.startupProbe.timeoutSeconds":      "1",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	probe := deployment.Spec.Template.Spec.Containers[0].StartupProbe
-
-	s.Require().EqualValues(5, probe.InitialDelaySeconds)
-	s.Require().EqualValues(10, probe.PeriodSeconds)
-	s.Require().EqualValues(1, probe.SuccessThreshold)
-	s.Require().EqualValues(5, probe.FailureThreshold)
-	s.Require().EqualValues(1, probe.TimeoutSeconds)
-}
-
-func (s *deploymentTemplateTest) TestContainerReadinessProbe() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.enabled":                            "true",
-			"connectors.readinessProbe.enabled":             "true",
-			"connectors.readinessProbe.initialDelaySeconds": "5",
-			"connectors.readinessProbe.periodSeconds":       "10",
-			"connectors.readinessProbe.successThreshold":    "1",
-			"connectors.readinessProbe.failureThreshold":    "5",
-			"connectors.readinessProbe.timeoutSeconds":      "1",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	probe := deployment.Spec.Template.Spec.Containers[0].ReadinessProbe
-
-	s.Require().EqualValues(5, probe.InitialDelaySeconds)
-	s.Require().EqualValues(10, probe.PeriodSeconds)
-	s.Require().EqualValues(1, probe.SuccessThreshold)
-	s.Require().EqualValues(5, probe.FailureThreshold)
-	s.Require().EqualValues(1, probe.TimeoutSeconds)
-}
-
-func (s *deploymentTemplateTest) TestContainerLivenessProbe() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.enabled":                           "true",
-			"connectors.livenessProbe.enabled":             "true",
-			"connectors.livenessProbe.initialDelaySeconds": "5",
-			"connectors.livenessProbe.periodSeconds":       "10",
-			"connectors.livenessProbe.successThreshold":    "1",
-			"connectors.livenessProbe.failureThreshold":    "5",
-			"connectors.livenessProbe.timeoutSeconds":      "1",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	probe := deployment.Spec.Template.Spec.Containers[0].LivenessProbe
-
-	s.Require().EqualValues(5, probe.InitialDelaySeconds)
-	s.Require().EqualValues(10, probe.PeriodSeconds)
-	s.Require().EqualValues(1, probe.SuccessThreshold)
-	s.Require().EqualValues(5, probe.FailureThreshold)
-	s.Require().EqualValues(1, probe.TimeoutSeconds)
-}
-
-func (s *deploymentTemplateTest) TestContainerProbesWithContextPath() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.contextPath":              "/test",
-			"connectors.startupProbe.enabled":     "true",
-			"connectors.startupProbe.probePath":   "/start",
-			"connectors.readinessProbe.enabled":   "true",
-			"connectors.readinessProbe.probePath": "/ready",
-			"connectors.livenessProbe.enabled":    "true",
-			"connectors.livenessProbe.probePath":  "/live",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	probe := deployment.Spec.Template.Spec.Containers[0]
-
-	s.Require().Equal("/test/start", probe.StartupProbe.HTTPGet.Path)
-	s.Require().Equal("/test/ready", probe.ReadinessProbe.HTTPGet.Path)
-	s.Require().Equal("/test/live", probe.LivenessProbe.HTTPGet.Path)
-}
-
-func (s *deploymentTemplateTest) TestContainerExtraVolumeMounts() {
-	//finding out the length of containers and volumeMounts array before addition of new volumeMount
-	var deploymentBefore appsv1.Deployment
-	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
-	helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
-	containerLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers)
-	volumeMountLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.enabled":                        "true",
-			"connectors.extraVolumeMounts[0].name":      "someConfig",
-			"connectors.extraVolumeMounts[0].mountPath": "/usr/local/config",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(containerLenBefore, len(containers))
-
-	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(volumeMountLenBefore+1, len(volumeMounts))
-	extraVolumeMount := volumeMounts[volumeMountLenBefore]
-	s.Require().Equal("someConfig", extraVolumeMount.Name)
-	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
-}
-
-func (s *deploymentTemplateTest) TestContainerExtraVolumes() {
-	//finding out the length of volumes array before addition of new volume
-	var deploymentBefore appsv1.Deployment
-	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
-	helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
-	volumeLenBefore := len(deploymentBefore.Spec.Template.Spec.Volumes)
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.enabled":                               "true",
-			"connectors.extraVolumes[0].name":                  "myExtraVolume",
-			"connectors.extraVolumes[0].configMap.name":        "otherConfigMap",
-			"connectors.extraVolumes[0].configMap.defaultMode": "744",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	volumes := deployment.Spec.Template.Spec.Volumes
-	s.Require().Equal(volumeLenBefore+1, len(volumes))
-
-	extraVolume := volumes[volumeLenBefore]
-	s.Require().Equal("myExtraVolume", extraVolume.Name)
-	s.Require().NotNil(*extraVolume.ConfigMap)
-	s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
-	s.Require().EqualValues(744, *extraVolume.ConfigMap.DefaultMode)
-}
-
-func (s *deploymentTemplateTest) TestContainerSetInboundModeDisabled() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.enabled":      "true",
-			"connectors.inbound.mode": "disabled",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-
-	for _, envvar := range env {
-		s.Require().NotEqual("CAMUNDA_OPERATE_CLIENT_PASSWORD", envvar.Name)
-		s.Require().NotEqual("CAMUNDA_OPERATE_CLIENT_CLIENT-SECRET", envvar.Name)
-	}
-
-}
-
-func (s *deploymentTemplateTest) TestContainerSetInboundModeCredentials() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.enabled":           "true",
-			"connectors.inbound.mode":      "credentials",
-			"global.identity.auth.enabled": "false",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-
-	for _, envvar := range env {
-		s.Require().NotEqual("CAMUNDA_OPERATE_CLIENT_CLIENT-SECRET", envvar.Name)
-		s.Require().NotEqual("SPRING_MAIN_WEB-APPLICATION-TYPE", envvar.Name)
-	}
-	s.Require().Contains(
-		env,
-		corev1.EnvVar{
-			Name:      "OPERATE_CLIENT_PASSWORD",
-			ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "camunda-platform-test-connectors-auth-credentials"}, Key: "connectors-secret"}}})
-}
-
-func (s *deploymentTemplateTest) TestContainerSetInboundModeOauthIdentity() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.enabled":           "true",
-			"connectors.inbound.mode":      "oauth",
-			"global.identity.auth.enabled": "true",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-
-	for _, envvar := range env {
-		s.Require().NotEqual("SPRING_MAIN_WEB-APPLICATION-TYPE", envvar.Name)
-		s.Require().NotEqual("OPERATE_CLIENT_PASSWORD", envvar.Name)
-	}
-
-	s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_CLIENT_AUTH_CLIENT_ID", Value: "zeebe"})
-	s.Require().Contains(
-		env,
-		corev1.EnvVar{
-			Name: "CAMUNDA_CLIENT_AUTH_CLIENT_SECRET",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "camunda-platform-test-zeebe-identity-secret"},
-					Key:                  "zeebe-secret",
-				},
+func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestContainerSetPodLabels",
+			Values: map[string]string{
+				"connectors.enabled":       "true",
+				"connectors.podLabels.foo": "bar",
 			},
-		})
-	s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_CLIENT_AUTH_ISSUER", Value: "http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/token"})
-	s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_CLIENT_ZEEBE_AUDIENCE", Value: "zeebe-api"})
-	s.Require().Contains(
-		env,
-		corev1.EnvVar{
-			Name: "CAMUNDA_IDENTITY_CLIENT_SECRET",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "camunda-platform-test-connectors-identity-secret"},
-					Key:                  "connectors-secret",
-				},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				s.Require().Equal("bar", deployment.Spec.Template.Labels["foo"])
 			},
-		})
-}
+		}, {
+			Name: "TestContainerSetPodAnnotations",
+			Values: map[string]string{
+				"connectors.enabled":            "true",
+				"connectors.podAnnotations.foo": "bar",
+				"connectors.podAnnotations.foz": "baz",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-func (s *deploymentTemplateTest) TestContainerSetSidecar() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.sidecars[0].name":                   "nginx",
-			"connectors.sidecars[0].image":                  "nginx:latest",
-			"connectors.sidecars[0].ports[0].containerPort": "80",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
+				// then
+				s.Require().Equal("bar", deployment.Spec.Template.Annotations["foo"])
+				s.Require().Equal("baz", deployment.Spec.Template.Annotations["foz"])
+			},
+		}, {
+			Name: "TestContainerSetGlobalAnnotations",
+			Values: map[string]string{
+				"connectors.enabled":     "true",
+				"global.annotations.foo": "bar",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+				// then
+				s.Require().Equal("bar", deployment.ObjectMeta.Annotations["foo"])
+			},
+		}, {
+			Name: "TestContainerSetImageNameSubChart",
+			Values: map[string]string{
+				"connectors.enabled":          "true",
+				"global.image.registry":       "global.custom.registry.io",
+				"global.image.tag":            "999.999.1",
+				"connectors.image.registry":   "subchart.custom.registry.io",
+				"connectors.image.tag":        "snapshot",
+				"connectors.image.repository": "connectors/connectors-bundle",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	// then
-	podContainers := deployment.Spec.Template.Spec.Containers
-	expectedContainer := corev1.Container{
-		Name:  "nginx",
-		Image: "nginx:latest",
-		Ports: []corev1.ContainerPort{
-			{
-				ContainerPort: 80,
+				// then
+				container := deployment.Spec.Template.Spec.Containers[0]
+				s.Require().Equal("subchart.custom.registry.io/connectors/connectors-bundle:snapshot", container.Image)
+			},
+		}, {
+			Name: "TestContainerSetImageNameGlobalRegistry",
+			Values: map[string]string{
+				"connectors.enabled":          "true",
+				"global.image.registry":       "global.custom.registry.io",
+				"connectors.image.registry":   "",
+				"connectors.image.tag":        "snapshot",
+				"connectors.image.repository": "connectors/connectors-bundle",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				container := deployment.Spec.Template.Spec.Containers[0]
+				s.Require().Equal("global.custom.registry.io/connectors/connectors-bundle:snapshot", container.Image)
+			},
+		}, {
+			Name: "TestContainerSetImagePullSecretsGlobal",
+			Values: map[string]string{
+				"connectors.enabled":               "true",
+				"global.image.pullSecrets[0].name": "SecretName",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				s.Require().Equal("SecretName", deployment.Spec.Template.Spec.ImagePullSecrets[0].Name)
+			},
+		}, {
+			Name: "TestContainerSetImagePullSecretsSubChart",
+			Values: map[string]string{
+				"connectors.enabled":                   "true",
+				"global.image.pullSecrets[0].name":     "SecretName",
+				"connectors.image.pullSecrets[0].name": "SecretNameSubChart",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				s.Require().Equal("SecretNameSubChart", deployment.Spec.Template.Spec.ImagePullSecrets[0].Name)
+			},
+		}, {
+			Name: "TestContainerOverwriteImageTag",
+			Values: map[string]string{
+				"connectors.enabled":   "true",
+				"connectors.image.tag": "a.b.c",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				expectedContainerImage := "camunda/connectors-bundle:a.b.c"
+				containers := deployment.Spec.Template.Spec.Containers
+				s.Require().Equal(1, len(containers))
+				s.Require().Equal(expectedContainerImage, containers[0].Image)
+			},
+		}, {
+			Name: "TestContainerOverwriteGlobalImageTag",
+			Values: map[string]string{
+				"connectors.enabled":   "true",
+				"connectors.image.tag": "",
+				"global.image.tag":     "a.b.c",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				expectedContainerImage := "camunda/connectors-bundle:a.b.c"
+				containers := deployment.Spec.Template.Spec.Containers
+				s.Require().Equal(1, len(containers))
+				s.Require().Equal(expectedContainerImage, containers[0].Image)
+			},
+		}, {
+			Name: "TestContainerOverwriteImageTagWithChartDirectSetting",
+			Values: map[string]string{
+				"connectors.enabled":   "true",
+				"connectors.image.tag": "a.b.c",
+				"global.image.tag":     "x.y.z",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				expectedContainerImage := "camunda/connectors-bundle:a.b.c"
+				containers := deployment.Spec.Template.Spec.Containers
+				s.Require().Equal(1, len(containers))
+				s.Require().Equal(expectedContainerImage, containers[0].Image)
+			},
+		}, {
+			Name: "TestContainerSetContainerCommand",
+			Values: map[string]string{
+				"connectors.enabled":    "true",
+				"connectors.command[0]": "printenv",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				containers := deployment.Spec.Template.Spec.Containers
+				s.Require().Equal(1, len(containers))
+				s.Require().Equal(1, len(containers[0].Command))
+				s.Require().Equal("printenv", containers[0].Command[0])
+			},
+		}, {
+			Name: "TestContainerSetServiceAccountName",
+			Values: map[string]string{
+				"connectors.enabled":             "true",
+				"connectors.serviceAccount.name": "accName",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				serviceAccName := deployment.Spec.Template.Spec.ServiceAccountName
+				s.Require().Equal("accName", serviceAccName)
+			},
+		}, {
+			Name: "TestPodSetSecurityContext",
+			Values: map[string]string{
+				"connectors.enabled":                      "true",
+				"connectors.podSecurityContext.runAsUser": "1000",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				securityContext := deployment.Spec.Template.Spec.SecurityContext
+				s.Require().EqualValues(1000, *securityContext.RunAsUser)
+			},
+		}, {
+			Name: "TestContainerSetSecurityContext",
+			Values: map[string]string{
+				"connectors.enabled":                             "true",
+				"connectors.containerSecurityContext.privileged": "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				securityContext := deployment.Spec.Template.Spec.Containers[0].SecurityContext
+				s.Require().True(*securityContext.Privileged)
+			},
+		}, {
+			// https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+			Name: "TestContainerSetNodeSelector",
+			Values: map[string]string{
+				"connectors.enabled":               "true",
+				"connectors.nodeSelector.disktype": "ssd",
+				"connectors.nodeSelector.cputype":  "arm",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				s.Require().Equal("ssd", deployment.Spec.Template.Spec.NodeSelector["disktype"])
+				s.Require().Equal("arm", deployment.Spec.Template.Spec.NodeSelector["cputype"])
+			},
+		}, {
+			// https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+			// affinity:
+			//	nodeAffinity:
+			//	 requiredDuringSchedulingIgnoredDuringExecution:
+			//	   nodeSelectorTerms:
+			//	   - matchExpressions:
+			//		 - key: kubernetes.io/e2e-az-name
+			//		   operator: In
+			//		   values:
+			//		   - e2e-az1
+			//		   - e2e-az2
+			//	 preferredDuringSchedulingIgnoredDuringExecution:
+			//	 - weight: 1
+			//	   preference:
+			//		 matchExpressions:
+			//		 - key: another-node-label-key
+			//		   operator: In
+			//		   values:
+			//		   - another-node-label-value
+			Name: "TestContainerSetAffinity",
+			Values: map[string]string{
+				"connectors.enabled": "true",
+				"connectors.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].key":       "kubernetes.io/e2e-az-name",
+				"connectors.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].operator":  "In",
+				"connectors.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].values[0]": "e2e-a1",
+				"connectors.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].values[1]": "e2e-a2",
+				"connectors.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight":                                         "1",
+				"connectors.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].key":             "another-node-label-key",
+				"connectors.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].operator":        "In",
+				"connectors.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].values[0]":       "another-node-label-value",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				nodeAffinity := deployment.Spec.Template.Spec.Affinity.NodeAffinity
+				s.Require().NotNil(nodeAffinity)
+
+				nodeSelectorTerm := nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0]
+				s.Require().NotNil(nodeSelectorTerm)
+				matchExpression := nodeSelectorTerm.MatchExpressions[0]
+				s.Require().NotNil(matchExpression)
+				s.Require().Equal("kubernetes.io/e2e-az-name", matchExpression.Key)
+				s.Require().EqualValues("In", matchExpression.Operator)
+				s.Require().Equal([]string{"e2e-a1", "e2e-a2"}, matchExpression.Values)
+
+				preferredSchedulingTerm := nodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0]
+				s.Require().NotNil(preferredSchedulingTerm)
+
+				matchExpression = preferredSchedulingTerm.Preference.MatchExpressions[0]
+				s.Require().NotNil(matchExpression)
+				s.Require().Equal("another-node-label-key", matchExpression.Key)
+				s.Require().EqualValues("In", matchExpression.Operator)
+				s.Require().Equal([]string{"another-node-label-value"}, matchExpression.Values)
+			},
+		}, {
+			// https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration
+			//tolerations:
+			//- key: "key1"
+			//  operator: "Equal"
+			//  value: "value1"
+			//  effect: "NoSchedule"
+			Name: "TestContainerSetTolerations",
+			Values: map[string]string{
+				"connectors.enabled":                 "true",
+				"connectors.tolerations[0].key":      "key1",
+				"connectors.tolerations[0].operator": "Equal",
+				"connectors.tolerations[0].value":    "Value1",
+				"connectors.tolerations[0].effect":   "NoSchedule",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				tolerations := deployment.Spec.Template.Spec.Tolerations
+				s.Require().Equal(1, len(tolerations))
+
+				toleration := tolerations[0]
+				s.Require().Equal("key1", toleration.Key)
+				s.Require().EqualValues("Equal", toleration.Operator)
+				s.Require().Equal("Value1", toleration.Value)
+				s.Require().EqualValues("NoSchedule", toleration.Effect)
+			},
+		}, {
+			Name: "TestContainerShouldOverwriteGlobalImagePullPolicy",
+			Values: map[string]string{
+				"connectors.enabled":      "true",
+				"global.image.pullPolicy": "Always",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				expectedPullPolicy := corev1.PullAlways
+				containers := deployment.Spec.Template.Spec.Containers
+				s.Require().Equal(1, len(containers))
+				pullPolicy := containers[0].ImagePullPolicy
+				s.Require().Equal(expectedPullPolicy, pullPolicy)
+			},
+		}, {
+			Name: "TestContainerStartupProbe",
+			Values: map[string]string{
+				"connectors.enabled":                          "true",
+				"connectors.startupProbe.enabled":             "true",
+				"connectors.startupProbe.initialDelaySeconds": "5",
+				"connectors.startupProbe.periodSeconds":       "10",
+				"connectors.startupProbe.successThreshold":    "1",
+				"connectors.startupProbe.failureThreshold":    "5",
+				"connectors.startupProbe.timeoutSeconds":      "1",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				probe := deployment.Spec.Template.Spec.Containers[0].StartupProbe
+
+				s.Require().EqualValues(5, probe.InitialDelaySeconds)
+				s.Require().EqualValues(10, probe.PeriodSeconds)
+				s.Require().EqualValues(1, probe.SuccessThreshold)
+				s.Require().EqualValues(5, probe.FailureThreshold)
+				s.Require().EqualValues(1, probe.TimeoutSeconds)
+			},
+		}, {
+			Name: "TestContainerReadinessProbe",
+			Values: map[string]string{
+				"connectors.enabled":                            "true",
+				"connectors.readinessProbe.enabled":             "true",
+				"connectors.readinessProbe.initialDelaySeconds": "5",
+				"connectors.readinessProbe.periodSeconds":       "10",
+				"connectors.readinessProbe.successThreshold":    "1",
+				"connectors.readinessProbe.failureThreshold":    "5",
+				"connectors.readinessProbe.timeoutSeconds":      "1",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				probe := deployment.Spec.Template.Spec.Containers[0].ReadinessProbe
+
+				s.Require().EqualValues(5, probe.InitialDelaySeconds)
+				s.Require().EqualValues(10, probe.PeriodSeconds)
+				s.Require().EqualValues(1, probe.SuccessThreshold)
+				s.Require().EqualValues(5, probe.FailureThreshold)
+				s.Require().EqualValues(1, probe.TimeoutSeconds)
+			},
+		}, {
+			Name: "TestContainerLivenessProbe",
+			Values: map[string]string{
+				"connectors.enabled":                           "true",
+				"connectors.livenessProbe.enabled":             "true",
+				"connectors.livenessProbe.initialDelaySeconds": "5",
+				"connectors.livenessProbe.periodSeconds":       "10",
+				"connectors.livenessProbe.successThreshold":    "1",
+				"connectors.livenessProbe.failureThreshold":    "5",
+				"connectors.livenessProbe.timeoutSeconds":      "1",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				probe := deployment.Spec.Template.Spec.Containers[0].LivenessProbe
+
+				s.Require().EqualValues(5, probe.InitialDelaySeconds)
+				s.Require().EqualValues(10, probe.PeriodSeconds)
+				s.Require().EqualValues(1, probe.SuccessThreshold)
+				s.Require().EqualValues(5, probe.FailureThreshold)
+				s.Require().EqualValues(1, probe.TimeoutSeconds)
+			},
+		}, {
+			Name: "TestContainerProbesWithContextPath",
+			Values: map[string]string{
+				"connectors.contextPath":              "/test",
+				"connectors.startupProbe.enabled":     "true",
+				"connectors.startupProbe.probePath":   "/start",
+				"connectors.readinessProbe.enabled":   "true",
+				"connectors.readinessProbe.probePath": "/ready",
+				"connectors.livenessProbe.enabled":    "true",
+				"connectors.livenessProbe.probePath":  "/live",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				probe := deployment.Spec.Template.Spec.Containers[0]
+
+				s.Require().Equal("/test/start", probe.StartupProbe.HTTPGet.Path)
+				s.Require().Equal("/test/ready", probe.ReadinessProbe.HTTPGet.Path)
+				s.Require().Equal("/test/live", probe.LivenessProbe.HTTPGet.Path)
+			},
+		}, {
+			Name: "TestContainerExtraVolumeMounts",
+			Values: map[string]string{
+				"connectors.enabled":                        "true",
+				"connectors.extraVolumeMounts[0].name":      "someConfig",
+				"connectors.extraVolumeMounts[0].mountPath": "/usr/local/config",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				// finding out the length of containers and volumeMounts array before addition of new volumeMount
+				var deploymentBefore appsv1.Deployment
+				before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
+				helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
+				containerLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers)
+				volumeMountLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				containers := deployment.Spec.Template.Spec.Containers
+				s.Require().Equal(containerLenBefore, len(containers))
+
+				volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
+				s.Require().Equal(volumeMountLenBefore+1, len(volumeMounts))
+				extraVolumeMount := volumeMounts[volumeMountLenBefore]
+				s.Require().Equal("someConfig", extraVolumeMount.Name)
+				s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
+			},
+		}, {
+			Name: "TestContainerExtraVolumes",
+			Values: map[string]string{
+				"connectors.enabled":                               "true",
+				"connectors.extraVolumes[0].name":                  "myExtraVolume",
+				"connectors.extraVolumes[0].configMap.name":        "otherConfigMap",
+				"connectors.extraVolumes[0].configMap.defaultMode": "744",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				// finding out the length of volumes array before addition of new volume
+				var deploymentBefore appsv1.Deployment
+				before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
+				helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
+				volumeLenBefore := len(deploymentBefore.Spec.Template.Spec.Volumes)
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				volumes := deployment.Spec.Template.Spec.Volumes
+				s.Require().Equal(volumeLenBefore+1, len(volumes))
+
+				extraVolume := volumes[volumeLenBefore]
+				s.Require().Equal("myExtraVolume", extraVolume.Name)
+				s.Require().NotNil(*extraVolume.ConfigMap)
+				s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
+				s.Require().EqualValues(744, *extraVolume.ConfigMap.DefaultMode)
+			},
+		}, {
+			Name: "TestContainerSetInboundModeDisabled",
+			Values: map[string]string{
+				"connectors.enabled":      "true",
+				"connectors.inbound.mode": "disabled",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+
+				for _, envvar := range env {
+					s.Require().NotEqual("CAMUNDA_OPERATE_CLIENT_PASSWORD", envvar.Name)
+					s.Require().NotEqual("CAMUNDA_OPERATE_CLIENT_CLIENT-SECRET", envvar.Name)
+				}
+			},
+		}, {
+			Name: "TestContainerSetInboundModeCredentials",
+			Values: map[string]string{
+				"connectors.enabled":           "true",
+				"connectors.inbound.mode":      "credentials",
+				"global.identity.auth.enabled": "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+
+				for _, envvar := range env {
+					s.Require().NotEqual("CAMUNDA_OPERATE_CLIENT_CLIENT-SECRET", envvar.Name)
+					s.Require().NotEqual("SPRING_MAIN_WEB-APPLICATION-TYPE", envvar.Name)
+				}
+				s.Require().Contains(
+					env,
+					corev1.EnvVar{
+						Name:      "OPERATE_CLIENT_PASSWORD",
+						ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "camunda-platform-test-connectors-auth-credentials"}, Key: "connectors-secret"}},
+					})
+			},
+		}, {
+			Name: "TestContainerSetInboundModeOauthIdentity",
+			Values: map[string]string{
+				"connectors.enabled":           "true",
+				"connectors.inbound.mode":      "oauth",
+				"global.identity.auth.enabled": "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+
+				for _, envvar := range env {
+					s.Require().NotEqual("SPRING_MAIN_WEB-APPLICATION-TYPE", envvar.Name)
+					s.Require().NotEqual("OPERATE_CLIENT_PASSWORD", envvar.Name)
+				}
+
+				s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_CLIENT_AUTH_CLIENT_ID", Value: "zeebe"})
+				s.Require().Contains(
+					env,
+					corev1.EnvVar{
+						Name: "CAMUNDA_CLIENT_AUTH_CLIENT_SECRET",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "camunda-platform-test-zeebe-identity-secret"},
+								Key:                  "zeebe-secret",
+							},
+						},
+					})
+				s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_CLIENT_AUTH_ISSUER", Value: "http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/token"})
+				s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_CLIENT_ZEEBE_AUDIENCE", Value: "zeebe-api"})
+				s.Require().Contains(
+					env,
+					corev1.EnvVar{
+						Name: "CAMUNDA_IDENTITY_CLIENT_SECRET",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "camunda-platform-test-connectors-identity-secret"},
+								Key:                  "connectors-secret",
+							},
+						},
+					})
+			},
+		}, {
+			Name: "TestContainerSetSidecar",
+			Values: map[string]string{
+				"connectors.sidecars[0].name":                   "nginx",
+				"connectors.sidecars[0].image":                  "nginx:latest",
+				"connectors.sidecars[0].ports[0].containerPort": "80",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				podContainers := deployment.Spec.Template.Spec.Containers
+				expectedContainer := corev1.Container{
+					Name:  "nginx",
+					Image: "nginx:latest",
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: 80,
+						},
+					},
+				}
+
+				s.Require().Contains(podContainers, expectedContainer)
+			},
+		}, {
+			Name: "TestContainerSetInitContainer",
+			Values: map[string]string{
+				"connectors.initContainers[0].name":                   "nginx",
+				"connectors.initContainers[0].image":                  "nginx:latest",
+				"connectors.initContainers[0].ports[0].containerPort": "80",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				podContainers := deployment.Spec.Template.Spec.InitContainers
+				expectedContainer := corev1.Container{
+					Name:  "nginx",
+					Image: "nginx:latest",
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: 80,
+						},
+					},
+				}
+
+				s.Require().Contains(podContainers, expectedContainer)
 			},
 		},
 	}
 
-	s.Require().Contains(podContainers, expectedContainer)
-}
-func (s *deploymentTemplateTest) TestContainerSetInitContainer() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.initContainers[0].name":                   "nginx",
-			"connectors.initContainers[0].image":                  "nginx:latest",
-			"connectors.initContainers[0].ports[0].containerPort": "80",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	podContainers := deployment.Spec.Template.Spec.InitContainers
-	expectedContainer := corev1.Container{
-		Name:  "nginx",
-		Image: "nginx:latest",
-		Ports: []corev1.ContainerPort{
-			{
-				ContainerPort: 80,
-			},
-		},
-	}
-
-	s.Require().Contains(podContainers, expectedContainer)
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }

--- a/charts/camunda-platform-8.7/test/unit/connectors/service_test.go
+++ b/charts/camunda-platform-8.7/test/unit/connectors/service_test.go
@@ -15,19 +15,19 @@
 package connectors
 
 import (
+	"camunda-platform/test/unit/testhelpers"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	coreV1 "k8s.io/api/core/v1"
 )
 
-type serviceTest struct {
+type ServiceTest struct {
 	suite.Suite
 	chartPath string
 	release   string
@@ -41,7 +41,7 @@ func TestServiceTemplate(t *testing.T) {
 	chartPath, err := filepath.Abs("../../../")
 	require.NoError(t, err)
 
-	suite.Run(t, &serviceTest{
+	suite.Run(t, &ServiceTest{
 		chartPath: chartPath,
 		release:   "camunda-platform-test",
 		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
@@ -49,40 +49,36 @@ func TestServiceTemplate(t *testing.T) {
 	})
 }
 
-func (s *serviceTest) TestContainerSetGlobalAnnotations() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.enabled":     "true",
-			"global.annotations.foo": "bar",
+func (s *ServiceTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestContainerSetGlobalAnnotations",
+			Values: map[string]string{
+				"connectors.enabled":     "true",
+				"global.annotations.foo": "bar",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var service coreV1.Service
+				helm.UnmarshalK8SYaml(s.T(), output, &service)
+
+				// then
+				s.Require().Equal("bar", service.ObjectMeta.Annotations["foo"])
+			},
+		}, {
+			Name: "TestContainerServiceAnnotations",
+			Values: map[string]string{
+				"connectors.enabled":                 "true",
+				"connectors.service.annotations.foo": "bar",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var service coreV1.Service
+				helm.UnmarshalK8SYaml(s.T(), output, &service)
+
+				// then
+				s.Require().Equal("bar", service.ObjectMeta.Annotations["foo"])
+			},
 		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 	}
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var service coreV1.Service
-	helm.UnmarshalK8SYaml(s.T(), output, &service)
-
-	// then
-	s.Require().Equal("bar", service.ObjectMeta.Annotations["foo"])
-}
-
-func (s *serviceTest) TestContainerServiceAnnotations() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"connectors.enabled":                 "true",
-			"connectors.service.annotations.foo": "bar",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var service coreV1.Service
-	helm.UnmarshalK8SYaml(s.T(), output, &service)
-
-	// then
-	s.Require().Equal("bar", service.ObjectMeta.Annotations["foo"])
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }

--- a/charts/camunda-platform-8.7/test/unit/testhelpers/testhelpers.go
+++ b/charts/camunda-platform-8.7/test/unit/testhelpers/testhelpers.go
@@ -1,28 +1,108 @@
+// Package testhelpers provides utilities for testing Helm charts.
+// To enable verbose logging, set the VERBOSE_TEST_LOGGING environment variable to "true".
+// Example: VERBOSE_TEST_LOGGING=true go test ./...
 package testhelpers
 
 import (
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 )
 
-type TestCase struct {
-	Name     string
-	Values   map[string]string
-	Expected map[string]string
+type CaseTemplate struct {
+	Templates []string
 }
 
-// RenderTemplate renders the specified Helm templates into a Kubernetes ConfigMap
-func RenderTemplate(t *testing.T, chartPath, release string, namespace string, templates []string, values map[string]string) corev1.ConfigMap {
+// TestCase represents a single test scenario for Helm chart testing.
+// It encapsulates all the necessary configuration and validation logic for a test.
+type TestCase struct {
+	// Name is the descriptive name of the test case, used for identification in test output
+	Name string
+
+	// HelmOptionsExtraArgs contains additional arguments to pass to the Helm command
+	// The key spaecifies the Helm command (e.g., "install", "upgrade"), and the value is a slice of arguments
+	// This allows customizing the Helm command behavior for specific test cases
+	HelmOptionsExtraArgs map[string][]string
+
+	// RenderTemplateExtraArgs contains additional arguments for template rendering
+	// These are passed to the template rendering process
+	RenderTemplateExtraArgs []string
+
+	// When provided, this function is called to get the templates to render. This overrides the
+	// templates set in the test suite
+	CaseTemplates *CaseTemplate
+
+	// Values represents the Helm chart values to set for this test case
+	// These are equivalent to values passed with --set flag in Helm CLI
+	Values map[string]string
+
+	// Expected contains key-value pairs that should be present in the rendered output
+	// For error tests, it should contain an "ERROR" key with the expected error message
+	// For ConfigMap tests, keys can be direct data keys or dot-notation paths into application.yaml
+	Expected map[string]string
+
+	// Verifier is a custom function for complex validation scenarios
+	// When provided, it overrides the default validation logic
+	// It receives the rendered output and any error that occurred during rendering
+	Verifier func(t *testing.T, output string, err error)
+}
+
+// quietLogger returns a logger that only logs errors
+func quietLogger() *logger.Logger {
+	// Check if verbose logging is enabled via environment variable
+	if os.Getenv("VERBOSE_TEST_LOGGING") == "true" {
+		return logger.Default
+	}
+	// Create a logger that discards all output
+	return logger.Discard
+}
+
+func setupHelmOptions(namespace string, values map[string]string, helmOptionsExtraArgs map[string][]string) *helm.Options {
 	options := &helm.Options{
 		SetValues:      values,
 		KubectlOptions: k8s.NewKubectlOptions("", "", namespace),
+		Logger:         quietLogger(), // Use quiet logger to reduce verbosity
+		ExtraArgs:      helmOptionsExtraArgs,
 	}
+	return options
+}
+
+func renderTemplateE(t *testing.T, chartPath, release string, namespace string, templates []string, values map[string]string, extraArgs map[string][]string, renderTemplateExtraArgs []string) (string, error) {
+	options := setupHelmOptions(namespace, values, extraArgs)
+
+	output, err := helm.RenderTemplateE(t, options, chartPath, release, templates, renderTemplateExtraArgs...)
+	return output, err
+}
+
+func RunTestCasesE(t *testing.T, chartPath, release, namespace string, templates []string, testCases []TestCase) {
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			var caseTemplates []string
+			if tc.CaseTemplates != nil {
+				caseTemplates = tc.CaseTemplates.Templates
+			} else {
+				caseTemplates = templates
+			}
+			output, err := renderTemplateE(t, chartPath, release, namespace, caseTemplates, tc.Values, tc.HelmOptionsExtraArgs, tc.RenderTemplateExtraArgs)
+			if tc.Verifier != nil {
+				tc.Verifier(t, output, err)
+			} else {
+				require.ErrorContains(t, err, tc.Expected["ERROR"])
+			}
+		})
+	}
+}
+
+// renderTemplate renders the specified Helm templates into a Kubernetes ConfigMap
+func renderTemplate(t *testing.T, chartPath, release string, namespace string, templates []string, values map[string]string) corev1.ConfigMap {
+	options := setupHelmOptions(namespace, values, nil)
 
 	output := helm.RenderTemplate(t, options, chartPath, release, templates)
 	var configmap corev1.ConfigMap
@@ -30,62 +110,62 @@ func RenderTemplate(t *testing.T, chartPath, release string, namespace string, t
 	return configmap
 }
 
-// VerifyConfigMap checks whether the generated ConfigMap contains the expected key-value pairs
-func VerifyConfigMap(t *testing.T, testCase string, configmap corev1.ConfigMap, expectedValues map[string]string) {
-	for keyPath, expectedValue := range expectedValues {
-		var actualValue string
-		if strings.HasPrefix(keyPath, "configmapApplication.") {
-            var configmapApplication map[string]interface{}
-            err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
-            require.NoError(t, err)
-            actualValue = getConfigMapFieldValue(configmapApplication, strings.Split(keyPath, ".")[1:])
-        } else {
-            actualValue = strings.TrimSpace(configmap.Data[keyPath])
-        }
-		require.Equal(t, expectedValue, actualValue, "Test case '%s': Expected key '%s' to have value '%s', but got '%s'", testCase, keyPath, expectedValue, actualValue)
-	}
-}
-
 // RunTestCases executes multiple test cases using the provided Helm chart and ConfigMap validation
 func RunTestCases(t *testing.T, chartPath, release, namespace string, templates []string, testCases []TestCase) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			configmap := RenderTemplate(t, chartPath, release, namespace, templates, tc.Values)
-			VerifyConfigMap(t, tc.Name, configmap, tc.Expected)
+			configmap := renderTemplate(t, chartPath, release, namespace, templates, tc.Values)
+			verifyConfigMap(t, tc.Name, configmap, tc.Expected)
 		})
+	}
+}
+
+// verifyConfigMap checks whether the generated ConfigMap contains the expected key-value pairs
+func verifyConfigMap(t *testing.T, testCase string, configmap corev1.ConfigMap, expectedValues map[string]string) {
+	for keyPath, expectedValue := range expectedValues {
+		var actualValue string
+		if strings.HasPrefix(keyPath, "configmapApplication.") {
+			var configmapApplication map[string]any
+			err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+			require.NoError(t, err)
+			actualValue = getConfigMapFieldValue(configmapApplication, strings.Split(keyPath, ".")[1:])
+		} else {
+			actualValue = strings.TrimSpace(configmap.Data[keyPath])
+		}
+		require.Equal(t, expectedValue, actualValue, "Test case '%s': Expected key '%s' to have value '%s', but got '%s'", testCase, keyPath, expectedValue, actualValue)
 	}
 }
 
 // getConfigMapFieldValue function traverses a nested map structure based on a given key path.
 // It handles maps with both interface{} and string keys, converting them as necessary to retrieve the desired value.
 // If the key is not found or the final value is not a string, the function returns an empty string.
-func getConfigMapFieldValue(configmapApplication map[string]interface{}, keyPath []string) string {
-	var current interface{} = configmapApplication
+func getConfigMapFieldValue(configmapApplication map[string]any, keyPath []string) string {
+	var current any = configmapApplication
 
 	for _, key := range keyPath {
-        if nestedMap, ok := current.(map[interface{}]interface{}); ok {
-            // Convert map[interface{}]interface{} to map[string]interface{}
-            stringMap := make(map[string]interface{})
-            for k, v := range nestedMap {
-                if strKey, isString := k.(string); isString {
-                    stringMap[strKey] = v
-                }
-            }
-            // Move to the next level in the map
-            current = stringMap[key]
-        } else if nestedMap, ok := current.(map[string]interface{}); ok {
-            // If the current level is already a map with string keys, move to the next level
-            current = nestedMap[key]
-        } else {
-            // If the key is not found, return an empty string
-            return ""
-        }
-    }
+		if nestedMap, ok := current.(map[any]any); ok {
+			// Convert map[interface{}]any to map[string]any
+			stringMap := make(map[string]any)
+			for k, v := range nestedMap {
+				if strKey, isString := k.(string); isString {
+					stringMap[strKey] = v
+				}
+			}
+			// Move to the next level in the map
+			current = stringMap[key]
+		} else if nestedMap, ok := current.(map[string]any); ok {
+			// If the current level is already a map with string keys, move to the next level
+			current = nestedMap[key]
+		} else {
+			// If the key is not found, return an empty string
+			return ""
+		}
+	}
 
-    // If the final value is a string, return it
-    if value, ok := current.(string); ok {
-        return value
-    }
-    // If the final value is not a string, return an empty string
-    return ""
+	// If the final value is a string, return it
+	if value, ok := current.(string); ok {
+		return value
+	}
+	// If the final value is not a string, return an empty string
+	return ""
 }


### PR DESCRIPTION
### Which problem does the PR fix?

https://github.com/camunda/team-distribution/issues/448

### What's in this PR?

- Refactor of 8.7 units tests in connectors to the new style

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
