### PR TITLE
ci: fix license key word-splitting in helm install/upgrade

### DIFF
--- a/test/integration/scenarios/chart-full-setup/Taskfile.yaml
+++ b/test/integration/scenarios/chart-full-setup/Taskfile.yaml
@@ -332,12 +332,21 @@ tasks:
         --interactive=false \
         --log-level info)
       
+      # Write license key to a file and use --set-file to avoid shell word-splitting.
+      # License keys contain spaces and semicolons which break --set via shell expansion.
+      LICENSE_KEY_ARGS=""
+      if [ -n "${E2E_TESTS_LICENSE_KEY:-}" ]; then
+        LICENSE_KEY_FILE="/tmp/license-key.txt"
+        printf '%s' "${E2E_TESTS_LICENSE_KEY}" > "$LICENSE_KEY_FILE"
+        LICENSE_KEY_ARGS="--set-file global.license.key=$LICENSE_KEY_FILE"
+      fi
+
       echo ""
       echo "=========================================="
       echo "Merged values file: $MERGED_VALUES"
       echo "Final helm install command:"
       echo "=========================================="
-      
+
       # Helm values precedence: last --values wins.
       # Order: common → digest (overlay) → extra → scenario (highest precedence).
       # This ensures scenario-specific values (e.g., CI Keycloak image) override
@@ -353,7 +362,7 @@ tasks:
         {{ end -}}
         --values /tmp/extra-values-file.yaml \
         --values "$MERGED_VALUES" \
-        ${E2E_TESTS_LICENSE_KEY:+--set global.license.key="${E2E_TESTS_LICENSE_KEY}"} \
+        $LICENSE_KEY_ARGS \
         --set orchestration.upgrade.allowPreReleaseImages=true \
         --timeout 20m0s \
         --wait \

--- a/test/integration/scenarios/lib/chart-upgrade-taskfile.yaml
+++ b/test/integration/scenarios/lib/chart-upgrade-taskfile.yaml
@@ -92,6 +92,15 @@ tasks:
           EXTRA_VALUES_ARGS="--values /tmp/extra-values-file.yaml"
         fi
         
+        # Write license key to a file and use --set-file to avoid shell word-splitting.
+        # License keys contain spaces and semicolons which break --set via shell expansion.
+        LICENSE_KEY_ARGS=""
+        if [ -n "${E2E_TESTS_LICENSE_KEY:-}" ]; then
+          LICENSE_KEY_FILE="/tmp/license-key.txt"
+          printf '%s' "${E2E_TESTS_LICENSE_KEY}" > "$LICENSE_KEY_FILE"
+          LICENSE_KEY_ARGS="--set-file global.license.key=$LICENSE_KEY_FILE"
+        fi
+
         # Helm values precedence: last --values wins.
         # Order: common → digest (overlay) → extra → scenario (highest precedence).
         # This ensures scenario-specific values (e.g., CI Keycloak image) override
@@ -106,7 +115,7 @@ tasks:
           {{ end -}}
           $EXTRA_VALUES_ARGS \
           --values "$MERGED_VALUES" \
-          ${E2E_TESTS_LICENSE_KEY:+--set global.license.key="${E2E_TESTS_LICENSE_KEY}"} \
+          $LICENSE_KEY_ARGS \
           --force \
           --timeout 20m0s \
           --set orchestration.upgrade.allowPreReleaseImages=true \


### PR DESCRIPTION
## Summary

- License keys contain spaces and semicolons (e.g. `customer = production_validation; expiryDate = unlimited;`) which cause shell word-splitting when passed via `--set` in Task runner shell expansion
- Replaces `${E2E_TESTS_LICENSE_KEY:+--set global.license.key="${E2E_TESTS_LICENSE_KEY}"}` with `--set-file global.license.key=/tmp/license-key.txt` which bypasses shell expansion entirely
- This bug was latent but unexposed until #5494 allowed the Vault-exported license key to flow through (previously it was always empty)

## Test plan

- [x] Verified locally that `--set-file` correctly renders the license key into the Kubernetes secret
- [x] Verified locally that `--set` with spaces/semicolons reproduces the exact CI error: `Error: INSTALLATION FAILED: expected at most two arguments, unexpected arguments: customer, =, production_validation;, ...`
- [ ] Trigger the [SM On-Demand License Key](https://github.com/camunda/c8-cross-component-e2e-tests/actions/workflows/playwright_sm_manual_license_key.yml) workflow pointing at this branch to verify end-to-end