### PR TITLE
fix: call TPL inside extraConfiguration and configuration

### DIFF
--- a/charts/camunda-platform-8.6/templates/connectors/configmap.yaml
+++ b/charts/camunda-platform-8.6/templates/connectors/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   {{- if .Values.connectors.configuration }}
   application.yml: |
-    {{ .Values.connectors.configuration | indent 4 | trim }}
+    {{ tpl .Values.connectors.configuration $ | indent 4 | trim }}
   {{- else }}
   application.yml: |
     server:

--- a/charts/camunda-platform-8.6/templates/identity/configmap.yaml
+++ b/charts/camunda-platform-8.6/templates/identity/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   {{- if .Values.identity.configuration }}
   application.yaml: |
-    {{ .Values.identity.configuration | indent 4 | trim }}
+    {{ tpl .Values.identity.configuration $ | indent 4 | trim }}
   {{- else }}
   application.yaml: |
     identity:

--- a/charts/camunda-platform-8.6/templates/operate/configmap.yaml
+++ b/charts/camunda-platform-8.6/templates/operate/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   {{- if .Values.operate.configuration }}
   application.yaml: |
-    {{ .Values.operate.configuration | indent 4 | trim }}
+    {{ tpl .Values.operate.configuration $ | indent 4 | trim }}
   {{- else }}
   application.yaml: |
     {{- if .Values.operate.contextPath }}

--- a/charts/camunda-platform-8.6/templates/optimize/configmap.yaml
+++ b/charts/camunda-platform-8.6/templates/optimize/configmap.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 data:
   {{- if .Values.optimize.configuration }}
   environment-config.yaml: |
-    {{ .Values.optimize.configuration | indent 4 | trim }}
+    {{ tpl .Values.optimize.configuration $ | indent 4 | trim }}
   {{- else }}
   environment-config.yaml: |
     {{- if .Values.optimize.contextPath }}

--- a/charts/camunda-platform-8.6/templates/tasklist/configmap.yaml
+++ b/charts/camunda-platform-8.6/templates/tasklist/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   {{- if .Values.tasklist.configuration }}
   application.yaml: |
-    {{ .Values.tasklist.configuration | indent 4 | trim }}
+    {{ tpl .Values.tasklist.configuration $ | indent 4 | trim }}
   {{- else }}
   application.yaml: |
     {{- if .Values.tasklist.contextPath }}

--- a/charts/camunda-platform-8.6/templates/web-modeler/configmap-restapi.yaml
+++ b/charts/camunda-platform-8.6/templates/web-modeler/configmap-restapi.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   {{- if .Values.webModeler.restapi.configuration }}
   application.yaml: |
-    {{ .Values.webModeler.restapi.configuration | indent 4 | trim }}
+    {{ tpl .Values.webModeler.restapi.configuration $ | indent 4 | trim }}
   {{- else }}
   application.yaml: |
     camunda:

--- a/charts/camunda-platform-8.6/templates/web-modeler/configmap-shared.yaml
+++ b/charts/camunda-platform-8.6/templates/web-modeler/configmap-shared.yaml
@@ -10,7 +10,7 @@ data:
   pusher-app-key: {{ randAlphaNum 20 }}
   {{- if .Values.webModeler.configuration }}
   application.yaml: |
-    {{ .Values.webModeler.configuration | indent 4 | trim }}
+    {{ tpl .Values.webModeler.configuration $ | indent 4 | trim }}
   {{- end }}
   {{- range $key, $val := .Values.webModeler.extraConfiguration }}
   {{ $key }}: |

--- a/charts/camunda-platform-8.6/templates/web-modeler/configmap-webapp.yaml
+++ b/charts/camunda-platform-8.6/templates/web-modeler/configmap-webapp.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   {{- if .Values.webModeler.webapp.configuration }}
   application.toml: |
-    {{ .Values.webModeler.webapp.configuration | indent 4 | trim }}
+    {{ tpl .Values.webModeler.webapp.configuration $ | indent 4 | trim }}
   {{- else }}
   application.toml: |
     httpWorkers = 2

