### PR TITLE
chore: gha for medic reporting

### DIFF
--- a/.github/workflows/medic-weekly-report.yml
+++ b/.github/workflows/medic-weekly-report.yml
@@ -1,0 +1,78 @@
+# type: Project Management
+# owner: @camunda/distribution-team
+---
+name: Medic - Weekly report
+
+on:
+  schedule:
+    - cron: '0 16 * * 5' # Every Friday 16:00 UTC
+  workflow_dispatch:
+    inputs:
+      week_offset:
+        description: 'Weeks back (0 = current week, 1 = last week)'
+        required: false
+        default: '0'
+
+concurrency:
+  group: medic-weekly-report
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  generate-report:
+    name: Generate distro medic report
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      MEDIC_USERGROUP_HANDLE: "distro-medic"
+      SLACK_CHANNEL: "#team-distribution-reports"
+      ALERT_CHANNEL: "#team-distribution-alerts"
+      SUPPORT_CHANNELS: "#ask-self-managed,#inc-*"
+      TRACKING_ISSUE_REPO: "camunda/team-distribution"
+      TRACKING_ISSUE_NUMBER: "418"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install tools
+        uses: ./.github/actions/install-tool-versions
+        with:
+          tools: |
+            golang
+
+      - name: Import Vault secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        id: vault-secrets
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/distribution/ci GH_APP_ID_DISTRO_CI;
+            secret/data/products/distribution/ci GH_APP_PRIVATE_KEY_DISTRO_CI;
+            secret/data/products/distribution/ci GLEAN_API_TOKEN;
+            secret/data/products/distribution/ci SLACK_BOT_TOKEN;
+            secret/data/products/distribution/ci SLACK_DISTRO_BOT_WEBHOOK_REPORTS;
+          exportEnv: true
+
+      - name: Generate GitHub token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
+        id: generate-github-token
+        with:
+          app_id: ${{ env.GH_APP_ID_DISTRO_CI }}
+          private_key: ${{ env.GH_APP_PRIVATE_KEY_DISTRO_CI }}
+
+      - name: Set GitHub token
+        run: |
+          echo "GH_TOKEN=${{ steps.generate-github-token.outputs.token }}" >> "$GITHUB_ENV"
+
+      - name: Generate and publish weekly medic report
+        env:
+          WEEK_OFFSET: ${{ github.event.inputs.week_offset || '0' }}
+        run: |
+          cd scripts/medic-weekly-report
+          go run .

--- a/.github/workflows/medic-weekly-report.yml
+++ b/.github/workflows/medic-weekly-report.yml
@@ -30,8 +30,6 @@ jobs:
       SLACK_CHANNEL: "#team-distribution-reports"
       ALERT_CHANNEL: "#team-distribution-alerts"
       SUPPORT_CHANNELS: "#ask-self-managed,#inc-*"
-      TRACKING_ISSUE_REPO: "camunda/team-distribution"
-      TRACKING_ISSUE_NUMBER: "418"
 
     steps:
       - name: Checkout
@@ -52,22 +50,9 @@ jobs:
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           secrets: |
-            secret/data/products/distribution/ci GH_APP_ID_DISTRO_CI;
-            secret/data/products/distribution/ci GH_APP_PRIVATE_KEY_DISTRO_CI;
             secret/data/products/distribution/ci GLEAN_API_TOKEN;
             secret/data/products/distribution/ci SLACK_DISTRO_BOT_WEBHOOK_REPORTS;
           exportEnv: true
-
-      - name: Generate GitHub token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
-        id: generate-github-token
-        with:
-          app_id: ${{ env.GH_APP_ID_DISTRO_CI }}
-          private_key: ${{ env.GH_APP_PRIVATE_KEY_DISTRO_CI }}
-
-      - name: Set GitHub token
-        run: |
-          echo "GH_TOKEN=${{ steps.generate-github-token.outputs.token }}" >> "$GITHUB_ENV"
 
       - name: Generate and publish weekly medic report
         env:

--- a/.github/workflows/medic-weekly-report.yml
+++ b/.github/workflows/medic-weekly-report.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
-      MEDIC_USERGROUP_HANDLE: "distro-medic"
+      MEDIC_HANDLE: "@distro-medic"
       SLACK_CHANNEL: "#team-distribution-reports"
       ALERT_CHANNEL: "#team-distribution-alerts"
       SUPPORT_CHANNELS: "#ask-self-managed,#inc-*"
@@ -55,7 +55,6 @@ jobs:
             secret/data/products/distribution/ci GH_APP_ID_DISTRO_CI;
             secret/data/products/distribution/ci GH_APP_PRIVATE_KEY_DISTRO_CI;
             secret/data/products/distribution/ci GLEAN_API_TOKEN;
-            secret/data/products/distribution/ci SLACK_BOT_TOKEN;
             secret/data/products/distribution/ci SLACK_DISTRO_BOT_WEBHOOK_REPORTS;
           exportEnv: true
 

--- a/.github/workflows/medic-weekly-report.yml
+++ b/.github/workflows/medic-weekly-report.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Generate and publish weekly medic report
         env:
-          WEEK_OFFSET: ${{ github.event.inputs.week_offset || '0' }}
+          WEEK_OFFSET: ${{ github.event_name == 'schedule' && '1' || github.event.inputs.week_offset || '0' }}
         run: |
           cd scripts/medic-weekly-report
           go run .

--- a/scripts/medic-weekly-report/go.mod
+++ b/scripts/medic-weekly-report/go.mod
@@ -1,0 +1,3 @@
+module scripts/medic-weekly-report
+
+go 1.25.0

