### PR TITLE
ci: update the scenarios so they all get the credientals to pull from…

### DIFF
--- a/test/integration/testsuites/base/patches/job-image-pull-secrets.yaml
+++ b/test/integration/testsuites/base/patches/job-image-pull-secrets.yaml
@@ -4,3 +4,7 @@
   path: /spec/template/spec/imagePullSecrets/-
   value:
     name: index-docker-io
+- op: add
+  path: /spec/template/spec/imagePullSecrets/-
+  value:
+    name: registry-camunda-cloud


### PR DESCRIPTION
The app teams push PR images to habor. We require all apps to be able to pull from there


This pull request makes a minor update to the job image pull secrets configuration in the test suite. A new image pull secret has been added to support pulling images from an additional registry.

* Added a new image pull secret named `registry-camunda-cloud` to the `imagePullSecrets` list in `test/integration/testsuites/base/patches/job-image-pull-secrets.yaml` to enable access to the Camunda Cloud registry.… habor

### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
