### PR TITLE
docs: migrate GitHub wiki content into docs/

### DIFF
--- a/docs/breaking-changes.md
+++ b/docs/breaking-changes.md
@@ -3,6 +3,104 @@ id: breaking-changes
 title: Breaking Changes & Deprecation Policy
 ---
 
-:::caution Coming soon
-This page is being migrated from the [GitHub Wiki](https://github.com/camunda/camunda-platform-helm/wiki/Breaking-Changes-and-Deprecation-Policy).
-:::
+## Definition of a breaking change
+
+A breaking change is any change that breaks a previously stable interface/contract and requires user action to upgrade.
+
+### Helm chart "Public API"
+
+For the Camunda Helm chart, _the stable interface is `values.yaml`_: user-provided values are rendered by Helm templates into Kubernetes manifests. A change is breaking if it changes how existing `values.yaml` inputs map to rendered manifests in a way that is not backward compatible.
+
+### Classifying changes (examples)
+
+- **Feature:** Add a new optional values.yaml field that does not change existing behavior.
+  - _Example_: add an optional metrics section or a new env-var toggle.
+- **Bug:** A defect that forces users to apply mitigations (overrides/workarounds) to get expected behavior.
+  - _Example_: users must set a specific env var or template override to avoid incorrect behavior.
+- **Breaking change:** Remove/rename an existing field, or change its meaning/defaults such that upgrades require user updates.
+  - _Example_: deprecate a values.yaml key without backward compatibility.
+- **Unstructured override interaction:** Changes involving unstructured fields (e.g., `<component>.env` or `<component>.extraConfig`) are typically not breaking API changes to the chart, but can cause upgrade issues due to user-specific overrides; treat resulting incompatibilities as bugs (see [Unstructured fields](#unstructured-fields)).
+  - _Example_: a user-set env var workaround in `operate.env` conflicts after an upgrade because the underlying behavior changed.
+
+## Breaking Change Policy
+
+**Default rule:** Breaking changes are **not allowed in released (non-alpha) patch updates** (e.g., app versions releases `8.9.1 → 8.9.2`). Changes to the `values.yaml` schema, configuration structure, or rendering logic must be backward compatible.
+
+- _Exception:_ A breaking change in a released patch update is allowed only for a critical fix (major bug or security issue) where not changing would leave users severely broken or insecure.
+
+### Allowed cases
+
+- **Alpha charts:** Breaking changes are allowed in alpha Helm charts (e.g., `8.9-alpha3 → 8.9-alpha4`). Alpha releases are for development/testing and do not guarantee stability.
+- **Minor app versions:** Breaking changes are allowed between minor app versions (e.g., `8.8 → 8.9`) only when justifiable, and must follow the **Breaking change checklist**.
+
+## Breaking change checklist
+
+### Evaluate and justify breaking change
+
+A breaking change between minor app versions is justifiable only if all of the following are true:
+
+1. **No reasonable compatible approach:** A backward-compatible design exists only with disproportionate complexity, risk, or long-term maintenance cost (e.g., supporting two schemas/behaviors would be fragile, delay delivery significantly, or create ongoing upgrade/support burden).
+2. **Necessary outcome:** The change is required to deliver at least one of:
+   - a critical fix (security / severe malfunction), or
+   - a correctness fix that prevents wrong/unsafe deployments, or
+   - an essential architectural/maintainability improvement that otherwise blocks future work.
+3. **Customer impact is acceptable and understood:** Impacted users can be identified/estimated, and the migration is practical (clear steps; no "guessing" required).
+4. **Migration is documented:** Exact migration steps exist and can be included in docs/release notes/upgrade guide.
+
+If a breaking change is not justifiable, follow the [Deprecation Policy](#deprecation-policy).
+
+#### Approval / alignment
+
+1. Document and align with EM and PM justification of the breaking change (rationale, scope, customer impact, target version).
+2. Mark the change as breaking in the issue and PR (label `breaking-change` + clear description).
+3. Notify and align with affected stakeholder teams (InfraEx, QA, infra, Reliability Team).
+4. Proceed only once EM/PM approved and stakeholder teams explicitly acknowledged.
+
+#### Documentation
+
+5. Prepare and publish:
+   - Add docs about what changed (breaking behavior) and required customer actions.
+   - Add release notes (breaking change callout).
+   - Add release announcements (link to docs/migration guidance).
+   - Add upgrade guide (steps + links to docs).
+
+#### Merge and final internal communication
+
+- Merge PR(s).
+- Broadcast internally to [#engineering](https://camunda.slack.com/archives/C01H4NG9XDY) and, after alignment with PM, in [#team-tech-gtm](https://camunda.slack.com/archives/C03N6LM5QVD).
+
+## Deprecation Policy
+
+If a breaking change is not justifiable, follow this policy: deprecate first, remove in the next major chart release.
+
+_Default rule:_ Within the same major chart version, customers must not be forced to change values immediately. Deprecations may be introduced in minor releases; removals must only happen in the next major chart release (or via an explicitly announced exception; see [Breaking Change Policy](#breaking-change-policy)).
+
+Major chart releases follow Camunda's release cycle.
+
+### Deprecation Checklist
+
+1. **Deprecate (keep compatibility):**
+   - Add a `values.yaml` comment: `DEPRECATED since vX.Y.Z; remove in vNextMajor; use instead: ...`.
+   - On install/upgrade, warn if the deprecated key is set (old key, replacement, removal version).
+   - If both old and new are set: new wins + warning.
+
+2. **Document:**
+   - Release notes: "Deprecations" entry (old → new, removal version).
+   - Upgrade guide: migration steps (before/after) + removal version.
+   - Examples: use new format only.
+
+3. **Communicate:**
+   - Notify relevant channels/teams (InfraEx, QA, infra, Reliability Team).
+
+4. **Remove (next major only):**
+   - Follow the [Breaking change checklist](#breaking-change-checklist) (after the justification step).
+
+## Reference
+
+### Unstructured fields
+
+A more nuanced discussion arises with unstructured fields, such as `<component>.env`. These allow users to inject arbitrary environment variables into the Camunda platform components (e.g., Operate, Tasklist, or Zeebe). Because these overrides fall outside Helm's awareness or validation scope, they introduce a level of variability that can affect upgrade stability. For example, if a user overrides an environment variable to work around a previous limitation and a subsequent Helm chart update or upstream Camunda release resolves that limitation internally, the existing override may conflict with the new behavior.
+
+From a versioning and stability standpoint, this scenario does not constitute a breaking change in the Helm chart's API. The core capability — the ability to define environment variable overrides — remains stable. However, the functional outcome in the application layer may differ, and if that behavior deviates from expectations, it should be treated as a bug, not a breaking API change.
+
+Framing stability in this way helps maintain consistency in the Camunda Helm chart release process, ensuring that users can rely on `values.yaml` as the stable interface while understanding the inherent risks of unstructured overrides and Helm's limitations in validating them.

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -3,6 +3,71 @@ id: code-style
 title: Code Style
 ---
 
-:::caution Coming soon
-This page is being migrated from the [GitHub Wiki](https://github.com/camunda/camunda-platform-helm/wiki/Code-Style).
+## Deciding what to expose in `values.yaml`
+
+Only expose parameters in the `values.yaml` that are essential for end users or platform operators to configure directly.
+
+`values.yaml` entries typically fall into three main categories:
+
+- **Kubernetes configuration**
+  - Examples include service definitions, ingress configuration, persistence options, resource requests/limits, affinity and tolerations, pod labels/annotations, and autoscaling settings.
+- **Operational app settings**
+  - These cover database connections and credentials, administrative user accounts and passwords, hostnames or URLs, and log level controls.
+- **Opinionated "sane defaults" for UX**
+  - Adding an admin user or `firstUser` to Identity, default redirect URLs for Keycloak/OIDC authentication flows, and disabling multitenancy by default.
+
+Anything that falls outside these groups must have clear user demand or product management approval. This ensures the chart interface remains minimal and meaningful.
+
+:::note
+Keep purely internal or experimental application options out of the `values.yaml`. They belong in application configuration.
+
+For example, database credentials or connection settings may be exposed after explicit approval based on real user requirements, while feature toggles or minor exporter configurations remain purely application-level. Deep application-internal tuning options are not included in the groups mentioned above. Therefore, they must not be included in the Helm chart. Here is an [example issue](https://github.com/camunda/camunda/issues/37725) of application internals that do not belong in the `values.yaml`.
 :::
+
+## Configuration Mechanisms
+
+Applications are configured through Helm using a combination of ConfigMaps, Secrets, and Environment Variables.
+
+- **ConfigMaps:** Default location for component configuration. All non-sensitive application settings should reside here.
+- **Environment Variables:** Used only as a temporary workaround and must be justified. Prefer declarative configuration through ConfigMaps.
+- **Secrets:** All sensitive data (passwords, tokens, credentials) must follow the standard Kubernetes Secret design pattern.
+  - Inline secret: defining the secret as a string literal.
+  - Referenced secret: defining the referenced Kubernetes secret.
+  - Secret key: defining the secret key inside the Kubernetes secret.
+
+:::note
+Please refer to this [example secret configuration in `values.yaml`](https://github.com/camunda/camunda-platform-helm/blob/b776066d71511e63e4f421977c9c59ae4507ae6e/charts/camunda-platform-8.8/values.yaml#L205-L211).
+:::
+
+## Global vs. Component-Specific Configuration
+
+**Do not** introduce new global values unless absolutely necessary. All configuration should remain component-level by default. Components evolve independently across versions. Global keys can obscure version-specific behavior and create tightly coupled dependencies.
+
+Global values are exceptions, allowed only when the following criteria are met:
+
+| **Condition** | **Definition** | **Example** |
+|---|---|---|
+| **Shared semantic meaning** | The parameter represents the same conceptual feature or function across multiple components. | License key applied consistently to all components. |
+| **Stable behavior across versions** | The parameter's meaning and format remain consistent across versions and components. | Common ingress configuration shared across services. |
+| **Simplifies usage** | Adding a global parameter reduces configuration complexity, without hiding necessary component-level differences. | Shared document store settings used by multiple components. |
+
+### Overwriting global values
+
+Global overrides should generally be avoided. The preferred approach is explicit configuration at the component level, managed via Helm anchors to minimize duplication and maintain consistency. If it is necessary to overwrite the global value, then the component-level value should overwrite the global value.
+
+## Helm Defaults vs. Application Defaults
+
+The Helm chart should respect and propagate application-level defaults. The Helm chart should not override application defaults without strong justification.
+
+Good practice:
+
+- Allow upstream application defaults to handle standard behavior.
+- Propose upstream changes through the `values.yaml` if defaults are insufficient (e.g., timeout values, resource limits) instead of overriding them locally in the template.
+
+Here is the layered override chain, taking a Kubernetes ConfigMap as an example:
+
+```
+Helm values.yaml -> ConfigMap -> Pod Config -> Unzipped JAR -> application.yaml -> Application code
+```
+
+The Helm chart should only interact with exposed application defaults, leaving internal default logic to the owning application team.

--- a/docs/contribution-and-collaboration.md
+++ b/docs/contribution-and-collaboration.md
@@ -3,6 +3,248 @@ id: contribution-and-collaboration
 title: Contribution & Collaboration
 ---
 
-:::caution Coming soon
-This page is being migrated from the [GitHub Wiki](https://github.com/camunda/camunda-platform-helm/wiki/Contribution-And-Collaboration).
+The Camunda Helm chart is the integration point between the Camunda application components and Kubernetes. To maintain consistency, reliability, and ownership boundaries, contributions from application teams should follow a structured collaboration process. This ensures all configuration, feature, and bug-fix changes align with established review, testing, and documentation standards.
+
+## When App Teams Should Contribute Independently
+
+App teams are expected to contribute directly when changes primarily affect their application configuration, such as:
+
+- Adjustments to the ConfigMap or application-specific configuration fields.
+- Additions of new configuration properties to `values.yaml` or related templates.
+  - Note: With 8.9+, applications should be configured per default via the [`<component>.extraConfiguration`](https://docs.camunda.io/docs/next/self-managed/deployment/helm/configure/application-configs/#componentnameextraconfiguration) key.
+- Adding or updating secret references (for example, credential or endpoint configurations).
+
+Larger architectural or user-facing changes, such as new components or features that affect multiple components, should always be designed and implemented in collaboration with the Distribution team.
+
+:::note
+Read the [contribution guide](https://github.com/camunda/camunda-platform-helm/blob/main/CONTRIBUTING.md) to learn how to contribute.
 :::
+
+## General Collaboration Workflow
+
+### Initiate discussion (PDP/kickoff)
+
+For any major change, the process begins with a design discussion (PDP or kickoff meeting). The intent is to define the change scope, clarify responsibilities, and ensure alignment with existing Helm and Kubernetes design.
+
+### Determine ownership
+
+Depending on the nature of the change, either:
+
+- The Distro team implements the change directly.
+- The app team member creates the implementation, while the Distro team acts as reviewer and owner of Helm-related concerns.
+
+The Distro team remains the final reviewer and approval authority for all Helm chart modifications.
+
+### Propose an issue
+
+Each contribution begins with a GitHub issue describing:
+
+- Context and motivation.
+- The configuration or feature change.
+- Expected impact on existing values or manifests.
+- Linked documentation or references (if available).
+
+### Alignment and pull request (PR)
+
+Once agreed, the App team raises a PR referencing the issue. The Distro team participates during design review and functional validation stages to ensure chart consistency.
+
+## Contribution Policy
+
+### Configuration documentation
+
+Before adding or modifying any configuration in the Helm chart, contributors must ensure the change is properly documented.
+
+- Ideally, the configuration property should already be reflected in the user documentation.
+- At minimum, a GitHub issue must describe the property clearly — its purpose, effect, default behavior, and any important constraints.
+
+This requirement serves as a hard contribution criterion. Self-Managed engineers review documentation clarity as part of the code review process. Through this step, reviewers also deepen understanding of how the application integrates with its Helm configuration.
+
+:::note
+Configuration values represent the main handover point between the application and the Helm chart. Clear, accurate documentation ensures maintainability and shared understanding across teams.
+:::
+
+### Helm documentation
+
+The `values.yaml` file follows [Helm's best practices](https://helm.sh/docs/chart_best_practices/values/).
+
+This means:
+
+- Variable names should begin with a lowercase letter, and words should be separated using camelCase.
+- Every defined property in `values.yaml` should be documented. The documentation string should begin with the name of the property that it describes, followed by at least a one-sentence description.
+
+We use [bitnami/readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm) to generate the Helm chart values docs from the values file. Ensure to follow the same convention as the tool.
+
+### New applications: minimal requirements
+
+To ensure consistency and operational reliability across all components shipped within the Camunda Platform Helm chart, any new application introduced into the chart must meet a set of minimal, mandatory requirements:
+
+1. **Enable/Disable flag (`enabled`):** Allows users to explicitly opt-in to running the component, avoids accidental deployments, and ensures backward compatibility in chart upgrades.
+2. **Environment Variable Configuration:** Allows users to configure runtime behavior without modifying template files.
+
+   ```yaml
+   <appName>:
+     env: {}
+   ```
+
+3. **TLS / Java Keystore (JKS) Integration:** Provides consistent TLS behavior across all chart components and ensures secure communication patterns are applied uniformly.
+
+   ```yaml
+   <appName>:
+     tls:
+       enabled: false
+       existingSecret: ""
+       jks:
+         secret:
+           existingSecret: ""
+           existingSecretKey: ""
+           inlineSecret: ""
+   ```
+
+### Pull request requirements
+
+Every pull request (PR) related to Helm chart changes must adhere to the following checklist:
+
+- **Linked issue:** Every PR must reference a clearly described GitHub issue.
+- **Unit tests:** Changes should include or update corresponding unit tests where applicable.
+- **Documentation updates:** User or technical documentation must reflect configuration or behavior changes.
+- **Passing CI:** All CI checks must pass successfully before merge.
+- **Code review:** At least one formal review must be completed and approved.
+- **Atomic changes:** Aim for small, focused PRs that address a single issue or configuration change to simplify review and reduce merge complexity.
+
+### Helm version
+
+To have a smooth contribution experience, before working on a new PR make sure to use the exact Helm version that's currently used in the repo.
+
+The Helm version is set in the [`.tool-versions`](https://github.com/camunda/camunda-platform-helm/blob/main/.tool-versions) file, so you can use the [asdf version manager](https://github.com/asdf-vm/asdf) to install Helm locally or just install the same version manually.
+
+To install the Helm version that's used in this repo using asdf, in the repo root, run:
+
+```bash
+make tools.asdf-install
+```
+
+## Tests
+
+:::note
+For more details about Helm chart testing, read the blog post: [Advanced Test Practices For Helm Charts](https://medium.com/@zelldon91/advanced-test-practices-for-helm-charts-587caeeb4cb).
+:::
+
+In order to make sure that the Helm charts work properly and that further development doesn't break anything, we have introduced tests for the Helm charts. The tests are written in Go, using the [Terratest framework](https://terratest.gruntwork.io/).
+
+We separate our tests into two parts, with different targets and goals.
+
+1. **Template tests** (unit tests) verify the general structure. Is it YAML-conformant, does it have the right value/structure if set, do the default values not change or are they set at all?
+2. **Integration tests** verify whether the charts can be installed and used. This means: are the manifests accepted by the K8s API, and do they work? (it can be valid YAML but not accepted by Kubernetes). Can the services reach each other and are they working?
+
+**For new contributions it is expected to write new unit tests, but no integration tests.** We keep the count of integration tests to a minimum, and the knowledge for writing them is not expected for contributors.
+
+Tests can be found in the chart directory under `test/`. For each component we have a sub-directory in the `test/` directory.
+
+To run the tests, execute `make go.test` at the repository root.
+
+### Unit tests
+
+As mentioned earlier, we expect unit tests on new contributions. The unit tests (template tests) are divided into two parts: golden file tests and explicit property tests. In this section we explain when which test type should be used.
+
+#### Golden files
+
+We write new golden file tests for default values, where we can compare a complete manifest with its properties. Most of the golden file tests are part of `goldenfiles_test.go` in the corresponding sub-chart testing directory. For an example see `/test/zeebe/goldenfiles_test.go`.
+
+If the complete manifest can be enabled by a toggle, we also write a golden file test. This test is part of a `<manifestFileName>_test.go` file. The `<manifestFileName>` corresponds to the template filename in the sub-chart `templates` dir. For example, the Prometheus `templates/service-monitor.yaml` can be enabled by a toggle, so we write a golden file test in `test/servicemonitor_test.go`.
+
+To generate the golden files, run `go.test-golden-updated` at the repository root. This will add a new golden file in a `golden` sub-dir and run the corresponding test. The golden files should be named related to the manifest.
+
+#### Properties tests
+
+For things that are not enabled or set by default, we write a property test. Here we directly set the specific property/variable and verify that the Helm chart can be rendered and the property is set correctly on the object. This kind of test should be part of a `<manifestFileName>_test.go` file. The `<manifestFileName>` corresponds to the template filename in the sub-chart `templates` dir. For example, for the Zeebe StatefulSet manifest we have the test `test/zeebe/statefulset_test.go` under the `zeebe` sub-dir.
+
+It is always helpful to check existing tests to get a better understanding of how to write new tests, so do not hesitate to read and copy from them.
+
+### Test license headers
+
+Make sure that new Go tests contain the Apache license headers, otherwise the CI license check will fail. For adding and checking the license we use [addlicense](https://github.com/google/addlicense). To install it locally, run `make go.addlicense-install`. Afterward, you can run `make go.addlicense-run` to add the missing license header to a new Go file.
+
+## Backporting Policy
+
+Backports exist to deliver **critical fixes and stability improvements** to **actively supported** Camunda Helm chart releases, while minimizing regression risk and avoiding surprising changes for users.
+
+**Golden rule:** _If upgrading to a patch release changes a user's deployment in an unexpected way, the backport failed._
+
+Backporting must only be performed within actively supported versions as defined by the [Standard and Extended Support Periods](https://confluence.camunda.com/spaces/HAN/pages/245400921/Standard+and+Extended+Support+Periods).
+
+### Quick decision flow
+
+```mermaid
+graph TD
+    Start([Backport candidate]) --> V{Supported version?}
+    V -- No --> End([Archive: not supported])
+
+    V -- Yes --> R{New key in<br/>values.yaml?}
+    R -- Yes --> Reject([Reject: structural change])
+
+    R -- No --> M{Rendered output changes?}
+    M -- Yes --> B{Fixes documented bug?}
+    B -- No --> Reject
+    B -- Yes --> Approval([Maintainer approval])
+
+    M -- No --> Test{Golden tests<br/>match?}
+    Test -- No --> Reject
+    Test -- Yes --> Approval
+```
+
+### What we backport
+
+We backport only changes that are **safe and predictable**:
+
+- **Vital:** security fixes and "won't install / won't start" problems.
+- **Functional:** logic/template fixes or documentation fixes that **do not change the chart API**.
+
+### What we do _not_ backport
+
+We reject backports that are likely to surprise users:
+
+- **Structural:** anything that adds/changes the config surface (especially new keys/toggles in `values.yaml`) or big dependency upgrades.
+- **Anything requiring manual intervention:** if users must run commands or edit/delete resources, it's a migration and must wait for a minor/major release.
+- **Unexpected manifest changes:** if the rendered output changes in places unrelated to the bug fix, it's blocked.
+
+### General backporting guidance
+
+Backports must be minimal and focused on corrective action. Prefer smaller PRs targeting specific issues.
+
+All backports should maintain consistent behavior across supported versions to ensure predictability during upgrades.
+
+Each backport PR should include clear labeling (for example, `backport/<release>`) and link to the original fix or discussion for traceability.
+
+Backported changes follow the same testing and documentation requirements as any mainline contribution. CI must pass and any altered functionality must be covered by tests.
+
+### Backporting commits in subdirectory versioning
+
+#### `format-patch`
+
+`git format-patch` will export the git commits to a series of patch files that can be applied to a different branch or a different sub-directory.
+
+To export the last 3 commits as patch files, run:
+
+```bash
+git format-patch HEAD^3
+```
+
+New files will be created starting with `0001-`, `0002-`, etc.
+
+#### Applying patch files without AI
+
+Suppose you have a patch file `0001-refactor-web-modeler-make-webapp-memory-config-dynam.patch` that you want to apply to the `charts/camunda-platform-8.7` directory:
+
+```bash
+git apply -p3 --directory=charts/camunda-platform-8.7 0001-refactor-web-modeler-make-webapp-memory-config-dynam.patch
+```
+
+In many cases, this will apply cleanly. If the command does not work, you can try using OpenCode or your editor's AI integration.
+
+#### Applying patch files with AI
+
+If you have an AI tool integrated into your IDE, a query you can use is:
+
+```
+I have exported commits as patch files starting with 000*.patch using git format-patch. Please apply the patch to the charts/camunda-platform-8.7 directory.
+```

--- a/docs/github-actions-workflows.md
+++ b/docs/github-actions-workflows.md
@@ -3,6 +3,401 @@ id: github-actions-workflows
 title: GitHub Actions Workflows
 ---
 
-:::caution Coming soon
-This page is being migrated from the [GitHub Wiki](https://github.com/camunda/camunda-platform-helm/wiki/GitHub-Actions-Workflows).
-:::
+This repo has many [GitHub Actions workflows](https://github.com/camunda/camunda-platform-helm/tree/main/.github/workflows) for different aspects of the CI pipelines.
+
+- [Camunda Helm chart deployment](#camunda-helm-chart-deployment)
+  - [Getting started](#getting-started)
+  - [Workflow inputs](#workflow-inputs)
+  - [Workflow patterns](#workflow-patterns)
+- [Check `values-latest.yaml`](#check-values-latestyaml)
+- [Integration test workflows](#integration-test-workflows)
+
+## Camunda Helm chart deployment
+
+The Distro team provides a GitHub Actions workflow to deploy the Camunda Helm chart via GitHub Actions. This workflow is customizable and supports different patterns. For example: disabling integration tests, single namespace, multi-namespace, persistent setup with a defined TTL (not deleted after the workflow), and more.
+
+### Getting started
+
+The quickest way to use this workflow is the example template:
+
+- Copy [`test-helm-chart.yaml`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/examples/test-helm-chart.yaml) to your repo under `.github/workflows/test-helm-chart.yaml`.
+- Replace `<USE_CASE>` in that file with a clear identifier for your use case (e.g. `my-team-dev-env`).
+- **Done.** The Helm chart integration test will run with each PR in your repo.
+
+You can see the workflow in action on the Camunda apps repo: [Camunda Helm Chart Integration Test](https://github.com/camunda/camunda/actions/workflows/camunda-helm-integration.yaml).
+
+### Workflow inputs
+
+These inputs allow you to customize Helm chart deployments.
+
+In most cases, you just need to set `identifier`, `camunda-helm-dir`, and `extra-values`.
+
+```yaml
+jobs:
+  # ...
+  helm-deploy:
+    name: Helm chart Integration Tests
+    uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main
+    secrets: inherit
+    with:
+      # Unique identifier used in the deployment hostname
+      # Required: true
+      identifier: 'console-team-dev-env'
+
+      # A reference for the Camunda Helm chart directory which allows testing unreleased changes from the Git repo.
+      # The latest supported chart doesn't have a version in its directory name like `camunda-platform`.
+      # The previous releases have the Camunda version in their directory name e.g. `camunda-platform-8.4`.
+      # Required: true
+      camunda-helm-dir: 'camunda-platform-8.8'
+
+      # Optional: Deploy the packaged chart artifact from the OCI registry instead of packaging from the git checkout.
+      # Example values: '13.4.0-rc', '13.4.0', '13.4.0-dev-abc1234'
+      # Required: false
+      helmChartVersion: ''
+
+      # Pass extra values to the Helm chart during deployment
+      # Default: ''
+      # Required: false
+      extra-values: |
+        global:
+          image:
+            tag: 8.2.10
+        console:
+          image:
+            tag: xyz
+
+      # Git reference for the Camunda Helm chart repository
+      # Default: 'main'
+      # Required: false
+      camunda-helm-git-ref: 'main'
+
+      # Git reference of the caller's repository (branch, tag, or commit SHA) that initiated the workflow
+      # Default: 'main'
+      # Required: false
+      caller-git-ref: 'main'
+
+      # Define a TTL for the deployment after the workflow is completed
+      # Note: All persistent deployments will be deleted frequently to save costs
+      # Default: ''
+      # Required: false
+      deployment-ttl: ''
+
+      # Specifies the cloud platform that is currently used
+      # Default: 'gke'
+      # Required: false
+      platforms: 'gke'
+
+      # Types of operations to perform with the Helm chart, like install, upgrade
+      # Default: 'install'
+      # Required: false
+      flows: 'install'
+
+      # Flag to enable or disable the execution of test scenarios after Helm chart deployment
+      # Default: true
+      # Required: false
+      test-enabled: true
+
+      # Define the infrastructure that will be used to run the deployment.
+      # Default: 'preemptible'
+      # Required: false
+      infra-type: 'preemptible'
+```
+
+<details>
+  <summary>Notes</summary>
+
+**General**
+
+- Adjust `identifier`, `caller-git-ref`, `flows`, `test-enabled`, and `extra-values` as needed for your specific testing scenario.
+- The `identifier` is essential for distinguishing between different deployments, particularly useful in environments with multiple parallel deployments.
+- For `extra-values`, ensure the YAML format is correct and that the values specified meet the requirements for your environment.
+- For more details on how to use these inputs within the workflow or to modify them for specific testing needs, refer to the official [GitHub Actions documentation](https://docs.github.com/en/actions).
+
+**Lifecycle**
+
+- The default behavior in the integration tests workflow is to delete the test resources after the test is finished.
+- To keep the deployment for at least one day, set `deployment-ttl: 1d`.
+- You need to rerun the workflow when you need the deployment to be persistent with a defined `deployment-ttl`.
+- Example `deployment-ttl` values:
+  - `360s`: 360 seconds
+  - `10m`: 10 minutes
+  - `24h`: 24 hours
+  - `7d`: 7 days
+  - `2w`: 2 weeks
+
+</details>
+
+### Workflow patterns
+
+The most important workflow is the [main integration workflow](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/test-integration-template.yaml), where each Camunda component can reuse that workflow in their CI pipelines to ensure each component works as expected within Camunda as a whole.
+
+#### Single namespace
+
+To embed the Camunda Helm chart integration tests in your GHA workflow, use the following:
+
+```yaml
+jobs:
+  # ...
+  helm-deploy:
+    name: Helm chart Integration Tests
+    uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main
+    secrets: inherit
+    with:
+      identifier: dev-console-sm
+      extra-values: |
+        global:
+          image:
+            tag: 8.2.10
+        console:
+          image:
+            tag: xyz
+```
+
+Adding that will run Camunda Helm chart integration tests and add the deployment URL in your repo (the URL will show in the PR or the GH deployment section).
+
+Check the example in the [Getting started](#getting-started) section for more details.
+
+#### Multi-namespace
+
+```yaml
+jobs:
+  # ...
+  helm-deploy:
+    strategy:
+      matrix:
+        deployment:
+          - id: management
+            extra-values: |
+              zeebe:
+                enabled: false
+              zeebeGateway:
+                enabled: false
+              operate:
+                enabled: false
+              tasklist:
+                enabled: false
+              optimize:
+                enabled: false
+              connectors:
+                enabled: false
+              elasticsearch:
+                enabled: false
+          - id: team01
+            extra-values: |
+              global:
+                identity:
+                  service:
+                    url: "http://integration-identity.camunda-platform-id-dev-console-sm-main.svc.cluster.local:80/identity"
+                  keycloak:
+                    url:
+                      protocol: "http"
+                      host: "integration-keycloak.camunda-platform-id-dev-console-sm-main.svc.cluster.local"
+                      port: "80"
+              identity:
+                enabled: false
+              webModeler:
+                enabled: false
+              postgresql:
+                enabled: false
+              console:
+                enabled: false
+          - id: team02
+            extra-values: |
+              global:
+                identity:
+                  service:
+                    url: "http://integration-identity.camunda-platform-id-dev-console-sm-main.svc.cluster.local:80/identity"
+                  keycloak:
+                    url:
+                      protocol: "http"
+                      host: "integration-keycloak.camunda-platform-id-dev-console-sm-main.svc.cluster.local"
+                      port: "80"
+              identity:
+                enabled: false
+              webModeler:
+                enabled: false
+              postgresql:
+                enabled: false
+              console:
+                enabled: false
+    name: Helm integration tests - ${{ matrix.deployment.id }}
+    uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main
+    secrets: inherit
+    with:
+      identifier: dev-console-sm-${{ matrix.deployment.id }}
+      deployment-ttl: 1d
+      extra-values: |
+        ${{ matrix.deployment.extra-values }}
+```
+
+#### Persistent deployment
+
+If you have long-running workflows with multiple jobs, you can set `deployment-ttl: 1d`, which keeps the deployment namespace for one day instead of deleting it after the workflow is done.
+
+#### Non-ephemeral infrastructure
+
+By default, all of our CI workloads run on preemptible nodes, meaning the workflows should be fault-tolerant and have a retry mechanism. If your team needs a stable, non-ephemeral infrastructure, please contact the Distribution team for instructions.
+
+## Check `values-latest.yaml`
+
+The [`check-values-latest.yaml`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/check-values-latest.yaml) workflow validates that all `values-latest.yaml` files contain the latest Docker image versions for Camunda components.
+
+### Purpose
+
+We provide `values-latest.yaml` files as a method to install the latest app versions even before the next Helm chart is released. These files are automatically updated by Renovate, but this workflow validates that the auto-update process is working correctly.
+
+### When it runs
+
+- **Daily:** Scheduled to run at 6 AM UTC every day.
+- **On pull requests:** When changes are made to:
+  - `charts/camunda-platform-*/values-latest.yaml`
+  - `scripts/check-values-latest.sh`
+  - `.github/workflows/check-values-latest.yaml`
+- **Manually:** Via `workflow_dispatch` with an optional chart version parameter.
+
+### What it checks
+
+The workflow validates that image tags in `values-latest.yaml` files match the latest available tags in Docker Hub for:
+
+- Camunda components (console, connectors, operate, optimize, tasklist, zeebe, identity, webModeler).
+- All supported chart versions (8.2, 8.3, 8.4, 8.5, 8.6, 8.7, 8.8, 8.9).
+
+### Behavior
+
+- **SNAPSHOT/alpha tags:** Automatically skipped, as they always represent the latest development versions.
+- **Non-Camunda images:** Currently skipped (Bitnami images, etc.).
+- **Validation failures:** The workflow fails and comments on PRs if any image versions are outdated.
+
+### Manual usage
+
+To check a specific chart version:
+
+```yaml
+# Via GitHub UI: Actions > Check values-latest.yaml > Run workflow
+# Specify chart version (e.g. 8.7) or leave empty to check all versions
+```
+
+To run the validation script locally:
+
+```bash
+# Check all chart versions
+./scripts/check-values-latest.sh
+
+# Check specific version
+./scripts/check-values-latest.sh 8.7
+```
+
+#### Image git commit information
+
+The integration test workflows automatically display git commit information for each Docker image used in the deployment. This information appears in the GitHub Actions job summary after the Helm install or upgrade completes.
+
+The feature:
+
+- Extracts the `org.opencontainers.image.revision` label from each Docker image using `skopeo`.
+- Uses remote image inspection without pulling full images (fast and efficient).
+- Displays the git commit hash in a markdown table format.
+- Makes it easy to trace a CI job to specific application commits.
+- Eliminates the need to manually pull and inspect Docker images.
+
+Example output:
+
+| Component | Git Commit |
+|---|---|
+| zeebe | `f508f35d5b4` |
+| operate | `f508f35d5b4` |
+| tasklist | `f508f35d5b4` |
+
+This information is displayed automatically for all workflows using the `test-integration` templates.
+
+## Integration test workflows
+
+Integration tests use a three-layer workflow chain. Each layer fans out via GitHub Actions matrix strategies to test across platforms (GKE, EKS, ROSA) and flows (install, upgrade) in parallel.
+
+```
+test-chart-version-template.yaml          (Layer 1: per-platform dispatch)
+  └─▶ test-integration-template.yaml      (Layer 2: platform × flow matrix generation)
+       └─▶ test-integration-runner.yaml   (Layer 3: deploy + test execution per shard)
+```
+
+### Why three layers?
+
+GitHub Actions' `needs` keyword waits for _all_ matrix legs of an upstream job before _any_ downstream job starts. Without sharding into separate reusable workflow calls, GKE tests would block until the slowest platform (e.g. ROSA) finishes installing. Each reusable workflow call is an independent "shard" with its own `install → upgrade → test` pipeline, so platforms don't wait on each other.
+
+### Layer 1: `test-chart-version-template`
+
+> [`.github/workflows/test-chart-version-template.yaml`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/test-chart-version-template.yaml)
+
+Entry point called by PR and release workflows. Splits `platforms` (e.g. `"gke,eks"`) into a JSON array and calls Layer 2 once per platform. Sets `deployment-ttl` to `1w` when the PR has the `test-persistent` label.
+
+### Layer 2: `test-integration-template`
+
+> [`.github/workflows/test-integration-template.yaml`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/test-integration-template.yaml)
+
+Generates the full **platform × flow** matrix and dispatches each combination to Layer 3.
+
+#### How matrix generation works
+
+The `init` job reads [`.github/config/test-integration-matrix.yaml`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/config/test-integration-matrix.yaml) — a YAML file with `$VARIABLE` placeholders in `if` fields. The job:
+
+1. Exports boolean env vars (`INPUTS_PLATFORMS_GKE=true`, `INPUTS_FLOWS_INSTALL=false`, etc.) based on the workflow inputs.
+2. Runs `envsubst` to replace the `$VARIABLE` references with `true`/`false`.
+3. Relies on the matrix `exclude` block to remove entries where `if: false`.
+4. Converts the result to JSON via `yq` for the runner's `strategy.matrix`.
+
+The `matrix-data` input can override the file-based matrix entirely.
+
+### Layer 3: `test-integration-runner`
+
+> [`.github/workflows/test-integration-runner.yaml`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/test-integration-runner.yaml)
+
+Executes a single shard (one platform + one flow). Job dependency graph:
+
+```
+install ─────┬──→ upgrade ──────┬──→ playwright-ITs-after-upgrade ──┐
+             │                  └──→ playwright-e2e-after-upgrade ───┤
+             ├──→ playwright-ITs-after-install ─────────────────────┤
+             └──→ playwright-e2e-after-install ─────────────────────┤
+                                                                    ↓
+                                                          merge-e2e-reports
+                                                                    ↓
+                                                                cleanup
+```
+
+- **`install` flow:** install → tests → cleanup.
+- **`upgrade-*` flows:** install (old version) → upgrade (current version) → tests → cleanup.
+- **`modular-upgrade-minor`:** install skipped → upgrade only → tests → cleanup.
+
+Each job runs in a fresh container and re-authenticates to the cluster independently. The Kubernetes namespace is the shared state between jobs.
+
+### Test flows
+
+#### `install`
+
+Fresh deployment of the current branch's chart. Validates the chart installs cleanly.
+
+#### `upgrade-patch`
+
+Upgrade within the same minor version (e.g. `8.8.0 → 8.8.1`). The install job deploys the **latest released chart version** (via `camunda-helm-upgrade-version`), then the upgrade job upgrades to the current branch. A [pre-upgrade script](https://github.com/camunda/camunda-platform-helm/blob/main/charts/camunda-platform-8.8/test/integration/scenarios/pre-setup-scripts/pre-upgrade-patch.sh) handles incompatible resource cleanup (StatefulSets, PVCs).
+
+#### `upgrade-minor`
+
+Upgrade across minor versions (e.g. `8.7 → 8.8`). The install job deploys the **previous minor version** (via `camunda-version-previous`), then the upgrade job upgrades to the current version. For chart version 13+ (Camunda 8.13+), the upgrade automatically enables the data migrator.
+
+#### `modular-upgrade-minor`
+
+Component-by-component upgrade from a previous minor version. This flow **skips the install job** — it expects the namespace and Helm release to already exist from a prior deployment. It uses the same namespace (no suffix) as the install flow and runs only the upgrade job.
+
+> **Important:** This flow cannot be invoked via `generate-chart-matrix.sh`. It must be called directly on `test-integration-template.yaml`. When used alongside `install` in the same flows string (e.g. `"install,modular-upgrade-minor"`), the two run as independent shards with **no ordering guarantee**.
+
+### Namespace management
+
+Each flow creates (or reuses) a namespace with a flow-specific suffix:
+
+| Flow | Suffix | Example |
+|---|---|---|
+| `install` | _(none)_ | `ci-1234-intg-8.9-gke-es` |
+| `upgrade-patch` | `-upgp` | `ci-1234-intg-8.9-gke-es-upgp` |
+| `upgrade-minor` | `-upgm` | `ci-1234-intg-8.9-gke-es-upgm` |
+| `modular-upgrade-minor` | _(none, reuses install)_ | `ci-1234-intg-8.9-gke-es` |
+
+Namespaces are annotated with `cleaner/ttl` and `janitor/ttl` for automatic deletion by cluster-level cleaners, even if the workflow is cancelled. See [`.github/actions/workflow-vars/action.yaml`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/actions/workflow-vars/action.yaml) for naming logic.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -3,6 +3,249 @@ id: release-process
 title: Release Process
 ---
 
-:::caution Coming soon
-This page is being migrated from the [GitHub Wiki](https://github.com/camunda/camunda-platform-helm/wiki/Release-Process).
-:::
+The charts are built, linted, and tested on every push to the main branch. The release process follows a **3-stage pipeline** that ensures the exact artifact tested by QA is what gets publicly released — no rebuilding at release time.
+
+## Architecture Overview
+
+```
+┌─────────────────────┐     ┌─────────────────────┐     ┌─────────────────────┐
+│  1. DEV BUILD       │     │  2. RC PROMOTION    │     │  3. PUBLIC RELEASE  │
+│  (Every merge)      │ ──► │  (Manual trigger)   │ ──► │  (Manual trigger)   │
+├─────────────────────┤     ├─────────────────────┤     ├─────────────────────┤
+│ • Build dev package │     │ • Retag dev → RC    │     │ • Pull RC from      │
+│ • Push to Harbor    │     │ • Create release-   │     │   Harbor            │
+│ • Cosign signing    │     │   please PR         │     │ • Publish to GitHub │
+│ • Available for QA  │     │ • QA validation     │     │   Releases          │
+└─────────────────────┘     └─────────────────────┘     └─────────────────────┘
+        ↓                           ↓                           ↓
+   Harbor (internal)          Harbor (retag only)        GitHub Releases
+   {version}-dev-{sha}        {version}-rc               helm.camunda.io
+```
+
+## Registries
+
+| Registry | Purpose | Access |
+|---|---|---|
+| **Harbor** (`registry.camunda.cloud/team-distribution`) | Internal dev/RC storage | Internal only |
+| **GitHub Releases** (`helm.camunda.io`) | Public releases | Public |
+
+## Release Pipeline
+
+### Stage 1: Dev Package Build
+
+**Workflow:** [`chart-build-dev.yaml`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/chart-build-dev.yaml)
+
+**Trigger:** Automatic on every merge to `main` (for paths: `charts/camunda-platform-*/**`).
+
+**What happens:**
+
+1. Builds dev packages for all **active** chart versions (alpha + standard support).
+2. Computes the release version using `release-please --dry-run`.
+3. Applies release transformations (removes dev comments, badges).
+4. Generates release notes using `generate-release-notes.sh` (included in the package).
+5. Packages the chart with the **final release version** in `Chart.yaml`.
+6. Pushes to Harbor with dev tags.
+7. Signs with Cosign.
+
+**Tagging scheme:**
+
+| Tag | Example | Purpose |
+|---|---|---|
+| `{version}-dev-{sha}` | `13.4.0-dev-abc1234` | Immutable, traceable to commit |
+| `{chart-major}-dev-latest` | `13-dev-latest` | Rolling, always points to latest |
+
+**Workflow summary** shows:
+
+- Package location and tags.
+- All component image versions (from `values.yaml`).
+- Cosign verification status.
+
+> **Note:** The `Chart.yaml` inside the package contains the **real release version** (e.g. `13.4.0`), not the dev tag. This is computed via `release-please` dry-run at build time.
+
+### Stage 2: RC Promotion
+
+**Workflow:** [`chart-promote-rc.yaml`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/chart-promote-rc.yaml)
+
+**Trigger:** Manual `workflow_dispatch` with input:
+
+- `dev-tag`: The dev package to promote (e.g. `13.4.0-dev-abc1234` or `13-dev-latest`).
+
+**What happens:**
+
+1. Resolves rolling tags to actual dev tags via the Harbor API.
+2. Validates the commit is on the `main` branch.
+3. Runs `release-please release-pr` to create/update the release PR.
+4. Adds RC tags to the **same artifact** in Harbor (no rebuild!).
+
+**Tagging scheme:**
+
+| Tag | Example | Purpose |
+|---|---|---|
+| `{version}-rc` | `13.4.0-rc` | Immutable RC tag |
+| `{chart-major}-rc-latest` | `13-rc-latest` | Rolling, always points to latest RC |
+
+**Release-Please PR:**
+
+- Updates `Chart.yaml` version and changelog annotations.
+- Updates `.release-please-manifest.json`.
+- Triggers `chart-release-chores.yaml`, which generates:
+  - Release notes (`RELEASE-NOTES.md`).
+  - Version matrix files (component versions mapping).
+  - Updated README.
+
+### Stage 3: Public Release
+
+**Workflow:** [`chart-release-public.yaml`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/chart-release-public.yaml)
+
+**Trigger:** Manual `workflow_dispatch` with input:
+
+- `rc-tag`: The RC package to release (e.g. `13.4.0-rc` or `13-rc-latest`).
+
+**What happens:**
+
+1. Pulls the RC package from Harbor.
+2. Extracts metadata (version, app version) from the packaged `Chart.yaml`.
+3. Uploads to GitHub Releases using `helm-cr`.
+4. Updates the Helm repo index (`gh-pages` branch).
+5. Signs with Cosign and uploads the bundle to the release.
+6. Labels the `release-please` PR with `autorelease: published`.
+
+**Release tag format:** `camunda-platform-{appVersion}-{version}` (e.g. `camunda-platform-8.8-13.4.0`).
+
+**After public release:**
+
+1. Merge the `release-please` PR to sync `main` with the released artifact.
+2. This triggers `chart-public-files.yaml` to update:
+   - [Version matrix](https://helm.camunda.io/camunda-platform/version-matrix/) (component versions for each chart release).
+   - Public values files at `helm.camunda.io/camunda-platform/values/`.
+
+## Release Process Flowchart
+
+```mermaid
+graph TD
+    Step1[Step 1<br/>Automated<br/>---<br/>Dev packages built on every merge<br/>Renovatebot updates automerge]
+    Step2[Step 2<br/>Manual<br/>---<br/>Release manager verifies image versions<br/>and triggers RC Promotion]
+    Step3[Step 3<br/>Automated<br/>---<br/>Release-please creates PR<br/>Release chores generate notes + matrix]
+    Step4[Step 4<br/>External<br/>---<br/>QA tests RC package from Harbor]
+    Step5[Step 5<br/>Manual<br/>---<br/>Release manager triggers Public Release]
+    Step6[Step 6<br/>Manual<br/>---<br/>Release manager merges release-please PR<br/>Public files updated on helm.camunda.io]
+
+    Step1 ==> Step2
+    Step2 ==> Step3
+    Step3 ==> Step4
+    Step4 == QA sign-off ==> Step5
+    Step5 ==> Step6
+```
+
+## Version Tagging Summary
+
+| Stage | OCI Tag | `Chart.yaml` Version | Registry |
+|---|---|---|---|
+| Dev | `{version}-dev-{sha}` | `{version}` | Harbor |
+| RC | `{version}-rc` | `{version}` | Harbor |
+| Public | N/A (GitHub Release) | `{version}` | GitHub Releases |
+
+**Camunda version derivation:** The Helm chart major version maps to a Camunda version:
+
+- `11.x` = Camunda 8.6
+- `12.x` = Camunda 8.7
+- `13.x` = Camunda 8.8
+- `14.x` = Camunda 8.9
+
+## Supported Versions
+
+Active chart versions are defined in [`charts/chart-versions.yaml`](https://github.com/camunda/camunda-platform-helm/blob/main/charts/chart-versions.yaml).
+
+## Minor Version Chores
+
+When Camunda releases a new minor version (typically every 6 months), the following changes are needed.
+
+Assuming `current alpha is 8.9` (which will become `stable`) and the `new alpha is 8.10`:
+
+**Before starting:**
+
+1. Label all existing PRs with `backport-to-latest` so contributors know their PRs need updating.
+
+**Chart files updates:**
+
+1. Copy `charts/camunda-platform-8.9` to `charts/camunda-platform-8.10`.
+2. Update chart version in `charts/camunda-platform-8.9/Chart.yaml` (remove alpha, e.g. `14.0.0-alpha5` → `14.0.0`).
+3. Update image tags in `charts/camunda-platform-8.9/values-latest.yaml` (no `SNAPSHOT` tags).
+4. Update chart version in `charts/camunda-platform-8.10/Chart.yaml` (bump major, reset alpha, e.g. `14.0.0-alpha5` → `15.0.0-alpha1`).
+
+**Configuration files updates:**
+
+1. Update [`charts/chart-versions.yaml`](https://github.com/camunda/camunda-platform-helm/blob/main/charts/chart-versions.yaml).
+2. Update Release-Please config and manifest in `.github/config/release-please/`.
+3. Update [`renovate.json5`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/renovate.json5).
+4. Update GitHub Actions with version choices (search for `type: choice`).
+5. Update [`chart-release-snapshot.yaml`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/chart-release-snapshot.yaml) with new chart paths.
+6. Update [`pr-labeler.yaml`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/config/pr-labeler.yaml).
+7. Update `docs/release.md` examples.
+
+**Create a PR with the changes, and once merged, follow the normal release process.**
+
+## Artifact Hub
+
+The [Camunda repo](https://artifacthub.io/packages/search?repo=camunda) is configured on Artifact Hub. After a release, Artifact Hub automatically scans and indexes the new version.
+
+> **Note:** Charts may take up to 30 minutes to appear on Artifact Hub. After successful release, charts are immediately available via [`helm.camunda.io`](https://helm.camunda.io).
+
+## Troubleshooting
+
+### Dev package not found
+
+If RC promotion fails because the dev package doesn't exist:
+
+1. Check if the commit SHA is correct.
+2. Verify the dev build workflow succeeded for that commit.
+3. Check Harbor directly for available tags.
+
+### Release-Please PR not created
+
+If the RC promotion workflow doesn't create a `release-please` PR:
+
+1. Check for existing unmerged `release-please` PRs with the `autorelease: pending` label.
+2. Verify there are releasable commits (conventional commit format required).
+3. Check the `release-please` logs for errors.
+
+### Release already exists
+
+If the public release fails because the release tag already exists:
+
+1. Delete the existing release: `gh release delete <tag> --yes`.
+2. Re-run the public release workflow.
+
+### Image version mismatch
+
+Before promoting to RC, verify component image versions match the release train:
+
+1. Check the dev build workflow summary for image versions.
+2. Compare with the release train announcement (Slack/Tasklist).
+3. If there's a mismatch:
+   - **Option A:** Wait for Renovatebot to update and automerge.
+   - **Option B:** Manually trigger `chart-build-dev.yaml` with specific image tag inputs (the workflow supports overriding individual component versions).
+   - **Option C:** Manually create a PR to update `values.yaml`.
+
+## Related Workflows
+
+| Workflow | Purpose |
+|---|---|
+| [`chart-build-dev.yaml`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/chart-build-dev.yaml) | Stage 1: Build dev packages |
+| [`chart-promote-rc.yaml`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/chart-promote-rc.yaml) | Stage 2: Promote dev → RC |
+| [`chart-release-public.yaml`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/chart-release-public.yaml) | Stage 3: Publish to GitHub Releases |
+| [`chart-release-chores.yaml`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/chart-release-chores.yaml) | Auto-generate release notes, version matrix |
+| [`chart-release-artifact-verify.yaml`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/chart-release-artifact-verify.yaml) | Daily Cosign verification |
+| [`chart-public-files.yaml`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/chart-public-files.yaml) | Update public docs after PR merge |
+
+## Release Process Change Policy
+
+Avoid surprises during releases by ensuring all release-affecting changes are communicated clearly and early.
+
+Requirements:
+
+- Communicate before the change goes live.
+- Announce in `#c8-release-announcements` and CC:
+  - `@monorepo-release-manager`
+  - `@qa-release-manager`
+  - Others if relevant

--- a/docs/ticket-and-label-policy.md
+++ b/docs/ticket-and-label-policy.md
@@ -3,6 +3,104 @@ id: ticket-and-label-policy
 title: Ticket & Label Policy
 ---
 
-:::caution Coming soon
-This page is being migrated from the [GitHub Wiki](https://github.com/camunda/camunda-platform-helm/wiki/Ticket-and-Label-Policy).
-:::
+## 1. Ticket Creation Policy
+
+- Every Pull Request (PR) **must** be linked to a ticket.
+  - Preferred: use GitHub keywords in the PR description (e.g. "Closes #123", "Relates to #123").
+  - Exception (automation): for PRs created by automation (e.g. Renovate, `release-please`), the PR itself can serve as the tracking item if it carries the appropriate `automation/*` label.
+- Tickets are managed in one of the following systems:
+  - **Camunda Product Hub**
+  - **Internal Team Board**
+
+## 2. Scope Definition: Product Hub vs. Internal Team Board
+
+### Use **Camunda Product Hub** when the work:
+
+- Delivers significant customer-facing value.
+- Requires customer discovery and/or customer feedback inputs.
+- Requires coordination across multiple teams or stakeholders.
+- Introduces or changes public APIs or core platform components.
+- Has cross-team dependencies.
+
+> Product Hub epics must be created by PMs.
+
+### Use the **Internal Team Board** when the work:
+
+- Is limited in scope and owned by our team.
+- Can be delivered without broader coordination.
+- Covers internal improvements such as bug fixes, refactoring, or technical debt.
+- Represents implementation tasks or subtasks linked to a Product Hub epic.
+
+---
+
+## 3. Camunda Platform Helm Label Policy (Internal Team Board)
+
+This label policy applies to tickets tracked on the **Internal Team Board**. Product Hub epics follow ProductBoard/PDP conventions.
+
+### 3.1. `kind/`
+
+Use exactly **one** `kind/*` label per ticket indicating the kind of work.
+
+- **`kind/bug`:** A defect or regression.
+  - Requires:
+    - **`affects/x.y`:** Affected version(s) (e.g. `affects/8.9`).
+    - **`severity/low|mid|high|critical`:** User impact.
+    - **`likelihood/low|mid|high`:** How likely it is to occur.
+- **`kind/feature`:** New or improved behavior and enhancements.
+  - Requires:
+    - **`P0|P1|P2|P3`:** Priority.
+    - **`size/xs|s|m|l`:** Effort estimate.
+- **`kind/chore`:** Maintenance work (toil, cleanup, refactoring, tech debt, upgrades, housekeeping).
+- **`kind/research`:** Investigation work (research/spike/PoC/proposal/design to reduce uncertainty before implementation).
+- **`kind/internal`:** General internal work and improvements (not customer-facing).
+
+### 3.2. Domain
+
+**A) `area/*`**
+
+Use `area/*` to indicate the component or process the ticket relates to.
+
+Examples:
+
+- `area/ci`
+- `area/release`
+- `area/security`
+- `area/docs`
+- `area/test`
+- `area/ux`
+
+### 3.3. Ticket Status & Workflow
+
+These labels make it easy to triage, route, and track work consistently (what it is, how it relates to other work, and whether it needs attention).
+
+#### 3.3.1. Ticket category
+
+- **`support`:** Support-related tickets — used for report automation.
+  - Requires:
+    - **`version/x.y`:** Fixed version in question.
+    - **support ticket link** in the body of the ticket.
+- **`medic`:** Ticket for the medic to look into.
+- **`epic`:** Epic-level tracking ticket on the Internal Team Board.
+  - Use GitHub issue linking to relate work (child issues should link back to the epic).
+  - If it's not an epic, it's a task.
+- **`target/x.y[-suffix]`:** Intended release/milestone for completion (use when needed), e.g. `target/8.9-alpha4`.
+
+#### 3.3.2. Status & flags
+
+- **`needs-info`:** Needs more information, e.g. a question/discussion (not actionable work yet).
+- **`good first issue`:** Good for new contributors.
+- **`deprecated/8.x`:** Track work that gets deprecated in version `8.x`.
+- **`breaking change`:** Marks a breaking change that needs special attention and communication.
+
+### 3.4. Epic/Task Structure
+
+Use GitHub's issue linking to model epics and their work items.
+
+- Label the parent tracking ticket as **`epic`**.
+- Issues with no epic are tasks or subtasks by default.
+
+### 3.5. Best Practices
+
+- Always apply exactly one `kind/*` label.
+- Add `area/*`, ticket status, and workflow labels when they help automation and filtering.
+- Keep label meanings stable; if you introduce a new label, document it here.


### PR DESCRIPTION
## Summary

The 6 wiki-derived pages in `docs/` were placeholder stubs ("Coming soon. This page is being migrated from the GitHub Wiki…") with no real content. This PR fills them in with the actual content from <https://github.com/camunda/camunda-platform-helm/wiki>, adapted for Docusaurus so the rendered site at <https://helm.camunda.io/camunda-platform-helm/> stops dead-ending users.

Pages migrated:

| Wiki page | docs/ file |
|---|---|
| Home _(already migrated, untouched)_ | `index.md` |
| Breaking-Changes-and-Deprecation-Policy | `breaking-changes.md` |
| Code-Style | `code-style.md` |
| Collaboration-Guidelines | `contribution-and-collaboration.md` |
| GitHub-Actions-Workflows | `github-actions-workflows.md` |
| Release-Process | `release-process.md` |
| Ticket-and-Label-Policy | `ticket-and-label-policy.md` |

## Adaptations applied during migration

- Replaced GitHub-style admonitions (`> [!NOTE]`) with Docusaurus `:::note` blocks for consistency with `index.md`.
- Rewrote wiki-relative links (`../.github/workflows/...`) to absolute GitHub URLs (`https://github.com/.../blob/main/.github/workflows/...`) — wiki-relative paths don't resolve from the rendered docs site.
- Fixed one wiki link that pointed at `docs/.tool-versions` to point at the actual location, `.tool-versions` at the repo root.
- Replaced the autolink `<https://...>` in Code Style with an inline `[link](url)` — MDX parses bare angle-bracket URLs as JSX and the build fails on them.
- Preserved frontmatter (`id`, `title`) and the existing sidebar order in `helm-docs-site/sidebars.js`.

## Test plan

- [x] `cd helm-docs-site && npm run build` succeeds with no MDX or broken-link errors.
- [ ] Reviewer spot-checks rendered output on the PR preview deploy (the `docs-preview.yml` workflow should publish a preview URL).
- [ ] Reviewer skims each page for content fidelity vs. the wiki source — the migration is intended to be a faithful copy, not a rewrite.

## Follow-up (not in this PR)

Once these docs are live on `helm.camunda.io`, the wiki itself should get a deprecation banner pointing at the new location (and ideally be archived in repo settings). That requires pushing to `*.wiki.git` and is intentionally separate from this PR.