### PR TITLE
test: add sleep to entra to allow app to be created

### DIFF
--- a/scripts/deploy-camunda/entra/entra.go
+++ b/scripts/deploy-camunda/entra/entra.go
@@ -544,7 +544,7 @@ func EnsureVenomApp(ctx context.Context, opts Options) (*VenomApp, error) {
 		attempts := 0
 		successes := 0
 
-		for !propogated && attempts < 45 && successes < 3 {
+		for !propogated && attempts < 45 && successes < 5 {
 			appID, objectID, err = findApp(ctx, client, token, displayName)
 			if err != nil {
 				logging.Logger.Warn().Err(err).Msg("Error while checking for app registration propagation")


### PR DESCRIPTION
### Which problem does the PR fix?

closes https://github.com/camunda/camunda-platform-helm/issues/5666

esoi (oidc via entra) has been failing lately because after the Application Registration is created, we're immediately trying to create a Client Credential, but the Application Registration that was created has not yet been propogated to microsoft nodes. So this change adds a sleep statement.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
