### PR TITLE
ci: centralize hardcoded infrastructure values into infra.yaml

### DIFF
--- a/.github/actions/cluster-auth/action.yaml
+++ b/.github/actions/cluster-auth/action.yaml
@@ -71,7 +71,7 @@ runs:
       id: teleport-auth
       shell: bash
       env:
-        TELEPORT_PROXY: "camunda.teleport.sh:443"
+        TELEPORT_PROXY: ${{ env.INFRA_TELEPORT_PROXY || 'camunda.teleport.sh:443' }}
         TELEPORT_TOKEN: ${{ env.TELEPORT_TOKEN }}
         KUBERNETES_CLUSTER: ${{ env.CLUSTER_NAME }}
       run: |

--- a/.github/actions/integration-test-setup/action.yaml
+++ b/.github/actions/integration-test-setup/action.yaml
@@ -33,7 +33,7 @@ inputs:
     description: Unique identifier base used in the deployment hostname
     required: true
   ingress-hostname-base:
-    description: (deprecated, no longer used) Base ingress hostname — now loaded from .github/config/infra.yaml
+    description: "(deprecated, remove after 2026-07) Base ingress hostname — now loaded from .github/config/infra.yaml"
     required: false
     default: ""
   camunda-helm-dir:

--- a/.github/actions/integration-test-setup/action.yaml
+++ b/.github/actions/integration-test-setup/action.yaml
@@ -33,8 +33,9 @@ inputs:
     description: Unique identifier base used in the deployment hostname
     required: true
   ingress-hostname-base:
-    description: Base ingress hostname (e.g. ci.distro.ultrawombat.com)
-    required: true
+    description: (deprecated, no longer used) Base ingress hostname — now loaded from .github/config/infra.yaml
+    required: false
+    default: ""
   camunda-helm-dir:
     description: Helm chart directory name (e.g. camunda-platform-8.8)
     required: true
@@ -94,14 +95,32 @@ outputs:
 #   VAULT_ADDR, VAULT_ROLE_ID, VAULT_SECRET_ID   (always — used for the CI credentials import)
 #   GH_APP_ID, GH_APP_KEY                        (GitHub App token for cluster-auth)
 #   ROSA_URL, ROSA_USER, ROSA_PASS               (ROSA/OpenShift)
-#   CLUSTER_NAME, TELEPORT_TOKEN                 (EKS)
+#   TELEPORT_TOKEN                                (EKS)
 # Optional env vars (used as fallback overrides for the Vault-imported values):
 #   DISTRO_CI_DOCKER_USERNAME_DOCKERHUB, DISTRO_CI_DOCKER_PASSWORD_DOCKERHUB
 # GKE cluster coordinates and Docker Hub credentials are imported from Vault by this action.
+# EKS cluster name and AWS profile are loaded from .github/config/infra.yaml by workflow-vars.
 
 runs:
   using: composite
   steps:
+    # ------------------------------------------------------------------
+    # Workflow vars (namespace, ingress host, identifier, infra config…)
+    # Runs first so infra values (CLUSTER_NAME, AWS_PROFILE, etc.) are
+    # available to cluster-auth and all subsequent steps.
+    # ------------------------------------------------------------------
+    - name: CI Setup - Set workflow vars
+      id: vars
+      uses: ./.github/actions/workflow-vars
+      with:
+        deployment-ttl: ${{ inputs.deployment-ttl }}
+        setup-flow: ${{ inputs.flow }}
+        platform: ${{ inputs.distro-platform }}
+        identifier-base: ${{ inputs.identifier }}
+        chart-dir: ${{ inputs.camunda-helm-dir }}
+        chart-upgrade-version: ${{ inputs.camunda-helm-upgrade-version }}
+        prefix: ${{ inputs.namespace-prefix }}
+
     # ------------------------------------------------------------------
     # Vault: optional per-scenario secret import
     # ------------------------------------------------------------------
@@ -176,23 +195,7 @@ runs:
         ROSA_URL:         ${{ env.ROSA_URL }}
         ROSA_USER:        ${{ env.ROSA_USER }}
         ROSA_PASS:        ${{ env.ROSA_PASS }}
-        CLUSTER_NAME:     ${{ env.CLUSTER_NAME }}
-
-    # ------------------------------------------------------------------
-    # Workflow vars (namespace, ingress host, identifier, …)
-    # ------------------------------------------------------------------
-    - name: CI Setup - Set workflow vars
-      id: vars
-      uses: ./.github/actions/workflow-vars
-      with:
-        deployment-ttl: ${{ inputs.deployment-ttl }}
-        setup-flow: ${{ inputs.flow }}
-        platform: ${{ inputs.distro-platform }}
-        identifier-base: ${{ inputs.identifier }}
-        ingress-hostname-base: ${{ inputs.ingress-hostname-base }}
-        chart-dir: ${{ inputs.camunda-helm-dir }}
-        chart-upgrade-version: ${{ inputs.camunda-helm-upgrade-version }}
-        prefix: ${{ inputs.namespace-prefix }}
+        CLUSTER_NAME:     ${{ env.INFRA_CLUSTER_NAME }}
 
     # ------------------------------------------------------------------
     # Legacy ingress host arg (pre-8.10 charts use global.ingress.host)

--- a/.github/actions/playwright-e2e-tests/action.yaml
+++ b/.github/actions/playwright-e2e-tests/action.yaml
@@ -139,6 +139,18 @@ runs:
           zbctl
           jq
 
+    - name: Set workflow vars
+      id: vars
+      uses: ./.github/actions/workflow-vars
+      with:
+        deployment-ttl: ${{ inputs.deployment-ttl }}
+        setup-flow: ${{ inputs.flow }}
+        platform: ${{ inputs.distro-platform }}
+        identifier-base: ${{ inputs.identifier }}
+        chart-dir: ${{ inputs.camunda-helm-dir }}
+        chart-upgrade-version: ${{ inputs.camunda-helm-upgrade-version }}
+        prefix: ${{ inputs.namespace-prefix }}
+
     - name: Authenticate to cluster
       id: cluster-auth
       uses: ./.github/actions/cluster-auth
@@ -155,20 +167,7 @@ runs:
         ROSA_URL:         ${{ env.ROSA_URL }}
         ROSA_USER:        ${{ env.ROSA_USER }}
         ROSA_PASS:        ${{ env.ROSA_PASS }}
-        CLUSTER_NAME:     ${{ env.CLUSTER_NAME }}
-
-    - name: Set workflow vars
-      id: vars
-      uses: ./.github/actions/workflow-vars
-      with:
-        deployment-ttl: ${{ inputs.deployment-ttl }}
-        setup-flow: ${{ inputs.flow }}
-        platform: ${{ inputs.distro-platform }}
-        identifier-base: ${{ inputs.identifier }}
-        ingress-hostname-base: ${{ env.CI_HOSTNAME_BASE }}
-        chart-dir: ${{ inputs.camunda-helm-dir }}
-        chart-upgrade-version: ${{ inputs.camunda-helm-upgrade-version }}
-        prefix: ${{ inputs.namespace-prefix }}
+        CLUSTER_NAME:     ${{ env.INFRA_CLUSTER_NAME }}
 
     - name: Set test type vars
       id: test-type-vars

