### PR TITLE
fix: backporting changing image repository for keycloak in values-latest

### DIFF
--- a/charts/camunda-platform-8.6/values-latest.yaml
+++ b/charts/camunda-platform-8.6/values-latest.yaml
@@ -70,7 +70,7 @@ identity:
 identityKeycloak:
   # https://hub.docker.com/r/bitnami/keycloak/tags
   image:
-    repository: bitnamilegacy/keycloak
+    repository: camunda/keycloak
     tag: 25.0.6
   postgresql:
     # https://hub.docker.com/r/bitnami/postgresql/tags

--- a/charts/camunda-platform-8.7/values-latest.yaml
+++ b/charts/camunda-platform-8.7/values-latest.yaml
@@ -70,7 +70,7 @@ identity:
 identityKeycloak:
   # https://hub.docker.com/r/bitnami/keycloak/tags
   image:
-    repository: bitnamilegacy/keycloak
+    repository: camunda/keycloak
     tag: 26.3.3
   postgresql:
     # https://hub.docker.com/r/bitnami/postgresql/tags


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
