### PR TITLE
chore: update version matrix for 12.5.0 release

### DIFF
--- a/charts/camunda-platform-8.7/RELEASE-NOTES.md
+++ b/charts/camunda-platform-8.7/RELEASE-NOTES.md
@@ -25,7 +25,7 @@ Supported versions:
 Camunda images:
 
 - docker.io/camunda/connectors-bundle:8.7.7
-- docker.io/camunda/console:8.7.56
+- docker.io/camunda/console:8.7.58
 - docker.io/camunda/identity:8.7.6
 - docker.io/camunda/keycloak:26.1.4
 - docker.io/camunda/operate:8.7.11

--- a/version-matrix/camunda-8.7/README.md
+++ b/version-matrix/camunda-8.7/README.md
@@ -5,6 +5,7 @@
 
 ## ToC
 
+- [Helm chart 12.5.0](#helm-chart-1250)
 - [Helm chart 12.4.0](#helm-chart-1240)
 - [Helm chart 12.3.0](#helm-chart-1230)
 - [Helm chart 12.2.0](#helm-chart-1220)
@@ -14,6 +15,37 @@
 - [Helm chart 12.0.0](#helm-chart-1200)
 - [Helm chart 12.0.0-alpha5](#helm-chart-1200-alpha5)
 - [Helm chart 12.0.0-alpha4](#helm-chart-1200-alpha4)
+
+## Helm chart 12.5.0
+
+Supported versions:
+
+- Camunda applications: [8.7](https://github.com/camunda/camunda/releases?q=tag%3A8.7&expanded=true)
+- Camunda version matrix: [8.7](https://helm.camunda.io/camunda-platform/version-matrix/camunda-8.7)
+- Helm values: [12.5.0](https://artifacthub.io/packages/helm/camunda/camunda-platform/12.5.0#parameters)
+- Helm CLI: [3.18.6](https://github.com/helm/helm/releases/tag/v3.18.6)
+
+Camunda images:
+
+- docker.io/camunda/connectors-bundle:8.7.7
+- docker.io/camunda/console:8.7.56
+- docker.io/camunda/identity:8.7.6
+- docker.io/camunda/keycloak:26.1.4
+- docker.io/camunda/operate:8.7.11
+- docker.io/camunda/optimize:8.7.8
+- docker.io/camunda/tasklist:8.7.11
+- docker.io/camunda/web-modeler-restapi:8.7.8
+- docker.io/camunda/web-modeler-webapp:8.7.8
+- docker.io/camunda/web-modeler-websockets:8.7.8
+- docker.io/camunda/zeebe:8.7.11
+
+Non-Camunda images:
+
+- docker.io/bitnamilegacy/elasticsearch:8.17.4
+- docker.io/bitnamilegacy/os-shell:12-debian-12-r43
+- docker.io/bitnamilegacy/postgresql:14.18.0-debian-12-r0
+- docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
+
 
 ## Helm chart 12.4.0
 

--- a/version-matrix/camunda-8.7/README.md
+++ b/version-matrix/camunda-8.7/README.md
@@ -28,7 +28,7 @@ Supported versions:
 Camunda images:
 
 - docker.io/camunda/connectors-bundle:8.7.7
-- docker.io/camunda/console:8.7.56
+- docker.io/camunda/console:8.7.58
 - docker.io/camunda/identity:8.7.6
 - docker.io/camunda/keycloak:26.1.4
 - docker.io/camunda/operate:8.7.11

--- a/version-matrix/camunda-8.7/README.md
+++ b/version-matrix/camunda-8.7/README.md
@@ -59,7 +59,7 @@ Supported versions:
 Camunda images:
 
 - docker.io/camunda/connectors-bundle:8.7.7
-- docker.io/camunda/console:8.7.56
+- docker.io/camunda/console:8.7.58
 - docker.io/camunda/identity:8.7.5
 - docker.io/camunda/keycloak:26.1.4
 - docker.io/camunda/operate:8.7.10

--- a/version-matrix/camunda-8.7/version-matrix.json
+++ b/version-matrix/camunda-8.7/version-matrix.json
@@ -187,7 +187,7 @@
       "docker.io/bitnamilegacy/postgresql:14.18.0-debian-12-r0",
       "docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2",
       "docker.io/camunda/connectors-bundle:8.7.7",
-      "docker.io/camunda/console:8.7.56",
+      "docker.io/camunda/console:8.7.58",
       "docker.io/camunda/identity:8.7.6",
       "docker.io/camunda/keycloak:26.1.4",
       "docker.io/camunda/operate:8.7.11",

--- a/version-matrix/camunda-8.7/version-matrix.json
+++ b/version-matrix/camunda-8.7/version-matrix.json
@@ -167,7 +167,7 @@
       "docker.io/bitnamilegacy/postgresql:14.18.0-debian-12-r0",
       "docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2",
       "docker.io/camunda/connectors-bundle:8.7.7",
-      "docker.io/camunda/console:8.7.56",
+      "docker.io/camunda/console:8.7.58",
       "docker.io/camunda/identity:8.7.5",
       "docker.io/camunda/keycloak:26.1.4",
       "docker.io/camunda/operate:8.7.10",


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

When [releasing 12.5.0](https://github.com/camunda/camunda-platform-helm/pull/4005), the release matrix was not updated. This PR adds the updated version matrix with 12.5.0 included.

updated via running: `make release.generate-version-matrix-released`

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
