### PR TITLE
fix: use chartPath env var for post-release version labeling

### DIFF
--- a/.github/workflows/chart-release-public.yaml
+++ b/.github/workflows/chart-release-public.yaml
@@ -421,9 +421,8 @@ jobs:
       - name: Label PRs with version
         env:
           GH_TOKEN: ${{ steps.generate-github-token.outputs.token }}
-          chartPath: "charts/camunda-platform-${{ needs.release.outputs.chart-dir-id }}"
         run: |
-          make release.set-prs-version-label
+          make release.set-prs-version-label chartPath="charts/camunda-platform-${{ needs.release.outputs.chart-dir-id }}"
 
       - name: Mark release-please PR as published
         id: mark-published

--- a/scripts/set-prs-version-label.sh
+++ b/scripts/set-prs-version-label.sh
@@ -59,7 +59,15 @@ get_issues_per_pr () {
 
 # Run.
 # Label PRs with the app and chart version only if there is a change in the chart.
-ct list-changed | while read chart_dir; do
+# Use chartPath env var when set (e.g. in workflow_dispatch on main where ct list-changed
+# returns nothing because there is no branch diff), otherwise fall back to ct list-changed.
+if [[ -n "${chartPath:-}" ]]; then
+    chart_dirs="${chartPath}"
+else
+    chart_dirs="$(ct list-changed)"
+fi
+
+echo "${chart_dirs}" | while read chart_dir; do
     app_version="$(yq '.appVersion | sub("\..$", "")' ${chart_dir}/Chart.yaml)"
     chart_version="$(yq '.version' ${chart_dir}/Chart.yaml)"
     app_version_label="version/${app_version}"

--- a/scripts/set-prs-version-label.sh
+++ b/scripts/set-prs-version-label.sh
@@ -61,9 +61,8 @@ get_issues_per_pr () {
 # Label PRs with the app and chart version only if there is a change in the chart.
 # Use chartPath env var when set (e.g. in workflow_dispatch on main where ct list-changed
 # returns nothing because there is no branch diff), otherwise fall back to ct list-changed.
-# Normalize spaces to newlines so space-separated lists are handled correctly.
 if [[ -n "${chartPath:-}" ]]; then
-    chart_dirs="$(echo "${chartPath}" | tr ' ' '\n')"
+    chart_dirs="${chartPath}"
 else
     chart_dirs="$(ct list-changed)"
 fi

--- a/scripts/set-prs-version-label.sh
+++ b/scripts/set-prs-version-label.sh
@@ -61,13 +61,20 @@ get_issues_per_pr () {
 # Label PRs with the app and chart version only if there is a change in the chart.
 # Use chartPath env var when set (e.g. in workflow_dispatch on main where ct list-changed
 # returns nothing because there is no branch diff), otherwise fall back to ct list-changed.
+# Normalize spaces to newlines so space-separated lists are handled correctly.
 if [[ -n "${chartPath:-}" ]]; then
-    chart_dirs="${chartPath}"
+    chart_dirs="$(echo "${chartPath}" | tr ' ' '\n')"
 else
     chart_dirs="$(ct list-changed)"
 fi
 
-echo "${chart_dirs}" | while read chart_dir; do
+if [[ -z "${chart_dirs}" ]]; then
+    echo "No changed charts found, nothing to label."
+    exit 0
+fi
+
+echo "${chart_dirs}" | while read -r chart_dir; do
+    [[ -z "${chart_dir}" ]] && continue
     app_version="$(yq '.appVersion | sub("\..$", "")' ${chart_dir}/Chart.yaml)"
     chart_version="$(yq '.version' ${chart_dir}/Chart.yaml)"
     app_version_label="version/${app_version}"


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

No existing issue yet.

### What's in this PR?

- **Bug**: Post-release version labeling (e.g. `version:8.8-13.3.1`) stopped working after migration to `chart-release-public.yaml` in #4859 
  - Example issue: #5604 (example of missing specific version label)
  - How it was working before: #4857 (example of version labels present)
- **Cause**: `set-prs-version-label.sh` uses `ct list-changed` which compares current branch vs target branch. The public release workflow runs on `main` via `workflow_dispatch`, so `ct list-changed` compares `main` vs `main` → finds nothing → labels nothing
- **Fix**: Use `chartPath` env var (already set by the workflow) when available, fall back to `ct list-changed` for backward compatibility

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
