### PR TITLE
fix: setting zeebe image tag shouldnt disable broker profile

### DIFF
--- a/charts/camunda-platform-8.8/templates/z/1/2/3/4/5/6/7/8/z_compatibility_helpers.tpl
+++ b/charts/camunda-platform-8.8/templates/z/1/2/3/4/5/6/7/8/z_compatibility_helpers.tpl
@@ -80,7 +80,7 @@ Orchestration compatibility.
         {{- $_ := set .Values.orchestration "javaOpts" (.Values.orchestration.javaOpts | replace "zeebe" "camunda") -}}
     {{- end -}}
 
-    {{- if and .Values.zeebe -}}
+    {{- if and .Values.zeebe (hasKey .Values.zeebe "enabled") -}}
         {{/*
             zeebe.enabled => orchestration.profiles.broker
         */}}


### PR DESCRIPTION
### Which problem does the PR fix?

Closes: [#4338](https://github.com/camunda/camunda-platform-helm/issues/4338)

### What's in this PR?

**Before the fix:**
```bash
# Without zeebe values
active: "broker,identity,operate,tasklist,consolidated-auth"  

# With zeebe.image.tag=bla  
active: "identity,operate,tasklist,consolidated-auth"  
```

**After the fix:**
```bash
# Without zeebe values
active: "broker,identity,operate,tasklist,consolidated-auth"  

# With zeebe.image.tag=bla
active: "broker,identity,operate,tasklist,consolidated-auth" 
```

The fix ensures that setting `zeebe.image.tag` (or any other `zeebe.*` value) doesn't accidentally trigger the compatibility helper to disable the broker profile. 

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
