### PR TITLE
fix: remove the metadata in the namespace name

### DIFF
--- a/.github/workflows/test-chart-version-nightly-template.yaml
+++ b/.github/workflows/test-chart-version-nightly-template.yaml
@@ -51,7 +51,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/test-integration-template.yaml
     with:
-      identifier: "${{ inputs.scenario }}-${{ inputs.camunda-version }}-${{ inputs.auth }}"
+      identifier: "${{ inputs.camunda-version }}"
       platforms: "gke"
       flows: "install,upgrade"
       camunda-helm-dir: "camunda-platform-${{ inputs.camunda-version }}"

--- a/.github/workflows/test-chart-version-template.yaml
+++ b/.github/workflows/test-chart-version-template.yaml
@@ -66,7 +66,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/test-integration-template.yaml
     with:
-      identifier: "${{ github.event.pull_request.number }}-${{ inputs.scenario }}-intg-${{ inputs.camunda-version }}-${{ inputs.auth }}"
+      identifier: "${{ github.event.pull_request.number }}-intg-${{ inputs.camunda-version }}"
       deployment-ttl: "${{ contains(github.event.pull_request.labels.*.name, 'test-persistent') && '1w' || '' }}"
       platforms: "gke"
       flows: "install,upgrade"

--- a/charts/camunda-platform-8.8/Chart.yaml
+++ b/charts/camunda-platform-8.8/Chart.yaml
@@ -93,3 +93,4 @@ annotations:
       description: "Restore the original Zeebe startup script behaviour for backup operations"
     - kind: fixed
       description: "Readd Zeebe NodeId logic from multi-region for 8.8"
+


### PR DESCRIPTION



### Which problem does the PR fix?

A recent change introduced extra metadata into the namespace name https://github.com/camunda/camunda-platform-helm/pull/3675

One change that was made is that in the namespace name, the scenario is added to the namespace.

This part of the change is not okay because it further increases the likelihood of running into the 63 char limit and gives us the annoyingly confusing issue  where the namespace from the upgrade workflows conflict with the setup workflows described by this issue:

https://github.com/camunda/camunda-platform-helm/issues/3558

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

This PR will drop any extra metadata that #3675 introduced into the namespace name.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
