### PR TITLE
chore:  notify-pr-activity workflow misses PR opened notifications

### DIFF
--- a/.github/workflows/notify-pr-activity.yml
+++ b/.github/workflows/notify-pr-activity.yml
@@ -5,6 +5,7 @@
 #
 # Sends a message to #team-distribution-github (via distro-bot) when:
 #   - A PR is opened or converted from draft to ready for review
+#   - A PR is merged
 #   - A PR is closed without merge
 #
 # Draft PRs are skipped entirely.

--- a/.github/workflows/notify-pr-activity.yml
+++ b/.github/workflows/notify-pr-activity.yml
@@ -4,8 +4,7 @@
 # PR Activity Slack Notifications
 #
 # Sends a message to #team-distribution-github (via distro-bot) when:
-#   - A PR is assigned (fires after the auto-assignee is set, covers "PR opened" use case)
-#   - A PR is merged
+#   - A PR is opened or converted from draft to ready for review
 #   - A PR is closed without merge
 #
 # Draft PRs are skipped entirely.
@@ -25,12 +24,12 @@ on:
   # pull_request_target ensures secrets are available even for fork PRs.
   # Safe here because we never checkout PR code.
   pull_request_target:
-    types: [assigned, closed]
+    types: [opened, ready_for_review, closed]
 
   workflow_call:
     inputs:
       action:
-        description: 'PR event action: assigned, closed'
+        description: 'PR event action: opened, ready_for_review, closed'
         type: string
         required: true
       pr_repo:
@@ -103,13 +102,14 @@ on:
 
 jobs:
   notify-slack:
-    # Skip draft PRs; only run for assigned, closed+merged, or closed+unmerged events.
+    # Skip draft PRs; only run for opened, ready_for_review, closed+merged, or closed+unmerged events.
     # When called via workflow_call, the caller controls filtering via the pr_draft input.
     if: |
       (github.event_name == 'workflow_call' && inputs.pr_draft != 'true') ||
       (github.event_name == 'pull_request_target' &&
         !github.event.pull_request.draft && (
-          github.event.action == 'assigned' ||
+          github.event.action == 'opened' ||
+          github.event.action == 'ready_for_review' ||
           github.event.action == 'closed'
         ))
     runs-on: ubuntu-latest

--- a/scripts/notify-pr-activity/main.go
+++ b/scripts/notify-pr-activity/main.go
@@ -96,7 +96,7 @@ func buildMessage() string {
 	link := fmt.Sprintf("<%s|%s %s>", prURL, prNum, prTitle)
 
 	switch action {
-	case "assigned":
+	case "opened", "ready_for_review":
 		size := fmt.Sprintf("+%s/-%s", mustEnv("PR_ADDITIONS"), mustEnv("PR_DELETIONS"))
 		reviewers := parseReviewers(os.Getenv("PR_REVIEWERS_JSON"))
 		reviewText := ""


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

closes https://github.com/camunda/camunda-platform-helm/issues/5805

### What's in this PR?

This pull request updates the PR activity Slack notification workflow to better align with current PR lifecycle events and synchronizes container image digests for multiple Camunda platform charts. The workflow now sends notifications when a PR is opened or marked ready for review, and the supporting script and documentation have been updated accordingly. Additionally, several image digests have been updated to reference the latest builds.

**GitHub Actions Workflow Improvements:**

* Updated `.github/workflows/notify-pr-activity.yml` to send Slack notifications when a PR is opened or converted from draft to ready for review, instead of only when assigned. Updated documentation and event triggers to match this behavior, and adjusted the workflow's filtering logic to skip draft PRs and handle the new event types. [[1]](diffhunk://#diff-f6595e4411f7780a67ccdbb4961a1adf62de8274939ca48aa8191bc28074f4efL7-R7) [[2]](diffhunk://#diff-f6595e4411f7780a67ccdbb4961a1adf62de8274939ca48aa8191bc28074f4efL28-R32) [[3]](diffhunk://#diff-f6595e4411f7780a67ccdbb4961a1adf62de8274939ca48aa8191bc28074f4efL106-R112)
* Modified `scripts/notify-pr-activity/main.go` to generate Slack messages for the new PR events (`opened`, `ready_for_review`) instead of `assigned`.

**Container Image Digest Updates:**

* Updated the `console`, `webModeler`, and `identity` image digests in `charts/camunda-platform-8.9/values-digest.yaml`, `charts/camunda-platform-8.10/values-digest.yaml`, and `charts/camunda-platform-8.8/values-digest.yaml` to reference the latest builds. [[1]](diffhunk://#diff-66f15eeaeed950a636d1290ece6f7104a57868d0d4fe2f4e19f4713e79db6811L10-R10) [[2]](diffhunk://#diff-66f15eeaeed950a636d1290ece6f7104a57868d0d4fe2f4e19f4713e79db6811L36-R36) [[3]](diffhunk://#diff-66f15eeaeed950a636d1290ece6f7104a57868d0d4fe2f4e19f4713e79db6811L65-R65) [[4]](diffhunk://#diff-c273b8ae6a9d3498223e7e7abd764d22edd6d35749373526f2d788ac6c3b6fafL10-R10) [[5]](diffhunk://#diff-c273b8ae6a9d3498223e7e7abd764d22edd6d35749373526f2d788ac6c3b6fafL36-R36) [[6]](diffhunk://#diff-c273b8ae6a9d3498223e7e7abd764d22edd6d35749373526f2d788ac6c3b6fafL65-R65) [[7]](diffhunk://#diff-a4122547aaebcbe9c59727c0cd729c874812f129425e83e89962cc0f4a315166L10-R10)
<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
