### PR TITLE
test: re enable identity configmap tests

### DIFF
--- a/charts/camunda-platform-8.8/test/unit/identity/configmap_test.go
+++ b/charts/camunda-platform-8.8/test/unit/identity/configmap_test.go
@@ -39,10 +39,10 @@ func TestSpringConfigMapTemplate(t *testing.T) {
 func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 	testCases := []testhelpers.TestCase{
 		{
-			Skip:                 true,
 			Name:                 "TestContainerShouldAddContextPath",
 			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
 			Values: map[string]string{
+				"identity.enabled":     "true",
 				"identity.fullURL":     "https://mydomain.com/identity",
 				"identity.contextPath": "/identity",
 			},
@@ -61,11 +61,11 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 				s.Require().Equal("/identity", configmapApplication.Server.Servlet.ContextPath)
 			},
 		}, {
-			Skip: true,
 			Name: "TestConfigMapBuiltinDatabaseEnabled",
 			Values: map[string]string{
+				"identity.enabled":              "true",
 				"identity.multitenancy.enabled": "true",
-				"identityPostgresql.enabled":  "true",
+				"identityPostgresql.enabled":    "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var configmap corev1.ConfigMap
@@ -87,10 +87,10 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 		}, {
 			Name: "TestConfigMapGlobalMultitenancySetsIdentityFlag",
 			Values: map[string]string{
-				"global.multitenancy.enabled":   "true",
-				"identityPostgresql.enabled":    "true",
-				"identity.enabled":              "true",
-				"global.identity.auth.enabled":  "true",
+				"global.multitenancy.enabled":  "true",
+				"identityPostgresql.enabled":   "true",
+				"identity.enabled":             "true",
+				"global.identity.auth.enabled": "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var configmap corev1.ConfigMap
@@ -110,15 +110,15 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 		}, {
 			Name: "TestConfigMapExternalDatabaseEnabled",
 			Values: map[string]string{
-				"identity.enabled":                     "true",
-				"global.identity.auth.enabled":        "true",
-				"identity.multitenancy.enabled":       "true",
-				"identityPostgresql.enabled":          "false",
-				"identity.externalDatabase.enabled":   "true",
-				"identity.externalDatabase.host":      "my-database-host",
-				"identity.externalDatabase.port":      "2345",
-				"identity.externalDatabase.database":  "my-database-name",
-				"identity.externalDatabase.username":  "my-database-username",
+				"identity.enabled":                   "true",
+				"global.identity.auth.enabled":       "true",
+				"identity.multitenancy.enabled":      "true",
+				"identityPostgresql.enabled":         "false",
+				"identity.externalDatabase.enabled":  "true",
+				"identity.externalDatabase.host":     "my-database-host",
+				"identity.externalDatabase.port":     "2345",
+				"identity.externalDatabase.database": "my-database-name",
+				"identity.externalDatabase.username": "my-database-username",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var configmap corev1.ConfigMap
@@ -138,9 +138,9 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 				s.Require().Equal("my-database-username", configmapApplication.Spring.DataSource.Username)
 			},
 		}, {
-			Skip: true,
 			Name: "TestConfigMapAuthIssuerBackendUrlWhenExplicitlyDefined",
 			Values: map[string]string{
+				"identity.enabled":                      "true",
 				"identityKeycloak.enabled":              "false",
 				"global.identity.auth.enabled":          "false",
 				"global.identity.auth.issuerBackendUrl": "https://example.com/",
@@ -185,9 +185,9 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 				s.Require().Equal("https://camunda-platform-test.example.com/", configmapApplication.Identity.AuthProvider.BackendUrl)
 			},
 		}, {
-			Skip: true,
 			Name: "TestConfigMapAuthIssuerBackendUrlWhenKeycloakUrlDefined",
 			Values: map[string]string{
+				"identity.enabled":                      "true",
 				"global.identity.keycloak.url.protocol": "https",
 				"global.identity.keycloak.url.host":     "keycloak.com",
 				"global.identity.keycloak.url.port":     "443",
@@ -209,23 +209,6 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 
 				s.Require().Equal("https://keycloak.com:443/auth/camunda-platform", configmapApplication.Identity.AuthProvider.BackendUrl)
 			},
-		}, {
-			Skip:   true,
-			Name:   "TestConfigMapAuthIssuerBackendUrlWhenKeycloakNotDefined",
-			Values: map[string]string{},
-			Verifier: func(t *testing.T, output string, err error) {
-				var configmap corev1.ConfigMap
-				var configmapApplication IdentityConfigYAML
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
-				if e != nil {
-					s.Fail("Failed to unmarshal yaml. error=", e)
-				}
-
-				// then
-				s.NotEmpty(configmap.Data)
-
-				s.Require().Equal("http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform", configmapApplication.Identity.AuthProvider.BackendUrl)
-			},
 		},
 		// Hybrid Auth Tests - verify OIDC client config is only included for components using OIDC auth
 		{
@@ -233,11 +216,11 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 			Name:                 "TestBasicAuthExcludesOidcConfig",
 			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
 			Values: map[string]string{
-				"identity.enabled":                               "true",
-				"global.identity.auth.enabled":                   "true",
-				"connectors.security.authentication.method":      "basic",
-				"orchestration.security.authentication.method":   "basic",
-				"connectors.enabled":                             "true",
+				"identity.enabled":                             "true",
+				"global.identity.auth.enabled":                 "true",
+				"connectors.security.authentication.method":    "basic",
+				"orchestration.security.authentication.method": "basic",
+				"connectors.enabled":                           "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var configmap corev1.ConfigMap
@@ -256,10 +239,10 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 			Name:                 "TestGlobalOidcAuthIncludesBothOidcConfigs",
 			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
 			Values: map[string]string{
-				"identity.enabled":                            "true",
-				"global.identity.auth.enabled":                "true",
-				"global.security.authentication.method":       "oidc",
-				"connectors.enabled":                          "true",
+				"identity.enabled":                      "true",
+				"global.identity.auth.enabled":          "true",
+				"global.security.authentication.method": "oidc",
+				"connectors.enabled":                    "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var configmap corev1.ConfigMap
@@ -278,11 +261,11 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 			Name:                 "TestHybridAuthConnectorsBasicOrchestrationOidc",
 			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
 			Values: map[string]string{
-				"identity.enabled":                              "true",
-				"global.identity.auth.enabled":                  "true",
-				"connectors.security.authentication.method":     "basic",
-				"orchestration.security.authentication.method":  "oidc",
-				"connectors.enabled":                            "true",
+				"identity.enabled":                             "true",
+				"global.identity.auth.enabled":                 "true",
+				"connectors.security.authentication.method":    "basic",
+				"orchestration.security.authentication.method": "oidc",
+				"connectors.enabled":                           "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var configmap corev1.ConfigMap
@@ -302,10 +285,10 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 			Name:                 "TestFirstUserRolesExcludeOrchestrationWhenBasicAuth",
 			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
 			Values: map[string]string{
-				"identity.enabled":                              "true",
-				"identity.firstUser.enabled":                    "true",
-				"global.identity.auth.enabled":                  "true",
-				"orchestration.security.authentication.method":  "basic",
+				"identity.enabled":                             "true",
+				"identity.firstUser.enabled":                   "true",
+				"global.identity.auth.enabled":                 "true",
+				"orchestration.security.authentication.method": "basic",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var configmap corev1.ConfigMap
@@ -324,10 +307,10 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 			Name:                 "TestFirstUserRolesIncludeOrchestrationWhenOidcAuth",
 			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
 			Values: map[string]string{
-				"identity.enabled":                              "true",
-				"identity.firstUser.enabled":                    "true",
-				"global.identity.auth.enabled":                  "true",
-				"orchestration.security.authentication.method":  "oidc",
+				"identity.enabled":                             "true",
+				"identity.firstUser.enabled":                   "true",
+				"global.identity.auth.enabled":                 "true",
+				"orchestration.security.authentication.method": "oidc",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var configmap corev1.ConfigMap
@@ -346,10 +329,10 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 			Name:                 "TestConnectorsDisabledExcludesOidcConfig",
 			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
 			Values: map[string]string{
-				"identity.enabled":                        "true",
-				"global.identity.auth.enabled":            "true",
-				"global.security.authentication.method":   "oidc",
-				"connectors.enabled":                      "false",
+				"identity.enabled":                      "true",
+				"global.identity.auth.enabled":          "true",
+				"global.security.authentication.method": "oidc",
+				"connectors.enabled":                    "false",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var configmap corev1.ConfigMap
@@ -369,11 +352,11 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 			Name:                 "TestOrchestrationDisabledExcludesOidcConfig",
 			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
 			Values: map[string]string{
-				"identity.enabled":                        "true",
-				"global.identity.auth.enabled":            "true",
-				"global.security.authentication.method":   "oidc",
-				"orchestration.enabled":                   "false",
-				"connectors.enabled":                      "true",
+				"identity.enabled":                      "true",
+				"global.identity.auth.enabled":          "true",
+				"global.security.authentication.method": "oidc",
+				"orchestration.enabled":                 "false",
+				"connectors.enabled":                    "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var configmap corev1.ConfigMap
@@ -393,11 +376,11 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 			Name:                 "TestBothDisabledExcludesOidcConfig",
 			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
 			Values: map[string]string{
-				"identity.enabled":                        "true",
-				"global.identity.auth.enabled":            "true",
-				"global.security.authentication.method":   "oidc",
-				"connectors.enabled":                      "false",
-				"orchestration.enabled":                   "false",
+				"identity.enabled":                      "true",
+				"global.identity.auth.enabled":          "true",
+				"global.security.authentication.method": "oidc",
+				"connectors.enabled":                    "false",
+				"orchestration.enabled":                 "false",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var configmap corev1.ConfigMap

--- a/charts/camunda-platform-8.9/test/unit/identity/configmap_test.go
+++ b/charts/camunda-platform-8.9/test/unit/identity/configmap_test.go
@@ -39,10 +39,10 @@ func TestSpringConfigMapTemplate(t *testing.T) {
 func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 	testCases := []testhelpers.TestCase{
 		{
-			Skip:                 true,
 			Name:                 "TestContainerShouldAddContextPath",
 			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
 			Values: map[string]string{
+				"identity.enabled":     "true",
 				"identity.fullURL":     "https://mydomain.com/identity",
 				"identity.contextPath": "/identity",
 			},
@@ -61,11 +61,11 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 				s.Require().Equal("/identity", configmapApplication.Server.Servlet.ContextPath)
 			},
 		}, {
-			Skip: true,
 			Name: "TestConfigMapBuiltinDatabaseEnabled",
 			Values: map[string]string{
+				"identity.enabled":              "true",
 				"identity.multitenancy.enabled": "true",
-				"identityPostgresql.enabled":  "true",
+				"identityPostgresql.enabled":    "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var configmap corev1.ConfigMap
@@ -87,10 +87,10 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 		}, {
 			Name: "TestConfigMapGlobalMultitenancySetsIdentityFlag",
 			Values: map[string]string{
-				"global.multitenancy.enabled":   "true",
-				"identityPostgresql.enabled":    "true",
-				"identity.enabled":              "true",
-				"global.identity.auth.enabled":  "true",
+				"global.multitenancy.enabled":  "true",
+				"identityPostgresql.enabled":   "true",
+				"identity.enabled":             "true",
+				"global.identity.auth.enabled": "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var configmap corev1.ConfigMap
@@ -110,15 +110,15 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 		}, {
 			Name: "TestConfigMapExternalDatabaseEnabled",
 			Values: map[string]string{
-				"identity.enabled":                     "true",
-				"global.identity.auth.enabled":        "true",
-				"identity.multitenancy.enabled":       "true",
-				"identityPostgresql.enabled":          "false",
-				"identity.externalDatabase.enabled":   "true",
-				"identity.externalDatabase.host":      "my-database-host",
-				"identity.externalDatabase.port":      "2345",
-				"identity.externalDatabase.database":  "my-database-name",
-				"identity.externalDatabase.username":  "my-database-username",
+				"identity.enabled":                   "true",
+				"global.identity.auth.enabled":       "true",
+				"identity.multitenancy.enabled":      "true",
+				"identityPostgresql.enabled":         "false",
+				"identity.externalDatabase.enabled":  "true",
+				"identity.externalDatabase.host":     "my-database-host",
+				"identity.externalDatabase.port":     "2345",
+				"identity.externalDatabase.database": "my-database-name",
+				"identity.externalDatabase.username": "my-database-username",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var configmap corev1.ConfigMap
@@ -138,10 +138,10 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 				s.Require().Equal("my-database-username", configmapApplication.Spring.DataSource.Username)
 			},
 		}, {
-			Skip: true,
 			Name: "TestConfigMapAuthIssuerBackendUrlWhenExplicitlyDefined",
 			Values: map[string]string{
 				"identityKeycloak.enabled":              "false",
+				"identity.enabled":                      "true",
 				"global.identity.auth.enabled":          "false",
 				"global.identity.auth.issuerBackendUrl": "https://example.com/",
 			},
@@ -185,9 +185,9 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 				s.Require().Equal("https://camunda-platform-test.example.com/", configmapApplication.Identity.AuthProvider.BackendUrl)
 			},
 		}, {
-			Skip: true,
 			Name: "TestConfigMapAuthIssuerBackendUrlWhenKeycloakUrlDefined",
 			Values: map[string]string{
+				"identity.enabled":                      "true",
 				"global.identity.keycloak.url.protocol": "https",
 				"global.identity.keycloak.url.host":     "keycloak.com",
 				"global.identity.keycloak.url.port":     "443",
@@ -209,33 +209,16 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 
 				s.Require().Equal("https://keycloak.com:443/auth/camunda-platform", configmapApplication.Identity.AuthProvider.BackendUrl)
 			},
-		}, {
-			Skip:   true,
-			Name:   "TestConfigMapAuthIssuerBackendUrlWhenKeycloakNotDefined",
-			Values: map[string]string{},
-			Verifier: func(t *testing.T, output string, err error) {
-				var configmap corev1.ConfigMap
-				var configmapApplication IdentityConfigYAML
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
-				if e != nil {
-					s.Fail("Failed to unmarshal yaml. error=", e)
-				}
-
-				// then
-				s.NotEmpty(configmap.Data)
-
-				s.Require().Equal("http://camunda-platform-test-keycloak:80/auth/realms/camunda-platform", configmapApplication.Identity.AuthProvider.BackendUrl)
-			},
 		},
 		// Hybrid Auth Tests - verify OIDC client config is only included for components using OIDC auth
 		{
 			Name:                 "TestBasicAuthExcludesOidcConfig",
 			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
 			Values: map[string]string{
-				"identity.enabled":                       "true",
-				"global.identity.auth.enabled":           "true",
-				"global.security.authentication.method":  "basic",
-				"connectors.enabled":                     "true",
+				"identity.enabled":                      "true",
+				"global.identity.auth.enabled":          "true",
+				"global.security.authentication.method": "basic",
+				"connectors.enabled":                    "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var configmap corev1.ConfigMap
@@ -253,10 +236,10 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 			Name:                 "TestGlobalOidcAuthIncludesBothOidcConfigs",
 			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
 			Values: map[string]string{
-				"identity.enabled":                       "true",
-				"global.identity.auth.enabled":           "true",
-				"global.security.authentication.method":  "oidc",
-				"connectors.enabled":                     "true",
+				"identity.enabled":                      "true",
+				"global.identity.auth.enabled":          "true",
+				"global.security.authentication.method": "oidc",
+				"connectors.enabled":                    "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var configmap corev1.ConfigMap
@@ -274,11 +257,11 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 			Name:                 "TestHybridAuthConnectorsBasicOrchestrationOidc",
 			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
 			Values: map[string]string{
-				"identity.enabled":                             "true",
-				"global.identity.auth.enabled":                 "true",
-				"global.security.authentication.method":        "oidc",
-				"connectors.security.authentication.method":    "basic",
-				"connectors.enabled":                           "true",
+				"identity.enabled":                          "true",
+				"global.identity.auth.enabled":              "true",
+				"global.security.authentication.method":     "oidc",
+				"connectors.security.authentication.method": "basic",
+				"connectors.enabled":                        "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var configmap corev1.ConfigMap
@@ -297,10 +280,10 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 			Name:                 "TestFirstUserRolesExcludeOrchestrationWhenBasicAuth",
 			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
 			Values: map[string]string{
-				"identity.enabled":                              "true",
-				"identity.firstUser.enabled":                    "true",
-				"global.identity.auth.enabled":                  "true",
-				"orchestration.security.authentication.method":  "basic",
+				"identity.enabled":                             "true",
+				"identity.firstUser.enabled":                   "true",
+				"global.identity.auth.enabled":                 "true",
+				"orchestration.security.authentication.method": "basic",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var configmap corev1.ConfigMap
@@ -321,10 +304,10 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 			Name:                 "TestFirstUserRolesIncludeOrchestrationWhenOidcAuth",
 			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
 			Values: map[string]string{
-				"identity.enabled":                              "true",
-				"identity.firstUser.enabled":                    "true",
-				"global.identity.auth.enabled":                  "true",
-				"orchestration.security.authentication.method":  "oidc",
+				"identity.enabled":                             "true",
+				"identity.firstUser.enabled":                   "true",
+				"global.identity.auth.enabled":                 "true",
+				"orchestration.security.authentication.method": "oidc",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var configmap corev1.ConfigMap
@@ -342,10 +325,10 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 			Name:                 "TestConnectorsDisabledExcludesOidcConfig",
 			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
 			Values: map[string]string{
-				"identity.enabled":                         "true",
-				"global.identity.auth.enabled":             "true",
-				"global.security.authentication.method":    "oidc",
-				"connectors.enabled":                       "false",
+				"identity.enabled":                      "true",
+				"global.identity.auth.enabled":          "true",
+				"global.security.authentication.method": "oidc",
+				"connectors.enabled":                    "false",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var configmap corev1.ConfigMap
@@ -360,10 +343,10 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 			Name:                 "TestOrchestrationDisabledExcludesOidcConfig",
 			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
 			Values: map[string]string{
-				"identity.enabled":                         "true",
-				"global.identity.auth.enabled":             "true",
-				"global.security.authentication.method":    "oidc",
-				"orchestration.enabled":                    "false",
+				"identity.enabled":                      "true",
+				"global.identity.auth.enabled":          "true",
+				"global.security.authentication.method": "oidc",
+				"orchestration.enabled":                 "false",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var configmap corev1.ConfigMap
@@ -378,11 +361,11 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 			Name:                 "TestBothDisabledExcludesOidcConfig",
 			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
 			Values: map[string]string{
-				"identity.enabled":                         "true",
-				"global.identity.auth.enabled":             "true",
-				"global.security.authentication.method":    "oidc",
-				"connectors.enabled":                       "false",
-				"orchestration.enabled":                    "false",
+				"identity.enabled":                      "true",
+				"global.identity.auth.enabled":          "true",
+				"global.security.authentication.method": "oidc",
+				"connectors.enabled":                    "false",
+				"orchestration.enabled":                 "false",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var configmap corev1.ConfigMap


### PR DESCRIPTION
### Which problem does the PR fix?

enable tests that were previously skipped

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
