### PR TITLE
fix: fix configurations of identity migration

### DIFF
--- a/charts/camunda-platform-8.8/templates/orchestration/migration-identity-configmap.yaml
+++ b/charts/camunda-platform-8.8/templates/orchestration/migration-identity-configmap.yaml
@@ -33,7 +33,7 @@ data:
             {{- end }}
           management-identity:
             audience: {{ include "identity.authAudience" . | quote }}
-            base-url: {{ tpl .Values.global.identity.auth.identity.redirectUrl $ | quote }}
+            base-url: http://{{ include "identity.fullname" . }}:80
           {{- if eq (include "orchestration.authIssuerType" .) "KEYCLOAK" }}
             client-id: migration
           {{- else }}

--- a/charts/camunda-platform-8.8/templates/orchestration/migration-identity-configmap.yaml
+++ b/charts/camunda-platform-8.8/templates/orchestration/migration-identity-configmap.yaml
@@ -33,7 +33,7 @@ data:
             {{- end }}
           management-identity:
             audience: {{ include "identity.authAudience" . | quote }}
-            base-url: http://{{ include "identity.fullname" . }}:80
+            base-url: http://{{ include "identity.fullname" . }}:{{ .Values.identity.service.port }}{{ .Values.identity.contextPath }}
           {{- if eq (include "orchestration.authIssuerType" .) "KEYCLOAK" }}
             client-id: migration
           {{- else }}

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/migration-identity-configmap.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/migration-identity-configmap.golden.yaml
@@ -22,7 +22,7 @@ data:
               - camunda-platform-test-zeebe-2.${K8S_SERVICE_NAME}:26502
           management-identity:
             audience: "camunda-identity-resource-server"
-            base-url: "http://localhost:8085"
+            base-url: http://camunda-platform-test-identity:80
             client-id: migration
             client-secret: ${VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET:}
             issuer-backend-url: "http://:/auth/realms/camunda-platform"

--- a/charts/camunda-platform-8.8/values-digest.yaml
+++ b/charts/camunda-platform-8.8/values-digest.yaml
@@ -68,5 +68,5 @@ identity:
   # https://hub.docker.com/r/camunda/identity/tags
   image:
     repository: camunda/identity
-    tag: SNAPSHOT
+    tag: 8.8-SNAPSHOT
     digest: "sha256:675a5137cd3bb1cb02ac3078b766997e2603120c7410a29a65450ab8409c72ca"

--- a/charts/camunda-platform-8.8/values-digest.yaml
+++ b/charts/camunda-platform-8.8/values-digest.yaml
@@ -69,4 +69,4 @@ identity:
   image:
     repository: camunda/identity
     tag: 8.8-SNAPSHOT
-    digest: "sha256:675a5137cd3bb1cb02ac3078b766997e2603120c7410a29a65450ab8409c72ca"
+    digest: "sha256:75dbdde615d6b0bf657f11edf7c4ece3f1ee3f4e110bfc25f6e7487333b44d90"


### PR DESCRIPTION
### Which problem does the PR fix?

 * The base URL used by the identity migration needs to point to the
   management identity. Previously, it was using the redirectUrl going to localhost, which 
obviously failed the migration
 * Instead of using identity snapshot, which will be the latest version, we have to use for 8.8 the 8.8-SNAPSHOT.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

 * Fix the above

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
