### PR TITLE
feat(connectors): use issuer uri preferably if available

### DIFF
--- a/charts/camunda-platform-8.9/templates/connectors/files/_application.yaml
+++ b/charts/camunda-platform-8.9/templates/connectors/files/_application.yaml
@@ -42,7 +42,11 @@ camunda:
       password: {{ $user.password | quote }}
     {{- else if eq (include "connectors.authMethod" .) "oidc" }}
     auth:
+      {{- if (include "orchestration.authIssuerUrl" .) }}
+      issuer-url: {{ include "orchestration.authIssuerUrl" . | quote }}
+      {{- else }}
       token-url: {{ include "orchestration.authIssuerBackendUrlEndpointToken" . }}
+      {{- end }}
       client-id: {{ include "connectors.authClientId" . | quote }}
       client-secret: ${VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET}
       audience: {{ include "connectors.authAudience" . | quote }}


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

This PR adds the configuration option documented here: https://github.com/camunda/camunda-docs/pull/7564

This makes the tokenUrl optional for connectors.

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

This PR changes the rendering of the connectors application.yaml in a way that it first tries to use the issuer-url and falls back to the token-url if the issuer url is not set.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211900114299119