### PR TITLE
ci: fix esarm failures — increase identity startup probe for ARM, fix failed-pods-info

### DIFF
--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/arm.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/arm.yaml
@@ -1,5 +1,11 @@
 # ARM nodes (c4a-standard-8) don't support pd-balanced disks.
 # Use hyperdisk-balanced for all StatefulSet PVCs.
+
+# Identity startup is slower on ARM; increase startup probe budget.
+identity:
+  startupProbe:
+    failureThreshold: 180
+
 orchestration:
   pvcStorageClassName: hyperdisk-balanced
 

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/arm.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/arm.yaml
@@ -2,8 +2,11 @@
 # Use hyperdisk-balanced for all StatefulSet PVCs.
 
 # Identity startup is slower on ARM; increase startup probe budget.
+# periodSeconds is inherited from base.yaml (2s) but set explicitly here so the
+# effective budget (failureThreshold * periodSeconds = ~6min) is obvious.
 identity:
   startupProbe:
+    periodSeconds: 2
     failureThreshold: 180
 
 orchestration:

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/arm.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/arm.yaml
@@ -1,5 +1,11 @@
 # ARM nodes (c4a-standard-8) don't support pd-balanced disks.
 # Use hyperdisk-balanced for all StatefulSet PVCs.
+
+# Identity startup is slower on ARM; increase startup probe budget.
+identity:
+  startupProbe:
+    failureThreshold: 180
+
 orchestration:
   pvcStorageClassName: hyperdisk-balanced
 

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/arm.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/arm.yaml
@@ -2,8 +2,11 @@
 # Use hyperdisk-balanced for all StatefulSet PVCs.
 
 # Identity startup is slower on ARM; increase startup probe budget.
+# periodSeconds is inherited from base.yaml (2s) but set explicitly here so the
+# effective budget (failureThreshold * periodSeconds = ~6min) is obvious.
 identity:
   startupProbe:
+    periodSeconds: 2
     failureThreshold: 180
 
 orchestration:

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/arm.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/arm.yaml
@@ -1,5 +1,11 @@
 # ARM nodes (c4a-standard-8) don't support pd-balanced disks.
 # Use hyperdisk-balanced for all StatefulSet PVCs.
+
+# Identity startup is slower on ARM; increase startup probe budget.
+identity:
+  startupProbe:
+    failureThreshold: 180
+
 orchestration:
   pvcStorageClassName: hyperdisk-balanced
 

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/arm.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/arm.yaml
@@ -2,8 +2,11 @@
 # Use hyperdisk-balanced for all StatefulSet PVCs.
 
 # Identity startup is slower on ARM; increase startup probe budget.
+# periodSeconds is inherited from base.yaml (2s) but set explicitly here so the
+# effective budget (failureThreshold * periodSeconds = ~6min) is obvious.
 identity:
   startupProbe:
+    periodSeconds: 2
     failureThreshold: 180
 
 orchestration:


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #5800.

The esarm integration tests fail because identity's startup probe kills it
before Keycloak realm setup completes on ARM nodes, and the diagnostic action
hides the crash logs.

### What's in this PR?

**1. Increase identity startup probe for ARM** (`features/arm.yaml`, 8.8/8.9/8.10)

The base values set `failureThreshold: 60` (125s). On ARM, identity connects to
external Keycloak and performs realm setup which takes longer than on x86. Bumped
to `failureThreshold: 180` (~6min) so the startup probe doesn't kill identity
mid-realm-setup.

**2. Fix `failed-pods-info` diagnostic action**

The loop ran under `bash -eo pipefail`. When `kubectl logs` failed on a pod in
`PodInitializing` (connectors), the loop aborted before reaching identity
(the actually crashing pod). Added `|| true` and `--all-containers`.

### Validation

Deployed all 3 esarm scenarios in parallel with `deploy-camunda matrix run`:

| Version | Result | Time | Identity restarts |
|---------|--------|------|-------------------|
| 8.8 | PASS | 14m28s | 4 |
| 8.9 | PASS | 7m53s | 0 |
| 8.10 | PASS | 11m16s | 4 |

### Checklist

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).