### PR TITLE
feat: add MCP feature scenario for 8.10 integration tests

### DIFF
--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/mcp.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/mcp.yaml
@@ -1,0 +1,14 @@
+# MCP (Model Context Protocol) feature configuration for 8.10
+# Layer 4: Feature - MCP
+#
+# This feature file only enables the MCP gateway. It works with any secondary
+# storage type (elasticsearch, opensearch, rdbms) controlled by the persistence layer.
+
+# Enable MCP gateway
+orchestration:
+  extraConfiguration:
+    - file: mcp-gateway.yaml
+      content: |
+        camunda:
+          mcp:
+            enabled: true

--- a/docs/integration-test-scenario-resolution.md
+++ b/docs/integration-test-scenario-resolution.md
@@ -20,6 +20,7 @@ test scenario, from the CI config entry to the final `helm install -f` arguments
   - [8.7](#87)
   - [8.8](#88)
   - [8.9](#89)
+  - [8.10](#810)
 
 ---
 
@@ -205,32 +206,33 @@ Versions 8.2–8.5 use the legacy (non-layered) values system and do not have a
 - &#x2713; = file exists
 - &#x2717; = file does not exist
 
-| File | 8.6 | 8.7 | 8.8 | 8.9 |
-|------|-----|-----|-----|-----|
-| **Base** | | | | |
-| `base.yaml` | &#x2713; | &#x2713; | &#x2713; | &#x2713; |
-| `base-qa.yaml` | &#x2713; | &#x2713; | &#x2713; | &#x2713; |
-| `base-upgrade.yaml` | &#x2717; | &#x2713; | &#x2713; | &#x2713; |
-| `base-image-tags.yaml` | &#x2713; | &#x2713; | &#x2713; | &#x2713; |
-| **Identity** | | | | |
-| `identity/keycloak.yaml` | &#x2713; | &#x2713; | &#x2713; | &#x2713; |
-| `identity/keycloak-external.yaml` | &#x2713; | &#x2713; | &#x2713; | &#x2713; |
-| `identity/oidc.yaml` | &#x2717; | &#x2713; | &#x2713; | &#x2713; |
-| `identity/basic.yaml` | &#x2717; | &#x2717; | &#x2713; | &#x2713; |
-| `identity/hybrid.yaml` | &#x2717; | &#x2717; | &#x2713; | &#x2713; |
-| **Persistence** | | | | |
-| `persistence/elasticsearch.yaml` | &#x2713; | &#x2713; | &#x2713; | &#x2713; |
-| `persistence/elasticsearch-external.yaml` | &#x2713; | &#x2713; | &#x2713; | &#x2713; |
-| `persistence/opensearch.yaml` | &#x2713; | &#x2713; | &#x2713; | &#x2713; |
-| `persistence/rdbms.yaml` | &#x2717; | &#x2717; | &#x2717; | &#x2713; |
-| `persistence/rdbms-oracle.yaml` | &#x2717; | &#x2717; | &#x2717; | &#x2713; |
-| **Platform** | | | | |
-| `platform/gke.yaml` | &#x2713; | &#x2713; | &#x2713; | &#x2713; |
-| `platform/eks.yaml` | &#x2713; | &#x2713; | &#x2713; | &#x2713; |
-| **Features** | | | | |
-| `features/multitenancy.yaml` | &#x2713; | &#x2713; | &#x2713; | &#x2713; |
-| `features/rba.yaml` | &#x2713; | &#x2713; | &#x2713; | &#x2713; |
-| `features/documentstore.yaml` | &#x2717; | &#x2713; | &#x2713; | &#x2713; |
+| File | 8.6 | 8.7 | 8.8 | 8.9 | 8.10 |
+|------|-----|-----|-----|-----|------|
+| **Base** | | | | | |
+| `base.yaml` | &#x2713; | &#x2713; | &#x2713; | &#x2713; | &#x2713; |
+| `base-qa.yaml` | &#x2713; | &#x2713; | &#x2713; | &#x2713; | &#x2713; |
+| `base-upgrade.yaml` | &#x2717; | &#x2713; | &#x2713; | &#x2713; | &#x2713; |
+| `base-image-tags.yaml` | &#x2713; | &#x2713; | &#x2713; | &#x2713; | &#x2713; |
+| **Identity** | | | | | |
+| `identity/keycloak.yaml` | &#x2713; | &#x2713; | &#x2713; | &#x2713; | &#x2713; |
+| `identity/keycloak-external.yaml` | &#x2713; | &#x2713; | &#x2713; | &#x2713; | &#x2713; |
+| `identity/oidc.yaml` | &#x2717; | &#x2713; | &#x2713; | &#x2713; | &#x2713; |
+| `identity/basic.yaml` | &#x2717; | &#x2717; | &#x2713; | &#x2713; | &#x2713; |
+| `identity/hybrid.yaml` | &#x2717; | &#x2717; | &#x2713; | &#x2713; | &#x2713; |
+| **Persistence** | | | | | |
+| `persistence/elasticsearch.yaml` | &#x2713; | &#x2713; | &#x2713; | &#x2713; | &#x2713; |
+| `persistence/elasticsearch-external.yaml` | &#x2713; | &#x2713; | &#x2713; | &#x2713; | &#x2713; |
+| `persistence/opensearch.yaml` | &#x2713; | &#x2713; | &#x2713; | &#x2713; | &#x2713; |
+| `persistence/rdbms.yaml` | &#x2717; | &#x2717; | &#x2717; | &#x2713; | &#x2713; |
+| `persistence/rdbms-oracle.yaml` | &#x2717; | &#x2717; | &#x2717; | &#x2713; | &#x2713; |
+| **Platform** | | | | | |
+| `platform/gke.yaml` | &#x2713; | &#x2713; | &#x2713; | &#x2713; | &#x2713; |
+| `platform/eks.yaml` | &#x2713; | &#x2713; | &#x2713; | &#x2713; | &#x2713; |
+| **Features** | | | | | |
+| `features/multitenancy.yaml` | &#x2713; | &#x2713; | &#x2713; | &#x2713; | &#x2713; |
+| `features/rba.yaml` | &#x2713; | &#x2713; | &#x2713; | &#x2713; | &#x2713; |
+| `features/documentstore.yaml` | &#x2717; | &#x2713; | &#x2713; | &#x2713; | &#x2713; |
+| `features/mcp.yaml` | &#x2717; | &#x2717; | &#x2717; | &#x2713; | &#x2713; |
 
 ---
 
@@ -647,6 +649,40 @@ values/platform/gke.yaml
 - `gateway-keycloak` scenario
 - Documentation comments in ci-test-config.yaml describing the Selection +
   Composition approach
+
+---
+
+### 8.10
+
+Adds MCP (Model Context Protocol) feature support for Self-Managed MCP cluster tools testing.
+
+#### Scenarios
+
+All scenarios from 8.9 apply. The `mcp` feature scenario is now available.
+
+#### What 8.10 Adds Over 8.9
+- `features/mcp.yaml` — MCP gateway enabled via `orchestration.extraConfiguration`
+
+#### Resolved Values Files
+
+**`mcp` on GKE:**
+```
+values/base.yaml
+values/identity/keycloak.yaml
+values/persistence/elasticsearch-external.yaml
+values/platform/gke.yaml
+values/features/mcp.yaml
+```
+
+**`qa-elasticsearch-mcp` on GKE:**
+```
+values/base.yaml
+values/base-qa.yaml
+values/identity/keycloak.yaml
+values/persistence/elasticsearch-external.yaml
+values/platform/gke.yaml
+values/features/mcp.yaml
+```
 
 ---
 

--- a/docs/integration-test-scenario-resolution.md
+++ b/docs/integration-test-scenario-resolution.md
@@ -654,14 +654,14 @@ values/platform/gke.yaml
 
 ### 8.10
 
-Adds MCP (Model Context Protocol) feature support for Self-Managed MCP cluster tools testing.
+Includes MCP (Model Context Protocol) feature support for Self-Managed MCP cluster tools testing (introduced in 8.9).
 
 #### Scenarios
 
-All scenarios from 8.9 apply. The `mcp` feature scenario is now available.
+All scenarios from 8.9 apply, including the `mcp` feature scenario.
 
-#### What 8.10 Adds Over 8.9
-- `features/mcp.yaml` — MCP gateway enabled via `orchestration.extraConfiguration`
+#### 8.10 Layer Notes
+- `features/mcp.yaml` — enables the MCP gateway via `orchestration.extraConfiguration`
 
 #### Resolved Values Files
 
@@ -669,7 +669,7 @@ All scenarios from 8.9 apply. The `mcp` feature scenario is now available.
 ```
 values/base.yaml
 values/identity/keycloak.yaml
-values/persistence/elasticsearch-external.yaml
+values/persistence/elasticsearch.yaml
 values/platform/gke.yaml
 values/features/mcp.yaml
 ```
@@ -679,7 +679,7 @@ values/features/mcp.yaml
 values/base.yaml
 values/base-qa.yaml
 values/identity/keycloak.yaml
-values/persistence/elasticsearch-external.yaml
+values/persistence/elasticsearch.yaml
 values/platform/gke.yaml
 values/features/mcp.yaml
 ```


### PR DESCRIPTION
## Summary

Applies the same MCP (Model Context Protocol) feature scenario support from [#5475](https://github.com/camunda/camunda-platform-helm/pull/5475) (8.9) to the 8.10 chart version.

- Created `values/features/mcp.yaml` for 8.10 — enables the MCP gateway via `orchestration.extraConfiguration`
- Updated `docs/integration-test-scenario-resolution.md` to include 8.10 in the available layer files table and adds a new 8.10 scenario resolution section

## Changes

| File | Change |
|------|--------|
| `charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/mcp.yaml` | Created |
| `docs/integration-test-scenario-resolution.md` | Updated — added 8.10 column + `features/mcp.yaml` row + 8.10 section |

> No changes to `scripts/camunda-core/pkg/scenarios/scenarios.go` or `scenarios_test.go` — those were already updated in #5475 (shared scripts, not version-specific).

## Scenarios Enabled

- `mcp`
- `qa-elasticsearch-mcp`
- Any scenario name containing `mcp`

## Related

- Closes #5474
- Follow-up to #5475 (same change for 8.9)

## Test plan

- [ ] Verify `mcp.yaml` is picked up by `ResolvePaths` for an `mcp` scenario on 8.10
- [ ] Run `cd scripts/camunda-core && go test ./pkg/scenarios/...` — existing MCP test cases already cover the scenario detection logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)