### PR TITLE
ci: use GITHUB_TOKEN for GHCR login in CI runner image build

### DIFF
--- a/.github/workflows/build-ci-runner-image.yaml
+++ b/.github/workflows/build-ci-runner-image.yaml
@@ -45,15 +45,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Generate GitHub App token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
-        id: generate-github-token
-        with:
-          app_id: ${{ secrets.GH_APP_ID_DISTRO_CI }}
-          private_key: ${{ secrets.GH_APP_PRIVATE_KEY_DISTRO_CI }}
-          repositories: '["team-distribution"]'
-          permissions: '{"packages": "write"}'
-
       - name: Generate image tags
         id: tags
         run: |
@@ -97,8 +88,8 @@ jobs:
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         with:
           registry: ${{ env.REGISTRY }}
-          username: x-access-token
-          password: ${{ steps.generate-github-token.outputs.token }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Copy .tool-versions for CI Runner build
         run: |


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #5521

The CI runner image build workflow fails with 403 when pushing to GHCR. The workflow uses a GitHub App token to authenticate, but GitHub App installation tokens are not authorized by GHCR package-level access controls (Manage Actions access), which only govern GITHUB_TOKEN.

### What's in this PR?

- Remove the Generate GitHub App token step from the build job (it was only used for GHCR login)
- Switch Docker login to use GITHUB_TOKEN with packages: write permission

This works because camunda-platform-helm already has Admin access on the team-distribution/ci-runner, team-distribution/playwright-runner, and team-distribution/keycloak-ci GHCR packages.

The verify job still uses the GitHub App token for read-only access, which is unaffected.

### Checklist

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?