### PR TITLE
ci: scope version matrix regeneration to releasing chart only

### DIFF
--- a/.github/workflows/chart-release-chores.yaml
+++ b/.github/workflows/chart-release-chores.yaml
@@ -101,8 +101,10 @@ jobs:
       - name: Generate version matrix
         run: |
           make helm.repos-add
-          make release.generate-version-matrix-released
           for chartPath in "${CHANGED_CHARTS}"; do
+            # Extract app version (e.g., 8.8 from charts/camunda-platform-8.8)
+            appVersion=$(echo "$chartPath" | sed 's|charts/camunda-platform-||')
+            CAMUNDA_VERSION=$appVersion make -e release.generate-version-matrix-released
             chartPath=$chartPath make -e release.generate-version-matrix-index
             chartPath=$chartPath make -e release.generate-version-matrix-unreleased
           done

--- a/scripts/generate-version-matrix.sh
+++ b/scripts/generate-version-matrix.sh
@@ -128,9 +128,17 @@ generate_version_matrix_single () {
 # Generate a version matrix for each released and supported Camunda version.
 # It's still possible to generate the version matrix for all released Camunda versions by setting 
 # CAMUNDA_APPS_UNSUPPORTED_VERSIONS_REGEX to "any" so it will match all versions even unsupported ones.
+# Set CAMUNDA_VERSION to only regenerate a specific version (e.g., CAMUNDA_VERSION=8.8).
 generate_version_matrix_released () {
     get_versions_filtered | jq -c '.[]' | while read SUPPORTED_CAMUNDA_VERSION_DATA; do
         SUPPORTED_CAMUNDA_VERSION="$(echo ${SUPPORTED_CAMUNDA_VERSION_DATA} | jq -r '.app')"
+        
+        # If CAMUNDA_VERSION is set, only process that specific version
+        if [[ -n "${CAMUNDA_VERSION:-}" && "${SUPPORTED_CAMUNDA_VERSION}" != "${CAMUNDA_VERSION}" ]]; then
+            echo -e "#\n# Skipping Camunda ${SUPPORTED_CAMUNDA_VERSION} (CAMUNDA_VERSION=${CAMUNDA_VERSION})\n#"
+            continue
+        fi
+        
         mkdir -p "version-matrix/camunda-${SUPPORTED_CAMUNDA_VERSION}"
         echo -e "#\n# Generating version matrix for Camunda ${SUPPORTED_CAMUNDA_VERSION}\n#"
         generate_version_matrix_single "${SUPPORTED_CAMUNDA_VERSION_DATA}" | tee \


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #4994

When release-please creates a PR, version matrix regeneration processes ALL supported Camunda versions instead of just the releasing chart. This causes unrelated charts to have their Helm CLI versions incorrectly modified.

### What's in this PR?

Adds `CAMUNDA_VERSION` env var support to scope `generate_version_matrix_released()` to only process the specified version.

### Checklist

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`. N/A - script/workflow change only
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed). N/A
- [x] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed). N/A