### PR TITLE
ci: use auth subkey for opensearch credentials

### DIFF
--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-opensearch.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-opensearch.yaml
@@ -10,9 +10,10 @@ orchestration:
       type: opensearch
       opensearch:
         url: "https://$AWS_HOST_URL:443"
-        username: "$OPENSEARCH_USERNAME"
-        secret:
-          inlineSecret: "$OPENSEARCH_PASSWORD"
+        auth:
+          username: "$OPENSEARCH_USERNAME"
+          secret:
+            inlineSecret: "$OPENSEARCH_PASSWORD"
   security:
     authentication:
       method: oidc

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-opensearch.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-opensearch.yaml
@@ -10,9 +10,10 @@ orchestration:
       type: opensearch
       opensearch:
         url: "https://$AWS_HOST_URL:443"
-        username: "$OPENSEARCH_USERNAME"
-        secret:
-          inlineSecret: "$OPENSEARCH_PASSWORD"
+        auth:
+          username: "$OPENSEARCH_USERNAME"
+          secret:
+            inlineSecret: "$OPENSEARCH_PASSWORD"
   security:
     authentication:
       method: oidc


### PR DESCRIPTION
### Which problem does the PR fix?

the qa-opensearch scenario has an issue with it where it cannot log into opensearch. The reason for this is it's using the wrong username and password options in values.yaml. it's missing the `auth.` part of the yaml path.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

The auth subkey is added to the scenario.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
