### PR TITLE
ci: delete camunda sts before the upgrade

### DIFF
--- a/charts/camunda-platform-8.8/test/integration/scenarios/pre-upgrade/delete-camunda-sts.sh
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/pre-upgrade/delete-camunda-sts.sh
@@ -1,0 +1,6 @@
+# Delete the StatefulSet of Camunda Orchestration cluster as the "matchLabels" changed
+# after the rename from "core" to "orchestration".
+kubectl delete sts -n "${TEST_NAMESPACE}" -l app.kubernetes.io/component=core --ignore-not-found
+# Adding "orchestration" also, as this will change again before the final release, to avoid the need to delete the StatefulSet.
+# It will be again "zeebe-broker" as the 8.7 release.
+kubectl delete sts -n "${TEST_NAMESPACE}" -l app.kubernetes.io/component=orchestration --ignore-not-found


### PR DESCRIPTION
### Which problem does the PR fix?

Related to: https://github.com/camunda/camunda-platform-helm/issues/3455

### What's in this PR?

Since we renamed `core` to `orchestration` , the upgrade from alpha 7 will fail as the `matchLabels` key is immutable.

I also found that the ability to run scripts before the different flows (install, install in upgrade, upgrade) is not clear enough, and I will make it more visible in another PR.