### PR TITLE
feat: add companion chart deployment support to deploy-camunda

### DIFF
--- a/charts/camunda-platform-8.10/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.10/test/ci-test-config.yaml
@@ -86,6 +86,8 @@ integration:
             - chart: opensearch/opensearch
               version: "3.6.0"
               release-name: opensearch
+              repo-name: opensearch
+              repo-url: https://opensearch-project.github.io/helm-charts/
               values-file: test/integration/companion-values/opensearch.yaml
         - name: upgrade-migration
           # upgrade migrators are only for 8.7 -> 8.8, not for 8.10

--- a/charts/camunda-platform-8.10/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.10/test/ci-test-config.yaml
@@ -71,6 +71,22 @@ integration:
           infra-type:
             gke: distroci
           platforms: [gke]
+        - name: opensearch-embedded
+          enabled: false
+          shortname: osem
+          exclude: []
+          auth: keycloak
+          identity: keycloak
+          persistence: opensearch-embedded
+          flow: install
+          infra-type:
+            gke: distroci
+          platforms: [gke]
+          dependencies:
+            - chart: opensearch/opensearch
+              version: "3.6.0"
+              release-name: opensearch
+              values-file: test/integration/companion-values/opensearch.yaml
         - name: upgrade-migration
           # upgrade migrators are only for 8.7 -> 8.8, not for 8.10
           enabled: false

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/persistence/opensearch-embedded.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/persistence/opensearch-embedded.yaml
@@ -1,0 +1,34 @@
+# OpenSearch backend configuration for 8.10
+# Layer 3: Backend - OpenSearch (embedded companion chart)
+#
+# Connects to the OpenSearch companion chart deployed as a separate Helm release
+# by deploy-camunda before the main Camunda chart. The companion chart values
+# are in charts/opensearch-3/ci-values.yaml (security disabled, single node).
+
+global:
+  elasticsearch:
+    enabled: false
+
+orchestration:
+  data:
+    secondaryStorage:
+      type: opensearch
+      opensearch:
+        url: "http://opensearch-master:9200"
+
+optimize:
+  enabled: true
+  database:
+    elasticsearch:
+      enabled: false
+    opensearch:
+      enabled: true
+      aws:
+        enabled: false
+      url:
+        protocol: http
+        host: "opensearch-master"
+        port: 9200
+
+elasticsearch:
+  enabled: false

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/persistence/opensearch-embedded.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/persistence/opensearch-embedded.yaml
@@ -3,7 +3,7 @@
 #
 # Connects to the OpenSearch companion chart deployed as a separate Helm release
 # by deploy-camunda before the main Camunda chart. The companion chart values
-# are in charts/opensearch-3/ci-values.yaml (security disabled, single node).
+# are in test/integration/companion-values/opensearch.yaml (security disabled, single node).
 
 global:
   elasticsearch:

--- a/charts/camunda-platform-8.8/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.8/test/ci-test-config.yaml
@@ -179,6 +179,8 @@ integration:
             - chart: opensearch/opensearch
               version: "3.6.0"
               release-name: opensearch
+              repo-name: opensearch
+              repo-url: https://opensearch-project.github.io/helm-charts/
               values-file: test/integration/companion-values/opensearch.yaml
         - name: documentstore
           enabled: true

--- a/charts/camunda-platform-8.8/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.8/test/ci-test-config.yaml
@@ -164,6 +164,22 @@ integration:
           infra-type:
             gke: distroci
           platforms: [gke]
+        - name: opensearch-embedded
+          enabled: false
+          shortname: osem
+          exclude: []
+          auth: keycloak
+          identity: keycloak
+          persistence: opensearch-embedded
+          flow: install
+          infra-type:
+            gke: distroci
+          platforms: [gke]
+          dependencies:
+            - chart: opensearch/opensearch
+              version: "3.6.0"
+              release-name: opensearch
+              values-file: test/integration/companion-values/opensearch.yaml
         - name: documentstore
           enabled: true
           exclude: []

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/persistence/opensearch-embedded.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/persistence/opensearch-embedded.yaml
@@ -3,7 +3,7 @@
 #
 # Connects to the OpenSearch companion chart deployed as a separate Helm release
 # by deploy-camunda before the main Camunda chart. The companion chart values
-# are in charts/opensearch-3/ci-values.yaml (security disabled, single node).
+# are in test/integration/companion-values/opensearch.yaml (security disabled, single node).
 
 global:
   elasticsearch:

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/persistence/opensearch-embedded.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/persistence/opensearch-embedded.yaml
@@ -1,0 +1,21 @@
+# OpenSearch backend configuration for 8.8
+# Layer 3: Backend - OpenSearch (embedded companion chart)
+#
+# Connects to the OpenSearch companion chart deployed as a separate Helm release
+# by deploy-camunda before the main Camunda chart. The companion chart values
+# are in charts/opensearch-3/ci-values.yaml (security disabled, single node).
+
+global:
+  elasticsearch:
+    enabled: false
+  opensearch:
+    enabled: true
+    aws:
+      enabled: false
+    url:
+      protocol: http
+      host: "opensearch-master"
+      port: 9200
+
+elasticsearch:
+  enabled: false

--- a/charts/camunda-platform-8.9/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.9/test/ci-test-config.yaml
@@ -97,6 +97,8 @@ integration:
             - chart: opensearch/opensearch
               version: "3.6.0"
               release-name: opensearch
+              repo-name: opensearch
+              repo-url: https://opensearch-project.github.io/helm-charts/
               values-file: test/integration/companion-values/opensearch.yaml
         - name: elasticsearch-basic
           enabled: false

--- a/charts/camunda-platform-8.9/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.9/test/ci-test-config.yaml
@@ -82,6 +82,22 @@ integration:
           infra-type:
             gke: distroci
           platforms: [gke]
