### PR TITLE
ci: skip Slack notifications for automerge Renovate PRs

### DIFF
--- a/.github/workflows/notify-pr-activity.yml
+++ b/.github/workflows/notify-pr-activity.yml
@@ -93,6 +93,11 @@ on:
         type: string
         required: false
         default: 'false'
+      pr_labels_json:
+        description: 'JSON array of label objects: [{"name":"automerge"},...]'
+        type: string
+        required: false
+        default: '[]'
     secrets:
       VAULT_ADDR:
         required: true
@@ -160,6 +165,7 @@ jobs:
           PR_CREATED_AT:    ${{ inputs.pr_created_at  || github.event.pull_request.created_at }}
           PR_MERGED_AT:     ${{ inputs.pr_merged_at   || github.event.pull_request.merged_at }}
           PR_REVIEWERS_JSON: ${{ inputs.pr_reviewers_json || toJSON(github.event.pull_request.requested_reviewers) }}
+          PR_LABELS_JSON:   ${{ inputs.pr_labels_json   || toJSON(github.event.pull_request.labels) }}
         run: |
           cd scripts/notify-pr-activity
           go run .

--- a/scripts/notify-pr-activity/main.go
+++ b/scripts/notify-pr-activity/main.go
@@ -160,7 +160,31 @@ func sendSlack(webhook, message string) error {
 	return nil
 }
 
+// hasLabel reports whether the JSON label array contains a label with the given name.
+// The array has the shape [{"name":"automerge",...},...]
+func hasLabel(labelsJSON, name string) bool {
+	var labels []struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal([]byte(labelsJSON), &labels); err != nil {
+		return false
+	}
+	for _, l := range labels {
+		if l.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
 func main() {
+	// Renovate PRs labelled "automerge" are handled automatically and generate no useful signal.
+	// Renovate PRs without "automerge" (e.g. major updates) still need human attention — notify those.
+	if os.Getenv("PR_AUTHOR") == "renovate[bot]" && hasLabel(os.Getenv("PR_LABELS_JSON"), "automerge") {
+		fmt.Println("ℹ️  Skipping Slack notification: automerge Renovate PR.")
+		return
+	}
+
 	webhook := mustEnv("SLACK_WEBHOOK")
 	message := buildMessage()
 


### PR DESCRIPTION
## Summary

Implements part 1 of #5835.

- Renovate PRs carrying the `automerge` label are auto-merged without human intervention, so Slack notifications for them are pure noise — skip them.
- Major Renovate PRs (`requires-manual-review` label, no `automerge`) still trigger notifications since they need human attention.
- Added `hasLabel()` helper in the Go script to parse the labels JSON array.
- Added `pr_labels_json` input to the `workflow_call` interface so callers from other repos can pass label data.

## How it works

In `main()`, before building the Slack message:

```go
if os.Getenv("PR_AUTHOR") == "renovate[bot]" && hasLabel(os.Getenv("PR_LABELS_JSON"), "automerge") {
    fmt.Println("ℹ️  Skipping Slack notification: automerge Renovate PR.")
    return
}
```

The `PR_LABELS_JSON` env var is populated from `github.event.pull_request.labels` (via `toJSON()`) for `pull_request_target` events, or from the `pr_labels_json` workflow_call input.

## Test plan

- [ ] Trigger the workflow on a Renovate PR with the `automerge` label → no Slack message sent
- [ ] Trigger on a Renovate PR with `requires-manual-review` (no `automerge`) → Slack message sent
- [ ] Trigger on a human PR → Slack message sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)