### PR TITLE
fix(ci): remove duplicate --force flag in chart-upgrade-taskfile.yaml

### DIFF
--- a/test/integration/scenarios/lib/chart-upgrade-taskfile.yaml
+++ b/test/integration/scenarios/lib/chart-upgrade-taskfile.yaml
@@ -78,6 +78,5 @@ tasks:
         --force \
         --timeout 20m0s \
         --set orchestration.upgrade.allowPreReleaseImages=true \
-        --force \
         --wait-for-jobs \
         --wait {{ .TEST_HELM_EXTRA_ARGS }} |& grep -v 'Ignoring non-table value'


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->
Fixes #5302

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->
- Remove duplicate `--force` flag from `test/integration/scenarios/lib/chart-upgrade-taskfile.yaml` to prevent potential confusion or issues with the helm upgrade command.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only` (Skipped as no Go code changes).
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?