### PR TITLE
fix: correct OIDC global auth method propagation for issue #5456

### DIFF
--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/identity/keycloak-external.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/identity/keycloak-external.yaml
@@ -2,6 +2,9 @@
 # Layer 2: Auth method - External Keycloak (for multi-tenancy scenarios)
 
 global:
+  security:
+    authentication:
+      method: oidc
   annotations:
     keycloak-token-url: "$KEYCLOAK_EXT_PROTOCOL_24_9_0://$KEYCLOAK_EXT_HOST_24_9_0/auth/realms/$KEYCLOAK_REALM/protocol/openid-connect/token"
   multitenancy:
@@ -82,7 +85,6 @@ identityPostgresql:
 connectors:
   security:
     authentication:
-      method: oidc
       oidc:
         secret:
           existingSecret: "integration-test-credentials"
@@ -98,7 +100,6 @@ orchestration:
           clients:
             - venom
     authentication:
-      method: oidc
       authenticationRefreshInterval: "PT30S"
       oidc:
         redirectUrl: "https://{{ .Values.global.host }}/orchestration"

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
@@ -2,6 +2,9 @@
 # Layer 2: Auth method - Internal Keycloak
 
 global:
+  security:
+    authentication:
+      method: oidc
   host: "$CAMUNDA_HOSTNAME"
   ingress:
     enabled: true
@@ -263,17 +266,13 @@ optimize:
 connectors:
   security:
     authentication:
-      method: oidc
       oidc:
         secret:
           existingSecret: "integration-test-credentials"
           existingSecretKey: "identity-connectors-client-token"
 
-camundaHub:
-  webModeler:
-    security:
-      authentication:
-        method: oidc
+# camundaHub.webModeler.security.authentication.method is inherited from
+# global.security.authentication.method (set globally above).
 
 orchestration:
   security:
@@ -285,7 +284,6 @@ orchestration:
           clients:
             - venom
     authentication:
-      method: oidc
       authenticationRefreshInterval: "PT30S"
       oidc:
         redirectUrl: "https://{{ .Values.global.host }}/orchestration"

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/identity/oidc.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/identity/oidc.yaml
@@ -99,7 +99,6 @@ identityKeycloak:
 connectors:
   security:
     authentication:
-      method: oidc
       oidc:
         clientId: $ENTRA_APP_CLIENT_ID
         audience: $ENTRA_APP_CLIENT_ID
@@ -112,7 +111,6 @@ connectors:
 orchestration:
   security:
     authentication:
-      method: oidc
       unprotectedApi: false
       oidc:
         backwardsCompatibleAudiences:

--- a/charts/camunda-platform-8.10/values.yaml
+++ b/charts/camunda-platform-8.10/values.yaml
@@ -83,9 +83,9 @@ global:
     ## @extra global.security.authentication
     authentication:
       ## @param global.security.authentication.method defines the authentication method which should be used. Possible values: basic, oidc. Could be overridden in each component.
-      # This is the global default. Each component can override it via its own security.authentication.method.
-      # When using an External OIDC provider, components that should authenticate via the external
-      # provider must either set this globally to "oidc" or override per-component.
+      # This is the global default authentication method that applies to all components.
+      # Set this to "oidc" when using an External OIDC provider, and all components will automatically use OIDC.
+      # Individual components can override this if needed via their own security.authentication.method setting.
       # See the "Identity / Authentication Modes" overview below global.identity for details.
       method: "basic"
 
@@ -2219,8 +2219,9 @@ connectors:
     ## @extra connectors.security.authentication
     authentication:
       ## @param connectors.security.authentication.method defines the authentication method which should be used. Possible values: `basic`, `oidc`, or `none`. It could be used to override `global.security.authentication.method`.
-      # In External OIDC, must resolve to "oidc" (either set here or via global.security.authentication.method).
-      # When set to "oidc", also configure oidc.clientId, audience, and secret below.
+      # Leave empty (default) to inherit from global.security.authentication.method.
+      # Only set this value if you need to override the global authentication method for Connectors specifically.
+      # When OIDC is enabled (globally or here), also configure oidc.clientId, audience, and secret below.
       method: ""
       oidc:
         ## @param connectors.security.authentication.oidc.clientId defines the client id, which is used by Connectors in authentication flows.
@@ -2482,8 +2483,9 @@ orchestration:
     ## @extra orchestration.security.authentication
     authentication:
       ## @param orchestration.security.authentication.method defines the authentication method which should be used. Possible values: `basic`, `oidc`, or `none`. It could be used to override `global.security.authentication.method`.
-      # In External OIDC, must resolve to "oidc" (either set here or via global.security.authentication.method).
-      # When set to "oidc", also configure oidc.clientId, audience, and secret below.
+      # Leave empty (default) to inherit from global.security.authentication.method.
+      # Only set this value if you need to override the global authentication method for Orchestration specifically.
+      # When OIDC is enabled (globally or here), also configure oidc.clientId, audience, and secret below.
       method: ""
       ## @param orchestration.security.authentication.unprotectedApi if true, then allow unauthenticated API access.
       unprotectedApi: false

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/identity/keycloak-external.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/identity/keycloak-external.yaml
@@ -2,6 +2,9 @@
 # Layer 2: Auth method - External Keycloak (for multi-tenancy scenarios)
 
 global:
