### PR TITLE
ci: run helm dependency update before generating release notes

### DIFF
--- a/.github/workflows/chart-build-dev.yaml
+++ b/.github/workflows/chart-build-dev.yaml
@@ -511,6 +511,12 @@ jobs:
         run: |
           make -C ../.. helm.repos-add
 
+      - name: Helm dependency update
+        if: env.SKIP_BUILD == 'false'
+        run: |
+          make -C ../.. helm.dependency-update \
+            chartPath=${{ matrix.chart.directory }}
+
       #
       # Generate release notes
       #
@@ -537,12 +543,6 @@ jobs:
       #
       # Package and publish
       #
-
-      - name: Helm dependency update
-        if: env.SKIP_BUILD == 'false'
-        run: |
-          make -C ../.. helm.dependency-update \
-            chartPath=${{ matrix.chart.directory }}
 
       - name: Package Helm chart
         if: env.SKIP_BUILD == 'false'


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

The `Generate RELEASE-NOTES.md` step fails because `helm template` runs before chart dependencies are downloaded.

Related: https://github.com/camunda/camunda-platform-helm/actions/runs/21749986247

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

Moves `Helm dependency update` step before `Generate RELEASE-NOTES.md`.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
