### PR TITLE
chore: add action to notify and report on prs updates

### DIFF
--- a/.github/workflows/notify-pr-activity.yml
+++ b/.github/workflows/notify-pr-activity.yml
@@ -1,0 +1,165 @@
+# type: Notifications
+# owner: @camunda/distribution-team
+---
+# PR Activity Slack Notifications
+#
+# Sends a message to #team-distribution-github (via distro-bot) when:
+#   - A PR is assigned (fires after the auto-assignee is set, covers "PR opened" use case)
+#   - A PR is merged
+#   - A PR is closed without merge
+#
+# Draft PRs are skipped entirely.
+#
+# Can be called from other repos via workflow_call — pass all pr_* inputs explicitly.
+#
+# Message format:
+#   ↗️ [helm] PR opened · by @author · review: @rev1 · +42/-7 — #123 feat: add support for X
+#   🎉 [helm] PR merged after 1d 4h · by @author · merged by @merger — #123 feat: add support for X
+#   ❌ [helm] PR closed without merge · by @author — #123 feat: add support for X
+#
+# Notification logic is implemented in scripts/notify-pr-activity (Go).
+#
+name: Notify - PR Activity
+
+on:
+  # pull_request_target ensures secrets are available even for fork PRs.
+  # Safe here because we never checkout PR code.
+  pull_request_target:
+    types: [assigned, closed]
+
+  workflow_call:
+    inputs:
+      action:
+        description: 'PR event action: assigned, closed'
+        type: string
+        required: true
+      pr_repo:
+        description: 'Repository name (e.g. camunda-platform-helm)'
+        type: string
+        required: true
+      pr_number:
+        description: 'PR number'
+        type: string
+        required: true
+      pr_title:
+        description: 'PR title'
+        type: string
+        required: true
+      pr_url:
+        description: 'PR HTML URL'
+        type: string
+        required: true
+      pr_author:
+        description: 'PR author login'
+        type: string
+        required: true
+      pr_additions:
+        description: 'Lines added'
+        type: string
+        required: false
+        default: '0'
+      pr_deletions:
+        description: 'Lines deleted'
+        type: string
+        required: false
+        default: '0'
+      pr_merged:
+        description: 'Whether the PR was merged (true/false)'
+        type: string
+        required: false
+        default: 'false'
+      pr_merged_by:
+        description: 'Login of the user who merged the PR'
+        type: string
+        required: false
+        default: ''
+      pr_created_at:
+        description: 'PR creation timestamp (2006-01-02T15:04:05Z)'
+        type: string
+        required: false
+        default: ''
+      pr_merged_at:
+        description: 'PR merge timestamp (2006-01-02T15:04:05Z)'
+        type: string
+        required: false
+        default: ''
+      pr_reviewers_json:
+        description: 'JSON array of requested reviewer objects: [{"login":"user1"},...]'
+        type: string
+        required: false
+        default: '[]'
+      pr_draft:
+        description: 'Whether the PR is a draft (true/false)'
+        type: string
+        required: false
+        default: 'false'
+    secrets:
+      VAULT_ADDR:
+        required: true
+      VAULT_ROLE_ID:
+        required: true
+      VAULT_SECRET_ID:
+        required: true
+
+jobs:
+  notify-slack:
+    # Skip draft PRs; only run for assigned, closed+merged, or closed+unmerged events.
+    # When called via workflow_call, the caller controls filtering via the pr_draft input.
+    if: |
+      (github.event_name == 'workflow_call' && inputs.pr_draft != 'true') ||
+      (github.event_name == 'pull_request_target' &&
+        !github.event.pull_request.draft && (
+          github.event.action == 'assigned' ||
+          github.event.action == 'closed'
+        ))
+    runs-on: ubuntu-latest
+    permissions: {}
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          sparse-checkout: scripts/notify-pr-activity
+          sparse-checkout-cone-mode: true
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: scripts/notify-pr-activity/go.mod
+          cache-dependency-path: scripts/notify-pr-activity/go.sum
+
+      - name: Import Vault secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b  # v3.4.0
+        id: vault-secrets
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/distribution/ci SLACK_DISTRO_BOT_WEBHOOK_GH;
+          exportEnv: true
+
+      - name: Send Slack notification
+        continue-on-error: true
+        env:
+          SLACK_WEBHOOK: ${{ env.SLACK_DISTRO_BOT_WEBHOOK_GH }}
+          # Resolve from workflow_call inputs first, fall back to pull_request_target event
+          GH_ACTION:        ${{ inputs.action        || github.event.action }}
+          PR_REPO:          ${{ inputs.pr_repo        || github.event.repository.name }}
+          PR_NUMBER:        ${{ inputs.pr_number      || github.event.pull_request.number }}
+          PR_TITLE:         ${{ inputs.pr_title       || github.event.pull_request.title }}
+          PR_URL:           ${{ inputs.pr_url         || github.event.pull_request.html_url }}
+          PR_AUTHOR:        ${{ inputs.pr_author      || github.event.pull_request.user.login }}
+          PR_ADDITIONS:     ${{ inputs.pr_additions   || github.event.pull_request.additions }}
+          PR_DELETIONS:     ${{ inputs.pr_deletions   || github.event.pull_request.deletions }}
+          PR_MERGED:        ${{ inputs.pr_merged      || github.event.pull_request.merged }}
+          PR_CREATED_AT:    ${{ inputs.pr_created_at  || github.event.pull_request.created_at }}
+          PR_MERGED_AT:     ${{ inputs.pr_merged_at   || github.event.pull_request.merged_at }}
+          PR_REVIEWERS_JSON: ${{ inputs.pr_reviewers_json || toJSON(github.event.pull_request.requested_reviewers) }}
+        run: |
+          cd scripts/notify-pr-activity
+          go run .
+
+

