### PR TITLE
style: better error message with docs link for sec-storage

### DIFF
--- a/charts/camunda-platform-8.9/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.9/templates/common/constraints.tpl
@@ -29,7 +29,7 @@ Multi-Tenancy requirements: https://docs.camunda.io/docs/self-managed/concepts/m
 Fail if there is no secondary storage type specified and if noSecondaryStorage is not enabled.
 */}}
 {{- if eq (include "orchestration.secondaryStorage" .) "unset" }}
-  {{- fail "Please enable a secondary storage type. Either Elasticsearch, OpenSearch or Postgres" -}}
+  {{- fail "Please configure an expected secondary storage type under `orchestration.data.secondaryStorage.type`, available values are [elasticsearch, opensearch, rdbms]. For more details, see our documentation here: https://docs.camunda.io/docs/next/self-managed/concepts/secondary-storage/configuring-secondary-storage/" -}}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
### Which problem does the PR fix?

The previous error message "Please enable a secondary storage type. Either Elasticsearch, OpenSearch or Postgres" leaves out some necessary details leading to certain information being implied, such as whether there are subcharts for these 3 storage options, or leaving out information on what you actually need to do. 



<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

Rather than provide all of the information upfront, I think it's best to rely on a documentation link on how to configure this section, as well as a brief tidbit on which option you should be looking at.

@ChrisKujawa graced us with this better error message that as I read, is much better than the old one:

> Please configure an expected secondary storage type under `orchestration.data.secondaryStorage.type`, available values are [elasticsearch, opensearch, rdbms]. For more details, see our documentation here: https://docs.camunda.io/docs/next/self-managed/concepts/secondary-storage/configuring-secondary-storage/

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
