### PR TITLE
fix: remove prerelease

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -41,7 +41,6 @@ entries:
           url: https://docs.camunda.io/docs/self-managed/about-self-managed/
         - name: Camunda 8 Self-Managed Helm charts
           url: https://github.com/camunda/camunda-platform-helm
-      artifacthub.io/prerelease: "true"
       camunda.io/component-image-versions: |
         camunda: 8.9.0
         managementIdentity: 8.9.0
@@ -27087,4 +27086,5 @@ entries:
     urls:
     - https://github.com/camunda-community-hub/camunda-cloud-helm/releases/download/zeebe-zeeqs-helm-1.0.0/zeebe-zeeqs-helm-1.0.0.tgz
     version: 1.0.0
-generated: "2026-04-17T11:27:30.487805517Z"
+generated: "2026-04-20T12:05:52.487805517Z"
+


### PR DESCRIPTION
### Which problem does the PR fix?

<img width="1065" height="906" alt="image" src="https://github.com/user-attachments/assets/f16faea4-e093-4f71-b139-b3e397a0febe" />

the 8.9 release is publicly available and supported now, so it should not be prerelease.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
