### PR TITLE
fix(web-modeler): use built-in self-managed profile for restapi configuration

### DIFF
--- a/charts/camunda-platform-8.10/templates/web-modeler/configmap-restapi.yaml
+++ b/charts/camunda-platform-8.10/templates/web-modeler/configmap-restapi.yaml
@@ -7,10 +7,10 @@ metadata:
   annotations: {{- toYaml .Values.global.annotations | nindent 4 }}
 data:
   {{- if .Values.webModeler.restapi.configuration }}
-  application.yaml: |
+  application-self-managed.yaml: |
     {{ .Values.webModeler.restapi.configuration | indent 4 | trim }}
   {{- else }}
-  application.yaml: |
+  application-self-managed.yaml: |
     camunda:
       {{- if or .Values.global.identity.auth.enabled (eq (include "webModeler.authMethod" .) "oidc") }}
       identity:

--- a/charts/camunda-platform-8.10/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform-8.10/templates/web-modeler/deployment-restapi.yaml
@@ -148,8 +148,8 @@ spec:
             - name: tmp
               mountPath: /tmp
             - name: config
-              mountPath: /home/runner/config/application.yaml
-              subPath: application.yaml
+              mountPath: /home/runner/config/application-self-managed.yaml
+              subPath: application-self-managed.yaml
           {{- with .Values.webModeler.restapi.extraConfiguration }}
           {{- include "camundaPlatform.extraConfigurationVolumeMounts" (dict "extraConfig" . "volumeName" "config" "basePath" "/home/runner/config") | trim | nindent 12 }}
           {{- end }}

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/configmap_restapi_test.go
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/configmap_restapi_test.go
@@ -66,7 +66,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectAuthClientAp
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -96,7 +96,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectAuthPublicAp
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -126,7 +126,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectAuthClientId
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -156,7 +156,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectAuthTokenUse
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -186,7 +186,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectIdentityServ
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -216,7 +216,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectIdentityServ
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -252,7 +252,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectIdentityType
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -284,7 +284,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectKeycloakServ
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -316,7 +316,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectKeycloakServ
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -345,7 +345,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetSmtpCredentials() {
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -376,7 +376,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetExternalDatabaseCon
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -409,7 +409,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetExternalDatabaseCon
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -478,7 +478,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldConfigureClusterFromSa
 			var configmapApplication WebModelerRestAPIApplicationYAML
 			helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-			err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+			err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 			if err != nil {
 				s.Fail("Failed to unmarshal yaml. error=", err)
 			}
@@ -539,7 +539,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldUseClustersFromCustomC
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -589,7 +589,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldNotConfigureClustersIf
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -619,7 +619,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetJwkSetUriFromJwksUr
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -649,7 +649,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetJwkSetUriFromIssuer
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -683,7 +683,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetJwkSetUriFromKeyclo
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -715,7 +715,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetJdbcUrlFromHostPort
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -745,7 +745,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectServerUrlAnd
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -776,7 +776,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectContextPath(
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -807,7 +807,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectClientPusher
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -840,7 +840,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectClientPusher
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -876,7 +876,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectClientPusher
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -898,7 +898,7 @@ func (s *configmapRestAPITemplateTest) TestGlobalIngressHostTemplating() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
@@ -924,7 +924,7 @@ func (s *configmapRestAPITemplateTest) TestGlobalIngressHostTemplating() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/golden/configmap-restapi.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/golden/configmap-restapi.golden.yaml
@@ -15,7 +15,7 @@ metadata:
   annotations:
     {}
 data:
-  application.yaml: |
+  application-self-managed.yaml: |
     camunda:
       identity:
         base-url: "http://camunda-platform-test-identity:80"

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -101,8 +101,8 @@ spec:
             - name: tmp
               mountPath: /tmp
             - name: config
-              mountPath: /home/runner/config/application.yaml
-              subPath: application.yaml
+              mountPath: /home/runner/config/application-self-managed.yaml
+              subPath: application-self-managed.yaml
       volumes:
         - name: tmp
           emptyDir: {}

--- a/charts/camunda-platform-8.6/templates/web-modeler/configmap-restapi.yaml
+++ b/charts/camunda-platform-8.6/templates/web-modeler/configmap-restapi.yaml
@@ -7,10 +7,10 @@ metadata:
   annotations: {{- toYaml .Values.global.annotations | nindent 4 }}
 data:
   {{- if .Values.webModeler.restapi.configuration }}
-  application.yaml: |
+  application-self-managed.yaml: |
     {{ .Values.webModeler.restapi.configuration | indent 4 | trim }}
   {{- else }}
-  application.yaml: |
+  application-self-managed.yaml: |
     camunda:
       identity:
     {{- if .Values.identity.enabled }}

--- a/charts/camunda-platform-8.6/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform-8.6/templates/web-modeler/deployment-restapi.yaml
@@ -130,8 +130,8 @@ spec:
             - name: tmp
               mountPath: /tmp
             - name: config
-              mountPath: /home/runner/config/application.yaml
-              subPath: application.yaml
+              mountPath: /home/runner/config/application-self-managed.yaml
+              subPath: application-self-managed.yaml
           {{- range $key, $val := .Values.webModeler.restapi.extraConfiguration }}
             - name: config
               mountPath: /home/runner/config/{{ $key }}

--- a/charts/camunda-platform-8.6/test/unit/web-modeler/configmap_restapi_test.go
+++ b/charts/camunda-platform-8.6/test/unit/web-modeler/configmap_restapi_test.go
@@ -50,7 +50,7 @@ func (s *ConfigmapRestAPITemplateTest) TestDifferentValuesInputs() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
@@ -70,7 +70,7 @@ func (s *ConfigmapRestAPITemplateTest) TestDifferentValuesInputs() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
@@ -90,7 +90,7 @@ func (s *ConfigmapRestAPITemplateTest) TestDifferentValuesInputs() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
@@ -110,7 +110,7 @@ func (s *ConfigmapRestAPITemplateTest) TestDifferentValuesInputs() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
@@ -131,7 +131,7 @@ func (s *ConfigmapRestAPITemplateTest) TestDifferentValuesInputs() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
@@ -153,7 +153,7 @@ func (s *ConfigmapRestAPITemplateTest) TestDifferentValuesInputs() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
@@ -175,7 +175,7 @@ func (s *ConfigmapRestAPITemplateTest) TestDifferentValuesInputs() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
@@ -196,7 +196,7 @@ func (s *ConfigmapRestAPITemplateTest) TestDifferentValuesInputs() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
@@ -219,7 +219,7 @@ func (s *ConfigmapRestAPITemplateTest) TestDifferentValuesInputs() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
@@ -240,7 +240,7 @@ func (s *ConfigmapRestAPITemplateTest) TestDifferentValuesInputs() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
@@ -260,7 +260,7 @@ func (s *ConfigmapRestAPITemplateTest) TestDifferentValuesInputs() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
@@ -284,7 +284,7 @@ func (s *ConfigmapRestAPITemplateTest) TestDifferentValuesInputs() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}

--- a/charts/camunda-platform-8.6/test/unit/web-modeler/golden/configmap-restapi.golden.yaml
+++ b/charts/camunda-platform-8.6/test/unit/web-modeler/golden/configmap-restapi.golden.yaml
@@ -15,7 +15,7 @@ metadata:
   annotations:
     {}
 data:
-  application.yaml: |
+  application-self-managed.yaml: |
     camunda:
       identity:
         base-url: "http://camunda-platform-test-identity:80"

--- a/charts/camunda-platform-8.6/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform-8.6/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -109,8 +109,8 @@ spec:
             - name: tmp
               mountPath: /tmp
             - name: config
-              mountPath: /home/runner/config/application.yaml
-              subPath: application.yaml
+              mountPath: /home/runner/config/application-self-managed.yaml
+              subPath: application-self-managed.yaml
       volumes:
         - name: tmp
           emptyDir: {}

--- a/charts/camunda-platform-8.7/templates/web-modeler/configmap-restapi.yaml
+++ b/charts/camunda-platform-8.7/templates/web-modeler/configmap-restapi.yaml
@@ -7,10 +7,10 @@ metadata:
   annotations: {{- toYaml .Values.global.annotations | nindent 4 }}
 data:
   {{- if .Values.webModeler.restapi.configuration }}
-  application.yaml: |
+  application-self-managed.yaml: |
     {{ .Values.webModeler.restapi.configuration | indent 4 | trim }}
   {{- else }}
-  application.yaml: |
+  application-self-managed.yaml: |
     camunda:
       identity:
     {{- if .Values.identity.enabled }}

--- a/charts/camunda-platform-8.7/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform-8.7/templates/web-modeler/deployment-restapi.yaml
@@ -148,8 +148,8 @@ spec:
             - name: tmp
               mountPath: /tmp
             - name: config
-              mountPath: /home/runner/config/application.yaml
-              subPath: application.yaml
+              mountPath: /home/runner/config/application-self-managed.yaml
+              subPath: application-self-managed.yaml
           {{- range $key, $val := .Values.webModeler.restapi.extraConfiguration }}
             - name: config
               mountPath: /home/runner/config/{{ $key }}

--- a/charts/camunda-platform-8.7/test/unit/web-modeler/configmap_restapi_test.go
+++ b/charts/camunda-platform-8.7/test/unit/web-modeler/configmap_restapi_test.go
@@ -50,7 +50,7 @@ func (s *ConfigmapRestAPITemplateTest) TestDifferentValuesInputs() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
@@ -70,7 +70,7 @@ func (s *ConfigmapRestAPITemplateTest) TestDifferentValuesInputs() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
@@ -90,7 +90,7 @@ func (s *ConfigmapRestAPITemplateTest) TestDifferentValuesInputs() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
@@ -110,7 +110,7 @@ func (s *ConfigmapRestAPITemplateTest) TestDifferentValuesInputs() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
@@ -131,7 +131,7 @@ func (s *ConfigmapRestAPITemplateTest) TestDifferentValuesInputs() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
@@ -153,7 +153,7 @@ func (s *ConfigmapRestAPITemplateTest) TestDifferentValuesInputs() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
@@ -175,7 +175,7 @@ func (s *ConfigmapRestAPITemplateTest) TestDifferentValuesInputs() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
@@ -196,7 +196,7 @@ func (s *ConfigmapRestAPITemplateTest) TestDifferentValuesInputs() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
@@ -219,7 +219,7 @@ func (s *ConfigmapRestAPITemplateTest) TestDifferentValuesInputs() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
@@ -249,7 +249,7 @@ func (s *ConfigmapRestAPITemplateTest) TestDifferentValuesInputs() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
@@ -286,7 +286,7 @@ func (s *ConfigmapRestAPITemplateTest) TestDifferentValuesInputs() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
@@ -322,7 +322,7 @@ func (s *ConfigmapRestAPITemplateTest) TestDifferentValuesInputs() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
@@ -370,7 +370,7 @@ func (s *ConfigmapRestAPITemplateTest) TestDifferentValuesInputs() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
@@ -407,7 +407,7 @@ func (s *ConfigmapRestAPITemplateTest) TestDifferentValuesInputs() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
@@ -427,7 +427,7 @@ func (s *ConfigmapRestAPITemplateTest) TestDifferentValuesInputs() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
@@ -447,7 +447,7 @@ func (s *ConfigmapRestAPITemplateTest) TestDifferentValuesInputs() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
@@ -471,7 +471,7 @@ func (s *ConfigmapRestAPITemplateTest) TestDifferentValuesInputs() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
@@ -484,7 +484,7 @@ func (s *ConfigmapRestAPITemplateTest) TestDifferentValuesInputs() {
 			Values: map[string]string{
 				"webModeler.enabled":                           "true",
 				"webModeler.restapi.mail.fromAddress":          "example@example.com",
-				"postgresql.enabled": 					        "false",
+				"postgresql.enabled":                           "false",
 				"webModeler.restapi.externalDatabase.host":     "custom-db.example.com",
 				"webModeler.restapi.externalDatabase.port":     "65432",
 				"webModeler.restapi.externalDatabase.database": "custom-modeler-db",
@@ -494,7 +494,7 @@ func (s *ConfigmapRestAPITemplateTest) TestDifferentValuesInputs() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}

--- a/charts/camunda-platform-8.7/test/unit/web-modeler/golden/configmap-restapi.golden.yaml
+++ b/charts/camunda-platform-8.7/test/unit/web-modeler/golden/configmap-restapi.golden.yaml
@@ -15,7 +15,7 @@ metadata:
   annotations:
     {}
 data:
-  application.yaml: |
+  application-self-managed.yaml: |
     camunda:
       identity:
         base-url: "http://camunda-platform-test-identity:80"

--- a/charts/camunda-platform-8.7/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform-8.7/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -112,8 +112,8 @@ spec:
             - name: tmp
               mountPath: /tmp
             - name: config
-              mountPath: /home/runner/config/application.yaml
-              subPath: application.yaml
+              mountPath: /home/runner/config/application-self-managed.yaml
+              subPath: application-self-managed.yaml
       volumes:
         - name: tmp
           emptyDir: {}

--- a/charts/camunda-platform-8.8/templates/web-modeler/configmap-restapi.yaml
+++ b/charts/camunda-platform-8.8/templates/web-modeler/configmap-restapi.yaml
@@ -7,10 +7,10 @@ metadata:
   annotations: {{- toYaml .Values.global.annotations | nindent 4 }}
 data:
   {{- if .Values.webModeler.restapi.configuration }}
-  application.yaml: |
+  application-self-managed.yaml: |
     {{ .Values.webModeler.restapi.configuration | indent 4 | trim }}
   {{- else }}
-  application.yaml: |
+  application-self-managed.yaml: |
     camunda:
       {{- if or .Values.global.identity.auth.enabled (eq (include "webModeler.authMethod" .) "oidc") }}
       identity:

--- a/charts/camunda-platform-8.8/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform-8.8/templates/web-modeler/deployment-restapi.yaml
@@ -155,8 +155,8 @@ spec:
             - name: tmp
               mountPath: /tmp
             - name: config
-              mountPath: /home/runner/config/application.yaml
-              subPath: application.yaml
+              mountPath: /home/runner/config/application-self-managed.yaml
+              subPath: application-self-managed.yaml
           {{- range $key, $val := .Values.webModeler.restapi.extraConfiguration }}
             - name: config
               mountPath: /home/runner/config/{{ $key }}

--- a/charts/camunda-platform-8.8/test/unit/web-modeler/configmap_restapi_test.go
+++ b/charts/camunda-platform-8.8/test/unit/web-modeler/configmap_restapi_test.go
@@ -63,7 +63,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectAuthClientAp
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -91,7 +91,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectAuthPublicAp
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -119,7 +119,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectIdentityServ
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -147,7 +147,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectIdentityServ
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -181,7 +181,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectIdentityType
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -211,7 +211,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectKeycloakServ
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -241,7 +241,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectKeycloakServ
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -269,7 +269,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetSmtpCredentials() {
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -299,7 +299,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetExternalDatabaseCon
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -366,7 +366,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldConfigureClusterFromSa
 			var configmapApplication WebModelerRestAPIApplicationYAML
 			helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-			err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+			err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 			if err != nil {
 				s.Fail("Failed to unmarshal yaml. error=", err)
 			}
@@ -425,7 +425,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldUseClustersFromCustomC
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -473,7 +473,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldNotConfigureClustersIf
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -501,7 +501,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetJwkSetUriFromJwksUr
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -529,7 +529,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetJwkSetUriFromIssuer
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -561,7 +561,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetJwkSetUriFromKeyclo
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -591,7 +591,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetJdbcUrlFromHostPort
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}

--- a/charts/camunda-platform-8.8/test/unit/web-modeler/golden/configmap-restapi.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/web-modeler/golden/configmap-restapi.golden.yaml
@@ -15,7 +15,7 @@ metadata:
   annotations:
     {}
 data:
-  application.yaml: |
+  application-self-managed.yaml: |
     camunda:
       identity:
         base-url: "http://camunda-platform-test-identity:80"

--- a/charts/camunda-platform-8.8/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -109,8 +109,8 @@ spec:
             - name: tmp
               mountPath: /tmp
             - name: config
-              mountPath: /home/runner/config/application.yaml
-              subPath: application.yaml
+              mountPath: /home/runner/config/application-self-managed.yaml
+              subPath: application-self-managed.yaml
       volumes:
         - name: tmp
           emptyDir: {}

--- a/charts/camunda-platform-8.9/templates/web-modeler/configmap-restapi.yaml
+++ b/charts/camunda-platform-8.9/templates/web-modeler/configmap-restapi.yaml
@@ -7,10 +7,10 @@ metadata:
   annotations: {{- toYaml .Values.global.annotations | nindent 4 }}
 data:
   {{- if .Values.webModeler.restapi.configuration }}
-  application.yaml: |
+  application-self-managed.yaml: |
     {{ .Values.webModeler.restapi.configuration | indent 4 | trim }}
   {{- else }}
-  application.yaml: |
+  application-self-managed.yaml: |
     camunda:
       {{- if or .Values.global.identity.auth.enabled (eq (include "webModeler.authMethod" .) "oidc") }}
       identity:

--- a/charts/camunda-platform-8.9/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform-8.9/templates/web-modeler/deployment-restapi.yaml
@@ -152,8 +152,8 @@ spec:
             - name: tmp
               mountPath: /tmp
             - name: config
-              mountPath: /home/runner/config/application.yaml
-              subPath: application.yaml
+              mountPath: /home/runner/config/application-self-managed.yaml
+              subPath: application-self-managed.yaml
           {{- with .Values.webModeler.restapi.extraConfiguration }}
           {{- include "camundaPlatform.extraConfigurationVolumeMounts" (dict "extraConfig" . "volumeName" "config" "basePath" "/home/runner/config") | trim | nindent 12 }}
           {{- end }}

--- a/charts/camunda-platform-8.9/test/unit/web-modeler/configmap_restapi_test.go
+++ b/charts/camunda-platform-8.9/test/unit/web-modeler/configmap_restapi_test.go
@@ -66,7 +66,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectAuthClientAp
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -96,7 +96,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectAuthPublicAp
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -126,7 +126,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectAuthClientId
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -156,7 +156,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectAuthTokenUse
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -186,7 +186,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectIdentityServ
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -216,7 +216,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectIdentityServ
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -252,7 +252,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectIdentityType
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -284,7 +284,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectKeycloakServ
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -316,7 +316,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectKeycloakServ
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -345,7 +345,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetSmtpCredentials() {
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -376,7 +376,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetExternalDatabaseCon
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -409,7 +409,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetExternalDatabaseCon
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -443,7 +443,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldPrioritizeUsernameOver
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -512,7 +512,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldConfigureClusterFromSa
 			var configmapApplication WebModelerRestAPIApplicationYAML
 			helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-			err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+			err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 			if err != nil {
 				s.Fail("Failed to unmarshal yaml. error=", err)
 			}
@@ -573,7 +573,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldUseClustersFromCustomC
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -623,7 +623,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldNotConfigureClustersIf
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -653,7 +653,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetJwkSetUriFromJwksUr
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -683,7 +683,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetJwkSetUriFromIssuer
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -717,7 +717,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetJwkSetUriFromKeyclo
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -749,7 +749,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetJdbcUrlFromHostPort
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -779,7 +779,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectServerUrlAnd
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -810,7 +810,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectContextPath(
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -841,7 +841,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectClientPusher
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -874,7 +874,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectClientPusher
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -910,7 +910,7 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectClientPusher
 	var configmapApplication WebModelerRestAPIApplicationYAML
 	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	err := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 	if err != nil {
 		s.Fail("Failed to unmarshal yaml. error=", err)
 	}
@@ -932,7 +932,7 @@ func (s *configmapRestAPITemplateTest) TestGlobalIngressHostTemplating() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
@@ -958,7 +958,7 @@ func (s *configmapRestAPITemplateTest) TestGlobalIngressHostTemplating() {
 				var configmapApplication WebModelerRestAPIApplicationYAML
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+				e := yaml.Unmarshal([]byte(configmap.Data["application-self-managed.yaml"]), &configmapApplication)
 				if e != nil {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}

--- a/charts/camunda-platform-8.9/test/unit/web-modeler/golden/configmap-restapi.golden.yaml
+++ b/charts/camunda-platform-8.9/test/unit/web-modeler/golden/configmap-restapi.golden.yaml
@@ -15,7 +15,7 @@ metadata:
   annotations:
     {}
 data:
-  application.yaml: |
+  application-self-managed.yaml: |
     camunda:
       identity:
         base-url: "http://camunda-platform-test-identity:80"

--- a/charts/camunda-platform-8.9/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform-8.9/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -109,8 +109,8 @@ spec:
             - name: tmp
               mountPath: /tmp
             - name: config
-              mountPath: /home/runner/config/application.yaml
-              subPath: application.yaml
+              mountPath: /home/runner/config/application-self-managed.yaml
+              subPath: application-self-managed.yaml
       volumes:
         - name: tmp
           emptyDir: {}


### PR DESCRIPTION
### Which problem does the PR fix?

- Closes #5535
- Reverts the changes from #5525

### What's in this PR?

Mounts the configuration file for Web Modeler's `restapi` component as `application-self-managed.yaml` instead of just `application.yaml`. This will load the configuration properties as part of the built-in Spring profile `self-managed` (which is active by default), and override the default values from the in-JAR configuration file again properly.

The change is necessary due to a [regression](https://github.com/spring-projects/spring-boot/issues/49724) in the latest Spring Boot versions which made externally loaded configuration files no longer override built-in, profile-specific configuration.

Once the issue is fixed in Spring Boot and Web Modeler has been updated to the latest Spring Boot patch versions, this change can be reverted again.

See also this [Slack](https://camunda.slack.com/archives/C07USKREKDL/p1774354274372889) thread.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?