### PR TITLE
fix: set basic.allow-unauthenticated-api-access on unprotectedApi

### DIFF
--- a/charts/camunda-platform-8.10/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.10/templates/common/constraints.tpl
@@ -45,14 +45,6 @@ Fail with a message if noSecondaryStorage is enabled but Elasticsearch or OpenSe
     -}}
     {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
   {{- end }}
-  {{- if eq (include "orchestration.authMethod" .) "basic" }}
-    {{- $errorMessage := printf "[camunda][error] %s %s %s"
-        "When \"global.noSecondaryStorage\" is enabled, basic authentication for Orchestration is not supported."
-        "Please set \"orchestration.security.authentication.method\" to \"oidc\" and configure OIDC authentication"
-        "when using \"global.noSecondaryStorage: true\"."
-    -}}
-    {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
-  {{- end }}
 {{- end }}
 
 {{/*

--- a/charts/camunda-platform-8.10/templates/orchestration/files/_application.yaml
+++ b/charts/camunda-platform-8.10/templates/orchestration/files/_application.yaml
@@ -135,6 +135,10 @@ camunda:
   # Security configuration - Separated syntax.
   security:
     authentication:
+    {{- if and (eq (include "orchestration.authMethod" .) "basic") (.Values.orchestration.security.authentication.unprotectedApi) }}
+      basic:
+        allow-unauthenticated-api-access: {{ .Values.orchestration.security.authentication.unprotectedApi }}
+    {{- end }}
     {{- if eq (include "orchestration.authMethod" .) "oidc" }}
       oidc:
         username-claim: {{ .Values.orchestration.security.authentication.oidc.usernameClaim | quote }}

--- a/charts/camunda-platform-8.10/templates/orchestration/files/_application.yaml
+++ b/charts/camunda-platform-8.10/templates/orchestration/files/_application.yaml
@@ -194,16 +194,15 @@ camunda:
     multiTenancy:
       checksEnabled: {{ include "orchestration.multitenancyChecksEnabled" . }}
       apiEnabled: {{ include "orchestration.multitenancyApiEnabled" . }}
-
-  persistent:
-    sessions:
-      enabled: {{ include "orchestration.persistentSessionsEnabled" . }}
-
   {{- if eq (include "orchestration.authMethod" .) "oidc" }}
   identity:
     clientId: {{ include "orchestration.authClientId" . | quote }}
     audience: {{ include "orchestration.authAudience" . | quote }}
   {{- end }}
+  persistent:
+    sessions:
+      enabled: {{ include "orchestration.persistentSessionsEnabled" . }}
+
 
 {{- if .Values.orchestration.profiles.operate -}}
   {{- "\n" }}

--- a/charts/camunda-platform-8.10/test/unit/orchestration/configmap_unified_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/configmap_unified_test.go
@@ -108,9 +108,9 @@ func (s *ConfigmapTemplateTest) TestDifferentValuesInputsUnified() {
 		{
 			Name: "TestApplicationYamlNoWebAppProfilesWhenNoSecondaryStorageEnabled",
 			Values: map[string]string{
-				"global.noSecondaryStorage":    "true",
-				"global.elasticsearch.enabled": "false",
-				"elasticsearch.enabled":        "false",
+				"global.noSecondaryStorage":                    "true",
+				"global.elasticsearch.enabled":                 "false",
+				"elasticsearch.enabled":                        "false",
 				"orchestration.security.authentication.method": "oidc",
 			},
 			Expected: map[string]string{
@@ -295,6 +295,45 @@ func (s *ConfigmapTemplateTest) TestMappingRulesConditionalRendering() {
 				require.NoError(t, err)
 				require.Contains(t, output, "mapping-rules")
 				require.Contains(t, output, "demo-user-mapping-rule")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
+func (s *ConfigmapTemplateTest) TestUnprotectedApiConditionalRendering() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestApplicationYamlShouldContainAllowUnauthenticatedApiAccessWhenBasicAuthAndUnprotectedApiTrue",
+			Values: map[string]string{
+				"orchestration.security.authentication.method":         "basic",
+				"orchestration.security.authentication.unprotectedApi": "true",
+			},
+			Expected: map[string]string{
+				"configmapApplication.camunda.security.authentication.basic.allow-unauthenticated-api-access": "true",
+			},
+		},
+		{
+			Name: "TestApplicationYamlShouldNotContainAllowUnauthenticatedApiAccessWhenBasicAuthAndUnprotectedApiFalse",
+			Values: map[string]string{
+				"orchestration.security.authentication.method":         "basic",
+				"orchestration.security.authentication.unprotectedApi": "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.NotContains(t, output, "allow-unauthenticated-api-access")
+			},
+		},
+		{
+			Name: "TestApplicationYamlShouldNotContainAllowUnauthenticatedApiAccessWhenOidcAuthAndUnprotectedApiTrue",
+			Values: map[string]string{
+				"orchestration.security.authentication.method":         "oidc",
+				"orchestration.security.authentication.unprotectedApi": "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.NotContains(t, output, "allow-unauthenticated-api-access")
 			},
 		},
 	}

--- a/charts/camunda-platform-8.10/test/unit/orchestration/configmap_unified_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/configmap_unified_test.go
@@ -105,6 +105,18 @@ func (s *ConfigmapTemplateTest) TestDifferentValuesInputsUnified() {
 				"configmapApplication.camunda.security.authentication.oidc.client-id": "orchestration",
 			},
 		},
+		{
+			Name: "TestApplicationYamlNoWebAppProfilesWhenNoSecondaryStorageEnabled",
+			Values: map[string]string{
+				"global.noSecondaryStorage":    "true",
+				"global.elasticsearch.enabled": "false",
+				"elasticsearch.enabled":        "false",
+				"orchestration.security.authentication.method": "oidc",
+			},
+			Expected: map[string]string{
+				"configmapApplication.spring.profiles.active": "admin,broker,consolidated-auth",
+			},
+		},
 	}
 
 	testhelpers.RunTestCases(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)

--- a/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap-authorizations.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap-authorizations.golden.yaml
@@ -133,7 +133,6 @@ data:
         multiTenancy:
           checksEnabled: false
           apiEnabled: true
-    
       persistent:
         sessions:
           enabled: true

--- a/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap-log4j2.golden.yaml
@@ -133,7 +133,6 @@ data:
         multiTenancy:
           checksEnabled: false
           apiEnabled: true
-    
       persistent:
         sessions:
           enabled: true

--- a/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap-retention.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap-retention.golden.yaml
@@ -138,7 +138,6 @@ data:
         multiTenancy:
           checksEnabled: false
           apiEnabled: true
-    
       persistent:
         sessions:
           enabled: true

--- a/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap.golden.yaml
@@ -133,7 +133,6 @@ data:
         multiTenancy:
           checksEnabled: false
           apiEnabled: true
-    
       persistent:
         sessions:
           enabled: true

--- a/charts/camunda-platform-8.9/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.9/templates/common/constraints.tpl
@@ -45,14 +45,6 @@ Fail with a message if noSecondaryStorage is enabled but Elasticsearch or OpenSe
     -}}
     {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
   {{- end }}
-  {{- if eq (include "orchestration.authMethod" .) "basic" }}
-    {{- $errorMessage := printf "[camunda][error] %s %s %s"
-        "When \"global.noSecondaryStorage\" is enabled, basic authentication for Orchestration is not supported."
-        "Please set \"orchestration.security.authentication.method\" to \"oidc\" and configure OIDC authentication"
-        "when using \"global.noSecondaryStorage: true\"."
-    -}}
-    {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
-  {{- end }}
 {{- end }}
 
 {{/*

--- a/charts/camunda-platform-8.9/templates/orchestration/files/_application.yaml
+++ b/charts/camunda-platform-8.9/templates/orchestration/files/_application.yaml
@@ -135,6 +135,10 @@ camunda:
   # Security configuration - Separated syntax.
   security:
     authentication:
+    {{- if and (eq (include "orchestration.authMethod" .) "basic") (.Values.orchestration.security.authentication.unprotectedApi) }}
+      basic:
+        allow-unauthenticated-api-access: {{ .Values.orchestration.security.authentication.unprotectedApi }}
+    {{- end }}
     {{- if eq (include "orchestration.authMethod" .) "oidc" }}
       oidc:
         username-claim: {{ .Values.orchestration.security.authentication.oidc.usernameClaim | quote }}

--- a/charts/camunda-platform-8.9/templates/orchestration/files/_application.yaml
+++ b/charts/camunda-platform-8.9/templates/orchestration/files/_application.yaml
@@ -194,16 +194,15 @@ camunda:
     multiTenancy:
       checksEnabled: {{ include "orchestration.multitenancyChecksEnabled" . }}
       apiEnabled: {{ include "orchestration.multitenancyApiEnabled" . }}
-
-  persistent:
-    sessions:
-      enabled: {{ include "orchestration.persistentSessionsEnabled" . }}
-
   {{- if eq (include "orchestration.authMethod" .) "oidc" }}
   identity:
     clientId: {{ include "orchestration.authClientId" . | quote }}
     audience: {{ include "orchestration.authAudience" . | quote }}
   {{- end }}
+  persistent:
+    sessions:
+      enabled: {{ include "orchestration.persistentSessionsEnabled" . }}
+
 
 {{- if .Values.orchestration.profiles.operate -}}
   {{- "\n" }}

--- a/charts/camunda-platform-8.9/test/unit/orchestration/configmap_unified_test.go
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/configmap_unified_test.go
@@ -127,9 +127,9 @@ func (s *ConfigmapTemplateTest) TestDifferentValuesInputsUnified() {
 		{
 			Name: "TestApplicationYamlNoWebAppProfilesWhenNoSecondaryStorageEnabled",
 			Values: map[string]string{
-				"global.noSecondaryStorage":    "true",
-				"global.elasticsearch.enabled": "false",
-				"elasticsearch.enabled":        "false",
+				"global.noSecondaryStorage":                    "true",
+				"global.elasticsearch.enabled":                 "false",
+				"elasticsearch.enabled":                        "false",
 				"orchestration.security.authentication.method": "oidc",
 			},
 			Expected: map[string]string{
@@ -314,6 +314,45 @@ func (s *ConfigmapTemplateTest) TestMappingRulesConditionalRendering() {
 				require.NoError(t, err)
 				require.Contains(t, output, "mapping-rules")
 				require.Contains(t, output, "demo-user-mapping-rule")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
+func (s *ConfigmapTemplateTest) TestUnprotectedApiConditionalRendering() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestApplicationYamlShouldContainAllowUnauthenticatedApiAccessWhenBasicAuthAndUnprotectedApiTrue",
+			Values: map[string]string{
+				"orchestration.security.authentication.method":         "basic",
+				"orchestration.security.authentication.unprotectedApi": "true",
+			},
+			Expected: map[string]string{
+				"configmapApplication.camunda.security.authentication.basic.allow-unauthenticated-api-access": "true",
+			},
+		},
+		{
+			Name: "TestApplicationYamlShouldNotContainAllowUnauthenticatedApiAccessWhenBasicAuthAndUnprotectedApiFalse",
+			Values: map[string]string{
+				"orchestration.security.authentication.method":         "basic",
+				"orchestration.security.authentication.unprotectedApi": "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.NotContains(t, output, "allow-unauthenticated-api-access")
+			},
+		},
+		{
+			Name: "TestApplicationYamlShouldNotContainAllowUnauthenticatedApiAccessWhenOidcAuthAndUnprotectedApiTrue",
+			Values: map[string]string{
+				"orchestration.security.authentication.method":         "oidc",
+				"orchestration.security.authentication.unprotectedApi": "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.NotContains(t, output, "allow-unauthenticated-api-access")
 			},
 		},
 	}

--- a/charts/camunda-platform-8.9/test/unit/orchestration/configmap_unified_test.go
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/configmap_unified_test.go
@@ -124,6 +124,18 @@ func (s *ConfigmapTemplateTest) TestDifferentValuesInputsUnified() {
 				"configmapApplication.spring.profiles.active": "admin,broker,operate,tasklist,consolidated-auth",
 			},
 		},
+		{
+			Name: "TestApplicationYamlNoWebAppProfilesWhenNoSecondaryStorageEnabled",
+			Values: map[string]string{
+				"global.noSecondaryStorage":    "true",
+				"global.elasticsearch.enabled": "false",
+				"elasticsearch.enabled":        "false",
+				"orchestration.security.authentication.method": "oidc",
+			},
+			Expected: map[string]string{
+				"configmapApplication.spring.profiles.active": "admin,broker,consolidated-auth",
+			},
+		},
 	}
 
 	testhelpers.RunTestCases(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)

--- a/charts/camunda-platform-8.9/test/unit/orchestration/golden/configmap-authorizations.golden.yaml
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/golden/configmap-authorizations.golden.yaml
@@ -133,7 +133,6 @@ data:
         multiTenancy:
           checksEnabled: false
           apiEnabled: true
-    
       persistent:
         sessions:
           enabled: true

--- a/charts/camunda-platform-8.9/test/unit/orchestration/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/golden/configmap-log4j2.golden.yaml
@@ -133,7 +133,6 @@ data:
         multiTenancy:
           checksEnabled: false
           apiEnabled: true
-    
       persistent:
         sessions:
           enabled: true

--- a/charts/camunda-platform-8.9/test/unit/orchestration/golden/configmap-retention.golden.yaml
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/golden/configmap-retention.golden.yaml
@@ -138,7 +138,6 @@ data:
         multiTenancy:
           checksEnabled: false
           apiEnabled: true
-    
       persistent:
         sessions:
           enabled: true

--- a/charts/camunda-platform-8.9/test/unit/orchestration/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/golden/configmap.golden.yaml
@@ -133,7 +133,6 @@ data:
         multiTenancy:
           checksEnabled: false
           apiEnabled: true
-    
       persistent:
         sessions:
           enabled: true


### PR DESCRIPTION
## Which problem does the PR fix?

this comment: [camunda/camunda-platform-helm#5213 (comment)](https://github.com/camunda/camunda-platform-helm/issues/5213#issuecomment-4050518626)
casted doubt onto whether the right profiles were being set when noSecondaryStorage was enabled. There was also a functionality gap where despite the unprotectedApi setting is being set, when using basic auth, it seemingly was not applied. This is due to a new setting allow-unauthenticated-api-access that was not set previously by the helm chart.

## What's in this PR?
This PR adds a unit test to validate that it is the case

in commits 2 and 3, I also bound the setting allow-unauthenticated-api-access to the existing setting orchestration.security.authentication.unprote ctedApiorchestration.security.authentication.unprotectedApi

## Checklist
Please make sure to follow our [Contributing Guide](https://github.com/camunda/camunda-platform-helm/blob/main/docs/contributing.md).

## Before opening the PR:

- [ ] In the repo's root dir, run make go.update-golden-only.
- [ ] There is no other open [pull request](https://github.com/camunda/camunda-platform-helm/pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](https://github.com/camunda/camunda-platform-helm/blob/main/docs/contributing.md#documentation) are updated (if needed).

After opening the PR:
- [ ]  Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ]  Did all checks/tests pass in the PR?