--- a/.github/actions/workflow-vars/action.yaml
+++ b/.github/actions/workflow-vars/action.yaml
@@ -36,48 +36,8 @@ outputs:
     description: The namespace for the deployment
     value: ${{ steps.vars.outputs.namespace }}
   es-pool-index:
-    description: Elasticsearch pool index (0-3) for per-scenario hash-based cluster routing
+    description: Elasticsearch pool index (0..pools-1) for per-scenario hash-based cluster routing
     value: ${{ steps.vars.outputs.es-pool-index }}
-  # Infrastructure outputs (loaded from .github/config/infra.yaml)
-  cluster-name:
-    description: EKS cluster name
-    value: ${{ steps.infra.outputs.cluster-name }}
-  aws-profile:
-    description: AWS profile for EKS
-    value: ${{ steps.infra.outputs.aws-profile }}
-  es-host:
-    description: In-cluster Elasticsearch host
-    value: ${{ steps.infra.outputs.es-host }}
-  es-namespace:
-    description: In-cluster Elasticsearch Kubernetes namespace
-    value: ${{ steps.infra.outputs.es-namespace }}
-  os-host:
-    description: In-cluster OpenSearch host base (append -pool-N for pooled access)
-    value: ${{ steps.infra.outputs.os-host }}
-  opensearch-aws-host:
-    description: AWS OpenSearch host
-    value: ${{ steps.infra.outputs.opensearch-aws-host }}
-  opensearch-aws-protocol:
-    description: AWS OpenSearch protocol
-    value: ${{ steps.infra.outputs.opensearch-aws-protocol }}
-  opensearch-aws-port:
-    description: AWS OpenSearch port
-    value: ${{ steps.infra.outputs.opensearch-aws-port }}
-  postgresql-jdbc-url:
-    description: PostgreSQL JDBC URL (without database name)
-    value: ${{ steps.infra.outputs.postgresql-jdbc-url }}
-  teleport-proxy:
-    description: Teleport proxy address
-    value: ${{ steps.infra.outputs.teleport-proxy }}
-  teleport-token-default:
-    description: Default Teleport token for the distribution platform
-    value: ${{ steps.infra.outputs.teleport-token-default }}
-  s3-bucket:
-    description: S3 bucket name
-    value: ${{ steps.infra.outputs.s3-bucket }}
-  keycloak-version-prefix:
-    description: Keycloak version prefix for hostnames
-    value: ${{ steps.infra.outputs.keycloak-version-prefix }}
 
 runs:
   using: composite
@@ -87,12 +47,22 @@ runs:
     run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
   - name: Load infra config
-    id: infra
     shell: bash
     run: |
       # Load infrastructure values from centralized config.
       INFRA_CONFIG=".github/config/infra.yaml"
+
+      # Extract first platform when a comma-separated list is passed (e.g. "gke,eks").
       PLATFORM="${{ inputs.platform }}"
+      PLATFORM="${PLATFORM%%,*}"
+      if [[ -z "$PLATFORM" ]]; then
+        echo "::error::platform input must not be empty"
+        exit 1
+      fi
+      if ! yq -e ".$PLATFORM" "$INFRA_CONFIG" > /dev/null 2>&1; then
+        echo "::error::platform '$PLATFORM' not found in $INFRA_CONFIG"
+        exit 1
+      fi
 
       # Platform-specific values.
       INFRA_INGRESS_HOSTNAME_BASE=$(yq ".$PLATFORM.ingress-hostname-base" "$INFRA_CONFIG")
@@ -106,8 +76,6 @@ runs:
       echo "INFRA_CLUSTER_NAME=${INFRA_CLUSTER_NAME}" | tee -a $GITHUB_ENV
       echo "CLUSTER_NAME=${INFRA_CLUSTER_NAME}" | tee -a $GITHUB_ENV
       echo "AWS_PROFILE=${INFRA_AWS_PROFILE}" | tee -a $GITHUB_ENV
-      echo "cluster-name=${INFRA_CLUSTER_NAME}" >> $GITHUB_OUTPUT
-      echo "aws-profile=${INFRA_AWS_PROFILE}" >> $GITHUB_OUTPUT
 
       # Elasticsearch (in-cluster).
       INFRA_ES_HOST=$(yq '.elasticsearch.host' "$INFRA_CONFIG")
@@ -116,15 +84,12 @@ runs:
       echo "INFRA_ES_HOST=${INFRA_ES_HOST}" | tee -a $GITHUB_ENV
       echo "INFRA_ES_NAMESPACE=${INFRA_ES_NAMESPACE}" | tee -a $GITHUB_ENV
       echo "INFRA_ES_POOLS=${INFRA_ES_POOLS}" | tee -a $GITHUB_ENV
-      echo "es-host=${INFRA_ES_HOST}" >> $GITHUB_OUTPUT
-      echo "es-namespace=${INFRA_ES_NAMESPACE}" >> $GITHUB_OUTPUT
 
       # OpenSearch (in-cluster).
       INFRA_OS_HOST=$(yq '.opensearch.host' "$INFRA_CONFIG")
       INFRA_OS_POOLS=$(yq '.opensearch.pools' "$INFRA_CONFIG")
       echo "INFRA_OS_HOST=${INFRA_OS_HOST}" | tee -a $GITHUB_ENV
       echo "INFRA_OS_POOLS=${INFRA_OS_POOLS}" | tee -a $GITHUB_ENV
-      echo "os-host=${INFRA_OS_HOST}" >> $GITHUB_OUTPUT
 
       # OpenSearch (AWS) — also set consumer-facing env vars for existing workflow references.
       INFRA_OPENSEARCH_AWS_HOST=$(yq '.opensearch.aws.host' "$INFRA_CONFIG")
@@ -136,33 +101,22 @@ runs:
       echo "OPENSEARCH_HOST=${INFRA_OPENSEARCH_AWS_HOST}" | tee -a $GITHUB_ENV
       echo "OPENSEARCH_PROTOCOL=${INFRA_OPENSEARCH_AWS_PROTOCOL}" | tee -a $GITHUB_ENV
       echo "OPENSEARCH_PORT=${INFRA_OPENSEARCH_AWS_PORT}" | tee -a $GITHUB_ENV
-      echo "opensearch-aws-host=${INFRA_OPENSEARCH_AWS_HOST}" >> $GITHUB_OUTPUT
-      echo "opensearch-aws-protocol=${INFRA_OPENSEARCH_AWS_PROTOCOL}" >> $GITHUB_OUTPUT
-      echo "opensearch-aws-port=${INFRA_OPENSEARCH_AWS_PORT}" >> $GITHUB_OUTPUT
 
       # PostgreSQL — also set consumer-facing env var.
       INFRA_PG_HOST=$(yq '.postgresql.jdbc-host' "$INFRA_CONFIG")
       INFRA_PG_PORT=$(yq '.postgresql.jdbc-port' "$INFRA_CONFIG")
       echo "POSTGRESQL_JDBC_URL=jdbc:postgresql://${INFRA_PG_HOST}:${INFRA_PG_PORT}" | tee -a $GITHUB_ENV
