### PR TITLE
chore(deps):  fix elasticsearch version in 8.6

### DIFF
--- a/charts/camunda-platform-8.6/Chart.yaml
+++ b/charts/camunda-platform-8.6/Chart.yaml
@@ -46,7 +46,7 @@ dependencies:
   # Shared Dependencies.
   - name: elasticsearch
     repository: oci://registry-1.docker.io/bitnamicharts
-    version: 21.4.9
+    version: 21.3.24
     condition: "elasticsearch.enabled"
   # Helpers.
   - name: common


### PR DESCRIPTION
### Which problem does the PR fix?
`chart.yaml` has the incorrect elasticsearch version in 8.6
<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?
replaces incorrect version of elasticsearch to correct 21.3.24.
<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
