### PR TITLE
feat(ingress): route Web Modeler API requests directly to restapi service

### DIFF
--- a/charts/camunda-platform-8.9/templates/common/ingress-http.yaml
+++ b/charts/camunda-platform-8.9/templates/common/ingress-http.yaml
@@ -58,6 +58,13 @@ spec:
           {{- if and .Values.webModeler.enabled .Values.webModeler.contextPath }}
           - backend:
               service:
+                name: {{ template "webModeler.restapi.fullname" . }}
+                port:
+                  number: {{ .Values.webModeler.restapi.service.port }}
+            path: {{ .Values.webModeler.contextPath }}/api
+            pathType: {{ .Values.global.ingress.pathType }}
+          - backend:
+              service:
                 name: {{ template "webModeler.webapp.fullname" . }}
                 port:
                   number: {{ .Values.webModeler.webapp.service.port }}


### PR DESCRIPTION
### Which problem does the PR fix?
Closes https://github.com/camunda/web-modeler/issues/19623.

### What's in this PR?
Adapt the Ingress rule for Web Modeler, so that all API requests are routed directly to the `restapi` service and are no longer proxied through the `webapp`.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?