### PR TITLE
fix: revert webmodeler externaldb change

### DIFF
--- a/charts/camunda-platform-8.8/templates/web-modeler/_helpers.tpl
+++ b/charts/camunda-platform-8.8/templates/web-modeler/_helpers.tpl
@@ -191,14 +191,8 @@ Define match labels for Web Modeler websockets to be used in matchLabels selecto
         (include "webModeler.postgresql.fullname" .)
         (.Values.webModelerPostgresql.auth.database)
       -}}
-  {{- else if .Values.webModeler.restapi.externalDatabase.url -}}
+  {{- else -}}
     {{- .Values.webModeler.restapi.externalDatabase.url -}}
-  {{- else if .Values.webModeler.restapi.externalDatabase.host -}}
-    {{- printf "jdbc:postgresql://%s:%s/%s"
-        .Values.webModeler.restapi.externalDatabase.host
-        (toString (.Values.webModeler.restapi.externalDatabase.port))
-        (.Values.webModeler.restapi.externalDatabase.database)
-      -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/camunda-platform-8.8/values.yaml
+++ b/charts/camunda-platform-8.8/values.yaml
@@ -1422,15 +1422,8 @@ webModeler:
 
     ## @extra webModeler.restapi.externalDatabase can be used to configure a connection to an external database; will only be applied if the postgresql dependency chart is disabled (with `postgresql.enabled=false`)
     externalDatabase:
-      ## @param webModeler.restapi.externalDatabase.url (DEPRECATED - use host, port, and database instead) defines the JDBC url of the database instance.
-      # Note: If url is provided, it takes precedence over individual connection parameters (host, port, database)
+      ## @param webModeler.restapi.externalDatabase.url defines the JDBC url of the database instance. 
       url: ""
-      ## @param webModeler.restapi.externalDatabase.host Database host (used when url is not provided)
-      host: ""
-      ## @param webModeler.restapi.externalDatabase.port Database port number (used when url is not provided)
-      port: 5432
-      ## @param webModeler.restapi.externalDatabase.database The database name (used when url is not provided)
-      database: "web-modeler"
       ## @param webModeler.restapi.externalDatabase.user defines the database user
       user: ""
       ## @param webModeler.restapi.externalDatabase.password (DEPRECATED - use webModeler.restapi.externalDatabase.secret instead) can be used to provide the database user's password; ignored if `webModeler.restapi.externalDatabase.existingSecret` is set


### PR DESCRIPTION
### Which problem does the PR fix?

Closes: https://github.com/camunda/camunda-platform-helm/issues/4046

### What's in this PR?

Revert prior webmodeler DB change, favoring JDBC URL only configuration

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
