### PR TITLE
ci: es preflight fix

### DIFF
--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -300,6 +300,7 @@ jobs:
           if [[ ${{ matrix.scenario.flow }} == 'upgrade' ]] &&
           [[ "${{ inputs.camunda-helm-dir }}" == "${{ env.TEST_CAMUNDA_HELM_DIR_ALPHA }}" ]]; then
             TEST_HELM_EXTRA_ARGS_INSTALL="${TEST_HELM_EXTRA_ARGS_INSTALL} --set zeebe.image.tag=SNAPSHOT"
+            TEST_HELM_EXTRA_ARGS_INSTALL="${TEST_HELM_EXTRA_ARGS_INSTALL} --set global.ingress.host=${{ steps.vars.outputs.ingress-host }}"
             echo "TEST_HELM_EXTRA_ARGS_INSTALL=${TEST_HELM_EXTRA_ARGS_INSTALL}" | tee -a $GITHUB_ENV
             TEST_HELM_EXTRA_ARGS_UPGRADE="${TEST_HELM_EXTRA_ARGS_UPGRADE} --set zeebe.image.tag=SNAPSHOT"
             echo "TEST_HELM_EXTRA_ARGS_UPGRADE=${TEST_HELM_EXTRA_ARGS_UPGRADE}" | tee -a $GITHUB_ENV
@@ -319,21 +320,19 @@ jobs:
           TEST_INGRESS_HOST: ${{ steps.vars.outputs.ingress-host }}
           TEST_SCENARIO: ${{ inputs.scenario }}
         run: |
-          task -d ${CI_TASKS_BASE_DIR}/chart-full-setup setup.pre
-
           echo "Extra values from workflow:"
           echo "${{ inputs.extra-values }}" | tee /tmp/extra-values-file.yaml
+
+          task -d ${CI_TASKS_BASE_DIR}/chart-full-setup setup.pre
       - name: 🌟 Setup Camunda chart 🌟
         env:
           TEST_CHART_FLOW: ${{ matrix.scenario.flow }}
           TEST_OPENSHIFT_POST_RENDER: ${{ inputs.camunda-helm-post-render }}
           TEST_CASE: "${{ inputs.test-case }}"
           TEST_VALUES_SCENARIO: "${{ inputs.scenario }}"
+          INFRA_TYPE: ${{ inputs.infra-type }}
           TEST_HELM_EXTRA_ARGS: >-
             ${{ env.TEST_HELM_EXTRA_ARGS_INSTALL }}
-            --set global.ingress.host=${{ steps.vars.outputs.ingress-host }}
-            --values ${{ steps.test-type-vars.outputs.valuesBaseDir }}/infra/values-infra-${{ inputs.infra-type }}.yaml
-            --values /tmp/extra-values-file.yaml
         run: |
           task -d ${CI_TASKS_BASE_DIR}/chart-full-setup setup.exec
       - name: Post setup

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -297,12 +297,13 @@ jobs:
         env:
           TEST_INGRESS_HOST: ${{ steps.vars.outputs.ingress-host }}
         run: |
+          TEST_HELM_EXTRA_ARGS_INSTALL="${TEST_HELM_EXTRA_ARGS_INSTALL} --set global.ingress.host=${TEST_INGRESS_HOST}"
+          echo "TEST_HELM_EXTRA_ARGS_INSTALL=${TEST_HELM_EXTRA_ARGS_INSTALL}" | tee -a $GITHUB_ENV
           # Since Zeebe 8.6 it's not possible to upgrade from/to alpha version.
           # The Zeebe team advised to use SNAPSHOT tag instead.
           if [[ ${{ matrix.scenario.flow }} == 'upgrade' ]] &&
           [[ "${{ inputs.camunda-helm-dir }}" == "${{ env.TEST_CAMUNDA_HELM_DIR_ALPHA }}" ]]; then
             TEST_HELM_EXTRA_ARGS_INSTALL="${TEST_HELM_EXTRA_ARGS_INSTALL} --set zeebe.image.tag=SNAPSHOT"
