### PR TITLE
fix: added missing config to orchestration cluster

### DIFF
--- a/charts/camunda-platform-8.8/templates/orchestration/configmap.yaml
+++ b/charts/camunda-platform-8.8/templates/orchestration/configmap.yaml
@@ -184,6 +184,10 @@ data:
         {{- end }}
 
     camunda:
+      data:
+        secondary-storage:
+          elasticsearch:
+            url: {{ include "camundaPlatform.elasticsearchURL" . | quote }}
       persistent:
         sessions:
           enabled: {{ include "orchestration.persistentSessionsEnabled" . }}

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-authorizations.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-authorizations.golden.yaml
@@ -110,6 +110,10 @@ data:
                 maxDelayBetweenRuns: 60000
 
     camunda:
+      data:
+        secondary-storage:
+          elasticsearch:
+            url: "http://camunda-platform-test-elasticsearch:9200"
       persistent:
         sessions:
           enabled: true

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-log4j2.golden.yaml
@@ -110,6 +110,10 @@ data:
                 maxDelayBetweenRuns: 60000
 
     camunda:
+      data:
+        secondary-storage:
+          elasticsearch:
+            url: "http://camunda-platform-test-elasticsearch:9200"
       persistent:
         sessions:
           enabled: true

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap.golden.yaml
@@ -110,6 +110,10 @@ data:
                 maxDelayBetweenRuns: 60000
 
     camunda:
+      data:
+        secondary-storage:
+          elasticsearch:
+            url: "http://camunda-platform-test-elasticsearch:9200"
       persistent:
         sessions:
           enabled: true

--- a/charts/camunda-platform-8.8/values-digest.yaml
+++ b/charts/camunda-platform-8.8/values-digest.yaml
@@ -1,19 +1,19 @@
 connectors:
   image:
     repository: camunda/connectors-bundle
-    digest: sha256:1e8d07d80794775f5bf5a305e35ffe69a33367769b1f1d0b5653a13c06f50b99
+    digest: sha256:88f5dab42fefacc830a102bda3e2fbe790809b7a2e7ab49e90baa525e3b9d4e0
 
 optimize:
   image:
     repository: camunda/optimize
-    digest: sha256:4b1a79b534efe23b0c6d7303e872257257e18238a32e8c2cc53f091f6bdbbeac
+    digest: sha256:38ed7071d6dbb6c5d3d9ec120b98e2c1151136c0093134e31035a72bb6c52da2
 
 orchestration:
   image:
     repository: camunda/camunda
-    digest: sha256:41a5ff4b75d5a24cd85561b8317ae4998ea73dbc49992c60ae0613353352424d
+    digest: sha256:19d112a5d8a7916722a13574c54901b8780930d96c5aff5adf99798a9c316149
 
 identity:
   image:
-    digest: sha256:60a3de422e887a071238a775cd4580887cc99cc26abc6a8246d1110d7608457f
+    digest: sha256:3021e0c8d43e0fdfbc2f98184810c1d2dcdabca18080e9c0ca49e981f055ff37
 


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
I added the missing config to the orchestration cluster which was causing the orchestraiton cluster to fail and I also updated the values-digest to the latest SNAPSHOT
### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
