### PR TITLE
ci: make ghToken creation a reusable workflow

### DIFF
--- a/.github/workflows/closed-issue.yml
+++ b/.github/workflows/closed-issue.yml
@@ -17,11 +17,11 @@ jobs:
           echo "now=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
 
       - name: Generate GitHub token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
         id: generate-github-token
+        uses: ./.github/workflows/generate-github-app-token.yml
         with:
-          app_id: ${{ secrets.GH_APP_ID_DISTRO_CI }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY_DISTRO_CI }}
+          GH_APP_ID: ${{ secrets.GH_APP_ID_DISTRO_CI }}
+          GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY_DISTRO_CI }}
 
       - name: Debug GitHub Event
         run: echo '${{ toJson(github.event) }}'

--- a/.github/workflows/generate-github-app-token.yaml
+++ b/.github/workflows/generate-github-app-token.yaml
@@ -1,0 +1,22 @@
+name: Generate GitHub App Token
+
+on:
+  workflow_call:
+    secrets:
+      GH_APP_ID:
+        required: true
+      GH_APP_PRIVATE_KEY:
+        required: true
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    outputs:
+      token: ${{ steps.token.outputs.token }}
+    steps:
+      - name: Generate GitHub token
+        id: generate-github-token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
+        with:
+          app_id: ${{ secrets.GH_APP_ID }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

Make the [GH Token Generation step](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/closed-issue.yml#L19) from the closed-issue.yaml workflow reusable. This is needed so that it can also be called from the camunda/camunda repo [workflows to run on closed c8run related tickets](https://github.com/camunda/camunda/blob/main/.github/workflows/c8run-closed-issue.yaml#L43) - as the secrets from other repos can not get accessed otherwise 🤞 

Related to: https://github.com/camunda/team-distribution/issues/467


### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
