### PR TITLE
revert: "fix: add env vars to web-modeler restapi deployment for Spring Boot 4.0.4 compatibility"

### DIFF
--- a/charts/camunda-platform-8.10/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform-8.10/templates/web-modeler/deployment-restapi.yaml
@@ -71,47 +71,6 @@ spec:
             ) | nindent 12 }}
             - name: ZEEBE_CLIENT_CONFIG_PATH
               value: {{ .Values.webModeler.restapi.zeebeClientConfigPath | default "/tmp/zeebe_client_cache.txt" | quote }}
-            # -- Pusher (WebSocket) configuration env vars --
-            # Required because the in-JAR application-self-managed.yml uses ${ENV_VAR:} placeholders
-            # that must be resolved via environment variables (not overridable via external configmap).
-            - name: RESTAPI_PUSHER_HOST
-              value: {{ include "webModeler.websockets.fullname" . | quote }}
-            - name: RESTAPI_PUSHER_PORT
-              value: {{ .Values.webModeler.websockets.service.port | quote }}
-            - name: CLIENT_PUSHER_HOST
-              value: {{ include "webModeler.publicWebsocketHost" . | quote }}
-            - name: CLIENT_PUSHER_PORT
-              value: {{ include "webModeler.publicWebsocketPort" . | quote }}
-            {{- if and .Values.global.ingress.enabled .Values.webModeler.contextPath }}
-            - name: CLIENT_PUSHER_PATH
-              value: {{ include "webModeler.websocketContextPath" . | quote }}
-            {{- end }}
-            - name: CLIENT_PUSHER_FORCE_TLS
-              value: {{ include "webModeler.websocketTlsEnabled" . | quote }}
-            # -- Server configuration env vars --
-            - name: RESTAPI_SERVER_URL
-              value: {{ tpl .Values.global.identity.auth.webModeler.redirectUrl $ | quote }}
-            - name: SERVER_HTTPS_ONLY
-              value: {{ hasPrefix "https://" (tpl .Values.global.identity.auth.webModeler.redirectUrl $) | quote }}
-            # -- OAuth2 / Identity env vars --
-            - name: OAUTH2_CLIENT_ID
-              value: {{ include "webModeler.authClientId" . | quote }}
-            # -- Mail env vars --
-            - name: RESTAPI_MAIL_FROM_ADDRESS
-              value: {{ .Values.webModeler.restapi.mail.fromAddress | quote }}
-            - name: RESTAPI_MAIL_FROM_NAME
-              value: {{ .Values.webModeler.restapi.mail.fromName | quote }}
-            # -- Identity / Auth env vars (conditional) --
-            {{- if .Values.identity.enabled }}
-            - name: RESTAPI_IDENTITY_BASE_URL
-              value: {{ include "camundaPlatform.identityURL" . | quote }}
-            {{- end }}
-            {{- if or .Values.global.identity.auth.enabled (eq (include "webModeler.authMethod" .) "oidc") }}
-            - name: RESTAPI_OAUTH2_TOKEN_ISSUER
-              value: {{ include "camundaPlatform.authIssuerUrlWithFallback" . | quote }}
-            - name: RESTAPI_OAUTH2_TOKEN_ISSUER_BACKEND_URL
-              value: {{ include "camundaPlatform.authIssuerBackendUrl" . | quote }}
-            {{- end }}
             {{- if and .Values.global.documentStore.type.aws.enabled (not .Values.global.documentStore.type.aws.irsa.enabled) }}
             - name: AWS_ACCESS_KEY_ID
               {{- include "camundaPlatform.emitAwsDocumentStoreSecret" (dict

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -70,39 +70,6 @@ spec:
             
             - name: ZEEBE_CLIENT_CONFIG_PATH
               value: "/tmp/zeebe_client_cache.txt"
-            # -- Pusher (WebSocket) configuration env vars --
-            # Required because the in-JAR application-self-managed.yml uses ${ENV_VAR:} placeholders
-            # that must be resolved via environment variables (not overridable via external configmap).
-            - name: RESTAPI_PUSHER_HOST
-              value: "camunda-platform-test-web-modeler-websockets"
-            - name: RESTAPI_PUSHER_PORT
-              value: "80"
-            - name: CLIENT_PUSHER_HOST
-              value: "localhost"
-            - name: CLIENT_PUSHER_PORT
-              value: "8085"
-            - name: CLIENT_PUSHER_FORCE_TLS
-              value: "false"
-            # -- Server configuration env vars --
-            - name: RESTAPI_SERVER_URL
-              value: "http://localhost:8070"
-            - name: SERVER_HTTPS_ONLY
-              value: "false"
-            # -- OAuth2 / Identity env vars --
-            - name: OAUTH2_CLIENT_ID
-              value: "web-modeler"
-            # -- Mail env vars --
-            - name: RESTAPI_MAIL_FROM_ADDRESS
-              value: "example@example.com"
-            - name: RESTAPI_MAIL_FROM_NAME
-              value: "Camunda 8"
-            # -- Identity / Auth env vars (conditional) --
-            - name: RESTAPI_IDENTITY_BASE_URL
-              value: "http://camunda-platform-test-identity:80"
-            - name: RESTAPI_OAUTH2_TOKEN_ISSUER
-              value: "http://localhost:18080/auth/realms/camunda-platform"
-            - name: RESTAPI_OAUTH2_TOKEN_ISSUER_BACKEND_URL
-              value: "http://camunda-platform-test-keycloak/auth/realms/camunda-platform"
           envFrom:
             - configMapRef:
                 name: camunda-platform-test-documentstore-env-vars

--- a/charts/camunda-platform-8.9/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform-8.9/templates/web-modeler/deployment-restapi.yaml
@@ -75,47 +75,6 @@ spec:
             ) | nindent 12 }}
             - name: ZEEBE_CLIENT_CONFIG_PATH
               value: {{ .Values.webModeler.restapi.zeebeClientConfigPath | default "/tmp/zeebe_client_cache.txt" | quote }}
