### PR TITLE
fix: the region is mapped to the document store env

### DIFF
--- a/charts/camunda-platform-8.7/templates/camunda/configmap-documentstore.yaml
+++ b/charts/camunda-platform-8.7/templates/camunda/configmap-documentstore.yaml
@@ -15,6 +15,9 @@ data:
   {{- if .Values.global.documentStore.type.aws.bucketPath }}
   DOCUMENT_STORE_{{ $awsPrefix }}_BUCKET_PATH: {{ .Values.global.documentStore.type.aws.bucketPath | quote }}
   {{- end }}
+  {{- if .Values.global.documentStore.type.aws.region }}
+  AWS_REGION: {{ .Values.global.documentStore.type.aws.region | quote }}
+  {{- end }}
   {{- if .Values.global.documentStore.type.aws.bucketTtl }}
   DOCUMENT_STORE_{{ $awsPrefix }}_BUCKET_TTL: {{ .Values.global.documentStore.type.aws.bucketTtl | quote }}
   {{- end }}

--- a/charts/camunda-platform-8.8/templates/common/configmap-documentstore.yaml
+++ b/charts/camunda-platform-8.8/templates/common/configmap-documentstore.yaml
@@ -18,6 +18,9 @@ data:
   {{- if .Values.global.documentStore.type.aws.bucketTtl }}
   DOCUMENT_STORE_{{ $awsPrefix }}_BUCKET_TTL: {{ .Values.global.documentStore.type.aws.bucketTtl | quote }}
   {{- end }}
+  {{- if .Values.global.documentStore.type.aws.region }}
+  AWS_REGION: {{ .Values.global.documentStore.type.aws.region | quote }}
+  {{- end }}
   {{- else if eq $active "gcp" }}
     {{- $gcpPrefix := upper (default "GCP" .Values.global.documentStore.type.gcp.storeId) }}
   DOCUMENT_STORE_{{ $gcpPrefix }}_CLASS: {{ .Values.global.documentStore.type.gcp.class | quote }}


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

closes #3622 

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

This PR adds an optional env to the document store env configmap so that the aws region is mapped if aws is used.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
