### PR TITLE
ci: add OpenSearch index cleanup to CI and fix nightly cleanup regex

### DIFF
--- a/.github/workflows/cleanup-opensearch-entra.yaml
+++ b/.github/workflows/cleanup-opensearch-entra.yaml
@@ -27,22 +27,100 @@ jobs:
           cluster-location: ${{ secrets.DISTRO_CI_GCP_GKE_CLUSTER_LOCATION }}
           workload-identity-provider: ${{ secrets.DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service-account: ${{ secrets.DISTRO_CI_GCP_SERVICE_ACCOUNT }}
-      - name: cleanup OpenSerach
+      - name: cleanup OpenSearch
         env:
           OPENSEARCH_BASIC_AUTH_BASE64: ${{ secrets.OPENSEARCH_BASIC_AUTH_BASE64 }}
         shell: bash
         run: |
           # OpenSearch endpoint
           OPENSEARCH_HOST="https://search-qa-e2e-5q5uium4w7pgfz7i5tviimmmgm.eu-north-1.es.amazonaws.com:443"
-          # Get all namespaces and extract run-IDs from namespaces
-          KEEP_PREFIXES=($(kubectl get namespaces -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | grep -oP '\d+$'))
-          # this element is needed since the master user does not have permissions to delete default OpenSearch prefixes which start with "."
-          KEEP_PREFIXES+=(".")
+
+          # Get all namespace names
+          ALL_NS=$(kubectl get namespaces -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n')
+
+          # Extract 6-char hex job IDs from namespace names (new naming convention)
+          # Namespaces end with -{hex} or -{hex}-upgp/-upgm
+          HEX_PREFIXES=($(echo "$ALL_NS" | grep -oP '[a-f0-9]{6}(?=(-upgp|-upgm)?$)' || true))
+
+          # Extract old-style trailing numeric run IDs for backward compatibility
+          NUM_PREFIXES=($(echo "$ALL_NS" | grep -oP '\d+$' || true))
+
+          # Combine, deduplicate, and add "." to protect OpenSearch system indices
+          KEEP_PREFIXES=($(printf '%s\n' "${HEX_PREFIXES[@]}" "${NUM_PREFIXES[@]}" "." | sort -u))
+
           echo "prefixes to keep:"
           echo "${KEEP_PREFIXES[@]}"
           #Exclude prefixes from `KEEP_PREFIXES`array
           EXCLUSIONS=$(printf -- ",-%s*" "${KEEP_PREFIXES[@]}" | cut -c2-)
           curl -L -X DELETE ${OPENSEARCH_HOST}/*,${EXCLUSIONS} -H "Authorization: Basic $OPENSEARCH_BASIC_AUTH_BASE64"
+      - name: update ISM policy
+        env:
+          OPENSEARCH_BASIC_AUTH_BASE64: ${{ secrets.OPENSEARCH_BASIC_AUTH_BASE64 }}
+        shell: bash
+        run: |
+          OPENSEARCH_HOST="https://search-qa-e2e-5q5uium4w7pgfz7i5tviimmmgm.eu-north-1.es.amazonaws.com:443"
+          # Update the delete-after-48h ISM policy to cover both old and new index naming patterns.
+          # First, get current seq_no and primary_term (required for updating existing policies).
+          POLICY_RESP=$(curl -s -L "${OPENSEARCH_HOST}/_plugins/_ism/policies/delete-after-48h" \
+            -H "Authorization: Basic $OPENSEARCH_BASIC_AUTH_BASE64")
+          SEQ_NO=$(echo "$POLICY_RESP" | jq -r '._seq_no // empty')
+          PRIMARY_TERM=$(echo "$POLICY_RESP" | jq -r '._primary_term // empty')
+
+          POLICY_BODY='{
+            "policy": {
+              "policy_id": "delete-after-48h",
+              "description": "Delete indices after 24 hours",
+              "default_state": "hot",
+              "states": [
+                {
+                  "name": "hot",
+                  "actions": [],
+                  "transitions": [
+                    {
+                      "state_name": "delete",
+                      "conditions": {
+                        "min_index_age": "24h"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "name": "delete",
+                  "actions": [
+                    {
+                      "retry": {
+                        "count": 3,
+                        "backoff": "exponential",
+                        "delay": "1m"
+                      },
+                      "delete": {}
+                    }
+                  ],
+                  "transitions": []
+                }
+              ],
+              "ism_template": [
+                {
+                  "index_patterns": ["*-qae2e-*", "*-install-*"],
+                  "priority": 100
+                }
+              ]
+            }
+          }'
+
+          if [[ -n "$SEQ_NO" && -n "$PRIMARY_TERM" ]]; then
+            echo "Updating existing ISM policy (seq_no=$SEQ_NO, primary_term=$PRIMARY_TERM)..."
+            curl -L -X PUT "${OPENSEARCH_HOST}/_plugins/_ism/policies/delete-after-48h?if_seq_no=${SEQ_NO}&if_primary_term=${PRIMARY_TERM}" \
+              -H "Authorization: Basic $OPENSEARCH_BASIC_AUTH_BASE64" \
+              -H "Content-Type: application/json" \
+              -d "$POLICY_BODY" || echo "Warning: ISM policy update failed, skipping..."
+          else
+            echo "Creating new ISM policy..."
+            curl -L -X PUT "${OPENSEARCH_HOST}/_plugins/_ism/policies/delete-after-48h" \
+              -H "Authorization: Basic $OPENSEARCH_BASIC_AUTH_BASE64" \
+              -H "Content-Type: application/json" \
+              -d "$POLICY_BODY" || echo "Warning: ISM policy creation failed, skipping..."
+          fi
       - name: cleanup Entra
         env: 
           ENTRA_PARENT_APP_DIRECTORY_ID: ${{ secrets.ENTRA_PARENT_APP_DIRECTORY_ID }}

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -1276,6 +1276,7 @@ jobs:
             kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=1s --overwrite=true
             kubectl annotate ns $TEST_NAMESPACE janitor/ttl=1s --overwrite=true
             scripts/apply-ttl-to-elasticsearch-indexes.sh --prefix "${GITHUB_WORKFLOW_JOB_ID}" --ttl 1s --url "https://elasticsearch-21-6-3.ci.distro.ultrawombat.com" --user "elastic" --elasticsearch-namespace "distribution-elasticsearch-21-6-3" --debug || echo "Warning: Elasticsearch index cleanup failed (credentials inaccessible), skipping..."
+            scripts/apply-ttl-to-elasticsearch-indexes.sh --prefix "${GITHUB_WORKFLOW_JOB_ID}" --ttl 1s --url "${OPENSEARCH_PROTOCOL}://${OPENSEARCH_HOST}:${OPENSEARCH_PORT}" --user "${OPENSEARCH_USERNAME}" --pass "${OPENSEARCH_PASSWORD}" --debug || echo "Warning: OpenSearch index cleanup failed, skipping..."
           else
             if [[ "${{ inputs.distro-type }}" == "kubernetes" && "${{ env.CI_DEPLOYMENT_TTL }}" != "" ]]; then
               kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${CI_DEPLOYMENT_TTL} --overwrite=true || true
@@ -1284,5 +1285,6 @@ jobs:
               kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=1s --overwrite=true || true
               kubectl annotate ns $TEST_NAMESPACE janitor/ttl=1s --overwrite=true || true
               scripts/apply-ttl-to-elasticsearch-indexes.sh --prefix "${GITHUB_WORKFLOW_JOB_ID}" --ttl 1s --url "https://elasticsearch-21-6-3.ci.distro.ultrawombat.com" --user "elastic" --elasticsearch-namespace "distribution-elasticsearch-21-6-3" --debug || echo "Warning: Elasticsearch index cleanup failed (credentials inaccessible), skipping..."
+              scripts/apply-ttl-to-elasticsearch-indexes.sh --prefix "${GITHUB_WORKFLOW_JOB_ID}" --ttl 1s --url "${OPENSEARCH_PROTOCOL}://${OPENSEARCH_HOST}:${OPENSEARCH_PORT}" --user "${OPENSEARCH_USERNAME}" --pass "${OPENSEARCH_PASSWORD}" --debug || echo "Warning: OpenSearch index cleanup failed, skipping..."
             fi
           fi


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #5127

### What's in this PR?

The shared AWS OpenSearch cluster used by CI integration tests hits its 3000 shard limit because indices from completed test runs are never cleaned up. This PR fixes three gaps:

- **CI teardown** (`test-integration-runner.yaml`): Added `apply-ttl-to-elasticsearch-indexes.sh` calls targeting the OpenSearch endpoint alongside the existing Elasticsearch cleanup. Uses the already-available `OPENSEARCH_*` env vars.

- **Nightly cleanup regex** (`cleanup-opensearch-entra.yaml`): Replaced `grep -oP '\d+$'` (trailing digits only) with extraction of 6-char hex job IDs from namespace names, handling `-upgp`/`-upgm` suffixes. Old numeric extraction kept for backward compatibility.

- **ISM policy** (`cleanup-opensearch-entra.yaml`): Added a step to update the `delete-after-48h` ISM policy so its `ism_template` covers both `*-qae2e-*` (old naming) and `*-install-*` (new naming) index patterns. Handles the OpenSearch ISM update API with `seq_no`/`primary_term` for existing policies.

### Checklist

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?