### PR TITLE
feat: add springImport flag to extraConfiguration entries

### DIFF
--- a/charts/camunda-platform-8.10/templates/connectors/files/_application.yaml
+++ b/charts/camunda-platform-8.10/templates/connectors/files/_application.yaml
@@ -25,11 +25,17 @@ management:
           - processDefinitionImport
           - zeebeClient
 
-{{- if .Values.connectors.extraConfiguration }}
+{{- $springImports := list }}
+{{- range .Values.connectors.extraConfiguration }}
+  {{- if not (and (hasKey . "springImport") (eq .springImport false)) }}
+    {{- $springImports = append $springImports . }}
+  {{- end }}
+{{- end }}
+{{- if $springImports }}
 spring:
   config:
     import:
-    {{- range .Values.connectors.extraConfiguration }}
+    {{- range $springImports }}
       - optional:file:/config/{{ .file }}
     {{- end }}
 {{- end }}

--- a/charts/camunda-platform-8.10/templates/identity/configmap.yaml
+++ b/charts/camunda-platform-8.10/templates/identity/configmap.yaml
@@ -322,10 +322,16 @@ data:
       {{- end }}
 
     spring:
-    {{- if .Values.identity.extraConfiguration }}
+    {{- $springImports := list }}
+    {{- range .Values.identity.extraConfiguration }}
+      {{- if not (and (hasKey . "springImport") (eq .springImport false)) }}
+        {{- $springImports = append $springImports . }}
+      {{- end }}
+    {{- end }}
+    {{- if $springImports }}
       config:
         import:
-        {{- range .Values.identity.extraConfiguration }}
+        {{- range $springImports }}
           - optional:file:/app/config/{{ .file }}
         {{- end }}
     {{- end }}

--- a/charts/camunda-platform-8.10/templates/optimize/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/optimize/_helpers.tpl
@@ -135,11 +135,14 @@ When neither backend is explicitly enabled, falls back to "zeebe-record".
 
 {{/*
 [optimize] Build a comma-separated spring.config.import line from extraConfiguration files.
+Entries with springImport: false are excluded.
 */}}
 {{- define "optimize.springConfigImport" -}}
 {{- $imports := list -}}
 {{- range .Values.optimize.extraConfiguration -}}
-  {{- $imports = append $imports (printf "optional:file:/optimize/config/%s" .file) -}}
+  {{- if not (and (hasKey . "springImport") (eq .springImport false)) -}}
+    {{- $imports = append $imports (printf "optional:file:/optimize/config/%s" .file) -}}
+  {{- end -}}
 {{- end -}}
 {{- join "," $imports -}}
 {{- end -}}

--- a/charts/camunda-platform-8.10/templates/optimize/configmap.yaml
+++ b/charts/camunda-platform-8.10/templates/optimize/configmap.yaml
@@ -14,10 +14,11 @@ data:
   {{- end }}
   {{- if or .Values.global.identity.auth.enabled .Values.optimize.extraConfiguration }}
   application-ccsm.yaml: |
-    {{- if .Values.optimize.extraConfiguration }}
+    {{- $springImport := include "optimize.springConfigImport" . }}
+    {{- if $springImport }}
     spring:
       config:
-        import: {{ include "optimize.springConfigImport" . }}
+        import: {{ $springImport }}
     {{- end }}
     {{- if .Values.global.identity.auth.enabled }}
     camunda:

--- a/charts/camunda-platform-8.10/templates/orchestration/files/_application.yaml
+++ b/charts/camunda-platform-8.10/templates/orchestration/files/_application.yaml
@@ -3,10 +3,16 @@ This file name should start with an underscore to avoid rendering it as a templa
 It is included (imported) in the ConfigMap.
 */}}
 spring:
-  {{- if .Values.orchestration.extraConfiguration }}
+  {{- $springImports := list }}
+  {{- range .Values.orchestration.extraConfiguration }}
+    {{- if not (and (hasKey . "springImport") (eq .springImport false)) }}
+      {{- $springImports = append $springImports . }}
+    {{- end }}
+  {{- end }}
+  {{- if $springImports }}
   config:
     import:
-    {{- range .Values.orchestration.extraConfiguration }}
+    {{- range $springImports }}
       - optional:file:/usr/local/camunda/config/{{ .file }}
     {{- end }}
   {{- end }}

--- a/charts/camunda-platform-8.10/templates/web-modeler/configmap-restapi.yaml
+++ b/charts/camunda-platform-8.10/templates/web-modeler/configmap-restapi.yaml
@@ -79,10 +79,16 @@ data:
         {{- end }}
 
     spring:
-      {{- if .Values.webModeler.restapi.extraConfiguration }}
+      {{- $springImports := list }}
+      {{- range .Values.webModeler.restapi.extraConfiguration }}
+        {{- if not (and (hasKey . "springImport") (eq .springImport false)) }}
+          {{- $springImports = append $springImports . }}
+        {{- end }}
+      {{- end }}
+      {{- if $springImports }}
       config:
         import:
-        {{- range .Values.webModeler.restapi.extraConfiguration }}
+        {{- range $springImports }}
           - optional:file:/home/runner/config/{{ .file }}
         {{- end }}
       {{- end }}

