### PR TITLE
fix: remove client permissions for orchestration cluster and connectors from management identity

### DIFF
--- a/charts/camunda-platform-8.9/templates/identity/configmap.yaml
+++ b/charts/camunda-platform-8.9/templates/identity/configmap.yaml
@@ -211,12 +211,6 @@ data:
               definition: read
             - resourceServerId: camunda-identity-resource-server
               definition: write
-            {{- if eq (include "orchestration.authMethod" .) "oidc" }}
-            - resourceServerId: orchestration-api
-              definition: read:*
-            - resourceServerId: orchestration-api
-              definition: write:*
-            {{- end }}
             - resourceServerId: optimize-api
               definition: write:*
             - resourceServerId: web-modeler-api
@@ -259,9 +253,6 @@ data:
             {{- end }}
             {{- if .Values.console.enabled }}
             - Console
-            {{- end }}
-            {{- if eq (include "orchestration.authMethod" .) "oidc" }}
-            - Orchestration
             {{- end }}
           {{- end }}
         {{- end }}


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
closes: https://github.com/camunda/camunda-platform-helm/issues/4447
### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
