### PR TITLE
fix: the version label in format appX.appY-chartX.chartY.chartZ

### DIFF
--- a/scripts/set-prs-version-label.sh
+++ b/scripts/set-prs-version-label.sh
@@ -65,7 +65,7 @@ ct list-changed | while read chart_dir; do
     app_version_label="version/${app_version}"
     # The "version:x.y.z" label format is used by the support team,
     # it must not changed without checking with the support team.
-    chart_version_label="version:camunda-platform-${app_version}-${chart_version}"
+    chart_version_label="version:${app_version}-${chart_version}"
 
     echo -e "\nChart dir: ${chart_dir}"
     echo "Apps version: ${app_version}"


### PR DESCRIPTION
### Which problem does the PR fix?

Turns out the format of the version label is expected to match the release train format, not a git tag.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