-            TEST_HELM_EXTRA_ARGS_INSTALL="${TEST_HELM_EXTRA_ARGS_INSTALL} --set global.ingress.host=${TEST_INGRESS_HOST}"
             echo "TEST_HELM_EXTRA_ARGS_INSTALL=${TEST_HELM_EXTRA_ARGS_INSTALL}" | tee -a $GITHUB_ENV
             TEST_HELM_EXTRA_ARGS_UPGRADE="${TEST_HELM_EXTRA_ARGS_UPGRADE} --set zeebe.image.tag=SNAPSHOT"
             echo "TEST_HELM_EXTRA_ARGS_UPGRADE=${TEST_HELM_EXTRA_ARGS_UPGRADE}" | tee -a $GITHUB_ENV

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -317,6 +317,7 @@ jobs:
         env:
           TEST_CHART_FLOW: ${{ matrix.scenario.flow }}
           TEST_INGRESS_HOST: ${{ steps.vars.outputs.ingress-host }}
+          TEST_SCENARIO: ${{ inputs.scenario }}
         run: |
           task -d ${CI_TASKS_BASE_DIR}/chart-full-setup setup.pre
 

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -294,13 +294,15 @@ jobs:
           fi
 
       - name: Set Helm extra args
+        env:
+          TEST_INGRESS_HOST: ${{ steps.vars.outputs.ingress-host }}
         run: |
           # Since Zeebe 8.6 it's not possible to upgrade from/to alpha version.
           # The Zeebe team advised to use SNAPSHOT tag instead.
           if [[ ${{ matrix.scenario.flow }} == 'upgrade' ]] &&
           [[ "${{ inputs.camunda-helm-dir }}" == "${{ env.TEST_CAMUNDA_HELM_DIR_ALPHA }}" ]]; then
             TEST_HELM_EXTRA_ARGS_INSTALL="${TEST_HELM_EXTRA_ARGS_INSTALL} --set zeebe.image.tag=SNAPSHOT"
-            TEST_HELM_EXTRA_ARGS_INSTALL="${TEST_HELM_EXTRA_ARGS_INSTALL} --set global.ingress.host=${{ steps.vars.outputs.ingress-host }}"
+            TEST_HELM_EXTRA_ARGS_INSTALL="${TEST_HELM_EXTRA_ARGS_INSTALL} --set global.ingress.host=${TEST_INGRESS_HOST}"
             echo "TEST_HELM_EXTRA_ARGS_INSTALL=${TEST_HELM_EXTRA_ARGS_INSTALL}" | tee -a $GITHUB_ENV
             TEST_HELM_EXTRA_ARGS_UPGRADE="${TEST_HELM_EXTRA_ARGS_UPGRADE} --set zeebe.image.tag=SNAPSHOT"
             echo "TEST_HELM_EXTRA_ARGS_UPGRADE=${TEST_HELM_EXTRA_ARGS_UPGRADE}" | tee -a $GITHUB_ENV

--- a/test/integration/scenarios/chart-full-setup/Taskfile.yaml
+++ b/test/integration/scenarios/chart-full-setup/Taskfile.yaml
@@ -58,14 +58,10 @@ tasks:
         --docker-password "${TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD}"
     # Set Venom vars.
     - |
-      if [[ "${TEST_SCENARIO}" == 'opensearch' ]]; then
-        echo "VENOM_VAR_SKIP_TEST_ELASTICSEARCH=true" >> "${VARIABLES_ENV_FILE}"
-      else
-        echo "VENOM_VAR_SKIP_TEST_ELASTICSEARCH=false" >> "${VARIABLES_ENV_FILE}"
-      fi
       echo "VENOM_VAR_SKIP_TEST_INGRESS=false" >> "${VARIABLES_ENV_FILE}"
       echo "VENOM_VAR_TEST_INGRESS_HOST=${TEST_INGRESS_HOST}" >> "${VARIABLES_ENV_FILE}"
       echo "VENOM_VAR_SKIP_TEST_WEBMODELER=false" >> "${VARIABLES_ENV_FILE}"
+      echo "VENOM_VAR_SKIP_TEST_ELASTICSEARCH=$(yq eval-all '. as $item ireduce ({}; . * $item )' {{ .TEST_VALUES_BASE_DIR }}/common/values-integration-test.yaml {{ .TEST_VALUES_BASE_DIR }}/chart-full-setup/values-integration-test-ingress-base.yaml {{ .TEST_VALUES_BASE_DIR }}/chart-full-setup/values-integration-test-ingress-{{ .TEST_VALUES_SCENARIO }}.yaml {{ .TEST_VALUES_BASE_DIR }}/infra/values-infra-{{ .INFRA_TYPE }}.yaml /tmp/extra-values-file.yaml | yq '.elasticsearch.enabled // false | not' {{ .TEST_CHART_DIR }}/values.yaml)" >> "${VARIABLES_ENV_FILE}"
       echo "VENOM_EXTRA_ARGS=--var-from-file=./vars/variables-ingress-combined.yaml" >> "${VARIABLES_ENV_FILE}"
       echo "ZEEBE_VERSION=$(yq '.zeebe.image.tag' {{ .TEST_CHART_DIR }}/values.yaml)" >> "${VARIABLES_ENV_FILE}"
       # In case the Zeebe version has not been released officially yet.
