### PR TITLE
Increase timeout for integration test runner

### DIFF
--- a/.github/actions/test-type-vars/action.yml
+++ b/.github/actions/test-type-vars/action.yml
@@ -69,7 +69,7 @@ runs:
         # Charts dir.
         charts_base_dir="$(echo ${integration_vars} | jq -r '.vars.chartsBaseDir')"
         echo "TEST_CHART_DIR=${charts_base_dir}/${{ inputs.chart-dir }}" | tee -a $GITHUB_ENV
-        echo "ABSOLUTE_TEST_CHART_DIR=/home/runner/work/camunda-platform-helm/${CHART_PATH}" | tee -a $GITHUB_ENV
+        echo "ABSOLUTE_TEST_CHART_DIR=${GITHUB_WORKSPACE}/${CHART_PATH}" | tee -a $GITHUB_ENV
 
         if [[ "${{ inputs.enterprise }}" == "true" ]]; then
           echo "TEST_HELM_EXTRA_ARGS=--values ${charts_base_dir}/${{ inputs.chart-dir }}/values-enterprise.yaml" | tee -a $GITHUB_ENV

--- a/.github/actions/test-type-vars/action.yml
+++ b/.github/actions/test-type-vars/action.yml
@@ -69,7 +69,7 @@ runs:
         # Charts dir.
         charts_base_dir="$(echo ${integration_vars} | jq -r '.vars.chartsBaseDir')"
         echo "TEST_CHART_DIR=${charts_base_dir}/${{ inputs.chart-dir }}" | tee -a $GITHUB_ENV
-        echo "ABSOLUTE_TEST_CHART_DIR=${GITHUB_WORKSPACE}/${CHART_PATH}" | tee -a $GITHUB_ENV
+        echo "ABSOLUTE_TEST_CHART_DIR=/home/runner/work/camunda-platform-helm/${CHART_PATH}" | tee -a $GITHUB_ENV
 
         if [[ "${{ inputs.enterprise }}" == "true" ]]; then
           echo "TEST_HELM_EXTRA_ARGS=--values ${charts_base_dir}/${{ inputs.chart-dir }}/values-enterprise.yaml" | tee -a $GITHUB_ENV

--- a/.github/actions/workflow-vars/action.yml
+++ b/.github/actions/workflow-vars/action.yml
@@ -111,7 +111,16 @@ runs:
         export INGRESS_HOSTNAME_BASE=ci.distro.ultrawombat.com
       fi
 
-      TEST_INGRESS_HOST="${TEST_IDENTIFIER}.${INGRESS_HOSTNAME_BASE}"
+      # Constants for hostname length management
+      MAX_LABEL=63
+      SUFFIX="-${{ inputs.setup-flow }}-${{ inputs.platform }}"         # e.g. "-install-gke"
+      
+      # Clamp identifier to prevent long hostnames
+      SAFE_ID="${{ inputs.identifier-base }}"
+      SAFE_ID="${SAFE_ID:0:$((MAX_LABEL - ${#SUFFIX}))}"
+      
+      # Build the hostname with clamped identifier
+      TEST_INGRESS_HOST="${SAFE_ID}${SUFFIX}.${INGRESS_HOSTNAME_BASE}"
       if [[ "${{ inputs.deployment-ttl }}" == "" ]] && is_pr; then
         TEST_INGRESS_HOST="${GITHUB_WORKFLOW_JOB_ID}-${TEST_INGRESS_HOST}"
       fi

--- a/.github/actions/workflow-vars/action.yml
+++ b/.github/actions/workflow-vars/action.yml
@@ -111,14 +111,16 @@ runs:
         export INGRESS_HOSTNAME_BASE=ci.distro.ultrawombat.com
       fi
 
+      # Truncate to 58 chars max and append 4 random chars
+      RANDOM_SUFFIX=$(openssl rand -hex 2)
+      TEST_IDENTIFIER="$(printf '%s' "$TEST_IDENTIFIER" | head -c 40 | sed 's/-$//')-${RANDOM_SUFFIX}"
+
       TEST_INGRESS_HOST="${TEST_IDENTIFIER}.${INGRESS_HOSTNAME_BASE}"
       if [[ "${{ inputs.deployment-ttl }}" == "" ]] && is_pr; then
+        GITHUB_WORKFLOW_JOB_ID="$(printf '%s' "$GITHUB_WORKFLOW_JOB_ID" | head -c 40 | sed 's/-$//')-${RANDOM_SUFFIX}"
         TEST_INGRESS_HOST="${GITHUB_WORKFLOW_JOB_ID}-${TEST_INGRESS_HOST}"
       fi
       # Ensure ingress host is under 63 characters (DNS label limit)
-      # Truncate to 58 chars max and append 4 random chars
-      RANDOM_SUFFIX=$(openssl rand -hex 2)
-      TEST_INGRESS_HOST="$(printf '%s' "$TEST_INGRESS_HOST" | head -c 40 | sed 's/-$//')-${RANDOM_SUFFIX}"
       # The var is needed in some non-shell steps.
       echo "ingress-host=${TEST_INGRESS_HOST}" | tee -a $GITHUB_OUTPUT
 

