### PR TITLE
fix: add env vars to web-modeler restapi deployment for Spring Boot 4.0.4 compatibility

### DIFF
--- a/charts/camunda-platform-8.10/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform-8.10/templates/web-modeler/deployment-restapi.yaml
@@ -71,6 +71,47 @@ spec:
             ) | nindent 12 }}
             - name: ZEEBE_CLIENT_CONFIG_PATH
               value: {{ .Values.webModeler.restapi.zeebeClientConfigPath | default "/tmp/zeebe_client_cache.txt" | quote }}
+            # -- Pusher (WebSocket) configuration env vars --
+            # Required because the in-JAR application-self-managed.yml uses ${ENV_VAR:} placeholders
+            # that must be resolved via environment variables (not overridable via external configmap).
+            - name: RESTAPI_PUSHER_HOST
+              value: {{ include "webModeler.websockets.fullname" . | quote }}
+            - name: RESTAPI_PUSHER_PORT
+              value: {{ .Values.webModeler.websockets.service.port | quote }}
+            - name: CLIENT_PUSHER_HOST
+              value: {{ include "webModeler.publicWebsocketHost" . | quote }}
+            - name: CLIENT_PUSHER_PORT
+              value: {{ include "webModeler.publicWebsocketPort" . | quote }}
+            {{- if and .Values.global.ingress.enabled .Values.webModeler.contextPath }}
+            - name: CLIENT_PUSHER_PATH
+              value: {{ include "webModeler.websocketContextPath" . | quote }}
+            {{- end }}
+            - name: CLIENT_PUSHER_FORCE_TLS
+              value: {{ include "webModeler.websocketTlsEnabled" . | quote }}
+            # -- Server configuration env vars --
+            - name: RESTAPI_SERVER_URL
+              value: {{ tpl .Values.global.identity.auth.webModeler.redirectUrl $ | quote }}
+            - name: SERVER_HTTPS_ONLY
+              value: {{ hasPrefix "https://" (tpl .Values.global.identity.auth.webModeler.redirectUrl $) | quote }}
+            # -- OAuth2 / Identity env vars --
+            - name: OAUTH2_CLIENT_ID
+              value: {{ include "webModeler.authClientId" . | quote }}
+            # -- Mail env vars --
+            - name: RESTAPI_MAIL_FROM_ADDRESS
+              value: {{ .Values.webModeler.restapi.mail.fromAddress | quote }}
+            - name: RESTAPI_MAIL_FROM_NAME
+              value: {{ .Values.webModeler.restapi.mail.fromName | quote }}
+            # -- Identity / Auth env vars (conditional) --
+            {{- if .Values.identity.enabled }}
+            - name: RESTAPI_IDENTITY_BASE_URL
+              value: {{ include "camundaPlatform.identityURL" . | quote }}
+            {{- end }}
+            {{- if or .Values.global.identity.auth.enabled (eq (include "webModeler.authMethod" .) "oidc") }}
+            - name: RESTAPI_OAUTH2_TOKEN_ISSUER
+              value: {{ include "camundaPlatform.authIssuerUrlWithFallback" . | quote }}
+            - name: RESTAPI_OAUTH2_TOKEN_ISSUER_BACKEND_URL
+              value: {{ include "camundaPlatform.authIssuerBackendUrl" . | quote }}
+            {{- end }}
             {{- if and .Values.global.documentStore.type.aws.enabled (not .Values.global.documentStore.type.aws.irsa.enabled) }}
             - name: AWS_ACCESS_KEY_ID
               {{- include "camundaPlatform.emitAwsDocumentStoreSecret" (dict

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -70,6 +70,39 @@ spec:
             
             - name: ZEEBE_CLIENT_CONFIG_PATH
               value: "/tmp/zeebe_client_cache.txt"
+            # -- Pusher (WebSocket) configuration env vars --
+            # Required because the in-JAR application-self-managed.yml uses ${ENV_VAR:} placeholders
+            # that must be resolved via environment variables (not overridable via external configmap).
+            - name: RESTAPI_PUSHER_HOST
+              value: "camunda-platform-test-web-modeler-websockets"
+            - name: RESTAPI_PUSHER_PORT
+              value: "80"
+            - name: CLIENT_PUSHER_HOST
+              value: "localhost"
+            - name: CLIENT_PUSHER_PORT
+              value: "8085"
+            - name: CLIENT_PUSHER_FORCE_TLS
+              value: "false"
+            # -- Server configuration env vars --
+            - name: RESTAPI_SERVER_URL
+              value: "http://localhost:8070"
+            - name: SERVER_HTTPS_ONLY
+              value: "false"
+            # -- OAuth2 / Identity env vars --
+            - name: OAUTH2_CLIENT_ID
+              value: "web-modeler"
+            # -- Mail env vars --
+            - name: RESTAPI_MAIL_FROM_ADDRESS
+              value: "example@example.com"
+            - name: RESTAPI_MAIL_FROM_NAME
+              value: "Camunda 8"
+            # -- Identity / Auth env vars (conditional) --
+            - name: RESTAPI_IDENTITY_BASE_URL
+              value: "http://camunda-platform-test-identity:80"
+            - name: RESTAPI_OAUTH2_TOKEN_ISSUER
+              value: "http://localhost:18080/auth/realms/camunda-platform"
+            - name: RESTAPI_OAUTH2_TOKEN_ISSUER_BACKEND_URL
+              value: "http://camunda-platform-test-keycloak/auth/realms/camunda-platform"
           envFrom:
             - configMapRef:
                 name: camunda-platform-test-documentstore-env-vars

--- a/charts/camunda-platform-8.9/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform-8.9/templates/web-modeler/deployment-restapi.yaml
@@ -75,6 +75,47 @@ spec:
             ) | nindent 12 }}
             - name: ZEEBE_CLIENT_CONFIG_PATH
               value: {{ .Values.webModeler.restapi.zeebeClientConfigPath | default "/tmp/zeebe_client_cache.txt" | quote }}
