### PR TITLE
fix(orchestration): restore mapping-rules rendering in 8.9 and 8.10

### DIFF
--- a/charts/camunda-platform-8.10/templates/orchestration/files/_application.yaml
+++ b/charts/camunda-platform-8.10/templates/orchestration/files/_application.yaml
@@ -179,6 +179,10 @@ camunda:
       users:
         {{- .Values.orchestration.security.initialization.users | toYaml | nindent 8 }}
       {{- end }}
+      {{- if .Values.orchestration.security.initialization.mappingRules }}
+      mapping-rules:
+        {{- .Values.orchestration.security.initialization.mappingRules | toYaml | nindent 8 }}
+      {{- end }}
       {{- if .Values.orchestration.security.initialization.authorizations }}
       authorizations:
         {{- .Values.orchestration.security.initialization.authorizations | toYaml | nindent 8 }}

--- a/charts/camunda-platform-8.10/test/unit/orchestration/configmap_unified_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/configmap_unified_test.go
@@ -240,6 +240,37 @@ func (s *ConfigmapTemplateTest) TestGroupsClaimConditionalRendering() {
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
 
+func (s *ConfigmapTemplateTest) TestMappingRulesConditionalRendering() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestApplicationYamlShouldNotContainMappingRulesWhenDefault",
+			Values: map[string]string{
+				"orchestration.data.secondaryStorage.type": "elasticsearch",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.NotContains(t, output, "mapping-rules")
+			},
+		},
+		{
+			Name: "TestApplicationYamlShouldContainMappingRulesWhenSet",
+			Values: map[string]string{
+				"orchestration.data.secondaryStorage.type":                            "elasticsearch",
+				"orchestration.security.initialization.mappingRules[0].mappingRuleID": "demo-user-mapping-rule",
+				"orchestration.security.initialization.mappingRules[0].claimName":     "preferred_username",
+				"orchestration.security.initialization.mappingRules[0].claimValue":    "demo",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.Contains(t, output, "mapping-rules")
+				require.Contains(t, output, "demo-user-mapping-rule")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
 func (s *ConfigmapTemplateTest) TestDifferentValuesInputsUnifiedRDBMS() {
 	testCases := []testhelpers.TestCase{
 		{

--- a/charts/camunda-platform-8.9/templates/orchestration/files/_application.yaml
+++ b/charts/camunda-platform-8.9/templates/orchestration/files/_application.yaml
@@ -179,6 +179,10 @@ camunda:
       users:
         {{- .Values.orchestration.security.initialization.users | toYaml | nindent 8 }}
       {{- end }}
+      {{- if .Values.orchestration.security.initialization.mappingRules }}
+      mapping-rules:
+        {{- .Values.orchestration.security.initialization.mappingRules | toYaml | nindent 8 }}
+      {{- end }}
       {{- if .Values.orchestration.security.initialization.authorizations }}
       authorizations:
         {{- .Values.orchestration.security.initialization.authorizations | toYaml | nindent 8 }}

--- a/charts/camunda-platform-8.9/test/unit/orchestration/configmap_unified_test.go
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/configmap_unified_test.go
@@ -223,8 +223,8 @@ func (s *ConfigmapTemplateTest) TestGroupsClaimConditionalRendering() {
 		{
 			Name: "TestApplicationYamlShouldNotContainGroupsClaimWhenDefault",
 			Values: map[string]string{
-				"orchestration.security.authentication.method":      "oidc",
-				"orchestration.data.secondaryStorage.type":          "elasticsearch",
+				"orchestration.security.authentication.method": "oidc",
+				"orchestration.data.secondaryStorage.type":     "elasticsearch",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				require.NoError(t, err)
@@ -234,7 +234,7 @@ func (s *ConfigmapTemplateTest) TestGroupsClaimConditionalRendering() {
 		{
 			Name: "TestApplicationYamlShouldNotContainGroupsClaimWhenExplicitlyEmpty",
 			Values: map[string]string{
-				"orchestration.security.authentication.method":            "oidc",
+				"orchestration.security.authentication.method":           "oidc",
 				"orchestration.security.authentication.oidc.groupsClaim": "",
 				"orchestration.data.secondaryStorage.type":               "elasticsearch",
 			},
@@ -246,12 +246,43 @@ func (s *ConfigmapTemplateTest) TestGroupsClaimConditionalRendering() {
 		{
 			Name: "TestApplicationYamlShouldContainGroupsClaimWhenSet",
 			Values: map[string]string{
-				"orchestration.security.authentication.method":            "oidc",
+				"orchestration.security.authentication.method":           "oidc",
 				"orchestration.security.authentication.oidc.groupsClaim": "custom-groups",
 				"orchestration.data.secondaryStorage.type":               "elasticsearch",
 			},
 			Expected: map[string]string{
 				"configmapApplication.camunda.security.authentication.oidc.groups-claim": "custom-groups",
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
+func (s *ConfigmapTemplateTest) TestMappingRulesConditionalRendering() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestApplicationYamlShouldNotContainMappingRulesWhenDefault",
+			Values: map[string]string{
+				"orchestration.data.secondaryStorage.type": "elasticsearch",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.NotContains(t, output, "mapping-rules")
+			},
+		},
+		{
+			Name: "TestApplicationYamlShouldContainMappingRulesWhenSet",
+			Values: map[string]string{
+				"orchestration.data.secondaryStorage.type":                            "elasticsearch",
+				"orchestration.security.initialization.mappingRules[0].mappingRuleID": "demo-user-mapping-rule",
+				"orchestration.security.initialization.mappingRules[0].claimName":     "preferred_username",
+				"orchestration.security.initialization.mappingRules[0].claimValue":    "demo",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.Contains(t, output, "mapping-rules")
+				require.Contains(t, output, "demo-user-mapping-rule")
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

- In 8.9 and 8.10, the `mapping-rules` block was silently dropped when `_application-unified.yaml` was renamed to `_application.yaml`. The value `orchestration.security.initialization.mappingRules` was already documented and present in `values.yaml` but was never rendered into the application config.
- This fix restores the conditional `mapping-rules:` block in the `initialization:` section of `_application.yaml` for both 8.9 and 8.10, matching the existing 8.8 behaviour exactly.
- Unit tests are added to both charts' `configmap_unified_test.go` to assert the block is absent by default (empty list) and present when rules are configured.

## Changes

- `charts/camunda-platform-8.9/templates/orchestration/files/_application.yaml` — inserted `mapping-rules` conditional block
- `charts/camunda-platform-8.10/templates/orchestration/files/_application.yaml` — same fix
- `charts/camunda-platform-8.9/test/unit/orchestration/configmap_unified_test.go` — new `TestMappingRulesConditionalRendering` test method
- `charts/camunda-platform-8.10/test/unit/orchestration/configmap_unified_test.go` — same test

## Testing

All unit tests pass for both charts:
```
make go.test chartPath=charts/camunda-platform-8.9   # all ok
make go.test chartPath=charts/camunda-platform-8.10  # all ok
```