### PR TITLE
fix: remove any trailing hyphen for test_namespaces

### DIFF
--- a/.github/actions/workflow-vars/action.yml
+++ b/.github/actions/workflow-vars/action.yml
@@ -63,7 +63,9 @@ runs:
       if [[ "${{ inputs.setup-flow }}" == 'upgrade' ]]; then
         TEST_NAMESPACE="${TEST_NAMESPACE}-upgrade"
       fi
-
+      
+      TEST_NAMESPACE="${TEST_NAMESPACE%-}"
+      
       echo "TEST_NAMESPACE=$(echo ${TEST_NAMESPACE} | head -c 63)" | tee -a $GITHUB_ENV
 
       # Get alpha chart dir.

--- a/.github/actions/workflow-vars/action.yml
+++ b/.github/actions/workflow-vars/action.yml
@@ -64,9 +64,7 @@ runs:
         TEST_NAMESPACE="${TEST_NAMESPACE}-upgrade"
       fi
       
-      TEST_NAMESPACE="${TEST_NAMESPACE%-}"
-      
-      echo "TEST_NAMESPACE=$(echo ${TEST_NAMESPACE} | head -c 63)" | tee -a $GITHUB_ENV
+      echo "TEST_NAMESPACE=$(printf '%s' "${TEST_NAMESPACE%-}" | head -c 63)" | tee -a $GITHUB_ENV
 
       # Get alpha chart dir.
       TEST_CAMUNDA_HELM_DIR_ALPHA="$(basename $(ls -d1 charts/camunda-platform-8.* | sort -V | tail -n1))"


### PR DESCRIPTION
### Which problem does the PR fix?
When the QA test namespace hits Kubernetes’ 63-character limit, it can be cut off right after a hyphen—leaving the name ending in “–” and invalid under RFC 1123.

https://github.com/camunda/camunda-platform-helm/blob/47bd4f91407a550820af74cb32d1f5cf0f4ad08f/.github/actions/workflow-vars/action.yml#L67

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?
Before applying the 63-character head truncation, we now strip any trailing hyphens from the generated `TEST_NAMESPACE`. This ensures the final namespace always ends in an alphanumeric character and passes Kubernetes’ naming requirements.
<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
