### PR TITLE
ci: actually retry entra addPassword on graph 404

### DIFF
--- a/scripts/deploy-camunda/entra/entra.go
+++ b/scripts/deploy-camunda/entra/entra.go
@@ -5,6 +5,7 @@
 package entra
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -207,14 +208,59 @@ func graphGet(ctx context.Context, client *http.Client, token, path string) ([]b
 	return body, err
 }
 
-// postWithGraphRetry wraps graphPost with bounded exponential backoff. It
-// retries on transport errors, 404 (Graph is eventually consistent after a
-// new object is created), 408/429 (throttling), and 5xx. Terminal statuses
-// like 400/401/403 are returned to the caller without retries.
+// retryPredicate decides whether to retry a Graph response. statusCode and
+// body come from the last response; err is non-nil for transport-level errors
+// (in which case statusCode/body are zero-valued).
+type retryPredicate func(statusCode int, body []byte, err error) bool
+
+// defaultRetryable retries on transport errors and the statuses Graph commonly
+// returns while propagating a newly-created object: 404, 408, 429, and 5xx.
+// Terminal statuses (400, 401, 403) are treated as caller errors.
+func defaultRetryable(statusCode int, _ []byte, err error) bool {
+	if err != nil {
+		return true
+	}
+	switch {
+	case statusCode == http.StatusNotFound:
+		return true
+	case statusCode == http.StatusRequestTimeout:
+		return true
+	case statusCode == http.StatusTooManyRequests:
+		return true
+	case statusCode >= 500 && statusCode <= 599:
+		return true
+	}
+	return false
+}
+
+// servicePrincipalCreateRetryable extends defaultRetryable with the specific
+// 400 Request_BadRequest that Graph returns when a just-created appId isn't
+// yet visible to the /servicePrincipals endpoint — a known eventual-consistency
+// race, not a caller bug. Narrowly matched on error code + message to avoid
+// retrying legitimate 400s.
+func servicePrincipalCreateRetryable(statusCode int, body []byte, err error) bool {
+	if defaultRetryable(statusCode, body, err) {
+		return true
+	}
+	if statusCode == http.StatusBadRequest &&
+		bytes.Contains(body, []byte("Request_BadRequest")) &&
+		bytes.Contains(body, []byte("does not reference a valid application")) {
+		return true
+	}
+	return false
+}
+
+// postWithGraphRetry wraps graphPost with bounded exponential backoff. The
+// retryable predicate decides which non-2xx responses to retry; pass nil for
+// defaultRetryable. 2xx always short-circuits as success; anything the
+// predicate rejects is returned as a non-retryable error.
 //
 // On success it returns (body, statusCode, nil). On give-up it returns the
 // last status and body together with a wrapped error describing attempt count.
