### PR TITLE
fix: remove zeebe subpath in rest configmap

### DIFF
--- a/charts/camunda-platform-8.8/templates/web-modeler/configmap-restapi.yaml
+++ b/charts/camunda-platform-8.8/templates/web-modeler/configmap-restapi.yaml
@@ -56,9 +56,8 @@ data:
             authorizations:
               enabled: {{ .Values.global.security.authorizations.enabled }}
             url:
-              zeebe:
-                grpc: "grpc://{{ include "orchestration.fullname" . }}:{{ .Values.orchestration.service.grpcPort }}"
-                rest: "{{ include "camundaPlatform.zeebeGatewayRESTURL" . }}"
+              grpc: "grpc://{{ include "orchestration.fullname" . }}:{{ .Values.orchestration.service.grpcPort }}"
+              rest: "{{ include "camundaPlatform.zeebeGatewayRESTURL" . }}"
               operate: {{ include "camundaPlatform.OrchestrationURL" . | quote }}
               tasklist: {{ include "camundaPlatform.OrchestrationURL" . | quote }}
           {{- end }}

--- a/charts/camunda-platform-8.8/test/unit/web-modeler/golden/configmap-restapi.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/web-modeler/golden/configmap-restapi.golden.yaml
@@ -49,9 +49,8 @@ data:
             authorizations:
               enabled: true
             url:
-              zeebe:
-                grpc: "grpc://camunda-platform-test-orchestration:26500"
-                rest: "http://camunda-platform-test-orchestration:8080"
+              grpc: "grpc://camunda-platform-test-orchestration:26500"
+              rest: "http://camunda-platform-test-orchestration:8080"
               operate: "http://camunda-platform-test-orchestration:8080"
               tasklist: "http://camunda-platform-test-orchestration:8080"
 


### PR DESCRIPTION
### Which problem does the PR fix?

The orchestration core team woke up this morning to find that their builds were failing due to a configuration issue within the web modeler. The problem was that there was a recent web modeler configuration change that removes the `zeebe` part of the path in the web modeler config.

I think this change only applies to non-released alphas, so only SNAPSHOT.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

removes the zeebe part of `camunda.modeler.clusters[0].url.zeebe.rest`

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
