### PR TITLE
feat: implement YAML marshaling for Kubernetes Secret and add yaml.v3…

### DIFF
--- a/scripts/vault-secret-mapper/go.mod
+++ b/scripts/vault-secret-mapper/go.mod
@@ -2,4 +2,4 @@ module vault-secret-mapper
 
 go 1.21
 
-
+require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/scripts/vault-secret-mapper/go.sum
+++ b/scripts/vault-secret-mapper/go.sum
@@ -1,0 +1,3 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This PR fixes an issue where multiline ENV VARs for ENV VARs starting with `---------` like the license keys, produced invalid yaml


----- COPILOT SUMMARY ----
This pull request refactors the `vault-secret-mapper` script to simplify and improve the generation of Kubernetes Secret YAML files. The main change is switching from manual string-building of YAML to using the `yaml.v3` library for serialization, which enhances maintainability and correctness. Additional improvements include restructuring how secret data and metadata are handled.

**YAML serialization and data handling:**

* Replaced manual YAML string construction with structured types (`Secret`, `Metadata`) and marshaling using the `gopkg.in/yaml.v3` library, ensuring more robust and maintainable YAML output. [[1]](diffhunk://#diff-94dc7e41dd944b0e94dae026ca4ccac703545fab0389b2312a2c122b505e5f4aR8-R25) [[2]](diffhunk://#diff-94dc7e41dd944b0e94dae026ca4ccac703545fab0389b2312a2c122b505e5f4aL38-R83) [[3]](diffhunk://#diff-764aa0fe5d0a6f7a31c0b05fbc09dd1015235848689e82ec17832310557796f7L5-R5)
* Changed the `stringData` collection from a slice of key-value pairs to a map, simplifying data handling and integration with the YAML library.

**Metadata and labels:**

* Added automatic population of the `managed-by` label and conditional inclusion of the `github-id` label from environment variables in the Secret metadata.

**Code cleanup:**

* Removed legacy functions for manual YAML quoting and escaping, as well as the old string-building logic for YAML output, since these are now handled by the YAML library.

**Minor fixes:**

* Simplified line trimming logic in `parseMapping` by removing redundant checks.… dependency

### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
