### PR TITLE
fix: include retention configuration for migration config

### DIFF
--- a/charts/camunda-platform-8.8/templates/orchestration/migration-data-configmap.yaml
+++ b/charts/camunda-platform-8.8/templates/orchestration/migration-data-configmap.yaml
@@ -30,6 +30,12 @@ data:
         username: {{ .Values.global.elasticsearch.auth.username }}
         password: ${VALUES_ELASTICSEARCH_PASSWORD:}
         {{- end }}
+        {{- if .Values.orchestration.history.retention.enabled }}
+        retention:
+          enabled: true
+          minimumAge: {{ .Values.orchestration.history.retention.minimumAge | quote }}
+          policyName: {{ .Values.orchestration.history.retention.policyName | quote }}
+        {{- end }}
     {{- else }}
     camunda:
       data:
@@ -56,6 +62,12 @@ data:
         {{- if and .Values.global.opensearch.auth.username .Values.global.opensearch.auth.password }}
         username: {{ .Values.global.opensearch.auth.username }}
         password: ${VALUES_OPENSEARCH_PASSWORD:}
+        {{- end }}
+        {{- if .Values.orchestration.history.retention.enabled }}
+        retention:
+          enabled: true
+          minimumAge: {{ .Values.orchestration.history.retention.minimumAge | quote }}
+          policyName: {{ .Values.orchestration.history.retention.policyName | quote }}
         {{- end }}
     {{- end }}
       migration:


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?
Tasklist Task migration requires the Retention configuration to be passed so as to apply the custom ILM/ISM policies on the new created dated indices for ES/OS.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
