### PR TITLE
test: fix stale bats test for keycloak-mt scenario

### DIFF
--- a/test/scripts/generate_chart_matrix.bats
+++ b/test/scripts/generate_chart_matrix.bats
@@ -180,12 +180,13 @@ get_first_version() {
 }
 
 @test "upgrade-patch is skipped for keycloak-mt even with manual flow" {
-  # Ensure 8.8 is among active versions; skip if not present
-  if ! printf "%s\n" $AV | grep -q '^8\.8$'; then
-    skip "8.8 not available in active versions"
+  # Ensure 8.7 is among active versions; skip if not present.
+  # keycloak-mt exists in 8.7 (not in 8.8+).
+  if ! printf "%s\n" $AV | grep -q '^8\.7$'; then
+    skip "8.7 not available in active versions"
   fi
   run bash "$ROOT/scripts/generate-chart-matrix.sh" \
-    --manual-trigger "8.8" \
+    --manual-trigger "8.7" \
     --active-versions "$AV" \
     --manual-flow "install,upgrade-patch"
   assert_success


### PR DESCRIPTION
## Summary
- Fix `generate_chart_matrix.bats` test "upgrade-patch is skipped for keycloak-mt even with manual flow" which was targeting version 8.8 where the `keycloak-mt` scenario no longer exists
- Changed test to use version 8.7 where `keycloak-mt` is still present in ci-test-config

## Test plan
- [x] Verified bats tests pass locally with `bats test/scripts/generate_chart_matrix.bats`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>