### PR TITLE
refactor: submit the release job manually

### DIFF
--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -4,10 +4,10 @@ on:
   # Allow to run the workflow from GitHub UI and other workflows.
   workflow_dispatch:
     inputs:
-      id:
-        description: Camunda chart dir id like x.y
+      camunda-version:
+        description: Camunda version in form of x.y
         required: true
-        type: string
+        type: choice
         options:
           - "8.3"
           - "8.4"
@@ -30,7 +30,7 @@ jobs:
     name: Get Chart version from app version
     runs-on: ubuntu-latest
     env:
-      CHART_DIR: "charts/camunda-platform-${{ inputs.id }}"
+      CHART_DIR: "charts/camunda-platform-${{ inputs.camunda-version }}"
     outputs:
       chart_version: ${{ steps.get_chart_version.outputs.chart_version }}
     steps:
@@ -42,7 +42,7 @@ jobs:
           chart_version="$(yq '.version' "${chart_file}")"
           echo "chart_version=${chart_version}" | tee -a $GITHUB_OUTPUT
   release:
-    name: Release - ${{ needs.get_chart_version.outputs.chart_version }} (camunda-platform-${{ inputs.id }})
+    name: Release - ${{ needs.get_chart_version.outputs.chart_version }} (camunda-platform-${{ inputs.camunda-version }})
     needs: get_chart_version
     runs-on: ubuntu-latest
     permissions:
@@ -50,10 +50,10 @@ jobs:
       id-token: write
     env:
       CHART_RELEASER_CONFIG: ".github/config/chart-releaser.yaml"
-      CHART_DIR: "charts/camunda-platform-${{ inputs.id }}"
+      CHART_DIR: "charts/camunda-platform-${{ inputs.camunda-version }}"
       CHART_VERSION: "${{ needs.get_chart_version.outputs.chart_version }}"
       CHART_PACKAGE_NAME: "camunda-platform-${{ needs.get_chart_version.outputs.chart_version }}"
-      CHART_TAG_NAME: "camunda-platform-${{ inputs.id }}-${{ needs.get_chart_version.outputs.chart_version }}"
+      CHART_TAG_NAME: "camunda-platform-${{ inputs.camunda-version }}-${{ needs.get_chart_version.outputs.chart_version }}"
     steps:
       # Init.
       - name: Checkout
@@ -179,7 +179,7 @@ jobs:
           EOF
 
   post-release:
-    name: Post-Release - ${{ needs.get_chart_version.outputs.chart_version }} (camunda-platform-${{ inputs.id }})
+    name: Post-Release - ${{ needs.get_chart_version.outputs.chart_version }} (camunda-platform-${{ inputs.camunda-version }})
     needs: [get_chart_version, release]
     runs-on: ubuntu-latest
     permissions:
@@ -187,7 +187,7 @@ jobs:
       pull-requests: write
       issues: write
     env:
-      CHART_DIR: "charts/camunda-platform-${{ inputs.id }}"
+      CHART_DIR: "charts/camunda-platform-${{ inputs.camunda-version }}"
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5


### PR DESCRIPTION
### Which problem does the PR fix?

In the most recent release, we encountered an issue where trying to release 8.6 actually overwrote an 8.8 release. And the diff that caused this release bug was due to a change not relating to releases, but rather in the generate-chart-matrix action that the test suite uses. My thinking is that we decouple the version you're releasing from our testsuites  by manually submitting the job to release and input the version you want to release.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

This adds an input field for the id, just as we do for chart-release-pr, and use that rather than a sort of git-diff generating a list of json blobs.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
