### PR TITLE
fix: refactored unit tests to new style in identity 8.5

### DIFF
--- a/.github/workflows/test-chart-version-template.yaml
+++ b/.github/workflows/test-chart-version-template.yaml
@@ -8,9 +8,13 @@ on:
         description: Chart version to test
         required: true
         type: string
+      pr_number:
+        description: Pull Request number. Required due to a github bug that is not giving the concurrency group the pull_request number from the github event
+        required: true
+        type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ inputs.chart-version }}
+  group: ${{ github.workflow }}-${{ inputs.pr_number }}-${{ inputs.chart-version }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/test-chart-version.yaml
+++ b/.github/workflows/test-chart-version.yaml
@@ -4,14 +4,14 @@ name: "Test - Chart Version"
 on:
   pull_request:
     paths:
-      - '.github/workflows/chart-validate-template.yaml'
-      - '.github/workflows/test-unit-template.yml'
-      - '.github/workflows/test-integration-template.yaml'
-      - '.github/workflows/test-chart-version-template.yaml'
-      - '.github/workflows/test-chart-version.yaml'
-      - '.tool-versions'
-      - 'charts/camunda-platform-8*/**'
-  workflow_dispatch: { }
+      - ".github/workflows/chart-validate-template.yaml"
+      - ".github/workflows/test-unit-template.yml"
+      - ".github/workflows/test-integration-template.yaml"
+      - ".github/workflows/test-chart-version-template.yaml"
+      - ".github/workflows/test-chart-version.yaml"
+      - ".tool-versions"
+      - "charts/camunda-platform-8*/**"
+  workflow_dispatch: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.run_id }}
@@ -48,3 +48,4 @@ jobs:
     secrets: inherit
     with:
       chart-version: "${{ matrix.version }}"
+      pr_number: "${{ github.event.pull_request.number }}" # Required as there is a github bug that prevent the concurrency group on the sub workflow getting the pull_request number from the github event

--- a/charts/camunda-platform-8.5/test/unit/identity/configmap_test.go
+++ b/charts/camunda-platform-8.5/test/unit/identity/configmap_test.go
@@ -1,12 +1,12 @@
 package identity
 
 import (
+	"camunda-platform/test/unit/testhelpers"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -14,7 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-type configMapSpringTemplateTest struct {
+type ConfigMapSpringTemplateTest struct {
 	suite.Suite
 	chartPath string
 	release   string
@@ -28,7 +28,7 @@ func TestSpringConfigMapTemplate(t *testing.T) {
 	chartPath, err := filepath.Abs("../../../")
 	require.NoError(t, err)
 
-	suite.Run(t, &configMapSpringTemplateTest{
+	suite.Run(t, &ConfigMapSpringTemplateTest{
 		chartPath: chartPath,
 		release:   "camunda-platform-test",
 		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
@@ -36,201 +36,170 @@ func TestSpringConfigMapTemplate(t *testing.T) {
 	})
 }
 
-func (s *configMapSpringTemplateTest) TestContainerShouldAddContextPath() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"identity.fullURL":     "https://mydomain.com/identity",
-			"identity.contextPath": "/identity",
+func (s *ConfigMapSpringTemplateTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name:                 "TestContainerShouldAddContextPath",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values: map[string]string{
+				"identity.fullURL":     "https://mydomain.com/identity",
+				"identity.contextPath": "/identity",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				var configmapApplication IdentityConfigYAML
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				if e != nil {
+					s.Fail("Failed to unmarshal yaml. error=", e)
+				}
+
+				// then
+				s.Require().Equal("https://mydomain.com/identity", configmapApplication.Identity.Url)
+				s.Require().Equal("/identity", configmapApplication.Server.Servlet.ContextPath)
+			},
+		}, {
+			Name: "TestConfigMapBuiltinDatabaseEnabled",
+			Values: map[string]string{
+				"global.multitenancy.enabled": "true",
+				"identityPostgresql.enabled":  "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				var configmapApplication IdentityConfigYAML
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				if e != nil {
+					s.Fail("Failed to unmarshal yaml. error=", e)
+				}
+
+				// then
+				s.NotEmpty(configmap.Data)
+
+				s.Require().Equal("true", configmapApplication.Identity.Flags.MultiTenancy)
+				s.Require().Equal("jdbc:postgresql://camunda-platform-test-identity-postgresql:5432/identity", configmapApplication.Spring.DataSource.Url)
+				s.Require().Equal("identity", configmapApplication.Spring.DataSource.Username)
+			},
+		}, {
+			Name: "TestConfigMapExternalDatabaseEnabled",
+			Values: map[string]string{
+				"global.multitenancy.enabled":        "true",
+				"identityPostgresql.enabled":         "false",
+				"identity.externalDatabase.enabled":  "true",
+				"identity.externalDatabase.host":     "my-database-host",
+				"identity.externalDatabase.port":     "2345",
+				"identity.externalDatabase.database": "my-database-name",
+				"identity.externalDatabase.username": "my-database-username",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				var configmapApplication IdentityConfigYAML
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				if e != nil {
+					s.Fail("Failed to unmarshal yaml. error=", e)
+				}
+
+				// then
+				s.NotEmpty(configmap.Data)
+
+				s.Require().Equal("true", configmapApplication.Identity.Flags.MultiTenancy)
+				s.Require().Equal("jdbc:postgresql://my-database-host:2345/my-database-name", configmapApplication.Spring.DataSource.Url)
+				s.Require().Equal("my-database-username", configmapApplication.Spring.DataSource.Username)
+			},
+		}, {
+			Name: "TestConfigMapAuthIssuerBackendUrlWhenExplicitlyDefined",
+			Values: map[string]string{
+				"identityKeycloak.enabled":              "false",
+				"global.identity.auth.enabled":          "false",
+				"global.identity.auth.issuerBackendUrl": "https://example.com/",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				var configmapApplication IdentityConfigYAML
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				if e != nil {
+					s.Fail("Failed to unmarshal yaml. error=", e)
+				}
+
+				// then
+				s.NotEmpty(configmap.Data)
+
+				s.Require().Equal("https://example.com/", configmapApplication.Identity.AuthProvider.BackendUrl)
+			},
+		}, {
+			Name: "TestConfigMapAuthIssuerBackendUrlWhenKeycloakUrlDefined",
+			Values: map[string]string{
+				"global.identity.keycloak.url.protocol": "https",
+				"global.identity.keycloak.url.host":     "keycloak.com",
+				"global.identity.keycloak.url.port":     "443",
+				"global.identity.keycloak.contextPath":  "/auth/",
+				"global.identity.keycloak.realm":        "camunda-platform",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				var configmapApplication IdentityConfigYAML
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				if e != nil {
+					s.Fail("Failed to unmarshal yaml. error=", e)
+				}
+
+				// then
+				s.NotEmpty(configmap.Data)
+
+				s.Require().Equal("https://keycloak.com:443/auth/camunda-platform", configmapApplication.Identity.AuthProvider.BackendUrl)
+			},
+		}, {
+			Name:   "TestConfigMapAuthIssuerBackendUrlWhenKeycloakNotDefined",
+			Values: map[string]string{},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				var configmapApplication IdentityConfigYAML
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				if e != nil {
+					s.Fail("Failed to unmarshal yaml. error=", e)
+				}
+
+				// then
+				s.NotEmpty(configmap.Data)
+
+				s.Require().Equal("http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform", configmapApplication.Identity.AuthProvider.BackendUrl)
+			},
+		}, {
+			Name: "TestConfigMapClientIdWhenClientSecretSet",
+			Values: map[string]string{
+				"global.identity.auth.type":                    "GENERIC",
+				"global.identity.auth.issuerBackendUrl":        "https://my.idp.org",
+				"global.identity.auth.issuer":                  "https://my.idp.org",
+				"global.identity.auth.identity.audience":       "identity-client",
+				"global.identity.auth.identity.clientId":       "identity-client",
+				"global.identity.auth.identity.existingSecret": "superSecret",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				var configmapApplication IdentityConfigYAML
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				if e != nil {
+					s.Fail("Failed to unmarshal yaml. error=", e)
+				}
+
+				// then
+				s.NotEmpty(configmap.Data)
+				s.Require().Equal("identity-client", configmapApplication.Camunda.Identity.ClientId)
+			},
 		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
 	}
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var configmap corev1.ConfigMap
-	var configmapApplication IdentityConfigYAML
-	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
-	if err != nil {
-		s.Fail("Failed to unmarshal yaml. error=", err)
-	}
-
-	// then
-	s.Require().Equal("https://mydomain.com/identity", configmapApplication.Identity.Url)
-	s.Require().Equal("/identity", configmapApplication.Server.Servlet.ContextPath)
-}
-
-func (s *configMapSpringTemplateTest) TestConfigMapBuiltinDatabaseEnabled() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.multitenancy.enabled": "true",
-			"identityPostgresql.enabled":  "true",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var configmap corev1.ConfigMap
-	var configmapApplication IdentityConfigYAML
-	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
-	if err != nil {
-		s.Fail("Failed to unmarshal yaml. error=", err)
-	}
-
-	// then
-	s.NotEmpty(configmap.Data)
-
-	s.Require().Equal("true", configmapApplication.Identity.Flags.MultiTenancy)
-	s.Require().Equal("jdbc:postgresql://camunda-platform-test-identity-postgresql:5432/identity", configmapApplication.Spring.DataSource.Url)
-	s.Require().Equal("identity", configmapApplication.Spring.DataSource.Username)
-}
-
-func (s *configMapSpringTemplateTest) TestConfigMapExternalDatabaseEnabled() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.multitenancy.enabled":        "true",
-			"identityPostgresql.enabled":         "false",
-			"identity.externalDatabase.enabled":  "true",
-			"identity.externalDatabase.host":     "my-database-host",
-			"identity.externalDatabase.port":     "2345",
-			"identity.externalDatabase.database": "my-database-name",
-			"identity.externalDatabase.username": "my-database-username",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var configmap corev1.ConfigMap
-	var configmapApplication IdentityConfigYAML
-	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
-	if err != nil {
-		s.Fail("Failed to unmarshal yaml. error=", err)
-	}
-
-	// then
-	s.NotEmpty(configmap.Data)
-
-	s.Require().Equal("true", configmapApplication.Identity.Flags.MultiTenancy)
-	s.Require().Equal("jdbc:postgresql://my-database-host:2345/my-database-name", configmapApplication.Spring.DataSource.Url)
-	s.Require().Equal("my-database-username", configmapApplication.Spring.DataSource.Username)
-}
-func (s *configMapSpringTemplateTest) TestConfigMapAuthIssuerBackendUrlWhenExplicitlyDefined() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"identityKeycloak.enabled":              "false",
-			"global.identity.auth.enabled":          "false",
-			"global.identity.auth.issuerBackendUrl": "https://example.com/",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var configmap corev1.ConfigMap
-	var configmapApplication IdentityConfigYAML
-	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
-	if err != nil {
-		s.Fail("Failed to unmarshal yaml. error=", err)
-	}
-
-	// then
-	s.NotEmpty(configmap.Data)
-
-	s.Require().Equal("https://example.com/", configmapApplication.Identity.AuthProvider.BackendUrl)
-}
-func (s *configMapSpringTemplateTest) TestConfigMapAuthIssuerBackendUrlWhenKeycloakUrlDefined() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.identity.keycloak.url.protocol": "https",
-			"global.identity.keycloak.url.host":     "keycloak.com",
-			"global.identity.keycloak.url.port":     "443",
-			"global.identity.keycloak.contextPath":  "/auth/",
-			"global.identity.keycloak.realm":        "camunda-platform",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var configmap corev1.ConfigMap
-	var configmapApplication IdentityConfigYAML
-	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
-	if err != nil {
-		s.Fail("Failed to unmarshal yaml. error=", err)
-	}
-
-	// then
-	s.NotEmpty(configmap.Data)
-
-	s.Require().Equal("https://keycloak.com:443/auth/camunda-platform", configmapApplication.Identity.AuthProvider.BackendUrl)
-}
-func (s *configMapSpringTemplateTest) TestConfigMapAuthIssuerBackendUrlWhenKeycloakNotDefined() {
-	// given
-	options := &helm.Options{
-		SetValues:      map[string]string{},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var configmap corev1.ConfigMap
-	var configmapApplication IdentityConfigYAML
-	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
-	if err != nil {
-		s.Fail("Failed to unmarshal yaml. error=", err)
-	}
-
-	// then
-	s.NotEmpty(configmap.Data)
-
-	s.Require().Equal("http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform", configmapApplication.Identity.AuthProvider.BackendUrl)
-}
-
-func (s *configMapSpringTemplateTest) TestConfigMapClientIdWhenClientSecretSet() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.identity.auth.type":                    "GENERIC",
-			"global.identity.auth.issuerBackendUrl":        "https://my.idp.org",
-			"global.identity.auth.issuer":                  "https://my.idp.org",
-			"global.identity.auth.identity.audience":       "identity-client",
-			"global.identity.auth.identity.clientId":       "identity-client",
-			"global.identity.auth.identity.existingSecret": "superSecret",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var configmap corev1.ConfigMap
-	var configmapApplication IdentityConfigYAML
-	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
-	if err != nil {
-		s.Fail("Failed to unmarshal yaml. error=", err)
-	}
-
-	// then
-	s.NotEmpty(configmap.Data)
-	s.Require().Equal("identity-client", configmapApplication.Camunda.Identity.ClientId)
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }

