### PR TITLE
fix: disable pinDigests in renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -53,6 +53,7 @@
         'patch',
         'pin',
       ],
+      pinDigests: false,
     },
     {
       groupName: 'camunda-platform-8.3',
@@ -68,6 +69,7 @@
         'patch',
         'pin',
       ],
+      pinDigests: false,
     },
     {
       groupName: 'camunda-platform-8.4',
@@ -83,6 +85,7 @@
         'patch',
         'pin',
       ],
+      pinDigests: false,
     },
     {
       groupName: 'camunda-platform-8.5',
@@ -98,6 +101,7 @@
         'patch',
         'pin',
       ],
+      pinDigests: false,
     },
     {
       groupName: 'camunda-platform-8.6',
@@ -113,6 +117,7 @@
         'patch',
         'pin',
       ],
+      pinDigests: false,
     },
     {
       groupName: 'camunda-platform-8.7',
@@ -128,6 +133,7 @@
         'patch',
         'pin',
       ],
+      pinDigests: false,
     },
     {
       groupName: 'camunda-platform-8.8',
@@ -145,6 +151,7 @@
         'minor',
         'patch',
       ],
+      pinDigests: false,
     },
     // End of minor cycle chores.
 


### PR DESCRIPTION
In my previous commit, I removed the update type but that is not enough to prevent from checking for digests. We also need to include pinDigests option:

https://docs.renovatebot.com/presets-docker/#dockerpindigests

### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