-            # -- Pusher (WebSocket) configuration env vars --
-            # Required because the in-JAR application-self-managed.yml uses ${ENV_VAR:} placeholders
-            # that must be resolved via environment variables (not overridable via external configmap).
-            - name: RESTAPI_PUSHER_HOST
-              value: {{ include "webModeler.websockets.fullname" . | quote }}
-            - name: RESTAPI_PUSHER_PORT
-              value: {{ .Values.webModeler.websockets.service.port | quote }}
-            - name: CLIENT_PUSHER_HOST
-              value: {{ include "webModeler.publicWebsocketHost" . | quote }}
-            - name: CLIENT_PUSHER_PORT
-              value: {{ include "webModeler.publicWebsocketPort" . | quote }}
-            {{- if and .Values.global.ingress.enabled .Values.webModeler.contextPath }}
-            - name: CLIENT_PUSHER_PATH
-              value: {{ include "webModeler.websocketContextPath" . | quote }}
-            {{- end }}
-            - name: CLIENT_PUSHER_FORCE_TLS
-              value: {{ include "webModeler.websocketTlsEnabled" . | quote }}
-            # -- Server configuration env vars --
-            - name: RESTAPI_SERVER_URL
-              value: {{ tpl .Values.global.identity.auth.webModeler.redirectUrl $ | quote }}
-            - name: SERVER_HTTPS_ONLY
-              value: {{ hasPrefix "https://" (tpl .Values.global.identity.auth.webModeler.redirectUrl $) | quote }}
-            # -- OAuth2 / Identity env vars --
-            - name: OAUTH2_CLIENT_ID
-              value: {{ include "webModeler.authClientId" . | quote }}
-            # -- Mail env vars --
-            - name: RESTAPI_MAIL_FROM_ADDRESS
-              value: {{ .Values.webModeler.restapi.mail.fromAddress | quote }}
-            - name: RESTAPI_MAIL_FROM_NAME
-              value: {{ .Values.webModeler.restapi.mail.fromName | quote }}
-            # -- Identity / Auth env vars (conditional) --
-            {{- if .Values.identity.enabled }}
-            - name: RESTAPI_IDENTITY_BASE_URL
-              value: {{ include "camundaPlatform.identityURL" . | quote }}
-            {{- end }}
-            {{- if or .Values.global.identity.auth.enabled (eq (include "webModeler.authMethod" .) "oidc") }}
-            - name: RESTAPI_OAUTH2_TOKEN_ISSUER
-              value: {{ include "camundaPlatform.authIssuerUrlWithFallback" . | quote }}
-            - name: RESTAPI_OAUTH2_TOKEN_ISSUER_BACKEND_URL
-              value: {{ include "camundaPlatform.authIssuerBackendUrl" . | quote }}
-            {{- end }}
             {{- if and .Values.global.documentStore.type.aws.enabled (not .Values.global.documentStore.type.aws.irsa.enabled) }}
             - name: AWS_ACCESS_KEY_ID
               {{- include "camundaPlatform.emitAwsDocumentStoreSecret" (dict

--- a/charts/camunda-platform-8.9/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
+++ b/charts/camunda-platform-8.9/test/unit/web-modeler/golden/deployment-restapi.golden.yaml
@@ -78,39 +78,6 @@ spec:
                   key: pusher-app-secret
             - name: ZEEBE_CLIENT_CONFIG_PATH
               value: "/tmp/zeebe_client_cache.txt"
-            # -- Pusher (WebSocket) configuration env vars --
-            # Required because the in-JAR application-self-managed.yml uses ${ENV_VAR:} placeholders
-            # that must be resolved via environment variables (not overridable via external configmap).
-            - name: RESTAPI_PUSHER_HOST
-              value: "camunda-platform-test-web-modeler-websockets"
-            - name: RESTAPI_PUSHER_PORT
-              value: "80"
-            - name: CLIENT_PUSHER_HOST
-              value: "localhost"
-            - name: CLIENT_PUSHER_PORT
-              value: "8085"
-            - name: CLIENT_PUSHER_FORCE_TLS
-              value: "false"
-            # -- Server configuration env vars --
-            - name: RESTAPI_SERVER_URL
-              value: "http://localhost:8070"
-            - name: SERVER_HTTPS_ONLY
-              value: "false"
-            # -- OAuth2 / Identity env vars --
-            - name: OAUTH2_CLIENT_ID
-              value: "web-modeler"
-            # -- Mail env vars --
-            - name: RESTAPI_MAIL_FROM_ADDRESS
-              value: "example@example.com"
-            - name: RESTAPI_MAIL_FROM_NAME
-              value: "Camunda 8"
-            # -- Identity / Auth env vars (conditional) --
-            - name: RESTAPI_IDENTITY_BASE_URL
-              value: "http://camunda-platform-test-identity:80"
-            - name: RESTAPI_OAUTH2_TOKEN_ISSUER
-              value: "http://localhost:18080/auth/realms/camunda-platform"
-            - name: RESTAPI_OAUTH2_TOKEN_ISSUER_BACKEND_URL
-              value: "http://camunda-platform-test-keycloak/auth/realms/camunda-platform"
           envFrom:
             - configMapRef:
                 name: camunda-platform-test-documentstore-env-vars


### PR DESCRIPTION
### Which problem does the PR fix?
Closes #5535

### What's in this PR?

The PR reverts the changes from #5525. They are no longer necessary as Web Modeler has been updated to Spring Boot 4.0.5 which included a fix for https://github.com/spring-projects/spring-boot/issues/49724. The mounted `application.yaml` file from the ConfigMap is now correctly overriding the in-JAR configuration file again.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?