### PR TITLE
fix: adjust renovate lines to the one isolated change we think fixed something

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -348,12 +348,12 @@
       description: 'Parse Camunda 8.9 image tags as semver so alpha updates work',
       enabled: true,
       matchPackageNames: ['/.*camunda.*/'],
-      matchDatasources: ['docker'],
+      matchDatasources: ['helmv3', 'helm-values', 'docker', 'regex'],
       matchFileNames: [
+        'charts/camunda-platform-8.9/Chart.yaml',
         'charts/camunda-platform-8.9/values.yaml',
         'charts/camunda-platform-8.9/values-latest.yaml',
       ],
-      ignoreUnstable: false,
       versioning: 'semver'
     },
     {


### PR DESCRIPTION

### Which problem does the PR fix?

Immi's doing some minor tweaks to the renovate flows and I think there was a  good line changed, and 4 other lines that is causing unpredictable output. This PR minimizes that patch series to only the versioning semver change.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
