### PR TITLE
fix: schema type for `global.identity.auth.identity.existingSecret`

### DIFF
--- a/charts/camunda-platform-8.8/values.schema.json
+++ b/charts/camunda-platform-8.8/values.schema.json
@@ -546,11 +546,6 @@
                                             "description": "defines the audience, which is used by Identity.",
                                             "default": "camunda-identity-resource-server"
                                         },
-                                        "existingSecret": {
-                                            "type": "string",
-                                            "description": "can be used to reference an existing secret. This should ONLY be used for an external OIDC provider. If not set, a random secret is generated.",
-                                            "default": ""
-                                        },
                                         "existingSecretKey": {
                                             "type": "string",
                                             "description": "defines the key within the existing secret object.",

--- a/charts/camunda-platform-8.8/values.yaml
+++ b/charts/camunda-platform-8.8/values.yaml
@@ -331,7 +331,7 @@ global:
         clientId: camunda-identity
         ## @param global.identity.auth.identity.audience defines the audience, which is used by Identity.
         audience: camunda-identity-resource-server
-        ## @param global.identity.auth.identity.existingSecret can be used to reference an existing secret. This should ONLY be used for an external OIDC provider. If not set, a random secret is generated.
+        ## @param global.identity.auth.identity.existingSecret [string,object] can be used to reference an existing secret. This should ONLY be used for an external OIDC provider. If not set, a random secret is generated.
         existingSecret: ""
         ## @param global.identity.auth.identity.existingSecretKey defines the key within the existing secret object.
         existingSecretKey: identity-oidc-client-token


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
fixing the schema type or else this error is seen if the customer uses `global.identity.auth.identity.existingSecret.name`:
```
Error: INSTALLATION FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
camunda-platform:
- global.identity.auth.identity.existingSecret: Invalid type. Expected: string, given: object
```
### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
