### PR TITLE
feat: enable values to be source from this repo rather than push from the QA repo

### DIFF
--- a/.github/actions/workflow-vars/action.yml
+++ b/.github/actions/workflow-vars/action.yml
@@ -62,25 +62,18 @@ runs:
       PLATFORM=${{ inputs.platform }}
       echo PLATFORM=${{ inputs.platform }} | tee -a $GITHUB_ENV
 
-      # NOTE: We should use the matrix job id var once it's available.
-      # https://github.com/orgs/community/discussions/40291
-      GITHUB_WORKFLOW_JOB_ID=$(uuidgen | head -c 6)
-
       echo "Env vars:"
-
-      # Workflow.
-      echo "GITHUB_WORKFLOW_JOB_ID=$GITHUB_WORKFLOW_JOB_ID" | tee -a $GITHUB_ENV
-      echo "GITHUB_WORKFLOW_RUN_ID=${{ github.run_id }}" | tee -a $GITHUB_ENV
-
-      # Identifier
-      local_identifier=${{ inputs.identifier-base }}
-      if [[ -z "${{ inputs.identifier-base }}" ]]; then
-        local_identifier="no-id-use-ran-$(uuidgen | head -c 6)"
-      fi
-
       # Namespace.
       TRIGGER_KEY=$(is_pr && echo "pr" || echo "id")
       TEST_NAMESPACE="$NAMESPACE_PREFIX-$(echo ${TRIGGER_KEY}-${{ inputs.identifier-base }} | sed 's/\./-/g')"
+    
+      # NOTE: We should use the matrix job id var once it's available.
+      # https://github.com/orgs/community/discussions/40291
+      # NOTE we are using a hash here rather than a random value so that the namepsace is deterministic
+      GITHUB_WORKFLOW_JOB_ID=$(echo -n "$TEST_NAMESPACE" | sha256sum | head -c 6)
+      # Workflow.
+      echo "GITHUB_WORKFLOW_JOB_ID=$GITHUB_WORKFLOW_JOB_ID" | tee -a $GITHUB_ENV
+      echo "GITHUB_WORKFLOW_RUN_ID=${{ github.run_id }}" | tee -a $GITHUB_ENV
 
       if [[ "${{ inputs.deployment-ttl }}" == '' ]]; then
         TEST_NAMESPACE="${TEST_NAMESPACE}-${{ github.run_id }}-${GITHUB_WORKFLOW_JOB_ID}"
@@ -96,6 +89,12 @@ runs:
       echo "TEST_CAMUNDA_HELM_DIR_ALPHA=${TEST_CAMUNDA_HELM_DIR_ALPHA}" | tee -a $GITHUB_ENV
 
       echo "Output vars:"
+
+      # Identifier
+      local_identifier=${{ inputs.identifier-base }}
+      if [[ -z "${{ inputs.identifier-base }}" ]]; then
+        local_identifier="no-id-use-ran-$(uuidgen | head -c 6)"
+      fi
 
       # Deployment identifier.
       TEST_IDENTIFIER="$(echo ${{ inputs.platform }}-${local_identifier} | sed 's/\./-/g')"

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -591,16 +591,19 @@ jobs:
           ROSA_PASS:        ${{ secrets[inputs.password] }}
           CLUSTER_NAME:     ${{ env.CLUSTER_NAME }}
 
-      - name: Test - ⭐️ Run Venom Env Setup ⭐️        
+      - name: Test - ⭐️ Run Venom Env Setup ⭐️
         timeout-minutes: 1
         env:
           CI_TASKS_BASE_DIR: ${{ env.CI_TASKS_BASE_DIR }}
           TEST_CHART_DIR: ${{ env.TEST_CHART_DIR }}
           TEST_VALUES_BASE_DIR: ${{ env.TEST_VALUES_BASE_DIR }}
+          TEST_VALUES_SCENARIO: "${{ inputs.scenario }}"
           TEST_INGRESS_HOST: ${{ steps.vars.outputs.ingress-host }}
           TEST_NAMESPACE: ${{ env.TEST_NAMESPACE }}
         continue-on-error: false
         run: |
+          echo "Extra values from workflow:"
+          echo "${{ inputs.extra-values }}" | tee /tmp/extra-values-file.yaml
           task -d ${CI_TASKS_BASE_DIR}/chart-full-setup setup.venom.env
 
       - name: Test - ⭐️ Run Venom Preflight TestSuite ⭐️
@@ -730,7 +733,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: ${{ env.ABSOLUTE_TEST_CHART_DIR }}/test/integration/testsuites/playwright-report
-          name: playwright-report-${{ github.workflow }}-${{ inputs.identifier }}-${{ inputs.flow }}-${{ inputs.distro-platform }}-runner
+          name: playwright-report-${{ github.run_id }}-${{ inputs.identifier }}-${{ inputs.flow }}-${{ inputs.distro-platform }}-runner
           if-no-files-found: error
           retention-days: 5
 

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -737,7 +737,7 @@ jobs:
   playwright-e2e-tests:
     name: Playwright e2e - ${{ inputs.flow }} on ${{ inputs.distro-platform }} - ${{ inputs.shortname }} (${{ matrix.shardIndex }} of ${{ matrix.shardTotal }})
     needs: [ci-setup]
-    runs-on: ubuntu-latest
+    runs-on: gcp-core-32-longrunning-big-ssd
     if: ${{ inputs.test-enabled && inputs.e2e-enabled && contains(inputs.camunda-helm-dir, 'camunda-platform-8.7') }}
     timeout-minutes: 20
     env:
@@ -746,8 +746,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: ${{ fromJson(needs.ci-setup.outputs.SHARD_INDEX) }}
-        shardTotal: ${{ fromJson(needs.ci-setup.outputs.SHARD_TOTAL) }}
+        shardIndex: [1]
+        shardTotal: [1]
+        #shardIndex: ${{ fromJson(needs.ci-setup.outputs.SHARD_INDEX) }}
+        #shardTotal: ${{ fromJson(needs.ci-setup.outputs.SHARD_TOTAL) }}
     permissions:
         contents: read
         id-token: write
@@ -760,6 +762,15 @@ jobs:
           repository: camunda/camunda-platform-helm
           ref: ${{ inputs.camunda-helm-git-ref }}
 
+      - name: Install uuidgen
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y uuid-runtime
+          sudo apt-get install -y gettext
+          sudo apt-get install -y build-essential
+          sudo apt-get install -y libssl-dev
+
       - name: CI Setup - Install tools
         uses: ./.github/actions/install-tool-versions
         with:
@@ -770,6 +781,19 @@ jobs:
             oc
             task
             yq
+            make
+
+      - name: Upload on failure
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: install.log
+          path: /home/runner/.asdf/downloads/make/4.3
+
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
 
       - name: CI Setup - ℹ️ Set workflow vars for both install and upgrade ℹ️
         id: vars
@@ -831,7 +855,7 @@ jobs:
       - name: Test - ⭐️ Run Playwright E2E TestSuite (Github Runner) ⭐️
         run: |
           cd $GITHUB_WORKSPACE/scripts
-          ./run-e2e-tests.sh --absolute-chart-path ${{env.ABSOLUTE_TEST_CHART_DIR}} --namespace ${{env.TEST_NAMESPACE}} --shard-index ${{ matrix.shardIndex }} --shard-total ${{ matrix.shardTotal }} $( [ "${{ inputs.run-all-e2e-tests }}" = "false" ] && echo "--run-smoke-tests" ) $( [ "${{ inputs.scenario }}" = "qa-opensearch" ] && echo "--opensearch" ) --verbose
+          ./run-e2e-tests.sh --absolute-chart-path ${{env.ABSOLUTE_TEST_CHART_DIR}} --namespace ${{env.TEST_NAMESPACE}} --shard-index ${{ matrix.shardIndex }} --shard-total ${{ matrix.shardTotal }} $( [ "${{ inputs.run-all-e2e-tests }}" = "false" ] && echo "--run-smoke-tests" ) $( [ "${{ inputs.scenario }}" = "qa-opensearch" ] && echo "--opensearch" ) $( [ "${{ inputs.scenario }}" = "qa-elasticsearch-rba" ] && echo "--rba" ) $( [ "${{ inputs.scenario }}" = "qa-elasticsearch-mt" ] && echo "--mt" ) --verbose --not-ci
       - name: Upload blob report to GitHub Actions Artifacts
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -491,6 +491,7 @@ jobs:
           TEST_OPENSHIFT_POST_RENDER: ${{ inputs.camunda-helm-post-render }}
           TEST_CASE: ${{ inputs.test-case }}
           TEST_VALUES_SCENARIO: ${{ inputs.scenario }}
+          TEST_AUTH_TYPE: ${{ inputs.auth }}
           TEST_HELM_EXTRA_ARGS: >-
             ${{ env.TEST_HELM_EXTRA_ARGS_UPGRADE }}
             --set global.ingress.host=${{ steps.vars.outputs.ingress-host }}

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -480,9 +480,9 @@ jobs:
         run: |
           # Since Zeebe 8.6 it's not possible to upgrade from/to alpha version.
           # The Zeebe team advised to use SNAPSHOT tag instead.
-          TEST_HELM_EXTRA_ARGS_INSTALL="${TEST_HELM_EXTRA_ARGS_INSTALL} --set zeebe.image.tag=SNAPSHOT"
+          TEST_HELM_EXTRA_ARGS_INSTALL="${TEST_HELM_EXTRA_ARGS_INSTALL} --set core.image.tag=SNAPSHOT"
           echo "TEST_HELM_EXTRA_ARGS_INSTALL=${TEST_HELM_EXTRA_ARGS_INSTALL}" | tee -a $GITHUB_ENV
-          TEST_HELM_EXTRA_ARGS_UPGRADE="${TEST_HELM_EXTRA_ARGS_UPGRADE} --set zeebe.image.tag=SNAPSHOT"
+          TEST_HELM_EXTRA_ARGS_UPGRADE="${TEST_HELM_EXTRA_ARGS_UPGRADE} --set core.image.tag=SNAPSHOT"
           echo "TEST_HELM_EXTRA_ARGS_UPGRADE=${TEST_HELM_EXTRA_ARGS_UPGRADE}" | tee -a $GITHUB_ENV
 
       - name: Helm - Upgrade - 🌟 Upgrade Camunda chart 🌟

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -4,6 +4,11 @@ name: "Test - Integration - Runner"
 on:
   workflow_call:
     inputs:
+      values-config:
+        type: string
+        description: Some of the values files will allow subsitutions. For example, on the image.tags. This config supplies those values
+        default: '{}'
+        required: false
       auth:
         description: The authentication type to use for the tests.
         required: true
@@ -43,7 +48,7 @@ on:
       deployment-ttl:
         description: Define a TTL for the lifespan of the deployment.
         required: false
-        default: ""
+        default: "30m"
         type: string
       distro-platform:
         default: gke
@@ -162,6 +167,10 @@ on:
         default: "true"
         type: string
         description: Enable digest values
+    outputs:
+      deployment-url:
+        description: The URL of the deployed application.
+        value: ${{ jobs.ci-setup.outputs.vars-ingress-host }}
 
 permissions:
   contents: read
@@ -334,8 +343,8 @@ jobs:
           kubectl label ns $TEST_NAMESPACE test-flow=${{ inputs.flow }}
           kubectl label ns $TEST_NAMESPACE github-org=$(dirname $GITHUB_REPOSITORY)
           kubectl label ns $TEST_NAMESPACE github-repo=$(basename $GITHUB_REPOSITORY)
-          kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=30m
-          kubectl annotate ns $TEST_NAMESPACE janitor/ttl=30m
+          kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${{ inputs.deployment-ttl }}
+          kubectl annotate ns $TEST_NAMESPACE janitor/ttl=${{ inputs.deployment-ttl }}
           kubectl annotate ns $TEST_NAMESPACE camunda.cloud/ephemeral=true
           kubectl annotate ns $TEST_NAMESPACE github-workflow-run-url=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
           if [[ "${{ inputs.distro-platform }}" == "eks" ]]; then
@@ -404,6 +413,27 @@ jobs:
           fi
           echo "TEST_HELM_EXTRA_ARGS_INSTALL=${TEST_HELM_EXTRA_ARGS_INSTALL}" | tee -a $GITHUB_ENV
 
+      - name: Helm - Install - Fill out yaml with values-config
+        if: inputs.values-config != '{}'
+        env:
+          VALS_CONFIG: ${{ inputs.values-config }}
+          TEST_VALUES_SCENARIO: ${{ inputs.scenario }}
+          TMP_DIR: charts${{ inputs.chart-dir }}/test/integration/scenarios
+          CHART_PATH: charts/${{ inputs.camunda-helm-dir }}
+        run: |
+          echo "$VALS_CONFIG" > /tmp/values-config.json
+          cat /tmp/values-config.json
+          export $(jq -r 'to_entries | map("\(.key)=\(.value|tostring)") | .[]' /tmp/values-config.json)
+          env
+          TMP_DIR="${CHART_PATH}/test/integration/scenarios/chart-full-setup"
+          VAL_FI=values-integration-test-ingress-${TEST_VALUES_SCENARIO}.yaml
+          V=${TMP_DIR}/${VAL_FI}
+          ls -ls ${TMP_DIR}
+          cat $V
+          envsubst < $V > $V.bk
+          cat $V.bk
+          mv $V.bk $V
+
       - name: Helm - Install - 🌟 Install Camunda chart 🌟
         env:
           TEST_CHART_FLOW: ${{ inputs.flow }}
@@ -412,6 +442,7 @@ jobs:
           TEST_VALUES_SCENARIO: "${{ inputs.scenario }}"
           TEST_AUTH_TYPE: ${{ inputs.auth }}
           INFRA_TYPE: ${{ inputs.infra-type }}
+          VALUES_CONFIG: ${{ inputs.values-config }}
           TEST_HELM_EXTRA_ARGS: >-
             ${{ env.TEST_HELM_EXTRA_ARGS_INSTALL }}
             --set global.ingress.host=${{ steps.vars.outputs.ingress-host }}
@@ -498,12 +529,6 @@ jobs:
     needs: [ci-setup]
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    env:
-      CI_TASKS_BASE_DIR: ${{ needs.ci-setup.outputs.CI_TASKS_BASE_DIR }}
-      TEST_CHART_DIR: ${{ needs.ci-setup.outputs.TEST_CHART_DIR }}
-      TEST_VALUES_BASE_DIR: ${{ needs.ci-setup.outputs.TEST_VALUES_BASE_DIR }}
-      TEST_INGRESS_HOST: ${{ needs.ci-setup.outputs.vars-ingress-host }}
-      TEST_NAMESPACE: ${{ needs.ci-setup.outputs.TEST_NAMESPACE }}
     permissions:
       contents: read
       id-token: write
@@ -527,6 +552,27 @@ jobs:
             task
             yq
 
+      - name: CI Setup - ℹ️ Set workflow vars for both install and upgrade ℹ️
+        id: vars
+        uses: ./.github/actions/workflow-vars
+        with:
+          deployment-ttl: ${{ env.CI_DEPLOYMENT_TTL }}
+          setup-flow: ${{ inputs.flow }}
+          platform: ${{ inputs.distro-platform }}
+          identifier-base: ${{ inputs.identifier }}
+          ingress-hostname-base: ${{ env.CI_HOSTNAME_BASE }}
+          chart-dir: ${{ inputs.camunda-helm-dir }}
+          chart-upgrade-version: ${{ inputs.camunda-helm-upgrade-version }}
+          prefix: ${{ inputs.namespace-prefix }}
+    
+      - name: CI Setup - Set test type vars
+        id: test-type-vars
+        uses: ./.github/actions/test-type-vars
+        with:
+          chart-dir: "${{ inputs.camunda-helm-dir }}"
+          infra-type: "${{ inputs.infra-type }}"
+          platform: "${{ inputs.distro-platform }}"
+
       - name: CI Setup - Authenticate to cluster
         id: cluster-auth
         uses: ./.github/actions/cluster-auth
@@ -547,16 +593,34 @@ jobs:
 
       - name: Test - ⭐️ Run Venom Env Setup ⭐️        
         timeout-minutes: 1
+        env:
+          CI_TASKS_BASE_DIR: ${{ env.CI_TASKS_BASE_DIR }}
+          TEST_CHART_DIR: ${{ env.TEST_CHART_DIR }}
+          TEST_VALUES_BASE_DIR: ${{ env.TEST_VALUES_BASE_DIR }}
+          TEST_INGRESS_HOST: ${{ steps.vars.outputs.ingress-host }}
+          TEST_NAMESPACE: ${{ env.TEST_NAMESPACE }}
         continue-on-error: false
         run: |
           task -d ${CI_TASKS_BASE_DIR}/chart-full-setup setup.venom.env
 
       - name: Test - ⭐️ Run Venom Preflight TestSuite ⭐️
+        env:
+          CI_TASKS_BASE_DIR: ${{ env.CI_TASKS_BASE_DIR }}
+          TEST_CHART_DIR: ${{ env.TEST_CHART_DIR }}
+          TEST_VALUES_BASE_DIR: ${{ env.TEST_VALUES_BASE_DIR }}
+          TEST_INGRESS_HOST: ${{ steps.vars.outputs.ingress-host }}
+          TEST_NAMESPACE: ${{ env.TEST_NAMESPACE }}
         continue-on-error: true
         run: |
           task -d ${CI_TASKS_BASE_DIR}/chart-full-setup test.preflight
 
       - name: Test - ⭐️ Run Venom Core TestSuite ⭐️
+        env:
+          CI_TASKS_BASE_DIR: ${{ env.CI_TASKS_BASE_DIR }}
+          TEST_CHART_DIR: ${{ env.TEST_CHART_DIR }}
+          TEST_VALUES_BASE_DIR: ${{ env.TEST_VALUES_BASE_DIR }}
+          TEST_INGRESS_HOST: ${{ steps.vars.outputs.ingress-host }}
+          TEST_NAMESPACE: ${{ env.TEST_NAMESPACE }}
         id: core-testsuite
         run: |
           task -d ${CI_TASKS_BASE_DIR}/chart-full-setup test.core
@@ -600,6 +664,27 @@ jobs:
             yq
             zbctl
 
+      - name: CI Setup - ℹ️ Set workflow vars for both install and upgrade ℹ️
+        id: vars
+        uses: ./.github/actions/workflow-vars
+        with:
+          deployment-ttl: ${{ env.CI_DEPLOYMENT_TTL }}
+          setup-flow: ${{ inputs.flow }}
+          platform: ${{ inputs.distro-platform }}
+          identifier-base: ${{ inputs.identifier }}
+          ingress-hostname-base: ${{ env.CI_HOSTNAME_BASE }}
+          chart-dir: ${{ inputs.camunda-helm-dir }}
+          chart-upgrade-version: ${{ inputs.camunda-helm-upgrade-version }}
+          prefix: ${{ inputs.namespace-prefix }}
+
+      - name: CI Setup - Set test type vars
+        id: test-type-vars
+        uses: ./.github/actions/test-type-vars
+        with:
+          chart-dir: "${{ inputs.camunda-helm-dir }}"
+          infra-type: "${{ inputs.infra-type }}"
+          platform: "${{ inputs.distro-platform }}"
+
       - name: CI Setup - Authenticate to cluster
         id: cluster-auth
         uses: ./.github/actions/cluster-auth
@@ -622,8 +707,8 @@ jobs:
         id: cache-node
         uses: actions/cache@v4
         with:
-          path: ${{ needs.ci-setup.outputs.ABSOLUTE_TEST_CHART_DIR }}/test/integration/testsuites/node_modules
-          key: node_modules-${{ runner.os }}-${{ hashFiles(format('{0}/test/integration/testsuites/package-lock.json', needs.ci-setup.outputs.ABSOLUTE_TEST_CHART_DIR)) }}
+          path: ${{ env.ABSOLUTE_TEST_CHART_DIR }}/test/integration/testsuites/node_modules
+          key: node_modules-${{ runner.os }}-${{ hashFiles(format('{0}/test/integration/testsuites/package-lock.json', env.ABSOLUTE_TEST_CHART_DIR)) }}
           restore-keys: |
             node_modules-${{ runner.os }}-
   
@@ -632,19 +717,19 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-automation-${{ runner.os }}-${{ hashFiles(format('{0}/test/integration/testsuites/package-lock.json', needs.ci-setup.outputs.ABSOLUTE_TEST_CHART_DIR)) }}
+          key: playwright-automation-${{ runner.os }}-${{ hashFiles(format('{0}/test/integration/testsuites/package-lock.json', env.ABSOLUTE_TEST_CHART_DIR)) }}
           restore-keys: |
             playwright-automation-${{ runner.os }}-
 
       - name: Test - ⭐️ Run Playwright Core TestSuite (Github Runner) ⭐️
         run: |
           cd $GITHUB_WORKSPACE/scripts
-          ./run-integration-tests.sh --absolute-chart-path ${{needs.ci-setup.outputs.ABSOLUTE_TEST_CHART_DIR}} --namespace ${{ needs.ci-setup.outputs.TEST_NAMESPACE }}
+          ./run-integration-tests.sh --absolute-chart-path ${{env.ABSOLUTE_TEST_CHART_DIR}} --namespace ${{ env.TEST_NAMESPACE }}
 
       - name: Test - Upload Playwright report
         uses: actions/upload-artifact@v4
         with:
-          path: ${{ needs.ci-setup.outputs.ABSOLUTE_TEST_CHART_DIR }}/test/integration/testsuites/playwright-report
+          path: ${{ env.ABSOLUTE_TEST_CHART_DIR }}/test/integration/testsuites/playwright-report
           name: playwright-report-${{ github.workflow }}-${{ inputs.identifier }}-${{ inputs.flow }}-${{ inputs.distro-platform }}-runner
           if-no-files-found: error
           retention-days: 5
@@ -686,6 +771,27 @@ jobs:
             task
             yq
 
