### PR TITLE
ci: skip upgrade flows for Renovate image/digest PRs

### DIFF
--- a/.github/actions/generate-chart-matrix/action.yaml
+++ b/.github/actions/generate-chart-matrix/action.yaml
@@ -81,12 +81,27 @@ runs:
       env:
         ALL_MODIFIED_FILES: ${{ steps.changed-files.outputs.all_modified_files }}
       run: |
+        # Detect image-only PRs by branch name (Renovate groups image updates)
+        # Branch patterns that indicate image-only changes:
+        # - renovate/camunda-platform-images (patch updates)
+        # - renovate/patch-camunda-platform-images (patch updates)
+        # - renovate/camunda-platform-digests (digest updates)
+        SKIP_UPGRADE_FLOWS="false"
+        BRANCH_NAME="${GITHUB_HEAD_REF:-}"
+        echo "Branch name: ${BRANCH_NAME}"
+        
+        if [[ "$BRANCH_NAME" =~ ^renovate/(patch-)?camunda-platform-(images|digests)$ ]]; then
+          SKIP_UPGRADE_FLOWS="true"
+          echo "✅ Image/digest update branch detected - upgrade flows will be skipped"
+        fi
+
         bash scripts/generate-chart-matrix.sh \
           --manual-trigger "${{ inputs.manual-trigger }}" \
           --manual-scenario "${{ inputs.manual-scenario }}" \
           --manual-flow "${{ inputs.manual-flow }}" \
           --active-versions "${{ steps.get-chart-versions.outputs.active }}" \
-          --all-modified-files "${{ steps.changed-files.outputs.all_modified_files }}"
+          --all-modified-files "${{ steps.changed-files.outputs.all_modified_files }}" \
+          --skip-upgrade-flows "${SKIP_UPGRADE_FLOWS}"
     - name: Generate matrix Camunda versions
       shell: bash
       id: set-camunda-versions


### PR DESCRIPTION
### Which problem does the PR fix?


### What's in this PR?

When Renovate creates PRs for Camunda component image patches or digest updates, the full CI test matrix runs including `upgrade-patch` and `upgrade-minor` flows. These upgrade flows are unnecessary for image-only changes because they validate chart structural changes and migration logic—neither of which apply to image updates.

This PR detects Renovate image/digest PRs by branch name pattern and skips upgrade flows:
- `renovate/patch-camunda-platform-images`
- `renovate/camunda-platform-images`
- `renovate/camunda-platform-digests`

The `install` flow is still run to validate that the new images work correctly together.

**Expected Impact:**
- Reduce jobs from ~120 to ~40-50 for image update PRs
- Reduce CI time from ~35-45 min to ~15-20 min

### Checklist

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
