### PR TITLE
test: this assertion should be on 8.10 only

### DIFF
--- a/.github/workflows/test-unit-template.yaml
+++ b/.github/workflows/test-unit-template.yaml
@@ -1,6 +1,9 @@
 name: "Test - Unit - Template"
 
 on:
+  push:
+    paths:
+      - "test/scripts/generate_chart_matrix.bats"
   workflow_call:
     inputs:
       identifier:

--- a/test/scripts/generate_chart_matrix.bats
+++ b/test/scripts/generate_chart_matrix.bats
@@ -147,13 +147,13 @@ get_first_version() {
 
 }
 
-@test "upgrade-patch is filtered for version == 8.9 via YAML config" {
-  # Ensure 8.9 is among active versions; skip if not present
-  if ! printf "%s\n" $AV | grep -q '^8\.9$'; then
-    skip "8.9 not available in active versions"
+@test "upgrade-patch is filtered for version == 8.10 via YAML config" {
+  # Ensure 8.10 is among active versions; skip if not present
+  if ! printf "%s\n" $AV | grep -q '^8\.10$'; then
+    skip "8.10 not available in active versions"
   fi
   run bash "$ROOT/scripts/generate-chart-matrix.sh" \
-    --manual-trigger "8.9" \
+    --manual-trigger "8.10" \
     --active-versions "$AV" \
     --manual-flow "install,upgrade-patch,upgrade-minor"
   assert_success


### PR DESCRIPTION
### Which problem does the PR fix?

#5750 

one of the reasons bats is throwing errors is due to a faulty assertion thats checking 8.9 as the active version and not 8.10

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
