### PR TITLE
fix: add secondary-storage config to data migration

### DIFF
--- a/charts/camunda-platform-8.8/templates/orchestration/migration-data-configmap.yaml
+++ b/charts/camunda-platform-8.8/templates/orchestration/migration-data-configmap.yaml
@@ -7,6 +7,10 @@ data:
   application.yaml: |
     {{- if .Values.global.elasticsearch.enabled }}
     camunda:
+      data:
+        secondary-storage:
+          elasticsearch:
+            url: {{ include "camundaPlatform.elasticsearchURL" . | quote }}
       database:
         connect:
           cluster-name: {{ .Values.global.elasticsearch.clusterName }}
@@ -18,6 +22,10 @@ data:
         {{- end }}
     {{- else }}
     camunda:
+      data:
+        secondary-storage:
+          opensearch:
+            url: {{ include "camundaPlatform.elasticsearchURL" . | quote }}
       database:
         connect:
           cluster-name: {{ .Values.global.opensearch.clusterName }}


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
related slack thread: https://camunda.slack.com/archives/C07UA4C7STY/p1757503886239429?thread_ts=1757415966.937119&cid=C07UA4C7STY

This is the error received in the data migration:
```
Caused by: io.camunda.configuration.UnifiedConfigurationException: Ambiguous configuration. The value camunda.data.secondary-storage.elasticsearch.url=http://localhost:9200/ conflicts with t │
│ he values 'http://camunda-platform-elasticsearch:9200/' from the legacy properties camunda.operate.elasticsearch.url, camunda.tasklist.elasticsearch.url, camunda.database.url, zeebe.broker.exporters.camundaex │
│ porter.args.connect.url
```

The fix is in this PR.

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
