### PR TITLE
fix: we need the TEST_CHART_VERSION to be set on the modular-upgrade-minor

### DIFF
--- a/.github/actions/workflow-vars/action.yaml
+++ b/.github/actions/workflow-vars/action.yaml
@@ -130,7 +130,7 @@ runs:
     run: |
       # In the upgrade flow, the latest released chart for certain minor Camunda version will installed,
       # then upgraded from the PR branch to ensure upgradability.
-      if [[ "${{ inputs.setup-flow }}" == 'upgrade-patch' || "${{ inputs.setup-flow }}" == 'upgrade-minor' ]]; then
+      if [[ "${{ inputs.setup-flow }}" == 'upgrade-patch' || "${{ inputs.setup-flow }}" == 'upgrade-minor' || "${{ inputs.setup-flow }}" == 'modular-upgrade-minor' ]]; then
         if [[ -n "${{ inputs.chart-upgrade-version }}" ]]; then
           TEST_CHART_VERSION="${{ inputs.chart-upgrade-version }}"
         fi


### PR DESCRIPTION
Fixes [39795](https://github.com/camunda/camunda/issues/39795)

`modular-upgrade-minor` is the flow used by QA to first helm install, then inject data, then helm upgrade, then assert the state of the cluster. This was missing from the step that adds the TEST_CHART_VERSION to the ENV

### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
