### PR TITLE
ci: add run-name and concurrency group to chart-build-dev workflow

### DIFF
--- a/.github/workflows/chart-build-dev.yaml
+++ b/.github/workflows/chart-build-dev.yaml
@@ -1,4 +1,6 @@
 name: "Chart - Release - Pipeline - 1 - Build Dev"
+run-name: >-
+  Chart - Release - Pipeline - 1 - Build Dev${{ inputs.chart-version != '' && format(' [{0}]', inputs.chart-version) || '' }}
 
 # Builds immutable dev packages for all active chart versions.
 # These packages are release-ready (transformations applied) and stored in Harbor
@@ -64,6 +66,9 @@ on:
         type: string
         required: false
 
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.chart-version || 'push' }}
+  cancel-in-progress: false
 
 env:
   CHART_NAME: "camunda-platform"


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes race conditions in the QA BPMN automation when multiple chart versions (e.g., 8.7, 8.8, 8.9, 8.10) are released in parallel. Without run-name, all dispatched workflow runs have the same display_title, making it impossible for each BPMN process instance to identify its own build from the GitHub API response.

### What's in this PR?

Two improvements to chart-build-dev.yaml:

1. **run-name directive** - Appends [chart-version] to the workflow run display title when a specific version is dispatched. Examples:
   - Push trigger: `Chart - Release - Pipeline - 1 - Build Dev`
   - Dispatch for 8.8: `Chart - Release - Pipeline - 1 - Build Dev [8.8]`

   This allows the BPMN process to correlate dispatched builds to the correct chart version via the GitHub API display_title field.

2. **concurrency group** - Groups concurrent runs by workflow + chart-version (or push for push-triggered builds). Prevents redundant builds for the same version from queuing up. cancel-in-progress: false ensures running builds are not cancelled.

### Checklist

**Before opening the PR:**

- [x] There is no other open pull request for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo documentation are updated (if needed).