--- a/charts/camunda-platform-8.6/templates/web-modeler/configmap-websockets.yaml
+++ b/charts/camunda-platform-8.6/templates/web-modeler/configmap-websockets.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   {{- if .Values.webModeler.websockets.configuration }}
   application.yaml: |
-    {{ .Values.webModeler.websockets.configuration | indent 4 | trim }}
+    {{ tpl .Values.webModeler.websockets.configuration $ | indent 4 | trim }}
   {{- else }}
   application.yaml: |
   {{- end }}

--- a/charts/camunda-platform-8.6/templates/zeebe-gateway/configmap.yaml
+++ b/charts/camunda-platform-8.6/templates/zeebe-gateway/configmap.yaml
@@ -12,7 +12,7 @@ data:
 {{- end }}
 {{- if .Values.zeebeGateway.configuration }}
   application.yaml: |
-    {{ .Values.zeebeGateway.configuration | indent 4 | trim }}
+    {{ tpl .Values.zeebeGateway.configuration $ | indent 4 | trim }}
 {{- else }}
   application.yaml: |
     {{- if .Values.global.identity.auth.enabled }}

--- a/charts/camunda-platform-8.6/templates/zeebe/configmap.yaml
+++ b/charts/camunda-platform-8.6/templates/zeebe/configmap.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 data:
   {{- if .Values.zeebe.configuration }}
   application.yaml: |
-    {{ .Values.zeebe.configuration | indent 4 | trim }}
+    {{ tpl .Values.zeebe.configuration $ | indent 4 | trim }}
   {{- else }}
   application.yaml: |
     zeebe:

--- a/charts/camunda-platform-8.7/templates/connectors/configmap.yaml
+++ b/charts/camunda-platform-8.7/templates/connectors/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   {{- if .Values.connectors.configuration }}
   application.yml: |
-    {{ .Values.connectors.configuration | indent 4 | trim }}
+    {{ tpl .Values.connectors.configuration $ | indent 4 | trim }}
   {{- else }}
   application.yml: |
     server:

--- a/charts/camunda-platform-8.7/templates/identity/configmap.yaml
+++ b/charts/camunda-platform-8.7/templates/identity/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   {{- if .Values.identity.configuration }}
   application.yaml: |
-    {{ .Values.identity.configuration | indent 4 | trim }}
+    {{ tpl .Values.identity.configuration $ | indent 4 | trim }}
   {{- else }}
   application.yaml: |
     identity:

--- a/charts/camunda-platform-8.7/templates/operate/configmap.yaml
+++ b/charts/camunda-platform-8.7/templates/operate/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   {{- if .Values.operate.configuration }}
   application.yaml: |
-    {{ .Values.operate.configuration | indent 4 | trim }}
+    {{ tpl .Values.operate.configuration $ | indent 4 | trim }}
   {{- else }}
   application.yaml: |
     {{- if .Values.operate.contextPath }}

--- a/charts/camunda-platform-8.7/templates/optimize/configmap.yaml
+++ b/charts/camunda-platform-8.7/templates/optimize/configmap.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 data:
   {{- if .Values.optimize.configuration }}
   environment-config.yaml: |
-    {{ .Values.optimize.configuration | indent 4 | trim }}
+    {{ tpl .Values.optimize.configuration $ | indent 4 | trim }}
   {{- else }}
   environment-config.yaml: |
     {{- if .Values.optimize.contextPath }}

--- a/charts/camunda-platform-8.7/templates/tasklist/configmap.yaml
+++ b/charts/camunda-platform-8.7/templates/tasklist/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   {{- if .Values.tasklist.configuration }}
   application.yaml: |
-    {{ .Values.tasklist.configuration | indent 4 | trim }}
+    {{ tpl .Values.tasklist.configuration $ | indent 4 | trim }}
   {{- else }}
   application.yaml: |
     {{- if .Values.tasklist.contextPath }}

--- a/charts/camunda-platform-8.7/templates/web-modeler/configmap-restapi.yaml
+++ b/charts/camunda-platform-8.7/templates/web-modeler/configmap-restapi.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   {{- if .Values.webModeler.restapi.configuration }}
   application.yaml: |
