### PR TITLE
fix: es/os exporter inherit index replicas

### DIFF
--- a/charts/camunda-platform-8.8/templates/orchestration/files/_application-unified.yaml
+++ b/charts/camunda-platform-8.8/templates/orchestration/files/_application-unified.yaml
@@ -253,6 +253,7 @@ zeebe:
           url: {{ include "camundaPlatform.elasticsearchURL" . | quote }}
           index:
             prefix: {{ .Values.global.elasticsearch.prefix | quote }}
+            numberOfReplicas: {{ .Values.orchestration.index.replicas | quote }}
           {{- if .Values.orchestration.retention.enabled }}
           retention:
             enabled: true
@@ -271,6 +272,7 @@ zeebe:
           {{- end }}
           index:
             prefix: {{ .Values.global.opensearch.prefix | quote }}
+            numberOfReplicas: {{ .Values.orchestration.index.replicas | quote }}
           {{- if .Values.global.opensearch.aws.enabled }}
           aws:
             enabled: true


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

Elasticsearch and Opensearch Zeebe Exporters inherit the `orchestration.index.replicas` from the unified config

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->

closes: #4308
