### PR TITLE
feat: add basic auth for web-modeler

### DIFF
--- a/charts/camunda-platform-8.8/go.mod
+++ b/charts/camunda-platform-8.8/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/BurntSushi/toml v1.5.0
 	github.com/gruntwork-io/terratest v0.48.2
 	github.com/stretchr/testify v1.10.0
+	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.28.4
 )
@@ -115,7 +116,6 @@ require (
 	golang.org/x/time v0.8.0 // indirect
 	google.golang.org/protobuf v1.35.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/client-go v0.28.4 // indirect
 	k8s.io/klog/v2 v2.100.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9 // indirect

--- a/charts/camunda-platform-8.8/templates/web-modeler/_helpers.tpl
+++ b/charts/camunda-platform-8.8/templates/web-modeler/_helpers.tpl
@@ -326,3 +326,15 @@ Define match labels for Web Modeler websockets to be used in matchLabels selecto
 {{- define "webModeler.authPublicApiAudience" -}}
   {{- .Values.global.identity.auth.webModeler.publicApiAudience | default "web-modeler-public-api" -}}
 {{- end -}}
+
+{{- define "webModeler.authenticationType" -}}
+{{- if .Values.global.identity.auth.enabled }}
+  {{- if eq .Values.global.security.authentication.method "oidc" }}
+    {{- "BEARER_TOKEN" }}
+  {{- else if eq .Values.global.security.authentication.method "basic" }}
+    {{- "BASIC" }}
+  {{- end }}
+{{- else }}
+  {{- "NONE" }}
+{{- end }}
+{{- end }}

--- a/charts/camunda-platform-8.8/templates/web-modeler/configmap-restapi.yaml
+++ b/charts/camunda-platform-8.8/templates/web-modeler/configmap-restapi.yaml
@@ -52,7 +52,7 @@ data:
           - id: "default-cluster"
             name: {{ tpl .Values.global.zeebeClusterName . | quote }}
             version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.core) | quote }}
-            authentication: {{ .Values.global.identity.auth.enabled | ternary "BEARER_TOKEN" "NONE" | quote }}
+            authentication: {{ include "webModeler.authenticationType" . | quote }}
             url:
               zeebe:
                 grpc: "grpc://{{ include "core.fullname" . }}:{{ .Values.core.service.grpcPort }}"


### PR DESCRIPTION
### Which problem does the PR fix?

Closes https://github.com/camunda/web-modeler/issues/13713

### What's in this PR?

Adjusted the configuration of the default cluster for web-modeler depending on the auth configuration.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [ ] ~In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).~

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
