### PR TITLE
feat: move disk settings to configmap

### DIFF
--- a/charts/camunda-platform-8.7/templates/zeebe/configmap.yaml
+++ b/charts/camunda-platform-8.7/templates/zeebe/configmap.yaml
@@ -77,6 +77,12 @@ data:
         threads:
           cpuThreadCount: {{ .Values.zeebe.cpuThreadCount  | quote }}
           ioThreadCount: {{ .Values.zeebe.ioThreadCount  | quote }}
+        data:
+          snapshotPeriod: {{ .Values.zeebe.data.snapshotPeriod | quote }}
+          disk:
+            freeSpace:
+              processing: {{ .Values.zeebe.data.disk.freeSpace.processing | quote }}
+              replication: {{ .Values.zeebe.data.disk.freeSpace.replication | quote }}
 
     # Camunda Database configuration
     {{- if .Values.global.elasticsearch.enabled }}

--- a/charts/camunda-platform-8.7/test/unit/zeebe/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform-8.7/test/unit/zeebe/golden/configmap-log4j2.golden.yaml
@@ -47,6 +47,12 @@ data:
         threads:
           cpuThreadCount: "3"
           ioThreadCount: "3"
+        data:
+          snapshotPeriod: "5m"
+          disk:
+            freeSpace:
+              processing: "2GB"
+              replication: "3GB"
 
     # Camunda Database configuration
     camunda.database:

--- a/charts/camunda-platform-8.7/test/unit/zeebe/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.7/test/unit/zeebe/golden/configmap.golden.yaml
@@ -47,6 +47,12 @@ data:
         threads:
           cpuThreadCount: "3"
           ioThreadCount: "3"
+        data:
+          snapshotPeriod: "5m"
+          disk:
+            freeSpace:
+              processing: "2GB"
+              replication: "3GB"
 
     # Camunda Database configuration
     camunda.database:

--- a/charts/camunda-platform-8.7/test/unit/zeebe/golden/statefulset.golden.yaml
+++ b/charts/camunda-platform-8.7/test/unit/zeebe/golden/statefulset.golden.yaml
@@ -96,12 +96,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: ZEEBE_BROKER_DATA_SNAPSHOTPERIOD
-              value: 5m
-            - name: ZEEBE_BROKER_DATA_DISK_FREESPACE_REPLICATION
-              value: 2GB
-            - name: ZEEBE_BROKER_DATA_DISK_FREESPACE_PROCESSING
-              value: 3GB
           envFrom:
             - configMapRef:
                 name: camunda-platform-test-documentstore-env-vars

--- a/charts/camunda-platform-8.7/values.yaml
+++ b/charts/camunda-platform-8.7/values.yaml
@@ -740,19 +740,7 @@ zeebe:
   ## @param zeebe.replicationFactor defines how each partition is replicated, the value defines the number of nodes
   replicationFactor: "3"
   ## @extra zeebe.env can be used to set extra environment variables in each zeebe broker container
-  env:
-    ## @param zeebe.env[0].name
-    ## @param zeebe.env[0].value
-    ## @param zeebe.env[1].name
-    ## @param zeebe.env[1].value
-    ## @param zeebe.env[2].name
-    ## @param zeebe.env[2].value
-    - name: ZEEBE_BROKER_DATA_SNAPSHOTPERIOD
-      value: "5m"
-    - name: ZEEBE_BROKER_DATA_DISK_FREESPACE_REPLICATION
-      value: "2GB"
-    - name: ZEEBE_BROKER_DATA_DISK_FREESPACE_PROCESSING
-      value: "3GB"
+  env: []
   ## @param zeebe.envFrom list of environment variables to import from configMapRef and secretRef
   envFrom: []
   ## @extra zeebe.configMap configuration which will be applied to the mounted config map.
@@ -844,6 +832,20 @@ zeebe:
   ## @param zeebe.pvcSelector can be used to specify a label selector for Zeebe's persistent volume claims for further filtering of the set of persistent volumes to select.
   # https://kubernetes.io/docs/concepts/storage/persistent-volumes/#selector
   pvcSelector: {}
+  ## @extra zeebe.data configuration to configure the data handling of the Zeebe broker pods
+  data:
+    ## @param zeebe.data.snapshotPeriod defines the period, after which a snapshot is created https://docs.camunda.io/docs/self-managed/zeebe-deployment/configuration/broker-config/#zeebebrokerdata
+    snapshotPeriod: "5m"
+    ## @extra zeebe.data.disk configuration to configure the disk storage of the Zeebe broker pods
+    disk:
+      ## @extra zeebe.data.disk.freeSpace configuration to configure the free space handling of the Zeebe broker pods
+      freeSpace:
+        ## @param zeebe.data.disk.freeSpace.processing the minimum free space which should be available on the disk, before the broker stops processing commands https://docs.camunda.io/docs/self-managed/zeebe-deployment/configuration/broker-config/#zeebebrokerdatadiskfreespace
+        processing: 2GB
+        ## @param zeebe.data.disk.freeSpace.replication the minimum free space which should be available on the disk, before the broker stops receicing replicated events https://docs.camunda.io/docs/self-managed/zeebe-deployment/configuration/broker-config/#zeebebrokerdatadiskfreespace
+        replication: 3GB
+
+  ## @param zeebe.
   ## @param zeebe.extraVolumes can be used to define extra volumes for the broker pods, useful for additional exporters
   extraVolumes: []
   ## @param zeebe.extraVolumeMounts can be used to mount extra volumes for the broker pods, useful for additional exporters


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

This PR fixes an issue that was flagged by @ingorichtsmeier : https://camunda.slack.com/archives/C03UR0V2R2M/p1750169144827329

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

This PR moves the env for zeebe that was previously part of the values to the zeebe configmap.

On top, it creates dedicated values to parameterize the configmap.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
