### PR TITLE
ci: report Check PR Conventions on release-please branch pushes

### DIFF
--- a/.github/workflows/repo-pr-conventions.yaml
+++ b/.github/workflows/repo-pr-conventions.yaml
@@ -3,19 +3,26 @@ name: Repo - Pull Request Conventions
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
+  push:
+    branches:
+      - 'release-please--branches--*'
 
 jobs:
   check:
     name: Check PR Conventions
+    # Do NOT run PR conventions on release-please PRs.
+    # The required "Check PR Conventions" status is instead reported by a
+    # lightweight push-triggered run on release-please branches.
+    if: ${{ github.event_name == 'push' || !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     steps:
-      - name: Skip conventions for release-please PRs
-        if: ${{ startsWith(github.head_ref, 'release-please--') }}
+      - name: Report required status for release-please branch pushes
+        if: ${{ github.event_name == 'push' }}
         run: |
-          echo "Release-please PR detected (${GITHUB_HEAD_REF}); skipping PR conventions checks."
+          echo "Release-please branch push detected (${GITHUB_REF_NAME}); reporting required status only."
 
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
-        if: ${{ !startsWith(github.head_ref, 'release-please--') }}
+        if: ${{ github.event_name == 'pull_request' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -49,13 +56,13 @@ jobs:
           # to also validate the commit message for one commit PRs.
           validateSingleCommit: true
       - name: Checkout
-        if: ${{ !startsWith(github.head_ref, 'release-please--') }}
+        if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
       - name: Ensure PR branch is up to date
-        if: ${{ !startsWith(github.head_ref, 'release-please--') }}
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           (git rev-list --left-right --count origin/main...HEAD | grep -q "^0") \
             || (echo "PR branch is not up to date with main. Please rebase or merge main into your branch." && exit 1) \


### PR DESCRIPTION
### Which problem does the PR fix?

Release-please PRs get blocked by "Check PR Conventions" showing "Expected — Waiting for status to be reported".

When chart-release-chores pushes a follow-up commit to a release-please PR branch, the required status isn't reported on the new head SHA because commits from GitHub Apps don't reliably trigger `pull_request` events.

### What's in this PR?

Adds a `push` trigger for `release-please--branches--*` branches to the PR conventions workflow so the required "Check PR Conventions" status is reported after every push to release-please branches.

- Push events on release-please branches run a lightweight no-op that reports success
- PR conventions checks are skipped for release-please PRs (they don't need semantic title validation)

### Checklist

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed). N/A - workflow change only
- [x] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed). N/A