### PR TITLE
fix: use 8.9-SNAPSHOT for values-digest

### DIFF
--- a/charts/camunda-platform-8.9/values-digest.yaml
+++ b/charts/camunda-platform-8.9/values-digest.yaml
@@ -13,15 +13,15 @@ connectors:
   # https://hub.docker.com/r/camunda/connectors-bundle/tags
   image:
     repository: camunda/connectors-bundle
-    tag: SNAPSHOT
-    digest: "sha256:cfbacd127fd2023582a1444a883df527404022690c3478f8f125e2bb0d8f1797"
+    tag: 8.9-SNAPSHOT
+    digest: "sha256:02816f005603e60d1cdfc4733c3de454b5b0979e0941fe08814cf35f0942815d"
 
 optimize:
   # https://hub.docker.com/r/camunda/optimize/tags
   image:
     repository: camunda/optimize
-    tag: 8-SNAPSHOT
-    digest: "sha256:7d68642af4617100ca96b0a527a4f1d85be4b6a3691aad6f50106f07a617ba48"
+    tag: 8.9-SNAPSHOT
+    digest: "sha256:78ff7d7dd64b8c20032777aca12502fbaac63a4261dab2bb70d50cdb625204eb"
 
 #
 # Web Modeler
@@ -50,8 +50,8 @@ orchestration:
   # https://hub.docker.com/r/camunda/camunda/tags
   image:
     repository: camunda/camunda
-    tag: SNAPSHOT
-    digest: "sha256:6cb9a8687f5e5a3c64ce1bbe3736fc4abf00c7b54a0e6891866d8255bf299f0e"
+    tag: 8.9-SNAPSHOT
+    digest: "sha256:e1275b3b178fdb098ccbc9c3c24bc8ac40d1c86febd5fcbc1b5306cdeae11571"
 
 #
 # Identity


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

values-digest improperly references 8.10 images causing release confusion.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