+        - name: opensearch-embedded
+          enabled: false
+          shortname: osem
+          exclude: []
+          auth: keycloak
+          identity: keycloak
+          persistence: opensearch-embedded
+          flow: install
+          infra-type:
+            gke: distroci
+          platforms: [gke]
+          dependencies:
+            - chart: opensearch/opensearch
+              version: "3.6.0"
+              release-name: opensearch
+              values-file: test/integration/companion-values/opensearch.yaml
         - name: elasticsearch-basic
           enabled: false
           shortname: esba

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/persistence/opensearch-embedded.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/persistence/opensearch-embedded.yaml
@@ -1,0 +1,34 @@
+# OpenSearch backend configuration for 8.9
+# Layer 3: Backend - OpenSearch (embedded companion chart)
+#
+# Connects to the OpenSearch companion chart deployed as a separate Helm release
+# by deploy-camunda before the main Camunda chart. The companion chart values
+# are in charts/opensearch-3/ci-values.yaml (security disabled, single node).
+
+global:
+  elasticsearch:
+    enabled: false
+
+orchestration:
+  data:
+    secondaryStorage:
+      type: opensearch
+      opensearch:
+        url: "http://opensearch-master:9200"
+
+optimize:
+  enabled: true
+  database:
+    elasticsearch:
+      enabled: false
+    opensearch:
+      enabled: true
+      aws:
+        enabled: false
+      url:
+        protocol: http
+        host: "opensearch-master"
+        port: 9200
+
+elasticsearch:
+  enabled: false

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/persistence/opensearch-embedded.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/persistence/opensearch-embedded.yaml
@@ -3,7 +3,7 @@
 #
 # Connects to the OpenSearch companion chart deployed as a separate Helm release
 # by deploy-camunda before the main Camunda chart. The companion chart values
-# are in charts/opensearch-3/ci-values.yaml (security disabled, single node).
+# are in test/integration/companion-values/opensearch.yaml (security disabled, single node).
 
 global:
   elasticsearch:

--- a/scripts/camunda-core/pkg/scenarios/scenarios.go
+++ b/scripts/camunda-core/pkg/scenarios/scenarios.go
@@ -69,7 +69,7 @@ func (c *DeploymentConfig) Validate() error {
 	}
 
 	// Validate persistence values
-	validPersistence := []string{"elasticsearch", "elasticsearch-external", "elasticsearch-external-self-signed", "elasticsearch-self-signed", "no-elasticsearch", "opensearch", "opensearch-external", "rdbms", "rdbms-external", "rdbms-oracle"}
+	validPersistence := []string{"elasticsearch", "elasticsearch-external", "elasticsearch-external-self-signed", "elasticsearch-self-signed", "no-elasticsearch", "opensearch", "opensearch-embedded", "opensearch-external", "rdbms", "rdbms-external", "rdbms-oracle"}
 	if !contains(validPersistence, c.Persistence) {
 		return fmt.Errorf("invalid --persistence value %q: must be one of: %s", c.Persistence, strings.Join(validPersistence, ", "))
 	}

--- a/scripts/camunda-deployer/pkg/deployer/deployer.go
+++ b/scripts/camunda-deployer/pkg/deployer/deployer.go
@@ -117,5 +117,20 @@ func Deploy(ctx context.Context, o types.Options) error {
 		}
 	}
 
+	// Deploy companion charts (e.g., OpenSearch) as separate Helm releases
+	// in the same namespace. Each chart is deployed with --wait to ensure
+	// it is ready before the main Camunda chart deployment begins.
+	for i, cc := range o.CompanionCharts {
+		logging.Logger.Info().
+			Str("chart", cc.ChartRef).
+			Str("version", cc.Version).
+			Str("release", cc.ReleaseName).
+			Str("namespace", o.Namespace).
+			Msg("Deploying companion chart")
+		if err := deployCompanionChart(ctx, cc, o); err != nil {
+			return fmt.Errorf("companion chart [%d] %q failed: %w", i, cc.ReleaseName, err)
+		}
+	}
+
 	return upgradeInstall(ctx, o)
 }

