### PR TITLE
chore: notify on new triaged issues

### DIFF
--- a/.github/workflows/triage-ai-issue.yml
+++ b/.github/workflows/triage-ai-issue.yml
@@ -79,6 +79,7 @@ jobs:
             secret/data/products/distribution/ci GH_APP_ID_DISTRO_CI;
             secret/data/products/distribution/ci GH_APP_PRIVATE_KEY_DISTRO_CI;
             secret/data/products/distribution/ci GLEAN_API_TOKEN;
+            secret/data/products/distribution/ci SLACK_DISTRO_BOT_WEBHOOK_GH;
           exportEnv: true
 
       - name: Generate GitHub token
@@ -453,6 +454,44 @@ jobs:
 
               echo "✅ Moved to Backlog"
             fi
+
+            # Send Slack notification to #team-distribution-github
+            echo "📣 Sending Slack notification..."
+            ISSUE_URL="$GITHUB_SERVER_URL/$OWNER/$REPO/issues/$ISSUE_NUMBER"
+            SHORT_REPO=$(echo "$REPO" | sed 's/camunda-platform-//')
+
+            # Pick an emoji based on kind
+            KIND_EMOJI=":label:"
+            case "${KIND:-unknown}" in
+              bug)             KIND_EMOJI=":bug:" ;;
+              chore)           KIND_EMOJI=":wrench:" ;;
+              docs)            KIND_EMOJI=":memo:" ;;
+              feature-request) KIND_EMOJI=":bulb:" ;;
+              internal)        KIND_EMOJI=":nut_and_bolt:" ;;
+              refactor)        KIND_EMOJI=":recycle:" ;;
+              research)        KIND_EMOJI=":microscope:" ;;
+            esac
+
+            SLACK_PAYLOAD=$(jq -n \
+              --arg emoji "$KIND_EMOJI" \
+              --arg repo "$SHORT_REPO" \
+              --arg kind "${KIND:-unknown}" \
+              --arg severity "${SEVERITY_EMOJI} ${SEVERITY}" \
+              --arg issue_url "$ISSUE_URL" \
+              --arg issue_number "#${ISSUE_NUMBER}" \
+              --arg title "$ISSUE_TITLE" \
+              '{
+                "blocks": [{
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ($emoji + " [" + $repo + "] " + $kind + " · " + $severity + " severity — <" + $issue_url + "|" + $issue_number + " " + $title + ">")
+                  }
+                }]
+              }')
+            curl -s -X POST "$SLACK_DISTRO_BOT_WEBHOOK_GH" \
+              -H "Content-Type: application/json" \
+              --data "$SLACK_PAYLOAD" > /dev/null || echo "⚠️  Slack notification failed (non-fatal)"
 
             echo "✅ Triage completed for issue #${ISSUE_NUMBER}"
           done


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

closes: https://github.com/camunda/camunda-platform-helm/issues/5770

### What's in this PR?

1. Added new Webhook to vault for [#team-distribution-github](https://camunda.slack.com/archives/C03T7E7769K)
2. Send a nice notification to the 🔝 channel in case a new issue was triaged.
   - e.g. `🐛 [helm] bug · ⚠️ mid severity — #247 Helm chart fails to deploy when Keycloak is disabled`

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
