### PR TITLE
fix: add missing properties and annotations to values.schema.json

### DIFF
--- a/.github/workflows/chart-validate-template.yaml
+++ b/.github/workflows/chart-validate-template.yaml
@@ -103,3 +103,18 @@ jobs:
         run: |
           # Call yamllint via asdf because there is an issue loading the correct version of yamllint in GHA workflow.
           $(asdf which yamllint) -c .github/config/yamllint.yaml ./charts/${{ inputs.camunda-helm-dir }}/test/unit
+      # Schema freshness check.
+      - name: Install readme-generator-for-helm
+        if: ${{ hashFiles(format('charts/{0}/values.schema.json', inputs.camunda-helm-dir)) != '' }}
+        run: |
+          # renovate: datasource=npm depName=@bitnami/readme-generator-for-helm
+          npm install -g @bitnami/readme-generator-for-helm@2.7.2
+      - name: Check schema is up-to-date
+        if: ${{ hashFiles(format('charts/{0}/values.schema.json', inputs.camunda-helm-dir)) != '' }}
+        run: |
+          export chartPath="charts/${{ inputs.camunda-helm-dir }}"
+          make helm.schema-update
+          if ! git diff --exit-code "${chartPath}/values.schema.json"; then
+            echo "::error::values.schema.json is out of date. Run 'make helm.schema-update chartPath=${chartPath}' and commit the result."
+            exit 1
+          fi

