### PR TITLE
test: include version check env var in base-upgrade values

### DIFF
--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/base-upgrade.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/base-upgrade.yaml
@@ -8,3 +8,5 @@ orchestration:
   env:
     - name: CAMUNDA_DATABASE_SCHEMAMANAGER_VERSIONCHECKRESTRICTIONENABLED
       value: "false"
+    - name: CAMUNDA_SYSTEM_UPGRADE_ENABLEVERSIONCHECK
+      value: "false"

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/base-upgrade.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/base-upgrade.yaml
@@ -8,3 +8,5 @@ orchestration:
   env:
     - name: CAMUNDA_DATABASE_SCHEMAMANAGER_VERSIONCHECKRESTRICTIONENABLED
       value: "false"
+    - name: CAMUNDA_SYSTEM_UPGRADE_ENABLEVERSIONCHECK
+      value: "false"


### PR DESCRIPTION
### Which problem does the PR fix?

All 8.9 and 8.10 upgrade-minor Playwright e2e smoke tests fail with 404 on
`/orchestration/admin` after `helm upgrade --force`. This has been broken since
the 14.0.0 release (April 9), affecting every PR.

### What's in this PR?

`base-upgrade.yaml` sets `orchestration.env` as a YAML array with one entry.
Since Helm arrays replace rather than merge, this clobbers the common values'
`orchestration.env` which also contains
`CAMUNDA_SYSTEM_UPGRADE_ENABLEVERSIONCHECK=false`.

Without that env var (defaults to `true`), the orchestration app's version check
detects a mismatch between installed data (released 8.9.0/8.10.0) and the running
binary (SNAPSHOT), and disables the admin webapp — returning 404.

Fix: include both env vars in `base-upgrade.yaml` for 8.9 and 8.10.

### Checklist

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).