### PR TITLE
ci: enterprise images version matrix for charts 8.8 and 8.9

### DIFF
--- a/scripts/generate-version-matrix.sh
+++ b/scripts/generate-version-matrix.sh
@@ -120,14 +120,24 @@ get_chart_enterprise_images () {
       else
         helm_version_arg="--version ${chart_version}"
       fi
-      # Enable all optional components to ensure all images are listed,
-      # without depending on the integration test values file.
+      # Enable all optional components and subcharts to ensure all enterprise images are listed.
+      # Detect correct postgres key (renamed from postgresql to webModelerPostgresql in 8.8+).
+      if yq -e 'has("postgresql")' "${CHART_DIR}/values.yaml" > /dev/null 2>&1; then
+        webmodeler_pg_flag="--set postgresql.enabled=true"
+      else
+        webmodeler_pg_flag="--set webModelerPostgresql.enabled=true"
+      fi
       chart_enterprise_images="$(
         helm template --skip-tests camunda "${CHART_SOURCE}" ${helm_version_arg} \
           --set webModeler.enabled=true \
           --set webModeler.restapi.mail.fromAddress=noreply@example.com \
           --set console.enabled=true \
-          --set postgresql.enabled=true \
+          --set identity.enabled=true \
+          --set identityKeycloak.enabled=true \
+          --set identityPostgresql.enabled=true \
+          --set elasticsearch.enabled=true \
+          --set orchestration.data.secondaryStorage.type=elasticsearch \
+          ${webmodeler_pg_flag} \
           --values "${enterprise_values_file}" 2> /dev/null |
         tr -d "\"'" | awk '/image:/{gsub(/^(camunda|bitnami)/, "docker.io/&", $2); printf "%s\n", $2}' |
         sort | uniq;
@@ -317,7 +327,7 @@ while test -n "${1:-}"; do
             echo "[ERROR] Chart dir and Helm chart version are needed as an arg for this option";
             exit 1
           )
-          CHART_DIR="${2}" get_chart_enterprise_images "${3}" | grep "registry.camunda.cloud"
+          CHART_DIR="${2}" get_chart_enterprise_images "${3}" | grep "registry.camunda.cloud" || true
           shift 2
           ;;
         *)


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #5278

The enterprise Bitnami images feature added in #5272 breaks the version matrix generation for charts 8.8 and 8.9. The `helm template` call in `get_chart_enterprise_images` uses `--set` flags that violate constraints introduced in newer charts:

- `console.enabled=true` without `identity.enabled=true` (8.8+)
- `postgresql` key renamed to `webModelerPostgresql` (8.8+)
- `orchestration.data.secondaryStorage.type` required (8.9)
- `identityKeycloak`, `identityPostgresql`, `elasticsearch` disabled by default (8.8+)

Errors are suppressed by `2>/dev/null`, so `helm template` silently returns nothing, then `grep "registry.camunda.cloud"` fails with exit 1 under `set -euo pipefail`.

Failing run: https://github.com/camunda/camunda-platform-helm/actions/runs/22688018028

### What's in this PR?

Two changes in `scripts/generate-version-matrix.sh`:

1. **Version-adaptive `helm template` flags** in `get_chart_enterprise_images()`:
   - Detect correct postgresql key (`postgresql` vs `webModelerPostgresql`) via `yq`
   - Add `--set identity.enabled=true` (required by console constraint in 8.8+)
   - Add `--set identityKeycloak.enabled=true`, `--set identityPostgresql.enabled=true`, `--set elasticsearch.enabled=true` (disabled by default in 8.8+)
   - Add `--set orchestration.data.secondaryStorage.type=elasticsearch` (required in 8.9)
   - All extra flags are harmless for older chart versions (unknown keys ignored by helm)

2. **Defensive `|| true`** on the `grep "registry.camunda.cloud"` in the `--chart-images-enterprise` handler to prevent crash on empty output.

Tested locally against all chart versions:
- 8.6: 5 enterprise images listed
- 8.7: 5 enterprise images listed
- 8.8: 5 enterprise images listed
- 8.9: 5 enterprise images listed

### Checklist

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?