### PR TITLE
fix: adjust chart-release to reflect that matrix is no longer just a list of versions

### DIFF
--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -52,7 +52,7 @@ jobs:
           # Create a tmp file and ensure it's empty.
           echo "" > "${matrix_file}"
 
-          echo '${{ steps.generate-chart-versions.outputs.matrix }}' | jq -cr '.[]' | while read -r dir_id; do
+          echo '${{ steps.generate-chart-versions.outputs.matrix }}' | jq -cr '.[].version' | while read -r dir_id; do
             chart_file="charts/camunda-platform-${dir_id}/Chart.yaml"
 
             # Extract version info.


### PR DESCRIPTION
### Which problem does the PR fix?

this failure: https://github.com/camunda/camunda-platform-helm/actions/runs/14930335394/job/41944667698?pr=3429

`Error: open charts/camunda-platform-[{"version":"8.4","case":"pr","scenarios":"base"}]/Chart.yaml: no such file or directory`

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

Only append the version to the directory name, not the entire list of objects

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
