### PR TITLE
fix: data and identity migraiton accept orchestration env

### DIFF
--- a/charts/camunda-platform-8.8/templates/orchestration/migration-data-job.yaml
+++ b/charts/camunda-platform-8.8/templates/orchestration/migration-data-job.yaml
@@ -58,6 +58,9 @@ spec:
                 "config" .Values.global.opensearch.auth
             ) | nindent 12 }}
             {{- end }}
+            {{- with .Values.orchestration.env }}
+              {{- tpl (toYaml .) $ | nindent 12 }}
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "orchestration.fullname" . }}-importer-env-vars

--- a/charts/camunda-platform-8.8/templates/orchestration/migration-identity-job.yaml
+++ b/charts/camunda-platform-8.8/templates/orchestration/migration-identity-job.yaml
@@ -46,6 +46,9 @@ spec:
                 "envName" "VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET"
                 "config" .Values.orchestration.security.authentication.oidc
             ) | nindent 12 }}
+            {{- with .Values.orchestration.env }}
+              {{- tpl (toYaml .) $ | nindent 12 }}
+            {{- end }}
           command:
             - /usr/local/camunda/bin/identity-migration
           resources:


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

Allow `data-migration-job` and `identity-migration-job` to inherit `orchestration.env` pass variables. This is to make sure that any variable that affects the global state, in this case _SchemaManager_ config should be present in the deployments as well.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->

closes: #4226
