### PR TITLE
ci: execute the rerun-failed-run gha only once per workflow run

### DIFF
--- a/.github/workflows/test-chart-version-template.yaml
+++ b/.github/workflows/test-chart-version-template.yaml
@@ -71,6 +71,11 @@ on:
         default: false
         type: boolean
         required: false
+      github-workflow-rerun-enabled:
+        description: Flag to enable or disable retries for failed runs
+        required: false
+        default: true
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.pr-number }}-${{ inputs.shortname }}-${{ inputs.flows }}-${{ inputs.camunda-version }}-${{ inputs.auth }}-${{ inputs.flows }}-${{ inputs.exclude }}-${{ inputs.platforms }}
@@ -125,6 +130,7 @@ jobs:
       camunda-helm-upgrade-version: "${{ inputs.camunda-helm-upgrade-version }}"
       camunda-version-previous: "${{ inputs.camunda-version-previous }}"
       always-delete-namespace: "${{ inputs.always-delete-namespace }}"
+      github-workflow-rerun-enabled: "${{ inputs.github-workflow-rerun-enabled }}"
       vault-secret-mapping: |
         secret/data/products/distribution/ci ENTRA_APP_CLIENT_ID;
         secret/data/products/distribution/ci ENTRA_APP_CLIENT_SECRET;

--- a/.github/workflows/test-chart-version.yaml
+++ b/.github/workflows/test-chart-version.yaml
@@ -93,6 +93,11 @@ on:
         default: true
         type: boolean
         required: false
+      skip-github-workflow-rerun:
+        description: Flag to skip retries for failed runs
+        default: false
+        type: boolean
+        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.run_id }}
@@ -189,3 +194,23 @@ jobs:
       camunda-version-previous: ${{ matrix.camundaVersionPrevious }}
       test-enabled: ${{ inputs.test-enabled || true }}
       always-delete-namespace: ${{ inputs.always-delete-namespace || true }}
+      github-workflow-rerun-enabled: false
+
+  rerun-failed-jobs:
+    name: Rerun failed jobs
+    needs: [integration-tests]
+    if: failure() && (!inputs.skip-github-workflow-rerun) && fromJSON(github.run_attempt) < 3
+    runs-on: ubuntu-latest
+    steps:
+      - name: Retrigger job
+        uses: camunda/infra-global-github-actions/rerun-failed-run@main
+        with:
+          error-messages: |
+            lost communication with the server.
+            The runner has received a shutdown signal.
+            Process completed with exit code 1.
+          run-id: ${{ github.run_id }}
+          repository: ${{ github.repository }}
+          vault-addr: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}


### PR DESCRIPTION
### Which problem does the PR fix?

The reusable `test-integration-template.yaml` workflow [uses the rerun-failed-run composite action](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/test-integration-template.yaml#L333-L350) and is invoked multiple times via [test-chart-version.yml](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/test-chart-version.yaml) via a matrix.

👉 When several jobs fail, each invocation triggers `rerun-failed-run`, resulting in multiple simultaneous retry attempts for the same workflow run, which causes issues e.g. https://github.com/camunda/infra-global-github-actions/actions/runs/19137844553/job/54694442963

Tests (includes temporary changes to simulate job failures):
- push/pr event: https://github.com/camunda/camunda-platform-helm/actions/runs/19140650205
- dispatch event with skip-rerun enabled: https://github.com/camunda/camunda-platform-helm/actions/runs/19140995871/job/54705727429

### What's in this PR?

- `rerun-failed-run` is now executed only once, as the final job of the `test-chart-version.yml` workflow
- concerned reusable workflows are configured so they don’t trigger reruns themselves

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
