### PR TITLE
test: enable skipped tests 8.9

### DIFF
--- a/.github/config/permitted-flows.yaml
+++ b/.github/config/permitted-flows.yaml
@@ -7,10 +7,6 @@ rules:
   - match: "<=8.7"
     deny:
       - upgrade-minor
-  - match: "==8.9"
-    deny:
-      - upgrade-patch
-      - upgrade-minor
   - match: "==8.10"
     deny:
       - upgrade-patch


### PR DESCRIPTION
### Which problem does the PR fix?

closes #5750 

bats test is failing due to a standard support of camunda disabling upgrade-patch and upgrade-minor. Bats test now passes as I stopped denying those flows.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
