### PR TITLE
ci: remove secret prefix from connectors

### DIFF
--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/base-qa.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/base-qa.yaml
@@ -129,6 +129,8 @@ connectors:
     authentication:
       method: oidc
   env:
+    - name: CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_PREFIX
+      value: ""
     - name: username
       value: username
     - name: password

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/base-qa.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/base-qa.yaml
@@ -113,6 +113,8 @@ connectors:
     authentication:
       method: oidc
   env:
+    - name: CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_PREFIX
+      value: ""
     - name: username
       value: username
     - name: password


### PR DESCRIPTION
relevant slack thread:
https://camunda.slack.com/archives/C02JLRNQQ05/p1775042436755489

This pull request adds a new environment variable configuration to the connector setup in both the 8.9 and 8.10 integration test scenarios. The main purpose is to explicitly set the `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_PREFIX` to an empty string, likely to control or override the default behavior regarding secret provider environment variable prefixes during testing.

Configuration updates for integration tests:

* Added `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_PREFIX` with an empty value to the connector environment in `charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/base-qa.yaml`
* Added `CAMUNDA_CONNECTOR_SECRETPROVIDER_ENVIRONMENT_PREFIX` with an empty value to the connector environment in `charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/base-qa.yaml`### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
