### PR TITLE
fix: check out code before referencing it in pr labeler

### DIFF
--- a/.github/workflows/repo-pr-labeler.yaml
+++ b/.github/workflows/repo-pr-labeler.yaml
@@ -10,6 +10,11 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
       - name: Run Labeler
         uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
         with:


### PR DESCRIPTION
### Which problem does the PR fix?

PR labeler is erroring on every PR because it doesn't check out the code first.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
