### PR TITLE
fix: refactor test-integration-template and introduce integration run…

### DIFF
--- a/.github/actions/workflow-vars/action.yml
+++ b/.github/actions/workflow-vars/action.yml
@@ -6,8 +6,10 @@ inputs:
     default: "install"
   ingress-hostname-base:
     description: The base of the Ingress hostname.
+    required: true
   platform:
     description: The deployment cloud platform like GKE or ROSA.
+    default: "gke"
   deployment-ttl:
     description: Define a ttl for the lifespan of the deployment
     required: false
@@ -16,6 +18,7 @@ inputs:
     description: The fixed string in the identifier of the deployment it could be PR number or another specified name.
   chart-dir:
     description: A reference for the Camunda Helm chart directory which allows to test unreleased chagnes from Git repo.
+    required: true
   chart-upgrade-version:
     description: The Helm chart released version to upgrade from.
     required: false
@@ -33,86 +36,93 @@ outputs:
 runs:
   using: composite
   steps:
-  - name: Set workflow vars
-    id: vars
-    shell: bash
-    run: |
-      # Generate workflow vars.
-      is_pr() {
-        echo ${{ github.event.pull_request.number }} | grep -q .
-      }
+    - name: Set workflow vars
+      id: vars
+      shell: bash
+      run: |
+        # Generate workflow vars.
+        is_pr() {
+          echo ${{ github.event.pull_request.number }} | grep -q .
+        }
 
-      # NOTE: We should use the matrix job id var once it's available.
-      # https://github.com/orgs/community/discussions/40291
-      GITHUB_WORKFLOW_JOB_ID=$(uuidgen | head -c 6)
+        # NOTE: We should use the matrix job id var once it's available.
+        # https://github.com/orgs/community/discussions/40291
+        GITHUB_WORKFLOW_JOB_ID=$(uuidgen | head -c 6)
 
-      echo "Env vars:"
+        echo "Env vars:"
 
-      # Workflow.
-      echo "GITHUB_WORKFLOW_JOB_ID=$GITHUB_WORKFLOW_JOB_ID" | tee -a $GITHUB_ENV
-      echo "GITHUB_WORKFLOW_RUN_ID=${{ github.run_id }}" | tee -a $GITHUB_ENV
+        # Workflow.
+        echo "GITHUB_WORKFLOW_JOB_ID=$GITHUB_WORKFLOW_JOB_ID" | tee -a $GITHUB_ENV
+        echo "GITHUB_WORKFLOW_RUN_ID=${{ github.run_id }}" | tee -a $GITHUB_ENV
 
-      # Namespace.
-      TRIGGER_KEY=$(is_pr && echo "pr" || echo "id")
-      TEST_NAMESPACE="$(echo camunda-${TRIGGER_KEY}-${{ inputs.identifier-base }} | sed 's/\./-/g')"
-
-      if [[ "${{ inputs.deployment-ttl }}" == '' ]]; then
-        TEST_NAMESPACE="${TEST_NAMESPACE}-run-${{ github.run_id }}-sfx-${GITHUB_WORKFLOW_JOB_ID}"
-      fi
-
-      if [[ "${{ inputs.setup-flow }}" == 'upgrade' ]]; then
-        TEST_NAMESPACE="${TEST_NAMESPACE}-upgrade"
-      fi
-      
-      echo "TEST_NAMESPACE=$(printf '%s' "${TEST_NAMESPACE%-}" | head -c 63)" | tee -a $GITHUB_ENV
-
-      # Get alpha chart dir.
-      TEST_CAMUNDA_HELM_DIR_ALPHA="$(basename $(ls -d1 charts/camunda-platform-8.* | sort -V | tail -n1))"
-      echo "TEST_CAMUNDA_HELM_DIR_ALPHA=${TEST_CAMUNDA_HELM_DIR_ALPHA}" | tee -a $GITHUB_ENV
-
-      echo "Output vars:"
-
-      # Deployment identifier.
-      TEST_IDENTIFIER="$(echo ${{ inputs.platform }}-${{ inputs.identifier-base }} | sed 's/\./-/g')"
-      if [[ "${{ inputs.setup-flow }}" == 'upgrade' ]]; then
-        TEST_IDENTIFIER="${TEST_IDENTIFIER}-upgrade"
-      fi
-      echo "identifier=${TEST_IDENTIFIER}" | tee -a $GITHUB_OUTPUT
-
-      # Ingress hostname.
-      TEST_INGRESS_HOST="${TEST_IDENTIFIER}.${{ inputs.ingress-hostname-base }}"
-      if [[ "${{ inputs.deployment-ttl }}" == "" ]] && is_pr; then
-        TEST_INGRESS_HOST="${GITHUB_WORKFLOW_JOB_ID}-${TEST_INGRESS_HOST}"
-      fi
-      # The var is needed in some non-shell steps.
-      echo "ingress-host=${TEST_INGRESS_HOST}" | tee -a $GITHUB_OUTPUT
-
-  - name: Set workflow vars - Chart version
-    shell: bash
-    run: |
-      # In the upgrade flow, the latest released chart for certain minor Camunda version will installed,
-      # then upgraded from the PR branch to ensure upgradability.
-      if [[ "${{ inputs.setup-flow }}" == 'upgrade' ]]; then
-        if [[ -n "${{ inputs.chart-upgrade-version }}" ]]; then
-          TEST_CHART_VERSION="${{ inputs.chart-upgrade-version }}"
+        # Identifier
+        local_identifier=${{ inputs.identifier-base }}
+        if [[ -z "${{ inputs.identifier-base }}" ]]; then
+          local_identifier="no-id-use-ran-$(uuidgen | head -c 6)"
         fi
