### PR TITLE
fix: add trailing slash to console redirect uri in tests

### DIFF
--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-keycloak.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-keycloak.yaml
@@ -27,7 +27,7 @@ global:
       webModeler:
         redirectUrl: "https://{{ .Values.global.ingress.host }}/modeler"
       console:
-        redirectUrl: "https://{{ .Values.global.ingress.host }}"
+        redirectUrl: "https://{{ .Values.global.ingress.host }}/"
         existingSecret:
           name: "integration-test-credentials"
       #######################


### PR DESCRIPTION
### Which problem does the PR fix?

A recent change #4096 introduced a context path in console, which breaks the redirect URI for console in QA e2e tests. With this PR, I add the trailing slash into the redirect URI for console so that it matches the expected redirect-uri in keycloak.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
