### PR TITLE
ci: release workflow finetunings

### DIFF
--- a/.github/workflows/chart-build-dev.yaml
+++ b/.github/workflows/chart-build-dev.yaml
@@ -1,4 +1,4 @@
-name: "Chart - Build - Dev"
+name: "Chart - Release - Pipeline - 1 - Build Dev"
 
 # Builds immutable dev packages for all active chart versions.
 # These packages are release-ready (transformations applied) and stored in Harbor
@@ -296,6 +296,53 @@ jobs:
 
           echo "Updated Chart.yaml:"
           head -50 Chart.yaml
+
+      - name: Add component image versions to Chart.yaml annotations
+        if: env.SKIP_BUILD == 'false'
+        run: |
+          # Extract image tags from values.yaml and add as Chart.yaml annotation
+          # This makes the artifact self-documenting with exact component versions
+
+          get_tag() {
+            local path=$1
+            yq -r "${path} // \"N/A\"" values.yaml
+          }
+
+          # Version-specific components (order matches workflow summary)
+          CAMUNDA_MINOR=$(echo "${{ env.CAMUNDA_VERSION }}" | sed 's/^8\.//')
+
+          if [[ ${CAMUNDA_MINOR} -ge 8 ]]; then
+            # 8.8+ orchestration architecture
+            IMAGE_VERSIONS=$(cat << YAML
+          camunda: $(get_tag '.orchestration.image.tag')
+          managementIdentity: $(get_tag '.identity.image.tag')
+          optimize: $(get_tag '.optimize.image.tag')
+          webModeler: $(get_tag '.webModeler.image.tag')
+          connectors: $(get_tag '.connectors.image.tag')
+          console: $(get_tag '.console.image.tag')
+          YAML
+            )
+          else
+            # 8.6-8.7 classic architecture
+            IMAGE_VERSIONS=$(cat << YAML
+          zeebe: $(get_tag '.zeebe.image.tag')
+          operate: $(get_tag '.operate.image.tag')
+          tasklist: $(get_tag '.tasklist.image.tag')
+          identity: $(get_tag '.identity.image.tag')
+          optimize: $(get_tag '.optimize.image.tag')
+          webModeler: $(get_tag '.webModeler.image.tag')
+          connectors: $(get_tag '.connectors.image.tag')
+          console: $(get_tag '.console.image.tag')
+          YAML
+            )
+          fi
+
+          # Write to temp file and add annotation
+          echo "${IMAGE_VERSIONS}" > /tmp/image-versions.yaml
+          yq -i '.annotations."camunda.io/component-image-versions" = load_str("/tmp/image-versions.yaml")' Chart.yaml
+
+          echo "Added camunda.io/component-image-versions annotation:"
+          yq '.annotations."camunda.io/component-image-versions"' Chart.yaml
 
       - name: Show computed version info
         if: env.SKIP_BUILD == 'false'

--- a/.github/workflows/chart-promote-rc.yaml
+++ b/.github/workflows/chart-promote-rc.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow
 ---
-name: "Chart - Promote RC"
+name: "Chart - Release - Pipeline - 2 - Promote RC"
 
 on:
   workflow_dispatch:
@@ -184,6 +184,14 @@ jobs:
           echo "camunda_version=${camunda_version}" | tee -a $GITHUB_OUTPUT
           echo "chart_dir_id=${camunda_version}" | tee -a $GITHUB_OUTPUT
 
+          # Extract component image versions from annotation (added by dev build)
+          image_versions=$(yq '.annotations."camunda.io/component-image-versions" // ""' /tmp/Chart.yaml)
+          if [[ -n "${image_versions}" ]]; then
+            echo "image_versions<<EOF" >> $GITHUB_OUTPUT
+            echo "${image_versions}" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          fi
+
       - name: Install release-please
         run: npm i release-please -g
 
@@ -315,22 +323,55 @@ jobs:
 
       - name: Summary
         run: |
-          cat >> $GITHUB_STEP_SUMMARY << 'EOF'
+          # Build workflow search URLs for traceability
+          COMMIT_URL="https://github.com/${{ github.repository }}/commit/${{ steps.parse.outputs.sha }}"
+          DEV_BUILD_SEARCH_URL="https://github.com/${{ github.repository }}/actions/workflows/chart-build-dev.yaml?query=branch%3Amain+is%3Asuccess"
+          SHORT_SHA="${${{ steps.parse.outputs.sha }}:0:7}"
+
+          cat >> $GITHUB_STEP_SUMMARY << EOF
           ## RC Promotion Summary
           
           | Property | Value |
           |----------|-------|