-        if [[ -z "${{ inputs.chart-upgrade-version }}" ]]; then
-          test "$(git branch --show-current)" != "main" &&
-          git fetch origin main:main --no-tags
-          if [[ -n "$(git ls-tree main -- charts/${{ inputs.chart-dir }}/Chart.yaml)" ]]; then
-            TEST_CHART_VERSION="$(git show main:charts/${{ inputs.chart-dir }}/Chart.yaml | yq '.version')"
-          else
-            # Fallback (needed only when we add a new chart directory).
-            TEST_CHART_VERSION="$(cat charts/${{ inputs.chart-dir }}/Chart.yaml | yq '.version')"
+
+        # Namespace.
+        TRIGGER_KEY=$(is_pr && echo "pr" || echo "id")
+        TEST_NAMESPACE="$(echo camunda-${TRIGGER_KEY}-${local_identifier} | sed 's/\./-/g')"
+
+        if [[ "${{ inputs.deployment-ttl }}" == '' ]]; then
+          TEST_NAMESPACE="${TEST_NAMESPACE}-run-${{ github.run_id }}-sfx-${GITHUB_WORKFLOW_JOB_ID}"
+        fi
+
+        if [[ "${{ inputs.setup-flow }}" == 'upgrade' ]]; then
+          TEST_NAMESPACE="${TEST_NAMESPACE}-upgrade"
+        fi
+
+        max_length_for_k8s_dns_labels_limits=63
+        echo "TEST_NAMESPACE=$(printf '%s' "$TEST_NAMESPACE" | head -c $max_length_for_k8s_dns_labels_limits | sed 's/-$//')" | tee -a $GITHUB_ENV
+
+        # Get alpha chart dir.
+        TEST_CAMUNDA_HELM_DIR_ALPHA="$(basename $(ls -d1 charts/camunda-platform-8.* | sort -V | tail -n1))"
+        echo "TEST_CAMUNDA_HELM_DIR_ALPHA=${TEST_CAMUNDA_HELM_DIR_ALPHA}" | tee -a $GITHUB_ENV
+
+        echo "Output vars:"
+
+        # Deployment identifier.
+        TEST_IDENTIFIER="$(echo ${{ inputs.platform }}-${local_identifier} | sed 's/\./-/g')"
+        if [[ "${{ inputs.setup-flow }}" == 'upgrade' ]]; then
+          TEST_IDENTIFIER="${TEST_IDENTIFIER}-upgrade"
+        fi
+        echo "identifier=${TEST_IDENTIFIER}" | tee -a $GITHUB_OUTPUT
+
+        # Ingress hostname.
+        TEST_INGRESS_HOST="${TEST_IDENTIFIER}.${{ inputs.ingress-hostname-base }}"
+        if [[ "${{ inputs.deployment-ttl }}" == "" ]] && is_pr; then
+          TEST_INGRESS_HOST="${GITHUB_WORKFLOW_JOB_ID}-${TEST_INGRESS_HOST}"
+        fi
+        # The var is needed in some non-shell steps.
+        echo "ingress-host=${TEST_INGRESS_HOST}" | tee -a $GITHUB_OUTPUT
+
+    - name: Set workflow vars - Chart version
+      shell: bash
+      run: |
+        # In the upgrade flow, the latest released chart for certain minor Camunda version will installed,
+        # then upgraded from the PR branch to ensure upgradability.
+        if [[ "${{ inputs.setup-flow }}" == 'upgrade' ]]; then
+          if [[ -n "${{ inputs.chart-upgrade-version }}" ]]; then
+            TEST_CHART_VERSION="${{ inputs.chart-upgrade-version }}"
           fi
+          if [[ -z "${{ inputs.chart-upgrade-version }}" ]]; then
+            test "$(git branch --show-current)" != "main" &&
+            git fetch origin main:main --no-tags
+            if [[ -n "$(git ls-tree main -- charts/${{ inputs.chart-dir }}/Chart.yaml)" ]]; then
+              TEST_CHART_VERSION="$(git show main:charts/${{ inputs.chart-dir }}/Chart.yaml | yq '.version')"
+            else
+              # Fallback (needed only when we add a new chart directory).
+              TEST_CHART_VERSION="$(cat charts/${{ inputs.chart-dir }}/Chart.yaml | yq '.version')"
+            fi
+          fi
+          echo "TEST_CHART_VERSION=${TEST_CHART_VERSION}" | tee -a $GITHUB_ENV
         fi
-        echo "TEST_CHART_VERSION=${TEST_CHART_VERSION}" | tee -a $GITHUB_ENV
-      fi
 
-    # Avoid confusion about the chart version since we only change the version during the release process
-    # as the "version" field in "Chart.yaml" file doesn't reflect the changes since the latest release.
-  - name: Set chart version
-    shell: bash
-    run: |
-      chart_version="$(echo ${{ inputs.chart-dir }} | sed 's/camunda-platform/0.0.0-ci-snapshot/g')" \
-        yq -i '.version = env(chart_version)' charts/${{ inputs.chart-dir }}/Chart.yaml
+      # Avoid confusion about the chart version since we only change the version during the release process
+      # as the "version" field in "Chart.yaml" file doesn't reflect the changes since the latest release.
+    - name: Set chart version
+      shell: bash
+      run: |
+        chart_version="$(echo ${{ inputs.chart-dir }} | sed 's/camunda-platform/0.0.0-ci-snapshot/g')" \
+          yq -i '.version = env(chart_version)' charts/${{ inputs.chart-dir }}/Chart.yaml

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -479,7 +479,7 @@ jobs:
         timeout-minutes: 5
         run: |
           cd $GITHUB_WORKSPACE/scripts
-          ./run-integration-tests.sh --absolute-chart-path ${ABSOLUTE_TEST_CHART_DIR} --namespace $TEST_NAMESPACE
+          ./run-integration-tests.sh --absolute-chart-path ${ABSOLUTE_TEST_CHART_DIR} --namespace $TEST_NAMESPACE --update-helm-dependencies
 
       - name: Test - Upload Playwright report
         if: ${{ always() && inputs.test-enabled && (steps.core-testsuite.outcome == 'success' || steps.core-testsuite.outcome == 'failure') && contains(inputs.camunda-helm-dir, 'camunda-platform-8.7') }}

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -3,6 +3,50 @@ name: "Test - Integration - Template"
 
 on:
   workflow_dispatch:
+    inputs:
+      camunda-helm-dir:
+        description: The directory name of the chart to build upon
+        required: false
+        default: camunda-platform-8.8
+        type: string
+      platforms:
+        description: The platforms to run the test on
+        required: false
+        default: gke
+        type: string
+      flows:
+        description: The flows to run the test on
+        required: false
+        default: install,upgrade
+        type: string
+      infra-type:
+        description: Define the infrastructure that will be used to run the deployment.
+        default: preemptible
+        type: string
+      scenario:
+        description: The scenario to run the test on
+        required: false
+        default: base
+        type: string
+      camunda-helm-repo:
+        description: The Helm repo which is used during the upgrade flow.
+        required: false
+        default: camunda/camunda-platform
+        type: string
+      camunda-helm-credentials-source:
+        description: |
+          Auto-generate credentials or copy them from external secret.
+          Valid options: auto-generated or external-secret-only.
+          New optional auto-generated secrets are only supported in Camunda 8.4 chart and above.
+        required: false
+        default: auto-generated
+        type: string
+      test-enabled:
+        description: Flag to enable or disable the test suites
+        required: false
+        default: true
+        type: boolean
+
   workflow_call:
     inputs:
       identifier:
@@ -124,12 +168,14 @@ jobs:
     outputs:
       matrix: ${{ steps.generate-workflow-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: CI Setup - Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           # This is needed if the workflow is triggered by workflow_call.
           repository: camunda/camunda-platform-helm
           ref: ${{ inputs.camunda-helm-git-ref }}
-      - name: Generate workflow matrix
+
+      - name: CI Setup - Generate workflow matrix
         id: generate-workflow-matrix
         env:
           CI_MATRIX_FILE: ".github/config/test-integration-matrix.yaml"
@@ -166,7 +212,7 @@ jobs:
       TEST_CLUSTER_TYPE: ${{ matrix.distro.type || inputs.cluster-type }}
 
     steps:
-      - name: ℹ️ Print workflow inputs ℹ️
+      - name: Info - ℹ️ Print workflow inputs ℹ️
         env:
           GITHUB_CONTEXT: ${{ toJson(inputs) }}
         run: |
@@ -174,14 +220,17 @@ jobs:
           echo "${GITHUB_CONTEXT}" | jq '."extra-values" = "<Check below>"'
           echo "Workflow Inputs - Extra Values:"
           echo "${GITHUB_CONTEXT}" | jq -r '."extra-values"'
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: CI Setup - Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           # This is needed to load repo GH composite actions if the workflow triggered by workflow_call.
           repository: camunda/camunda-platform-helm
           ref: ${{ inputs.camunda-helm-git-ref }}
+
       # When there is a vault-secret-mapping input given, use Vault instead of GitHub secrets
       # and populate environment variables from Vault
-      - name: Import Vault secrets
+      - name: CI Setup - Import Vault secrets
         id: secrets
         uses: hashicorp/vault-action@7709c609789c5e27b757a85817483caadbb5939a # v3.3.0
         if: inputs.vault-secret-mapping != ''
@@ -192,15 +241,17 @@ jobs:
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           secrets: ${{ inputs.vault-secret-mapping }}
           exportEnv: true
+
       # Used to create/delete GitHub environment.
       # NOTE: The GH app requires "administration:write" access to be able to delete the GH environment.
-      - name: Generate GitHub token
+      - name: CI Setup - Generate GitHub token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
         id: generate-github-token
         with:
           app_id: ${{ secrets.GH_APP_ID_DISTRO_CI_MANAGE_GH_ENVS }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY_DISTRO_CI_MANAGE_GH_ENVS }}
-      - name: Install tools
+
+      - name: CI Setup - Install tools
         uses: ./.github/actions/install-tool-versions
         with:
           tools: |
@@ -210,8 +261,10 @@ jobs:
             oc
             task
             yq
+            zbctl
+            
       # TODO: Later, find a way to abstract the auth for different platforms.
-      - name: Authenticate to GKE
+      - name: CI Setup - Authenticate to GKE
         if: matrix.distro.platform == 'gke' && inputs.auth-data == ''
         uses: ./.github/actions/gke-login
         with:
@@ -219,14 +272,16 @@ jobs:
           cluster-location: ${{ secrets[matrix.distro.secret.cluster-location] }}
           workload-identity-provider: ${{ secrets[matrix.distro.secret.workload-identity-provider] }}
           service-account: ${{ secrets[matrix.distro.secret.service-account] }}
-      - name: Authenticate to OpenShift
+
+      - name: CI Setup - Authenticate to OpenShift
         if: matrix.distro.platform == 'rosa' && inputs.auth-data == ''
         uses: redhat-actions/oc-login@5eb45e848b168b6bf6b8fe7f1561003c12e3c99d # v1
         with:
           openshift_server_url: ${{ secrets[matrix.distro.secret.server-url] }}
           openshift_username: ${{ secrets[matrix.distro.secret.username] }}
           openshift_password: ${{ secrets[matrix.distro.secret.password] }}
-      - name: Authenticate via var
+
+      - name: CI Setup - Authenticate via var
         if: inputs.auth-data != ''
         run: |
           mkdir -p $HOME/.kube
@@ -234,7 +289,8 @@ jobs:
           openssl enc -aes-256-cbc -d -in encrypted_kubeconfig.enc -out "$HOME/.kube/config" -pass pass:"${GITHUB_TOKEN}" -pbkdf2
           rm encrypted_kubeconfig.enc
           chmod 600 $HOME/.kube/config
-      - name: ℹ️ Set workflow vars ℹ️
+
+      - name: CI Setup - ℹ️ Set workflow vars for both install and upgrade ℹ️
         id: vars
         uses: ./.github/actions/workflow-vars
         with:
@@ -245,17 +301,29 @@ jobs:
           ingress-hostname-base: ${{ env.CI_HOSTNAME_BASE }}
           chart-dir: ${{ inputs.camunda-helm-dir }}
           chart-upgrade-version: ${{ inputs.camunda-helm-upgrade-version }}
-      - name: Set test type vars
+
+      - name: CI Setup - Set test type vars
         id: test-type-vars
         uses: ./.github/actions/test-type-vars
         with:
           chart-dir: "${{ inputs.camunda-helm-dir }}"
-      - name: Add Helm repos and dependencies
+
+      - name: CI Setup - Add Helm repos and update helm dependencies
         run: |
           export chartPath="charts/${{ inputs.camunda-helm-dir }}"
           make helm.repos-add
           make helm.dependency-update
-      - name: Create test namespace
+
+      - name: CI Setup - Start GitHub deployment
+        uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1
+        id: deployment
+        with:
+          step: start
+          token: ${{ steps.generate-github-token.outputs.token }}
+          env: ${{ steps.vars.outputs.identifier }}
+          ref: ${{ inputs.caller-git-ref }}
+
+      - name: Cluster Setup - Configure the namespace
         run: |
           echo $TEST_NAMESPACE
           kubectl delete ns --ignore-not-found=true \
@@ -269,7 +337,18 @@ jobs:
           kubectl label ns $TEST_NAMESPACE github-repo=$(basename $GITHUB_REPOSITORY)
           kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=1d
           kubectl annotate ns $TEST_NAMESPACE github-workflow-run-url=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
-      - name: Set Deployment Secrets
+
+      - name: Cluster Setup - Install docker registry on cluster
+        run: |
+          kubectl create secret docker-registry registry-camunda-cloud \
+          --namespace $TEST_NAMESPACE \
+          --docker-server "registry.camunda.cloud" \
+          --docker-username $TEST_DOCKER_USERNAME_CAMUNDA_CLOUD \
+          --docker-password $TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD
+
+          task -d ${CI_TASKS_BASE_DIR}/chart-full-setup init.seed
+
+      - name: Cluster Setup - Configure TLS Certificates/Secrets
         run: |
           kubectl apply -n $TEST_NAMESPACE \
             -f .github/config/external-secret/external-secret-certificates.yaml
@@ -285,34 +364,7 @@ jobs:
             kubectl wait --for=condition=Ready externalsecret/$secret -n distribution-team --timeout=300s
           done
 
-          # Auto-generated secrets that are generated by the chart at the installation.
-          if [[ ${{ matrix.scenario.flow }} == 'install' ]]; then
-            if [[ ${{ inputs.camunda-helm-credentials-source }} == 'auto-generated' ]]; then
-              TEST_HELM_EXTRA_ARGS_INSTALL="${TEST_HELM_EXTRA_ARGS} --set global.secrets.autoGenerated=true"
-              echo "TEST_HELM_EXTRA_ARGS_INSTALL=${TEST_HELM_EXTRA_ARGS_INSTALL}" | tee -a $GITHUB_ENV
-            fi
-          fi
-
-      - name: Set Helm extra args
-        run: |
-          # Since Zeebe 8.6 it's not possible to upgrade from/to alpha version.
-          # The Zeebe team advised to use SNAPSHOT tag instead.
-          if [[ ${{ matrix.scenario.flow }} == 'upgrade' ]] &&
-          [[ "${{ inputs.camunda-helm-dir }}" == "${{ env.TEST_CAMUNDA_HELM_DIR_ALPHA }}" ]]; then
-            TEST_HELM_EXTRA_ARGS_INSTALL="${TEST_HELM_EXTRA_ARGS_INSTALL} --set zeebe.image.tag=SNAPSHOT"
-            echo "TEST_HELM_EXTRA_ARGS_INSTALL=${TEST_HELM_EXTRA_ARGS_INSTALL}" | tee -a $GITHUB_ENV
-            TEST_HELM_EXTRA_ARGS_UPGRADE="${TEST_HELM_EXTRA_ARGS_UPGRADE} --set zeebe.image.tag=SNAPSHOT"
-            echo "TEST_HELM_EXTRA_ARGS_UPGRADE=${TEST_HELM_EXTRA_ARGS_UPGRADE}" | tee -a $GITHUB_ENV
-          fi
-      - name: Start GitHub deployment
-        uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1
-        id: deployment
-        with:
-          step: start
-          token: ${{ steps.generate-github-token.outputs.token }}
-          env: ${{ steps.vars.outputs.identifier }}
-          ref: ${{ inputs.caller-git-ref }}
-      - name: Pre setup
+      - name: Helm - Execute before install lifecycle tasks
         timeout-minutes: 5
         env:
           TEST_CHART_FLOW: ${{ matrix.scenario.flow }}
@@ -322,7 +374,14 @@ jobs:
 
           echo "Extra values from workflow:"
           echo "${{ inputs.extra-values }}" | tee /tmp/extra-values-file.yaml
-      - name: 🌟 Setup Camunda chart 🌟
+
+      - name: Helm - Install - Setup helm extra args
+        if: matrix.scenario.flow == 'install' && inputs.camunda-helm-credentials-source == 'auto-generated'
+        run: |
+          TEST_HELM_EXTRA_ARGS_INSTALL="${TEST_HELM_EXTRA_ARGS} --set global.secrets.autoGenerated=true"
+          echo "TEST_HELM_EXTRA_ARGS_INSTALL=${TEST_HELM_EXTRA_ARGS_INSTALL}" | tee -a $GITHUB_ENV
+
+      - name: Helm - Install - 🌟 Install Camunda chart 🌟
         env:
           TEST_CHART_FLOW: ${{ matrix.scenario.flow }}
           TEST_OPENSHIFT_POST_RENDER: ${{ inputs.camunda-helm-post-render }}
@@ -335,15 +394,28 @@ jobs:
             --values /tmp/extra-values-file.yaml
         run: |
           task -d ${CI_TASKS_BASE_DIR}/chart-full-setup setup.exec
-      - name: Post setup
+
+      - name: Helm - Execute after install lifecycle tasks
         timeout-minutes: 5
         run: |
           task -d ${CI_TASKS_BASE_DIR}/chart-full-setup setup.post
-      - name: Pre Upgrade
+
+      - name: Helm - Upgrade - Setup helm extra args
+        if: matrix.scenario.flow == 'upgrade' && inputs.camunda-helm-dir == env.TEST_CAMUNDA_HELM_DIR_ALPHA
+        run: |
+          # Since Zeebe 8.6 it's not possible to upgrade from/to alpha version.
+          # The Zeebe team advised to use SNAPSHOT tag instead.
+          TEST_HELM_EXTRA_ARGS_INSTALL="${TEST_HELM_EXTRA_ARGS_INSTALL} --set zeebe.image.tag=SNAPSHOT"
+          echo "TEST_HELM_EXTRA_ARGS_INSTALL=${TEST_HELM_EXTRA_ARGS_INSTALL}" | tee -a $GITHUB_ENV
+          TEST_HELM_EXTRA_ARGS_UPGRADE="${TEST_HELM_EXTRA_ARGS_UPGRADE} --set zeebe.image.tag=SNAPSHOT"
+          echo "TEST_HELM_EXTRA_ARGS_UPGRADE=${TEST_HELM_EXTRA_ARGS_UPGRADE}" | tee -a $GITHUB_ENV
+
+      - name: Helm - Upgrade - Execute before upgrade lifecycle tasks
         if: matrix.scenario.flow == 'upgrade'
         run: |
           task -d ${CI_TASKS_BASE_DIR}/chart-full-setup upgrade.pre
-      - name: 🌟 Upgrade Camunda chart 🌟
+
+      - name: Helm - Upgrade - 🌟 Upgrade Camunda chart 🌟
         if: matrix.scenario.flow == 'upgrade'
         env:
           TEST_OPENSHIFT_POST_RENDER: ${{ inputs.camunda-helm-post-render }}
@@ -356,7 +428,8 @@ jobs:
             --values /tmp/extra-values-file.yaml
         run: |
           task -d ${CI_TASKS_BASE_DIR}/chart-full-setup upgrade.exec
-      - name: Update GitHub deployment status
+
+      - name: CI Setup - Update GitHub deployment status
         uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1
         with:
           step: finish
@@ -366,19 +439,33 @@ jobs:
           env_url: https://${{ steps.vars.outputs.ingress-host }}
           env: ${{ steps.vars.outputs.identifier }}
           ref: ${{ inputs.caller-git-ref }}
-      - name: ⭐️ Run Preflight TestSuite ⭐️
+
+      - name: Test - ⭐️ Run Venom Env Setup ⭐️
         if: inputs.test-enabled
+        env:
+          TEST_INGRESS_HOST: ${{ steps.vars.outputs.ingress-host }}
+        timeout-minutes: 1
+        continue-on-error: false
+        run: |
+          task -d ${CI_TASKS_BASE_DIR}/chart-full-setup setup.venom.env
+
+      - name: Testplit- ⭐️ Run Venom Preflight TestSuite ⭐️
+        if: inputs.test-enabled
+        env:
+          TEST_INGRESS_HOST: ${{ steps.vars.outputs.ingress-host }}
         timeout-minutes: 10
         continue-on-error: true
         run: |
           task -d ${CI_TASKS_BASE_DIR}/chart-full-setup test.preflight
-      - name: ⭐️ Run Core TestSuite ⭐️
+
+      - name: Test - ⭐️ Run Venom Core TestSuite ⭐️
         id: core-testsuite
         if: inputs.test-enabled
         timeout-minutes: 20
         run: |
           task -d ${CI_TASKS_BASE_DIR}/chart-full-setup test.core
-      - name: ⭐️ Run Playwright Core TestSuite ⭐️
+
+      - name: Test - ⭐️ Run Playwright Core TestSuite ⭐️
         if: ${{ always() && inputs.test-enabled && (steps.core-testsuite.outcome == 'success' || steps.core-testsuite.outcome == 'failure') && contains(inputs.camunda-helm-dir, 'camunda-platform-8.7') }}
         timeout-minutes: 20
         run: |
@@ -386,10 +473,28 @@ jobs:
           envsubst < ${ABSOLUTE_TEST_CHART_DIR}/test/integration/testsuites/vars/playwright/files/playwright-job-vars.env.template > ${ABSOLUTE_TEST_CHART_DIR}/test/integration/testsuites/vars/playwright/files/variables.env
           cat ${ABSOLUTE_TEST_CHART_DIR}/test/integration/testsuites/vars/playwright/files/variables.env
           task -d ${CI_TASKS_BASE_DIR}/chart-full-setup test.playwright.core
-      - name: 🚨 Get failed Pods info 🚨
+
+      - name: Test - ⭐️ Run Playwright Core TestSuite (Github Runner) ⭐️
+        if: ${{ always() && inputs.test-enabled && (steps.core-testsuite.outcome == 'success' || steps.core-testsuite.outcome == 'failure') && contains(inputs.camunda-helm-dir, 'camunda-platform-8.7') }}
+        timeout-minutes: 5
+        run: |
+          cd $GITHUB_WORKSPACE/scripts
+          ./run-integration-tests.sh --absolute-chart-path ${ABSOLUTE_TEST_CHART_DIR} --namespace $TEST_NAMESPACE
+
+      - name: Test - Upload Playwright report
+        if: ${{ always() && inputs.test-enabled && (steps.core-testsuite.outcome == 'success' || steps.core-testsuite.outcome == 'failure') && contains(inputs.camunda-helm-dir, 'camunda-platform-8.7') }}
+        uses: actions/upload-artifact@v4
+        with:
+          path: ${{ env.ABSOLUTE_TEST_CHART_DIR }}/test/integration/testsuites/test-results/
+          name: playwright-report
+          if-no-files-found: error
+          retention-days: 5
+        
+      - name: CI Cleanup - 🚨 Get failed Pods info 🚨
         if: failure()
         uses: ./.github/actions/failed-pods-info
-      - name: Cleanup GitHub deployment
+
+      - name: CI Cleanup - Cleanup GitHub deployment
         if: always() && (env.CI_DEPLOYMENT_TTL == '' || matrix.distro.type != 'kubernetes')
         uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1
         with:
@@ -397,7 +502,8 @@ jobs:
           token: ${{ steps.generate-github-token.outputs.token }}
           env: ${{ steps.vars.outputs.identifier }}
           ref: ${{ inputs.caller-git-ref }}
-      - name: Cleanup test namespace
+
+      - name: CI Cleanup - Cleanup test namespace
         if: always()
         run: |
           if [ "${{ env.CI_DEPLOYMENT_TTL }}" != "" ]; then

--- a/charts/camunda-platform-8.7/test/integration/testsuites/playwright.config.ts
+++ b/charts/camunda-platform-8.7/test/integration/testsuites/playwright.config.ts
@@ -2,9 +2,6 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
-  defaultTimeout: 30000,
   fullyParallel: true,
-  retries: 2,
-  reporter: [['html', { open: 'never' }], ['list'], ['junit', { outputFile: 'test-results/results.xml' }]],
-  use: { baseURL: 'https://camunda.local', trace: 'on-first-retry' },
+  retries: 0,
 })

