### PR TITLE
chore(ci): enforce Go for non-trivial workflow automation scripts

### DIFF
--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -30,9 +30,6 @@ These are first-class review criteria. Flag PRs that violate them:
   core (e.g., OpenSearch, Bitnami sub-charts beyond what already exists).
 - **No workarounds** — the chart must not patch or work around application-level issues or
   technical debt. If an application bug requires a workaround, fix the application instead.
-- **1:1 mapping** — changes should maintain a 1:1 mapping between application configuration
-  and Helm values. New abstraction layers require strong justification.
-
 ---
 
 ## Critical Rules
@@ -162,6 +159,14 @@ func TestDeploymentTemplate(t *testing.T) {
   should be in Secrets, not ConfigMaps?
 - [ ] Are `containerSecurityContext` and `podSecurityContext` fields preserved, not removed?
 
+### Workflow Automation Implementation
+
+- [ ] Does the PR introduce new non-trivial workflow automation logic in Bash (`run:` blocks or
+  `scripts/*.sh`) instead of Go?
+- [ ] If the workflow logic calls external APIs, parses JSON, or contains branching/orchestration,
+  is that logic implemented in Go under `scripts/<feature>/` (or existing Go tooling)?
+- [ ] If Bash remains, is it only thin glue (roughly <=20 lines), with business logic moved to Go?
+
 ```yaml
 # GOOD — action pinned to SHA with version comment
 - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -222,6 +227,10 @@ func TestDeploymentTemplate(t *testing.T) {
 
 8. **Using `assert` instead of `require` for fatal Go test setup** — allows tests to continue
    with bad state and produces confusing failure messages.
+
+9. **Non-trivial workflow automation in Bash** — API orchestration, JSON parsing, and branching
+  added in `run:` blocks or `scripts/*.sh` should be flagged and migrated to Go for testability
+  and maintainability.
 
 ---
 

--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -30,6 +30,8 @@ These are first-class review criteria. Flag PRs that violate them:
   core (e.g., OpenSearch, Bitnami sub-charts beyond what already exists).
 - **No workarounds** — the chart must not patch or work around application-level issues or
   technical debt. If an application bug requires a workaround, fix the application instead.
+- **1:1 mapping** — maintain a 1:1 mapping between application configuration and Helm values
+  wherever possible. Do not add Helm-only abstraction that has no equivalent in the app.
 ---
 
 ## Critical Rules
@@ -207,30 +209,30 @@ func TestDeploymentTemplate(t *testing.T) {
    CI will fail. Check that `test/unit/<component>/golden/*.golden.yaml` files are committed
    alongside template changes.
 
-2. **Undocumented values field** — a new `values.yaml` field without `## @param` will be
+3. **Undocumented values field** — a new `values.yaml` field without `## @param` will be
    invisible in generated docs. Flag as a required fix.
 
-3. **Missing `kindIs "slice"` check on `extraConfiguration`** — the field supports both map
+4. **Missing `kindIs "slice"` check on `extraConfiguration`** — the field supports both map
    and list forms. Handlers that only loop with `range $k, $v := ...` will panic on list input.
 
-4. **`indent` without `trim` on multiline strings** — produces a leading newline before the
+5. **`indent` without `trim` on multiline strings** — produces a leading newline before the
    content block, causing YAML parse errors at helm install time.
 
-5. **Cross-version scope creep** — a fix applied to `8.10` templates may also be needed in
+6. **Cross-version scope creep** — a fix applied to `8.10` templates may also be needed in
    `8.8` and `8.9`. Flag if the PR description doesn't address this.
 
-6. **Inline bash >20 lines** — complex shell logic without tests. Flag and suggest moving to
+7. **Inline bash >20 lines** — complex shell logic without tests. Flag and suggest moving to
    a Go script in `scripts/` with unit tests per `.github/AGENTS.md` policy.
 
-7. **`fail-fast: true` (or default) on test matrix** — in GitHub Actions workflows, the default
+8. **`fail-fast: true` (or default) on test matrix** — in GitHub Actions workflows, the default
    for `fail-fast` is `true`. Test matrices should set `fail-fast: false`.
 
-8. **Using `assert` instead of `require` for fatal Go test setup** — allows tests to continue
+9. **Using `assert` instead of `require` for fatal Go test setup** — allows tests to continue
    with bad state and produces confusing failure messages.
 
-9. **Non-trivial workflow automation in Bash** — API orchestration, JSON parsing, and branching
-  added in `run:` blocks or `scripts/*.sh` should be flagged and migrated to Go for testability
-  and maintainability.
+10. **Non-trivial workflow automation in Bash** — API orchestration, JSON parsing, and branching
+    added in `run:` blocks or `scripts/*.sh` should be flagged and migrated to Go for testability
+    and maintainability.
 
 ---
 

--- a/.github/instructions/github-actions.instructions.md
+++ b/.github/instructions/github-actions.instructions.md
@@ -12,7 +12,7 @@ template workflows (named `*-template.yaml`) are called by trigger workflows (na
 for security. Vault is the source of truth for secrets — never hard-code credentials. The
 `hashicorp/vault-action` step imports secrets as environment variables before any step that
 needs them. Complex logic (>20 lines of shell) must be implemented as a Go script, not inline
-bash. Commit messages from automated workflow steps follow Conventional Commits with the
+bash or standalone bash scripts. Commit messages from automated workflow steps follow Conventional Commits with the
 `chore(ci):` type. Always set `permissions:` explicitly to the minimum required.
 
 ---
@@ -26,6 +26,8 @@ bash. Commit messages from automated workflow steps follow Conventional Commits 
   variables. All secrets come from Vault via `hashicorp/vault-action`.
 - **NEVER** write inline bash scripts longer than ~20 lines — implement as a Go script with tests
   in `scripts/` instead.
+- **NEVER** add new bash business-logic scripts in `scripts/` for workflow automation when logic
+  exceeds ~20 lines, includes branching, calls APIs, or parses JSON.
 - **NEVER** omit `concurrency:` on workflows triggered by `push` or `pull_request` — duplicate
   runs waste CI resources.
 - **NEVER** use `strategy.fail-fast: true` for integration test matrices — one flaky test must
@@ -41,6 +43,8 @@ bash. Commit messages from automated workflow steps follow Conventional Commits 
 - **ALWAYS** use `make` targets (not raw commands) so local and CI behaviour match.
 - **ALWAYS** install tools via `.github/actions/install-tool-versions` before using `go`, `helm`,
   `kubectl`, etc. — this respects the pinned versions in `.tool-versions`.
+- **ALWAYS** implement new non-trivial workflow automation logic in Go under `scripts/<feature>/`
+  (or an existing Go tooling module), with tests where practical.
 
 ---
 
@@ -235,19 +239,23 @@ jobs:
 3. **Inline bash >20 lines** — complex logic in `run:` blocks has no tests and is hard to
    maintain. Move it to a Go script in `scripts/` with unit tests.
 
-4. **Missing `fail-fast: false`** — default is `true`, which cancels all matrix jobs when one
+4. **Standalone bash automation scripts for business logic** — adding new `scripts/*.sh` files
+  that perform API orchestration, JSON parsing, and branching duplicates logic that should live in
+  Go and be testable.
+
+5. **Missing `fail-fast: false`** — default is `true`, which cancels all matrix jobs when one
    fails. This is almost never wanted for test matrices.
 
-5. **Skipping `concurrency:`** — PR workflows without concurrency run duplicate jobs on rapid
+6. **Skipping `concurrency:`** — PR workflows without concurrency run duplicate jobs on rapid
    force-pushes, wasting CI minutes.
 
-6. **Not using `make` targets** — running `go test ./...` directly instead of `make go.test`
+7. **Not using `make` targets** — running `go test ./...` directly instead of `make go.test`
    skips pre-test steps (license checks, formatting, dependency updates).
 
-7. **Missing `id-token: write`** — OIDC-based Vault auth requires `permissions.id-token: write`
+8. **Missing `id-token: write`** — OIDC-based Vault auth requires `permissions.id-token: write`
    at job or workflow level.
 
-8. **Skipping debug output** — add an info step (`echo "output: ${{ steps.id.outputs.val }}"`)
+9. **Skipping debug output** — add an info step (`echo "output: ${{ steps.id.outputs.val }}"`)
    after complex composite actions so failures are easier to diagnose.
 
 ---

--- a/.github/instructions/scripting.instructions.md
+++ b/.github/instructions/scripting.instructions.md
@@ -1,0 +1,49 @@
+---
+applyTo: "scripts/**"
+---
+
+# Scripting — Scoped Instructions
+
+## Overview
+
+This repository prefers Go for non-trivial automation. Scripts under `scripts/` are often used
+from CI workflows and should be testable, maintainable, and explicit about error handling.
+Use Bash only for thin wrappers and command glue.
+
+---
+
+## Critical Rules
+
+### NEVER
+- **NEVER** introduce new Bash business logic in `scripts/` when the script exceeds ~20 lines.
+- **NEVER** implement API orchestration (HTTP calls + response handling) in new Bash scripts.
+- **NEVER** implement JSON parsing and branching workflows in new Bash scripts.
+
+### ALWAYS
+- **ALWAYS** implement new non-trivial automation in Go under `scripts/<feature>/`.
+- **ALWAYS** add or update tests for new Go automation logic where practical.
+- **ALWAYS** keep Bash scripts as thin wrappers only (argument/env validation and delegation).
+
+---
+
+## Decision Heuristics
+
+Use Go if one or more of the following is true:
+- Script calls external APIs.
+- Script parses JSON/YAML and branches on values.
+- Script coordinates multiple systems (GitHub, Slack, Vault, OpsGenie, etc.).
+- Script needs retries, error classification, or structured output.
+
+Bash is acceptable when all are true:
+- Glue-only command composition.
+- Minimal branching.
+- Roughly <=20 lines.
+- No complex parsing or orchestration.
+
+---
+
+## Common Mistakes
+
+1. **Growing one-off Bash scripts into orchestration code** — difficult to test and reason about.
+2. **Copying API + jq patterns across scripts** — leads to duplicated, fragile behavior.
+3. **Embedding business rules in workflow `run:` blocks** — move to Go tooling and call it.


### PR DESCRIPTION
Closes camunda/camunda-platform-helm#5826

## Summary

Tightens the AI agent and contributor guidance so that non-trivial workflow automation always lands in Go, not Bash.

## What changed

- `.github/instructions/github-actions.instructions.md`
  - Added NEVER rule: no new Bash business-logic scripts in `scripts/` when logic exceeds ~20 lines, includes branching, calls APIs, or parses JSON.
  - Added ALWAYS rule: new non-trivial workflow automation must be in Go under `scripts/<feature>/`.
  - Added common-mistake entry for standalone Bash automation scripts.

- `.github/instructions/scripting.instructions.md` _(new file, scoped to `scripts/**`)_
  - NEVER/ALWAYS rules for Bash vs Go selection.
  - Decision heuristics: when to use Go, when thin Bash glue is acceptable.
  - Common mistakes section.

- `.github/instructions/code-review.instructions.md`
  - Added a **Workflow Automation Implementation** checklist section.
  - Added common-mistake entry camunda/camunda-platform-helm#9 flagging non-trivial Bash automation for migration.

## Why

When implementing camunda/team-distribution#765 the automation was initially written in Bash. The existing instructions only prohibited inline `run:` blocks, not standalone `scripts/*.sh` files, and no scripting policy file existed. These changes close that gap.