### PR TITLE
test: set JOB_WORKER_TENANT_IDS var only multitenancy

### DIFF
--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
@@ -34,3 +34,12 @@ identityPostgresql:
 identity:
   externalDatabase:
     enabled: false
+
+connectors:
+  env:
+    - name: username
+      value: username
+    - name: password
+      value: password
+    - name: CAMUNDA_CLIENT_DEFAULT_JOB_WORKER_TENANT_IDS
+      value: "<default>, Tenant_Main_Connectors, Tenant_Second_Connectors, Tenant_1_Connectors, Tenant_2_Connectors"

--- a/charts/camunda-platform-8.6/test/integration/scenarios/chart-full-setup/values/base-qa.yaml
+++ b/charts/camunda-platform-8.6/test/integration/scenarios/chart-full-setup/values/base-qa.yaml
@@ -128,5 +128,3 @@ connectors:
       value: username
     - name: password
       value: password
-    - name: ZEEBE_CLIENT_DEFAULT_JOB_WORKER_TENANT_IDS
-      value: "<default>, Tenant_Main_Connectors, Tenant_Second_Connectors, Tenant_1_Connectors, Tenant_2_Connectors"

--- a/charts/camunda-platform-8.6/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
+++ b/charts/camunda-platform-8.6/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
@@ -39,3 +39,12 @@ identity:
       value: APPLICATION
     - name: IDENTITY_TENANTS_0_MEMBERS_4_APPLICATIONID
       value: zeebe
+
+connectors:
+  env:
+    - name: username
+      value: username
+    - name: password
+      value: password
+    - name: ZEEBE_CLIENT_DEFAULT_JOB_WORKER_TENANT_IDS
+      value: "<default>, Tenant_Main_Connectors, Tenant_Second_Connectors, Tenant_1_Connectors, Tenant_2_Connectors"

--- a/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values/base-qa.yaml
+++ b/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values/base-qa.yaml
@@ -134,8 +134,6 @@ connectors:
       value: username
     - name: password
       value: password
-    - name: CAMUNDA_CLIENT_DEFAULT_JOB_WORKER_TENANT_IDS
-      value: "<default>, Tenant_Main_Connectors, Tenant_Second_Connectors, Tenant_1_Connectors, Tenant_2_Connectors"
 
 optimize:
   caches:

--- a/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
+++ b/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
@@ -31,3 +31,12 @@ identity:
       value: APPLICATION
     - name: IDENTITY_TENANTS_0_MEMBERS_4_APPLICATIONID
       value: zeebe
+
+connectors:
+  env:
+    - name: username
+      value: username
+    - name: password
+      value: password
+    - name: CAMUNDA_CLIENT_DEFAULT_JOB_WORKER_TENANT_IDS
+      value: "<default>, Tenant_Main_Connectors, Tenant_Second_Connectors, Tenant_1_Connectors, Tenant_2_Connectors"

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/base-qa.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/base-qa.yaml
@@ -73,8 +73,6 @@ connectors:
       value: username
     - name: password
       value: password
-    - name: ZEEBE_CLIENT_DEFAULT_JOB_WORKER_TENANT_IDS
-      value: "<default>, Tenant_Main_Connectors, Tenant_Second_Connectors, Tenant_1_Connectors, Tenant_2_Connectors"
 
 console:
   overrideConfiguration: |

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
@@ -34,3 +34,12 @@ identityPostgresql:
 identity:
   externalDatabase:
     enabled: false
+
+connectors:
+  env:
+    - name: username
+      value: username
+    - name: password
+      value: password
+    - name: ZEEBE_CLIENT_DEFAULT_JOB_WORKER_TENANT_IDS
+      value: "<default>, Tenant_Main_Connectors, Tenant_Second_Connectors, Tenant_1_Connectors, Tenant_2_Connectors"

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/base-qa.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/base-qa.yaml
@@ -117,8 +117,6 @@ connectors:
       value: username
     - name: password
       value: password
-    - name: CAMUNDA_CLIENT_DEFAULT_JOB_WORKER_TENANT_IDS
-      value: "<default>, Tenant_Main_Connectors, Tenant_Second_Connectors, Tenant_1_Connectors, Tenant_2_Connectors"
 
 console:
   overrideConfiguration: |

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
@@ -34,3 +34,12 @@ identityPostgresql:
 identity:
   externalDatabase:
     enabled: false
+
+connectors:
+  env:
+    - name: username
+      value: username
+    - name: password
+      value: password
+    - name: CAMUNDA_CLIENT_DEFAULT_JOB_WORKER_TENANT_IDS
+      value: "<default>, Tenant_Main_Connectors, Tenant_Second_Connectors, Tenant_1_Connectors, Tenant_2_Connectors"


### PR DESCRIPTION
### Which problem does the PR fix?

The env var `CAMUNDA_CLIENT_DEFAULT_JOB_WORKER_TENANT_IDS` should only be set if multitenancy is enabled. otherwise connectors will make an invalid request to non-multitenant zeebe/operate.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

move env var from base-qa to multitenancy feature while making sure to not clear out the username+password env vars since those would get overwritten otherwise.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