--- a/.github/actions/workflow-vars/action.yml
+++ b/.github/actions/workflow-vars/action.yml
@@ -118,7 +118,7 @@ runs:
       # Ensure ingress host is under 63 characters (DNS label limit)
       # Truncate to 58 chars max and append 4 random chars
       RANDOM_SUFFIX=$(openssl rand -hex 2)
-      TEST_INGRESS_HOST="$(printf '%s' "$TEST_INGRESS_HOST" | head -c 58 | sed 's/-$//')-${RANDOM_SUFFIX}"
+      TEST_INGRESS_HOST="$(printf '%s' "$TEST_INGRESS_HOST" | head -c 40 | sed 's/-$//')-${RANDOM_SUFFIX}"
       # The var is needed in some non-shell steps.
       echo "ingress-host=${TEST_INGRESS_HOST}" | tee -a $GITHUB_OUTPUT
 

--- a/.github/actions/workflow-vars/action.yml
+++ b/.github/actions/workflow-vars/action.yml
@@ -111,19 +111,14 @@ runs:
         export INGRESS_HOSTNAME_BASE=ci.distro.ultrawombat.com
       fi
 
-      # Constants for hostname length management
-      MAX_LABEL=63
-      SUFFIX="-${{ inputs.setup-flow }}-${{ inputs.platform }}"         # e.g. "-install-gke"
-      
-      # Clamp identifier to prevent long hostnames
-      SAFE_ID="${{ inputs.identifier-base }}"
-      SAFE_ID="${SAFE_ID:0:$((MAX_LABEL - ${#SUFFIX}))}"
-      
-      # Build the hostname with clamped identifier
-      TEST_INGRESS_HOST="${SAFE_ID}${SUFFIX}.${INGRESS_HOSTNAME_BASE}"
+      TEST_INGRESS_HOST="${TEST_IDENTIFIER}.${INGRESS_HOSTNAME_BASE}"
       if [[ "${{ inputs.deployment-ttl }}" == "" ]] && is_pr; then
         TEST_INGRESS_HOST="${GITHUB_WORKFLOW_JOB_ID}-${TEST_INGRESS_HOST}"
       fi
+      # Ensure ingress host is under 63 characters (DNS label limit)
+      # Truncate to 58 chars max and append 4 random chars
+      RANDOM_SUFFIX=$(openssl rand -hex 2)
+      TEST_INGRESS_HOST="$(printf '%s' "$TEST_INGRESS_HOST" | head -c 58 | sed 's/-$//')-${RANDOM_SUFFIX}"
       # The var is needed in some non-shell steps.
       echo "ingress-host=${TEST_INGRESS_HOST}" | tee -a $GITHUB_OUTPUT
 

--- a/.github/actions/workflow-vars/action.yml
+++ b/.github/actions/workflow-vars/action.yml
@@ -111,7 +111,7 @@ runs:
         export INGRESS_HOSTNAME_BASE=ci.distro.ultrawombat.com
       fi
 
-      # Truncate to 58 chars max and append 4 random chars
+      # Truncate to 40 chars max and append 4 random chars
       RANDOM_SUFFIX=$(openssl rand -hex 2)
       TEST_IDENTIFIER="$(printf '%s' "$TEST_IDENTIFIER" | head -c 40 | sed 's/-$//')-${RANDOM_SUFFIX}"
 
@@ -120,7 +120,6 @@ runs:
         GITHUB_WORKFLOW_JOB_ID="$(printf '%s' "$GITHUB_WORKFLOW_JOB_ID" | head -c 40 | sed 's/-$//')-${RANDOM_SUFFIX}"
         TEST_INGRESS_HOST="${GITHUB_WORKFLOW_JOB_ID}-${TEST_INGRESS_HOST}"
       fi
-      # Ensure ingress host is under 63 characters (DNS label limit)
       # The var is needed in some non-shell steps.
       echo "ingress-host=${TEST_INGRESS_HOST}" | tee -a $GITHUB_OUTPUT
 

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -87,7 +87,7 @@ on:
         type: string
       scenario:
         required: false
-        default: "base"
+        default: "elasticsearch"
         type: string
       camunda-helm-post-render:
         description: Set to true if you would like to run the post-renderer script for OpenShift
@@ -145,7 +145,7 @@ on:
       shortname:
         description: The shortname of the scenario.
         required: true
-        default: ""
+        default: "eske"
         type: string
       namespace-prefix:
         description: The prefix for the namespace. This is necessary because we only have permissions to create namespaces with a specific prefix.
@@ -368,6 +368,8 @@ jobs:
         env:
           TEST_CHART_FLOW: ${{ inputs.flow }}
           TEST_INGRESS_HOST: ${{ steps.vars.outputs.ingress-host }}
