### PR TITLE
ci: preflight test skip for elasticsearch 8.6 and 8.8

### DIFF
--- a/.github/workflows/test-chart-version-nightly-template.yaml
+++ b/.github/workflows/test-chart-version-nightly-template.yaml
@@ -66,8 +66,6 @@ jobs:
       identifier: "${{ matrix.scenario }}-intg-${{ inputs.camunda-version }}"
       platforms: "gke"
       flows: "install,upgrade"
-      #remove
-      camunda-helm-git-ref: preflight-es-disable
       camunda-helm-dir: "camunda-platform-${{ inputs.camunda-version }}"
       test-case: ${{inputs.case}}
       scenario: ${{matrix.scenario}}

--- a/.github/workflows/test-chart-version-nightly-template.yaml
+++ b/.github/workflows/test-chart-version-nightly-template.yaml
@@ -66,6 +66,8 @@ jobs:
       identifier: "${{ matrix.scenario }}-intg-${{ inputs.camunda-version }}"
       platforms: "gke"
       flows: "install,upgrade"
+      #remove
+      camunda-helm-git-ref: preflight-es-disable
       camunda-helm-dir: "camunda-platform-${{ inputs.camunda-version }}"
       test-case: ${{inputs.case}}
       scenario: ${{matrix.scenario}}

--- a/charts/camunda-platform-8.6/test/integration/testsuites/vars/files/testsuite-preflight.yaml
+++ b/charts/camunda-platform-8.6/test/integration/testsuites/vars/files/testsuite-preflight.yaml
@@ -6,8 +6,27 @@ name: Run preflight checks for Camunda
 vars:
   releaseName: integration
   skipTestWebModeler: '{{ .SKIP_TEST_WEBMODELER }}'
+  # Skip the Elasticsearch test
+  skipTestElasticsearch: "{{ .SKIP_TEST_ELASTICSEARCH }}"
 
 testcases:
+- name: TEST - Readiness Elasticsearch
+  skip:
+  # The var with "skip" section should be in lower case as there is a bug in Venom:
+  # https://github.com/ovh/venom/issues/654
+  - skiptestelasticsearch ShouldBeFalse
+  steps:
+    - name: Elasticsearch
+      type: http
+      method: GET
+      url: "{{ .preflightVars.baseURLs.elasticsearch }}/_cluster/health?&timeout=1s"
+      retry: 3
+      delay: 10
+      info: |
+        Elasticsearch URL: {{ .preflightVars.baseURLs.elasticsearch }}/_cluster/health?&timeout=1s
+        Response Body: {{ .result.body }}
+      assertions:
+        - result.statuscode ShouldEqual 200
 
 - name: TEST - Readiness
   steps:
@@ -15,8 +34,6 @@ testcases:
     type: http
     range:
     # Dependencies.
-    - component: Elasticsearch
-      url: "{{ .preflightVars.baseURLs.elasticsearch }}/_cluster/health?&timeout=1s"
     - component: Keycloak
       url: "{{ .preflightVars.baseURLs.keycloak }}/auth/realms/master"
     # Camunda.
@@ -60,14 +77,30 @@ testcases:
     assertions:
     - result.statuscode ShouldEqual 200
 
+- name: TEST - Liveness Elasticsearch
+  skip:
+  # The var with "skip" section should be in lower case as there is a bug in Venom:
+  # https://github.com/ovh/venom/issues/654
+  - skiptestelasticsearch ShouldBeFalse
+  steps:
+  - name: Elasticsearch
+    type: http
+    method: GET
+    url: "{{ .preflightVars.baseURLs.elasticsearch }}/_cluster/health?wait_for_status=green&timeout=1s"
+    retry: 3
+    delay: 10
+    info: |
+      Elasticsearch URL: {{ .preflightVars.baseURLs.elasticsearch }}/_cluster/health?wait_for_status=green&timeout=1s
+      Response Body: {{ .result.body }}
+    assertions:
+    - result.statuscode ShouldEqual 200
+
 - name: TEST - Liveness
   steps:
   - name: "{{ .value.component }}"
     type: http
     range:
     # Dependencies.