--- a/charts/camunda-platform-8.5/test/unit/identity/deployment_test.go
+++ b/charts/camunda-platform-8.5/test/unit/identity/deployment_test.go
@@ -15,12 +15,12 @@
 package identity
 
 import (
+	"camunda-platform/test/unit/testhelpers"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -28,7 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-type deploymentTemplateTest struct {
+type DeploymentTemplateTest struct {
 	suite.Suite
 	chartPath string
 	release   string
@@ -42,7 +42,7 @@ func TestDeploymentTemplate(t *testing.T) {
 	chartPath, err := filepath.Abs("../../../")
 	require.NoError(t, err)
 
-	suite.Run(t, &deploymentTemplateTest{
+	suite.Run(t, &DeploymentTemplateTest{
 		chartPath: chartPath,
 		release:   "camunda-platform-test",
 		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
@@ -50,1186 +50,940 @@ func TestDeploymentTemplate(t *testing.T) {
 	})
 }
 
-func (s *deploymentTemplateTest) TestContainerWithExternalKeycloak() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"identityKeycloak.enabled":                        "false",
-			"global.identity.keycloak.url.protocol":           "https",
-			"global.identity.keycloak.url.host":               "keycloak.prod.svc.cluster.local",
-			"global.identity.keycloak.url.port":               "8443",
-			"global.identity.keycloak.auth.adminUser":         "testAdmin",
-			"global.identity.keycloak.auth.existingSecret":    "ownExistingSecretKeycloak",
-			"global.identity.keycloak.auth.existingSecretKey": "test-admin",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-	s.Require().Contains(env,
-		corev1.EnvVar{
-			Name:  "KEYCLOAK_URL",
-			Value: "https://keycloak.prod.svc.cluster.local:8443/auth",
-		})
-	s.Require().Contains(env,
-		corev1.EnvVar{
-			Name:  "KEYCLOAK_SETUP_USER",
-			Value: "testAdmin",
-		})
-	s.Require().Contains(env,
-		corev1.EnvVar{
-			Name: "KEYCLOAK_SETUP_PASSWORD",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "ownExistingSecretKeycloak"},
-					Key:                  "test-admin",
-				},
+func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name:                 "TestContainerWithExternalKeycloak",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values: map[string]string{
+				"identityKeycloak.enabled":                        "false",
+				"global.identity.keycloak.url.protocol":           "https",
+				"global.identity.keycloak.url.host":               "keycloak.prod.svc.cluster.local",
+				"global.identity.keycloak.url.port":               "8443",
+				"global.identity.keycloak.auth.adminUser":         "testAdmin",
+				"global.identity.keycloak.auth.existingSecret":    "ownExistingSecretKeycloak",
+				"global.identity.keycloak.auth.existingSecretKey": "test-admin",
 			},
-		})
-}
-
-func (s *deploymentTemplateTest) TestContainerSetPodLabels() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"identity.podLabels.foo": "bar",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	s.Require().Equal("bar", deployment.Spec.Template.Labels["foo"])
-}
-
-func (s *deploymentTemplateTest) TestContainerSetPodAnnotations() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"identity.podAnnotations.foo": "bar",
-			"identity.podAnnotations.foz": "baz",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	s.Require().Equal("bar", deployment.Spec.Template.Annotations["foo"])
-	s.Require().Equal("baz", deployment.Spec.Template.Annotations["foz"])
-}
-
-func (s *deploymentTemplateTest) TestContainerSetGlobalAnnotations() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.annotations.foo": "bar",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	s.Require().Equal("bar", deployment.ObjectMeta.Annotations["foo"])
-}
-
-func (s *deploymentTemplateTest) TestContainerSetImageNameSubChart() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.image.registry":     "global.custom.registry.io",
-			"global.image.tag":          "8.x.x",
-			"identity.image.registry":   "subchart.custom.registry.io",
-			"identity.image.repository": "camunda/identity-test",
-			"identity.image.tag":        "snapshot",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	container := deployment.Spec.Template.Spec.Containers[0]
-	s.Require().Equal(container.Image, "subchart.custom.registry.io/camunda/identity-test:snapshot")
-}
-
-func (s *deploymentTemplateTest) TestContainerSetImagePullSecretsGlobal() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.image.pullSecrets[0].name": "SecretName",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	s.Require().Equal("SecretName", deployment.Spec.Template.Spec.ImagePullSecrets[0].Name)
-}
-
-func (s *deploymentTemplateTest) TestContainerSetImagePullSecretsSubChart() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.image.pullSecrets[0].name":   "SecretName",
-			"identity.image.pullSecrets[0].name": "SecretNameSubChart",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	s.Require().Equal("SecretNameSubChart", deployment.Spec.Template.Spec.ImagePullSecrets[0].Name)
-}
-
-func (s *deploymentTemplateTest) TestContainerOverwriteImageTag() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"identity.image.tag": "a.b.c",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	expectedContainerImage := "camunda/identity:a.b.c"
-	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
-	s.Require().Equal(expectedContainerImage, containers[0].Image)
-}
-
-func (s *deploymentTemplateTest) TestContainerOverwriteGlobalImageTag() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.image.tag":   "a.b.c",
-			"identity.image.tag": "",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	expectedContainerImage := "camunda/identity:a.b.c"
-	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
-	s.Require().Equal(expectedContainerImage, containers[0].Image)
-}
-
-func (s *deploymentTemplateTest) TestContainerOverwriteImageTagWithChartDirectSetting() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.image.tag":   "x.y.z",
-			"identity.image.tag": "a.b.c",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	expectedContainerImage := "camunda/identity:a.b.c"
-	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
-	s.Require().Equal(expectedContainerImage, containers[0].Image)
-}
-
-func (s *deploymentTemplateTest) TestContainerSetContainerCommand() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"identity.command[0]": "printenv",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
-	s.Require().Equal(1, len(containers[0].Command))
-	s.Require().Equal("printenv", containers[0].Command[0])
-}
-
-func (s *deploymentTemplateTest) TestContainerSetExtraVolumes() {
-	//finding out the length of volumes array before addition of new volume
-	var deploymentBefore appsv1.Deployment
-	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
-	helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
-	volumeLenBefore := len(deploymentBefore.Spec.Template.Spec.Volumes)
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"identity.extraVolumes[0].name":                  "extraVolume",
-			"identity.extraVolumes[0].configMap.name":        "otherConfigMap",
-			"identity.extraVolumes[0].configMap.defaultMode": "744",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	volumes := deployment.Spec.Template.Spec.Volumes
-	s.Require().Equal(volumeLenBefore+1, len(volumes))
-
-	extraVolume := volumes[volumeLenBefore]
-	s.Require().Equal("extraVolume", extraVolume.Name)
-	s.Require().NotNil(*extraVolume.ConfigMap)
-	s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
-	s.Require().EqualValues(744, *extraVolume.ConfigMap.DefaultMode)
-}
-
-func (s *deploymentTemplateTest) TestContainerSetExtraVolumeMounts() {
-	//finding out the length of containers and volumeMounts array before addition of new volumeMount
-	var deploymentBefore appsv1.Deployment
-	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
-	helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
-	containerLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers)
-	volumeMountLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"identity.extraVolumeMounts[0].name":      "otherConfigMap",
-			"identity.extraVolumeMounts[0].mountPath": "/usr/local/config",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(containerLenBefore, len(containers))
-
-	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(volumeMountLenBefore+1, len(volumeMounts))
-	extraVolumeMount := volumeMounts[volumeMountLenBefore]
-	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
-	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
-}
-
-func (s *deploymentTemplateTest) TestContainerSetExtraVolumesAndMounts() {
-	//finding out the length of volumes, volumemounts array before addition of new volume
-	var deploymentBefore appsv1.Deployment
-	before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
-	helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
-	volumeLenBefore := len(deploymentBefore.Spec.Template.Spec.Volumes)
-	volumeMountLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
-	containerLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers)
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"identity.extraVolumeMounts[0].name":             "otherConfigMap",
-			"identity.extraVolumeMounts[0].mountPath":        "/usr/local/config",
-			"identity.extraVolumes[0].name":                  "extraVolume",
-			"identity.extraVolumes[0].configMap.name":        "otherConfigMap",
-			"identity.extraVolumes[0].configMap.defaultMode": "744",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	volumes := deployment.Spec.Template.Spec.Volumes
-	s.Require().Equal(volumeLenBefore+1, len(volumes))
-
-	extraVolume := volumes[volumeLenBefore]
-	s.Require().Equal("extraVolume", extraVolume.Name)
-	s.Require().NotNil(*extraVolume.ConfigMap)
-	s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
-	s.Require().EqualValues(744, *extraVolume.ConfigMap.DefaultMode)
-
-	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(containerLenBefore, len(containers))
-
-	volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
-	s.Require().Equal(volumeMountLenBefore+1, len(volumeMounts))
-	extraVolumeMount := volumeMounts[volumeMountLenBefore]
-	s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
-	s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
-}
-
-func (s *deploymentTemplateTest) TestContainerSetServiceAccountName() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"identity.serviceAccount.name": "accName",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	serviceAccName := deployment.Spec.Template.Spec.ServiceAccountName
-	s.Require().Equal("accName", serviceAccName)
-}
-
-func (s *deploymentTemplateTest) TestPodSetSecurityContext() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"identity.podSecurityContext.runAsUser": "1000",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	securityContext := deployment.Spec.Template.Spec.SecurityContext
-	s.Require().EqualValues(1000, *securityContext.RunAsUser)
-}
-
-func (s *deploymentTemplateTest) TestContainerSetSecurityContext() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"identity.containerSecurityContext.privileged":          "true",
-			"identity.containerSecurityContext.capabilities.add[0]": "NET_ADMIN",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	securityContext := deployment.Spec.Template.Spec.Containers[0].SecurityContext
-	s.Require().True(*securityContext.Privileged)
-	s.Require().EqualValues("NET_ADMIN", securityContext.Capabilities.Add[0])
-}
-
-// https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
-func (s *deploymentTemplateTest) TestContainerSetNodeSelector() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"identity.nodeSelector.disktype": "ssd",
-			"identity.nodeSelector.cputype":  "arm",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	s.Require().Equal("ssd", deployment.Spec.Template.Spec.NodeSelector["disktype"])
-	s.Require().Equal("arm", deployment.Spec.Template.Spec.NodeSelector["cputype"])
-}
-
-// https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
-func (s *deploymentTemplateTest) TestContainerSetAffinity() {
-	// given
-
-	//affinity:
-	//	nodeAffinity:
-	//	 requiredDuringSchedulingIgnoredDuringExecution:
-	//	   nodeSelectorTerms:
-	//	   - matchExpressions:
-	//		 - key: kubernetes.io/e2e-az-name
-	//		   operator: In
-	//		   values:
-	//		   - e2e-az1
-	//		   - e2e-az2
-	//	 preferredDuringSchedulingIgnoredDuringExecution:
-	//	 - weight: 1
-	//	   preference:
-	//		 matchExpressions:
-	//		 - key: another-node-label-key
-	//		   operator: In
-	//		   values:
-	//		   - another-node-label-value
-
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"identity.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].key":       "kubernetes.io/e2e-az-name",
-			"identity.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].operator":  "In",
-			"identity.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].values[0]": "e2e-a1",
-			"identity.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].values[1]": "e2e-a2",
-			"identity.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight":                                         "1",
-			"identity.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].key":             "another-node-label-key",
-			"identity.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].operator":        "In",
-			"identity.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].values[0]":       "another-node-label-value",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	nodeAffinity := deployment.Spec.Template.Spec.Affinity.NodeAffinity
-	s.Require().NotNil(nodeAffinity)
-
-	nodeSelectorTerm := nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0]
-	s.Require().NotNil(nodeSelectorTerm)
-	matchExpression := nodeSelectorTerm.MatchExpressions[0]
-	s.Require().NotNil(matchExpression)
-	s.Require().Equal("kubernetes.io/e2e-az-name", matchExpression.Key)
-	s.Require().EqualValues("In", matchExpression.Operator)
-	s.Require().Equal([]string{"e2e-a1", "e2e-a2"}, matchExpression.Values)
-
-	preferredSchedulingTerm := nodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0]
-	s.Require().NotNil(preferredSchedulingTerm)
-
-	matchExpression = preferredSchedulingTerm.Preference.MatchExpressions[0]
-	s.Require().NotNil(matchExpression)
-	s.Require().Equal("another-node-label-key", matchExpression.Key)
-	s.Require().EqualValues("In", matchExpression.Operator)
-	s.Require().Equal([]string{"another-node-label-value"}, matchExpression.Values)
-}
-
-// https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration
-func (s *deploymentTemplateTest) TestContainerSetTolerations() {
-	// given
-
-	//tolerations:
-	//- key: "key1"
-	//  operator: "Equal"
-	//  value: "value1"
-	//  effect: "NoSchedule"
-
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"identity.tolerations[0].key":      "key1",
-			"identity.tolerations[0].operator": "Equal",
-			"identity.tolerations[0].value":    "Value1",
-			"identity.tolerations[0].effect":   "NoSchedule",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	tolerations := deployment.Spec.Template.Spec.Tolerations
-	s.Require().Equal(1, len(tolerations))
-
-	toleration := tolerations[0]
-	s.Require().Equal("key1", toleration.Key)
-	s.Require().EqualValues("Equal", toleration.Operator)
-	s.Require().Equal("Value1", toleration.Value)
-	s.Require().EqualValues("NoSchedule", toleration.Effect)
-}
-
-func (s *deploymentTemplateTest) TestContainerShouldSetTemplateEnvVars() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"identity.env[0].name":  "RELEASE_NAME",
-			"identity.env[0].value": "test-{{ .Release.Name }}",
-			"identity.env[1].name":  "OTHER_ENV",
-			"identity.env[1].value": "nothingToSeeHere",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-	s.Require().Contains(env, corev1.EnvVar{Name: "RELEASE_NAME", Value: "test-camunda-platform-test"})
-	s.Require().Contains(env, corev1.EnvVar{Name: "OTHER_ENV", Value: "nothingToSeeHere"})
-}
-
-func (s *deploymentTemplateTest) TestContainerShouldSetCorrectSecret() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"identityKeycloak.enabled":                "true",
-			"identityKeycloak.auth.existingSecret":    "ownExistingSecret",
-			"identityKeycloak.auth.passwordSecretKey": "test-admin",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-	s.Require().Contains(env,
-		corev1.EnvVar{
-			Name: "KEYCLOAK_SETUP_PASSWORD",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "ownExistingSecret"},
-					Key:                  "test-admin",
-				},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env,
+					corev1.EnvVar{
+						Name:  "KEYCLOAK_URL",
+						Value: "https://keycloak.prod.svc.cluster.local:8443/auth",
+					})
+				s.Require().Contains(env,
+					corev1.EnvVar{
+						Name:  "KEYCLOAK_SETUP_USER",
+						Value: "testAdmin",
+					})
+				s.Require().Contains(env,
+					corev1.EnvVar{
+						Name: "KEYCLOAK_SETUP_PASSWORD",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "ownExistingSecretKeycloak"},
+								Key:                  "test-admin",
+							},
+						},
+					})
 			},