--- a/charts/camunda-platform-8.10/values.schema.extra.json
+++ b/charts/camunda-platform-8.10/values.schema.extra.json
@@ -1,5 +1,51 @@
 {
     "properties": {
+        "global": {
+            "properties": {
+                "ingress": {
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "description": "defines the ingress related annotations, consumed mostly by the ingress controller",
+                            "default": {},
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "identity": {
+                    "properties": {
+                        "keycloak": {
+                            "properties": {
+                                "url": {
+                                    "type": "object",
+                                    "description": "can be used incorporate with \"identityKeycloak.enabled: false\" to use your own Keycloak instead of the one comes with Camunda Helm chart. The \"host\" field supports templating (e.g., {{ .Release.Namespace }}).",
+                                    "default": {},
+                                    "properties": {
+                                        "protocol": {
+                                            "type": "string",
+                                            "description": "defines the protocol used for Keycloak URL (e.g., https).",
+                                            "default": ""
+                                        },
+                                        "host": {
+                                            "type": "string",
+                                            "description": "defines the hostname for Keycloak. Supports templating (e.g., {{ .Release.Namespace }}).",
+                                            "default": ""
+                                        },
+                                        "port": {
+                                            "type": ["string", "integer"],
+                                            "description": "defines the port for Keycloak (e.g., 443).",
+                                            "default": ""
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "console": {
             "properties": {
                 "env": {
@@ -182,6 +228,42 @@
         },
         "orchestration": {
             "properties": {
+                "ingress": {
+                    "properties": {
+                        "grpc": {
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "defines the ingress related annotations, consumed mostly by the ingress controller",
+                                    "default": {},
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "service": {
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "description": "can be used to define annotations, which will be applied to the service",
+                            "default": {},
+                            "additionalProperties": true
+                        },
+                        "headless": {
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "can be used to define annotations, which will be applied to the headless service",
+                                    "default": {},
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    }
+                },
                 "env": {
                     "type": "array",
                     "items": {

--- a/charts/camunda-platform-8.10/values.schema.extra.json
+++ b/charts/camunda-platform-8.10/values.schema.extra.json
@@ -250,7 +250,7 @@
                             "type": "object",
                             "description": "can be used to define annotations, which will be applied to the service",
                             "default": {},
-                            "additionalProperties": true
+                            "additionalProperties": { "type": "string" }
                         },
                         "headless": {
                             "properties": {
@@ -258,7 +258,7 @@
                                     "type": "object",
                                     "description": "can be used to define annotations, which will be applied to the headless service",
                                     "default": {},
-                                    "additionalProperties": true
+                                    "additionalProperties": { "type": "string" }
                                 }
                             }
                         }

--- a/charts/camunda-platform-8.10/values.schema.json
+++ b/charts/camunda-platform-8.10/values.schema.json
@@ -218,6 +218,14 @@
                                     "default": "camunda-platform"
                                 }
                             }
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "defines the ingress related annotations, consumed mostly by the ingress controller",
+                            "default": {},
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     }
                 },
@@ -460,7 +468,27 @@
                                 "url": {
                                     "type": "object",
                                     "description": "can be used incorporate with \"identityKeycloak.enabled: false\" to use your own Keycloak instead of the one comes with Camunda Helm chart. The \"host\" field supports templating (e.g., {{ .Release.Namespace }}).",
-                                    "default": {}
+                                    "default": {},
+                                    "properties": {
+                                        "protocol": {
+                                            "type": "string",
+                                            "description": "defines the protocol used for Keycloak URL (e.g., https).",
+                                            "default": ""
+                                        },
+                                        "host": {
+                                            "type": "string",
+                                            "description": "defines the hostname for Keycloak. Supports templating (e.g., {{ .Release.Namespace }}).",
+                                            "default": ""
+                                        },
+                                        "port": {
+                                            "type": [
+                                                "string",
+                                                "integer"
+                                            ],
+                                            "description": "defines the port for Keycloak (e.g., 443).",
+                                            "default": ""
+                                        }
+                                    }
                                 },
                                 "contextPath": {
                                     "type": "string",
@@ -4941,7 +4969,8 @@
                         "annotations": {
                             "type": "object",
                             "description": "can be used to define annotations, which will be applied to the service",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": true
                         },
                         "headless": {
                             "type": "object",
@@ -4949,7 +4978,8 @@
                                 "annotations": {
                                     "type": "object",
                                     "description": "can be used to define annotations, which will be applied to the headless service",
-                                    "default": {}
+                                    "default": {},
+                                    "additionalProperties": true
                                 },
                                 "type": {
                                     "type": "string",
@@ -5126,6 +5156,14 @@
                                             "description": "defines the secret name which contains the TLS private key and certificate",
                                             "default": "camunda-platform-zeebe-gateway"
                                         }
+                                    }
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "defines the ingress related annotations, consumed mostly by the ingress controller",
+                                    "default": {},
+                                    "additionalProperties": {
+                                        "type": "string"
                                     }
                                 }
                             }

--- a/charts/camunda-platform-8.10/values.schema.json
+++ b/charts/camunda-platform-8.10/values.schema.json
@@ -4970,7 +4970,9 @@
                             "type": "object",
                             "description": "can be used to define annotations, which will be applied to the service",
                             "default": {},
-                            "additionalProperties": true
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         },
                         "headless": {
                             "type": "object",
@@ -4979,7 +4981,9 @@
                                     "type": "object",
                                     "description": "can be used to define annotations, which will be applied to the headless service",
                                     "default": {},
-                                    "additionalProperties": true
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    }
                                 },
                                 "type": {
                                     "type": "string",

--- a/charts/camunda-platform-8.8/values.schema.extra.json
+++ b/charts/camunda-platform-8.8/values.schema.extra.json
@@ -1,5 +1,51 @@
 {
     "properties": {
+        "global": {
+            "properties": {
+                "ingress": {
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "description": "defines the ingress related annotations, consumed mostly by the ingress controller",
+                            "default": {},
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "identity": {
+                    "properties": {
+                        "keycloak": {
+                            "properties": {
+                                "url": {
+                                    "type": "object",
+                                    "description": "can be used incorporate with \"identityKeycloak.enabled: false\" to use your own Keycloak instead of the one comes with Camunda Helm chart. The \"host\" field supports templating (e.g., {{ .Release.Namespace }}).",
+                                    "default": {},
+                                    "properties": {
+                                        "protocol": {
+                                            "type": "string",
+                                            "description": "defines the protocol used for Keycloak URL (e.g., https).",
+                                            "default": ""
+                                        },
+                                        "host": {
+                                            "type": "string",
+                                            "description": "defines the hostname for Keycloak. Supports templating (e.g., {{ .Release.Namespace }}).",
+                                            "default": ""
+                                        },
+                                        "port": {
+                                            "type": ["string", "integer"],
+                                            "description": "defines the port for Keycloak (e.g., 443).",
+                                            "default": ""
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "console": {
             "properties": {
                 "env": {
@@ -182,6 +228,42 @@
         },
         "orchestration": {
             "properties": {
+                "ingress": {
+                    "properties": {
+                        "grpc": {
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "defines the ingress related annotations, consumed mostly by the ingress controller",
+                                    "default": {},
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "service": {
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "description": "can be used to define annotations, which will be applied to the service",
+                            "default": {},
+                            "additionalProperties": true
+                        },
+                        "headless": {
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "can be used to define annotations, which will be applied to the headless service",
+                                    "default": {},
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    }
+                },
                 "env": {
                     "type": "array",
                     "items": {

--- a/charts/camunda-platform-8.8/values.schema.extra.json
+++ b/charts/camunda-platform-8.8/values.schema.extra.json
@@ -250,7 +250,7 @@
                             "type": "object",
                             "description": "can be used to define annotations, which will be applied to the service",
                             "default": {},
-                            "additionalProperties": true
+                            "additionalProperties": { "type": "string" }
                         },
                         "headless": {
                             "properties": {
@@ -258,7 +258,7 @@
                                     "type": "object",
                                     "description": "can be used to define annotations, which will be applied to the headless service",
                                     "default": {},
-                                    "additionalProperties": true
+                                    "additionalProperties": { "type": "string" }
                                 }
                             }
                         }

--- a/charts/camunda-platform-8.8/values.schema.json
+++ b/charts/camunda-platform-8.8/values.schema.json
@@ -218,6 +218,14 @@
                                     "default": "camunda-platform"
                                 }
                             }
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "defines the ingress related annotations, consumed mostly by the ingress controller",
+                            "default": {},
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     }
                 },
@@ -520,7 +528,27 @@
                                 "url": {
                                     "type": "object",
                                     "description": "can be used incorporate with \"identityKeycloak.enabled: false\" to use your own Keycloak instead of the one comes with Camunda Helm chart. The \"host\" field supports templating (e.g., {{ .Release.Namespace }}).",
-                                    "default": {}
+                                    "default": {},
+                                    "properties": {
+                                        "protocol": {
+                                            "type": "string",
+                                            "description": "defines the protocol used for Keycloak URL (e.g., https).",
+                                            "default": ""
+                                        },
+                                        "host": {
+                                            "type": "string",
+                                            "description": "defines the hostname for Keycloak. Supports templating (e.g., {{ .Release.Namespace }}).",
+                                            "default": ""
+                                        },
+                                        "port": {
+                                            "type": [
+                                                "string",
+                                                "integer"
+                                            ],
+                                            "description": "defines the port for Keycloak (e.g., 443).",
+                                            "default": ""
+                                        }
+                                    }
                                 },
                                 "contextPath": {
                                     "type": "string",
@@ -5747,7 +5775,8 @@
                         "annotations": {
                             "type": "object",
                             "description": "can be used to define annotations, which will be applied to the service",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": true
                         },
                         "headless": {
                             "type": "object",
@@ -5755,7 +5784,8 @@
                                 "annotations": {
                                     "type": "object",
                                     "description": "can be used to define annotations, which will be applied to the headless service",
-                                    "default": {}
+                                    "default": {},
+                                    "additionalProperties": true
                                 },
                                 "type": {
                                     "type": "string",
@@ -5912,6 +5942,14 @@
                                             "description": "defines the secret name which contains the TLS private key and certificate",
                                             "default": "camunda-platform-zeebe-gateway"
                                         }
+                                    }
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "defines the ingress related annotations, consumed mostly by the ingress controller",
+                                    "default": {},
+                                    "additionalProperties": {
+                                        "type": "string"
                                     }
                                 }
                             }

--- a/charts/camunda-platform-8.8/values.schema.json
+++ b/charts/camunda-platform-8.8/values.schema.json
@@ -5776,7 +5776,9 @@
                             "type": "object",
                             "description": "can be used to define annotations, which will be applied to the service",
                             "default": {},
-                            "additionalProperties": true
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         },
                         "headless": {
                             "type": "object",
@@ -5785,7 +5787,9 @@
                                     "type": "object",
                                     "description": "can be used to define annotations, which will be applied to the headless service",
                                     "default": {},
-                                    "additionalProperties": true
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    }
                                 },
                                 "type": {
                                     "type": "string",

--- a/charts/camunda-platform-8.9/values.schema.extra.json
+++ b/charts/camunda-platform-8.9/values.schema.extra.json
@@ -1,5 +1,51 @@
 {
     "properties": {
+        "global": {
+            "properties": {
+                "ingress": {
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "description": "defines the ingress related annotations, consumed mostly by the ingress controller",
+                            "default": {},
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "identity": {
+                    "properties": {
+                        "keycloak": {
+                            "properties": {
+                                "url": {
+                                    "type": "object",
+                                    "description": "can be used incorporate with \"identityKeycloak.enabled: false\" to use your own Keycloak instead of the one comes with Camunda Helm chart. The \"host\" field supports templating (e.g., {{ .Release.Namespace }}).",
+                                    "default": {},
+                                    "properties": {
+                                        "protocol": {
+                                            "type": "string",
+                                            "description": "defines the protocol used for Keycloak URL (e.g., https).",
+                                            "default": ""
+                                        },
+                                        "host": {
+                                            "type": "string",
+                                            "description": "defines the hostname for Keycloak. Supports templating (e.g., {{ .Release.Namespace }}).",
+                                            "default": ""
+                                        },
+                                        "port": {
+                                            "type": ["string", "integer"],
+                                            "description": "defines the port for Keycloak (e.g., 443).",
+                                            "default": ""
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "console": {
             "properties": {
                 "env": {
@@ -182,6 +228,42 @@
         },
         "orchestration": {
             "properties": {
+                "ingress": {
+                    "properties": {
+                        "grpc": {
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "defines the ingress related annotations, consumed mostly by the ingress controller",
+                                    "default": {},
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "service": {
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "description": "can be used to define annotations, which will be applied to the service",
+                            "default": {},
+                            "additionalProperties": true
+                        },
+                        "headless": {
+                            "properties": {
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "can be used to define annotations, which will be applied to the headless service",
+                                    "default": {},
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    }
+                },
                 "env": {
                     "type": "array",
                     "items": {

--- a/charts/camunda-platform-8.9/values.schema.extra.json
+++ b/charts/camunda-platform-8.9/values.schema.extra.json
@@ -250,7 +250,7 @@
                             "type": "object",
                             "description": "can be used to define annotations, which will be applied to the service",
                             "default": {},
-                            "additionalProperties": true
+                            "additionalProperties": { "type": "string" }
                         },
                         "headless": {
                             "properties": {
@@ -258,7 +258,7 @@
                                     "type": "object",
                                     "description": "can be used to define annotations, which will be applied to the headless service",
                                     "default": {},
-                                    "additionalProperties": true
+                                    "additionalProperties": { "type": "string" }
                                 }
                             }
                         }

--- a/charts/camunda-platform-8.9/values.schema.json
+++ b/charts/camunda-platform-8.9/values.schema.json
@@ -223,6 +223,14 @@
                                     "default": "camunda-platform"
                                 }
                             }
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "description": "defines the ingress related annotations, consumed mostly by the ingress controller",
+                            "default": {},
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     }
                 },
@@ -475,7 +483,27 @@
                                 "url": {
                                     "type": "object",
                                     "description": "can be used incorporate with \"identityKeycloak.enabled: false\" to use your own Keycloak instead of the one comes with Camunda Helm chart. The \"host\" field supports templating (e.g., {{ .Release.Namespace }}).",
-                                    "default": {}
+                                    "default": {},
+                                    "properties": {
+                                        "protocol": {
+                                            "type": "string",
+                                            "description": "defines the protocol used for Keycloak URL (e.g., https).",
+                                            "default": ""
+                                        },
+                                        "host": {
+                                            "type": "string",
+                                            "description": "defines the hostname for Keycloak. Supports templating (e.g., {{ .Release.Namespace }}).",
+                                            "default": ""
+                                        },
+                                        "port": {
+                                            "type": [
+                                                "string",
+                                                "integer"
+                                            ],
+                                            "description": "defines the port for Keycloak (e.g., 443).",
+                                            "default": ""
+                                        }
+                                    }
                                 },
                                 "contextPath": {
                                     "type": "string",
@@ -4971,7 +4999,8 @@
                         "annotations": {
                             "type": "object",
                             "description": "can be used to define annotations, which will be applied to the service",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": true
                         },
                         "headless": {
                             "type": "object",
@@ -4979,7 +5008,8 @@
                                 "annotations": {
                                     "type": "object",
                                     "description": "can be used to define annotations, which will be applied to the headless service",
-                                    "default": {}
+                                    "default": {},
+                                    "additionalProperties": true
                                 },
                                 "type": {
                                     "type": "string",
@@ -5156,6 +5186,14 @@
                                             "description": "defines the secret name which contains the TLS private key and certificate",
                                             "default": "camunda-platform-zeebe-gateway"
                                         }
+                                    }
+                                },
+                                "annotations": {
+                                    "type": "object",
+                                    "description": "defines the ingress related annotations, consumed mostly by the ingress controller",
+                                    "default": {},
+                                    "additionalProperties": {
+                                        "type": "string"
                                     }
                                 }
                             }

--- a/charts/camunda-platform-8.9/values.schema.json
+++ b/charts/camunda-platform-8.9/values.schema.json
@@ -5000,7 +5000,9 @@
                             "type": "object",
                             "description": "can be used to define annotations, which will be applied to the service",
                             "default": {},
-                            "additionalProperties": true
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         },
                         "headless": {
                             "type": "object",
@@ -5009,7 +5011,9 @@
                                     "type": "object",
                                     "description": "can be used to define annotations, which will be applied to the headless service",
                                     "default": {},
-                                    "additionalProperties": true
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    }
                                 },
                                 "type": {
                                     "type": "string",


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-platform-helm/issues/5930

Add missing schema definitions that cause false-positive validation errors when strict JSON Schema validation is applied to deployed values:

- global.identity.keycloak.url: add properties for protocol, host, port
- global.ingress: add annotations property
- orchestration.ingress.grpc: add annotations property
- orchestration.service.annotations: add additionalProperties
- orchestration.service.headless.annotations: add additionalProperties

Fixes are added via values.schema.extra.json (the designed mechanism for extending the auto-generated schema) and regenerated with make helm.schema-update.

Also adds a schema freshness CI check to chart-validate-template.yaml that regenerates the schema and fails if it differs from the committed version, preventing future drift.

### Which problem does the PR fix?

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
