### PR TITLE
fix: add initContainer to connectors

### DIFF
--- a/charts/camunda-platform-8.9/test/integration/scenarios/common/values-integration-test.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/common/values-integration-test.yaml
@@ -30,6 +30,23 @@ orchestration:
     - name: CAMUNDA_SYSTEM_UPGRADE_ENABLEVERSIONCHECK
       value: "false"
 
+connectors:
+  initContainers:
+    - name: wait-for-orchestration
+      image: busybox:1.36
+      command:
+        - sh
+        - -c
+        - |
+          echo "Waiting for Orchestration cluster to be healthy..."
+          until wget --spider -q http://integration-zeebe-gateway:9600/orchestration/actuator/health/readiness 2>/dev/null; do
+            echo "Orchestration cluster not ready yet, waiting..."
+            sleep 5
+          done
+          echo "Orchestration cluster is healthy!"
+      securityContext:
+        runAsUser: 1000
+
 optimize:
   initContainers:
     - name: wait-for-orchestration


### PR DESCRIPTION
### Which problem does the PR fix?

Related to https://github.com/camunda/camunda-platform-helm/issues/5232


We learned recently that connectors will hammer the keycloak API until it gets a 200 , and that this can cause keycloak to get overwhelmed with requests and respond with 500 or 503 on other CI runs that would otherwise pass.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

Add an initContainer that will wait for orchestration cluster to be healthy before running connectors.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
