### PR TITLE
ci: add tasklist v1 mode scenarios to HC matrix

### DIFF
--- a/.github/workflows/test-backward-compat.yaml
+++ b/.github/workflows/test-backward-compat.yaml
@@ -86,6 +86,16 @@ jobs:
             shortname: qadoc
           - name: qa-elasticsearch-tasklist-v1
             shortname: qaeltlv1
+          - name: qa-opensearch-tasklist-v1
+            shortname: qaosupg
+          - name: qa-elasticsearch-rba-tasklist-v1
+            shortname: qaelrbaupg
+          - name: qa-elasticsearch-mt-tasklist-v1
+            shortname: qaelmtupg
+            e2e-enabled: false
+          - name: qa-license-tasklist-v1
+            shortname: licupg
+            licenseVaultMapping: "secret/data/products/qa/ci/cross-component-e2e-test-suite LICENSE_VALID_COMMERCIAL_UNLIMITED | E2E_TESTS_LICENSE_KEY;"
           - name: qa-elasticsearch-upg
             shortname: qaelupg
           - name: qa-opensearch-upg


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #4927

### What's in this PR?

Adds Tasklist v1 mode scenario definitions for the backward-compatibility test matrix (8.8+), extending the existing `qa-elasticsearch-tasklist-v1` (`qaeltlv1`) entry with 4 new variants:

| Scenario | Shortname | Notes |
|---|---|---|
| `qa-opensearch-tasklist-v1` | `qaosupg` | OpenSearch |
| `qa-elasticsearch-rba-tasklist-v1` | `qaelrbaupg` | RBA |
| `qa-elasticsearch-mt-tasklist-v1` | `qaelmtupg` | MT (`e2e-enabled: false`) |
| `qa-license-tasklist-v1` | `licupg` | License Key |

The corresponding e2e nightly/manual workflow changes are in [camunda/c8-cross-component-e2e-tests#1823](https://github.com/camunda/c8-cross-component-e2e-tests/pull/1823).

### Checklist

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).