### PR TITLE
fix: update jq command for new matrix json format

### DIFF
--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -52,7 +52,7 @@ jobs:
           # Create a tmp file and ensure it's empty.
           echo "" > "${matrix_file}"
 
-          echo '${{ steps.generate-chart-versions.outputs.matrix }}' | jq -cr '.[].version' | while read -r dir_id; do
+          echo '${{ steps.generate-chart-versions.outputs.matrix }}' | jq -cr '.include.[].version' | while read -r dir_id; do
             chart_file="charts/camunda-platform-${dir_id}/Chart.yaml"
 
             # Extract version info.


### PR DESCRIPTION
fix: format of the matrix is {"include":[{"version":"8.4","case":"pr","scenarios":"base"}]}. update jq accordingly

### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
