### PR TITLE
fix(openshift): when es is disabled, fix templating error of label

### DIFF
--- a/charts/camunda-platform-8.6/templates/zeebe/1/2/3/4/5/6/7/8/z_compatibility_helpers.tpl
+++ b/charts/camunda-platform-8.6/templates/zeebe/1/2/3/4/5/6/7/8/z_compatibility_helpers.tpl
@@ -80,14 +80,16 @@ Also, recent OpenShift versions (> 4.10) have adjusted the virtual memory of the
 OpenShift.
 The label `tuned.openshift.io/elasticsearch` is added to ensure compatibility with the previous Camunda Helm charts.
 Without this label, the Helm upgrade will fail for OpenShift because it is already set for the volumeClaimTemplate.
+This is only needed when elasticsearch is actually enabled and deployed.
 */}}
 
-{{- if .Values.elasticsearch.enabled -}}
-  {{- if eq .Values.global.compatibility.openshift.adaptSecurityContext "force" -}}
-      {{- if not (hasKey .Values.elasticsearch.commonLabels "tuned.openshift.io/elasticsearch") -}}
-          {{- $_ := set .Values.elasticsearch.commonLabels "tuned.openshift.io/elasticsearch" "" -}}
-      {{- end -}}
-  {{- end -}}
+{{- if and (eq .Values.global.compatibility.openshift.adaptSecurityContext "force") .Values.elasticsearch.enabled -}}
+    {{- if not (hasKey .Values.elasticsearch "commonLabels") -}}
+        {{- $_ := set .Values.elasticsearch "commonLabels" (dict) -}}
+    {{- end -}}
+    {{- if not (hasKey .Values.elasticsearch.commonLabels "tuned.openshift.io/elasticsearch") -}}
+        {{- $_ := set .Values.elasticsearch.commonLabels "tuned.openshift.io/elasticsearch" "" -}}
+    {{- end -}}
 {{- end -}}
 {{/*
 Elasticsearch.

--- a/charts/camunda-platform-8.6/test/unit/camunda/compatibility_helpers_test.go
+++ b/charts/camunda-platform-8.6/test/unit/camunda/compatibility_helpers_test.go
@@ -1,0 +1,99 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package camunda
+
+import (
+	"camunda-platform/test/unit/testhelpers"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type CompatibilityHelpersTest struct {
+	suite.Suite
+	chartPath string
+	release   string
+	namespace string
+	templates []string
+}
+
+func TestCompatibilityHelpers(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../")
+	require.NoError(t, err)
+
+	suite.Run(t, &CompatibilityHelpersTest{
+		chartPath: chartPath,
+		release:   "camunda-platform-test",
+		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
+		templates: []string{"templates/camunda/configmap-release.yaml"},
+	})
+}
+
+func (c *CompatibilityHelpersTest) TestElasticsearchDisabledWithOpenShiftAdaptSecurityContext() {
+	// This test verifies that the chart can be rendered when elasticsearch is disabled
+	// and OpenShift adaptSecurityContext is set to "force".
+	// This is a regression test for the bug where hasKey was called on a nil commonLabels.
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "ElasticsearchDisabledWithOpenShiftForce",
+			Values: map[string]string{
+				"elasticsearch.enabled":                                  "false",
+				"global.compatibility.openshift.adaptSecurityContext":    "force",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.Nil(t, err, "Chart rendering should succeed when elasticsearch is disabled with OpenShift adaptSecurityContext=force")
+			},
+		},
+		{
+			Name: "ElasticsearchDisabledWithOpenShiftForceNoCommonLabels",
+			Values: map[string]string{
+				"elasticsearch.enabled":                                  "false",
+				"global.compatibility.openshift.adaptSecurityContext":    "force",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.Nil(t, err, "Chart rendering should succeed when elasticsearch is disabled without commonLabels defined")
+			},
+		},
+		{
+			Name: "ElasticsearchEnabledWithOpenShiftForce",
+			Values: map[string]string{
+				"elasticsearch.enabled":                                  "true",
+				"global.compatibility.openshift.adaptSecurityContext":    "force",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.Nil(t, err, "Chart rendering should succeed when elasticsearch is enabled with OpenShift adaptSecurityContext=force")
+			},
+		},
+		{
+			Name: "ElasticsearchEnabledWithOpenShiftForceAndExistingCommonLabels",
+			Values: map[string]string{
+				"elasticsearch.enabled":                                  "true",
+				"global.compatibility.openshift.adaptSecurityContext":    "force",
+				"elasticsearch.commonLabels.custom-label":                "custom-value",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.Nil(t, err, "Chart rendering should succeed when elasticsearch is enabled with existing commonLabels")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(c.T(), c.chartPath, c.release, c.namespace, c.templates, testCases)
+}

--- a/charts/camunda-platform-8.7/templates/zeebe/1/2/3/4/5/6/7/8/z_compatibility_helpers.tpl
+++ b/charts/camunda-platform-8.7/templates/zeebe/1/2/3/4/5/6/7/8/z_compatibility_helpers.tpl
@@ -80,14 +80,16 @@ Also, recent OpenShift versions (> 4.10) have adjusted the virtual memory of the
 OpenShift.
 The label `tuned.openshift.io/elasticsearch` is added to ensure compatibility with the previous Camunda Helm charts.
 Without this label, the Helm upgrade will fail for OpenShift because it is already set for the volumeClaimTemplate.
+This is only needed when elasticsearch is actually enabled and deployed.
 */}}
 
