### PR TITLE
fix: bump version in webModeler alpha to alpha5.1

### DIFF
--- a/charts/camunda-platform-8.8/README.md
+++ b/charts/camunda-platform-8.8/README.md
@@ -851,17 +851,17 @@ Please see the corresponding [release guide](../../docs/release.md) to find out 
 
 ### WebModeler Parameters
 
-| Name                           | Description                                                                                                                                   | Value          |
-| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
-| `webModeler.enabled`           | if true, the WebModeler deployment and its related resources are deployed via a helm release                                                  | `false`        |
-| `webModeler.fullnameOverride`  | can be used to override the full name of the WebModeler resources                                                                             | `""`           |
-| `webModeler.nameOverride`      | can be used to partly override the name of the WebModeler resources (names will still be prefixed with the release name)                      | `""`           |
-| `webModeler.image`             | configuration of the WebModeler Docker images                                                                                                 |                |
-| `webModeler.image.registry`    | can be used to set the Docker registry for the WebModeler images (overwrites global.image.registry)                                           | `""`           |
-| `webModeler.image.tag`         | can be used to set the Docker image tag for the WebModeler images (overwrites global.image.tag)                                               | `8.8.0-alpha5` |
-| `webModeler.image.digest`      | can be used to set image digest (overrides tag if set, e.g. "sha256:abcd...")                                                                 | `""`           |
-| `webModeler.image.pullSecrets` | can be used to configure image pull secrets, see https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod  | `[]`           |
-| `webModeler.contextPath`       | can be used to make WebModeler available on a custom sub-path. This is mainly used to run the Camunda web applications under a single domain. | `""`           |
+| Name                           | Description                                                                                                                                   | Value            |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `webModeler.enabled`           | if true, the WebModeler deployment and its related resources are deployed via a helm release                                                  | `false`          |
+| `webModeler.fullnameOverride`  | can be used to override the full name of the WebModeler resources                                                                             | `""`             |
+| `webModeler.nameOverride`      | can be used to partly override the name of the WebModeler resources (names will still be prefixed with the release name)                      | `""`             |
+| `webModeler.image`             | configuration of the WebModeler Docker images                                                                                                 |                  |
+| `webModeler.image.registry`    | can be used to set the Docker registry for the WebModeler images (overwrites global.image.registry)                                           | `""`             |
+| `webModeler.image.tag`         | can be used to set the Docker image tag for the WebModeler images (overwrites global.image.tag)                                               | `8.8.0-alpha5.1` |
+| `webModeler.image.digest`      | can be used to set image digest (overrides tag if set, e.g. "sha256:abcd...")                                                                 | `""`             |
+| `webModeler.image.pullSecrets` | can be used to configure image pull secrets, see https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod  | `[]`             |
+| `webModeler.contextPath`       | can be used to make WebModeler available on a custom sub-path. This is mainly used to run the Camunda web applications under a single domain. | `""`             |
 
 ### WebModeler - RestAPI Parameters
 

--- a/charts/camunda-platform-8.8/test/unit/web-modeler/golden/configmap-restapi.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/web-modeler/golden/configmap-restapi.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: web-modeler
-    app.kubernetes.io/version: "8.8.0-alpha5"
+    app.kubernetes.io/version: "8.8.0-alpha5.1"
   annotations:
     {}
 data:

--- a/charts/camunda-platform-8.8/test/unit/web-modeler/golden/configmap-shared.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/web-modeler/golden/configmap-shared.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: web-modeler
-    app.kubernetes.io/version: "8.8.0-alpha5"
+    app.kubernetes.io/version: "8.8.0-alpha5.1"
   annotations:
     {}
 data:

--- a/charts/camunda-platform-8.8/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -41,7 +41,7 @@ spec:
         []
       containers:
         - name: web-modeler-restapi
-          image: "camunda/web-modeler-restapi:8.8.0-alpha5"
+          image: "camunda/web-modeler-restapi:8.8.0-alpha5.1"
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/camunda-platform-8.8/test/unit/web-modeler/golden/deployment-webapp.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/web-modeler/golden/deployment-webapp.golden.yaml
@@ -41,7 +41,7 @@ spec:
         []
       containers:
         - name: web-modeler-webapp
-          image: "camunda/web-modeler-webapp:8.8.0-alpha5"
+          image: "camunda/web-modeler-webapp:8.8.0-alpha5.1"
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/camunda-platform-8.8/test/unit/web-modeler/golden/deployment-websockets.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/web-modeler/golden/deployment-websockets.golden.yaml
@@ -41,7 +41,7 @@ spec:
         []
       containers:
         - name: web-modeler-websockets
-          image: "camunda/web-modeler-websockets:8.8.0-alpha5"
+          image: "camunda/web-modeler-websockets:8.8.0-alpha5.1"
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/camunda-platform-8.8/test/unit/web-modeler/golden/secret-shared.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/web-modeler/golden/secret-shared.golden.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: web-modeler
-    app.kubernetes.io/version: "8.8.0-alpha5"
+    app.kubernetes.io/version: "8.8.0-alpha5.1"
   annotations:
     {}
 type: Opaque

--- a/charts/camunda-platform-8.8/test/unit/web-modeler/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/web-modeler/golden/serviceaccount.golden.yaml
@@ -11,5 +11,5 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: camunda-platform
     app.kubernetes.io/component: web-modeler
-    app.kubernetes.io/version: "8.8.0-alpha5"
+    app.kubernetes.io/version: "8.8.0-alpha5.1"
 automountServiceAccountToken: false

--- a/charts/camunda-platform-8.8/values.schema.json
+++ b/charts/camunda-platform-8.8/values.schema.json
@@ -2408,7 +2408,7 @@
                         "tag": {
                             "type": "string",
                             "description": "can be used to set the Docker image tag for the WebModeler images (overwrites global.image.tag)",
-                            "default": "8.8.0-alpha5"
+                            "default": "8.8.0-alpha5.1"
                         },
                         "digest": {
                             "type": "string",

--- a/charts/camunda-platform-8.8/values.yaml
+++ b/charts/camunda-platform-8.8/values.yaml
@@ -1274,7 +1274,7 @@ webModeler:
     registry: ""
     ## @param webModeler.image.tag can be used to set the Docker image tag for the WebModeler images (overwrites global.image.tag)
     # renovate: datasource=docker depName=camunda/web-modeler-restapi
-    tag: 8.8.0-alpha5
+    tag: 8.8.0-alpha5.1
     ## @param webModeler.image.digest can be used to set image digest (overrides tag if set, e.g. "sha256:abcd...")
     digest: ""
     ## @param webModeler.image.pullSecrets can be used to configure image pull secrets, see https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod


### PR DESCRIPTION
### Which problem does the PR fix?
bump version in webModeler alpha to alpha5.1
<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
