### PR TITLE
ci: skip elasticsearch in preflight tests

### DIFF
--- a/charts/camunda-platform-8.7/test/integration/testsuites/vars/files/testsuite-preflight.yaml
+++ b/charts/camunda-platform-8.7/test/integration/testsuites/vars/files/testsuite-preflight.yaml
@@ -5,9 +5,26 @@ name: Run preflight checks for Camunda
 # Vars without defaults are passed as a Venom var, e.g. "VENOM_VAR_TEST_CLIENT_SECRET".
 vars:
   releaseName: integration
-  skipTestWebModeler: '{{ .SKIP_TEST_WEBMODELER }}'
+  skipTestWebModeler: "{{ .SKIP_TEST_WEBMODELER }}"
+  # Skip the Elasticsearch test
+  skipes: "{{ .SKIP_TEST_ELASTICSEARCH }}"
 
 testcases:
+- name: TEST - Readiness Elasticsearch
+  skip:
+    - skipes ShouldBeFalse
+  steps:
+    - name: Elasticsearch
+      type: http
+      method: GET
+      url: "{{ .preflightVars.baseURLs.elasticsearch }}/_cluster/health?&timeout=1s"
+      retry: 3
+      delay: 10
+      info: |
+        Elasticsearch URL: {{ .preflightVars.baseURLs.elasticsearch }}/_cluster/health?&timeout=1s
+        Response Body: {{ .result.body }}
+      assertions:
+        - result.statuscode ShouldEqual 200
 
 - name: TEST - Readiness
   steps:
@@ -15,8 +32,6 @@ testcases:
     type: http
     range:
     # Dependencies.
-    - component: Elasticsearch
-      url: "{{ .preflightVars.baseURLs.elasticsearch }}/_cluster/health?&timeout=1s"
     - component: Keycloak
       url: "{{ .preflightVars.baseURLs.keycloak }}/auth/realms/master"
     # Camunda.

--- a/test/integration/scenarios/chart-full-setup/Taskfile.yaml
+++ b/test/integration/scenarios/chart-full-setup/Taskfile.yaml
@@ -56,6 +56,7 @@ tasks:
       echo "VENOM_VAR_SKIP_TEST_INGRESS=false" >> "${VARIABLES_ENV_FILE}"
       echo "VENOM_VAR_TEST_INGRESS_HOST=${TEST_INGRESS_HOST}" >> "${VARIABLES_ENV_FILE}"
       echo "VENOM_VAR_SKIP_TEST_WEBMODELER=false" >> "${VARIABLES_ENV_FILE}"
+      echo "VENOM_VAR_SKIP_TEST_ELASTICSEARCH=false" >> "${VARIABLES_ENV_FILE}"
       echo "VENOM_EXTRA_ARGS=--var-from-file=./vars/variables-ingress-combined.yaml" >> "${VARIABLES_ENV_FILE}"
       echo "ZEEBE_VERSION=$(yq '.zeebe.image.tag' {{ .TEST_CHART_DIR }}/values.yaml)" >> "${VARIABLES_ENV_FILE}"
       # In case the Zeebe version has not been released officially yet.


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
related: https://github.com/camunda/camunda-platform-helm/issues/3415
### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->
I am adding the option to skip elasticsearch checks, so OpenSearch can be supported by our integration testing.
### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
