### PR TITLE
ci: rename prefix-certs namespace to prefix

### DIFF
--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -384,9 +384,9 @@ jobs:
             done
           else
             # running in EKS
-            kubectl get secret -n ${NAMESPACE_PREFIX} ${NAMESPACE_PREFIX}-aws-camunda-cloud-tls -o yaml > ${NAMESPACE_PREFIX}-aws-camunda-cloud-tls.yaml
-            sed -i "s/namespace: ${NAMESPACE_PREFIX}/namespace: $TEST_NAMESPACE/g" ${NAMESPACE_PREFIX}-aws-camunda-cloud-tls.yaml
-            kubectl apply -f ${NAMESPACE_PREFIX}-aws-camunda-cloud-tls.yaml -n $TEST_NAMESPACE
+            kubectl get secret -n ${NAMESPACE_PREFIX} aws-camunda-cloud-tls -o yaml > aws-camunda-cloud-tls.yaml
+            sed -i "s/namespace: ${NAMESPACE_PREFIX}/namespace: $TEST_NAMESPACE/g" aws-camunda-cloud-tls.yaml
+            kubectl apply -f aws-camunda-cloud-tls.yaml -n $TEST_NAMESPACE
           fi
 
       - name: Helm - Install - Execute before install lifecycle tasks

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -384,8 +384,8 @@ jobs:
             done
           else
             # running in EKS
-            kubectl get secret -n ${NAMESPACE_PREFIX}-certs ${NAMESPACE_PREFIX}-aws-camunda-cloud-tls -o yaml > ${NAMESPACE_PREFIX}-aws-camunda-cloud-tls.yaml
-            sed -i "s/namespace: ${NAMESPACE_PREFIX}-certs/namespace: $TEST_NAMESPACE/g" ${NAMESPACE_PREFIX}-aws-camunda-cloud-tls.yaml
+            kubectl get secret -n ${NAMESPACE_PREFIX} ${NAMESPACE_PREFIX}-aws-camunda-cloud-tls -o yaml > ${NAMESPACE_PREFIX}-aws-camunda-cloud-tls.yaml
+            sed -i "s/namespace: ${NAMESPACE_PREFIX}/namespace: $TEST_NAMESPACE/g" ${NAMESPACE_PREFIX}-aws-camunda-cloud-tls.yaml
             kubectl apply -f ${NAMESPACE_PREFIX}-aws-camunda-cloud-tls.yaml -n $TEST_NAMESPACE
           fi
 

--- a/charts/camunda-platform-8.2/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-infra.yaml
+++ b/charts/camunda-platform-8.2/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-infra.yaml
@@ -4,7 +4,7 @@ global:
     camunda.cloud/ephemeral: "true"
   ingress:
     tls:
-      secretName: "distribution-aws-camunda-cloud-tls"
+      secretName: "aws-camunda-cloud-tls"
 identity:
   keycloak:
     postgresql:
@@ -21,7 +21,7 @@ postgresql:
 zeebe-gateway:
   ingress:
     tls:
-      secretName: distribution-aws-camunda-cloud-tls
+      secretName: aws-camunda-cloud-tls
 elasticsearch:
   commonLabels:
     janitor/ttl: 1h

--- a/charts/camunda-platform-8.3/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-infra.yaml
+++ b/charts/camunda-platform-8.3/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-infra.yaml
@@ -4,7 +4,7 @@ global:
     camunda.cloud/ephemeral: "true"
   ingress:
     tls:
-      secretName: distribution-aws-camunda-cloud-tls
+      secretName: aws-camunda-cloud-tls
 identity:
   keycloak:
     commonLabels:
@@ -21,7 +21,7 @@ postgresql:
 zeebe-gateway:
   ingress:
     tls:
-      secretName: distribution-aws-camunda-cloud-tls
+      secretName: aws-camunda-cloud-tls
 elasticsearch:
   commonLabels:
     janitor/ttl: 1h

