### PR TITLE
fix: connectors inbound disabled mode

### DIFF
--- a/charts/camunda-platform-8.7/templates/connectors/configmap.yaml
+++ b/charts/camunda-platform-8.7/templates/connectors/configmap.yaml
@@ -55,6 +55,11 @@ data:
         profile: "simple"
         {{- end }}
     {{- end }}
+    {{- if eq .Values.connectors.inbound.mode "disabled" }}
+    operate:
+      client:
+        enabled: false
+    {{- end }}
   {{- end }}
 
 {{- range $key, $val := .Values.connectors.extraConfiguration }}


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes: https://github.com/camunda/camunda-platform-helm/issues/3696
Related to:
- https://github.com/camunda/connectors/pull/4897
- https://github.com/camunda/camunda-platform-helm/pull/3679


### What's in this PR?

Add the needed config to make the Connectors' inbound disabled mode work.

Without this option, Connectors will not start and log an error like:

```
Caused by: java.lang.IllegalStateException: Property 'operate.client.profile' is required
	at io.camunda.operate.spring.OperateClientConfiguration.operateAuthentication(OperateClientConfiguration.java:63)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Unknown Source)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.lambda$instantiate$0(SimpleInstantiationStrategy.java:171)
	... 122 common frames omitted
```
