### PR TITLE
ci: use correct secret format for 8.6 elasticsearch

### DIFF
--- a/charts/camunda-platform-8.6/test/integration/scenarios/chart-full-setup/values/persistence/elasticsearch-external.yaml
+++ b/charts/camunda-platform-8.6/test/integration/scenarios/chart-full-setup/values/persistence/elasticsearch-external.yaml
@@ -12,9 +12,8 @@ global:
     prefix: $ZEEBE_INDEX_PREFIX-$FLOW
     auth:
       username: elastic
-      secret:
-        existingSecret: infra-credentials
-        existingSecretKey: elasticsearch-password
+      existingSecret: infra-credentials
+      existingSecretKey: elasticsearch-password
     url:
       protocol: https
       host: elasticsearch-21-6-3-pool-${ES_POOL_INDEX}.ci.distro.ultrawombat.com


### PR DESCRIPTION
### Which problem does the PR fix?

Closes: https://github.com/camunda/camunda-platform-helm/issues/5523

### What's in this PR?

Use the legacy schema for 8.6 ES secret

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
