### PR TITLE
ci: skip triage of already triaged issues

### DIFF
--- a/.github/workflows/triage-ai-issue.yml
+++ b/.github/workflows/triage-ai-issue.yml
@@ -174,6 +174,12 @@ jobs:
             echo "📄 Title: $ISSUE_TITLE"
             echo "🏷️  Labels: ${ISSUE_LABELS:-none}"
 
+            # Check if already triaged or marked for manual review
+            if echo "$ISSUE_LABELS" | grep -qi "TRIAGE:COMPLETED"; then
+              echo "⏭️  Skipping: already has TRIAGE:COMPLETED label"
+              continue
+            fi
+
             # Check if already has triage:manual label
             if echo "$ISSUE_LABELS" | grep -q "triage:manual"; then
               echo "⏭️  Skipping: has triage:manual label"


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

Skip issues that have `triage:completed` label - e.g. https://github.com/camunda/camunda-platform-helm/issues/3823

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
