### PR TITLE
fix: ingress port not rendering when identityKeycloak enabled

### DIFF
--- a/charts/camunda-platform-8.8/templates/identity/_helpers.tpl
+++ b/charts/camunda-platform-8.8/templates/identity/_helpers.tpl
@@ -133,9 +133,7 @@ For more details, please check Camunda Helm chart documentation.
     {{- if and .Values.global.identity.keycloak.url .Values.global.identity.keycloak.url.protocol -}}
         {{- .Values.global.identity.keycloak.url.protocol -}}
     {{- else -}}
-        {{- if .Values.identityKeycloak.enabled -}}
             {{- ternary "https" "http" (.Values.identityKeycloak.tls.enabled) -}}
-        {{- end -}}
     {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
closes: https://github.com/camunda/camunda-platform-helm/issues/3448

When `identityKecloak` and ingress is enabled. The port for keycloak fails to render. It is because of the extra if condition.
This extra check is not need anyway since the parent helper function checks if `identityKeycloak` is enabled.
When `identity
### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
