### PR TITLE
fix: missing else in identity multitenancy configuration

### DIFF
--- a/charts/camunda-platform-8.8/templates/identity/_helpers.tpl
+++ b/charts/camunda-platform-8.8/templates/identity/_helpers.tpl
@@ -191,6 +191,8 @@ This is mainly used to access the external Keycloak service in the global Ingres
             {{ .Values.identity.multitenancy.enabled }}
         {{- else if .Values.global.multitenancy.enabled -}}
             {{ .Values.global.multitenancy.enabled }}
+        {{- else -}}
+          false
         {{- end -}}
     {{- else -}}
       false


### PR DESCRIPTION
### Which problem does the PR fix?

I missed an else condition in the identity multitenancy options. If you recognize this one @aabouzaid , it's because theres a very similar block in the orchestration _helpers.tpl you told me to fix. 

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

Added else condition.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
