### PR TITLE
fix: noSecondaryStorage constraint no longer breaks unit tests

### DIFF
--- a/charts/camunda-platform-8.8/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.8/templates/common/constraints.tpl
@@ -38,7 +38,7 @@ Fail with a message if noSecondaryStorage is enabled but Elasticsearch or OpenSe
     -}}
     {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
   {{- end }}
-  {{- if .Values.orchestration.security.authentication.method "basic" }}
+  {{- if eq .Values.orchestration.security.authentication.method "basic" }}
     {{- $errorMessage := printf "[camunda][error] %s %s %s"
         "When \"global.noSecondaryStorage\" is enabled, basic authentication for Orchestration is not supported."
         "Please set \"orchestration.security.authentication.method\" to \"oidc\" and configure OIDC authentication"

--- a/charts/camunda-platform-8.8/test/unit/common/no_secondary_storage_test.go
+++ b/charts/camunda-platform-8.8/test/unit/common/no_secondary_storage_test.go
@@ -53,9 +53,11 @@ func (s *NoSecondaryStorageTemplateTest) TestNoSecondaryStorageGlobalValue() {
 			Name:                 "TestGlobalNoSecondaryStorageTogglesAllExpectedValues",
 			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
 			Values: map[string]string{
-				"global.noSecondaryStorage":    "true",
-				"global.elasticsearch.enabled": "false",
-				"global.opensearch.enabled":    "false",
+				"global.noSecondaryStorage":                     "true",
+				"global.elasticsearch.enabled":                 "false",
+				"global.opensearch.enabled":                    "false",
+				"elasticsearch.enabled":                        "false",
+				"orchestration.security.authentication.method": "oidc",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				require.NoError(t, err)


### PR DESCRIPTION
### Which problem does the PR fix?

noSecondaryStorage unit test was not correctly setting helm values

### What's in this PR?

Change test to set values as the constraint requires it
Also fix a basic auth equality check

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
