### PR TITLE
fix: call generate-version-matrix-unreleased in chart-release

### DIFF
--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -285,6 +285,7 @@ jobs:
           make helm.repos-add
           make release.generate-version-matrix-index
           make release.generate-version-matrix-released
+          make release.generate-version-matrix-unreleased
       # We use git-chglog to generate the release notes and release-please
       # doesn't have an option to disable the generation of CHANGELOG.md files.
       # https://github.com/googleapis/release-please/issues/2007


### PR DESCRIPTION
### Which problem does the PR fix?

#3689 

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
