### PR TITLE
fix: change volumePermissions image in web-modeler-postgresql

### DIFF
--- a/charts/web-modeler-postgresql/README.md
+++ b/charts/web-modeler-postgresql/README.md
@@ -369,18 +369,18 @@ kubectl delete pvc -l release=my-release
 
 ### Volume Permissions parameters
 
-| Name                                                   | Description                                                                                                                       | Value                   |
-| ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
-| `volumePermissions.enabled`                            | Enable init container that changes the owner and group of the persistent volume                                                   | `false`                 |
-| `volumePermissions.image.registry`                     | Init container volume-permissions image registry                                                                                  | `docker.io`             |
-| `volumePermissions.image.repository`                   | Init container volume-permissions image repository                                                                                | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`                          | Init container volume-permissions image tag (immutable tags are recommended)                                                      | `11-debian-11-r136`     |
-| `volumePermissions.image.digest`                       | Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                    |
-| `volumePermissions.image.pullPolicy`                   | Init container volume-permissions image pull policy                                                                               | `IfNotPresent`          |
-| `volumePermissions.image.pullSecrets`                  | Init container volume-permissions image pull secrets                                                                              | `[]`                    |
-| `volumePermissions.resources.limits`                   | Init container volume-permissions resource limits                                                                                 | `{}`                    |
-| `volumePermissions.resources.requests`                 | Init container volume-permissions resource requests                                                                               | `{}`                    |
-| `volumePermissions.containerSecurityContext.runAsUser` | User ID for the init container                                                                                                    | `0`                     |
+| Name                                                   | Description                                                                                                                       | Value               |
+| ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| `volumePermissions.enabled`                            | Enable init container that changes the owner and group of the persistent volume                                                   | `false`             |
+| `volumePermissions.image.registry`                     | Init container volume-permissions image registry                                                                                  | `docker.io`         |
+| `volumePermissions.image.repository`                   | Init container volume-permissions image repository                                                                                | `bitnami/os-shell`  |
+| `volumePermissions.image.tag`                          | Init container volume-permissions image tag (immutable tags are recommended)                                                      | `11-debian-11-r112` |
+| `volumePermissions.image.digest`                       | Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                |
+| `volumePermissions.image.pullPolicy`                   | Init container volume-permissions image pull policy                                                                               | `IfNotPresent`      |
+| `volumePermissions.image.pullSecrets`                  | Init container volume-permissions image pull secrets                                                                              | `[]`                |
+| `volumePermissions.resources.limits`                   | Init container volume-permissions resource limits                                                                                 | `{}`                |
+| `volumePermissions.resources.requests`                 | Init container volume-permissions resource requests                                                                               | `{}`                |
+| `volumePermissions.containerSecurityContext.runAsUser` | User ID for the init container                                                                                                    | `0`                 |
 
 ### Other Parameters
 

--- a/charts/web-modeler-postgresql/values.schema.json
+++ b/charts/web-modeler-postgresql/values.schema.json
@@ -1,156 +1,2107 @@
 {
-  "$schema": "http://json-schema.org/schema#",
-  "type": "object",
-  "properties": {
-    "architecture": {
-      "type": "string",
-      "title": "PostgreSQL architecture",
-      "form": true,
-      "description": "Allowed values: `standalone` or `replication`"
-    },
-    "auth": {
-      "type": "object",
-      "title": "Authentication configuration",
-      "form": true,
-      "properties": {
-        "enablePostgresUser": {
-          "type": "boolean",
-          "title": "Enable \"postgres\" admin user",
-          "description": "Assign a password to the \"postgres\" admin user. Otherwise, remote access will be blocked for this user",
-          "form": true
-        },
-        "postgresPassword": {
-          "type": "string",
-          "title": "Password for the \"postgres\" admin user",
-          "description": "Defaults to a random 10-character alphanumeric string if not set",
-          "form": true
-        },
-        "database": {
-          "type": "string",
-          "title": "PostgreSQL custom database",
-          "description": "Name of the custom database to be created during the 1st initialization of PostgreSQL",
-          "form": true
-        },
-        "username": {
-          "type": "string",
-          "title": "PostgreSQL custom user",
-          "description": "Name of the custom user to be created during the 1st initialization of PostgreSQL. This user only has permissions on the PostgreSQL custom database",
-          "form": true
-        },
-        "password": {
-          "type": "string",
-          "title": "Password for the custom user to create",
-          "description": "Defaults to a random 10-character alphanumeric string if not set",
-          "form": true
-        },
-        "replicationUsername": {
-          "type": "string",
-          "title": "PostgreSQL replication user",
-          "description": "Name of user used to manage replication.",
-          "form": true,
-          "hidden": {
-            "value": "standalone",
-            "path": "architecture"
-          }
-        },
-        "replicationPassword": {
-          "type": "string",
-          "title": "Password for PostgreSQL replication user",
-          "description": "Defaults to a random 10-character alphanumeric string if not set",
-          "form": true,
-          "hidden": {
-            "value": "standalone",
-            "path": "architecture"
-          }
-        }
-      }
-    },
-    "persistence": {
-      "type": "object",
-      "properties": {
-        "size": {
-          "type": "string",
-          "title": "Persistent Volume Size",
-          "form": true,
-          "render": "slider",
-          "sliderMin": 1,
-          "sliderMax": 100,
-          "sliderUnit": "Gi"
-        }
-      }
-    },
-    "resources": {
-      "type": "object",
-      "title": "Required Resources",
-      "description": "Configure resource requests",
-      "form": true,
-      "properties": {
-        "requests": {
-          "type": "object",
-          "properties": {
-            "memory": {
-              "type": "string",
-              "form": true,
-              "render": "slider",
-              "title": "Memory Request",
-              "sliderMin": 10,
-              "sliderMax": 2048,
-              "sliderUnit": "Mi"
-            },
-            "cpu": {
-              "type": "string",
-              "form": true,
-              "render": "slider",
-              "title": "CPU Request",
-              "sliderMin": 10,
-              "sliderMax": 2000,
-              "sliderUnit": "m"
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "imageRegistry": {
+                    "type": "string",
+                    "description": "Global Docker image registry",
+                    "default": ""
+                },
+                "imagePullSecrets": {
+                    "type": "array",
+                    "description": "Global Docker registry secret names as an array",
+                    "default": [],
+                    "items": {}
+                },
+                "storageClass": {
+                    "type": "string",
+                    "description": "Global StorageClass for Persistent Volume(s)",
+                    "default": ""
+                },
+                "postgresql": {
+                    "type": "object",
+                    "properties": {
+                        "auth": {
+                            "type": "object",
+                            "properties": {
+                                "postgresPassword": {
+                                    "type": "string",
+                                    "description": "Password for the \"postgres\" admin user (overrides `auth.postgresPassword`)",
+                                    "default": ""
+                                },
+                                "username": {
+                                    "type": "string",
+                                    "description": "Name for a custom user to create (overrides `auth.username`)",
+                                    "default": ""
+                                },
+                                "password": {
+                                    "type": "string",
+                                    "description": "Password for the custom user to create (overrides `auth.password`)",
+                                    "default": ""
+                                },
+                                "database": {
+                                    "type": "string",
+                                    "description": "Name for a custom database to create (overrides `auth.database`)",
+                                    "default": ""
+                                },
+                                "existingSecret": {
+                                    "type": "string",
+                                    "description": "Name of existing secret to use for PostgreSQL credentials (overrides `auth.existingSecret`).",
+                                    "default": ""
+                                },
+                                "secretKeys": {
+                                    "type": "object",
+                                    "properties": {
+                                        "adminPasswordKey": {
+                                            "type": "string",
+                                            "description": "Name of key in existing secret to use for PostgreSQL credentials (overrides `auth.secretKeys.adminPasswordKey`). Only used when `global.postgresql.auth.existingSecret` is set.",
+                                            "default": ""
+                                        },
+                                        "userPasswordKey": {
+                                            "type": "string",
+                                            "description": "Name of key in existing secret to use for PostgreSQL credentials (overrides `auth.secretKeys.userPasswordKey`). Only used when `global.postgresql.auth.existingSecret` is set.",
+                                            "default": ""
+                                        },
+                                        "replicationPasswordKey": {
+                                            "type": "string",
+                                            "description": "Name of key in existing secret to use for PostgreSQL credentials (overrides `auth.secretKeys.replicationPasswordKey`). Only used when `global.postgresql.auth.existingSecret` is set.",
+                                            "default": ""
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "ports": {
+                                    "type": "object",
+                                    "properties": {
+                                        "postgresql": {
+                                            "type": "string",
+                                            "description": "PostgreSQL service port (overrides `service.ports.postgresql`)",
+                                            "default": ""
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
-          }
-        }
-      }
-    },
-    "replication": {
-      "type": "object",
-      "form": true,
-      "title": "Replication Details",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Enable Replication",
-          "form": true
+        },
+        "kubeVersion": {
+            "type": "string",
+            "description": "Override Kubernetes version",
+            "default": ""
+        },
+        "nameOverride": {
+            "type": "string",
+            "description": "String to partially override common.names.fullname template (will maintain the release name)",
+            "default": ""
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "description": "String to fully override common.names.fullname template",
+            "default": ""
+        },
+        "clusterDomain": {
+            "type": "string",
+            "description": "Kubernetes Cluster Domain",
+            "default": "cluster.local"
+        },
+        "extraDeploy": {
+            "type": "array",
+            "description": "Array of extra objects to deploy with the release (evaluated as a template)",
+            "default": [],
+            "items": {}
+        },
+        "commonLabels": {
+            "type": "object",
+            "description": "Add labels to all the deployed resources",
+            "default": {}
+        },
+        "commonAnnotations": {
+            "type": "object",
+            "description": "Add annotations to all the deployed resources",
+            "default": {}
+        },
+        "diagnosticMode": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable diagnostic mode (all probes will be disabled and the command will be overridden)",
+                    "default": false
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Command to override all containers in the statefulset",
+                    "default": [
+                        "sleep"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Args to override all containers in the statefulset",
+                    "default": [
+                        "infinity"
+                    ],
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string",
+                    "description": "PostgreSQL image registry",
+                    "default": "docker.io"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "PostgreSQL image repository",
+                    "default": "bitnami/postgresql"
+                },
+                "tag": {
+                    "type": "string",
+                    "description": "PostgreSQL image tag (immutable tags are recommended)",
+                    "default": "14.18.0-debian-12-r0"
+                },
+                "digest": {
+                    "type": "string",
+                    "description": "PostgreSQL image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                    "default": ""
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "PostgreSQL image pull policy",
+                    "default": "IfNotPresent"
+                },
+                "pullSecrets": {
+                    "type": "array",
+                    "description": "Specify image pull secrets",
+                    "default": [],
+                    "items": {}
+                },
+                "debug": {
+                    "type": "boolean",
+                    "description": "Specify if debug values should be set",
+                    "default": false
+                }
+            }
+        },
+        "auth": {
+            "type": "object",
+            "properties": {
+                "enablePostgresUser": {
+                    "type": "boolean",
+                    "description": "Assign a password to the \"postgres\" admin user. Otherwise, remote access will be blocked for this user",
+                    "default": true
+                },
+                "postgresPassword": {
+                    "type": "string",
+                    "description": "Password for the \"postgres\" admin user. Ignored if `auth.existingSecret` with key `postgres-password` is provided",
+                    "default": ""
+                },
+                "username": {
+                    "type": "string",
+                    "description": "Name for a custom user to create",
+                    "default": ""
+                },
+                "password": {
+                    "type": "string",
+                    "description": "Password for the custom user to create. Ignored if `auth.existingSecret` with key `password` is provided",
+                    "default": ""
+                },
+                "database": {
+                    "type": "string",
+                    "description": "Name for a custom database to create",
+                    "default": ""
+                },
+                "replicationUsername": {
+                    "type": "string",
+                    "description": "Name of the replication user",
+                    "default": "repl_user"
+                },
+                "replicationPassword": {
+                    "type": "string",
+                    "description": "Password for the replication user. Ignored if `auth.existingSecret` with key `replication-password` is provided",
+                    "default": ""
+                },
+                "existingSecret": {
+                    "type": "string",
+                    "description": "Name of existing secret to use for PostgreSQL credentials. `auth.postgresPassword`, `auth.password`, and `auth.replicationPassword` will be ignored and picked up from this secret. The secret might also contains the key `ldap-password` if LDAP is enabled. `ldap.bind_password` will be ignored and picked from this secret in this case.",
+                    "default": ""
+                },
+                "secretKeys": {
+                    "type": "object",
+                    "properties": {
+                        "adminPasswordKey": {
+                            "type": "string",
+                            "description": "Name of key in existing secret to use for PostgreSQL credentials. Only used when `auth.existingSecret` is set.",
+                            "default": "postgres-password"
+                        },
+                        "userPasswordKey": {
+                            "type": "string",
+                            "description": "Name of key in existing secret to use for PostgreSQL credentials. Only used when `auth.existingSecret` is set.",
+                            "default": "password"
+                        },
+                        "replicationPasswordKey": {
+                            "type": "string",
+                            "description": "Name of key in existing secret to use for PostgreSQL credentials. Only used when `auth.existingSecret` is set.",
+                            "default": "replication-password"
+                        }
+                    }
+                },
+                "usePasswordFiles": {
+                    "type": "boolean",
+                    "description": "Mount credentials as a files instead of using an environment variable",
+                    "default": false
+                }
+            }
+        },
+        "architecture": {
+            "type": "string",
+            "description": "PostgreSQL architecture (`standalone` or `replication`)",
+            "default": "standalone"
+        },
+        "replication": {
+            "type": "object",
+            "properties": {
+                "synchronousCommit": {
+                    "type": "string",
+                    "description": "Set synchronous commit mode. Allowed values: `on`, `remote_apply`, `remote_write`, `local` and `off`",
+                    "default": "off"
+                },
+                "numSynchronousReplicas": {
+                    "type": "number",
+                    "description": "Number of replicas that will have synchronous replication. Note: Cannot be greater than `readReplicas.replicaCount`.",
+                    "default": 0
+                },
+                "applicationName": {
+                    "type": "string",
+                    "description": "Cluster application name. Useful for advanced replication settings",
+                    "default": "my_application"
+                }
+            }
+        },
+        "containerPorts": {
+            "type": "object",
+            "properties": {
+                "postgresql": {
+                    "type": "number",
+                    "description": "PostgreSQL container port",
+                    "default": 5432
+                }
+            }
+        },
+        "audit": {
+            "type": "object",
+            "properties": {
+                "logHostname": {
+                    "type": "boolean",
+                    "description": "Log client hostnames",
+                    "default": false
+                },
+                "logConnections": {
+                    "type": "boolean",
+                    "description": "Add client log-in operations to the log file",
+                    "default": false
+                },
+                "logDisconnections": {
+                    "type": "boolean",
+                    "description": "Add client log-outs operations to the log file",
+                    "default": false
+                },
+                "pgAuditLog": {
+                    "type": "string",
+                    "description": "Add operations to log using the pgAudit extension",
+                    "default": ""
+                },
+                "pgAuditLogCatalog": {
+                    "type": "string",
+                    "description": "Log catalog using pgAudit",
+                    "default": "off"
+                },
+                "clientMinMessages": {
+                    "type": "string",
+                    "description": "Message log level to share with the user",
+                    "default": "error"
+                },
+                "logLinePrefix": {
+                    "type": "string",
+                    "description": "Template for log line prefix (default if not set)",
+                    "default": ""
+                },
+                "logTimezone": {
+                    "type": "string",
+                    "description": "Timezone for the log timestamps",
+                    "default": ""
+                }
+            }
+        },
+        "ldap": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable LDAP support",
+                    "default": false
+                },
+                "server": {
+                    "type": "string",
+                    "description": "IP address or name of the LDAP server.",
+                    "default": ""
+                },
+                "port": {
+                    "type": "string",
+                    "description": "Port number on the LDAP server to connect to",
+                    "default": ""
+                },
+                "prefix": {
+                    "type": "string",
+                    "description": "String to prepend to the user name when forming the DN to bind",
+                    "default": ""
+                },
+                "suffix": {
+                    "type": "string",
+                    "description": "String to append to the user name when forming the DN to bind",
+                    "default": ""
+                },
+                "basedn": {
+                    "type": "string",
+                    "description": "Root DN to begin the search for the user in",
+                    "default": ""
+                },
+                "binddn": {
+                    "type": "string",
+                    "description": "DN of user to bind to LDAP",
+                    "default": ""
+                },
+                "bindpw": {
+                    "type": "string",
+                    "description": "Password for the user to bind to LDAP",
+                    "default": ""
+                },
+                "searchAttribute": {
+                    "type": "string",
+                    "description": "Attribute to match against the user name in the search",
+                    "default": ""
+                },
+                "searchFilter": {
+                    "type": "string",
+                    "description": "The search filter to use when doing search+bind authentication",
+                    "default": ""
+                },
+                "scheme": {
+                    "type": "string",
+                    "description": "Set to `ldaps` to use LDAPS",
+                    "default": ""
+                },
+                "tls": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Se to true to enable TLS encryption",
+                            "default": false
+                        }
+                    }
+                },
+                "uri": {
+                    "type": "string",
+                    "description": "LDAP URL beginning in the form `ldap[s]://host[:port]/basedn`. If provided, all the other LDAP parameters will be ignored.",
+                    "default": ""
+                }
+            }
+        },
+        "postgresqlDataDir": {
+            "type": "string",
+            "description": "PostgreSQL data dir folder",
+            "default": "/bitnami/postgresql/data"
+        },
+        "postgresqlSharedPreloadLibraries": {
+            "type": "string",
+            "description": "Shared preload libraries (comma-separated list)",
+            "default": "pgaudit"
+        },
+        "shmVolume": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable emptyDir volume for /dev/shm for PostgreSQL pod(s)",
+                    "default": true
+                },
+                "sizeLimit": {
+                    "type": "string",
+                    "description": "Set this to enable a size limit on the shm tmpfs",
+                    "default": ""
+                }
+            }
+        },
+        "tls": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable TLS traffic support",
+                    "default": false
+                },
+                "autoGenerated": {
+                    "type": "boolean",
+                    "description": "Generate automatically self-signed TLS certificates",
+                    "default": false
+                },
+                "preferServerCiphers": {
+                    "type": "boolean",
+                    "description": "Whether to use the server's TLS cipher preferences rather than the client's",
+                    "default": true
+                },
+                "certificatesSecret": {
+                    "type": "string",
+                    "description": "Name of an existing secret that contains the certificates",
+                    "default": ""
+                },
+                "certFilename": {
+                    "type": "string",
+                    "description": "Certificate filename",
+                    "default": ""
+                },
+                "certKeyFilename": {
+                    "type": "string",
+                    "description": "Certificate key filename",
+                    "default": ""
+                },
+                "certCAFilename": {
+                    "type": "string",
+                    "description": "CA Certificate filename",
+                    "default": ""
+                },
+                "crlFilename": {
+                    "type": "string",
+                    "description": "File containing a Certificate Revocation List",
+                    "default": ""
+                }
+            }
+        },
+        "primary": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Name of the primary database (eg primary, master, leader, ...)",
+                    "default": "primary"
+                },
+                "configuration": {
+                    "type": "string",
+                    "description": "PostgreSQL Primary main configuration to be injected as ConfigMap",
+                    "default": ""
+                },
+                "pgHbaConfiguration": {
+                    "type": "string",
+                    "description": "PostgreSQL Primary client authentication configuration",
+                    "default": ""
+                },
+                "existingConfigmap": {
+                    "type": "string",
+                    "description": "Name of an existing ConfigMap with PostgreSQL Primary configuration",
+                    "default": ""
+                },
+                "extendedConfiguration": {
+                    "type": "string",
+                    "description": "Extended PostgreSQL Primary configuration (appended to main or default configuration)",
+                    "default": ""
+                },
+                "existingExtendedConfigmap": {
+                    "type": "string",
+                    "description": "Name of an existing ConfigMap with PostgreSQL Primary extended configuration",
+                    "default": ""
+                },
+                "initdb": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "string",
+                            "description": "PostgreSQL initdb extra arguments",
+                            "default": ""
+                        },
+                        "postgresqlWalDir": {
+                            "type": "string",
+                            "description": "Specify a custom location for the PostgreSQL transaction log",
+                            "default": ""
+                        },
+                        "scripts": {
+                            "type": "object",
+                            "description": "Dictionary of initdb scripts",
+                            "default": {}
+                        },
+                        "scriptsConfigMap": {
+                            "type": "string",
+                            "description": "ConfigMap with scripts to be run at first boot",
+                            "default": ""
+                        },
+                        "scriptsSecret": {
+                            "type": "string",
+                            "description": "Secret with scripts to be run at first boot (in case it contains sensitive information)",
+                            "default": ""
+                        },
+                        "user": {
+                            "type": "string",
+                            "description": "Specify the PostgreSQL username to execute the initdb scripts",
+                            "default": ""
+                        },
+                        "password": {
+                            "type": "string",
+                            "description": "Specify the PostgreSQL password to execute the initdb scripts",
+                            "default": ""
+                        }
+                    }
+                },
+                "standby": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Whether to enable current cluster's primary as standby server of another cluster or not",
+                            "default": false
+                        },
+                        "primaryHost": {
+                            "type": "string",
+                            "description": "The Host of replication primary in the other cluster",
+                            "default": ""
+                        },
+                        "primaryPort": {
+                            "type": "string",
+                            "description": "The Port of replication primary in the other cluster",
+                            "default": ""
+                        }
+                    }
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to PostgreSQL Primary nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for PostgreSQL Primary nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for PostgreSQL Primary nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on PostgreSQL Primary containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on PostgreSQL Primary containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on PostgreSQL Primary containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the PostgreSQL Primary container to automate configuration before or after startup",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the PostgreSQL Primary containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "memory": {
+                                    "type": "string",
+                                    "description": "The requested memory for the PostgreSQL Primary containers",
+                                    "default": "256Mi"
+                                },
+                                "cpu": {
+                                    "type": "string",
+                                    "description": "The requested cpu for the PostgreSQL Primary containers",
+                                    "default": "250m"
+                                }
+                            }
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the pod",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable container security context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the container",
+                            "default": 1001
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "PostgreSQL primary pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "hostNetwork": {
+                    "type": "boolean",
+                    "description": "Specify if host network should be enabled for PostgreSQL pod (postgresql primary)",
+                    "default": false
+                },
+                "hostIPC": {
+                    "type": "boolean",
+                    "description": "Specify if host IPC should be enabled for PostgreSQL pod (postgresql primary)",
+                    "default": false
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Map of labels to add to the statefulset (postgresql primary)",
+                    "default": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for PostgreSQL primary pods",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Map of labels to add to the pods (postgresql primary)",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Map of annotations to add to the pods (postgresql primary)",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "PostgreSQL primary pod affinity preset. Ignored if `primary.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "PostgreSQL primary pod anti-affinity preset. Ignored if `primary.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "PostgreSQL primary node affinity preset type. Ignored if `primary.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "PostgreSQL primary node label key to match Ignored if `primary.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "PostgreSQL primary node label values to match. Ignored if `primary.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for PostgreSQL primary pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for PostgreSQL primary pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for PostgreSQL primary pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Priority Class to use for each pod (postgresql primary)",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Use an alternate scheduler, e.g. \"stork\".",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds PostgreSQL primary pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "PostgreSQL Primary statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "PostgreSQL Primary statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the PostgreSQL Primary container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the PostgreSQL Primary pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the PostgreSQL Primary pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the PostgreSQL Primary pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPodSpec": {
+                    "type": "object",
+                    "description": "Optionally specify extra PodSpec for the PostgreSQL Primary pod(s)",
+                    "default": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes Service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "postgresql": {
+                                    "type": "number",
+                                    "description": "PostgreSQL service port",
+                                    "default": 5432
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "postgresql": {
+                                    "type": "string",
+                                    "description": "Node port for PostgreSQL",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Static clusterIP or None for headless services",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for PostgreSQL primary service",
+                            "default": {}
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Load balancer IP if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Enable client source IP preservation",
+                            "default": "Cluster"
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Addresses that are allowed when service is LoadBalancer",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the PostgreSQL primary service",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable PostgreSQL Primary data persistence using PVC",
+                            "default": true
+                        },
+                        "existingClaim": {
+                            "type": "string",
+                            "description": "Name of an existing PVC to use",
+                            "default": ""
+                        },
+                        "mountPath": {
+                            "type": "string",
+                            "description": "The path the volume will be mounted at",
+                            "default": "/bitnami/postgresql"
+                        },
+                        "subPath": {
+                            "type": "string",
+                            "description": "The subdirectory of the volume to mount to",
+                            "default": ""
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "PVC Storage Class for PostgreSQL Primary data volume",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "PVC Access Mode for PostgreSQL volume",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "PVC Storage Request for PostgreSQL volume",
+                            "default": "8Gi"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the PVC",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Labels for the PVC",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Selector to match an existing Persistent Volume (this value is evaluated as a template)",
+                            "default": {}
+                        },
+                        "dataSource": {
+                            "type": "object",
+                            "description": "Custom PVC data source",
+                            "default": {}
+                        }
+                    }
+                }
+            }
         },
         "readReplicas": {
-          "type": "integer",
-          "title": "read Replicas",
-          "form": true,
-          "hidden": {
-            "value": "standalone",
-            "path": "architecture"
-          }
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Name of the read replicas database (eg secondary, slave, ...)",
+                    "default": "read"
+                },
+                "replicaCount": {
+                    "type": "number",
+                    "description": "Number of PostgreSQL read only replicas",
+                    "default": 1
+                },
+                "extendedConfiguration": {
+                    "type": "string",
+                    "description": "Extended PostgreSQL read only replicas configuration (appended to main or default configuration)",
+                    "default": ""
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Array with extra environment variables to add to PostgreSQL read only nodes",
+                    "default": [],
+                    "items": {}
+                },
+                "extraEnvVarsCM": {
+                    "type": "string",
+                    "description": "Name of existing ConfigMap containing extra env vars for PostgreSQL read only nodes",
+                    "default": ""
+                },
+                "extraEnvVarsSecret": {
+                    "type": "string",
+                    "description": "Name of existing Secret containing extra env vars for PostgreSQL read only nodes",
+                    "default": ""
+                },
+                "command": {
+                    "type": "array",
+                    "description": "Override default container command (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "args": {
+                    "type": "array",
+                    "description": "Override default container args (useful when using custom images)",
+                    "default": [],
+                    "items": {}
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on PostgreSQL read only containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on PostgreSQL read only containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on PostgreSQL read only containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 30
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "lifecycleHooks": {
+                    "type": "object",
+                    "description": "for the PostgreSQL read only container to automate configuration before or after startup",
+                    "default": {}
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the PostgreSQL read only containers",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "memory": {
+                                    "type": "string",
+                                    "description": "The requested memory for the PostgreSQL read only containers",
+                                    "default": "256Mi"
+                                },
+                                "cpu": {
+                                    "type": "string",
+                                    "description": "The requested cpu for the PostgreSQL read only containers",
+                                    "default": "250m"
+                                }
+                            }
+                        }
+                    }
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable security context",
+                            "default": true
+                        },
+                        "fsGroup": {
+                            "type": "number",
+                            "description": "Group ID for the pod",
+                            "default": 1001
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable container security context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the container",
+                            "default": 1001
+                        }
+                    }
+                },
+                "hostAliases": {
+                    "type": "array",
+                    "description": "PostgreSQL read only pods host aliases",
+                    "default": [],
+                    "items": {}
+                },
+                "hostNetwork": {
+                    "type": "boolean",
+                    "description": "Specify if host network should be enabled for PostgreSQL pod (PostgreSQL read only)",
+                    "default": false
+                },
+                "hostIPC": {
+                    "type": "boolean",
+                    "description": "Specify if host IPC should be enabled for PostgreSQL pod (postgresql primary)",
+                    "default": false
+                },
+                "labels": {
+                    "type": "object",
+                    "description": "Map of labels to add to the statefulset (PostgreSQL read only)",
+                    "default": {}
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Annotations for PostgreSQL read only pods",
+                    "default": {}
+                },
+                "podLabels": {
+                    "type": "object",
+                    "description": "Map of labels to add to the pods (PostgreSQL read only)",
+                    "default": {}
+                },
+                "podAnnotations": {
+                    "type": "object",
+                    "description": "Map of annotations to add to the pods (PostgreSQL read only)",
+                    "default": {}
+                },
+                "podAffinityPreset": {
+                    "type": "string",
+                    "description": "PostgreSQL read only pod affinity preset. Ignored if `primary.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": ""
+                },
+                "podAntiAffinityPreset": {
+                    "type": "string",
+                    "description": "PostgreSQL read only pod anti-affinity preset. Ignored if `primary.affinity` is set. Allowed values: `soft` or `hard`",
+                    "default": "soft"
+                },
+                "nodeAffinityPreset": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "PostgreSQL read only node affinity preset type. Ignored if `primary.affinity` is set. Allowed values: `soft` or `hard`",
+                            "default": ""
+                        },
+                        "key": {
+                            "type": "string",
+                            "description": "PostgreSQL read only node label key to match Ignored if `primary.affinity` is set.",
+                            "default": ""
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "PostgreSQL read only node label values to match. Ignored if `primary.affinity` is set.",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "affinity": {
+                    "type": "object",
+                    "description": "Affinity for PostgreSQL read only pods assignment",
+                    "default": {}
+                },
+                "nodeSelector": {
+                    "type": "object",
+                    "description": "Node labels for PostgreSQL read only pods assignment",
+                    "default": {}
+                },
+                "tolerations": {
+                    "type": "array",
+                    "description": "Tolerations for PostgreSQL read only pods assignment",
+                    "default": [],
+                    "items": {}
+                },
+                "topologySpreadConstraints": {
+                    "type": "array",
+                    "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+                    "default": [],
+                    "items": {}
+                },
+                "priorityClassName": {
+                    "type": "string",
+                    "description": "Priority Class to use for each pod (PostgreSQL read only)",
+                    "default": ""
+                },
+                "schedulerName": {
+                    "type": "string",
+                    "description": "Use an alternate scheduler, e.g. \"stork\".",
+                    "default": ""
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "string",
+                    "description": "Seconds PostgreSQL read only pod needs to terminate gracefully",
+                    "default": ""
+                },
+                "updateStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "PostgreSQL read only statefulset strategy type",
+                            "default": "RollingUpdate"
+                        },
+                        "rollingUpdate": {
+                            "type": "object",
+                            "description": "PostgreSQL read only statefulset rolling update configuration parameters",
+                            "default": {}
+                        }
+                    }
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumeMounts for the PostgreSQL read only container(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "description": "Optionally specify extra list of additional volumes for the PostgreSQL read only pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "sidecars": {
+                    "type": "array",
+                    "description": "Add additional sidecar containers to the PostgreSQL read only pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "initContainers": {
+                    "type": "array",
+                    "description": "Add additional init containers to the PostgreSQL read only pod(s)",
+                    "default": [],
+                    "items": {}
+                },
+                "extraPodSpec": {
+                    "type": "object",
+                    "description": "Optionally specify extra PodSpec for the PostgreSQL read only pod(s)",
+                    "default": {}
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Kubernetes Service type",
+                            "default": "ClusterIP"
+                        },
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "postgresql": {
+                                    "type": "number",
+                                    "description": "PostgreSQL service port",
+                                    "default": 5432
+                                }
+                            }
+                        },
+                        "nodePorts": {
+                            "type": "object",
+                            "properties": {
+                                "postgresql": {
+                                    "type": "string",
+                                    "description": "Node port for PostgreSQL",
+                                    "default": ""
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Static clusterIP or None for headless services",
+                            "default": ""
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for PostgreSQL read only service",
+                            "default": {}
+                        },
+                        "loadBalancerIP": {
+                            "type": "string",
+                            "description": "Load balancer IP if service type is `LoadBalancer`",
+                            "default": ""
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string",
+                            "description": "Enable client source IP preservation",
+                            "default": "Cluster"
+                        },
+                        "loadBalancerSourceRanges": {
+                            "type": "array",
+                            "description": "Addresses that are allowed when service is LoadBalancer",
+                            "default": [],
+                            "items": {}
+                        },
+                        "extraPorts": {
+                            "type": "array",
+                            "description": "Extra ports to expose in the PostgreSQL read only service",
+                            "default": [],
+                            "items": {}
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Session Affinity for Kubernetes service, can be \"None\" or \"ClientIP\"",
+                            "default": "None"
+                        },
+                        "sessionAffinityConfig": {
+                            "type": "object",
+                            "description": "Additional settings for the sessionAffinity",
+                            "default": {}
+                        }
+                    }
+                },
+                "persistence": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable PostgreSQL read only data persistence using PVC",
+                            "default": true
+                        },
+                        "existingClaim": {
+                            "type": "string",
+                            "description": "Name of an existing PVC to use",
+                            "default": ""
+                        },
+                        "mountPath": {
+                            "type": "string",
+                            "description": "The path the volume will be mounted at",
+                            "default": "/bitnami/postgresql"
+                        },
+                        "subPath": {
+                            "type": "string",
+                            "description": "The subdirectory of the volume to mount to",
+                            "default": ""
+                        },
+                        "storageClass": {
+                            "type": "string",
+                            "description": "PVC Storage Class for PostgreSQL read only data volume",
+                            "default": ""
+                        },
+                        "accessModes": {
+                            "type": "array",
+                            "description": "PVC Access Mode for PostgreSQL volume",
+                            "default": [
+                                "ReadWriteOnce"
+                            ],
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "string",
+                            "description": "PVC Storage Request for PostgreSQL volume",
+                            "default": "8Gi"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "Annotations for the PVC",
+                            "default": {}
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Labels for the PVC",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Selector to match an existing Persistent Volume (this value is evaluated as a template)",
+                            "default": {}
+                        },
+                        "dataSource": {
+                            "type": "object",
+                            "description": "Custom PVC data source",
+                            "default": {}
+                        }
+                    }
+                }
+            }
+        },
+        "networkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable network policies",
+                    "default": false
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable network policies for metrics (prometheus)",
+                            "default": false
+                        }
+                    }
+                },
+                "ingressRules": {
+                    "type": "object",
+                    "properties": {
+                        "primaryAccessOnlyFrom": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable ingress rule that makes PostgreSQL primary node only accessible from a particular origin.",
+                                    "default": false
+                                }
+                            }
+                        },
+                        "readReplicasAccessOnlyFrom": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean",
+                                    "description": "Enable ingress rule that makes PostgreSQL read-only nodes only accessible from a particular origin.",
+                                    "default": false
+                                }
+                            }
+                        }
+                    }
+                },
+                "egressRules": {
+                    "type": "object",
+                    "properties": {
+                        "denyConnectionsToExternal": {
+                            "type": "boolean",
+                            "description": "Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).",
+                            "default": false
+                        }
+                    }
+                }
+            }
+        },
+        "volumePermissions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable init container that changes the owner and group of the persistent volume",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image repository",
+                            "default": "bitnami/os-shell"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image tag (immutable tags are recommended)",
+                            "default": "11-debian-11-r112"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "Init container volume-permissions image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Init container volume-permissions image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "Init container volume-permissions resource limits",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "Init container volume-permissions resource requests",
+                            "default": {}
+                        }
+                    }
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "User ID for the init container",
+                            "default": 0
+                        }
+                    }
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Enable creation of ServiceAccount for PostgreSQL pod",
+                    "default": false
+                },
+                "name": {
+                    "type": "string",
+                    "description": "The name of the ServiceAccount to use.",
+                    "default": ""
+                },
+                "automountServiceAccountToken": {
+                    "type": "boolean",
+                    "description": "Allows auto mount of ServiceAccountToken on the serviceAccount created",
+                    "default": true
+                },
+                "annotations": {
+                    "type": "object",
+                    "description": "Additional custom annotations for the ServiceAccount",
+                    "default": {}
+                }
+            }
+        },
+        "rbac": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Create Role and RoleBinding (required for PSP to work)",
+                    "default": false
+                },
+                "rules": {
+                    "type": "array",
+                    "description": "Custom RBAC rules to set",
+                    "default": [],
+                    "items": {}
+                }
+            }
+        },
+        "psp": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "description": "Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later",
+                    "default": false
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Start a prometheus exporter",
+                    "default": false
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string",
+                            "description": "PostgreSQL Prometheus Exporter image registry",
+                            "default": "docker.io"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "description": "PostgreSQL Prometheus Exporter image repository",
+                            "default": "bitnami/postgres-exporter"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "description": "PostgreSQL Prometheus Exporter image tag (immutable tags are recommended)",
+                            "default": "0.17.1"
+                        },
+                        "digest": {
+                            "type": "string",
+                            "description": "PostgreSQL image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag",
+                            "default": ""
+                        },
+                        "pullPolicy": {
+                            "type": "string",
+                            "description": "PostgreSQL Prometheus Exporter image pull policy",
+                            "default": "IfNotPresent"
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "description": "Specify image pull secrets",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                },
+                "customMetrics": {
+                    "type": "object",
+                    "description": "Define additional custom metrics",
+                    "default": {}
+                },
+                "extraEnvVars": {
+                    "type": "array",
+                    "description": "Extra environment variables to add to PostgreSQL Prometheus exporter",
+                    "default": [],
+                    "items": {}
+                },
+                "containerSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable PostgreSQL Prometheus exporter containers' Security Context",
+                            "default": true
+                        },
+                        "runAsUser": {
+                            "type": "number",
+                            "description": "Set PostgreSQL Prometheus exporter containers' Security Context runAsUser",
+                            "default": 1001
+                        },
+                        "runAsNonRoot": {
+                            "type": "boolean",
+                            "description": "Set PostgreSQL Prometheus exporter containers' Security Context runAsNonRoot",
+                            "default": true
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable livenessProbe on PostgreSQL Prometheus exporter containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for livenessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for livenessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for livenessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for livenessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable readinessProbe on PostgreSQL Prometheus exporter containers",
+                            "default": true
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for readinessProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for readinessProbe",
+                            "default": 5
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for readinessProbe",
+                            "default": 6
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for readinessProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Enable startupProbe on PostgreSQL Prometheus exporter containers",
+                            "default": false
+                        },
+                        "initialDelaySeconds": {
+                            "type": "number",
+                            "description": "Initial delay seconds for startupProbe",
+                            "default": 10
+                        },
+                        "periodSeconds": {
+                            "type": "number",
+                            "description": "Period seconds for startupProbe",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "type": "number",
+                            "description": "Timeout seconds for startupProbe",
+                            "default": 1
+                        },
+                        "failureThreshold": {
+                            "type": "number",
+                            "description": "Failure threshold for startupProbe",
+                            "default": 15
+                        },
+                        "successThreshold": {
+                            "type": "number",
+                            "description": "Success threshold for startupProbe",
+                            "default": 1
+                        }
+                    }
+                },
+                "customLivenessProbe": {
+                    "type": "object",
+                    "description": "Custom livenessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customReadinessProbe": {
+                    "type": "object",
+                    "description": "Custom readinessProbe that overrides the default one",
+                    "default": {}
+                },
+                "customStartupProbe": {
+                    "type": "object",
+                    "description": "Custom startupProbe that overrides the default one",
+                    "default": {}
+                },
+                "containerPorts": {
+                    "type": "object",
+                    "properties": {
+                        "metrics": {
+                            "type": "number",
+                            "description": "PostgreSQL Prometheus exporter metrics container port",
+                            "default": 9187
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "description": "The resources limits for the PostgreSQL Prometheus exporter container",
+                            "default": {}
+                        },
+                        "requests": {
+                            "type": "object",
+                            "description": "The requested resources for the PostgreSQL Prometheus exporter container",
+                            "default": {}
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "ports": {
+                            "type": "object",
+                            "properties": {
+                                "metrics": {
+                                    "type": "number",
+                                    "description": "PostgreSQL Prometheus Exporter service port",
+                                    "default": 9187
+                                }
+                            }
+                        },
+                        "clusterIP": {
+                            "type": "string",
+                            "description": "Static clusterIP or None for headless services",
+                            "default": ""
+                        },
+                        "sessionAffinity": {
+                            "type": "string",
+                            "description": "Control where client requests go, to the same pod or round-robin",
+                            "default": "None"
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create ServiceMonitor Resource for scraping metrics using Prometheus Operator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace for the ServiceMonitor Resource (defaults to the Release Namespace)",
+                            "default": ""
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": "Interval at which metrics should be scraped.",
+                            "default": ""
+                        },
+                        "scrapeTimeout": {
+                            "type": "string",
+                            "description": "Timeout after which the scrape is ended",
+                            "default": ""
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so ServiceMonitor will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "selector": {
+                            "type": "object",
+                            "description": "Prometheus instance selector labels",
+                            "default": {}
+                        },
+                        "relabelings": {
+                            "type": "array",
+                            "description": "RelabelConfigs to apply to samples before scraping",
+                            "default": [],
+                            "items": {}
+                        },
+                        "metricRelabelings": {
+                            "type": "array",
+                            "description": "MetricRelabelConfigs to apply to samples before ingestion",
+                            "default": [],
+                            "items": {}
+                        },
+                        "honorLabels": {
+                            "type": "boolean",
+                            "description": "Specify honorLabels parameter to add the scrape endpoint",
+                            "default": false
+                        },
+                        "jobLabel": {
+                            "type": "string",
+                            "description": "The name of the label on the target service to use as the job name in prometheus.",
+                            "default": ""
+                        }
+                    }
+                },
+                "prometheusRule": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Create a PrometheusRule for Prometheus Operator",
+                            "default": false
+                        },
+                        "namespace": {
+                            "type": "string",
+                            "description": "Namespace for the PrometheusRule Resource (defaults to the Release Namespace)",
+                            "default": ""
+                        },
+                        "labels": {
+                            "type": "object",
+                            "description": "Additional labels that can be used so PrometheusRule will be discovered by Prometheus",
+                            "default": {}
+                        },
+                        "rules": {
+                            "type": "array",
+                            "description": "PrometheusRule definitions",
+                            "default": [],
+                            "items": {}
+                        }
+                    }
+                }
+            }
         }
-      }
-    },
-    "volumePermissions": {
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "form": true,
-          "title": "Enable Init Containers",
-          "description": "Change the owner of the persist volume mountpoint to RunAsUser:fsGroup"
-        }
-      }
-    },
-    "metrics": {
-      "type": "object",
-      "properties": {
-        "enabled": {
-          "type": "boolean",
-          "title": "Configure metrics exporter",
-          "form": true
-        }
-      }
     }
-  }
 }

--- a/charts/web-modeler-postgresql/values.yaml
+++ b/charts/web-modeler-postgresql/values.yaml
@@ -1117,8 +1117,8 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    repository: bitnami/bitnami-shell
-    tag: 11-debian-11-r136
+    repository: bitnami/os-shell
+    tag: 11-debian-11-r112
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
### What's in this PR?

Changed the image volumePermissions and downgraded the image tag from `11-debian-11-r136` to `11-debian-11-r112`, as the newer image doesn't exist anymore.
