### PR TITLE
ci: skip empty chart matrix

### DIFF
--- a/scripts/generate-chart-matrix.sh
+++ b/scripts/generate-chart-matrix.sh
@@ -254,8 +254,9 @@ fi
 cat matrix_versions.txt
 
 if [ "$(cat matrix_versions.txt)" = "matrix:" ]; then
-  echo "The matrix.txt file is empty. This workflow is only triggered when there are changes to the code. Aborting."
-  exit 1
+  echo "No matching chart changes detected; emitting empty matrix and skipping downstream jobs."
+  echo 'matrix={"include":[]}' | tee -a "${GITHUB_OUTPUT:-/dev/null}"
+  exit 0
 fi
 
 matrix="$(cat matrix_versions.txt | yq -o=json '.matrix' | jq -c '{ "include": . }' \

--- a/test/scripts/generate_chart_matrix.bats
+++ b/test/scripts/generate_chart_matrix.bats
@@ -70,6 +70,23 @@ get_first_version() {
 }
 
 
+@test "non-chart changes produce an empty matrix and succeed" {
+  export GITHUB_OUTPUT="$TMPDIR_TEST/github_output"
+  : > "$GITHUB_OUTPUT"
+
+  # Simulate a PR that only changes tooling/scripts paths, not charts.
+  run bash "$ROOT/scripts/generate-chart-matrix.sh" \
+    --manual-trigger none \
+    --active-versions "$AV" \
+    --all-modified-files "scripts/camunda-core"
+  assert_success
+
+  # The script should emit an empty JSON matrix for downstream jobs to skip.
+  run bash -c 'grep -E "^matrix=\{\\\"include\\\":\[\]\}$" "$GITHUB_OUTPUT"'
+  assert_success
+}
+
+
 @test "manual flow single value applies to all entries" {
   v="$(get_first_version)"
   run bash "$ROOT/scripts/generate-chart-matrix.sh" \


### PR DESCRIPTION
### Which problem does the PR fix?

- Fixes CI failures on PRs that only touch non-chart paths, where the `Test - Chart Version` workflow fails in "Generate chart matrix" with: "The matrix.txt file is empty..." (see #4882).
- This behavior originates from the matrix generation introduced in #4648 and later adjusted in #4707.

### What's in this PR?

- Update the chart matrix generator to treat an empty matrix as a valid no-op:
  - When no chart versions are matched, emit `{"include":[]}` to `$GITHUB_OUTPUT` and exit successfully.
  - Downstream matrix jobs will then be skipped naturally by GitHub Actions.
- Add a bats test covering the empty-matrix case.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
