### PR TITLE
ci: fix the preemption on CI for tests

### DIFF
--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -1107,7 +1107,7 @@ jobs:
   playwright-e2e-tests-after-install:
     name: Playwright e2e after install - ${{ inputs.flow }} on ${{ inputs.distro-platform }} - ${{ inputs.shortname }} (${{ matrix.shardIndex }} of ${{ matrix.shardTotal }})
     needs: [install]
-    runs-on: gcp-core-8-release
+    runs-on: gcp-core-32-longrunning-big-ssd
     container:
       image: ghcr.io/camunda/team-distribution/playwright-runner:latest
       credentials:
@@ -1171,7 +1171,7 @@ jobs:
   playwright-e2e-tests-after-upgrade:
     name: Playwright e2e after upgrade - ${{ inputs.flow }} on ${{ inputs.distro-platform }} - ${{ inputs.shortname }} (${{ matrix.shardIndex }} of ${{ matrix.shardTotal }})
     needs: [upgrade]
-    runs-on: gcp-core-8-release
+    runs-on: gcp-core-32-longrunning-big-ssd
     container:
       image: ghcr.io/camunda/team-distribution/playwright-runner:latest
       credentials:

--- a/.github/workflows/test-local-template.yaml
+++ b/.github/workflows/test-local-template.yaml
@@ -27,7 +27,7 @@ jobs:
     name: Local cluster - KIND
     # This job needs to run on self-hosted runners because it requires more resources
     # than the default GitHub runners provide.
-    runs-on: gcp-core-8-release
+    runs-on: gcp-core-32-longrunning-big-ssd
     env:
       TEST_NAMESPACE: camunda-platform
     steps:


### PR DESCRIPTION
### Which problem does the PR fix?

Playwright e2e tests and local KIND cluster tests were being preempted on CI due to insufficient runner resources.

### What's in this PR?

Changes the `runs-on` runner type for the following jobs from `gcp-core-8-default` to `gcp-core-32-longrunning-big-ssd` to prevent preemption:

- `playwright-e2e-tests-after-install` in `.github/workflows/test-integration-runner.yaml`
- `playwright-e2e-tests-after-upgrade` in `.github/workflows/test-integration-runner.yaml`
- Local cluster KIND job in `.github/workflows/test-local-template.yaml`

The branch has also been rebased onto the latest `main` to resolve conflicts introduced by upstream changes that renamed the default runner to `gcp-core-8-release`.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?