### PR TITLE
fix: elasticsearch.extraConfig is a table

### DIFF
--- a/charts/camunda-platform-8.7/values.yaml
+++ b/charts/camunda-platform-8.7/values.yaml
@@ -3807,7 +3807,7 @@ elasticsearch:
     ## @param elasticsearch.image.tag
     tag: 8.17.4
   ## @param elasticsearch.extraConfig Append extra configuration to the elasticsearch node configuration
-  extraConfig: |
+  extraConfig:
     # Disable deprecation warnings - https://github.com/camunda/camunda/issues/26285
     logger.org.elasticsearch.deprecation: "OFF"
   master:

--- a/charts/camunda-platform-8.8/values.schema.json
+++ b/charts/camunda-platform-8.8/values.schema.json
@@ -5422,7 +5422,7 @@
                     }
                 },
                 "extraConfig": {
-                    "type": "string",
+                    "type": "object",
                     "description": "Append extra configuration to the elasticsearch node configuration",
                     "default": "# Disable deprecation warnings - https://github.com/camunda/camunda/issues/26285\nlogger.org.elasticsearch.deprecation: \"OFF\"\n"
                 },

--- a/charts/camunda-platform-8.8/values.yaml
+++ b/charts/camunda-platform-8.8/values.yaml
@@ -2728,7 +2728,7 @@ elasticsearch:
     ## @param elasticsearch.image.tag
     tag: 8.17.4
   ## @param elasticsearch.extraConfig Append extra configuration to the elasticsearch node configuration
-  extraConfig: |
+  extraConfig:
     # Disable deprecation warnings - https://github.com/camunda/camunda/issues/26285
     logger.org.elasticsearch.deprecation: "OFF"
   master:


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

This PR fixes an issue that an installation of the 12.0.0 chart gives this warning:

```
coalesce.go:301: warning: destination for camunda-platform.elasticsearch.extraConfig is a table. Ignoring non-table value (# Disable deprecation warnings - https://github.com/camunda/camunda/issues/26285
logger.org.elasticsearch.deprecation: "OFF"
)

```

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

As the `elasticsearch.extraConfig` should be a table, I would adjust this as shown.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
