### PR TITLE
chore: adjust bug labels and automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_report_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_report_template.md
@@ -2,7 +2,7 @@
 name: Issue report
 about: "Create an issue report"
 title: "[ISSUE] <issue title>"
-labels: kind/issue
+labels: kind/bug
 ---
 
 **Describe the issue:**
@@ -15,6 +15,8 @@ labels: kind/issue
 How severe is the issue? Her are the options:
 
 Low, Medium, High, Critical, Unknown
+
+Please set the respective severity label accordingly
 -->
 
 **Likelihood:**
@@ -23,6 +25,8 @@ Low, Medium, High, Critical, Unknown
 How likely is the issue to occur:
 
 Low, Medium, High
+
+Please set the respective lieklihood label accordingly
 -->
 
 **Actual behavior:**
@@ -51,5 +55,5 @@ If possible add a minimal reproducer code sample in a new repo/branch.
 
 - Platform: <!-- [e.g. GCP, AWS, etc] -->
 - Helm CLI version: <!-- [e.g. 3.10.0] -->
-- Chart version: <!-- [e.g. 8.x.x] -->
+- Chart version: <!-- [e.g. 8.x.x]. Please set the affects label accordingly -->
 - Values file: <!-- [e.g. include or link to your values file] -->

--- a/.github/workflows/add-new-issue.yaml
+++ b/.github/workflows/add-new-issue.yaml
@@ -46,6 +46,7 @@ jobs:
         with:
           github-token: ${{ steps.generate-github-token.outputs.token }}
           project-number: "187"
+          component-label: "component/helm"
         # Only run this job for issues labeled as 'kind/bug' and
         # for the relevant GitHub issue events that indicate a new or updated issue.
         if: >


### PR DESCRIPTION
This PR updates the issue template and automation workflow to better align bug issue handling:

- Changed issue template label from 'kind/issue' to 'kind/bug'
- Added instructions to set severity label based on severity selection
- Added instructions to set likelihood label based on likelihood assessment
- Added instruction to set affects label based on chart version
- Added 'component/helm' label to GitHub workflow that adds bug issues to the Quality Board project