### PR TITLE
chore(web-modeler): use JAVA_TOOL_OPTIONS instead of JAVA_OPTIONS for JVM arguments

### DIFF
--- a/charts/camunda-platform-8.2/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform-8.2/templates/web-modeler/deployment-restapi.yaml
@@ -32,7 +32,7 @@ spec:
         securityContext: {{- toYaml .Values.webModeler.restapi.containerSecurityContext | nindent 10 }}
         {{- end }}
         env:
-          - name: JAVA_OPTIONS
+          - name: JAVA_TOOL_OPTIONS
             value: "-Xmx1536m"
           - name: RESTAPI_DB_HOST
             value: {{ include "webModeler.restapi.databaseHost" . | quote }}

--- a/charts/camunda-platform-8.2/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform-8.2/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -44,7 +44,7 @@ spec:
         image: "registry.camunda.cloud/web-modeler-ee/modeler-restapi:8.2.20"
         imagePullPolicy: IfNotPresent
         env:
-          - name: JAVA_OPTIONS
+          - name: JAVA_TOOL_OPTIONS
             value: "-Xmx1536m"
           - name: RESTAPI_DB_HOST
             value: "camunda-platform-test-postgresql-web-modeler"

--- a/charts/camunda-platform-8.3/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform-8.3/templates/web-modeler/deployment-restapi.yaml
@@ -34,7 +34,7 @@ spec:
           securityContext: {{- toYaml .Values.webModeler.restapi.containerSecurityContext | nindent 12 }}
           {{- end }}
           env:
-            - name: JAVA_OPTIONS
+            - name: JAVA_TOOL_OPTIONS
               value: "-Xmx1536m"
             - name: SPRING_DATASOURCE_URL
               value: {{ include "webModeler.restapi.databaseUrl" . | quote }}

--- a/charts/camunda-platform-8.3/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform-8.3/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -52,7 +52,7 @@ spec:
             runAsNonRoot: true
             runAsUser: 1000
           env:
-            - name: JAVA_OPTIONS
+            - name: JAVA_TOOL_OPTIONS
               value: "-Xmx1536m"
             - name: SPRING_DATASOURCE_URL
               value: "jdbc:postgresql://camunda-platform-test-postgresql-web-modeler:5432/web-modeler"

--- a/charts/camunda-platform-8.4/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform-8.4/templates/web-modeler/deployment-restapi.yaml
@@ -34,7 +34,7 @@ spec:
           securityContext: {{- toYaml .Values.webModeler.restapi.containerSecurityContext | nindent 12 }}
           {{- end }}
           env:
-            - name: JAVA_OPTIONS
+            - name: JAVA_TOOL_OPTIONS
               value: "-Xmx1536m"
             {{- if .Values.identity.enabled }}
             - name: CAMUNDA_IDENTITY_BASEURL

--- a/charts/camunda-platform-8.4/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform-8.4/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -52,7 +52,7 @@ spec:
             runAsNonRoot: true
             runAsUser: 1000
           env:
-            - name: JAVA_OPTIONS
+            - name: JAVA_TOOL_OPTIONS
               value: "-Xmx1536m"
             - name: CAMUNDA_IDENTITY_BASEURL
               value: "http://camunda-platform-test-identity:80"

--- a/charts/camunda-platform-8.5/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform-8.5/templates/web-modeler/deployment-restapi.yaml
@@ -34,7 +34,7 @@ spec:
           securityContext: {{- toYaml .Values.webModeler.restapi.containerSecurityContext | nindent 12 }}
           {{- end }}
           env:
-            - name: JAVA_OPTIONS
+            - name: JAVA_TOOL_OPTIONS
               value: "-XX:MaxRAMPercentage=80.0"
             {{- if or (not .Values.webModeler.restapi.externalDatabase.enabled) .Values.webModeler.restapi.externalDatabase.password }}
             - name: SPRING_DATASOURCE_PASSWORD

