### PR TITLE
ci: fix double quotes for extra-values option

### DIFF
--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -392,13 +392,14 @@ jobs:
           TEST_VALUES_SCENARIO: "${{ inputs.scenario }}"
           TEST_AUTH_TYPE: ${{ inputs.auth }}
           INFRA_TYPE: ${{ inputs.infra-type }}
+          EXTRA_VALUES: ${{ inputs.extra-values }}
           TEST_HELM_EXTRA_ARGS: >-
             ${{ env.TEST_HELM_EXTRA_ARGS }}
             --set global.ingress.host=${{ steps.vars.outputs.ingress-host }}
 
         run: |
           echo "Extra values from workflow:"
-          echo '${{ inputs.extra-values }}' | tee /tmp/extra-values-file.yaml
+          echo "$EXTRA_VALUES" | tee /tmp/extra-values-file.yaml
 
           task -d ${CI_TASKS_BASE_DIR}/chart-full-setup setup.pre
 
@@ -601,10 +602,11 @@ jobs:
           TEST_VALUES_SCENARIO: "${{ inputs.scenario }}"
           TEST_INGRESS_HOST: ${{ steps.vars.outputs.ingress-host }}
           TEST_NAMESPACE: ${{ env.TEST_NAMESPACE }}
+          EXTRA_VALUES: ${{ inputs.extra-values }}
         continue-on-error: false
         run: |
           echo "Extra values from workflow:"
-          echo '${{ inputs.extra-values }}' | tee /tmp/extra-values-file.yaml
+          echo "$EXTRA_VALUES" | tee /tmp/extra-values-file.yaml
           task -d ${CI_TASKS_BASE_DIR}/chart-full-setup setup.venom.env
 
       - name: Test - ⭐️ Run Venom Preflight TestSuite ⭐️


### PR DESCRIPTION
### Which problem does the PR fix?

Console team passes in strings like
```
    console:
        enabled: true
        contextPath: "/"
        image:
          tag: 8.8.0-alpha7
          registry: "registry.camunda.cloud"
          repository: "team-console/console-sm"
        env:
          - name: "CAMUNDA_CONSOLE_TELEMETRY"
            value: "download"
          - name: "CAMUNDA_CONSOLE_CUSTOMERID"
            value: "test"
          - name: "CAMUNDA_CONSOLE_INSTALLATIONID"
            value: "dev"
          - name: "CAMUNDA_LICENSE_KEY"
            value: "insert-license"
          - name: "CAMUNDA_CONSOLE_DISABLE_AUTH"
            value: "true"
          - name: "CAMUNDA_LICENSE_KEY_IS_TEST"
            value: "true"
```

Into the extra-values option, but because the
test-integration-runner.yaml puts doublequotes around the extra-values input when echoing it to a file, the doublequotes get stripped out.

```
    Extra values from workflow:
     console:
      enabled: true
      contextPath: /
      image:
        tag: 8.8.0-alpha7
        registry: registry.camunda.cloud
        repository: team-console/console-sm
      env:
        - name: CAMUNDA_CONSOLE_TELEMETRY
          value: download
        - name: CAMUNDA_CONSOLE_CUSTOMERID
          value: test
        - name: CAMUNDA_CONSOLE_INSTALLATIONID
          value: dev
        - name: CAMUNDA_LICENSE_KEY
          value: insert-license
        - name: CAMUNDA_CONSOLE_DISABLE_AUTH
          value: true
        - name: CAMUNDA_LICENSE_KEY_IS_TEST
          value: true
```

The lack of quotes around "true" cause the CI to fail



<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

This PR switches from using direct string injection from GHA to using an environment variable.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