@@ -102,6 +98,8 @@ tasks:
         --values {{ .TEST_VALUES_BASE_DIR }}/common/values-integration-test.yaml
         --values {{ .TEST_VALUES_BASE_DIR }}/chart-full-setup/values-integration-test-ingress-base.yaml
         --values {{ .TEST_VALUES_BASE_DIR }}/chart-full-setup/values-integration-test-ingress-{{ .TEST_VALUES_SCENARIO }}.yaml
+        --values {{ .TEST_VALUES_BASE_DIR }}/infra/values-infra-{{ .INFRA_TYPE }}.yaml
+        --values /tmp/extra-values-file.yaml
         --timeout 20m0s
         --wait
         {{ .TEST_HELM_EXTRA_ARGS }}

--- a/test/integration/scenarios/chart-full-setup/Taskfile.yaml
+++ b/test/integration/scenarios/chart-full-setup/Taskfile.yaml
@@ -58,6 +58,11 @@ tasks:
         --docker-password "${TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD}"
     # Set Venom vars.
     - |
+      if [[ "${TEST_SCENARIO}" == 'opensearch' ]]; then
+        echo "VENOM_VAR_SKIP_TEST_ELASTICSEARCH=true" >> "${VARIABLES_ENV_FILE}"
+      else
+        echo "VENOM_VAR_SKIP_TEST_ELASTICSEARCH=false" >> "${VARIABLES_ENV_FILE}"
+      fi
       echo "VENOM_VAR_SKIP_TEST_INGRESS=false" >> "${VARIABLES_ENV_FILE}"
       echo "VENOM_VAR_TEST_INGRESS_HOST=${TEST_INGRESS_HOST}" >> "${VARIABLES_ENV_FILE}"
       echo "VENOM_VAR_SKIP_TEST_WEBMODELER=false" >> "${VARIABLES_ENV_FILE}"

--- a/test/integration/scenarios/chart-full-setup/Taskfile.yaml
+++ b/test/integration/scenarios/chart-full-setup/Taskfile.yaml
@@ -61,7 +61,7 @@ tasks:
       echo "VENOM_VAR_SKIP_TEST_INGRESS=false" >> "${VARIABLES_ENV_FILE}"
       echo "VENOM_VAR_TEST_INGRESS_HOST=${TEST_INGRESS_HOST}" >> "${VARIABLES_ENV_FILE}"
       echo "VENOM_VAR_SKIP_TEST_WEBMODELER=false" >> "${VARIABLES_ENV_FILE}"
-      echo "VENOM_VAR_SKIP_TEST_ELASTICSEARCH=$(yq eval-all '. as $item ireduce ({}; . * $item )' {{ .TEST_VALUES_BASE_DIR }}/common/values-integration-test.yaml {{ .TEST_VALUES_BASE_DIR }}/chart-full-setup/values-integration-test-ingress-base.yaml {{ .TEST_VALUES_BASE_DIR }}/chart-full-setup/values-integration-test-ingress-{{ .TEST_VALUES_SCENARIO }}.yaml {{ .TEST_VALUES_BASE_DIR }}/infra/values-infra-{{ .INFRA_TYPE }}.yaml /tmp/extra-values-file.yaml | yq '.elasticsearch.enabled // false | not' {{ .TEST_CHART_DIR }}/values.yaml)" >> "${VARIABLES_ENV_FILE}"
+      echo "VENOM_VAR_SKIP_TEST_ELASTICSEARCH=$(yq eval-all '. as $item ireduce ({}; . * $item )' {{ .TEST_VALUES_BASE_DIR }}/common/values-integration-test.yaml {{ .TEST_VALUES_BASE_DIR }}/chart-full-setup/values-integration-test-ingress-base.yaml {{ .TEST_VALUES_BASE_DIR }}/chart-full-setup/values-integration-test-ingress-{{ .TEST_VALUES_SCENARIO }}.yaml {{ .TEST_VALUES_BASE_DIR }}/infra/values-infra-{{ .INFRA_TYPE }}.yaml /tmp/extra-values-file.yaml | yq '.elasticsearch.enabled // false | not')" >> "${VARIABLES_ENV_FILE}"
       echo "VENOM_EXTRA_ARGS=--var-from-file=./vars/variables-ingress-combined.yaml" >> "${VARIABLES_ENV_FILE}"
       echo "ZEEBE_VERSION=$(yq '.zeebe.image.tag' {{ .TEST_CHART_DIR }}/values.yaml)" >> "${VARIABLES_ENV_FILE}"
       # In case the Zeebe version has not been released officially yet.

