### PR TITLE
fix: set service account on orchestration migration jobs

### DIFF
--- a/charts/camunda-platform-8.8/templates/orchestration/migration-data-job.yaml
+++ b/charts/camunda-platform-8.8/templates/orchestration/migration-data-job.yaml
@@ -16,6 +16,7 @@ spec:
         checksum/env-vars: {{ include (print $.Template.BasePath "/orchestration/migration-data-configmap-env-vars.yaml") . | sha256sum }}
     spec:
       restartPolicy: OnFailure
+      serviceAccountName: {{ include "orchestration.serviceAccountName" . }}
       imagePullSecrets: {{- include "orchestration.imagePullSecrets" . | nindent 8 }}
       {{- if .Values.orchestration.podSecurityContext }}
       securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" $.Values.orchestration.podSecurityContext "context" $) | nindent 8 }}

--- a/charts/camunda-platform-8.8/templates/orchestration/migration-identity-job.yaml
+++ b/charts/camunda-platform-8.8/templates/orchestration/migration-identity-job.yaml
@@ -15,6 +15,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/orchestration/migration-identity-configmap.yaml") . | sha256sum }}
     spec:
       restartPolicy: OnFailure
+      serviceAccountName: {{ include "orchestration.serviceAccountName" . }}
       imagePullSecrets: {{- include "orchestration.imagePullSecrets" . | nindent 8 }}
       {{- if .Values.orchestration.podSecurityContext }}
       securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" $.Values.orchestration.podSecurityContext "context" $) | nindent 8 }}

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/migration-data-job.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/migration-data-job.golden.yaml
@@ -29,6 +29,7 @@ spec:
       annotations:
     spec:
       restartPolicy: OnFailure
+      serviceAccountName: camunda-platform-test-zeebe
       imagePullSecrets:
         []
       securityContext:

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/migration-identity-job.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/migration-identity-job.golden.yaml
@@ -29,6 +29,7 @@ spec:
       annotations:
     spec:
       restartPolicy: OnFailure
+      serviceAccountName: camunda-platform-test-zeebe
       imagePullSecrets:
         []
       securityContext:

--- a/charts/camunda-platform-8.8/test/unit/orchestration/migration_data_job_test.go
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/migration_data_job_test.go
@@ -319,3 +319,33 @@ func (s *MigrationDataJobTest) TestCustomTrustStoreConfiguration() {
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
+
+func (s *MigrationDataJobTest) TestServiceAccount() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestServiceAccountDefault",
+			Values: map[string]string{
+				"orchestration.migration.data.enabled": "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var job batchv1.Job
+				helm.UnmarshalK8SYaml(s.T(), output, &job)
+				s.Require().Equal("camunda-platform-test-zeebe", job.Spec.Template.Spec.ServiceAccountName)
+			},
+		},
+		{
+			Name: "TestServiceAccountCustomName",
+			Values: map[string]string{
+				"orchestration.migration.data.enabled": "true",
+				"orchestration.serviceAccount.name":    "custom-sa",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var job batchv1.Job
+				helm.UnmarshalK8SYaml(s.T(), output, &job)
+				s.Require().Equal("custom-sa", job.Spec.Template.Spec.ServiceAccountName)
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}

--- a/charts/camunda-platform-8.8/test/unit/orchestration/migration_identity_job_test.go
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/migration_identity_job_test.go
@@ -158,3 +158,35 @@ func (s *MigrationIdentityJobTest) TestDifferentValuesInputs() {
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
+
+func (s *MigrationIdentityJobTest) TestServiceAccount() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestServiceAccountDefault",
+			Values: map[string]string{
+				"orchestration.migration.identity.enabled":             "true",
+				"orchestration.migration.identity.secret.inlineSecret": "very-secret-thus-plaintext",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var job batchv1.Job
+				helm.UnmarshalK8SYaml(s.T(), output, &job)
+				s.Require().Equal("camunda-platform-test-zeebe", job.Spec.Template.Spec.ServiceAccountName)
+			},
+		},
+		{
+			Name: "TestServiceAccountCustomName",
+			Values: map[string]string{
+				"orchestration.migration.identity.enabled":             "true",
+				"orchestration.migration.identity.secret.inlineSecret": "very-secret-thus-plaintext",
+				"orchestration.serviceAccount.name":                    "custom-sa",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var job batchv1.Job
+				helm.UnmarshalK8SYaml(s.T(), output, &job)
+				s.Require().Equal("custom-sa", job.Spec.Template.Spec.ServiceAccountName)
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}


### PR DESCRIPTION
### Which problem does the PR fix?


Support: https://jira.camunda.com/browse/SUPPORT-31299
Closes #5972.

The 8.7 → 8.8 upgrade `zeebe-migration-data` Job did not set `serviceAccountName` on its pod spec, so the pod fell through to the namespace's `default` ServiceAccount. On AWS deployments using IRSA via `orchestration.serviceAccount.annotations.eks.amazonaws.com/role-arn`, the IRSA annotation lives on the orchestration SA — `default` has none — so the migration job could not assume the IAM role and got stuck on `Failed to check if index [operate-metadata-8.8.0_]`. The sibling `zeebe-migration-identity` Job had the same gap.

### What's in this PR?

Adds `serviceAccountName: {{ include "orchestration.serviceAccountName" . }}` to both `migration-data-job.yaml` and `migration-identity-job.yaml`, mirroring the pattern already used by the orchestration StatefulSet and importer Deployment. Both jobs now inherit the orchestration SA and any IRSA / RBAC configuration attached to it.

New `TestServiceAccount` suite cases on both job test files cover the default rendering and the `orchestration.serviceAccount.name` override path. Golden snapshots regenerated via `make go.update-golden-only`.

End-to-end validated via `deploy-camunda --render-templates` against `chart-full-setup --identity keycloak-external --persistence opensearch-external --upgrade-flow`: without the fix, neither rendered job has `serviceAccountName`; with the fix, both render `serviceAccountName: <release>-zeebe`, and with `orchestration.serviceAccount.annotations.eks.amazonaws.com/role-arn` set the same SA is rendered with the IRSA annotation.

### Checklist

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open pull request for the same update/change.
- [x] Tests for charts are added (if needed).
- [ ] In-repo documentation are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?