### PR TITLE
fix: ignore release-please config changes on generate-chart-matrix

### DIFF
--- a/.github/actions/generate-chart-matrix/action.yml
+++ b/.github/actions/generate-chart-matrix/action.yml
@@ -116,13 +116,24 @@ runs:
           echo "Changed files:"
           printf "%s\n" ${ALL_MODIFIED_FILES}
 
-          # If any workflow, action, or external secret config files have changed, build all chart versions
-          if echo "${ALL_MODIFIED_FILES}" | grep -qE "\.github/(workflows|actions|config)"; then
-            echo "Changes in .github/workflows, .github/actions, or .github/config detected — building all chart versions"
+          # If any workflow, action, files have changed, build all chart versions
+          if echo "${ALL_MODIFIED_FILES}" | grep -qE "\.github/(workflows|actions)"; then
+            echo "Changes in .github/workflows or .github/actions detected — building all chart versions"
             for camunda_version in ${{ steps.get-chart-versions.outputs.active }}; do
               chart_dir="charts/camunda-platform-${camunda_version}"
               write_matrix_entry "$camunda_version" "$chart_dir"
             done
+
+          # If any external secret config files have changed, build all chart versions
+          elif echo "${ALL_MODIFIED_FILES}" | grep -qE "\.github/config" && \
+              ! echo "${ALL_MODIFIED_FILES}" | grep -qE "\.github/config/release-please"; then
+            echo "Changes in .github/config (excluding release-please) detected — building all chart versions"
+            for camunda_version in ${{ steps.get-chart-versions.outputs.active }}; do
+              chart_dir="charts/camunda-platform-${camunda_version}"
+              write_matrix_entry "$camunda_version" "$chart_dir"
+            done
+
+          # Else, only rebuild the affected charts
           else
             for camunda_version in ${{ steps.get-chart-versions.outputs.active }}; do
               chart_dir="charts/camunda-platform-${camunda_version}"


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

During the release of 8.6 we encountered a bug in the generate-chart-matrix. [This change](https://github.com/camunda/camunda-platform-helm/pull/3908/files) introduced a logic to release all charts if there is a change in the `.github/config` folder. During a release, the [chart matrix of all versions](https://github.com/camunda/camunda-platform-helm/actions/runs/17273657738/job/49024803852) is now generated (which is not wanted in case of a release of a single version). The problem is that during the release, the [`.github/config/release-please` file](https://github.com/camunda/camunda-platform-helm/pull/4004/files) is always adjusted to the latest release version.

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

This PR excludes the config/release-please file from changes (as the original intent based on the comment was to only handle external secret config file changes).

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