--- a/scripts/camunda-deployer/pkg/deployer/helm.go
+++ b/scripts/camunda-deployer/pkg/deployer/helm.go
@@ -170,6 +170,16 @@ func formatArgs(args []string) string {
 // in the same namespace as the main Camunda chart. It uses helm upgrade --install
 // with --wait to ensure the chart is fully ready before returning.
 func deployCompanionChart(ctx context.Context, cc types.CompanionChart, o types.Options) error {
+	// Ensure the Helm repo is registered when a repo-style chart ref is used.
+	if cc.RepoName != "" && cc.RepoURL != "" {
+		if err := helm.RepoAdd(ctx, cc.RepoName, cc.RepoURL); err != nil {
+			return fmt.Errorf("companion chart %q: repo add failed: %w", cc.ReleaseName, err)
+		}
+		if err := helm.RepoUpdate(ctx); err != nil {
+			return fmt.Errorf("companion chart %q: repo update failed: %w", cc.ReleaseName, err)
+		}
+	}
+
 	args := []string{
 		"upgrade", "--install",
 		cc.ReleaseName,

--- a/scripts/camunda-deployer/pkg/deployer/helm.go
+++ b/scripts/camunda-deployer/pkg/deployer/helm.go
@@ -165,3 +165,45 @@ func formatArgs(args []string) string {
 	}
 	return strings.Join(parts, " ")
 }
+
+// deployCompanionChart deploys a single companion chart as its own Helm release
+// in the same namespace as the main Camunda chart. It uses helm upgrade --install
+// with --wait to ensure the chart is fully ready before returning.
+func deployCompanionChart(ctx context.Context, cc types.CompanionChart, o types.Options) error {
+	args := []string{
+		"upgrade", "--install",
+		cc.ReleaseName,
+		cc.ChartRef,
+		"-n", o.Namespace,
+		"--create-namespace",
+		"--wait",
+	}
+
+	// Pin chart version (required for remote charts)
+	if cc.Version != "" {
+		args = append(args, "--version", cc.Version)
+	}
+
+	// Use the same timeout as the main deployment
+	if o.Timeout > 0 {
+		args = append(args, "--timeout", fmt.Sprintf("%ds", int(o.Timeout.Seconds())))
+	}
+
+	// Kubernetes connection
+	args = append(args, composeKubeArgs(o.Kubeconfig, o.KubeContext)...)
+
+	// Values file (optional)
+	if cc.ValuesFile != "" {
+		args = append(args, "-f", cc.ValuesFile)
+	}
+
+	err := helm.Run(ctx, args, "")
+	if err != nil {
+		return &HelmError{
+			Reason:  fmt.Sprintf("companion chart %q helm upgrade --install failed", cc.ReleaseName),
+			Command: "helm " + formatArgs(args),
+			Cause:   err,
+		}
+	}
+	return nil
+}

--- a/scripts/camunda-deployer/pkg/deployer/helm.go
+++ b/scripts/camunda-deployer/pkg/deployer/helm.go
@@ -9,6 +9,15 @@ import (
 	"strings"
 )
 
+// Package-level function variables for helm operations. These default to the
+// real implementations but can be swapped in tests to avoid shelling out to
+// the helm binary.
+var (
+	helmRun        = helm.Run
+	helmRepoAdd    = helm.RepoAdd
+	helmRepoUpdate = helm.RepoUpdate
+)
+
 // HelmError is a structured error for helm command failures that separates
 // the high-level failure reason from the full command details. This allows
 // consumers to display a short summary or the full details as needed.
@@ -129,7 +138,7 @@ func upgradeInstall(ctx context.Context, o types.Options) error {
 	}
 
 	// Execute via thin helm wrapper
-	err := helm.Run(ctx, args, "")
+	err := helmRun(ctx, args, "")
 	if err != nil {
 		return &HelmError{
 			Reason:  "helm upgrade --install failed",
@@ -172,10 +181,10 @@ func formatArgs(args []string) string {
 func deployCompanionChart(ctx context.Context, cc types.CompanionChart, o types.Options) error {
 	// Ensure the Helm repo is registered when a repo-style chart ref is used.
 	if cc.RepoName != "" && cc.RepoURL != "" {
-		if err := helm.RepoAdd(ctx, cc.RepoName, cc.RepoURL); err != nil {
+		if err := helmRepoAdd(ctx, cc.RepoName, cc.RepoURL); err != nil {
 			return fmt.Errorf("companion chart %q: repo add failed: %w", cc.ReleaseName, err)
 		}
-		if err := helm.RepoUpdate(ctx); err != nil {
+		if err := helmRepoUpdate(ctx); err != nil {
 			return fmt.Errorf("companion chart %q: repo update failed: %w", cc.ReleaseName, err)
 		}
 	}
@@ -207,7 +216,7 @@ func deployCompanionChart(ctx context.Context, cc types.CompanionChart, o types.
 		args = append(args, "-f", cc.ValuesFile)
 	}
 
-	err := helm.Run(ctx, args, "")
+	err := helmRun(ctx, args, "")
 	if err != nil {
 		return &HelmError{
 			Reason:  fmt.Sprintf("companion chart %q helm upgrade --install failed", cc.ReleaseName),

--- a/scripts/camunda-deployer/pkg/deployer/helm_test.go
+++ b/scripts/camunda-deployer/pkg/deployer/helm_test.go
@@ -1,10 +1,13 @@
 package deployer
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"scripts/camunda-deployer/pkg/types"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestHelmError_Error(t *testing.T) {
@@ -75,5 +78,255 @@ func TestShortenPaths_NoAbsolutePaths(t *testing.T) {
 	got := shortenPaths(cmd)
 	if got != cmd {
 		t.Errorf("shortenPaths: should not modify command without absolute paths: got %q, want %q", got, cmd)
+	}
+}
+
+// stubHelm replaces the package-level helm function variables with test stubs
+// and returns a restore function that must be called (typically via defer) to
+// reset the originals.
+func stubHelm(
+	runFn func(ctx context.Context, args []string, workDir string) error,
+	repoAddFn func(ctx context.Context, name, url string) error,
+	repoUpdateFn func(ctx context.Context) error,
+) func() {
+	origRun, origAdd, origUpdate := helmRun, helmRepoAdd, helmRepoUpdate
+	helmRun = runFn
+	helmRepoAdd = repoAddFn
+	helmRepoUpdate = repoUpdateFn
+	return func() {
+		helmRun, helmRepoAdd, helmRepoUpdate = origRun, origAdd, origUpdate
+	}
+}
+
+func TestDeployCompanionChart(t *testing.T) {
+	tests := []struct {
+		name        string
+		cc          types.CompanionChart
+		opts        types.Options
+		runErr      error
+		repoAddErr  error
+		repoUpdErr  error
+		wantErr     string   // substring expected in error message; empty = no error
+		wantArgs    []string // substrings expected in the helm run args
+		notWantArgs []string // substrings that must NOT appear in helm run args
+		wantRepoAdd bool     // expect helmRepoAdd to be called
+	}{
+		{
+			name: "remote chart with version and repo registration",
+			cc: types.CompanionChart{
+				ChartRef:    "opensearch/opensearch",
+				Version:     "3.6.0",
+				ReleaseName: "opensearch",
+				ValuesFile:  "/tmp/values.yaml",
+				RepoName:    "opensearch",
+				RepoURL:     "https://opensearch-project.github.io/helm-charts/",
+			},
+			opts: types.Options{
+				Namespace:   "test-ns",
+				Kubeconfig:  "/tmp/kubeconfig",
+				KubeContext: "test-ctx",
+				Timeout:     5 * time.Minute,
+			},
+			wantArgs: []string{
+				"upgrade", "--install",
+				"opensearch",
+				"opensearch/opensearch",
+				"-n", "test-ns",
+				"--create-namespace",
+				"--wait",
+				"--version", "3.6.0",
+				"--timeout", "300s",
+				"--kubeconfig", "/tmp/kubeconfig",
+				"--kube-context", "test-ctx",
+				"-f", "/tmp/values.yaml",
+			},
+			wantRepoAdd: true,
+		},
+		{
+			name: "local chart path without version or repo",
+			cc: types.CompanionChart{
+				ChartRef:    "/charts/local-chart",
+				ReleaseName: "local",
+			},
+			opts: types.Options{
+				Namespace: "default",
+			},
+			wantArgs: []string{
+				"upgrade", "--install",
+				"local",
+				"/charts/local-chart",
+				"-n", "default",
+				"--create-namespace",
+				"--wait",
+			},
+			notWantArgs: []string{"--version"},
+			wantRepoAdd: false,
+		},
+		{
+			name: "no values file omits -f flag",
+			cc: types.CompanionChart{
+				ChartRef:    "bitnami/redis",
+				Version:     "18.0.0",
+				ReleaseName: "redis",
+			},
+			opts: types.Options{
+				Namespace: "cache-ns",
+			},
+			notWantArgs: []string{"-f"},
+			wantRepoAdd: false,
+		},
+		{
+			name: "no timeout omits --timeout flag",
+			cc: types.CompanionChart{
+				ChartRef:    "bitnami/redis",
+				Version:     "18.0.0",
+				ReleaseName: "redis",
+			},
+			opts: types.Options{
+				Namespace: "cache-ns",
+			},
+			notWantArgs: []string{"--timeout"},
+		},
+		{
+			name: "repo add error propagates",
+			cc: types.CompanionChart{
+				ChartRef:    "opensearch/opensearch",
+				Version:     "3.6.0",
+				ReleaseName: "opensearch",
+				RepoName:    "opensearch",
+				RepoURL:     "https://example.com/charts",
+			},
+			opts:        types.Options{Namespace: "ns"},
+			repoAddErr:  fmt.Errorf("network timeout"),
+			wantErr:     "repo add failed",
+			wantRepoAdd: true,
+		},
+		{
+			name: "repo update error propagates",
+			cc: types.CompanionChart{
+				ChartRef:    "opensearch/opensearch",
+				Version:     "3.6.0",
+				ReleaseName: "opensearch",
+				RepoName:    "opensearch",
+				RepoURL:     "https://example.com/charts",
+			},
+			opts:        types.Options{Namespace: "ns"},
+			repoUpdErr:  fmt.Errorf("index fetch failed"),
+			wantErr:     "repo update failed",
+			wantRepoAdd: true,
+		},
+		{
+			name: "helm run error wraps as HelmError",
+			cc: types.CompanionChart{
+				ChartRef:    "opensearch/opensearch",
+				Version:     "3.6.0",
+				ReleaseName: "opensearch",
+			},
+			opts:    types.Options{Namespace: "ns"},
+			runErr:  fmt.Errorf("exit status 1"),
+			wantErr: "helm upgrade --install failed",
+		},
+		{
+			name: "repo fields partially set skips repo registration",
+			cc: types.CompanionChart{
+				ChartRef:    "opensearch/opensearch",
+				Version:     "3.6.0",
+				ReleaseName: "opensearch",
+				RepoName:    "opensearch",
+				// RepoURL intentionally empty
+			},
+			opts:        types.Options{Namespace: "ns"},
+			wantRepoAdd: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedArgs []string
+			repoAddCalled := false
+
+			restore := stubHelm(
+				func(ctx context.Context, args []string, workDir string) error {
+					capturedArgs = args
+					return tt.runErr
+				},
+				func(ctx context.Context, name, url string) error {
+					repoAddCalled = true
+					return tt.repoAddErr
+				},
+				func(ctx context.Context) error {
+					return tt.repoUpdErr
+				},
+			)
+			defer restore()
+
+			err := deployCompanionChart(context.Background(), tt.cc, tt.opts)
+
+			// Check error expectations
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("error = %q, want substring %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Check repo add was/wasn't called
+			if tt.wantRepoAdd != repoAddCalled {
+				t.Errorf("helmRepoAdd called = %v, want %v", repoAddCalled, tt.wantRepoAdd)
+			}
+
+			// Check expected args are present
+			argsStr := strings.Join(capturedArgs, " ")
+			for _, want := range tt.wantArgs {
+				if !strings.Contains(argsStr, want) {
+					t.Errorf("args = %q, missing expected substring %q", argsStr, want)
+				}
+			}
+
+			// Check unwanted args are absent
+			for _, notWant := range tt.notWantArgs {
+				if strings.Contains(argsStr, notWant) {
+					t.Errorf("args = %q, should not contain %q", argsStr, notWant)
+				}
+			}
+		})
+	}
+}
+
+func TestDeployCompanionChart_HelmErrorType(t *testing.T) {
+	restore := stubHelm(
+		func(ctx context.Context, args []string, workDir string) error {
+			return fmt.Errorf("exit status 1")
+		},
+		func(ctx context.Context, name, url string) error { return nil },
+		func(ctx context.Context) error { return nil },
+	)
+	defer restore()
+
+	err := deployCompanionChart(context.Background(), types.CompanionChart{
+		ChartRef:    "opensearch/opensearch",
+		Version:     "3.6.0",
+		ReleaseName: "opensearch",
+	}, types.Options{Namespace: "ns"})
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var helmErr *HelmError
+	if !errors.As(err, &helmErr) {
+		t.Fatalf("expected *HelmError, got %T", err)
+	}
+	if !strings.Contains(helmErr.Reason, "companion chart") {
+		t.Errorf("HelmError.Reason = %q, want it to mention companion chart", helmErr.Reason)
+	}
+	if !strings.Contains(helmErr.Command, "helm upgrade --install") {
+		t.Errorf("HelmError.Command = %q, want it to contain full command", helmErr.Command)
 	}
 }

--- a/scripts/camunda-deployer/pkg/types/types.go
+++ b/scripts/camunda-deployer/pkg/types/types.go
@@ -95,6 +95,12 @@ type CompanionChart struct {
 	ReleaseName string
 	// ValuesFile is the absolute path to a values file. Empty means use chart defaults.
 	ValuesFile string
+	// RepoName is the Helm repository name to register before installing
+	// (e.g., "opensearch"). Empty means no repo registration is needed.
+	RepoName string
+	// RepoURL is the Helm repository URL
+	// (e.g., "https://opensearch-project.github.io/helm-charts/").
+	RepoURL string
 }
 
 type CIMetadata struct {

--- a/scripts/camunda-deployer/pkg/types/types.go
+++ b/scripts/camunda-deployer/pkg/types/types.go
@@ -74,6 +74,27 @@ type Options struct {
 	// in the namespace at install time but cannot be created earlier because
 	// the namespace may not yet exist or may be recreated.
 	PreInstallHooks []func(ctx context.Context) error
+
+	// CompanionCharts are Helm charts deployed as separate releases in the
+	// same namespace before the main Camunda chart. Each companion chart is
+	// deployed with helm upgrade --install --wait to ensure it is ready
+	// before the main chart deployment begins.
+	CompanionCharts []CompanionChart
+}
+
+// CompanionChart represents a Helm chart that should be deployed as a
+// separate release before the main Camunda chart.
+type CompanionChart struct {
+	// ChartRef is the Helm chart reference — either a repo/chart name
+	// (e.g., "opensearch/opensearch") or an absolute local path.
+	ChartRef string
+	// Version is the chart version to install (e.g., "3.6.0").
+	// Empty means latest (for remote) or ignore (for local).
+	Version string
+	// ReleaseName is the Helm release name for this companion chart.
+	ReleaseName string
+	// ValuesFile is the absolute path to a values file. Empty means use chart defaults.
+	ValuesFile string
 }
 
 type CIMetadata struct {

--- a/scripts/deploy-camunda/cmd/prepare_values.go
+++ b/scripts/deploy-camunda/cmd/prepare_values.go
@@ -89,7 +89,7 @@ All diagnostic output goes to stderr via the logger.`,
 	f.StringVar(&pv.chartPath, "chart-path", "", "Path to the Camunda chart directory (used to derive scenario-path if not set)")
 	f.StringVar(&pv.scenario, "scenario", "chart-full-setup", "Scenario name (used to derive defaults from naming conventions)")
 	f.StringVar(&pv.identity, "identity", "", "Identity selection: keycloak, keycloak-external, oidc, basic, hybrid")
-	f.StringVar(&pv.persistence, "persistence", "", "Persistence selection: elasticsearch, elasticsearch-external, elasticsearch-self-signed, elasticsearch-external-self-signed, opensearch, opensearch-external, rdbms, rdbms-oracle")
+	f.StringVar(&pv.persistence, "persistence", "", "Persistence selection: elasticsearch, elasticsearch-external, elasticsearch-self-signed, elasticsearch-external-self-signed, opensearch, opensearch-embedded, opensearch-external, rdbms, rdbms-oracle")
 	f.StringVar(&pv.testPlatform, "test-platform", "", "Test platform selection: gke, eks, openshift")
 	f.StringVar(&pv.platform, "platform", "gke", "Deploy platform: gke, rosa, eks (fallback for --test-platform)")
 	f.StringSliceVar(&pv.features, "features", nil, "Feature selections (comma-separated): multitenancy, rba, documentstore")
@@ -110,7 +110,7 @@ All diagnostic output goes to stderr via the logger.`,
 		return []string{"keycloak", "keycloak-external", "oidc", "basic", "hybrid"}, cobra.ShellCompDirectiveNoFileComp
 	})
 	_ = cmd.RegisterFlagCompletionFunc("persistence", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"elasticsearch", "elasticsearch-external", "elasticsearch-self-signed", "elasticsearch-external-self-signed", "opensearch", "rdbms", "rdbms-external", "rdbms-oracle"}, cobra.ShellCompDirectiveNoFileComp
+		return []string{"elasticsearch", "elasticsearch-external", "elasticsearch-self-signed", "elasticsearch-external-self-signed", "opensearch", "opensearch-embedded", "opensearch-external", "rdbms", "rdbms-external", "rdbms-oracle"}, cobra.ShellCompDirectiveNoFileComp
 	})
 	_ = cmd.RegisterFlagCompletionFunc("test-platform", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return config.TestPlatforms, cobra.ShellCompDirectiveNoFileComp

--- a/scripts/deploy-camunda/cmd/root.go
+++ b/scripts/deploy-camunda/cmd/root.go
@@ -241,7 +241,7 @@ func NewRootCommand() *cobra.Command {
 	f.BoolVar(&flags.Secrets.UseVaultBackedSecrets, "use-vault-backed-secrets", false, "Use vault-backed external secrets (selects -vault.yaml suffix files)")
 	// Selection + composition model (new - preferred over deprecated --scenario)
 	f.StringVar(&flags.Selection.Identity, "identity", "", "Identity selection: keycloak, keycloak-external, oidc, basic, hybrid")
-	f.StringVar(&flags.Selection.Persistence, "persistence", "", "Persistence selection: elasticsearch, elasticsearch-self-signed, elasticsearch-external-self-signed, opensearch, opensearch-external, rdbms, rdbms-external, rdbms-oracle")
+	f.StringVar(&flags.Selection.Persistence, "persistence", "", "Persistence selection: elasticsearch, elasticsearch-self-signed, elasticsearch-external-self-signed, opensearch, opensearch-embedded, opensearch-external, rdbms, rdbms-external, rdbms-oracle")
 	f.StringVar(&flags.Selection.TestPlatform, "test-platform", "", "Test platform selection: gke, eks, openshift")
 	f.StringSliceVar(&flags.Selection.Features, "features", nil, "Feature selections (comma-separated): multitenancy, rba, documentstore")
 	f.BoolVar(&flags.Selection.QA, "qa", false, "Enable QA configuration (test users, etc.)")

--- a/scripts/deploy-camunda/config/merge.go
+++ b/scripts/deploy-camunda/config/merge.go
@@ -244,6 +244,12 @@ type CompanionChart struct {
 	ReleaseName string
 	// ValuesFile is the absolute path to a values file. Empty means use chart defaults.
 	ValuesFile string
+	// RepoName is the Helm repository name to register before installing
+	// (e.g., "opensearch"). Empty means no repo registration is needed.
+	RepoName string
+	// RepoURL is the Helm repository URL
+	// (e.g., "https://opensearch-project.github.io/helm-charts/").
+	RepoURL string
 }
 
 // ParseDebugFlag parses a debug flag value in the format "component" or "component:port".

--- a/scripts/deploy-camunda/config/merge.go
+++ b/scripts/deploy-camunda/config/merge.go
@@ -210,6 +210,11 @@ type RuntimeFlags struct {
 	// CONNECTORS_CLIENT_ID in an isolated map instead of relying on os.Setenv.
 	ExtraEnv map[string]string
 
+	// CompanionCharts are Helm charts to deploy as separate releases in the
+	// same namespace before the main Camunda chart. Each entry specifies the
+	// chart path, release name, and optional values file.
+	CompanionCharts []CompanionChart
+
 	// OnPhase is called when the deployment transitions to a new phase
 	// (e.g., "deploying", "testing"). Used by the matrix status display to
 	// show fine-grained progress. Nil disables the callback.
@@ -223,6 +228,22 @@ type RuntimeFlags struct {
 	// e2e test script output. Used by the matrix runner to redirect
 	// e2e output to a per-entry log file instead of polluting the terminal.
 	E2EOutputWriter io.Writer
+}
+
+// CompanionChart represents a Helm chart to deploy as a separate release
+// before the main Camunda chart. Used to deploy infrastructure dependencies
+// (e.g., OpenSearch) in the same namespace.
+type CompanionChart struct {
+	// ChartRef is the Helm chart reference — either a repo/chart name
+	// (e.g., "opensearch/opensearch") or an absolute local path.
+	ChartRef string
+	// Version is the chart version to install (e.g., "3.6.0").
+	// Empty means use the latest version (for remote) or ignore (for local).
+	Version string
+	// ReleaseName is the Helm release name for this companion chart.
+	ReleaseName string
+	// ValuesFile is the absolute path to a values file. Empty means use chart defaults.
+	ValuesFile string
 }
 
 // ParseDebugFlag parses a debug flag value in the format "component" or "component:port".

--- a/scripts/deploy-camunda/deploy/deploy.go
+++ b/scripts/deploy-camunda/deploy/deploy.go
@@ -432,6 +432,8 @@ func toDeployerCompanionCharts(charts []config.CompanionChart) []types.Companion
 			Version:     c.Version,
 			ReleaseName: c.ReleaseName,
 			ValuesFile:  c.ValuesFile,
+			RepoName:    c.RepoName,
+			RepoURL:     c.RepoURL,
 		}
 	}
 	return result

--- a/scripts/deploy-camunda/deploy/deploy.go
+++ b/scripts/deploy-camunda/deploy/deploy.go
@@ -312,6 +312,7 @@ func executeDeployment(ctx context.Context, prepared *PreparedScenario, flags *c
 		ExtraArgs:             flags.Deployment.ExtraHelmArgs,
 		SetPairs:              flags.Deployment.ExtraHelmSets,
 		PreInstallHooks:       flags.PreInstallHooks,
+		CompanionCharts:       toDeployerCompanionCharts(flags.CompanionCharts),
 	}
 
 	// Log deployment options (redact sensitive fields)
@@ -417,4 +418,21 @@ func executeDeployment(ctx context.Context, prepared *PreparedScenario, flags *c
 // deleteNamespace deletes a Kubernetes namespace.
 func deleteNamespace(ctx context.Context, kubeContext, namespace string) error {
 	return kube.DeleteNamespace(ctx, "", kubeContext, namespace)
+}
+
+// toDeployerCompanionCharts converts config.CompanionChart to types.CompanionChart.
+func toDeployerCompanionCharts(charts []config.CompanionChart) []types.CompanionChart {
+	if len(charts) == 0 {
+		return nil
+	}
+	result := make([]types.CompanionChart, len(charts))
+	for i, c := range charts {
+		result[i] = types.CompanionChart{
+			ChartRef:    c.ChartRef,
+			Version:     c.Version,
+			ReleaseName: c.ReleaseName,
+			ValuesFile:  c.ValuesFile,
+		}
+	}
+	return result
 }

--- a/scripts/deploy-camunda/matrix/config.go
+++ b/scripts/deploy-camunda/matrix/config.go
@@ -93,6 +93,28 @@ type CIScenario struct {
 	// replacing hardcoded shortname-based skip logic in both the Go CLI and GHA workflows.
 	SkipE2E bool `yaml:"skip-e2e,omitempty"`
 	SkipIT  bool `yaml:"skip-it,omitempty"`
+
+	// Dependencies specifies companion charts to deploy before the main Camunda chart.
+	// Each dependency is deployed as a separate Helm release in the same namespace.
+	Dependencies []ChartDependency `yaml:"dependencies,omitempty"`
+}
+
+// ChartDependency represents a companion chart that must be deployed
+// before the main Camunda chart. The chart is deployed as a separate
+// Helm release in the same namespace.
+type ChartDependency struct {
+	// Chart is the Helm chart reference. This can be a repo/chart name
+	// (e.g., "opensearch/opensearch") or a local path relative to the repo root.
+	Chart string `yaml:"chart"`
+	// Version is the chart version to install (e.g., "3.6.0").
+	// Required for remote charts; ignored for local paths.
+	Version string `yaml:"version,omitempty"`
+	// ReleaseName is the Helm release name for the companion chart.
+	// Example: "opensearch"
+	ReleaseName string `yaml:"release-name"`
+	// ValuesFile is the path to a values file for the companion chart,
+	// relative to the repo root. Optional — omit to use chart defaults.
+	ValuesFile string `yaml:"values-file,omitempty"`
 }
 
 // LoadCITestConfig reads and parses the ci-test-config.yaml for a given chart directory.

--- a/scripts/deploy-camunda/matrix/config.go
+++ b/scripts/deploy-camunda/matrix/config.go
@@ -105,16 +105,24 @@ type CIScenario struct {
 type ChartDependency struct {
 	// Chart is the Helm chart reference. This can be a repo/chart name
 	// (e.g., "opensearch/opensearch") or a local path relative to the repo root.
-	Chart string `yaml:"chart"`
+	Chart string `yaml:"chart" json:"chart"`
 	// Version is the chart version to install (e.g., "3.6.0").
 	// Required for remote charts; ignored for local paths.
-	Version string `yaml:"version,omitempty"`
+	Version string `yaml:"version,omitempty" json:"version,omitempty"`
 	// ReleaseName is the Helm release name for the companion chart.
 	// Example: "opensearch"
-	ReleaseName string `yaml:"release-name"`
+	ReleaseName string `yaml:"release-name" json:"release-name"`
 	// ValuesFile is the path to a values file for the companion chart,
 	// relative to the repo root. Optional — omit to use chart defaults.
-	ValuesFile string `yaml:"values-file,omitempty"`
+	ValuesFile string `yaml:"values-file,omitempty" json:"values-file,omitempty"`
+	// RepoName is the Helm repository name to register before installing
+	// the chart (e.g., "opensearch"). Required for repo-style chart refs;
+	// not needed for OCI or local paths.
+	RepoName string `yaml:"repo-name,omitempty" json:"repo-name,omitempty"`
+	// RepoURL is the Helm repository URL (e.g.,
+	// "https://opensearch-project.github.io/helm-charts/").
+	// Required when RepoName is set.
+	RepoURL string `yaml:"repo-url,omitempty" json:"repo-url,omitempty"`
 }
 
 // LoadCITestConfig reads and parses the ci-test-config.yaml for a given chart directory.

--- a/scripts/deploy-camunda/matrix/matrix.go
+++ b/scripts/deploy-camunda/matrix/matrix.go
@@ -38,6 +38,9 @@ type Entry struct {
 	// Test skip flags — declarative controls from ci-test-config.yaml.
 	SkipE2E bool `json:"skipE2E,omitempty"`
 	SkipIT  bool `json:"skipIT,omitempty"`
+
+	// Dependencies specifies companion charts to deploy before the main Camunda chart.
+	Dependencies []ChartDependency `json:"dependencies,omitempty"`
 }
 
 // GenerateOptions controls matrix generation.
@@ -155,25 +158,26 @@ func Generate(repoRoot string, opts GenerateOptions) ([]Entry, error) {
 			for _, flow := range permittedFlows {
 				for _, platform := range platforms {
 					entries = append(entries, Entry{
-						Version:     version,
-						ChartPath:   chartDir,
-						Scenario:    scenario.Name,
-						Shortname:   scenario.Shortname,
-						Auth:        scenario.Auth,
-						Flow:        flow,
-						Platform:    platform,
-						InfraType:   resolveInfraType(scenario.InfraType, platform),
-						Exclude:     scenario.Exclude,
-						Enabled:     scenario.Enabled,
-						Identity:    scenario.Identity,
-						Persistence: scenario.Persistence,
-						Features:    scenario.Features,
-						QA:          scenario.QA,
-						ImageTags:   scenario.ImageTags,
-						Upgrade:     scenario.Upgrade,
-						Enterprise:  scenario.Enterprise,
-						SkipE2E:     scenario.SkipE2E,
-						SkipIT:      scenario.SkipIT,
+						Version:      version,
+						ChartPath:    chartDir,
+						Scenario:     scenario.Name,
+						Shortname:    scenario.Shortname,
+						Auth:         scenario.Auth,
+						Flow:         flow,
+						Platform:     platform,
+						InfraType:    resolveInfraType(scenario.InfraType, platform),
+						Exclude:      scenario.Exclude,
+						Enabled:      scenario.Enabled,
+						Identity:     scenario.Identity,
+						Persistence:  scenario.Persistence,
+						Features:     scenario.Features,
+						QA:           scenario.QA,
+						ImageTags:    scenario.ImageTags,
+						Upgrade:      scenario.Upgrade,
+						Enterprise:   scenario.Enterprise,
+						SkipE2E:      scenario.SkipE2E,
+						SkipIT:       scenario.SkipIT,
+						Dependencies: scenario.Dependencies,
 					})
 				}
 			}

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -1495,20 +1495,24 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions, entryIndex 
 
 	// Wire companion chart dependencies from ci-test-config.yaml.
 	// Values file paths are resolved relative to the repo root.
-	// Chart references are passed through as-is (remote repo/chart names)
-	// or resolved to absolute paths (local directories).
+	// Chart references are resolved to absolute paths when they point to an
+	// existing local directory under the repo root; otherwise they are passed
+	// through as-is as remote repo/chart names.
 	if len(entry.Dependencies) > 0 {
 		for _, dep := range entry.Dependencies {
 			chartRef := dep.Chart
-			// If the chart reference looks like a local path (contains a slash
-			// but no repo prefix like "reponame/chartname"), resolve it.
-			if !strings.Contains(dep.Chart, "/") || strings.HasPrefix(dep.Chart, ".") || strings.HasPrefix(dep.Chart, "charts/") {
-				chartRef = filepath.Join(opts.RepoRoot, dep.Chart)
+			version := dep.Version
+			localChartPath := filepath.Join(opts.RepoRoot, dep.Chart)
+			if info, err := os.Stat(localChartPath); err == nil && info.IsDir() {
+				chartRef = localChartPath
+				version = "" // --version is only meaningful for remote charts
 			}
 			cc := config.CompanionChart{
 				ChartRef:    chartRef,
-				Version:     dep.Version,
+				Version:     version,
 				ReleaseName: dep.ReleaseName,
+				RepoName:    dep.RepoName,
+				RepoURL:     dep.RepoURL,
 			}
 			if dep.ValuesFile != "" {
 				cc.ValuesFile = filepath.Join(opts.RepoRoot, dep.ValuesFile)

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -1493,6 +1493,30 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions, entryIndex 
 	flags.ESPoolIndex = strconv.Itoa(entryIndex % numESPools)
 	flags.OSPoolIndex = strconv.Itoa(entryIndex % numOSPools)
 
+	// Wire companion chart dependencies from ci-test-config.yaml.
+	// Values file paths are resolved relative to the repo root.
+	// Chart references are passed through as-is (remote repo/chart names)
+	// or resolved to absolute paths (local directories).
+	if len(entry.Dependencies) > 0 {
+		for _, dep := range entry.Dependencies {
+			chartRef := dep.Chart
+			// If the chart reference looks like a local path (contains a slash
+			// but no repo prefix like "reponame/chartname"), resolve it.
+			if !strings.Contains(dep.Chart, "/") || strings.HasPrefix(dep.Chart, ".") || strings.HasPrefix(dep.Chart, "charts/") {
+				chartRef = filepath.Join(opts.RepoRoot, dep.Chart)
+			}
+			cc := config.CompanionChart{
+				ChartRef:    chartRef,
+				Version:     dep.Version,
+				ReleaseName: dep.ReleaseName,
+			}
+			if dep.ValuesFile != "" {
+				cc.ValuesFile = filepath.Join(opts.RepoRoot, dep.ValuesFile)
+			}
+			flags.CompanionCharts = append(flags.CompanionCharts, cc)
+		}
+	}
+
 	// Wire phase reporting: deploy.Execute and RunTests call flags.OnPhase,
 	// which we forward to the matrix-level OnPhaseChange callback.
 	if opts.OnPhaseChange != nil {

--- a/test/integration/companion-values/opensearch.yaml
+++ b/test/integration/companion-values/opensearch.yaml
@@ -1,0 +1,36 @@
+# CI values for the embedded OpenSearch 3 companion chart.
+# Security disabled, single node, minimal resources for CI/dev environments.
+#
+# Deployed as a separate Helm release by deploy-camunda before the main
+# Camunda chart. Referenced from ci-test-config.yaml dependencies.
+
+clusterName: "opensearch"
+masterService: "opensearch-master"
+
+singleNode: true
+
+replicas: 1
+
+protocol: http
+
+config:
+  opensearch.yml: |
+    cluster.name: opensearch
+    network.host: 0.0.0.0
+    plugins:
+      security:
+        disabled: true
+
+securityConfig:
+  enabled: false
+
+sysctlInit:
+  enabled: true
+
+resources:
+  requests:
+    cpu: "500m"
+    memory: "1Gi"
+  limits:
+    cpu: "1"
+    memory: "2Gi"


### PR DESCRIPTION
## Summary

- Adds a generic `dependencies` mechanism to `ci-test-config.yaml` scenarios that deploys arbitrary Helm charts as companion releases in the same namespace before the main Camunda chart
- Enables testing with infrastructure dependencies (databases, auth providers, etc.) without requiring dedicated managed services or pool-routed external infrastructure
- Includes a disabled `opensearch-embedded` scenario for 8.8, 8.9, and 8.10 that deploys OpenSearch 3.6.0 from the upstream Helm repo as a companion chart

## Motivation

Closes #4728 (part 1 of 2)

Currently, testing Camunda against OpenSearch requires access to shared external OpenSearch pools managed by the CI infrastructure team. This creates bottlenecks and makes it impossible to test against specific OpenSearch versions or configurations in isolation.

This PR adds a general-purpose companion chart deployment feature so that **any Helm chart** (OpenSearch, PostgreSQL, Redis, etc.) can be deployed into the test namespace alongside Camunda. The second PR will enable the opensearch-embedded scenarios in CI.

## How it works

A new `dependencies` block in `ci-test-config.yaml` scenario entries:

```yaml
- name: opensearch-embedded
  enabled: false
  # ... other scenario fields ...
  dependencies:
    - chart: opensearch/opensearch
      version: "3.6.0"
      release-name: opensearch
      values-file: test/integration/companion-values/opensearch.yaml
```

The data flows through the full pipeline:

```
ci-test-config.yaml (dependencies)
  → matrix/config.go (ChartDependency)
  → matrix/matrix.go (Entry.Dependencies)
  → matrix/runner.go (→ config.CompanionChart)
  → deploy/deploy.go (→ types.CompanionChart)
  → deployer/deployer.go (iterates CompanionCharts before main chart)
  → deployer/helm.go (helm upgrade --install --wait --version)
```

Each companion chart is deployed with `helm upgrade --install --wait` to ensure it's fully ready before the main Camunda chart deployment begins.

## Testing

Validated end-to-end on GKE (`distro-ci`) for all three chart versions:

| Version | Result | Time |
|---------|--------|------|
| 8.8 | PASS | ~4m |
| 8.9 | PASS | ~3m |
| 8.10 | PASS | ~3m |

All Camunda pods healthy with zero restarts, connecting to the companion OpenSearch instance at `opensearch-master:9200` over HTTP.

## Files changed

**Go pipeline (companion chart feature):**
- `scripts/deploy-camunda/matrix/config.go` — `ChartDependency` type, `Dependencies` field on `CIScenario`
- `scripts/deploy-camunda/matrix/matrix.go` — `Dependencies` on `Entry`, propagated in `Generate()`
- `scripts/deploy-camunda/matrix/runner.go` — wire `Dependencies` → `CompanionCharts` with path resolution
- `scripts/deploy-camunda/config/merge.go` — `CompanionChart` type, field on `RuntimeFlags`
- `scripts/deploy-camunda/deploy/deploy.go` — `toDeployerCompanionCharts()` converter
- `scripts/camunda-deployer/pkg/types/types.go` — `CompanionChart` type, field on `Options`
- `scripts/camunda-deployer/pkg/deployer/deployer.go` — companion chart deployment loop
- `scripts/camunda-deployer/pkg/deployer/helm.go` — `deployCompanionChart()` function

**Scenario configuration:**
- `charts/camunda-platform-8.{8,9,10}/test/ci-test-config.yaml` — `opensearch-embedded` scenario with `dependencies` block
- `charts/camunda-platform-8.{8,9,10}/.../opensearch-embedded.yaml` — external-style values pointing to companion OpenSearch
- `test/integration/companion-values/opensearch.yaml` — shared companion chart values (security disabled, single node)
- `scripts/camunda-core/pkg/scenarios/scenarios.go` — `opensearch-embedded` in `validPersistence`