### PR TITLE
ci: right-size CI resource requests based on 7-day GMP P99 data

### DIFF
--- a/SKILLS.md
+++ b/SKILLS.md
@@ -408,6 +408,122 @@ kubectl -n $NS get deploy integration-optimize -o json \
 
 ---
 
+## Running E2E Tests
+
+### Generate a per-environment .env file
+
+After deploying a namespace, generate the `.env.test` file that the Playwright test suite needs. This file contains the ingress hostname, resolved credentials (from Kubernetes secrets), Keycloak URLs, and feature flags — all auto-resolved from the live cluster.
+
+**Via `deploy-camunda`:**
+
+```bash
+# Generate .env.test alongside the deployment
+deploy-camunda \
+  --chart-path ./charts/camunda-platform-8.9 \
+  --namespace $NS --release $RELEASE \
+  --scenario chart-full-setup --identity keycloak --persistence elasticsearch \
+  --output-test-env
+
+# Custom path (useful for multiple environments side by side)
+deploy-camunda ... --output-test-env --output-test-env-path .env.test.eske
+```
+
+For multi-scenario parallel deployments, each scenario gets its own `.env.test.{scenario}` file automatically.
+
+**Standalone against an existing namespace:**
+
+```bash
+./scripts/render-e2e-env.sh \
+  --absolute-chart-path $PWD/charts/camunda-platform-8.9 \
+  --namespace $NS \
+  --output .env.test \
+  --kube-context $CTX        # optional: target a specific cluster
+  # --opensearch             # set IS_OPENSEARCH=true
+  # --rba                    # set IS_RBA=true
+  # --mt                     # set IS_MT=true
+  # --run-smoke-tests        # set IS_SMOKE=true
+  # -v                       # verbose: show resolved values
+```
+
+### Run the tests
+
+**Via `deploy-camunda` (deploy + test in one step):**
+
+```bash
+deploy-camunda \
+  --chart-path ./charts/camunda-platform-8.9 \
+  --namespace $NS --release $RELEASE \
+  --scenario chart-full-setup --identity keycloak --persistence elasticsearch \
+  --test-e2e          # e2e tests after deploy
+  # --test-it         # integration tests instead
+  # --test-all        # both
+```
+
+**Via `c8e2e` (distributed Playwright runner on Kubernetes):**
+
+`c8e2e` (`@camunda/c8e2e`) launches sharded Playwright test pods directly on the cluster — faster and more reliable than running locally. Point it at a deployed environment by its ingress URL:
+
+```bash
+# Run against a deployed namespace
+c8e2e test \
+  --target SM-8.9 \
+  --endpoint https://$NS.ci.distro.ultrawombat.com \
+  --feature-flags smoke \
+  --follow
+
+# Full test suite with sharding
+c8e2e test \
+  --target SM-8.9 \
+  --endpoint https://my-env.ci.distro.ultrawombat.com \
+  --shards 4 \
+  --follow
+
+# Filter to specific tests
+c8e2e test \
+  --target SM-8.9 \
+  --endpoint https://my-env.ci.distro.ultrawombat.com \
+  --grep "Basic Navigation"
+
+# OpenSearch environment with multitenancy
+c8e2e test \
+  --target SM-8.9 \
+  --endpoint https://os-env.ci.distro.ultrawombat.com \
+  --feature-flags opensearch,mt \
+  --follow
+```
+
+Manage running tests:
+
+```bash
+c8e2e list                    # List active test runs
+c8e2e status <run-id>         # Check status
+c8e2e logs <run-id>           # Stream logs
+c8e2e results <run-id>        # Download results
+c8e2e cancel <run-id>         # Cancel a run
+```
+
+### Multiple environments in parallel
+
+Deploy multiple namespaces with unique subdomains, then run `c8e2e` against each:
+
+```bash
+# Deploy two environments with unique hostnames
+deploy-camunda --chart-path ./charts/camunda-platform-8.9 \
+  --namespace test-es --release camunda --ingress-subdomain test-es \
+  --identity keycloak --persistence elasticsearch
+
+deploy-camunda --chart-path ./charts/camunda-platform-8.9 \
+  --namespace test-os --release camunda --ingress-subdomain test-os \
+  --identity keycloak --persistence opensearch
+
+# Run e2e against each in parallel
+c8e2e test --target SM-8.9 --endpoint https://test-es.ci.distro.ultrawombat.com --feature-flags smoke --follow &
+c8e2e test --target SM-8.9 --endpoint https://test-os.ci.distro.ultrawombat.com --feature-flags smoke,opensearch --follow &
+wait
+```
+
+---
+
 ## Reproducing a CI Test Failure Locally
 
 See [docs/reproducing-ci-e2e-failures.md](docs/reproducing-ci-e2e-failures.md) for the step-by-step guide to pulling logs, downloading artifacts, decoding CI scenario shortnames, and spinning up an identical local environment.

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/base.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/base.yaml
@@ -26,6 +26,14 @@ global:
 identity:
   enabled: true
   contextPath: "/identity"
+  # Right-sized for CI: "camunda-platform" container P99 mem 849Mi (from 400Mi default).
+  resources:
+    requests:
+      cpu: 600m
+      memory: 1150Mi
+    limits:
+      cpu: 2000m
+      memory: 2Gi
   startupProbe:
     enabled: true
     initialDelaySeconds: 5