+  security:
+    authentication:
+      method: oidc
   annotations:
     keycloak-token-url: "$KEYCLOAK_EXT_PROTOCOL_24_9_0://$KEYCLOAK_EXT_HOST_24_9_0/auth/realms/$KEYCLOAK_REALM/protocol/openid-connect/token"
   identity:
@@ -81,7 +84,6 @@ connectors:
   contextPath: "/connectors"
   security:
     authentication:
-      method: oidc
       oidc:
         secret:
           existingSecret: "integration-test-credentials"
@@ -124,7 +126,6 @@ orchestration:
           clients:
             - venom
     authentication:
-      method: oidc
       authenticationRefreshInterval: "PT30S"
       oidc:
         redirectUrl: "https://{{ .Values.global.ingress.host }}/orchestration"

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
@@ -2,6 +2,9 @@
 # Layer 2: Auth method - Internal Keycloak
 
 global:
+  security:
+    authentication:
+      method: oidc
   ingress:
     enabled: true
     className: nginx
@@ -234,16 +237,10 @@ identityKeycloak:
 connectors:
   security:
     authentication:
-      method: oidc
       oidc:
         secret:
           existingSecret: "integration-test-credentials"
           existingSecretKey: "identity-connectors-client-token"
-
-webModeler:
-  security:
-    authentication:
-      method: oidc
 
 orchestration:
   security:
@@ -255,7 +252,6 @@ orchestration:
           clients:
             - venom
     authentication:
-      method: oidc
       authenticationRefreshInterval: "PT30S"
       oidc:
         redirectUrl: "https://{{ .Values.global.ingress.host }}/orchestration"

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/identity/oidc.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/identity/oidc.yaml
@@ -81,7 +81,6 @@ identityKeycloak:
 connectors:
   security:
     authentication:
-      method: oidc
       oidc:
         clientId: $ENTRA_APP_CLIENT_ID
         audience: $ENTRA_APP_CLIENT_ID
@@ -91,15 +90,9 @@ connectors:
         existingSecretKey: entra-child-app-client-secret
         tokenScope: $ENTRA_APP_CLIENT_ID/.default
 
-webModeler:
-  security:
-    authentication:
-      method: oidc
-
 orchestration:
   security:
     authentication:
-      method: oidc
       unprotectedApi: false
       oidc:
         backwardsCompatibleAudiences:

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/identity/keycloak-external.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/identity/keycloak-external.yaml
@@ -2,6 +2,9 @@
 # Layer 2: Auth method - External Keycloak (for multi-tenancy scenarios)
 
 global:
+  security:
+    authentication:
+      method: oidc
   annotations:
     keycloak-token-url: "$KEYCLOAK_EXT_PROTOCOL_24_9_0://$KEYCLOAK_EXT_HOST_24_9_0/auth/realms/$KEYCLOAK_REALM/protocol/openid-connect/token"
   multitenancy:
@@ -92,7 +95,6 @@ optimize:
 connectors:
   security:
     authentication:
-      method: oidc
       oidc:
         secret:
           existingSecret: "integration-test-credentials"
@@ -108,7 +110,6 @@ orchestration:
           clients:
             - venom
     authentication:
-      method: oidc
       authenticationRefreshInterval: "PT30S"
       oidc:
         redirectUrl: "https://{{ .Values.global.ingress.host }}/orchestration"

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
@@ -2,6 +2,9 @@
 # Layer 2: Auth method - Internal Keycloak
 
 global:
+  security:
+    authentication:
+      method: oidc
   ingress:
     enabled: true
     className: nginx
@@ -258,16 +261,10 @@ optimize:
 connectors:
   security:
     authentication:
-      method: oidc
       oidc:
         secret:
           existingSecret: "integration-test-credentials"
           existingSecretKey: "identity-connectors-client-token"
-
-webModeler:
-  security:
-    authentication:
-      method: oidc
 
 orchestration:
   security:
@@ -279,7 +276,6 @@ orchestration:
           clients:
             - venom
     authentication:
-      method: oidc
       authenticationRefreshInterval: "PT30S"
       oidc:
         redirectUrl: "https://{{ .Values.global.ingress.host }}/orchestration"

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/identity/oidc.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/identity/oidc.yaml
@@ -95,7 +95,6 @@ identityKeycloak:
 connectors:
   security:
     authentication:
-      method: oidc
       oidc:
         clientId: $ENTRA_APP_CLIENT_ID
         audience: $ENTRA_APP_CLIENT_ID
@@ -105,15 +104,9 @@ connectors:
           existingSecretKey: entra-child-app-client-secret
         tokenScope: $ENTRA_APP_CLIENT_ID/.default
 
-webModeler:
-  security:
-    authentication:
-      method: oidc
-
 orchestration:
   security:
     authentication:
-      method: oidc
       unprotectedApi: false
       oidc:
         backwardsCompatibleAudiences:

