### PR TITLE
ci: run all chart version tests on .tool-versions changes

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -12,4 +12,4 @@ oc 4.17.11
 task 3.30.1 # Task is mainly used to run tests locally or in the CI pipeline.
 yamllint 1.37.1
 yq 4.45.4
-zbctl 8.5.6 #test change
+zbctl 8.5.6


### PR DESCRIPTION
### Which problem does the PR fix?

Closes: [#3724](https://github.com/camunda/camunda-platform-helm/issues/3724)

### What's in this PR?

Add `.tool-versions` to the files that will trigger a matrix build that will run tests for all chart versions.


### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