-		})
-}
-
-func (s *deploymentTemplateTest) TestContainerShouldDisableIntegration() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.identity.auth.enabled": "false",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-
-	for _, envvar := range env {
-		s.Require().NotEqual("KEYCLOAK_INIT_OPERATE_ROOT_URL", envvar.Name)
-		s.Require().NotEqual("KEYCLOAK_INIT_OPERATE_SECRET", envvar.Name)
-		s.Require().NotEqual("KEYCLOAK_INIT_TASKLIST_ROOT_URL", envvar.Name)
-		s.Require().NotEqual("KEYCLOAK_INIT_TASKLIST_SECRET", envvar.Name)
-	}
-}
-
-func (s *deploymentTemplateTest) TestContainerShouldSetOperateIdentitySecretValue() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.identity.auth.operate.existingSecret": "secretValue",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-	s.Require().Contains(env,
-		corev1.EnvVar{
-			Name: "KEYCLOAK_INIT_OPERATE_SECRET",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "camunda-platform-test-operate-identity-secret"},
-					Key:                  "operate-secret",
-				},
+		}, {
+			Name: "TestContainerSetPodLabels",
+			Values: map[string]string{
+				"identity.podLabels.foo": "bar",
 			},
-		})
-}
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-func (s *deploymentTemplateTest) TestContainerShouldSetOperateIdentitySecretViaReference() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.identity.auth.operate.existingSecret.name": "ownExistingSecret",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-	s.Require().Contains(env,
-		corev1.EnvVar{
-			Name: "KEYCLOAK_INIT_OPERATE_SECRET",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "ownExistingSecret"},
-					Key:                  "operate-secret",
-				},
+				// then
+				s.Require().Equal("bar", deployment.Spec.Template.Labels["foo"])
 			},
