### PR TITLE
fix: disable the keycloak initContainer package from renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -458,7 +458,7 @@
     // This package name is used by the initContainer for keycloak in v8.5, and doesn't make sense to
     // be processed by renovate because it requires helm templating to render the real image name.
     {
-      "matchDepNames": ["{{ .Values.global.identity.image.registry }}/{{ .Values.global.identity.image.repository }}"],
+      "matchDepNames": ["{{ .Values.global.identity.image.registry }}/{{ .Values.global.identity.image.repository }}{{ if .Values.global.identity.image.digest }}"],
       "enabled": false
     },
   ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -455,6 +455,12 @@
       platformAutomerge: false,
       automerge: true,
     },
+    // This package name is used by the initContainer for keycloak in v8.5, and doesn't make sense to
+    // be processed by renovate because it requires helm templating to render the real image name.
+    {
+      "matchDepNames": ["{{ .Values.global.identity.image.registry }}/{{ .Values.global.identity.image.repository }}"],
+      "enabled": false
+    },
   ],
   customManagers: [
     {


### PR DESCRIPTION
### Which problem does the PR fix?

Renovate was having issues this morning due to the following error:

Failed job: https://developer.mend.io/github/camunda/camunda-platform-helm/-/job/4c3d9133-b524-4152-ba28-dc6cd73022b7


<details>
DEBUG: getDigest(https://{{ .Values.global.identity.image.registry }}, {{ .Values.global.identity.image.repository }}{{ if .Values.global.identity.image.digest }}, undefined)
DEBUG: getManifestResponse(https://{{ .Values.global.identity.image.registry }}, {{ .Values.global.identity.image.repository }}{{ if .Values.global.identity.image.digest }}, latest, head)
ERROR: Request Error: cannot parse url
{
  "url": "https://{{ .Values.global.identity.image.registry }}/v2/"
  "resolvedUrl": "https://{{ .Values.global.identity.image.registry }}/v2/"
}

WARN: Error obtaining docker token
{
  "registryHost": "https://{{ .Values.global.identity.image.registry }}"
  "dockerRepository": "{{ .Values.global.identity.image.repository }}{{ if .Values.global.identity.image.digest }}"
  "err": {
    "message": "Invalid URL",
    "stack": "Error: Invalid URL\n    at Http.resolveUrl (/usr/local/renovate/lib/util/http/http.ts:287:13)\n    at Http.request (/usr/local/renovate/lib/util/http/http.ts:123:30)\n    at Http.get (/usr/local/renovate/lib/util/http/http.ts:300:17)\n    at getAuthHeaders (/usr/local/renovate/lib/modules/datasource/docker/common.ts:65:20)\n    at DockerDatasource.getManifestResponse (/usr/local/renovate/lib/modules/datasource/docker/index.ts:109:43)\n    at DockerDatasource.getDigest (/usr/local/renovate/lib/modules/datasource/docker/index.ts:866:39)\n    at callback (/usr/local/renovate/lib/util/decorator/index.ts:55:34)\n    at /usr/local/renovate/lib/util/cache/package/decorator.ts:131:26\n    at processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at lookupUpdates (/usr/local/renovate/lib/workers/repository/process/lookup/index.ts:691:14)\n    at /usr/local/renovate/lib/workers/repository/process/fetch.ts:79:12\n    at Function.wrap (/usr/local/renovate/lib/util/stats.ts:38:20)\n    at /usr/local/renovate/lib/workers/repository/process/fetch.ts:125:23\n    at /usr/local/renovate/node_modules/.pnpm/p-map@4.0.0/node_modules/p-map/index.js:57:22"
  }
}

WARN: No docker auth found - returning
</details>

The gist is that renovate is trying to upgrade the keycloak initContainer, but it can't look up the image because the image is produced through a helm template, and is not an explicit image directly.

This patch disables renovate changes from the packageName called `{{ .Values.global.identity.image.registry }}/{{ .Values.global.identity.image.repository }}`

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