-func postWithGraphRetry(ctx context.Context, client *http.Client, token, path string, payload interface{}, op string) ([]byte, int, error) {
+func postWithGraphRetry(ctx context.Context, client *http.Client, token, path string, payload interface{}, op string, retryable retryPredicate) ([]byte, int, error) {
+	if retryable == nil {
+		retryable = defaultRetryable
+	}
 	var (
 		body       []byte
 		statusCode int
@@ -235,7 +281,7 @@ func postWithGraphRetry(ctx context.Context, client *http.Client, token, path st
 			return body, statusCode, nil
 		}
 
-		if lastErr == nil && !isRetryableStatus(statusCode) {
+		if !retryable(statusCode, body, lastErr) {
 			return body, statusCode, fmt.Errorf("%s: non-retryable status=%d body=%s", op, statusCode, string(body))
 		}
 
@@ -270,23 +316,6 @@ func postWithGraphRetry(ctx context.Context, client *http.Client, token, path st
 		return body, statusCode, fmt.Errorf("%s: gave up after %d attempts: %w", op, retryMaxAttempts, lastErr)
 	}
 	return body, statusCode, fmt.Errorf("%s: gave up after %d attempts (last status=%d body=%s)", op, retryMaxAttempts, statusCode, string(body))
-}
-
-// isRetryableStatus reports whether an HTTP status code from Graph is worth
-// retrying. 404 is included because Graph's write endpoints can briefly
-// return 404 for newly-created objects (eventual consistency).
-func isRetryableStatus(statusCode int) bool {
-	switch {
-	case statusCode == http.StatusNotFound:
-		return true
-	case statusCode == http.StatusRequestTimeout:
-		return true
-	case statusCode == http.StatusTooManyRequests:
-		return true
-	case statusCode >= 500 && statusCode <= 599:
-		return true
-	}
-	return false
 }
 
 // graphPost performs a POST request to the Graph API.
@@ -502,7 +531,7 @@ func rotateCredentials(ctx context.Context, client *http.Client, token, objectID
 	}
 
 	secretBody, statusCode, err := postWithGraphRetry(ctx, client, token,
-		fmt.Sprintf("/applications/%s/addPassword", objectID), addPayload, "addPassword")
+		fmt.Sprintf("/applications/%s/addPassword", objectID), addPayload, "addPassword", nil)
 	if err != nil {
 		return "", fmt.Errorf("add password: %w", err)
 	}
@@ -546,10 +575,15 @@ func ensureServicePrincipal(ctx context.Context, client *http.Client, token, app
 		return nil
 	}
 
-	// Create service principal.
+	// Create service principal. Graph's /servicePrincipals endpoint can lag
+	// behind a newly-created app registration and return 400 Request_BadRequest
+	// ("does not reference a valid application") for seconds after the app is
+	// visible via direct GET/POST on /applications/{objectId}. Retry narrowly
+	// on that specific error.
 	logging.Logger.Debug().Str("appId", appID).Msg("Creating new service principal")
 	spPayload := map[string]string{"appId": appID}
-	spBody, statusCode, err := graphPost(ctx, client, token, "/servicePrincipals", spPayload)
+	spBody, statusCode, err := postWithGraphRetry(ctx, client, token,
+		"/servicePrincipals", spPayload, "createServicePrincipal", servicePrincipalCreateRetryable)
 	if err != nil {
 		return fmt.Errorf("create service principal: %w", err)
 	}

--- a/scripts/deploy-camunda/entra/entra.go
+++ b/scripts/deploy-camunda/entra/entra.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"os"
@@ -22,6 +23,18 @@ import (
 // graphBaseURL is the Microsoft Graph API base URL. It is a variable so tests
 // can override it with a local httptest server URL.
 var graphBaseURL = "https://graph.microsoft.com/v1.0"
+
+// retryBaseBackoff is the initial backoff for graph retry loops. Exposed as a
+// variable so tests can set it to millisecond scale.
+var retryBaseBackoff = 1 * time.Second
+
+// retryMaxBackoff caps the per-attempt backoff.
+var retryMaxBackoff = 8 * time.Second
+
+// retryMaxAttempts bounds the total number of retries for graph write calls
+// that may race against Graph backend propagation (e.g. addPassword, create SP
+// right after creating an app registration).
+var retryMaxAttempts = 15
 
 // loginBaseURL is the Microsoft identity platform base URL. It is a variable
 // so tests can override it with a local httptest server URL.
@@ -192,6 +205,88 @@ func graphGet(ctx context.Context, client *http.Client, token, path string) ([]b
 	body, err := io.ReadAll(resp.Body)
 	logging.Logger.Debug().Int("statusCode", resp.StatusCode).Int("bodyLen", len(body)).Msg("Graph API GET response")
 	return body, err
+}
+
+// postWithGraphRetry wraps graphPost with bounded exponential backoff. It
+// retries on transport errors, 404 (Graph is eventually consistent after a
+// new object is created), 408/429 (throttling), and 5xx. Terminal statuses
+// like 400/401/403 are returned to the caller without retries.
+//
+// On success it returns (body, statusCode, nil). On give-up it returns the
+// last status and body together with a wrapped error describing attempt count.
+func postWithGraphRetry(ctx context.Context, client *http.Client, token, path string, payload interface{}, op string) ([]byte, int, error) {
+	var (
+		body       []byte
+		statusCode int
+		lastErr    error
+	)
+	backoff := retryBaseBackoff
+	for attempt := 1; attempt <= retryMaxAttempts; attempt++ {
+		body, statusCode, lastErr = graphPost(ctx, client, token, path, payload)
+
+		if lastErr == nil && statusCode >= 200 && statusCode < 300 {
+			if attempt > 1 {
+				logging.Logger.Info().
+					Str("op", op).
+					Int("attempt", attempt).
+					Int("statusCode", statusCode).
+					Msg("Graph call succeeded after retry")
+			}
+			return body, statusCode, nil
+		}
+
+		if lastErr == nil && !isRetryableStatus(statusCode) {
+			return body, statusCode, fmt.Errorf("%s: non-retryable status=%d body=%s", op, statusCode, string(body))
+		}
+
+		if attempt == retryMaxAttempts {
+			break
+		}
+
+		wait := backoff + time.Duration(rand.Int63n(int64(backoff/4)+1))
+		logging.Logger.Warn().
+			Str("op", op).
+			Int("attempt", attempt).
+			Int("statusCode", statusCode).
+			Err(lastErr).
+			Dur("nextBackoff", wait).
+			Msg("Graph call failed, retrying")
+
+		select {
+		case <-ctx.Done():
+			return body, statusCode, ctx.Err()
+		case <-time.After(wait):
+		}
+
+		if backoff < retryMaxBackoff {
+			backoff *= 2
+			if backoff > retryMaxBackoff {
+				backoff = retryMaxBackoff
+			}
+		}
+	}
+
+	if lastErr != nil {
+		return body, statusCode, fmt.Errorf("%s: gave up after %d attempts: %w", op, retryMaxAttempts, lastErr)
+	}
+	return body, statusCode, fmt.Errorf("%s: gave up after %d attempts (last status=%d body=%s)", op, retryMaxAttempts, statusCode, string(body))
+}
+
+// isRetryableStatus reports whether an HTTP status code from Graph is worth
+// retrying. 404 is included because Graph's write endpoints can briefly
+// return 404 for newly-created objects (eventual consistency).
+func isRetryableStatus(statusCode int) bool {
+	switch {
+	case statusCode == http.StatusNotFound:
+		return true
+	case statusCode == http.StatusRequestTimeout:
+		return true
+	case statusCode == http.StatusTooManyRequests:
+		return true
+	case statusCode >= 500 && statusCode <= 599:
+		return true
+	}
+	return false
 }
 
 // graphPost performs a POST request to the Graph API.
@@ -395,7 +490,9 @@ func rotateCredentials(ctx context.Context, client *http.Client, token, objectID
 		}
 	}
 
-	// Add a new client secret.
+	// Add a new client secret. Graph's backend is eventually consistent after
+	// an app registration is created, so addPassword may return 404 for tens
+	// of seconds after POST /applications succeeds. Retry with backoff.
 	logging.Logger.Debug().Str("objectId", objectID).Msg("Adding new password credential")
 	addPayload := map[string]interface{}{
 		"passwordCredential": map[string]string{
@@ -404,15 +501,8 @@ func rotateCredentials(ctx context.Context, client *http.Client, token, objectID
 		},
 	}
 
-	err = fmt.Errorf("dummy error")
-	attempts := 0
-	statusCode := 0
-	var secretBody []byte
-	for err != nil && statusCode != 201 && attempts < 30 {
-		secretBody, statusCode, err = graphPost(ctx, client, token, fmt.Sprintf("/applications/%s/addPassword", objectID), addPayload)
-		attempts++
-		time.Sleep(5 * time.Second)
-	}
+	secretBody, statusCode, err := postWithGraphRetry(ctx, client, token,
+		fmt.Sprintf("/applications/%s/addPassword", objectID), addPayload, "addPassword")
 	if err != nil {
 		return "", fmt.Errorf("add password: %w", err)
 	}

--- a/scripts/deploy-camunda/entra/entra_test.go
+++ b/scripts/deploy-camunda/entra/entra_test.go
@@ -516,6 +516,88 @@ func TestEnsureServicePrincipal_Creates(t *testing.T) {
 	}
 }
 
+// TestEnsureServicePrincipal_RetriesOn400RequestBadRequest verifies that the
+// /servicePrincipals POST retries the specific 400 Request_BadRequest race
+// Graph returns when the appId of a just-created app isn't yet visible to
+// the SP endpoint.
+func TestEnsureServicePrincipal_RetriesOn400RequestBadRequest(t *testing.T) {
+	shrinkRetryTimings(t)
+
+	var postAttempts int32
+	const flakyAttempts int32 = 2
+
+	srv := newTestServer(t, map[string]http.HandlerFunc{
+		"GET /servicePrincipals": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, map[string]interface{}{
+				"value": []interface{}{},
+			})
+		},
+		"POST /servicePrincipals": func(w http.ResponseWriter, r *http.Request) {
+			n := atomic.AddInt32(&postAttempts, 1)
+			if n <= flakyAttempts {
+				jsonResponse(w, 400, map[string]interface{}{
+					"error": map[string]string{
+						"code":    "Request_BadRequest",
+						"message": "The appId 'abc-123' of the service principal does not reference a valid application object.",
+					},
+				})
+				return
+			}
+			jsonResponse(w, 201, map[string]string{"id": "sp-recovered"})
+		},
+	})
+	defer srv.Close()
+
+	origGraph := graphBaseURL
+	graphBaseURL = srv.URL
+	defer func() { graphBaseURL = origGraph }()
+
+	if err := ensureServicePrincipal(context.Background(), srv.Client(), "token", "abc-123"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := atomic.LoadInt32(&postAttempts); got != flakyAttempts+1 {
+		t.Errorf("POST attempts = %d, want %d (retry loop should recover from 400 Request_BadRequest)", got, flakyAttempts+1)
+	}
+}
+
+// TestEnsureServicePrincipal_DoesNotRetryGeneric400 verifies the SP retry
+// predicate is narrow — a 400 that is NOT Request_BadRequest with the appId
+// message must fail fast.
+func TestEnsureServicePrincipal_DoesNotRetryGeneric400(t *testing.T) {
+	shrinkRetryTimings(t)
+
+	var postAttempts int32
+	srv := newTestServer(t, map[string]http.HandlerFunc{
+		"GET /servicePrincipals": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, map[string]interface{}{
+				"value": []interface{}{},
+			})
+		},
+		"POST /servicePrincipals": func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&postAttempts, 1)
+			jsonResponse(w, 400, map[string]interface{}{
+				"error": map[string]string{
+					"code":    "Request_BadRequest",
+					"message": "Some other validation failure unrelated to propagation.",
+				},
+			})
+		},
+	})
+	defer srv.Close()
+
+	origGraph := graphBaseURL
+	graphBaseURL = srv.URL
+	defer func() { graphBaseURL = origGraph }()
+
+	err := ensureServicePrincipal(context.Background(), srv.Client(), "token", "app-id")
+	if err == nil {
+		t.Fatal("expected error on generic 400, got nil")
+	}
+	if got := atomic.LoadInt32(&postAttempts); got != 1 {
+		t.Errorf("POST attempts = %d, want 1 (generic 400 should not be retried)", got)
+	}
+}
+
 func TestCleanupVenomApp_AppExists(t *testing.T) {
 	deleted := false
 	srv := newTestServer(t, map[string]http.HandlerFunc{

--- a/scripts/deploy-camunda/entra/entra_test.go
+++ b/scripts/deploy-camunda/entra/entra_test.go
@@ -7,7 +7,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // newTestServer creates an httptest server that handles Graph API and login
@@ -314,6 +316,151 @@ func TestRotateCredentials(t *testing.T) {
 	}
 	if secret != "new-secret-value" {
 		t.Errorf("secret = %q, want %q", secret, "new-secret-value")
+	}
+}
+
+// shrinkRetryTimings scales the graph retry knobs down to millisecond scale
+// so retry tests complete in milliseconds, not minutes.
+func shrinkRetryTimings(t *testing.T) {
+	t.Helper()
+	origBase, origMax, origAttempts := retryBaseBackoff, retryMaxBackoff, retryMaxAttempts
+	retryBaseBackoff = time.Millisecond
+	retryMaxBackoff = 4 * time.Millisecond
+	retryMaxAttempts = 8
+	t.Cleanup(func() {
+		retryBaseBackoff = origBase
+		retryMaxBackoff = origMax
+		retryMaxAttempts = origAttempts
+	})
+}
+
+// TestRotateCredentials_RetriesOn404ThenSucceeds verifies that addPassword
+// is retried when Graph returns 404 for a newly-created object id (eventual
+// consistency), and that the rotated secret is returned once Graph recovers.
+func TestRotateCredentials_RetriesOn404ThenSucceeds(t *testing.T) {
+	shrinkRetryTimings(t)
+
+	var addAttempts int32
+	const flakyAttempts int32 = 3
+
+	srv := newTestServer(t, map[string]http.HandlerFunc{
+		"GET /applications/obj-flaky": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, map[string]interface{}{
+				"passwordCredentials": []map[string]string{},
+			})
+		},
+		"POST /applications/obj-flaky/addPassword": func(w http.ResponseWriter, r *http.Request) {
+			n := atomic.AddInt32(&addAttempts, 1)
+			if n <= flakyAttempts {
+				jsonResponse(w, 404, map[string]interface{}{
+					"error": map[string]string{
+						"code":    "Request_ResourceNotFound",
+						"message": "Resource 'obj-flaky' does not exist",
+					},
+				})
+				return
+			}
+			jsonResponse(w, 201, map[string]string{
+				"secretText": "fresh-secret",
+			})
+		},
+	})
+	defer srv.Close()
+
+	origGraph := graphBaseURL
+	graphBaseURL = srv.URL
+	defer func() { graphBaseURL = origGraph }()
+
+	secret, err := rotateCredentials(context.Background(), srv.Client(), "token", "obj-flaky")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if secret != "fresh-secret" {
+		t.Errorf("secret = %q, want %q", secret, "fresh-secret")
+	}
+	if got := atomic.LoadInt32(&addAttempts); got != flakyAttempts+1 {
+		t.Errorf("addPassword attempts = %d, want %d (retry loop did not retry through 404s)", got, flakyAttempts+1)
+	}
+}
+
+// TestRotateCredentials_GivesUpAfterMaxAttempts verifies the retry loop
+// terminates with an error that references the last status and body when
+// Graph persistently returns 404.
+func TestRotateCredentials_GivesUpAfterMaxAttempts(t *testing.T) {
+	shrinkRetryTimings(t)
+
+	var addAttempts int32
+	srv := newTestServer(t, map[string]http.HandlerFunc{
+		"GET /applications/obj-stuck": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, map[string]interface{}{
+				"passwordCredentials": []map[string]string{},
+			})
+		},
+		"POST /applications/obj-stuck/addPassword": func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&addAttempts, 1)
+			jsonResponse(w, 404, map[string]interface{}{
+				"error": map[string]string{
+					"code":    "Request_ResourceNotFound",
+					"message": "Resource 'obj-stuck' does not exist",
+				},
+			})
+		},
+	})
+	defer srv.Close()
+
+	origGraph := graphBaseURL
+	graphBaseURL = srv.URL
+	defer func() { graphBaseURL = origGraph }()
+
+	_, err := rotateCredentials(context.Background(), srv.Client(), "token", "obj-stuck")
+	if err == nil {
+		t.Fatal("expected error when addPassword never succeeds, got nil")
+	}
+	if !strings.Contains(err.Error(), "gave up") {
+		t.Errorf("error should mention give-up, got: %v", err)
+	}
+	if got := atomic.LoadInt32(&addAttempts); got != int32(retryMaxAttempts) {
+		t.Errorf("addPassword attempts = %d, want %d (retry loop did not use full budget)", got, retryMaxAttempts)
+	}
+}
+
+// TestRotateCredentials_DoesNotRetry401 verifies terminal auth errors fail
+// fast rather than burning the retry budget.
+func TestRotateCredentials_DoesNotRetry401(t *testing.T) {
+	shrinkRetryTimings(t)
+
+	var addAttempts int32
+	srv := newTestServer(t, map[string]http.HandlerFunc{
+		"GET /applications/obj-unauthorized": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, map[string]interface{}{
+				"passwordCredentials": []map[string]string{},
+			})
+		},
+		"POST /applications/obj-unauthorized/addPassword": func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&addAttempts, 1)
+			jsonResponse(w, 401, map[string]interface{}{
+				"error": map[string]string{
+					"code":    "InvalidAuthenticationToken",
+					"message": "Access token has expired",
+				},
+			})
+		},
+	})
+	defer srv.Close()
+
+	origGraph := graphBaseURL
+	graphBaseURL = srv.URL
+	defer func() { graphBaseURL = origGraph }()
+
+	_, err := rotateCredentials(context.Background(), srv.Client(), "token", "obj-unauthorized")
+	if err == nil {
+		t.Fatal("expected error on 401, got nil")
+	}
+	if !strings.Contains(err.Error(), "non-retryable") {
+		t.Errorf("error should be non-retryable, got: %v", err)
+	}
+	if got := atomic.LoadInt32(&addAttempts); got != 1 {
+		t.Errorf("addPassword attempts = %d, want 1 (should not retry on 401)", got)
 	}
 }
 


