### PR TITLE
ci: extend retry for externalsecret operator

### DIFF
--- a/.github/actions/cluster-setup-secrets/action.yaml
+++ b/.github/actions/cluster-setup-secrets/action.yaml
@@ -31,7 +31,7 @@ runs:
         apply_external_secret_with_retry() {
           local file="$1"
           local namespace="$2"
-          local max_retries=5
+          local max_retries=20
           local retry_delay=10
           
           for ((i=1; i<=max_retries; i++)); do

--- a/charts/camunda-platform-8.9/Chart.yaml
+++ b/charts/camunda-platform-8.9/Chart.yaml
@@ -103,4 +103,3 @@ annotations:
       description: "Consolidated-auth should be disabled"
     - kind: fixed
       description: "Remove importer from 8.9 and 8.10"
-


### PR DESCRIPTION
### Which problem does the PR fix?

I've been seeing some test failures lately with the waits on the externalsecrets operator. @bkenez mentioned that he thinks its related to the gke nodes needing to scale up to accommodate more load, and if thats true then we should account for that extra delay in the retry loop.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

Up retry number.

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
