### PR TITLE
fix: disable persistent sessions in noSecondaryStorage mode

### DIFF
--- a/charts/camunda-platform-8.8/templates/orchestration/_helpers.tpl
+++ b/charts/camunda-platform-8.8/templates/orchestration/_helpers.tpl
@@ -130,3 +130,7 @@ app.kubernetes.io/component: orchestration
         {{- fail "Please enable a secondary storage type. Either Elasticsearch or OpenSearch" -}}
     {{- end -}}
 {{- end -}}
+
+{{- define "orchestration.persistentSessionsEnabled" -}}
+    {{- not .Values.global.noSecondaryStorage -}}
+{{- end -}}

--- a/charts/camunda-platform-8.8/templates/orchestration/configmap.yaml
+++ b/charts/camunda-platform-8.8/templates/orchestration/configmap.yaml
@@ -206,7 +206,7 @@ data:
     camunda:
       persistent:
         sessions:
-          enabled: {{ not .Values.global.noSecondaryStorage }}
+          enabled: {{ include "orchestration.persistentSessionsEnabled" . }}
 
       rest:
         query:
@@ -291,7 +291,7 @@ data:
         {{- if .Values.orchestration.migration.process.enabled }}
         importerEnabled: true
         {{- end }}
-        persistentSessionsEnabled: {{ not .Values.global.noSecondaryStorage }}
+        persistentSessionsEnabled: {{ include "orchestration.persistentSessionsEnabled" . }}
         {{- if .Values.global.opensearch.enabled }}
         database: opensearch
         {{- end }}

--- a/charts/camunda-platform-8.8/templates/orchestration/configmap.yaml
+++ b/charts/camunda-platform-8.8/templates/orchestration/configmap.yaml
@@ -206,7 +206,7 @@ data:
     camunda:
       persistent:
         sessions:
-          enabled: true
+          enabled: {{ not .Values.global.noSecondaryStorage }}
 
       rest:
         query:
@@ -261,7 +261,7 @@ data:
       #
       # Camunda Database Configuration.
       #
-      {{- if or .Values.global.elasticsearch.enabled .Values.global.opensearch.enabled }}
+      {{- if or .Values.global.elasticsearch.enabled .Values.global.opensearch.enabled .Values.global.noSecondaryStorage }}
       database:
         type: {{ if .Values.global.noSecondaryStorage }}none{{ else if .Values.global.elasticsearch.enabled }}elasticsearch{{ else }}opensearch{{ end }}
         {{- if .Values.global.elasticsearch.enabled }}
@@ -291,7 +291,7 @@ data:
         {{- if .Values.orchestration.migration.process.enabled }}
         importerEnabled: true
         {{- end }}
-        persistentSessionsEnabled: true
+        persistentSessionsEnabled: {{ not .Values.global.noSecondaryStorage }}
         {{- if .Values.global.opensearch.enabled }}
         database: opensearch
         {{- end }}

--- a/charts/camunda-platform-8.8/test/unit/common/no_secondary_storage_test.go
+++ b/charts/camunda-platform-8.8/test/unit/common/no_secondary_storage_test.go
@@ -52,12 +52,17 @@ func (s *NoSecondaryStorageTemplateTest) TestNoSecondaryStorageGlobalValue() {
 			Name:                 "TestGlobalNoSecondaryStorageTogglesAllExpectedValues",
 			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
 			Values: map[string]string{
-				"global.noSecondaryStorage": "true",
+				"global.noSecondaryStorage":    "true",
+				"global.elasticsearch.enabled": "false",
+				"global.opensearch.enabled":    "false",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				require.NoError(t, err)
 				// Database type should be none
 				require.Contains(t, output, "database:\n        type: none")
+				// Persistent sessions should be disabled
+				require.Contains(t, output, "sessions:\n          enabled: false")
+				require.Contains(t, output, "persistentSessionsEnabled: false")
 				// Agentic AI and inbound connectors should be disabled
 				require.Contains(t, output, "webhook:\n          enabled: false")
 				require.Contains(t, output, "polling:\n          enabled: false")


### PR DESCRIPTION
### Which problem does the PR fix?

Related to #34386 and most recent QA findings

### What's in this PR?

This PR is fixing 2 bugs
- When starting in `noSecondaryStorage` mode we get prompted to disable `global.elasticsearch` and `global.opensearch` but when we do that the [database section](https://github.com/camunda/camunda-platform-helm/blob/376099b5ab30d8bac2d8706e0a7ce0cbb0a5c88f/charts/camunda-platform-8.8/templates/orchestration/configmap.yaml#L253) is disabled entirely which is not what we want. Instead we want to set `camunda.database.type=none`
- When persistent session is enabled, the cluster tries to read configs from the search layer (which isn't relevant since we don't use search layer in `noSecondaryStorage` mode). Also the persistent session is used for webapps (operate and tasklist) which we also disable
```
No qualifying bean
 of type 'io.camunda.search.connect.configuration.ConnectConfiguration' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {}
```

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