### PR DESCRIPTION
### Which problem does the PR fix?

closes #5846

### What's in this PR?

Two independent eventual-consistency races against Microsoft Graph break the Entra provisioning path for `esoi` scenarios. This PR fixes both with a shared retry helper.

**1. `addPassword` returns 404 after `POST /applications` succeeds**

The existing retry loop short-circuited on the first response: `graphPost` returns `err == nil` for any HTTP status, so `for err != nil && statusCode != 201` exited after one attempt. Under Graph's eventual-consistency window after creating an app registration, `addPassword` routinely 404s for 1–14 s.

**2. `createServicePrincipal` returns 400 `Request_BadRequest` with "appId … does not reference a valid application object"**

Same race class, different endpoint: Graph's `/servicePrincipals` index lags behind `/applications/{objectId}`. Surfaced in this PR's own CI test run after (1) was fixed — see https://github.com/camunda/camunda-platform-helm/actions/runs/24556517350/job/71794368069.

**Fix**

Introduced `postWithGraphRetry(..., retryable retryPredicate)` with bounded exponential backoff + jitter (base 1s, cap 8s, 15 attempts ≈ 90s worst case). Two predicates:

- `defaultRetryable` — transport errors, `404`, `408`, `429`, `5xx`. Used for `addPassword`.
- `servicePrincipalCreateRetryable` — default set **plus** exactly `400` `Request_BadRequest` with `"does not reference a valid application"`. Narrow match avoids retrying legitimate 400s.

