### PR TITLE
fix: define importer node id based on regionId

### DIFF
--- a/charts/camunda-platform-8.8/templates/orchestration/importer-deployment.yaml
+++ b/charts/camunda-platform-8.8/templates/orchestration/importer-deployment.yaml
@@ -54,7 +54,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: VALUES_ORCHESTRATION_NODE_ID
-              value: "-1"
+              value: {{ sub -1 .Values.global.multiregion.regionId | quote }}
             {{- include "camundaPlatform.emitEnvVarFromSecretConfig" (dict
                 "envName" "VALUES_ORCHESTRATION_LICENSE_KEY"
                 "config" .Values.global.license


### PR DESCRIPTION
### Which problem does the PR fix?

cant be a string like the data-migrator topic does.
Must be an interger for gossip.

If it's the same value like before hardcoded you block the migration in the other region until you manually remove the deployment. As a member has "joined" the cluster under the previously hardcoded value `-1` already.

### What's in this PR?

Therefore, use the regionId to decrease the value.

regionId 0 (default) --> -1
regionId 1 --> -2
regionId 2 --> -3
...

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