--- a/charts/camunda-platform-8.5/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform-8.5/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -52,7 +52,7 @@ spec:
             seccompProfile:
               type: RuntimeDefault
           env:
-            - name: JAVA_OPTIONS
+            - name: JAVA_TOOL_OPTIONS
               value: "-XX:MaxRAMPercentage=80.0"
             - name: SPRING_DATASOURCE_PASSWORD
               valueFrom:

--- a/charts/camunda-platform-8.6/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform-8.6/templates/web-modeler/deployment-restapi.yaml
@@ -39,7 +39,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "camundaPlatform.licenseSecretName" . }}
                   key: {{ include "camundaPlatform.licenseSecretKey" . }}
-            - name: JAVA_OPTIONS
+            - name: JAVA_TOOL_OPTIONS
               value: "-XX:MaxRAMPercentage=80.0"
             - name: SPRING_DATASOURCE_PASSWORD
               valueFrom:

--- a/charts/camunda-platform-8.6/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform-8.6/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -57,7 +57,7 @@ spec:
                 secretKeyRef:
                   name: camunda-platform-test-license
                   key: CAMUNDA_LICENSE_KEY
-            - name: JAVA_OPTIONS
+            - name: JAVA_TOOL_OPTIONS
               value: "-XX:MaxRAMPercentage=80.0"
             - name: SPRING_DATASOURCE_PASSWORD
               valueFrom:

--- a/charts/camunda-platform-8.7/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform-8.7/templates/web-modeler/deployment-restapi.yaml
@@ -39,7 +39,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "camundaPlatform.licenseSecretName" . }}
                   key: {{ include "camundaPlatform.licenseSecretKey" . }}
-            - name: JAVA_OPTIONS
+            - name: JAVA_TOOL_OPTIONS
               value: "-XX:MaxRAMPercentage=80.0"
             - name: SPRING_DATASOURCE_PASSWORD
               valueFrom:

--- a/charts/camunda-platform-8.7/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform-8.7/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -57,7 +57,7 @@ spec:
                 secretKeyRef:
                   name: camunda-platform-test-license
                   key: CAMUNDA_LICENSE_KEY
-            - name: JAVA_OPTIONS
+            - name: JAVA_TOOL_OPTIONS
               value: "-XX:MaxRAMPercentage=80.0"
             - name: SPRING_DATASOURCE_PASSWORD
               valueFrom:

--- a/charts/camunda-platform-8.8/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform-8.8/templates/web-modeler/deployment-restapi.yaml
@@ -39,7 +39,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "camundaPlatform.licenseSecretName" . }}
                   key: {{ include "camundaPlatform.licenseSecretKey" . }}
-            - name: JAVA_OPTIONS
+            - name: JAVA_TOOL_OPTIONS
               value: "-XX:MaxRAMPercentage=80.0"
             - name: SPRING_DATASOURCE_PASSWORD
               valueFrom:

--- a/charts/camunda-platform-8.8/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -57,7 +57,7 @@ spec:
                 secretKeyRef:
                   name: camunda-platform-test-license
                   key: CAMUNDA_LICENSE_KEY
-            - name: JAVA_OPTIONS
+            - name: JAVA_TOOL_OPTIONS
               value: "-XX:MaxRAMPercentage=80.0"
             - name: SPRING_DATASOURCE_PASSWORD
               valueFrom:


### PR DESCRIPTION
### Which problem does the PR fix?
Relates to https://github.com/camunda/web-modeler/issues/16044 and https://github.com/camunda/camunda-docs/pull/6363: We recommend users to provide their proxy settings for Web Modeler via `JAVA_OPTIONS`, but this should not override the default JVM arguments in the Helm setup (which are currently also set via `JAVA_OPTIONS`).

### What's in this PR?

Switch to `JAVA_TOOL_OPTIONS` to provide the JVM arguments for the Web Modeler `restapi` component.

_Note_: This environment variable is also used in the Helm chart by the other C8 components.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?