### PR TITLE
ci: adjust add-to-qa-board input

### DIFF
--- a/.github/workflows/add-new-issue.yaml
+++ b/.github/workflows/add-new-issue.yaml
@@ -46,7 +46,7 @@ jobs:
         with:
           github-token: ${{ steps.generate-github-token.outputs.token }}
           project-number: "187"
-          component-label: "component/helm"
+          labels: "component/helm"
         # Only run this job for issues labeled as 'kind/bug' and
         # for the relevant GitHub issue events that indicate a new or updated issue.
         if: >


### PR DESCRIPTION
change label input in action call

### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
adjust input for https://github.com/camunda/infra-global-github-actions/tree/main/add-bug-to-quality-board

closes: https://github.com/camunda/camunda-platform-helm/issues/5178

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->
change input filed `component-label` --> `labels`

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
