### PR TITLE
fix: grpc port of zeebe gateway for venom tests

### DIFF
--- a/charts/camunda-platform-8.5/test/integration/testsuites/vars/files/variables-default.yaml
+++ b/charts/camunda-platform-8.5/test/integration/testsuites/vars/files/variables-default.yaml
@@ -23,7 +23,7 @@ coreVars:
     tasklist: http://integration-tasklist
     connectors: http://integration-connectors:8080/inbound
     webModelerRestapi: http://integration-web-modeler-restapi
-    zeebeGatewayGRPC: http://integration-zeebe-gateway:26500
+    zeebeGatewayGRPC: integration-zeebe-gateway:26500
     zeebeGatewayREST: http://integration-zeebe-gateway:8080
   zbctl:
     extraArgs: "--insecure"

--- a/charts/camunda-platform-8.5/test/integration/testsuites/vars/files/variables-default.yaml
+++ b/charts/camunda-platform-8.5/test/integration/testsuites/vars/files/variables-default.yaml
@@ -23,7 +23,7 @@ coreVars:
     tasklist: http://integration-tasklist
     connectors: http://integration-connectors:8080/inbound
     webModelerRestapi: http://integration-web-modeler-restapi
-    zeebeGatewayGRPC: http://integration-zeebe-gateway:9600
+    zeebeGatewayGRPC: http://integration-zeebe-gateway:26500
     zeebeGatewayREST: http://integration-zeebe-gateway:8080
   zbctl:
     extraArgs: "--insecure"

--- a/charts/camunda-platform-8.6/test/integration/testsuites/vars/files/variables-default.yaml
+++ b/charts/camunda-platform-8.6/test/integration/testsuites/vars/files/variables-default.yaml
@@ -23,7 +23,7 @@ coreVars:
     tasklist: http://integration-tasklist
     connectors: http://integration-connectors:8080/inbound
     webModelerRestapi: http://integration-web-modeler-restapi
-    zeebeGatewayGRPC: http://integration-zeebe-gateway:26500
+    zeebeGatewayGRPC: integration-zeebe-gateway:26500
     zeebeGatewayREST: http://integration-zeebe-gateway:8080
   zbctl:
     extraArgs: "--insecure"

--- a/charts/camunda-platform-8.6/test/integration/testsuites/vars/files/variables-default.yaml
+++ b/charts/camunda-platform-8.6/test/integration/testsuites/vars/files/variables-default.yaml
@@ -23,7 +23,7 @@ coreVars:
     tasklist: http://integration-tasklist
     connectors: http://integration-connectors:8080/inbound
     webModelerRestapi: http://integration-web-modeler-restapi
-    zeebeGatewayGRPC: http://integration-zeebe-gateway:9600
+    zeebeGatewayGRPC: http://integration-zeebe-gateway:26500
     zeebeGatewayREST: http://integration-zeebe-gateway:8080
   zbctl:
     extraArgs: "--insecure"

--- a/charts/camunda-platform-8.7/test/integration/testsuites/vars/files/variables-default.yaml
+++ b/charts/camunda-platform-8.7/test/integration/testsuites/vars/files/variables-default.yaml
@@ -23,7 +23,7 @@ coreVars:
     tasklist: http://integration-tasklist
     connectors: http://integration-connectors:8080/inbound
     webModelerRestapi: http://integration-web-modeler-restapi
-    zeebeGatewayGRPC: http://integration-zeebe-gateway:26500
+    zeebeGatewayGRPC: integration-zeebe-gateway:26500
     zeebeGatewayREST: http://integration-zeebe-gateway:8080
   zbctl:
     extraArgs: "--insecure"

--- a/charts/camunda-platform-8.7/test/integration/testsuites/vars/files/variables-default.yaml
+++ b/charts/camunda-platform-8.7/test/integration/testsuites/vars/files/variables-default.yaml
@@ -23,7 +23,7 @@ coreVars:
     tasklist: http://integration-tasklist
     connectors: http://integration-connectors:8080/inbound
     webModelerRestapi: http://integration-web-modeler-restapi
-    zeebeGatewayGRPC: http://integration-zeebe-gateway:9600
+    zeebeGatewayGRPC: http://integration-zeebe-gateway:26500
     zeebeGatewayREST: http://integration-zeebe-gateway:8080
   zbctl:
     extraArgs: "--insecure"


### PR DESCRIPTION
### Which problem does the PR fix?

For < 8.5 the zeebe-gateway port for gRPC was properly defined in venom.
In >= 8.5 the port was on the management port (9600) instead of gRPC (26500), due to which for example Venom test will fail in non-domain setups.
Additionally it was defining `http://`, which breaks gRPC as well.

Looks like the tests in this repo always run with domain, so they would never catch it.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

A simple fix of the right gRPC port for venom tests with no domain + removal of http

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
