### PR TITLE
ci: enable minor upgrade migration from 8.7 to 8.8

### DIFF
--- a/.github/workflows/test-local-template.yaml
+++ b/.github/workflows/test-local-template.yaml
@@ -44,8 +44,8 @@ jobs:
           buildx-enabled: "false"
           java-enabled: "false"
           python-enabled: "false"
-      - name: Install build dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential gawk
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential gawk make
       - name: Install tools
         uses: ./.github/actions/install-tool-versions
         with:
@@ -53,7 +53,6 @@ jobs:
             helm
             kind
             kubectl
-            make
             task
       - name: CI Setup - Set test type vars
         uses: ./.github/actions/test-type-vars

--- a/.tool-versions
+++ b/.tool-versions
@@ -7,7 +7,6 @@ helm-ct 3.11.0
 kind 0.30.0
 kubectl 1.27.16 # The kubectl version depends on the K8s CI cluster version
 kustomize 5.7.1
-make 4.3
 oc 4.17.11
 task 3.30.1 # Task is mainly used to run tests locally or in the CI pipeline.
 yamllint 1.37.1

--- a/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-upgrade-migration.yaml
+++ b/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-upgrade-migration.yaml
@@ -1,0 +1,4 @@
+# Added for upgrade-migration scenario in 8.8
+# No migration options are needed to be configured as it's only needed for 8.8 values.
+elasticsearch:
+  maxUnavailable: 0

--- a/charts/camunda-platform-8.8/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.8/test/ci-test-config.yaml
@@ -25,6 +25,12 @@ integration:
           auth: keycloak
           shortname: eske
           exclude: []
+        - name: upgrade-migration
+          enabled: true
+          flow: upgrade-minor
+          auth: keycloak
+          shortname: eske-upgm
+          exclude: []
         - name: elasticsearch
           enabled: false
           shortname: esba

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-upgrade-migration.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-upgrade-migration.yaml
@@ -1,0 +1,66 @@
+elasticsearch:
+  maxUnavailable: 0
+
+orchestration:
+  importer:
+    enabled: true
+  migration:
+    data:
+      enabled: true
+    identity:
+      enabled: true
+    process:
+      enabled: true
+
+# We need to use different client order for test here to not interfere with the identity migration client.
+# This overrides the env vars in ../common/values-integration-test.yaml
+identity:
+  env:
+    - name: KEYCLOAK_CLIENTS_3_ID
+      value: venom
+    - name: KEYCLOAK_CLIENTS_3_NAME
+      value: Venom
+    - name: KEYCLOAK_CLIENTS_3_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: integration-test-credentials
+          key: identity-admin-client-password
+    - name: KEYCLOAK_CLIENTS_3_REDIRECT_URIS_0
+      value: /dummy
+    - name: KEYCLOAK_CLIENTS_3_ROOT_URL
+      value: http://dummy
+    - name: KEYCLOAK_CLIENTS_3_TYPE
+      value: CONFIDENTIAL
+    # Identity access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_DEFINITION
+      value: read
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_RESOURCE_SERVER_ID
+      value: camunda-identity-resource-server
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_DEFINITION
+      value: write
+    # # Orchestration access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_RESOURCE_SERVER_ID
+      value: orchestration-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_DEFINITION
+      value: "read:*"
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_RESOURCE_SERVER_ID
+      value: orchestration-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_DEFINITION
+      value: "write:*"
+    # Optimize access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_RESOURCE_SERVER_ID
+      value: optimize-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_DEFINITION
+      value: "write:*"
+    # WebModeler access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_RESOURCE_SERVER_ID
+      value: web-modeler-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_DEFINITION
+      value: "write:*"
+    # Console access.
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_RESOURCE_SERVER_ID
+      value: console-api
+    - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_DEFINITION
+      value: "write:*"

--- a/test/integration/scenarios/lib/chart-upgrade-taskfile.yaml
+++ b/test/integration/scenarios/lib/chart-upgrade-taskfile.yaml
@@ -32,10 +32,10 @@ tasks:
     - |
       helm upgrade integration {{ .TEST_CHART_NAME }} \
         --namespace {{ .TEST_NAMESPACE }} \
-        --values {{ .TEST_VALUES_BASE_DIR }}/chart-full-setup/values-integration-test-ingress-{{ .TEST_AUTH_TYPE }}.yaml \
-        --values {{ .TEST_VALUES_BASE_DIR }}/chart-full-setup/values-integration-test-ingress-{{ .TEST_VALUES_SCENARIO }}.yaml \
         --values {{ .TEST_VALUES_BASE_DIR }}/common/values-integration-test.yaml \
         --values {{ .TEST_VALUES_BASE_DIR }}/common/values-integration-test-pull-secrets.yaml \
+        --values {{ .TEST_VALUES_BASE_DIR }}/chart-full-setup/values-integration-test-ingress-{{ .TEST_AUTH_TYPE }}.yaml \
+        --values {{ .TEST_VALUES_BASE_DIR }}/chart-full-setup/values-integration-test-ingress-{{ .TEST_VALUES_SCENARIO }}.yaml \
         {{ if eq .PLATFORM "eks" -}}
         --values {{ .TEST_VALUES_BASE_DIR }}/chart-full-setup/values-integration-test-ingress-infra.yaml \
         {{ end -}}


### PR DESCRIPTION
### Which problem does the PR fix?

Task: https://github.com/camunda/camunda-platform-helm/issues/959

### What's in this PR?

Add a scenario to upgrade with migration enabled (also keep when migration is disabled, which is the default).
