### PR TITLE
fix: add existingSecret object to core

### DIFF
--- a/charts/camunda-platform-8.8/templates/camunda/secret-core.yaml
+++ b/charts/camunda-platform-8.8/templates/camunda/secret-core.yaml
@@ -1,0 +1,11 @@
+{{- if and (.Values.global.identity.auth.enabled) (or (not .Values.global.identity.auth.core.existingSecret) (typeIs "string" .Values.global.identity.auth.core.existingSecret)) }}
+{{- $secretName := include "camundaPlatform.identitySecretName" (dict "context" . "component" "core") }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels: {{- include "camundaPlatform.identityLabels" . | nindent 4 }}
+type: Opaque
+data:
+  {{ .Values.global.identity.auth.core.existingSecretKey }}: {{ include "common.secrets.passwords.manage" (dict "secret" $secretName "key" .Values.global.identity.auth.core.existingSecretKey "length" 10 "providedValues" (list "global.identity.auth.core.existingSecret") "context" $) }}
+{{- end }} 


### PR DESCRIPTION
### Which problem does the PR fix?

Closes: https://github.com/camunda/camunda-platform-helm/issues/3492

### What's in this PR?

Implements existingSecret handling for global.identity.auth.core as currently is for global.identity.auth.optimize.
Allowing for a plaintext override for VALUES_CAMUNDA_CORE_CLIENT_SECRET for testing purposes when set to a string directly.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
