### PR TITLE
fix: enable camunda backup webapps and remove other excludes when rdbms is enabled

### DIFF
--- a/charts/camunda-platform-8.10/templates/orchestration/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/orchestration/_helpers.tpl
@@ -275,7 +275,7 @@ Authentication.
 
 
 {{- define "orchestration.hasCamundaExporter" -}}
-{{- and (not (eq (include "orchestration.secondaryStorage" .) "none")) .Values.orchestration.exporters.camunda.enabled (not .Values.orchestration.exporters.rdbms.enabled) -}}
+{{- and (not (eq (include "orchestration.secondaryStorage" .) "none")) .Values.orchestration.exporters.camunda.enabled -}}
 {{- end -}}
 
 {{- define "orchestration.hasNoExporter" -}}
@@ -290,7 +290,7 @@ and
 {{- define "orchestration.hasLegacyElasticsearchExporter" -}}
 {{- and
       (or 
-        (and .Values.orchestration.exporters.rdbms.enabled .Values.optimize.enabled)
+        .Values.optimize.enabled
         (or
           (and .Values.global.elasticsearch.enabled .Values.orchestration.exporters.zeebe.enabled)
           (and (or .Values.global.elasticsearch.enabled .Values.optimize.database.elasticsearch.enabled) .Values.optimize.enabled)

--- a/charts/camunda-platform-8.10/templates/orchestration/files/_application.yaml
+++ b/charts/camunda-platform-8.10/templates/orchestration/files/_application.yaml
@@ -38,11 +38,6 @@ management:
     base-path: {{ include "camundaPlatform.joinpath" (list .Values.orchestration.contextPath) | quote }}
 
 camunda:
-  {{- if .Values.orchestration.exporters.rdbms.enabled }}
-  backup:
-    webapps:
-      enabled: false
-  {{- end }}
   license:
     key: "${VALUES_ORCHESTRATION_LICENSE_KEY}"
   {{- if eq (include "orchestration.hasAzureDocumentStore" .) "true" }}

--- a/charts/camunda-platform-8.9/templates/orchestration/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/orchestration/_helpers.tpl
@@ -275,7 +275,7 @@ Authentication.
 
 
 {{- define "orchestration.hasCamundaExporter" -}}
-{{- and (not (eq (include "orchestration.secondaryStorage" .) "none")) .Values.orchestration.exporters.camunda.enabled (not .Values.orchestration.exporters.rdbms.enabled) -}}
+{{- and (not (eq (include "orchestration.secondaryStorage" .) "none")) .Values.orchestration.exporters.camunda.enabled -}}
 {{- end -}}
 
 {{- define "orchestration.hasNoExporter" -}}
@@ -290,7 +290,7 @@ and
 {{- define "orchestration.hasLegacyElasticsearchExporter" -}}
 {{- and
       (or 
-        (and .Values.orchestration.exporters.rdbms.enabled .Values.optimize.enabled)
+        .Values.optimize.enabled
         (or
           (and .Values.global.elasticsearch.enabled .Values.orchestration.exporters.zeebe.enabled)
           (and (or .Values.global.elasticsearch.enabled .Values.optimize.database.elasticsearch.enabled) .Values.optimize.enabled)

--- a/charts/camunda-platform-8.9/templates/orchestration/files/_application.yaml
+++ b/charts/camunda-platform-8.9/templates/orchestration/files/_application.yaml
@@ -38,11 +38,6 @@ management:
     base-path: {{ include "camundaPlatform.joinpath" (list .Values.orchestration.contextPath) | quote }}
 
 camunda:
-  {{- if .Values.orchestration.exporters.rdbms.enabled }}
-  backup:
-    webapps:
-      enabled: false
-  {{- end }}
   license:
     key: "${VALUES_ORCHESTRATION_LICENSE_KEY}"
   {{- if eq (include "orchestration.hasAzureDocumentStore" .) "true" }}


### PR DESCRIPTION
### Which problem does the PR fix?

closes https://github.com/camunda/camunda-platform-helm/issues/4676

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

Things previously excluded when RDBMS is enabled:
* camunda webapp backups
* removing redundant elasticsearch exporter and opensearch exporter.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
