### PR TITLE
fix: drop rc in official tgz filename

### DIFF
--- a/.github/workflows/chart-release-public.yaml
+++ b/.github/workflows/chart-release-public.yaml
@@ -164,7 +164,7 @@ jobs:
 
           # drop -rc from filename
           filename=$(ls .cr-release-packages/camunda-platform-*-rc*.tgz)
-          mv ".cr-release-packages/$filename" ".cr-release-packages/${filename/-rc/}"
+          mv "$filename" "${filename/-rc/}"
           
           echo "Downloaded package:"
           ls -la .cr-release-packages/


### PR DESCRIPTION
### Which problem does the PR fix?

In the public release, there is currently a -rc  in the filename. However, that is supposed to represent the official release, so it should not be a release candidate.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

renames the file 

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
