### PR TITLE
test: adjust indexes on test to match 2 new ports

### DIFF
--- a/charts/camunda-platform-8.9/test/unit/orchestration/service_headless_test.go
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/service_headless_test.go
@@ -81,9 +81,9 @@ func (s *GatewayServiceTest) TestGatewayServiceDifferentValuesInputs() {
 				expectedTargetPort := int32(5701)
 				ports := service.Spec.Ports
 
-				s.Require().Equal(expectedPort, ports[3].Port)
-				s.Require().Equal(expectedName, ports[3].Name)
-				s.Require().Equal(expectedTargetPort, ports[3].TargetPort.IntVal)
+				s.Require().Equal(expectedPort, ports[5].Port)
+				s.Require().Equal(expectedName, ports[5].Name)
+				s.Require().Equal(expectedTargetPort, ports[5].TargetPort.IntVal)
 			},
 		}, {
 			Name: "TestContainerServiceAnnotations",


### PR DESCRIPTION
### Which problem does the PR fix?

tests fail on main currently due to the new ports being added to the orchestration service.

closes https://github.com/camunda/camunda-platform-helm/issues/5109

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

port index adjustment.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
