### PR TITLE
fix: the IT scripts are detecting the  cluster as our naming on secre…

### DIFF
--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -662,6 +662,7 @@ jobs:
       TEST_NAMESPACE: ${{ needs.ci-setup.outputs.TEST_NAMESPACE }}
       ABSOLUTE_TEST_CHART_DIR: ${{ needs.ci-setup.outputs.ABSOLUTE_TEST_CHART_DIR }}
       TEST_EXCLUDE: ${{ inputs.exclude }}
+      PLATFORM: ${{ inputs.distro-platform }}
       TEST_AUTH_TYPE: ${{ inputs.auth }}
     steps:
       - name: CI Setup - Checkout

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -51,7 +51,7 @@ setup_env_file() {
   # with an authorized kubectl context.
 
   if [[ "$test_suite_path" == *"8.8"* ]]; then
-    if [[ "$namespace" == *"camunda-"* ]]; then #gke
+    if [[ "$PLATFORM" == "gke" ]]; then
       for svc in CONNECTORS TASKLIST OPTIMIZE OPERATE ZEEBE ORCHESTRATION; do
         secret=$(kubectl -n "$namespace" \
           get secret integration-test-credentials \
@@ -69,7 +69,7 @@ setup_env_file() {
   fi
 
   if [[ "$test_suite_path" == *"8.7"* ]]; then
-    if [[ "$namespace" == *"camunda-"* ]]; then # gke
+    if [[ "$PLATFORM" == "gke" ]]; then
       for svc in CONNECTORS TASKLIST OPTIMIZE OPERATE ZEEBE ORCHESTRATION; do
         secret=$(kubectl -n "$namespace" \
           get secret integration-test-credentials \


### PR DESCRIPTION
…ts differs between EKS and GKE. This was flaky

NOTE: the better solution is to align these so this logic doesn't exist but right now the QA builds are breaking the external-dns so this will do for now until the longer work of decommissioning eks can be done.

### Which problem does the PR fix?

Related to this PR in the QA repo https://github.com/camunda/c8-cross-component-e2e-tests/pull/1125

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