--- a/.github/workflows/notify-pr-activity.yml
+++ b/.github/workflows/notify-pr-activity.yml
@@ -113,7 +113,8 @@ jobs:
           github.event.action == 'closed'
         ))
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      contents: read
     timeout-minutes: 5
 
     steps:
@@ -124,10 +125,9 @@ jobs:
           sparse-checkout-cone-mode: true
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6
         with:
           go-version-file: scripts/notify-pr-activity/go.mod
-          cache-dependency-path: scripts/notify-pr-activity/go.sum
 
       - name: Import Vault secrets
         uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b  # v3.4.0
@@ -155,6 +155,7 @@ jobs:
           PR_ADDITIONS:     ${{ inputs.pr_additions   || github.event.pull_request.additions }}
           PR_DELETIONS:     ${{ inputs.pr_deletions   || github.event.pull_request.deletions }}
           PR_MERGED:        ${{ inputs.pr_merged      || github.event.pull_request.merged }}
+          PR_MERGED_BY:     ${{ inputs.pr_merged_by || (github.event.pull_request.merged_by && github.event.pull_request.merged_by.login) || '' }}
           PR_CREATED_AT:    ${{ inputs.pr_created_at  || github.event.pull_request.created_at }}
           PR_MERGED_AT:     ${{ inputs.pr_merged_at   || github.event.pull_request.merged_at }}
           PR_REVIEWERS_JSON: ${{ inputs.pr_reviewers_json || toJSON(github.event.pull_request.requested_reviewers) }}

--- a/scripts/notify-pr-activity/go.mod
+++ b/scripts/notify-pr-activity/go.mod
@@ -1,0 +1,3 @@
+module scripts/notify-pr-activity
+
+go 1.25.0

