### PR TITLE
fix: set context path only if optimize is enabled

### DIFF
--- a/charts/camunda-platform-8.8/templates/camunda/ingress-http.yaml
+++ b/charts/camunda-platform-8.8/templates/camunda/ingress-http.yaml
@@ -75,7 +75,9 @@ spec:
                   number: {{ .Values.core.service.httpPort }}
             path: {{ .Values.core.contextPath }}
             pathType: {{ .Values.global.ingress.pathType }}
-          # Core - Optimize.
+          {{- end }}
+          {{- if and .Values.optimize.enabled .Values.optimize.contextPath }}
+          # Optimize.
           - backend:
               service:
                 name: {{ template "optimize.fullname" . }}


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes: https://github.com/camunda/camunda-platform-helm/issues/3490

### What's in this PR?

As Optimize will not be part of the Core group, it should be separated and the context path should be set only if Optimize is enabled.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