+      - name: CI Setup - ℹ️ Set workflow vars for both install and upgrade ℹ️
+        id: vars
+        uses: ./.github/actions/workflow-vars
+        with:
+          deployment-ttl: ${{ env.CI_DEPLOYMENT_TTL }}
+          setup-flow: ${{ inputs.flow }}
+          platform: ${{ inputs.distro-platform }}
+          identifier-base: ${{ inputs.identifier }}
+          ingress-hostname-base: ${{ env.CI_HOSTNAME_BASE }}
+          chart-dir: ${{ inputs.camunda-helm-dir }}
+          chart-upgrade-version: ${{ inputs.camunda-helm-upgrade-version }}
+          prefix: ${{ inputs.namespace-prefix }}
+
+      - name: CI Setup - Set test type vars
+        id: test-type-vars
+        uses: ./.github/actions/test-type-vars
+        with:
+          chart-dir: "${{ inputs.camunda-helm-dir }}"
+          infra-type: "${{ inputs.infra-type }}"
+          platform: "${{ inputs.distro-platform }}"
+
       - name: CI Setup - Authenticate to cluster
         id: cluster-auth
         uses: ./.github/actions/cluster-auth
@@ -708,8 +814,8 @@ jobs:
         id: cache-node
         uses: actions/cache@v4
         with:
-          path: ${{ needs.ci-setup.outputs.ABSOLUTE_TEST_CHART_DIR }}/test/integration/testsuites/node_modules
-          key: node_modules-${{ runner.os }}-${{ hashFiles(format('{0}/test/integration/testsuites/package-lock.json', needs.ci-setup.outputs.ABSOLUTE_TEST_CHART_DIR)) }}
+          path: ${{ env.ABSOLUTE_TEST_CHART_DIR }}/test/integration/testsuites/node_modules
+          key: node_modules-${{ runner.os }}-${{ hashFiles(format('{0}/test/integration/testsuites/package-lock.json', env.ABSOLUTE_TEST_CHART_DIR)) }}
           restore-keys: |
             node_modules-${{ runner.os }}-
 
@@ -718,21 +824,20 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-automation-${{ runner.os }}-${{ hashFiles(format('{0}/test/integration/testsuites/package-lock.json', needs.ci-setup.outputs.ABSOLUTE_TEST_CHART_DIR)) }}
+          key: playwright-automation-${{ runner.os }}-${{ hashFiles(format('{0}/test/integration/testsuites/package-lock.json', env.ABSOLUTE_TEST_CHART_DIR)) }}
           restore-keys: |
             playwright-automation-${{ runner.os }}-
 
-      - name: Test - ⭐️ Run Playwright Core TestSuite (Github Runner) ⭐️
+      - name: Test - ⭐️ Run Playwright E2E TestSuite (Github Runner) ⭐️
         run: |
           cd $GITHUB_WORKSPACE/scripts
-          ./run-e2e-tests.sh --absolute-chart-path ${{needs.ci-setup.outputs.ABSOLUTE_TEST_CHART_DIR}} --namespace ${{needs.ci-setup.outputs.TEST_NAMESPACE}} --shard-index ${{ matrix.shardIndex }} --shard-total ${{ matrix.shardTotal }} $( [ "${{ inputs.run-all-e2e-tests }}" = "false" ] && echo "--run-smoke-tests" )
-
+          ./run-e2e-tests.sh --absolute-chart-path ${{env.ABSOLUTE_TEST_CHART_DIR}} --namespace ${{env.TEST_NAMESPACE}} --shard-index ${{ matrix.shardIndex }} --shard-total ${{ matrix.shardTotal }} $( [ "${{ inputs.run-all-e2e-tests }}" = "false" ] && echo "--run-smoke-tests" ) $( [ "${{ inputs.scenario }}" = "qa-opensearch" ] && echo "--opensearch" ) --verbose
       - name: Upload blob report to GitHub Actions Artifacts
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: blob-report-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.flow }}-${{ inputs.distro-platform }}-${{ matrix.shardIndex }}
-          path: ${{needs.ci-setup.outputs.ABSOLUTE_TEST_CHART_DIR}}/test/e2e/blob-report
+          path: ${{env.ABSOLUTE_TEST_CHART_DIR}}/test/e2e/blob-report
           retention-days: 1
 
   merge-reports:
@@ -743,15 +848,40 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          # This is needed to load repo GH composite actions if the workflow triggered by workflow_call.
+          repository: camunda/camunda-platform-helm
+          ref: ${{ inputs.camunda-helm-git-ref }}
 
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
           
+      - name: CI Setup - ℹ️ Set workflow vars for both install and upgrade ℹ️
+        id: vars
+        uses: ./.github/actions/workflow-vars
+        with:
+          deployment-ttl: ${{ env.CI_DEPLOYMENT_TTL }}
+          setup-flow: ${{ inputs.flow }}
+          platform: ${{ inputs.distro-platform }}
+          identifier-base: ${{ inputs.identifier }}
+          ingress-hostname-base: ${{ env.CI_HOSTNAME_BASE }}
+          chart-dir: ${{ inputs.camunda-helm-dir }}
+          chart-upgrade-version: ${{ inputs.camunda-helm-upgrade-version }}
+          prefix: ${{ inputs.namespace-prefix }}
+
+      - name: CI Setup - Set test type vars
+        id: test-type-vars
+        uses: ./.github/actions/test-type-vars
+        with:
+          chart-dir: "${{ inputs.camunda-helm-dir }}"
+          infra-type: "${{ inputs.infra-type }}"
+          platform: "${{ inputs.distro-platform }}"
+
       - name: Install dependencies
         run: |
-          cd ${{needs.ci-setup.outputs.ABSOLUTE_TEST_CHART_DIR}}/test/e2e
+          cd ${{env.ABSOLUTE_TEST_CHART_DIR}}/test/e2e
           npm ci
 
       - name: Download blob reports from GitHub Actions Artifacts
@@ -790,6 +920,27 @@ jobs:
           # This is needed to load repo GH composite actions if the workflow triggered by workflow_call.
           repository: camunda/camunda-platform-helm
           ref: ${{ inputs.camunda-helm-git-ref }}
+
+      - name: CI Setup - ℹ️ Set workflow vars for both install and upgrade ℹ️
+        id: vars
+        uses: ./.github/actions/workflow-vars
+        with:
+          deployment-ttl: ${{ env.CI_DEPLOYMENT_TTL }}
+          setup-flow: ${{ inputs.flow }}
+          platform: ${{ inputs.distro-platform }}
+          identifier-base: ${{ inputs.identifier }}
+          ingress-hostname-base: ${{ env.CI_HOSTNAME_BASE }}
+          chart-dir: ${{ inputs.camunda-helm-dir }}
+          chart-upgrade-version: ${{ inputs.camunda-helm-upgrade-version }}
+          prefix: ${{ inputs.namespace-prefix }}
+
+      - name: CI Setup - Set test type vars
+        id: test-type-vars
+        uses: ./.github/actions/test-type-vars
+        with:
+          chart-dir: "${{ inputs.camunda-helm-dir }}"
+          infra-type: "${{ inputs.infra-type }}"
+          platform: "${{ inputs.distro-platform }}"
 
       - name: CI Setup - Install tools
         uses: ./.github/actions/install-tool-versions
@@ -832,6 +983,6 @@ jobs:
       - name: CI Cleanup - 🚨 Mark namespace as failed 🚨
         if: failure()
         run: |
-          kubectl annotate ns ${{ needs.ci-setup.outputs.TEST_NAMESPACE }} build-failed=true
-          kubectl annotate ns ${{ needs.ci-setup.outputs.TEST_NAMESPACE }} cleaner/ttl=1d
-          kubectl annotate ns ${{ needs.ci-setup.outputs.TEST_NAMESPACE }} janitor/ttl=1d
+          kubectl annotate ns ${{ env.TEST_NAMESPACE }} build-failed=true
+          kubectl annotate ns ${{ env.TEST_NAMESPACE }} cleaner/ttl=1d
+          kubectl annotate ns ${{ env.TEST_NAMESPACE }} janitor/ttl=1d

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -4,6 +4,11 @@ name: "Test - Integration - Template"
 on:
   workflow_call:
     inputs:
+      values-config:
+        type: string
+        description: Some of the values files will allow subsitutions. For example, on the image.tags. This config supplies those values
+        default: '{}'
+        required: false
       identifier:
         description: The unique identifier of used in the deployment hostname.
         required: true
@@ -81,7 +86,7 @@ on:
         type: string
       shortname:
         required: false
-        default: "elasticsearch"
+        default: "es"
         type: string
       auth:
         required: false
@@ -135,6 +140,10 @@ on:
         required: false
         default: false
         type: boolean
+    outputs:
+      deployment-url:
+        description: The URL of the deployed application.
+        value: ${{ jobs.print-outputs.outputs.deployment-url }}
 
 permissions:
   contents: read
@@ -219,6 +228,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.init.outputs.matrix) }}
     with:
+      values-config: ${{ inputs.values-config }}
       auth: ${{ inputs.auth }}
       exclude: ${{ inputs.exclude }}
       identifier: ${{ inputs.identifier }}-${{ inputs.shortname }}
@@ -255,6 +265,38 @@ jobs:
       namespace-prefix: ${{ inputs.namespace-prefix }}
       values-digest: ${{ inputs.values-digest }}
       values-enterprise: ${{ inputs.values-enterprise }}
+
+  print-outputs:
+    name: Print outputs
+    runs-on: ubuntu-latest
+    needs: [runner]
+    outputs:
+      deployment-url: ${{ steps.vars.outputs.ingress-host }}
+    steps:
+      - name: CI Setup - Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          # This is needed to load repo GH composite actions if the workflow triggered by workflow_call.
+          repository: camunda/camunda-platform-helm
+          ref: ${{ inputs.camunda-helm-git-ref }}
+
+      - name: CI Setup - ℹ️ Set workflow vars for both install and upgrade ℹ️
+        id: vars
+        uses: ./.github/actions/workflow-vars
+        with:
+          deployment-ttl: 30m
+          setup-flow: install
+          platform: gke
+          identifier-base: ${{ inputs.identifier }}-${{ inputs.shortname }}
+          ingress-hostname-base: ci.distro.ultrawombat.com
+          chart-dir: ${{ inputs.camunda-helm-dir }}
+          chart-upgrade-version: 8.7
+          prefix: ${{ inputs.namespace-prefix }}
+
+      - name: Print outputs
+        run: |
+          echo "Deployment URL: ${{ needs.runner.outputs.deployment-url }}"
+          echo "deployment-url=${{ steps.vars.outputs.ingress-host }}" >> $GITHUB_OUTPUT
 
   # Rerun failed jobs running on self-hosted runners in case of network issues or node preemption
   rerun-failed-jobs:

--- a/charts/camunda-platform-8.4/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch-mt.yaml
+++ b/charts/camunda-platform-8.4/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch-mt.yaml
@@ -1,0 +1,273 @@
+global:
+  image:
+    pullPolicy: Always
+  multitenancy:
+    enabled: true
+zeebe:
+  image:
+    tag: "$E2E_TESTS_ZEEBE_IMAGE_TAG"
+tasklist:
+  image:
+    tag: "$E2E_TESTS_TASKLIST_IMAGE_TAG"
+operate:
+  image:
+    tag: "$E2E_TESTS_OPERATE_IMAGE_TAG"
+optimize:
+  image:
+    tag: "$E2E_TESTS_OPTIMIZE_IMAGE_TAG"
+webModeler:
+  restapi:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  webapp:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  websockets:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+console:
+  image:
+    tag: "$E2E_TESTS_CONSOLE_IMAGE_TAG"
+identity:
+  image:
+    tag: "$E2E_TESTS_IDENTITY_IMAGE_TAG"
+  firstUser:
+    existingSecret: null
+    user: demo
+    password: $DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+  postgresql:
+    enabled: true
+  externalDatabase:
+    enabled: false
+  # Keycloak client seed which is used to query Camunda APIs. 
+  env:
+    # TODO: Remove the KEYCLOAK_USERS env vars in favor of relying on the default configmap values
+    - name: KEYCLOAK_USERS_0_USERNAME
+      value: 'demo'
+    - name: KEYCLOAK_USERS_0_EMAIL
+      value: 'demo@example.com'
+    - name: KEYCLOAK_USERS_0_FIRSTNAME
+      value: 'Demo'
+    - name: KEYCLOAK_USERS_0_LASTNAME
+      value: 'User'
+    - name: KEYCLOAK_USERS_0_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+    - name: KEYCLOAK_USERS_0_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_0_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_0_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_0_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_0_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_0_ROLES_5
+      value: Console
+    - name: KEYCLOAK_CLIENTS_2_ID
+      value: venom
+    - name: KEYCLOAK_CLIENTS_2_NAME
+      value: Venom
+    - name: KEYCLOAK_CLIENTS_2_SECRET
+    - name: KEYCLOAK_CLIENTS_2_ID
+      value: venom
+    - name: KEYCLOAK_CLIENTS_2_NAME
+      value: Venom
+    - name: KEYCLOAK_CLIENTS_2_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: integration-test-credentials
+          key: identity-admin-client-password
+    - name: KEYCLOAK_CLIENTS_2_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_2_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_2_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_DEFINITION
+      value: write
+    - name: KEYCLOAK_USERS_1_FIRST_NAME
+      value: Lisa
+    - name: KEYCLOAK_USERS_1_LAST_NAME
+      value: Doe
+    - name: KEYCLOAK_USERS_1_EMAIL
+      value: cawemodev+lisa@gmail.com
+    - name: KEYCLOAK_USERS_1_USERNAME
+      value: lisa
+    - name: KEYCLOAK_USERS_1_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_SECONDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_1_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_1_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_1_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_1_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_1_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_1_ROLES_5
+      value: Console
+    - name: KEYCLOAK_USERS_2_FIRST_NAME
+      value: Bart
+    - name: KEYCLOAK_USERS_2_LAST_NAME
+      value: Foo
+    - name: KEYCLOAK_USERS_2_EMAIL
+      value: cawemodev+bart@gmail.com
+    - name: KEYCLOAK_USERS_2_USERNAME
+      value: bart
+    - name: KEYCLOAK_USERS_2_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_THIRDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_2_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_2_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_2_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_2_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_2_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_2_ROLES_5
+      value: Console
+    # Operate access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # Tasklist access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    # Zeebe access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_RESOURCE_SERVER_ID
+      value: zeebe-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_DEFINITION
+      value: "write:*"
+    # WebModeler access.
+    # NOTE: This actually should be only in the chart-with-web-modeler scenarios,
+    # but since Helm doesn't support merge lists it's added here.
+    # It could be removed later when the env vars could be configured via ConfigMap.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_8_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_8_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_9_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_9_DEFINITION
+      value: "write:*"
+    - name: KEYCLOAK_CLIENTS_3_ID
+      value: test
+    - name: KEYCLOAK_CLIENTS_3_NAME
+      value: Test
+    - name: KEYCLOAK_CLIENTS_3_SECRET
+      value: $DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET
+    - name: KEYCLOAK_CLIENTS_3_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_3_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_3_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_DEFINITION
+      value: write
+    # Operate access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # Tasklist access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    # Zeebe access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_RESOURCE_SERVER_ID
+      value: zeebe-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_DEFINITION
+      value: "write:*"
+    # WebModeler access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_8_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_8_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_DEFINITION
+      value: "write:*"
+    - name: IDENTITY_TENANTS_0_NAME
+      value: Default
+    - name: IDENTITY_TENANTS_0_TENANTID
+      value: <default>
+    - name: IDENTITY_TENANTS_0_MEMBERS_0_TYPE
+      value: USER
+    - name: IDENTITY_TENANTS_0_MEMBERS_0_USERNAME
+      value: demo
+    - name: IDENTITY_TENANTS_0_MEMBERS_1_TYPE
+      value: APPLICATION
+    - name: IDENTITY_TENANTS_0_MEMBERS_1_APPLICATIONID
+      value: operate
+    - name: IDENTITY_TENANTS_0_MEMBERS_2_TYPE
+      value: APPLICATION
+    - name: IDENTITY_TENANTS_0_MEMBERS_2_APPLICATIONID
+      value: test
+    - name: IDENTITY_TENANTS_0_MEMBERS_3_TYPE
+      value: APPLICATION
+    - name: IDENTITY_TENANTS_0_MEMBERS_3_APPLICATIONID
+      value: connectors
+    - name: IDENTITY_TENANTS_0_MEMBERS_4_TYPE
+      value: APPLICATION
+    - name: IDENTITY_TENANTS_0_MEMBERS_4_APPLICATIONID
+      value: zeebe
+connectors:
+  image:
+    tag: "$E2E_TESTS_CONNECTORS_IMAGE_TAG"
+  env:
+    - name: username
+      value: username
+    - name: password
+      value: password
+    - name: ZEEBE_CLIENT_DEFAULT_JOB_WORKER_TENANT_IDS
+      value: "Tenant_Main_Connectors, Tenant_Second_Connectors, Tenant_1_Connectors, Tenant_2_Connectors"

--- a/charts/camunda-platform-8.4/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch-rba.yaml
+++ b/charts/camunda-platform-8.4/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch-rba.yaml
@@ -1,0 +1,251 @@
+global:
+  image:
+    pullPolicy: Always
+zeebe:
+  image:
+    tag: "$E2E_TESTS_ZEEBE_IMAGE_TAG"
+tasklist:
+  image:
+    tag: "$E2E_TESTS_TASKLIST_IMAGE_TAG"
+  env:
+    - name: CAMUNDA_TASKLIST_IDENTITY_RESOURCE_PERMISSIONS_ENABLED
+      value: 'true'
+operate:
+  image:
+    tag: "$E2E_TESTS_OPERATE_IMAGE_TAG"
+  env:
+    - name: CAMUNDA_OPERATE_IDENTITY_RESOURCEPERMISSIONSENABLED
+      value: 'true'
+optimize:
+  image:
+    tag: "$E2E_TESTS_OPTIMIZE_IMAGE_TAG"
+webModeler:
+  restapi:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  webapp:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  websockets:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+console:
+  image:
+    tag: "$E2E_TESTS_CONSOLE_IMAGE_TAG"
+identity:
+  image:
+    tag: "$E2E_TESTS_IDENTITY_IMAGE_TAG"
+  firstUser:
+    existingSecret: null
+    user: demo
+    password: $DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+  postgresql:
+    enabled: true
+  # Keycloak client seed which is used to query Camunda APIs. 
+  env:
+    # TODO: Remove the KEYCLOAK_USERS env vars in favor of relying on the default configmap values
+    - name: KEYCLOAK_USERS_0_USERNAME
+      value: 'demo'
+    - name: KEYCLOAK_USERS_0_EMAIL
+      value: 'demo@example.com'
+    - name: KEYCLOAK_USERS_0_FIRSTNAME
+      value: 'Demo'
+    - name: KEYCLOAK_USERS_0_LASTNAME
+      value: 'User'
+    - name: KEYCLOAK_USERS_0_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+    - name: KEYCLOAK_USERS_0_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_0_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_0_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_0_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_0_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_0_ROLES_5
+      value: Console
+    - name: KEYCLOAK_CLIENTS_2_ID
+      value: venom
+    - name: KEYCLOAK_CLIENTS_2_NAME
+      value: Venom
+    - name: KEYCLOAK_CLIENTS_2_SECRET
+    - name: KEYCLOAK_CLIENTS_2_ID
+      value: venom
+    - name: KEYCLOAK_CLIENTS_2_NAME
+      value: Venom
+    - name: KEYCLOAK_CLIENTS_2_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: integration-test-credentials
+          key: identity-admin-client-password
+    - name: KEYCLOAK_CLIENTS_2_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_2_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_2_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_DEFINITION
+      value: write
+    - name: KEYCLOAK_USERS_1_FIRST_NAME
+      value: Lisa
+    - name: KEYCLOAK_USERS_1_LAST_NAME
+      value: Doe
+    - name: KEYCLOAK_USERS_1_EMAIL
+      value: cawemodev+lisa@gmail.com
+    - name: KEYCLOAK_USERS_1_USERNAME
+      value: lisa
+    - name: KEYCLOAK_USERS_1_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_SECONDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_1_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_1_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_1_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_1_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_1_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_1_ROLES_5
+      value: Console
+    - name: KEYCLOAK_USERS_2_FIRST_NAME
+      value: Bart
+    - name: KEYCLOAK_USERS_2_LAST_NAME
+      value: Foo
+    - name: KEYCLOAK_USERS_2_EMAIL
+      value: cawemodev+bart@gmail.com
+    - name: KEYCLOAK_USERS_2_USERNAME
+      value: bart
+    - name: KEYCLOAK_USERS_2_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_THIRDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_2_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_2_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_2_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_2_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_2_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_2_ROLES_5
+      value: Console
+    # Operate access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # Tasklist access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    # Zeebe access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_RESOURCE_SERVER_ID
+      value: zeebe-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_DEFINITION
+      value: "write:*"
+    # WebModeler access.
+    # NOTE: This actually should be only in the chart-with-web-modeler scenarios,
+    # but since Helm doesn't support merge lists it's added here.
+    # It could be removed later when the env vars could be configured via ConfigMap.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_8_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_8_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_9_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_9_DEFINITION
+      value: "write:*"
+    - name: KEYCLOAK_CLIENTS_3_ID
+      value: test
+    - name: KEYCLOAK_CLIENTS_3_NAME
+      value: Test
+    - name: KEYCLOAK_CLIENTS_3_SECRET
+      value: $DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET
+    - name: KEYCLOAK_CLIENTS_3_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_3_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_3_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_DEFINITION
+      value: write
+    # Operate access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # Tasklist access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    # Zeebe access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_RESOURCE_SERVER_ID
+      value: zeebe-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_DEFINITION
+      value: "write:*"
+    # WebModeler access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_8_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_8_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_DEFINITION
+      value: "write:*"
+    - name: RESOURCE_PERMISSIONS_ENABLED
+      value: 'true'
+connectors:
+  image:
+    tag: "$E2E_TESTS_CONNECTORS_IMAGE_TAG"
+  env:
+    - name: username
+      value: username
+    - name: password
+      value: password

