### PR TITLE
fix: update condition for Playwright Core TestSuite execution to incl…

### DIFF
--- a/.github/actions/generate-chart-matrix/action.yml
+++ b/.github/actions/generate-chart-matrix/action.yml
@@ -1,3 +1,40 @@
+# -----------------------------------------------------------------------------
+# Camunda Platform Helm – Build Matrix Generator (Purpose & Rationale)
+#
+# Problem
+# -------
+# The repository hosts many versioned Camunda Platform Helm charts (8.2, 8.3, …).
+# Building and testing every single chart on every pull-request would slow the
+# feedback loop and needlessly consume CI resources.
+#
+# Goal
+# ----
+# Run the smallest *sufficient* set of chart builds for a given change set while
+# still guaranteeing correctness when the build or release process itself is
+# modified.
+#
+# Strategy
+# --------
+# 1. Detect which files were modified in the commit / PR.
+# 2. Derive the **minimum chart version matrix** from that file list.
+#    • Regular code or chart changes  → build only the impacted versions.
+#    • Changes in CI configuration    → build *all* versions, as any could be
+#      affected.
+# 3. Provide the resulting set as a JSON matrix so downstream workflows can
+#    fan-out their jobs.
+#
+# When is *every* chart built?
+# ---------------------------
+# If the change touches `.github/workflows/**` or `.github/actions/**`, the
+# CI pipeline itself may have changed. In the absence of guarantees we take the
+# conservative route and rebuild every chart to retain confidence.
+#
+# Manual override
+# ---------------
+# Maintainers can bypass automatic detection by passing the `manual-trigger`
+# input, forcing the matrix to contain exactly one desired version. This is
+# useful for re-publishing a chart or running ad-hoc validations.
+# -----------------------------------------------------------------------------
 name: Generate chart matrix
 description: Find changed charts and generate matrix for changed ones only.
 inputs:
@@ -69,12 +106,22 @@ runs:
           echo "Setting matrix based on changed files"
           echo "Changed files:"
           printf "%s\n" ${ALL_MODIFIED_FILES}
-          ls -d ${{ inputs.charts-path }} | while read chart_dir; do
-            if [[ $(echo ${ALL_MODIFIED_FILES} | grep "${chart_dir}") ]]; then
+
+          # If any workflow or action files have changed, build all chart versions
+          if echo "${ALL_MODIFIED_FILES}" | grep -qE "\.github/(workflows|actions)/"; then
+            echo "Changes in .github/workflows or .github/actions detected — building all chart versions"
+            ls -d ${{ inputs.charts-path }} | while read chart_dir; do
               camunda_version="$(basename ${chart_dir} | sed 's/camunda-platform-//')"
               write_matrix_entry "$camunda_version" "$chart_dir"
-            fi
-          done
+            done
+          else
+            ls -d ${{ inputs.charts-path }} | while read chart_dir; do
+              if [[ $(echo ${ALL_MODIFIED_FILES} | grep "${chart_dir}") ]]; then
+                camunda_version="$(basename ${chart_dir} | sed 's/camunda-platform-//')"
+                write_matrix_entry "$camunda_version" "$chart_dir"
+              fi
+            done
+          fi
         fi
         cat matrix_versions.txt
 

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -379,7 +379,7 @@ jobs:
         run: |
           task -d ${CI_TASKS_BASE_DIR}/chart-full-setup test.core
       - name: ⭐️ Run Playwright Core TestSuite ⭐️
-        if: ${{ always() && inputs.test-enabled && (steps.core-testsuite.outcome == 'success' || steps.core-testsuite.outcome == 'failure') }}
+        if: ${{ always() && inputs.test-enabled && (steps.core-testsuite.outcome == 'success' || steps.core-testsuite.outcome == 'failure') && contains(inputs.camunda-helm-dir, 'camunda-platform-8.7') }}
         timeout-minutes: 20
         run: |
           export TEST_INGRESS_HOST="${{ steps.vars.outputs.ingress-host }}"

--- a/charts/camunda-platform-8.6/test/unit/camunda/golden/keycloak-statefulset.golden.yaml
+++ b/charts/camunda-platform-8.6/test/unit/camunda/golden/keycloak-statefulset.golden.yaml
@@ -19,6 +19,7 @@ spec:
   updateStrategy:
     rollingUpdate: {}
     type: RollingUpdate
+  minReadySeconds: 0
   selector:
     matchLabels:
       app.kubernetes.io/instance: camunda-platform-test

--- a/test/integration/scenarios/lib/testsuite-deploy-taskfile-playwright.yaml
+++ b/test/integration/scenarios/lib/testsuite-deploy-taskfile-playwright.yaml
@@ -52,10 +52,6 @@ tasks:
             echo "ℹ️  TEST_CREATE_DOCKER_LOGIN_SECRET not set – skipping imagePullSecrets patch step"
           fi
       # Deploy.
-      - cmd: |
-          echo "🔎 Listing files in $TEST_DIR"
-          ls -la $TEST_DIR
-          ls -la /home/runner/work/camunda-platform-helm/camunda-platform-helm
       - |
         echo "🚀 Deploying Playwright test job at $TEST_DIR into namespace $TEST_NAMESPACE"
         if ! kubectl kustomize $TEST_DIR --load-restrictor=LoadRestrictionsNone | kubectl apply -n $TEST_NAMESPACE -f -; then


### PR DESCRIPTION
…ude specific Camunda version check

### Which problem does the PR fix?

- limit playwright run on the CI to chart for 8.7

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
