### PR TITLE
fix: use correct upgrade strategy for importer deployment

### DIFF
--- a/charts/camunda-platform-8.8/templates/orchestration/importer-deployment.yaml
+++ b/charts/camunda-platform-8.8/templates/orchestration/importer-deployment.yaml
@@ -14,7 +14,7 @@ spec:
   selector:
     matchLabels:
       {{- include "orchestration.matchLabelsImporter" . | nindent 6 }}
-  updateStrategy:
+  strategy:
     type: RollingUpdate
   template:
     metadata:

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/importer-deployment.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/importer-deployment.golden.yaml
@@ -23,7 +23,7 @@ spec:
       app.kubernetes.io/managed-by: Helm
       app.kubernetes.io/part-of: camunda-platform
       app.kubernetes.io/component: zeebe-broker-importer
-  updateStrategy:
+  strategy:
     type: RollingUpdate
   template:
     metadata:


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

The deployment was using to parts spec of a statefulset that caused problems deploying it.
The Helm chart upgrade or install may have hidden the problem. It's more visible when applying it directly via e.g. template.

```
Error from server (BadRequest): error when creating "charts/camunda-platform-8.8/test/unit/orchestration/golden/importer-deployment.golden.yaml": Deployment in version "v1" cannot be handled as a Deployment: strict decoding error: unknown field "spec.updateStrategy"
```

[Deployment docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) vs [Statefulset](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies)

### What's in this PR?

A quick fix to use the deployment compatible version of what was wanted.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
