### PR TITLE
fix: disable version check restrict on qa upgrades

### DIFF
--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch-upg.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch-upg.yaml
@@ -51,6 +51,8 @@ orchestration:
   env:
     - name: JAVA_TOOL_OPTIONS
       value: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5007"
+    - name: CAMUNDA_DATABASE_SCHEMAMANAGER_VERSIONCHECKRESTRICTIONENABLED
+      value: "false"
   importer:
     enabled: true
   migration:


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

The version check restriction needs to be updated on QA upgrade workflows so that we can test the upgrade path between 8.7-SNAPSHOT -> 8.8-SNAPSHOT.

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
