### PR TITLE
fix: disable renovate for the elasticsearch-curator-archived image

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -250,6 +250,14 @@
       ],
     },
     {
+      // This docker image appears to require authentication, and is only used for 8.2 HC's so I'm disabling it to prevent issues with renovate.
+      enabled: false,
+      matchPackageNames: [
+        'bitnamilegacy/elasticsearch-curator-archived',
+        'elasticsearch-curator-archived',
+      ],
+    },
+    {
       // Enable app patch version update in the previous Camunda Helm charts.
       matchDatasources: [
         'helmv3',


### PR DESCRIPTION
### Which problem does the PR fix?

closes #3901 

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

This PR disables renovate updates for the elasticsearch-curator-archived image.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