-    {{ .Values.webModeler.restapi.configuration | indent 4 | trim }}
+    {{ tpl .Values.webModeler.restapi.configuration $ | indent 4 | trim }}
   {{- else }}
   application.yaml: |
     camunda:

--- a/charts/camunda-platform-8.7/templates/web-modeler/configmap-shared.yaml
+++ b/charts/camunda-platform-8.7/templates/web-modeler/configmap-shared.yaml
@@ -10,7 +10,7 @@ data:
   pusher-app-key: {{ randAlphaNum 20 }}
   {{- if .Values.webModeler.configuration }}
   application.yaml: |
-    {{ .Values.webModeler.configuration | indent 4 | trim }}
+    {{ tpl .Values.webModeler.configuration $ | indent 4 | trim }}
   {{- end }}
   {{- range $key, $val := .Values.webModeler.extraConfiguration }}
   {{ $key }}: |

--- a/charts/camunda-platform-8.7/templates/web-modeler/configmap-webapp.yaml
+++ b/charts/camunda-platform-8.7/templates/web-modeler/configmap-webapp.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   {{- if .Values.webModeler.webapp.configuration }}
   application.toml: |
-    {{ .Values.webModeler.webapp.configuration | indent 4 | trim }}
+    {{ tpl .Values.webModeler.webapp.configuration $ | indent 4 | trim }}
   {{- else }}
   application.toml: |
     httpWorkers = 2

--- a/charts/camunda-platform-8.7/templates/web-modeler/configmap-websockets.yaml
+++ b/charts/camunda-platform-8.7/templates/web-modeler/configmap-websockets.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   {{- if .Values.webModeler.websockets.configuration }}
   application.yaml: |
-    {{ .Values.webModeler.websockets.configuration | indent 4 | trim }}
+    {{ tpl .Values.webModeler.websockets.configuration $ | indent 4 | trim }}
   {{- else }}
   application.yaml: |
   {{- end }}

--- a/charts/camunda-platform-8.7/templates/zeebe-gateway/configmap.yaml
+++ b/charts/camunda-platform-8.7/templates/zeebe-gateway/configmap.yaml
@@ -12,7 +12,7 @@ data:
 {{- end }}
 {{- if .Values.zeebeGateway.configuration }}
   application.yaml: |
-    {{ .Values.zeebeGateway.configuration | indent 4 | trim }}
+    {{ tpl .Values.zeebeGateway.configuration $ | indent 4 | trim }}
 {{- else }}
   application.yaml: |
     spring:

--- a/charts/camunda-platform-8.7/templates/zeebe/configmap.yaml
+++ b/charts/camunda-platform-8.7/templates/zeebe/configmap.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 data:
   {{- if .Values.zeebe.configuration }}
   application.yaml: |
-    {{ .Values.zeebe.configuration | indent 4 | trim }}
+    {{ tpl .Values.zeebe.configuration $ | indent 4 | trim }}
   {{- else }}
   application.yaml: |
     zeebe:

--- a/charts/camunda-platform-8.8/templates/connectors/configmap.yaml
+++ b/charts/camunda-platform-8.8/templates/connectors/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   {{- if .Values.connectors.configuration }}
   application.yaml: |
-    {{ .Values.connectors.configuration | indent 4 | trim }}
+    {{ tpl .Values.connectors.configuration $ | indent 4 | trim }}
   {{- else }}
   application.yaml: |
     {{- (include (print $.Template.BasePath "/connectors/files/_application.yaml") $) | indent 4 }}

--- a/charts/camunda-platform-8.8/templates/identity/configmap.yaml
+++ b/charts/camunda-platform-8.8/templates/identity/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   {{- if .Values.identity.configuration }}
   application.yaml: |
-    {{ .Values.identity.configuration | indent 4 | trim }}
+    {{ tpl .Values.identity.configuration $ | indent 4 | trim }}
   {{- else }}
   application.yaml: |
     # NOTE:

--- a/charts/camunda-platform-8.8/templates/optimize/configmap.yaml
+++ b/charts/camunda-platform-8.8/templates/optimize/configmap.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 data:
   {{- if .Values.optimize.configuration }}
   environment-config.yaml: |
