### PR TITLE
ci: enable liveness probe for optimize

### DIFF
--- a/charts/camunda-platform-8.9/test/integration/scenarios/common/values-integration-test.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/common/values-integration-test.yaml
@@ -52,6 +52,8 @@ connectors:
       io.camunda.client.job.poller: INFO
 
 optimize:
+  livenessProbe:
+    enabled: true
   initContainers:
     - name: wait-for-orchestration
       image: busybox:1.36


### PR DESCRIPTION
### Which problem does the PR fix?

closes #5295 

Optimize sometimes fails to come up healthy due to it not doing any retries on it's queries to elasticsearch. When this happens, it's usually due to an intermittent elasticsearch error like it being briefly overwhelmed. When this happens, optimize does nothing and the process stays as a zombie process. 



<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

Add liveness probe to optimize CI

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