--- a/charts/camunda-platform-8.4/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch.yaml
+++ b/charts/camunda-platform-8.4/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch.yaml
@@ -1,0 +1,241 @@
+global:
+  image:
+    pullPolicy: Always
+zeebe:
+  image:
+    tag: "$E2E_TESTS_ZEEBE_IMAGE_TAG"
+tasklist:
+  image:
+    tag: "$E2E_TESTS_TASKLIST_IMAGE_TAG"
+operate:
+  image:
+    tag: "$E2E_TESTS_OPERATE_IMAGE_TAG"
+optimize:
+  image:
+    tag: "$E2E_TESTS_OPTIMIZE_IMAGE_TAG"
+webModeler:
+  restapi:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  webapp:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  websockets:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+console:
+  image:
+    tag: "$E2E_TESTS_CONSOLE_IMAGE_TAG"
+identity:
+  image:
+    tag: "$E2E_TESTS_IDENTITY_IMAGE_TAG"
+  firstUser:
+    existingSecret: null
+    user: demo
+    password: $DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+  # Keycloak client seed which is used to query Camunda APIs. 
+  env:
+    # TODO: Remove the KEYCLOAK_USERS env vars in favor of relying on the default configmap values
+    - name: KEYCLOAK_USERS_0_USERNAME
+      value: 'demo'
+    - name: KEYCLOAK_USERS_0_EMAIL
+      value: 'demo@example.com'
+    - name: KEYCLOAK_USERS_0_FIRSTNAME
+      value: 'Demo'
+    - name: KEYCLOAK_USERS_0_LASTNAME
+      value: 'User'
+    - name: KEYCLOAK_USERS_0_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+    - name: KEYCLOAK_USERS_0_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_0_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_0_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_0_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_0_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_0_ROLES_5
+      value: Console
+    - name: KEYCLOAK_CLIENTS_2_ID
+      value: venom
+    - name: KEYCLOAK_CLIENTS_2_NAME
+      value: Venom
+    - name: KEYCLOAK_CLIENTS_2_SECRET
+    - name: KEYCLOAK_CLIENTS_2_ID
+      value: venom
+    - name: KEYCLOAK_CLIENTS_2_NAME
+      value: Venom
+    - name: KEYCLOAK_CLIENTS_2_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: integration-test-credentials
+          key: identity-admin-client-password
+    - name: KEYCLOAK_CLIENTS_2_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_2_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_2_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_DEFINITION
+      value: write
+    - name: KEYCLOAK_USERS_1_FIRST_NAME
+      value: Lisa
+    - name: KEYCLOAK_USERS_1_LAST_NAME
+      value: Doe
+    - name: KEYCLOAK_USERS_1_EMAIL
+      value: cawemodev+lisa@gmail.com
+    - name: KEYCLOAK_USERS_1_USERNAME
+      value: lisa
+    - name: KEYCLOAK_USERS_1_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_SECONDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_1_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_1_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_1_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_1_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_1_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_1_ROLES_5
+      value: Console
+    - name: KEYCLOAK_USERS_2_FIRST_NAME
+      value: Bart
+    - name: KEYCLOAK_USERS_2_LAST_NAME
+      value: Foo
+    - name: KEYCLOAK_USERS_2_EMAIL
+      value: cawemodev+bart@gmail.com
+    - name: KEYCLOAK_USERS_2_USERNAME
+      value: bart
+    - name: KEYCLOAK_USERS_2_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_THIRDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_2_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_2_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_2_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_2_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_2_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_2_ROLES_5
+      value: Console
+    # Operate access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # Tasklist access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    # Zeebe access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_RESOURCE_SERVER_ID
+      value: zeebe-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_DEFINITION
+      value: "write:*"
+    # WebModeler access.
+    # NOTE: This actually should be only in the chart-with-web-modeler scenarios,
+    # but since Helm doesn't support merge lists it's added here.
+    # It could be removed later when the env vars could be configured via ConfigMap.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_8_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_8_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_9_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_9_DEFINITION
+      value: "write:*"
+    - name: KEYCLOAK_CLIENTS_3_ID
+      value: test
+    - name: KEYCLOAK_CLIENTS_3_NAME
+      value: Test
+    - name: KEYCLOAK_CLIENTS_3_SECRET
+      value: $DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET
+    - name: KEYCLOAK_CLIENTS_3_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_3_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_3_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_DEFINITION
+      value: write
+    # Operate access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # Tasklist access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    # Zeebe access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_RESOURCE_SERVER_ID
+      value: zeebe-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_DEFINITION
+      value: "write:*"
+    # WebModeler access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_8_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_8_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_DEFINITION
+      value: "write:*"
+connectors:
+  image:
+    tag: "$E2E_TESTS_CONNECTORS_IMAGE_TAG"
+  env:
+    - name: username
+      value: username
+    - name: password
+      value: password

--- a/charts/camunda-platform-8.5/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch-mt.yaml
+++ b/charts/camunda-platform-8.5/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch-mt.yaml
@@ -9,15 +9,9 @@ zeebe:
 tasklist:
   image:
     tag: "$E2E_TESTS_TASKLIST_IMAGE_TAG"
-  env:
-    - name: CAMUNDA_TASKLIST_IDENTITY_RESOURCE_PERMISSIONS_ENABLED
-      value: 'true'
 operate:
   image:
     tag: "$E2E_TESTS_OPERATE_IMAGE_TAG"
-  env:
-    - name: CAMUNDA_OPERATE_IDENTITY_RESOURCEPERMISSIONSENABLED
-      value: 'true'
 optimize:
   image:
     tag: "$E2E_TESTS_OPTIMIZE_IMAGE_TAG"
@@ -268,8 +262,6 @@ identity:
       value: console-api
     - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_DEFINITION
       value: "write:*"
-    - name: RESOURCE_PERMISSIONS_ENABLED
-      value: 'true'
     - name: IDENTITY_TENANTS_0_NAME
       value: Default
     - name: IDENTITY_TENANTS_0_TENANTID
@@ -294,10 +286,10 @@ identity:
       value: APPLICATION
     - name: IDENTITY_TENANTS_0_MEMBERS_4_APPLICATIONID
       value: zeebe
-    - name: IDENTITY_TENANTS_0_MEMBERS_2_APPLICATIONID
-      value: venom
-    - name: IDENTITY_TENANTS_0_MEMBERS_3_TYPE
+    - name: IDENTITY_TENANTS_0_MEMBERS_5_TYPE
       value: APPLICATION
+    - name: IDENTITY_TENANTS_0_MEMBERS_5_APPLICATIONID
+      value: venom
 connectors:
   image:
     tag: "$E2E_TESTS_CONNECTORS_IMAGE_TAG"
@@ -307,4 +299,4 @@ connectors:
     - name: password
       value: password
     - name: ZEEBE_CLIENT_DEFAULT_JOB_WORKER_TENANT_IDS
-      value: "<default>, Tenant_Main_Connectors, Tenant_Second_Connectors, Tenant_1_Connectors, Tenant_2_Connectors"
+      value: "Tenant_Main_Connectors, Tenant_Second_Connectors, Tenant_1_Connectors, Tenant_2_Connectors"

--- a/charts/camunda-platform-8.5/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch-mt.yaml
+++ b/charts/camunda-platform-8.5/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch-mt.yaml
@@ -1,0 +1,310 @@
+global:
+  image:
+    pullPolicy: Always
+  multitenancy:
+    enabled: true
+zeebe:
+  image:
+    tag: "$E2E_TESTS_ZEEBE_IMAGE_TAG"
+tasklist:
+  image:
+    tag: "$E2E_TESTS_TASKLIST_IMAGE_TAG"
+  env:
+    - name: CAMUNDA_TASKLIST_IDENTITY_RESOURCE_PERMISSIONS_ENABLED
+      value: 'true'
+operate:
+  image:
+    tag: "$E2E_TESTS_OPERATE_IMAGE_TAG"
+  env:
+    - name: CAMUNDA_OPERATE_IDENTITY_RESOURCEPERMISSIONSENABLED
+      value: 'true'
+optimize:
+  image:
+    tag: "$E2E_TESTS_OPTIMIZE_IMAGE_TAG"
+webModeler:
+  restapi:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  webapp:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  websockets:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+console:
+  image:
+    tag: "$E2E_TESTS_CONSOLE_IMAGE_TAG"
+  overrideConfiguration: |
+    camunda:
+      console:
+        managed:
+          releases:
+            - name: integration
+              namespace: $TEST_NAMESPACE
+              tags:
+                - dev
+                - custom
+                - stage
+                - prod
+                - test
+              custom-properties:
+                - description: "This is the main integration environment for the Camunda Platform."
+                  links:
+                    - name: "Camunda"
+                      url: "https://camunda.com"
+                    - name: "Camunda Docs"
+                      url: "https://docs.camunda.io"
+  env:
+    - name: CAMUNDA_CONSOLE_EXPERIMENTAL_TAGS
+      value: "true"
+identity:
+  image:
+    tag: "$E2E_TESTS_IDENTITY_IMAGE_TAG"
+  postgresql:
+    enabled: true
+  externalDatabase:
+    enabled: false
+  firstUser:
+    existingSecret: null
+    user: demo
+    existingSecret: integration-test-credentials
+    existingSecretKey: identity-user-password
+  # Keycloak client seed which is used to query Camunda APIs. 
+  env:
+    # TODO: Remove the KEYCLOAK_USERS env vars in favor of relying on the default configmap values
+    - name: KEYCLOAK_USERS_0_USERNAME
+      value: 'demo'
+    - name: KEYCLOAK_USERS_0_EMAIL
+      value: 'demo@example.com'
+    - name: KEYCLOAK_USERS_0_FIRSTNAME
+      value: 'Demo'
+    - name: KEYCLOAK_USERS_0_LASTNAME
+      value: 'User'
+    - name: KEYCLOAK_USERS_0_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+    - name: KEYCLOAK_USERS_0_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_0_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_0_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_0_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_0_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_0_ROLES_5
+      value: Console
+    - name: KEYCLOAK_USERS_0_ROLES_6
+      value: "Zeebe"
+    - name: KEYCLOAK_CLIENTS_2_ID
+      value: venom
+    - name: KEYCLOAK_CLIENTS_2_NAME
+      value: Venom
+    - name: KEYCLOAK_CLIENTS_2_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: integration-test-credentials
+          key: identity-admin-client-password
+    - name: KEYCLOAK_CLIENTS_2_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_2_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_2_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_DEFINITION
+      value: write
+    - name: KEYCLOAK_USERS_1_FIRST_NAME
+      value: Lisa
+    - name: KEYCLOAK_USERS_1_LAST_NAME
+      value: Doe
+    - name: KEYCLOAK_USERS_1_EMAIL
+      value: cawemodev+lisa@gmail.com
+    - name: KEYCLOAK_USERS_1_USERNAME
+      value: lisa
+    - name: KEYCLOAK_USERS_1_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_SECONDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_1_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_1_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_1_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_1_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_1_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_1_ROLES_5
+      value: Console
+    - name: KEYCLOAK_USERS_1_ROLES_6
+      value: "Zeebe"
+    - name: KEYCLOAK_USERS_2_FIRST_NAME
+      value: Bart
+    - name: KEYCLOAK_USERS_2_LAST_NAME
+      value: Foo
+    - name: KEYCLOAK_USERS_2_EMAIL
+      value: cawemodev+bart@gmail.com
+    - name: KEYCLOAK_USERS_2_USERNAME
+      value: bart
+    - name: KEYCLOAK_USERS_2_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_THIRDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_2_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_2_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_2_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_2_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_2_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_2_ROLES_5
+      value: Console
+    - name: KEYCLOAK_USERS_2_ROLES_6
+      value: "Zeebe"
+    # Operate access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # Tasklist access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    # Zeebe access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_RESOURCE_SERVER_ID
+      value: zeebe-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_DEFINITION
+      value: "write:*"
+    # WebModeler access.
+    # NOTE: This actually should be only in the chart-with-web-modeler scenarios,
+    # but since Helm doesn't support merge lists it's added here.
+    # It could be removed later when the env vars could be configured via ConfigMap.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_8_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_8_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_9_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_9_DEFINITION
+      value: "write:*"
+    - name: KEYCLOAK_CLIENTS_3_ID
+      value: test
+    - name: KEYCLOAK_CLIENTS_3_NAME
+      value: Test
+    - name: KEYCLOAK_CLIENTS_3_SECRET
+      value: $DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET
+    - name: KEYCLOAK_CLIENTS_3_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_3_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_3_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_DEFINITION
+      value: write
+    # Operate access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # Tasklist access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    # Zeebe access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_RESOURCE_SERVER_ID
+      value: zeebe-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_DEFINITION
+      value: "write:*"
+    # WebModeler access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_8_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_8_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_DEFINITION
+      value: "write:*"
+    - name: RESOURCE_PERMISSIONS_ENABLED
+      value: 'true'
+    - name: IDENTITY_TENANTS_0_NAME
+      value: Default
+    - name: IDENTITY_TENANTS_0_TENANTID
+      value: <default>
+    - name: IDENTITY_TENANTS_0_MEMBERS_0_TYPE
+      value: USER
+    - name: IDENTITY_TENANTS_0_MEMBERS_0_USERNAME
+      value: demo
+    - name: IDENTITY_TENANTS_0_MEMBERS_1_TYPE
+      value: APPLICATION
+    - name: IDENTITY_TENANTS_0_MEMBERS_1_APPLICATIONID
+      value: operate
+    - name: IDENTITY_TENANTS_0_MEMBERS_2_TYPE
+      value: APPLICATION
+    - name: IDENTITY_TENANTS_0_MEMBERS_2_APPLICATIONID
+      value: test
+    - name: IDENTITY_TENANTS_0_MEMBERS_3_TYPE
+      value: APPLICATION
+    - name: IDENTITY_TENANTS_0_MEMBERS_3_APPLICATIONID
+      value: connectors
+    - name: IDENTITY_TENANTS_0_MEMBERS_4_TYPE
+      value: APPLICATION
+    - name: IDENTITY_TENANTS_0_MEMBERS_4_APPLICATIONID
+      value: zeebe
+    - name: IDENTITY_TENANTS_0_MEMBERS_2_APPLICATIONID
+      value: venom
+    - name: IDENTITY_TENANTS_0_MEMBERS_3_TYPE
+      value: APPLICATION
+connectors:
+  image:
+    tag: "$E2E_TESTS_CONNECTORS_IMAGE_TAG"
+  env:
+    - name: username
+      value: username
+    - name: password
+      value: password
+    - name: ZEEBE_CLIENT_DEFAULT_JOB_WORKER_TENANT_IDS
+      value: "<default>, Tenant_Main_Connectors, Tenant_Second_Connectors, Tenant_1_Connectors, Tenant_2_Connectors"

--- a/charts/camunda-platform-8.5/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch-rba.yaml
+++ b/charts/camunda-platform-8.5/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch-rba.yaml
@@ -1,0 +1,251 @@
+global:
+  image:
+    pullPolicy: Always
+zeebe:
+  image:
+    tag: "$E2E_TESTS_ZEEBE_IMAGE_TAG"
+tasklist:
+  image:
+    tag: "$E2E_TESTS_TASKLIST_IMAGE_TAG"
+  env:
+    - name: CAMUNDA_TASKLIST_IDENTITY_RESOURCE_PERMISSIONS_ENABLED
+      value: 'true'
+operate:
+  image:
+    tag: "$E2E_TESTS_OPERATE_IMAGE_TAG"
+  env:
+    - name: CAMUNDA_OPERATE_IDENTITY_RESOURCEPERMISSIONSENABLED
+      value: 'true'
+optimize:
+  image:
+    tag: "$E2E_TESTS_OPTIMIZE_IMAGE_TAG"
+webModeler:
+  restapi:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  webapp:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  websockets:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+console:
+  image:
+    tag: "$E2E_TESTS_CONSOLE_IMAGE_TAG"
+identity:
+  image:
+    tag: "$E2E_TESTS_IDENTITY_IMAGE_TAG"
+  firstUser:
+    existingSecret: null
+    user: demo
+    password: $DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+  postgresql:
+    enabled: true
+  # Keycloak client seed which is used to query Camunda APIs. 
+  env:
+    # TODO: Remove the KEYCLOAK_USERS env vars in favor of relying on the default configmap values
+    - name: KEYCLOAK_USERS_0_USERNAME
+      value: 'demo'
+    - name: KEYCLOAK_USERS_0_EMAIL
+      value: 'demo@example.com'
+    - name: KEYCLOAK_USERS_0_FIRSTNAME
+      value: 'Demo'
+    - name: KEYCLOAK_USERS_0_LASTNAME
+      value: 'User'
+    - name: KEYCLOAK_USERS_0_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+    - name: KEYCLOAK_USERS_0_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_0_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_0_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_0_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_0_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_0_ROLES_5
+      value: Console
+    - name: KEYCLOAK_CLIENTS_2_ID
+      value: venom
+    - name: KEYCLOAK_CLIENTS_2_NAME
+      value: Venom
+    - name: KEYCLOAK_CLIENTS_2_SECRET
+    - name: KEYCLOAK_CLIENTS_2_ID
+      value: venom
+    - name: KEYCLOAK_CLIENTS_2_NAME
+      value: Venom
+    - name: KEYCLOAK_CLIENTS_2_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: integration-test-credentials
+          key: identity-admin-client-password
+    - name: KEYCLOAK_CLIENTS_2_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_2_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_2_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_DEFINITION
+      value: write
+    - name: KEYCLOAK_USERS_1_FIRST_NAME
+      value: Lisa
+    - name: KEYCLOAK_USERS_1_LAST_NAME
+      value: Doe
+    - name: KEYCLOAK_USERS_1_EMAIL
+      value: cawemodev+lisa@gmail.com
+    - name: KEYCLOAK_USERS_1_USERNAME
+      value: lisa
+    - name: KEYCLOAK_USERS_1_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_SECONDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_1_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_1_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_1_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_1_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_1_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_1_ROLES_5
+      value: Console
+    - name: KEYCLOAK_USERS_2_FIRST_NAME
+      value: Bart
+    - name: KEYCLOAK_USERS_2_LAST_NAME
+      value: Foo
+    - name: KEYCLOAK_USERS_2_EMAIL
+      value: cawemodev+bart@gmail.com
+    - name: KEYCLOAK_USERS_2_USERNAME
+      value: bart
+    - name: KEYCLOAK_USERS_2_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_THIRDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_2_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_2_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_2_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_2_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_2_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_2_ROLES_5
+      value: Console
+    # Operate access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # Tasklist access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    # Zeebe access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_RESOURCE_SERVER_ID
+      value: zeebe-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_DEFINITION
+      value: "write:*"
+    # WebModeler access.
+    # NOTE: This actually should be only in the chart-with-web-modeler scenarios,
+    # but since Helm doesn't support merge lists it's added here.
+    # It could be removed later when the env vars could be configured via ConfigMap.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_8_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_8_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_9_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_9_DEFINITION
+      value: "write:*"
+    - name: KEYCLOAK_CLIENTS_3_ID
+      value: test
+    - name: KEYCLOAK_CLIENTS_3_NAME
+      value: Test
+    - name: KEYCLOAK_CLIENTS_3_SECRET
+      value: $DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET
+    - name: KEYCLOAK_CLIENTS_3_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_3_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_3_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_DEFINITION
+      value: write
+    # Operate access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # Tasklist access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    # Zeebe access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_RESOURCE_SERVER_ID
+      value: zeebe-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_DEFINITION
+      value: "write:*"
+    # WebModeler access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_8_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_8_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_DEFINITION
+      value: "write:*"
+    - name: RESOURCE_PERMISSIONS_ENABLED
+      value: 'true'
+connectors:
+  image:
+    tag: "$E2E_TESTS_CONNECTORS_IMAGE_TAG"
+  env:
+    - name: username
+      value: username
+    - name: password
+      value: password

