### PR TITLE
chore: update renovate config to let 8.9 update to alphas

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -342,11 +342,23 @@
         'charts/camunda-platform-8.9/values.yaml',
         'charts/camunda-platform-8.9/values-latest.yaml',
       ],
-      // force permanent unstable updates for a packages (e.g. alpha, see https://docs.renovatebot.com/configuration-options/#ignoreunstable)
-      ignoreUnstable: false,
       matchUpdateTypes: ['major', 'minor', 'patch'],
       schedule: ['at any time'],
       addLabels: ['camunda-platform', 'priority-high'],
+    },
+    {
+      // needed as ignoreUnstable does not work with 'matchUpdateTypes' from above
+      description: 'Allow alpha/pre-release tags for Camunda 8.9 images',
+      enabled: true,
+      matchPackageNames: ['/.*camunda.*/'],
+      matchDatasources: ['helmv3', 'helm-values', 'docker', 'regex'],
+      matchFileNames: [
+        'charts/camunda-platform-8.9/Chart.yaml',
+        'charts/camunda-platform-8.9/values.yaml',
+        'charts/camunda-platform-8.9/values-latest.yaml',
+      ],
+      // force permanent unstable updates for a packages (e.g. alpha, see https://docs.renovatebot.com/configuration-options/#ignoreunstable)
+      ignoreUnstable: false,
     },
     {
       enabled: true,


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

closes https://github.com/camunda/camunda-platform-helm/issues/4979

### What's in this PR?

Renovate treats alpha versions as unstable by default (see [docs](https://docs.renovatebot.com/configuration-options/#ignoreunstable)).
Even though we pin 8.9 to an alpha-only regex, Renovate will not propose alpha → alpha updates unless ignoreUnstable is disabled.

This PR:
- removes a duplicate 8.9 alpha packageRule
- updates the remaining rule (line ~274) to set `ignoreUnstable: false`

🤞 

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
