### PR TITLE
fix: fallback to vault secret for registry cred if github secrets is empty

### DIFF
--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -273,8 +273,8 @@ jobs:
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           secrets: |
             secret/data/products/distribution/ci INTEGRATION_TEST_CREDENTIALS;
-            secret/data/products/web-modeler/ci/common CAMUNDA_CONTAINER_REGISTRY_USER;
-            secret/data/products/web-modeler/ci/common CAMUNDA_CONTAINER_REGISTRY_PASSWORD;
+            secret/data/products/distribution/ci NEXUS_USERNAME;
+            secret/data/products/distribution/ci NEXUS_PASSWORD;
           exportEnv: true
 
       - name: CI Setup - Authenticate to cluster
@@ -363,8 +363,8 @@ jobs:
 
           task -d ${CI_TASKS_BASE_DIR}/chart-full-setup init.seed
         env:
-          TEST_DOCKER_USERNAME_CAMUNDA_CLOUD: ${{ env.TEST_DOCKER_USERNAME_CAMUNDA_CLOUD || env.CAMUNDA_CONTAINER_REGISTRY_USER }}
-          TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD: ${{ env.TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD || env.CAMUNDA_CONTAINER_REGISTRY_PASSWORD }}
+          TEST_DOCKER_USERNAME_CAMUNDA_CLOUD: ${{ env.TEST_DOCKER_USERNAME_CAMUNDA_CLOUD || env.NEXUS_USERNAME }}
+          TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD: ${{ env.TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD || env.NEXUS_PASSWORD }}
 
       - name: Cluster Setup - Configure TLS Certificates/Secrets
         run: |


### PR DESCRIPTION
### Which problem does the PR fix?

Our github actions workflow requires a couple github secrets to be set for credentials to registry.camunda.cloud . However, because they are github secrets, we cannot observe what those machine credentials are, and the Infra-team does not seem to want to create new credentials to be put into a github secret.


<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

This PR makes use of a secret to credentials to registry.camunda.cloud  that already exists in vault if the github secret is not found. 


<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
