### PR TITLE
ci: simplify chart-chores workflow by inlining branch condition

### DIFF
--- a/.github/workflows/chart-chores.yaml
+++ b/.github/workflows/chart-chores.yaml
@@ -13,30 +13,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  init:
-    name: Check Conditions
-    runs-on: ubuntu-latest
-    steps:
-      # The workflow shouldn't run on some branches where we have independent workflows for them.
-      - name: Check conditions
-        id: conditions
-        run: |
-          set -x
-          SHOULD_RUN=true
-          case "${{ github.head_ref }}" in
-              "renovate/"*)
-                  SHOULD_RUN="false"
-                  ;;
-              "release-please--"*)
-                  SHOULD_RUN="false"
-              ;;
-          esac
-          echo "should-run=${SHOULD_RUN}" | tee -a ${GITHUB_OUTPUT}
-    outputs:
-      should-run: ${{ steps.conditions.outputs.should-run }}
   chores:
-    needs: [init]
-    if: needs.init.outputs.should-run == 'true'
+    if: ${{ !startsWith(github.head_ref, 'renovate/') && !startsWith(github.head_ref, 'release-please--') }}
     name: Chart chores
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- Removes the separate `init` job that checked branch conditions in the chart-chores workflow
- Replaces it with an inline `if` condition using `startsWith()` directly on the `chores` job
- Functionally equivalent but eliminates an unnecessary job and its dependency chain

## Related Issue

Closes https://github.com/camunda/team-distribution/issues/538