### PR TITLE
fix: fix links in helpers 8.9+ to upgrade docs

### DIFF
--- a/charts/camunda-platform-8.10/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/common/_helpers.tpl
@@ -957,7 +957,7 @@ Release highlights.
 {{- define "camundaPlatform.ReleaseHighlights" }}
 ## [info] Helm chart release highlights
 - Some values have been renamed or moved in the new chart structure.
-- When upgraded from 8.7 to 8.8, manual adjustments may be required for some cases like custom configurations.
+- When upgraded from 8.9 to 8.10, manual adjustments may be required for some cases like custom configurations.
 - Please refer to the official docs for more details.
-https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/upgrade-hc-870-880/
+https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/upgrade-hc-890-8100/
 {{- end -}}

--- a/charts/camunda-platform-8.9/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/common/_helpers.tpl
@@ -990,7 +990,7 @@ Release highlights.
 {{- define "camundaPlatform.ReleaseHighlights" }}
 ## [info] Helm chart release highlights
 - Some values have been renamed or moved in the new chart structure.
-- When upgraded from 8.7 to 8.8, manual adjustments may be required for some cases like custom configurations.
+- When upgraded from 8.8 to 8.9, manual adjustments may be required for some cases like custom configurations.
 - Please refer to the official docs for more details.
-https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/upgrade-hc-870-880/
+https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/upgrade-hc-880-890/
 {{- end -}}


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

closes https://github.com/camunda/camunda-platform-helm/issues/5639

This pull request updates the release highlights in the Helm chart templates for versions 8.9 and 8.10 to reflect the correct upgrade paths and documentation links. The changes ensure that users see accurate information about manual adjustments required and are directed to the appropriate upgrade guides.

Release highlights documentation updates:

* Updated the upgrade notice in `charts/camunda-platform-8.9/templates/common/_helpers.tpl` to reference the 8.8 to 8.9 upgrade, including the correct documentation link.
* Updated the upgrade notice in `charts/camunda-platform-8.10/templates/common/_helpers.tpl` to reference the 8.9 to 8.10 upgrade, including the correct documentation link.

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
