### PR TITLE
chore(web-modeler): remove default JVM option

### DIFF
--- a/charts/camunda-platform-8.6/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform-8.6/templates/web-modeler/deployment-restapi.yaml
@@ -39,8 +39,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "camundaPlatform.licenseSecretName" . }}
                   key: {{ include "camundaPlatform.licenseSecretKey" . }}
-            - name: JAVA_OPTIONS
-              value: "-XX:MaxRAMPercentage=80.0"
             - name: SPRING_DATASOURCE_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/camunda-platform-8.6/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform-8.6/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -57,8 +57,6 @@ spec:
                 secretKeyRef:
                   name: camunda-platform-test-license
                   key: CAMUNDA_LICENSE_KEY
-            - name: JAVA_OPTIONS
-              value: "-XX:MaxRAMPercentage=80.0"
             - name: SPRING_DATASOURCE_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/camunda-platform-8.7/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform-8.7/templates/web-modeler/deployment-restapi.yaml
@@ -39,8 +39,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "camundaPlatform.licenseSecretName" . }}
                   key: {{ include "camundaPlatform.licenseSecretKey" . }}
-            - name: JAVA_OPTIONS
-              value: "-XX:MaxRAMPercentage=80.0"
             - name: SPRING_DATASOURCE_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/camunda-platform-8.7/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform-8.7/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -57,8 +57,6 @@ spec:
                 secretKeyRef:
                   name: camunda-platform-test-license
                   key: CAMUNDA_LICENSE_KEY
-            - name: JAVA_OPTIONS
-              value: "-XX:MaxRAMPercentage=80.0"
             - name: SPRING_DATASOURCE_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/camunda-platform-8.8/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform-8.8/templates/web-modeler/deployment-restapi.yaml
@@ -39,8 +39,6 @@ spec:
                 "config" .Values.global.license
                 "plaintextKey" "key"
             ) | nindent 12 }}
-            - name: JAVA_OPTIONS
-              value: "-XX:MaxRAMPercentage=80.0"
             {{- if not .Values.webModelerPostgresql.enabled }}
             {{- include "camundaPlatform.emitEnvVarFromSecretConfig" (dict
                 "envName" "SPRING_DATASOURCE_PASSWORD"

--- a/charts/camunda-platform-8.8/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -53,8 +53,6 @@ spec:
               type: RuntimeDefault
           env:
             
-            - name: JAVA_OPTIONS
-              value: "-XX:MaxRAMPercentage=80.0"
             - name: SPRING_DATASOURCE_PASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
### Which problem does the PR fix?
Follow-up for https://github.com/camunda/camunda-platform-helm/pull/3968#issuecomment-3236769387.

### What's in this PR?
Removes the default JVM option for the maximum heap size for Web Modeler's `restapi` component, as it should not really be necessary. We're not setting something similar for the other C8 components either (which are also Java / Spring Boot applications).

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?