Retry knobs (`retryBaseBackoff`, `retryMaxBackoff`, `retryMaxAttempts`) are package vars so tests run in milliseconds.

**Tests** (all in `entra_test.go`):
- `TestRotateCredentials_RetriesOn404ThenSucceeds`
- `TestRotateCredentials_GivesUpAfterMaxAttempts`
- `TestRotateCredentials_DoesNotRetry401`
- `TestEnsureServicePrincipal_RetriesOn400RequestBadRequest`
- `TestEnsureServicePrincipal_DoesNotRetryGeneric400`

**Validation**
- Real Entra tenant, single run: addPassword recovered on attempt 2 (~1.2 s backoff).
- 3-way parallel matrix run (8.7/8.8/8.9 `esoi install gke`, `--max-parallel 3`): `addPassword` race hit 2/3 entries, all recovered; all three completed.
- CI (this PR): initial run exposed Race 2; that's what the second commit fixes.

### Checklist

**Before opening the PR:**

- [x] There is no other open pull request for the same update/change.
- [x] Tests for charts are added (if needed). — N/A, Go-only unit tests added.
- [x] In-repo documentation are updated (if needed). — N/A, no user-facing docs touched.

**After opening the PR:**

- [ ] Did you sign our CLA? (will check after open)
- [ ] Did all checks/tests pass in the PR?