--- a/charts/camunda-platform-8.5/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch.yaml
+++ b/charts/camunda-platform-8.5/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch.yaml
@@ -1,0 +1,241 @@
+global:
+  image:
+    pullPolicy: Always
+zeebe:
+  image:
+    tag: "$E2E_TESTS_ZEEBE_IMAGE_TAG"
+tasklist:
+  image:
+    tag: "$E2E_TESTS_TASKLIST_IMAGE_TAG"
+operate:
+  image:
+    tag: "$E2E_TESTS_OPERATE_IMAGE_TAG"
+optimize:
+  image:
+    tag: "$E2E_TESTS_OPTIMIZE_IMAGE_TAG"
+webModeler:
+  restapi:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  webapp:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  websockets:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+console:
+  image:
+    tag: "$E2E_TESTS_CONSOLE_IMAGE_TAG"
+identity:
+  image:
+    tag: "$E2E_TESTS_IDENTITY_IMAGE_TAG"
+  firstUser:
+    existingSecret: null
+    user: demo
+    password: $DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+  # Keycloak client seed which is used to query Camunda APIs. 
+  env:
+    # TODO: Remove the KEYCLOAK_USERS env vars in favor of relying on the default configmap values
+    - name: KEYCLOAK_USERS_0_USERNAME
+      value: 'demo'
+    - name: KEYCLOAK_USERS_0_EMAIL
+      value: 'demo@example.com'
+    - name: KEYCLOAK_USERS_0_FIRSTNAME
+      value: 'Demo'
+    - name: KEYCLOAK_USERS_0_LASTNAME
+      value: 'User'
+    - name: KEYCLOAK_USERS_0_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+    - name: KEYCLOAK_USERS_0_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_0_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_0_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_0_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_0_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_0_ROLES_5
+      value: Console
+    - name: KEYCLOAK_CLIENTS_2_ID
+      value: venom
+    - name: KEYCLOAK_CLIENTS_2_NAME
+      value: Venom
+    - name: KEYCLOAK_CLIENTS_2_SECRET
+    - name: KEYCLOAK_CLIENTS_2_ID
+      value: venom
+    - name: KEYCLOAK_CLIENTS_2_NAME
+      value: Venom
+    - name: KEYCLOAK_CLIENTS_2_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: integration-test-credentials
+          key: identity-admin-client-password
+    - name: KEYCLOAK_CLIENTS_2_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_2_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_2_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_DEFINITION
+      value: write
+    - name: KEYCLOAK_USERS_1_FIRST_NAME
+      value: Lisa
+    - name: KEYCLOAK_USERS_1_LAST_NAME
+      value: Doe
+    - name: KEYCLOAK_USERS_1_EMAIL
+      value: cawemodev+lisa@gmail.com
+    - name: KEYCLOAK_USERS_1_USERNAME
+      value: lisa
+    - name: KEYCLOAK_USERS_1_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_SECONDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_1_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_1_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_1_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_1_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_1_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_1_ROLES_5
+      value: Console
+    - name: KEYCLOAK_USERS_2_FIRST_NAME
+      value: Bart
+    - name: KEYCLOAK_USERS_2_LAST_NAME
+      value: Foo
+    - name: KEYCLOAK_USERS_2_EMAIL
+      value: cawemodev+bart@gmail.com
+    - name: KEYCLOAK_USERS_2_USERNAME
+      value: bart
+    - name: KEYCLOAK_USERS_2_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_THIRDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_2_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_2_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_2_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_2_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_2_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_2_ROLES_5
+      value: Console
+    # Operate access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # Tasklist access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    # Zeebe access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_RESOURCE_SERVER_ID
+      value: zeebe-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_DEFINITION
+      value: "write:*"
+    # WebModeler access.
+    # NOTE: This actually should be only in the chart-with-web-modeler scenarios,
+    # but since Helm doesn't support merge lists it's added here.
+    # It could be removed later when the env vars could be configured via ConfigMap.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_8_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_8_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_9_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_9_DEFINITION
+      value: "write:*"
+    - name: KEYCLOAK_CLIENTS_3_ID
+      value: test
+    - name: KEYCLOAK_CLIENTS_3_NAME
+      value: Test
+    - name: KEYCLOAK_CLIENTS_3_SECRET
+      value: $DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET
+    - name: KEYCLOAK_CLIENTS_3_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_3_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_3_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_DEFINITION
+      value: write
+    # Operate access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # Tasklist access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    # Zeebe access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_RESOURCE_SERVER_ID
+      value: zeebe-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_DEFINITION
+      value: "write:*"
+    # WebModeler access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_8_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_8_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_DEFINITION
+      value: "write:*"
+connectors:
+  image:
+    tag: "$E2E_TESTS_CONNECTORS_IMAGE_TAG"
+  env:
+    - name: username
+      value: username
+    - name: password
+      value: password

--- a/charts/camunda-platform-8.6/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch-mt.yaml
+++ b/charts/camunda-platform-8.6/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch-mt.yaml
@@ -261,10 +261,10 @@ identity:
       value: APPLICATION
     - name: IDENTITY_TENANTS_0_MEMBERS_4_APPLICATIONID
       value: zeebe
-    - name: IDENTITY_TENANTS_0_MEMBERS_2_APPLICATIONID
-      value: venom
-    - name: IDENTITY_TENANTS_0_MEMBERS_3_TYPE
+    - name: IDENTITY_TENANTS_0_MEMBERS_5_TYPE
       value: APPLICATION
+    - name: IDENTITY_TENANTS_0_MEMBERS_5_APPLICATIONID
+      value: venom
 connectors:
   image:
     tag: "$E2E_TESTS_CONNECTORS_IMAGE_TAG"

--- a/charts/camunda-platform-8.6/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch-mt.yaml
+++ b/charts/camunda-platform-8.6/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch-mt.yaml
@@ -1,0 +1,277 @@
+global:
+  image:
+    pullPolicy: Always
+  multitenancy:
+    enabled: true
+zeebe:
+  image:
+    tag: "$E2E_TESTS_ZEEBE_IMAGE_TAG"
+tasklist:
+  image:
+    tag: "$E2E_TESTS_TASKLIST_IMAGE_TAG"
+operate:
+  image:
+    tag: "$E2E_TESTS_OPERATE_IMAGE_TAG"
+optimize:
+  image:
+    tag: "$E2E_TESTS_OPTIMIZE_IMAGE_TAG"
+webModeler:
+  restapi:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  webapp:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  websockets:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+console:
+  image:
+    tag: "$E2E_TESTS_CONSOLE_IMAGE_TAG"
+identity:
+  image:
+    tag: "$E2E_TESTS_IDENTITY_IMAGE_TAG"
+  firstUser:
+    existingSecret: null
+    user: demo
+    password: $DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+  postgresql:
+    enabled: true
+  externalDatabase:
+    enabled: false
+  # Keycloak client seed which is used to query Camunda APIs. 
+  env:
+    # TODO: Remove the KEYCLOAK_USERS env vars in favor of relying on the default configmap values
+    - name: KEYCLOAK_USERS_0_USERNAME
+      value: 'demo'
+    - name: KEYCLOAK_USERS_0_EMAIL
+      value: 'demo@example.com'
+    - name: KEYCLOAK_USERS_0_FIRSTNAME
+      value: 'Demo'
+    - name: KEYCLOAK_USERS_0_LASTNAME
+      value: 'User'
+    - name: KEYCLOAK_USERS_0_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+    - name: KEYCLOAK_USERS_0_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_0_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_0_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_0_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_0_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_0_ROLES_5
+      value: Console
+    - name: KEYCLOAK_CLIENTS_2_ID
+      value: venom
+    - name: KEYCLOAK_CLIENTS_2_NAME
+      value: Venom
+    - name: KEYCLOAK_CLIENTS_2_SECRET
+    - name: KEYCLOAK_CLIENTS_2_ID
+      value: venom
+    - name: KEYCLOAK_CLIENTS_2_NAME
+      value: Venom
+    - name: KEYCLOAK_CLIENTS_2_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: integration-test-credentials
+          key: identity-admin-client-password
+    - name: KEYCLOAK_CLIENTS_2_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_2_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_2_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_DEFINITION
+      value: write
+    - name: KEYCLOAK_USERS_1_FIRST_NAME
+      value: Lisa
+    - name: KEYCLOAK_USERS_1_LAST_NAME
+      value: Doe
+    - name: KEYCLOAK_USERS_1_EMAIL
+      value: cawemodev+lisa@gmail.com
+    - name: KEYCLOAK_USERS_1_USERNAME
+      value: lisa
+    - name: KEYCLOAK_USERS_1_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_SECONDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_1_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_1_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_1_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_1_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_1_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_1_ROLES_5
+      value: Console
+    - name: KEYCLOAK_USERS_2_FIRST_NAME
+      value: Bart
+    - name: KEYCLOAK_USERS_2_LAST_NAME
+      value: Foo
+    - name: KEYCLOAK_USERS_2_EMAIL
+      value: cawemodev+bart@gmail.com
+    - name: KEYCLOAK_USERS_2_USERNAME
+      value: bart
+    - name: KEYCLOAK_USERS_2_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_THIRDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_2_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_2_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_2_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_2_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_2_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_2_ROLES_5
+      value: Console
+    # Operate access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # Tasklist access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    # Zeebe access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_RESOURCE_SERVER_ID
+      value: zeebe-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_DEFINITION
+      value: "write:*"
+    # WebModeler access.
+    # NOTE: This actually should be only in the chart-with-web-modeler scenarios,
+    # but since Helm doesn't support merge lists it's added here.
+    # It could be removed later when the env vars could be configured via ConfigMap.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_8_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_8_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_9_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_9_DEFINITION
+      value: "write:*"
+    - name: KEYCLOAK_CLIENTS_3_ID
+      value: test
+    - name: KEYCLOAK_CLIENTS_3_NAME
+      value: Test
+    - name: KEYCLOAK_CLIENTS_3_SECRET
+      value: $DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET
+    - name: KEYCLOAK_CLIENTS_3_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_3_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_3_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_DEFINITION
+      value: write
+    # Operate access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # Tasklist access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    # Zeebe access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_RESOURCE_SERVER_ID
+      value: zeebe-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_DEFINITION
+      value: "write:*"
+    # WebModeler access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_8_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_8_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_DEFINITION
+      value: "write:*"
+    - name: IDENTITY_TENANTS_0_NAME
+      value: Default
+    - name: IDENTITY_TENANTS_0_TENANTID
+      value: <default>
+    - name: IDENTITY_TENANTS_0_MEMBERS_0_TYPE
+      value: USER
+    - name: IDENTITY_TENANTS_0_MEMBERS_0_USERNAME
+      value: demo
+    - name: IDENTITY_TENANTS_0_MEMBERS_1_TYPE
+      value: APPLICATION
+    - name: IDENTITY_TENANTS_0_MEMBERS_1_APPLICATIONID
+      value: operate
+    - name: IDENTITY_TENANTS_0_MEMBERS_2_TYPE
+      value: APPLICATION
+    - name: IDENTITY_TENANTS_0_MEMBERS_2_APPLICATIONID
+      value: test
+    - name: IDENTITY_TENANTS_0_MEMBERS_3_TYPE
+      value: APPLICATION
+    - name: IDENTITY_TENANTS_0_MEMBERS_3_APPLICATIONID
+      value: connectors
+    - name: IDENTITY_TENANTS_0_MEMBERS_4_TYPE
+      value: APPLICATION
+    - name: IDENTITY_TENANTS_0_MEMBERS_4_APPLICATIONID
+      value: zeebe
+    - name: IDENTITY_TENANTS_0_MEMBERS_2_APPLICATIONID
+      value: venom
+    - name: IDENTITY_TENANTS_0_MEMBERS_3_TYPE
+      value: APPLICATION
+connectors:
+  image:
+    tag: "$E2E_TESTS_CONNECTORS_IMAGE_TAG"
+  env:
+    - name: username
+      value: username
+    - name: password
+      value: password
+    - name: ZEEBE_CLIENT_DEFAULT_JOB_WORKER_TENANT_IDS
+      value: "<default>, Tenant_Main_Connectors, Tenant_Second_Connectors, Tenant_1_Connectors, Tenant_2_Connectors"

--- a/charts/camunda-platform-8.6/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch-rba.yaml
+++ b/charts/camunda-platform-8.6/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch-rba.yaml
@@ -1,0 +1,251 @@
+global:
+  image:
+    pullPolicy: Always
+zeebe:
+  image:
+    tag: "$E2E_TESTS_ZEEBE_IMAGE_TAG"
+tasklist:
+  image:
+    tag: "$E2E_TESTS_TASKLIST_IMAGE_TAG"
+  env:
+    - name: CAMUNDA_TASKLIST_IDENTITY_RESOURCE_PERMISSIONS_ENABLED
+      value: 'true'
+operate:
+  image:
+    tag: "$E2E_TESTS_OPERATE_IMAGE_TAG"
+  env:
+    - name: CAMUNDA_OPERATE_IDENTITY_RESOURCEPERMISSIONSENABLED
+      value: 'true'
+optimize:
+  image:
+    tag: "$E2E_TESTS_OPTIMIZE_IMAGE_TAG"
+webModeler:
+  restapi:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  webapp:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  websockets:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+console:
+  image:
+    tag: "$E2E_TESTS_CONSOLE_IMAGE_TAG"
+identity:
+  image:
+    tag: "$E2E_TESTS_IDENTITY_IMAGE_TAG"
+  firstUser:
+    existingSecret: null
+    user: demo
+    password: $DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+  postgresql:
+    enabled: true
+  # Keycloak client seed which is used to query Camunda APIs. 
+  env:
+    # TODO: Remove the KEYCLOAK_USERS env vars in favor of relying on the default configmap values
+    - name: KEYCLOAK_USERS_0_USERNAME
+      value: 'demo'
+    - name: KEYCLOAK_USERS_0_EMAIL
+      value: 'demo@example.com'
+    - name: KEYCLOAK_USERS_0_FIRSTNAME
+      value: 'Demo'
+    - name: KEYCLOAK_USERS_0_LASTNAME
+      value: 'User'
+    - name: KEYCLOAK_USERS_0_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+    - name: KEYCLOAK_USERS_0_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_0_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_0_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_0_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_0_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_0_ROLES_5
+      value: Console
+    - name: KEYCLOAK_CLIENTS_2_ID
+      value: venom
+    - name: KEYCLOAK_CLIENTS_2_NAME
+      value: Venom
+    - name: KEYCLOAK_CLIENTS_2_SECRET
+    - name: KEYCLOAK_CLIENTS_2_ID
+      value: venom
+    - name: KEYCLOAK_CLIENTS_2_NAME
+      value: Venom
+    - name: KEYCLOAK_CLIENTS_2_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: integration-test-credentials
+          key: identity-admin-client-password
+    - name: KEYCLOAK_CLIENTS_2_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_2_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_2_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_DEFINITION
+      value: write
+    - name: KEYCLOAK_USERS_1_FIRST_NAME
+      value: Lisa
+    - name: KEYCLOAK_USERS_1_LAST_NAME
+      value: Doe
+    - name: KEYCLOAK_USERS_1_EMAIL
+      value: cawemodev+lisa@gmail.com
+    - name: KEYCLOAK_USERS_1_USERNAME
+      value: lisa
+    - name: KEYCLOAK_USERS_1_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_SECONDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_1_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_1_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_1_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_1_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_1_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_1_ROLES_5
+      value: Console
+    - name: KEYCLOAK_USERS_2_FIRST_NAME
+      value: Bart
+    - name: KEYCLOAK_USERS_2_LAST_NAME
+      value: Foo
+    - name: KEYCLOAK_USERS_2_EMAIL
+      value: cawemodev+bart@gmail.com
+    - name: KEYCLOAK_USERS_2_USERNAME
+      value: bart
+    - name: KEYCLOAK_USERS_2_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_THIRDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_2_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_2_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_2_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_2_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_2_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_2_ROLES_5
+      value: Console
+    # Operate access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # Tasklist access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    # Zeebe access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_RESOURCE_SERVER_ID
+      value: zeebe-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_DEFINITION
+      value: "write:*"
+    # WebModeler access.
+    # NOTE: This actually should be only in the chart-with-web-modeler scenarios,
+    # but since Helm doesn't support merge lists it's added here.
+    # It could be removed later when the env vars could be configured via ConfigMap.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_8_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_8_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_9_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_9_DEFINITION
+      value: "write:*"
+    - name: KEYCLOAK_CLIENTS_3_ID
+      value: test
+    - name: KEYCLOAK_CLIENTS_3_NAME
+      value: Test
+    - name: KEYCLOAK_CLIENTS_3_SECRET
+      value: $DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET
+    - name: KEYCLOAK_CLIENTS_3_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_3_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_3_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_DEFINITION
+      value: write
+    # Operate access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # Tasklist access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    # Zeebe access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_RESOURCE_SERVER_ID
+      value: zeebe-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_DEFINITION
+      value: "write:*"
+    # WebModeler access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_8_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_8_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_DEFINITION
+      value: "write:*"
+    - name: RESOURCE_PERMISSIONS_ENABLED
+      value: 'true'
+connectors:
+  image:
+    tag: "$E2E_TESTS_CONNECTORS_IMAGE_TAG"
+  env:
+    - name: username
+      value: username
+    - name: password
+      value: password

--- a/charts/camunda-platform-8.6/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch.yaml
+++ b/charts/camunda-platform-8.6/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch.yaml
@@ -1,0 +1,241 @@
+global:
+  image:
+    pullPolicy: Always
+zeebe:
+  image:
+    tag: "$E2E_TESTS_ZEEBE_IMAGE_TAG"
+tasklist:
+  image:
+    tag: "$E2E_TESTS_TASKLIST_IMAGE_TAG"
+operate:
+  image:
+    tag: "$E2E_TESTS_OPERATE_IMAGE_TAG"
+optimize:
+  image:
+    tag: "$E2E_TESTS_OPTIMIZE_IMAGE_TAG"
+webModeler:
+  restapi:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  webapp:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  websockets:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+console:
+  image:
+    tag: "$E2E_TESTS_CONSOLE_IMAGE_TAG"
+identity:
+  image:
+    tag: "$E2E_TESTS_IDENTITY_IMAGE_TAG"
+  firstUser:
+    existingSecret: null
+    user: demo
+    password: $DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+  # Keycloak client seed which is used to query Camunda APIs. 
+  env:
+    # TODO: Remove the KEYCLOAK_USERS env vars in favor of relying on the default configmap values
+    - name: KEYCLOAK_USERS_0_USERNAME
+      value: 'demo'
+    - name: KEYCLOAK_USERS_0_EMAIL
+      value: 'demo@example.com'
+    - name: KEYCLOAK_USERS_0_FIRSTNAME
+      value: 'Demo'
+    - name: KEYCLOAK_USERS_0_LASTNAME
+      value: 'User'
+    - name: KEYCLOAK_USERS_0_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+    - name: KEYCLOAK_USERS_0_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_0_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_0_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_0_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_0_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_0_ROLES_5
+      value: Console
+    - name: KEYCLOAK_CLIENTS_2_ID
+      value: venom
+    - name: KEYCLOAK_CLIENTS_2_NAME
+      value: Venom
+    - name: KEYCLOAK_CLIENTS_2_SECRET
+    - name: KEYCLOAK_CLIENTS_2_ID
+      value: venom
+    - name: KEYCLOAK_CLIENTS_2_NAME
+      value: Venom
+    - name: KEYCLOAK_CLIENTS_2_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: integration-test-credentials
+          key: identity-admin-client-password
+    - name: KEYCLOAK_CLIENTS_2_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_2_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_2_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_DEFINITION
+      value: write
+    - name: KEYCLOAK_USERS_1_FIRST_NAME
+      value: Lisa
+    - name: KEYCLOAK_USERS_1_LAST_NAME
+      value: Doe
+    - name: KEYCLOAK_USERS_1_EMAIL
+      value: cawemodev+lisa@gmail.com
+    - name: KEYCLOAK_USERS_1_USERNAME
+      value: lisa
+    - name: KEYCLOAK_USERS_1_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_SECONDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_1_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_1_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_1_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_1_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_1_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_1_ROLES_5
+      value: Console
+    - name: KEYCLOAK_USERS_2_FIRST_NAME
+      value: Bart
+    - name: KEYCLOAK_USERS_2_LAST_NAME
+      value: Foo
+    - name: KEYCLOAK_USERS_2_EMAIL
+      value: cawemodev+bart@gmail.com
+    - name: KEYCLOAK_USERS_2_USERNAME
+      value: bart
+    - name: KEYCLOAK_USERS_2_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_THIRDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_2_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_2_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_2_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_2_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_2_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_2_ROLES_5
+      value: Console
+    # Operate access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # Tasklist access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    # Zeebe access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_RESOURCE_SERVER_ID
+      value: zeebe-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_DEFINITION
+      value: "write:*"
+    # WebModeler access.
+    # NOTE: This actually should be only in the chart-with-web-modeler scenarios,
+    # but since Helm doesn't support merge lists it's added here.
+    # It could be removed later when the env vars could be configured via ConfigMap.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_8_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_8_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_9_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_9_DEFINITION
+      value: "write:*"
+    - name: KEYCLOAK_CLIENTS_3_ID
+      value: test
+    - name: KEYCLOAK_CLIENTS_3_NAME
+      value: Test
+    - name: KEYCLOAK_CLIENTS_3_SECRET
+      value: $DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET
+    - name: KEYCLOAK_CLIENTS_3_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_3_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_3_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_DEFINITION
+      value: write
+    # Operate access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # Tasklist access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    # Zeebe access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_RESOURCE_SERVER_ID
+      value: zeebe-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_DEFINITION
+      value: "write:*"
+    # WebModeler access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_8_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_8_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_DEFINITION
+      value: "write:*"
+connectors:
+  image:
+    tag: "$E2E_TESTS_CONNECTORS_IMAGE_TAG"
+  env:
+    - name: username
+      value: username
+    - name: password
+      value: password

