### PR TITLE
test: incorrect tenant variable name in mt 8.9 and 8.10

### DIFF
--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
@@ -41,5 +41,5 @@ connectors:
       value: username
     - name: password
       value: password
-    - name: CAMUNDA_CLIENT_DEFAULT_JOB_WORKER_TENANT_IDS
+    - name: CAMUNDA_CLIENT_WORKER_DEFAULTS_TENANTIDS
       value: "<default>, Tenant_Main_Connectors, Tenant_Second_Connectors, Tenant_1_Connectors, Tenant_2_Connectors"

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
@@ -41,5 +41,5 @@ connectors:
       value: username
     - name: password
       value: password
-    - name: CAMUNDA_CLIENT_DEFAULT_JOB_WORKER_TENANT_IDS
+    - name: CAMUNDA_CLIENT_WORKER_DEFAULTS_TENANTIDS
       value: "<default>, Tenant_Main_Connectors, Tenant_Second_Connectors, Tenant_1_Connectors, Tenant_2_Connectors"


### PR DESCRIPTION
### Which problem does the PR fix?

https://github.com/camunda/camunda-platform-helm/issues/5532

This pull request updates the environment variable name used to configure tenant IDs for Camunda client workers in the multitenancy test scenarios for both version 8.9 and 8.10 charts. 



<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

Configuration updates for multitenancy test scenarios:

* Changed the environment variable from `CAMUNDA_CLIENT_DEFAULT_JOB_WORKER_TENANT_IDS` to `CAMUNDA_CLIENT_WORKER_DEFAULTS_TENANTIDS` in the `connectors` section of `multitenancy.yaml` for both `8.9` and `8.10` integration test scenarios.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