--- a/scripts/medic-weekly-report/main.go
+++ b/scripts/medic-weekly-report/main.go
@@ -1,0 +1,388 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	gleanAPIURL            = "https://camunda-be.glean.com/rest/api/v1/chat"
+	slackAPIBaseURL        = "https://slack.com/api"
+	githubIssueCommentPath = "https://api.github.com/repos/%s/issues/%s/comments"
+)
+
+type config struct {
+	WeekOffset         int
+	GleanAPIToken      string
+	SlackBotToken      string
+	SlackWebhookURL    string
+	TrackingIssueRepo  string
+	TrackingIssueNum   string
+	MedicUsergroupID   string
+	MedicUsergroupName string
+	SlackChannel       string
+	AlertChannel       string
+	SupportChannels    string
+	GitHubToken        string
+}
+
+type gleanRequest struct {
+	Messages []gleanMessage `json:"messages"`
+}
+
+type gleanMessage struct {
+	Author      string          `json:"author"`
+	MessageType string          `json:"messageType"`
+	Fragments   []gleanFragment `json:"fragments"`
+}
+
+type gleanFragment struct {
+	Text string `json:"text"`
+}
+
+type gleanResponse struct {
+	Messages []gleanMessage `json:"messages"`
+}
+
+type slackPayload struct {
+	Channel string       `json:"channel"`
+	Blocks  []slackBlock `json:"blocks"`
+}
+
+type slackBlock struct {
+	Type string    `json:"type"`
+	Text slackText `json:"text"`
+}
+
+type slackText struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type slackUsergroupsListResponse struct {
+	OK         bool   `json:"ok"`
+	Error      string `json:"error"`
+	Usergroups []struct {
+		ID     string `json:"id"`
+		Handle string `json:"handle"`
+	} `json:"usergroups"`
+}
+
+type slackUsergroupUsersListResponse struct {
+	OK    bool     `json:"ok"`
+	Error string   `json:"error"`
+	Users []string `json:"users"`
+}
+
+type slackUsersInfoResponse struct {
+	OK    bool   `json:"ok"`
+	Error string `json:"error"`
+	User  struct {
+		Name     string `json:"name"`
+		RealName string `json:"real_name"`
+		Profile  struct {
+			DisplayName string `json:"display_name"`
+			RealName    string `json:"real_name"`
+		} `json:"profile"`
+	} `json:"user"`
+}
+
+func mustEnv(name string) string {
+	v := os.Getenv(name)
+	if v == "" {
+		fmt.Fprintf(os.Stderr, "missing required environment variable: %s\n", name)
+		os.Exit(1)
+	}
+	return v
+}
+
+func loadConfig() config {
+	weekOffsetRaw := mustEnv("WEEK_OFFSET")
+	weekOffset, err := strconv.Atoi(weekOffsetRaw)
+	if err != nil || weekOffset < 0 {
+		fmt.Fprintf(os.Stderr, "WEEK_OFFSET must be a non-negative integer: %q\n", weekOffsetRaw)
+		os.Exit(1)
+	}
+
+	return config{
+		WeekOffset:        weekOffset,
+		GleanAPIToken:     mustEnv("GLEAN_API_TOKEN"),
+		SlackBotToken:     mustEnv("SLACK_BOT_TOKEN"),
+		SlackWebhookURL:   mustEnv("SLACK_DISTRO_BOT_WEBHOOK_REPORTS"),
+		TrackingIssueRepo: mustEnv("TRACKING_ISSUE_REPO"),
+		TrackingIssueNum:  mustEnv("TRACKING_ISSUE_NUMBER"),
+		MedicUsergroupID:  os.Getenv("MEDIC_USERGROUP_ID"),
+		MedicUsergroupName: func() string {
+			h := mustEnv("MEDIC_USERGROUP_HANDLE")
+			return strings.TrimPrefix(h, "@")
+		}(),
+		SlackChannel:      mustEnv("SLACK_CHANNEL"),
+		AlertChannel:      mustEnv("ALERT_CHANNEL"),
+		SupportChannels:   mustEnv("SUPPORT_CHANNELS"),
+		GitHubToken:       mustEnv("GH_TOKEN"),
+	}
+}
+
+func weekWindow(now time.Time, offsetWeeks int) (time.Time, time.Time) {
+	reference := now.UTC().AddDate(0, 0, -7*offsetWeeks)
+	weekday := int(reference.Weekday())
+	if weekday == 0 {
+		weekday = 7
+	}
+	start := time.Date(reference.Year(), reference.Month(), reference.Day(), 0, 0, 0, 0, time.UTC)
+	start = start.AddDate(0, 0, -(weekday - 1))
+	end := start.AddDate(0, 0, 6)
+	return start, end
+}
+
+func doJSONRequest(ctx context.Context, method, endpoint string, headers map[string]string, reqBody any, respBody any) error {
+	var bodyReader io.Reader
+	if reqBody != nil {
+		payload, err := json.Marshal(reqBody)
+		if err != nil {
+			return fmt.Errorf("marshal request body: %w", err)
+		}
+		bodyReader = bytes.NewReader(payload)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, bodyReader)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	client := &http.Client{Timeout: 20 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respRaw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response body: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("unexpected status %s: %s", resp.Status, strings.TrimSpace(string(respRaw)))
+	}
+
+	if respBody != nil {
+		if err := json.Unmarshal(respRaw, respBody); err != nil {
+			return fmt.Errorf("unmarshal response: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func resolveMedicName(ctx context.Context, cfg config) (string, error) {
+	headers := map[string]string{
+		"Authorization": "Bearer " + cfg.SlackBotToken,
+	}
+
+	usergroupID := cfg.MedicUsergroupID
+	if usergroupID == "" {
+		listEndpoint := fmt.Sprintf("%s/usergroups.list?include_count=false&include_disabled=false", slackAPIBaseURL)
+		var groups slackUsergroupsListResponse
+		if err := doJSONRequest(ctx, http.MethodGet, listEndpoint, headers, nil, &groups); err != nil {
+			return "", err
+		}
+		if !groups.OK {
+			return "", fmt.Errorf("slack usergroups.list failed: %s", groups.Error)
+		}
+
+		for _, g := range groups.Usergroups {
+			if g.Handle == cfg.MedicUsergroupName {
+				usergroupID = g.ID
+				break
+			}
+		}
+		if usergroupID == "" {
+			return "", fmt.Errorf("slack usergroup @%s not found", cfg.MedicUsergroupName)
+		}
+	}
+
+	usersQuery := url.Values{}
+	usersQuery.Set("usergroup", usergroupID)
+	usersQuery.Set("include_disabled", "false")
+	usersEndpoint := fmt.Sprintf("%s/usergroups.users.list?%s", slackAPIBaseURL, usersQuery.Encode())
+
+	var groupUsers slackUsergroupUsersListResponse
+	if err := doJSONRequest(ctx, http.MethodGet, usersEndpoint, headers, nil, &groupUsers); err != nil {
+		return "", err
+	}
+	if !groupUsers.OK {
+		return "", fmt.Errorf("slack usergroups.users.list failed: %s", groupUsers.Error)
+	}
+	if len(groupUsers.Users) == 0 {
+		return "@" + cfg.MedicUsergroupName, nil
+	}
+
+	infoQuery := url.Values{}
+	infoQuery.Set("user", groupUsers.Users[0])
+	infoEndpoint := fmt.Sprintf("%s/users.info?%s", slackAPIBaseURL, infoQuery.Encode())
+
+	var userInfo slackUsersInfoResponse
+	if err := doJSONRequest(ctx, http.MethodGet, infoEndpoint, headers, nil, &userInfo); err != nil {
+		return "", err
+	}
+	if !userInfo.OK {
+		return "", fmt.Errorf("slack users.info failed: %s", userInfo.Error)
+	}
+
+	if userInfo.User.Profile.RealName != "" {
+		return userInfo.User.Profile.RealName, nil
+	}
+	if userInfo.User.RealName != "" {
+		return userInfo.User.RealName, nil
+	}
+	if userInfo.User.Profile.DisplayName != "" {
+		return userInfo.User.Profile.DisplayName, nil
+	}
+	if userInfo.User.Name != "" {
+		return userInfo.User.Name, nil
+	}
+
+	return "@" + cfg.MedicUsergroupName, nil
+}
+
+func buildPrompt(cfg config, weekStart, weekEnd time.Time, medicName string) string {
+	_, isoWeek := weekStart.ISOWeek()
+	return fmt.Sprintf(`You are generating the weekly distro-medic report for the Distribution team at Camunda.
+
+Report period: %s to %s (W%02d)
+Current medic: %s
+
+Follow the Distro - Medic Report Guidelines from the Camunda Confluence documentation exactly.
+Search all data sources listed in the guidelines for activity during this period.
+Ensure you include activity from support channels (%s) and alert channel (%s) when relevant.
+Cross-reference with previous medic reports in https://github.com/%s/issues/%s for recurring themes.
+
+Respond ONLY with the Slack message content. No wrapping, no explanation.
+`, weekStart.Format("2006-01-02"), weekEnd.Format("2006-01-02"), isoWeek, medicName, cfg.SupportChannels, cfg.AlertChannel, cfg.TrackingIssueRepo, cfg.TrackingIssueNum)
+}
+
+func generateReport(ctx context.Context, cfg config, prompt string) (string, error) {
+	var out gleanResponse
+	err := doJSONRequest(ctx, http.MethodPost, gleanAPIURL, map[string]string{
+		"Authorization": "Bearer " + cfg.GleanAPIToken,
+		"Content-Type":  "application/json",
+	}, gleanRequest{Messages: []gleanMessage{{
+		Author:      "USER",
+		MessageType: "CONTENT",
+		Fragments:   []gleanFragment{{Text: prompt}},
+	}}}, &out)
+	if err != nil {
+		return "", err
+	}
+
+	var sb strings.Builder
+	for _, msg := range out.Messages {
+		if msg.MessageType != "CONTENT" || msg.Author != "GLEAN_AI" {
+			continue
+		}
+		for _, frag := range msg.Fragments {
+			if frag.Text != "" {
+				sb.WriteString(frag.Text)
+			}
+		}
+	}
+
+	report := strings.TrimSpace(sb.String())
+	if report == "" {
+		return "", fmt.Errorf("glean response did not contain report content")
+	}
+	return report, nil
+}
+
+func postSlack(ctx context.Context, cfg config, report string) error {
+	payload := slackPayload{
+		Channel: cfg.SlackChannel,
+		Blocks: []slackBlock{{
+			Type: "section",
+			Text: slackText{Type: "mrkdwn", Text: report},
+		}},
+	}
+	return doJSONRequest(ctx, http.MethodPost, cfg.SlackWebhookURL, map[string]string{
+		"Content-Type": "application/json",
+	}, payload, nil)
+}
+
+func commentOnIssue(ctx context.Context, cfg config, weekStart, weekEnd time.Time, medicName, report string) error {
+	_, isoWeek := weekStart.ISOWeek()
+	comment := fmt.Sprintf("## Weekly distro-medic report (W%02d)\n\nPeriod: %s to %s\nMedic: %s\nSlack channel: %s\n\n%s",
+		isoWeek,
+		weekStart.Format("2006-01-02"),
+		weekEnd.Format("2006-01-02"),
+		medicName,
+		cfg.SlackChannel,
+		report,
+	)
+
+	endpoint := fmt.Sprintf(githubIssueCommentPath, cfg.TrackingIssueRepo, cfg.TrackingIssueNum)
+	return doJSONRequest(ctx, http.MethodPost, endpoint, map[string]string{
+		"Authorization": "Bearer " + cfg.GitHubToken,
+		"Accept":        "application/vnd.github+json",
+		"Content-Type":  "application/json",
+	}, map[string]string{"body": comment}, nil)
+}
+
+func main() {
+	cfg := loadConfig()
+	ctx := context.Background()
+
+	weekStart, weekEnd := weekWindow(time.Now(), cfg.WeekOffset)
+	_, isoWeek := weekStart.ISOWeek()
+	fmt.Printf("Reporting period: %s to %s (W%02d)\n", weekStart.Format("2006-01-02"), weekEnd.Format("2006-01-02"), isoWeek)
+
+	medicName, err := resolveMedicName(ctx, cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "resolve medic from Slack usergroup: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Resolved medic: %s\n", medicName)
+
+	prompt := buildPrompt(cfg, weekStart, weekEnd, medicName)
+	report, err := generateReport(ctx, cfg, prompt)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "generate report from Glean: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := postSlack(ctx, cfg, report); err != nil {
+		fmt.Fprintf(os.Stderr, "post report to Slack: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := commentOnIssue(ctx, cfg, weekStart, weekEnd, medicName, report); err != nil {
+		fmt.Fprintf(os.Stderr, "comment report on GitHub issue: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Weekly medic report generated and published successfully")
+}

--- a/scripts/medic-weekly-report/main.go
+++ b/scripts/medic-weekly-report/main.go
@@ -30,6 +30,8 @@ import (
 const (
 	gleanAPIURL            = "https://camunda-be.glean.com/rest/api/v1/chat"
 	githubIssueCommentPath = "https://api.github.com/repos/%s/issues/%s/comments"
+	gleanRequestTimeout    = 120 * time.Second
+	defaultRequestTimeout  = 20 * time.Second
 )
 
 type config struct {
@@ -121,7 +123,7 @@ func weekWindow(now time.Time, offsetWeeks int) (time.Time, time.Time) {
 	return start, end
 }
 
-func doJSONRequest(ctx context.Context, method, endpoint string, headers map[string]string, reqBody any, respBody any) error {
+func doJSONRequest(ctx context.Context, method, endpoint string, headers map[string]string, reqBody any, respBody any, timeout time.Duration) error {
 	var bodyReader io.Reader
 	if reqBody != nil {
 		payload, err := json.Marshal(reqBody)
@@ -139,7 +141,7 @@ func doJSONRequest(ctx context.Context, method, endpoint string, headers map[str
 		req.Header.Set(k, v)
 	}
 
-	client := &http.Client{Timeout: 20 * time.Second}
+	client := &http.Client{Timeout: timeout}
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("send request: %w", err)
@@ -189,7 +191,7 @@ func generateReport(ctx context.Context, cfg config, prompt string) (string, err
 		Author:      "USER",
 		MessageType: "CONTENT",
 		Fragments:   []gleanFragment{{Text: prompt}},
-	}}}, &out)
+	}}}, &out, gleanRequestTimeout)
 	if err != nil {
 		return "", err
 	}
@@ -223,7 +225,7 @@ func postSlack(ctx context.Context, cfg config, report string) error {
 	}
 	return doJSONRequest(ctx, http.MethodPost, cfg.SlackWebhookURL, map[string]string{
 		"Content-Type": "application/json",
-	}, payload, nil)
+	}, payload, nil, defaultRequestTimeout)
 }
 
 func commentOnIssue(ctx context.Context, cfg config, weekStart, weekEnd time.Time, report string) error {
@@ -241,7 +243,7 @@ func commentOnIssue(ctx context.Context, cfg config, weekStart, weekEnd time.Tim
 		"Authorization": "Bearer " + cfg.GitHubToken,
 		"Accept":        "application/vnd.github+json",
 		"Content-Type":  "application/json",
-	}, map[string]string{"body": comment}, nil)
+	}, map[string]string{"body": comment}, nil, defaultRequestTimeout)
 }
 
 func main() {

--- a/scripts/medic-weekly-report/main.go
+++ b/scripts/medic-weekly-report/main.go
@@ -28,23 +28,19 @@ import (
 )
 
 const (
-	gleanAPIURL            = "https://camunda-be.glean.com/rest/api/v1/chat"
-	githubIssueCommentPath = "https://api.github.com/repos/%s/issues/%s/comments"
-	gleanRequestTimeout    = 120 * time.Second
-	defaultRequestTimeout  = 20 * time.Second
+	gleanAPIURL           = "https://camunda-be.glean.com/rest/api/v1/chat"
+	gleanRequestTimeout   = 120 * time.Second
+	defaultRequestTimeout = 20 * time.Second
 )
 
 type config struct {
-	WeekOffset         int
-	GleanAPIToken      string
-	SlackWebhookURL    string
-	TrackingIssueRepo  string
-	TrackingIssueNum   string
-	MedicHandle        string
-	SlackChannel       string
-	AlertChannel       string
-	SupportChannels    string
-	GitHubToken        string
+	WeekOffset      int
+	GleanAPIToken   string
+	SlackWebhookURL string
+	MedicHandle     string
+	SlackChannel    string
+	AlertChannel    string
+	SupportChannels string
 }
 
 type gleanRequest struct {
@@ -98,16 +94,13 @@ func loadConfig() config {
 	}
 
 	return config{
-		WeekOffset:        weekOffset,
-		GleanAPIToken:     mustEnv("GLEAN_API_TOKEN"),
-		SlackWebhookURL:   mustEnv("SLACK_DISTRO_BOT_WEBHOOK_REPORTS"),
-		TrackingIssueRepo: mustEnv("TRACKING_ISSUE_REPO"),
-		TrackingIssueNum:  mustEnv("TRACKING_ISSUE_NUMBER"),
-		MedicHandle:       mustEnv("MEDIC_HANDLE"),
-		SlackChannel:      mustEnv("SLACK_CHANNEL"),
-		AlertChannel:      mustEnv("ALERT_CHANNEL"),
-		SupportChannels:   mustEnv("SUPPORT_CHANNELS"),
-		GitHubToken:       mustEnv("GH_TOKEN"),
+		WeekOffset:      weekOffset,
+		GleanAPIToken:   mustEnv("GLEAN_API_TOKEN"),
+		SlackWebhookURL: mustEnv("SLACK_DISTRO_BOT_WEBHOOK_REPORTS"),
+		MedicHandle:     mustEnv("MEDIC_HANDLE"),
+		SlackChannel:    mustEnv("SLACK_CHANNEL"),
+		AlertChannel:    mustEnv("ALERT_CHANNEL"),
+		SupportChannels: mustEnv("SUPPORT_CHANNELS"),
 	}
 }
 
@@ -176,10 +169,9 @@ Search all data sources listed in the guidelines for activity during this period
 Determine who was medic for this report period by looking up the Slack @%s user group membership/activity in that period.
 Include a line in the report: Current medic: <name>.
 Ensure you include activity from support channels (%s) and alert channel (%s) when relevant.
-Cross-reference with previous medic reports in https://github.com/%s/issues/%s for recurring themes.
 
 Respond ONLY with the Slack message content. No wrapping, no explanation.
-`, weekStart.Format("2006-01-02"), weekEnd.Format("2006-01-02"), isoWeek, strings.TrimPrefix(cfg.MedicHandle, "@"), cfg.SupportChannels, cfg.AlertChannel, cfg.TrackingIssueRepo, cfg.TrackingIssueNum)
+`, weekStart.Format("2006-01-02"), weekEnd.Format("2006-01-02"), isoWeek, strings.TrimPrefix(cfg.MedicHandle, "@"), cfg.SupportChannels, cfg.AlertChannel)
 }
 
 func generateReport(ctx context.Context, cfg config, prompt string) (string, error) {
@@ -228,24 +220,6 @@ func postSlack(ctx context.Context, cfg config, report string) error {
 	}, payload, nil, defaultRequestTimeout)
 }
 
