### PR TITLE
ci: set prCreation to immediate for camunda image renovate rules

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -322,6 +322,7 @@
       matchUpdateTypes: ['patch', 'pin'],
       schedule: ['at any time'],
       addLabels: ['camunda-platform', 'priority-high'],
+      prCreation: 'immediate',
     },
     {
       enabled: true,
@@ -343,6 +344,7 @@
       matchUpdateTypes: ['major', 'minor', 'patch'],
       schedule: ['at any time'],
       addLabels: ['camunda-platform', 'priority-high'],
+      prCreation: 'immediate',
     },
     {
       description: 'Parse Camunda 8.9 image tags as semver so alpha updates work',
@@ -374,6 +376,7 @@
       matchUpdateTypes: ['digest'],
       schedule: ['at any time'],
       addLabels: ['camunda-platform', 'priority-high'],
+      prCreation: 'immediate',
     },
     {
       matchFileNames: [


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #5184

### What's in this PR?

Adds `prCreation: 'immediate'` to the three Camunda-specific Renovate package rules
(`camunda-platform-images` and `camunda-platform-digests`).

The global `prCreation: 'not-pending'` was blocking PR creation for Camunda image
version bumps when status checks were pending. This override ensures Camunda image
PRs are created immediately while all other dependencies keep the existing behavior.

Automerge still requires CI to pass (`ignoreTests: false`).

### Checklist

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?