### PR TITLE
fix: remove installationType for 8.7

### DIFF
--- a/charts/camunda-platform-8.7/templates/camunda/constraints.tpl
+++ b/charts/camunda-platform-8.7/templates/camunda/constraints.tpl
@@ -223,10 +223,6 @@ The following values inside your values.yaml need to be set but were not:
       {{- end }}
     {{- end }}
   {{- end }}
-  {{- if .Values.global.multiregion.installationType }}
-    {{- $installationTypeMessage := "[camunda][warning]\nDEPRECATION NOTICE: Starting from appVersion 8.7, the Camunda Helm chart will no longer support the global.multiregion.installationType option. This is replaced with a new procedure for managing multi-region installations documented here:\nhttps://docs.camunda.io/docs/self-managed/operational-guides/multi-region/dual-region-operational-procedure/\nPlease unset this option to remove the warning.\n" }}
-    {{ printf "\n%s" $installationTypeMessage }}
-  {{- end }}
 {{- end }}
 
 

--- a/charts/camunda-platform-8.7/templates/zeebe/statefulset.yaml
+++ b/charts/camunda-platform-8.7/templates/zeebe/statefulset.yaml
@@ -10,12 +10,7 @@ metadata:
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
-  {{- if eq .Values.global.multiregion.installationType "failOver" }}
-  replicas: {{ div (div .Values.zeebe.clusterSize .Values.global.multiregion.regions) 2 }}
-  {{- end }}
-  {{- if ne .Values.global.multiregion.installationType "failOver" }}
   replicas: {{ div .Values.zeebe.clusterSize .Values.global.multiregion.regions }}
-  {{- end }}
   selector:
     matchLabels:
       {{- include "zeebe.matchLabels.broker" . | nindent 6 }}

--- a/charts/camunda-platform-8.7/test/unit/zeebe/configmap_test.go
+++ b/charts/camunda-platform-8.7/test/unit/zeebe/configmap_test.go
@@ -68,66 +68,6 @@ func TestGoldenConfigmapWithLog4j2(t *testing.T) {
 	})
 }
 
-func TestGoldenConfigmapWithMultiregionNormal(t *testing.T) {
-	t.Parallel()
-
-	chartPath, err := filepath.Abs("../../../")
-	require.NoError(t, err)
-
-	suite.Run(t, &utils.TemplateGoldenTest{
-		ChartPath:      chartPath,
-		Release:        "camunda-platform-test",
-		Namespace:      "camunda-platform-" + strings.ToLower(random.UniqueId()),
-		GoldenFileName: "configmap",
-		Templates:      []string{"templates/zeebe/configmap.yaml"},
-		SetValues: map[string]string{
-			"global.multiregion.regions":          "1",
-			"global.multiregion.regionId":         "0",
-			"global.multiregion.installationType": "normal",
-		},
-	})
-}
-
-func TestGoldenConfigmapWithMultiregionFailOver(t *testing.T) {
-	t.Parallel()
-
-	chartPath, err := filepath.Abs("../../../")
-	require.NoError(t, err)
-
-	suite.Run(t, &utils.TemplateGoldenTest{
-		ChartPath:      chartPath,
-		Release:        "camunda-platform-test",
-		Namespace:      "camunda-platform-" + strings.ToLower(random.UniqueId()),
-		GoldenFileName: "configmap-multiregion-failOver",
-		Templates:      []string{"templates/zeebe/configmap.yaml"},
-		SetValues: map[string]string{
-			"global.multiregion.regions":          "1",
-			"global.multiregion.regionId":         "0",
-			"global.multiregion.installationType": "failOver",
-		},
-	})
-}
-
-func TestGoldenConfigmapWithMultiregionFailBack(t *testing.T) {
-	t.Parallel()
-
-	chartPath, err := filepath.Abs("../../../")
-	require.NoError(t, err)
-
-	suite.Run(t, &utils.TemplateGoldenTest{
-		ChartPath:      chartPath,
-		Release:        "camunda-platform-test",
-		Namespace:      "camunda-platform-" + strings.ToLower(random.UniqueId()),
-		GoldenFileName: "configmap-multiregion-failBack",
-		Templates:      []string{"templates/zeebe/configmap.yaml"},
-		SetValues: map[string]string{
-			"global.multiregion.regions":          "1",
-			"global.multiregion.regionId":         "0",
-			"global.multiregion.installationType": "failBack",
-		},
-	})
-}
-
 func (s *configmapTemplateTest) TestContainerShouldContainExporterClassPerDefault() {
 	// given
 	options := &helm.Options{

--- a/charts/camunda-platform-8.7/values.yaml
+++ b/charts/camunda-platform-8.7/values.yaml
@@ -383,8 +383,6 @@ global:
     regions: 1
     ## @skip global.multiregion.regionId unique id of the region. MUST start at 0 for the computation to work correctly. With 2 regions, you would have region 0 and 1.
     regionId: 0
-    ## @skip global.multiregion.installationType mode of installation for multi-region disaster recovery: normal, failOver, failBack
-    installationType: normal
 
   ## Document Store Configuration
   ## @extra global.documentStore These parameters are used to configure the document storage backend across all Camunda components.


### PR DESCRIPTION
### Which problem does the PR fix?

https://github.com/camunda/camunda-platform-helm/issues/2286

This change was accidentally undone by 
https://github.com/camunda/camunda-platform-helm/pull/2790

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?
I took the diff from that PR and re-added it into this new PR. However, with one small difference. I did not re-add the error message when installationType is set explicitly by the user, as that would be a breaking change in a stable release of the Helm chart.  :cry: 

This change does not need to be re-applied to 8.8 since 8.8 was not copied from 8.6 in the way that 8.7 was created by copying it from 8.6.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