+            # -- Pusher (WebSocket) configuration env vars --
+            # Required because the in-JAR application-self-managed.yml uses ${ENV_VAR:} placeholders
+            # that must be resolved via environment variables (not overridable via external configmap).
+            - name: RESTAPI_PUSHER_HOST
+              value: {{ include "webModeler.websockets.fullname" . | quote }}
+            - name: RESTAPI_PUSHER_PORT
+              value: {{ .Values.webModeler.websockets.service.port | quote }}
+            - name: CLIENT_PUSHER_HOST
+              value: {{ include "webModeler.publicWebsocketHost" . | quote }}
+            - name: CLIENT_PUSHER_PORT
+              value: {{ include "webModeler.publicWebsocketPort" . | quote }}
+            {{- if and .Values.global.ingress.enabled .Values.webModeler.contextPath }}
+            - name: CLIENT_PUSHER_PATH
+              value: {{ include "webModeler.websocketContextPath" . | quote }}
+            {{- end }}
+            - name: CLIENT_PUSHER_FORCE_TLS
+              value: {{ include "webModeler.websocketTlsEnabled" . | quote }}
+            # -- Server configuration env vars --
+            - name: RESTAPI_SERVER_URL
+              value: {{ tpl .Values.global.identity.auth.webModeler.redirectUrl $ | quote }}
+            - name: SERVER_HTTPS_ONLY
+              value: {{ hasPrefix "https://" (tpl .Values.global.identity.auth.webModeler.redirectUrl $) | quote }}
+            # -- OAuth2 / Identity env vars --
+            - name: OAUTH2_CLIENT_ID
+              value: {{ include "webModeler.authClientId" . | quote }}
+            # -- Mail env vars --
+            - name: RESTAPI_MAIL_FROM_ADDRESS
+              value: {{ .Values.webModeler.restapi.mail.fromAddress | quote }}
+            - name: RESTAPI_MAIL_FROM_NAME
+              value: {{ .Values.webModeler.restapi.mail.fromName | quote }}
+            # -- Identity / Auth env vars (conditional) --
+            {{- if .Values.identity.enabled }}
+            - name: RESTAPI_IDENTITY_BASE_URL
+              value: {{ include "camundaPlatform.identityURL" . | quote }}
+            {{- end }}
+            {{- if or .Values.global.identity.auth.enabled (eq (include "webModeler.authMethod" .) "oidc") }}
+            - name: RESTAPI_OAUTH2_TOKEN_ISSUER
+              value: {{ include "camundaPlatform.authIssuerUrlWithFallback" . | quote }}
+            - name: RESTAPI_OAUTH2_TOKEN_ISSUER_BACKEND_URL
+              value: {{ include "camundaPlatform.authIssuerBackendUrl" . | quote }}
+            {{- end }}
             {{- if and .Values.global.documentStore.type.aws.enabled (not .Values.global.documentStore.type.aws.irsa.enabled) }}
             - name: AWS_ACCESS_KEY_ID
               {{- include "camundaPlatform.emitAwsDocumentStoreSecret" (dict

--- a/charts/camunda-platform-8.9/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform-8.9/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -78,6 +78,39 @@ spec:
                   key: pusher-app-secret
             - name: ZEEBE_CLIENT_CONFIG_PATH
               value: "/tmp/zeebe_client_cache.txt"
+            # -- Pusher (WebSocket) configuration env vars --
+            # Required because the in-JAR application-self-managed.yml uses ${ENV_VAR:} placeholders
+            # that must be resolved via environment variables (not overridable via external configmap).
+            - name: RESTAPI_PUSHER_HOST
+              value: "camunda-platform-test-web-modeler-websockets"
+            - name: RESTAPI_PUSHER_PORT
+              value: "80"
+            - name: CLIENT_PUSHER_HOST
+              value: "localhost"
+            - name: CLIENT_PUSHER_PORT
+              value: "8085"
+            - name: CLIENT_PUSHER_FORCE_TLS
+              value: "false"
+            # -- Server configuration env vars --
+            - name: RESTAPI_SERVER_URL
+              value: "http://localhost:8070"
+            - name: SERVER_HTTPS_ONLY
+              value: "false"
+            # -- OAuth2 / Identity env vars --
+            - name: OAUTH2_CLIENT_ID
+              value: "web-modeler"
+            # -- Mail env vars --
+            - name: RESTAPI_MAIL_FROM_ADDRESS
+              value: "example@example.com"
+            - name: RESTAPI_MAIL_FROM_NAME
+              value: "Camunda 8"
+            # -- Identity / Auth env vars (conditional) --
+            - name: RESTAPI_IDENTITY_BASE_URL
+              value: "http://camunda-platform-test-identity:80"
+            - name: RESTAPI_OAUTH2_TOKEN_ISSUER
+              value: "http://localhost:18080/auth/realms/camunda-platform"
+            - name: RESTAPI_OAUTH2_TOKEN_ISSUER_BACKEND_URL
+              value: "http://camunda-platform-test-keycloak/auth/realms/camunda-platform"
           envFrom:
             - configMapRef:
                 name: camunda-platform-test-documentstore-env-vars


### PR DESCRIPTION
## Summary

- Add 14 environment variables to the web-modeler restapi deployment template in charts 8.9 and 8.10 to fix restapi pod crashes caused by the Spring Boot 4.0.3→4.0.4 config ordering fix.
- The in-JAR `application-self-managed.yml` profile config now correctly takes precedence over the externally mounted `application.yaml` configmap, leaving `${ENV_VAR:}` placeholders unresolved.
- Setting env vars directly in the deployment ensures Spring Boot resolves all placeholders regardless of config source ordering.

## Root Cause

[Spring Boot #49482](https://github.com/spring-projects/spring-boot/issues/49482) fixed a bug where external non-profile configs incorrectly overrode in-JAR profile-specific configs. After upgrading to Spring Boot 4.0.4 (via [camunda-hub#22422](https://github.com/camunda/camunda-hub/pull/22422)), the restapi's `application-self-managed.yml` properties like `camunda.modeler.pusher.host: ${RESTAPI_PUSHER_HOST:}` now win over the Helm-mounted `application.yaml` configmap, resolving to empty strings since the env vars were never set.

## Changes

### Env vars added to `deployment-restapi.yaml` (both 8.9 and 8.10):

| Env Var | Condition | Source |
|---------|-----------|--------|
| `RESTAPI_PUSHER_HOST` | always | `webModeler.websockets.fullname` helper |
| `RESTAPI_PUSHER_PORT` | always | `.Values.webModeler.websockets.service.port` |
| `CLIENT_PUSHER_HOST` | always | `webModeler.publicWebsocketHost` helper |
| `CLIENT_PUSHER_PORT` | always | `webModeler.publicWebsocketPort` helper |
| `CLIENT_PUSHER_PATH` | ingress + contextPath | `webModeler.websocketContextPath` helper |
| `CLIENT_PUSHER_FORCE_TLS` | always | `webModeler.websocketTlsEnabled` helper |
| `RESTAPI_SERVER_URL` | always | `global.identity.auth.webModeler.redirectUrl` |
| `SERVER_HTTPS_ONLY` | always | derived from redirectUrl |
| `OAUTH2_CLIENT_ID` | always | `webModeler.authClientId` helper |
| `RESTAPI_MAIL_FROM_ADDRESS` | always | `.Values.webModeler.restapi.mail.fromAddress` |
| `RESTAPI_MAIL_FROM_NAME` | always | `.Values.webModeler.restapi.mail.fromName` |
| `RESTAPI_IDENTITY_BASE_URL` | identity enabled | `camundaPlatform.identityURL` helper |
| `RESTAPI_OAUTH2_TOKEN_ISSUER` | auth enabled / oidc | `camundaPlatform.authIssuerUrlWithFallback` helper |
| `RESTAPI_OAUTH2_TOKEN_ISSUER_BACKEND_URL` | auth enabled / oidc | `camundaPlatform.authIssuerBackendUrl` helper |

### Not changed:
- `configmap-restapi.yaml` — kept as-is (still provides values for non-overlapping properties and serves as documentation)
- `deployment-websockets.yaml` — Node.js app, uses env vars directly, not affected by Spring Boot config ordering

## Validation

- `helm template` renders cleanly for both charts 8.9 and 8.10
- Conditional env vars (`RESTAPI_IDENTITY_BASE_URL`, `RESTAPI_OAUTH2_TOKEN_ISSUER*`) correctly appear/disappear based on `identity.enabled` and `global.identity.auth.enabled`
- Live-tested equivalent fix via `kubectl set env` on namespace `qa-yuliia-89-camunda-platform` — pods are running