### PR TITLE
fix: revert orchestration service name for backward compatibility

### DIFF
--- a/charts/camunda-platform-8.8/templates/orchestration/_helpers.tpl
+++ b/charts/camunda-platform-8.8/templates/orchestration/_helpers.tpl
@@ -213,7 +213,7 @@ Service names.
 [orchestration] Define Orchestration Cluster service name - Main.
 */}}
 {{- define "orchestration.serviceName" }}
-    {{- include "orchestration.fullname" . -}}
+    {{- include "orchestration.fullname" . -}}-gateway
 {{- end -}}
 
 {{/*
@@ -234,7 +234,7 @@ Service names.
 [orchestration] Define Orchestration Cluster service name - Headless.
 */}}
 {{- define "orchestration.serviceNameHeadless" }}
-    {{- include "orchestration.fullname" . -}}-headless
+    {{- include "orchestration.fullname" . -}}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform-8.8/test/unit/common/golden/orchestration-service-monitor.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/common/golden/orchestration-service-monitor.golden.yaml
@@ -3,7 +3,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: camunda-platform-test-zeebe
+  name: camunda-platform-test-zeebe-gateway
   labels:
     app: camunda-platform
     app.kubernetes.io/name: camunda-platform
@@ -26,7 +26,7 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: camunda-platform-test-zeebe-headless
+  name: camunda-platform-test-zeebe
   labels:
     app: camunda-platform
     app.kubernetes.io/name: camunda-platform

--- a/charts/camunda-platform-8.8/test/unit/connectors/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/connectors/golden/configmap.golden.yaml
@@ -35,8 +35,8 @@ data:
 
     camunda:
       client:
-        rest-address: http://camunda-platform-test-zeebe:8080
-        grpc-address: http://camunda-platform-test-zeebe:26500
+        rest-address: http://camunda-platform-test-zeebe-gateway:8080
+        grpc-address: http://camunda-platform-test-zeebe-gateway:26500
         worker:
           defaults:
             max-jobs-active: 32

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-authorizations.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-authorizations.golden.yaml
@@ -123,7 +123,7 @@ data:
         # Zeebe instance
         zeebe:
           # Gateway address
-          gatewayAddress: "camunda-platform-test-zeebe:26500"
+          gatewayAddress: "camunda-platform-test-zeebe-gateway:26500"
     
       #
       # Camunda Tasklist Configuration - Separated syntax.
@@ -134,8 +134,8 @@ data:
         # Zeebe instance
         zeebe:
           # Gateway address
-          gatewayAddress: "camunda-platform-test-zeebe:26500"
-          restAddress: "http://camunda-platform-test-zeebe:8080"
+          gatewayAddress: "camunda-platform-test-zeebe-gateway:26500"
+          restAddress: "http://camunda-platform-test-zeebe-gateway:8080"
     
     #
     # Camunda Zeebe Configuration - Separated syntax.

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-log4j2.golden.yaml
@@ -123,7 +123,7 @@ data:
         # Zeebe instance
         zeebe:
           # Gateway address
-          gatewayAddress: "camunda-platform-test-zeebe:26500"
+          gatewayAddress: "camunda-platform-test-zeebe-gateway:26500"
     
       #
       # Camunda Tasklist Configuration - Separated syntax.
@@ -134,8 +134,8 @@ data:
         # Zeebe instance
         zeebe:
           # Gateway address
-          gatewayAddress: "camunda-platform-test-zeebe:26500"
-          restAddress: "http://camunda-platform-test-zeebe:8080"
+          gatewayAddress: "camunda-platform-test-zeebe-gateway:26500"
+          restAddress: "http://camunda-platform-test-zeebe-gateway:8080"
     
     #
     # Camunda Zeebe Configuration - Separated syntax.

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-unified.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-unified.golden.yaml
@@ -123,7 +123,7 @@ data:
         # Zeebe instance
         zeebe:
           # Gateway address
-          gatewayAddress: "camunda-platform-test-zeebe:26500"
+          gatewayAddress: "camunda-platform-test-zeebe-gateway:26500"
     
       #
       # Camunda Tasklist Configuration - Separated syntax.
