### PR TITLE
Bugfix Issue #4567 - Identity Keycloak URL default context path

### DIFF
--- a/charts/camunda-platform-8.5/templates/identity/_helpers.tpl
+++ b/charts/camunda-platform-8.5/templates/identity/_helpers.tpl
@@ -179,7 +179,7 @@ This is mainly used to access the external Keycloak service in the global Ingres
 [identity] Get Keycloak contextPath based on global value.
 */}}
 {{- define "identity.keycloak.contextPath" -}}
-    {{ .Values.global.identity.keycloak.contextPath | default "/auth/" }}
+    {{ .Values.global.identity.keycloak.contextPath | default "/" }}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform-8.6/templates/identity/_helpers.tpl
+++ b/charts/camunda-platform-8.6/templates/identity/_helpers.tpl
@@ -179,7 +179,7 @@ This is mainly used to access the external Keycloak service in the global Ingres
 [identity] Get Keycloak contextPath based on global value.
 */}}
 {{- define "identity.keycloak.contextPath" -}}
-    {{ .Values.global.identity.keycloak.contextPath | default "/auth/" }}
+    {{ .Values.global.identity.keycloak.contextPath | default "/" }}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform-8.7/templates/identity/_helpers.tpl
+++ b/charts/camunda-platform-8.7/templates/identity/_helpers.tpl
@@ -179,7 +179,7 @@ This is mainly used to access the external Keycloak service in the global Ingres
 [identity] Get Keycloak contextPath based on global value.
 */}}
 {{- define "identity.keycloak.contextPath" -}}
-    {{ .Values.global.identity.keycloak.contextPath | default "/auth/" }}
+    {{ .Values.global.identity.keycloak.contextPath | default "/" }}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform-8.8/templates/identity/_helpers.tpl
+++ b/charts/camunda-platform-8.8/templates/identity/_helpers.tpl
@@ -167,7 +167,7 @@ This is mainly used to access the external Keycloak service in the global Ingres
 [identity] Get Keycloak contextPath based on global value.
 */}}
 {{- define "identity.keycloak.contextPath" -}}
-    {{ .Values.global.identity.keycloak.contextPath | default "/auth/" }}
+    {{ .Values.global.identity.keycloak.contextPath | default "/" }}
 {{- end -}}
 
 

--- a/charts/camunda-platform-8.9/templates/identity/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/identity/_helpers.tpl
@@ -167,7 +167,7 @@ This is mainly used to access the external Keycloak service in the global Ingres
 [identity] Get Keycloak contextPath based on global value.
 */}}
 {{- define "identity.keycloak.contextPath" -}}
-    {{ .Values.global.identity.keycloak.contextPath | default "/auth/" }}
+    {{ .Values.global.identity.keycloak.contextPath | default "/" }}
 {{- end -}}
 
 


### PR DESCRIPTION
### Which problem does the PR fix?

Issue # 4567 https://github.com/camunda/camunda-platform-helm/issues/4567

### What's in this PR?

Update the Identity helper to default to a context path of `/` when `global.identity.keycloak.contextPath` is falsy

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
