### PR TITLE
fix(alpha): correct the keycloak proto function to get the svc port

### DIFF
--- a/charts/camunda-platform-8.8/templates/identity/_helpers.tpl
+++ b/charts/camunda-platform-8.8/templates/identity/_helpers.tpl
@@ -134,7 +134,7 @@ For more details, please check Camunda Helm chart documentation.
         {{- .Values.global.identity.keycloak.url.protocol -}}
     {{- else -}}
         {{- if .Values.identityKeycloak.enabled -}}
-            {{- template "common.names.fullname" .Subcharts.identityKeycloak -}}
+            {{- ternary "https" "http" (.Values.identityKeycloak.tls.enabled) -}}
         {{- end -}}
     {{- end -}}
 {{- end -}}

--- a/charts/camunda-platform-8.8/test/unit/identity/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/identity/golden/configmap.golden.yaml
@@ -26,7 +26,7 @@ data:
 
       authProvider:
         issuer-url: "http://localhost:18080/auth/realms/camunda-platform"
-        backend-url: "camunda-platform-test-keycloak://camunda-platform-test-keycloak:/auth/realms/camunda-platform"
+        backend-url: "http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform"
 
       component-presets:
         connectors:
@@ -170,7 +170,7 @@ data:
                 - audience: "web-modeler-api"
                   definition: admin:*
     keycloak:
-      url: "camunda-platform-test-keycloak://camunda-platform-test-keycloak:/auth"
+      url: "http://camunda-platform-test-keycloak:80/auth"
       setup:
         user: "admin"
         password: ${VALUES_KEYCLOAK_SETUP_PASSWORD:}

--- a/charts/camunda-platform-8.8/test/unit/web-modeler/golden/configmap-restapi.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/web-modeler/golden/configmap-restapi.golden.yaml
@@ -20,7 +20,7 @@ data:
       identity:
         base-url: "http://camunda-platform-test-identity:80"
         issuer: "http://localhost:18080/auth/realms/camunda-platform"
-        issuerBackendUrl: "camunda-platform-test-keycloak://camunda-platform-test-keycloak:/auth/realms/camunda-platform"
+        issuerBackendUrl: "http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform"
         type: "KEYCLOAK"
 
       modeler:
@@ -30,7 +30,7 @@ data:
         security:
           jwt:
             issuer:
-              backend-url: "camunda-platform-test-keycloak://camunda-platform-test-keycloak:/auth/realms/camunda-platform"
+              backend-url: "http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform"
             audience:
               internal-api: "web-modeler-api"
               public-api: "web-modeler-public-api"
@@ -71,7 +71,7 @@ data:
           resourceserver:
             jwt:
               issuer-uri: "http://localhost:18080/auth/realms/camunda-platform"
-              jwk-set-uri: "camunda-platform-test-keycloak://camunda-platform-test-keycloak:/auth/realms/camunda-platform/protocol/openid-connect/certs"
+              jwk-set-uri: "http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform/protocol/openid-connect/certs"
 
       servlet:
         multipart:


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes: https://github.com/camunda/camunda-platform-helm/issues/3381

### What's in this PR?

Update the named template `identity.keycloak.protocol` to get the correct Keycloak protocol used to get the protocol port.