### PR TITLE
fix: remove duplicate servicemonitor

### DIFF
--- a/charts/camunda-platform-8.8/templates/service-monitor/orchestration-service-monitor.yaml
+++ b/charts/camunda-platform-8.8/templates/service-monitor/orchestration-service-monitor.yaml
@@ -15,21 +15,4 @@ spec:
       path: {{ include "camundaPlatform.joinpath" (list .Values.orchestration.contextPath .Values.orchestration.metrics.prometheus) }}
       port: {{ default "server" .Values.orchestration.service.managementName }}
       interval: {{ .Values.prometheusServiceMonitor.scrapeInterval }}
----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: {{ include "orchestration.serviceNameHeadless" . }}
-  labels: {{- include "camundaPlatform.labels" . | nindent 4 }}
-    {{- toYaml .Values.prometheusServiceMonitor.labels | nindent 4}}
-spec:
-  selector:
-    matchLabels:
-      {{- toYaml .Values.global.labels | nindent 6 }}
-      app.kubernetes.io/component: {{ printf "%s-headless" (include "orchestration.componentName" .) }}
-  endpoints:
-    - honorLabels: true
-      path: {{ include "camundaPlatform.joinpath" (list .Values.orchestration.contextPath .Values.orchestration.metrics.prometheus) }}
-      port: {{ default "server" .Values.orchestration.service.managementName }}
-      interval: {{ .Values.prometheusServiceMonitor.scrapeInterval }}
 {{- end }}

--- a/charts/camunda-platform-8.8/test/unit/common/golden/orchestration-service-monitor.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/common/golden/orchestration-service-monitor.golden.yaml
@@ -21,26 +21,3 @@ spec:
       path: /actuator/prometheus
       port: server
       interval: 10s
----
-# Source: camunda-platform/templates/service-monitor/orchestration-service-monitor.yaml
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: camunda-platform-test-zeebe
-  labels:
-    app: camunda-platform
-    app.kubernetes.io/name: camunda-platform
-    app.kubernetes.io/instance: camunda-platform-test
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: camunda-platform
-    release: metrics
-spec:
-  selector:
-    matchLabels:
-      app: camunda-platform
-      app.kubernetes.io/component: zeebe-broker-headless
-  endpoints:
-    - honorLabels: true
-      path: /actuator/prometheus
-      port: server
-      interval: 10s


### PR DESCRIPTION
### Which problem does the PR fix?

 * We had two service monitors created, as we have two services, but both are exposing the port of the same pods
 * This caused us to duplicate our metrics unnecessarily. 
<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

closes https://github.com/camunda/camunda-platform-helm/issues/4425

### What's in this PR?

To avoid this, we removed the servicemonitor for the headless service
<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