--- a/charts/camunda-platform-8.4/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-infra.yaml
+++ b/charts/camunda-platform-8.4/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-infra.yaml
@@ -4,7 +4,7 @@ global:
     camunda.cloud/ephemeral: "true"
   ingress:
     tls:
-      secretName: distribution-aws-camunda-cloud-tls
+      secretName: aws-camunda-cloud-tls
 identity:
   keycloak:
     commonLabels:
@@ -21,7 +21,7 @@ postgresql:
 zeebe-gateway:
   ingress:
     tls:
-      secretName: distribution-aws-camunda-cloud-tls
+      secretName: aws-camunda-cloud-tls
 elasticsearch:
   commonLabels:
     janitor/ttl: 1h

--- a/charts/camunda-platform-8.5/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-infra.yaml
+++ b/charts/camunda-platform-8.5/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-infra.yaml
@@ -4,7 +4,7 @@ global:
     camunda.cloud/ephemeral: "true"
   ingress:
     tls:
-      secretName: distribution-aws-camunda-cloud-tls
+      secretName: aws-camunda-cloud-tls
 identityKeycloak:
   postgresql:
     commonLabels:
@@ -25,7 +25,7 @@ zeebeGateway:
   ingress:
     grpc:
       tls:
-        secretName: distribution-aws-camunda-cloud-tls
+        secretName: aws-camunda-cloud-tls
 elasticsearch:
   commonLabels:
     janitor/ttl: 1h

--- a/charts/camunda-platform-8.6/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-infra.yaml
+++ b/charts/camunda-platform-8.6/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-infra.yaml
@@ -4,7 +4,7 @@ global:
     camunda.cloud/ephemeral: "true"
   ingress:
     tls:
-      secretName: distribution-aws-camunda-cloud-tls
+      secretName: aws-camunda-cloud-tls
 identityKeycloak:
   commonLabels:
     janitor/ttl: 1h
@@ -21,7 +21,7 @@ zeebeGateway:
   ingress:
     grpc:
       tls:
-        secretName: distribution-aws-camunda-cloud-tls
+        secretName: aws-camunda-cloud-tls
 elasticsearch:
   commonLabels:
     janitor/ttl: 1h

--- a/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-infra.yaml
+++ b/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-infra.yaml
@@ -4,7 +4,7 @@ global:
     camunda.cloud/ephemeral: "true"
   ingress:
     tls:
-      secretName: distribution-aws-camunda-cloud-tls
+      secretName: aws-camunda-cloud-tls
 identityKeycloak:
   commonLabels:
     janitor/ttl: 1h
@@ -21,7 +21,7 @@ zeebeGateway:
   ingress:
     grpc:
       tls:
-        secretName: distribution-aws-camunda-cloud-tls
+        secretName: aws-camunda-cloud-tls
 elasticsearch:
   commonLabels:
     janitor/ttl: 1h

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-infra.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-infra.yaml
@@ -4,7 +4,7 @@ global:
     camunda.cloud/ephemeral: "true"
   ingress:
     tls:
-      secretName: distribution-aws-camunda-cloud-tls
+      secretName: aws-camunda-cloud-tls
 identityKeycloak:
   commonLabels:
     janitor/ttl: 1h
@@ -21,7 +21,7 @@ orchestration:
   ingress:
     grpc:
       tls:
-        secretName: distribution-aws-camunda-cloud-tls
+        secretName: aws-camunda-cloud-tls
 elasticsearch:
   commonLabels:
     janitor/ttl: 1h


### PR DESCRIPTION
### Which problem does the PR fix?

in support of this refactor: https://github.com/camunda/infra-core/pull/10148

The TLS certificate secret will be renamed from `NAMESPACE_PREFIX-aws-camunda-cloud-tls` to `aws-camunda-cloud-tls`. 

We benefit from this because it means that our CI can run with the same secret name regardless  of whether we're ran from QA env or Distribution env. But we are still restricted to the urls we can access. So we are still on `*.distribution.aws.camunda.cloud` and QA is still on `*.qa.aws.camunda.cloud`.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

renamed where the TLS certificates for AWS are located.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
