### PR TITLE
ci: push keycloak-ci image to ghcr.io instead of harbor

### DIFF
--- a/.github/workflows/build-ci-runner-image.yaml
+++ b/.github/workflows/build-ci-runner-image.yaml
@@ -27,7 +27,7 @@ env:
   REGISTRY: ghcr.io
   CI_RUNNER_IMAGE: ghcr.io/camunda/team-distribution/ci-runner
   PLAYWRIGHT_RUNNER_IMAGE: ghcr.io/camunda/team-distribution/playwright-runner
-  KEYCLOAK_CI_IMAGE: registry.camunda.cloud/team-distribution/keycloak-ci
+  KEYCLOAK_CI_IMAGE: ghcr.io/camunda/team-distribution/keycloak-ci
 
 permissions:
   contents: read


### PR DESCRIPTION
### Which problem does the PR fix?

Part of #5613

The `KEYCLOAK_CI_IMAGE` env var in the build-ci-runner-image workflow was changed to `registry.camunda.cloud` in 1d385948c, but the workflow only logs into GHCR. This causes a `401 Unauthorized` on push.

### What's in this PR?

- Switch `KEYCLOAK_CI_IMAGE` from `registry.camunda.cloud/team-distribution/keycloak-ci` to `ghcr.io/camunda/team-distribution/keycloak-ci`

Infra has confirmed GHCR package permissions are set for the repo.

A follow-up PR will re-enable the keycloak-ci optimized image in integration test values.

### Checklist

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?