@@ -75,6 +83,14 @@ identity:
 optimize:
   enabled: true
   contextPath: "/optimize"
+  # Right-sized for CI: CPU P99 369m (from 600m default), memory P99 840Mi INCREASE (from 1Gi default).
+  resources:
+    requests:
+      cpu: 475m
+      memory: 1150Mi
+    limits:
+      cpu: 2000m
+      memory: 2Gi
   startupProbe:
     enabled: true
     initialDelaySeconds: 10
@@ -95,6 +111,14 @@ optimize:
 
 connectors:
   contextPath: "/connectors"
+  # Right-sized for CI: CPU P99 389m (from 1000m default), memory P99 531Mi (from 1Gi default).
+  resources:
+    requests:
+      cpu: 500m
+      memory: 700Mi
+    limits:
+      cpu: 1000m
+      memory: 1400Mi
   startupProbe:
     enabled: true
     initialDelaySeconds: 10
@@ -121,6 +145,14 @@ webModeler:
       - name: index-docker-io
       - name: registry-camunda-cloud
   restapi:
+    # Right-sized for CI: CPU P99 640m INCREASE (from 500m default), memory P99 1132Mi INCREASE (from 1Gi default).
+    resources:
+      requests:
+        cpu: 850m
+        memory: 1550Mi
+      limits:
+        cpu: 2000m
+        memory: 2Gi
     # Wait for PostgreSQL to accept connections before starting restapi.
     # Prevents restapi from failing on DB connection during Spring context init.
     initContainers:
@@ -149,6 +181,26 @@ webModeler:
     mail:
       fromAddress: noreply@example.com
 
+  webapp:
+    # Right-sized for CI: CPU P99 47m (from 400m default), memory P99 216Mi INCREASE (from 256Mi default).
+    resources:
+      requests:
+        cpu: 60m
+        memory: 300Mi
+      limits:
+        cpu: 400m
+        memory: 512Mi
+
+  websockets:
+    # Right-sized for CI: CPU P99 3m (from 100m default), memory P99 33Mi (from 64Mi default).
+    resources:
+      requests:
+        cpu: 25m
+        memory: 50Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+
 webModelerPostgresql:
   enabled: true
   auth:
@@ -157,13 +209,13 @@ webModelerPostgresql:
       adminPasswordKey: "webmodeler-postgresql-admin-password"
       userPasswordKey: "webmodeler-postgresql-user-password"
   primary:
-    # Resource allocation for faster startup
+    # Right-sized for CI: CPU P99 61m (from 500m), memory P99 92Mi (from 256Mi).
     resources:
       requests:
-        cpu: 500m
-        memory: 256Mi
+        cpu: 80m
+        memory: 125Mi
       limits:
-        cpu: 1000m
+        cpu: 500m
         memory: 512Mi
     # PostgreSQL configuration optimized for fast startup in integration tests.
     # WARNING: These settings trade durability for speed — NOT suitable for production.
@@ -182,13 +234,14 @@ orchestration:
   contextPath: "/orchestration"
   # JVM startup optimizations: TieredStopAtLevel=1 skips C2 compiler for ~30-50% faster startup,
   # pre-sized heap avoids resizing overhead, G1GC with string deduplication for efficiency.
+  # Right-sized for CI: CPU P99 481m (from 2000m), memory P99 1012Mi (from 2000Mi).
   resources:
     requests:
-      cpu: 2000m
-      memory: 2000Mi
+      cpu: 600m
+      memory: 1350Mi
     limits:
       cpu: 2000m
-      memory: 3000Mi
+      memory: 2000Mi
   startupProbe:
     enabled: true
     initialDelaySeconds: 30
@@ -217,10 +270,29 @@ orchestration:
 console:
   enabled: true
   contextPath: "/"
+  # Right-sized for CI: "camunda-platform" container CPU P99 493m (from 1000m default), memory P99 849Mi INCREASE (from 1Gi default).
+  resources:
+    requests:
+      cpu: 650m
+      memory: 1150Mi
+    limits:
+      cpu: 2000m
+      memory: 2Gi
   image:
     pullSecrets:
       - name: index-docker-io
       - name: registry-camunda-cloud
+
+# Right-sized for CI: CPU P99 621m (from 1000m default), memory P99 1572Mi INCREASE (from 2Gi default).
+elasticsearch:
+  master:
+    resources:
+      requests:
+        cpu: 800m
+        memory: 2100Mi
+      limits:
+        cpu: 2000m
+        memory: 2560Mi
 
 prometheusServiceMonitor:
   enabled: true

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
@@ -138,10 +138,12 @@ identityKeycloak:
     enabled: false
   # CPU-heavy startup (class loading): give 4 cores limit and 2 cores request
   # so the scheduler guarantees real CPU capacity from the start.
+  # Right-sized for CI: CPU P99 919m (from 2 CPU), memory P99 657Mi (from 1Gi).
+  # Keep high CPU limit for startup burst (class loading).
   resources:
     requests:
-      cpu: "2"
-      memory: 1Gi
+      cpu: 1200m
+      memory: 900Mi
     limits:
       cpu: "4"
       memory: 2Gi
