### PR TITLE
ci: fix missing digest values file when doesn't exist

### DIFF
--- a/test/integration/scenarios/chart-full-setup/Taskfile.yaml
+++ b/test/integration/scenarios/chart-full-setup/Taskfile.yaml
@@ -213,8 +213,12 @@ tasks:
         --values {{ .TEST_VALUES_BASE_DIR }}/common/values-integration-test-pull-secrets.yaml \
         --values {{ .TEST_VALUES_BASE_DIR }}/chart-full-setup/values-integration-test-ingress-{{ .TEST_AUTH_TYPE }}.yaml \
         --values {{ .TEST_VALUES_BASE_DIR }}/chart-full-setup/values-integration-test-ingress-{{ .TEST_VALUES_SCENARIO }}.yaml \
-        {{ eq .PLATFORM "eks" | ternary (printf "--values %s/chart-full-setup/values-integration-test-ingress-infra.yaml" .TEST_VALUES_BASE_DIR) "" }} \
-        {{ if eq .TEST_CHART_FLOW "install" }}--values {{ .TEST_HELM_DIGEST_VALUES }}{{ end }} \
+        {{ if eq .PLATFORM "eks" -}}
+        --values {{ .TEST_VALUES_BASE_DIR }}/chart-full-setup/values-integration-test-ingress-infra.yaml \
+        {{ end -}}
+        {{ if and (eq .TEST_CHART_FLOW "install") (not (empty .TEST_HELM_DIGEST_VALUES)) -}}
+        --values {{ .TEST_HELM_DIGEST_VALUES }} \
+        {{ end -}}
         --values {{ .INFRA_TYPE_VALUES }} \
         --values /tmp/extra-values-file.yaml \
         --timeout 20m0s \

--- a/test/integration/scenarios/lib/chart-upgrade-taskfile.yaml
+++ b/test/integration/scenarios/lib/chart-upgrade-taskfile.yaml
@@ -23,8 +23,12 @@ tasks:
         --values {{ .TEST_VALUES_BASE_DIR }}/chart-full-setup/values-integration-test-ingress-{{ .TEST_VALUES_SCENARIO }}.yaml \
         --values {{ .TEST_VALUES_BASE_DIR }}/common/values-integration-test.yaml \
         --values {{ .TEST_VALUES_BASE_DIR }}/common/values-integration-test-pull-secrets.yaml \
-        {{ eq (env "PLATFORM") "eks" | ternary (printf "--values %s/chart-full-setup/values-integration-test-ingress-infra.yaml" .TEST_VALUES_BASE_DIR) "" }}  \
-        --values {{ env "INFRA_TYPE_VALUES" }} \
+        {{ if eq .PLATFORM "eks" -}}
+        --values {{ .TEST_VALUES_BASE_DIR }}/chart-full-setup/values-integration-test-ingress-infra.yaml \
+        {{ end -}}
+        {{ if not (empty .TEST_HELM_DIGEST_VALUES) -}}
         --values {{ .TEST_HELM_DIGEST_VALUES }} \
+        {{ end -}}
+        --values {{ .INFRA_TYPE_VALUES }} \
         --timeout 20m0s \
         --wait {{ .TEST_HELM_EXTRA_ARGS }}


### PR DESCRIPTION
### Which problem does the PR fix?

Related to: https://github.com/camunda/camunda-platform-helm/pull/4120

### What's in this PR?

Fix missing digest values file when it doesn't exist (which is true for the non-alpha versions).
