### PR TITLE
refactor: revert to zeebe as name for orchestration cluster

### DIFF
--- a/charts/camunda-platform-8.8/templates/orchestration/_helpers.tpl
+++ b/charts/camunda-platform-8.8/templates/orchestration/_helpers.tpl
@@ -4,18 +4,12 @@
 [orchestration] Create a default fully qualified app name.
 */}}
 {{- define "orchestration.fullname" -}}
+    {{- /* NOTE: The value is set to "zeebe" for backward compatibility between 8.7 and 8.8. */ -}}
     {{- include "camundaPlatform.componentFullname" (dict
-        "componentName" "orchestration"
+        "componentName" "zeebe"
         "componentValues" .Values.orchestration
         "context" $
     ) -}}
-{{- end -}}
-
-{{/*
-[orchestration] The old name used in PVC which is used to avoid upgrade downtime.
-*/}}
-{{- define "orchestration.legacyName" -}}
-    {{- printf "%s-zeebe" .Release.Name -}}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform-8.8/templates/orchestration/configmap.yaml
+++ b/charts/camunda-platform-8.8/templates/orchestration/configmap.yaml
@@ -86,7 +86,7 @@ data:
           # nodeId:
           initialContactPoints:
           {{- range (untilStep 0 (int .Values.orchestration.clusterSize) 1) }}
-            - {{ include "orchestration.legacyName" $ }}-{{ . }}.${K8S_SERVICE_NAME}:{{$.Values.orchestration.service.internalPort}}
+            - {{ include "orchestration.fullname" $ }}-{{ . }}.${K8S_SERVICE_NAME}:{{$.Values.orchestration.service.internalPort}}
           {{- end }}
           clusterSize: {{ .Values.orchestration.clusterSize | quote }}
           replicationFactor: {{ .Values.orchestration.replicationFactor | quote }}

--- a/charts/camunda-platform-8.8/templates/orchestration/files/_application-unified.yaml
+++ b/charts/camunda-platform-8.8/templates/orchestration/files/_application-unified.yaml
@@ -85,7 +85,7 @@ camunda:
         # advertisedPort:
     initial-contact-points:
       {{- range (untilStep 0 (int .Values.orchestration.clusterSize) 1) }}
-        - {{ include "orchestration.legacyName" $ }}-{{ . }}.${K8S_SERVICE_NAME}:{{$.Values.orchestration.service.internalPort}}
+        - {{ include "orchestration.fullname" $ }}-{{ . }}.${K8S_SERVICE_NAME}:{{$.Values.orchestration.service.internalPort}}
       {{- end }}
     # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
     # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_NODE_ID" env var.

--- a/charts/camunda-platform-8.8/templates/orchestration/identity-migration-configmap.yaml
+++ b/charts/camunda-platform-8.8/templates/orchestration/identity-migration-configmap.yaml
@@ -24,7 +24,7 @@ data:
             replication-factor: {{ .Values.orchestration.replicationFactor }}
             initial-contact-points:
             {{- range (untilStep 0 (int .Values.orchestration.clusterSize) 1) }}
-              - {{ include "orchestration.legacyName" $ }}-{{ . }}.{{ include "orchestration.fullname" $ }}:{{$.Values.orchestration.service.internalPort}}
+              - {{ include "orchestration.fullname" $ }}-{{ . }}.{{ include "orchestration.fullname" $ }}:{{$.Values.orchestration.service.internalPort}}
             {{- end }}
           management-identity:
             audience: {{ include "identity.authAudience" . | quote }}

--- a/charts/camunda-platform-8.8/templates/orchestration/statefulset.yaml
+++ b/charts/camunda-platform-8.8/templates/orchestration/statefulset.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "orchestration.legacyName" . }}
+  name: {{ include "orchestration.fullname" . }}
   labels:
     {{- include "orchestration.labels" . | nindent 4 }}
   annotations:

--- a/charts/camunda-platform-8.8/test/unit/common/golden/core-service-monitor.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/common/golden/core-service-monitor.golden.yaml
@@ -3,7 +3,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: camunda-platform-test-orchestration
+  name: camunda-platform-test-zeebe
   labels:
     app: camunda-platform
     app.kubernetes.io/name: camunda-platform

--- a/charts/camunda-platform-8.8/test/unit/common/golden/secret-core.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/common/golden/secret-core.golden.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: camunda-platform-test-orchestration-identity-secret
+  name: camunda-platform-test-zeebe-identity-secret
   labels:
     app: camunda-platform
     app.kubernetes.io/name: identity

--- a/charts/camunda-platform-8.8/test/unit/common/ingress_test.go
+++ b/charts/camunda-platform-8.8/test/unit/common/ingress_test.go
@@ -221,7 +221,7 @@ func (s *IngressTemplateTest) TestDifferentValuesInputs() {
 				s.Require().NotContains(output, "name: camunda-platform-test-optimize")
 				s.Require().NotContains(output, "name: camunda-platform-test-web-modeler-webapp")
 				s.Require().NotContains(output, "name: camunda-platform-test-web-modeler-websockets")
-				s.Require().NotContains(output, "name: camunda-platform-test-orchestration")
+				s.Require().NotContains(output, "name: camunda-platform-test-zeebe")
 			},
 		},
 		{
@@ -239,7 +239,7 @@ func (s *IngressTemplateTest) TestDifferentValuesInputs() {
 				s.Require().NotContains(output, "name: camunda-platform-test-optimize")
 				s.Require().NotContains(output, "name: camunda-platform-test-web-modeler-webapp")
 				s.Require().NotContains(output, "name: camunda-platform-test-web-modeler-websockets")
-				s.Require().NotContains(output, "name: camunda-platform-test-orchestration")
+				s.Require().NotContains(output, "name: camunda-platform-test-zeebe")
 			},
 		},
 		{

--- a/charts/camunda-platform-8.8/test/unit/connectors/configmap_test.go
+++ b/charts/camunda-platform-8.8/test/unit/connectors/configmap_test.go
@@ -93,9 +93,9 @@ func (s *ConfigMapTemplateTest) TestDifferentValuesInputs() {
 // 	s.Require().Empty(configmapApplication.Camunda.Operate.Client.KeycloakTokenURL)
 // 	s.Require().Empty(configmapApplication.Camunda.Operate.Client.ClientId)
 
-// 	s.Require().Equal("camunda-platform-test-orchestration:26500", configmapApplication.Zeebe.Client.Broker.GatewayAddress)
+// 	s.Require().Equal("camunda-platform-test-zeebe:26500", configmapApplication.Zeebe.Client.Broker.GatewayAddress)
 // 	s.Require().Equal("true", configmapApplication.Zeebe.Client.Security.Plaintext)
-// 	s.Require().Equal("http://camunda-platform-test-orchestration:80/v1", configmapApplication.Camunda.Operate.Client.Url)
+// 	s.Require().Equal("http://camunda-platform-test-zeebe:80/v1", configmapApplication.Camunda.Operate.Client.Url)
 // 	s.Require().Equal("connectors", configmapApplication.Camunda.Operate.Client.Username)
 // }
 
@@ -159,7 +159,7 @@ func (s *ConfigMapTemplateTest) TestDifferentValuesInputs() {
 // 	s.Require().Empty(configmapApplication.Camunda.Connector.WebHook.Enabled)
 // 	s.Require().Empty(configmapApplication.Camunda.Operate.Client.Username)
 
-// 	s.Require().Equal("camunda-platform-test-orchestration:26500/v1", configmapApplication.Zeebe.Client.Broker.GatewayAddress)
+// 	s.Require().Equal("camunda-platform-test-zeebe:26500/v1", configmapApplication.Zeebe.Client.Broker.GatewayAddress)
 // 	s.Require().Equal("true", configmapApplication.Zeebe.Client.Security.Plaintext)
 // 	s.Require().Equal("http://camunda-platform-test-operate:80", configmapApplication.Camunda.Operate.Client.Url)
 // 	s.Require().Equal("operate-api", configmapApplication.Camunda.Identity.Audience)

--- a/charts/camunda-platform-8.8/test/unit/connectors/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/connectors/golden/configmap.golden.yaml
@@ -35,8 +35,8 @@ data:
 
     camunda:
       client:
-        rest-address: http://camunda-platform-test-orchestration-gateway:8080
-        grpc-address: http://camunda-platform-test-orchestration-gateway:26500
+        rest-address: http://camunda-platform-test-zeebe-gateway:8080
+        grpc-address: http://camunda-platform-test-zeebe-gateway:26500
         worker:
           defaults:
             max-jobs-active: 32

--- a/charts/camunda-platform-8.8/test/unit/console/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/console/golden/configmap.golden.yaml
@@ -54,23 +54,23 @@ data:
             - name: Operate
               id: operate
               url: http://localhost:8088/operate
-              readiness: http://camunda-platform-test-orchestration.camunda-platform:9600/actuator/health/readiness
-              metrics: http://camunda-platform-test-orchestration.camunda-platform:9600/actuator/prometheus
+              readiness: http://camunda-platform-test-zeebe.camunda-platform:9600/actuator/health/readiness
+              metrics: http://camunda-platform-test-zeebe.camunda-platform:9600/actuator/prometheus
             - name: Tasklist
               id: tasklist
               url: http://localhost:8088/tasklist
-              readiness: http://camunda-platform-test-orchestration.camunda-platform:9600/actuator/health/readiness
-              metrics: http://camunda-platform-test-orchestration.camunda-platform:9600/actuator/prometheus
+              readiness: http://camunda-platform-test-zeebe.camunda-platform:9600/actuator/health/readiness
+              metrics: http://camunda-platform-test-zeebe.camunda-platform:9600/actuator/prometheus
             - name: Orchestration Identity
               id: orchestrationIdentity
               url: http://localhost:8088/identity
-              readiness: http://camunda-platform-test-orchestration.camunda-platform:9600/actuator/health/readiness
-              metrics: http://camunda-platform-test-orchestration.camunda-platform:9600/actuator/prometheus
+              readiness: http://camunda-platform-test-zeebe.camunda-platform:9600/actuator/health/readiness
+              metrics: http://camunda-platform-test-zeebe.camunda-platform:9600/actuator/prometheus
           
             - name: Orchestration Cluster
               id: orchestration
               urls:
                 grpc: http://localhost:26500
                 http: http://localhost:8088
-              readiness: http://camunda-platform-test-orchestration.camunda-platform:9600/actuator/health/readiness
-              metrics: http://camunda-platform-test-orchestration.camunda-platform:9600/actuator/prometheus
+              readiness: http://camunda-platform-test-zeebe.camunda-platform:9600/actuator/health/readiness
+              metrics: http://camunda-platform-test-zeebe.camunda-platform:9600/actuator/prometheus

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-authorizations.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-authorizations.golden.yaml
@@ -2,7 +2,7 @@
 # Source: camunda-platform/templates/orchestration/configmap.yaml
 kind: ConfigMap
 metadata:
-  name: camunda-platform-test-orchestration-configuration
+  name: camunda-platform-test-zeebe-configuration
   labels:
     app: camunda-platform
     app.kubernetes.io/name: camunda-platform
@@ -184,7 +184,7 @@ data:
         # Zeebe instance
         zeebe:
           # Gateway address
-          gatewayAddress: "camunda-platform-test-orchestration:26500"
+          gatewayAddress: "camunda-platform-test-zeebe:26500"
 
       #
       # Camunda Tasklist Configuration.
@@ -224,7 +224,7 @@ data:
         # Zeebe instance
         zeebe:
           # Gateway address
-          gatewayAddress: camunda-platform-test-orchestration:26500
-          restAddress: "http://camunda-platform-test-orchestration:8080"
+          gatewayAddress: camunda-platform-test-zeebe:26500
+          restAddress: "http://camunda-platform-test-zeebe:8080"
 
   log4j2.xml: |

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-log4j2.golden.yaml
@@ -2,7 +2,7 @@
 # Source: camunda-platform/templates/orchestration/configmap.yaml
 kind: ConfigMap
 metadata:
-  name: camunda-platform-test-orchestration-configuration
+  name: camunda-platform-test-zeebe-configuration
   labels:
     app: camunda-platform
     app.kubernetes.io/name: camunda-platform
@@ -184,7 +184,7 @@ data:
         # Zeebe instance
         zeebe:
           # Gateway address
-          gatewayAddress: "camunda-platform-test-orchestration:26500"
+          gatewayAddress: "camunda-platform-test-zeebe:26500"
 
       #
       # Camunda Tasklist Configuration.
@@ -224,8 +224,8 @@ data:
         # Zeebe instance
         zeebe:
           # Gateway address
-          gatewayAddress: camunda-platform-test-orchestration:26500
-          restAddress: "http://camunda-platform-test-orchestration:8080"
+          gatewayAddress: camunda-platform-test-zeebe:26500
+          restAddress: "http://camunda-platform-test-zeebe:8080"
 
   log4j2.xml: |
     <xml>

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-unified.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-unified.golden.yaml
@@ -2,7 +2,7 @@
 # Source: camunda-platform/templates/orchestration/configmap-unified.yaml
 kind: ConfigMap
 metadata:
-  name: camunda-platform-test-orchestration-configuration-unified
+  name: camunda-platform-test-zeebe-configuration-unified
   labels:
     app: camunda-platform
     app.kubernetes.io/name: camunda-platform
@@ -247,7 +247,7 @@ data:
           #   lock-timeout: '60s'
           # alerting-webbook: ''
           zeebe:
-            gateway-address: "camunda-platform-test-orchestration:26500"
+            gateway-address: "camunda-platform-test-zeebe:26500"
             secure: false
             certificate-path: ''
           # TODO: What kind of value is expected here compared to the 8.7 version?

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap.golden.yaml
@@ -2,7 +2,7 @@
 # Source: camunda-platform/templates/orchestration/configmap.yaml
 kind: ConfigMap
 metadata:
-  name: camunda-platform-test-orchestration-configuration
+  name: camunda-platform-test-zeebe-configuration
   labels:
     app: camunda-platform
     app.kubernetes.io/name: camunda-platform
@@ -184,7 +184,7 @@ data:
         # Zeebe instance
         zeebe:
           # Gateway address
-          gatewayAddress: "camunda-platform-test-orchestration:26500"
+          gatewayAddress: "camunda-platform-test-zeebe:26500"
 
       #
       # Camunda Tasklist Configuration.
@@ -224,7 +224,7 @@ data:
         # Zeebe instance
         zeebe:
           # Gateway address
-          gatewayAddress: camunda-platform-test-orchestration:26500
-          restAddress: "http://camunda-platform-test-orchestration:8080"
+          gatewayAddress: camunda-platform-test-zeebe:26500
+          restAddress: "http://camunda-platform-test-zeebe:8080"
 
   log4j2.xml: |

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/gateway-service.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/gateway-service.golden.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: camunda-platform-test-orchestration-gateway
+  name: camunda-platform-test-zeebe-gateway
   labels:
     app: camunda-platform
     app.kubernetes.io/name: camunda-platform

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/poddisruptionbudget.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/poddisruptionbudget.golden.yaml
@@ -3,7 +3,7 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: camunda-platform-test-orchestration
+  name: camunda-platform-test-zeebe
   labels:
     app: camunda-platform
     app.kubernetes.io/name: camunda-platform

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/service.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/service.golden.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: camunda-platform-test-orchestration
+  name: camunda-platform-test-zeebe
   labels:
     app: camunda-platform
     app.kubernetes.io/name: camunda-platform

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/serviceaccount.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/serviceaccount.golden.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: camunda-platform-test-orchestration
+  name: camunda-platform-test-zeebe
   labels:
     app: camunda-platform
     app.kubernetes.io/name: camunda-platform

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/statefulset.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/statefulset.golden.yaml
@@ -23,7 +23,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: zeebe-broker
-  serviceName: camunda-platform-test-orchestration
+  serviceName: camunda-platform-test-zeebe
   updateStrategy:
     type: RollingUpdate
   podManagementPolicy: Parallel
@@ -65,7 +65,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: K8S_SERVICE_NAME
-              value: camunda-platform-test-orchestration
+              value: camunda-platform-test-zeebe
             - name: K8S_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -124,13 +124,13 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: camunda-platform-test-orchestration-configuration
+            name: camunda-platform-test-zeebe-configuration
             defaultMode: 492
         - name: exporters
           emptyDir: {}
         - name: tmp
           emptyDir: {}
-      serviceAccountName: camunda-platform-test-orchestration
+      serviceAccountName: camunda-platform-test-zeebe
       securityContext:
         fsGroup: 1001
         runAsNonRoot: true

--- a/charts/camunda-platform-8.8/test/unit/web-modeler/configmap_restapi_test.go
+++ b/charts/camunda-platform-8.8/test/unit/web-modeler/configmap_restapi_test.go
@@ -359,8 +359,8 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldConfigureClusterFromSa
 			s.Require().Equal("8.8.x-alpha1", configmapApplication.Camunda.Modeler.Clusters[0].Version)
 			s.Require().Equal(tc.expectedAuthentication, configmapApplication.Camunda.Modeler.Clusters[0].Authentication)
 			s.Require().Equal(false, configmapApplication.Camunda.Modeler.Clusters[0].Authorizations.Enabled)
-			s.Require().Equal("grpc://camunda-platform-test-orchestration:26600", configmapApplication.Camunda.Modeler.Clusters[0].Url.Grpc)
-			s.Require().Equal("http://camunda-platform-test-orchestration:8090/orchestration", configmapApplication.Camunda.Modeler.Clusters[0].Url.Rest)
+			s.Require().Equal("grpc://camunda-platform-test-zeebe:26600", configmapApplication.Camunda.Modeler.Clusters[0].Url.Grpc)
+			s.Require().Equal("http://camunda-platform-test-zeebe:8090/orchestration", configmapApplication.Camunda.Modeler.Clusters[0].Url.Rest)
 			s.Require().Equal("https://example.com/orchestration", configmapApplication.Camunda.Modeler.Clusters[0].Url.WebApp)
 		})
 	}

--- a/charts/camunda-platform-8.8/test/unit/web-modeler/golden/configmap-restapi.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/web-modeler/golden/configmap-restapi.golden.yaml
@@ -49,8 +49,8 @@ data:
             authorizations:
               enabled: true
             url:
-              grpc: "grpc://camunda-platform-test-orchestration:26500"
-              rest: "http://camunda-platform-test-orchestration:8080"
+              grpc: "grpc://camunda-platform-test-zeebe:26500"
+              rest: "http://camunda-platform-test-zeebe:8080"
               web-app: "http://localhost:8088"
 
     spring:


### PR DESCRIPTION
### Which problem does the PR fix?

Part of: https://github.com/camunda/camunda-platform-helm/issues/4026

### What's in this PR?

We use `zeebe` as a name for The Orchestration cluster, mainly for backward compatibility with the 8.7 setup.
However, it could be confusing to have it as `zeebe` for the StatefulSet and `orchestration` for other resources.

For consistency, we use `zeebe` as the name for everything on the manifests level (not the end user level).