@@ -211,12 +213,13 @@ identityKeycloak:
       persistence:
         enabled: true
       # Bump PG resources: request enough CPU to get guaranteed capacity.
+      # Right-sized for CI: CPU P99 61m (from 500m), memory P99 92Mi (from 256Mi).
       resources:
         requests:
-          cpu: "500m"
-          memory: 256Mi
+          cpu: 80m
+          memory: 125Mi
         limits:
-          cpu: "1"
+          cpu: 500m
           memory: 512Mi
       # Enable startup probe with tight timing so PG is marked ready ASAP.
       startupProbe:

--- a/charts/camunda-platform-8.10/test/integration/scenarios/infra/values-infra-standard.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/infra/values-infra-standard.yaml
@@ -77,9 +77,6 @@ optimize:
     key: workload
     operator: Equal
     value: standard
-  resources:
-    requests:
-      cpu: 2000m
 
 # Web Modeler.
 webModeler:
@@ -118,11 +115,6 @@ orchestration:
     key: workload
     operator: Equal
     value: standard
-  resources:
-    requests:
-      cpu: 4000m
-    limits:
-      cpu: 4000m
 zeebeGateway:
   nodeSelector:
     workload: standard

--- a/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values/base.yaml
+++ b/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values/base.yaml
@@ -29,6 +29,14 @@ global:
 # Context paths for all components
 identity:
   contextPath: "/identity"
+  # Right-sized for CI: "camunda-platform" container P99 mem 849Mi (from 400Mi default).
+  resources:
+    requests:
+      cpu: 600m
+      memory: 1150Mi
+    limits:
+      cpu: 2000m
+      memory: 2Gi
   startupProbe:
     enabled: true
     initialDelaySeconds: 5
@@ -90,6 +98,14 @@ identityPostgresql:
 
 operate:
   contextPath: "/operate"
+  # Right-sized for CI: CPU P99 446m (from 600m default), memory P99 499Mi INCREASE (from 400Mi default).
+  resources:
+    requests:
+      cpu: 600m
+      memory: 650Mi
+    limits:
+      cpu: 2000m
+      memory: 2Gi
   startupProbe:
     enabled: true
     initialDelaySeconds: 10
@@ -110,6 +126,14 @@ operate:
 
 optimize:
   contextPath: "/optimize"
+  # Right-sized for CI: CPU P99 369m (from 600m default), memory P99 840Mi INCREASE (from 1Gi default).
+  resources:
+    requests:
+      cpu: 475m
+      memory: 1150Mi
+    limits:
+      cpu: 2000m
+      memory: 2Gi
   startupProbe:
     enabled: true
     initialDelaySeconds: 10
@@ -130,6 +154,14 @@ optimize:
 
 tasklist:
   contextPath: "/tasklist"
+  # Right-sized for CI: CPU P99 253m (from 400m default), memory P99 425Mi (from 1Gi default).
+  resources:
+    requests:
+      cpu: 325m
+      memory: 550Mi
+    limits:
+      cpu: 1000m
+      memory: 2Gi
   startupProbe:
     enabled: true
     initialDelaySeconds: 10
@@ -150,6 +182,14 @@ tasklist:
 
 connectors:
   contextPath: "/connectors"
+  # Right-sized for CI: CPU P99 389m (from 1000m default), memory P99 531Mi (from 1Gi default).
+  resources:
+    requests:
+      cpu: 500m
+      memory: 700Mi
+    limits:
+      cpu: 1000m
+      memory: 1400Mi
   startupProbe:
     enabled: true
     initialDelaySeconds: 10
@@ -176,6 +216,14 @@ webModeler:
       - name: index-docker-io
       - name: registry-camunda-cloud
   restapi:
+    # Right-sized for CI: CPU P99 640m INCREASE (from 500m default), memory P99 1132Mi INCREASE (from 1Gi default).
+    resources:
+      requests:
+        cpu: 850m
+        memory: 1550Mi
+      limits:
+        cpu: 2000m
+        memory: 2Gi
     # Wait for PostgreSQL to accept connections before starting restapi.
     # Prevents restapi from failing on DB connection during Spring context init.
     initContainers:
@@ -204,6 +252,14 @@ webModeler:
     mail:
       fromAddress: noreply@example.com
   webapp:
+    # Right-sized for CI: CPU P99 47m (from 400m default), memory P99 216Mi INCREASE (from 256Mi default).
+    resources:
+      requests:
+        cpu: 60m
+        memory: 300Mi
+      limits:
+        cpu: 400m
+        memory: 512Mi
     replicas: 2
     affinity:
       podAntiAffinity:
@@ -218,6 +274,16 @@ webModeler:
                       - webapp
               topologyKey: kubernetes.io/hostname
 
+  websockets:
+    # Right-sized for CI: CPU P99 3m (from 100m default), memory P99 33Mi (from 64Mi default).
+    resources:
+      requests:
+        cpu: 25m
+        memory: 50Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+
 # WebModeler Database (8.7 uses postgresql, not webModelerPostgresql)
 postgresql:
   enabled: true
