### PR TITLE
ci: double timeout for integration test runs

### DIFF
--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -621,7 +621,7 @@ jobs:
     needs: [ci-setup]
     runs-on: ubuntu-latest
     if: ${{ inputs.test-enabled && inputs.e2e-enabled && contains(inputs.camunda-helm-dir, 'camunda-platform-8.7') }}
-    timeout-minutes: 10
+    timeout-minutes: 20
     env:
       TEST_EXCLUDE: ${{ inputs.exclude }}
       TEST_AUTH_TYPE: ${{ inputs.auth }}


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

<img width="1494" height="752" alt="image" src="https://github.com/user-attachments/assets/35ac4db0-df90-4361-a31f-39073b82266f" />

QA tests keep failing with "Operation cancalled" around ±10min. There is a timeout set for the test-integration-runner.yaml for 10min.

This PR is doubling the time. 

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
