### PR TITLE
ci: drop log level of connectors

### DIFF
--- a/charts/camunda-platform-8.9/test/integration/scenarios/common/values-integration-test.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/common/values-integration-test.yaml
@@ -46,3 +46,9 @@ optimize:
           echo "Orchestration cluster is healthy!"
       securityContext:
         runAsUser: 1000
+
+connectors:
+  logging:
+    level:
+        io.camunda.client.job.worker: INFO
+


### PR DESCRIPTION
### Which problem does the PR fix?

closes https://github.com/camunda/camunda-platform-helm/issues/5214

Connectors has these long annoying logs that floods our CI making it difficult to find logs actually relating to errors of other components.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

Drop log level in CI for connectors for the specific message that floods the logs.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