-		})
-}
-
-func (s *deploymentTemplateTest) TestContainerShouldSetTasklistIdentitySecretValue() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.identity.auth.tasklist.existingSecret": "secretValue",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-	s.Require().Contains(env,
-		corev1.EnvVar{
-			Name: "KEYCLOAK_INIT_TASKLIST_SECRET",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "camunda-platform-test-tasklist-identity-secret"},
-					Key:                  "tasklist-secret",
-				},
+		}, {
+			Name: "TestContainerSetPodAnnotations",
+			Values: map[string]string{
+				"identity.podAnnotations.foo": "bar",
+				"identity.podAnnotations.foz": "baz",
 			},
-		})
-}
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-func (s *deploymentTemplateTest) TestContainerShouldSetTasklistIdentitySecretViaReference() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.identity.auth.tasklist.existingSecret.name": "ownExistingSecret",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-	s.Require().Contains(env,
-		corev1.EnvVar{
-			Name: "KEYCLOAK_INIT_TASKLIST_SECRET",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "ownExistingSecret"},
-					Key:                  "tasklist-secret",
-				},
+				// then
+				s.Require().Equal("bar", deployment.Spec.Template.Annotations["foo"])
+				s.Require().Equal("baz", deployment.Spec.Template.Annotations["foz"])
 			},
-		})
-}
-
-func (s *deploymentTemplateTest) TestContainerShouldSetOptimizeIdentitySecretValue() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.identity.auth.optimize.existingSecret": "secretValue",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-	s.Require().Contains(env,
-		corev1.EnvVar{
-			Name: "KEYCLOAK_INIT_OPTIMIZE_SECRET",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "camunda-platform-test-optimize-identity-secret"},
-					Key:                  "optimize-secret",
-				},
+		}, {
+			Name: "TestContainerSetGlobalAnnotations",
+			Values: map[string]string{
+				"global.annotations.foo": "bar",
 			},
-		})
-}
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-func (s *deploymentTemplateTest) TestContainerShouldSetOptimizeIdentitySecretViaReference() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.identity.auth.optimize.existingSecret.name": "ownExistingSecret",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-	s.Require().Contains(env,
-		corev1.EnvVar{
-			Name: "KEYCLOAK_INIT_OPTIMIZE_SECRET",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "ownExistingSecret"},
-					Key:                  "optimize-secret",
-				},
+				// then
+				s.Require().Equal("bar", deployment.ObjectMeta.Annotations["foo"])
 			},
-		})
-}
+		}, {
+			Name: "TestContainerSetImageNameSubChart",
+			Values: map[string]string{
+				"global.image.registry":     "global.custom.registry.io",
+				"global.image.tag":          "8.x.x",
+				"identity.image.registry":   "subchart.custom.registry.io",
+				"identity.image.repository": "camunda/identity-test",
+				"identity.image.tag":        "snapshot",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-func (s *deploymentTemplateTest) TestContainerShouldOverwriteGlobalImagePullPolicy() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.image.pullPolicy": "Always",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
+				// then
+				container := deployment.Spec.Template.Spec.Containers[0]
+				s.Require().Equal(container.Image, "subchart.custom.registry.io/camunda/identity-test:snapshot")
+			},
+		}, {
+			Name: "TestContainerSetImagePullSecretsGlobal",
+			Values: map[string]string{
+				"global.image.pullSecrets[0].name": "SecretName",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+				// then
+				s.Require().Equal("SecretName", deployment.Spec.Template.Spec.ImagePullSecrets[0].Name)
+			},
+		}, {
+			Name: "TestContainerSetImagePullSecretsSubChart",
+			Values: map[string]string{
+				"global.image.pullSecrets[0].name":   "SecretName",
+				"identity.image.pullSecrets[0].name": "SecretNameSubChart",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	// then
-	expectedPullPolicy := corev1.PullAlways
-	containers := deployment.Spec.Template.Spec.Containers
-	s.Require().Equal(1, len(containers))
-	pullPolicy := containers[0].ImagePullPolicy
-	s.Require().Equal(expectedPullPolicy, pullPolicy)
-}
+				// then
+				s.Require().Equal("SecretNameSubChart", deployment.Spec.Template.Spec.ImagePullSecrets[0].Name)
+			},
+		}, {
+			Name: "TestContainerOverwriteImageTag",
+			Values: map[string]string{
+				"identity.image.tag": "a.b.c",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-// readinessProbe is enabled by default so it's tested by golden files.
+				// then
+				expectedContainerImage := "camunda/identity:a.b.c"
+				containers := deployment.Spec.Template.Spec.Containers
+				s.Require().Equal(1, len(containers))
+				s.Require().Equal(expectedContainerImage, containers[0].Image)
+			},
+		}, {
+			Name: "TestContainerOverwriteGlobalImageTag",
+			Values: map[string]string{
+				"global.image.tag":   "a.b.c",
+				"identity.image.tag": "",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-func (s *deploymentTemplateTest) TestContainerStartupProbe() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"identity.startupProbe.enabled":             "true",
-			"identity.startupProbe.probePath":           "/healthz",
-			"identity.startupProbe.initialDelaySeconds": "5",
-			"identity.startupProbe.periodSeconds":       "10",
-			"identity.startupProbe.successThreshold":    "1",
-			"identity.startupProbe.failureThreshold":    "5",
-			"identity.startupProbe.timeoutSeconds":      "1",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
+				// then
+				expectedContainerImage := "camunda/identity:a.b.c"
+				containers := deployment.Spec.Template.Spec.Containers
+				s.Require().Equal(1, len(containers))
+				s.Require().Equal(expectedContainerImage, containers[0].Image)
+			},
+		}, {
+			Name: "TestContainerOverwriteImageTagWithChartDirectSetting",
+			Values: map[string]string{
+				"global.image.tag":   "x.y.z",
+				"identity.image.tag": "a.b.c",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+				// then
+				expectedContainerImage := "camunda/identity:a.b.c"
+				containers := deployment.Spec.Template.Spec.Containers
+				s.Require().Equal(1, len(containers))
+				s.Require().Equal(expectedContainerImage, containers[0].Image)
+			},
+		}, {
+			Name: "TestContainerSetContainerCommand",
+			Values: map[string]string{
+				"identity.command[0]": "printenv",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	// then
-	probe := deployment.Spec.Template.Spec.Containers[0].StartupProbe
+				// then
+				containers := deployment.Spec.Template.Spec.Containers
+				s.Require().Equal(1, len(containers))
+				s.Require().Equal(1, len(containers[0].Command))
+				s.Require().Equal("printenv", containers[0].Command[0])
+			},
+		}, {
+			Name: "TestContainerSetExtraVolumes",
+			Values: map[string]string{
+				"identity.extraVolumes[0].name":                  "extraVolume",
+				"identity.extraVolumes[0].configMap.name":        "otherConfigMap",
+				"identity.extraVolumes[0].configMap.defaultMode": "744",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				// finding out the length of volumes array before addition of new volume
+				var deploymentBefore appsv1.Deployment
+				before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
+				helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
+				volumeLenBefore := len(deploymentBefore.Spec.Template.Spec.Volumes)
+				// given
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	s.Require().Equal("/healthz", probe.HTTPGet.Path)
-	s.Require().EqualValues(5, probe.InitialDelaySeconds)
-	s.Require().EqualValues(10, probe.PeriodSeconds)
-	s.Require().EqualValues(1, probe.SuccessThreshold)
-	s.Require().EqualValues(5, probe.FailureThreshold)
-	s.Require().EqualValues(1, probe.TimeoutSeconds)
-}
+				// then
+				volumes := deployment.Spec.Template.Spec.Volumes
+				s.Require().Equal(volumeLenBefore+1, len(volumes))
 
-func (s *deploymentTemplateTest) TestContainerLivenessProbe() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"identity.livenessProbe.enabled":             "true",
-			"identity.livenessProbe.probePath":           "/healthz",
-			"identity.livenessProbe.initialDelaySeconds": "5",
-			"identity.livenessProbe.periodSeconds":       "10",
-			"identity.livenessProbe.successThreshold":    "1",
-			"identity.livenessProbe.failureThreshold":    "5",
-			"identity.livenessProbe.timeoutSeconds":      "1",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
+				extraVolume := volumes[volumeLenBefore]
+				s.Require().Equal("extraVolume", extraVolume.Name)
+				s.Require().NotNil(*extraVolume.ConfigMap)
+				s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
+				s.Require().EqualValues(744, *extraVolume.ConfigMap.DefaultMode)
+			},
+		}, {
+			Name: "TestContainerSetExtraVolumeMounts",
+			Values: map[string]string{
+				"identity.extraVolumeMounts[0].name":      "otherConfigMap",
+				"identity.extraVolumeMounts[0].mountPath": "/usr/local/config",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				// finding out the length of containers and volumeMounts array before addition of new volumeMount
+				var deploymentBefore appsv1.Deployment
+				before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
+				helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
+				containerLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers)
+				volumeMountLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
+				// given
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+				// then
+				containers := deployment.Spec.Template.Spec.Containers
+				s.Require().Equal(containerLenBefore, len(containers))
 
-	// then
-	probe := deployment.Spec.Template.Spec.Containers[0].LivenessProbe
+				volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
+				s.Require().Equal(volumeMountLenBefore+1, len(volumeMounts))
+				extraVolumeMount := volumeMounts[volumeMountLenBefore]
+				s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
+				s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
+			},
+		}, {
+			Name: "TestContainerSetExtraVolumesAndMounts",
+			Values: map[string]string{
+				"identity.extraVolumeMounts[0].name":             "otherConfigMap",
+				"identity.extraVolumeMounts[0].mountPath":        "/usr/local/config",
+				"identity.extraVolumes[0].name":                  "extraVolume",
+				"identity.extraVolumes[0].configMap.name":        "otherConfigMap",
+				"identity.extraVolumes[0].configMap.defaultMode": "744",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				// finding out the length of volumes, volumemounts array before addition of new volume
+				var deploymentBefore appsv1.Deployment
+				before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates)
+				helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
+				volumeLenBefore := len(deploymentBefore.Spec.Template.Spec.Volumes)
+				volumeMountLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
+				containerLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers)
+				// given
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	s.Require().EqualValues("/healthz", probe.HTTPGet.Path)
-	s.Require().EqualValues(5, probe.InitialDelaySeconds)
-	s.Require().EqualValues(10, probe.PeriodSeconds)
-	s.Require().EqualValues(1, probe.SuccessThreshold)
-	s.Require().EqualValues(5, probe.FailureThreshold)
-	s.Require().EqualValues(1, probe.TimeoutSeconds)
-}
+				// then
+				volumes := deployment.Spec.Template.Spec.Volumes
+				s.Require().Equal(volumeLenBefore+1, len(volumes))
 
