### PR TITLE
ci: harden post-release workflow against labeling failures

### DIFF
--- a/.github/workflows/chart-release-public.yaml
+++ b/.github/workflows/chart-release-public.yaml
@@ -426,6 +426,7 @@ jobs:
 
       - name: Mark release-please PR as published
         id: mark-published
+        if: ${{ !cancelled() }}
         env:
           GH_TOKEN: ${{ steps.generate-github-token.outputs.token }}
           CHART_DIR_ID: "${{ needs.release.outputs.chart-dir-id }}"
@@ -453,6 +454,7 @@ jobs:
 
       - name: Approve and auto-merge release-please PR
         id: auto-merge
+        if: ${{ !cancelled() && steps.mark-published.outcome == 'success' }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.generate-github-token.outputs.token }}
@@ -479,6 +481,7 @@ jobs:
           echo "enabled=true" >> $GITHUB_OUTPUT
 
       - name: Summary
+        if: ${{ !cancelled() }}
         env:
           GH_TOKEN: ${{ steps.generate-github-token.outputs.token }}
         run: |

--- a/scripts/set-prs-version-label.sh
+++ b/scripts/set-prs-version-label.sh
@@ -42,8 +42,8 @@ get_prs_per_chart_dir () {
 # Note: GH CLI doesn't support this so we use the API call directly.
 # https://github.com/cli/cli/discussions/7097#discussioncomment-5229031
 get_issues_per_pr () {
-    pr_nubmer="${1}"
-    gh api graphql -F owner="${REPO_OWNER}" -F repo="${REPO_NAME}" -F pr="${pr_nubmer}" -f query='
+    pr_number="${1}"
+    gh api graphql -F owner="${REPO_OWNER}" -F repo="${REPO_NAME}" -F pr="${pr_number}" -f query='
         query ($owner: String!, $repo: String!, $pr: Int!) {
             repository(owner: $owner, name: $repo) {
                 pullRequest(number: $pr) {
@@ -94,34 +94,34 @@ echo "${chart_dirs}" | while read -r chart_dir; do
     # Update GH PRs and Issues with the chart version.
     # Labeling is best-effort: a single failure (non-PR reference, transient API
     # error, etc.) must not abort the post-release workflow.
-    get_prs_per_chart_dir "${chart_dir}" | while read pr_nubmer; do
+    get_prs_per_chart_dir "${chart_dir}" | while read -r pr_number; do
         # Commit messages may reference issues by #NNNN too; skip those.
         # The REST pulls endpoint 404s for issue numbers (gh pr view would
         # silently fall back to issue view, so it can't be used here).
-        if ! gh api "repos/${REPO_OWNER}/${REPO_NAME}/pulls/${pr_nubmer}" --silent >/dev/null 2>&1; then
-            printf -- "- [#${pr_nubmer}] not a PR, skipping.\n"
+        if ! gh api "repos/${REPO_OWNER}/${REPO_NAME}/pulls/${pr_number}" --silent >/dev/null 2>&1; then
+            printf -- "- [#${pr_number}] not a PR, skipping.\n"
             continue
         fi
         # Label PR.
-        printf "[PR ${pr_nubmer}] Labeling the PR with chart version label ${chart_version_label}"
-        if ! pr_edit_out="$(gh pr edit "${pr_nubmer}" --add-label "${app_version_label},${chart_version_label}" 2>&1)"; then
-            printf -- "\n- [PR ${pr_nubmer}] labeling failed, skipping: %s\n" "${pr_edit_out}"
+        printf "[PR ${pr_number}] Labeling the PR with chart version label ${chart_version_label}"
+        if ! pr_edit_out="$(gh pr edit "${pr_number}" --add-label "${app_version_label},${chart_version_label}" 2>&1)"; then
+            printf -- "\n- [PR ${pr_number}] labeling failed, skipping: %s\n" "${pr_edit_out}"
             continue
         fi
         printf -- " - %s\n" "${pr_edit_out}"
         # Label the PR's corresponding issue.
-        if ! issue_nubmers="$(get_issues_per_pr ${pr_nubmer})"; then
-            printf -- "- [PR ${pr_nubmer}] could not fetch linked issues, skipping.\n"
+        if ! issue_numbers="$(get_issues_per_pr "${pr_number}")"; then
+            printf -- "- [PR ${pr_number}] could not fetch linked issues, skipping.\n"
             continue
         fi
-        test -z "${issue_nubmers}" && {
-            printf -- "- PR no. ${pr_nubmer} has no corresponding issues.\n"
+        test -z "${issue_numbers}" && {
+            printf -- "- PR no. ${pr_number} has no corresponding issues.\n"
             continue
         }
-        echo -e "${issue_nubmers}" | while read issue_nubmer; do
-            printf -- "- [Issue ${issue_nubmer}] Labeling the issue with chart version label ${chart_version_label}"
-            if ! issue_edit_out="$(gh issue edit "${issue_nubmer}" --add-label "${app_version_label},${chart_version_label}" 2>&1)"; then
-                printf -- "\n- [Issue ${issue_nubmer}] labeling failed, skipping: %s\n" "${issue_edit_out}"
+        echo -e "${issue_numbers}" | while read -r issue_number; do
+            printf -- "- [Issue ${issue_number}] Labeling the issue with chart version label ${chart_version_label}"
+            if ! issue_edit_out="$(gh issue edit "${issue_number}" --add-label "${app_version_label},${chart_version_label}" 2>&1)"; then
+                printf -- "\n- [Issue ${issue_number}] labeling failed, skipping: %s\n" "${issue_edit_out}"
                 continue
             fi
             printf -- " - %s\n" "${issue_edit_out}"

--- a/scripts/set-prs-version-label.sh
+++ b/scripts/set-prs-version-label.sh
@@ -92,19 +92,39 @@ echo "${chart_dirs}" | while read -r chart_dir; do
             --description "Issues and PRs related to chart version ${chart_version}"
 
     # Update GH PRs and Issues with the chart version.
+    # Labeling is best-effort: a single failure (non-PR reference, transient API
+    # error, etc.) must not abort the post-release workflow.
     get_prs_per_chart_dir "${chart_dir}" | while read pr_nubmer; do
+        # Commit messages may reference issues by #NNNN too; skip those.
+        # The REST pulls endpoint 404s for issue numbers (gh pr view would
+        # silently fall back to issue view, so it can't be used here).
+        if ! gh api "repos/${REPO_OWNER}/${REPO_NAME}/pulls/${pr_nubmer}" --silent >/dev/null 2>&1; then
+            printf -- "- [#${pr_nubmer}] not a PR, skipping.\n"
+            continue
+        fi
         # Label PR.
         printf "[PR ${pr_nubmer}] Labeling the PR with chart version label ${chart_version_label}"
-        printf -- " - %s\n" $(gh pr edit "${pr_nubmer}" --add-label "${app_version_label},${chart_version_label}")
+        if ! pr_edit_out="$(gh pr edit "${pr_nubmer}" --add-label "${app_version_label},${chart_version_label}" 2>&1)"; then
+            printf -- "\n- [PR ${pr_nubmer}] labeling failed, skipping: %s\n" "${pr_edit_out}"
+            continue
+        fi
+        printf -- " - %s\n" "${pr_edit_out}"
         # Label the PR's corresponding issue.
-        issue_nubmers="$(get_issues_per_pr ${pr_nubmer})"
+        if ! issue_nubmers="$(get_issues_per_pr ${pr_nubmer})"; then
+            printf -- "- [PR ${pr_nubmer}] could not fetch linked issues, skipping.\n"
+            continue
+        fi
         test -z "${issue_nubmers}" && {
             printf -- "- PR no. ${pr_nubmer} has no corresponding issues.\n"
             continue
         }
         echo -e "${issue_nubmers}" | while read issue_nubmer; do
             printf -- "- [Issue ${issue_nubmer}] Labeling the issue with chart version label ${chart_version_label}"
-            printf -- " - %s\n" $(gh issue edit "${issue_nubmer}" --add-label "${app_version_label},${chart_version_label}")
+            if ! issue_edit_out="$(gh issue edit "${issue_nubmer}" --add-label "${app_version_label},${chart_version_label}" 2>&1)"; then
+                printf -- "\n- [Issue ${issue_nubmer}] labeling failed, skipping: %s\n" "${issue_edit_out}"
+                continue
+            fi
+            printf -- " - %s\n" "${issue_edit_out}"
         done
     done
 done


### PR DESCRIPTION
### Which problem does the PR fix?

closes #5945

### What's in this PR?

The post-release job in `chart-release-public.yaml` aborted at the "Label PRs with version" step for the 8.9 release
([failing run](https://github.com/camunda/camunda-platform-helm/actions/runs/24834134425/job/72689928743)),
which also skipped the downstream `autorelease: published` label swap and release-please PR auto-merge —
steps that are critical to preparing the next release and are logically independent of labeling.

Two changes:

1. **Make the label script robust** (`scripts/set-prs-version-label.sh`)
   - Probe each `#NNNN` reference with `gh api repos/.../pulls/NNNN` and skip non-PRs with a log line. (The REST pulls endpoint 404s for issue numbers; `gh pr view` silently falls back to issue view so it can't be used here.)
   - Make PR labeling, linked-issue lookup, and issue labeling best-effort at the operation level: capture per-operation failures and continue instead of aborting the whole step.

2. **Decouple downstream steps from the label step outcome** (`.github/workflows/chart-release-public.yaml`)
   - `Mark release-please PR as published` — `if: ${{ !cancelled() }}`
   - `Approve and auto-merge release-please PR` — `if: ${{ !cancelled() && steps.mark-published.outcome == 'success' }}` (still requires the publish-label swap for `pr_number`)
   - `Summary` — `if: ${{ !cancelled() }}`
   - Notification steps keep their existing `auto-merge.outputs.enabled == 'true'` gate; `notify-on-failure` still fires on any step failure, so a genuinely broken label step stays loud (labels feed support ticket automation — we want it visible).

### Checklist

**Before opening the PR:**

- [x] There is no other open pull request for the same update/change.

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)?
- [ ] Did all checks/tests pass in the PR?