### PR TITLE
fix: deduplicate scenario-independent jobs

### DIFF
--- a/.github/workflows/test-chart-version-template.yaml
+++ b/.github/workflows/test-chart-version-template.yaml
@@ -63,14 +63,6 @@ jobs:
           json=$(echo "$SCENARIOS_LIST" | jq -R -c 'split(",")')
           echo "json_array=$json" | tee -a $GITHUB_OUTPUT
 
-  unit:
-    name: Camunda ${{ inputs.camunda-version }} - Unit Test
-    uses: ./.github/workflows/test-unit-template.yml
-    with:
-      identifier: "${{ github.event.pull_request.number }}-${{ inputs.scenario }}-unit-${{ inputs.camunda-version }}-${{ inputs.auth }}-${{ inputs.exclude }}"
-      camunda-helm-dir: "camunda-platform-${{ inputs.camunda-version }}"
-      camunda-helm-git-ref: "${{ github.event.pull_request.head.sha }}"
-
   integration:
     name: Camunda ${{ inputs.camunda-version }} - Integration Test
     needs: validation

--- a/.github/workflows/test-chart-version-template.yaml
+++ b/.github/workflows/test-chart-version-template.yaml
@@ -37,17 +37,8 @@ permissions:
   contents: read
 
 jobs:
-  validation:
-    name: Camunda ${{ inputs.camunda-version }} - Validation
-    uses: ./.github/workflows/chart-validate-template.yaml
-    with:
-      identifier: "${{ github.event.pull_request.number }}-${{ inputs.scenario }}-vald-${{ inputs.camunda-version }}-${{ inputs.auth }}-${{ inputs.exclude }}"
-      camunda-helm-dir: "camunda-platform-${{ inputs.camunda-version }}"
-      camunda-helm-git-ref: "${{ github.event.pull_request.head.sha }}"
-
   init:
     name: Init Scenarios
-    needs: validation
     runs-on: ubuntu-latest
     env:
       SCENARIOS_LIST: ${{ inputs.scenarios }}
@@ -65,7 +56,6 @@ jobs:
 
   integration:
     name: Camunda ${{ inputs.camunda-version }} - Integration Test
-    needs: validation
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/test-chart-version-template.yaml
+++ b/.github/workflows/test-chart-version-template.yaml
@@ -71,18 +71,6 @@ jobs:
       camunda-helm-dir: "camunda-platform-${{ inputs.camunda-version }}"
       camunda-helm-git-ref: "${{ github.event.pull_request.head.sha }}"
 
-  local:
-    name: Local cluster - KIND
-    needs: [init]
-    permissions:
-      contents: read
-    secrets: inherit
-    uses: ./.github/workflows/test-local-template.yml
-    with:
-      identifier: "${{ github.event.pull_request.number }}-loc-${{ inputs.camunda-version }}"
-      camunda-helm-dir: "camunda-platform-${{ inputs.camunda-version }}"
-      camunda-helm-git-ref: "${{ github.event.pull_request.head.sha }}"
-
   integration:
     name: Camunda ${{ inputs.camunda-version }} - Integration Test
     needs: validation

--- a/.github/workflows/test-chart-version.yaml
+++ b/.github/workflows/test-chart-version.yaml
@@ -79,10 +79,24 @@ jobs:
       camunda-helm-dir: "camunda-platform-${{ matrix.version }}"
       camunda-helm-git-ref: "${{ github.event.pull_request.head.sha }}"
 
+  validation:
+    if: ${{ needs.matrix-version-only.outputs.matrix != '[]' }}
+    name: Camunda ${{ matrix.version }} - Validation
+    needs: [init, matrix-version-only]
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ${{ fromJson(needs.matrix-version-only.outputs.matrix) }}
+    uses: ./.github/workflows/chart-validate-template.yaml
+    with:
+      identifier: "${{ github.event.pull_request.number }}-vald-${{ matrix.version }}"
+      camunda-helm-dir: "camunda-platform-${{ matrix.version }}"
+      camunda-helm-git-ref: "${{ github.event.pull_request.head.sha }}"
+
   local:
     if: ${{ needs.matrix-version-only.outputs.matrix != '[]' }}
     name: Local cluster - KIND ${{ matrix.version }}
-    needs: [init, matrix-version-only]
+    needs: [init, matrix-version-only, validation]
     strategy:
       fail-fast: false
       matrix:
@@ -99,7 +113,7 @@ jobs:
   test:
     if: ${{ needs.init.outputs.matrix != '[]' }}
     name: Camunda ${{ matrix.version }}
-    needs: init
+    needs: [init, validation]
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.init.outputs.matrix) }}

--- a/.github/workflows/test-chart-version.yaml
+++ b/.github/workflows/test-chart-version.yaml
@@ -49,6 +49,39 @@ jobs:
         with:
           charts-path: "charts/camunda-platform-8*"
           manual-trigger: ${{ github.event.inputs.manual-trigger }}
