### PR TITLE
ci: delegate PR activity notifications to team-distribution

### DIFF
--- a/.github/workflows/notify-pr-activity.yml
+++ b/.github/workflows/notify-pr-activity.yml
@@ -3,171 +3,43 @@
 ---
 # PR Activity Slack Notifications
 #
-# Sends a message to #team-distribution-github (via distro-bot) when:
-#   - A PR is opened or converted from draft to ready for review
-#   - A PR is merged
-#   - A PR is closed without merge
-#
-# Draft PRs are skipped entirely.
-#
-# Can be called from other repos via workflow_call — pass all pr_* inputs explicitly.
-#
-# Message format:
-#   ↗️ [helm] PR opened · by @author · review: @rev1 · +42/-7 — #123 feat: add support for X
-#   🎉 [helm] PR merged after 1d 4h · by @author · merged by @merger — #123 feat: add support for X
-#   ❌ [helm] PR closed without merge · by @author — #123 feat: add support for X
-#
-# Notification logic is implemented in scripts/notify-pr-activity (Go).
+# Delegates to the canonical workflow in camunda/team-distribution.
+# See that repo for implementation details and the full input reference.
 #
 name: Notify - PR Activity
 
 on:
-  # pull_request_target ensures secrets are available even for fork PRs.
-  # Safe here because we never checkout PR code.
   pull_request_target:
     types: [opened, ready_for_review, closed]
 
-  workflow_call:
-    inputs:
-      action:
-        description: 'PR event action: opened, ready_for_review, closed'
-        type: string
-        required: true
-      pr_repo:
-        description: 'Repository name (e.g. camunda-platform-helm)'
-        type: string
-        required: true
-      pr_number:
-        description: 'PR number'
-        type: string
-        required: true
-      pr_title:
-        description: 'PR title'
-        type: string
-        required: true
-      pr_url:
-        description: 'PR HTML URL'
-        type: string
-        required: true
-      pr_author:
-        description: 'PR author login'
-        type: string
-        required: true
-      pr_additions:
-        description: 'Lines added'
-        type: string
-        required: false
-        default: '0'
-      pr_deletions:
-        description: 'Lines deleted'
-        type: string
-        required: false
-        default: '0'
-      pr_merged:
-        description: 'Whether the PR was merged (true/false)'
-        type: string
-        required: false
-        default: 'false'
-      pr_merged_by:
-        description: 'Login of the user who merged the PR'
-        type: string
-        required: false
-        default: ''
-      pr_created_at:
-        description: 'PR creation timestamp (2006-01-02T15:04:05Z)'
-        type: string
-        required: false
-        default: ''
-      pr_merged_at:
-        description: 'PR merge timestamp (2006-01-02T15:04:05Z)'
-        type: string
-        required: false
-        default: ''
-      pr_reviewers_json:
-        description: 'JSON array of requested reviewer objects: [{"login":"user1"},...]'
-        type: string
-        required: false
-        default: '[]'
-      pr_draft:
-        description: 'Whether the PR is a draft (true/false)'
-        type: string
-        required: false
-        default: 'false'
-      pr_labels_json:
-        description: 'JSON array of label objects: [{"name":"automerge"},...]'
-        type: string
-        required: false
-        default: '[]'
-    secrets:
-      VAULT_ADDR:
-        required: true
-      VAULT_ROLE_ID:
-        required: true
-      VAULT_SECRET_ID:
-        required: true
+permissions: {}
 
 jobs:
-  notify-slack:
-    # Skip draft PRs; only run for opened, ready_for_review, closed+merged, or closed+unmerged events.
-    # When called via workflow_call, the caller controls filtering via the pr_draft input.
+  notify:
     if: |
