### PR TITLE
fix: renovate should not update digests that default to empty string

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -52,7 +52,6 @@
       matchUpdateTypes: [
         'patch',
         'pin',
-        'digest',
       ],
     },
     {
@@ -68,7 +67,6 @@
       matchUpdateTypes: [
         'patch',
         'pin',
-        'digest',
       ],
     },
     {
@@ -84,7 +82,6 @@
       matchUpdateTypes: [
         'patch',
         'pin',
-        'digest',
       ],
     },
     {
@@ -100,7 +97,6 @@
       matchUpdateTypes: [
         'patch',
         'pin',
-        'digest',
       ],
     },
     {
@@ -116,7 +112,6 @@
       matchUpdateTypes: [
         'patch',
         'pin',
-        'digest',
       ],
     },
     {
@@ -132,7 +127,6 @@
       matchUpdateTypes: [
         'patch',
         'pin',
-        'digest',
       ],
     },
     {


### PR DESCRIPTION
### Which problem does the PR fix?

A recent PR that introduced image digests causes errors in renovate because renovate expects to have the digest be something other than an empty string. And we do not want to mandate all customers have digests by default because then the StatefulSet matchLabels may fail to match on a helm-upgrade.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

Change the updateTypes in renovate to no longer include "digest"

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
