### PR TITLE
fix: migration identity client secret gets set to migration secret instead of orchestration client secret

### DIFF
--- a/charts/camunda-platform-8.8/templates/identity/deployment.yaml
+++ b/charts/camunda-platform-8.8/templates/identity/deployment.yaml
@@ -140,7 +140,7 @@ spec:
             {{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.global.identity.auth.identity)) "true" }}
             {{- include "camundaPlatform.emitEnvVarFromSecretConfig" (dict
               "envName" "VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET"
-              "config" .Values.global.identity.auth.identity
+              "config" .Values.orchestration.security.authentication.oidc
             ) | nindent 12 }}
             - name: CAMUNDA_OPTIMIZE_CLIENT_ID
               value: {{ .Values.global.identity.auth.optimize.clientId | quote }}

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-keycloak-mt.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-keycloak-mt.yaml
@@ -117,6 +117,9 @@ orchestration:
     identity:
       enabled: true
       backoffLimit: 12
+      secret:
+        existingSecret: integration-test-credentials
+        existingSecretKey: identity-migration-client-secret
     data:
       enabled: true
   security:

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-keycloak-rba.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-keycloak-rba.yaml
@@ -36,6 +36,9 @@ orchestration:
       resourceAuthorizationsEnabled: true
       enabled: true
       backoffLimit: 12
+      secret:
+        existingSecret: integration-test-credentials
+        existingSecretKey: identity-migration-client-secret
     data:
       enabled: true
 

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-keycloak.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-keycloak.yaml
@@ -115,6 +115,9 @@ orchestration:
     identity:
       enabled: true
       backoffLimit: 12
+      secret:
+        existingSecret: integration-test-credentials
+        existingSecretKey: identity-migration-client-secret
     data:
       enabled: true
   security:


### PR DESCRIPTION
### Which problem does the PR fix?

I found that the orchestration client secret was being used instead of the migration identity jobs dedicated client secret. This PR adds in autogeneration for the migration identity job's client secret, as well as corrects identity.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

```diff
            {{- include "camundaPlatform.emitEnvVarFromSecretConfig" (dict
                "envName" "KEYCLOAK_CLIENTS_2_SECRET"
-                "config" .Values.orchestration.security.authentication.oidc
+                "config" .Values.orchestration.migration.identity
            ) | nindent 12 }}
```

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
