### PR TITLE
deps: update keycloak bitnamichart to 25.2.0

### DIFF
--- a/charts/camunda-platform-8.8/Chart.yaml
+++ b/charts/camunda-platform-8.8/Chart.yaml
@@ -30,7 +30,7 @@ dependencies:
   - name: keycloak
     alias: identityKeycloak
     repository: oci://registry-1.docker.io/bitnamicharts
-    version: 24.9.0
+    version: 25.2.0
     condition: "identityKeycloak.enabled"
   - name: postgresql
     alias: identityPostgresql

--- a/charts/camunda-platform-8.8/test/unit/common/golden/keycloak-statefulset.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/common/golden/keycloak-statefulset.golden.yaml
@@ -9,21 +9,22 @@ metadata:
     app.kubernetes.io/instance: camunda-platform-test
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.2
+    app.kubernetes.io/version: 26.3.3
     app.kubernetes.io/component: keycloak
+    app.kubernetes.io/part-of: keycloak
 spec:
   replicas: 1
   revisionHistoryLimit: 10
   podManagementPolicy: Parallel
   serviceName: camunda-platform-test-keycloak-headless
   updateStrategy:
-    rollingUpdate: {}
     type: RollingUpdate
   selector:
     matchLabels:
       app.kubernetes.io/instance: camunda-platform-test
       app.kubernetes.io/name: keycloak
       app.kubernetes.io/component: keycloak
+      app.kubernetes.io/part-of: keycloak
   template:
     metadata:
       annotations:
@@ -31,9 +32,9 @@ spec:
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak
-        app.kubernetes.io/version: 26.3.2
+        app.kubernetes.io/version: 26.3.3
         app.kubernetes.io/component: keycloak
-        app.kubernetes.io/app-version: 26.3.2
+        app.kubernetes.io/part-of: keycloak
     spec:
       serviceAccountName: camunda-platform-test-keycloak
       
@@ -48,6 +49,7 @@ spec:
                   matchLabels:
                     app.kubernetes.io/instance: camunda-platform-test
                     app.kubernetes.io/name: keycloak
+                    app.kubernetes.io/component: keycloak
                 topologyKey: kubernetes.io/hostname
               weight: 1
         nodeAffinity:
@@ -63,21 +65,6 @@ spec:
         - name: prepare-write-dirs
           image: docker.io/camunda/keycloak:26.1.4
           imagePullPolicy: IfNotPresent
-          command:
-            - /bin/bash
-          args:
-            - -ec
-            - |
-              . /opt/bitnami/scripts/liblog.sh
-
-              info "Copying writable dirs to empty dir"
-              # In order to not break the application functionality we need to make some
-              # directories writable, so we need to copy it to an empty dir volume
-              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/lib/quarkus /emptydir/app-quarkus-dir
-              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/data /emptydir/app-data-dir
-              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/providers /emptydir/app-providers-dir
-              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/themes /emptydir/app-themes-dir
-              info "Copy operation completed"
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -93,11 +80,28 @@ spec:
               type: RuntimeDefault
           resources:
             limits:
-              cpu: 2000m
-              memory: 2Gi
+              cpu: 150m
+              ephemeral-storage: 2Gi
+              memory: 192Mi
             requests:
-              cpu: 1000m
-              memory: 1Gi
+              cpu: 100m
+              ephemeral-storage: 50Mi
+              memory: 128Mi
+          command:
+            - /bin/bash
+          args:
+            - -ec
+            - |
+              . /opt/bitnami/scripts/liblog.sh
+        
+              info "Copying writable dirs to empty dir"
+              # In order to not break the application functionality we need to make some
+              # directories writable, so we need to copy it to an empty dir volume
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/lib/quarkus /emptydir/app-quarkus-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/data /emptydir/app-data-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/providers /emptydir/app-providers-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/themes /emptydir/app-themes-dir
+              info "Copy operation completed"
           volumeMounts:
            - name: empty-dir
              mountPath: /emptydir
@@ -124,16 +128,6 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
-            - name: BITNAMI_DEBUG
-              value: "false"
-            - name: KC_BOOTSTRAP_ADMIN_PASSWORD_FILE
-              value: /opt/bitnami/keycloak/secrets/identity-keycloak-admin-password
-            - name: KEYCLOAK_DATABASE_PASSWORD_FILE
-              value: /opt/bitnami/keycloak/secrets/db-identity-keycloak-postgresql-user-password
-            - name: KEYCLOAK_HTTP_RELATIVE_PATH
-              value: "/auth/"
-            - name: KC_SPI_ADMIN_REALM
-              value: "master"
             - name: KEYCLOAK_PROXY_ADDRESS_FORWARDING
               value: 'false'
           envFrom:
@@ -154,7 +148,7 @@ spec:
               containerPort: 7800
           livenessProbe:
             failureThreshold: 3
-            initialDelaySeconds: 300
+            initialDelaySeconds: 120
             periodSeconds: 1
             successThreshold: 1
             timeoutSeconds: 5
@@ -169,6 +163,7 @@ spec:
             httpGet:
               path: /auth/realms/master
               port: http
+              scheme: HTTP
           volumeMounts:
             - name: empty-dir
               mountPath: /tmp


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

part of https://github.com/camunda/team-distribution/issues/434 

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
