### PR TITLE
ci: fix public release auto-merge for release-please branches

### DIFF
--- a/.github/workflows/chart-release-public.yaml
+++ b/.github/workflows/chart-release-public.yaml
@@ -380,6 +380,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          token: ${{ steps.generate-github-token.outputs.token }}
 
       - name: Install tools
         uses: ./.github/actions/install-tool-versions
@@ -435,6 +436,8 @@ jobs:
           head_ref="release-please--branches--main--components--camunda-platform-${{ needs.release.outputs.chart-dir-id }}"
 
           # Rebase onto main so the branch is not behind (strict status checks).
+          git config user.name "distro-ci[bot]"
+          git config user.email "122795778+distro-ci[bot]@users.noreply.github.com"
           git fetch origin main "${head_ref}"
           if ! git merge-base --is-ancestor origin/main "origin/${head_ref}"; then
             git checkout -B "${head_ref}" "origin/${head_ref}"


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #5321

### What's in this PR?

Two fixes for the `Approve and auto-merge release-please PR` step in the post-release job:

1. **Rebase instead of merge**: Replaces the `update-branch` API call (which creates a merge commit) with `git rebase` + `git push --force-with-lease`. Release-please branches enforce `required_linear_history`, causing the API to fail with HTTP 422.

2. **`GITHUB_TOKEN` for approval**: The PR is authored by `distro-ci[bot]`, so approving with the same token triggers a self-approval error. Approval now uses `GITHUB_TOKEN` (`github-actions[bot]`). The merge step still uses the distro-ci app token.

### Checklist

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).
- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