-func commentOnIssue(ctx context.Context, cfg config, weekStart, weekEnd time.Time, report string) error {
-	_, isoWeek := weekStart.ISOWeek()
-	comment := fmt.Sprintf("## Weekly distro-medic report (W%02d)\n\nPeriod: %s to %s\nSlack channel: %s\n\n%s",
-		isoWeek,
-		weekStart.Format("2006-01-02"),
-		weekEnd.Format("2006-01-02"),
-		cfg.SlackChannel,
-		report,
-	)
-
-	endpoint := fmt.Sprintf(githubIssueCommentPath, cfg.TrackingIssueRepo, cfg.TrackingIssueNum)
-	return doJSONRequest(ctx, http.MethodPost, endpoint, map[string]string{
-		"Authorization": "Bearer " + cfg.GitHubToken,
-		"Accept":        "application/vnd.github+json",
-		"Content-Type":  "application/json",
-	}, map[string]string{"body": comment}, nil, defaultRequestTimeout)
-}
-
 func main() {
 	cfg := loadConfig()
 	ctx := context.Background()
@@ -266,10 +240,5 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := commentOnIssue(ctx, cfg, weekStart, weekEnd, report); err != nil {
-		fmt.Fprintf(os.Stderr, "comment report on GitHub issue: %v\n", err)
-		os.Exit(1)
-	}
-
-	fmt.Println("Weekly medic report generated and published successfully")
+	fmt.Println("Weekly medic report generated and posted to Slack successfully")
 }

