### PR TITLE
ci: Remove duplicate --force flag in chart-upgrade-taskfile.yaml

### DIFF
--- a/test/integration/scenarios/lib/chart-upgrade-taskfile.yaml
+++ b/test/integration/scenarios/lib/chart-upgrade-taskfile.yaml
@@ -78,6 +78,5 @@ tasks:
         --force \
         --timeout 20m0s \
         --set orchestration.upgrade.allowPreReleaseImages=true \
-        --force \
         --wait-for-jobs \
         --wait {{ .TEST_HELM_EXTRA_ARGS }} |& grep -v 'Ignoring non-table value'


### PR DESCRIPTION
## Summary
Fixes #5302 by removing the duplicate `--force` flag in `test/integration/scenarios/lib/chart-upgrade-taskfile.yaml`.

## Description
The `exec` task in `chart-upgrade-taskfile.yaml` passed the `--force` flag twice in the `helm upgrade` command. One instance was removed.

## Changes
- Remove duplicate `--force` flag from `helm upgrade` command in `test/integration/scenarios/lib/chart-upgrade-taskfile.yaml`