-      echo "postgresql-jdbc-url=jdbc:postgresql://${INFRA_PG_HOST}:${INFRA_PG_PORT}" >> $GITHUB_OUTPUT
 
       # Teleport.
       INFRA_TELEPORT_PROXY=$(yq '.teleport.proxy' "$INFRA_CONFIG")
       INFRA_TELEPORT_TOKEN=$(yq '.teleport.token-distribution' "$INFRA_CONFIG")
       echo "INFRA_TELEPORT_PROXY=${INFRA_TELEPORT_PROXY}" | tee -a $GITHUB_ENV
-      echo "teleport-proxy=${INFRA_TELEPORT_PROXY}" >> $GITHUB_OUTPUT
-      echo "teleport-token-default=${INFRA_TELEPORT_TOKEN}" >> $GITHUB_OUTPUT
 
       # Keycloak.
       INFRA_KEYCLOAK_PREFIX=$(yq '.keycloak.version-prefix' "$INFRA_CONFIG")
       INFRA_KEYCLOAK_PROTOCOL=$(yq '.keycloak.protocol' "$INFRA_CONFIG")
       echo "INFRA_KEYCLOAK_PREFIX=${INFRA_KEYCLOAK_PREFIX}" | tee -a $GITHUB_ENV
       echo "INFRA_KEYCLOAK_PROTOCOL=${INFRA_KEYCLOAK_PROTOCOL}" | tee -a $GITHUB_ENV
-      echo "keycloak-version-prefix=${INFRA_KEYCLOAK_PREFIX}" >> $GITHUB_OUTPUT
-
-      # S3.
-      INFRA_S3_BUCKET=$(yq '.s3.bucket' "$INFRA_CONFIG")
-      echo "s3-bucket=${INFRA_S3_BUCKET}" >> $GITHUB_OUTPUT
 
   - name: Set workflow vars
     id: vars

--- a/.github/actions/workflow-vars/action.yaml
+++ b/.github/actions/workflow-vars/action.yaml
@@ -109,7 +109,6 @@ runs:
 
       # Teleport.
       INFRA_TELEPORT_PROXY=$(yq '.teleport.proxy' "$INFRA_CONFIG")
-      INFRA_TELEPORT_TOKEN=$(yq '.teleport.token-distribution' "$INFRA_CONFIG")
       echo "INFRA_TELEPORT_PROXY=${INFRA_TELEPORT_PROXY}" | tee -a $GITHUB_ENV
 
       # Keycloak.

--- a/.github/actions/workflow-vars/action.yaml
+++ b/.github/actions/workflow-vars/action.yaml
@@ -4,9 +4,6 @@ inputs:
   setup-flow:
     description: The chart setup flow either "install", "upgrade-patch", or "upgrade-minor".
     default: "install"
-  ingress-hostname-base:
-    description: The base of the Ingress hostname.
-    required: true
   platform:
     description: The deployment cloud platform like GKE or ROSA.
   deployment-ttl:
@@ -41,6 +38,46 @@ outputs:
   es-pool-index:
     description: Elasticsearch pool index (0-3) for per-scenario hash-based cluster routing
     value: ${{ steps.vars.outputs.es-pool-index }}
+  # Infrastructure outputs (loaded from .github/config/infra.yaml)
+  cluster-name:
+    description: EKS cluster name
+    value: ${{ steps.infra.outputs.cluster-name }}
+  aws-profile:
+    description: AWS profile for EKS
+    value: ${{ steps.infra.outputs.aws-profile }}
+  es-host:
+    description: In-cluster Elasticsearch host
+    value: ${{ steps.infra.outputs.es-host }}
+  es-namespace:
+    description: In-cluster Elasticsearch Kubernetes namespace
+    value: ${{ steps.infra.outputs.es-namespace }}
+  os-host:
+    description: In-cluster OpenSearch host base (append -pool-N for pooled access)
+    value: ${{ steps.infra.outputs.os-host }}
+  opensearch-aws-host:
+    description: AWS OpenSearch host
+    value: ${{ steps.infra.outputs.opensearch-aws-host }}
+  opensearch-aws-protocol:
+    description: AWS OpenSearch protocol
+    value: ${{ steps.infra.outputs.opensearch-aws-protocol }}
+  opensearch-aws-port:
+    description: AWS OpenSearch port
+    value: ${{ steps.infra.outputs.opensearch-aws-port }}
+  postgresql-jdbc-url:
+    description: PostgreSQL JDBC URL (without database name)
+    value: ${{ steps.infra.outputs.postgresql-jdbc-url }}
+  teleport-proxy:
+    description: Teleport proxy address
+    value: ${{ steps.infra.outputs.teleport-proxy }}
+  teleport-token-default:
+    description: Default Teleport token for the distribution platform
+    value: ${{ steps.infra.outputs.teleport-token-default }}
+  s3-bucket:
+    description: S3 bucket name
+    value: ${{ steps.infra.outputs.s3-bucket }}
+  keycloak-version-prefix:
+    description: Keycloak version prefix for hostnames
+    value: ${{ steps.infra.outputs.keycloak-version-prefix }}
 
 runs:
   using: composite
@@ -48,6 +85,84 @@ runs:
   - name: Configure Git safe directory
     shell: bash
     run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+