-// Identity doesn't support contextPath for health endpoints.
-func (s *deploymentTemplateTest) TestContainerProbesWithContextPath() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"identity.contextPath":              "/test",
-			"identity.startupProbe.enabled":     "true",
-			"identity.startupProbe.probePath":   "/start",
-			"identity.readinessProbe.enabled":   "true",
-			"identity.readinessProbe.probePath": "/ready",
-			"identity.livenessProbe.enabled":    "true",
-			"identity.livenessProbe.probePath":  "/live",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
+				extraVolume := volumes[volumeLenBefore]
+				s.Require().Equal("extraVolume", extraVolume.Name)
+				s.Require().NotNil(*extraVolume.ConfigMap)
+				s.Require().Equal("otherConfigMap", extraVolume.ConfigMap.Name)
+				s.Require().EqualValues(744, *extraVolume.ConfigMap.DefaultMode)
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+				containers := deployment.Spec.Template.Spec.Containers
+				s.Require().Equal(containerLenBefore, len(containers))
 
-	// then
-	probe := deployment.Spec.Template.Spec.Containers[0]
+				volumeMounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
+				s.Require().Equal(volumeMountLenBefore+1, len(volumeMounts))
+				extraVolumeMount := volumeMounts[volumeMountLenBefore]
+				s.Require().Equal("otherConfigMap", extraVolumeMount.Name)
+				s.Require().Equal("/usr/local/config", extraVolumeMount.MountPath)
+			},
+		}, {
+			Name: "TestContainerSetServiceAccountName",
+			Values: map[string]string{
+				"identity.serviceAccount.name": "accName",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	s.Require().Equal("/start", probe.StartupProbe.HTTPGet.Path)
-	s.Require().Equal("/ready", probe.ReadinessProbe.HTTPGet.Path)
-	s.Require().Equal("/live", probe.LivenessProbe.HTTPGet.Path)
-}
+				// then
+				serviceAccName := deployment.Spec.Template.Spec.ServiceAccountName
+				s.Require().Equal("accName", serviceAccName)
+			},
+		}, {
+			Name: "TestPodSetSecurityContext",
+			Values: map[string]string{
+				"identity.podSecurityContext.runAsUser": "1000",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-func (s *deploymentTemplateTest) TestContainerSetSidecar() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"identity.sidecars[0].name":                   "nginx",
-			"identity.sidecars[0].image":                  "nginx:latest",
-			"identity.sidecars[0].ports[0].containerPort": "80",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
+				// then
+				securityContext := deployment.Spec.Template.Spec.SecurityContext
+				s.Require().EqualValues(1000, *securityContext.RunAsUser)
+			},
+		}, {
+			Name: "TestContainerSetSecurityContext",
+			Values: map[string]string{
+				"identity.containerSecurityContext.privileged":          "true",
+				"identity.containerSecurityContext.capabilities.add[0]": "NET_ADMIN",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+				// then
+				securityContext := deployment.Spec.Template.Spec.Containers[0].SecurityContext
+				s.Require().True(*securityContext.Privileged)
+				s.Require().EqualValues("NET_ADMIN", securityContext.Capabilities.Add[0])
+			},
+		}, {
+			// https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+			Name: "TestContainerSetNodeSelector",
+			Values: map[string]string{
+				"identity.nodeSelector.disktype": "ssd",
+				"identity.nodeSelector.cputype":  "arm",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
-	// then
-	podContainers := deployment.Spec.Template.Spec.Containers
-	expectedContainer := corev1.Container{
-		Name:  "nginx",
-		Image: "nginx:latest",
-		Ports: []corev1.ContainerPort{
-			{
-				ContainerPort: 80,
+				// then
+				s.Require().Equal("ssd", deployment.Spec.Template.Spec.NodeSelector["disktype"])
+				s.Require().Equal("arm", deployment.Spec.Template.Spec.NodeSelector["cputype"])
+			},
+		}, {
+			// https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+			// affinity:
+			//	nodeAffinity:
+			//	 requiredDuringSchedulingIgnoredDuringExecution:
+			//	   nodeSelectorTerms:
+			//	   - matchExpressions:
+			//		 - key: kubernetes.io/e2e-az-name
+			//		   operator: In
+			//		   values:
+			//		   - e2e-az1
+			//		   - e2e-az2
+			//	 preferredDuringSchedulingIgnoredDuringExecution:
+			//	 - weight: 1
+			//	   preference:
+			//		 matchExpressions:
+			//		 - key: another-node-label-key
+			//		   operator: In
+			//		   values:
+			//		   - another-node-label-value
+			Name: "TestContainerSetAffinity",
+			Values: map[string]string{
+				"identity.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].key":       "kubernetes.io/e2e-az-name",
+				"identity.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].operator":  "In",
+				"identity.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].values[0]": "e2e-a1",
+				"identity.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchexpressions[0].values[1]": "e2e-a2",
+				"identity.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight":                                         "1",
+				"identity.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].key":             "another-node-label-key",
+				"identity.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].operator":        "In",
+				"identity.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].values[0]":       "another-node-label-value",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				nodeAffinity := deployment.Spec.Template.Spec.Affinity.NodeAffinity
+				s.Require().NotNil(nodeAffinity)
+
+				nodeSelectorTerm := nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0]
+				s.Require().NotNil(nodeSelectorTerm)
+				matchExpression := nodeSelectorTerm.MatchExpressions[0]
+				s.Require().NotNil(matchExpression)
+				s.Require().Equal("kubernetes.io/e2e-az-name", matchExpression.Key)
+				s.Require().EqualValues("In", matchExpression.Operator)
+				s.Require().Equal([]string{"e2e-a1", "e2e-a2"}, matchExpression.Values)
+
+				preferredSchedulingTerm := nodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0]
+				s.Require().NotNil(preferredSchedulingTerm)
+
+				matchExpression = preferredSchedulingTerm.Preference.MatchExpressions[0]
+				s.Require().NotNil(matchExpression)
+				s.Require().Equal("another-node-label-key", matchExpression.Key)
+				s.Require().EqualValues("In", matchExpression.Operator)
+				s.Require().Equal([]string{"another-node-label-value"}, matchExpression.Values)
+			},
+		}, {
+			// https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration
+			//tolerations:
+			//- key: "key1"
+			//  operator: "Equal"
+			//  value: "value1"
+			//  effect: "NoSchedule"
+			Name: "TestContainerSetTolerations",
+			Values: map[string]string{
+				"identity.tolerations[0].key":      "key1",
+				"identity.tolerations[0].operator": "Equal",
+				"identity.tolerations[0].value":    "Value1",
+				"identity.tolerations[0].effect":   "NoSchedule",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				tolerations := deployment.Spec.Template.Spec.Tolerations
+				s.Require().Equal(1, len(tolerations))
+
+				toleration := tolerations[0]
+				s.Require().Equal("key1", toleration.Key)
+				s.Require().EqualValues("Equal", toleration.Operator)
+				s.Require().Equal("Value1", toleration.Value)
+				s.Require().EqualValues("NoSchedule", toleration.Effect)
+			},
+		}, {
+			Name:                 "TestContainerShouldSetTemplateEnvVars",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values: map[string]string{
+				"identity.env[0].name":  "RELEASE_NAME",
+				"identity.env[0].value": "test-{{ .Release.Name }}",
+				"identity.env[1].name":  "OTHER_ENV",
+				"identity.env[1].value": "nothingToSeeHere",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env, corev1.EnvVar{Name: "RELEASE_NAME", Value: "test-camunda-platform-test"})
+				s.Require().Contains(env, corev1.EnvVar{Name: "OTHER_ENV", Value: "nothingToSeeHere"})
+			},
+		}, {
+			Name:                 "TestContainerShouldSetCorrectSecret",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values: map[string]string{
+				"identityKeycloak.enabled":                "true",
+				"identityKeycloak.auth.existingSecret":    "ownExistingSecret",
+				"identityKeycloak.auth.passwordSecretKey": "test-admin",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env,
+					corev1.EnvVar{
+						Name: "KEYCLOAK_SETUP_PASSWORD",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "ownExistingSecret"},
+								Key:                  "test-admin",
+							},
+						},
+					})
+			},
+		}, {
+			Name:                 "TestContainerShouldDisableIntegration",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values: map[string]string{
+				"global.identity.auth.enabled": "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+
+				for _, envvar := range env {
+					s.Require().NotEqual("KEYCLOAK_INIT_OPERATE_ROOT_URL", envvar.Name)
+					s.Require().NotEqual("KEYCLOAK_INIT_OPERATE_SECRET", envvar.Name)
+					s.Require().NotEqual("KEYCLOAK_INIT_TASKLIST_ROOT_URL", envvar.Name)
+					s.Require().NotEqual("KEYCLOAK_INIT_TASKLIST_SECRET", envvar.Name)
+				}
+			},
+		}, {
+			Name:                 "TestContainerShouldSetOperateIdentitySecretValue",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values: map[string]string{
+				"global.identity.auth.operate.existingSecret": "secretValue",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env,
+					corev1.EnvVar{
+						Name: "KEYCLOAK_INIT_OPERATE_SECRET",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "camunda-platform-test-operate-identity-secret"},
+								Key:                  "operate-secret",
+							},
+						},
+					})
+			},
+		}, {
+			Name:                 "TestContainerShouldSetOperateIdentitySecretViaReference",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values: map[string]string{
+				"global.identity.auth.operate.existingSecret.name": "ownExistingSecret",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env,
+					corev1.EnvVar{
+						Name: "KEYCLOAK_INIT_OPERATE_SECRET",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "ownExistingSecret"},
+								Key:                  "operate-secret",
+							},
+						},
+					})
+			},
+		}, {
+			Name:                 "TestContainerShouldSetTasklistIdentitySecretValue",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values: map[string]string{
+				"global.identity.auth.tasklist.existingSecret": "secretValue",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env,
+					corev1.EnvVar{
+						Name: "KEYCLOAK_INIT_TASKLIST_SECRET",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "camunda-platform-test-tasklist-identity-secret"},
+								Key:                  "tasklist-secret",
+							},
+						},
+					})
+			},
+		}, {
+			Name:                 "TestContainerShouldSetTasklistIdentitySecretViaReference",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values: map[string]string{
+				"global.identity.auth.tasklist.existingSecret.name": "ownExistingSecret",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env,
+					corev1.EnvVar{
+						Name: "KEYCLOAK_INIT_TASKLIST_SECRET",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "ownExistingSecret"},
+								Key:                  "tasklist-secret",
+							},
+						},
+					})
+			},
+		}, {
+			Name:                 "TestContainerShouldSetOptimizeIdentitySecretValue",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values: map[string]string{
+				"global.identity.auth.optimize.existingSecret": "secretValue",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env,
+					corev1.EnvVar{
+						Name: "KEYCLOAK_INIT_OPTIMIZE_SECRET",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "camunda-platform-test-optimize-identity-secret"},
+								Key:                  "optimize-secret",
+							},
+						},
+					})
+			},
+		}, {
+			Name:                 "TestContainerShouldSetOptimizeIdentitySecretViaReference",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values: map[string]string{
+				"global.identity.auth.optimize.existingSecret.name": "ownExistingSecret",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env,
+					corev1.EnvVar{
+						Name: "KEYCLOAK_INIT_OPTIMIZE_SECRET",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "ownExistingSecret"},
+								Key:                  "optimize-secret",
+							},
+						},
+					})
+			},
+		}, {
+			Name: "TestContainerShouldOverwriteGlobalImagePullPolicy",
+			Values: map[string]string{
+				"global.image.pullPolicy": "Always",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				expectedPullPolicy := corev1.PullAlways
+				containers := deployment.Spec.Template.Spec.Containers
+				s.Require().Equal(1, len(containers))
+				pullPolicy := containers[0].ImagePullPolicy
+				s.Require().Equal(expectedPullPolicy, pullPolicy)
+			},
+		}, {
+			Name:                 "TestContainerStartupProbe",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values: map[string]string{
+				"identity.startupProbe.enabled":             "true",
+				"identity.startupProbe.probePath":           "/healthz",
+				"identity.startupProbe.initialDelaySeconds": "5",
+				"identity.startupProbe.periodSeconds":       "10",
+				"identity.startupProbe.successThreshold":    "1",
+				"identity.startupProbe.failureThreshold":    "5",
+				"identity.startupProbe.timeoutSeconds":      "1",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				probe := deployment.Spec.Template.Spec.Containers[0].StartupProbe
+
+				s.Require().Equal("/healthz", probe.HTTPGet.Path)
+				s.Require().EqualValues(5, probe.InitialDelaySeconds)
+				s.Require().EqualValues(10, probe.PeriodSeconds)
+				s.Require().EqualValues(1, probe.SuccessThreshold)
+				s.Require().EqualValues(5, probe.FailureThreshold)
+				s.Require().EqualValues(1, probe.TimeoutSeconds)
+			},
+		}, {
+			// readinessProbe is enabled by default so it's tested by golden files.
+			Name:                 "TestContainerLivenessProbe",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values: map[string]string{
+				"identity.livenessProbe.enabled":             "true",
+				"identity.livenessProbe.probePath":           "/healthz",
+				"identity.livenessProbe.initialDelaySeconds": "5",
+				"identity.livenessProbe.periodSeconds":       "10",
+				"identity.livenessProbe.successThreshold":    "1",
+				"identity.livenessProbe.failureThreshold":    "5",
+				"identity.livenessProbe.timeoutSeconds":      "1",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				probe := deployment.Spec.Template.Spec.Containers[0].LivenessProbe
+
+				s.Require().EqualValues("/healthz", probe.HTTPGet.Path)
+				s.Require().EqualValues(5, probe.InitialDelaySeconds)
+				s.Require().EqualValues(10, probe.PeriodSeconds)
+				s.Require().EqualValues(1, probe.SuccessThreshold)
+				s.Require().EqualValues(5, probe.FailureThreshold)
+				s.Require().EqualValues(1, probe.TimeoutSeconds)
+			},
+		}, {
+			// Identity doesn't support contextPath for health endpoints.
+			Name:                 "TestContainerProbesWithContextPath",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values: map[string]string{
+				"identity.contextPath":              "/test",
+				"identity.startupProbe.enabled":     "true",
+				"identity.startupProbe.probePath":   "/start",
+				"identity.readinessProbe.enabled":   "true",
+				"identity.readinessProbe.probePath": "/ready",
+				"identity.livenessProbe.enabled":    "true",
+				"identity.livenessProbe.probePath":  "/live",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				probe := deployment.Spec.Template.Spec.Containers[0]
+
+				s.Require().Equal("/start", probe.StartupProbe.HTTPGet.Path)
+				s.Require().Equal("/ready", probe.ReadinessProbe.HTTPGet.Path)
+				s.Require().Equal("/live", probe.LivenessProbe.HTTPGet.Path)
+			},
+		}, {
+			Name: "TestContainerSetSidecar",
+			Values: map[string]string{
+				"identity.sidecars[0].name":                   "nginx",
+				"identity.sidecars[0].image":                  "nginx:latest",
+				"identity.sidecars[0].ports[0].containerPort": "80",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				podContainers := deployment.Spec.Template.Spec.Containers
+				expectedContainer := corev1.Container{
+					Name:  "nginx",
+					Image: "nginx:latest",
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: 80,
+						},
+					},
+				}
+
+				s.Require().Contains(podContainers, expectedContainer)
+			},
+		}, {
+			Name: "TestInitContainers",
+			Values: map[string]string{
+				"identity.initContainers[0].name":                   "nginx",
+				"identity.initContainers[0].image":                  "nginx:latest",
+				"identity.initContainers[0].ports[0].containerPort": "80",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				podContainers := deployment.Spec.Template.Spec.InitContainers
+				expectedContainer := corev1.Container{
+					Name:  "nginx",
+					Image: "nginx:latest",
+					Ports: []corev1.ContainerPort{
+						{
+							ContainerPort: 80,
+						},
+					},
+				}
+
+				s.Require().Contains(podContainers, expectedContainer)
+			},
+		}, {
+			Name:                 "TestContainerShouldSetFirstUserExistingSecretValue",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values: map[string]string{
+				"identity.firstUser.existingSecret": "identityFirstUserSecret",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env,
+					corev1.EnvVar{
+						Name: "KEYCLOAK_USERS_0_PASSWORD",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "identityFirstUserSecret"},
+								Key:                  "identity-firstuser-password",
+							},
+						},
+					})
+			},
+		}, {
+			Name: "TestContainerShouldSetExternalDatabaseExistingSecret",
+			Values: map[string]string{
+				"identityPostgresql.enabled":                          "false",
+				"identity.externalDatabase.enabled":                   "true",
+				"identity.externalDatabase.existingSecret":            "postgres-secret-ext",
+				"identity.externalDatabase.existingSecretPasswordKey": "identity-password-ext",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env,
+					corev1.EnvVar{
+						Name: "IDENTITY_DATABASE_PASSWORD",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "postgres-secret-ext"},
+								Key:                  "identity-password-ext",
+							},
+						},
+					})
+			},
+		}, {
+			Name: "TestSetDnsPolicyAndDnsConfig",
+			Values: map[string]string{
+				"identity.dnsPolicy":                "ClusterFirst",
+				"identity.dnsConfig.nameservers[0]": "8.8.8.8",
+				"identity.dnsConfig.searches[0]":    "example.com",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				// Check if dnsPolicy is set
+				require.NotEmpty(s.T(), deployment.Spec.Template.Spec.DNSPolicy, "dnsPolicy should not be empty")
+
+				// Check if dnsConfig is set
+				require.NotNil(s.T(), deployment.Spec.Template.Spec.DNSConfig, "dnsConfig should not be nil")
+
+				expectedDNSConfig := &corev1.PodDNSConfig{
+					Nameservers: []string{"8.8.8.8"},
+					Searches:    []string{"example.com"},
+				}
+
+				require.Equal(s.T(), expectedDNSConfig, deployment.Spec.Template.Spec.DNSConfig, "dnsConfig should match the expected configuration")
+			},
+		}, {
+			Name: "TestClientSecretPlaintextWhenAuthTypeGeneric",
+			Values: map[string]string{
+				"global.identity.auth.type":                    "GENERIC",
+				"global.identity.auth.issuerBackendUrl":        "https://my.idp.org",
+				"global.identity.auth.issuer":                  "https://my.idp.org",
+				"global.identity.auth.identity.audience":       "identity-client",
+				"global.identity.auth.identity.clientId":       "identity-client",
+				"global.identity.auth.identity.existingSecret": "superSecret",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env,
+					corev1.EnvVar{
+						Name:  "CAMUNDA_IDENTITY_CLIENT_SECRET",
+						Value: "superSecret",
+					})
+			},
+		}, {
+			Name: "TestClientSecretRefWhenAuthTypeGeneric",
+			Values: map[string]string{
+				"global.identity.auth.type":                         "GENERIC",
+				"global.identity.auth.issuerBackendUrl":             "https://my.idp.org",
+				"global.identity.auth.issuer":                       "https://my.idp.org",
+				"global.identity.auth.identity.audience":            "identity-client",
+				"global.identity.auth.identity.clientId":            "identity-client",
+				"global.identity.auth.identity.existingSecret.name": "super-secret",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env,
+					corev1.EnvVar{
+						Name: "CAMUNDA_IDENTITY_CLIENT_SECRET",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "super-secret"},
+								Key:                  "identity-secret",
+							},
+						},
+					})
+			},
+		}, {
+			Name: "TestClientSecretPlaintextWhenAuthTypeMicrosoft",
+			Values: map[string]string{
+				"global.identity.auth.type":                    "MICROSOFT",
+				"global.identity.auth.issuerBackendUrl":        "https://my.idp.org",
+				"global.identity.auth.issuer":                  "https://my.idp.org",
+				"global.identity.auth.identity.audience":       "identity-client",
+				"global.identity.auth.identity.clientId":       "identity-client",
+				"global.identity.auth.identity.existingSecret": "superSecret",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env,
+					corev1.EnvVar{
+						Name:  "CAMUNDA_IDENTITY_CLIENT_SECRET",
+						Value: "superSecret",
+					})
+			},
+		}, {
+			Name: "TestClientSecretRefWhenAuthTypeMicrosoft",
+			Values: map[string]string{
+				"global.identity.auth.type":                         "MICROSOFT",
+				"global.identity.auth.issuerBackendUrl":             "https://my.idp.org",
+				"global.identity.auth.issuer":                       "https://my.idp.org",
+				"global.identity.auth.identity.audience":            "identity-client",
+				"global.identity.auth.identity.clientId":            "identity-client",
+				"global.identity.auth.identity.existingSecret.name": "super-secret",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				// then
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env,
+					corev1.EnvVar{
+						Name: "CAMUNDA_IDENTITY_CLIENT_SECRET",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "super-secret"},
+								Key:                  "identity-secret",
+							},
+						},
+					})
 			},
 		},
 	}
 
