### PR TITLE
ci: increase playwright timeout for opensearch

### DIFF
--- a/charts/camunda-platform-8.7/test/integration/testsuites/tests/login.spec.ts
+++ b/charts/camunda-platform-8.7/test/integration/testsuites/tests/login.spec.ts
@@ -261,7 +261,7 @@ test.describe("Camunda core", () => {
         ],
         { stdio: "inherit" },
       );
-      await new Promise((resolve) => setTimeout(resolve, 15000));
+      await new Promise((resolve) => setTimeout(resolve, 30000));
       // TODO change this as it is not testing what we think it is testing
       const r = await api.post(
         `${config.base.operate}/v1/process-definitions/search`,
@@ -285,7 +285,7 @@ test.describe("Camunda core", () => {
     });
   }
 
-  test.afterEach(async ({}, testInfo) => {
+  test.afterEach(async ({ }, testInfo) => {
     // If the test outcome is different from what was expected (i.e. the test failed),
     // dump the resolved configuration so that it is visible in the Playwright output.
     if (testInfo.status !== testInfo.expectedStatus) {
@@ -293,7 +293,7 @@ test.describe("Camunda core", () => {
       // If this becomes a concern, mask the values here before logging.
       console.error(
         "\n===== CONFIG DUMP (test failed) =====\n" +
-          JSON.stringify(config, null, 2),
+        JSON.stringify(config, null, 2),
       );
     }
   });

--- a/charts/camunda-platform-8.8/test/integration/testsuites/tests/core-grpc.spec.ts
+++ b/charts/camunda-platform-8.8/test/integration/testsuites/tests/core-grpc.spec.ts
@@ -196,7 +196,7 @@ test.describe("core-grpc", () => {
         ],
         { stdio: "inherit" },
       );
-      await new Promise((resolve) => setTimeout(resolve, 15000));
+      await new Promise((resolve) => setTimeout(resolve, 30000));
 
       const r = await api.post(
         `${config.base.coreOperate}/v2/process-definitions/search`,


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
It takes longer for the model to be deployed for the opensearch scenario. This is why I have increased the timeout.
### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