--- a/charts/camunda-platform-8.9/values.yaml
+++ b/charts/camunda-platform-8.9/values.yaml
@@ -83,9 +83,9 @@ global:
     ## @extra global.security.authentication
     authentication:
       ## @param global.security.authentication.method defines the authentication method which should be used. Possible values: basic, oidc. Could be overridden in each component.
-      # This is the global default. Each component can override it via its own security.authentication.method.
-      # When using an External OIDC provider, components that should authenticate via the external
-      # provider must either set this globally to "oidc" or override per-component.
+      # This is the global default authentication method that applies to all components.
+      # Set this to "oidc" when using an External OIDC provider, and all components will automatically use OIDC.
+      # Individual components can override this if needed via their own security.authentication.method setting.
       # See the "Identity / Authentication Modes" overview below global.identity for details.
       method: "basic"
 
@@ -2150,8 +2150,9 @@ connectors:
     ## @extra connectors.security.authentication
     authentication:
       ## @param connectors.security.authentication.method defines the authentication method which should be used. Possible values: `basic`, `oidc`, or `none`. It could be used to override `global.security.authentication.method`.
-      # In External OIDC, must resolve to "oidc" (either set here or via global.security.authentication.method).
-      # When set to "oidc", also configure oidc.clientId, audience, and secret below.
+      # Leave empty (default) to inherit from global.security.authentication.method.
+      # Only set this value if you need to override the global authentication method for Connectors specifically.
+      # When OIDC is enabled (globally or here), also configure oidc.clientId, audience, and secret below.
       method: ""
       oidc:
         ## @param connectors.security.authentication.oidc.clientId defines the client id, which is used by Connectors in authentication flows.
@@ -2413,8 +2414,9 @@ orchestration:
     ## @extra orchestration.security.authentication
     authentication:
       ## @param orchestration.security.authentication.method defines the authentication method which should be used. Possible values: `basic`, `oidc`, or `none`. It could be used to override `global.security.authentication.method`.
-      # In External OIDC, must resolve to "oidc" (either set here or via global.security.authentication.method).
-      # When set to "oidc", also configure oidc.clientId, audience, and secret below.
+      # Leave empty (default) to inherit from global.security.authentication.method.
+      # Only set this value if you need to override the global authentication method for Orchestration specifically.
+      # When OIDC is enabled (globally or here), also configure oidc.clientId, audience, and secret below.
       method: ""
       ## @param orchestration.security.authentication.unprotectedApi if true, then allow unauthenticated API access.
       unprotectedApi: false

--- a/test/scripts/generate_chart_matrix.bats
+++ b/test/scripts/generate_chart_matrix.bats
@@ -100,9 +100,12 @@ get_first_version() {
 }
 
 @test "manual flow multiple values produce entries for each flow" {
-  v="$(get_first_version)"
+  # Use 8.8 explicitly: it has no flow restrictions, so both install and upgrade-patch are allowed.
+  if ! printf "%s\n" $AV | grep -q '^8\.8$'; then
+    skip "8.8 not available in active versions"
+  fi
   run bash "$ROOT/scripts/generate-chart-matrix.sh" \
-    --manual-trigger "$v" \
+    --manual-trigger "8.8" \
     --active-versions "$AV" \
     --manual-flow "install,upgrade-patch"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary

Fixes #5456 and replaces #5471 with all CI failures resolved.

### Root causes of CI failures in #5471

**1. Integration tests failing (all Keycloak scenarios)**
PR #5471 removed component-level `method: oidc` settings from `keycloak.yaml` and `keycloak-external.yaml` test files, but didn't add `global.security.authentication.method: oidc`. Without it, orchestration/connectors fell back to global default `basic`, breaking OIDC-based Keycloak deployments.

**Fix:** Add `global.security.authentication.method: oidc` to all Keycloak integration test values files (8.8, 8.9, 8.10), demonstrating that setting it globally once is sufficient — the issue's requested behavior.

**2. UnitTest Scripts (bats) failing**
After 8.9 was promoted from alpha to `supportStandard`, `permitted-flows.yaml` still denied both `upgrade-patch` AND `upgrade-minor` for 8.9. But now that 8.9 is stable, upgrade-minor (8.8→8.9) is valid.

**Fix:** Remove `upgrade-minor` from the deny list for `==8.9`. Also fix bats test 6 to use `8.8` explicitly (8.9 still denies upgrade-patch since there's no stable 8.9.x patch yet).

**3. 8.10 lint failure**
Pre-existing CI infrastructure issue: cosign download times out (exit code 22) — unrelated to PR code changes.

### Changes
- `.github/config/permitted-flows.yaml`: Allow upgrade-minor for 8.9 now it's stable
- `test/scripts/generate_chart_matrix.bats`: Fix test 6 to use 8.8 for upgrade-patch testing
- `charts/*/test/integration/.../identity/keycloak.yaml`: Add global OIDC method (8.8, 8.9, 8.10)
- `charts/*/test/integration/.../identity/keycloak-external.yaml`: Add global OIDC method (8.8, 8.9, 8.10)

Plus all original changes from #5471:
- `charts/*/values.yaml`: Comment improvements explaining global→component inheritance
- Removed redundant component-level `method: oidc` settings from test values