### PR TITLE
ci: fix canellation job to run if tests are skipped or cancelled

### DIFF
--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -972,7 +972,7 @@ jobs:
   cleanup:
     name: Cleanup - ${{ inputs.flow }} on ${{ inputs.distro-platform }} - ${{ inputs.shortname }}
     needs: [playwright-e2e-tests, playwright-integration-tests-after-install, playwright-integration-tests-after-upgrade]
-    if: ${{ always() && contains(needs.*.result, 'success') }}
+    if: ${{ always() && (contains(needs.*.result, 'success') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
The problem: the intent of cleanup job is to clean up the namespace after all other jobs have run. The expectation was that by putting `if: always()` in the job, it would always run. This is not the case though. The `always()` clause on a job is only evaluated after the job is scheduled. And the job is only schedule if the `needs:` determines that it should be scheduled

The effect is, always will only apply if a needs job has succeeded.  To fix this, you need to include the conditions under which the job should run in the `if:` clause

So what we see before this change is, if install fails, then the tests are skipped and the cleanup doesn't run. 

What will happen after this change is, if install fails, then the tests are skipped and the cleanup WILL run.


---- COPILOT -----

This pull request makes a small adjustment to the workflow cleanup logic in `.github/workflows/test-integration-runner.yaml`. The change ensures that the cleanup job runs not only when all dependent jobs succeed, but also when any are skipped or cancelled.

* Updated the `cleanup` job condition to trigger if any of the required jobs are successful, skipped, or cancelled, instead of only on success.### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
