### PR TITLE
chore: fix the readme of 8.7-12.5.0 release

### DIFF
--- a/version-matrix/README.md
+++ b/version-matrix/README.md
@@ -31,6 +31,7 @@ For the best experience, please remember:
 
 ## [Camunda 8.7](./camunda-8.7)
 
+### [Helm chart 12.5.0](./camunda-8.7/#helm-chart-1250)
 ### [Helm chart 12.4.0](./camunda-8.7/#helm-chart-1240)
 ### [Helm chart 12.3.0](./camunda-8.7/#helm-chart-1230)
 ### [Helm chart 12.2.0](./camunda-8.7/#helm-chart-1220)


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

I learned that I also needed to run `make release.generate-version-matrix-index` to update the readme of the version-matrix. Else the version-matrix is not updated on helm.camunda.io.

Hopefully the last fix related to:
* https://github.com/camunda/camunda-platform-helm/pull/4036/files

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
