### PR TITLE
chore: correct version-matrix index after 8.6 and 8.7 releases

### DIFF
--- a/version-matrix/README.md
+++ b/version-matrix/README.md
@@ -62,6 +62,7 @@ For the best experience, please remember:
 
 ## [Camunda 8.6](./camunda-8.6)
 
+### [Helm chart 11.11.0](./camunda-8.6/#helm-chart-11110)
 ### [Helm chart 11.10.3](./camunda-8.6/#helm-chart-11103)
 ### [Helm chart 11.10.2](./camunda-8.6/#helm-chart-11102)
 ### [Helm chart 11.10.1](./camunda-8.6/#helm-chart-11101)
@@ -274,7 +275,3 @@ For the best experience, please remember:
 ### [Helm chart 0.0.30](./camunda-1.3/#helm-chart-0030)
 ### [Helm chart 0.0.29](./camunda-1.3/#helm-chart-0029)
 ### [Helm chart 0.0.28](./camunda-1.3/#helm-chart-0028)
-
-## [Camunda ](./camunda-)
-
-### [Helm chart ](./camunda-/#helm-chart-)


### PR DESCRIPTION
## Description

Fixes the version-matrix index file after the 8.6 and 8.7 releases:
- Add missing 11.11.0 entry under Camunda 8.6 section
- Add missing 12.7.1 entry under Camunda 8.7 section
- Remove malformed empty Camunda section at end of file