### PR TITLE
fix: zeebe gateway has a context path

### DIFF
--- a/charts/camunda-platform-8.7/templates/connectors/_helpers.tpl
+++ b/charts/camunda-platform-8.7/templates/connectors/_helpers.tpl
@@ -17,7 +17,7 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{- define "connectors.zeebeRestEndpoint" -}}
-  http://{{- include "zeebe.names.gateway" . | replace "\"" "" -}}:{{- .Values.zeebeGateway.service.restPort -}}
+  http://{{- include "zeebe.names.gateway" . | replace "\"" "" -}}:{{- .Values.zeebeGateway.service.restPort -}}{{- .Values.zeebeGateway.contextPath -}}
 {{- end -}}
 
 {{- define "connectors.fullname" -}}


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

This PR fixes the zeebeGatewayRestAddress for the connector runtime by appending the context path

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
