### PR TITLE
ci: use correct tibdex/github-app-token commit SHA in closed-issue workflow

### DIFF
--- a/.github/workflows/closed-issue.yaml
+++ b/.github/workflows/closed-issue.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Generate GitHub token
         id: generate-github-token
-        uses: tibdex/github-app-token@a3da042061e3b5d09ad01f41d2328f429d8d1c62
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
         with:
           app_id: ${{ secrets.GH_APP_ID_DISTRO_CI }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY_DISTRO_CI }}


### PR DESCRIPTION
### Which problem does the PR fix?

Closes camunda/team-distribution#689

The `closed-issue.yaml` workflow was failing because it referenced an invalid commit SHA for `tibdex/github-app-token`.

**Failed run:** https://github.com/camunda/camunda-platform-helm/actions/runs/21138918659

### What's in this PR?

Updated the commit SHA from `a3da042061e3b5d09ad01f41d2328f429d8d1c62` (non-existent) to `3beb63f4bd073e61482598c45c71c1019b59b73a` (v2), matching all other workflows in the repo.

### Checklist

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).