### PR TITLE
ci: handle breaking change commits in git-cliff config

### DIFF
--- a/.github/config/cliff.toml
+++ b/.github/config/cliff.toml
@@ -19,11 +19,17 @@ body = """
 {% else %}\
     ## [unreleased]
 {% endif %}\
+{% set breaking_commits = commits | filter(attribute="breaking", value=true) %}\
+{% if breaking_commits | length > 0 %}
+    ### ⚠ BREAKING CHANGES
+    {% for commit in breaking_commits %}
+        - **{{ commit.message | upper_first }}**\
+    {% endfor %}
+{% endif %}\
 {% for group, commits in commits | group_by(attribute="group") %}
     ### {{ group | striptags | trim | upper_first }}
     {% for commit in commits %}
-        - {% if commit.breaking %}**⚠ BREAKING CHANGE** {% endif %}\
-            {{ commit.message | upper_first }}\
+        - {{ commit.message | upper_first }}\
     {% endfor %}
 {% endfor %}\n
 """
@@ -55,14 +61,14 @@ commit_preprocessors = [
 ]
 # regex for parsing and grouping commits
 commit_parsers = [
-  { message = "^feat:", group = "<!-- 0 -->Features" },
-  { message = "^refactor:", group = "<!-- 1 -->Refactor" },
-  { message = "^fix:", group = "<!-- 2 -->Fixes" },
-  { message = "^docs:", group = "<!-- 3 -->Documentation" },
-  { message = "^revert:", group = "<!-- 4 -->Revert" },
+  { message = "^feat(!)?:", group = "<!-- 0 -->Features" },
+  { message = "^refactor(!)?:", group = "<!-- 1 -->Refactor" },
+  { message = "^fix(!)?:", group = "<!-- 2 -->Fixes" },
+  { message = "^docs(!)?:", group = "<!-- 3 -->Documentation" },
+  { message = "^revert(!)?:", group = "<!-- 4 -->Revert" },
 ]
 # protect breaking changes from being skipped due to matching a skipping commit_parser
-protect_breaking_commits = false
+protect_breaking_commits = true
 # filter out the commits that are not matched by commit parsers
 filter_commits = true
 # regex for matching git tags


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #5011

### What's in this PR?

Updates `.github/config/cliff.toml`:
- Fix regex patterns to match `type!:` breaking change notation
- Enable `protect_breaking_commits = true`
- Add dedicated `### ⚠ BREAKING CHANGES` section in changelog template

### Checklist

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open pull request for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo documentation are updated (if needed).