### PR TITLE
fix: resume alpha upgrades by renovate post-alpha6

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -377,7 +377,7 @@
         // bump these to whatever the latest alpha is
         'charts/camunda-platform-8.8/Chart.yaml',
       ],
-      versioning: 'regex:^(?<major>\\d+)(.(?<minor>\\d+))(.(?<patch>\\d+))(-(?<prerelease>alpha[1-6]))$',
+      versioning: 'regex:^(?<major>\\d+)(.(?<minor>\\d+))(.(?<patch>\\d+))(-(?<prerelease>alpha[1-9]))$',
     },
     //
     // General.
@@ -398,7 +398,7 @@
       ],
       // Ignore non-semver versions like 8.6.0-alpha3-rc3 which has a higher precedence than 8.6.0-alpha3
       // which is not the case.
-      versionCompatibility: '^(?<version>\\d+.\\d+.\\d+(-alpha[1-6])?)(?<compatibility>.*)$',
+      versionCompatibility: '^(?<version>\\d+.\\d+.\\d+(-alpha[1-9])?)(?<compatibility>.*)$',
       // setting versioning to semver is important because by default docker versioning will
       // assume that anything after the dash is a compatibility rather than a prerelease
       // indicator. Some docker images have versions like 8.5.0-alpine but in camunda
@@ -417,7 +417,7 @@
       matchFileNames: [
         'charts/camunda-platform-8.8/Chart.yaml',
       ],
-      versioning: 'regex:^(?<major>\\d+)(.(?<minor>\\d+))(.(?<patch>\\d+))(-(?<prerelease>alpha[1-6]))$',
+      versioning: 'regex:^(?<major>\\d+)(.(?<minor>\\d+))(.(?<patch>\\d+))(-(?<prerelease>alpha[1-9]))$',
     },
     {
       enabled: true,
@@ -435,7 +435,7 @@
       ],
       // Ignore non-semver versions like 8.6.0-alpha3-rc3 which has a higher precedence than 8.6.0-alpha3
       // which is not the case.
-      versionCompatibility: '^(?<version>\\d+.\\d+.\\d+-alpha[1-6])(?<compatibility>.*)$',
+      versionCompatibility: '^(?<version>\\d+.\\d+.\\d+-alpha[1-9])(?<compatibility>.*)$',
       versioning: 'semver',
     },
     {


### PR DESCRIPTION
### Which problem does the PR fix?

fixes https://github.com/camunda/camunda-platform-helm/issues/3714

in .github/renovate.json5, we have a hard-coded maximum alpha number that we do not upgrade past. That number is alpha6, and we did not expect to exceed this number because that represents 6 months after a minor release (time for the next minor). But 8.8 is special in that we started releasing 8.8 alpha's prior to the official minor release of 8.7.


<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?


I propose that we up this value to alpha9. Historically, we did not have a maximum on the alpha number, but we found that application teams would sometimes publish debug images under camunda/camunda:8.8-alpha99. We wanted to avoid upgrades to such versions, which is also why adding a + to the regex isn't the best solution here.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
