### PR TITLE
fix: reference correct migration app secret property for keycloak

### DIFF
--- a/charts/camunda-platform-8.8/templates/identity/deployment.yaml
+++ b/charts/camunda-platform-8.8/templates/identity/deployment.yaml
@@ -110,7 +110,7 @@ spec:
               value: Migration
             {{- include "camundaPlatform.emitEnvVarFromSecretConfig" (dict
                 "envName" "KEYCLOAK_CLIENTS_2_SECRET"
-                "config" .Values.orchestration.security.authentication.oidc
+                "config" .Values.orchestration.migration.identity
             ) | nindent 12 }}
             - name: KEYCLOAK_CLIENTS_2_REDIRECT_URIS_0
               value: /dummy


### PR DESCRIPTION
### Which problem does the PR fix?

This was missed with https://github.com/camunda/camunda-platform-helm/pull/4387

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