@@ -227,13 +293,13 @@ postgresql:
       adminPasswordKey: "webmodeler-postgresql-admin-password"
       userPasswordKey: "webmodeler-postgresql-user-password"
   primary:
-    # Resource allocation for faster startup
+    # Right-sized for CI: CPU P99 61m (from 500m), memory P99 92Mi (from 256Mi).
     resources:
       requests:
-        cpu: 500m
-        memory: 256Mi
+        cpu: 80m
+        memory: 125Mi
       limits:
-        cpu: 1000m
+        cpu: 500m
         memory: 512Mi
     # PostgreSQL configuration optimized for fast startup in integration tests.
     # WARNING: These settings trade durability for speed — NOT suitable for production.
@@ -249,10 +315,11 @@ postgresql:
 zeebe:
   # JVM startup optimizations: TieredStopAtLevel=1 skips C2 compiler for ~30-50% faster startup,
   # pre-sized heap avoids resizing overhead, G1GC with string deduplication for efficiency.
+  # Right-sized for CI: CPU P99 378m (from 2000m), memory P99 1361Mi (from 2000Mi).
   resources:
     requests:
-      cpu: 2000m
-      memory: 2000Mi
+      cpu: 500m
+      memory: 1850Mi
     limits:
       cpu: 2000m
       memory: 3000Mi
@@ -276,6 +343,14 @@ zeebe:
 
 zeebeGateway:
   contextPath: "/zeebe"
+  # Right-sized for CI: CPU P99 236m (from 400m default), memory P99 364Mi (from 800Mi default).
+  resources:
+    requests:
+      cpu: 300m
+      memory: 500Mi
+    limits:
+      cpu: 400m
+      memory: 800Mi
   startupProbe:
     enabled: true
     initialDelaySeconds: 10
@@ -309,6 +384,14 @@ console:
   replicas: 2
   enabled: true
   contextPath: "/"
+  # Right-sized for CI: "camunda-platform" container CPU P99 493m (from 1000m default), memory P99 849Mi INCREASE (from 1Gi default).
+  resources:
+    requests:
+      cpu: 650m
+      memory: 1150Mi
+    limits:
+      cpu: 2000m
+      memory: 2Gi
   image:
     pullSecrets:
       - name: index-docker-io
@@ -325,6 +408,17 @@ console:
                   values:
                     - console
             topologyKey: kubernetes.io/hostname
+
+# Right-sized for CI: CPU P99 621m (from 1000m default), memory P99 1572Mi INCREASE (from 2Gi default).
+elasticsearch:
+  master:
+    resources:
+      requests:
+        cpu: 800m
+        memory: 2100Mi
+      limits:
+        cpu: 2000m
+        memory: 2560Mi
 
 prometheusServiceMonitor:
   enabled: false

--- a/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
+++ b/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
@@ -132,10 +132,12 @@ identityKeycloak:
     enabled: false
   # CPU-heavy startup (class loading): give 4 cores limit and 2 cores request
   # so the scheduler guarantees real CPU capacity from the start.
+  # Right-sized for CI: CPU P99 919m (from 2 CPU), memory P99 657Mi (from 1Gi).
+  # Keep high CPU limit for startup burst (class loading).
   resources:
     requests:
-      cpu: "2"
-      memory: 1Gi
+      cpu: 1200m
+      memory: 900Mi
     limits:
       cpu: "4"
       memory: 2Gi
@@ -202,12 +204,13 @@ identityKeycloak:
     primary:
       persistence:
         enabled: true
+      # Right-sized for CI: CPU P99 61m (from 500m), memory P99 92Mi (from 256Mi).
       resources:
         requests:
-          cpu: "500m"
-          memory: 256Mi
+          cpu: 80m
+          memory: 125Mi
         limits:
-          cpu: "1"
+          cpu: 500m
           memory: 512Mi
       startupProbe:
         enabled: true

--- a/charts/camunda-platform-8.7/test/integration/scenarios/infra/values-infra-standard.yaml
+++ b/charts/camunda-platform-8.7/test/integration/scenarios/infra/values-infra-standard.yaml
@@ -77,9 +77,6 @@ optimize:
     key: workload
     operator: Equal
     value: standard
-  resources:
-    requests:
-      cpu: 2000m
 
 # Web Modeler.
 webModeler:
@@ -126,13 +123,6 @@ zeebe:
     key: workload
     operator: Equal
     value: standard
-  resources:
-    requests:
-      cpu: 4
-      memory: 1Gi
-    limits:
-      cpu: 4
-      memory: 2Gi
 zeebeGateway:
   nodeSelector:
     workload: standard

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/base.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/base.yaml
@@ -27,6 +27,14 @@ global:
 identity:
   enabled: true
   contextPath: "/identity"
+  # Right-sized for CI: "camunda-platform" container P99 mem 849Mi (from 400Mi default).
+  resources:
+    requests:
+      cpu: 600m
+      memory: 1150Mi
+    limits:
+      cpu: 2000m
+      memory: 2Gi
   startupProbe:
     enabled: true
     initialDelaySeconds: 5
@@ -82,6 +90,14 @@ identityPostgresql:
 optimize:
   enabled: true
   contextPath: "/optimize"
