### PR TITLE
feat: add documentStore to QA ES values

### DIFF
--- a/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch.yaml
+++ b/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch.yaml
@@ -1,6 +1,19 @@
 global:
   image:
     pullPolicy: Always
+  documentStore:
+    activeStoreId: "aws"
+    type:
+      aws:
+        enabled: true
+        storeId: "aws"
+        bucket: "camunda-ci-eks-prod-team-bucket-qa"
+        region: "eu-central-1"
+        bucketPath: "documents"
+        class: "io.camunda.document.store.aws.AwsDocumentStoreProvider"
+        existingSecret: "s3-bucket-credentials"
+        accessKeyIdKey: "access-key-id"
+        secretAccessKeyKey: "secret-access-key"
 zeebe:
   image:
     tag: "$E2E_TESTS_ZEEBE_IMAGE_TAG"

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch.yaml
@@ -6,6 +6,19 @@ global:
       enabled: true
     auth:
       enabled: true
+  documentStore:
+    activeStoreId: "aws"
+    type:
+      aws:
+        enabled: true
+        storeId: "aws"
+        bucket: "camunda-ci-eks-prod-team-bucket-qa"
+        region: "eu-central-1"
+        bucketPath: "documents"
+        class: "io.camunda.document.store.aws.AwsDocumentStoreProvider"
+        existingSecret: "s3-bucket-credentials"
+        accessKeyIdKey: "access-key-id"
+        secretAccessKeyKey: "secret-access-key"
 orchestration:
   image:
     tag: "$E2E_TESTS_ORCHESTRATION_IMAGE_TAG"


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

This incorporates the S3 bucket into the QA workflows. This is an outcome of the [following Slack](https://camunda.slack.com/archives/C06BN4SRB6C/p1756124817500019?thread_ts=1752062127.599289&cid=C06BN4SRB6C) conversation. 

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