-    {{ .Values.optimize.configuration | indent 4 | trim }}
+    {{ tpl .Values.optimize.configuration $ | indent 4 | trim }}
   {{- else }}
   environment-config.yaml: |
     {{- if .Values.optimize.contextPath }}

--- a/charts/camunda-platform-8.8/templates/orchestration/configmap-unified.yaml
+++ b/charts/camunda-platform-8.8/templates/orchestration/configmap-unified.yaml
@@ -20,7 +20,7 @@ data:
 
   {{- if .Values.orchestration.configuration }}
   application.yaml: |
-    {{ .Values.orchestration.configuration | indent 4 | trim }}
+    {{ tpl .Values.orchestration.configuration $ | indent 4 | trim }}
   {{- else }}
   application.yaml: |
     {{- (include (print $.Template.BasePath "/orchestration/files/_application-unified.yaml") $) | indent 4 }}

--- a/charts/camunda-platform-8.8/templates/web-modeler/configmap-restapi.yaml
+++ b/charts/camunda-platform-8.8/templates/web-modeler/configmap-restapi.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   {{- if .Values.webModeler.restapi.configuration }}
   application.yaml: |
-    {{ .Values.webModeler.restapi.configuration | indent 4 | trim }}
+    {{ tpl .Values.webModeler.restapi.configuration $ | indent 4 | trim }}
   {{- else }}
   application.yaml: |
     camunda:

--- a/charts/camunda-platform-8.8/templates/web-modeler/configmap-shared.yaml
+++ b/charts/camunda-platform-8.8/templates/web-modeler/configmap-shared.yaml
@@ -10,7 +10,7 @@ data:
   pusher-app-key: {{ randAlphaNum 20 }}
   {{- if .Values.webModeler.configuration }}
   application.yaml: |
-    {{ .Values.webModeler.configuration | indent 4 | trim }}
+    {{ tpl .Values.webModeler.configuration $ | indent 4 | trim }}
   {{- end }}
   {{- range $key, $val := .Values.webModeler.extraConfiguration }}
   {{ $key }}: |

--- a/charts/camunda-platform-8.8/templates/web-modeler/configmap-webapp.yaml
+++ b/charts/camunda-platform-8.8/templates/web-modeler/configmap-webapp.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   {{- if .Values.webModeler.webapp.configuration }}
   application.toml: |
-    {{ .Values.webModeler.webapp.configuration | indent 4 | trim }}
+    {{ tpl .Values.webModeler.webapp.configuration $ | indent 4 | trim }}
   {{- else }}
   application.toml: |
     httpWorkers = 2

--- a/charts/camunda-platform-8.8/templates/web-modeler/configmap-websockets.yaml
+++ b/charts/camunda-platform-8.8/templates/web-modeler/configmap-websockets.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   {{- if .Values.webModeler.websockets.configuration }}
   application.yaml: |
-    {{ .Values.webModeler.websockets.configuration | indent 4 | trim }}
+    {{ tpl .Values.webModeler.websockets.configuration $ | indent 4 | trim }}
   {{- else }}
   application.yaml: |
   {{- end }}

--- a/charts/camunda-platform-8.9/templates/connectors/configmap.yaml
+++ b/charts/camunda-platform-8.9/templates/connectors/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   {{- if .Values.connectors.configuration }}
   application.yaml: |
-    {{ .Values.connectors.configuration | indent 4 | trim }}
+    {{ tpl .Values.connectors.configuration $ | indent 4 | trim }}
   {{- else }}
   application.yaml: |
     {{- (include (print $.Template.BasePath "/connectors/files/_application.yaml") $) | indent 4 }}

--- a/charts/camunda-platform-8.9/templates/identity/configmap.yaml
+++ b/charts/camunda-platform-8.9/templates/identity/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   {{- if .Values.identity.configuration }}
   application.yaml: |
-    {{ .Values.identity.configuration | indent 4 | trim }}
+    {{ tpl .Values.identity.configuration $ | indent 4 | trim }}
   {{- else }}
   application.yaml: |
     # NOTE:

--- a/charts/camunda-platform-8.9/templates/optimize/configmap.yaml
+++ b/charts/camunda-platform-8.9/templates/optimize/configmap.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 data:
   {{- if .Values.optimize.configuration }}
   environment-config.yaml: |
-    {{ .Values.optimize.configuration | indent 4 | trim }}
+    {{ tpl .Values.optimize.configuration $ | indent 4 | trim }}
   {{- else }}
   environment-config.yaml: |
     {{- if .Values.optimize.contextPath }}

--- a/charts/camunda-platform-8.9/templates/orchestration/configmap-unified.yaml
+++ b/charts/camunda-platform-8.9/templates/orchestration/configmap-unified.yaml
@@ -20,7 +20,7 @@ data:
 
   {{- if .Values.orchestration.configuration }}
   application.yaml: |
-    {{ .Values.orchestration.configuration | indent 4 | trim }}
+    {{ tpl .Values.orchestration.configuration $ | indent 4 | trim }}
   {{- else }}
   application.yaml: |
     {{- (include (print $.Template.BasePath "/orchestration/files/_application-unified.yaml") $) | indent 4 }}

--- a/charts/camunda-platform-8.9/templates/web-modeler/configmap-restapi.yaml
+++ b/charts/camunda-platform-8.9/templates/web-modeler/configmap-restapi.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   {{- if .Values.webModeler.restapi.configuration }}
   application.yaml: |
-    {{ .Values.webModeler.restapi.configuration | indent 4 | trim }}
+    {{ tpl .Values.webModeler.restapi.configuration $ | indent 4 | trim }}
   {{- else }}
   application.yaml: |
     camunda:

--- a/charts/camunda-platform-8.9/templates/web-modeler/configmap-shared.yaml
+++ b/charts/camunda-platform-8.9/templates/web-modeler/configmap-shared.yaml
@@ -10,7 +10,7 @@ data:
   pusher-app-key: {{ randAlphaNum 20 }}
   {{- if .Values.webModeler.configuration }}
   application.yaml: |
-    {{ .Values.webModeler.configuration | indent 4 | trim }}
+    {{ tpl .Values.webModeler.configuration $ | indent 4 | trim }}
   {{- end }}
   {{- range $key, $val := .Values.webModeler.extraConfiguration }}
   {{ $key }}: |

--- a/charts/camunda-platform-8.9/templates/web-modeler/configmap-webapp.yaml
+++ b/charts/camunda-platform-8.9/templates/web-modeler/configmap-webapp.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   {{- if .Values.webModeler.webapp.configuration }}
   application.toml: |
-    {{ .Values.webModeler.webapp.configuration | indent 4 | trim }}
+    {{ tpl .Values.webModeler.webapp.configuration $ | indent 4 | trim }}
   {{- else }}
   application.toml: |
     httpWorkers = 2

--- a/charts/camunda-platform-8.9/templates/web-modeler/configmap-websockets.yaml
+++ b/charts/camunda-platform-8.9/templates/web-modeler/configmap-websockets.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   {{- if .Values.webModeler.websockets.configuration }}
   application.yaml: |
-    {{ .Values.webModeler.websockets.configuration | indent 4 | trim }}
+    {{ tpl .Values.webModeler.websockets.configuration $ | indent 4 | trim }}
   {{- else }}
   application.yaml: |
   {{- end }}


### PR DESCRIPTION
### Which problem does the PR fix?

In my latest conversation with @mlowe-camunda , we decided upon the heuristic of allowing processing of {{ }} expressions anywhere where a URL is defined. And this includes the extraConfiguration and configuration sections of values.yaml.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

To test this, I saved the following as `k.yaml`

```yaml
jesse: jesseRules

orchestration:
  configuration: |
      {{ .Values.jesse | quote }}

  extraConfiguration:
    jesse: {{ .Values.jesse | quote }}
```

and then ran
```bash
helm template cpt charts/camunda-platform-8.9 -f k.yaml --show-only templates/orchestration/configmap-unified.yaml
```

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
