### PR TITLE
ci: consolidate concurrency groups to prevent orphaned namespaces

### DIFF
--- a/.github/workflows/test-chart-version-template.yaml
+++ b/.github/workflows/test-chart-version-template.yaml
@@ -124,7 +124,7 @@ on:
         type: boolean
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.pr-number }}-${{ inputs.shortname }}-${{ inputs.flows }}-${{ inputs.camunda-version }}-${{ inputs.auth }}-${{ inputs.flows }}-${{ inputs.exclude }}-${{ inputs.platforms }}-${{ github.ref_name || github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.pr-number }}-${{ inputs.shortname }}-${{ inputs.flows }}-${{ inputs.camunda-version }}-${{ inputs.auth }}-${{ inputs.exclude }}-${{ inputs.platforms }}-${{ github.ref_name || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -241,9 +241,9 @@ permissions:
   deployments: write
   packages: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ inputs.identifier }}-${{ inputs.flow }}-${{ inputs.distro-platform }}-${{ github.ref_name || github.ref }}-runner
-  cancel-in-progress: true
+# No concurrency block here — this is the innermost layer containing the cleanup job.
+# cancel-in-progress at this level kills ALL jobs including cleanup, causing orphaned
+# cloud resources. Cancellation is handled by outer caller workflows. See #5307.
 
 env:
   # Vars with "CI_" prefix are used in the CI workflow only.

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -215,9 +215,8 @@ permissions:
   deployments: write
   packages: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ inputs.identifier }}-${{ inputs.shortname }}-${{ inputs.scenario }}-${{ inputs.auth }}-${{ inputs.flows }}-${{ inputs.exclude }}-${{ inputs.platforms }}-${{ github.ref_name || github.ref }}
-  cancel-in-progress: true
+# No concurrency block here — cancellation is handled by each caller workflow.
+# Adding cancel-in-progress here would kill the runner's cleanup job. See #5307.
 
 env:
   # Vars with "CI_" prefix are used in the CI workflow only.


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #5307

Related: #5308, #5383

### What's in this PR?

Removes `cancel-in-progress` concurrency blocks from the inner workflow layers (`test-integration-template`, `test-integration-runner`) so that cancellation is handled exclusively by each outermost caller workflow. This prevents the cleanup job in the runner from being killed mid-install, which was causing orphaned namespaces and cloud resources.

**Changes:**
- Removed concurrency block from `test-integration-runner.yaml` (Layer 3 — contains the cleanup job)
- Removed concurrency block from `test-integration-template.yaml` (Layer 2 — called by multiple parent workflows that each define their own concurrency)
- Fixed duplicate `inputs.flows` in `test-chart-version-template.yaml` concurrency group key

All callers of Layer 2 (except the example workflow) already define their own concurrency with `cancel-in-progress: true`, so no protection is lost. External callers (`c8-cross-component-e2e-tests`, `camunda/camunda`) are also unaffected.

### Checklist

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?