-          | **Input Tag** | `${{ inputs.dev-tag }}` |
-          | **Resolved Dev Tag** | `${{ steps.parse.outputs.resolved_tag }}` |
-          | **RC Tag** | `${{ steps.parse.outputs.rc_tag }}` |
-          | **RC Latest Tag** | `${{ steps.parse.outputs.rc_latest_tag }}` |
-          | **Version** | `${{ steps.parse.outputs.version }}` |
-          | **Commit SHA** | `${{ steps.parse.outputs.sha }}` |
-          | **Camunda Version** | `${{ steps.package.outputs.camunda_version }}` |
-          | **Chart Path** | `charts/camunda-platform-${{ steps.package.outputs.chart_dir_id }}` |
+          | **Input Tag** | \`${{ inputs.dev-tag }}\` |
+          | **Resolved Dev Tag** | \`${{ steps.parse.outputs.resolved_tag }}\` |
+          | **RC Tag** | \`${{ steps.parse.outputs.rc_tag }}\` |
+          | **RC Latest Tag** | \`${{ steps.parse.outputs.rc_latest_tag }}\` |
+          | **Version** | \`${{ steps.parse.outputs.version }}\` |
+          | **Camunda Version** | \`${{ steps.package.outputs.camunda_version }}\` |
+          | **Chart Path** | \`charts/camunda-platform-${{ steps.package.outputs.chart_dir_id }}\` |
+
+          ### 🔗 Traceability
+
+          | Resource | Link |
+          |----------|------|
+          | **Source Commit** | [\`${SHORT_SHA}\`](${COMMIT_URL}) |
+          | **Dev Build Workflow** | [Find build run](${DEV_BUILD_SEARCH_URL}) (search for commit \`${SHORT_SHA}\`) |
+          EOF
+
+          # Add image versions table if available
+          IMAGE_VERSIONS="${{ steps.package.outputs.image_versions }}"
+          if [[ -n "${IMAGE_VERSIONS}" ]]; then
+            cat >> $GITHUB_STEP_SUMMARY << 'EOF'
+
+          ### 🐳 Component Image Versions
+
+          | Component | Version |
+          |-----------|---------|
+          EOF
+            # Parse YAML and format as markdown table rows
+            echo "${IMAGE_VERSIONS}" | while IFS=': ' read -r component version; do
+              [[ -n "${component}" && -n "${version}" ]] && echo "| ${component} | \`${version}\` |" >> $GITHUB_STEP_SUMMARY
+            done
+          fi
+
+          cat >> $GITHUB_STEP_SUMMARY << 'EOF'
           
           ### Release Please PR
-          ${{ steps.release-please.outputs.pr_url || 'PR URL not captured - check release-please output' }}
+          EOF
+          echo "${{ steps.release-please.outputs.pr_url || 'PR URL not captured - check release-please output' }}" >> $GITHUB_STEP_SUMMARY
+          
+          cat >> $GITHUB_STEP_SUMMARY << 'EOF'
           
           ### Next Steps
           1. QA: Test RC package from Harbor using tag `${{ steps.parse.outputs.rc_tag }}`

--- a/.github/workflows/chart-release-public.yaml
+++ b/.github/workflows/chart-release-public.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow
 ---
-name: "Chart - Release Public"
+name: "Chart - Release - Pipeline - 3 - Public"
 
 on:
   workflow_dispatch:
@@ -108,6 +108,24 @@ jobs:
           version="${rc_tag%-rc}"
           echo "version=${version}" | tee -a $GITHUB_OUTPUT
 
+          # Find the dev tag associated with this RC for traceability
+          # Query all tags on this artifact to find the dev tag (format: {version}-dev-{sha})
+          all_tags=$(curl -sf "${HARBOR_API}/${HARBOR_REPO}/artifacts/${rc_tag}/tags" \
+            -u "${HARBOR_REGISTRY_USER}:${HARBOR_REGISTRY_PASSWORD}" | jq -r '.[].name' 2>/dev/null || echo "")
+          
+          dev_tag=$(echo "${all_tags}" | grep -E "^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?-dev-[a-f0-9]+$" | head -1 || echo "")
+          if [[ -n "${dev_tag}" ]]; then
+            echo "dev_tag=${dev_tag}" | tee -a $GITHUB_OUTPUT
+            # Extract commit SHA from dev tag (everything after -dev-)
+            commit_sha="${dev_tag##*-dev-}"
+            echo "commit_sha=${commit_sha}" | tee -a $GITHUB_OUTPUT
+            echo "::notice::Found source dev tag: ${dev_tag} (commit: ${commit_sha})"
+          else
+            echo "::warning::Could not find associated dev tag for traceability"
+            echo "dev_tag=" >> $GITHUB_OUTPUT
+            echo "commit_sha=" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
@@ -177,6 +195,14 @@ jobs:
           echo "cosign_bundle=camunda-platform-${version}-cosign-bundle.json" | tee -a $GITHUB_OUTPUT
           echo "cosign_verify=camunda-platform-${version}-cosign-verify.sh" | tee -a $GITHUB_OUTPUT
 
+          # Extract component image versions from annotation (added by dev build)
+          image_versions=$(yq '.annotations."camunda.io/component-image-versions" // ""' /tmp/Chart.yaml)
+          if [[ -n "${image_versions}" ]]; then
+            echo "image_versions<<EOF" >> $GITHUB_OUTPUT
+            echo "${image_versions}" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          fi
+
       - name: Check if release already exists
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -227,7 +253,8 @@ jobs:
         id: rekor
         working-directory: .cr-release-packages
         run: |
-          rekor_log_index=$(jq '.rekorBundle.Payload.logIndex' "${{ steps.metadata.outputs.cosign_bundle }}")
+          # New cosign bundle format uses .verificationMaterial.tlogEntries[0].logIndex
+          rekor_log_index=$(jq -r '.verificationMaterial.tlogEntries[0].logIndex // .rekorBundle.Payload.logIndex // "unavailable"' "${{ steps.metadata.outputs.cosign_bundle }}")
           echo "log_index=${rekor_log_index}" | tee -a $GITHUB_OUTPUT
 
       - name: Create Cosign verify script
@@ -270,13 +297,79 @@ jobs:
 
       - name: Add release info to workflow summary
         run: |
-          echo "ℹ️ Release Published ℹ️" >> $GITHUB_STEP_SUMMARY
-          cat << EOF >> $GITHUB_STEP_SUMMARY
-          - GitHub: https://github.com/${GITHUB_REPOSITORY}/releases/tag/${{ steps.metadata.outputs.release_tag }}
-          - Artifact Hub: https://artifacthub.io/packages/helm/camunda/camunda-platform/${{ steps.metadata.outputs.version }}
-          - Rekor record: https://search.sigstore.dev/?logIndex=${{ steps.rekor.outputs.log_index }}
-          Note: Artifact Hub link needs some time till AH scrapes the Helm repo index.
+          cat >> $GITHUB_STEP_SUMMARY << 'EOF'
+          ## 🚀 Release Published
+
+          ### Release Info
+
+          | Property | Value |
+          |----------|-------|
+          | **Chart Version** | `${{ steps.metadata.outputs.version }}` |
+          | **Camunda Version** | `${{ steps.metadata.outputs.app_version }}` |
+          | **Release Tag** | `${{ steps.metadata.outputs.release_tag }}` |
+          | **Input RC Tag** | `${{ inputs.rc-tag }}` |
+          | **Prerelease** | `${{ steps.metadata.outputs.prerelease }}` |
+
+          ### Links
+
+          | Resource | URL |
+          |----------|-----|
+          | **GitHub Release** | [View Release](https://github.com/${{ github.repository }}/releases/tag/${{ steps.metadata.outputs.release_tag }}) |
+          | **Artifact Hub** | [View on Artifact Hub](https://artifacthub.io/packages/helm/camunda/camunda-platform/${{ steps.metadata.outputs.version }}) |
+          | **Rekor Transparency Log** | [View Record](https://search.sigstore.dev/?logIndex=${{ steps.rekor.outputs.log_index }}) |
+
+          > **Note:** Artifact Hub may take a few minutes to index the new release.
           EOF
+
+          # Add image versions table if available
+          IMAGE_VERSIONS="${{ steps.metadata.outputs.image_versions }}"
+          if [[ -n "${IMAGE_VERSIONS}" ]]; then
+            cat >> $GITHUB_STEP_SUMMARY << 'EOF'
+
+          ### 🐳 Component Image Versions
+
+          | Component | Version |
+          |-----------|---------|
+          EOF
+            # Parse YAML and format as markdown table rows
+            echo "${IMAGE_VERSIONS}" | while IFS=': ' read -r component version; do
+              [[ -n "${component}" && -n "${version}" ]] && echo "| ${component} | \`${version}\` |" >> $GITHUB_STEP_SUMMARY
+            done
+          fi
+
+          cat >> $GITHUB_STEP_SUMMARY << 'EOF'
+
+          ### Install
+
+          ```bash
+          helm repo add camunda https://helm.camunda.io
+          helm repo update
+          helm install camunda camunda/camunda-platform --version ${{ steps.metadata.outputs.version }}
+          ```
+          EOF
+
+          # Add traceability section if we have the source info
+          DEV_TAG="${{ steps.parse.outputs.dev_tag }}"
+          COMMIT_SHA="${{ steps.parse.outputs.commit_sha }}"
+          if [[ -n "${DEV_TAG}" && -n "${COMMIT_SHA}" ]]; then
+            SHORT_SHA="${COMMIT_SHA:0:7}"
+            COMMIT_URL="https://github.com/${{ github.repository }}/commit/${COMMIT_SHA}"
+            DEV_BUILD_URL="https://github.com/${{ github.repository }}/actions/workflows/chart-build-dev.yaml?query=branch%3Amain+is%3Asuccess"
+            RC_PROMOTE_URL="https://github.com/${{ github.repository }}/actions/workflows/chart-promote-rc.yaml?query=is%3Asuccess"
+
+            cat >> $GITHUB_STEP_SUMMARY << EOF
+
+          ### 🔗 Traceability
+
+          | Stage | Reference |
+          |-------|-----------|
+          | **Source Commit** | [\`${SHORT_SHA}\`](${COMMIT_URL}) |
+          | **Dev Tag** | \`${DEV_TAG}\` |
+          | **RC Tag** | \`${{ steps.parse.outputs.resolved_tag }}\` |
+          | **Dev Build** | [Find workflow run](${DEV_BUILD_URL}) |
+          | **RC Promotion** | [Find workflow run](${RC_PROMOTE_URL}) |
+          EOF
+          fi
 
   post-release:
     name: Post-Release


### PR DESCRIPTION
### Which problem does the PR fix?

Minor cosmetic and style improvements to the release workflows for better readability and consistency.

Closes #4992
Closes #4995
Closes #4996

### What's in this PR?

This PR contains cosmetic finetunings across the three release workflows without affecting functionality:

**Workflows affected:**
- `.github/workflows/chart-build-dev.yaml`
- `.github/workflows/chart-promote-rc.yaml`
- `.github/workflows/chart-release-public.yaml`

**Changes:**
- [x] Add `camunda.io/component-image-versions` annotation to Chart.yaml during dev build, making the artifact self-documenting with exact component versions (order matches workflow summary)
- [x] Add component image versions table to RC promotion workflow summary (extracted from the annotation added during dev build)
- [x] Fix Rekor log index bug in public release workflow (was showing "null" due to outdated jq path for new cosign bundle format)
- [x] Revamp public release workflow summary to be more informative with tables, clickable links, image versions, and install instructions
- [x] Add traceability cross-links between workflows: RC promotion links to source commit and dev build; public release extracts dev tag from Harbor and links to commit, dev build, and RC promotion workflows
- [x] Rename release pipeline workflows for consistent naming and grouping in GitHub UI:
  - `"Chart - Build - Dev"` → `"Chart - Release - Pipeline - 1 - Build Dev"`
  - `"Chart - Promote RC"` → `"Chart - Release - Pipeline - 2 - Promote RC"`
  - `"Chart - Release Public"` → `"Chart - Release - Pipeline - 3 - Public"`

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`. N/A - workflow changes only
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed). N/A - workflow changes only
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed). N/A

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
