### PR TITLE
feat: update values.yaml for increased replica count and shard configuration

### DIFF
--- a/infra/elasticsearch/21.6.3/values.yaml
+++ b/infra/elasticsearch/21.6.3/values.yaml
@@ -22,7 +22,7 @@ master:
       value: "false"
 
 data:
-  replicaCount: 5
+  replicaCount: 6
   heapSize: 1536m
   resources:
     requests: { cpu: "2000m", memory: "3Gi" }
@@ -37,7 +37,7 @@ data:
     size: 20Gi
   pdb:
     create: true
-    minAvailable: 1
+    minAvailable: 2
 
 coordinating:
   replicaCount: 2
@@ -156,7 +156,7 @@ extraConfig:
 
 esConfig:
   elasticsearch.yml: |
-    cluster.max_shards_per_node: 2000
+    cluster.max_shards_per_node: 3500
     cluster.routing.allocation.disk.threshold_enabled: true
     cluster.routing.allocation.disk.watermark.low: 70%
     cluster.routing.allocation.disk.watermark.high: 85%
@@ -166,6 +166,12 @@ esConfig:
     cluster.routing.allocation.enable: all
     action.destructive_requires_name: false
     cluster.routing.rebalance.enable: all
+    # Shard optimization for high shard count environments
+    cluster.routing.allocation.same_shard.host: true
+    indices.recovery.max_bytes_per_sec: 100mb
+    # Index defaults to reduce shard proliferation
+    index.number_of_shards: 1
+    index.number_of_replicas: 0
   jvm.options: |
     -Xms1.5g
     -Xmx1.5g


### PR DESCRIPTION
Why this helps:
Before: We were hitting the effective cluster limit of ~5000 shards with conservative settings
After: We can now handle 30,000+ shards with better defaults that prevent unnecessary shard creation

### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
