### PR TITLE
fix: add missing opensearch fields in templates

### DIFF
--- a/charts/camunda-platform-8.8/templates/optimize/configmap.yaml
+++ b/charts/camunda-platform-8.8/templates/optimize/configmap.yaml
@@ -19,7 +19,6 @@ data:
     zeebe:
       enabled: true
       partitionCount: {{ .Values.optimize.partitionCount }}
-      name: {{ .Values.global.elasticsearch.prefix }}
 
     {{- if .Values.global.elasticsearch.enabled }}
     es:

--- a/charts/camunda-platform-8.8/templates/orchestration/files/_application-unified.yaml
+++ b/charts/camunda-platform-8.8/templates/orchestration/files/_application-unified.yaml
@@ -258,6 +258,8 @@ zeebe:
             username: {{ .Values.global.opensearch.auth.username | quote }}
             password: "${VALUES_OPENSEARCH_PASSWORD:}"
           {{- end }}
+          index:
+            prefix: {{ .Values.global.opensearch.prefix | quote }}
           {{- if .Values.global.opensearch.aws.enabled }}
           aws:
             enabled: true


### PR DESCRIPTION
### Which problem does the PR fix?

This update fixes an issue with custom prefixes where the default index prefix used to export from zeebe was the default inside zeebe and the prefix index used for import in optimize was the elasticsearch default.

Longer term fix should be to remove all usage of the env variables and restructure the index prefixes under a simple value structure, much like the global identity settings. 

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
