### PR TITLE
fix: remove importer affinity in 8.8

### DIFF
--- a/charts/camunda-platform-8.8/templates/orchestration/importer-deployment.yaml
+++ b/charts/camunda-platform-8.8/templates/orchestration/importer-deployment.yaml
@@ -241,9 +241,4 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
 {{- end }}
-# yamllint disable
-{{- with .Values.orchestration.affinity }}
-      affinity:
-{{ toYaml . | indent 8 }}
-{{- end }}
 {{- end }}

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/importer-deployment.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/importer-deployment.golden.yaml
@@ -134,14 +134,3 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-# yamllint disable
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app.kubernetes.io/component
-                operator: In
-                values:
-                - zeebe-broker
-            topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
### Which problem does the PR fix?

Removes the importer deployment affinity as it actively overlaps with the zeebe-broker.

Depending on cluster size and broker count this can impact users to block the migration or delay it since no node may be available. This will be a temporary deployment and doesn't actually house data nor is it important for resilience or similar. Therefore, proposing to remove the affinity.

We don't have affinities in place either for the migration jobs of data / identity.

### What's in this PR?

- Removal of affinity for the importer deployment

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