--- a/charts/camunda-platform-8.7/test/integration/testsuites/tests/login.spec.ts
+++ b/charts/camunda-platform-8.7/test/integration/testsuites/tests/login.spec.ts
@@ -54,6 +54,7 @@ const config = {
   },
   venomID: process.env.TEST_CLIENT_ID ?? "venom",
   venomSec: requireEnv("PLAYWRIGHT_VAR_TEST_CLIENT_SECRET"),
+  fixturesDir: process.env.FIXTURES_DIR || "/mnt/fixtures",
 };
 
 // Helper to fetch a token
@@ -216,7 +217,7 @@ test.describe("Camunda core", () => {
         "zbctl",
         [
           "deploy",
-          `/mnt/fixtures/${file}`,
+          `${config.fixturesDir}/${file}`,
           "--clientCache",
           "/tmp/zeebe",
           "--clientId",
@@ -246,7 +247,7 @@ test.describe("Camunda core", () => {
         "zbctl",
         [
           "deploy",
-          `/mnt/fixtures/${file}`,
+          `${config.fixturesDir}/${file}`,
           "--clientCache",
           "/tmp/zeebe",
           "--clientId",

--- a/charts/camunda-platform-8.7/test/integration/testsuites/vars/playwright/files/playwright-job-vars.env.template
+++ b/charts/camunda-platform-8.7/test/integration/testsuites/vars/playwright/files/playwright-job-vars.env.template
@@ -6,13 +6,13 @@ AUTH_URL=https://${TEST_INGRESS_HOST}/auth/realms/camunda-platform/protocol/open
 TEST_CLIENT_ID=venom
 
 # === Public base URLs (Ingress) ==============================================
-CONSOLE_BASE_URL=https://${TEST_INGRESS_HOST}
+CONSOLE_BASE_URL=https://${TEST_INGRESS_HOST}/console
 CONNECTORS_BASE_URL=https://${TEST_INGRESS_HOST}/connectors/inbound
 TASKLIST_BASE_URL=https://${TEST_INGRESS_HOST}/tasklist
 OPERATE_BASE_URL=https://${TEST_INGRESS_HOST}/operate
 OPTIMIZE_BASE_URL=https://${TEST_INGRESS_HOST}/optimize
 KEYCLOAK_BASE_URL=https://${TEST_INGRESS_HOST}/auth
-IDENTITY_BASE_URL=https://${TEST_INGRESS_HOST}/identity
+IDENTITY_BASE_URL=https://${TEST_INGRESS_HOST}/identity/
 WEBMODELER_BASE_URL=https://${TEST_INGRESS_HOST}/modeler
 ZEEBE_GATEWAY_GRPC=zeebe-${TEST_INGRESS_HOST}:443
 ZEEBE_GATEWAY_REST=https://${TEST_INGRESS_HOST}:26501/

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+
+# ==============================================================================
+# Camunda Platform – Integration-Test Runner
+# ------------------------------------------------------------------------------
+# Why does this script exist?
+#   *  A single, developer-friendly entry-point for running the Playwright-based
+#      integration test-suite that lives under <chart>/test/integration.
+#   *  Works both locally on a developer laptop **and** inside GitHub Actions
+#      without modification.
+#   *  Hardened: performs extensive sanity-checks, validates prerequisites and
+#      cleans up after itself so CI troubleshooting is painless.
+#
+# What does it actually do?
+#   1. Verifies required CLI tools are available (kubectl, jq, git, npm, …).
+#   2. Validates the supplied Helm chart path and Kubernetes namespace.
+#   3. Ensures Helm repos/dependencies for the chart are up-to-date (via Make).
+#   4. Detects the ingress hostname for the Camunda Platform installation and
+#      exports it for the tests as TEST_INGRESS_HOST.
+#   5. Builds a temporary .env file populated with service client secrets and
+#      Playwright variables, removing it automatically on exit.
+#   6. Installs Node dependencies with `npm ci` and finally executes the
+#      Playwright test runner.
+#
+# Expected environment / assumptions
+#   • kubectl context points at a cluster where the Camunda Platform Helm chart
+#     is already installed in the provided namespace.
+#   • A secret named `integration-test-credentials` exists in that namespace and
+#     contains `identity-admin-client-password`.
+#
+# Usage examples
+#   # Local run against KIND cluster
+#   ./scripts/run-integration-tests.sh \
+#       --chart-path /home/runner/work/camunda-platform-helm/charts/camunda-platform-8.7 \
+#       --namespace camunda
+#
+#   # Inside GitHub Actions (see .github/workflows/test-integration-template.yml)
+#   # The same invocation is used; the workflow sets the arguments.
+#
+# Any failure will terminate the script with a non-zero exit code so that CI
+# systems mark the job as failed.
+# ============================================================================
+
+set -euo pipefail
+
+cleanup() {
+  [[ -n "${ENV_FILE:-}" && -f "$ENV_FILE" ]] && rm -f "$ENV_FILE"
+}
+
+validate_args() {
+  local chart_path="$1"
+  local namespace="$2"
+
+  if [[ -z "$chart_path" ]]; then
+    echo "--chart-path is required"
+    exit 1
+  fi
+
+  if [[ ! -f "$chart_path/Chart.yaml" ]]; then
+    echo "Error: chart path '$chart_path' does not contain a Chart.yaml file" >&2
+    exit 1
+  fi
+
+  if [[ -z "$namespace" ]]; then
+    echo "--namespace is required"
+    exit 1
+  fi
+
+  if ! kubectl get namespace "$namespace" >/dev/null 2>&1; then
+    echo "Error: namespace '$namespace' not found in the current Kubernetes context" >&2
+    exit 1
+  fi
+}
+
+log() {
+  if $VERBOSE; then
+    echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $*"
+  fi
+}
+
+install_helm_dependencies() {
+  local chart_path="$1"
+  local repo_root="$2"
+
+  export chartPath="charts/$(basename "$chart_path")" # this is used implicitly in the Makefile
+  log "Installing Helm repos and dependencies with chartPath=$chartPath"
+  cd "$repo_root"
+  make helm.repos-add
+  make helm.dependency-update
+}
+
+get_ingress_hostname() {
+  local namespace="$1"
+  local hostname
+  
+  hostname=$(kubectl -n "$namespace" get ingress -o json | jq -r '
+    .items[]
+    | select(all(.spec.rules[].host; contains("zeebe") | not))
+    | ([.spec.rules[].host] | join(","))')
+
+  if [[ -z "$hostname" || "$hostname" == "null" ]]; then
+    echo "Error: unable to determine ingress hostname in namespace '$namespace'" >&2
+    exit 1
+  fi
+
+  echo "$hostname"
+}
+
+setup_env_file() {
+  local env_file="$1"
+  local test_suite_path="$2"
+  local hostname="$3"
+  local repo_root="$4"
+  local namespace="$5"
+  
+  export TEST_INGRESS_HOST="$hostname"
+  envsubst < "$test_suite_path"/vars/playwright/files/playwright-job-vars.env.template > "$env_file"
+
+  # during helm install, we create a secret with the credentials for the services
+  # that are used to test the platform. This is grabbing those credentials and
+  # adding them to the .env file so that we can run the tests from any environment
+  # with an authorized kubectl context.
+  for svc in CONNECTORS TASKLIST OPTIMIZE OPERATE TEST; do
+    secret=$(kubectl -n "$namespace" \
+               get secret integration-test-credentials \
+               -o jsonpath='{.data.identity-admin-client-password}' | base64 -d)
+    echo "PLAYWRIGHT_VAR_${svc}_CLIENT_SECRET=${secret}" >> "$env_file"
+  done
+
+  # fixtures are the *.bpmn files that are used to test the platform. This is likely to change
+  # to be more flexible in what we are testing.
+  log "Setting FIXTURES_DIR to ${repo_root%/}/test/integration/testsuites/playwright.core/files"
+  echo "FIXTURES_DIR=${repo_root%/}/test/integration/testsuites/playwright.core/files" >> "$env_file"
+
+  log "Contents of .env file:"
+  if $VERBOSE; then
+    cat "$env_file"
+  fi
+}
+
+run_playwright_tests() {
+  local test_suite_path="$1"
+  local show_html_report="$2"
+  log "Changing directory to $test_suite_path"
+  log "Running test suite"
+
+  cd "$test_suite_path"
+  npm ci --no-audit --no-fund
+
+  playwright_status=0
+  npx playwright test --reporter=line,json${show_html_report:+",html"} || playwright_status=$?
+
+  if $show_html_report; then
+    npx playwright show-report || playwright_status=$?
+  fi
+
+  exit $playwright_status
+}
+
+usage() {
+  cat <<EOF
+This script runs the integration tests for the Camunda Platform Helm chart.
+
+Usage:
+  $0 [options]
+
+Options:
+  --absolute-chart-path ABSOLUTE_CHART_PATH   The absolute path to the chart directory.
+  --namespace NAMESPACE                       The namespace c8 is deployed into
+  --show-html-report                          Show the HTML report after the tests have run.
+  -v | --verbose                              Show verbose output.
+  -h | --help                                 Show this help message and exit.
+EOF
+}
+
+# ------------------------------------------------------------------------------
+# Main
+# ------------------------------------------------------------------------------
+
+ABSOLUTE_CHART_PATH=""
+NAMESPACE=""
+SHOW_HTML_REPORT=false
+VERBOSE=false
+
+required_cmds=(kubectl jq git envsubst npm npx make)
+for cmd in "${required_cmds[@]}"; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Error: required command '$cmd' not found in PATH" >&2
+    exit 127
+  fi
+done
+
+trap cleanup EXIT
+trap 'echo "[ERROR] Script failed at line $LINENO"; exit 1' ERR
+
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+  --absolute-chart-path)
+    ABSOLUTE_CHART_PATH="$2"
+    shift 2
+    ;;
+  --namespace)
+    NAMESPACE="$2"
+    shift 2
+    ;;
+  --show-html-report)
+    SHOW_HTML_REPORT=true
+    shift
+    ;;
+  -v | --verbose)
+    VERBOSE=true
+    shift
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "Unknown option: $key"
+    usage
+    exit 1
+    ;;
+  esac
+done
+
+validate_args "$ABSOLUTE_CHART_PATH" "$NAMESPACE"
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+TEST_SUITE_PATH="${ABSOLUTE_CHART_PATH%/}/test/integration/testsuites"
+
+install_helm_dependencies "$ABSOLUTE_CHART_PATH" "$REPO_ROOT"
+hostname=$(get_ingress_hostname "$NAMESPACE")
+setup_env_file "$TEST_SUITE_PATH/.env" "$TEST_SUITE_PATH" "$hostname" "$REPO_ROOT" "$NAMESPACE"
+
+run_playwright_tests "$TEST_SUITE_PATH" "$SHOW_HTML_REPORT"

--- a/test/integration/scenarios/chart-full-setup/Taskfile.yaml
+++ b/test/integration/scenarios/chart-full-setup/Taskfile.yaml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 
 vars:
   TEST_NAMESPACE: '{{ env "TEST_NAMESPACE" | default "camunda-platform" }}'
@@ -7,14 +7,14 @@ vars:
   TEST_CHART_VERSION: '{{ env "TEST_CHART_VERSION" | default ">0.0.0" | quote }}'
 
 dotenv:
-- ../vars/common.env
-- ../vars/dynamic.env
-- ../vars/{{ .TEST_CLUSTER_TYPE }}.env
+  - ../vars/common.env
+  - ../vars/dynamic.env
+  - ../vars/{{ .TEST_CLUSTER_TYPE }}.env
 
 includes:
   init.seed:
     taskfile: ../lib/init-seed-taskfile.yaml
-    internal: true
+    internal: false
   upgrade:
     taskfile: ../lib/chart-upgrade-taskfile.yaml
     internal: true
@@ -43,56 +43,52 @@ includes:
 
 tasks:
   setup.pre:
-    preconditions:
-    - test -n "${TEST_DOCKER_USERNAME_CAMUNDA_CLOUD}"
-    - test -n "${TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD}"
-    - test -n "${TEST_INGRESS_HOST}"
     env:
       VARIABLES_ENV_FILE: "{{ .TEST_CHART_DIR }}/test/integration/testsuites/vars/files/variables.env"
     cmds:
-    # This is needed to access WebModeler Docker image since it's not public.
-    - kubectl create secret docker-registry registry-camunda-cloud
-        --namespace {{ .TEST_NAMESPACE }}
-        --docker-server "registry.camunda.cloud"
-        --docker-username "${TEST_DOCKER_USERNAME_CAMUNDA_CLOUD}"
-        --docker-password "${TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD}"
-    # Set Venom vars.
-    - |
-      echo "VENOM_VAR_SKIP_TEST_INGRESS=false" >> "${VARIABLES_ENV_FILE}"
-      echo "VENOM_VAR_TEST_INGRESS_HOST=${TEST_INGRESS_HOST}" >> "${VARIABLES_ENV_FILE}"
-      echo "VENOM_VAR_SKIP_TEST_WEBMODELER=false" >> "${VARIABLES_ENV_FILE}"
-      echo "VENOM_VAR_SKIP_TEST_ELASTICSEARCH=$(yq '.elasticsearch.enabled // false | not' {{ .TEST_CHART_DIR }}/values.yaml)" >> "${VARIABLES_ENV_FILE}"
-      echo "VENOM_EXTRA_ARGS=--var-from-file=./vars/variables-ingress-combined.yaml" >> "${VARIABLES_ENV_FILE}"
-      echo "ZEEBE_VERSION=$(yq '.zeebe.image.tag' {{ .TEST_CHART_DIR }}/values.yaml)" >> "${VARIABLES_ENV_FILE}"
-      # In case the Zeebe version has not been released officially yet.
-      echo "ZEEBE_VERSION_FALLBACK=$(grep zbctl ../../../../.tool-versions | cut -d " " -f 2)" >> "${VARIABLES_ENV_FILE}"
-    - |
-      if [[ "${TEST_CHART_FLOW}" == 'upgrade' ]]; then
-        # Extract OpenShift values from released chart for upgrade test.
-        helm pull {{ .TEST_CHART_NAME }} --untar --untardir {{ .TEST_TMP_DIR }} \
-          --version {{ .TEST_CHART_VERSION }}
-        # Preinstall in upgrade flow.
-        test -f {{ .TEST_VALUES_BASE_DIR }}/pre-install-upgrade/* || {
+      - |
+        if [[ "${TEST_CHART_FLOW}" == 'upgrade' ]]; then
+          # Extract OpenShift values from released chart for upgrade test.
+          helm pull {{ .TEST_CHART_NAME }} --untar --untardir {{ .TEST_TMP_DIR }} \
+            --version {{ .TEST_CHART_VERSION }}
+          # Preinstall in upgrade flow.
+          test -f {{ .TEST_VALUES_BASE_DIR }}/pre-install-upgrade/* || {
+            exit 0
+          }
+          export TEST_NAMESPACE={{ .TEST_NAMESPACE }}
+          bash -x {{ .TEST_VALUES_BASE_DIR }}/pre-install-upgrade/*.sh
+        fi
+      - |
+        # Create the local chart package to install.
+        pwd
+        helm package {{ .TEST_CHART_DIR }}/
+      - |
+        test -f {{ .TEST_VALUES_BASE_DIR }}/pre-install/* || {
           exit 0
         }
         export TEST_NAMESPACE={{ .TEST_NAMESPACE }}
-        bash -x {{ .TEST_VALUES_BASE_DIR }}/pre-install-upgrade/*.sh
-      fi
-    - |
-      # Create the local chart package to install.
-      pwd
-      helm package {{ .TEST_CHART_DIR }}/
-    - |
-      test -f {{ .TEST_VALUES_BASE_DIR }}/pre-install/* || {
-        exit 0
-      }
-      export TEST_NAMESPACE={{ .TEST_NAMESPACE }}
-      bash -x {{ .TEST_VALUES_BASE_DIR }}/pre-install/*.sh
+        bash -x {{ .TEST_VALUES_BASE_DIR }}/pre-install/*.sh
+
+  setup.venom.env:
+    preconditions:
+      - test -n "${TEST_INGRESS_HOST}"
+    env:
+      VARIABLES_ENV_FILE: "{{ .TEST_CHART_DIR }}/test/integration/testsuites/vars/files/variables.env"
+    cmds:
+      - |
+        echo "VENOM_VAR_SKIP_TEST_INGRESS=false" >> "${VARIABLES_ENV_FILE}"
+        echo "VENOM_VAR_TEST_INGRESS_HOST=${TEST_INGRESS_HOST}" >> "${VARIABLES_ENV_FILE}"
+        echo "VENOM_VAR_SKIP_TEST_WEBMODELER=false" >> "${VARIABLES_ENV_FILE}"
+        echo "VENOM_VAR_SKIP_TEST_ELASTICSEARCH=$(yq '.elasticsearch.enabled // false | not' {{ .TEST_CHART_DIR }}/values.yaml)" >> "${VARIABLES_ENV_FILE}"
+        echo "VENOM_EXTRA_ARGS=--var-from-file=./vars/variables-ingress-combined.yaml" >> "${VARIABLES_ENV_FILE}"
+        echo "ZEEBE_VERSION=$(yq '.zeebe.image.tag' {{ .TEST_CHART_DIR }}/values.yaml)" >> "${VARIABLES_ENV_FILE}"
+        # In case the Zeebe version has not been released officially yet.
+        echo "ZEEBE_VERSION_FALLBACK=$(grep zbctl ../../../../.tool-versions | cut -d " " -f 2)" >> "${VARIABLES_ENV_FILE}"
+        cat ${VARIABLES_ENV_FILE}
 
   setup.exec:
-    deps: [init.seed]
     cmds:
-    - helm install integration {{ .TEST_CHART_NAME }}
+      - helm install integration {{ .TEST_CHART_NAME }}
         --version {{ .TEST_CHART_VERSION }}
         --namespace {{ .TEST_NAMESPACE }}
         --values {{ .TEST_VALUES_BASE_DIR }}/common/values-integration-test.yaml
@@ -104,12 +100,12 @@ tasks:
 
   setup.post:
     cmds:
-    - echo "No post task for this test."
+      - echo "No post task for this test."
 
   setup.clean:
     cmds:
-    - kubectl delete secret registry-camunda-cloud --ignore-not-found=true
-    - git checkout {{ .TEST_CHART_DIR }}/test/integration/testsuites/vars/files/variables.env
+      - kubectl delete secret registry-camunda-cloud --ignore-not-found=true
+      - git checkout {{ .TEST_CHART_DIR }}/test/integration/testsuites/vars/files/variables.env
 
   upgrade.pre:
     deps: [upgrade:pre]
@@ -119,10 +115,10 @@ tasks:
 
   all:
     cmds:
-    - task: init.seed
-    - task: setup.pre
-    - task: setup.exec
-    - task: setup.post
-    - task: test.preflight
-    - task: test.core
-    - task: test.playwright.core
+      - task: init.seed
+      - task: setup.pre
+      - task: setup.exec
+      - task: setup.post
+      - task: test.preflight
+      - task: test.core
+      - task: test.playwright.core


### PR DESCRIPTION
### Which problem does the PR fix?

https://github.com/camunda/team-distribution/issues/525

### What's in this PR?

- Refactor test-integration-template to make it more maintainable
- Introduce ./script/run-integration-tests.sh script to consolidate local DX and CI
- Enable developers to run integration tests locally just how they run
  in CI

NOTE: I've left venom and playwright tests running inside the cluster for now. Its useful to keep these until this is ported to the other versions are there can be issues with domain resolution, namespaces, file paths, etc. Having those test suites running first allows use to know if the tests fail due to real failures, or test configuration issues

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
