### PR TITLE
feat: support issuer backend url in the orchestration config

### DIFF
--- a/charts/camunda-platform-8.8/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.8/templates/common/_helpers.tpl
@@ -226,6 +226,13 @@ Keycloak templates.
 {{- end -}}
 
 {{/*
+[camunda-platform] Keycloak auth URL which used externally by the user.
+*/}}
+{{- define "camundaPlatform.authIssuerUrlEndpointAuth" -}}
+    {{- include "camundaPlatform.authIssuerUrl" . -}}/protocol/openid-connect/auth
+{{- end -}}
+
+{{/*
 [camunda-platform] Keycloak issuer backend URL which used internally for Camunda apps.
 TODO: Most of the Keycloak config is handeled in Identity sub-chart, but it should be in the main chart.
 */}}
@@ -258,7 +265,7 @@ TODO: Most of the Keycloak config is handeled in Identity sub-chart, but it shou
 {{/*
 [camunda-platform] Keycloak auth token URL which used internally for Camunda apps.
 */}}
-{{- define "camundaPlatform.authIssuerBackendUrlTokenEndpoint" -}}
+{{- define "camundaPlatform.authIssuerBackendUrlEndpointToken" -}}
   {{- if .Values.global.identity.auth.tokenUrl -}}
     {{- .Values.global.identity.auth.tokenUrl -}}
   {{- else -}}
@@ -266,11 +273,10 @@ TODO: Most of the Keycloak config is handeled in Identity sub-chart, but it shou
   {{- end -}}
 {{- end -}}
 
-
 {{/*
 [camunda-platform] Keycloak auth certs URL which used internally for Camunda apps.
 */}}
-{{- define "camundaPlatform.authIssuerBackendUrlCertsEndpoint" -}}
+{{- define "camundaPlatform.authIssuerBackendUrlEndpointCerts" -}}
   {{- if .Values.global.identity.auth.jwksUrl -}}
     {{- .Values.global.identity.auth.jwksUrl -}}
   {{- else -}}

--- a/charts/camunda-platform-8.8/templates/connectors/configmap.yaml
+++ b/charts/camunda-platform-8.8/templates/connectors/configmap.yaml
@@ -59,7 +59,7 @@ data:
           password: {{ $user.password | quote }}
         {{- else }}
         auth:
-          token-url: {{ include "camundaPlatform.authIssuerBackendUrlTokenEndpoint" . }}
+          token-url: {{ include "camundaPlatform.authIssuerBackendUrlEndpointToken" . }}
           client-id: {{ include "connectors.authClientId" . | quote }}
           client-secret: ${VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET}
           audience: {{ include "orchestration.authAudience" . | quote }}

--- a/charts/camunda-platform-8.8/templates/console/configmap.yaml
+++ b/charts/camunda-platform-8.8/templates/console/configmap.yaml
@@ -17,7 +17,7 @@ data:
           audience: {{ .Values.global.identity.auth.console.audience | quote }}
           clientId: {{ .Values.global.identity.auth.console.clientId | quote }}
           issuer: {{ include "camundaPlatform.authIssuerUrl" . | quote }}
-          jwksUri: {{ include "camundaPlatform.authIssuerBackendUrlCertsEndpoint" . | quote }}
+          jwksUri: {{ include "camundaPlatform.authIssuerBackendUrlEndpointCerts" . | quote }}
           type: {{ include "camundaPlatform.authType" . | quote }}
           wellKnown: {{ .Values.global.identity.auth.console.wellKnown | quote }}
         managed:

--- a/charts/camunda-platform-8.8/templates/optimize/configmap.yaml
+++ b/charts/camunda-platform-8.8/templates/optimize/configmap.yaml
@@ -64,7 +64,7 @@ data:
           redirectRootUrl: {{ tpl .Values.global.identity.auth.optimize.redirectUrl $ | quote }}
     api:
       audience: {{ include "optimize.authAudience" . | quote }}
-      jwtSetUri: {{ include "camundaPlatform.authIssuerBackendUrlCertsEndpoint" . | quote }}
+      jwtSetUri: {{ include "camundaPlatform.authIssuerBackendUrlEndpointCerts" . | quote }}
     {{- end }}
   {{- end }}
 

--- a/charts/camunda-platform-8.8/templates/orchestration/_helpers.tpl
+++ b/charts/camunda-platform-8.8/templates/orchestration/_helpers.tpl
@@ -267,3 +267,17 @@ Service labels.
     {{- "\n" }}
     {{- include "orchestration.extraLabelsHeadless" . }}
 {{- end -}}
+
+{{/*
+********************************************************************************
+URIs.
+********************************************************************************
+*/}}
+
+{{/*
+[orchestration] Orchestration Cluster Redirect URI.
+*/}}
+{{- define "orchestration.RedirectURI" -}}
+    {{- $redirectURIDefault := include "orchestration.serviceNameHTTP" . -}}
+    {{- tpl .Values.orchestration.security.authentication.oidc.redirectUrl . | default $redirectURIDefault -}}
+{{- end -}}

--- a/charts/camunda-platform-8.8/templates/orchestration/files/_application-unified.yaml
+++ b/charts/camunda-platform-8.8/templates/orchestration/files/_application-unified.yaml
@@ -96,13 +96,10 @@ camunda:
           - {{ .Values.orchestration.security.authentication.oidc.audience | quote }}
           - {{ .Values.global.identity.auth.webModeler.clientApiAudience | quote }}
           - {{ .Values.global.identity.auth.webModeler.publicApiAudience | quote }}
