### PR TITLE
fix: attempt to fix renovate ignoring versions <8.8

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -159,15 +159,6 @@
         'elasticsearch-curator-archived',
       ],
     },
-    {
-      description: 'Enable patch updates for Camunda components in previous chart versions.',
-      matchDatasources: ['helmv3', 'helm-values', 'docker', 'regex'],
-      matchFileNames: [
-        'charts/camunda-platform-8.*/values.yaml',
-        'charts/camunda-platform-8.*/values-latest.yaml',
-      ],
-      matchUpdateTypes: ['patch'],
-    },
     // Elasticsearch version constraints per chart version
     {
       description: 'Camunda 8.3: Limit Elasticsearch to 8.13.x',
@@ -289,7 +280,8 @@
         '/.*camunda.*/',
       ],
       matchDatasources: [
-        'helm',
+        'helmv3',
+        'helm-values',
         'docker',
         'regex',
       ],
@@ -327,7 +319,8 @@
         '/.*camunda.*/',
       ],
       matchDatasources: [
-        'helm',
+        'helmv3',
+        'helm-values',
         'docker',
         'regex',
       ],


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

For some mystery reason, renovate ignored updating docker image versions for camunda charts <8.8 even though the same rules applied to earlier version. This is an attempt to fix it.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
