### PR TITLE
fix: normalize authIssuerBackendUrl to prevent double-slash when contextPath is root

### DIFF
--- a/charts/camunda-platform-8.8/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.8/templates/common/_helpers.tpl
@@ -227,15 +227,16 @@ TODO: Most of the Keycloak config is handeled in Identity sub-chart, but it shou
   {{- else if eq (include "camundaPlatform.authIssuerType" .) "KEYCLOAK" -}}
     {{- if .Values.global.identity.keycloak.url -}}
       {{-
-        printf "%s://%s:%v%s%s"
+        printf "%s://%s:%v%s"
           .Values.global.identity.keycloak.url.protocol
           .Values.global.identity.keycloak.url.host
           .Values.global.identity.keycloak.url.port
-          .Values.global.identity.keycloak.contextPath
-          .Values.global.identity.keycloak.realm
+          (include "camundaPlatform.joinpath" (list .Values.global.identity.keycloak.contextPath .Values.global.identity.keycloak.realm))
       -}}
     {{- else -}}
-      {{- include "identity.keycloak.url" . -}}{{- .Values.global.identity.keycloak.realm -}}
+      {{- $url := include "identity.keycloak.url" . | trimSuffix "/" -}}
+      {{- $realm := .Values.global.identity.keycloak.realm | trimPrefix "/" -}}
+      {{- printf "%s/%s" $url $realm -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/charts/camunda-platform-8.8/test/unit/identity/configmap_test.go
+++ b/charts/camunda-platform-8.8/test/unit/identity/configmap_test.go
@@ -209,6 +209,31 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 
 				s.Require().Equal("https://keycloak.com:443/auth/camunda-platform", configmapApplication.Identity.AuthProvider.BackendUrl)
 			},
+		}, {
+			Name: "TestConfigMapAuthIssuerBackendUrlNoDoubleSlashWhenContextPathIsRoot",
+			Values: map[string]string{
+				"identity.enabled":                      "true",
+				"identityKeycloak.enabled":              "false",
+				"global.identity.keycloak.url.protocol": "https",
+				"global.identity.keycloak.url.host":     "keycloak.example.com",
+				"global.identity.keycloak.url.port":     "443",
+				"global.identity.keycloak.contextPath":  "/",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				var configmapApplication IdentityConfigYAML
+				helm.UnmarshalK8SYaml(t, output, &configmap)
+
+				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				if e != nil {
+					s.Fail("Failed to unmarshal yaml. error=", e)
+				}
+
+				// then
+				s.NotEmpty(configmap.Data)
+
+				s.Require().Equal("https://keycloak.example.com:443/realms/camunda-platform", configmapApplication.Identity.AuthProvider.BackendUrl)
+			},
 		},
 		// Hybrid Auth Tests - verify OIDC client config is only included for components using OIDC auth
 		{

--- a/charts/camunda-platform-8.9/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/common/_helpers.tpl
@@ -227,15 +227,16 @@ TODO: Most of the Keycloak config is handeled in Identity sub-chart, but it shou
   {{- else if eq (include "camundaPlatform.authIssuerType" .) "KEYCLOAK" -}}
     {{- if .Values.global.identity.keycloak.url -}}
       {{-
-        printf "%s://%s:%v%s%s"
+        printf "%s://%s:%v%s"
           .Values.global.identity.keycloak.url.protocol
           .Values.global.identity.keycloak.url.host
           .Values.global.identity.keycloak.url.port
-          .Values.global.identity.keycloak.contextPath
-          .Values.global.identity.keycloak.realm
+          (include "camundaPlatform.joinpath" (list .Values.global.identity.keycloak.contextPath .Values.global.identity.keycloak.realm))
       -}}
     {{- else -}}
-      {{- include "identity.keycloak.url" . -}}{{- .Values.global.identity.keycloak.realm -}}
+      {{- $url := include "identity.keycloak.url" . | trimSuffix "/" -}}
+      {{- $realm := .Values.global.identity.keycloak.realm | trimPrefix "/" -}}
+      {{- printf "%s/%s" $url $realm -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/charts/camunda-platform-8.9/test/unit/identity/configmap_test.go
+++ b/charts/camunda-platform-8.9/test/unit/identity/configmap_test.go
@@ -209,6 +209,31 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 
 				s.Require().Equal("https://keycloak.com:443/auth/camunda-platform", configmapApplication.Identity.AuthProvider.BackendUrl)
 			},
+		}, {
+			Name: "TestConfigMapAuthIssuerBackendUrlNoDoubleSlashWhenContextPathIsRoot",
+			Values: map[string]string{
+				"identity.enabled":                      "true",
+				"identityKeycloak.enabled":              "false",
+				"global.identity.keycloak.url.protocol": "https",
+				"global.identity.keycloak.url.host":     "keycloak.example.com",
+				"global.identity.keycloak.url.port":     "443",
+				"global.identity.keycloak.contextPath":  "/",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				var configmapApplication IdentityConfigYAML
+				helm.UnmarshalK8SYaml(t, output, &configmap)
+
+				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				if e != nil {
+					s.Fail("Failed to unmarshal yaml. error=", e)
+				}
+
+				// then
+				s.NotEmpty(configmap.Data)
+
+				s.Require().Equal("https://keycloak.example.com:443/realms/camunda-platform", configmapApplication.Identity.AuthProvider.BackendUrl)
+			},
 		},
 		// Hybrid Auth Tests - verify OIDC client config is only included for components using OIDC auth
 		{


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #5112

### What's in this PR?

The `camundaPlatform.authIssuerBackendUrl` helper concatenates `contextPath` and `realm` via `printf` without normalizing the path. When `contextPath="/"` (the documented default for Keycloak v19+) and `realm="/realms/camunda-platform"`, the output contains a double slash: `https://host:443//realms/camunda-platform`.

This fix uses the existing `camundaPlatform.joinpath` helper to normalize the path portion in the explicit URL branch, and `trimSuffix`/`trimPrefix` for the internal Keycloak branch (where `joinpath` cannot be used since it would corrupt `://` in full URLs).

Changes in both 8.8 and 8.9 charts:
- `templates/common/_helpers.tpl` — normalize path joining in `authIssuerBackendUrl`
- `test/unit/identity/configmap_test.go` — add `TestConfigMapAuthIssuerBackendUrlNoDoubleSlashWhenContextPathIsRoot`

### Checklist

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).