### PR TITLE
fix(8.8/identity): correct existingsecret rendering with oidc used

### DIFF
--- a/charts/camunda-platform-8.8/templates/identity/configmap.yaml
+++ b/charts/camunda-platform-8.8/templates/identity/configmap.yaml
@@ -313,7 +313,11 @@ data:
         audience: {{ include "identity.authAudience" . | quote }}
         {{- if (tpl ( include "identity.authClientSecret" . ) .)}}
         client-id: {{ include "identity.authClientId" .  | quote }}
-        client-secret: {{ include "identity.authClientSecret" . | quote }}
+        {{- if eq (typeOf .Values.global.identity.auth.identity.existingSecret) "string" }}
+        client-secret: {{ .Values.global.identity.auth.identity.existingSecret | quote }}
+        {{- else }}
+        client-secret: ${VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET}
+        {{- end }}
         {{- end }}
         {{- if ne .Values.global.identity.auth.type "KEYCLOAK" }}
         baseUrl: {{ include "identity.internalUrl" . | quote }}


### PR DESCRIPTION
### Which problem does the PR fix?

Closes: [#3695](https://github.com/camunda/camunda-platform-helm/issues/3695)

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
