### PR TITLE
fix: no longer use githubs prerelease marker and set latest if it's latest stable

### DIFF
--- a/.github/workflows/chart-release-public.yaml
+++ b/.github/workflows/chart-release-public.yaml
@@ -187,6 +187,13 @@ jobs:
           echo "version=${version}" | tee -a $GITHUB_OUTPUT
           echo "app_version=${app_version}" | tee -a $GITHUB_OUTPUT
           echo "prerelease=${prerelease}" | tee -a $GITHUB_OUTPUT
+
+          latest_app_version="$(yq '.camundaVersions.supportStandard.[0]' $(git rev-parse --show-toplevel)/charts/chart-versions.yaml)"
+          is_latest_stable="false"
+          if [[ "${app_version}" == "${latest_app_version}" ]]; then
+            is_latest_stable="true"
+          fi
+          echo "is_latest_stable=${is_latest_stable}" | tee -a $GITHUB_OUTPUT
           
           # Chart dir ID is the app version (e.g., 8.8)
           echo "chart_dir_id=${app_version}" | tee -a $GITHUB_OUTPUT
@@ -226,6 +233,7 @@ jobs:
             --push \
             --owner "${{ github.repository_owner }}" \
             --git-repo "$(basename ${{ github.repository }})" \
+            --make-release-latest "${{ steps.metadata.outputs.is_latest_stable }}" \
             --release-name-template "${{ steps.metadata.outputs.release_tag }}"
 
       - name: Run Chart Releaser - Indexing
@@ -237,15 +245,6 @@ jobs:
             --owner "${{ github.repository_owner }}" \
             --git-repo "$(basename ${{ github.repository }})" \
             --release-name-template "${{ steps.metadata.outputs.release_tag }}"
-
-      - name: Set GitHub release type (prerelease)
-        if: ${{ steps.metadata.outputs.prerelease == 'true' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release edit "${{ steps.metadata.outputs.release_tag }}" \
-            --repo "${GITHUB_REPOSITORY}" \
-            --prerelease
 
       - name: Sign Helm chart with Cosign
         working-directory: .cr-release-packages


### PR DESCRIPTION

### Which problem does the PR fix?

In conversation with @maxdanilov , we came to the conclusion that the helm chart should fall in line with the camunda/camunda repo regarding how we set the prerelease annotation in the Github Release. This marker should not be used for alpha builds. We also want to set the Latest github release bubble to be used when the release is the latest stable version of camunda.

slack link: https://camunda.slack.com/archives/C03UR0V2R2M/p1768322261520889

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

minor tweaks to the public release flow

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
