### PR TITLE
ci: add slack failure notifications to release workflows

### DIFF
--- a/.github/workflows/chart-build-dev.yaml
+++ b/.github/workflows/chart-build-dev.yaml
@@ -823,3 +823,45 @@ jobs:
           EOF
             fi
           fi
+
+  notify-on-failure:
+    name: Notify on Failure
+    needs: [setup, build]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Import Vault secrets
+        id: secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/distribution/ci SLACK_DISTRO_BOT_WEBHOOK;
+          exportEnv: false
+      - name: Send Slack notification
+        continue-on-error: true
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ steps.secrets.outputs.SLACK_DISTRO_BOT_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  text: "Chart Dev Build Failed"
+                  emoji: true
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: |
+                    <!subteam^S05K9BK6RTK> :rotating_light:
+                    The *Chart Dev Build* pipeline has failed.
+
+                    *Chart version:* ${{ inputs.chart-version || 'all active versions' }}
+                    *Trigger:* ${{ github.event_name }}
+
+                    <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View failed workflow>

--- a/.github/workflows/chart-promote-rc.yaml
+++ b/.github/workflows/chart-promote-rc.yaml
@@ -454,3 +454,44 @@ jobs:
           2. Review release-please PR
           3. Run **Chart - Release - Pipeline - 3 - Public** with \`${RC_TAG}\`
           EOF
+
+  notify-on-failure:
+    name: Notify on Failure
+    needs: [promote-rc]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Import Vault secrets
+        id: secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/distribution/ci SLACK_DISTRO_BOT_WEBHOOK;
+          exportEnv: false
+      - name: Send Slack notification
+        continue-on-error: true
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ steps.secrets.outputs.SLACK_DISTRO_BOT_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  text: "Chart RC Promotion Failed"
+                  emoji: true
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: |
+                    <!subteam^S05K9BK6RTK> :rotating_light:
+                    The *Chart RC Promotion* pipeline has failed.
+
+                    *Dev tag:* ${{ inputs.dev-tag }}
+
+                    <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View failed workflow>

--- a/.github/workflows/chart-release-public.yaml
+++ b/.github/workflows/chart-release-public.yaml
@@ -440,3 +440,44 @@ jobs:
           Merge the release-please PR to complete the release process.
           ${PR_URL:+**PR:** ${PR_URL}}
           EOF
+
+  notify-on-failure:
+    name: Notify on Failure
+    needs: [release, post-release]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Import Vault secrets
+        id: secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/distribution/ci SLACK_DISTRO_BOT_WEBHOOK;
+          exportEnv: false
+      - name: Send Slack notification
+        continue-on-error: true
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ steps.secrets.outputs.SLACK_DISTRO_BOT_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  text: "Chart Public Release Failed"
+                  emoji: true
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: |
+                    <!subteam^S05K9BK6RTK> :rotating_light:
+                    The *Chart Public Release* pipeline has failed.
+
+                    *RC tag:* ${{ inputs.rc-tag }}
+
+                    <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View failed workflow>


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #5194

### What's in this PR?

Adds a `notify-on-failure` job to each of the 3 automated release workflows. When any job in a workflow fails, the new job runs, imports the `SLACK_DISTRO_BOT_WEBHOOK` from Vault, and sends a tailored Slack message mentioning `@distribution-release-manager` with a link to the failed run.

- `chart-build-dev.yaml` — notifies on failure of `setup` or `build` jobs; includes chart version and trigger
- `chart-promote-rc.yaml` — notifies on failure of `promote-rc` job; includes dev tag
- `chart-release-public.yaml` — notifies on failure of `release` or `post-release` jobs; includes RC tag

The Slack step uses `continue-on-error: true` so the notification itself can never fail the workflow.

### Checklist

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?