### PR TITLE
test(web-modeler): use ingress host for cluster webapp url

### DIFF
--- a/charts/camunda-platform-8.8/test/unit/web-modeler/configmap_restapi_test.go
+++ b/charts/camunda-platform-8.8/test/unit/web-modeler/configmap_restapi_test.go
@@ -310,6 +310,9 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldConfigureClusterFromSa
 				"global.identity.auth.enabled":           tc.authEnabled,
 				"global.security.authentication.method":  tc.authMethod,
 				"global.security.authorizations.enabled": "false",
+				"global.ingress.enabled":                 "true",
+				"global.ingress.tls.enabled":             "true",
+				"global.ingress.host":                    "example.com",
 				"orchestration.image.tag":                "8.8.x-alpha1",
 				"orchestration.contextPath":              "/orchestration",
 				"orchestration.service.grpcPort":         "26600",
@@ -336,12 +339,12 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldConfigureClusterFromSa
 			s.Require().Equal(1, len(configmapApplication.Camunda.Modeler.Clusters))
 			s.Require().Equal("default-cluster", configmapApplication.Camunda.Modeler.Clusters[0].Id)
 			s.Require().Equal("test-zeebe", configmapApplication.Camunda.Modeler.Clusters[0].Name)
-			s.Require().Equal("8.x.x-alpha1", configmapApplication.Camunda.Modeler.Clusters[0].Version)
+			s.Require().Equal("8.8.x-alpha1", configmapApplication.Camunda.Modeler.Clusters[0].Version)
 			s.Require().Equal(tc.expectedAuthentication, configmapApplication.Camunda.Modeler.Clusters[0].Authentication)
 			s.Require().Equal(false, configmapApplication.Camunda.Modeler.Clusters[0].Authorizations.Enabled)
 			s.Require().Equal("grpc://camunda-platform-test-orchestration:26600", configmapApplication.Camunda.Modeler.Clusters[0].Url.Grpc)
 			s.Require().Equal("http://camunda-platform-test-orchestration:8090/orchestration", configmapApplication.Camunda.Modeler.Clusters[0].Url.Rest)
-			s.Require().Equal("http://localhost:8088", configmapApplication.Camunda.Modeler.Clusters[0].Url.WebApp)
+			s.Require().Equal("https://example.com/orchestration", configmapApplication.Camunda.Modeler.Clusters[0].Url.WebApp)
 		})
 	}
 }

--- a/charts/camunda-platform-8.8/values.yaml
+++ b/charts/camunda-platform-8.8/values.yaml
@@ -502,7 +502,7 @@ global:
         storeId: "INMEMORY"
         ## @param global.documentStore.type.inmemory.class Fully qualified class name for the in-memory document store provider.
         class: "io.camunda.document.store.inmemory.InMemoryDocumentStoreProvider"
-  
+
   ## @extra global.exporter configuration for Elasticsearch and Opensearch exporters.
   exporter:
     ## @param global.exporter.enabled if true, enables Elasticsearch and Opensearch exporters.
@@ -1420,7 +1420,7 @@ webModeler:
     #    authentication: "BEARER_TOKEN"
     #    url:
     #      grpc: "grpc://camunda-platform-orchestration:26500"
-    #      rest: "http://camunda-platform-orchestration:8080/v1"
+    #      rest: "http://camunda-platform-orchestration:8080"
     #      web-app: "http://localhost:8088"
 
     ## @param webModeler.restapi.podAnnotations can be used to define extra restapi pod annotations


### PR DESCRIPTION
### Which problem does the PR fix?

Follow-up for https://github.com/camunda/camunda-platform-helm/pull/3961.

Relates to https://github.com/camunda/web-modeler/issues/16977.

### What's in this PR?

Test the case that the global Ingress is enabled and the Ingress host is used for the cluster's webapp URL in the Web Modeler configuration.

The default case (Ingress disabled) is already covered by the golden files test.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?