### PR TITLE
ci: replace stale SLACK_DISTRO_TEAM_WEBHOOK vault secret

### DIFF
--- a/.github/workflows/chart-release-artifact-verify.yaml
+++ b/.github/workflows/chart-release-artifact-verify.yaml
@@ -27,7 +27,7 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           secrets: |
-            secret/data/products/distribution/ci SLACK_DISTRO_TEAM_WEBHOOK;
+            secret/data/products/distribution/ci SLACK_DISTRO_BOT_WEBHOOK;
           exportEnv: true
       - name: Get chart versions
         id: get-chart-versions
@@ -136,7 +136,7 @@ jobs:
         if: failure()
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
-          webhook: ${{ env.SLACK_DISTRO_TEAM_WEBHOOK }}
+          webhook: ${{ env.SLACK_DISTRO_BOT_WEBHOOK }}
           webhook-type: incoming-webhook
           payload: |
             blocks:

--- a/.github/workflows/check-values-latest.yaml
+++ b/.github/workflows/check-values-latest.yaml
@@ -33,18 +33,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Import Vault secrets
-        id: test-credentials-secret
-        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secrets: |
-            secret/data/products/distribution/ci SLACK_DISTRO_TEAM_WEBHOOK;
-          exportEnv: true
-
       - name: Install tools
         uses: ./.github/actions/install-tool-versions
         with:


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #5746

After the recent secrets rotation, the Vault key `SLACK_DISTRO_TEAM_WEBHOOK` no longer exists
at `secret/data/products/distribution/ci`, causing CI workflows to fail at the
"Import Vault secrets" step.

### What's in this PR?

- **`check-values-latest.yaml`**: Removed the entire Vault import step — the secret was only
  used by a Slack notification step that is already commented out (dead code).
- **`chart-release-artifact-verify.yaml`**: Replaced `SLACK_DISTRO_TEAM_WEBHOOK` with
  `SLACK_DISTRO_BOT_WEBHOOK` (the rotated equivalent already used by `chart-promote-rc`,
  `chart-build-dev`, and `chart-release-public` workflows).

### Checklist

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).