--- a/test/integration/scenarios/chart-full-setup/Taskfile.yaml
+++ b/test/integration/scenarios/chart-full-setup/Taskfile.yaml
@@ -58,11 +58,7 @@ tasks:
         --docker-password "${TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD}"
     # Set Venom vars.
     - |
-      if [[ "${TEST_SCENARIO}" == 'opensearch' ]]; then
-        echo "VENOM_VAR_SKIP_TEST_ELASTICSEARCH=true" >> "${VARIABLES_ENV_FILE}"
-      else
-        echo "VENOM_VAR_SKIP_TEST_ELASTICSEARCH=false" >> "${VARIABLES_ENV_FILE}"
-      fi
+      echo "VENOM_VAR_SKIP_TEST_ELASTICSEARCH=$([ "${TEST_SCENARIO}" = 'opensearch' ] && echo true || echo false)" >> "${VARIABLES_ENV_FILE}"
       echo "VENOM_VAR_SKIP_TEST_INGRESS=false" >> "${VARIABLES_ENV_FILE}"
       echo "VENOM_VAR_TEST_INGRESS_HOST=${TEST_INGRESS_HOST}" >> "${VARIABLES_ENV_FILE}"
       echo "VENOM_VAR_SKIP_TEST_WEBMODELER=false" >> "${VARIABLES_ENV_FILE}"

--- a/test/integration/scenarios/chart-full-setup/Taskfile.yaml
+++ b/test/integration/scenarios/chart-full-setup/Taskfile.yaml
@@ -58,11 +58,14 @@ tasks:
         --docker-password "${TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD}"
     # Set Venom vars.
     - |
-      echo "VENOM_VAR_SKIP_TEST_ELASTICSEARCH=$([ "${TEST_SCENARIO}" = 'opensearch' ] && echo true || echo false)" >> "${VARIABLES_ENV_FILE}"
+      if [[ "${TEST_SCENARIO}" == 'opensearch' ]]; then
+        echo "VENOM_VAR_SKIP_TEST_ELASTICSEARCH=true" >> "${VARIABLES_ENV_FILE}"
+      else
+        echo "VENOM_VAR_SKIP_TEST_ELASTICSEARCH=false" >> "${VARIABLES_ENV_FILE}"
+      fi
       echo "VENOM_VAR_SKIP_TEST_INGRESS=false" >> "${VARIABLES_ENV_FILE}"
       echo "VENOM_VAR_TEST_INGRESS_HOST=${TEST_INGRESS_HOST}" >> "${VARIABLES_ENV_FILE}"
       echo "VENOM_VAR_SKIP_TEST_WEBMODELER=false" >> "${VARIABLES_ENV_FILE}"
-      echo "VENOM_VAR_SKIP_TEST_ELASTICSEARCH=$(yq '.elasticsearch.enabled // false | not' {{ .TEST_CHART_DIR }}/values.yaml)" >> "${VARIABLES_ENV_FILE}"
       echo "VENOM_EXTRA_ARGS=--var-from-file=./vars/variables-ingress-combined.yaml" >> "${VARIABLES_ENV_FILE}"
       echo "ZEEBE_VERSION=$(yq '.zeebe.image.tag' {{ .TEST_CHART_DIR }}/values.yaml)" >> "${VARIABLES_ENV_FILE}"
       # In case the Zeebe version has not been released officially yet.


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
Venom only checks the default values.yaml file to see if elasticsearch is disabled. Now, instead of just checking the default, `yq` merges the yaml files and then checks if Elasticsearch is disabled.

Also, I moved the values.yaml files defined in the workflow are moved to the task file so all the values files are in one location and not separated in two places. 
### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