+  # Right-sized for CI: CPU P99 369m (from 600m default), memory P99 840Mi INCREASE (from 1Gi default).
+  resources:
+    requests:
+      cpu: 475m
+      memory: 1150Mi
+    limits:
+      cpu: 2000m
+      memory: 2Gi
   startupProbe:
     enabled: true
     initialDelaySeconds: 10
@@ -102,6 +118,14 @@ optimize:
 
 connectors:
   contextPath: "/connectors"
+  # Right-sized for CI: CPU P99 389m (from 1000m default), memory P99 531Mi (from 1Gi default).
+  resources:
+    requests:
+      cpu: 500m
+      memory: 700Mi
+    limits:
+      cpu: 1000m
+      memory: 1400Mi
   startupProbe:
     enabled: true
     initialDelaySeconds: 10
@@ -128,6 +152,14 @@ webModeler:
       - name: index-docker-io
       - name: registry-camunda-cloud
   restapi:
+    # Right-sized for CI: CPU P99 640m INCREASE (from 500m default), memory P99 1132Mi INCREASE (from 1Gi default).
+    resources:
+      requests:
+        cpu: 850m
+        memory: 1550Mi
+      limits:
+        cpu: 2000m
+        memory: 2Gi
     # Wait for PostgreSQL to accept connections before starting restapi.
     # Prevents restapi from failing on DB connection during Spring context init.
     initContainers:
@@ -156,6 +188,14 @@ webModeler:
     mail:
       fromAddress: noreply@example.com
   webapp:
+    # Right-sized for CI: CPU P99 47m (from 400m default), memory P99 216Mi INCREASE (from 256Mi default).
+    resources:
+      requests:
+        cpu: 60m
+        memory: 300Mi
+      limits:
+        cpu: 400m
+        memory: 512Mi
     replicas: 2
     affinity:
       podAntiAffinity:
@@ -170,6 +210,16 @@ webModeler:
                       - webapp
               topologyKey: kubernetes.io/hostname
 
+  websockets:
+    # Right-sized for CI: CPU P99 3m (from 100m default), memory P99 33Mi (from 64Mi default).
+    resources:
+      requests:
+        cpu: 25m
+        memory: 50Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+
 webModelerPostgresql:
   enabled: true
   auth:
@@ -178,13 +228,13 @@ webModelerPostgresql:
       adminPasswordKey: "webmodeler-postgresql-admin-password"
       userPasswordKey: "webmodeler-postgresql-user-password"
   primary:
-    # Resource allocation for faster startup
+    # Right-sized for CI: CPU P99 61m (from 500m), memory P99 92Mi (from 256Mi).
     resources:
       requests:
-        cpu: 500m
-        memory: 256Mi
+        cpu: 80m
+        memory: 125Mi
       limits:
-        cpu: 1000m
+        cpu: 500m
         memory: 512Mi
     # PostgreSQL configuration optimized for fast startup in integration tests.
     # WARNING: These settings trade durability for speed — NOT suitable for production.
@@ -198,15 +248,14 @@ webModelerPostgresql:
 
 orchestration:
   contextPath: "/orchestration"
-  # JVM startup optimizations: TieredStopAtLevel=1 skips C2 compiler for ~30-50% faster startup,
-  # pre-sized heap avoids resizing overhead, G1GC with string deduplication for efficiency.
+  # Right-sized for CI: CPU P99 481m (from 2000m), memory P99 1012Mi (from 2000Mi).
   resources:
     requests:
-      cpu: 2000m
-      memory: 2000Mi
+      cpu: 600m
+      memory: 1350Mi
     limits:
       cpu: 2000m
-      memory: 3000Mi
+      memory: 2000Mi
   startupProbe:
     enabled: true
     # Use /readiness instead of /startup because the migration importer Deployment
@@ -242,6 +291,14 @@ console:
   replicas: 2
   enabled: true
   contextPath: "/"
+  # Right-sized for CI: "camunda-platform" container CPU P99 493m (from 1000m default), memory P99 849Mi INCREASE (from 1Gi default).
+  resources:
+    requests:
+      cpu: 650m
+      memory: 1150Mi
+    limits:
+      cpu: 2000m
+      memory: 2Gi
   image:
     pullSecrets:
       - name: index-docker-io
@@ -258,6 +315,17 @@ console:
                   values:
                     - console
             topologyKey: kubernetes.io/hostname
+
+# Right-sized for CI: CPU P99 621m (from 1000m default), memory P99 1572Mi INCREASE (from 2Gi default).
+elasticsearch:
+  master:
+    resources:
+      requests:
+        cpu: 800m
+        memory: 2100Mi
+      limits:
+        cpu: 2000m
+        memory: 2560Mi
 
 prometheusServiceMonitor:
   enabled: true

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
@@ -119,12 +119,12 @@ identityKeycloak:
   # Single replica: disable distributed cache (no JGroups/Infinispan overhead).
   cache:
     enabled: false
-  # CPU-heavy startup (class loading): give 4 cores limit and 2 cores request
-  # so the scheduler guarantees real CPU capacity from the start.
+  # Right-sized for CI: CPU P99 919m (from 2 CPU), memory P99 657Mi (from 1Gi).
+  # Keep high CPU limit for startup burst (class loading).
   resources:
     requests:
