### PR TITLE
fix: opensearch config and index replica placement

### DIFF
--- a/charts/camunda-platform-8.8/templates/orchestration/files/_application-unified.yaml
+++ b/charts/camunda-platform-8.8/templates/orchestration/files/_application-unified.yaml
@@ -292,12 +292,13 @@ zeebe:
             {{- if .Values.orchestration.index.prefix }}
             indexPrefix: {{ .Values.orchestration.index.prefix | quote }}
             {{- end }}
-            numberOfReplicas: {{ .Values.orchestration.index.replicas | quote }}
           {{- if or .Values.global.elasticsearch.auth.username .Values.global.opensearch.auth.username }}
             username: {{ if .Values.global.elasticsearch.auth.username }}{{ .Values.global.elasticsearch.auth.username | quote }}{{ else }}{{ .Values.global.opensearch.auth.username | quote }}{{- end }}
             password: "{{ if .Values.global.elasticsearch.auth.username }}${VALUES_ELASTICSEARCH_PASSWORD:}{{ else }}${VALUES_OPENSEARCH_PASSWORD:}{{- end }}"
           {{- end }}
             awsEnabled: {{ .Values.global.opensearch.aws.enabled }}
+          index:
+            numberOfReplicas: {{ .Values.orchestration.index.replicas | quote }}
         {{- if .Values.orchestration.retention.enabled }}
           retention:
             enabled: true

--- a/charts/camunda-platform-8.8/templates/orchestration/importer-configmap-env-vars.yaml
+++ b/charts/camunda-platform-8.8/templates/orchestration/importer-configmap-env-vars.yaml
@@ -38,11 +38,11 @@ data:
 {{- end }}
 {{- end }}
 {{- if .Values.global.opensearch.enabled }}
-  CAMUNDA_OPERATE_ZEEBEOPENSEARCH_URL: {{ include "camundaPlatform.elasticsearchURL" . | quote }}
-  CAMUNDA_OPERATE_ZEEBEOPENSEARCH_CLUSTERNAME: "{{ .Values.global.elasticsearch.clusterName }}"
-  CAMUNDA_OPERATE_ZEEBEOPENSEARCH_PREFIX: "{{ .Values.global.elasticsearch.prefix }}"
-  CAMUNDA_OPERATE_ZEEBEOPENSEARCH_HOST: "{{ include "camundaPlatform.elasticsearchHost" . }}"
-  CAMUNDA_OPERATE_ZEEBEOPENSEARCH_PORT: {{ .Values.global.elasticsearch.url.port | quote}}
+  CAMUNDA_OPERATE_ZEEBEOPENSEARCH_URL: {{ include "camundaPlatform.opensearchURL" . | quote }}
+  CAMUNDA_OPERATE_ZEEBEOPENSEARCH_CLUSTERNAME: "{{ .Values.global.opensearch.clusterName }}"
+  CAMUNDA_OPERATE_ZEEBEOPENSEARCH_PREFIX: "{{ .Values.global.opensearch.prefix }}"
+  CAMUNDA_OPERATE_ZEEBEOPENSEARCH_HOST: "{{ include "camundaPlatform.opensearchHost" . }}"
+  CAMUNDA_OPERATE_ZEEBEOPENSEARCH_PORT: {{ .Values.global.opensearch.url.port | quote}}
   CAMUNDA_OPERATE_ZEEBEOPENSEARCH_AWSENABLED: "{{ .Values.global.opensearch.aws.enabled }}"
 {{- if .Values.global.opensearch.external }}
   CAMUNDA_OPERATE_ZEEBEOPENSEARCH_USERNAME: {{ .Values.global.opensearch.auth.username | quote }}
@@ -65,11 +65,11 @@ data:
 {{- end }}
 {{- end }}
 {{- if .Values.global.opensearch.enabled }}