-      (github.event_name == 'workflow_call' && inputs.pr_draft != 'true') ||
-      (github.event_name == 'pull_request_target' &&
-        !github.event.pull_request.draft && (
-          github.event.action == 'opened' ||
-          github.event.action == 'ready_for_review' ||
-          github.event.action == 'closed'
-        ))
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    timeout-minutes: 5
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          sparse-checkout: scripts/notify-pr-activity
-          sparse-checkout-cone-mode: true
-
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
-        with:
-          go-version-file: scripts/notify-pr-activity/go.mod
-
-      - name: Import Vault secrets
-        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b  # v3.4.0
-        id: vault-secrets
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secrets: |
-            secret/data/products/distribution/ci SLACK_DISTRO_BOT_WEBHOOK_GH;
-          exportEnv: true
-
-      - name: Send Slack notification
-        continue-on-error: true
-        env:
-          SLACK_WEBHOOK: ${{ env.SLACK_DISTRO_BOT_WEBHOOK_GH }}
-          # Resolve from workflow_call inputs first, fall back to pull_request_target event
-          GH_ACTION:        ${{ inputs.action        || github.event.action }}
-          PR_REPO:          ${{ inputs.pr_repo        || github.event.repository.name }}
-          PR_NUMBER:        ${{ inputs.pr_number      || github.event.pull_request.number }}
-          PR_TITLE:         ${{ inputs.pr_title       || github.event.pull_request.title }}
-          PR_URL:           ${{ inputs.pr_url         || github.event.pull_request.html_url }}
-          PR_AUTHOR:        ${{ inputs.pr_author      || github.event.pull_request.user.login }}
-          PR_ADDITIONS:     ${{ inputs.pr_additions   || github.event.pull_request.additions }}
-          PR_DELETIONS:     ${{ inputs.pr_deletions   || github.event.pull_request.deletions }}
-          PR_MERGED:        ${{ inputs.pr_merged      || github.event.pull_request.merged }}
-          PR_MERGED_BY:     ${{ inputs.pr_merged_by || (github.event.pull_request.merged_by && github.event.pull_request.merged_by.login) || '' }}
-          PR_CREATED_AT:    ${{ inputs.pr_created_at  || github.event.pull_request.created_at }}
-          PR_MERGED_AT:     ${{ inputs.pr_merged_at   || github.event.pull_request.merged_at }}
-          PR_REVIEWERS_JSON: ${{ inputs.pr_reviewers_json || toJSON(github.event.pull_request.requested_reviewers) }}
-          PR_LABELS_JSON:   ${{ inputs.pr_labels_json   || toJSON(github.event.pull_request.labels) }}
-        run: |
-          cd scripts/notify-pr-activity
-          go run .
-
-
+      !github.event.pull_request.draft && (
+        github.event.action == 'opened' ||
+        github.event.action == 'ready_for_review' ||
+        github.event.action == 'closed'
+      )
+    uses: camunda/team-distribution/.github/workflows/notify-pr-activity.yml@main
+    with:
+      action:           ${{ github.event.action }}
+      pr_repo:          ${{ github.event.repository.name }}
+      pr_number:        ${{ github.event.pull_request.number }}
+      pr_title:         ${{ github.event.pull_request.title }}
+      pr_url:           ${{ github.event.pull_request.html_url }}
+      pr_author:        ${{ github.event.pull_request.user.login }}
+      pr_additions:     ${{ github.event.pull_request.additions }}
+      pr_deletions:     ${{ github.event.pull_request.deletions }}
+      pr_merged:        ${{ github.event.pull_request.merged }}
+      pr_merged_by:     ${{ (github.event.pull_request.merged_by && github.event.pull_request.merged_by.login) || '' }}
+      pr_created_at:    ${{ github.event.pull_request.created_at }}
+      pr_merged_at:     ${{ github.event.pull_request.merged_at || '' }}
+      pr_reviewers_json: ${{ toJSON(github.event.pull_request.requested_reviewers) }}
+      pr_draft:         ${{ github.event.pull_request.draft }}
+      pr_labels_json:   ${{ toJSON(github.event.pull_request.labels) }}
+    secrets:
+      VAULT_ADDR:       ${{ secrets.VAULT_ADDR }}
+      VAULT_ROLE_ID:    ${{ secrets.VAULT_ROLE_ID }}
+      VAULT_SECRET_ID:  ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/notify-pr-activity.yml
+++ b/.github/workflows/notify-pr-activity.yml
@@ -12,8 +12,6 @@ on:
   pull_request_target:
     types: [opened, ready_for_review, closed]
 
-permissions: {}
-
 jobs:
   notify:
     if: |


### PR DESCRIPTION
## Summary
- The `notify-pr-activity` workflow and its Go script have been centralised in `camunda/team-distribution`
- Replaces the full implementation here with a thin `workflow_call` caller — no behaviour change

## Related
- team-distribution PR that adds the canonical implementation: camunda/team-distribution#768

🤖 Generated with [Claude Code](https://claude.com/claude-code)