-      cpu: "2"
-      memory: 1Gi
+      cpu: 1200m
+      memory: 900Mi
     limits:
       cpu: "4"
       memory: 2Gi
@@ -193,13 +193,13 @@ identityKeycloak:
       # Use PVC for upgrade stability across pod replacements/restarts.
       persistence:
         enabled: true
-      # Bump PG resources: request enough CPU to get guaranteed capacity.
+      # Right-sized for CI: CPU P99 61m (from 500m), memory P99 92Mi (from 256Mi).
       resources:
         requests:
-          cpu: "500m"
-          memory: 256Mi
+          cpu: 80m
+          memory: 125Mi
         limits:
-          cpu: "1"
+          cpu: 500m
           memory: 512Mi
       # Enable startup probe with tight timing so PG is marked ready ASAP.
       startupProbe:

--- a/charts/camunda-platform-8.8/test/integration/scenarios/infra/values-infra-standard.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/infra/values-infra-standard.yaml
@@ -77,9 +77,6 @@ optimize:
     key: workload
     operator: Equal
     value: standard
-  resources:
-    requests:
-      cpu: 2000m
 
 # Web Modeler.
 webModeler:
@@ -126,11 +123,6 @@ orchestration:
     key: workload
     operator: Equal
     value: standard
-  resources:
-    requests:
-      cpu: 4000m
-    limits:
-      cpu: 4000m
 zeebeGateway:
   nodeSelector:
     workload: standard

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/base.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/base.yaml
@@ -30,6 +30,14 @@ global:
 identity:
   enabled: true
   contextPath: "/identity"
+  # Right-sized for CI: "camunda-platform" container P99 mem 849Mi (from 400Mi default).
+  resources:
+    requests:
+      cpu: 600m
+      memory: 1150Mi
+    limits:
+      cpu: 2000m
+      memory: 2Gi
   startupProbe:
     enabled: true
     initialDelaySeconds: 5
@@ -79,6 +87,14 @@ identity:
 optimize:
   enabled: true
   contextPath: "/optimize"
+  # Right-sized for CI: CPU P99 369m (from 600m default), memory P99 840Mi INCREASE (from 1Gi default).
+  resources:
+    requests:
+      cpu: 475m
+      memory: 1150Mi
+    limits:
+      cpu: 2000m
+      memory: 2Gi
   startupProbe:
     enabled: true
     initialDelaySeconds: 10
@@ -99,6 +115,14 @@ optimize:
 
 connectors:
   contextPath: "/connectors"
+  # Right-sized for CI: CPU P99 389m (from 1000m default), memory P99 531Mi (from 1Gi default).
+  resources:
+    requests:
+      cpu: 500m
+      memory: 700Mi
+    limits:
+      cpu: 1000m
+      memory: 1400Mi
   startupProbe:
     enabled: true
     initialDelaySeconds: 10
@@ -125,6 +149,14 @@ webModeler:
       - name: index-docker-io
       - name: registry-camunda-cloud
   restapi:
+    # Right-sized for CI: CPU P99 640m INCREASE (from 500m default), memory P99 1132Mi INCREASE (from 1Gi default).
+    resources:
+      requests:
+        cpu: 850m
+        memory: 1550Mi
+      limits:
+        cpu: 2000m
+        memory: 2Gi
     # Wait for PostgreSQL to accept connections before starting restapi.
     # Prevents restapi from failing on DB connection during Spring context init.
     initContainers:
@@ -153,6 +185,26 @@ webModeler:
     mail:
       fromAddress: noreply@example.com
 
+  webapp:
+    # Right-sized for CI: CPU P99 47m (from 400m default), memory P99 216Mi INCREASE (from 256Mi default).
+    resources:
+      requests:
+        cpu: 60m
+        memory: 300Mi
+      limits:
+        cpu: 400m
+        memory: 512Mi
+
+  websockets:
+    # Right-sized for CI: CPU P99 3m (from 100m default), memory P99 33Mi (from 64Mi default).
+    resources:
+      requests:
+        cpu: 25m
+        memory: 50Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+
 webModelerPostgresql:
   enabled: true
   auth:
@@ -161,13 +213,13 @@ webModelerPostgresql:
       adminPasswordKey: "webmodeler-postgresql-admin-password"
       userPasswordKey: "webmodeler-postgresql-user-password"
   primary:
-    # Resource allocation for faster startup
+    # Right-sized for CI: CPU P99 61m (from 500m), memory P99 92Mi (from 256Mi).
     resources:
       requests:
-        cpu: 500m
-        memory: 256Mi
+        cpu: 80m
+        memory: 125Mi
       limits:
-        cpu: 1000m
+        cpu: 500m
         memory: 512Mi
     # PostgreSQL configuration optimized for fast startup in integration tests.
     # WARNING: These settings trade durability for speed — NOT suitable for production.
@@ -186,13 +238,14 @@ orchestration:
   contextPath: "/orchestration"
   # JVM startup optimizations: TieredStopAtLevel=1 skips C2 compiler for ~30-50% faster startup,
   # pre-sized heap avoids resizing overhead, G1GC with string deduplication for efficiency.
+  # Right-sized for CI: CPU P99 481m (from 2000m), memory P99 1012Mi (from 2000Mi).
   resources:
     requests:
-      cpu: 2000m
-      memory: 2000Mi
+      cpu: 600m
+      memory: 1350Mi
     limits:
       cpu: 2000m
-      memory: 3000Mi
+      memory: 2000Mi
   startupProbe:
     enabled: true
     initialDelaySeconds: 30
@@ -221,10 +274,29 @@ orchestration:
 console:
   enabled: true
   contextPath: "/"
+  # Right-sized for CI: "camunda-platform" container CPU P99 493m (from 1000m default), memory P99 849Mi INCREASE (from 1Gi default).
+  resources:
+    requests:
+      cpu: 650m
+      memory: 1150Mi
+    limits:
+      cpu: 2000m
+      memory: 2Gi
   image:
     pullSecrets:
       - name: index-docker-io
       - name: registry-camunda-cloud
+
+# Right-sized for CI: CPU P99 621m (from 1000m default), memory P99 1572Mi INCREASE (from 2Gi default).
+elasticsearch:
+  master:
+    resources:
+      requests:
+        cpu: 800m
+        memory: 2100Mi
+      limits:
+        cpu: 2000m
+        memory: 2560Mi
 
 prometheusServiceMonitor:
   enabled: true

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
@@ -134,10 +134,12 @@ identityKeycloak:
     enabled: false
   # CPU-heavy startup (class loading): give 4 cores limit and 2 cores request
   # so the scheduler guarantees real CPU capacity from the start.
+  # Right-sized for CI: CPU P99 919m (from 2 CPU), memory P99 657Mi (from 1Gi).
+  # Keep high CPU limit for startup burst (class loading).
   resources:
     requests:
-      cpu: "2"
-      memory: 1Gi
+      cpu: 1200m
+      memory: 900Mi
     limits:
       cpu: "4"
       memory: 2Gi
@@ -206,12 +208,13 @@ identityKeycloak:
       persistence:
         enabled: true
       # Bump PG resources: request enough CPU to get guaranteed capacity.
+      # Right-sized for CI: CPU P99 61m (from 500m), memory P99 92Mi (from 256Mi).
       resources:
         requests:
-          cpu: "500m"
-          memory: 256Mi
+          cpu: 80m
+          memory: 125Mi
         limits:
-          cpu: "1"
+          cpu: 500m
           memory: 512Mi
       # Enable startup probe with tight timing so PG is marked ready ASAP.
       startupProbe:

--- a/charts/camunda-platform-8.9/test/integration/scenarios/infra/values-infra-standard.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/infra/values-infra-standard.yaml
@@ -77,9 +77,6 @@ optimize:
     key: workload
     operator: Equal
     value: standard
-  resources:
-    requests:
-      cpu: 2000m
 
 # Web Modeler.
 webModeler:
@@ -118,11 +115,6 @@ orchestration:
     key: workload
     operator: Equal
     value: standard
-  resources:
-    requests:
-      cpu: 4000m
-    limits:
-      cpu: 4000m
 zeebeGateway:
   nodeSelector:
     workload: standard


### PR DESCRIPTION
## Summary

- Right-sizes CPU and memory requests for all CI integration test deployments across charts 8.7, 8.8, 8.9, 8.10
- Based on 7-day P50/P95/P99 percentile data from Cloud Monitoring (GMP) across thousands of ephemeral CI namespace lifecycles in the distro-ci cluster
- Reduces per-namespace CPU requests by ~56% while **increasing** memory for 6 components at OOM risk
- Removes over-sized infra-standard resource overrides (orchestration 4000m, optimize 2000m)
- Adds E2E testing documentation to SKILLS.md (c8e2e, render-e2e-env.sh, per-environment .env generation)

### Resource changes (charts 8.8+, unified orchestration)

| Component | CPU Request | Memory Request | Note |
|---|---|---|---|
| orchestration | 2000m → 600m | 2000Mi → 1350Mi | |
| keycloak | 2000m → 1200m | 1Gi → 900Mi | |
| connectors | 1000m → 500m | 1Gi → 700Mi | |
| console | 1000m → 650m | 1Gi → **1150Mi** | mem INCREASE |
| identity | 600m (keep) | 400Mi → **1150Mi** | mem INCREASE — OOM risk |
| optimize | 600m → 475m | 1Gi → **1150Mi** | mem INCREASE |
| web-modeler-restapi | 500m → **850m** | 1Gi → **1550Mi** | both INCREASE |
| web-modeler-webapp | 400m → 60m | 256Mi → **300Mi** | mem INCREASE |
| web-modeler-websockets | 100m → 25m | 64Mi → 50Mi | |
| postgresql | 500m → 80m | 256Mi → 125Mi | |
| elasticsearch | 1000m → 800m | 2Gi → **2100Mi** | mem INCREASE |
| infra-standard overrides | **removed** | | orchestration 4000m, optimize 2000m |

Chart 8.7 additionally right-sizes zeebe (2000m→500m), zeebeGateway (400m→300m), operate (600m, mem 400Mi→650Mi), and tasklist (400m→325m) as separate components.

### Methodology