+  - name: Load infra config
+    id: infra
+    shell: bash
+    run: |
+      # Load infrastructure values from centralized config.
+      INFRA_CONFIG=".github/config/infra.yaml"
+      PLATFORM="${{ inputs.platform }}"
+
+      # Platform-specific values.
+      INFRA_INGRESS_HOSTNAME_BASE=$(yq ".$PLATFORM.ingress-hostname-base" "$INFRA_CONFIG")
+      INFRA_NAMESPACE_PREFIX=$(yq ".$PLATFORM.namespace-prefix" "$INFRA_CONFIG")
+      echo "INFRA_INGRESS_HOSTNAME_BASE=${INFRA_INGRESS_HOSTNAME_BASE}" | tee -a $GITHUB_ENV
+      echo "INFRA_NAMESPACE_PREFIX=${INFRA_NAMESPACE_PREFIX}" | tee -a $GITHUB_ENV
+
+      # EKS-specific values.
+      INFRA_CLUSTER_NAME=$(yq '.eks.cluster-name' "$INFRA_CONFIG")
+      INFRA_AWS_PROFILE=$(yq '.eks.aws-profile' "$INFRA_CONFIG")
+      echo "INFRA_CLUSTER_NAME=${INFRA_CLUSTER_NAME}" | tee -a $GITHUB_ENV
+      echo "CLUSTER_NAME=${INFRA_CLUSTER_NAME}" | tee -a $GITHUB_ENV
+      echo "AWS_PROFILE=${INFRA_AWS_PROFILE}" | tee -a $GITHUB_ENV
+      echo "cluster-name=${INFRA_CLUSTER_NAME}" >> $GITHUB_OUTPUT
+      echo "aws-profile=${INFRA_AWS_PROFILE}" >> $GITHUB_OUTPUT
+
+      # Elasticsearch (in-cluster).
+      INFRA_ES_HOST=$(yq '.elasticsearch.host' "$INFRA_CONFIG")
+      INFRA_ES_NAMESPACE=$(yq '.elasticsearch.namespace' "$INFRA_CONFIG")
+      INFRA_ES_POOLS=$(yq '.elasticsearch.pools' "$INFRA_CONFIG")
+      echo "INFRA_ES_HOST=${INFRA_ES_HOST}" | tee -a $GITHUB_ENV
+      echo "INFRA_ES_NAMESPACE=${INFRA_ES_NAMESPACE}" | tee -a $GITHUB_ENV
+      echo "INFRA_ES_POOLS=${INFRA_ES_POOLS}" | tee -a $GITHUB_ENV
+      echo "es-host=${INFRA_ES_HOST}" >> $GITHUB_OUTPUT
+      echo "es-namespace=${INFRA_ES_NAMESPACE}" >> $GITHUB_OUTPUT
+
+      # OpenSearch (in-cluster).
+      INFRA_OS_HOST=$(yq '.opensearch.host' "$INFRA_CONFIG")
+      INFRA_OS_POOLS=$(yq '.opensearch.pools' "$INFRA_CONFIG")
+      echo "INFRA_OS_HOST=${INFRA_OS_HOST}" | tee -a $GITHUB_ENV
+      echo "INFRA_OS_POOLS=${INFRA_OS_POOLS}" | tee -a $GITHUB_ENV
+      echo "os-host=${INFRA_OS_HOST}" >> $GITHUB_OUTPUT
+
+      # OpenSearch (AWS) — also set consumer-facing env vars for existing workflow references.
+      INFRA_OPENSEARCH_AWS_HOST=$(yq '.opensearch.aws.host' "$INFRA_CONFIG")
+      INFRA_OPENSEARCH_AWS_PROTOCOL=$(yq '.opensearch.aws.protocol' "$INFRA_CONFIG")
+      INFRA_OPENSEARCH_AWS_PORT=$(yq '.opensearch.aws.port' "$INFRA_CONFIG")
+      echo "INFRA_OPENSEARCH_AWS_HOST=${INFRA_OPENSEARCH_AWS_HOST}" | tee -a $GITHUB_ENV
+      echo "INFRA_OPENSEARCH_AWS_PROTOCOL=${INFRA_OPENSEARCH_AWS_PROTOCOL}" | tee -a $GITHUB_ENV
+      echo "INFRA_OPENSEARCH_AWS_PORT=${INFRA_OPENSEARCH_AWS_PORT}" | tee -a $GITHUB_ENV
+      echo "OPENSEARCH_HOST=${INFRA_OPENSEARCH_AWS_HOST}" | tee -a $GITHUB_ENV
+      echo "OPENSEARCH_PROTOCOL=${INFRA_OPENSEARCH_AWS_PROTOCOL}" | tee -a $GITHUB_ENV
+      echo "OPENSEARCH_PORT=${INFRA_OPENSEARCH_AWS_PORT}" | tee -a $GITHUB_ENV
+      echo "opensearch-aws-host=${INFRA_OPENSEARCH_AWS_HOST}" >> $GITHUB_OUTPUT
+      echo "opensearch-aws-protocol=${INFRA_OPENSEARCH_AWS_PROTOCOL}" >> $GITHUB_OUTPUT
+      echo "opensearch-aws-port=${INFRA_OPENSEARCH_AWS_PORT}" >> $GITHUB_OUTPUT
+
+      # PostgreSQL — also set consumer-facing env var.
+      INFRA_PG_HOST=$(yq '.postgresql.jdbc-host' "$INFRA_CONFIG")
+      INFRA_PG_PORT=$(yq '.postgresql.jdbc-port' "$INFRA_CONFIG")
+      echo "POSTGRESQL_JDBC_URL=jdbc:postgresql://${INFRA_PG_HOST}:${INFRA_PG_PORT}" | tee -a $GITHUB_ENV
+      echo "postgresql-jdbc-url=jdbc:postgresql://${INFRA_PG_HOST}:${INFRA_PG_PORT}" >> $GITHUB_OUTPUT
+
+      # Teleport.
+      INFRA_TELEPORT_PROXY=$(yq '.teleport.proxy' "$INFRA_CONFIG")
+      INFRA_TELEPORT_TOKEN=$(yq '.teleport.token-distribution' "$INFRA_CONFIG")
+      echo "INFRA_TELEPORT_PROXY=${INFRA_TELEPORT_PROXY}" | tee -a $GITHUB_ENV
+      echo "teleport-proxy=${INFRA_TELEPORT_PROXY}" >> $GITHUB_OUTPUT
+      echo "teleport-token-default=${INFRA_TELEPORT_TOKEN}" >> $GITHUB_OUTPUT
+
+      # Keycloak.
+      INFRA_KEYCLOAK_PREFIX=$(yq '.keycloak.version-prefix' "$INFRA_CONFIG")
+      INFRA_KEYCLOAK_PROTOCOL=$(yq '.keycloak.protocol' "$INFRA_CONFIG")
+      echo "INFRA_KEYCLOAK_PREFIX=${INFRA_KEYCLOAK_PREFIX}" | tee -a $GITHUB_ENV
+      echo "INFRA_KEYCLOAK_PROTOCOL=${INFRA_KEYCLOAK_PROTOCOL}" | tee -a $GITHUB_ENV
+      echo "keycloak-version-prefix=${INFRA_KEYCLOAK_PREFIX}" >> $GITHUB_OUTPUT
+
+      # S3.
+      INFRA_S3_BUCKET=$(yq '.s3.bucket' "$INFRA_CONFIG")
+      echo "s3-bucket=${INFRA_S3_BUCKET}" >> $GITHUB_OUTPUT
 
   - name: Set workflow vars
     id: vars
@@ -59,11 +174,7 @@ runs:
       }
 
       if [[ -z "${{ inputs.prefix }}" ]]; then
-        if [[ "${{ inputs.platform }}" == 'eks' ]]; then
-          export NAMESPACE_PREFIX=distribution
-        else
-          export NAMESPACE_PREFIX=camunda
-        fi
+        export NAMESPACE_PREFIX="${INFRA_NAMESPACE_PREFIX}"
       else
         export NAMESPACE_PREFIX="${{ inputs.prefix }}"
       fi
@@ -85,15 +196,15 @@ runs:
       echo "GITHUB_WORKFLOW_JOB_ID=$GITHUB_WORKFLOW_JOB_ID" | tee -a $GITHUB_ENV
       echo "GITHUB_WORKFLOW_RUN_ID=${{ github.run_id }}" | tee -a $GITHUB_ENV
 
