### PR TITLE
fix: update the links of upgrade instructions

### DIFF
--- a/charts/camunda-platform-8.5/templates/identity/constraints.tpl
+++ b/charts/camunda-platform-8.5/templates/identity/constraints.tpl
@@ -38,7 +38,7 @@ Chart Version: 10.0.0
     {{- $errorMessage := printf "[identity][error] %s %s %s"
         "The Keycloak key changed from \"identity.keycloak\" to \"identityKeycloak\"."
         "For more details, please check Camunda Helm chart documentation."
-        "https://docs.camunda.io/docs/self-managed/setup/upgrade/#version-update-instructions"
+        "https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/"
     -}}
     {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}
@@ -47,7 +47,7 @@ Chart Version: 10.0.0
     {{- $errorMessage := printf "[identity][error] %s %s %s"
         "The PostgreSQL key changed from \"identity.postgresq\" to \"identityPostgresql\"."
         "For more details, please check Camunda Helm chart documentation."
-        "https://docs.camunda.io/docs/self-managed/setup/upgrade/#version-update-instructions"
+        "https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/"
     -}}
     {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}

--- a/charts/camunda-platform-8.5/templates/zeebe-gateway/constraints.tpl
+++ b/charts/camunda-platform-8.5/templates/zeebe-gateway/constraints.tpl
@@ -13,7 +13,7 @@ Chart Version: 10.0.0
     {{- $errorMessage := printf "[zeebe-gateway] %s %s %s"
         "The Zeebe Gatway key changed from \"zeebe-gateway\" to \"zeebeGateway\"."
         "For more details, please check Camunda Helm chart documentation."
-        "https://docs.camunda.io/docs/self-managed/setup/upgrade/#version-update-instructions"
+        "https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/"
     -}}
     {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}
@@ -22,7 +22,7 @@ Chart Version: 10.0.0
     {{- $errorMessage := printf "[zeebe-gateway] %s %s %s"
         "The gRPC Ingress key changed from \"zeebeGateway.ingress\" to \"zeebeGateway.ingress.grpc\"."
         "For more details, please check Camunda Helm chart documentation."
-        "https://docs.camunda.io/docs/self-managed/setup/upgrade/#version-update-instructions"
+        "https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/"
     -}}
     {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}

--- a/charts/camunda-platform-8.6/templates/identity/constraints.tpl
+++ b/charts/camunda-platform-8.6/templates/identity/constraints.tpl
@@ -38,7 +38,7 @@ Chart Version: 10.0.0
     {{- $errorMessage := printf "[identity][error] %s %s %s"
         "The Keycloak key changed from \"identity.keycloak\" to \"identityKeycloak\"."
         "For more details, please check Camunda Helm chart documentation."
-        "https://docs.camunda.io/docs/self-managed/setup/upgrade/#version-update-instructions"
+        "https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/"
     -}}
     {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}
@@ -47,7 +47,7 @@ Chart Version: 10.0.0
     {{- $errorMessage := printf "[identity][error] %s %s %s"
         "The PostgreSQL key changed from \"identity.postgresq\" to \"identityPostgresql\"."
         "For more details, please check Camunda Helm chart documentation."
-        "https://docs.camunda.io/docs/self-managed/setup/upgrade/#version-update-instructions"
+        "https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/"
     -}}
     {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}

--- a/charts/camunda-platform-8.6/templates/zeebe-gateway/constraints.tpl
+++ b/charts/camunda-platform-8.6/templates/zeebe-gateway/constraints.tpl
@@ -13,7 +13,7 @@ Chart Version: 10.0.0
     {{- $errorMessage := printf "[zeebe-gateway] %s %s %s"
         "The Zeebe Gatway key changed from \"zeebe-gateway\" to \"zeebeGateway\"."
         "For more details, please check Camunda Helm chart documentation."
-        "https://docs.camunda.io/docs/self-managed/setup/upgrade/#version-update-instructions"
+        "https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/"
     -}}
     {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}
@@ -22,7 +22,7 @@ Chart Version: 10.0.0
     {{- $errorMessage := printf "[zeebe-gateway] %s %s %s"
         "The gRPC Ingress key changed from \"zeebeGateway.ingress\" to \"zeebeGateway.ingress.grpc\"."
         "For more details, please check Camunda Helm chart documentation."
-        "https://docs.camunda.io/docs/self-managed/setup/upgrade/#version-update-instructions"
+        "https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/"
     -}}
     {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}

--- a/charts/camunda-platform-8.7/templates/identity/constraints.tpl
+++ b/charts/camunda-platform-8.7/templates/identity/constraints.tpl
@@ -38,7 +38,7 @@ Chart Version: 10.0.0
     {{- $errorMessage := printf "[identity][error] %s %s %s"
         "The Keycloak key changed from \"identity.keycloak\" to \"identityKeycloak\"."
         "For more details, please check Camunda Helm chart documentation."
-        "https://docs.camunda.io/docs/self-managed/setup/upgrade/#version-update-instructions"
+        "https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/"
     -}}
     {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}
@@ -47,7 +47,7 @@ Chart Version: 10.0.0
     {{- $errorMessage := printf "[identity][error] %s %s %s"
         "The PostgreSQL key changed from \"identity.postgresq\" to \"identityPostgresql\"."
         "For more details, please check Camunda Helm chart documentation."
-        "https://docs.camunda.io/docs/self-managed/setup/upgrade/#version-update-instructions"
+        "https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/"
     -}}
     {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}

--- a/charts/camunda-platform-8.7/templates/zeebe-gateway/constraints.tpl
+++ b/charts/camunda-platform-8.7/templates/zeebe-gateway/constraints.tpl
@@ -13,7 +13,7 @@ Chart Version: 10.0.0
     {{- $errorMessage := printf "[zeebe-gateway] %s %s %s"
         "The Zeebe Gatway key changed from \"zeebe-gateway\" to \"zeebeGateway\"."
         "For more details, please check Camunda Helm chart documentation."
-        "https://docs.camunda.io/docs/self-managed/setup/upgrade/#version-update-instructions"
+        "https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/"
     -}}
     {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}
@@ -22,7 +22,7 @@ Chart Version: 10.0.0
     {{- $errorMessage := printf "[zeebe-gateway] %s %s %s"
         "The gRPC Ingress key changed from \"zeebeGateway.ingress\" to \"zeebeGateway.ingress.grpc\"."
         "For more details, please check Camunda Helm chart documentation."
-        "https://docs.camunda.io/docs/self-managed/setup/upgrade/#version-update-instructions"
+        "https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/"
     -}}
     {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

Update the links to the latest upgrade release notes: [https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/](https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/)

closes: https://github.com/camunda/camunda-platform-helm/issues/4167

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
