### PR TITLE
feat: opensearch aws enabled config now affects usage of AWS credentials

### DIFF
--- a/charts/camunda-platform-8.8/templates/orchestration/configmap.yaml
+++ b/charts/camunda-platform-8.8/templates/orchestration/configmap.yaml
@@ -158,6 +158,7 @@ data:
               {{- if or .Values.global.elasticsearch.auth.username .Values.global.opensearch.auth.username }}
                 username: {{ if .Values.global.elasticsearch.auth.username }}{{ .Values.global.elasticsearch.auth.username | quote }}{{ else }}{{ .Values.global.opensearch.auth.username | quote }}{{- end }}
               {{- end }}
+                awsEnabled: {{ .Values.global.opensearch.aws.enabled | default false }}
               {{- if .Values.orchestration.retention.enabled }}
               retention:
                 enabled: true

--- a/charts/camunda-platform-8.8/templates/orchestration/configmap.yaml
+++ b/charts/camunda-platform-8.8/templates/orchestration/configmap.yaml
@@ -285,6 +285,7 @@ data:
           minimumAge: {{ .Values.orchestration.history.retention.minimumAge | quote }}
           policyName: {{ .Values.orchestration.history.retention.policyName | quote }}
         {{- end }}
+        awsEnabled: {{ .Values.global.opensearch.aws.enabled | default false }}
       {{- end }}
 
       #

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-authorizations.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-authorizations.golden.yaml
@@ -103,6 +103,7 @@ data:
               connect:
                 type: elasticsearch
                 url: "http://camunda-platform-test-elasticsearch:9200"
+                awsEnabled: false
               history:
                 elsRolloverDateFormat: "date"
                 rolloverInterval: "1d"

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-authorizations.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-authorizations.golden.yaml
@@ -151,6 +151,7 @@ data:
         clusterName: elasticsearch
         # Database full url
         url: "http://camunda-platform-test-elasticsearch:9200"
+        awsEnabled: false
 
       #
       # Camunda Operate Configuration.

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-log4j2.golden.yaml
@@ -103,6 +103,7 @@ data:
               connect:
                 type: elasticsearch
                 url: "http://camunda-platform-test-elasticsearch:9200"
+                awsEnabled: false
               history:
                 elsRolloverDateFormat: "date"
                 rolloverInterval: "1d"

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-log4j2.golden.yaml
@@ -151,6 +151,7 @@ data:
         clusterName: elasticsearch
         # Database full url
         url: "http://camunda-platform-test-elasticsearch:9200"
+        awsEnabled: false
 
       #
       # Camunda Operate Configuration.

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap.golden.yaml
@@ -103,6 +103,7 @@ data:
               connect:
                 type: elasticsearch
                 url: "http://camunda-platform-test-elasticsearch:9200"
+                awsEnabled: false
               history:
                 elsRolloverDateFormat: "date"
                 rolloverInterval: "1d"

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap.golden.yaml
@@ -151,6 +151,7 @@ data:
         clusterName: elasticsearch
         # Database full url
         url: "http://camunda-platform-test-elasticsearch:9200"
+        awsEnabled: false
 
       #
       # Camunda Operate Configuration.


### PR DESCRIPTION
### Which problem does the PR fix?
https://github.com/camunda/camunda/issues/32007, aligns the `opensearch.aws.enabled` config with usage of AWS credentials, meaning:

- if false, will never use AWS credentials even if they exist in the form of envs or `.aws` folder
- if true, will use AWS credentials if they are configured

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?


