### PR TITLE
ci: remove pr trigger from nightly testing

### DIFF
--- a/.github/workflows/test-chart-version-nightly.yaml
+++ b/.github/workflows/test-chart-version-nightly.yaml
@@ -2,15 +2,6 @@
 name: "Test - Chart Version Nightly"
 
 on:
-  pull_request:
-    paths:
-      - ".github/workflows/chart-validate-template.yaml"
-      - ".github/workflows/test-unit-template.yml"
-      - ".github/workflows/test-integration-template.yaml"
-      - ".github/workflows/test-chart-version-nightly-template.yaml"
-      - ".github/workflows/test-chart-version-nightly.yaml"
-      - ".tool-versions"
-      - "charts/camunda-platform-8*/**"
   schedule:
     # Set the cron schedule to run nightly at midnight US time, EST (4AM UTC)
     - cron: "0 4 * * *"


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
