### PR TITLE
fix: stray-double-quote issue for descriptions in release notes script 

### DIFF
--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -67,7 +67,7 @@ main () {
         if [[ -n "${change_type_section}" && "${!kac_map[@]}" =~ "${change_type}" ]]; then
             echo "${change_type_section}" | egrep '^\-' | sed 's/^- //g' | while read commit_message; do
                 echo "    - kind: ${kac_map[${change_type}]}"
-                echo "      description: \"$(echo "$commit_message" | tr -d '"' | sed -E 's/[[:space:]]*\([^)]*\)$//')\""
+                echo "      description: \"$(echo "{$commit_message}" | tr -d '"' | sed -r "s/ \(.+\)$//")\""
             done >> "${artifacthub_changes_tmp}"
         fi
     done

--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -67,12 +67,7 @@ main () {
         if [[ -n "${change_type_section}" && "${!kac_map[@]}" =~ "${change_type}" ]]; then
             echo "${change_type_section}" | egrep '^\-' | sed 's/^- //g' | while read commit_message; do
                 echo "    - kind: ${kac_map[${change_type}]}"
-                echo "      description: \"$(sed -E \
-                  -e 's/[[:space:]]*\([^)]*\)$//' \
-                  -e 's/^"//' \
-                  -e 's/"$//' \
-                  -e 's/"/\\\"/g' \
-                <<<"$commit_message")\""
+                echo "      description: \"$(echo "$commit_message" | tr -d '"' | sed -E 's/[[:space:]]*\([^)]*\)$//')\""
             done >> "${artifacthub_changes_tmp}"
         fi
     done

--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -67,7 +67,12 @@ main () {
         if [[ -n "${change_type_section}" && "${!kac_map[@]}" =~ "${change_type}" ]]; then
             echo "${change_type_section}" | egrep '^\-' | sed 's/^- //g' | while read commit_message; do
                 echo "    - kind: ${kac_map[${change_type}]}"
-                echo "      description: \"$(echo ${commit_message} | sed -r "s/ \(.+\)$//")\""
+                echo "      description: \"$(sed -E \
+                  -e 's/[[:space:]]*\([^)]*\)$//' \
+                  -e 's/^"//' \
+                  -e 's/"$//' \
+                  -e 's/"/\\\"/g' \
+                <<<"$commit_message")\""
             done >> "${artifacthub_changes_tmp}"
         fi
     done

--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -67,7 +67,7 @@ main () {
         if [[ -n "${change_type_section}" && "${!kac_map[@]}" =~ "${change_type}" ]]; then
             echo "${change_type_section}" | egrep '^\-' | sed 's/^- //g' | while read commit_message; do
                 echo "    - kind: ${kac_map[${change_type}]}"
-                echo "      description: \"$(echo "{$commit_message}" | tr -d '"' | sed -r "s/ \(.+\)$//")\""
+                echo "      description: \"$(echo "${commit_message}" | tr -d '"' | sed -r "s/ \(.+\)$//")\""
             done >> "${artifacthub_changes_tmp}"
         fi
     done


### PR DESCRIPTION
### Which problem does the PR fix?
When a commit message contains leading or trailing ", or ends with (...), our YAML snippet ends up like:
      `description: "Some message""`

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?
`echo "      description: \"$(echo "$commit_message" | tr -d '"' | sed -E 's/[[:space:]]*\([^)]*\)$//')\""`

- `tr -d '"'` nukes every `"` in the raw commit message (so there are no stray leading/trailing quotes left).
- `sed -E 's/[[:space:]]*\([^)]*\)$//'` removes the trailing parentheses block.
- it wraps the cleaned result in one pair of quotes for valid YAML.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
