### PR TITLE
deps: enterprise elasticsearch version changed to 8.19.9

### DIFF
--- a/charts/camunda-platform-8.9/values-enterprise.yaml
+++ b/charts/camunda-platform-8.9/values-enterprise.yaml
@@ -109,7 +109,7 @@ elasticsearch:
   image:
     registry: registry.camunda.cloud
     repository: vendor-ee/elasticsearch
-    tag: 9.2.3
+    tag: 8.19.9
     pullSecrets:
       - name: registry-camunda-cloud
 


### PR DESCRIPTION
### Which problem does the PR fix?

Related: [#5029](https://github.com/camunda/camunda-platform-helm/issues/5029)

### What's in this PR?

Downgrading enterprise values elasticsearch version following the discussion in

https://camunda.slack.com/archives/C09K1FF3JF5/p1768582066531819

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