--- a/charts/camunda-platform-8.10/test/unit/connectors/configmap_test.go
+++ b/charts/camunda-platform-8.10/test/unit/connectors/configmap_test.go
@@ -128,6 +128,84 @@ func (s *ConfigMapTemplateTest) TestDifferentValuesInputs() {
 	testhelpers.RunTestCases(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
 
+func (s *ConfigMapTemplateTest) TestExtraConfigurationSpringImport() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestExtraConfigWithSpringImportDefault",
+			Values: map[string]string{
+				"connectors.enabled":                       "true",
+				"connectors.extraConfiguration[0].file":    "custom-spring.yaml",
+				"connectors.extraConfiguration[0].content": "some: config",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				applicationYaml := configmap.Data["application.yaml"]
+				// spring.config.import should include the file
+				s.Require().Contains(applicationYaml, "optional:file:/config/custom-spring.yaml",
+					"File without springImport should be included in spring.config.import")
+				// File content should be in ConfigMap
+				s.Require().Contains(configmap.Data["custom-spring.yaml"], "some: config",
+					"File content should be present in ConfigMap")
+			},
+		},
+		{
+			Name: "TestExtraConfigWithSpringImportFalse",
+			Values: map[string]string{
+				"connectors.enabled":                            "true",
+				"connectors.extraConfiguration[0].file":         "log4j2-spring.xml",
+				"connectors.extraConfiguration[0].springImport": "false",
+				"connectors.extraConfiguration[0].content":      "<Configuration/>",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				applicationYaml := configmap.Data["application.yaml"]
+				// spring.config.import should NOT include the file
+				s.Require().NotContains(applicationYaml, "log4j2-spring.xml",
+					"File with springImport: false should not be in spring.config.import")
+				// spring.config.import block should not be rendered at all
+				s.Require().NotContains(applicationYaml, "config:",
+					"spring.config.import block should not be rendered when all entries have springImport: false")
+				// File content should still be in ConfigMap
+				s.Require().Contains(configmap.Data["log4j2-spring.xml"], "<Configuration/>",
+					"File content should be present in ConfigMap even with springImport: false")
+			},
+		},
+		{
+			Name: "TestExtraConfigMixedSpringImport",
+			Values: map[string]string{
+				"connectors.enabled":                            "true",
+				"connectors.extraConfiguration[0].file":         "custom-spring.yaml",
+				"connectors.extraConfiguration[0].content":      "some: config",
+				"connectors.extraConfiguration[1].file":         "log4j2-spring.xml",
+				"connectors.extraConfiguration[1].springImport": "false",
+				"connectors.extraConfiguration[1].content":      "<Configuration/>",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				applicationYaml := configmap.Data["application.yaml"]
+				// Only custom-spring.yaml should be in spring.config.import
+				s.Require().Contains(applicationYaml, "optional:file:/config/custom-spring.yaml",
+					"File without springImport should be included in spring.config.import")
+				s.Require().NotContains(applicationYaml, "log4j2-spring.xml",
+					"File with springImport: false should not be in spring.config.import")
+				// Both files should be in ConfigMap
+				s.Require().Contains(configmap.Data["custom-spring.yaml"], "some: config",
+					"First file content should be present in ConfigMap")
+				s.Require().Contains(configmap.Data["log4j2-spring.xml"], "<Configuration/>",
+					"Second file content should be present in ConfigMap even with springImport: false")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
 // // TODO: Refactor the tests to work with the new Connectors config.
 // func (s *configMapTemplateTest) TestContainerConfigMapSetInboundModeCredentials() {
 // 	// given

--- a/charts/camunda-platform-8.10/test/unit/identity/configmap_test.go
+++ b/charts/camunda-platform-8.10/test/unit/identity/configmap_test.go
@@ -496,3 +496,78 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
+
+func (s *configMapSpringTemplateTest) TestExtraConfigurationSpringImport() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestExtraConfigWithSpringImportDefault",
+			Values: map[string]string{
+				"identity.enabled":                       "true",
+				"identity.extraConfiguration[0].file":    "custom-spring.yaml",
+				"identity.extraConfiguration[0].content": "some: config",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				applicationYaml := configmap.Data["application.yaml"]
+				// spring.config.import should include the file
+				s.Require().Contains(applicationYaml, "optional:file:/app/config/custom-spring.yaml",
+					"File without springImport should be included in spring.config.import")
+				// File content should be in ConfigMap
+				s.Require().Contains(configmap.Data["custom-spring.yaml"], "some: config",
+					"File content should be present in ConfigMap")
+			},
+		},
+		{
+			Name: "TestExtraConfigWithSpringImportFalse",
+			Values: map[string]string{
+				"identity.enabled":                            "true",
+				"identity.extraConfiguration[0].file":         "log4j2-spring.xml",
+				"identity.extraConfiguration[0].springImport": "false",
+				"identity.extraConfiguration[0].content":      "<Configuration/>",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				applicationYaml := configmap.Data["application.yaml"]
+				// spring.config.import should NOT include the file
+				s.Require().NotContains(applicationYaml, "log4j2-spring.xml",
+					"File with springImport: false should not be in spring.config.import")
+				// File content should still be in ConfigMap
+				s.Require().Contains(configmap.Data["log4j2-spring.xml"], "<Configuration/>",
+					"File content should be present in ConfigMap even with springImport: false")
+			},
+		},
+		{
+			Name: "TestExtraConfigMixedSpringImport",
+			Values: map[string]string{
+				"identity.enabled":                            "true",
+				"identity.extraConfiguration[0].file":         "custom-spring.yaml",
+				"identity.extraConfiguration[0].content":      "some: config",
+				"identity.extraConfiguration[1].file":         "log4j2-spring.xml",
+				"identity.extraConfiguration[1].springImport": "false",
+				"identity.extraConfiguration[1].content":      "<Configuration/>",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				applicationYaml := configmap.Data["application.yaml"]
+				// Only custom-spring.yaml should be in spring.config.import
+				s.Require().Contains(applicationYaml, "optional:file:/app/config/custom-spring.yaml",
+					"File without springImport should be included in spring.config.import")
+				s.Require().NotContains(applicationYaml, "log4j2-spring.xml",
+					"File with springImport: false should not be in spring.config.import")
+				// Both files should be in ConfigMap
+				s.Require().Contains(configmap.Data["custom-spring.yaml"], "some: config",
+					"First file content should be present in ConfigMap")
+				s.Require().Contains(configmap.Data["log4j2-spring.xml"], "<Configuration/>",
+					"Second file content should be present in ConfigMap even with springImport: false")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}

--- a/charts/camunda-platform-8.10/test/unit/identity/configmap_test.go
+++ b/charts/camunda-platform-8.10/test/unit/identity/configmap_test.go
@@ -535,6 +535,9 @@ func (s *configMapSpringTemplateTest) TestExtraConfigurationSpringImport() {
 				// spring.config.import should NOT include the file
 				s.Require().NotContains(applicationYaml, "log4j2-spring.xml",
 					"File with springImport: false should not be in spring.config.import")
+				// spring.config.import block should not be rendered
+				s.Require().NotContains(applicationYaml, "optional:file:",
+					"spring.config.import block should not be rendered when all entries have springImport: false")
 				// File content should still be in ConfigMap
 				s.Require().Contains(configmap.Data["log4j2-spring.xml"], "<Configuration/>",
 					"File content should be present in ConfigMap even with springImport: false")

--- a/charts/camunda-platform-8.10/test/unit/optimize/configmap_test.go
+++ b/charts/camunda-platform-8.10/test/unit/optimize/configmap_test.go
@@ -317,3 +317,84 @@ func (s *ConfigMapTemplateTest) TestDatabaseOverrides() {
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
+
+func (s *ConfigMapTemplateTest) TestExtraConfigurationSpringImport() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestExtraConfigWithSpringImportDefault",
+			Values: map[string]string{
+				"identity.enabled":                       "true",
+				"optimize.enabled":                       "true",
+				"optimize.extraConfiguration[0].file":    "custom-spring.yaml",
+				"optimize.extraConfiguration[0].content": "some: config",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				applicationCcsmYaml := configmap.Data["application-ccsm.yaml"]
+				// spring.config.import should include the file
+				s.Require().Contains(applicationCcsmYaml, "optional:file:/optimize/config/custom-spring.yaml",
+					"File without springImport should be included in spring.config.import")
+				// File content should be in ConfigMap
+				s.Require().Contains(configmap.Data["custom-spring.yaml"], "some: config",
+					"File content should be present in ConfigMap")
+			},
+		},
+		{
+			Name: "TestExtraConfigWithSpringImportFalse",
+			Values: map[string]string{
+				"identity.enabled":                            "true",
+				"optimize.enabled":                            "true",
+				"optimize.extraConfiguration[0].file":         "log4j2-spring.xml",
+				"optimize.extraConfiguration[0].springImport": "false",
+				"optimize.extraConfiguration[0].content":      "<Configuration/>",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				applicationCcsmYaml := configmap.Data["application-ccsm.yaml"]
+				// spring.config.import should NOT include the file
+				s.Require().NotContains(applicationCcsmYaml, "log4j2-spring.xml",
+					"File with springImport: false should not be in spring.config.import")
+				// spring.config.import block should not be rendered
+				s.Require().NotContains(applicationCcsmYaml, "config:",
+					"spring.config.import block should not be rendered when all entries have springImport: false")
+				// File content should still be in ConfigMap
+				s.Require().Contains(configmap.Data["log4j2-spring.xml"], "<Configuration/>",
+					"File content should be present in ConfigMap even with springImport: false")
+			},
+		},
+		{
+			Name: "TestExtraConfigMixedSpringImport",
+			Values: map[string]string{
+				"identity.enabled":                            "true",
+				"optimize.enabled":                            "true",
+				"optimize.extraConfiguration[0].file":         "custom-spring.yaml",
+				"optimize.extraConfiguration[0].content":      "some: config",
+				"optimize.extraConfiguration[1].file":         "log4j2-spring.xml",
+				"optimize.extraConfiguration[1].springImport": "false",
+				"optimize.extraConfiguration[1].content":      "<Configuration/>",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				applicationCcsmYaml := configmap.Data["application-ccsm.yaml"]
+				// Only custom-spring.yaml should be in spring.config.import
+				s.Require().Contains(applicationCcsmYaml, "optional:file:/optimize/config/custom-spring.yaml",
+					"File without springImport should be included in spring.config.import")
+				s.Require().NotContains(applicationCcsmYaml, "log4j2-spring.xml",
+					"File with springImport: false should not be in spring.config.import")
+				// Both files should be in ConfigMap
+				s.Require().Contains(configmap.Data["custom-spring.yaml"], "some: config",
+					"First file content should be present in ConfigMap")
+				s.Require().Contains(configmap.Data["log4j2-spring.xml"], "<Configuration/>",
+					"Second file content should be present in ConfigMap even with springImport: false")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}

--- a/charts/camunda-platform-8.10/test/unit/orchestration/configmap_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/configmap_test.go
@@ -119,3 +119,78 @@ func (s *ConfigmapLegacyTemplateTest) TestDifferentValuesInputs() {
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
+
+func (s *ConfigmapLegacyTemplateTest) TestExtraConfigurationSpringImport() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestExtraConfigWithSpringImportDefault",
+			Values: map[string]string{
+				"orchestration.extraConfiguration[0].file":    "custom-spring.yaml",
+				"orchestration.extraConfiguration[0].content": "some: config",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				applicationYaml := configmap.Data["application.yaml"]
+				// spring.config.import should include the file
+				s.Require().Contains(applicationYaml, "optional:file:/usr/local/camunda/config/custom-spring.yaml",
+					"File without springImport should be included in spring.config.import")
+				// File content should be in ConfigMap
+				s.Require().Contains(configmap.Data["custom-spring.yaml"], "some: config",
+					"File content should be present in ConfigMap")
+			},
+		},
+		{
+			Name: "TestExtraConfigWithSpringImportFalse",
+			Values: map[string]string{
+				"orchestration.extraConfiguration[0].file":         "log4j2-spring.xml",
+				"orchestration.extraConfiguration[0].springImport": "false",
+				"orchestration.extraConfiguration[0].content":      "<Configuration/>",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				applicationYaml := configmap.Data["application.yaml"]
+				// spring.config.import should NOT include the file
+				s.Require().NotContains(applicationYaml, "log4j2-spring.xml",
+					"File with springImport: false should not be in spring.config.import")
+				// spring.config.import block should not be rendered
+				s.Require().NotContains(applicationYaml, "config:\n      import:",
+					"spring.config.import block should not be rendered when all entries have springImport: false")
+				// File content should still be in ConfigMap
+				s.Require().Contains(configmap.Data["log4j2-spring.xml"], "<Configuration/>",
+					"File content should be present in ConfigMap even with springImport: false")
+			},
+		},
+		{
+			Name: "TestExtraConfigMixedSpringImport",
+			Values: map[string]string{
+				"orchestration.extraConfiguration[0].file":         "custom-spring.yaml",
+				"orchestration.extraConfiguration[0].content":      "some: config",
+				"orchestration.extraConfiguration[1].file":         "log4j2-spring.xml",
+				"orchestration.extraConfiguration[1].springImport": "false",
+				"orchestration.extraConfiguration[1].content":      "<Configuration/>",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				applicationYaml := configmap.Data["application.yaml"]
+				// Only custom-spring.yaml should be in spring.config.import
+				s.Require().Contains(applicationYaml, "optional:file:/usr/local/camunda/config/custom-spring.yaml",
+					"File without springImport should be included in spring.config.import")
+				s.Require().NotContains(applicationYaml, "log4j2-spring.xml",
+					"File with springImport: false should not be in spring.config.import")
+				// Both files should be in ConfigMap
+				s.Require().Contains(configmap.Data["custom-spring.yaml"], "some: config",
+					"First file content should be present in ConfigMap")
+				s.Require().Contains(configmap.Data["log4j2-spring.xml"], "<Configuration/>",
+					"Second file content should be present in ConfigMap even with springImport: false")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}

--- a/charts/camunda-platform-8.10/test/unit/orchestration/configmap_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/configmap_test.go
@@ -157,7 +157,7 @@ func (s *ConfigmapLegacyTemplateTest) TestExtraConfigurationSpringImport() {
 				s.Require().NotContains(applicationYaml, "log4j2-spring.xml",
 					"File with springImport: false should not be in spring.config.import")
 				// spring.config.import block should not be rendered
-				s.Require().NotContains(applicationYaml, "config:\n      import:",
+				s.Require().NotContains(applicationYaml, "optional:file:",
 					"spring.config.import block should not be rendered when all entries have springImport: false")
 				// File content should still be in ConfigMap
 				s.Require().Contains(configmap.Data["log4j2-spring.xml"], "<Configuration/>",

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/configmap_restapi_test.go
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/configmap_restapi_test.go
@@ -937,3 +937,90 @@ func (s *configmapRestAPITemplateTest) TestGlobalIngressHostTemplating() {
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
+
+func (s *configmapRestAPITemplateTest) TestExtraConfigurationSpringImport() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestExtraConfigWithSpringImportDefault",
+			Values: map[string]string{
+				"identity.enabled":                                 "true",
+				"webModeler.enabled":                               "true",
+				"webModeler.restapi.mail.fromAddress":              "example@example.com",
+				"webModeler.restapi.extraConfiguration[0].file":    "custom-spring.yaml",
+				"webModeler.restapi.extraConfiguration[0].content": "some: config",
+				"global.elasticsearch.enabled":                     "true",
+				"elasticsearch.enabled":                            "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				applicationYaml := configmap.Data["application.yaml"]
+				// spring.config.import should include the file
+				s.Require().Contains(applicationYaml, "optional:file:/home/runner/config/custom-spring.yaml",
+					"File without springImport should be included in spring.config.import")
+				// File content should be in ConfigMap
+				s.Require().Contains(configmap.Data["custom-spring.yaml"], "some: config",
+					"File content should be present in ConfigMap")
+			},
+		},
+		{
+			Name: "TestExtraConfigWithSpringImportFalse",
+			Values: map[string]string{
+				"identity.enabled":                                      "true",
+				"webModeler.enabled":                                    "true",
+				"webModeler.restapi.mail.fromAddress":                   "example@example.com",
+				"webModeler.restapi.extraConfiguration[0].file":         "log4j2-spring.xml",
+				"webModeler.restapi.extraConfiguration[0].springImport": "false",
+				"webModeler.restapi.extraConfiguration[0].content":      "<Configuration/>",
+				"global.elasticsearch.enabled":                          "true",
+				"elasticsearch.enabled":                                 "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				applicationYaml := configmap.Data["application.yaml"]
+				// spring.config.import should NOT include the file
+				s.Require().NotContains(applicationYaml, "log4j2-spring.xml",
+					"File with springImport: false should not be in spring.config.import")
+				// File content should still be in ConfigMap
+				s.Require().Contains(configmap.Data["log4j2-spring.xml"], "<Configuration/>",
+					"File content should be present in ConfigMap even with springImport: false")
+			},
+		},
+		{
+			Name: "TestExtraConfigMixedSpringImport",
+			Values: map[string]string{
+				"identity.enabled":                                      "true",
+				"webModeler.enabled":                                    "true",
+				"webModeler.restapi.mail.fromAddress":                   "example@example.com",
+				"webModeler.restapi.extraConfiguration[0].file":         "custom-spring.yaml",
+				"webModeler.restapi.extraConfiguration[0].content":      "some: config",
+				"webModeler.restapi.extraConfiguration[1].file":         "log4j2-spring.xml",
+				"webModeler.restapi.extraConfiguration[1].springImport": "false",
+				"webModeler.restapi.extraConfiguration[1].content":      "<Configuration/>",
+				"global.elasticsearch.enabled":                          "true",
+				"elasticsearch.enabled":                                 "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				applicationYaml := configmap.Data["application.yaml"]
+				// Only custom-spring.yaml should be in spring.config.import
+				s.Require().Contains(applicationYaml, "optional:file:/home/runner/config/custom-spring.yaml",
+					"File without springImport should be included in spring.config.import")
+				s.Require().NotContains(applicationYaml, "log4j2-spring.xml",
+					"File with springImport: false should not be in spring.config.import")
+				// Both files should be in ConfigMap
+				s.Require().Contains(configmap.Data["custom-spring.yaml"], "some: config",
+					"First file content should be present in ConfigMap")
+				s.Require().Contains(configmap.Data["log4j2-spring.xml"], "<Configuration/>",
+					"Second file content should be present in ConfigMap even with springImport: false")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/configmap_restapi_test.go
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/configmap_restapi_test.go
@@ -984,6 +984,9 @@ func (s *configmapRestAPITemplateTest) TestExtraConfigurationSpringImport() {
 				// spring.config.import should NOT include the file
 				s.Require().NotContains(applicationYaml, "log4j2-spring.xml",
 					"File with springImport: false should not be in spring.config.import")
+				// spring.config.import block should not be rendered
+				s.Require().NotContains(applicationYaml, "optional:file:",
+					"spring.config.import block should not be rendered when all entries have springImport: false")
 				// File content should still be in ConfigMap
 				s.Require().Contains(configmap.Data["log4j2-spring.xml"], "<Configuration/>",
 					"File content should be present in ConfigMap even with springImport: false")

--- a/charts/camunda-platform-8.10/values.yaml
+++ b/charts/camunda-platform-8.10/values.yaml
@@ -998,6 +998,8 @@ identity:
   ## @param identity.configuration if specified, contents will be used as the application.yaml
   configuration: ""
   ## @param identity.extraConfiguration if specified, contents will be used for any extra configuration files such as the log4j2.xml
+  ## Each entry has: file (filename), content (file contents), and optional springImport (bool, default true).
+  ## Set springImport to false to mount the file without adding it to spring.config.import (e.g. for log4j2.xml).
   extraConfiguration: []
   ## @param identity.dnsPolicy https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
   dnsPolicy: ""
@@ -1817,6 +1819,8 @@ webModeler:
     ## @param webModeler.restapi.configuration if specified, contents will be used as the application.yaml
     configuration: ""
     ## @param webModeler.restapi.extraConfiguration if specified, contents will be used for any extra configuration files such as log4j2.xml
+    ## Each entry has: file (filename), content (file contents), and optional springImport (bool, default true).
+    ## Set springImport to false to mount the file without adding it to spring.config.import (e.g. for log4j2.xml).
     extraConfiguration: []
     ## @param webModeler.restapi.dnsPolicy https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
     dnsPolicy: ""
@@ -2331,6 +2335,8 @@ connectors:
   ## @param connectors.configuration if specified, contents will be used as the application.yaml
   configuration: ""
   ## @param connectors.extraConfiguration if specified, contents will be used for any extra configuration files such as the log4j2.xml
+  ## Each entry has: file (filename), content (file contents), and optional springImport (bool, default true).
+  ## Set springImport to false to mount the file without adding it to spring.config.import (e.g. for log4j2.xml).
   extraConfiguration: []
   ## @param connectors.dnsPolicy https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
   dnsPolicy: ""
@@ -2978,6 +2984,8 @@ orchestration:
   ## @param orchestration.configuration if specified, contents will be used as the application.yaml
   configuration: ""
   ## @param orchestration.extraConfiguration if specified, contents will be used for any extra configuration files such as log4j2.xml
+  ## Each entry has: file (filename), content (file contents), and optional springImport (bool, default true).
+  ## Set springImport to false to mount the file without adding it to spring.config.import (e.g. for log4j2.xml).
   extraConfiguration: []
   ## @param orchestration.dnsPolicy https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
   dnsPolicy: ""
@@ -3303,6 +3311,8 @@ optimize:
   ## @param optimize.configuration if specified, contents will be used as the environment-config.yaml
   configuration: ""
   ## @param optimize.extraConfiguration if specified, contents will be used for any extra configuration files such as environment-logback.xml
+  ## Each entry has: file (filename), content (file contents), and optional springImport (bool, default true).
+  ## Set springImport to false to mount the file without adding it to spring.config.import (e.g. for logback.xml).
   extraConfiguration: []
   ## @param optimize.dnsPolicy https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
   dnsPolicy: ""

--- a/charts/camunda-platform-8.9/templates/connectors/files/_application.yaml
+++ b/charts/camunda-platform-8.9/templates/connectors/files/_application.yaml
@@ -25,11 +25,17 @@ management:
           - processDefinitionImport
           - zeebeClient
 
-{{- if .Values.connectors.extraConfiguration }}
+{{- $springImports := list }}
+{{- range .Values.connectors.extraConfiguration }}
+  {{- if not (and (hasKey . "springImport") (eq .springImport false)) }}
+    {{- $springImports = append $springImports . }}
+  {{- end }}
+{{- end }}
+{{- if $springImports }}
 spring:
   config:
     import:
-    {{- range .Values.connectors.extraConfiguration }}
+    {{- range $springImports }}
       - optional:file:/config/{{ .file }}
     {{- end }}
 {{- end }}

--- a/charts/camunda-platform-8.9/templates/identity/configmap.yaml
+++ b/charts/camunda-platform-8.9/templates/identity/configmap.yaml
@@ -322,10 +322,16 @@ data:
       {{- end }}
 
     spring:
-    {{- if .Values.identity.extraConfiguration }}
+    {{- $springImports := list }}
+    {{- range .Values.identity.extraConfiguration }}
+      {{- if not (and (hasKey . "springImport") (eq .springImport false)) }}
+        {{- $springImports = append $springImports . }}
+      {{- end }}
+    {{- end }}
+    {{- if $springImports }}
       config:
         import:
-        {{- range .Values.identity.extraConfiguration }}
+        {{- range $springImports }}
           - optional:file:/app/config/{{ .file }}
         {{- end }}
     {{- end }}

--- a/charts/camunda-platform-8.9/templates/optimize/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/optimize/_helpers.tpl
@@ -135,11 +135,14 @@ When neither backend is explicitly enabled, falls back to "zeebe-record".
 
 {{/*
 [optimize] Build a comma-separated spring.config.import line from extraConfiguration files.
+Entries with springImport: false are excluded.
 */}}
 {{- define "optimize.springConfigImport" -}}
 {{- $imports := list -}}
 {{- range .Values.optimize.extraConfiguration -}}
-  {{- $imports = append $imports (printf "optional:file:/optimize/config/%s" .file) -}}
+  {{- if not (and (hasKey . "springImport") (eq .springImport false)) -}}
+    {{- $imports = append $imports (printf "optional:file:/optimize/config/%s" .file) -}}
+  {{- end -}}
 {{- end -}}
 {{- join "," $imports -}}
 {{- end -}}

--- a/charts/camunda-platform-8.9/templates/optimize/configmap.yaml
+++ b/charts/camunda-platform-8.9/templates/optimize/configmap.yaml
@@ -14,10 +14,11 @@ data:
   {{- end }}
   {{- if or .Values.global.identity.auth.enabled .Values.optimize.extraConfiguration }}
   application-ccsm.yaml: |
-    {{- if .Values.optimize.extraConfiguration }}
+    {{- $springImport := include "optimize.springConfigImport" . }}
+    {{- if $springImport }}
     spring:
       config:
-        import: {{ include "optimize.springConfigImport" . }}
+        import: {{ $springImport }}
     {{- end }}
     {{- if .Values.global.identity.auth.enabled }}
     camunda:

--- a/charts/camunda-platform-8.9/templates/orchestration/files/_application.yaml
+++ b/charts/camunda-platform-8.9/templates/orchestration/files/_application.yaml
@@ -3,10 +3,16 @@ This file name should start with an underscore to avoid rendering it as a templa
 It is included (imported) in the ConfigMap.
 */}}
 spring:
-  {{- if .Values.orchestration.extraConfiguration }}
+  {{- $springImports := list }}
+  {{- range .Values.orchestration.extraConfiguration }}
+    {{- if not (and (hasKey . "springImport") (eq .springImport false)) }}
+      {{- $springImports = append $springImports . }}
+    {{- end }}
+  {{- end }}
+  {{- if $springImports }}
   config:
     import:
-    {{- range .Values.orchestration.extraConfiguration }}
+    {{- range $springImports }}
       - optional:file:/usr/local/camunda/config/{{ .file }}
     {{- end }}
   {{- end }}

--- a/charts/camunda-platform-8.9/templates/web-modeler/configmap-restapi.yaml
+++ b/charts/camunda-platform-8.9/templates/web-modeler/configmap-restapi.yaml
@@ -79,10 +79,16 @@ data:
         {{- end }}
 
     spring:
-      {{- if .Values.webModeler.restapi.extraConfiguration }}
+      {{- $springImports := list }}
+      {{- range .Values.webModeler.restapi.extraConfiguration }}
+        {{- if not (and (hasKey . "springImport") (eq .springImport false)) }}
+          {{- $springImports = append $springImports . }}
+        {{- end }}
+      {{- end }}
+      {{- if $springImports }}
       config:
         import:
-        {{- range .Values.webModeler.restapi.extraConfiguration }}
+        {{- range $springImports }}
           - optional:file:/home/runner/config/{{ .file }}
         {{- end }}
       {{- end }}

--- a/charts/camunda-platform-8.9/test/unit/connectors/configmap_test.go
+++ b/charts/camunda-platform-8.9/test/unit/connectors/configmap_test.go
@@ -128,6 +128,84 @@ func (s *ConfigMapTemplateTest) TestDifferentValuesInputs() {
 	testhelpers.RunTestCases(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
 
+func (s *ConfigMapTemplateTest) TestExtraConfigurationSpringImport() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestExtraConfigWithSpringImportDefault",
+			Values: map[string]string{
+				"connectors.enabled":                       "true",
+				"connectors.extraConfiguration[0].file":    "custom-spring.yaml",
+				"connectors.extraConfiguration[0].content": "some: config",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				applicationYaml := configmap.Data["application.yaml"]
+				// spring.config.import should include the file
+				s.Require().Contains(applicationYaml, "optional:file:/config/custom-spring.yaml",
+					"File without springImport should be included in spring.config.import")
+				// File content should be in ConfigMap
+				s.Require().Contains(configmap.Data["custom-spring.yaml"], "some: config",
+					"File content should be present in ConfigMap")
+			},
+		},
+		{
+			Name: "TestExtraConfigWithSpringImportFalse",
+			Values: map[string]string{
+				"connectors.enabled":                            "true",
+				"connectors.extraConfiguration[0].file":         "log4j2-spring.xml",
+				"connectors.extraConfiguration[0].springImport": "false",
+				"connectors.extraConfiguration[0].content":      "<Configuration/>",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				applicationYaml := configmap.Data["application.yaml"]
+				// spring.config.import should NOT include the file
+				s.Require().NotContains(applicationYaml, "log4j2-spring.xml",
+					"File with springImport: false should not be in spring.config.import")
+				// spring.config.import block should not be rendered at all
+				s.Require().NotContains(applicationYaml, "config:",
+					"spring.config.import block should not be rendered when all entries have springImport: false")
+				// File content should still be in ConfigMap
+				s.Require().Contains(configmap.Data["log4j2-spring.xml"], "<Configuration/>",
+					"File content should be present in ConfigMap even with springImport: false")
+			},
+		},
+		{
+			Name: "TestExtraConfigMixedSpringImport",
+			Values: map[string]string{
+				"connectors.enabled":                            "true",
+				"connectors.extraConfiguration[0].file":         "custom-spring.yaml",
+				"connectors.extraConfiguration[0].content":      "some: config",
+				"connectors.extraConfiguration[1].file":         "log4j2-spring.xml",
+				"connectors.extraConfiguration[1].springImport": "false",
+				"connectors.extraConfiguration[1].content":      "<Configuration/>",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				applicationYaml := configmap.Data["application.yaml"]
+				// Only custom-spring.yaml should be in spring.config.import
+				s.Require().Contains(applicationYaml, "optional:file:/config/custom-spring.yaml",
+					"File without springImport should be included in spring.config.import")
+				s.Require().NotContains(applicationYaml, "log4j2-spring.xml",
+					"File with springImport: false should not be in spring.config.import")
+				// Both files should be in ConfigMap
+				s.Require().Contains(configmap.Data["custom-spring.yaml"], "some: config",
+					"First file content should be present in ConfigMap")
+				s.Require().Contains(configmap.Data["log4j2-spring.xml"], "<Configuration/>",
+					"Second file content should be present in ConfigMap even with springImport: false")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
 // // TODO: Refactor the tests to work with the new Connectors config.
 // func (s *configMapTemplateTest) TestContainerConfigMapSetInboundModeCredentials() {
 // 	// given

--- a/charts/camunda-platform-8.9/test/unit/identity/configmap_test.go
+++ b/charts/camunda-platform-8.9/test/unit/identity/configmap_test.go
@@ -281,14 +281,14 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 			Name:                 "TestKeycloakAdminUserCustom",
 			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
 			Values: map[string]string{
-				"identity.enabled":                                "true",
-				"identityKeycloak.enabled":                        "false",
-				"global.identity.auth.enabled":                    "true",
-				"global.identity.keycloak.url.protocol":           "https",
-				"global.identity.keycloak.url.host":               "keycloak.example.com",
-				"global.identity.keycloak.url.port":               "8443",
-				"global.identity.keycloak.auth.adminUser":         "customAdmin",
-				"global.identity.keycloak.auth.existingSecret":    "some-secret",
+				"identity.enabled":                             "true",
+				"identityKeycloak.enabled":                     "false",
+				"global.identity.auth.enabled":                 "true",
+				"global.identity.keycloak.url.protocol":        "https",
+				"global.identity.keycloak.url.host":            "keycloak.example.com",
+				"global.identity.keycloak.url.port":            "8443",
+				"global.identity.keycloak.auth.adminUser":      "customAdmin",
+				"global.identity.keycloak.auth.existingSecret": "some-secret",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var configmap corev1.ConfigMap
@@ -489,6 +489,81 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 					"Optimize secret should not be present when optimize.enabled=false")
 				s.Require().NotContains(applicationYaml, "optimize-api",
 					"Optimize API should not be present when optimize.enabled=false")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
+func (s *configMapSpringTemplateTest) TestExtraConfigurationSpringImport() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestExtraConfigWithSpringImportDefault",
+			Values: map[string]string{
+				"identity.enabled":                       "true",
+				"identity.extraConfiguration[0].file":    "custom-spring.yaml",
+				"identity.extraConfiguration[0].content": "some: config",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				applicationYaml := configmap.Data["application.yaml"]
+				// spring.config.import should include the file
+				s.Require().Contains(applicationYaml, "optional:file:/app/config/custom-spring.yaml",
+					"File without springImport should be included in spring.config.import")
+				// File content should be in ConfigMap
+				s.Require().Contains(configmap.Data["custom-spring.yaml"], "some: config",
+					"File content should be present in ConfigMap")
+			},
+		},
+		{
+			Name: "TestExtraConfigWithSpringImportFalse",
+			Values: map[string]string{
+				"identity.enabled":                            "true",
+				"identity.extraConfiguration[0].file":         "log4j2-spring.xml",
+				"identity.extraConfiguration[0].springImport": "false",
+				"identity.extraConfiguration[0].content":      "<Configuration/>",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				applicationYaml := configmap.Data["application.yaml"]
+				// spring.config.import should NOT include the file
+				s.Require().NotContains(applicationYaml, "log4j2-spring.xml",
+					"File with springImport: false should not be in spring.config.import")
+				// File content should still be in ConfigMap
+				s.Require().Contains(configmap.Data["log4j2-spring.xml"], "<Configuration/>",
+					"File content should be present in ConfigMap even with springImport: false")
+			},
+		},
+		{
+			Name: "TestExtraConfigMixedSpringImport",
+			Values: map[string]string{
+				"identity.enabled":                            "true",
+				"identity.extraConfiguration[0].file":         "custom-spring.yaml",
+				"identity.extraConfiguration[0].content":      "some: config",
+				"identity.extraConfiguration[1].file":         "log4j2-spring.xml",
+				"identity.extraConfiguration[1].springImport": "false",
+				"identity.extraConfiguration[1].content":      "<Configuration/>",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				applicationYaml := configmap.Data["application.yaml"]
+				// Only custom-spring.yaml should be in spring.config.import
+				s.Require().Contains(applicationYaml, "optional:file:/app/config/custom-spring.yaml",
+					"File without springImport should be included in spring.config.import")
+				s.Require().NotContains(applicationYaml, "log4j2-spring.xml",
+					"File with springImport: false should not be in spring.config.import")
+				// Both files should be in ConfigMap
+				s.Require().Contains(configmap.Data["custom-spring.yaml"], "some: config",
+					"First file content should be present in ConfigMap")
+				s.Require().Contains(configmap.Data["log4j2-spring.xml"], "<Configuration/>",
+					"Second file content should be present in ConfigMap even with springImport: false")
 			},
 		},
 	}

--- a/charts/camunda-platform-8.9/test/unit/identity/configmap_test.go
+++ b/charts/camunda-platform-8.9/test/unit/identity/configmap_test.go
@@ -534,6 +534,9 @@ func (s *configMapSpringTemplateTest) TestExtraConfigurationSpringImport() {
 				// spring.config.import should NOT include the file
 				s.Require().NotContains(applicationYaml, "log4j2-spring.xml",
 					"File with springImport: false should not be in spring.config.import")
+				// spring.config.import block should not be rendered
+				s.Require().NotContains(applicationYaml, "optional:file:",
+					"spring.config.import block should not be rendered when all entries have springImport: false")
 				// File content should still be in ConfigMap
 				s.Require().Contains(configmap.Data["log4j2-spring.xml"], "<Configuration/>",
 					"File content should be present in ConfigMap even with springImport: false")

--- a/charts/camunda-platform-8.9/test/unit/optimize/configmap_test.go
+++ b/charts/camunda-platform-8.9/test/unit/optimize/configmap_test.go
@@ -314,3 +314,84 @@ func (s *ConfigMapTemplateTest) TestDatabaseOverrides() {
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
+
+func (s *ConfigMapTemplateTest) TestExtraConfigurationSpringImport() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestExtraConfigWithSpringImportDefault",
+			Values: map[string]string{
+				"identity.enabled":                       "true",
+				"optimize.enabled":                       "true",
+				"optimize.extraConfiguration[0].file":    "custom-spring.yaml",
+				"optimize.extraConfiguration[0].content": "some: config",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				applicationCcsmYaml := configmap.Data["application-ccsm.yaml"]
+				// spring.config.import should include the file
+				s.Require().Contains(applicationCcsmYaml, "optional:file:/optimize/config/custom-spring.yaml",
+					"File without springImport should be included in spring.config.import")
+				// File content should be in ConfigMap
+				s.Require().Contains(configmap.Data["custom-spring.yaml"], "some: config",
+					"File content should be present in ConfigMap")
+			},
+		},
+		{
+			Name: "TestExtraConfigWithSpringImportFalse",
+			Values: map[string]string{
+				"identity.enabled":                            "true",
+				"optimize.enabled":                            "true",
+				"optimize.extraConfiguration[0].file":         "log4j2-spring.xml",
+				"optimize.extraConfiguration[0].springImport": "false",
+				"optimize.extraConfiguration[0].content":      "<Configuration/>",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				applicationCcsmYaml := configmap.Data["application-ccsm.yaml"]
+				// spring.config.import should NOT include the file
+				s.Require().NotContains(applicationCcsmYaml, "log4j2-spring.xml",
+					"File with springImport: false should not be in spring.config.import")
+				// spring.config.import block should not be rendered
+				s.Require().NotContains(applicationCcsmYaml, "config:",
+					"spring.config.import block should not be rendered when all entries have springImport: false")
+				// File content should still be in ConfigMap
+				s.Require().Contains(configmap.Data["log4j2-spring.xml"], "<Configuration/>",
+					"File content should be present in ConfigMap even with springImport: false")
+			},
+		},
+		{
+			Name: "TestExtraConfigMixedSpringImport",
+			Values: map[string]string{
+				"identity.enabled":                            "true",
+				"optimize.enabled":                            "true",
+				"optimize.extraConfiguration[0].file":         "custom-spring.yaml",
+				"optimize.extraConfiguration[0].content":      "some: config",
+				"optimize.extraConfiguration[1].file":         "log4j2-spring.xml",
+				"optimize.extraConfiguration[1].springImport": "false",
+				"optimize.extraConfiguration[1].content":      "<Configuration/>",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				applicationCcsmYaml := configmap.Data["application-ccsm.yaml"]
+				// Only custom-spring.yaml should be in spring.config.import
+				s.Require().Contains(applicationCcsmYaml, "optional:file:/optimize/config/custom-spring.yaml",
+					"File without springImport should be included in spring.config.import")
+				s.Require().NotContains(applicationCcsmYaml, "log4j2-spring.xml",
+					"File with springImport: false should not be in spring.config.import")
+				// Both files should be in ConfigMap
+				s.Require().Contains(configmap.Data["custom-spring.yaml"], "some: config",
+					"First file content should be present in ConfigMap")
+				s.Require().Contains(configmap.Data["log4j2-spring.xml"], "<Configuration/>",
+					"Second file content should be present in ConfigMap even with springImport: false")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}

--- a/charts/camunda-platform-8.9/test/unit/orchestration/configmap_test.go
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/configmap_test.go
@@ -157,7 +157,7 @@ func (s *ConfigmapLegacyTemplateTest) TestExtraConfigurationSpringImport() {
 				s.Require().NotContains(applicationYaml, "log4j2-spring.xml",
 					"File with springImport: false should not be in spring.config.import")
 				// spring.config.import block should not be rendered
-				s.Require().NotContains(applicationYaml, "config:\n      import:",
+				s.Require().NotContains(applicationYaml, "optional:file:",
 					"spring.config.import block should not be rendered when all entries have springImport: false")
 				// File content should still be in ConfigMap
 				s.Require().Contains(configmap.Data["log4j2-spring.xml"], "<Configuration/>",

--- a/charts/camunda-platform-8.9/test/unit/orchestration/configmap_test.go
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/configmap_test.go
@@ -84,7 +84,6 @@ func TestGoldenConfigmapWithAuthorizationsEnabled(t *testing.T) {
 	})
 }
 
-
 func TestGoldenConfigmapWithHistoryRetentionEnabled(t *testing.T) {
 	t.Parallel()
 
@@ -112,9 +111,83 @@ func (s *ConfigmapLegacyTemplateTest) TestDifferentValuesInputs() {
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 				helm.UnmarshalK8SYaml(s.T(), configmap.Data["application.yaml"], &configmapApplication)
 
-
 				// then
 				s.Require().Equal("io.camunda.exporter.CamundaExporter", configmapApplication.Zeebe.Broker.Exporters.CamundaExporter.ClassName)
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
+func (s *ConfigmapLegacyTemplateTest) TestExtraConfigurationSpringImport() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestExtraConfigWithSpringImportDefault",
+			Values: map[string]string{
+				"orchestration.extraConfiguration[0].file":    "custom-spring.yaml",
+				"orchestration.extraConfiguration[0].content": "some: config",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				applicationYaml := configmap.Data["application.yaml"]
+				// spring.config.import should include the file
+				s.Require().Contains(applicationYaml, "optional:file:/usr/local/camunda/config/custom-spring.yaml",
+					"File without springImport should be included in spring.config.import")
+				// File content should be in ConfigMap
+				s.Require().Contains(configmap.Data["custom-spring.yaml"], "some: config",
+					"File content should be present in ConfigMap")
+			},
+		},
+		{
+			Name: "TestExtraConfigWithSpringImportFalse",
+			Values: map[string]string{
+				"orchestration.extraConfiguration[0].file":         "log4j2-spring.xml",
+				"orchestration.extraConfiguration[0].springImport": "false",
+				"orchestration.extraConfiguration[0].content":      "<Configuration/>",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				applicationYaml := configmap.Data["application.yaml"]
+				// spring.config.import should NOT include the file
+				s.Require().NotContains(applicationYaml, "log4j2-spring.xml",
+					"File with springImport: false should not be in spring.config.import")
+				// spring.config.import block should not be rendered
+				s.Require().NotContains(applicationYaml, "config:\n      import:",
+					"spring.config.import block should not be rendered when all entries have springImport: false")
+				// File content should still be in ConfigMap
+				s.Require().Contains(configmap.Data["log4j2-spring.xml"], "<Configuration/>",
+					"File content should be present in ConfigMap even with springImport: false")
+			},
+		},
+		{
+			Name: "TestExtraConfigMixedSpringImport",
+			Values: map[string]string{
+				"orchestration.extraConfiguration[0].file":         "custom-spring.yaml",
+				"orchestration.extraConfiguration[0].content":      "some: config",
+				"orchestration.extraConfiguration[1].file":         "log4j2-spring.xml",
+				"orchestration.extraConfiguration[1].springImport": "false",
+				"orchestration.extraConfiguration[1].content":      "<Configuration/>",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				applicationYaml := configmap.Data["application.yaml"]
+				// Only custom-spring.yaml should be in spring.config.import
+				s.Require().Contains(applicationYaml, "optional:file:/usr/local/camunda/config/custom-spring.yaml",
+					"File without springImport should be included in spring.config.import")
+				s.Require().NotContains(applicationYaml, "log4j2-spring.xml",
+					"File with springImport: false should not be in spring.config.import")
+				// Both files should be in ConfigMap
+				s.Require().Contains(configmap.Data["custom-spring.yaml"], "some: config",
+					"First file content should be present in ConfigMap")
+				s.Require().Contains(configmap.Data["log4j2-spring.xml"], "<Configuration/>",
+					"Second file content should be present in ConfigMap even with springImport: false")
 			},
 		},
 	}

--- a/charts/camunda-platform-8.9/test/unit/web-modeler/configmap_restapi_test.go
+++ b/charts/camunda-platform-8.9/test/unit/web-modeler/configmap_restapi_test.go
@@ -1018,6 +1018,9 @@ func (s *configmapRestAPITemplateTest) TestExtraConfigurationSpringImport() {
 				// spring.config.import should NOT include the file
 				s.Require().NotContains(applicationYaml, "log4j2-spring.xml",
 					"File with springImport: false should not be in spring.config.import")
+				// spring.config.import block should not be rendered
+				s.Require().NotContains(applicationYaml, "optional:file:",
+					"spring.config.import block should not be rendered when all entries have springImport: false")
 				// File content should still be in ConfigMap
 				s.Require().Contains(configmap.Data["log4j2-spring.xml"], "<Configuration/>",
 					"File content should be present in ConfigMap even with springImport: false")

--- a/charts/camunda-platform-8.9/test/unit/web-modeler/configmap_restapi_test.go
+++ b/charts/camunda-platform-8.9/test/unit/web-modeler/configmap_restapi_test.go
@@ -971,3 +971,90 @@ func (s *configmapRestAPITemplateTest) TestGlobalIngressHostTemplating() {
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
+
+func (s *configmapRestAPITemplateTest) TestExtraConfigurationSpringImport() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestExtraConfigWithSpringImportDefault",
+			Values: map[string]string{
+				"identity.enabled":                                 "true",
+				"webModeler.enabled":                               "true",
+				"webModeler.restapi.mail.fromAddress":              "example@example.com",
+				"webModeler.restapi.extraConfiguration[0].file":    "custom-spring.yaml",
+				"webModeler.restapi.extraConfiguration[0].content": "some: config",
+				"global.elasticsearch.enabled":                     "true",
+				"elasticsearch.enabled":                            "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				applicationYaml := configmap.Data["application.yaml"]
+				// spring.config.import should include the file
+				s.Require().Contains(applicationYaml, "optional:file:/home/runner/config/custom-spring.yaml",
+					"File without springImport should be included in spring.config.import")
+				// File content should be in ConfigMap
+				s.Require().Contains(configmap.Data["custom-spring.yaml"], "some: config",
+					"File content should be present in ConfigMap")
+			},
+		},
+		{
+			Name: "TestExtraConfigWithSpringImportFalse",
+			Values: map[string]string{
+				"identity.enabled":                                      "true",
+				"webModeler.enabled":                                    "true",
+				"webModeler.restapi.mail.fromAddress":                   "example@example.com",
+				"webModeler.restapi.extraConfiguration[0].file":         "log4j2-spring.xml",
+				"webModeler.restapi.extraConfiguration[0].springImport": "false",
+				"webModeler.restapi.extraConfiguration[0].content":      "<Configuration/>",
+				"global.elasticsearch.enabled":                          "true",
+				"elasticsearch.enabled":                                 "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				applicationYaml := configmap.Data["application.yaml"]
+				// spring.config.import should NOT include the file
+				s.Require().NotContains(applicationYaml, "log4j2-spring.xml",
+					"File with springImport: false should not be in spring.config.import")
+				// File content should still be in ConfigMap
+				s.Require().Contains(configmap.Data["log4j2-spring.xml"], "<Configuration/>",
+					"File content should be present in ConfigMap even with springImport: false")
+			},
+		},
+		{
+			Name: "TestExtraConfigMixedSpringImport",
+			Values: map[string]string{
+				"identity.enabled":                                      "true",
+				"webModeler.enabled":                                    "true",
+				"webModeler.restapi.mail.fromAddress":                   "example@example.com",
+				"webModeler.restapi.extraConfiguration[0].file":         "custom-spring.yaml",
+				"webModeler.restapi.extraConfiguration[0].content":      "some: config",
+				"webModeler.restapi.extraConfiguration[1].file":         "log4j2-spring.xml",
+				"webModeler.restapi.extraConfiguration[1].springImport": "false",
+				"webModeler.restapi.extraConfiguration[1].content":      "<Configuration/>",
+				"global.elasticsearch.enabled":                          "true",
+				"elasticsearch.enabled":                                 "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				applicationYaml := configmap.Data["application.yaml"]
+				// Only custom-spring.yaml should be in spring.config.import
+				s.Require().Contains(applicationYaml, "optional:file:/home/runner/config/custom-spring.yaml",
+					"File without springImport should be included in spring.config.import")
+				s.Require().NotContains(applicationYaml, "log4j2-spring.xml",
+					"File with springImport: false should not be in spring.config.import")
+				// Both files should be in ConfigMap
+				s.Require().Contains(configmap.Data["custom-spring.yaml"], "some: config",
+					"First file content should be present in ConfigMap")
+				s.Require().Contains(configmap.Data["log4j2-spring.xml"], "<Configuration/>",
+					"Second file content should be present in ConfigMap even with springImport: false")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}

--- a/charts/camunda-platform-8.9/values.yaml
+++ b/charts/camunda-platform-8.9/values.yaml
@@ -1010,6 +1010,8 @@ identity:
   ## @param identity.configuration if specified, contents will be used as the application.yaml
   configuration: ""
   ## @param identity.extraConfiguration if specified, contents will be used for any extra configuration files such as the log4j2.xml
+  ## Each entry has: file (filename), content (file contents), and optional springImport (bool, default true).
+  ## Set springImport to false to mount the file without adding it to spring.config.import (e.g. for log4j2.xml).
   extraConfiguration: []
   ## @param identity.dnsPolicy https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
   dnsPolicy: ""
@@ -1835,6 +1837,8 @@ webModeler:
     ## @param webModeler.restapi.configuration if specified, contents will be used as the application.yaml
     configuration: ""
     ## @param webModeler.restapi.extraConfiguration if specified, contents will be used for any extra configuration files such as log4j2.xml
+    ## Each entry has: file (filename), content (file contents), and optional springImport (bool, default true).
+    ## Set springImport to false to mount the file without adding it to spring.config.import (e.g. for log4j2.xml).
     extraConfiguration: []
     ## @param webModeler.restapi.dnsPolicy https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
     dnsPolicy: ""
@@ -2349,6 +2353,8 @@ connectors:
   ## @param connectors.configuration if specified, contents will be used as the application.yaml
   configuration: ""
   ## @param connectors.extraConfiguration if specified, contents will be used for any extra configuration files such as the log4j2.xml
+  ## Each entry has: file (filename), content (file contents), and optional springImport (bool, default true).
+  ## Set springImport to false to mount the file without adding it to spring.config.import (e.g. for log4j2.xml).
   extraConfiguration: []
   ## @param connectors.dnsPolicy https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
   dnsPolicy: ""
@@ -2998,6 +3004,8 @@ orchestration:
   ## @param orchestration.configuration if specified, contents will be used as the application.yaml
   configuration: ""
   ## @param orchestration.extraConfiguration if specified, contents will be used for any extra configuration files such as log4j2.xml
+  ## Each entry has: file (filename), content (file contents), and optional springImport (bool, default true).
+  ## Set springImport to false to mount the file without adding it to spring.config.import (e.g. for log4j2.xml).
   extraConfiguration: []
   ## @param orchestration.dnsPolicy https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
   dnsPolicy: ""
@@ -3323,6 +3331,8 @@ optimize:
   ## @param optimize.configuration if specified, contents will be used as the environment-config.yaml
   configuration: ""
   ## @param optimize.extraConfiguration if specified, contents will be used for any extra configuration files such as environment-logback.xml
+  ## Each entry has: file (filename), content (file contents), and optional springImport (bool, default true).
+  ## Set springImport to false to mount the file without adding it to spring.config.import (e.g. for logback.xml).
   extraConfiguration: []
   ## @param optimize.dnsPolicy https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
   dnsPolicy: ""


### PR DESCRIPTION
Closes https://github.com/camunda/camunda-platform-helm/issues/5616

Adds optional `springImport` boolean (default `true`) to `extraConfiguration` entries. When `false`, the file is still mounted but excluded from `spring.config.import`.

Applies to connectors, orchestration, identity, optimize, web-modeler (restapi) for both 8.9 and 8.10.