### PR TITLE
ci: double master nodes in ES

### DIFF
--- a/infra/elasticsearch/21.6.3/values.yaml
+++ b/infra/elasticsearch/21.6.3/values.yaml
@@ -1,5 +1,5 @@
 master:
-  replicaCount: 3
+  replicaCount: 6
   resources:
     requests: { cpu: "2000m", memory: "3Gi" }
     limits: { cpu: "4000m", memory: "3Gi" }


### PR DESCRIPTION
### Which problem does the PR fix?

closes https://github.com/camunda/camunda-platform-helm/issues/5298

I'm still getting 503 errors on elasticsearch. See 

https://productionresultssa0.blob.core.windows.net/actions-results/13972283-9b68-4990-9ef4-6a640bcdfdee/workflow-job-run-b53dea24-3726-5bb1-85c5-f8505d42f931/logs/job/job-logs.txt?rsct=text%2Fplain&se=2026-03-05T20%3A01%3A47Z&sig=JMaR3mRVVLyCPU20zGYJmqqgpHoLywDyDzktAVnnpUA%3D&ske=2026-03-05T23%3A10%3A12Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2026-03-05T19%3A10%3A12Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2026-03-05T19%3A51%3A42Z&sv=2025-11-05


I'm thinking this means our master nodes need to increase to handle the cluster state changes.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
