### PR TITLE
chore: fix ai issue triage non-determinitic responses

### DIFF
--- a/.github/workflows/triage-ai-issue.yml
+++ b/.github/workflows/triage-ai-issue.yml
@@ -286,7 +286,7 @@ jobs:
               echo "❌ Invalid JSON in AI response"
               echo "AI response: ${AI_TEXT}"
               echo "💬 Posting error comment and applying triage:manual label..."
-              gh issue comment "$ISSUE_NUMBER" --repo "$OWNER/$REPO" --body "$(printf '❌ **Error triaging #%s — manual triage required**\n\nThe AI triage assistant failed to produce a valid response for this issue. Please triage it manually and apply the appropriate labels.\n\nAdd the \`triage:manual\` label to suppress future automated triage attempts.' "$ISSUE_NUMBER")"
+              gh issue comment "$ISSUE_NUMBER" --repo "$OWNER/$REPO" --body "$(printf '❌ **Error triaging #%s — manual triage required**\n\nThe AI triage assistant failed to produce a valid response for this issue. Please triage it manually and apply the appropriate labels.\n\nAdd the `triage:manual` label to suppress future automated triage attempts.' "$ISSUE_NUMBER")" || true
               gh issue edit "$ISSUE_NUMBER" --repo "$OWNER/$REPO" --add-label "triage:manual" || true
               continue
             fi

--- a/.github/workflows/triage-ai-issue.yml
+++ b/.github/workflows/triage-ai-issue.yml
@@ -285,6 +285,9 @@ jobs:
             if ! echo "$AI_JSON" | jq -e . > /dev/null 2>&1; then
               echo "❌ Invalid JSON in AI response"
               echo "AI response: ${AI_TEXT}"
+              echo "💬 Posting error comment and applying triage:manual label..."
+              gh issue comment "$ISSUE_NUMBER" --repo "$OWNER/$REPO" --body "$(printf '❌ **Error triaging #%s — manual triage required**\n\nThe AI triage assistant failed to produce a valid response for this issue. Please triage it manually and apply the appropriate labels.\n\nAdd the \`triage:manual\` label to suppress future automated triage attempts.' "$ISSUE_NUMBER")"
+              gh issue edit "$ISSUE_NUMBER" --repo "$OWNER/$REPO" --add-label "triage:manual" || true
               continue
             fi
 

--- a/.github/workflows/triage-ai-issue.yml
+++ b/.github/workflows/triage-ai-issue.yml
@@ -273,8 +273,8 @@ jobs:
             # Extract JSON from AI response (it might be wrapped in markdown code blocks)
             AI_JSON=$(echo "$AI_TEXT" | sed -n '/^```json$/,/^```$/p' | sed '1d;$d')
             if [[ -z "$AI_JSON" ]]; then
-              # Extract the first JSON object, ignoring any trailing text (e.g. follow-up questions from the AI)
-              AI_JSON=$(echo "$AI_TEXT" | python3 -c "import sys,json;t=sys.stdin.read().strip();d=json.JSONDecoder();o,_=d.raw_decode(t);print(json.dumps(o))" 2>/dev/null || true)
+              # Extract the first JSON object, skipping any prose that precedes it
+              AI_JSON=$(echo "$AI_TEXT" | python3 -c "import sys,json;t=sys.stdin.read();start=t.find('{');d=json.JSONDecoder();o,_=d.raw_decode(t,start) if start>=0 else (None,0);print(json.dumps(o)) if o else ''" 2>/dev/null || true)
             fi
             if [[ -z "$AI_JSON" ]]; then
               # Last resort: use the full text

--- a/.github/workflows/triage-ai-issue.yml
+++ b/.github/workflows/triage-ai-issue.yml
@@ -274,7 +274,7 @@ jobs:
             AI_JSON=$(echo "$AI_TEXT" | sed -n '/^```json$/,/^```$/p' | sed '1d;$d')
             if [[ -z "$AI_JSON" ]]; then
               # Extract the first JSON object, skipping any prose that precedes it
-              AI_JSON=$(echo "$AI_TEXT" | python3 -c "import sys,json;t=sys.stdin.read();start=t.find('{');d=json.JSONDecoder();o,_=d.raw_decode(t,start) if start>=0 else (None,0);print(json.dumps(o)) if o else ''" 2>/dev/null || true)
+              AI_JSON=$(echo "$AI_TEXT" | python3 -c "import sys,json;t=sys.stdin.read();start=t.find('{');d=json.JSONDecoder();o,_=d.raw_decode(t,start) if start>=0 else (None,0);print(json.dumps(o)) if o is not None else ''" 2>/dev/null || true)
             fi
             if [[ -z "$AI_JSON" ]]; then
               # Last resort: use the full text

--- a/.github/workflows/triage-ai-issue.yml
+++ b/.github/workflows/triage-ai-issue.yml
@@ -286,7 +286,7 @@ jobs:
               echo "❌ Invalid JSON in AI response"
               echo "AI response: ${AI_TEXT}"
               echo "💬 Posting error comment and applying triage:manual label..."
-              gh issue comment "$ISSUE_NUMBER" --repo "$OWNER/$REPO" --body "$(printf '❌ **Error triaging #%s — manual triage required**\n\nThe AI triage assistant failed to produce a valid response for this issue. Please triage it manually and apply the appropriate labels.\n\nAdd the `triage:manual` label to suppress future automated triage attempts.' "$ISSUE_NUMBER")" || true
+              gh issue comment "$ISSUE_NUMBER" --repo "$OWNER/$REPO" --body "$(printf '❌ **Error triaging #%s — manual triage required**\n\nThe AI triage assistant failed to produce a valid response for this issue. Please triage it manually and apply the appropriate labels.\n\nThe `triage:manual` label has been applied to suppress future automated triage attempts.' "$ISSUE_NUMBER")" || true
               gh issue edit "$ISSUE_NUMBER" --repo "$OWNER/$REPO" --add-label "triage:manual" || true
               continue
             fi


### PR DESCRIPTION
### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

closes https://github.com/camunda/camunda-platform-helm/issues/5822

LLMs are non-deterministic — even with the same prompt, the response format can vary between calls. Sometimes the model returns clean JSON, sometimes it "thinks out loud" first with prose before the JSON block (as happened here).

Seems this is a common LLM reliability issue. The fix is to always extract JSON defensively rather than assuming the entire response is valid JSON using good old regex...

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

This pull request improves the robustness and user feedback of the AI triage workflow in `.github/workflows/triage-ai-issue.yml`. The main changes enhance how the workflow extracts JSON from AI responses and provide clearer communication in cases where the AI fails to produce valid output.

**Error handling and user feedback:**

* When the AI response contains invalid JSON, the workflow now posts an error comment on the issue and applies the `triage:manual` label to prompt manual intervention. This helps ensure issues are not left untriaged due to automation failures.

**JSON extraction improvements:**

* The logic for extracting the first JSON object from the AI response has been improved to skip any preceding prose, making the extraction more reliable even if the response is not strictly formatted.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
