### PR TITLE
feat: update Admin webapp URL

### DIFF
--- a/charts/camunda-platform-8.10/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/common/_helpers.tpl
@@ -477,7 +477,7 @@ Orchestration Identity templates.
 [camunda-platform] Orchestration Identity external URL.
 */}}
 {{- define "camundaPlatform.orchestrationIdentityExternalURL" }}
-  {{- printf "%s/identity" (include "camundaPlatform.orchestrationExternalURL" . | trimSuffix "/") -}}
+  {{- printf "%s/admin" (include "camundaPlatform.orchestrationExternalURL" . | trimSuffix "/") -}}
 {{- end -}}
 
 
@@ -759,7 +759,7 @@ Release templates.
     url: {{ include "camundaPlatform.tasklistExternalURL" . }}
     readiness: {{ printf "%s%s" $baseURLInternal (include "camundaPlatform.joinpath" (list .Values.orchestration.contextPath .Values.orchestration.readinessProbe.probePath)) }}
     metrics: {{ printf "%s%s" $baseURLInternal (include "camundaPlatform.joinpath" (list .Values.orchestration.contextPath .Values.orchestration.metrics.prometheus)) }}
-  - name: Orchestration Identity
+  - name: Orchestration Admin
     id: orchestrationIdentity
     version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.orchestration) }}
     url: {{ include "camundaPlatform.orchestrationIdentityExternalURL" . }}

--- a/charts/camunda-platform-8.10/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/common/_helpers.tpl
@@ -474,7 +474,7 @@ Orchestration Identity templates.
 */}}
 
 {{/*
-[camunda-platform] Orchestration Identity external URL.
+[camunda-platform] Orchestration Admin external URL.
 */}}
 {{- define "camundaPlatform.orchestrationIdentityExternalURL" }}
   {{- printf "%s/admin" (include "camundaPlatform.orchestrationExternalURL" . | trimSuffix "/") -}}

--- a/charts/camunda-platform-8.10/test/unit/console/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/console/golden/configmap.golden.yaml
@@ -61,9 +61,9 @@ data:
               url: http://localhost:8080/tasklist
               readiness: http://camunda-platform-test-zeebe.camunda-platform:9600/actuator/health/readiness
               metrics: http://camunda-platform-test-zeebe.camunda-platform:9600/actuator/prometheus
-            - name: Orchestration Identity
+            - name: Orchestration Admin
               id: orchestrationIdentity
-              url: http://localhost:8080/identity
+              url: http://localhost:8080/admin
               readiness: http://camunda-platform-test-zeebe.camunda-platform:9600/actuator/health/readiness
               metrics: http://camunda-platform-test-zeebe.camunda-platform:9600/actuator/prometheus
           


### PR DESCRIPTION
### Which problem does the PR fix?

Relates to https://github.com/camunda/camunda/issues/46027

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

For 8.9 we [evolved OC Identity to OC Admin](https://github.com/camunda/camunda/issues/44427). To ensure backwards compatibility we added redirects from the old `/identity...` URLs to the new `/admin...`. For 8.10, we can drop this.

Since the `/identity...`URLs will no longer be valid we need to replace them with the valid `/admin...` ones in the HCs.

### What's in this PR?

Replaces the legacy `/identity...` URLs for OC Admin with `/admin...`.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