-{{- if .Values.elasticsearch.enabled -}}
-  {{- if eq .Values.global.compatibility.openshift.adaptSecurityContext "force" -}}
-      {{- if not (hasKey .Values.elasticsearch.commonLabels "tuned.openshift.io/elasticsearch") -}}
-          {{- $_ := set .Values.elasticsearch.commonLabels "tuned.openshift.io/elasticsearch" "" -}}
-      {{- end -}}
-  {{- end -}}
+{{- if and (eq .Values.global.compatibility.openshift.adaptSecurityContext "force") .Values.elasticsearch.enabled -}}
+    {{- if not (hasKey .Values.elasticsearch "commonLabels") -}}
+        {{- $_ := set .Values.elasticsearch "commonLabels" (dict) -}}
+    {{- end -}}
+    {{- if not (hasKey .Values.elasticsearch.commonLabels "tuned.openshift.io/elasticsearch") -}}
+        {{- $_ := set .Values.elasticsearch.commonLabels "tuned.openshift.io/elasticsearch" "" -}}
+    {{- end -}}
 {{- end -}}
 {{/*
 Elasticsearch.

--- a/charts/camunda-platform-8.7/test/unit/camunda/compatibility_helpers_test.go
+++ b/charts/camunda-platform-8.7/test/unit/camunda/compatibility_helpers_test.go
@@ -1,0 +1,99 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package camunda
+
+import (
+	"camunda-platform/test/unit/testhelpers"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type CompatibilityHelpersTest struct {
+	suite.Suite
+	chartPath string
+	release   string
+	namespace string
+	templates []string
+}
+
+func TestCompatibilityHelpers(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../")
+	require.NoError(t, err)
+
+	suite.Run(t, &CompatibilityHelpersTest{
+		chartPath: chartPath,
+		release:   "camunda-platform-test",
+		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
+		templates: []string{"templates/camunda/configmap-release.yaml"},
+	})
+}
+
+func (c *CompatibilityHelpersTest) TestElasticsearchDisabledWithOpenShiftAdaptSecurityContext() {
+	// This test verifies that the chart can be rendered when elasticsearch is disabled
+	// and OpenShift adaptSecurityContext is set to "force".
+	// This is a regression test for the bug where hasKey was called on a nil commonLabels.
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "ElasticsearchDisabledWithOpenShiftForce",
+			Values: map[string]string{
+				"elasticsearch.enabled":                                  "false",
+				"global.compatibility.openshift.adaptSecurityContext":    "force",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.Nil(t, err, "Chart rendering should succeed when elasticsearch is disabled with OpenShift adaptSecurityContext=force")
+			},
+		},
+		{
+			Name: "ElasticsearchDisabledWithOpenShiftForceNoCommonLabels",
+			Values: map[string]string{
+				"elasticsearch.enabled":                                  "false",
+				"global.compatibility.openshift.adaptSecurityContext":    "force",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.Nil(t, err, "Chart rendering should succeed when elasticsearch is disabled without commonLabels defined")
+			},
+		},
+		{
+			Name: "ElasticsearchEnabledWithOpenShiftForce",
+			Values: map[string]string{
+				"elasticsearch.enabled":                                  "true",
+				"global.compatibility.openshift.adaptSecurityContext":    "force",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.Nil(t, err, "Chart rendering should succeed when elasticsearch is enabled with OpenShift adaptSecurityContext=force")
+			},
+		},
+		{
+			Name: "ElasticsearchEnabledWithOpenShiftForceAndExistingCommonLabels",
+			Values: map[string]string{
+				"elasticsearch.enabled":                                  "true",
+				"global.compatibility.openshift.adaptSecurityContext":    "force",
+				"elasticsearch.commonLabels.custom-label":                "custom-value",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.Nil(t, err, "Chart rendering should succeed when elasticsearch is enabled with existing commonLabels")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(c.T(), c.chartPath, c.release, c.namespace, c.templates, testCases)
+}

--- a/charts/camunda-platform-8.8/test/unit/common/compatibility_helpers_test.go
+++ b/charts/camunda-platform-8.8/test/unit/common/compatibility_helpers_test.go
@@ -1,0 +1,99 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package camunda
+
+import (
+	"camunda-platform/test/unit/testhelpers"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type CompatibilityHelpersTest struct {
+	suite.Suite
+	chartPath string
+	release   string
+	namespace string
+	templates []string
+}
+
+func TestCompatibilityHelpers(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../")
+	require.NoError(t, err)
+
+	suite.Run(t, &CompatibilityHelpersTest{
+		chartPath: chartPath,
+		release:   "camunda-platform-test",
+		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
+		templates: []string{"templates/common/configmap-release.yaml"},
+	})
+}
+
+func (c *CompatibilityHelpersTest) TestElasticsearchDisabledWithOpenShiftAdaptSecurityContext() {
+	// This test verifies that the chart can be rendered when elasticsearch is disabled
+	// and OpenShift adaptSecurityContext is set to "force".
+	// This is a regression test for the bug where hasKey was called on a nil commonLabels.
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "ElasticsearchDisabledWithOpenShiftForce",
+			Values: map[string]string{
+				"elasticsearch.enabled":                                  "false",
+				"global.compatibility.openshift.adaptSecurityContext":    "force",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.Nil(t, err, "Chart rendering should succeed when elasticsearch is disabled with OpenShift adaptSecurityContext=force")
+			},
+		},
+		{
+			Name: "ElasticsearchDisabledWithOpenShiftForceNoCommonLabels",
+			Values: map[string]string{
+				"elasticsearch.enabled":                                  "false",
+				"global.compatibility.openshift.adaptSecurityContext":    "force",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.Nil(t, err, "Chart rendering should succeed when elasticsearch is disabled without commonLabels defined")
+			},
+		},
+		{
+			Name: "ElasticsearchEnabledWithOpenShiftForce",
+			Values: map[string]string{
+				"elasticsearch.enabled":                                  "true",
+				"global.compatibility.openshift.adaptSecurityContext":    "force",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.Nil(t, err, "Chart rendering should succeed when elasticsearch is enabled with OpenShift adaptSecurityContext=force")
+			},
+		},
+		{
+			Name: "ElasticsearchEnabledWithOpenShiftForceAndExistingCommonLabels",
+			Values: map[string]string{
+				"elasticsearch.enabled":                                  "true",
+				"global.compatibility.openshift.adaptSecurityContext":    "force",
+				"elasticsearch.commonLabels.custom-label":                "custom-value",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.Nil(t, err, "Chart rendering should succeed when elasticsearch is enabled with existing commonLabels")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(c.T(), c.chartPath, c.release, c.namespace, c.templates, testCases)
+}

--- a/charts/camunda-platform-8.9/test/unit/common/compatibility_helpers_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/compatibility_helpers_test.go
@@ -1,0 +1,99 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package camunda
+
+import (
+	"camunda-platform/test/unit/testhelpers"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type CompatibilityHelpersTest struct {
+	suite.Suite
+	chartPath string
+	release   string
+	namespace string
+	templates []string
+}
+
+func TestCompatibilityHelpers(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../")
+	require.NoError(t, err)
+
+	suite.Run(t, &CompatibilityHelpersTest{
+		chartPath: chartPath,
+		release:   "camunda-platform-test",
+		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
+		templates: []string{"templates/common/configmap-release.yaml"},
+	})
+}
+
+func (c *CompatibilityHelpersTest) TestElasticsearchDisabledWithOpenShiftAdaptSecurityContext() {
+	// This test verifies that the chart can be rendered when elasticsearch is disabled
+	// and OpenShift adaptSecurityContext is set to "force".
+	// This is a regression test for the bug where hasKey was called on a nil commonLabels.
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "ElasticsearchDisabledWithOpenShiftForce",
+			Values: map[string]string{
+				"elasticsearch.enabled":                                  "false",
+				"global.compatibility.openshift.adaptSecurityContext":    "force",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.Nil(t, err, "Chart rendering should succeed when elasticsearch is disabled with OpenShift adaptSecurityContext=force")
+			},
+		},
+		{
+			Name: "ElasticsearchDisabledWithOpenShiftForceNoCommonLabels",
+			Values: map[string]string{
+				"elasticsearch.enabled":                                  "false",
+				"global.compatibility.openshift.adaptSecurityContext":    "force",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.Nil(t, err, "Chart rendering should succeed when elasticsearch is disabled without commonLabels defined")
+			},
+		},
+		{
+			Name: "ElasticsearchEnabledWithOpenShiftForce",
+			Values: map[string]string{
+				"elasticsearch.enabled":                                  "true",
+				"global.compatibility.openshift.adaptSecurityContext":    "force",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.Nil(t, err, "Chart rendering should succeed when elasticsearch is enabled with OpenShift adaptSecurityContext=force")
+			},
+		},
+		{
+			Name: "ElasticsearchEnabledWithOpenShiftForceAndExistingCommonLabels",
+			Values: map[string]string{
+				"elasticsearch.enabled":                                  "true",
+				"global.compatibility.openshift.adaptSecurityContext":    "force",
+				"elasticsearch.commonLabels.custom-label":                "custom-value",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.Nil(t, err, "Chart rendering should succeed when elasticsearch is enabled with existing commonLabels")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(c.T(), c.chartPath, c.release, c.namespace, c.templates, testCases)
+}


### PR DESCRIPTION
### Which problem does the PR fix?

closes https://github.com/camunda/camunda-platform-helm/issues/2779

Fixes Helm chart rendering failure when deploying on OpenShift with Elasticsearch disabled:

```
Error: INSTALLATION FAILED: template: camunda-platform/templates/zeebe/1/2/3/4/5/6/7/8/z_compatibility_helpers.tpl:87:30: 
at <.Values.elasticsearch.commonLabels>: wrong type for value; expected map[string]interface {}; got interface {}
```

This occurs with values like:
```yaml
elasticsearch:
  enabled: false

global:
  compatibility:
    openshift:
      adaptSecurityContext: force
```

**Root cause:** The `hasKey` function was called on `.Values.elasticsearch.commonLabels` without ensuring it was a proper map. When elasticsearch was disabled without explicitly defining `commonLabels: {}`, the value became `nil` causing the template to fail.

### What's in this PR?

Updated the compatibility helpers in charts **8.6** and **8.7** to match the already-correct implementation in 8.8/8.9:

1. Combine conditions using `and` (`elasticsearch.enabled` AND `adaptSecurityContext == "force"`)
2. First check if `commonLabels` key exists, create empty dict if not
3. Then safely check for the `tuned.openshift.io/elasticsearch` label

**Before:**
```go-template
{{- if .Values.elasticsearch.enabled -}}
  {{- if eq .Values.global.compatibility.openshift.adaptSecurityContext "force" -}}
      {{- if not (hasKey .Values.elasticsearch.commonLabels "tuned.openshift.io/elasticsearch") -}}
          {{- $_ := set .Values.elasticsearch.commonLabels "tuned.openshift.io/elasticsearch" "" -}}
      {{- end -}}
  {{- end -}}
{{- end -}}
```

**After:**
```go-template
{{- if and (eq .Values.global.compatibility.openshift.adaptSecurityContext "force") .Values.elasticsearch.enabled -}}
    {{- if not (hasKey .Values.elasticsearch "commonLabels") -}}
        {{- $_ := set .Values.elasticsearch "commonLabels" (dict) -}}
    {{- end -}}
    {{- if not (hasKey .Values.elasticsearch.commonLabels "tuned.openshift.io/elasticsearch") -}}
        {{- $_ := set .Values.elasticsearch.commonLabels "tuned.openshift.io/elasticsearch" "" -}}
    {{- end -}}
{{- end -}}
```

**Files changed:**
| Chart | File |
|-------|------|
| 8.6 | `templates/zeebe/1/2/3/4/5/6/7/8/z_compatibility_helpers.tpl` |
| 8.7 | `templates/zeebe/1/2/3/4/5/6/7/8/z_compatibility_helpers.tpl` |

**Unit tests added:**
| Chart | File |
|-------|------|
| 8.6 | `test/unit/camunda/compatibility_helpers_test.go` |
| 8.7 | `test/unit/camunda/compatibility_helpers_test.go` |
| 8.8 | `test/unit/common/compatibility_helpers_test.go` |
| 8.9 | `test/unit/common/compatibility_helpers_test.go` |

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
