### PR TITLE
feat: do not disable persistent web sessions on RDBMS

### DIFF
--- a/charts/camunda-platform-8.9/templates/orchestration/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/orchestration/_helpers.tpl
@@ -288,7 +288,7 @@ Authentication.
 {{- end -}}
 
 {{- define "orchestration.persistentSessionsEnabled" -}}
-    {{- and (not .Values.global.noSecondaryStorage) (not .Values.orchestration.exporters.rdbms.enabled) -}}
+    {{ not .Values.global.noSecondaryStorage -}}
 {{- end -}}
 
 

--- a/charts/camunda-platform-8.9/templates/orchestration/files/_application.yaml
+++ b/charts/camunda-platform-8.9/templates/orchestration/files/_application.yaml
@@ -244,6 +244,10 @@ camunda:
       checksEnabled: {{ include "orchestration.multitenancyChecksEnabled" . }}
       apiEnabled: {{ include "orchestration.multitenancyApiEnabled" . }}
 
+  persistent:
+    sessions:
+      enabled: {{ include "orchestration.persistentSessionsEnabled" . }}
+
   {{- if eq (include "orchestration.authMethod" .) "oidc" }}
   identity:
     clientId: {{ include "orchestration.authClientId" . | quote }}
@@ -255,8 +259,6 @@ camunda:
   #
   # Camunda Operate Configuration - Separated syntax.
   #
-  operate:
-    persistentSessionsEnabled: {{ include "orchestration.persistentSessionsEnabled" . }}
     multiTenancy:
       enabled: {{ include "orchestration.multitenancyChecksEnabled" . }}
     {{- if eq (include "orchestration.authMethod" .) "oidc" }}

--- a/charts/camunda-platform-8.9/test/unit/common/no_secondary_storage_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/no_secondary_storage_test.go
@@ -53,7 +53,7 @@ func (s *NoSecondaryStorageTemplateTest) TestNoSecondaryStorageGlobalValue() {
 			Name:                 "TestGlobalNoSecondaryStorageTogglesAllExpectedValues",
 			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
 			Values: map[string]string{
-				"global.noSecondaryStorage":                     "true",
+				"global.noSecondaryStorage":                    "true",
 				"global.elasticsearch.enabled":                 "false",
 				"global.opensearch.enabled":                    "false",
 				"elasticsearch.enabled":                        "false",
@@ -64,7 +64,7 @@ func (s *NoSecondaryStorageTemplateTest) TestNoSecondaryStorageGlobalValue() {
 				// Secondary storage type should be none
 				require.Contains(t, output, "secondary-storage:\n          autoconfigure-camunda-exporter: true\n          type: \"none\"")
 				// Persistent sessions should be disabled
-				require.Contains(t, output, "persistentSessionsEnabled: false")
+				require.Contains(t, output, "persistent:\n        sessions:\n          enabled: false")
 				// Agentic AI and inbound connectors should be disabled
 				require.Contains(t, output, "webhook:\n          enabled: false")
 				require.Contains(t, output, "polling:\n          enabled: false")

--- a/charts/camunda-platform-8.9/test/unit/orchestration/golden/configmap-authorizations.golden.yaml
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/golden/configmap-authorizations.golden.yaml
@@ -130,11 +130,13 @@ data:
           checksEnabled: false
           apiEnabled: true
     
+      persistent:
+        sessions:
+          enabled: true
+    
       #
       # Camunda Operate Configuration - Separated syntax.
       #
-      operate:
-        persistentSessionsEnabled: true
         multiTenancy:
           enabled: false
         # Zeebe instance

--- a/charts/camunda-platform-8.9/test/unit/orchestration/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/golden/configmap-log4j2.golden.yaml
@@ -130,11 +130,13 @@ data:
           checksEnabled: false
           apiEnabled: true
     
+      persistent:
+        sessions:
+          enabled: true
+    
       #
       # Camunda Operate Configuration - Separated syntax.
       #
-      operate:
-        persistentSessionsEnabled: true
         multiTenancy:
           enabled: false
         # Zeebe instance

--- a/charts/camunda-platform-8.9/test/unit/orchestration/golden/configmap-retention.golden.yaml
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/golden/configmap-retention.golden.yaml
@@ -135,11 +135,13 @@ data:
           checksEnabled: false
           apiEnabled: true
     
+      persistent:
+        sessions:
+          enabled: true
+    
       #
       # Camunda Operate Configuration - Separated syntax.
       #
-      operate:
-        persistentSessionsEnabled: true
         multiTenancy:
           enabled: false
         # Zeebe instance

--- a/charts/camunda-platform-8.9/test/unit/orchestration/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/golden/configmap.golden.yaml
@@ -130,11 +130,13 @@ data:
           checksEnabled: false
           apiEnabled: true
     
+      persistent:
+        sessions:
+          enabled: true
+    
       #
       # Camunda Operate Configuration - Separated syntax.
       #
-      operate:
-        persistentSessionsEnabled: true
         multiTenancy:
           enabled: false
         # Zeebe instance


### PR DESCRIPTION
### Which problem does the PR fix?

https://github.com/camunda/camunda-platform-helm/issues/5099

Based on slack [discussion](https://camunda.slack.com/archives/C07KBQY7H0C/p1770367684182109) we want to enable persistent web sessions also on RDBMS.

### What's in this PR?

- enable persistent web sessions also for RDBMS
- use the new property `camunda.persistent.sessions.enabled` and not the deprecated `camunda.operate.persistentSessionsEnabled`

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