-  CAMUNDA_TASKLIST_ZEEBEOPENSEARCH_URL: {{ include "camundaPlatform.elasticsearchURL" . | quote }}
-  CAMUNDA_TASKLIST_ZEEBEOPENSEARCH_CLUSTERNAME: "{{ .Values.global.elasticsearch.clusterName }}"
-  CAMUNDA_TASKLIST_ZEEBEOPENSEARCH_PREFIX: "{{ .Values.global.elasticsearch.prefix }}"
-  CAMUNDA_TASKLIST_ZEEBEOPENSEARCH_HOST: "{{ include "camundaPlatform.elasticsearchHost" . }}"
-  CAMUNDA_TASKLIST_ZEEBEOPENSEARCH_PORT: {{ .Values.global.elasticsearch.url.port | quote }}
+  CAMUNDA_TASKLIST_ZEEBEOPENSEARCH_URL: {{ include "camundaPlatform.opensearchURL" . | quote }}
+  CAMUNDA_TASKLIST_ZEEBEOPENSEARCH_CLUSTERNAME: "{{ .Values.global.opensearch.clusterName }}"
+  CAMUNDA_TASKLIST_ZEEBEOPENSEARCH_PREFIX: "{{ .Values.global.opensearch.prefix }}"
+  CAMUNDA_TASKLIST_ZEEBEOPENSEARCH_HOST: "{{ include "camundaPlatform.opensearchHost" . }}"
+  CAMUNDA_TASKLIST_ZEEBEOPENSEARCH_PORT: {{ .Values.global.opensearch.url.port | quote }}
   CAMUNDA_TASKLIST_ZEEBEOPENSEARCH_AWSENABLED: "{{ .Values.global.opensearch.aws.enabled }}"
 {{- if .Values.global.opensearch.external }}
   CAMUNDA_TASKLIST_ZEEBEOPENSEARCH_USERNAME: {{ .Values.global.opensearch.auth.username | quote }}
@@ -77,7 +77,7 @@ data:
 
 # Index replicas
 {{- if .Values.orchestration.index.replicas }}
-  CAMUNDA_DATABASE_INDEX_NUMBER_OF_REPLICAS: {{ .Values.orchestration.index.replicas }}
+  CAMUNDA_DATABASE_INDEX_NUMBER_OF_REPLICAS: {{ .Values.orchestration.index.replicas | quote }}
 {{- end }}
 
 {{- end }}

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-authorizations.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-authorizations.golden.yaml
@@ -178,8 +178,9 @@ data:
               connect:
                 type: "elasticsearch"
                 url: "http://camunda-platform-test-elasticsearch:9200"
-                numberOfReplicas: "1"
                 awsEnabled: false
+              index:
+                numberOfReplicas: "1"
               history:
                 elsRolloverDateFormat: "date"
                 rolloverInterval: "1d"

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-log4j2.golden.yaml
@@ -178,8 +178,9 @@ data:
               connect:
                 type: "elasticsearch"
                 url: "http://camunda-platform-test-elasticsearch:9200"
-                numberOfReplicas: "1"
                 awsEnabled: false
+              index:
+                numberOfReplicas: "1"
               history:
                 elsRolloverDateFormat: "date"
                 rolloverInterval: "1d"

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-unified.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-unified.golden.yaml
@@ -178,8 +178,9 @@ data:
               connect:
                 type: "elasticsearch"
                 url: "http://camunda-platform-test-elasticsearch:9200"
-                numberOfReplicas: "1"
                 awsEnabled: false
+              index:
+                numberOfReplicas: "1"
               history:
                 elsRolloverDateFormat: "date"
                 rolloverInterval: "1d"


### PR DESCRIPTION
### Which problem does the PR fix?

OpenSearch Configuration Fix
Exporter Configuration Fix

### What's in this PR?
- fix environment variables that were incorrectly using Elasticsearch helper functions and values for OpenSearch configurations
-  camundaPlatform.elasticsearchURL > camundaPlatform.opensearchURL
-  camundaPlatform.elasticsearchHost > camundaPlatform.opensearchHost
-  .Values.global.elasticsearch.* > .Values.global.opensearch.* 
-  quoting CAMUNDA_DATABASE_INDEX_NUMBER_OF_REPLICAS
- numberOfReplicas setting to the correct location under the index

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
