### PR TITLE
ci: update qa so it always uses internal elasticsearch

### DIFF
--- a/scripts/camunda-core/pkg/scenarios/scenarios.go
+++ b/scripts/camunda-core/pkg/scenarios/scenarios.go
@@ -310,6 +310,7 @@ func MapScenarioToConfig(scenario string) *DeploymentConfig {
 	// Derive QA mode from prefix
 	if strings.HasPrefix(s, "qa-") {
 		config.QA = true
+		config.Persistence = "elasticsearch"
 	}
 
 	// Handle well-known composite scenarios that can't be derived from name parsing alone.
@@ -401,7 +402,7 @@ type BuilderOverrides struct {
 	Flow         string   // install, upgrade-patch, upgrade-minor
 	QA           bool
 	ImageTags    bool
-	ImageTagsSet bool   // true when --image-tags was explicitly provided (prevents auto-detection override)
+	ImageTagsSet bool // true when --image-tags was explicitly provided (prevents auto-detection override)
 	Upgrade      bool
 	ChartVersion string
 	ValuesConfig string // JSON config string; if it contains *_IMAGE_TAG keys, ImageTags is auto-enabled (only when ImageTagsSet is false)


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
