### PR TITLE
fix: console digest now points to 8.8.0-alpha8.1

### DIFF
--- a/charts/camunda-platform-8.8/values-digest.yaml
+++ b/charts/camunda-platform-8.8/values-digest.yaml
@@ -7,7 +7,7 @@ console:
   image:
     repository: camunda/console
     tag: latest
-    digest: "sha256:a6e49d769d540daeaff2ff4972e29c5521a8277108bc2077269f89bf603348b9"
+    digest: "sha256:c93ffbd550026ff067716f8904765d10089fa5724ca6089832b0e3ffa76c44d8"
 
 connectors:
   # https://hub.docker.com/r/camunda/connectors-bundle/tags


### PR DESCRIPTION
### Which problem does the PR fix?

values-digest.yaml needs to be updated to 8.8.0-alpha8.1

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
