### PR TITLE
ci: scale keycloak up

### DIFF
--- a/infra/keycloak/24.9.0/values.yaml
+++ b/infra/keycloak/24.9.0/values.yaml
@@ -13,7 +13,7 @@ ingress:
       secretName: camunda-platform
 
 # --- CI-oriented Keycloak setup (non-production) ---
-replicaCount: 3
+replicaCount: 5
 
 resources:
   requests:


### PR DESCRIPTION
### Which problem does the PR fix?

#5298 

I noticed that our keycloak seems to have scaled down recently after someone manually scaled it up. This PR commits the scaling-up so that any recreations will persist.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
