### PR TITLE
fix: strip artifacthub.io/prerelease annotation during alpha-to-stable transition

### DIFF
--- a/.github/workflows/chart-build-dev.yaml
+++ b/.github/workflows/chart-build-dev.yaml
@@ -267,6 +267,7 @@ jobs:
             fi
 
             echo "RELEASE_VERSION=${RELEASE_VERSION}" | tee -a $GITHUB_ENV
+            echo "IS_PRERELEASE=${IS_PRERELEASE}" >> $GITHUB_ENV
             RELEASE_VERSION_COMPUTED=true
             echo "RELEASE_VERSION_COMPUTED=true" >> $GITHUB_ENV
             echo "::notice::Computed version: ${RELEASE_VERSION}"
@@ -400,6 +401,15 @@ jobs:
 
           # Update the version field
           yq -i ".version = \"${RELEASE_VERSION}\"" Chart.yaml
+
+          # Remove prerelease annotation for stable releases.
+          # During alpha-to-stable transitions the source Chart.yaml may still
+          # carry artifacthub.io/prerelease: "true". Strip it so Artifact Hub
+          # does not label the GA chart as a pre-release.
+          if [[ "${IS_PRERELEASE}" != "true" ]]; then
+            yq -i 'del(.annotations."artifacthub.io/prerelease")' Chart.yaml
+            echo "Removed artifacthub.io/prerelease annotation (stable release)"
+          fi
 
           # Extract and apply the artifacthub.io/changes annotation from trace
           # The trace output contains the full YAML block for the annotation


### PR DESCRIPTION
### Linked issue

https://github.com/camunda/camunda-platform-helm/issues/5874

## Summary

- During the 8.9 alpha-to-stable transition, the dev build pipeline correctly stripped the version suffix (`14.0.0-alpha5` → `14.0.0`) but did not remove the `artifacthub.io/prerelease: "true"` annotation from `Chart.yaml`. This caused the published 14.0.0 tarball to retain the annotation, making Artifact Hub label the GA chart as "Pre-release" (SUPPORT-32458).
- Strips the `artifacthub.io/prerelease` annotation in the "Apply Chart.yaml version" step whenever the build is not a prerelease.
- Persists `IS_PRERELEASE` to `GITHUB_ENV` so the variable is available across steps.

### Reproducing the issue

```bash
helm pull camunda/camunda-platform --version 14.0.0 -d /tmp/helm-inspect
tar -xzf /tmp/helm-inspect/camunda-platform-14.0.0.tgz -O camunda-platform/Chart.yaml | grep 'artifacthub.io/prerelease'
# Output: artifacthub.io/prerelease: "true"
```

### Note

This fix prevents recurrence for future alpha-to-stable transitions. The already-published 14.0.0 tarball still needs to be republished with corrected metadata to clear the badge on Artifact Hub.

## Test plan

- [ ] Verify `yq 'del(.annotations."artifacthub.io/prerelease")' Chart.yaml` is a no-op on charts without the annotation (safe for regular stable builds)
- [ ] Verify the annotation is stripped when building an alpha-to-stable transition (e.g., trigger dev build after moving a version from `alpha` to `supportStandard` in `chart-versions.yaml`)
- [ ] Verify alpha builds still retain the annotation