--- a/scripts/notify-pr-activity/main.go
+++ b/scripts/notify-pr-activity/main.go
@@ -1,0 +1,160 @@
+// Copyright 2025 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const timeLayout = "2006-01-02T15:04:05Z"
+
+type slackBlock struct {
+	Type string    `json:"type"`
+	Text slackText `json:"text"`
+}
+
+type slackText struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type slackPayload struct {
+	Blocks []slackBlock `json:"blocks"`
+}
+
+func mustEnv(key string) string {
+	v := os.Getenv(key)
+	if v == "" {
+		fmt.Fprintf(os.Stderr, "error: required env var %s is not set\n", key)
+		os.Exit(1)
+	}
+	return v
+}
+
+func shortRepo(name string) string {
+	return strings.TrimPrefix(name, "camunda-platform-")
+}
+
+func formatDuration(from, to time.Time) string {
+	diff := to.Sub(from)
+	days := int(diff.Hours()) / 24
+	hours := int(diff.Hours()) % 24
+	switch {
+	case days > 0 && hours > 0:
+		return fmt.Sprintf("%dd %dh", days, hours)
+	case days > 0:
+		return fmt.Sprintf("%dd", days)
+	case hours > 0:
+		return fmt.Sprintf("%dh", hours)
+	default:
+		return "< 1h"
+	}
+}
+
+// parseReviewers decodes a JSON array of GitHub user objects and returns "@login, ..." string.
+func parseReviewers(raw string) string {
+	var users []struct {
+		Login string `json:"login"`
+	}
+	if err := json.Unmarshal([]byte(raw), &users); err != nil || len(users) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(users))
+	for _, u := range users {
+		names = append(names, "@"+u.Login)
+	}
+	return strings.Join(names, ", ")
+}
+
+func buildMessage() string {
+	action := mustEnv("GH_ACTION")
+	repo := shortRepo(mustEnv("PR_REPO"))
+	prURL := mustEnv("PR_URL")
+	prNum := "#" + mustEnv("PR_NUMBER")
+	prTitle := mustEnv("PR_TITLE")
+	author := "@" + mustEnv("PR_AUTHOR")
+
+	link := fmt.Sprintf("<%s|%s %s>", prURL, prNum, prTitle)
+
+	switch action {
+	case "assigned":
+		size := fmt.Sprintf("+%s/-%s", mustEnv("PR_ADDITIONS"), mustEnv("PR_DELETIONS"))
+		reviewers := parseReviewers(os.Getenv("PR_REVIEWERS_JSON"))
+		reviewText := ""
+		if reviewers != "" {
+			reviewText = " · review: " + reviewers
+		}
+		return fmt.Sprintf(":arrow_heading_up: [%s] PR opened · by %s%s · %s — %s",
+			repo, author, reviewText, size, link)
+
+	case "closed":
+		merged := os.Getenv("PR_MERGED") == "true"
+		if merged {
+			createdAt, err1 := time.Parse(timeLayout, mustEnv("PR_CREATED_AT"))
+			mergedAt, err2 := time.Parse(timeLayout, mustEnv("PR_MERGED_AT"))
+			duration := "unknown"
+			if err1 == nil && err2 == nil {
+				duration = formatDuration(createdAt, mergedAt)
+			}
+			return fmt.Sprintf(":tada: [%s] PR merged after %s · by %s — %s",
+				repo, duration, author, link)
+		}
+		return fmt.Sprintf(":x: [%s] PR closed without merge · by %s — %s",
+			repo, author, link)
+
+	default:
+		fmt.Fprintf(os.Stderr, "error: unhandled action %q\n", action)
+		os.Exit(1)
+		return ""
+	}
+}
+
+func sendSlack(webhook, message string) error {
+	payload := slackPayload{
+		Blocks: []slackBlock{
+			{Type: "section", Text: slackText{Type: "mrkdwn", Text: message}},
+		},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal payload: %w", err)
+	}
+	resp, err := http.Post(webhook, "application/json", bytes.NewReader(body)) //nolint:noctx
+	if err != nil {
+		return fmt.Errorf("http post: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("unexpected status: %s", resp.Status)
+	}
+	return nil
+}
+
+func main() {
+	webhook := mustEnv("SLACK_WEBHOOK")
+	message := buildMessage()
+
+	fmt.Printf("📣 Sending Slack notification: %s\n", message)
+
+	if err := sendSlack(webhook, message); err != nil {
+		fmt.Fprintf(os.Stderr, "⚠️  Slack notification failed (non-fatal): %v\n", err)
+	}
+}

--- a/scripts/notify-pr-activity/main.go
+++ b/scripts/notify-pr-activity/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -24,7 +25,7 @@ import (
 	"time"
 )
 
-const timeLayout = "2006-01-02T15:04:05Z"
+const timeLayout = time.RFC3339
 
 type slackBlock struct {
 	Type string    `json:"type"`
@@ -137,7 +138,18 @@ func sendSlack(webhook, message string) error {
 	if err != nil {
 		return fmt.Errorf("marshal payload: %w", err)
 	}
-	resp, err := http.Post(webhook, "application/json", bytes.NewReader(body)) //nolint:noctx
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "POST", webhook, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("http post: %w", err)
 	}


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

closes https://github.com/camunda/camunda-platform-helm/issues/5776

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

Uses the SLACK_DISTRO_BOT_WEBHOOK_GH secret from Vault.

PR activity notifications (notify-pr-activity.yml)
Notifies on three PR events (draft PRs skipped):

```
↗️ [helm] PR opened · by @author · review: @rev1 · +42/-7 — #512 feat: add Zeebe limits
🎉 [helm] PR merged after 1d 4h · by @author — #512 feat: add Zeebe limits
❌ [helm] PR closed without merge · by @author — #512 feat: add Zeebe limits
```

Notification logic is implemented as a small Go tool in scripts/notify-pr-activity. The workflow also supports workflow_call so other repos (e.g. team-distribution) can reuse it by passing PR event data as inputs.

Prerequisites
SLACK_DISTRO_BOT_WEBHOOK_GH must be added to Vault at secret/data/products/distribution/ci, pointing to the #team-distribution-github incoming webhook.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
