### PR TITLE
fix: fix doc links for 8.8

### DIFF
--- a/charts/camunda-platform-8.8/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.8/templates/common/constraints.tpl
@@ -400,7 +400,7 @@ Usage:
         "[camunda][error] The Helm values file key changed from \"%s\" to \"%s\". %s %s"
         .oldName .newName
         "For more details, please check Camunda Helm chart documentation."
-        "https://docs.camunda.io/docs/self-managed/setup/upgrade/#version-update-instructions"
+        "https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/"
     -}}
     {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
   {{- end }}
@@ -422,7 +422,7 @@ Usage:
         "[camunda][error] The Helm values file key \"%s\" has been removed. %s %s"
         .oldName
         "For more details, please check Camunda Helm chart documentation."
-        "https://docs.camunda.io/docs/self-managed/setup/upgrade/#version-update-instructions"
+        "https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/"
     -}}
     {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
   {{- end }}

--- a/scripts/templates/version-matrix/VERSION-MATRIX-INDEX.md.tpl
+++ b/scripts/templates/version-matrix/VERSION-MATRIX-INDEX.md.tpl
@@ -15,7 +15,7 @@ For the best experience, please remember:
 
 - Always use the `Helm CLI` version that's used with the Helm chart. It's mentioned in the matrix for all charts or under chart annotation `camunda.io/helmCLIVersion` for newer charts.
 
-- During the upgrade from the non-patch versions, ensure to review [version update instructions](https://docs.camunda.io/docs/self-managed/setup/upgrade/#version-update-instructions).
+- During the upgrade from the non-patch versions, ensure to review [version update instructions](https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/).
 
 {{ range (ds "versions") }}
 {{- $appVersion := .app }}

--- a/version-matrix/README.md
+++ b/version-matrix/README.md
@@ -15,7 +15,7 @@ For the best experience, please remember:
 
 - Always use the `Helm CLI` version that's used with the Helm chart. It's mentioned in the matrix for all charts or under chart annotation `camunda.io/helmCLIVersion` for newer charts.
 
-- During the upgrade from the non-patch versions, ensure to review [version update instructions](https://docs.camunda.io/docs/self-managed/setup/upgrade/#version-update-instructions).
+- During the upgrade from the non-patch versions, ensure to review [version update instructions](https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/).
 
 
 ## [Camunda 8.8](./camunda-8.8)


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

Fixes the doc link for 8.8. Related to https://github.com/camunda/camunda-platform-helm/pull/4450

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
