### PR TITLE
fix: correct extraVolumeMounts binding in importer deployment

### DIFF
--- a/charts/camunda-platform-8.8/templates/orchestration/importer-deployment.yaml
+++ b/charts/camunda-platform-8.8/templates/orchestration/importer-deployment.yaml
@@ -201,7 +201,7 @@ spec:
               readOnly: true
             {{- end }}
             {{- if .Values.orchestration.importer.extraVolumeMounts }}
-            {{ .Values.orchestration.extraVolumeMounts | toYaml | nindent 12 }}
+            {{ .Values.orchestration.importer.extraVolumeMounts | toYaml | nindent 12 }}
             {{- end }}
       volumes:
         {{- if .Values.global.elasticsearch.tls.existingSecret }}


### PR DESCRIPTION
### Which problem does the PR fix?

Closes: https://github.com/camunda/camunda-platform-helm/issues/4819

### What's in this PR?

Fixes wrong binding of `extraVolumeMounts` in the importer deployment template.

The condition on line 203 checks `.Values.orchestration.importer.extraVolumeMounts` but line 204 was incorrectly using `.Values.orchestration.extraVolumeMounts` (missing `.importer`).

This fix ensures the correct value path is used consistently.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?