### PR TITLE
fix: adjust scripts with change from name ingress to ingress-base

### DIFF
--- a/scripts/generate-version-matrix.sh
+++ b/scripts/generate-version-matrix.sh
@@ -53,7 +53,7 @@ get_chart_images () {
       helm repo update > /dev/null
       chart_images="$(
         helm template --skip-tests camunda "${CHART_SOURCE}" --version "${chart_version}" \
-          --values "${CHART_DIR}/test/integration/scenarios/chart-full-setup/values-integration-test-ingress.yaml" 2> /dev/null |
+          --values "${CHART_DIR}/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-base.yaml" 2> /dev/null |
         tr -d "\"'" | awk '/image:/{gsub(/^(camunda|bitnami)/, "docker.io/&", $2); printf "%s\n", $2}' |
         sort | uniq;
       )"

--- a/scripts/list-chart-images.sh
+++ b/scripts/list-chart-images.sh
@@ -6,5 +6,5 @@ set -euo pipefail
 #
 
 helm template --skip-tests camunda "${CHART_SOURCE}" --version "${CHART_VERSION}" \
-    --values "${CHART_VALUES_DIR}test/integration/scenarios/chart-full-setup/values-integration-test-ingress.yaml" 2> /dev/null |
+    --values "${CHART_VALUES_DIR}test/integration/scenarios/chart-full-setup/values-integration-test-ingress-base.yaml" 2> /dev/null |
         tr -d "\"'" | awk '/image:/{gsub(/^(camunda|bitnami)/, "docker.io/&", $2); printf "- %s\n", $2}'


### PR DESCRIPTION
### Which problem does the PR fix?

In a recent PR , we renamed integration-test-ingress to integration-test-ingress-base but this was not updated in our scripts, resulting in some oddities in the release process.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
