### PR TITLE
test: added console tags and unique artifact name

### DIFF
--- a/.github/actions/playwright-integration-tests/action.yaml
+++ b/.github/actions/playwright-integration-tests/action.yaml
@@ -139,11 +139,16 @@ runs:
         cd "$GITHUB_WORKSPACE/scripts"
         ./run-integration-tests.sh --absolute-chart-path "${ABSOLUTE_TEST_CHART_DIR}" --namespace "${TEST_NAMESPACE}" --platform "${{ inputs.distro-platform }}" --test-auth-type "${{ inputs.auth }}" --test-exclude "${{ inputs.exclude }}"
 
+    - name: Set report date
+      id: report_date
+      shell: bash
+      run: echo "date=$(date +'%Y-%m-%d_%H-%M-%S')" >> $GITHUB_OUTPUT
+
     - name: Test - Upload Playwright report
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
       with:
         path: ${{ env.ABSOLUTE_TEST_CHART_DIR }}/test/integration/testsuites/playwright-report
-        name: playwright-report-${{ github.run_id }}-${{ inputs.identifier }}-${{ inputs.flow }}-${{ inputs.distro-platform }}-runner
+        name: playwright-report-${{ github.run_id }}-${{ inputs.identifier }}-${{ inputs.flow }}-${{ inputs.distro-platform }}-runner-${{ steps.report_date.outputs.date }}
         if-no-files-found: error
         retention-days: 5
 

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch-tasklist-v1.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch-tasklist-v1.yaml
@@ -105,6 +105,26 @@ console:
   enabled: true
   image:
     tag: "$E2E_TESTS_CONSOLE_IMAGE_TAG"
+  overrideConfiguration: |
+    camunda:
+      console:
+        managed:
+          releases:
+            - name: integration
+              namespace: "$TEST_NAMESPACE"
+              tags:
+                - dev
+                - custom
+                - stage
+                - prod
+                - test
+              custom-properties:
+                - description: "This is the main integration environment for the Camunda Platform."
+                  links:
+                    - name: "Camunda"
+                      url: "https://camunda.com"
+                    - name: "Camunda Docs"
+                      url: "https://docs.camunda.io"
 identity:
   enabled: true
   image:

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch-upg.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch-upg.yaml
@@ -105,6 +105,26 @@ console:
   enabled: true
   image:
     tag: "$E2E_TESTS_CONSOLE_IMAGE_TAG"
+  overrideConfiguration: |
+    camunda:
+      console:
+        managed:
+          releases:
+            - name: integration
+              namespace: "$TEST_NAMESPACE"
+              tags:
+                - dev
+                - custom
+                - stage
+                - prod
+                - test
+              custom-properties:
+                - description: "This is the main integration environment for the Camunda Platform."
+                  links:
+                    - name: "Camunda"
+                      url: "https://camunda.com"
+                    - name: "Camunda Docs"
+                      url: "https://docs.camunda.io"
 identity:
   enabled: true
   image:


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
This PR fixes two issues:
- For upgrade scenarios v1 and v2, console tags were missing because the configuration was not overridden.
- For the upgrade patch scenario, the same artifact that failed the test run was reused, since artifact names were not unique for each run.

### What's in this PR?

- Console config is overridden.
- A date is added to the artifact name to make it unique.

Successful run [here](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/20345927465) using this branch from our repo.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
