### PR TITLE
ci: set groups claim to empty string to show Groups tab

### DIFF
--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-oidc.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-oidc.yaml
@@ -138,6 +138,7 @@ orchestration:
       unprotectedApi: false
       oidc:
         usernameClaim: oid
+        groupsClaim: ""
     authorizations:
       enabled: true
     initialization:


### PR DESCRIPTION
### Which problem does the PR fix?

Related to https://github.com/camunda/camunda-platform-helm/issues/4003

The gist is that keycloak does not supply a groups claim attribute by default, and when we set it to a default value, the Groups tab does not show up. The QA team is not prepared to give up on the Groups tab for OIDC scenarios quite yet, and the functionality is still required by SaaS and will not be removed, so I think for testing scenarios, it makes sense to override this value to empty string.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
