### PR TITLE
fix: corrected a misplaced end key

### DIFF
--- a/charts/camunda-platform-8.7/templates/connectors/configmap.yaml
+++ b/charts/camunda-platform-8.7/templates/connectors/configmap.yaml
@@ -43,7 +43,9 @@ data:
     operate:
       client:
         base-url: {{ include "camundaPlatform.operateURL" . | quote }}
+        {{- if (and .Values.global.identity.auth.enabled (eq .Values.connectors.inbound.mode "oauth")) }}
         auth-url: {{ include "camundaPlatform.authIssuerBackendUrlTokenEndpoint" . | quote }}
+        {{- end }}
         {{- if eq .Values.connectors.inbound.mode "oauth" }}
         profile: "oidc"
         audience: {{ include "operate.authAudience" . | quote }}

--- a/charts/camunda-platform-8.7/templates/connectors/deployment.yaml
+++ b/charts/camunda-platform-8.7/templates/connectors/deployment.yaml
@@ -80,7 +80,6 @@ spec:
                   name: {{ include "camundaPlatform.identitySecretName" (dict "context" . "component" "connectors") }}
                   key: {{ .Values.global.identity.auth.connectors.existingSecretKey }}
               {{- end }}
-            {{- end }}
             - name: CAMUNDA_CLIENT_AUTH_CLIENT_ID
               value: {{ tpl .Values.global.identity.auth.zeebe.clientId $ | quote }}
             - name: CAMUNDA_CLIENT_AUTH_CLIENT_SECRET
@@ -103,6 +102,7 @@ spec:
             - name: CAMUNDA_CLIENT_ZEEBE_SCOPE
               value: {{ include "zeebe.authTokenScope" . | quote }}
             {{- end }}
+          {{- end }}
             {{- if .Values.global.documentStore.type.aws.enabled }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:


### PR DESCRIPTION
### Which problem does the PR fix?

Related to https://github.com/camunda/camunda-platform-helm/issues/3462

Introduced by https://github.com/camunda/camunda-platform-helm/pull/2855

The gist of this bug is that an extra misplaced {{- end -}} key was placed sooner than it should be. This caused environments where identity was enabled would still try to render OAuth2 environment variables and would sometimes fail because of that.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

Corrected a misplaced end key

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

closes https://github.com/camunda/camunda-platform-helm/issues/3462

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
