### PR TITLE
fix: remove debug state that looks for the workspace directory that i…

### DIFF
--- a/test/integration/scenarios/lib/testsuite-deploy-taskfile-playwright.yaml
+++ b/test/integration/scenarios/lib/testsuite-deploy-taskfile-playwright.yaml
@@ -52,10 +52,6 @@ tasks:
             echo "ℹ️  TEST_CREATE_DOCKER_LOGIN_SECRET not set – skipping imagePullSecrets patch step"
           fi
       # Deploy.
-      - cmd: |
-          echo "🔎 Listing files in $TEST_DIR"
-          ls -la $TEST_DIR
-          ls -la /home/runner/work/camunda-platform-helm/camunda-platform-helm
       - |
         echo "🚀 Deploying Playwright test job at $TEST_DIR into namespace $TEST_NAMESPACE"
         if ! kubectl kustomize $TEST_DIR --load-restrictor=LoadRestrictionsNone | kubectl apply -n $TEST_NAMESPACE -f -; then


### PR DESCRIPTION
…s hardcoded

### Which problem does the PR fix?

Remove debug statement that hardcoded the workspace to this repo. This broke cross-repo workflow calls

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
