### PR TITLE
refactor: remove fixture for GH secret and Vault (only use vault)

### DIFF
--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -435,9 +435,6 @@ jobs:
       - name: CI Setup - Login to Docker Hub
         run: |
           echo "${TEST_DOCKER_PASSWORD}" | helm registry login registry-1.docker.io -u "${TEST_DOCKER_USERNAME}" --password-stdin
-        env:
-          TEST_DOCKER_USERNAME: ${{ secrets.DISTRO_CI_DOCKER_USERNAME_DOCKERHUB || env.TEST_DOCKER_USERNAME }}
-          TEST_DOCKER_PASSWORD: ${{ secrets.DISTRO_CI_DOCKER_PASSWORD_DOCKERHUB || env.TEST_DOCKER_PASSWORD }}
 
       - name: CI Setup - Add Helm repos and update Helm dependencies
         run: |
@@ -510,8 +507,6 @@ jobs:
           TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD: ${{ env.TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD || env.NEXUS_PASSWORD }}
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TEST_DOCKER_USERNAME: ${{ secrets.DISTRO_CI_DOCKER_USERNAME_DOCKERHUB || env.TEST_DOCKER_USERNAME }}
-          TEST_DOCKER_PASSWORD: ${{ secrets.DISTRO_CI_DOCKER_PASSWORD_DOCKERHUB || env.TEST_DOCKER_PASSWORD }}
 
       ##########################################################################################################
       # Install
@@ -863,9 +858,6 @@ jobs:
       - name: CI Setup - Login to Docker Hub
         run: |
           echo "${TEST_DOCKER_PASSWORD}" | helm registry login registry-1.docker.io -u "${TEST_DOCKER_USERNAME}" --password-stdin
-        env:
-          TEST_DOCKER_USERNAME: ${{ secrets.DISTRO_CI_DOCKER_USERNAME_DOCKERHUB || env.TEST_DOCKER_USERNAME }}
-          TEST_DOCKER_PASSWORD: ${{ secrets.DISTRO_CI_DOCKER_PASSWORD_DOCKERHUB || env.TEST_DOCKER_PASSWORD }}
 
       - name: CI Setup - Add Helm repos and update Helm dependencies
         run: |

--- a/.github/workflows/test-local-template.yaml
+++ b/.github/workflows/test-local-template.yaml
@@ -83,8 +83,6 @@ jobs:
       - name: Create Docker login secret
         env:
           TEST_CREATE_DOCKER_LOGIN_SECRET: "TRUE"
-          TEST_DOCKER_USERNAME: ${{ env.TEST_DOCKER_USERNAME }}
-          TEST_DOCKER_PASSWORD: ${{ env.TEST_DOCKER_PASSWORD }}
         run: |
           kubectl create namespace ${{ env.TEST_NAMESPACE }}
           task docker-login --taskfile test/integration/scenarios/lib/init-seed-taskfile.yaml


### PR DESCRIPTION
### Which problem does the PR fix?

#5698 

In my previous PR I included a branching logic that uses either the github secret or the vault secret. But now the GH secret has been removed. Now I'm removing the GH secret references.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