+
+  matrixversiononly:
+    # Generates a chart matrix of just the versions changed
+    if: ${{ needs.init.outputs.matrix != '[]' }}
+    name: Generate versions from chart-matrix
+    runs-on: ubuntu-latest
+    needs: [init]
+    outputs:
+      matrix: ${{ steps.generate-chart-versions-only.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Generate chart versions
+        id: generate-chart-versions-only
+        run: |
+          printf matrix="$(echo '${{ needs.init.outputs.matrix }}' | jq -c '[.include.[].version] | unique')" | tee -a $GITHUB_OUTPUT
+
+  local:
+    if: ${{ needs.matrixversiononly.outputs.matrix != '[]' }}
+    name: Local cluster - KIND ${{ matrix.version }}
+    needs: [init, matrixversiononly]
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ${{ fromJson(needs.matrixversiononly.outputs.matrix) }}
+    permissions:
+      contents: read
+    secrets: inherit
+    uses: ./.github/workflows/test-local-template.yml
+    with:
+      identifier: "${{ github.event.pull_request.number }}-loc-${{ matrix.version }}"
+      camunda-helm-dir: "camunda-platform-${{ matrix.version }}"
+      camunda-helm-git-ref: "${{ github.event.pull_request.head.sha }}"
+
   test:
     if: ${{ needs.init.outputs.matrix != '[]' }}
     name: Camunda ${{ matrix.version }}

--- a/.github/workflows/test-chart-version.yaml
+++ b/.github/workflows/test-chart-version.yaml
@@ -50,7 +50,7 @@ jobs:
           charts-path: "charts/camunda-platform-8*"
           manual-trigger: ${{ github.event.inputs.manual-trigger }}
 
-  matrixversiononly:
+  matrix-version-only:
     # Generates a chart matrix of just the versions changed
     if: ${{ needs.init.outputs.matrix != '[]' }}
     name: Generate versions from chart-matrix
@@ -66,13 +66,13 @@ jobs:
           printf matrix="$(echo '${{ needs.init.outputs.matrix }}' | jq -c '[.include.[].version] | unique')" | tee -a $GITHUB_OUTPUT
 
   local:
-    if: ${{ needs.matrixversiononly.outputs.matrix != '[]' }}
+    if: ${{ needs.matrix-version-only.outputs.matrix != '[]' }}
     name: Local cluster - KIND ${{ matrix.version }}
-    needs: [init, matrixversiononly]
+    needs: [init, matrix-version-only]
     strategy:
       fail-fast: false
       matrix:
-        version: ${{ fromJson(needs.matrixversiononly.outputs.matrix) }}
+        version: ${{ fromJson(needs.matrix-version-only.outputs.matrix) }}
     permissions:
       contents: read
     secrets: inherit

--- a/.github/workflows/test-chart-version.yaml
+++ b/.github/workflows/test-chart-version.yaml
@@ -65,6 +65,20 @@ jobs:
         run: |
           printf matrix="$(echo '${{ needs.init.outputs.matrix }}' | jq -c '[.include.[].version] | unique')" | tee -a $GITHUB_OUTPUT
 
+  unit:
+    if: ${{ needs.matrix-version-only.outputs.matrix != '[]' }}
+    name: Camunda ${{ matrix.version }} - Unit Test
+    needs: [init, matrix-version-only]
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ${{ fromJson(needs.matrix-version-only.outputs.matrix) }}
+    uses: ./.github/workflows/test-unit-template.yml
+    with:
+      identifier: "${{ github.event.pull_request.number }}-unit-${{ matrix.version }}"
+      camunda-helm-dir: "camunda-platform-${{ matrix.version }}"
+      camunda-helm-git-ref: "${{ github.event.pull_request.head.sha }}"
+
   local:
     if: ${{ needs.matrix-version-only.outputs.matrix != '[]' }}
     name: Local cluster - KIND ${{ matrix.version }}

--- a/charts/camunda-platform-8.7/Chart.yaml
+++ b/charts/camunda-platform-8.7/Chart.yaml
@@ -76,4 +76,3 @@ annotations:
       description: "Support configure replicas for web modeler restapi and webapp"
     - kind: fixed
       description: "Cleanup multiregion installationtype"
-

--- a/charts/camunda-platform-8.7/Chart.yaml
+++ b/charts/camunda-platform-8.7/Chart.yaml
@@ -76,3 +76,4 @@ annotations:
       description: "Support configure replicas for web modeler restapi and webapp"
     - kind: fixed
       description: "Cleanup multiregion installationtype"
+


### PR DESCRIPTION
### Which problem does the PR fix?

I was finding it difficult to work with the local cluster - KIND workflows because there's a lot of jobs that were marked as Cancelled and I didn't know why. The reason why is that they are duplicates, and the original job is running on a different line.

Therefore, I separated the KIND workflows from the matrix that splits up the different test scenarios



<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

I moved where the "Local KIND" tests are being executed so that it would not be within the context of a scenario matrix. It would run its own matrix of just the version.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

Tests did not pass for the local KIND workflows due to the following issue:
https://github.com/camunda/camunda-platform-helm/issues/3752

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
