### PR TITLE
ci: scope app token to team-distribution repo for GHCR package access

### DIFF
--- a/.github/workflows/build-ci-runner-image.yaml
+++ b/.github/workflows/build-ci-runner-image.yaml
@@ -51,6 +51,8 @@ jobs:
         with:
           app_id: ${{ secrets.GH_APP_ID_DISTRO_CI }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY_DISTRO_CI }}
+          repositories: '["team-distribution"]'
+          permissions: '{"packages": "write"}'
 
       - name: Generate image tags
         id: tags
@@ -186,6 +188,8 @@ jobs:
         with:
           app_id: ${{ secrets.GH_APP_ID_DISTRO_CI }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY_DISTRO_CI }}
+          repositories: '["team-distribution"]'
+          permissions: '{"packages": "read"}'
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes #5505

The CI runner image build workflow (`build-ci-runner-image.yaml`) fails to push Docker images to `ghcr.io/camunda/team-distribution/*` with `403 Forbidden`. The GHCR packages are linked to the `camunda/team-distribution` repo, but the GitHub App token was scoped to `camunda-platform-helm` by default.

### What's in this PR?

Scope the `tibdex/github-app-token` step to the `team-distribution` repository with explicit package permissions:
- Build job: `repositories: ["team-distribution"]` + `permissions: {"packages": "write"}`
- Verify job: `repositories: ["team-distribution"]` + `permissions: {"packages": "read"}`

The default `installation_retrieval_payload` resolves to the current repo (`camunda-platform-helm`), so the token only has package access for that repo's linked packages. Since the CI runner images live under the `team-distribution` GHCR namespace, the token must be scoped there.

### Checklist

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?