### PR TITLE
chore: bump bitnami postgres chart version for Identity to latest sup…

### DIFF
--- a/charts/camunda-platform-8.9/Chart.yaml
+++ b/charts/camunda-platform-8.9/Chart.yaml
@@ -35,7 +35,7 @@ dependencies:
   - name: postgresql
     alias: identityPostgresql
     repository: oci://registry-1.docker.io/bitnamicharts
-    version: 15.x.x
+    version: 16.x.x
     condition: "identityPostgresql.enabled"
   # WebModeler Dependencies.
   - name: web-modeler-postgresql


### PR DESCRIPTION
…port version

### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

Closes https://github.com/camunda/identity/issues/3457

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

As per https://github.com/camunda/identity/issues/3457 we moved to support Postgres 17 with the 8.8 release. This PR upgrades the chart dependencies to ship Postgres v17 for 8.8 and 8.9.

Note: I have increased the postgres chart version for the 8.8 release, I hope this is fine and would like confirmation on this.
