### PR TITLE
fix(8.10): remove legacy ingress.kubernetes.io/rewrite-target annotation

### DIFF
--- a/charts/camunda-platform-8.10/values.yaml
+++ b/charts/camunda-platform-8.10/values.yaml
@@ -156,7 +156,6 @@ global:
     labels: {}
     ## @param global.ingress.annotations [object] defines the ingress related annotations, consumed mostly by the ingress controller
     annotations:
-      ingress.kubernetes.io/rewrite-target: "/"
       nginx.ingress.kubernetes.io/ssl-redirect: "false"
       nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
       nginx.ingress.kubernetes.io/proxy-buffering: "on"
@@ -2620,12 +2619,10 @@ orchestration:
       ## @param orchestration.ingress.grpc.labels [object] can be used to define labels which will be applied to the orchestration gRPC ingress resource
       labels: {}
       ## @param orchestration.ingress.grpc.annotations [object] defines the ingress related annotations, consumed mostly by the ingress controller
-      ## @skip orchestration.ingress.grpc.annotations.ingress.kubernetes.io/rewrite-target
       ## @skip orchestration.ingress.grpc.annotations.nginx.ingress.kubernetes.io/ssl-redirect
       ## @skip orchestration.ingress.grpc.annotations.nginx.ingress.kubernetes.io/backend-protocol
       ## @skip orchestration.ingress.grpc.annotations.nginx.ingress.kubernetes.io/proxy-buffer-size
       annotations:
-        ingress.kubernetes.io/rewrite-target: "/"
         nginx.ingress.kubernetes.io/ssl-redirect: "false"
         nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
         nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"


### PR DESCRIPTION
## Summary

Fixes #5423

- Removes the legacy `ingress.kubernetes.io/rewrite-target: "/"` annotation from `global.ingress.annotations` and `orchestration.ingress.grpc.annotations` in `charts/camunda-platform-8.10/values.yaml`.
- Also removes the corresponding `## @skip` doc-gen directive for the annotation in the gRPC ingress block.

## Why this annotation is wrong

The bare `ingress.kubernetes.io/` prefix is a **pre-0.9 (pre-2017) legacy format** from the original nginx-ingress implementation. Every modern ingress-nginx release (0.9+) only reads `nginx.ingress.kubernetes.io/rewrite-target` — the bare-prefix form is silently ignored by all controllers in common use today.

Beyond the wrong prefix, the value `"/"` is also architecturally incorrect for this chart. All Camunda components serve content at their own `contextPath` (e.g. Operate at `/operate`, Tasklist at `/tasklist`). No path rewriting should occur at the ingress layer — the remaining `nginx.ingress.kubernetes.io/`-prefixed annotations (ssl-redirect, proxy-buffer-size, proxy-buffering, proxy-body-size) are correct and untouched.

## Is this a breaking change?

**No.** The annotation is already a no-op in every ingress-nginx version in use today. Removing it produces no change in effective routing behaviour. The only scenario where it could matter is a controller from before 2017 — in which case honouring the annotation would have been actively harmful (rewriting all upstream requests to `/`, breaking contextPath routing).

## Testing

- Confirmed no golden test files in `charts/camunda-platform-8.10/test/` reference this annotation.
- All ingress unit tests pass: `go test ./common/... -run "(?i)ingress"` — PASS.

## Scope

Fix applied to **8.10 only** (the actively maintained latest chart). Older chart versions (8.6–8.9) carry the same annotation but are considered lower priority; they can be addressed in follow-up PRs if desired.