### PR TITLE
fix: cleanup multiregion installationtype

### DIFF
--- a/charts/camunda-platform-8.7/templates/zeebe/configmap.yaml
+++ b/charts/camunda-platform-8.7/templates/zeebe/configmap.yaml
@@ -104,11 +104,7 @@ data:
     #!/usr/bin/env bash
     set -eux -o pipefail
 
-{{- if eq .Values.global.multiregion.installationType "failOver" }}
-    export ZEEBE_BROKER_CLUSTER_NODEID=${ZEEBE_BROKER_CLUSTER_NODEID:-$[${K8S_NAME##*-} * 2 * {{.Values.global.multiregion.regions}} + {{.Values.global.multiregion.regionId}}]}
-{{- else }}
     export ZEEBE_BROKER_CLUSTER_NODEID=${ZEEBE_BROKER_CLUSTER_NODEID:-$[${K8S_NAME##*-} * {{.Values.global.multiregion.regions}} + {{.Values.global.multiregion.regionId}}]}
-{{- end }}
 
     if [ "$(ls -A /exporters/)" ]; then
       mkdir -p /usr/local/zeebe/exporters/
@@ -121,20 +117,13 @@ data:
 
     env
     {{- end }}
-{{- if eq .Values.global.multiregion.installationType "failBack" }}
-    if [ $[${K8S_NAME##*-} % 2] -eq 0 ]
-    then
-      trap : TERM INT; sleep infinity & wait
-    else
-      exec /usr/local/zeebe/bin/broker
-    fi
-{{- else }}
+
     if [ "${ZEEBE_RESTORE}" = "true" ]; then
       exec /usr/local/zeebe/bin/restore --backupId=${ZEEBE_RESTORE_FROM_BACKUP_ID}
     else
       exec /usr/local/zeebe/bin/broker
     fi
-{{- end }}
+
 
   broker-log4j2.xml: |
   {{- if .Values.zeebe.log4j2 }}

--- a/charts/camunda-platform-8.7/test/unit/zeebe/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform-8.7/test/unit/zeebe/golden/configmap-log4j2.golden.yaml
@@ -59,6 +59,7 @@ data:
   startup.sh: |
     #!/usr/bin/env bash
     set -eux -o pipefail
+
     export ZEEBE_BROKER_CLUSTER_NODEID=${ZEEBE_BROKER_CLUSTER_NODEID:-$[${K8S_NAME##*-} * 1 + 0]}
 
     if [ "$(ls -A /exporters/)" ]; then
@@ -67,11 +68,13 @@ data:
     else
       echo "No exporters available."
     fi
+
     if [ "${ZEEBE_RESTORE}" = "true" ]; then
       exec /usr/local/zeebe/bin/restore --backupId=${ZEEBE_RESTORE_FROM_BACKUP_ID}
     else
       exec /usr/local/zeebe/bin/broker
     fi
+
 
   broker-log4j2.xml: |
     <xml>

--- a/charts/camunda-platform-8.7/test/unit/zeebe/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.7/test/unit/zeebe/golden/configmap.golden.yaml
@@ -59,6 +59,7 @@ data:
   startup.sh: |
     #!/usr/bin/env bash
     set -eux -o pipefail
+
     export ZEEBE_BROKER_CLUSTER_NODEID=${ZEEBE_BROKER_CLUSTER_NODEID:-$[${K8S_NAME##*-} * 1 + 0]}
 
     if [ "$(ls -A /exporters/)" ]; then
@@ -67,10 +68,12 @@ data:
     else
       echo "No exporters available."
     fi
+
     if [ "${ZEEBE_RESTORE}" = "true" ]; then
       exec /usr/local/zeebe/bin/restore --backupId=${ZEEBE_RESTORE_FROM_BACKUP_ID}
     else
       exec /usr/local/zeebe/bin/broker
     fi
+
 
   broker-log4j2.xml: |


### PR DESCRIPTION
### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

Related to https://github.com/camunda/camunda-platform-helm/pull/3529

@jessesimpson36, @Langleu catched that we missed the removal of the following while removing the `global.multiregion.installationType`, see https://github.com/camunda/team-distribution/issues/408#issuecomment-2962838887


### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
