### PR TITLE
fix: openshift elasticsearch disabled error

### DIFF
--- a/charts/camunda-platform-8.6/templates/zeebe/1/2/3/4/5/6/7/8/z_compatibility_helpers.tpl
+++ b/charts/camunda-platform-8.6/templates/zeebe/1/2/3/4/5/6/7/8/z_compatibility_helpers.tpl
@@ -82,10 +82,12 @@ The label `tuned.openshift.io/elasticsearch` is added to ensure compatibility wi
 Without this label, the Helm upgrade will fail for OpenShift because it is already set for the volumeClaimTemplate.
 */}}
 
-{{- if eq .Values.global.compatibility.openshift.adaptSecurityContext "force" -}}
-    {{- if not (hasKey .Values.elasticsearch.commonLabels "tuned.openshift.io/elasticsearch") -}}
-        {{- $_ := set .Values.elasticsearch.commonLabels "tuned.openshift.io/elasticsearch" "" -}}
-    {{- end -}}
+{{- if .Values.elasticsearch.enabled -}}
+  {{- if eq .Values.global.compatibility.openshift.adaptSecurityContext "force" -}}
+      {{- if not (hasKey .Values.elasticsearch.commonLabels "tuned.openshift.io/elasticsearch") -}}
+          {{- $_ := set .Values.elasticsearch.commonLabels "tuned.openshift.io/elasticsearch" "" -}}
+      {{- end -}}
+  {{- end -}}
 {{- end -}}
 {{/*
 Elasticsearch.

--- a/charts/camunda-platform-8.7/templates/zeebe/1/2/3/4/5/6/7/8/z_compatibility_helpers.tpl
+++ b/charts/camunda-platform-8.7/templates/zeebe/1/2/3/4/5/6/7/8/z_compatibility_helpers.tpl
@@ -82,10 +82,12 @@ The label `tuned.openshift.io/elasticsearch` is added to ensure compatibility wi
 Without this label, the Helm upgrade will fail for OpenShift because it is already set for the volumeClaimTemplate.
 */}}
 
-{{- if eq .Values.global.compatibility.openshift.adaptSecurityContext "force" -}}
-    {{- if not (hasKey .Values.elasticsearch.commonLabels "tuned.openshift.io/elasticsearch") -}}
-        {{- $_ := set .Values.elasticsearch.commonLabels "tuned.openshift.io/elasticsearch" "" -}}
-    {{- end -}}
+{{- if .Values.elasticsearch.enabled -}}
+  {{- if eq .Values.global.compatibility.openshift.adaptSecurityContext "force" -}}
+      {{- if not (hasKey .Values.elasticsearch.commonLabels "tuned.openshift.io/elasticsearch") -}}
+          {{- $_ := set .Values.elasticsearch.commonLabels "tuned.openshift.io/elasticsearch" "" -}}
+      {{- end -}}
+  {{- end -}}
 {{- end -}}
 {{/*
 Elasticsearch.


### PR DESCRIPTION
### Which problem does the PR fix?

When elasticsearch is disabled and the chart is installed on OpenShift, the following error is given:
```
Error: template: camunda-platform/templates/zeebe/1/2/3/4/5/6/7/8/z_compatibility_helpers.tpl:86:30: executing "camunda-platform/templates/zeebe/1/2/3/4/5/6/7/8/z_compatibility_helpers.tpl" at <.Values.elasticsearch.commonLabels>: wrong type for value; expected map[string]interface {}; got interface {}
```

Here is the values.yaml:
```
global:
  compatibility:
    openshift:
      adaptSecurityContext: force
elasticsearch:
  enabled: false
```

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->
I have added an extra if statement to check if elasticsearch is disabled.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
