### PR TITLE
ci: fix harbor retry aborting when re-auth itself fails transiently

### DIFF
--- a/scripts/harbor-retry.sh
+++ b/scripts/harbor-retry.sh
@@ -11,7 +11,7 @@
 #   harbor_login   # login with retry
 
 HARBOR_RETRY_MAX=${HARBOR_RETRY_MAX:-3}
-HARBOR_RETRY_DELAY=${HARBOR_RETRY_DELAY:-10}
+HARBOR_RETRY_DELAY=${HARBOR_RETRY_DELAY:-30}
 
 # Resolve which env var holds the registry hostname.
 _harbor_host() {
@@ -50,10 +50,7 @@ harbor_retry() {
     fi
     if [[ ${attempt} -lt ${max_retries} ]]; then
       echo "::warning::${desc} failed on attempt ${attempt}, re-authenticating and retrying in ${retry_delay}s..."
-      if ! harbor_reauth; then
-        echo "::error::Harbor re-authentication failed after ${desc} failed on attempt ${attempt}; aborting retries"
-        return 1
-      fi
+      harbor_reauth || echo "::warning::Re-authentication also failed (attempt ${attempt}), will retry after backoff..."
       sleep "${retry_delay}"
       retry_delay=$((retry_delay * 2))
     fi
@@ -118,7 +115,7 @@ harbor_helm_pull() {
       echo "::warning::helm pull auth error on attempt ${attempt}/${max_retries}"
       cat "${pull_stderr}" >&2
       if [[ ${attempt} -lt ${max_retries} ]]; then
-        harbor_reauth
+        harbor_reauth || echo "::warning::Re-authentication also failed (attempt ${attempt}), will retry after backoff..."
         sleep "${retry_delay}"
         retry_delay=$((retry_delay * 2))
         continue


### PR DESCRIPTION
### Which problem does the PR fix?

Follow-up to #5736. When Harbor's token service is transiently down, `harbor_reauth` fails, and two things go wrong:

1. **`harbor_retry`**: aborts all retries immediately instead of sleeping and trying again
2. **`harbor_helm_pull`**: bare `harbor_reauth` call is unprotected — under GHA's `set -e`, the entire step dies instantly

Observed in https://github.com/camunda/camunda-platform-helm/actions/runs/24364939166/job/71154081127 — `oras push` got 401, re-auth also got 401 from token service, retries aborted after attempt 1. Re-run succeeded, proving the outage was transient.

### What's in this PR?

- Both `harbor_reauth` calls in retry loops now use `|| echo "::warning::..."` so they don't abort the loop or trigger `set -e`
- Increased default backoff from 10s to 30s to give Harbor more recovery time (backoff sequence: 30s, 60s → total ~90s before giving up)

### Checklist

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).