+          TEST_VALUES_SCENARIO: "${{ inputs.scenario }}"
+      
         run: |
           echo "Extra values from workflow:"
           echo "${{ inputs.extra-values }}" | tee /tmp/extra-values-file.yaml

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -369,7 +369,12 @@ jobs:
           TEST_CHART_FLOW: ${{ inputs.flow }}
           TEST_INGRESS_HOST: ${{ steps.vars.outputs.ingress-host }}
           TEST_VALUES_SCENARIO: "${{ inputs.scenario }}"
-      
+          TEST_AUTH_TYPE: ${{ inputs.auth }}
+          INFRA_TYPE: ${{ inputs.infra-type }}
+          TEST_HELM_EXTRA_ARGS: >-
+            ${{ env.TEST_HELM_EXTRA_ARGS_INSTALL }}
+            --set global.ingress.host=${{ steps.vars.outputs.ingress-host }}
+
         run: |
           echo "Extra values from workflow:"
           echo "${{ inputs.extra-values }}" | tee /tmp/extra-values-file.yaml

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -704,7 +704,8 @@ jobs:
 
   merge-reports:
     name: Merge reports - ${{ inputs.flow }} on ${{ inputs.distro-platform }} - ${{ inputs.shortname }}
-    if: ${{ !cancelled() && inputs.test-enabled && contains(inputs.camunda-helm-dir, 'camunda-platform-8.7') }}
+    # if: ${{ !cancelled() && inputs.test-enabled && contains(inputs.camunda-helm-dir, 'camunda-platform-8.7') }}
+    if: false
     needs: [ci-setup, playwright-e2e-tests]
 
     runs-on: ubuntu-latest

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -621,7 +621,7 @@ jobs:
     needs: [ci-setup]
     runs-on: ubuntu-latest
     if: ${{ inputs.test-enabled && inputs.e2e-enabled && contains(inputs.camunda-helm-dir, 'camunda-platform-8.7') }}
-    timeout-minutes: 10
+    timeout-minutes: 20
     env:
       TEST_EXCLUDE: ${{ inputs.exclude }}
       TEST_AUTH_TYPE: ${{ inputs.auth }}

--- a/test/integration/scenarios/chart-full-setup/Taskfile.yaml
+++ b/test/integration/scenarios/chart-full-setup/Taskfile.yaml
@@ -49,7 +49,7 @@ tasks:
       echo "VENOM_VAR_TEST_INGRESS_HOST=${TEST_INGRESS_HOST}" >> "${VARIABLES_ENV_FILE}"
       echo "VENOM_VAR_SKIP_TEST_WEBMODELER=false" >> "${VARIABLES_ENV_FILE}"
       echo "VENOM_VAR_SKIP_TEST_ELASTICSEARCH=$(yq eval-all '. as $item ireduce ({}; . * $item )' {{ .TEST_VALUES_BASE_DIR }}/common/values-integration-test.yaml {{ .TEST_VALUES_BASE_DIR }}/chart-full-setup/values-integration-test-ingress-{{ .TEST_VALUES_SCENARIO }}.yaml {{ env "INFRA_TYPE_VALUES" }} /tmp/extra-values-file.yaml | yq '.elasticsearch.enabled // false | not')" >> "${VARIABLES_ENV_FILE}"
-      echo "VENOM_VAR_SKIP_TEST_KEYCLOAK=$( [ "$TEST_SCENARIO" = "elasticsearch" ] && echo true || echo false )" >> "${VARIABLES_ENV_FILE}"
+      echo "VENOM_VAR_SKIP_TEST_KEYCLOAK=$( [ "$TEST_VALUES_SCENARIO" = "elasticsearch" ] && echo true || echo false )" >> "${VARIABLES_ENV_FILE}"
       echo "VENOM_EXTRA_ARGS=--var-from-file=./vars/variables-ingress-combined.yaml" >> "${VARIABLES_ENV_FILE}"
       echo "ZEEBE_VERSION=$(yq '.zeebe.image.tag' {{ .TEST_CHART_DIR }}/values.yaml)" >> "${VARIABLES_ENV_FILE}"
       # In case the Zeebe version has not been released officially yet.
@@ -158,7 +158,7 @@ tasks:
       VARIABLES_ENV_FILE: "{{ .TEST_CHART_DIR }}/test/integration/testsuites/vars/files/variables.env"
     cmds:
     - |
-      if [[ "${TEST_SCENARIO}" == 'opensearch' ]]; then
+      if [[ "${TEST_VALUES_SCENARIO}" == 'opensearch' ]]; then
         sed -i 's/custom/{{ .TEST_OPENSEARCH_PREFIX }}/g' {{ .TEST_VALUES_BASE_DIR }}/chart-full-setup/values-integration-test-ingress-{{ .TEST_VALUES_SCENARIO }}.yaml
       fi
     - |


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

<img width="1494" height="752" alt="image" src="https://github.com/user-attachments/assets/35ac4db0-df90-4361-a31f-39073b82266f" />

QA tests keep failing with "Operation cancalled" around ±10min. There is a timeout set for the test-integration-runner.yaml for 10min.

This PR is doubling the time. 


### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
