### PR TITLE
ci: remove dead env entries from playwright IT jobs and fix upgrade ingress host ref

### DIFF
--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -997,12 +997,7 @@ jobs:
       deployments: write
       packages: read
     env:
-      CI_TASKS_BASE_DIR: ${{ needs.install.outputs.CI_TASKS_BASE_DIR }}
-      TEST_CHART_DIR: ${{ needs.install.outputs.TEST_CHART_DIR }}
-      TEST_VALUES_BASE_DIR: ${{ needs.install.outputs.TEST_VALUES_BASE_DIR }}
       TEST_INGRESS_HOST: ${{ needs.install.outputs.vars-ingress-host }}
-      TEST_NAMESPACE: ${{ needs.install.outputs.TEST_NAMESPACE }}
-      ABSOLUTE_TEST_CHART_DIR: ${{ needs.install.outputs.ABSOLUTE_TEST_CHART_DIR }}
       TEST_EXCLUDE: ${{ inputs.exclude }}
       PLATFORM: ${{ inputs.distro-platform }}
       TEST_AUTH_TYPE: ${{ inputs.auth }}
@@ -1061,12 +1056,7 @@ jobs:
       deployments: write
       packages: read
     env:
-      CI_TASKS_BASE_DIR: ${{ needs.install.outputs.CI_TASKS_BASE_DIR }}
-      TEST_CHART_DIR: ${{ needs.install.outputs.TEST_CHART_DIR }}
-      TEST_VALUES_BASE_DIR: ${{ needs.install.outputs.TEST_VALUES_BASE_DIR }}
-      TEST_INGRESS_HOST: ${{ needs.install.outputs.vars-ingress-host }}
-      TEST_NAMESPACE: ${{ needs.install.outputs.TEST_NAMESPACE }}
-      ABSOLUTE_TEST_CHART_DIR: ${{ needs.install.outputs.ABSOLUTE_TEST_CHART_DIR }}
+      TEST_INGRESS_HOST: ${{ needs.upgrade.outputs.vars-ingress-host }}
       TEST_EXCLUDE: ${{ inputs.exclude }}
       PLATFORM: ${{ inputs.distro-platform }}
       TEST_AUTH_TYPE: ${{ inputs.auth }}


### PR DESCRIPTION
## Summary

- Removes 5 dead `env` entries (`CI_TASKS_BASE_DIR`, `TEST_CHART_DIR`, `TEST_VALUES_BASE_DIR`, `TEST_NAMESPACE`, `ABSOLUTE_TEST_CHART_DIR`) from the job-level `env` blocks in both `playwright-integration-tests-after-install` and `playwright-integration-tests-after-upgrade`. These keys were never declared as outputs on the `install` or `upgrade` jobs, so they always resolved to empty strings at runtime.
- These env vars are dead code: the `playwright-integration-tests` composite action is self-contained and recomputes all these values itself via `workflow-vars` and `test-type-vars` actions from its own inputs.
- Fixes `TEST_INGRESS_HOST` in `playwright-integration-tests-after-upgrade` which referenced `needs.install.outputs.vars-ingress-host` despite `install` not being in its `needs` list. Corrected to `needs.upgrade.outputs.vars-ingress-host`, which is a properly declared output on the `upgrade` job.

## Related

Closes #5304