### PR TITLE
chore(web-modeler): remove obsolete image digest for webapp component

### DIFF
--- a/charts/camunda-platform-8.9/values-digest.yaml
+++ b/charts/camunda-platform-8.9/values-digest.yaml
@@ -35,13 +35,6 @@ webModeler:
       tag: SNAPSHOT
       digest: "sha256:11005d0e6aee2cafc491942f31f2e4875dbee926bcbcd541ceb25ba50d8396bd"
 
-  # https://hub.docker.com/r/camunda/web-modeler-webapp/tags
-  webapp:
-    image:
-      repository: camunda/web-modeler-webapp
-      tag: SNAPSHOT
-      digest: "sha256:98411bc36d157613ab61eeff7ff9f5b0420e0451d5bb99922e7f705453fff91a"
-
   # https://hub.docker.com/r/camunda/web-modeler-websockets/tags
   websockets:
     image:


### PR DESCRIPTION
### Which problem does the PR fix?
- related to https://github.com/camunda/web-modeler/issues/19629
- follow-up for https://github.com/camunda/camunda-platform-helm/pull/5193

### What's in this PR?

Removes the image digest for Web Modeler's `webapp` component (which has been removed completely already with https://github.com/camunda/camunda-platform-helm/pull/5193).

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
