### PR TITLE
fix: add connectors logging to application.yaml

### DIFF
--- a/charts/camunda-platform-8.7/templates/connectors/configmap.yaml
+++ b/charts/camunda-platform-8.7/templates/connectors/configmap.yaml
@@ -60,6 +60,10 @@ data:
       client:
         enabled: false
     {{- end }}
+    logging:
+{{- with .Values.connectors.logging }}
+{{ . | toYaml | indent 6 }}
+{{- end }}
   {{- end }}
 
 {{- range $key, $val := .Values.connectors.extraConfiguration }}


### PR DESCRIPTION
Add logging configuration to the connectors configmap.

closes #3322 

### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

Currently, the `connectors.logging` properties are ignored.

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

This PR adds the `connectors.logging` in the exact same way as `operate.logging` is added to operate.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

### To-Do

- [ ] check whether this fix needs to be ported to older/newer versions
- [ ] create a test to verify the yaml format works as expected