-	s.Require().Contains(podContainers, expectedContainer)
-}
-
-func (s *deploymentTemplateTest) TestInitContainers() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"identity.initContainers[0].name":                   "nginx",
-			"identity.initContainers[0].image":                  "nginx:latest",
-			"identity.initContainers[0].ports[0].containerPort": "80",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	podContainers := deployment.Spec.Template.Spec.InitContainers
-	expectedContainer := corev1.Container{
-		Name:  "nginx",
-		Image: "nginx:latest",
-		Ports: []corev1.ContainerPort{
-			{
-				ContainerPort: 80,
-			},
-		},
-	}
-
-	s.Require().Contains(podContainers, expectedContainer)
-}
-
-func (s *deploymentTemplateTest) TestContainerShouldSetFirstUserExistingSecretValue() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"identity.firstUser.existingSecret": "identityFirstUserSecret",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-		ExtraArgs:      map[string][]string{"install": {"--debug"}},
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-	s.Require().Contains(env,
-		corev1.EnvVar{
-			Name: "KEYCLOAK_USERS_0_PASSWORD",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "identityFirstUserSecret"},
-					Key:                  "identity-firstuser-password",
-				},
-			},
-		})
-}
-
-func (s *deploymentTemplateTest) TestContainerShouldSetExternalDatabaseExistingSecret() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"identityPostgresql.enabled":                          "false",
-			"identity.externalDatabase.enabled":                   "true",
-			"identity.externalDatabase.existingSecret":            "postgres-secret-ext",
-			"identity.externalDatabase.existingSecretPasswordKey": "identity-password-ext",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-	s.Require().Contains(env,
-		corev1.EnvVar{
-			Name: "IDENTITY_DATABASE_PASSWORD",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "postgres-secret-ext"},
-					Key:                  "identity-password-ext",
-				},
-			},
-		})
-}
-func (s *deploymentTemplateTest) TestSetDnsPolicyAndDnsConfig() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"identity.dnsPolicy":                "ClusterFirst",
-			"identity.dnsConfig.nameservers[0]": "8.8.8.8",
-			"identity.dnsConfig.searches[0]":    "example.com",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	// Check if dnsPolicy is set
-	require.NotEmpty(s.T(), deployment.Spec.Template.Spec.DNSPolicy, "dnsPolicy should not be empty")
-
-	// Check if dnsConfig is set
-	require.NotNil(s.T(), deployment.Spec.Template.Spec.DNSConfig, "dnsConfig should not be nil")
-
-	expectedDNSConfig := &corev1.PodDNSConfig{
-		Nameservers: []string{"8.8.8.8"},
-		Searches:    []string{"example.com"},
-	}
-
-	require.Equal(s.T(), expectedDNSConfig, deployment.Spec.Template.Spec.DNSConfig, "dnsConfig should match the expected configuration")
-}
-
-func (s *deploymentTemplateTest) TestClientSecretPlaintextWhenAuthTypeGeneric() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.identity.auth.type":                    "GENERIC",
-			"global.identity.auth.issuerBackendUrl":        "https://my.idp.org",
-			"global.identity.auth.issuer":                  "https://my.idp.org",
-			"global.identity.auth.identity.audience":       "identity-client",
-			"global.identity.auth.identity.clientId":       "identity-client",
-			"global.identity.auth.identity.existingSecret": "superSecret",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-	s.Require().Contains(env,
-		corev1.EnvVar{
-			Name:  "CAMUNDA_IDENTITY_CLIENT_SECRET",
-			Value: "superSecret",
-		})
-}
-
-func (s *deploymentTemplateTest) TestClientSecretRefWhenAuthTypeGeneric() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.identity.auth.type":                         "GENERIC",
-			"global.identity.auth.issuerBackendUrl":             "https://my.idp.org",
-			"global.identity.auth.issuer":                       "https://my.idp.org",
-			"global.identity.auth.identity.audience":            "identity-client",
-			"global.identity.auth.identity.clientId":            "identity-client",
-			"global.identity.auth.identity.existingSecret.name": "super-secret",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-	s.Require().Contains(env,
-		corev1.EnvVar{
-			Name: "CAMUNDA_IDENTITY_CLIENT_SECRET",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "super-secret"},
-					Key:                  "identity-secret",
-				},
-			},
-		})
-}
-
-func (s *deploymentTemplateTest) TestClientSecretPlaintextWhenAuthTypeMicrosoft() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.identity.auth.type":                    "MICROSOFT",
-			"global.identity.auth.issuerBackendUrl":        "https://my.idp.org",
-			"global.identity.auth.issuer":                  "https://my.idp.org",
-			"global.identity.auth.identity.audience":       "identity-client",
-			"global.identity.auth.identity.clientId":       "identity-client",
-			"global.identity.auth.identity.existingSecret": "superSecret",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-	s.Require().Contains(env,
-		corev1.EnvVar{
-			Name:  "CAMUNDA_IDENTITY_CLIENT_SECRET",
-			Value: "superSecret",
-		})
-}
-
-func (s *deploymentTemplateTest) TestClientSecretRefWhenAuthTypeMicrosoft() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.identity.auth.type":                         "MICROSOFT",
-			"global.identity.auth.issuerBackendUrl":             "https://my.idp.org",
-			"global.identity.auth.issuer":                       "https://my.idp.org",
-			"global.identity.auth.identity.audience":            "identity-client",
-			"global.identity.auth.identity.clientId":            "identity-client",
-			"global.identity.auth.identity.existingSecret.name": "super-secret",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-	// then
-	env := deployment.Spec.Template.Spec.Containers[0].Env
-	s.Require().Contains(env,
-		corev1.EnvVar{
-			Name: "CAMUNDA_IDENTITY_CLIENT_SECRET",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "super-secret"},
-					Key:                  "identity-secret",
-				},
-			},
-		})
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }

