### PR TITLE
docs: synchronize agent guidance files

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -44,7 +44,8 @@ Keep it concise. The file should be useful to a fresh agent session that has nev
 
 ```
 charts/
-  camunda-platform-8.9/     # Latest (alpha) - unified "orchestration" component
+  camunda-platform-8.10/    # Latest - unified "orchestration" component
+  camunda-platform-8.9/     # Unified "orchestration" component
   camunda-platform-8.8/     # Unified "orchestration" component
   camunda-platform-8.7/     # Separate zeebe/, operate/, tasklist/ templates
   camunda-platform-8.6/     # Separate zeebe/, operate/, tasklist/ templates
@@ -67,15 +68,15 @@ test/
   integration/scenarios/     # Cross-version integration test scenarios
   integration/testsuites/    # Test suite definitions (Venom, Playwright)
 
-version-matrix/              # Version compatibility matrices (8.2 through 8.9)
+version-matrix/              # Version compatibility matrices (8.2 through 8.10)
 infra/                       # Infrastructure values for shared ES/Keycloak
 docs/                        # Internal developer documentation
 ```
 
-### Architecture: 8.6/8.7 vs 8.8/8.9
+### Architecture: 8.6/8.7 vs 8.8+
 
 - **8.6 and 8.7:** Separate template directories for `zeebe/`, `zeebe-gateway/`, `operate/`, `tasklist/`.
-- **8.8 and 8.9:** These merged into a single `orchestration/` component (Zeebe + Operate + Tasklist unified).
+- **8.8, 8.9, and 8.10:** These merged into a single `orchestration/` component (Zeebe + Operate + Tasklist unified).
 
 When making changes across chart versions, check which structure applies. Do not assume templates are the same across versions.
 
@@ -116,7 +117,8 @@ Keep the header under 120 chars (prefer under 72). The description should be in 
 - Go code uses the golden file (snapshot) testing pattern. After changes that affect rendered output, run:
 
   ```bash
-  make go.update-golden-only
+  make go.update-golden-only        # full regeneration (cleanup before re-render)
+  make go.update-golden-only-lite   # faster iteration (skips cleanup)
   ```
 
 ### Branches
@@ -144,14 +146,15 @@ Pinned in `.tool-versions` (managed by `asdf`). Install all with: `asdf install`
 make install.dx-tooling          # Build and install all Go CLI tools to $GOPATH/bin
 make go.test                     # Run unit tests (checks against golden files)
 make go.update-golden-only       # Update golden files after template changes
+make go.update-golden-only-lite  # Faster update during iteration (skips cleanup)
 make helm.lint                   # Lint all Helm charts
 make helm.dependency-update      # Update chart dependencies
 make precommit.chores            # Pre-commit chores (lint + readme + schema + golden files)
-make helm.template chartPath=charts/camunda-platform-8.9   # Template a chart (inspect output)
-make helm.dry-run chartPath=charts/camunda-platform-8.9    # Dry-run an install
+make helm.template chartPath=charts/camunda-platform-8.10  # Template a chart (inspect output)
+make helm.dry-run chartPath=charts/camunda-platform-8.10   # Dry-run an install
 ```
 
-Most `make` targets accept `chartPath` to target a specific version (e.g., `make go.test chartPath=charts/camunda-platform-8.9`).
+Most `make` targets accept `chartPath` to target a specific version (e.g., `make go.test chartPath=charts/camunda-platform-8.10`).
 
 ### Values Files
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,10 @@ make go.addlicense-run chartPath=charts/camunda-platform-8.10
 
 # Maintainer precommit chores
 make precommit.chores
+
+# Find values defined in values.yaml that are not referenced by any template
+# Build first: cd scripts/helm_unused_values && go build -o helm-unused-values
+./helm-unused-values charts/camunda-platform-8.10/templates
 ```
 
 ## Test Commands
@@ -168,6 +172,8 @@ make tools.asdf-install
 - `.github/AGENTS.md` — CI/CD architecture, repo structure, values files
 - `SKILLS.md` — deploy-camunda CLI patterns, kubectl usage
 - `STATE.md` — session continuity (gitignored, read on session start)
+- `helm-values-mcp/` — MCP server exposing chart values schema. Tools: `list_versions`, `list_components`, `search_configs`, `get_config_info`, `generate_values_example`.
+- `scripts/helm_unused_values/` — CLI to find values declared in `values.yaml` but never referenced in templates.
 
 ## Recommended Agent Workflow
 1. Select target chart version/component.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,7 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with this repository.
+Read `AGENTS.md` for commands and rules, `.github/AGENTS.md` for CI/CD architecture,
+and `SKILLS.md` for operational deployment patterns.
+
 @AGENTS.md


### PR DESCRIPTION
## Summary

Part 2 of the staged agentic-coding improvements: keep agent guidance documentation in sync and remove drift across `CLAUDE.md`, `AGENTS.md`, and `.github/AGENTS.md`.

- **`CLAUDE.md`** — trimmed to a lean entry point that bridges to `AGENTS.md`, `.github/AGENTS.md`, and `SKILLS.md`. The previous content duplicated architecture sections that already live in `.github/AGENTS.md`, so it would drift independently.
- **`.github/AGENTS.md`** — promote `camunda-platform-8.10` to "Latest" in the repo-structure block, fix stale "8.2 through 8.9" version-matrix annotation to "8.2 through 8.10", extend the 8.6/8.7 vs 8.8+ architecture section to include 8.10, surface `make go.update-golden-only-lite` alongside the full variant, and update example `chartPath` references to 8.10.
- **`AGENTS.md`** — surface the `scripts/helm_unused_values/` CLI in Lint Commands, and explicitly list `helm-values-mcp` server tool names (`list_versions`, `list_components`, `search_configs`, `get_config_info`, `generate_values_example`) so agents can discover them.

No code, schema, template, or test changes — pure documentation alignment.

## Test plan

- [ ] Skim rendered Markdown on GitHub for the three files; verify no broken links and no leftover 8.9-as-Latest references.
- [ ] Confirm `CLAUDE.md`'s `@AGENTS.md` reference still resolves correctly under Claude Code's loader.
- [ ] Verify `helm-unused-values` build instructions match `scripts/helm_unused_values/README.md`.