@@ -134,8 +134,8 @@ data:
         # Zeebe instance
         zeebe:
           # Gateway address
-          gatewayAddress: "camunda-platform-test-zeebe:26500"
-          restAddress: "http://camunda-platform-test-zeebe:8080"
+          gatewayAddress: "camunda-platform-test-zeebe-gateway:26500"
+          restAddress: "http://camunda-platform-test-zeebe-gateway:8080"
     
     #
     # Camunda Zeebe Configuration - Separated syntax.

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/service-headless.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/service-headless.golden.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: camunda-platform-test-zeebe-headless
+  name: camunda-platform-test-zeebe
   labels:
     app: camunda-platform
     app.kubernetes.io/name: camunda-platform

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/service.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/service.golden.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: camunda-platform-test-zeebe
+  name: camunda-platform-test-zeebe-gateway
   labels:
     app: camunda-platform
     app.kubernetes.io/name: camunda-platform

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/statefulset.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/statefulset.golden.yaml
@@ -23,7 +23,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: zeebe-broker
-  serviceName: "camunda-platform-test-zeebe-headless"
+  serviceName: "camunda-platform-test-zeebe"
   updateStrategy:
     type: RollingUpdate
   podManagementPolicy: Parallel
@@ -64,7 +64,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: K8S_SERVICE_NAME
-              value: "camunda-platform-test-zeebe-headless"
+              value: "camunda-platform-test-zeebe"
             - name: K8S_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/charts/camunda-platform-8.8/test/unit/web-modeler/configmap_restapi_test.go
+++ b/charts/camunda-platform-8.8/test/unit/web-modeler/configmap_restapi_test.go
@@ -359,8 +359,8 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldConfigureClusterFromSa
 			s.Require().Equal("8.8.x-alpha1", configmapApplication.Camunda.Modeler.Clusters[0].Version)
 			s.Require().Equal(tc.expectedAuthentication, configmapApplication.Camunda.Modeler.Clusters[0].Authentication)
 			s.Require().Equal(false, configmapApplication.Camunda.Modeler.Clusters[0].Authorizations.Enabled)
-			s.Require().Equal("grpc://camunda-platform-test-zeebe:26600", configmapApplication.Camunda.Modeler.Clusters[0].Url.Grpc)
-			s.Require().Equal("http://camunda-platform-test-zeebe:8090/orchestration", configmapApplication.Camunda.Modeler.Clusters[0].Url.Rest)
+			s.Require().Equal("grpc://camunda-platform-test-zeebe-gateway:26600", configmapApplication.Camunda.Modeler.Clusters[0].Url.Grpc)
+			s.Require().Equal("http://camunda-platform-test-zeebe-gateway:8090/orchestration", configmapApplication.Camunda.Modeler.Clusters[0].Url.Rest)
 			s.Require().Equal("https://example.com/orchestration", configmapApplication.Camunda.Modeler.Clusters[0].Url.WebApp)
 		})
 	}

--- a/charts/camunda-platform-8.8/test/unit/web-modeler/golden/configmap-restapi.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/web-modeler/golden/configmap-restapi.golden.yaml
@@ -49,8 +49,8 @@ data:
             authorizations:
               enabled: true
             url:
-              grpc: "grpc://camunda-platform-test-zeebe:26500"
-              rest: "http://camunda-platform-test-zeebe:8080"
+              grpc: "grpc://camunda-platform-test-zeebe-gateway:26500"
+              rest: "http://camunda-platform-test-zeebe-gateway:8080"
               web-app: "http://localhost:8088"
 
     spring:


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes:  https://github.com/camunda/camunda-platform-helm/issues/4262

### What's in this PR?

For a smooth upgrade from 8.7 to 8.8, we keep all names the same to avoid handling changes in the StatefulSet names.

So now we're back to the 8.7 service names:
- Zeebe brokers Pod-to-Pod service: `RELEASE-zeebe`
- Camunda components service-to-service: `RELEASE-zeebe-gateway`