### PR TITLE
refactor: rename connectors config file from yml to yaml

### DIFF
--- a/charts/camunda-platform-8.8/templates/connectors/configmap.yaml
+++ b/charts/camunda-platform-8.8/templates/connectors/configmap.yaml
@@ -7,10 +7,10 @@ metadata:
     {{- include "connectors.labels" . | nindent 4 }}
 data:
   {{- if .Values.connectors.configuration }}
-  application.yml: |
+  application.yaml: |
     {{ .Values.connectors.configuration | indent 4 | trim }}
   {{- else }}
-  application.yml: |
+  application.yaml: |
     server:
       port: {{ .Values.connectors.service.serverPort }}
     {{- if .Values.connectors.contextPath }}

--- a/charts/camunda-platform-8.8/templates/connectors/deployment.yaml
+++ b/charts/camunda-platform-8.8/templates/connectors/deployment.yaml
@@ -124,8 +124,8 @@ spec:
             - mountPath: /tmp
               name: tmp
             - name: config
-              mountPath: /config/application.yml
-              subPath: application.yml
+              mountPath: /config/application.yaml
+              subPath: application.yaml
           {{- range $key, $val := .Values.connectors.extraConfiguration }}
             - name: config
               mountPath: /config/{{ $key }}

--- a/charts/camunda-platform-8.8/test/unit/connectors/configmap_test.go
+++ b/charts/camunda-platform-8.8/test/unit/connectors/configmap_test.go
@@ -49,7 +49,7 @@ func (s *ConfigMapTemplateTest) TestDifferentValuesInputs() {
 				var configmapApplication ConnectorsConfigYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
@@ -82,7 +82,7 @@ func (s *ConfigMapTemplateTest) TestDifferentValuesInputs() {
 // 	var configmapApplication ConnectorsConfigYAML
 // 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-// 	err := yaml.Unmarshal([]byte(configmap.Data["application.yml"]), &configmapApplication)
+// 	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
 // 	if err != nil {
 // 		s.Fail("Failed to unmarshal yaml. error=", err)
 // 	}
@@ -115,7 +115,7 @@ func (s *ConfigMapTemplateTest) TestDifferentValuesInputs() {
 // 	var configmapApplication ConnectorsConfigYAML
 // 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-// 	err := yaml.Unmarshal([]byte(configmap.Data["application.yml"]), &configmapApplication)
+// 	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
 // 	if err != nil {
 // 		s.Fail("Failed to unmarshal yaml. error=", err)
 // 	}
@@ -149,7 +149,7 @@ func (s *ConfigMapTemplateTest) TestDifferentValuesInputs() {
 // 	var configmapApplication ConnectorsConfigYAML
 // 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-// 	err := yaml.Unmarshal([]byte(configmap.Data["application.yml"]), &configmapApplication)
+// 	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
 // 	if err != nil {
 // 		s.Fail("Failed to unmarshal yaml. error=", err)
 // 	}

--- a/charts/camunda-platform-8.8/test/unit/connectors/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/connectors/golden/configmap.golden.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/component: connectors
     app.kubernetes.io/version: "8.8.0-alpha7"
 data:
-  application.yml: |
+  application.yaml: |
     server:
       port: 8080
 

--- a/charts/camunda-platform-8.8/test/unit/connectors/golden/deployment.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/connectors/golden/deployment.golden.yaml
@@ -84,8 +84,8 @@ spec:
             - mountPath: /tmp
               name: tmp
             - name: config
-              mountPath: /config/application.yml
-              subPath: application.yml
+              mountPath: /config/application.yaml
+              subPath: application.yaml
       volumes:
         - name: tmp
           emptyDir: {}


### PR DESCRIPTION
### Which problem does the PR fix?

Related to: https://github.com/camunda/camunda-platform-helm/pull/4057

### What's in this PR?

Rename the Connectors config from `application.yml` to `application.yaml` to follow the naming convention.