### PR TITLE
ci: fix drop initialization mapping rules in oidc test

### DIFF
--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-oidc.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-oidc.yaml
@@ -164,15 +164,6 @@ orchestration:
         groupsClaim: ""
     authorizations:
       enabled: true
-    initialization:
-      defaultRoles:
-        admin:
-          mappingrules:
-            - demo-user-mapping-rule
-      mappingRules:
-        - mappingRuleID: demo-user-mapping-rule
-          claimName: oid
-          claimValue: $ENTRA_APP_OBJECT_ID
   migration:
     identity:
       claimName: "oid"

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-oidc.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-oidc.yaml
@@ -164,15 +164,6 @@ orchestration:
         groupsClaim: ""
     authorizations:
       enabled: true
-    initialization:
-      defaultRoles:
-        admin:
-          mappingrules:
-            - demo-user-mapping-rule
-      mappingRules:
-        - mappingRuleID: demo-user-mapping-rule
-          claimName: oid
-          claimValue: $ENTRA_APP_OBJECT_ID
 
 elasticsearch:
   maxUnavailable: 0


### PR DESCRIPTION
This PR initially reverted  camunda/camunda-platform-helm#4545

Because the oidc test was failing with this error:

```
camunda-migration [2025-10-24 14:17:02.461[] [main[] ERROR
camunda-migration     io.camunda.application.commons.migration.BlockingMigrationsRunner - The cause of the failed migration was: Failed to assign role: identity to mapping rule: default
camunda-migration io.camunda.migration.api.MigrationException: Failed to assign role: identity to mapping rule: default
camunda-migration     at io.camunda.migration.identity.handler.sm.MappingRuleMigrationHandler.lambda$assignRolesToMappingRule$6(MappingRuleMigrationHandler.java:138)
camunda-migration     at java.base/java.lang.Iterable.forEach(Unknown Source)
camunda-migration     at io.camunda.migration.identity.handler.sm.MappingRuleMigrationHandler.assignRolesToMappingRule(MappingRuleMigrationHandler.java:123)
camunda-migration     at io.camunda.migration.identity.handler.sm.MappingRuleMigrationHandler.lambda$process$2(MappingRuleMigrationHandler.java:104)
camunda-migration     at java.base/java.util.ArrayList.forEach(Unknown Source)
camunda-migration     at io.camunda.migration.identity.handler.sm.MappingRuleMigrationHandler.lambda$process$4(MappingRuleMigrationHandler.java:103)
stream closed EOF for camunda-pr-4575-intg-8-8-gke-esoi-6212ec-upgm/integration-zeebe-migration-identity-8h4vb (wait-for-orchestration)
camunda-migration     at java.base/java.util.HashMap$Values.forEach(Unknown Source)
camunda-migration     at io.camunda.migration.identity.handler.sm.MappingRuleMigrationHandler.process(MappingRuleMigrationHandler.java:77)
camunda-migration     at io.camunda.migration.identity.handler.MigrationHandler.migrate(MigrationHandler.java:51)
camunda-migration     at io.camunda.migration.identity.handler.IdentityMigrator.migrate(IdentityMigrator.java:50)
camunda-migration     at io.camunda.migration.identity.handler.IdentityMigrator.call(IdentityMigrator.java:42)
camunda-migration     at io.camunda.migration.identity.handler.IdentityMigrator.call(IdentityMigrator.java:21)
camunda-migration     at io.camunda.application.commons.migration.BlockingMigrationsRunner.run(BlockingMigrationsRunner.java:40)
camunda-migration     at io.camunda.application.StandaloneIdentityMigration.run(StandaloneIdentityMigration.java:58)
camunda-migration     at org.springframework.boot.SpringApplication.lambda$callRunner$5(SpringApplication.java:788)
camunda-migration     at org.springframework.util.function.ThrowingConsumer$1.acceptWithException(ThrowingConsumer.java:82)
camunda-migration     at org.springframework.util.function.ThrowingConsumer.accept(ThrowingConsumer.java:60)
camunda-migration     at org.springframework.util.function.ThrowingConsumer$1.accept(ThrowingConsumer.java:86)
camunda-migration     at org.springframework.boot.SpringApplication.callRunner(SpringApplication.java:796)
camunda-migration     at org.springframework.boot.SpringApplication.callRunner(SpringApplication.java:787)
camunda-migration     at org.springframework.boot.SpringApplication.lambda$callRunners$3(SpringApplication.java:772)
camunda-migration     at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(Unknown Source)
camunda-migration     at java.base/java.util.stream.SortedOps$SizedRefSortingSink.end(Unknown Source)
camunda-migration     at java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source)
camunda-migration     at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)
camunda-migration     at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(Unknown Source)
camunda-migration     at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(Unknown Source)
camunda-migration     at java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source)
camunda-migration     at java.base/java.util.stream.ReferencePipeline.forEach(Unknown Source)
camunda-migration     at org.springframework.boot.SpringApplication.callRunners(SpringApplication.java:772)
camunda-migration     at org.springframework.boot.SpringApplication.run(SpringApplication.java:325)
camunda-migration     at io.camunda.application.StandaloneIdentityMigration.main(StandaloneIdentityMigration.java:52)
camunda-migration Caused by: java.util.concurrent.CompletionException: io.camunda.service.exception.ServiceException: Command 'ADD_ENTITY' rejected with code 'NOT_FOUND': Expected to add an entity with ID 'default' and type 'MAPPING_RULE' to role with ID 'identity', but the entity doesn't exist.
camunda-migration     at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(Unknown Source)
camunda-migration     at java.base/java.util.concurrent.CompletableFuture.completeThrowable(Unknown Source)
camunda-migration     at java.base/java.util.concurrent.CompletableFuture.uniHandle(Unknown Source)
camunda-migration     at java.base/java.util.concurrent.CompletableFuture$UniHandle.tryFire(Unknown Source)
camunda-migration     at java.base/java.util.concurrent.CompletableFuture$Completion.run(Unknown Source)
camunda-migration     at java.base/java.lang.Thread.run(Unknown Source)
camunda-migration Caused by: io.camunda.service.exception.ServiceException: Command 'ADD_ENTITY' rejected with code 'NOT_FOUND': Expected to add an entity with ID 'default' and type 'MAPPING_RULE' to role with ID 'identity', but the entity doesn't exist.
camunda-migration     at io.camunda.service.exception.ErrorMapper.mapError(ErrorMapper.java:50)
camunda-migration     at io.camunda.service.ApiServices.lambda$sendBrokerRequestWithFullResponse$0(ApiServices.java:71)
camunda-migration     ... 4 more

```

After investigation, I found that the PR was correct, and that it was just the test configuration that is faulty.

In upgrade-minor workflows, it does not make sense to add the initialization options because the migrator serves the purpose of copying the roles and mapping rules over to the orchestration identity. If the initialization options are set, then the migrator gets confused. 

This option wasn't necessary anyway since the default mapping rules and default roles already work.