### PR TITLE
ci: the number of releases should not be proportional to the number o…

### DIFF
--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -50,7 +50,7 @@ jobs:
           # Create a tmp file and ensure it's empty.
           echo "" > "${matrix_file}"
 
-          echo '${{ steps.generate-chart-versions.outputs.matrix }}' | jq -cr '.include.[].version' | while read -r dir_id; do
+          echo '${{ steps.generate-chart-versions.outputs.matrix }}' | jq -cr '.include.[0].version' | while read -r dir_id; do
             chart_file="charts/camunda-platform-${dir_id}/Chart.yaml"
 
             # Extract version info.


### PR DESCRIPTION
…f scenarios

### Which problem does the PR fix?

If there are multiple scenarios then there will be multiple releases. I have made the change in the script that generates the matrix. It will now only focus on the first scenario.

Here is how you can test locally. You can run this on the parent directory of the helm repo:
```bash
echo "Generating release matrix ..."
matrix_file="matrix_versions.txt"

# Create a tmp file and ensure it's empty.
echo "" >"${matrix_file}"

echo '{"include":[{"version":"8.8","case":"pr","scenario":"elasticsearch","auth":"keycloak","exclude":null},{"version":"8.8","case":"pr","scenario":"elasticsearch","auth":"basic","exclude":"identity|console|core-grpc"}]}' | jq -cr '.include.[].version' | while read -r dir_id; do
  chart_file="charts/camunda-platform-${dir_id}/Chart.yaml"

  # Extract version info.
  chart_version="$(yq '.version' "${chart_file}")"
  camunda_version="$(yq '.appVersion' "${chart_file}" | sed 's/.x//')"
  chart_prerelease="$(yq '.annotations."artifacthub.io/prerelease" // "false"' "${chart_file}")"

  # Check if the release already exists.
  if gh release view "camunda-platform-${chart_version}" >/dev/null 2>&1; then
    echo "⚠️ Release Skipped ⚠️" >>"${GITHUB_STEP_SUMMARY}"
    cat <<EOF >>"${GITHUB_STEP_SUMMARY}"
      - The release for chart dir \`camunda-platform-${dir_id}\` with version \`${chart_version}\` already exists.
      - To rerelease, delete the GH release first.
      - Check it on: https://github.com/${GITHUB_REPOSITORY}/releases/tag/camunda-platform-${chart_version}
    ---
EOF
  else
    echo "[INFO] Add the chart in camunda-platform-${dir_id} to the release matrix."
    cat <<EOF >>"${matrix_file}"
      {
        "dirID": "${dir_id}",
        "version": "${chart_version}",
        "appVersion": "${camunda_version}",
        "prerelease": ${chart_prerelease}
      }
EOF
  fi
done

# Generate JSON matrix and set it as a GH output.
matrix_versions="$(jq --slurp --compact-output '.' ${matrix_file})"
echo "matrix=${matrix_versions}" | tee -a $GITHUB_OUTPUT

```

as you can see it generates a double matrix unless the change I made in this PR is added.
### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
