### PR TITLE
docs: add instructions for backporting

### DIFF
--- a/docs/backporting.md
+++ b/docs/backporting.md
@@ -1,0 +1,32 @@
+
+# Backporting commits in subdirectory versioning
+
+## format-patch
+
+git format-patch will export the git commits to a series of patch files that can be applied to a different branch or a different sub directory.
+
+To export the last 3 commits as patch files, run:
+
+```bash
+git format-patch HEAD^3
+```
+
+New files will be created starting with `0001-`, `0002-`, etc.
+
+## applying patch files without AI
+
+Suppose you have a patch file `0001-refactor-web-modeler-make-webapp-memory-config-dynam.patch` that you want to apply to the `charts/camunda-platform-8.7` directory.
+
+```bash
+git apply -p3 --directory=charts/camunda-platform-8.7 0001-refactor-web-modeler-make-webapp-memory-config-dynam.patch
+```
+
+In many cases, this will apply cleanly, but if the command does not work, you can try using OpenCode or your editors AI integration.
+
+## applying patch files with AI
+
+If you have an AI tool integrated into your IDE, a query you can use is:
+
+```
+I have exported commits as patch files starting with 000*.patch using git format-patch. Please apply the patch to the charts/camunda-platform-8.7 directory.
+```


### PR DESCRIPTION
### Which problem does the PR fix?

In our team meeting we discussed having a page explaining how to backport commits.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