--- a/charts/camunda-platform-8.6/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-opensearch.yaml
+++ b/charts/camunda-platform-8.6/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-opensearch.yaml
@@ -1,0 +1,286 @@
+optimize:
+  enabled: false
+global:
+  image:
+    pullPolicy: Always
+  elasticsearch:
+    enabled: false
+  opensearch:
+    enabled: true
+    auth:
+      username: "$OPENSEARCH_USERNAME"
+      password: "$OPENSEARCH_PASSWORD"
+    url:
+      protocol: https
+      host: "$AWS_HOST_URL"
+      port: 443
+elasticsearch:
+  enabled: false
+zeebe:
+  image:
+    tag: "$E2E_TESTS_ZEEBE_IMAGE_TAG"
+  env:
+    - name: ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_INDEX_PREFIX
+      value: "$E2E_AWS_OS_INDEX_PREFIX_ZEEBE"
+operate:
+  image:
+    tag: "$E2E_TESTS_OPERATE_IMAGE_TAG"
+  env: 
+    - name: CAMUNDA_OPERATE_OPENSEARCH_INDEXPREFIX
+      value: "$E2E_AWS_OS_INDEX_PREFIX_OPERATE"
+    - name: CAMUNDA_OPERATE_ZEEBEOPENSEARCH_PREFIX
+      value: "$E2E_AWS_OS_INDEX_PREFIX_ZEEBE"
+  migration:
+    env:
+      - name: CAMUNDA_OPERATE_OPENSEARCH_INDEXPREFIX
+        value: "$E2E_AWS_OS_INDEX_PREFIX_OPERATE"
+      - name: CAMUNDA_OPERATE_ZEEBEEOPENSEARCH_PREFIX
+        value: "$E2E_AWS_OS_INDEX_PREFIX_ZEEBE"
+tasklist:
+  image:
+    tag: "$E2E_TESTS_TASKLIST_IMAGE_TAG"
+  env:
+    - name: CAMUNDA_TASKLIST_OPENSEARCH_INDEXPREFIX
+      value: "$E2E_AWS_OS_INDEX_PREFIX_TASKLIST"
+    - name: CAMUNDA_TASKLIST_ZEEBEOPENSEARCH_PREFIX
+      value: "$E2E_AWS_OS_INDEX_PREFIX_ZEEBE"
+optimize:
+  image:
+    tag: "$E2E_TESTS_OPTIMIZE_IMAGE_TAG"
+  env: 
+    - name: CAMUNDA_OPTIMIZE_ZEEBE_NAME
+      value: "$E2E_AWS_OS_INDEX_PREFIX_ZEEBE"
+    - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_PREFIX
+      value: "$E2E_AWS_OS_INDEX_PREFIX_OPTIMIZE"
+  migration:
+    env:
+      - name: CAMUNDA_OPTIMIZE_ZEEBE_NAME
+        value: "$E2E_AWS_OS_INDEX_PREFIX_ZEEBE"
+      - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_PREFIX
+        value: "$E2E_AWS_OS_INDEX_PREFIX_OPTIMIZE"
+webModeler:
+  restapi:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  webapp:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  websockets:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+console:
+  image:
+    tag: "$E2E_TESTS_CONSOLE_IMAGE_TAG"
+identity:
+  image:
+    tag: "$E2E_TESTS_IDENTITY_IMAGE_TAG"
+  firstUser:
+    existingSecret: null
+    user: demo
+    password: $DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+  # Keycloak client seed which is used to query Camunda APIs. 
+  env:
+    # TODO: Remove the KEYCLOAK_USERS env vars in favor of relying on the default configmap values
+    - name: KEYCLOAK_USERS_0_USERNAME
+      value: 'demo'
+    - name: KEYCLOAK_USERS_0_EMAIL
+      value: 'demo@example.com'
+    - name: KEYCLOAK_USERS_0_FIRSTNAME
+      value: 'Demo'
+    - name: KEYCLOAK_USERS_0_LASTNAME
+      value: 'User'
+    - name: KEYCLOAK_USERS_0_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+    - name: KEYCLOAK_USERS_0_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_0_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_0_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_0_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_0_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_0_ROLES_5
+      value: Console
+    - name: KEYCLOAK_CLIENTS_2_ID
+      value: venom
+    - name: KEYCLOAK_CLIENTS_2_NAME
+      value: Venom
+    - name: KEYCLOAK_CLIENTS_2_SECRET
+    - name: KEYCLOAK_CLIENTS_2_ID
+      value: venom
+    - name: KEYCLOAK_CLIENTS_2_NAME
+      value: Venom
+    - name: KEYCLOAK_CLIENTS_2_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: integration-test-credentials
+          key: identity-admin-client-password
+    - name: KEYCLOAK_CLIENTS_2_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_2_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_2_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_DEFINITION
+      value: write
+    - name: KEYCLOAK_USERS_1_FIRST_NAME
+      value: Lisa
+    - name: KEYCLOAK_USERS_1_LAST_NAME
+      value: Doe
+    - name: KEYCLOAK_USERS_1_EMAIL
+      value: cawemodev+lisa@gmail.com
+    - name: KEYCLOAK_USERS_1_USERNAME
+      value: lisa
+    - name: KEYCLOAK_USERS_1_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_SECONDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_1_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_1_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_1_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_1_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_1_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_1_ROLES_5
+      value: Console
+    - name: KEYCLOAK_USERS_2_FIRST_NAME
+      value: Bart
+    - name: KEYCLOAK_USERS_2_LAST_NAME
+      value: Foo
+    - name: KEYCLOAK_USERS_2_EMAIL
+      value: cawemodev+bart@gmail.com
+    - name: KEYCLOAK_USERS_2_USERNAME
+      value: bart
+    - name: KEYCLOAK_USERS_2_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_THIRDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_2_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_2_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_2_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_2_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_2_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_2_ROLES_5
+      value: Console
+    # Operate access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # Tasklist access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    # Zeebe access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_RESOURCE_SERVER_ID
+      value: zeebe-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_DEFINITION
+      value: "write:*"
+    # WebModeler access.
+    # NOTE: This actually should be only in the chart-with-web-modeler scenarios,
+    # but since Helm doesn't support merge lists it's added here.
+    # It could be removed later when the env vars could be configured via ConfigMap.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_8_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_8_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_9_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_9_DEFINITION
+      value: "write:*"
+    - name: KEYCLOAK_CLIENTS_3_ID
+      value: test
+    - name: KEYCLOAK_CLIENTS_3_NAME
+      value: Test
+    - name: KEYCLOAK_CLIENTS_3_SECRET
+      value: $DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET
+    - name: KEYCLOAK_CLIENTS_3_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_3_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_3_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_DEFINITION
+      value: write
+    # Operate access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # Tasklist access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    # Zeebe access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_RESOURCE_SERVER_ID
+      value: zeebe-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_DEFINITION
+      value: "write:*"
+    # WebModeler access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_8_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_8_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_DEFINITION
+      value: "write:*"
+connectors:
+  image:
+    tag: "$E2E_TESTS_CONNECTORS_IMAGE_TAG"
+  env:
+    - name: username
+      value: username
+    - name: password
+      value: password

--- a/charts/camunda-platform-8.7/test/e2e/package-lock.json
+++ b/charts/camunda-platform-8.7/test/e2e/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@camunda/e2e-test-suite": "^0.0.1",
+        "@camunda/e2e-test-suite": "^0.0.15",
         "@eslint/js": "^9.26.0",
         "@playwright/test": "^1.52.0",
         "@types/node": "^22.15.14",
@@ -35,9 +35,9 @@
       }
     },
     "node_modules/@camunda/e2e-test-suite": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@camunda/e2e-test-suite/-/e2e-test-suite-0.0.1.tgz",