--- a/charts/camunda-platform-8.5/test/unit/identity/secret_test.go
+++ b/charts/camunda-platform-8.5/test/unit/identity/secret_test.go
@@ -15,12 +15,12 @@
 package identity
 
 import (
+	"camunda-platform/test/unit/testhelpers"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -28,7 +28,7 @@ import (
 	coreV1 "k8s.io/api/core/v1"
 )
 
-type secretTest struct {
+type SecretTest struct {
 	suite.Suite
 	chartPath  string
 	release    string
@@ -43,7 +43,7 @@ func TestSecretTemplate(t *testing.T) {
 	chartPath, err := filepath.Abs("../../../")
 	require.NoError(t, err)
 
-	suite.Run(t, &secretTest{
+	suite.Run(t, &SecretTest{
 		chartPath:  chartPath,
 		release:    "camunda-platform-test",
 		namespace:  "camunda-platform-" + strings.ToLower(random.UniqueId()),
@@ -52,84 +52,82 @@ func TestSecretTemplate(t *testing.T) {
 	})
 }
 
-func (s *secretTest) TestSecretExternalDatabaseEnabledWithDefinedPassword() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"identityPostgresql.enabled":         "false",
-			"identity.externalDatabase.enabled":  "true",
-			"identity.externalDatabase.password": "super-secure-ext",
+func (s *SecretTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestSecretExternalDatabaseEnabledWithDefinedPassword",
+			CaseTemplates: &testhelpers.CaseTemplate{
+				Templates: []string{"templates/identity/postgresql-secret.yaml"},
+			},
+			Values: map[string]string{
+				"identityPostgresql.enabled":         "false",
+				"identity.externalDatabase.enabled":  "true",
+				"identity.externalDatabase.password": "super-secure-ext",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var secret coreV1.Secret
+				helm.UnmarshalK8SYaml(s.T(), output, &secret)
+
+				// then
+				s.NotEmpty(secret.Data)
+				s.Require().Equal("super-secure-ext", string(secret.Data["password"]))
+			},
+		}, {
+			Name: "TestExternalIdentityPostgresqlSecretRenderedOnCompatibilityPostgresqlEnabled1",
+			CaseTemplates: &testhelpers.CaseTemplate{
+				Templates: []string{"charts/identityPostgresql/templates/secrets.yaml"},
+			},
+			Values: map[string]string{
+				// note how it's not identityPostgresql.enabled so we can reproduce SUPPORT-21601
+				"identity.postgresql.enabled":       "true",
+				"identity.externalDatabase.enabled": "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				// I expect Secret to be rendered via templates/identity/postgresql-secret.yaml
+				var secret coreV1.Secret
+				helm.UnmarshalK8SYaml(s.T(), output, &secret)
+				s.Require().Equal("camunda-platform-test-identity-postgresql", secret.ObjectMeta.Name)
+				s.Require().NotEmpty(string(secret.Data["password"]))
+			},
+		}, {
+			Name: "TestExternalIdentityPostgresqlSecretRenderedOnCompatibilityPostgresqlEnabled2",
+			CaseTemplates: &testhelpers.CaseTemplate{
+				Templates: []string{"templates/identity/postgresql-secret.yaml"},
+			},
+			Values: map[string]string{
+				// note how it's not identityPostgresql.enabled so we can reproduce SUPPORT-21601
+				"identity.postgresql.enabled":       "true",
+				"identity.externalDatabase.enabled": "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				// I expect Secret to NOT be rendered via charts/identityPostgresql/templates/secrets.yaml
+				s.Require().ErrorContains(err, "could not find template templates/identity/postgresql-secret.yaml in chart")
+			},
+		}, {
+			Name: "TestExternalIdentityPostgresqlSecretRenderedOnCompatibilityPostgresqlEnabled3",
+			CaseTemplates: &testhelpers.CaseTemplate{
+				Templates: []string{"templates/identity/deployment.yaml"},
+			},
+			Values: map[string]string{
+				// note how it's not identityPostgresql.enabled so we can reproduce SUPPORT-21601
+				"identity.postgresql.enabled":       "true",
+				"identity.externalDatabase.enabled": "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+				envVars := deployment.Spec.Template.Spec.Containers[0].Env
+				var identityDatabasePassword coreV1.EnvVar
+				for _, envVar := range envVars {
+					if envVar.Name == "IDENTITY_DATABASE_PASSWORD" {
+						identityDatabasePassword = envVar
+					}
+				}
+				s.Require().Equal("IDENTITY_DATABASE_PASSWORD", identityDatabasePassword.Name)
+				// I expect Deployment environment variable to reference the secret that is rendered
+				s.Require().Equal("camunda-platform-test-identity-postgresql", identityDatabasePassword.ValueFrom.SecretKeyRef.Name)
+			},
 		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 	}
-
-	s.templates = []string{
-		"templates/identity/postgresql-secret.yaml",
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var secret coreV1.Secret
-	helm.UnmarshalK8SYaml(s.T(), output, &secret)
-
-	// then
-	s.NotEmpty(secret.Data)
-	s.Require().Equal("super-secure-ext", string(secret.Data["password"]))
-}
-
-func (s *secretTest) TestExternalIdentityPostgresqlSecretRenderedOnCompatibilityPostgresqlEnabled() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			// note how it's not identityPostgresql.enabled so we can reproduce SUPPORT-21601
-			"identity.postgresql.enabled":       "true",
-			"identity.externalDatabase.enabled": "false",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// There are 2 possible ways for this secret to be rendered:
-	// 1. through charts/identityPostgresql/templates/secrets.yaml for situations when identityPostgresql is enabled
-	// 2. through templates/identity/postgresql-secret.yaml for situations when identityPostgresql is disabled but
-	//    there is an externalDatabase configured
-	postgresqlSubchartSecretTemplatePath := []string{
-		"charts/identityPostgresql/templates/secrets.yaml",
-	}
-
-	identityPostgresqlMainChartSecretTemplatePath := []string{
-		"templates/identity/postgresql-secret.yaml",
-	}
-
-	deploymentTemplateName := []string{
-		"templates/identity/deployment.yaml",
-	}
-
-	// when
-	postgresqlSubchartSecret := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, postgresqlSubchartSecretTemplatePath)
-	_, mainChartSecretError := helm.RenderTemplateE(s.T(), options, s.chartPath, s.release, identityPostgresqlMainChartSecretTemplatePath)
-	deploymentTemplate := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, deploymentTemplateName)
-	var secret coreV1.Secret
-	var deployment appsv1.Deployment
-
-	helm.UnmarshalK8SYaml(s.T(), postgresqlSubchartSecret, &secret)
-	helm.UnmarshalK8SYaml(s.T(), deploymentTemplate, &deployment)
-
-	envVars := deployment.Spec.Template.Spec.Containers[0].Env
-	var identityDatabasePassword coreV1.EnvVar
-	for _, envVar := range envVars {
-		if envVar.Name == "IDENTITY_DATABASE_PASSWORD" {
-			identityDatabasePassword = envVar
-		}
-	}
-
-	// then
-
-	// I expect Secret to NOT be rendered via charts/identityPostgresql/templates/secrets.yaml
-	s.Require().ErrorContains(mainChartSecretError, "could not find template templates/identity/postgresql-secret.yaml in chart")
-	s.Require().Equal("IDENTITY_DATABASE_PASSWORD", identityDatabasePassword.Name)
-	// I expect Deployment environment variable to reference the secret that is rendered
-	s.Require().Equal("camunda-platform-test-identity-postgresql", identityDatabasePassword.ValueFrom.SecretKeyRef.Name)
-	// I expect Secret to be rendered via templates/identity/postgresql-secret.yaml
-	s.Require().Equal("camunda-platform-test-identity-postgresql", secret.ObjectMeta.Name)
-	s.Require().NotEmpty(string(secret.Data["password"]))
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }

--- a/charts/camunda-platform-8.5/test/unit/identity/service_test.go
+++ b/charts/camunda-platform-8.5/test/unit/identity/service_test.go
@@ -15,19 +15,19 @@
 package identity
 
 import (
+	"camunda-platform/test/unit/testhelpers"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	coreV1 "k8s.io/api/core/v1"
 )
 
-type serviceTest struct {
+type ServiceTest struct {
 	suite.Suite
 	chartPath string
 	release   string
@@ -41,7 +41,7 @@ func TestServiceTemplate(t *testing.T) {
 	chartPath, err := filepath.Abs("../../../")
 	require.NoError(t, err)
 
-	suite.Run(t, &serviceTest{
+	suite.Run(t, &ServiceTest{
 		chartPath: chartPath,
 		release:   "camunda-platform-test",
 		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
@@ -49,60 +49,52 @@ func TestServiceTemplate(t *testing.T) {
 	})
 }
 
-func (s *serviceTest) TestContainerSetGlobalAnnotations() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.annotations.foo": "bar",
+func (s *ServiceTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestContainerSetGlobalAnnotations",
+			Values: map[string]string{
+				"global.annotations.foo": "bar",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var service coreV1.Service
+				helm.UnmarshalK8SYaml(s.T(), output, &service)
+
+				// then
+				s.Require().Equal("bar", service.ObjectMeta.Annotations["foo"])
+			},
+		}, {
+			Name: "TestContainerServiceAnnotations",
+			Values: map[string]string{
+				"identity.service.annotations.foo": "bar",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var service coreV1.Service
+				helm.UnmarshalK8SYaml(s.T(), output, &service)
+
+				// then
+				s.Require().Equal("bar", service.ObjectMeta.Annotations["foo"])
+			},
+		}, {
+			Name: "TestKeycloakExternalService",
+			CaseTemplates: &testhelpers.CaseTemplate{
+				Templates: []string{"templates/identity/keycloak-service.yaml"},
+			},
+			Values: map[string]string{
+				"global.identity.keycloak.internal":     "true",
+				"global.identity.keycloak.url.protocol": "https",
+				"global.identity.keycloak.url.host":     "keycloak.prod.svc.cluster.local",
+				"global.identity.keycloak.url.port":     "8443",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var service coreV1.Service
+				helm.UnmarshalK8SYaml(s.T(), output, &service)
+
+				s.Require().Equal(coreV1.ServiceType("ExternalName"), service.Spec.Type)
+				s.Require().Equal("keycloak.prod.svc.cluster.local", service.Spec.ExternalName)
+			},
 		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 	}
 
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var service coreV1.Service
-	helm.UnmarshalK8SYaml(s.T(), output, &service)
-
-	// then
-	s.Require().Equal("bar", service.ObjectMeta.Annotations["foo"])
-}
-
-func (s *serviceTest) TestContainerServiceAnnotations() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"identity.service.annotations.foo": "bar",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var service coreV1.Service
-	helm.UnmarshalK8SYaml(s.T(), output, &service)
-
-	// then
-	s.Require().Equal("bar", service.ObjectMeta.Annotations["foo"])
-}
-
-func (s *serviceTest) TestKeycloakExternalService() {
-	// given
-	options := &helm.Options{
-		SetValues: map[string]string{
-			"global.identity.keycloak.internal":     "true",
-			"global.identity.keycloak.url.protocol": "https",
-			"global.identity.keycloak.url.host":     "keycloak.prod.svc.cluster.local",
-			"global.identity.keycloak.url.port":     "8443",
-		},
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, []string{"templates/identity/keycloak-service.yaml"})
-	var service coreV1.Service
-	helm.UnmarshalK8SYaml(s.T(), output, &service)
-
-	// then
-	s.Require().Equal(coreV1.ServiceType("ExternalName"), service.Spec.Type)
-	s.Require().Equal("keycloak.prod.svc.cluster.local", service.Spec.ExternalName)
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }


### PR DESCRIPTION
### Which problem does the PR fix?

https://github.com/camunda/team-distribution/issues/448

### What's in this PR?

- refactored identity unit tests in 8.5 to the new style

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
