### PR TITLE
ci: pre-populate version-matrix when image overrides are used

### DIFF
--- a/.github/workflows/chart-promote-rc.yaml
+++ b/.github/workflows/chart-promote-rc.yaml
@@ -187,6 +187,7 @@ jobs:
           
           package_file=$(ls /tmp/camunda-platform-*.tgz)
           echo "✅ Dev package exists: ${package_file}"
+          echo "package_file=${package_file}" | tee -a $GITHUB_OUTPUT
           
           # Extract Camunda version from Chart.yaml inside the package
           tar -xzf "${package_file}" camunda-platform/Chart.yaml -O > /tmp/Chart.yaml
@@ -201,6 +202,14 @@ jobs:
             echo "image_versions<<EOF" >> $GITHUB_OUTPUT
             echo "${image_versions}" >> $GITHUB_OUTPUT
             echo "EOF" >> $GITHUB_OUTPUT
+          fi
+
+          # Check if image overrides were used during dev build
+          image_overrides=$(yq '.annotations."camunda.io/imageOverrides" // ""' /tmp/Chart.yaml)
+          if [[ -n "${image_overrides}" ]]; then
+            echo "has_image_overrides=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_image_overrides=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Install release-please
@@ -248,8 +257,70 @@ jobs:
             exit 1
           fi
           echo "pr_url=${pr_url}" | tee -a "$GITHUB_OUTPUT"
+          echo "head_ref=${head_ref}" | tee -a "$GITHUB_OUTPUT"
           
           echo "::notice::Release-please PR: ${pr_url}"
+
+      - name: Pre-populate version matrix from dev package
+        if: steps.package.outputs.has_image_overrides == 'true'
+        env:
+          GH_TOKEN: ${{ steps.generate-github-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          
+          chart_version="${{ steps.parse.outputs.version }}"
+          app_version="${{ steps.package.outputs.camunda_version }}"
+          head_ref="${{ steps.release-please.outputs.head_ref }}"
+          package_file="${{ steps.package.outputs.package_file }}"
+          chart_path="charts/camunda-platform-${app_version}"
+          
+          echo "Extracting images from dev package for version-matrix.json"
+          
+          # Extract the chart from the package
+          mkdir -p /tmp/rc-chart
+          tar -xzf "${package_file}" -C /tmp/rc-chart
+          
+          # Get images using helm template on the extracted package
+          chart_images=$(
+            helm template --skip-tests camunda /tmp/rc-chart/camunda-platform \
+              --values "${chart_path}/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-keycloak.yaml" 2>/dev/null |
+            tr -d "\"'" | awk '/image:/{gsub(/^(camunda|bitnami)/, "docker.io/&", $2); printf "%s\n", $2}' |
+            sort | uniq
+          )
+          chart_images_json=$(echo -e "$chart_images" | jq -R | jq -sc)
+          
+          # Checkout release-please branch to update version-matrix.json
+          git fetch origin "${head_ref}"
+          git checkout "${head_ref}"
+          
+          # Update version-matrix.json
+          version_matrix_file="version-matrix/camunda-${app_version}/version-matrix.json"
+          mkdir -p "$(dirname "${version_matrix_file}")"
+          test -f "${version_matrix_file}" || echo '[]' > "${version_matrix_file}"
+          
+          # Remove existing entry for this version if present, then add new one
+          updated_json=$(cat "${version_matrix_file}" | \
+            jq --arg ver "${chart_version}" 'map(select(.chart_version != $ver))' | \
+            jq --arg ver "${chart_version}" --argjson imgs "${chart_images_json}" \
+              '. + [{"chart_version": $ver, "chart_images": $imgs}]')
+          
+          echo "${updated_json}" > "${version_matrix_file}"
+          
+          # Check if there are changes to commit
+          if git diff --quiet "${version_matrix_file}"; then
+            echo "::notice::No changes to version-matrix.json"
+          else
+            git config user.name "distro-ci[bot]"
+            git config user.email "122795778+distro-ci[bot]@users.noreply.github.com"
+            git add "${version_matrix_file}"
+            git commit -m "chore: pre-populate version-matrix from dev package ${{ steps.parse.outputs.resolved_tag }}"
+            git push origin "${head_ref}"
+            echo "::notice::Updated version-matrix.json on release-please branch"
+          fi
+          
+          # Switch back to original checkout
+          git checkout "${{ steps.parse.outputs.sha }}"
+          rm -rf /tmp/rc-chart
 
       - name: Add RC tags to Harbor package
         env:


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #5083

### What's in this PR?

When image overrides are used during dev package build, the release notes and version matrix incorrectly show default image versions instead of the overridden ones.

This PR adds a step to `chart-promote-rc.yaml` that:
1. Detects if image overrides were used (via `camunda.io/imageOverrides` annotation)
2. If yes, extracts actual images from the dev package using `helm template`
3. Pre-populates `version-matrix.json` on the release-please branch with correct images

This ensures `generate-version-matrix.sh` finds cached data and uses it instead of running `helm template` on repo files with default values.

### Checklist

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
