### PR TITLE
fix: set separateMajorMinor and separateMinorPatch to true

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,8 +14,8 @@
   recreateWhen: 'always',
   rebaseWhen: 'behind-base-branch',
   commitBodyTable: true,
-  separateMajorMinor: false,
-  separateMinorPatch: false,
+  separateMajorMinor: true,
+  separateMinorPatch: true,
   ignoreTests: false,
   prCreation: 'not-pending',
   prBodyNotes: [


### PR DESCRIPTION

### Which problem does the PR fix?

closes https://github.com/camunda/camunda-platform-helm/issues/4628

Renovate wouldn't upgrade values-latest.yaml in 8.6 and 8.7 because it kept proposing upgrades to 8.8 and filtering out those updates after-the-fact.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

These need to be true so that 8.6 will stop trying to upgrade to 8.8 before filtering out the update because minor upgrades are not allowed.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