-      # Deterministically route each scenario to one of 4 ES pools for balanced load.
+      # Deterministically route each scenario to one of N ES/OS pools for balanced load.
       # The hash includes TEST_NAMESPACE (which is scenario-specific) so different
       # scenarios within the same CI run are distributed across pools.
-      ES_POOL_INDEX=$(( 16#$(echo -n "${TEST_NAMESPACE}-${{ github.run_id }}-${{ github.run_attempt }}" | sha256sum | head -c 8) % 4 ))
+      # Pool counts are read from .github/config/infra.yaml.
+      ES_POOL_INDEX=$(( 16#$(echo -n "${TEST_NAMESPACE}-${{ github.run_id }}-${{ github.run_attempt }}" | sha256sum | head -c 8) % INFRA_ES_POOLS ))
       echo "ES_POOL_INDEX=${ES_POOL_INDEX}" | tee -a $GITHUB_ENV
       echo "es-pool-index=${ES_POOL_INDEX}" >> $GITHUB_OUTPUT
 
-      # Deterministically route each scenario to one of 4 OS pools for balanced load.
-      OS_POOL_INDEX=$(( 16#$(echo -n "${TEST_NAMESPACE}-${{ github.run_id }}-${{ github.run_attempt }}" | sha256sum | head -c 8) % 4 ))
+      OS_POOL_INDEX=$(( 16#$(echo -n "${TEST_NAMESPACE}-${{ github.run_id }}-${{ github.run_attempt }}" | sha256sum | head -c 8) % INFRA_OS_POOLS ))
       echo "OS_POOL_INDEX=${OS_POOL_INDEX}" | tee -a $GITHUB_ENV
       echo "os-pool-index=${OS_POOL_INDEX}" >> $GITHUB_OUTPUT
 
@@ -153,11 +264,7 @@ runs:
       echo "identifier=${TEST_IDENTIFIER}" | tee -a $GITHUB_OUTPUT
 
       # Ingress hostname.
-      if [[ "${{ inputs.platform }}" == 'eks' ]]; then
-        export INGRESS_HOSTNAME_BASE=${NAMESPACE_PREFIX}.aws.camunda.cloud
-      else
-        export INGRESS_HOSTNAME_BASE=ci.distro.ultrawombat.com
-      fi
+      export INGRESS_HOSTNAME_BASE="${INFRA_INGRESS_HOSTNAME_BASE}"
 
       TEST_INGRESS_HOST="${TEST_IDENTIFIER}.${INGRESS_HOSTNAME_BASE}"
       if [[ "${{ inputs.deployment-ttl }}" == "" ]] && is_pr; then
@@ -184,11 +291,11 @@ runs:
       export KEYCLOAK_REALM=$keycloakRealm
       echo "KEYCLOAK_REALM=$KEYCLOAK_REALM" | tee -a $GITHUB_ENV
 
-      ## Keycloak external URL for Keycloak 24.9.0
+      ## Keycloak external URL
       # NOTE: In the future, if we test other Keycloak versions, we might need to generalize this.
-      export  KEYCLOAK_EXT_HOST_24_9_0="keycloak-24-9-0.${INGRESS_HOSTNAME_BASE}"
+      export  KEYCLOAK_EXT_HOST_24_9_0="keycloak-${INFRA_KEYCLOAK_PREFIX}.${INGRESS_HOSTNAME_BASE}"
       echo "KEYCLOAK_EXT_HOST_24_9_0=$KEYCLOAK_EXT_HOST_24_9_0" | tee -a $GITHUB_ENV
-      echo "KEYCLOAK_EXT_PROTOCOL_24_9_0=https" | tee -a $GITHUB_ENV
+      echo "KEYCLOAK_EXT_PROTOCOL_24_9_0=${INFRA_KEYCLOAK_PROTOCOL}" | tee -a $GITHUB_ENV
 
   - name: Set workflow vars - Chart version
     shell: bash

--- a/.github/config/infra.yaml
+++ b/.github/config/infra.yaml
@@ -41,11 +41,7 @@ postgresql:
 teleport:
   proxy: camunda.teleport.sh:443
   token-distribution: infra-ci-prod-github-action-distribution
-  token-qa: infra-ci-prod-github-action-qa
 
 keycloak:
   version-prefix: "24-9-0"
   protocol: https
-
-s3:
-  bucket: camunda-ci-eks-prod-team-bucket-qa

--- a/.github/config/infra.yaml
+++ b/.github/config/infra.yaml
@@ -40,7 +40,6 @@ postgresql:
 
 teleport:
   proxy: camunda.teleport.sh:443
-  token-distribution: infra-ci-prod-github-action-distribution
 
 keycloak:
   version-prefix: "24-9-0"

--- a/.github/config/infra.yaml
+++ b/.github/config/infra.yaml
@@ -1,0 +1,51 @@
+# CI infrastructure endpoints — single source of truth.
+# Consumed by .github/actions/workflow-vars/action.yaml and workflow cleanup jobs.
+#
+# When an infrastructure value changes (e.g. ES cluster migration, new OpenSearch endpoint),
+# update it HERE ONLY. All workflows read from this file via the workflow-vars action.
+
+gke:
+  ingress-hostname-base: ci.distro.ultrawombat.com
+  namespace-prefix: camunda
+
+eks:
+  ingress-hostname-base: distribution.aws.camunda.cloud
+  namespace-prefix: distribution
+  cluster-name: camunda-ci-eks
+  aws-profile: distribution
+
+rosa:
+  ingress-hostname-base: ci.distro.ultrawombat.com
+  namespace-prefix: camunda
+
+elasticsearch:
+  # In-cluster ES on GKE (4 pools: pool-0 through pool-3)
+  host: elasticsearch-21-6-3.ci.distro.ultrawombat.com
+  namespace: distribution-elasticsearch-21-6-3
+  pools: 4
+
+opensearch:
+  # In-cluster OS on GKE (4 pools: pool-0 through pool-3)
+  host: opensearch-2-19.ci.distro.ultrawombat.com
+  pools: 4
+  # AWS OpenSearch (used for EKS scenarios)
+  aws:
+    host: search-qa-e2e-5q5uium4w7pgfz7i5tviimmmgm.eu-north-1.es.amazonaws.com
+    protocol: https
+    port: "443"
+
+postgresql:
+  jdbc-host: postgresql-cluster-rw.distribution-postgresql.svc.cluster.local
+  jdbc-port: "5432"
+
+teleport:
+  proxy: camunda.teleport.sh:443
+  token-distribution: infra-ci-prod-github-action-distribution
+  token-qa: infra-ci-prod-github-action-qa
+
+keycloak:
+  version-prefix: "24-9-0"
+  protocol: https
+
+s3:
+  bucket: camunda-ci-eks-prod-team-bucket-qa

--- a/.github/workflows/cleanup-namespace.yaml
+++ b/.github/workflows/cleanup-namespace.yaml
@@ -65,6 +65,13 @@ jobs:
           echo "$filtered" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+      - name: Load infra config
+        id: infra
+        shell: bash
+        run: |
+          INFRA_CONFIG=".github/config/infra.yaml"
+          echo "CLUSTER_NAME=$(yq '.eks.cluster-name' "$INFRA_CONFIG")" >> $GITHUB_ENV
+
       - name: CI Setup - Install tools
         uses: ./.github/actions/install-tool-versions
         with:
@@ -104,7 +111,7 @@ jobs:
           ROSA_URL:         ${{ secrets[fromJson(steps.load-config.outputs.distro_config).secret.server-url] }}
           ROSA_USER:        ${{ secrets[fromJson(steps.load-config.outputs.distro_config).secret.username] }}
           ROSA_PASS:        ${{ secrets[fromJson(steps.load-config.outputs.distro_config).secret.password] }}
-          CLUSTER_NAME:     camunda-ci-eks
+          CLUSTER_NAME:     ${{ env.CLUSTER_NAME }}
 
       - name: CI Cleanup
         shell: bash

--- a/.github/workflows/cleanup-opensearch-entra.yaml
+++ b/.github/workflows/cleanup-opensearch-entra.yaml
@@ -49,6 +49,7 @@ jobs:
           OS_PROTOCOL=$(yq '.opensearch.aws.protocol' "$INFRA_CONFIG")
           OS_PORT=$(yq '.opensearch.aws.port' "$INFRA_CONFIG")
           echo "INFRA_OPENSEARCH_ENDPOINT=${OS_PROTOCOL}://${OS_HOST}:${OS_PORT}" >> $GITHUB_ENV
+
       - name: Authenticate to GKE
         uses: ./.github/actions/gke-login
         with:

--- a/.github/workflows/cleanup-opensearch-entra.yaml
+++ b/.github/workflows/cleanup-opensearch-entra.yaml
@@ -40,6 +40,15 @@ jobs:
           exportEnv: true
       - name: Configure curl and wget
         uses: ./.github/actions/setup-curl
+      - name: Load infra config
+        id: infra
+        shell: bash
+        run: |
+          INFRA_CONFIG=".github/config/infra.yaml"
+          OS_HOST=$(yq '.opensearch.aws.host' "$INFRA_CONFIG")
+          OS_PROTOCOL=$(yq '.opensearch.aws.protocol' "$INFRA_CONFIG")
+          OS_PORT=$(yq '.opensearch.aws.port' "$INFRA_CONFIG")
+          echo "INFRA_OPENSEARCH_ENDPOINT=${OS_PROTOCOL}://${OS_HOST}:${OS_PORT}" >> $GITHUB_ENV
       - name: Authenticate to GKE
         uses: ./.github/actions/gke-login
         with:
@@ -54,7 +63,7 @@ jobs:
         shell: bash
         run: |
           # OpenSearch endpoint
-          OPENSEARCH_HOST="https://search-qa-e2e-5q5uium4w7pgfz7i5tviimmmgm.eu-north-1.es.amazonaws.com:443"
+          OPENSEARCH_HOST="${INFRA_OPENSEARCH_ENDPOINT}"
 
           # Get all namespace names
           ALL_NS=$(kubectl get namespaces -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n')
@@ -77,7 +86,7 @@ jobs:
       - name: update ISM policy
         shell: bash
         run: |
-          OPENSEARCH_HOST="https://search-qa-e2e-5q5uium4w7pgfz7i5tviimmmgm.eu-north-1.es.amazonaws.com:443"
+          OPENSEARCH_HOST="${INFRA_OPENSEARCH_ENDPOINT}"
           # Update the delete-after-48h ISM policy to cover both old and new index naming patterns.
           # First, get current seq_no and primary_term (required for updating existing policies).
           POLICY_RESP=$(curl -s -L "${OPENSEARCH_HOST}/_plugins/_ism/policies/delete-after-48h" \

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -249,24 +249,19 @@ env:
   # Vars with "CI_" prefix are used in the CI workflow only.
   # Vars with "TEST_" prefix are used in the test runner tool (Task).
   CI_DEPLOYMENT_TTL: ${{ inputs.deployment-ttl }}
-  CI_HOSTNAME_BASE: ci.distro.ultrawombat.com
   # The Helm repo which is used during the upgrade flow.
   TEST_CHART_REPO: ${{ inputs.camunda-helm-repo }}
   # Docker Hub auth to avoid image pull rate limit.
   TEST_CREATE_DOCKER_LOGIN_SECRET: "TRUE"
-  OPENSEARCH_PROTOCOL: "https"
-  OPENSEARCH_HOST: "search-qa-e2e-5q5uium4w7pgfz7i5tviimmmgm.eu-north-1.es.amazonaws.com"
-  OPENSEARCH_PORT: "443"
-  # RDBMS (used for testing RDBMS-based secondary storage)
-  POSTGRESQL_JDBC_URL: "jdbc:postgresql://postgresql-cluster-rw.distribution-postgresql.svc.cluster.local:5432"
   # OIDC.
   INITIAL_CLAIM_VALUE: ${{ inputs.initialClaimValue }}
   # Mapping rule client IDs - defaults for Keycloak; overridden by entra.ensure-venom-app for OIDC.
   VENOM_CLIENT_ID: venom
   CONNECTORS_CLIENT_ID: connectors
   # Misc.
-  AWS_PROFILE: distribution
-  CLUSTER_NAME: camunda-ci-eks
+  # NOTE: Infrastructure values (CLUSTER_NAME, AWS_PROFILE, OPENSEARCH_HOST/PROTOCOL/PORT,
+  # POSTGRESQL_JDBC_URL) are loaded from .github/config/infra.yaml by the workflow-vars action
+  # (invoked via integration-test-setup) and exported to $GITHUB_ENV per-job.
   TELEPORT_TOKEN: ${{ inputs.teleport-token }}
   FLOW: ${{ inputs.flow }}
 
@@ -337,7 +332,6 @@ jobs:
           deployment-ttl:              ${{ env.CI_DEPLOYMENT_TTL }}
           flow:                        ${{ inputs.flow }}
           identifier:                  ${{ inputs.identifier }}
-          ingress-hostname-base:       ${{ env.CI_HOSTNAME_BASE }}
           camunda-helm-dir:            ${{ inputs.camunda-helm-dir }}
           camunda-helm-upgrade-version: ${{ inputs.camunda-helm-upgrade-version }}
           namespace-prefix:            ${{ inputs.namespace-prefix }}
@@ -354,7 +348,6 @@ jobs:
           ROSA_URL:         ${{ secrets[inputs.server-url] }}
           ROSA_USER:        ${{ secrets[inputs.username] }}
           ROSA_PASS:        ${{ secrets[inputs.password] }}
-          CLUSTER_NAME:     ${{ env.CLUSTER_NAME }}
           DISTRO_CI_DOCKER_USERNAME_DOCKERHUB: ${{ secrets.DISTRO_CI_DOCKER_USERNAME_DOCKERHUB }}
           DISTRO_CI_DOCKER_PASSWORD_DOCKERHUB: ${{ secrets.DISTRO_CI_DOCKER_PASSWORD_DOCKERHUB }}
 
@@ -679,7 +672,6 @@ jobs:
           deployment-ttl:              ${{ env.CI_DEPLOYMENT_TTL }}
           flow:                        ${{ inputs.flow }}
           identifier:                  ${{ inputs.identifier }}
-          ingress-hostname-base:       ${{ env.CI_HOSTNAME_BASE }}
           camunda-helm-dir:            ${{ inputs.camunda-helm-dir }}
           camunda-helm-upgrade-version: ${{ inputs.camunda-helm-upgrade-version }}
           namespace-prefix:            ${{ inputs.namespace-prefix }}
@@ -697,7 +689,6 @@ jobs:
           ROSA_URL:         ${{ secrets[inputs.server-url] }}
           ROSA_USER:        ${{ secrets[inputs.username] }}
           ROSA_PASS:        ${{ secrets[inputs.password] }}
-          CLUSTER_NAME:     ${{ env.CLUSTER_NAME }}
           DISTRO_CI_DOCKER_USERNAME_DOCKERHUB: ${{ secrets.DISTRO_CI_DOCKER_USERNAME_DOCKERHUB }}
           DISTRO_CI_DOCKER_PASSWORD_DOCKERHUB: ${{ secrets.DISTRO_CI_DOCKER_PASSWORD_DOCKERHUB }}
 
@@ -881,8 +872,6 @@ jobs:
           ROSA_URL:         ${{ secrets[inputs.server-url] }}
           ROSA_USER:        ${{ secrets[inputs.username] }}
           ROSA_PASS:        ${{ secrets[inputs.password] }}
-          CLUSTER_NAME:     ${{ env.CLUSTER_NAME }}
-          CI_HOSTNAME_BASE: ${{ env.CI_HOSTNAME_BASE }}
           CI_DEPLOYMENT_TTL: ${{ env.CI_DEPLOYMENT_TTL }}
         with:
           camunda-helm-git-ref: ${{ inputs.camunda-helm-git-ref }}
@@ -961,8 +950,6 @@ jobs:
           ROSA_URL:         ${{ secrets[inputs.server-url] }}
           ROSA_USER:        ${{ secrets[inputs.username] }}
           ROSA_PASS:        ${{ secrets[inputs.password] }}
-          CLUSTER_NAME:     ${{ env.CLUSTER_NAME }}
-          CI_HOSTNAME_BASE: ${{ env.CI_HOSTNAME_BASE }}
           CI_DEPLOYMENT_TTL: ${{ env.CI_DEPLOYMENT_TTL }}
         with:
           camunda-helm-git-ref: ${{ inputs.camunda-helm-git-ref }}
@@ -1100,7 +1087,6 @@ jobs:
           setup-flow: ${{ inputs.flow }}
           platform: ${{ inputs.distro-platform }}
           identifier-base: ${{ inputs.identifier }}
-          ingress-hostname-base: ${{ env.CI_HOSTNAME_BASE }}
           chart-dir: ${{ inputs.camunda-helm-dir }}
           chart-upgrade-version: ${{ inputs.camunda-helm-upgrade-version }}
           prefix: ${{ inputs.namespace-prefix }}
@@ -1148,8 +1134,8 @@ jobs:
           GKE_SA:           ${{ env.DISTRO_CI_GCP_SERVICE_ACCOUNT }}
           ROSA_URL:         ${{ secrets[inputs.server-url] }}
           ROSA_USER:        ${{ secrets[inputs.username] }}
-          ROSA_PASS:        ${{ secrets[inputs.password] }}      
-          CLUSTER_NAME:     ${{ env.CLUSTER_NAME }}
+          ROSA_PASS:        ${{ secrets[inputs.password] }}
+          CLUSTER_NAME:     ${{ env.INFRA_CLUSTER_NAME }}
 
       - name: CI Cleanup - Cleanup GitHub deployment
         if: always() && (env.CI_DEPLOYMENT_TTL == '' || inputs.distro-type != 'kubernetes')
@@ -1179,7 +1165,7 @@ jobs:
           if [[ "$(kubectl get ns $TEST_NAMESPACE --ignore-not-found)" != "" && "${{ env.CI_DEPLOYMENT_TTL }}" == "" ]]; then
             kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=1s --overwrite=true
             kubectl annotate ns $TEST_NAMESPACE janitor/ttl=1s --overwrite=true
-            scripts/apply-ttl-to-elasticsearch-indexes.sh --prefix "${GITHUB_WORKFLOW_JOB_ID}" --ttl 1s --url "https://elasticsearch-21-6-3-pool-${ES_POOL_INDEX}.ci.distro.ultrawombat.com" --user "elastic" --elasticsearch-namespace "distribution-elasticsearch-21-6-3-pool-${ES_POOL_INDEX}" --debug || echo "Warning: Elasticsearch index cleanup failed (credentials inaccessible), skipping..."
+            scripts/apply-ttl-to-elasticsearch-indexes.sh --prefix "${GITHUB_WORKFLOW_JOB_ID}" --ttl 1s --url "https://${INFRA_ES_HOST}" --user "elastic" --elasticsearch-namespace "${INFRA_ES_NAMESPACE}" --debug || echo "Warning: Elasticsearch index cleanup failed (credentials inaccessible), skipping..."
             scripts/apply-ttl-to-elasticsearch-indexes.sh --prefix "${GITHUB_WORKFLOW_JOB_ID}" --ttl 1s --url "${OPENSEARCH_PROTOCOL}://${OPENSEARCH_HOST}:${OPENSEARCH_PORT}" --user "${OPENSEARCH_USERNAME}" --pass "${OPENSEARCH_PASSWORD}" --debug || echo "Warning: OpenSearch index cleanup failed, skipping..."
           else
             if [[ "${{ inputs.distro-type }}" == "kubernetes" && "${{ env.CI_DEPLOYMENT_TTL }}" != "" ]]; then
@@ -1188,7 +1174,7 @@ jobs:
             else
               kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=1s --overwrite=true || true
               kubectl annotate ns $TEST_NAMESPACE janitor/ttl=1s --overwrite=true || true
-              scripts/apply-ttl-to-elasticsearch-indexes.sh --prefix "${GITHUB_WORKFLOW_JOB_ID}" --ttl 1s --url "https://elasticsearch-21-6-3-pool-${ES_POOL_INDEX}.ci.distro.ultrawombat.com" --user "elastic" --elasticsearch-namespace "distribution-elasticsearch-21-6-3-pool-${ES_POOL_INDEX}" --debug || echo "Warning: Elasticsearch index cleanup failed (credentials inaccessible), skipping..."
+              scripts/apply-ttl-to-elasticsearch-indexes.sh --prefix "${GITHUB_WORKFLOW_JOB_ID}" --ttl 1s --url "https://${INFRA_ES_HOST}" --user "elastic" --elasticsearch-namespace "${INFRA_ES_NAMESPACE}" --debug || echo "Warning: Elasticsearch index cleanup failed (credentials inaccessible), skipping..."
               scripts/apply-ttl-to-elasticsearch-indexes.sh --prefix "${GITHUB_WORKFLOW_JOB_ID}" --ttl 1s --url "${OPENSEARCH_PROTOCOL}://${OPENSEARCH_HOST}:${OPENSEARCH_PORT}" --user "${OPENSEARCH_USERNAME}" --pass "${OPENSEARCH_PASSWORD}" --debug || echo "Warning: OpenSearch index cleanup failed, skipping..."
             fi
           fi
@@ -1199,8 +1185,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          ES_URL="https://elasticsearch-21-6-3-pool-${ES_POOL_INDEX}.ci.distro.ultrawombat.com"
-          ES_NS="distribution-elasticsearch-21-6-3-pool-${ES_POOL_INDEX}"
+          ES_URL="https://${INFRA_ES_HOST}"
+          ES_NS="${INFRA_ES_NAMESPACE}"
 
           # Extract the 6-char hex suffix from the namespace.
           # Namespace patterns:

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -1165,7 +1165,7 @@ jobs:
           if [[ "$(kubectl get ns $TEST_NAMESPACE --ignore-not-found)" != "" && "${{ env.CI_DEPLOYMENT_TTL }}" == "" ]]; then
             kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=1s --overwrite=true
             kubectl annotate ns $TEST_NAMESPACE janitor/ttl=1s --overwrite=true
-            scripts/apply-ttl-to-elasticsearch-indexes.sh --prefix "${GITHUB_WORKFLOW_JOB_ID}" --ttl 1s --url "https://${INFRA_ES_HOST}" --user "elastic" --elasticsearch-namespace "${INFRA_ES_NAMESPACE}" --debug || echo "Warning: Elasticsearch index cleanup failed (credentials inaccessible), skipping..."
+            scripts/apply-ttl-to-elasticsearch-indexes.sh --prefix "${GITHUB_WORKFLOW_JOB_ID}" --ttl 1s --url "https://${INFRA_ES_HOST}-pool-${ES_POOL_INDEX}" --user "elastic" --elasticsearch-namespace "${INFRA_ES_NAMESPACE}-pool-${ES_POOL_INDEX}" --debug || echo "Warning: Elasticsearch index cleanup failed (credentials inaccessible), skipping..."
             scripts/apply-ttl-to-elasticsearch-indexes.sh --prefix "${GITHUB_WORKFLOW_JOB_ID}" --ttl 1s --url "${OPENSEARCH_PROTOCOL}://${OPENSEARCH_HOST}:${OPENSEARCH_PORT}" --user "${OPENSEARCH_USERNAME}" --pass "${OPENSEARCH_PASSWORD}" --debug || echo "Warning: OpenSearch index cleanup failed, skipping..."
           else
             if [[ "${{ inputs.distro-type }}" == "kubernetes" && "${{ env.CI_DEPLOYMENT_TTL }}" != "" ]]; then
@@ -1174,7 +1174,7 @@ jobs:
             else
               kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=1s --overwrite=true || true
               kubectl annotate ns $TEST_NAMESPACE janitor/ttl=1s --overwrite=true || true
-              scripts/apply-ttl-to-elasticsearch-indexes.sh --prefix "${GITHUB_WORKFLOW_JOB_ID}" --ttl 1s --url "https://${INFRA_ES_HOST}" --user "elastic" --elasticsearch-namespace "${INFRA_ES_NAMESPACE}" --debug || echo "Warning: Elasticsearch index cleanup failed (credentials inaccessible), skipping..."
+              scripts/apply-ttl-to-elasticsearch-indexes.sh --prefix "${GITHUB_WORKFLOW_JOB_ID}" --ttl 1s --url "https://${INFRA_ES_HOST}-pool-${ES_POOL_INDEX}" --user "elastic" --elasticsearch-namespace "${INFRA_ES_NAMESPACE}-pool-${ES_POOL_INDEX}" --debug || echo "Warning: Elasticsearch index cleanup failed (credentials inaccessible), skipping..."
               scripts/apply-ttl-to-elasticsearch-indexes.sh --prefix "${GITHUB_WORKFLOW_JOB_ID}" --ttl 1s --url "${OPENSEARCH_PROTOCOL}://${OPENSEARCH_HOST}:${OPENSEARCH_PORT}" --user "${OPENSEARCH_USERNAME}" --pass "${OPENSEARCH_PASSWORD}" --debug || echo "Warning: OpenSearch index cleanup failed, skipping..."
             fi
           fi
@@ -1185,8 +1185,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          ES_URL="https://${INFRA_ES_HOST}"
-          ES_NS="${INFRA_ES_NAMESPACE}"
+          ES_URL="https://${INFRA_ES_HOST}-pool-${ES_POOL_INDEX}"
+          ES_NS="${INFRA_ES_NAMESPACE}-pool-${ES_POOL_INDEX}"
 
           # Extract the 6-char hex suffix from the namespace.
           # Namespace patterns:

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -228,8 +228,8 @@ env:
   # Docker Hub auth to avoid image pull rate limit.
   TEST_CREATE_DOCKER_LOGIN_SECRET: "TRUE"
   # Misc.
-  AWS_PROFILE: distribution
-  CLUSTER_NAME: camunda-ci-eks
+  # NOTE: AWS_PROFILE and CLUSTER_NAME are loaded from .github/config/infra.yaml
+  # by the workflow-vars action and exported to $GITHUB_ENV per-job.
   TELEPORT_TOKEN: ${{ inputs.teleport-token }}
 
 jobs:
@@ -389,7 +389,6 @@ jobs:
           setup-flow: install
           platform: ${{ inputs.platforms }}
           identifier-base: ${{ inputs.identifier }}-${{ inputs.shortname }}
-          ingress-hostname-base: ci.distro.ultrawombat.com
           chart-dir: ${{ inputs.camunda-helm-dir }}
           chart-upgrade-version: ${{ inputs.camunda-helm-upgrade-version }}
           prefix: ${{ inputs.namespace-prefix }}


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #5310

Infrastructure constants (hostnames, cluster names, pool counts, credentials endpoints) were hardcoded and duplicated across multiple CI workflow files and composite actions, making infra migrations error-prone.

### What's in this PR?

Adds `.github/config/infra.yaml` as single source of truth for infrastructure constants. The `workflow-vars` composite action loads and exports all values from this config. Standalone cleanup workflows load what they need directly.

Changes:
- New `.github/config/infra.yaml` with all infrastructure constants
- `workflow-vars` loads config and exports values via `$GITHUB_ENV` and outputs
- Removed hardcoded duplicates from `test-integration-runner`, `test-integration-template`, `cleanup-namespace`, `cleanup-opensearch-entra`
- Pool index computation (`% 4`) now reads pool count from config
- `cluster-auth` reads Teleport proxy from config (with fallback)
- Fixed step ordering bug in `playwright-e2e-tests` where `cluster-auth` ran before `workflow-vars`
- Deprecated `ingress-hostname-base` input in `integration-test-setup` for backward compat

Cross-repo callers (`c8-cross-component-e2e-tests`) are unaffected — no interface changes to reusable workflow inputs/outputs.

### Checklist

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).