-        {{- $redirectURIDefault := printf "http://%s:8080" (include "orchestration.fullname" .) }}
-        {{- /*
-          TODO: Add "camundaPlatform.authIssuerBackendUrl" when "backend-url" config is supported by the Orchestration Identity.
-          For more details: https://github.com/camunda/camunda-platform-helm/issues/3952
-        */}}
-        issuer-uri: {{ (include "camundaPlatform.authIssuerUrl" .) | quote }}
-        redirect-uri: "{{ tpl .Values.orchestration.security.authentication.oidc.redirectUrl $ | default $redirectURIDefault }}/sso-callback"
+        authorization-uri: {{ include "camundaPlatform.authIssuerUrlEndpointAuth" . | quote }}
+        jwk-set-uri: {{ include "camundaPlatform.authIssuerBackendUrlEndpointCerts" . | quote }}
+        token-uri: {{ include "camundaPlatform.authIssuerBackendUrlEndpointToken" . | quote }}
+        redirect-uri: {{ printf "%s/sso-callback" (include "orchestration.RedirectURI" .) | quote }}
         authenticationRefreshInterval: {{ .Values.orchestration.security.authentication.authenticationRefreshInterval | quote }}
     {{- end }}
       method: {{ .Values.orchestration.security.authentication.method | quote }}
@@ -120,7 +117,7 @@ camunda:
       checksEnabled: {{ include "orchestration.multitenancyChecksEnabled" . }}
       apiEnabled: {{ include "orchestration.multitenancyApiEnabled" . }}
 
-  {{- if .Values.global.identity.auth.enabled }}
+  {{- if eq .Values.orchestration.security.authentication.method "oidc" }}
   identity:
     clientId: {{ include "orchestration.authClientId" . | quote }}
     audience: {{ include "orchestration.authAudience" . | quote }}
@@ -135,9 +132,9 @@ camunda:
     persistentSessionsEnabled: {{ include "orchestration.persistentSessionsEnabled" . }}
     multiTenancy:
       enabled: {{ include "orchestration.multitenancyChecksEnabled" . }}
-    {{- if .Values.global.identity.auth.enabled }}
+    {{- if eq .Values.orchestration.security.authentication.method "oidc" }}
     identity:
-      redirectRootUrl: "{{ tpl .Values.orchestration.security.authentication.oidc.redirectUrl $ }}/operate"
+      redirectRootUrl: {{ printf "%s/operate" (include "orchestration.RedirectURI" .) | quote }}
     {{- end }}
     {{- if .Values.global.opensearch.enabled }}
     # OpenSearch
@@ -168,9 +165,9 @@ camunda:
     multiTenancy:
       enabled: {{ include "orchestration.multitenancyChecksEnabled" . }}
 
-    {{- if .Values.global.identity.auth.enabled }}
+    {{- if eq .Values.orchestration.security.authentication.method "oidc" }}
     identity:
-      redirectRootUrl: "{{ tpl .Values.orchestration.security.authentication.oidc.redirectUrl $ }}/tasklist"
+      redirectRootUrl: {{ printf "%s/tasklist" (include "orchestration.RedirectURI" .) | quote }}
     {{- end }}
     {{- if .Values.global.opensearch.enabled }}
     # OpenSearch

--- a/charts/camunda-platform-8.8/templates/web-modeler/configmap-restapi.yaml
+++ b/charts/camunda-platform-8.8/templates/web-modeler/configmap-restapi.yaml
@@ -84,7 +84,7 @@ data:
             {{- if .Values.global.identity.auth.enabled }}
             jwt:
               issuer-uri: {{ include "camundaPlatform.authIssuerUrl" . | quote }}
-              jwk-set-uri: {{ include "camundaPlatform.authIssuerBackendUrlCertsEndpoint" . | quote }}
+              jwk-set-uri: {{ include "camundaPlatform.authIssuerBackendUrlEndpointCerts" . | quote }}
             {{- else }}
             jwt: null
             {{- end }}

--- a/charts/camunda-platform-8.8/templates/web-modeler/configmap-webapp.yaml
+++ b/charts/camunda-platform-8.8/templates/web-modeler/configmap-webapp.yaml
@@ -27,7 +27,7 @@ data:
     clientId = {{ include "webModeler.authClientId" . | quote }}
 
     [oAuth2.token]
-    jwksUrl = {{ include "camundaPlatform.authIssuerBackendUrlCertsEndpoint" . | quote }}
+    jwksUrl = {{ include "camundaPlatform.authIssuerBackendUrlEndpointCerts" . | quote }}
     audience = {{ include "webModeler.authClientApiAudience" . | quote }}
     issuer = {{ include "camundaPlatform.authIssuerUrl" . | quote }}
     usernameClaim = {{ .Values.orchestration.security.authentication.oidc.usernameClaim | quote }}

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-keycloak.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-keycloak.yaml
@@ -31,10 +31,6 @@ global:
         redirectUrl: "https://{{ .Values.global.ingress.host }}/optimize"
         existingSecret:
           name: "integration-test-credentials"
-      orchestration:
-        redirectUrl: "https://{{ .Values.global.ingress.host }}/orchestration"
-        existingSecret:
-          name: "integration-test-credentials"
 
 identity:
   enabled: true
@@ -112,6 +108,10 @@ orchestration:
     authentication:
       method: oidc
       authenticationRefreshInterval: "PT30S"
+      oidc:
+        redirectUrl: "https://{{ .Values.global.ingress.host }}/orchestration"
+        existingSecret:
+          name: "integration-test-credentials"
 
 console:
   enabled: true


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes: https://github.com/camunda/camunda-platform-helm/issues/3952

### What's in this PR?

Use the internal issuer backend URL again, so no need for an external Ingress to use the Helm chart.
