### PR TITLE
fix: unify default REST port to 8080 in helm chart 8.9

### DIFF
--- a/charts/camunda-platform-8.9/templates/NOTES.txt
+++ b/charts/camunda-platform-8.9/templates/NOTES.txt
@@ -79,7 +79,7 @@ The Cluster itself is not exposed as a service which means that you can use `kub
 > kubectl port-forward svc/{{ include "orchestration.serviceName" . }} 26500:26500 -n {{ .Release.Namespace }}
 > kubectl port-forward svc/{{ include "orchestration.serviceName" . }} 8080:8080 -n {{ .Release.Namespace }}
 
-Now you can connect your workers and clients to `localhost:26500` for gRPC or `localhost:26500` for REST API usage.
+Now you can connect your workers and clients to `localhost:26500` for gRPC or `localhost:8080` for REST API usage.
 
 {{ if or (.Values.orchestration.enabled) (.Values.identity.enabled) }}
 ### Connecting to Web apps

--- a/charts/camunda-platform-8.9/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/common/_helpers.tpl
@@ -568,7 +568,7 @@ Zeebe templates.
     {{ $proto := ternary "https" "http" .Values.global.ingress.tls.enabled -}}
     {{- printf "%s://%s%s" $proto .Values.global.ingress.host (include "camundaPlatform.joinpath" (list .Values.orchestration.contextPath)) -}}
   {{- else -}}
-    {{- printf "http://localhost:8088" -}}
+    {{- printf "http://localhost:8080" -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/camunda-platform-8.9/test/unit/console/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.9/test/unit/console/golden/configmap.golden.yaml
@@ -53,17 +53,17 @@ data:
               metrics: http://camunda-platform-test-connectors.camunda-platform:8080/actuator/prometheus
             - name: Operate
               id: operate
-              url: http://localhost:8088/operate
+              url: http://localhost:8080/operate
               readiness: http://camunda-platform-test-zeebe.camunda-platform:9600/actuator/health/readiness
               metrics: http://camunda-platform-test-zeebe.camunda-platform:9600/actuator/prometheus
             - name: Tasklist
               id: tasklist
-              url: http://localhost:8088/tasklist
+              url: http://localhost:8080/tasklist
               readiness: http://camunda-platform-test-zeebe.camunda-platform:9600/actuator/health/readiness
               metrics: http://camunda-platform-test-zeebe.camunda-platform:9600/actuator/prometheus
             - name: Orchestration Identity
               id: orchestrationIdentity
-              url: http://localhost:8088/identity
+              url: http://localhost:8080/identity
               readiness: http://camunda-platform-test-zeebe.camunda-platform:9600/actuator/health/readiness
               metrics: http://camunda-platform-test-zeebe.camunda-platform:9600/actuator/prometheus
           
@@ -71,6 +71,6 @@ data:
               id: orchestration
               urls:
                 grpc: http://localhost:26500
-                http: http://localhost:8088
+                http: http://localhost:8080
               readiness: http://camunda-platform-test-zeebe.camunda-platform:9600/actuator/health/readiness
               metrics: http://camunda-platform-test-zeebe.camunda-platform:9600/actuator/prometheus

--- a/charts/camunda-platform-8.9/test/unit/web-modeler/golden/configmap-restapi.golden.yaml
+++ b/charts/camunda-platform-8.9/test/unit/web-modeler/golden/configmap-restapi.golden.yaml
@@ -51,7 +51,7 @@ data:
             url:
               grpc: "grpc://camunda-platform-test-zeebe-gateway:26500"
               rest: "http://camunda-platform-test-zeebe-gateway:8080"
-              web-app: "http://localhost:8088"
+              web-app: "http://localhost:8080"
 
     spring:
       datasource:

--- a/charts/camunda-platform-8.9/values.yaml
+++ b/charts/camunda-platform-8.9/values.yaml
@@ -1512,7 +1512,7 @@ webModeler:
     #    url:
     #      grpc: "grpc://camunda-platform-orchestration:26500"
     #      rest: "http://camunda-platform-orchestration:8080"
-    #      web-app: "http://localhost:8088"
+    #      web-app: "http://localhost:8080"
 
     ## @param webModeler.restapi.podAnnotations can be used to define extra restapi pod annotations
     podAnnotations: {}


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #5049

### What's in this PR?

Updates localhost fallback URLs from port 8088 to 8080 in chart 8.9, fixing NOTES.txt REST reference (was incorrectly 26500).

Existing tests with 8088 in `webmodeler_test.go` are kept to verify user-provided port overrides work correctly. All unit tests pass.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