-    - component: Elasticsearch
-      url: "{{ .preflightVars.baseURLs.elasticsearch }}/_cluster/health?wait_for_status=green&timeout=1s"
     - component: Keycloak
       url:  "{{ .preflightVars.baseURLs.keycloak }}/auth/realms/camunda-platform"
     # Camunda.

--- a/charts/camunda-platform-8.8/test/integration/testsuites/vars/files/testsuite-preflight.yaml
+++ b/charts/camunda-platform-8.8/test/integration/testsuites/vars/files/testsuite-preflight.yaml
@@ -6,8 +6,27 @@ name: Run preflight checks for Camunda
 vars:
   releaseName: integration
   skipTestWebModeler: '{{ .SKIP_TEST_WEBMODELER }}'
+  # Skip the Elasticsearch test
+  skipTestElasticsearch: "{{ .SKIP_TEST_ELASTICSEARCH }}"
 
 testcases:
+- name: TEST - Readiness Elasticsearch
+  skip:
+  # The var with "skip" section should be in lower case as there is a bug in Venom:
+  # https://github.com/ovh/venom/issues/654
+  - skiptestelasticsearch ShouldBeFalse
+  steps:
+    - name: Elasticsearch
+      type: http
+      method: GET
+      url: "{{ .preflightVars.baseURLs.elasticsearch }}/_cluster/health?&timeout=1s"
+      retry: 3
+      delay: 10
+      info: |
+        Elasticsearch URL: {{ .preflightVars.baseURLs.elasticsearch }}/_cluster/health?&timeout=1s
+        Response Body: {{ .result.body }}
+      assertions:
+        - result.statuscode ShouldEqual 200
 
 - name: TEST - Readiness
   steps:
@@ -15,8 +34,6 @@ testcases:
     type: http
     range:
     # Dependencies.
-    - component: Elasticsearch
-      url: "{{ .preflightVars.baseURLs.elasticsearch }}/_cluster/health?&timeout=1s"
     # TODO: Enable test again for final 8.8.0 release.
     # - component: Keycloak
     #  url: "{{ .preflightVars.baseURLs.keycloak }}/auth/realms/master"
@@ -59,14 +76,30 @@ testcases:
   #  assertions:
   #  - result.statuscode ShouldEqual 200
 
+- name: TEST - Liveness Elasticsearch
+  skip:
+  # The var with "skip" section should be in lower case as there is a bug in Venom:
+  # https://github.com/ovh/venom/issues/654
+  - skiptestelasticsearch ShouldBeFalse
+  steps:
+  - name: Elasticsearch
+    type: http
+    method: GET
+    url: "{{ .preflightVars.baseURLs.elasticsearch }}/_cluster/health?wait_for_status=green&timeout=1s"
+    retry: 3
+    delay: 10
+    info: |
+      Elasticsearch URL: {{ .preflightVars.baseURLs.elasticsearch }}/_cluster/health?wait_for_status=green&timeout=1s
+      Response Body: {{ .result.body }}
+    assertions:
+    - result.statuscode ShouldEqual 200
+
 - name: TEST - Liveness
   steps:
   - name: "{{ .value.component }}"
     type: http
     range:
     # Dependencies.
-    - component: Elasticsearch
-      url: "{{ .preflightVars.baseURLs.elasticsearch }}/_cluster/health?wait_for_status=green&timeout=1s"
     # TODO: Enable test again for final 8.8.0 release.
     #- component: Keycloak
     #  url:  "{{ .preflightVars.baseURLs.keycloak }}/auth/realms/camunda-platform"


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
Adding functionality to skip elasticsearch in preflight tests for 8.6 and 8.8. This is just a backport. This already exists for 8.7: https://github.com/camunda/camunda-platform-helm/pull/3516
### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