-      "integrity": "sha512-5caS5sjw8cWRUiH3I8qo8eI9ICbNZTqHo5hoJ/3oKOeCKSM3VALVHb0oVhiIa/B2O3onqYoniclh5ljY9Y1iRg==",
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@camunda/e2e-test-suite/-/e2e-test-suite-0.0.15.tgz",
+      "integrity": "sha512-7+NZ+2AAZCKc2VH3zfe4ofKHcTHMazKUd9HRzi4uza+vdIOHvpE+av5B/kUEzoE6saJU988nsA+AUH7uI+DbPw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -236,13 +236,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.2.tgz",
-      "integrity": "sha512-4SaFZCNfJqvk/kenHpI8xvN42DMaoycy4PzKc5otHxRswww1kAt82OlBuwRVLofCACCTZEcla2Ydxv8scMXaTg==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
+      "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.15.0",
+        "@eslint/core": "^0.15.1",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -250,9 +250,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.0.tgz",
-      "integrity": "sha512-b7ePw78tEWWkpgZCDYkbqDOP8dmM6qe+AOC6iuJqlq1R/0ahMAeH3qynpnqKFGkMltrp44ohV4ubGyvLX28tzw==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
+      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/charts/camunda-platform-8.7/test/e2e/package.json
+++ b/charts/camunda-platform-8.7/test/e2e/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "description": "",
   "devDependencies": {
-    "@camunda/e2e-test-suite": "^0.0.1",
+    "@camunda/e2e-test-suite": "^0.0.15",
     "@eslint/js": "^9.26.0",
     "@playwright/test": "^1.52.0",
     "@types/node": "^22.15.14",

--- a/charts/camunda-platform-8.7/test/e2e/playwright.config.ts
+++ b/charts/camunda-platform-8.7/test/e2e/playwright.config.ts
@@ -18,7 +18,8 @@ export default defineConfig({
   fullyParallel: true,
   retries: 3,
   timeout: 5 * 60 * 1000, // no test should take more than 3 minutes (failing fast is important so that we can run our tests on each PR)
-  workers: process.env.CI == "true" ? 1 : "25%",
+  workers: "50%",
+  //workers: process.env.CI == "true" ? 1 : "50%",
   use: {
     baseURL: getBaseURL(),
     actionTimeout: 10000,

--- a/charts/camunda-platform-8.7/test/e2e/playwright.config.ts
+++ b/charts/camunda-platform-8.7/test/e2e/playwright.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
   ],
   fullyParallel: true,
   retries: 3,
-  timeout: 3 * 60 * 1000, // no test should take more than 3 minutes (failing fast is important so that we can run our tests on each PR)
+  timeout: 5 * 60 * 1000, // no test should take more than 3 minutes (failing fast is important so that we can run our tests on each PR)
   workers: process.env.CI == "true" ? 1 : "25%",
   use: {
     baseURL: getBaseURL(),

--- a/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch-mt.yaml
+++ b/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch-mt.yaml
@@ -1,0 +1,302 @@
+global:
+  multitenancy:
+    enabled: true
+  image:
+    pullPolicy: Always
+zeebe:
+  image:
+    tag: "$E2E_TESTS_ZEEBE_IMAGE_TAG"
+tasklist:
+  image:
+    tag: "$E2E_TESTS_TASKLIST_IMAGE_TAG"
+operate:
+  image:
+    tag: "$E2E_TESTS_OPERATE_IMAGE_TAG"
+optimize:
+  image:
+    tag: "$E2E_TESTS_OPTIMIZE_IMAGE_TAG"
+webModeler:
+  restapi:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  webapp:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  websockets:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+console:
+  image:
+    tag: "$E2E_TESTS_CONSOLE_IMAGE_TAG"
+  overrideConfiguration: |
+    camunda:
+      console:
+        managed:
+          releases:
+            - name: integration
+              namespace: $TEST_NAMESPACE
+              tags:
+                - dev
+                - custom
+                - stage
+                - prod
+                - test
+              custom-properties:
+                - description: "This is the main integration environment for the Camunda Platform."
+                  links:
+                    - name: "Camunda"
+                      url: "https://camunda.com"
+                    - name: "Camunda Docs"
+                      url: "https://docs.camunda.io"
+  env:
+    - name: CAMUNDA_CONSOLE_EXPERIMENTAL_TAGS
+      value: "true"
+identity:
+  image:
+    tag: "$E2E_TESTS_IDENTITY_IMAGE_TAG"
+  firstUser:
+    existingSecret: null
+    user: demo
+    existingSecret: integration-test-credentials
+    existingSecretKey: identity-user-password
+  postgresql:
+    enabled: true
+  externalDatabase:
+    enabled: false
+  # Keycloak client seed which is used to query Camunda APIs. 
+  env:
+    # TODO: Remove the KEYCLOAK_USERS env vars in favor of relying on the default configmap values
+    - name: KEYCLOAK_USERS_0_USERNAME
+      value: 'demo'
+    - name: KEYCLOAK_USERS_0_EMAIL
+      value: 'demo@example.com'
+    - name: KEYCLOAK_USERS_0_FIRSTNAME
+      value: 'Demo'
+    - name: KEYCLOAK_USERS_0_LASTNAME
+      value: 'User'
+    - name: KEYCLOAK_USERS_0_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+    - name: KEYCLOAK_USERS_0_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_0_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_0_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_0_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_0_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_0_ROLES_5
+      value: Console
+    - name: KEYCLOAK_USERS_0_ROLES_6
+      value: "Zeebe"
+    - name: KEYCLOAK_CLIENTS_2_ID
+      value: venom
+    - name: KEYCLOAK_CLIENTS_2_NAME
+      value: Venom
+    - name: KEYCLOAK_CLIENTS_2_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: integration-test-credentials
+          key: identity-admin-client-password
+    - name: KEYCLOAK_CLIENTS_2_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_2_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_2_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_DEFINITION
+      value: write
+    - name: KEYCLOAK_USERS_1_FIRST_NAME
+      value: Lisa
+    - name: KEYCLOAK_USERS_1_LAST_NAME
+      value: Doe
+    - name: KEYCLOAK_USERS_1_EMAIL
+      value: cawemodev+lisa@gmail.com
+    - name: KEYCLOAK_USERS_1_USERNAME
+      value: lisa
+    - name: KEYCLOAK_USERS_1_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_SECONDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_1_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_1_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_1_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_1_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_1_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_1_ROLES_5
+      value: Console
+    - name: KEYCLOAK_USERS_1_ROLES_6
+      value: "Zeebe"
+    - name: KEYCLOAK_USERS_2_FIRST_NAME
+      value: Bart
+    - name: KEYCLOAK_USERS_2_LAST_NAME
+      value: Foo
+    - name: KEYCLOAK_USERS_2_EMAIL
+      value: cawemodev+bart@gmail.com
+    - name: KEYCLOAK_USERS_2_USERNAME
+      value: bart
+    - name: KEYCLOAK_USERS_2_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_THIRDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_2_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_2_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_2_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_2_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_2_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_2_ROLES_5
+      value: Console
+    - name: KEYCLOAK_USERS_2_ROLES_6
+      value: "Zeebe"
+    # Operate access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # Tasklist access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    # Zeebe access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_RESOURCE_SERVER_ID
+      value: zeebe-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_DEFINITION
+      value: "write:*"
+    # WebModeler access.
+    # NOTE: This actually should be only in the chart-with-web-modeler scenarios,
+    # but since Helm doesn't support merge lists it's added here.
+    # It could be removed later when the env vars could be configured via ConfigMap.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_8_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_8_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_9_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_9_DEFINITION
+      value: "write:*"
+    - name: KEYCLOAK_CLIENTS_3_ID
+      value: test
+    - name: KEYCLOAK_CLIENTS_3_NAME
+      value: Test
+    - name: KEYCLOAK_CLIENTS_3_SECRET
+      value: $DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET
+    - name: KEYCLOAK_CLIENTS_3_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_3_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_3_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_DEFINITION
+      value: write
+    # Operate access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # Tasklist access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    # Zeebe access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_RESOURCE_SERVER_ID
+      value: zeebe-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_DEFINITION
+      value: "write:*"
+    # WebModeler access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_8_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_8_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_DEFINITION
+      value: "write:*"
+    - name: IDENTITY_TENANTS_0_NAME
+      value: Default
+    - name: IDENTITY_TENANTS_0_TENANTID
+      value: <default>
+    - name: IDENTITY_TENANTS_0_MEMBERS_0_TYPE
+      value: USER
+    - name: IDENTITY_TENANTS_0_MEMBERS_0_USERNAME
+      value: demo
+    - name: IDENTITY_TENANTS_0_MEMBERS_1_TYPE
+      value: APPLICATION
+    - name: IDENTITY_TENANTS_0_MEMBERS_1_APPLICATIONID
+      value: operate
+    - name: IDENTITY_TENANTS_0_MEMBERS_2_TYPE
+      value: APPLICATION
+    - name: IDENTITY_TENANTS_0_MEMBERS_2_APPLICATIONID
+      value: test
+    - name: IDENTITY_TENANTS_0_MEMBERS_3_TYPE
+      value: APPLICATION
+    - name: IDENTITY_TENANTS_0_MEMBERS_3_APPLICATIONID
+      value: connectors
+    - name: IDENTITY_TENANTS_0_MEMBERS_4_TYPE
+      value: APPLICATION
+    - name: IDENTITY_TENANTS_0_MEMBERS_4_APPLICATIONID
+      value: zeebe
+    - name: IDENTITY_TENANTS_0_MEMBERS_2_APPLICATIONID
+      value: venom
+    - name: IDENTITY_TENANTS_0_MEMBERS_3_TYPE
+      value: APPLICATION
+connectors:
+  image:
+    tag: "$E2E_TESTS_CONNECTORS_IMAGE_TAG"
+  env:
+    - name: username
+      value: username
+    - name: password
+      value: password
+    - name: ZEEBE_CLIENT_DEFAULT_JOB_WORKER_TENANT_IDS
+      value: "<default>, Tenant_Main_Connectors, Tenant_Second_Connectors, Tenant_1_Connectors, Tenant_2_Connectors"

--- a/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch-rba.yaml
+++ b/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch-rba.yaml
@@ -1,0 +1,276 @@
+global:
+  image:
+    pullPolicy: Always
+zeebe:
+  image:
+    tag: "$E2E_TESTS_ZEEBE_IMAGE_TAG"
+tasklist:
+  image:
+    tag: "$E2E_TESTS_TASKLIST_IMAGE_TAG"
+  env:
+    - name: CAMUNDA_TASKLIST_IDENTITY_RESOURCE_PERMISSIONS_ENABLED
+      value: 'true'
+operate:
+  image:
+    tag: "$E2E_TESTS_OPERATE_IMAGE_TAG"
+  env:
+    - name: CAMUNDA_OPERATE_IDENTITY_RESOURCEPERMISSIONSENABLED
+      value: 'true'
+optimize:
+  image:
+    tag: "$E2E_TESTS_OPTIMIZE_IMAGE_TAG"
+webModeler:
+  restapi:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  webapp:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  websockets:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+console:
+  image:
+    tag: "$E2E_TESTS_CONSOLE_IMAGE_TAG"
+  overrideConfiguration: |
+    camunda:
+      console:
+        managed:
+          releases:
+            - name: integration
+              namespace: $TEST_NAMESPACE
+              tags:
+                - dev
+                - custom
+                - stage
+                - prod
+                - test
+              custom-properties:
+                - description: "This is the main integration environment for the Camunda Platform."
+                  links:
+                    - name: "Camunda"
+                      url: "https://camunda.com"
+                    - name: "Camunda Docs"
+                      url: "https://docs.camunda.io"
+  env:
+    - name: CAMUNDA_CONSOLE_EXPERIMENTAL_TAGS
+      value: "true"
+identity:
+  image:
+    tag: "$E2E_TESTS_IDENTITY_IMAGE_TAG"
+  postgresql:
+    enabled: true
+  firstUser:
+    existingSecret: null
+    user: demo
+    existingSecret: integration-test-credentials
+    existingSecretKey: identity-user-password
+  # Keycloak client seed which is used to query Camunda APIs. 
+  env:
+    # TODO: Remove the KEYCLOAK_USERS env vars in favor of relying on the default configmap values
+    - name: KEYCLOAK_USERS_0_USERNAME
+      value: 'demo'
+    - name: KEYCLOAK_USERS_0_EMAIL
+      value: 'demo@example.com'
+    - name: KEYCLOAK_USERS_0_FIRSTNAME
+      value: 'Demo'
+    - name: KEYCLOAK_USERS_0_LASTNAME
+      value: 'User'
+    - name: KEYCLOAK_USERS_0_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+    - name: KEYCLOAK_USERS_0_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_0_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_0_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_0_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_0_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_0_ROLES_5
+      value: Console
+    - name: KEYCLOAK_USERS_0_ROLES_6
+      value: "Zeebe"
+    - name: KEYCLOAK_CLIENTS_2_ID
+      value: venom
+    - name: KEYCLOAK_CLIENTS_2_NAME
+      value: Venom
+    - name: KEYCLOAK_CLIENTS_2_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: integration-test-credentials
+          key: identity-admin-client-password
+    - name: KEYCLOAK_CLIENTS_2_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_2_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_2_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_DEFINITION
+      value: write
+    - name: KEYCLOAK_USERS_1_FIRST_NAME
+      value: Lisa
+    - name: KEYCLOAK_USERS_1_LAST_NAME
+      value: Doe
+    - name: KEYCLOAK_USERS_1_EMAIL
+      value: cawemodev+lisa@gmail.com
+    - name: KEYCLOAK_USERS_1_USERNAME
+      value: lisa
+    - name: KEYCLOAK_USERS_1_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_SECONDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_1_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_1_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_1_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_1_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_1_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_1_ROLES_5
+      value: Console
+    - name: KEYCLOAK_USERS_1_ROLES_6
+      value: "Zeebe"
+    - name: KEYCLOAK_USERS_2_FIRST_NAME
+      value: Bart
+    - name: KEYCLOAK_USERS_2_LAST_NAME
+      value: Foo
+    - name: KEYCLOAK_USERS_2_EMAIL
+      value: cawemodev+bart@gmail.com
+    - name: KEYCLOAK_USERS_2_USERNAME
+      value: bart
+    - name: KEYCLOAK_USERS_2_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_THIRDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_2_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_2_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_2_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_2_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_2_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_2_ROLES_5
+      value: Console
+    - name: KEYCLOAK_USERS_2_ROLES_6
+      value: "Zeebe"
+    # Operate access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # Tasklist access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    # Zeebe access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_RESOURCE_SERVER_ID
+      value: zeebe-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_DEFINITION
+      value: "write:*"
+    # WebModeler access.
+    # NOTE: This actually should be only in the chart-with-web-modeler scenarios,
+    # but since Helm doesn't support merge lists it's added here.
+    # It could be removed later when the env vars could be configured via ConfigMap.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_8_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_8_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_9_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_9_DEFINITION
+      value: "write:*"
+    - name: KEYCLOAK_CLIENTS_3_ID
+      value: test
+    - name: KEYCLOAK_CLIENTS_3_NAME
+      value: Test
+    - name: KEYCLOAK_CLIENTS_3_SECRET
+      value: $DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET
+    - name: KEYCLOAK_CLIENTS_3_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_3_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_3_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_DEFINITION
+      value: write
+    # Operate access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # Tasklist access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    # Zeebe access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_RESOURCE_SERVER_ID
+      value: zeebe-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_DEFINITION
+      value: "write:*"
+    # WebModeler access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_8_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_8_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_DEFINITION
+      value: "write:*"
+    - name: RESOURCE_PERMISSIONS_ENABLED
+      value: 'true'
+connectors:
+  image:
+    tag: "$E2E_TESTS_CONNECTORS_IMAGE_TAG"
+  env:
+    - name: username
+      value: username
+    - name: password
+      value: password

--- a/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch.yaml
+++ b/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch.yaml
@@ -1,0 +1,266 @@
+global:
+  image:
+    pullPolicy: Always
+zeebe:
+  image:
+    tag: "$E2E_TESTS_ZEEBE_IMAGE_TAG"
+tasklist:
+  image:
+    tag: "$E2E_TESTS_TASKLIST_IMAGE_TAG"
+operate:
+  image:
+    tag: "$E2E_TESTS_OPERATE_IMAGE_TAG"
+optimize:
+  image:
+    tag: "$E2E_TESTS_OPTIMIZE_IMAGE_TAG"
+webModeler:
+  restapi:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  webapp:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  websockets:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+console:
+  image:
+    tag: "$E2E_TESTS_CONSOLE_IMAGE_TAG"
+  overrideConfiguration: |
+    camunda:
+      console:
+        managed:
+          releases:
+            - name: integration
+              namespace: $TEST_NAMESPACE
+              tags:
+                - dev
+                - custom
+                - stage
+                - prod
+                - test
+              custom-properties:
+                - description: "This is the main integration environment for the Camunda Platform."
+                  links:
+                    - name: "Camunda"
+                      url: "https://camunda.com"
+                    - name: "Camunda Docs"
+                      url: "https://docs.camunda.io"
+  env:
+    - name: CAMUNDA_CONSOLE_EXPERIMENTAL_TAGS
+      value: "true"
+identity:
+  image:
+    tag: "$E2E_TESTS_IDENTITY_IMAGE_TAG"
+  firstUser:
+    existingSecret: null
+    user: demo
+    existingSecret: integration-test-credentials
+    existingSecretKey: identity-user-password
+  # Keycloak client seed which is used to query Camunda APIs. 
+  env:
+    # TODO: Remove the KEYCLOAK_USERS env vars in favor of relying on the default configmap values
+    - name: KEYCLOAK_USERS_0_USERNAME
+      value: 'demo'
+    - name: KEYCLOAK_USERS_0_EMAIL
+      value: 'demo@example.com'
+    - name: KEYCLOAK_USERS_0_FIRSTNAME
+      value: 'Demo'
+    - name: KEYCLOAK_USERS_0_LASTNAME
+      value: 'User'
+    - name: KEYCLOAK_USERS_0_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+    - name: KEYCLOAK_USERS_0_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_0_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_0_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_0_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_0_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_0_ROLES_5
+      value: Console
+    - name: KEYCLOAK_USERS_0_ROLES_6
+      value: "Zeebe"
+    - name: KEYCLOAK_CLIENTS_2_ID
+      value: venom
+    - name: KEYCLOAK_CLIENTS_2_NAME
+      value: Venom
+    - name: KEYCLOAK_CLIENTS_2_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: integration-test-credentials
+          key: identity-admin-client-password
+    - name: KEYCLOAK_CLIENTS_2_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_2_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_2_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_DEFINITION
+      value: write
+    - name: KEYCLOAK_USERS_1_FIRST_NAME
+      value: Lisa
+    - name: KEYCLOAK_USERS_1_LAST_NAME
+      value: Doe
+    - name: KEYCLOAK_USERS_1_EMAIL
+      value: cawemodev+lisa@gmail.com
+    - name: KEYCLOAK_USERS_1_USERNAME
+      value: lisa
+    - name: KEYCLOAK_USERS_1_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_SECONDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_1_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_1_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_1_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_1_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_1_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_1_ROLES_5
+      value: Console
+    - name: KEYCLOAK_USERS_1_ROLES_6
+      value: "Zeebe"
+    - name: KEYCLOAK_USERS_2_FIRST_NAME
+      value: Bart
+    - name: KEYCLOAK_USERS_2_LAST_NAME
+      value: Foo
+    - name: KEYCLOAK_USERS_2_EMAIL
+      value: cawemodev+bart@gmail.com
+    - name: KEYCLOAK_USERS_2_USERNAME
+      value: bart
+    - name: KEYCLOAK_USERS_2_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_THIRDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_2_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_2_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_2_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_2_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_2_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_2_ROLES_5
+      value: Console
+    - name: KEYCLOAK_USERS_2_ROLES_6
+      value: "Zeebe"
+    # Operate access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # Tasklist access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    # Zeebe access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_RESOURCE_SERVER_ID
+      value: zeebe-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_DEFINITION
+      value: "write:*"
+    # WebModeler access.
+    # NOTE: This actually should be only in the chart-with-web-modeler scenarios,
+    # but since Helm doesn't support merge lists it's added here.
+    # It could be removed later when the env vars could be configured via ConfigMap.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_8_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_8_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_9_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_9_DEFINITION
+      value: "write:*"
+    - name: KEYCLOAK_CLIENTS_3_ID
+      value: test
+    - name: KEYCLOAK_CLIENTS_3_NAME
+      value: Test
+    - name: KEYCLOAK_CLIENTS_3_SECRET
+      value: $DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET
+    - name: KEYCLOAK_CLIENTS_3_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_3_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_3_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_DEFINITION
+      value: write
+    # Operate access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # Tasklist access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    # Zeebe access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_RESOURCE_SERVER_ID
+      value: zeebe-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_DEFINITION
+      value: "write:*"
+    # WebModeler access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_8_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_8_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_DEFINITION
+      value: "write:*"
+connectors:
+  image:
+    tag: "$E2E_TESTS_CONNECTORS_IMAGE_TAG"
+  env:
+    - name: username
+      value: username
+    - name: password
+      value: password

--- a/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-opensearch.yaml
+++ b/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-opensearch.yaml
@@ -1,0 +1,314 @@
+optimize:
+  enabled: false
+global:
+  image:
+    pullPolicy: Always
+  elasticsearch:
+    enabled: false
+  opensearch:
+    enabled: true
+    auth:
+      username: "$OPENSEARCH_USERNAME"
+      password: "$OPENSEARCH_PASSWORD"
+    url:
+      protocol: https
+      host: "$AWS_HOST_URL"
+      port: 443
+elasticsearch:
+  enabled: false
+zeebe:
+  image:
+    tag: "$E2E_TESTS_ZEEBE_IMAGE_TAG"
+  env:
+    - name: ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_INDEX_PREFIX
+      value: "$E2E_AWS_OS_INDEX_PREFIX_ZEEBE"
+operate:
+  image:
+    tag: "$E2E_TESTS_OPERATE_IMAGE_TAG"
+  env: 
+    - name: CAMUNDA_OPERATE_OPENSEARCH_INDEXPREFIX
+      value: "$E2E_AWS_OS_INDEX_PREFIX_OPERATE"
+    - name: CAMUNDA_OPERATE_ZEEBEOPENSEARCH_PREFIX
+      value: "$E2E_AWS_OS_INDEX_PREFIX_ZEEBE"
+  migration:
+    env:
+      - name: CAMUNDA_OPERATE_OPENSEARCH_INDEXPREFIX
+        value: "$E2E_AWS_OS_INDEX_PREFIX_OPERATE"
+      - name: CAMUNDA_OPERATE_ZEEBEEOPENSEARCH_PREFIX
+        value: "$E2E_AWS_OS_INDEX_PREFIX_ZEEBE"
+tasklist:
+  image:
+    tag: "$E2E_TESTS_TASKLIST_IMAGE_TAG"
+  env:
+    - name: CAMUNDA_TASKLIST_OPENSEARCH_INDEXPREFIX
+      value: "$E2E_AWS_OS_INDEX_PREFIX_TASKLIST"
+    - name: CAMUNDA_TASKLIST_ZEEBEOPENSEARCH_PREFIX
+      value: "$E2E_AWS_OS_INDEX_PREFIX_ZEEBE"
+optimize:
+  image:
+    tag: "$E2E_TESTS_OPTIMIZE_IMAGE_TAG"
+  env: 
+    - name: CAMUNDA_OPTIMIZE_ZEEBE_NAME
+      value: "$E2E_AWS_OS_INDEX_PREFIX_ZEEBE"
+    - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_PREFIX
+      value: "$E2E_AWS_OS_INDEX_PREFIX_OPTIMIZE"
+  migration:
+    env:
+      - name: CAMUNDA_OPTIMIZE_ZEEBE_NAME
+        value: "$E2E_AWS_OS_INDEX_PREFIX_ZEEBE"
+      - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_PREFIX
+        value: "$E2E_AWS_OS_INDEX_PREFIX_OPTIMIZE"
+webModeler:
+  restapi:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  webapp:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  websockets:
+    image:
+      tag: SNAPSHOT
+console:
+  image:
+    tag: "$E2E_TESTS_CONSOLE_IMAGE_TAG"
+  overrideConfiguration: |
+    camunda:
+      console:
+        managed:
+          releases:
+            - name: integration
+              namespace: "$TEST_NAMESPACE"
+              tags:
+                - dev
+                - custom
+                - stage
+                - prod
+                - test
+              custom-properties:
+                - description: "This is the main integration environment for the Camunda Platform."
+                  links:
+                    - name: "Camunda"
+                      url: "https://camunda.com"
+                    - name: "Camunda Docs"
+                      url: "https://docs.camunda.io"
+  env:
+    - name: CAMUNDA_CONSOLE_EXPERIMENTAL_TAGS
+      value: 'true'      
+identity:
+  image:
+    tag: "$E2E_TESTS_IDENTITY_IMAGE_TAG"
+  firstUser:
+    user: demo
+    password: $DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+  # Keycloak client seed which is used to query Camunda APIs. 
+  env:
+    # TODO: Remove the KEYCLOAK_USERS env vars in favor of relying on the default configmap values
+    - name: KEYCLOAK_USERS_0_USERNAME
+      value: 'demo'
+    - name: KEYCLOAK_USERS_0_EMAIL
+      value: 'demo@example.com'
+    - name: KEYCLOAK_USERS_0_FIRSTNAME
+      value: 'Demo'
+    - name: KEYCLOAK_USERS_0_LASTNAME
+      value: 'User'
+    - name: KEYCLOAK_USERS_0_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+    - name: KEYCLOAK_USERS_0_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_0_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_0_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_0_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_0_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_0_ROLES_5
+      value: Console
+    - name: KEYCLOAK_USERS_0_ROLES_6
+      value: "Zeebe"
+    - name: KEYCLOAK_CLIENTS_2_ID
+      value: venom
+    - name: KEYCLOAK_CLIENTS_2_NAME
+      value: Venom
+    - name: KEYCLOAK_CLIENTS_2_SECRET
+    - name: KEYCLOAK_CLIENTS_2_ID
+      value: venom
+    - name: KEYCLOAK_CLIENTS_2_NAME
+      value: Venom
+    - name: KEYCLOAK_CLIENTS_2_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: integration-test-credentials
+          key: identity-admin-client-password
+    - name: KEYCLOAK_CLIENTS_2_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_2_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_2_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_DEFINITION
+      value: write
+    - name: KEYCLOAK_USERS_1_FIRST_NAME
+      value: Lisa
+    - name: KEYCLOAK_USERS_1_LAST_NAME
+      value: Doe
+    - name: KEYCLOAK_USERS_1_EMAIL
+      value: cawemodev+lisa@gmail.com
+    - name: KEYCLOAK_USERS_1_USERNAME
+      value: lisa
+    - name: KEYCLOAK_USERS_1_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_SECONDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_1_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_1_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_1_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_1_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_1_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_1_ROLES_5
+      value: Console
+    - name: KEYCLOAK_USERS_1_ROLES_6
+      value: "Zeebe"
+    - name: KEYCLOAK_USERS_2_FIRST_NAME
+      value: Bart
+    - name: KEYCLOAK_USERS_2_LAST_NAME
+      value: Foo
+    - name: KEYCLOAK_USERS_2_EMAIL
+      value: cawemodev+bart@gmail.com
+    - name: KEYCLOAK_USERS_2_USERNAME
+      value: bart
+    - name: KEYCLOAK_USERS_2_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_THIRDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_2_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_2_ROLES_1
+      value: Operate
+    - name: KEYCLOAK_USERS_2_ROLES_2
+      value: Tasklist
+    - name: KEYCLOAK_USERS_2_ROLES_3
+      value: Optimize
+    - name: KEYCLOAK_USERS_2_ROLES_4
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_2_ROLES_5
+      value: Console
+    - name: KEYCLOAK_USERS_2_ROLES_6
+      value: "Zeebe"
+    # Operate access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # Tasklist access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    # Zeebe access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_RESOURCE_SERVER_ID
+      value: zeebe-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_DEFINITION
+      value: "write:*"
+    # WebModeler access.
+    # NOTE: This actually should be only in the chart-with-web-modeler scenarios,
+    # but since Helm doesn't support merge lists it's added here.
+    # It could be removed later when the env vars could be configured via ConfigMap.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_8_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_8_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_9_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_9_DEFINITION
+      value: "write:*"
+    - name: KEYCLOAK_CLIENTS_3_ID
+      value: test
+    - name: KEYCLOAK_CLIENTS_3_NAME
+      value: Test
+    - name: KEYCLOAK_CLIENTS_3_SECRET
+      value: $DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET
+    - name: KEYCLOAK_CLIENTS_3_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_3_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_3_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_DEFINITION
+      value: write
+    # Operate access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: operate-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # Tasklist access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: tasklist-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    # Zeebe access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_RESOURCE_SERVER_ID
+      value: zeebe-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_DEFINITION
+      value: "write:*"
+    # WebModeler access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_8_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_8_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_DEFINITION
+      value: "write:*"
+connectors:
+  image:
+    tag: "$E2E_TESTS_CONNECTORS_IMAGE_TAG"
+  env:
+    - name: username
+      value: username
+    - name: password
+      value: password

--- a/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-opensearch.yaml
+++ b/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-opensearch.yaml
@@ -11,9 +11,9 @@ global:
       username: "$OPENSEARCH_USERNAME"
       password: "$OPENSEARCH_PASSWORD"
     url:
-      protocol: https
-      host: "$AWS_HOST_URL"
-      port: 443
+      protocol: $OPENSEARCH_PROTOCOL
+      host: "$OPENSEARCH_HOST"
+      port: $OPENSEARCH_PORT
 elasticsearch:
   enabled: false
 zeebe:

--- a/charts/camunda-platform-8.7/test/integration/testsuites/package-lock.json
+++ b/charts/camunda-platform-8.7/test/integration/testsuites/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@camunda/e2e-test-suite": "^0.0.1",
+        "@camunda/e2e-test-suite": "^0.0.15",
         "@eslint/js": "^9.26.0",
         "@playwright/test": "^1.52.0",
         "@types/node": "^22.15.14",
@@ -35,9 +35,9 @@
       }
     },
     "node_modules/@camunda/e2e-test-suite": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@camunda/e2e-test-suite/-/e2e-test-suite-0.0.1.tgz",
-      "integrity": "sha512-5caS5sjw8cWRUiH3I8qo8eI9ICbNZTqHo5hoJ/3oKOeCKSM3VALVHb0oVhiIa/B2O3onqYoniclh5ljY9Y1iRg==",
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@camunda/e2e-test-suite/-/e2e-test-suite-0.0.15.tgz",
+      "integrity": "sha512-7+NZ+2AAZCKc2VH3zfe4ofKHcTHMazKUd9HRzi4uza+vdIOHvpE+av5B/kUEzoE6saJU988nsA+AUH7uI+DbPw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch-mt.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch-mt.yaml
@@ -1,0 +1,329 @@
+global:
+  image:
+    pullPolicy: Always
+  identity:
+    auth:
+      enabled: true
+  security:
+    authentication:
+      method: oidc
+  multitenancy:
+    enabled: true
+core:
+  image:
+    tag: "$E2E_TESTS_CORE_IMAGE_TAG"
+  env:
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_0_MAPPINGID
+      value: "demo-user-mapping"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_0_CLAIMNAME
+      value: "preferred_username"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_0_CLAIMVALUE
+      value: "demo"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_1_MAPPINGID
+      value: "venom-client-mapping"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_1_CLAIMNAME
+      value: "client_id"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_1_CLAIMVALUE
+      value: "venom"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_2_MAPPINGID
+      value: "connectors-client-mapping"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_2_CLAIMNAME
+      value: "client_id"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_2_CLAIMVALUE
+      value: "connectors"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGS_0
+      value: "demo-user-mapping"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGS_1
+      value: "venom-client-mapping"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGS_2
+      value: "connectors-client-mapping"
+identityKeycloak:
+  enabled: true
+optimize:
+  enabled: true
+  image:
+    tag: "$E2E_TESTS_OPTIMIZE_IMAGE_TAG"
+webModeler:
+  enabled: true
+  restapi:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  webapp:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  websockets:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+webModelerPostgresql:
+  enabled: true
+console:
+  enabled: true
+  image:
+    tag: "$E2E_TESTS_CONSOLE_IMAGE_TAG"
+  overrideConfiguration: |
+    camunda:
+      console:
+        managed:
+          releases:
+            - name: integration
+              namespace: "$TEST_NAMESPACE"
+              tags:
+                - dev
+                - custom
+                - stage
+                - prod
+                - test
+              custom-properties:
+                - description: "This is the main integration environment for the Camunda Platform."
+                  links:
+                    - name: "Camunda"
+                      url: "https://camunda.com"
+                    - name: "Camunda Docs"
+                      url: "https://docs.camunda.io"
+  env:
+    - name: CAMUNDA_CONSOLE_EXPERIMENTAL_TAGS
+      value: 'true'      
+identityPostgresql:
+  enabled: true
+  auth:
+    existingSecret: "integration-test-credentials"
+    secretKeys:
+      adminPasswordKey: "identity-keycloak-postgresql-admin-password"
+      userPasswordKey: "identity-keycloak-postgresql-user-password"
+identity:
+  enabled: true
+  externalDatabase:
+    enabled: false
+  image:
+    tag: "$E2E_TESTS_IDENTITY_IMAGE_TAG"
+  firstUser:
+    existingSecret: null
+    user: demo
+    password: $DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+  # Keycloak client seed which is used to query Camunda APIs. 
+  env:
+    # TODO: Remove the KEYCLOAK_USERS env vars in favor of relying on the default configmap values
+    - name: KEYCLOAK_USERS_0_USERNAME
+      value: 'demo'
+    - name: KEYCLOAK_USERS_0_EMAIL
+      value: 'demo@example.com'
+    - name: KEYCLOAK_USERS_0_FIRSTNAME
+      value: 'Demo'
+    - name: KEYCLOAK_USERS_0_LASTNAME
+      value: 'User'
+    - name: KEYCLOAK_USERS_0_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+    - name: KEYCLOAK_USERS_0_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_0_ROLES_1
+      value: Optimize
+    - name: KEYCLOAK_USERS_0_ROLES_2
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_0_ROLES_3
+      value: Web Modeler Admin
+    - name: KEYCLOAK_USERS_0_ROLES_4
+      value: Console
+    - name: KEYCLOAK_USERS_0_ROLES_5
+      value: Core
+    - name: KEYCLOAK_CLIENTS_2_ID
+      value: venom
+    - name: KEYCLOAK_CLIENTS_2_NAME
+      value: Venom
+    - name: KEYCLOAK_CLIENTS_2_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: integration-test-credentials
+          key: identity-admin-client-password
+    - name: KEYCLOAK_CLIENTS_2_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_2_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_2_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_DEFINITION
+      value: write
+    - name: KEYCLOAK_USERS_1_FIRST_NAME
+      value: Lisa
+    - name: KEYCLOAK_USERS_1_LAST_NAME
+      value: Doe
+    - name: KEYCLOAK_USERS_1_EMAIL
+      value: cawemodev+lisa@gmail.com
+    - name: KEYCLOAK_USERS_1_USERNAME
+      value: lisa
+    - name: KEYCLOAK_USERS_1_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_SECONDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_1_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_1_ROLES_1
+      value: Optimize
+    - name: KEYCLOAK_USERS_1_ROLES_2
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_1_ROLES_3
+      value: Web Modeler Admin
+    - name: KEYCLOAK_USERS_1_ROLES_4
+      value: Console
+    - name: KEYCLOAK_USERS_1_ROLES_5
+      value: Core
+    - name: KEYCLOAK_USERS_2_FIRST_NAME
+      value: Bart
+    - name: KEYCLOAK_USERS_2_LAST_NAME
+      value: Foo
+    - name: KEYCLOAK_USERS_2_EMAIL
+      value: cawemodev+bart@gmail.com
+    - name: KEYCLOAK_USERS_2_USERNAME
+      value: bart
+    - name: KEYCLOAK_USERS_2_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_THIRDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_2_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_2_ROLES_1
+      value: Optimize
+    - name: KEYCLOAK_USERS_2_ROLES_2
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_2_ROLES_3
+      value: Web Modeler Admin
+    - name: KEYCLOAK_USERS_2_ROLES_4
+      value: Console
+    - name: KEYCLOAK_USERS_2_ROLES_5
+      value: Core
+    # # Core access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: core-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: core-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # # Tasklist access.
+    # - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_RESOURCE_SERVER_ID
+    #   value: tasklist-api
+    # - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_DEFINITION
+    #   value: "read:*"
+    # - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_RESOURCE_SERVER_ID
+    #   value: tasklist-api
+    # - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_DEFINITION
+    #   value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_DEFINITION
+      value: "write:*"
+    # # Zeebe access.
+    # - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_RESOURCE_SERVER_ID
+    #   value: zeebe-api
+    # - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_DEFINITION
+    #   value: "write:*"
+    # WebModeler access.
+    # NOTE: This actually should be only in the chart-with-web-modeler scenarios,
+    # but since Helm doesn't support merge lists it's added here.
+    # It could be removed later when the env vars could be configured via ConfigMap.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    - name: KEYCLOAK_CLIENTS_3_ID
+      value: test
+    - name: KEYCLOAK_CLIENTS_3_NAME
+      value: Test
+    - name: KEYCLOAK_CLIENTS_3_SECRET
+      value: $DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET
+    - name: KEYCLOAK_CLIENTS_3_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_3_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_3_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_DEFINITION
+      value: write
+    # Core access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: core-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: core-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # # Tasklist access.
+    # - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_RESOURCE_SERVER_ID
+    #   value: tasklist-api
+    # - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_DEFINITION
+    #   value: "read:*"
+    # - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_RESOURCE_SERVER_ID
+    #   value: tasklist-api
+    # - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_DEFINITION
+    #   value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_DEFINITION
+      value: "write:*"
+    # # Zeebe access.
+    # - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_RESOURCE_SERVER_ID
+    #   value: zeebe-api
+    # - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_DEFINITION
+    #   value: "write:*"
+    # WebModeler access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    - name: IDENTITY_TENANTS_0_NAME
+      value: Default
+    - name: IDENTITY_TENANTS_0_TENANTID
+      value: <default>
+    - name: IDENTITY_TENANTS_0_MEMBERS_0_TYPE
+      value: USER
+    - name: IDENTITY_TENANTS_0_MEMBERS_0_USERNAME
+      value: demo
+    - name: IDENTITY_TENANTS_0_MEMBERS_1_TYPE
+      value: APPLICATION
+    - name: IDENTITY_TENANTS_0_MEMBERS_1_APPLICATIONID
+      value: operate
+    - name: IDENTITY_TENANTS_0_MEMBERS_2_TYPE
+      value: APPLICATION
+    - name: IDENTITY_TENANTS_0_MEMBERS_2_APPLICATIONID
+      value: test
+    - name: IDENTITY_TENANTS_0_MEMBERS_3_TYPE
+      value: APPLICATION
+    - name: IDENTITY_TENANTS_0_MEMBERS_3_APPLICATIONID
+      value: connectors
+    - name: IDENTITY_TENANTS_0_MEMBERS_4_TYPE
+      value: APPLICATION
+    - name: IDENTITY_TENANTS_0_MEMBERS_4_APPLICATIONID
+      value: zeebe
+connectors:
+  image:
+    tag: "$E2E_TESTS_CONNECTORS_IMAGE_TAG"
+  env:
+    - name: username
+      value: username
+    - name: password
+      value: password
+    - name: ZEEBE_CLIENT_DEFAULT_JOB_WORKER_TENANT_IDS
+      value: "Tenant_Main_Connectors, Tenant_Second_Connectors, Tenant_1_Connectors, Tenant_2_Connectors"

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch-rba.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch-rba.yaml
@@ -1,0 +1,313 @@
+global:
+  image:
+    pullPolicy: Always
+  identity:
+    auth:
+      enabled: true
+    auth:
+      enabled: true
+  security:
+    authentication:
+      method: oidc
+core:
+  image:
+    tag: "$E2E_TESTS_CORE_IMAGE_TAG"
+  env:
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_0_MAPPINGID
+      value: "demo-user-mapping"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_0_CLAIMNAME
+      value: "preferred_username"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_0_CLAIMVALUE
+      value: "demo"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_1_MAPPINGID
+      value: "venom-client-mapping"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_1_CLAIMNAME
+      value: "client_id"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_1_CLAIMVALUE
+      value: "venom"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_2_MAPPINGID
+      value: "connectors-client-mapping"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_2_CLAIMNAME
+      value: "client_id"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_2_CLAIMVALUE
+      value: "connectors"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGS_0
+      value: "demo-user-mapping"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGS_1
+      value: "venom-client-mapping"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGS_2
+      value: "connectors-client-mapping"
+identityKeycloak:
+  enabled: true
+optimize:
+  enabled: true
+  image:
+    tag: "$E2E_TESTS_OPTIMIZE_IMAGE_TAG"
+webModeler:
+  enabled: true
+  restapi:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  webapp:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  websockets:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+webModelerPostgresql:
+  enabled: true
+console:
+  enabled: true
+  image:
+    tag: "$E2E_TESTS_CONSOLE_IMAGE_TAG"
+  overrideConfiguration: |
+    camunda:
+      console:
+        managed:
+          releases:
+            - name: integration
+              namespace: "$TEST_NAMESPACE"
+              tags:
+                - dev
+                - custom
+                - stage
+                - prod
+                - test
+              custom-properties:
+                - description: "This is the main integration environment for the Camunda Platform."
+                  links:
+                    - name: "Camunda"
+                      url: "https://camunda.com"
+                    - name: "Camunda Docs"
+                      url: "https://docs.camunda.io"
+  env:
+    - name: CAMUNDA_CONSOLE_EXPERIMENTAL_TAGS
+      value: 'true'      
+identityPostgresql:
+  enabled: true
+  auth:
+    existingSecret: "integration-test-credentials"
+    secretKeys:
+      adminPasswordKey: "identity-keycloak-postgresql-admin-password"
+      userPasswordKey: "identity-keycloak-postgresql-user-password"
+identity:
+  enabled: true
+  externalDatabase:
+    enabled: false
+  image:
+    tag: "$E2E_TESTS_IDENTITY_IMAGE_TAG"
+  firstUser:
+    existingSecret: null
+    user: demo
+    password: $DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+  # Keycloak client seed which is used to query Camunda APIs. 
+  env:
+    # TODO: Remove the KEYCLOAK_USERS env vars in favor of relying on the default configmap values
+    - name: KEYCLOAK_USERS_0_USERNAME
+      value: 'demo'
+    - name: KEYCLOAK_USERS_0_EMAIL
+      value: 'demo@example.com'
+    - name: KEYCLOAK_USERS_0_FIRSTNAME
+      value: 'Demo'
+    - name: KEYCLOAK_USERS_0_LASTNAME
+      value: 'User'
+    - name: KEYCLOAK_USERS_0_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+    - name: KEYCLOAK_USERS_0_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_0_ROLES_1
+      value: Optimize
+    - name: KEYCLOAK_USERS_0_ROLES_2
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_0_ROLES_3
+      value: Web Modeler Admin
+    - name: KEYCLOAK_USERS_0_ROLES_4
+      value: Console
+    - name: KEYCLOAK_USERS_0_ROLES_5
+      value: Core
+    - name: KEYCLOAK_CLIENTS_2_ID
+      value: venom
+    - name: KEYCLOAK_CLIENTS_2_NAME
+      value: Venom
+    - name: KEYCLOAK_CLIENTS_2_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: integration-test-credentials
+          key: identity-admin-client-password
+    - name: KEYCLOAK_CLIENTS_2_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_2_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_2_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_DEFINITION
+      value: write
+    - name: KEYCLOAK_USERS_1_FIRST_NAME
+      value: Lisa
+    - name: KEYCLOAK_USERS_1_LAST_NAME
+      value: Doe
+    - name: KEYCLOAK_USERS_1_EMAIL
+      value: cawemodev+lisa@gmail.com
+    - name: KEYCLOAK_USERS_1_USERNAME
+      value: lisa
+    - name: KEYCLOAK_USERS_1_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_SECONDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_1_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_1_ROLES_1
+      value: Optimize
+    - name: KEYCLOAK_USERS_1_ROLES_2
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_1_ROLES_3
+      value: Web Modeler Admin
+    - name: KEYCLOAK_USERS_1_ROLES_4
+      value: Console
+    - name: KEYCLOAK_USERS_1_ROLES_5
+      value: Core
+    - name: KEYCLOAK_USERS_2_FIRST_NAME
+      value: Bart
+    - name: KEYCLOAK_USERS_2_LAST_NAME
+      value: Foo
+    - name: KEYCLOAK_USERS_2_EMAIL
+      value: cawemodev+bart@gmail.com
+    - name: KEYCLOAK_USERS_2_USERNAME
+      value: bart
+    - name: KEYCLOAK_USERS_2_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_THIRDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_2_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_2_ROLES_1
+      value: Optimize
+    - name: KEYCLOAK_USERS_2_ROLES_2
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_2_ROLES_3
+      value: Web Modeler Admin
+    - name: KEYCLOAK_USERS_2_ROLES_4
+      value: Console
+    - name: KEYCLOAK_USERS_2_ROLES_5
+      value: Core
+    # # Core access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: core-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: core-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # # Tasklist access.
+    # - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_RESOURCE_SERVER_ID
+    #   value: tasklist-api
+    # - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_DEFINITION
+    #   value: "read:*"
+    # - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_RESOURCE_SERVER_ID
+    #   value: tasklist-api
+    # - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_DEFINITION
+    #   value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_DEFINITION
+      value: "write:*"
+    # # Zeebe access.
+    # - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_RESOURCE_SERVER_ID
+    #   value: zeebe-api
+    # - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_DEFINITION
+    #   value: "write:*"
+    # WebModeler access.
+    # NOTE: This actually should be only in the chart-with-web-modeler scenarios,
+    # but since Helm doesn't support merge lists it's added here.
+    # It could be removed later when the env vars could be configured via ConfigMap.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    - name: KEYCLOAK_CLIENTS_3_ID
+      value: test
+    - name: KEYCLOAK_CLIENTS_3_NAME
+      value: Test
+    - name: KEYCLOAK_CLIENTS_3_SECRET
+      value: $DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET
+    - name: KEYCLOAK_CLIENTS_3_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_3_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_3_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_DEFINITION
+      value: write
+    # Core access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: core-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: core-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # # Tasklist access.
+    # - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_RESOURCE_SERVER_ID
+    #   value: tasklist-api
+    # - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_DEFINITION
+    #   value: "read:*"
+    # - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_RESOURCE_SERVER_ID
+    #   value: tasklist-api
+    # - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_DEFINITION
+    #   value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_DEFINITION
+      value: "write:*"
+    # # Zeebe access.
+    # - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_RESOURCE_SERVER_ID
+    #   value: zeebe-api
+    # - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_DEFINITION
+    #   value: "write:*"
+    # WebModeler access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    - name: RESOURCE_PERMISSIONS_ENABLED
+      value: 'true'
+connectors:
+  image:
+    tag: "$E2E_TESTS_CONNECTORS_IMAGE_TAG"
+  env:
+    - name: username
+      value: username
+    - name: password
+      value: password
+tasklist:
+  env:
+    - name: CAMUNDA_TASKLIST_IDENTITY_RESOURCE_PERMISSIONS_ENABLED
+      value: 'true'
+operate:
+  env:
+    - name: CAMUNDA_OPERATE_IDENTITY_RESOURCEPERMISSIONSENABLED
+      value: 'true'

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch.yaml
@@ -1,0 +1,294 @@
+global:
+  image:
+    pullPolicy: Always
+  identity:
+    auth:
+      enabled: true
+    auth:
+      enabled: true
+  security:
+    authentication:
+      method: oidc
+core:
+  image:
+    tag: "$E2E_TESTS_CORE_IMAGE_TAG"
+  env:
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_0_MAPPINGID
+      value: "demo-user-mapping"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_0_CLAIMNAME
+      value: "preferred_username"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_0_CLAIMVALUE
+      value: "demo"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_1_MAPPINGID
+      value: "venom-client-mapping"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_1_CLAIMNAME
+      value: "client_id"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_1_CLAIMVALUE
+      value: "venom"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_2_MAPPINGID
+      value: "connectors-client-mapping"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_2_CLAIMNAME
+      value: "client_id"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_2_CLAIMVALUE
+      value: "connectors"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGS_0
+      value: "demo-user-mapping"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGS_1
+      value: "venom-client-mapping"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGS_2
+      value: "connectors-client-mapping"
+identityKeycloak:
+  enabled: true
+optimize:
+  enabled: true
+  image:
+    tag: "$E2E_TESTS_OPTIMIZE_IMAGE_TAG"
+webModeler:
+  enabled: true
+  restapi:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  webapp:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  websockets:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+webModelerPostgresql:
+  enabled: true
+console:
+  enabled: true
+  image:
+    tag: "$E2E_TESTS_CONSOLE_IMAGE_TAG"
+  overrideConfiguration: |
+    camunda:
+      console:
+        managed:
+          releases:
+            - name: integration
+              namespace: "$TEST_NAMESPACE"
+              tags:
+                - dev
+                - custom
+                - stage
+                - prod
+                - test
+              custom-properties:
+                - description: "This is the main integration environment for the Camunda Platform."
+                  links:
+                    - name: "Camunda"
+                      url: "https://camunda.com"
+                    - name: "Camunda Docs"
+                      url: "https://docs.camunda.io"
+  env:
+    - name: CAMUNDA_CONSOLE_EXPERIMENTAL_TAGS
+      value: 'true'      
+identity:
+  enabled: true
+  image:
+    tag: "$E2E_TESTS_IDENTITY_IMAGE_TAG"
+  firstUser:
+    existingSecret: null
+    user: demo
+    password: $DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+  # Keycloak client seed which is used to query Camunda APIs. 
+  env:
+    # TODO: Remove the KEYCLOAK_USERS env vars in favor of relying on the default configmap values
+    - name: KEYCLOAK_USERS_0_USERNAME
+      value: 'demo'
+    - name: KEYCLOAK_USERS_0_EMAIL
+      value: 'demo@example.com'
+    - name: KEYCLOAK_USERS_0_FIRSTNAME
+      value: 'Demo'
+    - name: KEYCLOAK_USERS_0_LASTNAME
+      value: 'User'
+    - name: KEYCLOAK_USERS_0_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+    - name: KEYCLOAK_USERS_0_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_0_ROLES_1
+      value: Optimize
+    - name: KEYCLOAK_USERS_0_ROLES_2
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_0_ROLES_3
+      value: Web Modeler Admin
+    - name: KEYCLOAK_USERS_0_ROLES_4
+      value: Console
+    - name: KEYCLOAK_USERS_0_ROLES_5
+      value: Core
+    - name: KEYCLOAK_CLIENTS_2_ID
+      value: venom
+    - name: KEYCLOAK_CLIENTS_2_NAME
+      value: Venom
+    - name: KEYCLOAK_CLIENTS_2_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: integration-test-credentials
+          key: identity-admin-client-password
+    - name: KEYCLOAK_CLIENTS_2_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_2_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_2_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_DEFINITION
+      value: write
+    - name: KEYCLOAK_USERS_1_FIRST_NAME
+      value: Lisa
+    - name: KEYCLOAK_USERS_1_LAST_NAME
+      value: Doe
+    - name: KEYCLOAK_USERS_1_EMAIL
+      value: cawemodev+lisa@gmail.com
+    - name: KEYCLOAK_USERS_1_USERNAME
+      value: lisa
+    - name: KEYCLOAK_USERS_1_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_SECONDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_1_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_1_ROLES_1
+      value: Optimize
+    - name: KEYCLOAK_USERS_1_ROLES_2
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_1_ROLES_3
+      value: Web Modeler Admin
+    - name: KEYCLOAK_USERS_1_ROLES_4
+      value: Console
+    - name: KEYCLOAK_USERS_1_ROLES_5
+      value: Core
+    - name: KEYCLOAK_USERS_2_FIRST_NAME
+      value: Bart
+    - name: KEYCLOAK_USERS_2_LAST_NAME
+      value: Foo
+    - name: KEYCLOAK_USERS_2_EMAIL
+      value: cawemodev+bart@gmail.com
+    - name: KEYCLOAK_USERS_2_USERNAME
+      value: bart
+    - name: KEYCLOAK_USERS_2_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_THIRDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_2_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_2_ROLES_1
+      value: Optimize
+    - name: KEYCLOAK_USERS_2_ROLES_2
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_2_ROLES_3
+      value: Web Modeler Admin
+    - name: KEYCLOAK_USERS_2_ROLES_4
+      value: Console
+    - name: KEYCLOAK_USERS_2_ROLES_5
+      value: Core
+    # # Core access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: core-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: core-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # # Tasklist access.
+    # - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_RESOURCE_SERVER_ID
+    #   value: tasklist-api
+    # - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_DEFINITION
+    #   value: "read:*"
+    # - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_RESOURCE_SERVER_ID
+    #   value: tasklist-api
+    # - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_DEFINITION
+    #   value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_DEFINITION
+      value: "write:*"
+    # # Zeebe access.
+    # - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_RESOURCE_SERVER_ID
+    #   value: zeebe-api
+    # - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_DEFINITION
+    #   value: "write:*"
+    # WebModeler access.
+    # NOTE: This actually should be only in the chart-with-web-modeler scenarios,
+    # but since Helm doesn't support merge lists it's added here.
+    # It could be removed later when the env vars could be configured via ConfigMap.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    - name: KEYCLOAK_CLIENTS_3_ID
+      value: test
+    - name: KEYCLOAK_CLIENTS_3_NAME
+      value: Test
+    - name: KEYCLOAK_CLIENTS_3_SECRET
+      value: $DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET
+    - name: KEYCLOAK_CLIENTS_3_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_3_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_3_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_DEFINITION
+      value: write
+    # Core access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: core-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: core-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # # Tasklist access.
+    # - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_RESOURCE_SERVER_ID
+    #   value: tasklist-api
+    # - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_DEFINITION
+    #   value: "read:*"
+    # - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_RESOURCE_SERVER_ID
+    #   value: tasklist-api
+    # - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_DEFINITION
+    #   value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_DEFINITION
+      value: "write:*"
+    # # Zeebe access.
+    # - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_RESOURCE_SERVER_ID
+    #   value: zeebe-api
+    # - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_DEFINITION
+    #   value: "write:*"
+    # WebModeler access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+connectors:
+  image:
+    tag: "$E2E_TESTS_CONNECTORS_IMAGE_TAG"
+  env:
+    - name: username
+      value: username
+    - name: password
+      value: password

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-opensearch.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-opensearch.yaml
@@ -1,0 +1,330 @@
+global:
+  image:
+    pullPolicy: Always
+  identity:
+    auth:
+      enabled: true
+  elasticsearch:
+    enabled: false
+  opensearch:
+    enabled: true
+    auth:
+      username: "$OPENSEARCH_USERNAME"
+      password: "$OPENSEARCH_PASSWORD"
+    url:
+      protocol: https
+      host: "$AWS_HOST_URL"
+      port: 443
+  security:
+    authentication:
+      method: oidc
+elasticsearch:
+  enabled: false
+core:
+  image:
+    tag: "$E2E_TESTS_CORE_IMAGE_TAG"
+  env:
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_0_MAPPINGID
+      value: "demo-user-mapping"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_0_CLAIMNAME
+      value: "preferred_username"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_0_CLAIMVALUE
+      value: "demo"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_1_MAPPINGID
+      value: "venom-client-mapping"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_1_CLAIMNAME
+      value: "client_id"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_1_CLAIMVALUE
+      value: "venom"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_2_MAPPINGID
+      value: "connectors-client-mapping"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_2_CLAIMNAME
+      value: "client_id"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGS_2_CLAIMVALUE
+      value: "connectors"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGS_0
+      value: "demo-user-mapping"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGS_1
+      value: "venom-client-mapping"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGS_2
+      value: "connectors-client-mapping"
+    - name: CAMUNDA_OPERATE_OPENSEARCH_INDEXPREFIX
+      value: "$E2E_AWS_OS_INDEX_PREFIX_OPERATE"
+    - name: CAMUNDA_TASKLIST_OPENSEARCH_INDEXPREFIX
+      value: "$E2E_AWS_OS_INDEX_PREFIX_OPERATE"
+    - name: ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_INDEXPREFIX
+      value: "$E2E_AWS_OS_INDEX_PREFIX_OPERATE"
+    - name: CAMUNDA_DATABASE_INDEXPREFIX
+      value: "$E2E_AWS_OS_INDEX_PREFIX_OPERATE"
+    - name: ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_INDEX_PREFIX
+      value: "$E2E_AWS_OS_INDEX_PREFIX_ZEEBE"
+    - name: CAMUNDA_OPERATE_ZEEBEOPENSEARCH_PREFIX
+      value: "$E2E_AWS_OS_INDEX_PREFIX_ZEEBE"
+    - name: CAMUNDA_TASKLIST_ZEEBEOPENSEARCH_PREFIX
+      value: "$E2E_AWS_OS_INDEX_PREFIX_ZEEBE"
+identityKeycloak:
+  enabled: true
+optimize:
+  enabled: true
+  image:
+    tag: "$E2E_TESTS_OPTIMIZE_IMAGE_TAG"
+  env: 
+    - name: CAMUNDA_OPTIMIZE_ZEEBE_NAME
+      value: "$E2E_AWS_OS_INDEX_PREFIX_ZEEBE"
+    - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_PREFIX
+      value: "$E2E_AWS_OS_INDEX_PREFIX_OPTIMIZE"
+  migration:
+    env:
+      - name: CAMUNDA_OPTIMIZE_ZEEBE_NAME
+        value: "$E2E_AWS_OS_INDEX_PREFIX_ZEEBE"
+      - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_PREFIX
+        value: "$E2E_AWS_OS_INDEX_PREFIX_OPTIMIZE"
+webModelerPostgresql:
+  enabled: true
+webModeler:
+  enabled: true
+  restapi:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  webapp:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  websockets:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+console:
+  enabled: true
+  image:
+    tag: "$E2E_TESTS_CONSOLE_IMAGE_TAG"
+  overrideConfiguration: |
+    camunda:
+      console:
+        managed:
+          releases:
+            - name: integration
+              namespace: "$TEST_NAMESPACE"
+              tags:
+                - dev
+                - custom
+                - stage
+                - prod
+                - test
+              custom-properties:
+                - description: "This is the main integration environment for the Camunda Platform."
+                  links:
+                    - name: "Camunda"
+                      url: "https://camunda.com"
+                    - name: "Camunda Docs"
+                      url: "https://docs.camunda.io"
+  env:
+    - name: CAMUNDA_CONSOLE_EXPERIMENTAL_TAGS
+      value: 'true'
+identity:
+  enabled: true
+  image:
+    tag: "$E2E_TESTS_IDENTITY_IMAGE_TAG"
+  firstUser:
+    existingSecret: null
+    user: demo
+    password: $DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+  # Keycloak client seed which is used to query Camunda APIs. 
+  env:
+    # TODO: Remove the KEYCLOAK_USERS env vars in favor of relying on the default configmap values
+    - name: KEYCLOAK_USERS_0_USERNAME
+      value: 'demo'
+    - name: KEYCLOAK_USERS_0_EMAIL
+      value: 'demo@example.com'
+    - name: KEYCLOAK_USERS_0_FIRSTNAME
+      value: 'Demo'
+    - name: KEYCLOAK_USERS_0_LASTNAME
+      value: 'User'
+    - name: KEYCLOAK_USERS_0_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+    - name: KEYCLOAK_USERS_0_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_0_ROLES_1
+      value: Optimize
+    - name: KEYCLOAK_USERS_0_ROLES_2
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_0_ROLES_3
+      value: Web Modeler Admin
+    - name: KEYCLOAK_USERS_0_ROLES_4
+      value: Console
+    - name: KEYCLOAK_USERS_0_ROLES_5
+      value: Core
+    - name: KEYCLOAK_CLIENTS_2_ID
+      value: venom
+    - name: KEYCLOAK_CLIENTS_2_NAME
+      value: Venom
+    - name: KEYCLOAK_CLIENTS_2_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: integration-test-credentials
+          key: identity-admin-client-password
+    - name: KEYCLOAK_CLIENTS_2_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_2_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_2_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_DEFINITION
+      value: write
+    - name: KEYCLOAK_USERS_1_FIRST_NAME
+      value: Lisa
+    - name: KEYCLOAK_USERS_1_LAST_NAME
+      value: Doe
+    - name: KEYCLOAK_USERS_1_EMAIL
+      value: cawemodev+lisa@gmail.com
+    - name: KEYCLOAK_USERS_1_USERNAME
+      value: lisa
+    - name: KEYCLOAK_USERS_1_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_SECONDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_1_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_1_ROLES_1
+      value: Optimize
+    - name: KEYCLOAK_USERS_1_ROLES_2
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_1_ROLES_3
+      value: Web Modeler Admin
+    - name: KEYCLOAK_USERS_1_ROLES_4
+      value: Console
+    - name: KEYCLOAK_USERS_1_ROLES_5
+      value: Core
+    - name: KEYCLOAK_USERS_2_FIRST_NAME
+      value: Bart
+    - name: KEYCLOAK_USERS_2_LAST_NAME
+      value: Foo
+    - name: KEYCLOAK_USERS_2_EMAIL
+      value: cawemodev+bart@gmail.com
+    - name: KEYCLOAK_USERS_2_USERNAME
+      value: bart
+    - name: KEYCLOAK_USERS_2_PASSWORD
+      value: $DISTRO_QA_E2E_TESTS_IDENTITY_THIRDUSER_PASSWORD
+    - name: KEYCLOAK_USERS_2_ROLES_0
+      value: Identity
+    - name: KEYCLOAK_USERS_2_ROLES_1
+      value: Optimize
+    - name: KEYCLOAK_USERS_2_ROLES_2
+      value: Web Modeler
+    - name: KEYCLOAK_USERS_2_ROLES_3
+      value: Web Modeler Admin
+    - name: KEYCLOAK_USERS_2_ROLES_4
+      value: Console
+    - name: KEYCLOAK_USERS_2_ROLES_5
+      value: Core
+    # # Core access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: core-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: core-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # # Tasklist access.
+    # - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_RESOURCE_SERVER_ID
+    #   value: tasklist-api
+    # - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_DEFINITION
+    #   value: "read:*"
+    # - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_RESOURCE_SERVER_ID
+    #   value: tasklist-api
+    # - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_DEFINITION
+    #   value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_DEFINITION
+      value: "write:*"
+    # # Zeebe access.
+    # - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_RESOURCE_SERVER_ID
+    #   value: zeebe-api
+    # - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_DEFINITION
+    #   value: "write:*"
+    # WebModeler access.
+    # NOTE: This actually should be only in the chart-with-web-modeler scenarios,
+    # but since Helm doesn't support merge lists it's added here.
+    # It could be removed later when the env vars could be configured via ConfigMap.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+    - name: KEYCLOAK_CLIENTS_3_ID
+      value: test
+    - name: KEYCLOAK_CLIENTS_3_NAME
+      value: Test
+    - name: KEYCLOAK_CLIENTS_3_SECRET
+      value: $DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET
+    - name: KEYCLOAK_CLIENTS_3_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_3_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_3_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_DEFINITION
+      value: write
+    # Core access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: core-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: core-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # # Tasklist access.
+    # - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_RESOURCE_SERVER_ID
+    #   value: tasklist-api
+    # - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_DEFINITION
+    #   value: "read:*"
+    # - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_RESOURCE_SERVER_ID
+    #   value: tasklist-api
+    # - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_DEFINITION
+    #   value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_DEFINITION
+      value: "write:*"
+    # # Zeebe access.
+    # - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_RESOURCE_SERVER_ID
+    #   value: zeebe-api
+    # - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_DEFINITION
+    #   value: "write:*"
+    # WebModeler access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_DEFINITION
+      value: "write:*"
+connectors:
+  image:
+    tag: "$E2E_TESTS_CONNECTORS_IMAGE_TAG"
+  env:
+    - name: username
+      value: username
+    - name: password
+      value: password

--- a/scripts/base_playwright_script.sh
+++ b/scripts/base_playwright_script.sh
@@ -88,6 +88,7 @@ run_playwright_tests() {
   cd "$test_suite_path" || exit
 
   npm ci --no-audit --no-fund --silent
+  sudo npx playwright install-deps
   npx playwright install
 
   if [[ $show_html_report == "true" ]]; then

--- a/scripts/base_playwright_script.sh
+++ b/scripts/base_playwright_script.sh
@@ -87,7 +87,7 @@ run_playwright_tests() {
 
   cd "$test_suite_path" || exit
 
-  npm ci --no-audit --no-fund --silent
+  npm i --no-audit --no-fund --silent
   sudo npx playwright install-deps
   npx playwright install
 

--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -34,6 +34,8 @@ setup_env_file() {
   local namespace="$4"
   local is_ci="$5"
   local is_opensearch="$6"
+  local is_rba="$7"
+  local is_mt="$8"
 
   export TEST_INGRESS_HOST="$hostname"
   envsubst <"$test_suite_path"/.env.template >"$env_file"
@@ -42,17 +44,24 @@ setup_env_file() {
   # that are used to test the platform. This is grabbing those credentials and
   # adding them to the .env file so that we can run the tests from any environment
   # with an authorized kubectl context.
+  identity_pod_name=$(kubectl -n "$namespace" get pods --no-headers -o custom-columns=':metadata.name' | grep identity | head -n 1)
+  DISTRO_QA_E2E_TESTS_KEYCLOAK_PASSWORD=$(kubectl -n "$namespace" exec "$identity_pod_name" -- printenv KEYCLOAK_SETUP_PASSWORD)
+
+  if [[ -z "$DISTRO_QA_E2E_TESTS_KEYCLOAK_PASSWORD" ]]; then
+    DISTRO_QA_E2E_TESTS_KEYCLOAK_PASSWORD=$(kubectl -n "$namespace" exec "$identity_pod_name" -- printenv VALUES_KEYCLOAK_SETUP_PASSWORD)
+  fi
 
   {
     echo "PLAYWRIGHT_BASE_URL=https://$hostname"
     echo "CLUSTER_VERSION=8"
     echo "MINOR_VERSION=SM-8.7"
-    identity_pod_name=$(kubectl -n "$namespace" get pods --no-headers -o custom-columns=':metadata.name' | grep identity | head -n 1)
     echo "DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD=$(kubectl -n "$namespace" exec "$identity_pod_name" -- printenv KEYCLOAK_USERS_0_PASSWORD)"
-    echo "DISTRO_QA_E2E_TESTS_KEYCLOAK_PASSWORD=$(kubectl -n "$namespace" exec "$identity_pod_name" -- printenv KEYCLOAK_SETUP_PASSWORD)"
+    echo "DISTRO_QA_E2E_TESTS_KEYCLOAK_PASSWORD=$DISTRO_QA_E2E_TESTS_KEYCLOAK_PASSWORD"
     echo "CI=${is_ci}"
     echo "CLUSTER_NAME=integration"
     echo "IS_OPENSEARCH=${is_opensearch}"
+    echo "IS_RBA=${is_rba}"
+    echo "IS_MT=${is_mt}"
   } >>"$env_file"
 
   if $VERBOSE; then
@@ -77,6 +86,9 @@ Options:
   --test-exclude TEST_EXCLUDE                  The tests to exclude
   --not-ci                                    Don't set the CI env var to true
   --run-smoke-tests                           Run the smoke tests
+  --opensearch                                Run the opensearch tests
+  --rba                                       Run the rba tests
+  --mt                                        Run the mt tests
   -v | --verbose                              Show verbose output.
   -h | --help                                 Show this help message and exit.
 EOF
@@ -96,6 +108,8 @@ TEST_EXCLUDE=""
 IS_CI=true
 RUN_SMOKE_TESTS=false
 IS_OPENSEARCH=false
+IS_RBA=false
+IS_MT=false
 
 check_required_cmds
 
@@ -138,6 +152,14 @@ while [[ $# -gt 0 ]]; do
     IS_OPENSEARCH=true
     shift
     ;;
+  --rba)
+    IS_RBA=true
+    shift
+    ;;
+  --mt)
+    IS_MT=true
+    shift
+    ;;
   -v | --verbose)
     VERBOSE=true
     shift
@@ -162,7 +184,13 @@ hostname=$(get_ingress_hostname "$NAMESPACE")
 if [ "$IS_OPENSEARCH" == "true" ]; then
   log "IS_OPENSEARCH is set to true"
 fi
-setup_env_file "$TEST_SUITE_PATH/.env" "$TEST_SUITE_PATH" "$hostname" "$NAMESPACE" "$IS_CI" "$IS_OPENSEARCH"
+if [ "$IS_RBA" == "true" ]; then
+  log "IS_RBA is set to true"
+fi
+if [ "$IS_MT" == "true" ]; then
+  log "IS_MT is set to true"
+fi
+setup_env_file "$TEST_SUITE_PATH/.env" "$TEST_SUITE_PATH" "$hostname" "$NAMESPACE" "$IS_CI" "$IS_OPENSEARCH" "$IS_RBA" "$IS_MT"
 
 log "$TEST_SUITE_PATH"
 log "Running smoke tests: $RUN_SMOKE_TESTS"

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -190,6 +190,7 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 TEST_SUITE_PATH="${ABSOLUTE_CHART_PATH%/}/test/integration/testsuites"
 
 hostname=$(get_ingress_hostname "$NAMESPACE")
+
 setup_env_file "${TEST_SUITE_PATH%/}/.env" "$TEST_SUITE_PATH" "$hostname" "$REPO_ROOT" "$NAMESPACE" "$TEST_AUTH_TYPE" "$IS_CI"
 
 run_playwright_tests "$TEST_SUITE_PATH" "$SHOW_HTML_REPORT" "1" "1" "html" "$TEST_EXCLUDE" false

--- a/test/integration/scenarios/chart-full-setup/Taskfile.yaml
+++ b/test/integration/scenarios/chart-full-setup/Taskfile.yaml
@@ -168,24 +168,27 @@ tasks:
         echo "VENOM_VAR_SKIP_TEST_INGRESS=false" >> "${VARIABLES_ENV_FILE}"
         echo "VENOM_VAR_TEST_INGRESS_HOST=${TEST_INGRESS_HOST}" >> "${VARIABLES_ENV_FILE}"
         echo "VENOM_VAR_SKIP_TEST_WEBMODELER=false" >> "${VARIABLES_ENV_FILE}"
-        echo "VENOM_VAR_SKIP_TEST_ELASTICSEARCH=$(yq '.elasticsearch.enabled // false | not' {{ .TEST_CHART_DIR }}/values.yaml)" >> "${VARIABLES_ENV_FILE}"
-        echo "VENOM_EXTRA_ARGS=--var-from-file=./vars/variables-ingress-combined.yaml" >> "${VARIABLES_ENV_FILE}"
-        echo "ZEEBE_VERSION=$(yq '.zeebe.image.tag' {{ .TEST_CHART_DIR }}/values.yaml)" >> "${VARIABLES_ENV_FILE}"
-        # In case the Zeebe version has not been released officially yet.
-        echo "ZEEBE_VERSION_FALLBACK=$(grep zbctl ../../../../.tool-versions | cut -d " " -f 2)" >> "${VARIABLES_ENV_FILE}"
-        cat ${VARIABLES_ENV_FILE}
-
-  setup.venom.env:
-    preconditions:
-      - test -n "${TEST_INGRESS_HOST}"
-    env:
-      VARIABLES_ENV_FILE: "{{ .TEST_CHART_DIR }}/test/integration/testsuites/vars/files/variables.env"
-    cmds:
-      - |
-        echo "VENOM_VAR_SKIP_TEST_INGRESS=false" >> "${VARIABLES_ENV_FILE}"
-        echo "VENOM_VAR_TEST_INGRESS_HOST=${TEST_INGRESS_HOST}" >> "${VARIABLES_ENV_FILE}"
-        echo "VENOM_VAR_SKIP_TEST_WEBMODELER=false" >> "${VARIABLES_ENV_FILE}"
-        echo "VENOM_VAR_SKIP_TEST_ELASTICSEARCH=$(yq '.elasticsearch.enabled // false | not' {{ .TEST_CHART_DIR }}/values.yaml)" >> "${VARIABLES_ENV_FILE}"
+        # Step 1: Merge all YAMLs
+        MERGED_YAML=$(yq eval-all '. as $item ireduce ({}; . * $item )' \
+          "${TEST_VALUES_BASE_DIR}/common/values-integration-test.yaml" \
+          "${TEST_VALUES_BASE_DIR}/chart-full-setup/values-integration-test-ingress-${TEST_VALUES_SCENARIO}.yaml" \
+          "${INFRA_TYPE_VALUES}" \
+          /tmp/extra-values-file.yaml)
+        
+        echo "--- Merged YAML ---"
+        echo "$MERGED_YAML"
+        echo "-------------------"
+        # Step 2: Extract the Elasticsearch enabled value
+        ES_ENABLED=$(echo "$MERGED_YAML" | yq '.elasticsearch.enabled // false')
+        
+        echo "Elasticsearch enabled: $ES_ENABLED"
+  
+        # Step 3: Determine if we should skip test
+        VENOM_VAR_SKIP_TEST_ELASTICSEARCH=$(echo "$ES_ENABLED" | yq 'not')
+        
+        echo "Skip Elasticsearch test: $VENOM_VAR_SKIP_TEST_ELASTICSEARCH"
+        echo "VENOM_VAR_SKIP_TEST_ELASTICSEARCH=$VENOM_VAR_SKIP_TEST_ELASTICSEARCH" >> "$VARIABLES_ENV_FILE"
+        #echo "VENOM_VAR_SKIP_TEST_ELASTICSEARCH=$(yq eval-all '. as $item ireduce ({}; . * $item )' {{ .TEST_VALUES_BASE_DIR }}/common/values-integration-test.yaml {{ .TEST_VALUES_BASE_DIR }}/chart-full-setup/values-integration-test-ingress-{{ .TEST_VALUES_SCENARIO }}.yaml {{ env "INFRA_TYPE_VALUES" }} /tmp/extra-values-file.yaml | yq '.elasticsearch.enabled // false | not')" >> "${VARIABLES_ENV_FILE}"
         echo "VENOM_EXTRA_ARGS=--var-from-file=./vars/variables-ingress-combined.yaml" >> "${VARIABLES_ENV_FILE}"
         echo "ZEEBE_VERSION=$(yq '.zeebe.image.tag' {{ .TEST_CHART_DIR }}/values.yaml)" >> "${VARIABLES_ENV_FILE}"
         # In case the Zeebe version has not been released officially yet.

--- a/test/integration/scenarios/chart-full-setup/Taskfile.yaml
+++ b/test/integration/scenarios/chart-full-setup/Taskfile.yaml
@@ -5,6 +5,7 @@ vars:
   TEST_CLUSTER_TYPE: '{{ env "TEST_CLUSTER_TYPE" | default "kubernetes" }}'
   TEST_HELM_EXTRA_ARGS: '{{ env "TEST_HELM_EXTRA_ARGS" }} {{ .TEST_OPENSHIFT_ARGS }}'
   TEST_CHART_VERSION: '{{ env "TEST_CHART_VERSION" | default ">0.0.0" | quote }}'
+  VALUES_CONFIG: '{{ env "VALUES_CONFIG" | default "{}" }}'
 
 dotenv:
 - ../vars/common.env
@@ -48,12 +49,34 @@ tasks:
       echo "VENOM_VAR_SKIP_TEST_INGRESS=false" >> "${VARIABLES_ENV_FILE}"
       echo "VENOM_VAR_TEST_INGRESS_HOST=${TEST_INGRESS_HOST}" >> "${VARIABLES_ENV_FILE}"
       echo "VENOM_VAR_SKIP_TEST_WEBMODELER=false" >> "${VARIABLES_ENV_FILE}"
-      echo "VENOM_VAR_SKIP_TEST_ELASTICSEARCH=$(yq eval-all '. as $item ireduce ({}; . * $item )' {{ .TEST_VALUES_BASE_DIR }}/common/values-integration-test.yaml {{ .TEST_VALUES_BASE_DIR }}/chart-full-setup/values-integration-test-ingress-{{ .TEST_VALUES_SCENARIO }}.yaml {{ env "INFRA_TYPE_VALUES" }} /tmp/extra-values-file.yaml | yq '.elasticsearch.enabled // false | not')" >> "${VARIABLES_ENV_FILE}"
+            
+      # Step 1: Merge all YAMLs
+      MERGED_YAML=$(yq eval-all '. as $item ireduce ({}; . * $item )' \
+        "${TEST_VALUES_BASE_DIR}/common/values-integration-test.yaml" \
+        "${TEST_VALUES_BASE_DIR}/chart-full-setup/values-integration-test-ingress-${TEST_VALUES_SCENARIO}.yaml" \
+        "${INFRA_TYPE_VALUES}" \
+        /tmp/extra-values-file.yaml)
+      
+      echo "--- Merged YAML ---"
+      echo "$MERGED_YAML"
+      echo "-------------------"
+      # Step 2: Extract the Elasticsearch enabled value
+      ES_ENABLED=$(echo "$MERGED_YAML" | yq '.elasticsearch.enabled // false')
+      
+      echo "Elasticsearch enabled: $ES_ENABLED"
+
+      # Step 3: Determine if we should skip test
+      VENOM_VAR_SKIP_TEST_ELASTICSEARCH=$(echo "$ES_ENABLED" | yq 'not')
+      
+      echo "Skip Elasticsearch test: $VENOM_VAR_SKIP_TEST_ELASTICSEARCH"
+      echo "VENOM_VAR_SKIP_TEST_ELASTICSEARCH=$VENOM_VAR_SKIP_TEST_ELASTICSEARCH" >> "$VARIABLES_ENV_FILE"
+      #echo "VENOM_VAR_SKIP_TEST_ELASTICSEARCH=$(yq eval-all '. as $item ireduce ({}; . * $item )' {{ .TEST_VALUES_BASE_DIR }}/common/values-integration-test.yaml {{ .TEST_VALUES_BASE_DIR }}/chart-full-setup/values-integration-test-ingress-{{ .TEST_VALUES_SCENARIO }}.yaml {{ env "INFRA_TYPE_VALUES" }} /tmp/extra-values-file.yaml | yq '.elasticsearch.enabled // false | not')" >> "${VARIABLES_ENV_FILE}"
       echo "VENOM_VAR_SKIP_TEST_KEYCLOAK=$( [ "$TEST_VALUES_SCENARIO" = "elasticsearch" ] && echo true || echo false )" >> "${VARIABLES_ENV_FILE}"
       echo "VENOM_EXTRA_ARGS=--var-from-file=./vars/variables-ingress-combined.yaml" >> "${VARIABLES_ENV_FILE}"
       echo "ZEEBE_VERSION=$(yq '.zeebe.image.tag' {{ .TEST_CHART_DIR }}/values.yaml)" >> "${VARIABLES_ENV_FILE}"
       # In case the Zeebe version has not been released officially yet.
       echo "ZEEBE_VERSION_FALLBACK=$(grep zbctl ../../../../.tool-versions | cut -d " " -f 2)" >> "${VARIABLES_ENV_FILE}"
+      cat "${VARIABLES_ENV_FILE}"
     - |
       if [[ "${TEST_CHART_FLOW}" == 'upgrade' ]]; then
         # Extract OpenShift values from released chart for upgrade test.
@@ -134,6 +157,23 @@ tasks:
           }"
 
       fi
+
+  setup.venom.env:
+    preconditions:
+      - test -n "${TEST_INGRESS_HOST}"
+    env:
+      VARIABLES_ENV_FILE: "{{ .TEST_CHART_DIR }}/test/integration/testsuites/vars/files/variables.env"
+    cmds:
+      - |
+        echo "VENOM_VAR_SKIP_TEST_INGRESS=false" >> "${VARIABLES_ENV_FILE}"
+        echo "VENOM_VAR_TEST_INGRESS_HOST=${TEST_INGRESS_HOST}" >> "${VARIABLES_ENV_FILE}"
+        echo "VENOM_VAR_SKIP_TEST_WEBMODELER=false" >> "${VARIABLES_ENV_FILE}"
+        echo "VENOM_VAR_SKIP_TEST_ELASTICSEARCH=$(yq '.elasticsearch.enabled // false | not' {{ .TEST_CHART_DIR }}/values.yaml)" >> "${VARIABLES_ENV_FILE}"
+        echo "VENOM_EXTRA_ARGS=--var-from-file=./vars/variables-ingress-combined.yaml" >> "${VARIABLES_ENV_FILE}"
+        echo "ZEEBE_VERSION=$(yq '.zeebe.image.tag' {{ .TEST_CHART_DIR }}/values.yaml)" >> "${VARIABLES_ENV_FILE}"
+        # In case the Zeebe version has not been released officially yet.
+        echo "ZEEBE_VERSION_FALLBACK=$(grep zbctl ../../../../.tool-versions | cut -d " " -f 2)" >> "${VARIABLES_ENV_FILE}"
+        cat ${VARIABLES_ENV_FILE}
 
   setup.venom.env:
     preconditions:

--- a/test/integration/scenarios/lib/chart-upgrade-taskfile.yaml
+++ b/test/integration/scenarios/lib/chart-upgrade-taskfile.yaml
@@ -19,6 +19,8 @@ tasks:
 
   # https://docs.camunda.io/docs/self-managed/setup/upgrade/
   exec:
+    env:
+      TEST_AUTH_TYPE: "{{ .TEST_AUTH_TYPE }}"
     cmds:
     - |
       #elif does not work properly in Taskfile. This is why the if statements are separated


### PR DESCRIPTION
### Which problem does the PR fix?

values.yaml are mapping over from QA repo to this repo.

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
