### PR TITLE
ci: double data nodes on ES

### DIFF
--- a/infra/elasticsearch/21.6.3/values.yaml
+++ b/infra/elasticsearch/21.6.3/values.yaml
@@ -28,7 +28,7 @@ master:
     periodSeconds: 20
 
 data:
-  replicaCount: 6
+  replicaCount: 12
   heapSize: 1536m
   resources:
     requests: { cpu: "2000m", memory: "3Gi" }


### PR DESCRIPTION
### Which problem does the PR fix?

Our elasticsearch instance is filled with indexes, and cannot handle the load we're throwing at it. Scale by doubling the number of data nodes.

Related to https://github.com/camunda/camunda-platform-helm/issues/5232

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
