### PR TITLE
chore: fix readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The dependency management is fully automated and managed by Helm itself.
 ## Documentation
 
 - Official docs (to install the platform via Helm chart): [Camunda 8 Self-Managed](https://docs.camunda.io/docs/self-managed/about-self-managed/).
-- This repo docs (e.g., tests, releases, etc.): [Camunda 8 Helm chart repo docs](./docs).
+- This repo wiki (e.g., contribution guidance, testing, etc.): [Camunda 8 Helm chart wiki](https://github.com/camunda/camunda-platform-helm/wiki).
 
 ## Versioning and Release Cycles
 
@@ -62,7 +62,7 @@ We value all feedback and contributions. To start contributing to this project, 
 
 ## Releasing
 
-Please visit the [Camunda 8 release guide](./docs/release.md) to find out how to release the charts.
+Please visit the [Camunda 8 release guide](https://github.com/camunda/camunda-platform-helm/wiki/release-process) to find out how to release the charts.
 
 ## License
 


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

closes https://github.com/camunda/camunda-platform-helm/issues/5048

This pull request updates the `README.md` to improve documentation references by pointing contributors to the GitHub wiki for guidance and release instructions.

Documentation improvements:

* Updated the documentation link for repo-specific guidance from the local `docs` directory to the official GitHub wiki at `https://github.com/camunda/camunda-platform-helm/wiki`.
* Changed the release guide link to reference the release process page on the GitHub wiki instead of the local `docs/release.md` file.

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
