### PR TITLE
fix: use gateway service in ingress's

### DIFF
--- a/charts/camunda-platform-8.8/templates/NOTES.txt
+++ b/charts/camunda-platform-8.8/templates/NOTES.txt
@@ -67,10 +67,10 @@
 
 The Cluster itself is not exposed as a service which means that you can use `kubectl port-forward` to access the Zeebe cluster from outside Kubernetes:
 
-> kubectl port-forward svc/{{ tpl .Values.global.zeebeClusterName . }}-gateway 26500:26500 -n {{ .Release.Namespace }}
-> kubectl port-forward svc/{{ tpl .Values.global.zeebeClusterName . }}-gateway 8088:8080 -n {{ .Release.Namespace }}
+> kubectl port-forward svc/{{ include "core.fullname" . }}-gateway 26500:26500 -n {{ .Release.Namespace }}
+> kubectl port-forward svc/{{ include "core.fullname" . }}-gateway 8088:8080 -n {{ .Release.Namespace }}
 
-Now you can connect your workers and clients to `localhost:26500`
+Now you can connect your workers and clients to `localhost:26500` for gRPC or `localhost:26500` for REST API usage.
 
 {{ if or (.Values.core.enabled) (.Values.identity.enabled) }}
 ### Connecting to Web apps

--- a/charts/camunda-platform-8.8/templates/camunda/ingress-grpc.yaml
+++ b/charts/camunda-platform-8.8/templates/camunda/ingress-grpc.yaml
@@ -24,7 +24,7 @@ spec:
             pathType: {{ .Values.core.ingress.grpc.pathType }}
             backend:
               service:
-                name: {{ include "core.fullname" . }}
+                name: {{ include "core.fullname" . }}-gateway
                 port:
                   number: {{ .Values.core.service.grpcPort }}
   {{- if .Values.core.ingress.grpc.tls.enabled }}

--- a/charts/camunda-platform-8.8/templates/camunda/ingress-http.yaml
+++ b/charts/camunda-platform-8.8/templates/camunda/ingress-http.yaml
@@ -70,7 +70,7 @@ spec:
           # Core.
           - backend:
               service:
-                name: {{ template "core.fullname" . }}
+                name: {{ template "core.fullname" . }}-gateway
                 port:
                   number: {{ .Values.core.service.httpPort }}
             path: {{ .Values.core.contextPath }}


### PR DESCRIPTION
### Which problem does the PR fix?

We have [introduced a new loadbalancing gateway service](https://github.com/camunda/camunda-platform-helm/pull/3791), and removed the gRPC/http endpoints from the headless service.

This breaks the ingress definitions, as they still use the old service.
<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

* Update the http and gRPC ingress definitions to use the right service
* Update the chart notes to correctly direct users to the right service

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