--- a/scripts/medic-weekly-report/main.go
+++ b/scripts/medic-weekly-report/main.go
@@ -220,6 +220,15 @@ func postSlack(ctx context.Context, cfg config, report string) error {
 	}, payload, nil, defaultRequestTimeout)
 }
 
+func buildFailureMessage(weekStart, weekEnd time.Time, err error) string {
+	return fmt.Sprintf(
+		":warning: Weekly distro-medic report generation failed.\nPeriod: %s to %s\nError: `%s`",
+		weekStart.Format("2006-01-02"),
+		weekEnd.Format("2006-01-02"),
+		err,
+	)
+}
+
 func main() {
 	cfg := loadConfig()
 	ctx := context.Background()
@@ -231,6 +240,10 @@ func main() {
 	prompt := buildPrompt(cfg, weekStart, weekEnd)
 	report, err := generateReport(ctx, cfg, prompt)
 	if err != nil {
+		failureMessage := buildFailureMessage(weekStart, weekEnd, err)
+		if notifyErr := postSlack(ctx, cfg, failureMessage); notifyErr != nil {
+			fmt.Fprintf(os.Stderr, "notify report failure to Slack: %v\n", notifyErr)
+		}
 		fmt.Fprintf(os.Stderr, "generate report from Glean: %v\n", err)
 		os.Exit(1)
 	}

--- a/scripts/medic-weekly-report/main.go
+++ b/scripts/medic-weekly-report/main.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -30,19 +29,16 @@ import (
 
 const (
 	gleanAPIURL            = "https://camunda-be.glean.com/rest/api/v1/chat"
-	slackAPIBaseURL        = "https://slack.com/api"
 	githubIssueCommentPath = "https://api.github.com/repos/%s/issues/%s/comments"
 )
 
 type config struct {
 	WeekOffset         int
 	GleanAPIToken      string
-	SlackBotToken      string
 	SlackWebhookURL    string
 	TrackingIssueRepo  string
 	TrackingIssueNum   string
-	MedicUsergroupID   string
-	MedicUsergroupName string
+	MedicHandle        string
 	SlackChannel       string
 	AlertChannel       string
 	SupportChannels    string
@@ -82,34 +78,6 @@ type slackText struct {
 	Text string `json:"text"`
 }
 
-type slackUsergroupsListResponse struct {
-	OK         bool   `json:"ok"`
-	Error      string `json:"error"`
-	Usergroups []struct {
-		ID     string `json:"id"`
-		Handle string `json:"handle"`
-	} `json:"usergroups"`
-}
-
-type slackUsergroupUsersListResponse struct {
-	OK    bool     `json:"ok"`
-	Error string   `json:"error"`
-	Users []string `json:"users"`
-}
-
-type slackUsersInfoResponse struct {
-	OK    bool   `json:"ok"`
-	Error string `json:"error"`
-	User  struct {
-		Name     string `json:"name"`
-		RealName string `json:"real_name"`
-		Profile  struct {
-			DisplayName string `json:"display_name"`
-			RealName    string `json:"real_name"`
-		} `json:"profile"`
-	} `json:"user"`
-}
-
 func mustEnv(name string) string {
 	v := os.Getenv(name)
 	if v == "" {
@@ -130,15 +98,10 @@ func loadConfig() config {
 	return config{
 		WeekOffset:        weekOffset,
 		GleanAPIToken:     mustEnv("GLEAN_API_TOKEN"),
-		SlackBotToken:     mustEnv("SLACK_BOT_TOKEN"),
 		SlackWebhookURL:   mustEnv("SLACK_DISTRO_BOT_WEBHOOK_REPORTS"),
 		TrackingIssueRepo: mustEnv("TRACKING_ISSUE_REPO"),
 		TrackingIssueNum:  mustEnv("TRACKING_ISSUE_NUMBER"),
-		MedicUsergroupID:  os.Getenv("MEDIC_USERGROUP_ID"),
-		MedicUsergroupName: func() string {
-			h := mustEnv("MEDIC_USERGROUP_HANDLE")
-			return strings.TrimPrefix(h, "@")
-		}(),
+		MedicHandle:       mustEnv("MEDIC_HANDLE"),
 		SlackChannel:      mustEnv("SLACK_CHANNEL"),
 		AlertChannel:      mustEnv("ALERT_CHANNEL"),
 		SupportChannels:   mustEnv("SUPPORT_CHANNELS"),
@@ -200,91 +163,21 @@ func doJSONRequest(ctx context.Context, method, endpoint string, headers map[str
 	return nil
 }
 
-func resolveMedicName(ctx context.Context, cfg config) (string, error) {
-	headers := map[string]string{
-		"Authorization": "Bearer " + cfg.SlackBotToken,
-	}
-
-	usergroupID := cfg.MedicUsergroupID
-	if usergroupID == "" {
-		listEndpoint := fmt.Sprintf("%s/usergroups.list?include_count=false&include_disabled=false", slackAPIBaseURL)
-		var groups slackUsergroupsListResponse
-		if err := doJSONRequest(ctx, http.MethodGet, listEndpoint, headers, nil, &groups); err != nil {
-			return "", err
-		}
-		if !groups.OK {
-			return "", fmt.Errorf("slack usergroups.list failed: %s", groups.Error)
-		}
-
-		for _, g := range groups.Usergroups {
-			if g.Handle == cfg.MedicUsergroupName {
-				usergroupID = g.ID
-				break
-			}
-		}
-		if usergroupID == "" {
-			return "", fmt.Errorf("slack usergroup @%s not found", cfg.MedicUsergroupName)
-		}
-	}
-
-	usersQuery := url.Values{}
-	usersQuery.Set("usergroup", usergroupID)
-	usersQuery.Set("include_disabled", "false")
-	usersEndpoint := fmt.Sprintf("%s/usergroups.users.list?%s", slackAPIBaseURL, usersQuery.Encode())
-
-	var groupUsers slackUsergroupUsersListResponse
-	if err := doJSONRequest(ctx, http.MethodGet, usersEndpoint, headers, nil, &groupUsers); err != nil {
-		return "", err
-	}
-	if !groupUsers.OK {
-		return "", fmt.Errorf("slack usergroups.users.list failed: %s", groupUsers.Error)
-	}
-	if len(groupUsers.Users) == 0 {
-		return "@" + cfg.MedicUsergroupName, nil
-	}
-
-	infoQuery := url.Values{}
-	infoQuery.Set("user", groupUsers.Users[0])
-	infoEndpoint := fmt.Sprintf("%s/users.info?%s", slackAPIBaseURL, infoQuery.Encode())
-
-	var userInfo slackUsersInfoResponse
-	if err := doJSONRequest(ctx, http.MethodGet, infoEndpoint, headers, nil, &userInfo); err != nil {
-		return "", err
-	}
-	if !userInfo.OK {
-		return "", fmt.Errorf("slack users.info failed: %s", userInfo.Error)
-	}
-
-	if userInfo.User.Profile.RealName != "" {
-		return userInfo.User.Profile.RealName, nil
-	}
-	if userInfo.User.RealName != "" {
-		return userInfo.User.RealName, nil
-	}
-	if userInfo.User.Profile.DisplayName != "" {
-		return userInfo.User.Profile.DisplayName, nil
-	}
-	if userInfo.User.Name != "" {
-		return userInfo.User.Name, nil
-	}
-
-	return "@" + cfg.MedicUsergroupName, nil
-}
-
-func buildPrompt(cfg config, weekStart, weekEnd time.Time, medicName string) string {
+func buildPrompt(cfg config, weekStart, weekEnd time.Time) string {
 	_, isoWeek := weekStart.ISOWeek()
 	return fmt.Sprintf(`You are generating the weekly distro-medic report for the Distribution team at Camunda.
 
 Report period: %s to %s (W%02d)
-Current medic: %s
 
 Follow the Distro - Medic Report Guidelines from the Camunda Confluence documentation exactly.
 Search all data sources listed in the guidelines for activity during this period.
+Determine who was medic for this report period by looking up the Slack @%s user group membership/activity in that period.
+Include a line in the report: Current medic: <name>.
 Ensure you include activity from support channels (%s) and alert channel (%s) when relevant.
 Cross-reference with previous medic reports in https://github.com/%s/issues/%s for recurring themes.
 
 Respond ONLY with the Slack message content. No wrapping, no explanation.
-`, weekStart.Format("2006-01-02"), weekEnd.Format("2006-01-02"), isoWeek, medicName, cfg.SupportChannels, cfg.AlertChannel, cfg.TrackingIssueRepo, cfg.TrackingIssueNum)
+`, weekStart.Format("2006-01-02"), weekEnd.Format("2006-01-02"), isoWeek, strings.TrimPrefix(cfg.MedicHandle, "@"), cfg.SupportChannels, cfg.AlertChannel, cfg.TrackingIssueRepo, cfg.TrackingIssueNum)
 }
 
 func generateReport(ctx context.Context, cfg config, prompt string) (string, error) {
@@ -333,13 +226,12 @@ func postSlack(ctx context.Context, cfg config, report string) error {
 	}, payload, nil)
 }
 
-func commentOnIssue(ctx context.Context, cfg config, weekStart, weekEnd time.Time, medicName, report string) error {
+func commentOnIssue(ctx context.Context, cfg config, weekStart, weekEnd time.Time, report string) error {
 	_, isoWeek := weekStart.ISOWeek()
-	comment := fmt.Sprintf("## Weekly distro-medic report (W%02d)\n\nPeriod: %s to %s\nMedic: %s\nSlack channel: %s\n\n%s",
+	comment := fmt.Sprintf("## Weekly distro-medic report (W%02d)\n\nPeriod: %s to %s\nSlack channel: %s\n\n%s",
 		isoWeek,
 		weekStart.Format("2006-01-02"),
 		weekEnd.Format("2006-01-02"),
-		medicName,
 		cfg.SlackChannel,
 		report,
 	)
@@ -360,14 +252,7 @@ func main() {
 	_, isoWeek := weekStart.ISOWeek()
 	fmt.Printf("Reporting period: %s to %s (W%02d)\n", weekStart.Format("2006-01-02"), weekEnd.Format("2006-01-02"), isoWeek)
 
-	medicName, err := resolveMedicName(ctx, cfg)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "resolve medic from Slack usergroup: %v\n", err)
-		os.Exit(1)
-	}
-	fmt.Printf("Resolved medic: %s\n", medicName)
-
-	prompt := buildPrompt(cfg, weekStart, weekEnd, medicName)
+	prompt := buildPrompt(cfg, weekStart, weekEnd)
 	report, err := generateReport(ctx, cfg, prompt)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "generate report from Glean: %v\n", err)
@@ -379,7 +264,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := commentOnIssue(ctx, cfg, weekStart, weekEnd, medicName, report); err != nil {
+	if err := commentOnIssue(ctx, cfg, weekStart, weekEnd, report); err != nil {
 		fmt.Fprintf(os.Stderr, "comment report on GitHub issue: %v\n", err)
 		os.Exit(1)
 	}

--- a/scripts/medic-weekly-report/main_test.go
+++ b/scripts/medic-weekly-report/main_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -70,6 +71,28 @@ func TestBuildPrompt(t *testing.T) {
 	for _, expected := range mustContain {
 		if !strings.Contains(prompt, expected) {
 			t.Fatalf("prompt missing expected content: %q", expected)
+		}
+	}
+}
+
+func TestBuildFailureMessage(t *testing.T) {
+	t.Parallel()
+
+	weekStart := time.Date(2026, time.April, 13, 0, 0, 0, 0, time.UTC)
+	weekEnd := time.Date(2026, time.April, 19, 0, 0, 0, 0, time.UTC)
+	err := fmt.Errorf("glean timeout")
+
+	msg := buildFailureMessage(weekStart, weekEnd, err)
+
+	mustContain := []string{
+		"Weekly distro-medic report generation failed",
+		"Period: 2026-04-13 to 2026-04-19",
+		"Error: `glean timeout`",
+	}
+
+	for _, expected := range mustContain {
+		if !strings.Contains(msg, expected) {
+			t.Fatalf("failure message missing expected content: %q", expected)
 		}
 	}
 }

--- a/scripts/medic-weekly-report/main_test.go
+++ b/scripts/medic-weekly-report/main_test.go
@@ -46,11 +46,9 @@ func TestBuildPrompt(t *testing.T) {
 	t.Parallel()
 
 	cfg := config{
-		TrackingIssueRepo: "camunda/team-distribution",
-		TrackingIssueNum:  "418",
-		MedicHandle:       "@distro-medic",
-		SupportChannels:   "#ask-self-managed,#inc-*",
-		AlertChannel:      "#team-distribution-alerts",
+		MedicHandle:     "@distro-medic",
+		SupportChannels: "#ask-self-managed,#inc-*",
+		AlertChannel:    "#team-distribution-alerts",
 	}
 
 	weekStart := time.Date(2026, time.April, 13, 0, 0, 0, 0, time.UTC)
@@ -66,7 +64,6 @@ func TestBuildPrompt(t *testing.T) {
 		"Current medic: <name>",
 		"#ask-self-managed,#inc-*",
 		"#team-distribution-alerts",
-		"https://github.com/camunda/team-distribution/issues/418",
 		"Respond ONLY with the Slack message content. No wrapping, no explanation.",
 	}
 

--- a/scripts/medic-weekly-report/main_test.go
+++ b/scripts/medic-weekly-report/main_test.go
@@ -1,0 +1,75 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWeekWindow(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.April, 15, 11, 30, 0, 0, time.UTC)
+
+	start, end := weekWindow(now, 0)
+	if got, want := start.Format("2006-01-02"), "2026-04-13"; got != want {
+		t.Fatalf("weekWindow start mismatch: got %s, want %s", got, want)
+	}
+	if got, want := end.Format("2006-01-02"), "2026-04-19"; got != want {
+		t.Fatalf("weekWindow end mismatch: got %s, want %s", got, want)
+	}
+
+	startPrev, endPrev := weekWindow(now, 1)
+	if got, want := startPrev.Format("2006-01-02"), "2026-04-06"; got != want {
+		t.Fatalf("weekWindow previous start mismatch: got %s, want %s", got, want)
+	}
+	if got, want := endPrev.Format("2006-01-02"), "2026-04-12"; got != want {
+		t.Fatalf("weekWindow previous end mismatch: got %s, want %s", got, want)
+	}
+}
+
+func TestBuildPrompt(t *testing.T) {
+	t.Parallel()
+
+	cfg := config{
+		TrackingIssueRepo: "camunda/team-distribution",
+		TrackingIssueNum:  "418",
+		SupportChannels:   "#ask-self-managed,#inc-*",
+		AlertChannel:      "#team-distribution-alerts",
+	}
+
+	weekStart := time.Date(2026, time.April, 13, 0, 0, 0, 0, time.UTC)
+	weekEnd := time.Date(2026, time.April, 19, 0, 0, 0, 0, time.UTC)
+
+	prompt := buildPrompt(cfg, weekStart, weekEnd, "John Medic")
+
+	mustContain := []string{
+		"Distro - Medic Report Guidelines",
+		"Report period: 2026-04-13 to 2026-04-19 (W16)",
+		"Current medic: John Medic",
+		"#ask-self-managed,#inc-*",
+		"#team-distribution-alerts",
+		"https://github.com/camunda/team-distribution/issues/418",
+		"Respond ONLY with the Slack message content. No wrapping, no explanation.",
+	}
+
+	for _, expected := range mustContain {
+		if !strings.Contains(prompt, expected) {
+			t.Fatalf("prompt missing expected content: %q", expected)
+		}
+	}
+}

--- a/scripts/medic-weekly-report/main_test.go
+++ b/scripts/medic-weekly-report/main_test.go
@@ -48,6 +48,7 @@ func TestBuildPrompt(t *testing.T) {
 	cfg := config{
 		TrackingIssueRepo: "camunda/team-distribution",
 		TrackingIssueNum:  "418",
+		MedicHandle:       "@distro-medic",
 		SupportChannels:   "#ask-self-managed,#inc-*",
 		AlertChannel:      "#team-distribution-alerts",
 	}
@@ -55,12 +56,14 @@ func TestBuildPrompt(t *testing.T) {
 	weekStart := time.Date(2026, time.April, 13, 0, 0, 0, 0, time.UTC)
 	weekEnd := time.Date(2026, time.April, 19, 0, 0, 0, 0, time.UTC)
 
-	prompt := buildPrompt(cfg, weekStart, weekEnd, "John Medic")
+	prompt := buildPrompt(cfg, weekStart, weekEnd)
 
 	mustContain := []string{
 		"Distro - Medic Report Guidelines",
 		"Report period: 2026-04-13 to 2026-04-19 (W16)",
-		"Current medic: John Medic",
+		"Determine who was medic for this report period",
+		"Slack @distro-medic user group membership/activity",
+		"Current medic: <name>",
 		"#ask-self-managed,#inc-*",
 		"#team-distribution-alerts",
 		"https://github.com/camunda/team-distribution/issues/418",


### PR DESCRIPTION
closes  https://github.com/camunda/team-distribution/issues/765

## Summary
This PR adds automated weekly distro-medic reporting via GitHub Actions + Glean Chat API, posting the result to Slack and commenting it on the tracking issue.

## What changed

- Added weekly workflow with:
   - schedule trigger (Friday 16:00 UTC)
   - manual trigger via workflow_dispatch with week_offset
- Implemented report generation in Go under scripts/medic-weekly-report.
- Workflow now:
   - loads secrets from Vault
   - generates report via Glean Chat API (see [instructions](https://confluence.camunda.com/spaces/HAN/pages/347898846/Distro+-+Medic+Report+Guidelines))
   - posts report to Slack channel #team-distribution-reports
- Replaced OpsGenie-based medic lookup with Glean-driven medic attribution:
   - prompt now instructs Glean to determine who was medic for the report period from Slack @distro-medic context
  - prompt requires including Current medic: <name> in report output
- Added/updated unit tests for week window and prompt content.
- Added instruction updates to enforce Go for non-trivial workflow automation logic.

## Config and secret changes

- Required secrets:
- GLEAN_API_TOKEN
- added SLACK_DISTRO_BOT_WEBHOOK_REPORTS
- GH_APP_ID_DISTRO_CI