### PR TITLE
ci: rework renovate configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -307,7 +307,7 @@
         'charts/camunda-platform-8.7/values*.yaml',
       ],
       matchUpdateTypes: ['patch', 'pin'],
-      schedule: ['every day'],
+      schedule: ['at any time'],
       addLabels: ['camunda-platform', 'priority-high'],
     },
     {
@@ -328,7 +328,7 @@
         'charts/camunda-platform-8.9/values*.yaml',
       ],
       matchUpdateTypes: ['major', 'minor', 'patch'],
-      schedule: ['every day'],
+      schedule: ['at any time'],
       addLabels: ['camunda-platform', 'priority-high'],
     },
     {
@@ -349,7 +349,7 @@
         'charts/camunda-platform-8.9/values*.yaml',
       ],
       matchUpdateTypes: ['digest'],
-      schedule: ['every day'],
+      schedule: ['at any time'],
       addLabels: ['camunda-platform', 'priority-high'],
     },
     {


### PR DESCRIPTION
### Which problem does the PR fix?

Closes: [[TASK] Update renovate configuration to batch PRs](https://github.com/camunda/team-distribution/issues/626)



### What's in this PR?

Example of PRs in forked repo: https://github.com/bkenez/camunda-platform-helm-renovate/pulls

**Before**: Per-version grouping (8.2, 8.3, 8.4, etc.) = 8+ separate PRs

**After**: Update-type grouping (minor-updates, patch-updates) = 2-3 PRs total

All version constraints still apply.

Added

- Rate limiting: Max 20 concurrent PRs, 6/hour
- Weekend scheduling: Major (Fri night), Minor (Sat), Patch (Sun)
- Labels: `upgrade:major`, `upgrade:minor`, `upgrade:patch`, `requires-manual-review`
- CI safety: Waits for ALL status checks before automerge
- Auto-rebase when PRs fall behind

Removed

- Per-version chart groups (8.2-8.9)
- Version-specific labels

Impact

- 80% fewer PRs (from 20-30 to 5-10)
- Major updates require manual approval
- PRs created on weekends only

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
