### PR TITLE
fix: drop secondary storage constraint if orchestration.enabled is false

### DIFF
--- a/charts/camunda-platform-8.9/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.9/templates/common/constraints.tpl
@@ -28,7 +28,7 @@ Multi-Tenancy requirements: https://docs.camunda.io/docs/self-managed/concepts/m
 {{/*
 Fail if there is no secondary storage type specified and if noSecondaryStorage is not enabled.
 */}}
-{{- if and (orchestration.enabled) (eq (include "orchestration.secondaryStorage" .) "unset") }}
+{{- if and .Values.orchestration.enabled (eq (include "orchestration.secondaryStorage" .) "unset") }}
   {{- fail "Please configure an expected secondary storage type under `orchestration.data.secondaryStorage.type`, available values are [elasticsearch, opensearch, rdbms]. For more details, see our documentation here: https://docs.camunda.io/docs/next/self-managed/concepts/secondary-storage/configuring-secondary-storage/" -}}
 {{- end }}
 


### PR DESCRIPTION
### Which problem does the PR fix?

closes #5191 

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

check if orchestration.enabled is true before applying constraint

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
