### PR TITLE
fix: adjust identity configmap with identity snapshot

### DIFF
--- a/charts/camunda-platform-8.8/templates/identity/configmap.yaml
+++ b/charts/camunda-platform-8.8/templates/identity/configmap.yaml
@@ -85,7 +85,7 @@ data:
                 - definition: write
                   description: "Write permission"
           roles:
-            - name: "Identity"
+            - name: "ManagementIdentity"
               description: "Provides full access to Identity"
               permissions:
                 - audience: {{ include "identity.authAudience" . | quote }}
@@ -212,7 +212,7 @@ data:
           email: {{ .Values.identity.firstUser.email | quote }}
           {{- if .Values.global.identity.auth.enabled }}
           roles:
-            - Identity
+            - ManagementIdentity
             - Optimize
             - Web Modeler
             - Web Modeler Admin


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
[Management Identity #3518](https://github.com/camunda-cloud/identity/issues/3518)

### What's in this PR?

To keep the the helmcharts template in sync with identity presets:

- [ ] The Identity role should be changed to "ManagementIdentity".

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
