### PR TITLE
fix: add constraints for ES and Basic auth in noSecondaryStorage mode

### DIFF
--- a/charts/camunda-platform-8.8/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.8/templates/common/constraints.tpl
@@ -29,12 +29,20 @@ Multi-Tenancy requirements: https://docs.camunda.io/docs/self-managed/concepts/m
 Fail with a message if noSecondaryStorage is enabled but Elasticsearch or OpenSearch are still enabled.
 */}}
 {{- if .Values.global.noSecondaryStorage }}
-  {{- if or .Values.global.elasticsearch.enabled .Values.global.opensearch.enabled }}
+  {{- if or .Values.global.elasticsearch.enabled .Values.global.opensearch.enabled .Values.elasticsearch.enabled }}
     {{- $errorMessage := printf "[camunda][error] %s %s %s %s"
         "When \"global.noSecondaryStorage\" is enabled, both Elasticsearch and OpenSearch must be disabled."
-        "Please ensure that \"global.elasticsearch.enabled: false\" and \"global.opensearch.enabled: false\""
+        "Please ensure that \"global.elasticsearch.enabled: false\", \"global.opensearch.enabled: false\", and \"elasticsearch.enabled: false\""
         "are set when using \"global.noSecondaryStorage: true\"."
         "Secondary storage components cannot be enabled when noSecondaryStorage is true."
+    -}}
+    {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
+  {{- end }}
+  {{- if .Values.orchestration.security.authentication.method "basic" }}
+    {{- $errorMessage := printf "[camunda][error] %s %s %s"
+        "When \"global.noSecondaryStorage\" is enabled, basic authentication for Orchestration is not supported."
+        "Please set \"orchestration.security.authentication.method\" to \"oidc\" and configure OIDC authentication"
+        "when using \"global.noSecondaryStorage: true\"."
     -}}
     {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
   {{- end }}


### PR DESCRIPTION
### Which problem does the PR fix?

The Helm chart continues to enable Elasticsearch, even though the no-db flag `global.noSecondaryStorage=true` is set. Output:

```## Installed Services:

- Console:
  - Enabled: false
- Orchestration:
  - Enabled: true
  - Docker Image used for Zeebe: camunda/camunda:8.8.0-alpha8
  - Zeebe Cluster Name: "my-camunda-devel-zeebe"
  - Prometheus ServiceMonitor Enabled: false
- Connectors:
  - Enabled: true
  - Docker Image used for Connectors: camunda/connectors-bundle:8.8.0-alpha8
- Identity:
  - Enabled: false
- Web Modeler:
  - Enabled: false
- Elasticsearch:
  - Enabled: true
  - Docker Image used for Elasticsearch: bitnamilegacy/elasticsearch:8.18.0
```

We still need to configure OIDC authentication with "no-secondary-storage" mode as Basic authentication is not supported.
There is some bad UX in the Helm chart, as users only discover this limitation when inspecting logs of crash-looping Zeebe Brokers. Example:

```
ERROR - io.camunda.application - Failed to start application with message: Error creating bean with name 'basicAuthenticationNoDbFailFastBean' defined in class path resource [io/camunda/authentication/config/WebSecurityConfig$BasicAuthenticationNoDbConfiguration.class]: Failed to instantiate [io.camunda.authentication.config.WebSecurityConfig$BasicAuthenticationNoDbFailFastBean]: Factory method 'basicAuthenticationNoDbFailFastBean' threw exception with message: Basic Authentication is not supported when secondary storage is disabled (
camunda.database.type=none). Basic Authentication requires access to user data stored in secondary storage.
Please either enable secondary storage by configuring camunda.database.type to a supported database type,
or use another authentication method by updating the camunda.security.authentication.method configuration. 
```

### What's in this PR?

I'm adding 2 new constraints
- on Basic Auth : we should warn users trying to deploy `noSecondaryStorage` mode with basic auth, it's not supported
- on `elasticsearch.enable` : this should be false when `noSecondaryStorage` is true (this config is different from `globale.elasticsearch.enable`)

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->

#closes https://github.com/camunda/camunda/issues/38186