### PR TITLE
refactor(web-modeler): make webapp memory config dynamic

### DIFF
--- a/charts/camunda-platform-8.5/templates/web-modeler/deployment-webapp.yaml
+++ b/charts/camunda-platform-8.5/templates/web-modeler/deployment-webapp.yaml
@@ -39,7 +39,7 @@ spec:
             - name: PLAY_ENABLED
               value: "true"
             - name: NODE_OPTIONS
-              value: "--max-old-space-size=128"
+              value: "--max-old-space-size-percentage=80"
             - name: PUSHER_APP_ID
               valueFrom:
                 configMapKeyRef:

--- a/charts/camunda-platform-8.5/test/unit/web-modeler/golden/deployment-webapp.golden.yaml
+++ b/charts/camunda-platform-8.5/test/unit/web-modeler/golden/deployment-webapp.golden.yaml
@@ -57,7 +57,7 @@ spec:
             - name: PLAY_ENABLED
               value: "true"
             - name: NODE_OPTIONS
-              value: "--max-old-space-size=128"
+              value: "--max-old-space-size-percentage=80"
             - name: PUSHER_APP_ID
               valueFrom:
                 configMapKeyRef:

--- a/charts/camunda-platform-8.6/templates/web-modeler/deployment-webapp.yaml
+++ b/charts/camunda-platform-8.6/templates/web-modeler/deployment-webapp.yaml
@@ -44,7 +44,7 @@ spec:
             - name: PLAY_ENABLED
               value: "true"
             - name: NODE_OPTIONS
-              value: "--max-old-space-size=128"
+              value: "--max-old-space-size-percentage=80"
             - name: PUSHER_APP_ID
               valueFrom:
                 configMapKeyRef:

--- a/charts/camunda-platform-8.6/test/unit/web-modeler/golden/deployment-webapp.golden.yaml
+++ b/charts/camunda-platform-8.6/test/unit/web-modeler/golden/deployment-webapp.golden.yaml
@@ -62,7 +62,7 @@ spec:
             - name: PLAY_ENABLED
               value: "true"
             - name: NODE_OPTIONS
-              value: "--max-old-space-size=128"
+              value: "--max-old-space-size-percentage=80"
             - name: PUSHER_APP_ID
               valueFrom:
                 configMapKeyRef:

--- a/charts/camunda-platform-8.7/templates/web-modeler/deployment-webapp.yaml
+++ b/charts/camunda-platform-8.7/templates/web-modeler/deployment-webapp.yaml
@@ -44,7 +44,7 @@ spec:
             - name: PLAY_ENABLED
               value: "true"
             - name: NODE_OPTIONS
-              value: "--max-old-space-size=128"
+              value: "--max-old-space-size-percentage=80"
             - name: PUSHER_APP_ID
               valueFrom:
                 configMapKeyRef:

--- a/charts/camunda-platform-8.7/test/unit/web-modeler/golden/deployment-webapp.golden.yaml
+++ b/charts/camunda-platform-8.7/test/unit/web-modeler/golden/deployment-webapp.golden.yaml
@@ -62,7 +62,7 @@ spec:
             - name: PLAY_ENABLED
               value: "true"
             - name: NODE_OPTIONS
-              value: "--max-old-space-size=128"
+              value: "--max-old-space-size-percentage=80"
             - name: PUSHER_APP_ID
               valueFrom:
                 configMapKeyRef:

--- a/charts/camunda-platform-8.8/templates/web-modeler/deployment-webapp.yaml
+++ b/charts/camunda-platform-8.8/templates/web-modeler/deployment-webapp.yaml
@@ -44,7 +44,7 @@ spec:
             - name: PLAY_ENABLED
               value: {{ ternary "false" "true" .Values.global.noSecondaryStorage | quote }}
             - name: NODE_OPTIONS
-              value: "--max-old-space-size=128"
+              value: "--max-old-space-size-percentage=80"
             - name: PUSHER_APP_ID
               valueFrom:
                 configMapKeyRef:

--- a/charts/camunda-platform-8.8/test/unit/web-modeler/golden/deployment-webapp.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/web-modeler/golden/deployment-webapp.golden.yaml
@@ -62,7 +62,7 @@ spec:
             - name: PLAY_ENABLED
               value: "true"
             - name: NODE_OPTIONS
-              value: "--max-old-space-size=128"
+              value: "--max-old-space-size-percentage=80"
             - name: PUSHER_APP_ID
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

Changes the Web Modeler `webapp`s memory allocation from a fixed amount to dynamically using 80%.

Related to https://github.com/camunda/web-modeler/issues/9003.

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