- **Data source**: `kubernetes.io/container/cpu/request_utilization` and `memory/request_utilization` at P50/P95/P99 percentiles, grouped by container name, 7-day window
- **Headroom**: CPU +30% above P99, Memory +35% above P99, minimum floors to prevent scheduling issues
- **Limits**: Kept high for burst (startup spikes); adjusted where request would exceed limit

### Not covered (external to chart)

opensearch, oracle, mariadb, mssql, mysql, kibana, dashboards — deployed outside the Helm chart

## Test plan

Validation was done in three layers — local pre-flight, this repo's PR CI, and the cross-repo SM nightly suite — to cover all consumers of the changed values files.

### 1. Local pre-flight (pre-CI)

- [x] `make helm.lint` passes for all 4 chart versions
- [x] `make go.test` passes for all 4 chart versions (8.7: 12 packages, 8.8/8.9/8.10: 7 packages each)
- [x] Live deployment to isolated `rightsizing` node pool (5–8× n2-standard-8) in distro-ci
- [x] All pods Running/Ready, **0 OOM kills, 0 restarts** across all 4 versions
- [x] All deployments completed within **5-minute startup budget**
- [x] Node utilization verified: CPU 4–11% actual, memory 19–35% actual (confirms headroom is generous)

### 2. PR CI (this repo, after rebase onto current main)

Run [`25049272634`](https://github.com/camunda/camunda-platform-helm/actions/runs/25049272634) — head commit `9f299d30f`.

| Result | Count | Notes |
|---|---|---|
| pass | 242 | all helm lint, unit tests, install + e2e across PR scenario matrix |
| skipping | 91 | scenarios disabled by `skip-e2e` flags or matrix exclusions |
| fail | 1 | `Check Task Link` (metadata-only — unrelated to resources or CI behavior) |

The three checks that failed on the previous (pre-rebase) run — `8.10 gatkc Playwright e2e after install`, `8.9 gatkc Playwright e2e after install`, `8.7 esoi upgrade-patch` — all pass on the rebased run. They were a pre-existing infra flake (`Login (/identity) failed after 3 attempts`) seen on unrelated PR #5926 with identical error and durations, and resolved on main between Apr 24 (PR #5938) and today.

Scenarios covered by PR CI matrix per chart version (chart-full-setup smoke):
- **8.7**: esoi (ES + OIDC, install + upgrade-patch), eske, esarm, kemt (multitenancy), kerba (RBA), keyc, keorg, osex (opensearch), nosec, gatkc (gateway-keycloak)
- **8.8 / 8.9 / 8.10**: esoi, eske, eske upgrade-minor, esarm, kemt + upgrade-minor, kerba, kerba upgrade-minor, keorg, gatkc, osex, nosec, rdbms, docstr (eks)

### 3. Cross-repo SM nightlies (`c8-cross-component-e2e-tests`)

The reusable workflow `playwright_sm_reusable_flow_8_8_plus.yaml` (and the 8.7 minus variant) calls `camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main` and pulls the helm chart at `helmRepositoryBranchName`. So once this PR merges to main, every SM nightly will pick up the right-sized values. To validate before merge, the four `playwright_sm_nightly_tests_chrome_8_*` workflows were dispatched manually with `camunda_helm_git_ref=ci-resource-right-sizing`, which exercises the heavier QA workload layer (qaelupg / qael install + upgrade flows) and full Playwright shards — workloads not covered by the PR's smoke scenarios.

| Version | Workflow | Run | Helm install (QA) | Playwright (Chrome shards) | Overall |
|---|---|---|---|---|---|
| 8.7  | SM Nightly Chrome 8.7  | [`25055085292`](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25055085292) | ✅ | ✅ | **success** |
| 8.8  | SM Nightly Chrome 8.8  | [`25055087692`](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25055087692) | ✅ (v1 + v2 matrix) | ✅ chromium-v1 + chromium-v2 + merge-reports | success* |
| 8.9  | SM Nightly Chrome 8.9  | [`25055090462`](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25055090462) | ✅ | ✅ | **success** |
| 8.10 | SM Nightly Chrome 8.10 | [`25055093141`](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25055093141) | ✅ | ✅ | **success** |

*8.8 reports as `failure` only because of a cancelled `Get Test URL` housekeeping job in the v2 matrix; the actual `Run tests - chromium-v1` and `Run tests - chromium-v2` Playwright jobs both passed and `merge-reports` succeeded. No resource regression.

QA layer files (`base-qa.yaml`, `values-infra-qa-workloads.yaml`) only set node selectors / tolerations / config — they do **not** override resources, so the QA nightly runs ran with the right-sized values directly and all helm installs and Playwright suites completed cleanly.

### Coverage summary

| Concern | Where validated |
|---|---|
| Helm template correctness for 4 versions | helm lint + unit tests (PR CI) |
| Pod startup under right-sized requests, no OOM | local pre-flight + PR install scenarios + cross-repo nightlies |
| Smoke e2e (Identity login, basic flows) | PR CI per scenario × version |
| Heavier QA / multi-shard Playwright | cross-repo SM nightlies (Chrome) on 8.7/8.8/8.9/8.10 |
| Upgrade flows under new resources | PR CI (`upgrade-patch`, `upgrade-minor` per version) + cross-repo `qaelupg` nightly install paths |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
