### PR TITLE
fix: correct release-please version

### DIFF
--- a/.github/config/release-please/.release-please-manifest.json
+++ b/.github/config/release-please/.release-please-manifest.json
@@ -2,7 +2,7 @@
     "charts/camunda-platform-8.3": "8.3.26",
     "charts/camunda-platform-8.4": "9.7.0",
     "charts/camunda-platform-8.5": "10.11.3",
-    "charts/camunda-platform-8.6": "11.9.0",
+    "charts/camunda-platform-8.6": "11.10.0",
     "charts/camunda-platform-8.7": "12.6.1",
     "charts/camunda-platform-8.8": "13.0.0-alpha8"
 }


### PR DESCRIPTION
### Which problem does the PR fix?

v11.10.0 has already been released, and although the manifest was updated in https://github.com/camunda/camunda-platform-helm/pull/4088, main does not currently reflect that.



<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

This PR corrects the release-please-manifest.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
