### PR TITLE
fix: prevent unauthenticated access to Spring Boot actuator metrics

### DIFF
--- a/charts/camunda-platform-8.10/templates/connectors/files/_application.yaml
+++ b/charts/camunda-platform-8.10/templates/connectors/files/_application.yaml
@@ -14,11 +14,11 @@ management:
   endpoints:
     web:
       exposure:
-        include: metrics,health,prometheus
+        include: health,prometheus
   endpoint:
     health:
-      show-details: always
-      show-components: always
+      show-details: never
+      show-components: never
       group:
         readiness:
           include:

--- a/charts/camunda-platform-8.10/test/unit/connectors/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/connectors/golden/configmap.golden.yaml
@@ -22,11 +22,11 @@ data:
       endpoints:
         web:
           exposure:
-            include: metrics,health,prometheus
+            include: health,prometheus
       endpoint:
         health:
-          show-details: always
-          show-components: always
+          show-details: never
+          show-components: never
           group:
             readiness:
               include:


### PR DESCRIPTION
### Which problem does the PR fix?

Not exposing the metrics endpoint https://gke-qaelupg-f1b9-8-10-qaelupg.ci.distro.ultrawombat.com/connectors/actuator/metrics 

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
