### PR TITLE
ci(workflow): extract shared setup steps into integration-test-setup composite action

### DIFF
--- a/.github/actions/integration-test-setup/action.yaml
+++ b/.github/actions/integration-test-setup/action.yaml
@@ -1,0 +1,239 @@
+name: Integration test setup
+description: |
+  Shared setup steps for the install and upgrade jobs in test-integration-runner.
+  Covers: Vault secret import, cluster authentication, workflow-vars, legacy-ingress
+  computation, test-type-vars, Docker Hub login, and Helm dependency update.
+
+inputs:
+  # ---- Vault ----
+  vault-secret-mapping:
+    description: (optional) defines how to map Vault secrets to distro CI environment variables
+    required: false
+    default: ""
+
+  # ---- Cluster auth ----
+  distro-platform:
+    description: gke | eks | rosa
+    required: true
+  auth-data:
+    description: base64-encrypted kubeconfig (for custom cluster)
+    required: false
+    default: ""
+
+  # ---- workflow-vars ----
+  deployment-ttl:
+    description: TTL for the lifespan of the deployment
+    required: false
+    default: ""
+  flow:
+    description: install | upgrade-patch | upgrade-minor
+    required: false
+    default: install
+  identifier:
+    description: Unique identifier base used in the deployment hostname
+    required: true
+  ingress-hostname-base:
+    description: Base ingress hostname (e.g. ci.distro.ultrawombat.com)
+    required: true
+  camunda-helm-dir:
+    description: Helm chart directory name (e.g. camunda-platform-8.8)
+    required: true
+  camunda-helm-upgrade-version:
+    description: Helm chart version used in the upgrade-patch flow
+    required: false
+    default: ""
+  namespace-prefix:
+    description: Namespace prefix (permissions constraint)
+    required: false
+    default: ""
+
+  # ---- test-type-vars ----
+  infra-type:
+    description: standard or preemptible
+    required: false
+    default: preemptible
+  values-enterprise:
+    description: Enable enterprise values
+    required: false
+    default: "false"
+  values-digest:
+    description: Enable digest values
+    required: false
+    default: "true"
+  camunda-version-previous:
+    description: Previous Camunda version used in upgrade-minor flow
+    required: false
+    default: ""
+
+outputs:
+  cluster-auth-token:
+    description: GitHub token produced by cluster-auth
+    value: ${{ steps.cluster-auth.outputs.token }}
+  identifier:
+    description: Deployment identifier
+    value: ${{ steps.vars.outputs.identifier }}
+  ingress-host:
+    description: Ingress hostname for the deployment
+    value: ${{ steps.vars.outputs.ingress-host }}
+  namespace:
+    description: Kubernetes namespace for the deployment
+    value: ${{ steps.vars.outputs.namespace }}
+  legacy-ingress-arg:
+    description: --set global.ingress.host=... for charts older than 8.10, empty otherwise
+    value: ${{ steps.legacy-ingress.outputs.arg }}
+
+# Secrets cannot be referenced directly inside a composite action.
+# Callers must forward the required secrets as environment variables using `env:` on the step.
+# Required env vars:
+#   VAULT_ADDR, VAULT_ROLE_ID, VAULT_SECRET_ID   (always — used for the CI credentials import)
+#   GH_APP_ID, GH_APP_KEY                        (GitHub App token for cluster-auth)
+#   ROSA_URL, ROSA_USER, ROSA_PASS               (ROSA/OpenShift)
+#   CLUSTER_NAME, TELEPORT_TOKEN                 (EKS)
+# Optional env vars (used as fallback overrides for the Vault-imported values):
+#   DISTRO_CI_DOCKER_USERNAME_DOCKERHUB, DISTRO_CI_DOCKER_PASSWORD_DOCKERHUB
+# GKE cluster coordinates and Docker Hub credentials are imported from Vault by this action.
+
+runs:
+  using: composite
+  steps:
+    # ------------------------------------------------------------------
+    # Vault: optional per-scenario secret import
+    # ------------------------------------------------------------------
+    - name: CI Setup - Import Vault secrets (per-scenario mapping)
+      id: secrets
+      uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+      if: inputs.vault-secret-mapping != ''
+      with:
+        url: ${{ env.VAULT_ADDR }}
+        method: approle
+        roleId: ${{ env.VAULT_ROLE_ID }}
+        secretId: ${{ env.VAULT_SECRET_ID }}
+        secrets: ${{ inputs.vault-secret-mapping }}
+        exportEnv: true
+
+    - name: CI Setup - Generate Secret manifest from Vault mapping
+      if: inputs.vault-secret-mapping != ''
+      shell: bash
+      env:
+        VSM: ${{ inputs.vault-secret-mapping }}
+      run: |
+        (cd ./scripts/vault-secret-mapper && go mod tidy && go run . --mapping "$VSM" --secret-name vault-mapped-secrets --output /tmp/vault-mapped-secrets.yaml)
+
+    # ------------------------------------------------------------------
+    # Vault: always-on CI credential import
+    # ------------------------------------------------------------------
+    - name: CI Setup - Import Vault secrets (CI credentials)
+      id: test-credentials-secret
+      uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+      with:
+        url: ${{ env.VAULT_ADDR }}
+        method: approle
+        roleId: ${{ env.VAULT_ROLE_ID }}
+        secretId: ${{ env.VAULT_SECRET_ID }}
+        secrets: |
+          secret/data/products/distribution/ci NEXUS_USERNAME;
+          secret/data/products/distribution/ci NEXUS_PASSWORD;
+          secret/data/products/distribution/ci HARBOR_REGISTRY_USER | TEST_DOCKER_USERNAME_CAMUNDA_CLOUD;
+          secret/data/products/distribution/ci HARBOR_REGISTRY_PASSWORD | TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD;
+          secret/data/products/distribution/ci DOCKERHUB_USERNAME | TEST_DOCKER_USERNAME;
+          secret/data/products/distribution/ci DOCKERHUB_PASSWORD | TEST_DOCKER_PASSWORD;
+          secret/data/products/distribution/ci DISTRO_AWS_OPENSEARCH_USERNAME | OPENSEARCH_USERNAME;
+          secret/data/products/distribution/ci DISTRO_AWS_OPENSEARCH_PASSWORD | OPENSEARCH_PASSWORD;
+          secret/data/products/distribution/ci ENTRA_APP_CLIENT_SECRET;
+          secret/data/products/distribution/ci ENTRA_APP_CLIENT_ID;
+          secret/data/products/distribution/ci ENTRA_APP_OBJECT_ID;
+          secret/data/products/distribution/ci ENTRA_APP_DIRECTORY_ID;
+          secret/data/products/distribution/ci RDBMS_POSTGRESQL_USERNAME;
+          secret/data/products/distribution/ci RDBMS_POSTGRESQL_PASSWORD;
+          secret/data/products/distribution/ci DISTRO_CI_GCP_GKE_CLUSTER_NAME;
+          secret/data/products/distribution/ci DISTRO_CI_GCP_GKE_CLUSTER_LOCATION;
+          secret/data/products/distribution/ci DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER;
+          secret/data/products/distribution/ci DISTRO_CI_GCP_SERVICE_ACCOUNT;
+        exportEnv: true
+
+    # ------------------------------------------------------------------
+    # Cluster authentication
+    # ------------------------------------------------------------------
+    - name: CI Setup - Authenticate to cluster
+      id: cluster-auth
+      uses: ./.github/actions/cluster-auth
+      with:
+        platform: ${{ inputs.distro-platform }}
+        auth-data: ${{ inputs.auth-data }}
+      env:
+        GH_APP_ID:        ${{ env.GH_APP_ID }}
+        GH_APP_KEY:       ${{ env.GH_APP_KEY }}
+        GKE_CLUSTER_NAME: ${{ env.DISTRO_CI_GCP_GKE_CLUSTER_NAME }}
+        GKE_CLUSTER_LOC:  ${{ env.DISTRO_CI_GCP_GKE_CLUSTER_LOCATION }}
+        GKE_WIP:          ${{ env.DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+        GKE_SA:           ${{ env.DISTRO_CI_GCP_SERVICE_ACCOUNT }}
+        ROSA_URL:         ${{ env.ROSA_URL }}
+        ROSA_USER:        ${{ env.ROSA_USER }}
+        ROSA_PASS:        ${{ env.ROSA_PASS }}
+        CLUSTER_NAME:     ${{ env.CLUSTER_NAME }}
+
+    # ------------------------------------------------------------------
+    # Workflow vars (namespace, ingress host, identifier, …)
+    # ------------------------------------------------------------------
+    - name: CI Setup - Set workflow vars
+      id: vars
+      uses: ./.github/actions/workflow-vars
+      with:
+        deployment-ttl: ${{ inputs.deployment-ttl }}
+        setup-flow: ${{ inputs.flow }}
+        platform: ${{ inputs.distro-platform }}
+        identifier-base: ${{ inputs.identifier }}
+        ingress-hostname-base: ${{ inputs.ingress-hostname-base }}
+        chart-dir: ${{ inputs.camunda-helm-dir }}
+        chart-upgrade-version: ${{ inputs.camunda-helm-upgrade-version }}
+        prefix: ${{ inputs.namespace-prefix }}
+
+    # ------------------------------------------------------------------
+    # Legacy ingress host arg (pre-8.10 charts use global.ingress.host)
+    # ------------------------------------------------------------------
+    - name: CI Setup - Compute legacy ingress host arg
+      id: legacy-ingress
+      shell: bash
+      run: |
+        MINOR=$(echo "${{ inputs.camunda-helm-dir }}" | grep -oP '8\.\K\d+')
+        if [[ "$MINOR" -lt 10 ]]; then
+          echo "arg=--set global.ingress.host=${{ steps.vars.outputs.ingress-host }}" >> "$GITHUB_OUTPUT"
+        else
+          echo "arg=" >> "$GITHUB_OUTPUT"
+        fi
+
+    # ------------------------------------------------------------------
+    # Test-type vars (CHART_PATH, CI_TASKS_BASE_DIR, TEST_HELM_EXTRA_ARGS, …)
+    # ------------------------------------------------------------------
+    - name: CI Setup - Set test type vars
+      id: test-type-vars
+      uses: ./.github/actions/test-type-vars
+      with:
+        chart-dir: ${{ inputs.camunda-helm-dir }}
+        infra-type: ${{ inputs.infra-type }}
+        platform: ${{ inputs.distro-platform }}
+        values-enterprise: ${{ inputs.values-enterprise }}
+        values-digest: ${{ inputs.values-digest }}
+        flow: ${{ inputs.flow }}
+        camunda-version-previous: ${{ inputs.camunda-version-previous }}
+
+    # ------------------------------------------------------------------
+    # Docker Hub login (avoids rate limits for Helm dependency pulls)
+    # ------------------------------------------------------------------
+    - name: CI Setup - Login to Docker Hub
+      shell: bash
+      env:
+        TEST_DOCKER_USERNAME: ${{ env.DISTRO_CI_DOCKER_USERNAME_DOCKERHUB || env.TEST_DOCKER_USERNAME }}
+        TEST_DOCKER_PASSWORD: ${{ env.DISTRO_CI_DOCKER_PASSWORD_DOCKERHUB || env.TEST_DOCKER_PASSWORD }}
+      run: |
+        echo "${TEST_DOCKER_PASSWORD}" | helm registry login registry-1.docker.io -u "${TEST_DOCKER_USERNAME}" --password-stdin
+
+    # ------------------------------------------------------------------
+    # Helm repos + dependency update
+    # ------------------------------------------------------------------
+    - name: CI Setup - Add Helm repos and update Helm dependencies
+      shell: bash
+      run: |
+        export chartPath="${{ env.CHART_PATH }}"
+        make helm.repos-add
+        make helm.dependency-update

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -285,9 +285,9 @@ jobs:
       run:
         shell: bash
     outputs:
-      vars-identifier: ${{ steps.vars.outputs.identifier }}
-      vars-ingress-host: ${{ steps.vars.outputs.ingress-host }}
-      vars-namespace: ${{ steps.vars.outputs.namespace }}
+      vars-identifier: ${{ steps.setup.outputs.identifier }}
+      vars-ingress-host: ${{ steps.setup.outputs.ingress-host }}
+      vars-namespace: ${{ steps.setup.outputs.namespace }}
       SHARD_TOTAL: ${{ env.SHARD_TOTAL }}
       SHARD_INDEX: ${{ env.SHARD_INDEX }}
     permissions:
@@ -327,128 +327,44 @@ jobs:
       # Tools (golang, helm, kubectl, oc, task, yq, zbctl) are pre-installed in the CI runner container image
       # See: .github/docker/ci-runner/Dockerfile
 
-      # When there is a vault-secret-mapping input given, use Vault instead of GitHub secrets
-      # and populate environment variables from Vault
-      - name: CI Setup - Import Vault secrets
-        id: secrets
-        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
-        if: inputs.vault-secret-mapping != ''
+      - name: CI Setup - Shared integration test setup
+        id: setup
+        uses: ./.github/actions/integration-test-setup
         with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secrets: ${{ inputs.vault-secret-mapping }}
-          exportEnv: true
-
-      - name: Generate Secret manifest from Vault mapping
-        if: inputs.vault-secret-mapping != ''
+          vault-secret-mapping:        ${{ inputs.vault-secret-mapping }}
+          distro-platform:             ${{ inputs.distro-platform }}
+          auth-data:                   ${{ inputs.auth-data }}
+          deployment-ttl:              ${{ env.CI_DEPLOYMENT_TTL }}
+          flow:                        ${{ inputs.flow }}
+          identifier:                  ${{ inputs.identifier }}
+          ingress-hostname-base:       ${{ env.CI_HOSTNAME_BASE }}
+          camunda-helm-dir:            ${{ inputs.camunda-helm-dir }}
+          camunda-helm-upgrade-version: ${{ inputs.camunda-helm-upgrade-version }}
+          namespace-prefix:            ${{ inputs.namespace-prefix }}
+          infra-type:                  ${{ inputs.infra-type }}
+          values-enterprise:           ${{ inputs.values-enterprise }}
+          values-digest:               ${{ inputs.values-digest }}
+          camunda-version-previous:    ${{ inputs.camunda-version-previous }}
         env:
-          VSM: ${{ inputs.vault-secret-mapping }}
-        run: |
-          (cd ./scripts/vault-secret-mapper && go mod tidy && go run . --mapping "$VSM" --secret-name vault-mapped-secrets --output /tmp/vault-mapped-secrets.yaml)
-
-
-      - name: Import Vault secrets
-        id: test-credentials-secret
-        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secrets: |
-            secret/data/products/distribution/ci NEXUS_USERNAME;
-            secret/data/products/distribution/ci NEXUS_PASSWORD;
-            secret/data/products/distribution/ci HARBOR_REGISTRY_USER | TEST_DOCKER_USERNAME_CAMUNDA_CLOUD;
-            secret/data/products/distribution/ci HARBOR_REGISTRY_PASSWORD | TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD;
-            secret/data/products/distribution/ci DOCKERHUB_USERNAME | TEST_DOCKER_USERNAME;
-            secret/data/products/distribution/ci DOCKERHUB_PASSWORD | TEST_DOCKER_PASSWORD;
-            secret/data/products/distribution/ci DISTRO_AWS_OPENSEARCH_USERNAME | OPENSEARCH_USERNAME;
-            secret/data/products/distribution/ci DISTRO_AWS_OPENSEARCH_PASSWORD | OPENSEARCH_PASSWORD;
-            secret/data/products/distribution/ci ENTRA_APP_CLIENT_SECRET;
-            secret/data/products/distribution/ci ENTRA_APP_CLIENT_ID;
-            secret/data/products/distribution/ci ENTRA_APP_OBJECT_ID;
-            secret/data/products/distribution/ci ENTRA_APP_DIRECTORY_ID;
-            secret/data/products/distribution/ci DISTRO_CI_GCP_GKE_CLUSTER_NAME;
-            secret/data/products/distribution/ci DISTRO_CI_GCP_GKE_CLUSTER_LOCATION;
-            secret/data/products/distribution/ci DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER;
-            secret/data/products/distribution/ci DISTRO_CI_GCP_SERVICE_ACCOUNT;
-          exportEnv: true
-
-      - name: CI Setup - Authenticate to cluster
-        id: cluster-auth
-        uses: ./.github/actions/cluster-auth
-        with:
-          platform: ${{ inputs.distro-platform }}
-          auth-data: ${{ inputs.auth-data }}
-        env:
+          VAULT_ADDR:       ${{ secrets.VAULT_ADDR }}
+          VAULT_ROLE_ID:    ${{ secrets.VAULT_ROLE_ID }}
+          VAULT_SECRET_ID:  ${{ secrets.VAULT_SECRET_ID }}
           GH_APP_ID:        ${{ secrets.GH_APP_ID_DISTRO_CI_MANAGE_GH_ENVS }}
           GH_APP_KEY:       ${{ secrets.GH_APP_PRIVATE_KEY_DISTRO_CI_MANAGE_GH_ENVS }}
-          GKE_CLUSTER_NAME: ${{ env.DISTRO_CI_GCP_GKE_CLUSTER_NAME }}
-          GKE_CLUSTER_LOC:  ${{ env.DISTRO_CI_GCP_GKE_CLUSTER_LOCATION }}
-          GKE_WIP:          ${{ env.DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          GKE_SA:           ${{ env.DISTRO_CI_GCP_SERVICE_ACCOUNT }}
           ROSA_URL:         ${{ secrets[inputs.server-url] }}
           ROSA_USER:        ${{ secrets[inputs.username] }}
           ROSA_PASS:        ${{ secrets[inputs.password] }}
           CLUSTER_NAME:     ${{ env.CLUSTER_NAME }}
-
-      - name: CI Setup - ℹ️ Set workflow vars for both install and upgrade ℹ️
-        id: vars
-        uses: ./.github/actions/workflow-vars
-        with:
-          deployment-ttl: ${{ env.CI_DEPLOYMENT_TTL }}
-          setup-flow: ${{ inputs.flow }}
-          platform: ${{ inputs.distro-platform }}
-          identifier-base: ${{ inputs.identifier }}
-          ingress-hostname-base: ${{ env.CI_HOSTNAME_BASE }}
-          chart-dir: ${{ inputs.camunda-helm-dir }}
-          chart-upgrade-version: ${{ inputs.camunda-helm-upgrade-version }}
-          prefix: ${{ inputs.namespace-prefix }}
-
-      # Charts older than 8.10 use global.ingress.host, while 8.10+ uses global.host
-      # and rejects global.ingress.host via a keyRemoved constraint.
-      - name: CI Setup - Compute legacy ingress host arg
-        id: legacy-ingress
-        run: |
-          MINOR=$(echo "${{ inputs.camunda-helm-dir }}" | grep -oP '8\.\K\d+')
-          if [[ "$MINOR" -lt 10 ]]; then
-            echo "arg=--set global.ingress.host=${{ steps.vars.outputs.ingress-host }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "arg=" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: CI Setup - ℹ️ Set test type vars ℹ️
-        id: test-type-vars
-        uses: ./.github/actions/test-type-vars
-        with:
-          chart-dir: "${{ inputs.camunda-helm-dir }}"
-          infra-type: "${{ inputs.infra-type }}"
-          platform: "${{ inputs.distro-platform }}"
-          values-enterprise: "${{ inputs.values-enterprise }}"
-          values-digest: "${{ inputs.values-digest }}"
-          flow: "${{ inputs.flow }}"
-          camunda-version-previous: "${{ inputs.camunda-version-previous }}"
-
-      # Login to Docker Hub to avoid rate limits when pulling Helm chart dependencies (e.g., bitnamicharts/keycloak)
-      - name: CI Setup - Login to Docker Hub
-        run: |
-          echo "${TEST_DOCKER_PASSWORD}" | helm registry login registry-1.docker.io -u "${TEST_DOCKER_USERNAME}" --password-stdin
-
-      - name: CI Setup - Add Helm repos and update Helm dependencies
-        run: |
-          export chartPath="${{ env.CHART_PATH }}"
-          make helm.repos-add
-          make helm.dependency-update
+          DISTRO_CI_DOCKER_USERNAME_DOCKERHUB: ${{ secrets.DISTRO_CI_DOCKER_USERNAME_DOCKERHUB }}
+          DISTRO_CI_DOCKER_PASSWORD_DOCKERHUB: ${{ secrets.DISTRO_CI_DOCKER_PASSWORD_DOCKERHUB }}
 
       - name: CI Setup - Start GitHub deployment
         uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1
         id: deployment
         with:
           step: start
-          token: ${{ steps.cluster-auth.outputs.token }}
-          env: ${{ steps.vars.outputs.identifier }}
+          token: ${{ steps.setup.outputs.cluster-auth-token }}
+          env: ${{ steps.setup.outputs.identifier }}
           ref: ${{ inputs.caller-git-ref }}
 
       - name: Cluster Setup - Configure the namespace
@@ -468,7 +384,7 @@ jobs:
             fi
           fi
           kubectl create ns $TEST_NAMESPACE --dry-run=client -o yaml | kubectl apply -f -
-          kubectl label ns $TEST_NAMESPACE github-id=${{ steps.vars.outputs.identifier }} --overwrite
+          kubectl label ns $TEST_NAMESPACE github-id=${{ steps.setup.outputs.identifier }} --overwrite
           kubectl label ns $TEST_NAMESPACE test-flow=${{ inputs.flow }} --overwrite
           kubectl label ns $TEST_NAMESPACE github-run-id=$GITHUB_WORKFLOW_RUN_ID --overwrite
           kubectl label ns $TEST_NAMESPACE github-job-id=$GITHUB_WORKFLOW_JOB_ID --overwrite
@@ -525,7 +441,7 @@ jobs:
         timeout-minutes: 5
         env:
           TEST_CHART_FLOW: ${{ inputs.flow }}
-          TEST_INGRESS_HOST: ${{ steps.vars.outputs.ingress-host }}
+          TEST_INGRESS_HOST: ${{ steps.setup.outputs.ingress-host }}
           TEST_VALUES_SCENARIO: "${{ inputs.scenario }}"
           TEST_AUTH_TYPE: ${{ inputs.auth }}
           INFRA_TYPE: ${{ inputs.infra-type }}
@@ -537,8 +453,8 @@ jobs:
           TEST_FEATURES: ${{ inputs.test-features }}
           TEST_HELM_EXTRA_ARGS: >-
             ${{ env.TEST_HELM_EXTRA_ARGS }}
-            ${{ steps.legacy-ingress.outputs.arg }}
-            --set global.host=${{ steps.vars.outputs.ingress-host }}
+            ${{ steps.setup.outputs.legacy-ingress-arg }}
+            --set global.host=${{ steps.setup.outputs.ingress-host }}
         run: |
           echo "Extra values from workflow:"
           echo "$EXTRA_VALUES" | tee /tmp/extra-values-file.yaml
@@ -560,14 +476,14 @@ jobs:
         timeout-minutes: 5
         env:
           TEST_CHART_FLOW: ${{ inputs.flow }}
-          TEST_INGRESS_HOST: ${{ steps.vars.outputs.ingress-host }}
+          TEST_INGRESS_HOST: ${{ steps.setup.outputs.ingress-host }}
           TEST_VALUES_SCENARIO: "${{ inputs.scenario }}"
           TEST_AUTH_TYPE: ${{ inputs.auth }}
           INFRA_TYPE: ${{ inputs.infra-type }}
           EXTRA_VALUES: ${{ inputs.extra-values }}
           VALUES_CONFIG: ${{ inputs.values-config }}
           # CAMUNDA_HOSTNAME is required by layered values (e.g. base.yaml contains $CAMUNDA_HOSTNAME)
-          CAMUNDA_HOSTNAME: ${{ steps.vars.outputs.ingress-host }}
+          CAMUNDA_HOSTNAME: ${{ steps.setup.outputs.ingress-host }}
           # Selection + composition model environment variables (new - preferred)
           TEST_IDENTITY: ${{ inputs.test-identity }}
           TEST_PERSISTENCE: ${{ inputs.test-persistence }}
@@ -578,8 +494,8 @@ jobs:
           TEST_IMAGE_TAGS: ${{ inputs.include-image-tags }}
           TEST_HELM_EXTRA_ARGS: >-
             ${{ env.TEST_HELM_EXTRA_ARGS }}
-            ${{ steps.legacy-ingress.outputs.arg }}
-            --set global.host=${{ steps.vars.outputs.ingress-host }}
+            ${{ steps.setup.outputs.legacy-ingress-arg }}
+            --set global.host=${{ steps.setup.outputs.ingress-host }}
         run: |
           # Configure OpenSearch environment if using opensearch scenario
           if [[ "${{ inputs.scenario }}" == "opensearch" ]] && [[ -n "${OPENSEARCH_USERNAME}" ]] && [[ -n "${OPENSEARCH_PASSWORD}" ]]; then
@@ -630,7 +546,7 @@ jobs:
           INFRA_TYPE: ${{ inputs.infra-type }}
           VALUES_CONFIG: ${{ inputs.values-config }}
           # CAMUNDA_HOSTNAME is required by layered values (e.g. base.yaml contains $CAMUNDA_HOSTNAME)
-          CAMUNDA_HOSTNAME: ${{ steps.vars.outputs.ingress-host }}
+          CAMUNDA_HOSTNAME: ${{ steps.setup.outputs.ingress-host }}
           # License key for Camunda Platform (injected via --set in helm install).
           # Use the GitHub secret if available, otherwise fall back to the Vault-exported env var.
           E2E_TESTS_LICENSE_KEY: ${{ secrets.E2E_TESTS_LICENSE_KEY || env.E2E_TESTS_LICENSE_KEY }}
@@ -643,8 +559,8 @@ jobs:
           TEST_UPGRADE: ${{ inputs.test-upgrade }}
           TEST_IMAGE_TAGS: ${{ inputs.include-image-tags }}
           TEST_HELM_EXTRA_ARGS: >-
-            ${{ steps.legacy-ingress.outputs.arg }}
-            --set global.host=${{ steps.vars.outputs.ingress-host }}
+            ${{ steps.setup.outputs.legacy-ingress-arg }}
+            --set global.host=${{ steps.setup.outputs.ingress-host }}
         run: |
           task -d ${CI_TASKS_BASE_DIR}/chart-full-setup setup.exec
 
@@ -673,11 +589,11 @@ jobs:
         uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1
         with:
           step: finish
-          token: ${{ steps.cluster-auth.outputs.token }}
+          token: ${{ steps.setup.outputs.cluster-auth-token }}
           status: ${{ job.status }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          env_url: https://${{ steps.vars.outputs.ingress-host }}
-          env: ${{ steps.vars.outputs.identifier }}
+          env_url: https://${{ steps.setup.outputs.ingress-host }}
+          env: ${{ steps.setup.outputs.identifier }}
           ref: ${{ inputs.caller-git-ref }}
 
       - name: Calculate Playwright sharding matrix
@@ -714,9 +630,9 @@ jobs:
         shell: bash
     needs: [install]
     outputs:
-      vars-identifier: ${{ steps.vars.outputs.identifier }}
-      vars-ingress-host: ${{ steps.vars.outputs.ingress-host }}
-      vars-namespace: ${{ steps.vars.outputs.namespace }}
+      vars-identifier: ${{ steps.setup.outputs.identifier }}
+      vars-ingress-host: ${{ steps.setup.outputs.ingress-host }}
+      vars-namespace: ${{ steps.setup.outputs.namespace }}
       SHARD_TOTAL: ${{ env.SHARD_TOTAL }}
       SHARD_INDEX: ${{ env.SHARD_INDEX }}
     permissions:
@@ -753,117 +669,36 @@ jobs:
       # Tools (golang, helm, kubectl, oc, task, yq, zbctl) are pre-installed in the CI runner container image
       # See: .github/docker/ci-runner/Dockerfile
 
-      # When there is a vault-secret-mapping input given, use Vault instead of GitHub secrets
-      # and populate environment variables from Vault
-      - name: CI Setup - Import Vault secrets
-        id: secrets
-        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
-        if: inputs.vault-secret-mapping != ''
+      - name: CI Setup - Shared integration test setup
+        id: setup
+        uses: ./.github/actions/integration-test-setup
         with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secrets: ${{ inputs.vault-secret-mapping }}
-          exportEnv: true
-
-      - name: Generate Secret manifest from Vault mapping
-        if: inputs.vault-secret-mapping != ''
+          vault-secret-mapping:        ${{ inputs.vault-secret-mapping }}
+          distro-platform:             ${{ inputs.distro-platform }}
+          auth-data:                   ${{ inputs.auth-data }}
+          deployment-ttl:              ${{ env.CI_DEPLOYMENT_TTL }}
+          flow:                        ${{ inputs.flow }}
+          identifier:                  ${{ inputs.identifier }}
+          ingress-hostname-base:       ${{ env.CI_HOSTNAME_BASE }}
+          camunda-helm-dir:            ${{ inputs.camunda-helm-dir }}
+          camunda-helm-upgrade-version: ${{ inputs.camunda-helm-upgrade-version }}
+          namespace-prefix:            ${{ inputs.namespace-prefix }}
+          infra-type:                  ${{ inputs.infra-type }}
+          values-enterprise:           ${{ inputs.values-enterprise }}
+          values-digest:               ${{ inputs.values-digest }}
+          camunda-version-previous:    ${{ inputs.camunda-version-previous }}
         env:
-          VSM: ${{ inputs.vault-secret-mapping }}
-        run: |
-          (cd ./scripts/vault-secret-mapper && go mod tidy && go run . --mapping "$VSM" --secret-name vault-mapped-secrets --output /tmp/vault-mapped-secrets.yaml)
-
-      - name: Import Vault secrets
-        id: test-credentials-secret
-        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secrets: |
-            secret/data/products/distribution/ci NEXUS_USERNAME;
-            secret/data/products/distribution/ci NEXUS_PASSWORD;
-            secret/data/products/distribution/ci ENTRA_APP_CLIENT_SECRET;
-            secret/data/products/distribution/ci ENTRA_APP_CLIENT_ID;
-            secret/data/products/distribution/ci ENTRA_APP_OBJECT_ID;
-            secret/data/products/distribution/ci ENTRA_APP_DIRECTORY_ID;
-            secret/data/products/distribution/ci DOCKERHUB_USERNAME | TEST_DOCKER_USERNAME;
-            secret/data/products/distribution/ci DOCKERHUB_PASSWORD | TEST_DOCKER_PASSWORD;
-            secret/data/products/distribution/ci RDBMS_POSTGRESQL_USERNAME;
-            secret/data/products/distribution/ci RDBMS_POSTGRESQL_PASSWORD;
-            secret/data/products/distribution/ci DISTRO_CI_GCP_GKE_CLUSTER_NAME;
-            secret/data/products/distribution/ci DISTRO_CI_GCP_GKE_CLUSTER_LOCATION;
-            secret/data/products/distribution/ci DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER;
-            secret/data/products/distribution/ci DISTRO_CI_GCP_SERVICE_ACCOUNT;
-          exportEnv: true
-
-      - name: CI Setup - Authenticate to cluster
-        id: cluster-auth
-        uses: ./.github/actions/cluster-auth
-        with:
-          platform: ${{ inputs.distro-platform }}
-          auth-data: ${{ inputs.auth-data }}
-        env:
+          VAULT_ADDR:       ${{ secrets.VAULT_ADDR }}
+          VAULT_ROLE_ID:    ${{ secrets.VAULT_ROLE_ID }}
+          VAULT_SECRET_ID:  ${{ secrets.VAULT_SECRET_ID }}
           GH_APP_ID:        ${{ secrets.GH_APP_ID_DISTRO_CI_MANAGE_GH_ENVS }}
           GH_APP_KEY:       ${{ secrets.GH_APP_PRIVATE_KEY_DISTRO_CI_MANAGE_GH_ENVS }}
-          GKE_CLUSTER_NAME: ${{ env.DISTRO_CI_GCP_GKE_CLUSTER_NAME }}
-          GKE_CLUSTER_LOC:  ${{ env.DISTRO_CI_GCP_GKE_CLUSTER_LOCATION }}
-          GKE_WIP:          ${{ env.DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          GKE_SA:           ${{ env.DISTRO_CI_GCP_SERVICE_ACCOUNT }}
           ROSA_URL:         ${{ secrets[inputs.server-url] }}
           ROSA_USER:        ${{ secrets[inputs.username] }}
           ROSA_PASS:        ${{ secrets[inputs.password] }}
           CLUSTER_NAME:     ${{ env.CLUSTER_NAME }}
-
-      - name: CI Setup - ℹ️ Set workflow vars for both install and upgrade ℹ️
-        id: vars
-        uses: ./.github/actions/workflow-vars
-        with:
-          deployment-ttl: ${{ env.CI_DEPLOYMENT_TTL }}
-          setup-flow: ${{ inputs.flow }}
-          platform: ${{ inputs.distro-platform }}
-          identifier-base: ${{ inputs.identifier }}
-          ingress-hostname-base: ${{ env.CI_HOSTNAME_BASE }}
-          chart-dir: ${{ inputs.camunda-helm-dir }}
-          chart-upgrade-version: ${{ inputs.camunda-helm-upgrade-version }}
-          prefix: ${{ inputs.namespace-prefix }}
-
-      # Charts older than 8.10 use global.ingress.host, while 8.10+ uses global.host
-      # and rejects global.ingress.host via a keyRemoved constraint.
-      - name: CI Setup - Compute legacy ingress host arg
-        id: legacy-ingress
-        run: |
-          MINOR=$(echo "${{ inputs.camunda-helm-dir }}" | grep -oP '8\.\K\d+')
-          if [[ "$MINOR" -lt 10 ]]; then
-            echo "arg=--set global.ingress.host=${{ steps.vars.outputs.ingress-host }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "arg=" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: CI Setup - ℹ️ Set test type vars ℹ️
-        id: test-type-vars
-        uses: ./.github/actions/test-type-vars
-        with:
-          chart-dir: "${{ inputs.camunda-helm-dir }}"
-          infra-type: "${{ inputs.infra-type }}"
-          platform: "${{ inputs.distro-platform }}"
-          values-enterprise: "${{ inputs.values-enterprise }}"
-          values-digest: "${{ inputs.values-digest }}"
-          flow: "${{ inputs.flow }}"
-          camunda-version-previous: "${{ inputs.camunda-version-previous }}"
-
-      # Login to Docker Hub to avoid rate limits when pulling Helm chart dependencies (e.g., bitnamicharts/keycloak)
-      - name: CI Setup - Login to Docker Hub
-        run: |
-          echo "${TEST_DOCKER_PASSWORD}" | helm registry login registry-1.docker.io -u "${TEST_DOCKER_USERNAME}" --password-stdin
-
-      - name: CI Setup - Add Helm repos and update Helm dependencies
-        run: |
-          export chartPath="${{ env.CHART_PATH }}"
-          make helm.repos-add
-          make helm.dependency-update
+          DISTRO_CI_DOCKER_USERNAME_DOCKERHUB: ${{ secrets.DISTRO_CI_DOCKER_USERNAME_DOCKERHUB }}
+          DISTRO_CI_DOCKER_PASSWORD_DOCKERHUB: ${{ secrets.DISTRO_CI_DOCKER_PASSWORD_DOCKERHUB }}
 
       ##########################################################################################################
       # Upgrade
@@ -873,7 +708,7 @@ jobs:
         timeout-minutes: 5
         env:
           TEST_CHART_FLOW: ${{ inputs.flow }}
-          TEST_INGRESS_HOST: ${{ steps.vars.outputs.ingress-host }}
+          TEST_INGRESS_HOST: ${{ steps.setup.outputs.ingress-host }}
           TEST_VALUES_SCENARIO: "${{ inputs.scenario }}"
           TEST_AUTH_TYPE: ${{ inputs.auth }}
           INFRA_TYPE: ${{ inputs.infra-type }}
@@ -885,8 +720,8 @@ jobs:
           TEST_FEATURES: ${{ inputs.test-features }}
           TEST_HELM_EXTRA_ARGS: >-
             ${{ env.TEST_HELM_EXTRA_ARGS }}
-            ${{ steps.legacy-ingress.outputs.arg }}
-            --set global.host=${{ steps.vars.outputs.ingress-host }}
+            ${{ steps.setup.outputs.legacy-ingress-arg }}
+            --set global.host=${{ steps.setup.outputs.ingress-host }}
         run: |
           echo "Extra values from workflow:"
           echo "$EXTRA_VALUES" | tee /tmp/extra-values-file.yaml
@@ -927,7 +762,7 @@ jobs:
         env:
           TEST_CHART_FLOW: ${{ inputs.flow }}
           VALUES_CONFIG: ${{ inputs.values-config }}
-          CAMUNDA_HOSTNAME: ${{ steps.vars.outputs.ingress-host }}
+          CAMUNDA_HOSTNAME: ${{ steps.setup.outputs.ingress-host }}
           TEST_VALUES_SCENARIO: "${{ inputs.scenario }}"
           TEST_AUTH_TYPE: ${{ inputs.auth }}
           INFRA_TYPE: ${{ inputs.infra-type }}
@@ -951,7 +786,7 @@ jobs:
           TEST_CHART_FLOW: ${{ inputs.flow }}
           VALUES_CONFIG: ${{ inputs.values-config }}
           # CAMUNDA_HOSTNAME is required by layered values (e.g. base.yaml contains $CAMUNDA_HOSTNAME)
-          CAMUNDA_HOSTNAME: ${{ steps.vars.outputs.ingress-host }}
+          CAMUNDA_HOSTNAME: ${{ steps.setup.outputs.ingress-host }}
           # License key for Camunda Platform (injected via --set in helm install).
           # Use the GitHub secret if available, otherwise fall back to the Vault-exported env var.
           E2E_TESTS_LICENSE_KEY: ${{ secrets.E2E_TESTS_LICENSE_KEY || env.E2E_TESTS_LICENSE_KEY }}
@@ -964,8 +799,8 @@ jobs:
           TEST_UPGRADE: ${{ inputs.test-upgrade }}
           TEST_IMAGE_TAGS: ${{ inputs.include-image-tags }}
           TEST_HELM_EXTRA_ARGS: >-
-            ${{ steps.legacy-ingress.outputs.arg }}
-            --set global.host=${{ steps.vars.outputs.ingress-host }}
+            ${{ steps.setup.outputs.legacy-ingress-arg }}
+            --set global.host=${{ steps.setup.outputs.ingress-host }}
         run: |
           task -d ${CI_TASKS_BASE_DIR}/chart-full-setup upgrade.exec
 


### PR DESCRIPTION
## Summary

- Extracts ~150 lines of duplicated setup steps from the `install` and `upgrade` jobs in `.github/workflows/test-integration-runner.yaml` into a new reusable composite action at `.github/actions/integration-test-setup/action.yaml`
- The composite action encapsulates: Vault secret import (conditional + always-on), cluster authentication, workflow vars, legacy ingress host arg computation, test-type vars, Docker Hub login, and Helm repo/dependency setup
- Callers replace ~8 steps with a single `id: setup` invocation; all downstream step references updated from `steps.vars.outputs.*` / `steps.cluster-auth.outputs.*` / `steps.legacy-ingress.outputs.*` to `steps.setup.outputs.*`

## Notes

- Secrets are forwarded via `env:` on the composite action call step (composite actions cannot reference `secrets.*` directly — consistent with how the existing `cluster-auth` action works)
- The `cleanup` job was intentionally left untouched; its setup is different (no Vault secret import) and should not be merged
- Both YAML files validated with `yq` before committing

Closes #5303