### PR TITLE
feat(schema): automated additionalProperties:false strictifier for #4564

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,11 @@ helm.readme-update:
 # helm.schema-update: generate schema from values file
 .PHONY: helm.schema-update
 # TODO: Once 8.7 is released, remove "alpha" name from the excluded versions.
+# strict_versions limits the additionalProperties: false post-processing to
+# specific chart versions during pilot rollout (issue #4564). Extend this
+# regex to include 8.8 / 8.9 once the 8.10 pilot is validated.
 helm.schema-update:
+	strict_versions="camunda-platform-8\.10$$"; \
 	for chart_dir in $(chartPath); do \
 		excluded_charts="keycloak|postgres|elasticsearch"; \
 		if echo "$${chart_dir}" | grep -qE "$${excluded_charts}"; then \
@@ -259,15 +263,20 @@ helm.schema-update:
 		readme-generator \
 			--values "$${chart_dir}/values.yaml" \
 			--schema "$${chart_dir}/values.schema.json"; \
-		if [ ! -f "$${chart_dir}/values.schema.extra.json" ]; then \
+		if [ -f "$${chart_dir}/values.schema.extra.json" ]; then \
+			echo "[$@] Merging with extra schema"; \
+			jq --indent 4 -s 'reduce .[] as $$obj ({}; . * $$obj)' \
+				"$${chart_dir}/values.schema.json" \
+				"$${chart_dir}/values.schema.extra.json" > "$${chart_dir}/values.schema.tmp.json" \
+				&& mv "$${chart_dir}/values.schema.tmp.json" "$${chart_dir}/values.schema.json"; \
+		else \
 			echo "[$@] No extra schema to merge"; \
-			continue; \
 		fi; \
-		echo "[$@] Merging with extra schema"; \
-		jq --indent 4 -s 'reduce .[] as $$obj ({}; . * $$obj)' \
-			"$${chart_dir}/values.schema.json" \
-			"$${chart_dir}/values.schema.extra.json" > "$${chart_dir}/values.schema.tmp.json" \
-			&& mv "$${chart_dir}/values.schema.tmp.json" "$${chart_dir}/values.schema.json"; \
+		if echo "$${chart_dir}" | grep -qE "$${strict_versions}"; then \
+			echo "[$@] Applying strict additionalProperties (issue #4564)"; \
+			abs_schema="$$(cd "$${chart_dir}" && pwd)/values.schema.json"; \
+			(cd scripts/make-schema-strict && go run . -i "$${abs_schema}" -o "$${abs_schema}"); \
+		fi; \
 	done
 
 # helm.get-images: list all images in the chart.

--- a/charts/camunda-platform-8.10/values.schema.json
+++ b/charts/camunda-platform-8.10/values.schema.json
@@ -26,9 +26,11 @@
                                     "description": "defines the key within the existing secret object.",
                                     "default": ""
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "compatibility": {
                     "type": "object",
@@ -41,9 +43,11 @@
                                     "description": "Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: force (perform the adaptation always), disabled (do not perform adaptation)",
                                     "default": "disabled"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "config": {
                     "type": "object",
@@ -53,7 +57,8 @@
                             "description": "defines applications request body size which used for upload files.",
                             "default": "10MB"
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "multitenancy": {
                     "type": "object",
@@ -63,7 +68,8 @@
                             "description": "if true, then enable multitenancy in all applicable components.",
                             "default": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "security": {
                     "type": "object",
@@ -76,9 +82,11 @@
                                     "description": "defines the authentication method which should be used. Possible values: basic, oidc. Could be overridden in each component.",
                                     "default": "basic"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "createReleaseInfo": {
                     "type": "boolean",
@@ -88,7 +96,8 @@
                 "annotations": {
                     "type": "object",
                     "description": "Annotations can be used to define common annotations, which should be applied to all deployments",
-                    "default": {}
+                    "default": {},
+                    "additionalProperties": false
                 },
                 "labels": {
                     "type": "object",
@@ -98,17 +107,20 @@
                             "description": "Name of the application",
                             "default": "camunda-platform"
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "commonLabels": {
                     "type": "object",
                     "description": "can be used to apply mutable labels to all Camunda resources.",
-                    "default": {}
+                    "default": {},
+                    "additionalProperties": false
                 },
                 "nodeSelector": {
                     "type": "object",
                     "description": "can be used to define Kubernetes node selectors to run Camunda components, unless overridden by component-specific nodeSelector.",
-                    "default": {}
+                    "default": {},
+                    "additionalProperties": false
                 },
                 "image": {
                     "type": "object",
@@ -129,7 +141,8 @@
                             "default": [],
                             "items": {}
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "host": {
                     "type": "string",
@@ -172,14 +185,16 @@
                                     "description": "defines the secret name which contains the TLS private key and certificate",
                                     "default": "camunda-platform"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "controllerNamespace": {
                             "type": "string",
                             "description": "defines the namespace where the gateway controller is running. This is only needed if the controller is running in a different namespace than the Camunda components.",
                             "default": ""
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "ingress": {
                     "type": "object",
@@ -217,7 +232,8 @@
                                     "description": "defines the secret name which contains the TLS private key and certificate",
                                     "default": "camunda-platform"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "annotations": {
                             "type": "object",
@@ -227,7 +243,8 @@
                                 "type": "string"
                             }
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "elasticsearch": {
                     "type": "object",
@@ -263,9 +280,11 @@
                                             "description": "(DEPRECATED - use component-specific options instead, e.g., optimize.database.elasticsearch.tls.secret.existingSecretKey or orchestration.data.secondaryStorage.elasticsearch.tls.secret.existingSecretKey) can be used to provide the key within the secret containing the certificate",
                                             "default": "externaldb.jks"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "auth": {
                             "type": "object",
@@ -293,9 +312,11 @@
                                             "description": "(DEPRECATED - use component-specific options instead, e.g., optimize.database.elasticsearch.auth.secret.existingSecretKey or orchestration.data.secondaryStorage.elasticsearch.auth.secret.existingSecretKey) defines the key within the existing secret object.",
                                             "default": ""
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "disableExporter": {
                             "type": "boolean",
@@ -320,7 +341,8 @@
                                     "description": "(DEPRECATED - use component-specific options instead, e.g., optimize.database.elasticsearch.url.port or orchestration.data.secondaryStorage.elasticsearch.url) Elasticsearch.port defines the elasticsearch port, under which elasticsearch can be accessed",
                                     "default": 9200
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "clusterName": {
                             "type": "string",
@@ -332,7 +354,8 @@
                             "description": "(DEPRECATED - use component-specific options instead, e.g., optimize.database.elasticsearch.prefix or orchestration.data.secondaryStorage.elasticsearch) defines the prefix which is used by the old Zeebe Elasticsearch Exporter to create Elasticsearch indexes and consumed by Optimize.",
                             "default": "zeebe-record"
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "opensearch": {
                     "type": "object",
@@ -350,7 +373,8 @@
                                     "description": "(DEPRECATED - use component-specific options instead, e.g., optimize.database.opensearch.aws.enabled or orchestration.data.secondaryStorage.opensearch) Enabling AWS IRSA",
                                     "default": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "tls": {
                             "type": "object",
@@ -373,9 +397,11 @@
                                             "description": "(DEPRECATED - use component-specific options instead, e.g., optimize.database.opensearch.tls.secret.existingSecretKey or orchestration.data.secondaryStorage.opensearch.tls.secret.existingSecretKey) can be used to provide the key within the secret containing the certificate",
                                             "default": "externaldb.jks"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "auth": {
                             "type": "object",
@@ -403,9 +429,11 @@
                                             "description": "(DEPRECATED - use component-specific options instead, e.g., optimize.database.opensearch.auth.secret.existingSecretKey or orchestration.data.secondaryStorage.opensearch.auth.secret.existingSecretKey) defines the key within the existing secret object.",
                                             "default": ""
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "url": {
                             "type": "object",
@@ -425,7 +453,8 @@
                                     "description": "(DEPRECATED - use component-specific options instead, e.g., optimize.database.opensearch.url.port or orchestration.data.secondaryStorage.opensearch.url) defines the external opensearch port, under which opensearch can be accessed",
                                     "default": 443
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "clusterName": {
                             "type": "string",
@@ -437,7 +466,8 @@
                             "description": "(DEPRECATED - use component-specific options instead, e.g., optimize.database.opensearch.prefix or orchestration.data.secondaryStorage.opensearch) defines the prefix which is used by the old Zeebe OpenSearch Exporter to create OpenSearch indexes and consumed by Optimize.",
                             "default": "zeebe-record"
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "zeebeClusterName": {
                     "type": "string",
@@ -455,7 +485,8 @@
                                     "description": "",
                                     "default": ""
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "keycloak": {
                             "type": "object",
@@ -488,7 +519,8 @@
                                             "description": "defines the port for Keycloak (e.g., 443).",
                                             "default": ""
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "contextPath": {
                                     "type": "string",
@@ -526,11 +558,14 @@
                                                     "description": "defines the key within the existing secret object containing the Keycloak admin password.",
                                                     "default": ""
                                                 }
-                                            }
+                                            },
+                                            "additionalProperties": false
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "auth": {
                             "type": "object",
@@ -606,9 +641,11 @@
                                                     "description": "defines the key within the existing secret object.",
                                                     "default": ""
                                                 }
-                                            }
+                                            },
+                                            "additionalProperties": false
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "identity": {
                                     "type": "object",
@@ -641,7 +678,8 @@
                                                     "description": "defines the key within the existing secret object.",
                                                     "default": ""
                                                 }
-                                            }
+                                            },
+                                            "additionalProperties": false
                                         },
                                         "initialClaimName": {
                                             "type": "string",
@@ -653,7 +691,8 @@
                                             "description": "defines the initial claim value, which is used by Management  Identity to configure initial mapping rules.",
                                             "default": ""
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "console": {
                                     "type": "object",
@@ -678,7 +717,8 @@
                                             "description": "defines the root URL which is used by Keycloak to access WebModeler.",
                                             "default": "http://localhost:8087"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "webModeler": {
                                     "type": "object",
@@ -703,7 +743,8 @@
                                             "description": "defines the root URL which is used by Keycloak to access WebModeler.",
                                             "default": "http://localhost:8070"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "optimize": {
                                     "type": "object",
@@ -736,18 +777,22 @@
                                                     "description": "defines the key within the existing secret object.",
                                                     "default": ""
                                                 }
-                                            }
+                                            },
+                                            "additionalProperties": false
                                         },
                                         "redirectUrl": {
                                             "type": "string",
                                             "description": "defines the root (or redirect) URL, which is used by Keycloak to access Optimize.",
                                             "default": "http://localhost:8083"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "documentStore": {
                     "type": "object",
@@ -776,7 +821,8 @@
                                                     "description": "When set to true, no AWS credentials are injected into pods, allowing IRSA to be used for authentication. When false (default), credentials are required via existingSecret or accessKeyId/secretAccessKey configuration.",
                                                     "default": false
                                                 }
-                                            }
+                                            },
+                                            "additionalProperties": false
                                         },
                                         "storeId": {
                                             "type": "string",
@@ -829,9 +875,11 @@
                                                             "description": "defines the key within the existing secret object.",
                                                             "default": "access-key-id"
                                                         }
-                                                    }
+                                                    },
+                                                    "additionalProperties": false
                                                 }
-                                            }
+                                            },
+                                            "additionalProperties": false
                                         },
                                         "secretAccessKey": {
                                             "type": "object",
@@ -854,11 +902,14 @@
                                                             "description": "defines the key within the existing secret object.",
                                                             "default": "secret-access-key"
                                                         }
-                                                    }
+                                                    },
+                                                    "additionalProperties": false
                                                 }
-                                            }
+                                            },
+                                            "additionalProperties": false
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "gcp": {
                                     "type": "object",
@@ -906,9 +957,11 @@
                                                     "description": "defines the key within the existing secret object.",
                                                     "default": "service-account.json"
                                                 }
-                                            }
+                                            },
+                                            "additionalProperties": false
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "inmemory": {
                                     "type": "object",
@@ -928,7 +981,8 @@
                                             "description": "Fully qualified class name for the in-memory document store provider.",
                                             "default": "io.camunda.document.store.inmemory.InMemoryDocumentStoreProvider"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "azure": {
                                     "type": "object",
@@ -954,15 +1008,20 @@
                                                             "description": "defines the key within the existing secret object.",
                                                             "default": "connection-string"
                                                         }
-                                                    }
+                                                    },
+                                                    "additionalProperties": false
                                                 }
-                                            }
+                                            },
+                                            "additionalProperties": false
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "extraManifests": {
                     "type": "array",
@@ -975,7 +1034,8 @@
                     "description": "if true, enables engine-only/no-secondary-storage mode; this disables all secondary-storage-dependent features and components.",
                     "default": false
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "identity": {
             "type": "object",
@@ -1041,9 +1101,11 @@
                                     "description": "defines the key within the existing secret object.",
                                     "default": ""
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "users": {
                     "type": "array",
@@ -1086,7 +1148,8 @@
                             "default": [],
                             "items": {}
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "multitenancy": {
                     "type": "object",
@@ -1096,7 +1159,8 @@
                             "description": "can be used to enable multitenancy in management identity",
                             "default": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "sidecars": {
                     "type": "array",
@@ -1123,12 +1187,14 @@
                 "podAnnotations": {
                     "type": "object",
                     "description": "can be used to define extra Management Identity pod annotations. Supports templating (e.g., {{ .Release.Name }}).",
-                    "default": {}
+                    "default": {},
+                    "additionalProperties": false
                 },
                 "podLabels": {
                     "type": "object",
                     "description": "can be used to define extra Management Identity pod labels. Supports templating (e.g., {{ .Release.Name }}).",
-                    "default": {}
+                    "default": {},
+                    "additionalProperties": false
                 },
                 "logging": {
                     "type": "object",
@@ -1141,9 +1207,11 @@
                                     "description": "",
                                     "default": "INFO"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "service": {
                     "type": "object",
@@ -1151,7 +1219,8 @@
                         "annotations": {
                             "type": "object",
                             "description": "can be used to define annotations, which will be applied to the identity service",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": false
                         },
                         "type": {
                             "type": "string",
@@ -1173,7 +1242,8 @@
                             "description": "defines the name of the service on which the identity metrics will be available",
                             "default": "metrics"
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "podSecurityContext": {
                     "type": "object",
@@ -1196,9 +1266,11 @@
                                     "description": "",
                                     "default": "RuntimeDefault"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "containerSecurityContext": {
                     "type": "object",
@@ -1236,9 +1308,11 @@
                                     "description": "",
                                     "default": "RuntimeDefault"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "startupProbe": {
                     "type": "object",
@@ -1283,7 +1357,8 @@
                             "description": "defines the seconds after the probe times out",
                             "default": 1
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "readinessProbe": {
                     "type": "object",
@@ -1328,7 +1403,8 @@
                             "description": "defines the seconds after the probe times out",
                             "default": 1
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "livenessProbe": {
                     "type": "object",
@@ -1373,7 +1449,8 @@
                             "description": "defines the seconds after the probe times out",
                             "default": 1
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "metrics": {
                     "type": "object",
@@ -1383,12 +1460,14 @@
                             "description": "Prometheus metrics endpoint",
                             "default": "/actuator/prometheus"
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "nodeSelector": {
                     "type": "object",
                     "description": "can be used to define on which nodes the Management Identity pods should run",
-                    "default": {}
+                    "default": {},
+                    "additionalProperties": false
                 },
                 "tolerations": {
                     "type": "array",
@@ -1399,7 +1478,8 @@
                 "affinity": {
                     "type": "object",
                     "description": "can be used to define pod affinity or anti-affinity https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity",
-                    "default": {}
+                    "default": {},
+                    "additionalProperties": false
                 },
                 "resources": {
                     "type": "object",
@@ -1417,7 +1497,8 @@
                                     "description": "",
                                     "default": "600m"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "limits": {
                             "type": "object",
@@ -1432,9 +1513,11 @@
                                     "description": "",
                                     "default": "2Gi"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "env": {
                     "type": "array",
@@ -1461,7 +1544,8 @@
                             },
                             "valueFrom": {
                                 "description": "Source for the environment variable's value",
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                             }
                         },
                         "required": [
@@ -1510,14 +1594,16 @@
                         "annotations": {
                             "type": "object",
                             "description": "can be used to set the annotations of the identity service account",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": false
                         },
                         "automountServiceAccountToken": {
                             "type": "boolean",
                             "description": "can be used to control whether the service account token should be automatically mounted",
                             "default": true
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "externalDatabase": {
                     "type": "object",
@@ -1565,9 +1651,11 @@
                                     "description": "defines the key within the existing secret object.",
                                     "default": ""
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "configuration": {
                     "type": "string",
@@ -1588,7 +1676,8 @@
                 "dnsConfig": {
                     "type": "object",
                     "description": "https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config",
-                    "default": {}
+                    "default": {},
+                    "additionalProperties": false
                 },
                 "persistence": {
                     "type": "object",
@@ -1626,16 +1715,20 @@
                         "annotations": {
                             "type": "object",
                             "description": "can be used to define annotations to add to the persistent volume claim",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": false
                         },
                         "selector": {
                             "type": "object",
                             "description": "can be used to define a label selector for the persistent volume claim",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "identityPostgresql": {
             "type": "object",
@@ -1659,11 +1752,14 @@
                                             "description": "(DEPRECATED) Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: force (perform the adaptation always), disabled (do not perform adaptation)",
                                             "default": "{{ .Values.global.compatibility.openshift.adaptSecurityContext | default \"disabled\" }}"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "image": {
                     "type": "object",
@@ -1683,7 +1779,8 @@
                             "description": "(DEPRECATED) can be used to set image digest (overrides tag if set, e.g. \"sha256:abcd...\")",
                             "default": ""
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "nameOverride": {
                     "type": "string",
@@ -1726,9 +1823,11 @@
                                     "description": "(DEPRECATED) defines the key within the existing secret object for PostgreSQL user.",
                                     "default": "identity-postgresql-user-password"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "volumePermissions": {
                     "type": "object",
@@ -1741,9 +1840,11 @@
                                     "description": "(DEPRECATED)",
                                     "default": "bitnamilegacy/os-shell"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "metrics": {
                     "type": "object",
@@ -1756,11 +1857,14 @@
                                     "description": "(DEPRECATED)",
                                     "default": "bitnamilegacy/postgres-exporter"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "identityKeycloak": {
             "type": "object",
@@ -1784,9 +1888,11 @@
                                             "description": "(DEPRECATED) Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: force (perform the adaptation always), disabled (do not perform adaptation)",
                                             "default": "{{ .Values.global.compatibility.openshift.adaptSecurityContext | default \"disabled\" }}"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "security": {
                             "type": "object",
@@ -1796,9 +1902,11 @@
                                     "description": "(DEPRECATED) Allows the use of the Camunda build Keycloak image (including the Management Identity login theme)",
                                     "default": true
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "nameOverride": {
                     "type": "string",
@@ -1823,7 +1931,8 @@
                             "description": "(DEPRECATED) can be used to set image digest (overrides tag if set, e.g. \"sha256:abcd...\")",
                             "default": ""
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "resources": {
                     "type": "object",
@@ -1841,7 +1950,8 @@
                                     "description": "(DEPRECATED)",
                                     "default": "1Gi"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "limits": {
                             "type": "object",
@@ -1856,9 +1966,11 @@
                                     "description": "(DEPRECATED)",
                                     "default": "2Gi"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "postgresql": {
                     "type": "object",
@@ -1881,7 +1993,8 @@
                                     "description": "(DEPRECATED) can be used to set image digest (overrides tag if set, e.g. \"sha256:abcd...\")",
                                     "default": ""
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "auth": {
                             "type": "object",
@@ -1904,9 +2017,11 @@
                                             "description": "(DEPRECATED) defines the key within the existing secret object for PostgreSQL user.",
                                             "default": "identity-keycloak-postgresql-user-password"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "primary": {
                             "type": "object",
@@ -1957,7 +2072,8 @@
                                                         "type": "string"
                                                     }
                                                 }
-                                            }
+                                            },
+                                            "additionalProperties": false
                                         },
                                         "seccompProfile": {
                                             "type": "object",
@@ -1967,9 +2083,11 @@
                                                     "description": "(DEPRECATED)",
                                                     "default": "RuntimeDefault"
                                                 }
-                                            }
+                                            },
+                                            "additionalProperties": false
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "podSecurityContext": {
                                     "type": "object",
@@ -1989,9 +2107,11 @@
                                             "description": "(DEPRECATED)",
                                             "default": 1001
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "volumePermissions": {
                             "type": "object",
@@ -2004,9 +2124,11 @@
                                             "description": "(DEPRECATED)",
                                             "default": "bitnamilegacy/os-shell"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "metrics": {
                             "type": "object",
@@ -2019,11 +2141,14 @@
                                             "description": "(DEPRECATED)",
                                             "default": "bitnamilegacy/postgres-exporter"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "proxy": {
                     "type": "string",
@@ -2038,7 +2163,8 @@
                             "description": "(DEPRECATED) enabling tls",
                             "default": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "extraVolumeMounts": {
                     "type": "array",
@@ -2054,7 +2180,8 @@
                                 "type": "string",
                                 "description": "(DEPRECATED)"
                             }
-                        }
+                        },
+                        "additionalProperties": false
                     }
                 },
                 "containerSecurityContext": {
@@ -2098,7 +2225,8 @@
                                         "type": "string"
                                     }
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "seccompProfile": {
                             "type": "object",
@@ -2108,9 +2236,11 @@
                                     "description": "(DEPRECATED)",
                                     "default": "RuntimeDefault"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "podSecurityContext": {
                     "type": "object",
@@ -2125,7 +2255,8 @@
                             "description": "(DEPRECATED)",
                             "default": 1001
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "httpRelativePath": {
                     "type": "string",
@@ -2160,14 +2291,16 @@
                         "labels": {
                             "type": "object",
                             "description": "(DEPRECATED) [object] can be used to define labels which will be applied to the Keycloak ingress resource",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": false
                         },
                         "pathType": {
                             "type": "string",
                             "description": "(DEPRECATED) defines Ingress path type.",
                             "default": "Prefix"
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "service": {
                     "type": "object",
@@ -2177,7 +2310,8 @@
                             "description": "(DEPRECATED) can be set to change the service type.",
                             "default": "ClusterIP"
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "auth": {
                     "type": "object",
@@ -2197,7 +2331,8 @@
                             "description": "(DEPRECATED) defines the key within the existing secret object.",
                             "default": "identity-keycloak-admin-password"
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "keycloakConfigCli": {
                     "type": "object",
@@ -2210,11 +2345,14 @@
                                     "description": "(DEPRECATED)",
                                     "default": "bitnamilegacy/keycloak-config-cli"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "console": {
             "type": "object",
@@ -2264,7 +2402,8 @@
                             "default": [],
                             "items": {}
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "nodeEnv": {
                     "type": "string",
@@ -2303,9 +2442,11 @@
                                     "description": "can be used to provide the name of an existing Kubernetes secret containing TLS certificates",
                                     "default": ""
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "keycloak": {
                     "type": "object",
@@ -2315,7 +2456,8 @@
                             "description": "Specifies the Keycloak realm used for authentication.",
                             "default": "camunda-platform"
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "contextPath": {
                     "type": "string",
@@ -2331,17 +2473,20 @@
                 "podAnnotations": {
                     "type": "object",
                     "description": "can be used to define extra Console pod annotations. Supports templating (e.g., {{ .Release.Name }}).",
-                    "default": {}
+                    "default": {},
+                    "additionalProperties": false
                 },
                 "podLabels": {
                     "type": "object",
                     "description": "can be used to define extra Console pod labels. Supports templating (e.g., {{ .Release.Name }}).",
-                    "default": {}
+                    "default": {},
+                    "additionalProperties": false
                 },
                 "logging": {
                     "type": "object",
                     "description": "configuration for the Console logging. This template will be directly included in the configuration YAML file",
-                    "default": {}
+                    "default": {},
+                    "additionalProperties": false
                 },
                 "service": {
                     "type": "object",
@@ -2349,7 +2494,8 @@
                         "annotations": {
                             "type": "object",
                             "description": "can be used to define annotations, which will be applied to the Console service",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": false
                         },
                         "type": {
                             "type": "string",
@@ -2371,7 +2517,8 @@
                             "description": "defines the management port used to access metrics and app status",
                             "default": 9100
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "resources": {
                     "type": "object",
@@ -2384,7 +2531,8 @@
                                     "description": "",
                                     "default": "1Gi"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "limits": {
                             "type": "object",
@@ -2394,9 +2542,11 @@
                                     "description": "",
                                     "default": "2Gi"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "env": {
                     "type": "array",
@@ -2423,7 +2573,8 @@
                             },
                             "valueFrom": {
                                 "description": "Source for the environment variable's value",
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                             }
                         },
                         "required": [
@@ -2499,7 +2650,8 @@
                             "description": "defines the seconds after the probe times out",
                             "default": 1
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "readinessProbe": {
                     "type": "object",
@@ -2544,7 +2696,8 @@
                             "description": "defines the seconds after the probe times out",
                             "default": 1
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "livenessProbe": {
                     "type": "object",
@@ -2589,7 +2742,8 @@
                             "description": "defines the seconds after the probe times out",
                             "default": 1
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "metrics": {
                     "type": "object",
@@ -2599,7 +2753,8 @@
                             "description": "Prometheus metrics endpoint",
                             "default": "/prometheus"
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "serviceAccount": {
                     "type": "object",
@@ -2617,14 +2772,16 @@
                         "annotations": {
                             "type": "object",
                             "description": "can be used to set the annotations of the service account",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": false
                         },
                         "automountServiceAccountToken": {
                             "type": "boolean",
                             "description": "can be used to control whether the service account token should be automatically mounted",
                             "default": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "podSecurityContext": {
                     "type": "object",
@@ -2647,9 +2804,11 @@
                                     "description": "",
                                     "default": "RuntimeDefault"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "containerSecurityContext": {
                     "type": "object",
@@ -2687,14 +2846,17 @@
                                     "description": "",
                                     "default": "RuntimeDefault"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "nodeSelector": {
                     "type": "object",
                     "description": "can be used to define on which nodes the Console pods should run",
-                    "default": {}
+                    "default": {},
+                    "additionalProperties": false
                 },
                 "tolerations": {
                     "type": "array",
@@ -2705,7 +2867,8 @@
                 "affinity": {
                     "type": "object",
                     "description": "can be used to define pod affinity or anti-affinity https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity",
-                    "default": {}
+                    "default": {},
+                    "additionalProperties": false
                 },
                 "dnsPolicy": {
                     "type": "string",
@@ -2715,9 +2878,11 @@
                 "dnsConfig": {
                     "type": "object",
                     "description": "https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config",
-                    "default": {}
+                    "default": {},
+                    "additionalProperties": false
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "webModeler": {
             "type": "object",
@@ -2756,7 +2921,8 @@
                             "default": [],
                             "items": {}
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "contextPath": {
                     "type": "string",
@@ -2774,9 +2940,11 @@
                                     "description": "defines the authentication method which should be used. Possible values: `basic`, `oidc`, or `none`. It could be used to override `global.security.authentication.method`.",
                                     "default": ""
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "restapi": {
                     "type": "object",
@@ -2794,7 +2962,8 @@
                                     "description": "can be used to set image digest (overrides tag if set, e.g. \"sha256:abcd...\")",
                                     "default": ""
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "sidecars": {
                             "type": "array",
@@ -2854,9 +3023,11 @@
                                             "description": "defines the key within the existing secret object.",
                                             "default": ""
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "mail": {
                             "type": "object",
@@ -2899,7 +3070,8 @@
                                             "description": "defines the key within the existing secret object.",
                                             "default": ""
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "fromAddress": {
                                     "type": "string",
@@ -2911,7 +3083,8 @@
                                     "description": "defines the name that will be displayed as the sender of emails sent by WebModeler",
                                     "default": "Camunda 8"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "pusher": {
                             "type": "object",
@@ -2937,9 +3110,11 @@
                                                     "description": "defines the key within the existing secret object",
                                                     "default": ""
                                                 }
-                                            }
+                                            },
+                                            "additionalProperties": false
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "secret": {
                                     "type": "object",
@@ -2959,9 +3134,11 @@
                                             "description": "defines the key within the existing secret object",
                                             "default": ""
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "clusters": {
                             "type": "array",
@@ -2972,12 +3149,14 @@
                         "podAnnotations": {
                             "type": "object",
                             "description": "can be used to define extra restapi pod annotations. Supports templating (e.g., {{ .Release.Name }}).",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": false
                         },
                         "podLabels": {
                             "type": "object",
                             "description": "can be used to define extra restapi pod labels. Supports templating (e.g., {{ .Release.Name }}).",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": false
                         },
                         "env": {
                             "type": "array",
@@ -3035,9 +3214,11 @@
                                             "description": "",
                                             "default": "RuntimeDefault"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "containerSecurityContext": {
                             "type": "object",
@@ -3075,9 +3256,11 @@
                                             "description": "",
                                             "default": "RuntimeDefault"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "startupProbe": {
                             "type": "object",
@@ -3122,7 +3305,8 @@
                                     "description": "defines the number of seconds after which the probe times out",
                                     "default": 1
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "readinessProbe": {
                             "type": "object",
@@ -3167,7 +3351,8 @@
                                     "description": "defines the number of seconds after which the probe times out",
                                     "default": 1
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "livenessProbe": {
                             "type": "object",
@@ -3212,7 +3397,8 @@
                                     "description": "defines the number of seconds after which the probe times out",
                                     "default": 1
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "metrics": {
                             "type": "object",
@@ -3222,12 +3408,14 @@
                                     "description": "Prometheus metrics endpoint",
                                     "default": "/metrics"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "nodeSelector": {
                             "type": "object",
                             "description": "can be used to select the nodes the restapi pods should run on",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": false
                         },
                         "tolerations": {
                             "type": "array",
@@ -3238,7 +3426,8 @@
                         "affinity": {
                             "type": "object",
                             "description": "can be used to define pod affinity or anti-affinity, see https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": false
                         },
                         "resources": {
                             "type": "object",
@@ -3256,7 +3445,8 @@
                                             "description": "",
                                             "default": "1280Mi"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "limits": {
                                     "type": "object",
@@ -3271,9 +3461,11 @@
                                             "description": "",
                                             "default": "2560Mi"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "service": {
                             "type": "object",
@@ -3281,7 +3473,8 @@
                                 "annotations": {
                                     "type": "object",
                                     "description": "can be used to define annotations which will be applied to the service",
-                                    "default": {}
+                                    "default": {},
+                                    "additionalProperties": false
                                 },
                                 "type": {
                                     "type": "string",
@@ -3298,7 +3491,8 @@
                                     "description": "defines the management port of the service",
                                     "default": 8091
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "configuration": {
                             "type": "string",
@@ -3319,7 +3513,8 @@
                         "dnsConfig": {
                             "type": "object",
                             "description": "https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": false
                         },
                         "javaOpts": {
                             "type": "string",
@@ -3331,7 +3526,8 @@
                             "description": "can be used to set a custom path for the Zeebe client configuration file",
                             "default": "/tmp/zeebe_client_cache.txt"
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "websockets": {
                     "type": "object",
@@ -3349,7 +3545,8 @@
                                     "description": "can be used to set image digest (overrides tag if set, e.g. \"sha256:abcd...\")",
                                     "default": ""
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "sidecars": {
                             "type": "array",
@@ -3376,12 +3573,14 @@
                         "podAnnotations": {
                             "type": "object",
                             "description": "can be used to define extra websockets pod annotations. Supports templating (e.g., {{ .Release.Name }}).",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": false
                         },
                         "podLabels": {
                             "type": "object",
                             "description": "can be used to define extra websockets pod labels. Supports templating (e.g., {{ .Release.Name }}).",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": false
                         },
                         "env": {
                             "type": "array",
@@ -3434,9 +3633,11 @@
                                             "description": "",
                                             "default": "RuntimeDefault"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "containerSecurityContext": {
                             "type": "object",
@@ -3474,9 +3675,11 @@
                                             "description": "",
                                             "default": "RuntimeDefault"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "startupProbe": {
                             "type": "object",
@@ -3521,7 +3724,8 @@
                                     "description": "defines the number of seconds after which the probe times out",
                                     "default": 1
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "readinessProbe": {
                             "type": "object",
@@ -3566,7 +3770,8 @@
                                     "description": "defines the number of seconds after which the probe times out",
                                     "default": 1
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "livenessProbe": {
                             "type": "object",
@@ -3611,12 +3816,14 @@
                                     "description": "defines the number of seconds after which the probe times out",
                                     "default": 1
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "nodeSelector": {
                             "type": "object",
                             "description": "can be used to select the nodes the websockets pods should run on",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": false
                         },
                         "tolerations": {
                             "type": "array",
@@ -3627,7 +3834,8 @@
                         "affinity": {
                             "type": "object",
                             "description": "can be used to define pod affinity or anti-affinity, see https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": false
                         },
                         "resources": {
                             "type": "object",
@@ -3645,7 +3853,8 @@
                                             "description": "",
                                             "default": "64Mi"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "limits": {
                                     "type": "object",
@@ -3660,9 +3869,11 @@
                                             "description": "",
                                             "default": "128Mi"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "service": {
                             "type": "object",
@@ -3670,7 +3881,8 @@
                                 "annotations": {
                                     "type": "object",
                                     "description": "can be used to define annotations which will be applied to the service",
-                                    "default": {}
+                                    "default": {},
+                                    "additionalProperties": false
                                 },
                                 "type": {
                                     "type": "string",
@@ -3682,7 +3894,8 @@
                                     "description": "defines the port of the service",
                                     "default": 80
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "configuration": {
                             "type": "string",
@@ -3692,7 +3905,8 @@
                         "extraConfiguration": {
                             "type": "object",
                             "description": "if specified, contents will be used for any extra configuration files such as log4j2.xml",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": false
                         },
                         "dnsPolicy": {
                             "type": "string",
@@ -3702,9 +3916,11 @@
                         "dnsConfig": {
                             "type": "object",
                             "description": "https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "serviceAccount": {
                     "type": "object",
@@ -3722,14 +3938,16 @@
                         "annotations": {
                             "type": "object",
                             "description": "can be used to set the annotations of the WebModeler service account",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": false
                         },
                         "automountServiceAccountToken": {
                             "type": "boolean",
                             "description": "can be used to control whether the service account token should be automatically mounted",
                             "default": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "persistence": {
                     "type": "object",
@@ -3767,14 +3985,17 @@
                         "annotations": {
                             "type": "object",
                             "description": "can be used to define annotations to add to the persistent volume claim",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": false
                         },
                         "selector": {
                             "type": "object",
                             "description": "can be used to define a label selector for the persistent volume claim",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 }
             },
             "restapi": {
@@ -3802,7 +4023,8 @@
                                 },
                                 "valueFrom": {
                                     "description": "Source for the environment variable's value",
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                 }
                             },
                             "required": [
@@ -3811,7 +4033,8 @@
                             "additionalProperties": false
                         }
                     }
-                }
+                },
+                "additionalProperties": false
             },
             "websockets": {
                 "properties": {
@@ -3838,7 +4061,8 @@
                                 },
                                 "valueFrom": {
                                     "description": "Source for the environment variable's value",
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                 }
                             },
                             "required": [
@@ -3847,8 +4071,10 @@
                             "additionalProperties": false
                         }
                     }
-                }
-            }
+                },
+                "additionalProperties": false
+            },
+            "additionalProperties": false
         },
         "webModelerPostgresql": {
             "type": "object",
@@ -3872,11 +4098,14 @@
                                             "description": "(DEPRECATED) Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: force (perform the adaptation always), disabled (do not perform adaptation)",
                                             "default": "{{ .Values.global.compatibility.openshift.adaptSecurityContext | default \"disabled\" }}"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "nameOverride": {
                     "type": "string",
@@ -3901,7 +4130,8 @@
                             "description": "(DEPRECATED) can be used to set image digest (overrides tag if set, e.g. \"sha256:abcd...\")",
                             "default": ""
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "auth": {
                     "type": "object",
@@ -3939,9 +4169,11 @@
                                     "description": "(DEPRECATED) defines the key within the existing secret object for PostgreSQL user.",
                                     "default": "web-modeler-postgresql-user-password"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "primary": {
                     "type": "object",
@@ -3992,7 +4224,8 @@
                                                 "type": "string"
                                             }
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "seccompProfile": {
                                     "type": "object",
@@ -4002,9 +4235,11 @@
                                             "description": "(DEPRECATED)",
                                             "default": "RuntimeDefault"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "podSecurityContext": {
                             "type": "object",
@@ -4024,11 +4259,14 @@
                                     "description": "(DEPRECATED)",
                                     "default": 1001
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "connectors": {
             "type": "object",
@@ -4080,13 +4318,17 @@
                                                     "description": "defines the key within the existing secret object.",
                                                     "default": ""
                                                 }
-                                            }
+                                            },
+                                            "additionalProperties": false
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "image": {
                     "type": "object",
@@ -4117,7 +4359,8 @@
                             "default": [],
                             "items": {}
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "sidecars": {
                     "type": "array",
@@ -4144,12 +4387,14 @@
                 "podAnnotations": {
                     "type": "object",
                     "description": "can be used to define extra Connectors pod annotations. Supports templating (e.g., {{ .Release.Name }}).",
-                    "default": {}
+                    "default": {},
+                    "additionalProperties": false
                 },
                 "podLabels": {
                     "type": "object",
                     "description": "can be used to define extra Connectors pod labels. Supports templating (e.g., {{ .Release.Name }}).",
-                    "default": {}
+                    "default": {},
+                    "additionalProperties": false
                 },
                 "service": {
                     "type": "object",
@@ -4157,7 +4402,8 @@
                         "annotations": {
                             "type": "object",
                             "description": "can be used to define annotations, which will be applied to the Connectors service",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": false
                         },
                         "type": {
                             "type": "string",
@@ -4174,7 +4420,8 @@
                             "description": "defines the port name where the Connector web application will be available",
                             "default": "http"
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "resources": {
                     "type": "object",
@@ -4187,7 +4434,8 @@
                                     "description": "",
                                     "default": "1Gi"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "limits": {
                             "type": "object",
@@ -4197,9 +4445,11 @@
                                     "description": "",
                                     "default": "2Gi"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "env": {
                     "type": "array",
@@ -4226,7 +4476,8 @@
                             },
                             "valueFrom": {
                                 "description": "Source for the environment variable's value",
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                             }
                         },
                         "required": [
@@ -4302,7 +4553,8 @@
                             "description": "defines the seconds after the probe times out",
                             "default": 1
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "readinessProbe": {
                     "type": "object",
@@ -4347,7 +4599,8 @@
                             "description": "defines the seconds after the probe times out",
                             "default": 1
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "livenessProbe": {
                     "type": "object",
@@ -4392,7 +4645,8 @@
                             "description": "defines the seconds after the probe times out",
                             "default": 1
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "metrics": {
                     "type": "object",
@@ -4402,7 +4656,8 @@
                             "description": "Prometheus metrics endpoint",
                             "default": "/actuator/prometheus"
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "serviceAccount": {
                     "type": "object",
@@ -4420,14 +4675,16 @@
                         "annotations": {
                             "type": "object",
                             "description": "can be used to set the annotations of the service account",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": false
                         },
                         "automountServiceAccountToken": {
                             "type": "boolean",
                             "description": "can be used to control whether the service account token should be automatically mounted",
                             "default": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "podSecurityContext": {
                     "type": "object",
@@ -4450,9 +4707,11 @@
                                     "description": "",
                                     "default": "RuntimeDefault"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "containerSecurityContext": {
                     "type": "object",
@@ -4490,14 +4749,17 @@
                                     "description": "",
                                     "default": "RuntimeDefault"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "nodeSelector": {
                     "type": "object",
                     "description": "can be used to define on which nodes the Connectors pods should run",
-                    "default": {}
+                    "default": {},
+                    "additionalProperties": false
                 },
                 "tolerations": {
                     "type": "array",
@@ -4508,7 +4770,8 @@
                 "affinity": {
                     "type": "object",
                     "description": "can be used to define pod affinity or anti-affinity https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity",
-                    "default": {}
+                    "default": {},
+                    "additionalProperties": false
                 },
                 "configuration": {
                     "type": "string",
@@ -4529,7 +4792,8 @@
                 "dnsConfig": {
                     "type": "object",
                     "description": "https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config",
-                    "default": {}
+                    "default": {},
+                    "additionalProperties": false
                 },
                 "persistence": {
                     "type": "object",
@@ -4567,16 +4831,20 @@
                         "annotations": {
                             "type": "object",
                             "description": "can be used to define annotations to add to the persistent volume claim",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": false
                         },
                         "selector": {
                             "type": "object",
                             "description": "can be used to define a label selector for the persistent volume claim",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "orchestration": {
             "type": "object",
@@ -4710,11 +4978,14 @@
                                                     "description": "defines the key within the existing secret object.",
                                                     "default": ""
                                                 }
-                                            }
+                                            },
+                                            "additionalProperties": false
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "authorizations": {
                             "type": "object",
@@ -4724,7 +4995,8 @@
                                     "description": "if true, then enable authorizations checks in all applicable components.",
                                     "default": true
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "initialization": {
                             "type": "object",
@@ -4751,7 +5023,8 @@
                                                 "type": "string",
                                                 "description": ""
                                             }
-                                        }
+                                        },
+                                        "additionalProperties": false
                                     }
                                 },
                                 "defaultRoles": {
@@ -4770,7 +5043,8 @@
                                                         "type": "string"
                                                     }
                                                 }
-                                            }
+                                            },
+                                            "additionalProperties": false
                                         },
                                         "connectors": {
                                             "type": "object",
@@ -4795,9 +5069,11 @@
                                                         "type": "string"
                                                     }
                                                 }
-                                            }
+                                            },
+                                            "additionalProperties": false
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "mappingRules": {
                                     "type": "array",
@@ -4811,9 +5087,11 @@
                                     "default": [],
                                     "items": {}
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "image": {
                     "type": "object",
@@ -4844,7 +5122,8 @@
                             "default": [],
                             "items": {}
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "sidecars": {
                     "type": "array",
@@ -4863,7 +5142,8 @@
                                     "description": "if true, then enable multitenancy checks in all applicable components.",
                                     "default": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "api": {
                             "type": "object",
@@ -4873,9 +5153,11 @@
                                     "description": "if true, then enable multitenancy API used for tenant management.",
                                     "default": true
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "clusterSize": {
                     "type": "string",
@@ -4917,7 +5199,8 @@
                             },
                             "valueFrom": {
                                 "description": "Source for the environment variable's value",
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                             }
                         },
                         "required": [
@@ -4940,7 +5223,8 @@
                             "description": "can be used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. see https://github.com/kubernetes/api/blob/master/core/v1/types.go#L1615-L1623",
                             "default": 754
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "command": {
                     "type": "array",
@@ -4990,7 +5274,8 @@
                                     "description": "defines the type of the headless service https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types",
                                     "default": "ClusterIP"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "type": {
                             "type": "string",
@@ -5064,7 +5349,8 @@
                             "default": [],
                             "items": {}
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "serviceAccount": {
                     "type": "object",
@@ -5082,14 +5368,16 @@
                         "annotations": {
                             "type": "object",
                             "description": "can be used to set the annotations of the broker service account",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": false
                         },
                         "automountServiceAccountToken": {
                             "type": "boolean",
                             "description": "can be used to control whether the service account token should be automatically mounted",
                             "default": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "gateway": {
                     "type": "object",
@@ -5107,9 +5395,11 @@
                                     "description": "defines the url for the GRPC k8s Gateway resources",
                                     "default": "grpc-{{ .Values.global.host }}"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "ingress": {
                     "type": "object",
@@ -5160,7 +5450,8 @@
                                             "description": "defines the secret name which contains the TLS private key and certificate",
                                             "default": "camunda-platform-zeebe-gateway"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "annotations": {
                                     "type": "object",
@@ -5170,9 +5461,11 @@
                                         "type": "string"
                                     }
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "contextPath": {
                     "type": "string",
@@ -5205,7 +5498,8 @@
                                     "description": "",
                                     "default": "1500Mi"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "limits": {
                             "type": "object",
@@ -5220,9 +5514,11 @@
                                     "description": "",
                                     "default": "3000Mi"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "persistenceType": {
                     "type": "string",
@@ -5252,12 +5548,14 @@
                 "pvcAnnotations": {
                     "type": "object",
                     "description": "can be used to specify custom annotations for persistent volume claims, enhancing storage configuration flexibility.",
-                    "default": {}
+                    "default": {},
+                    "additionalProperties": false
                 },
                 "pvcSelector": {
                     "type": "object",
                     "description": "can be used to specify a label selector for persistent volume claims for further filtering of the set of persistent volumes to select.",
-                    "default": {}
+                    "default": {},
+                    "additionalProperties": false
                 },
                 "data": {
                     "type": "object",
@@ -5283,9 +5581,11 @@
                                             "description": "the minimum free space which should be available on the disk, before the broker stops receicing replicated events https://docs.camunda.io/docs/self-managed/zeebe-deployment/configuration/broker-config/#zeebebrokerdatadiskfreespace",
                                             "default": "1GB"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "secondaryStorage": {
                             "type": "object",
@@ -5306,7 +5606,8 @@
                                                     "description": "enable AWS IAM Database Authentication for RDBMS connection",
                                                     "default": false
                                                 }
-                                            }
+                                            },
+                                            "additionalProperties": false
                                         },
                                         "url": {
                                             "type": "string",
@@ -5336,9 +5637,11 @@
                                                     "description": "defines the key within the existing Kubernetes Secret",
                                                     "default": ""
                                                 }
-                                            }
+                                            },
+                                            "additionalProperties": false
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "elasticsearch": {
                                     "type": "object",
@@ -5351,7 +5654,8 @@
                                                     "description": "enable AWS IRSA for Elasticsearch connection",
                                                     "default": false
                                                 }
-                                            }
+                                            },
+                                            "additionalProperties": false
                                         },
                                         "url": {
                                             "type": "string",
@@ -5384,9 +5688,11 @@
                                                             "description": "defines the key within the existing Kubernetes Secret",
                                                             "default": ""
                                                         }
-                                                    }
+                                                    },
+                                                    "additionalProperties": false
                                                 }
-                                            }
+                                            },
+                                            "additionalProperties": false
                                         },
                                         "tls": {
                                             "type": "object",
@@ -5404,11 +5710,14 @@
                                                             "description": "defines the key within the existing Kubernetes Secret for TLS trust store",
                                                             "default": ""
                                                         }
-                                                    }
+                                                    },
+                                                    "additionalProperties": false
                                                 }
-                                            }
+                                            },
+                                            "additionalProperties": false
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "opensearch": {
                                     "type": "object",
@@ -5421,7 +5730,8 @@
                                                     "description": "enable AWS IRSA for OpenSearch connection",
                                                     "default": false
                                                 }
-                                            }
+                                            },
+                                            "additionalProperties": false
                                         },
                                         "url": {
                                             "type": "string",
@@ -5454,9 +5764,11 @@
                                                             "description": "defines the key within the existing Kubernetes Secret",
                                                             "default": ""
                                                         }
-                                                    }
+                                                    },
+                                                    "additionalProperties": false
                                                 }
-                                            }
+                                            },
+                                            "additionalProperties": false
                                         },
                                         "tls": {
                                             "type": "object",
@@ -5474,15 +5786,20 @@
                                                             "description": "defines the key within the existing Kubernetes Secret for TLS trust store",
                                                             "default": ""
                                                         }
-                                                    }
+                                                    },
+                                                    "additionalProperties": false
                                                 }
-                                            }
+                                            },
+                                            "additionalProperties": false
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "extraVolumes": {
                     "type": "array",
@@ -5511,12 +5828,14 @@
                 "podAnnotations": {
                     "type": "object",
                     "description": "can be used to define extra broker pod annotations. Supports templating (e.g., {{ .Release.Name }}).",
-                    "default": {}
+                    "default": {},
+                    "additionalProperties": false
                 },
                 "podLabels": {
                     "type": "object",
                     "description": "can be used to define extra broker pod labels. Supports templating (e.g., {{ .Release.Name }}).",
-                    "default": {}
+                    "default": {},
+                    "additionalProperties": false
                 },
                 "podDisruptionBudget": {
                     "type": "object",
@@ -5536,7 +5855,8 @@
                             "description": "can be used to set how many pods should be at max. unavailable",
                             "default": 1
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "podSecurityContext": {
                     "type": "object",
@@ -5559,9 +5879,11 @@
                                     "description": "",
                                     "default": "RuntimeDefault"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "containerSecurityContext": {
                     "type": "object",
@@ -5599,9 +5921,11 @@
                                     "description": "",
                                     "default": "RuntimeDefault"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "startupProbe": {
                     "type": "object",
@@ -5646,7 +5970,8 @@
                             "description": "defines the seconds after the probe times out",
                             "default": 1
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "readinessProbe": {
                     "type": "object",
@@ -5691,7 +6016,8 @@
                             "description": "defines the seconds after the probe times out",
                             "default": 1
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "livenessProbe": {
                     "type": "object",
@@ -5736,7 +6062,8 @@
                             "description": "defines the seconds after the probe times out",
                             "default": 1
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "metrics": {
                     "type": "object",
@@ -5746,12 +6073,14 @@
                             "description": "Prometheus metrics endpoint",
                             "default": "/actuator/prometheus"
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "nodeSelector": {
                     "type": "object",
                     "description": "can be used to define on which nodes the broker pods should run",
-                    "default": {}
+                    "default": {},
+                    "additionalProperties": false
                 },
                 "tolerations": {
                     "type": "array",
@@ -5775,7 +6104,8 @@
                                     "description": "if true, enables the new Camunda exporter.",
                                     "default": true
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "rdbms": {
                             "type": "object",
@@ -5785,7 +6115,8 @@
                                     "description": "if true, enables the new RDBMS exporter.",
                                     "default": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "zeebe": {
                             "type": "object",
@@ -5795,7 +6126,8 @@
                                     "description": "if true, enables the legacy Zeebe Elasticsearch and OpenSearch exporters.",
                                     "default": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "appIntegrations": {
                             "type": "object",
@@ -5821,13 +6153,17 @@
                                                     "description": "defines the key within the existing Kubernetes Secret.",
                                                     "default": ""
                                                 }
-                                            }
+                                            },
+                                            "additionalProperties": false
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "index": {
                     "type": "object",
@@ -5842,7 +6178,8 @@
                             "description": "can be used to specify the number of replicas for Orchestration Cluster indices.",
                             "default": 1
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "retention": {
                     "type": "object",
@@ -5862,7 +6199,8 @@
                             "description": "defines the name of the created and applied ILM policy.",
                             "default": "zeebe-record-retention-policy"
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "history": {
                     "type": "object",
@@ -5925,9 +6263,11 @@
                                     "description": "defines the name of the created and applied ILM policy to usage metric indices.",
                                     "default": "camunda-usage-metrics-retention-policy"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "configuration": {
                     "type": "string",
@@ -5948,7 +6288,8 @@
                 "dnsConfig": {
                     "type": "object",
                     "description": "https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config",
-                    "default": {}
+                    "default": {},
+                    "additionalProperties": false
                 },
                 "extraVolumeClaimTemplates": {
                     "type": "array",
@@ -5964,9 +6305,11 @@
                             "description": "if true, allows the use of pre-release images for the orchestration cluster. Prerelease images are, by their nature, unstable and should be used with caution. This flag should only be used for testing purposes.",
                             "default": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "optimize": {
             "type": "object",
@@ -6005,7 +6348,8 @@
                             "default": [],
                             "items": {}
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "database": {
                     "type": "object",
@@ -6044,9 +6388,11 @@
                                                     "description": "can be used to provide the key within the secret containing the certificate",
                                                     "default": "externaldb.jks"
                                                 }
-                                            }
+                                            },
+                                            "additionalProperties": false
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "auth": {
                                     "type": "object",
@@ -6074,9 +6420,11 @@
                                                     "description": "defines the key within the existing secret object.",
                                                     "default": ""
                                                 }
-                                            }
+                                            },
+                                            "additionalProperties": false
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "url": {
                                     "type": "object",
@@ -6096,14 +6444,16 @@
                                             "description": "Elasticsearch.port defines the elasticsearch port, under which elasticsearch can be accessed. Falls back to global.elasticsearch.url.port.",
                                             "default": 0
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "prefix": {
                                     "type": "string",
                                     "description": "defines the prefix which is used by the old Zeebe Elasticsearch Exporter to create Elasticsearch indexes and consumed by Optimize.",
                                     "default": "zeebe-record"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "opensearch": {
                             "type": "object",
@@ -6121,7 +6471,8 @@
                                             "description": "Enabling AWS IRSA",
                                             "default": false
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "tls": {
                                     "type": "object",
@@ -6144,9 +6495,11 @@
                                                     "description": "can be used to provide the key within the secret containing the certificate",
                                                     "default": "externaldb.jks"
                                                 }
-                                            }
+                                            },
+                                            "additionalProperties": false
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "auth": {
                                     "type": "object",
@@ -6174,9 +6527,11 @@
                                                     "description": "defines the key within the existing secret object.",
                                                     "default": ""
                                                 }
-                                            }
+                                            },
+                                            "additionalProperties": false
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "url": {
                                     "type": "object",
@@ -6196,16 +6551,19 @@
                                             "description": "defines the external opensearch port, under which opensearch can be accessed. Falls back to global.opensearch.url.port.",
                                             "default": 0
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "prefix": {
                                     "type": "string",
                                     "description": "defines the prefix which is used by the old Zeebe OpenSearch Exporter to create OpenSearch indexes and consumed by Optimize.",
                                     "default": "zeebe-record"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "migration": {
                     "type": "object",
@@ -6237,7 +6595,8 @@
                                             "description": "",
                                             "default": "1Gi"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "limits": {
                                     "type": "object",
@@ -6252,11 +6611,14 @@
                                             "description": "",
                                             "default": "2Gi"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "sidecars": {
                     "type": "array",
@@ -6277,17 +6639,20 @@
                             "description": "can be used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.",
                             "default": 754
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "podAnnotations": {
                     "type": "object",
                     "description": "can be used to define extra Optimize pod annotations. Supports templating (e.g., {{ .Release.Name }}).",
-                    "default": {}
+                    "default": {},
+                    "additionalProperties": false
                 },
                 "podLabels": {
                     "type": "object",
                     "description": "can be used to define extra Optimize pod labels. Supports templating (e.g., {{ .Release.Name }}).",
-                    "default": {}
+                    "default": {},
+                    "additionalProperties": false
                 },
                 "logLevel": {
                     "type": "string",
@@ -6334,7 +6699,8 @@
                             },
                             "valueFrom": {
                                 "description": "Source for the environment variable's value",
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false
                             }
                         },
                         "required": [
@@ -6389,14 +6755,16 @@
                         "annotations": {
                             "type": "object",
                             "description": "can be used to set the annotations of the Optimize service account",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": false
                         },
                         "automountServiceAccountToken": {
                             "type": "boolean",
                             "description": "can be used to control whether the service account token should be automatically mounted",
                             "default": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "service": {
                     "type": "object",
@@ -6404,7 +6772,8 @@
                         "annotations": {
                             "type": "object",
                             "description": "can be used to define annotations, which will be applied to the Optimize service",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": false
                         },
                         "type": {
                             "type": "string",
@@ -6421,7 +6790,8 @@
                             "description": "defines the port where actuator will be available. Also required to reach backup API",
                             "default": 8092
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "podSecurityContext": {
                     "type": "object",
@@ -6444,9 +6814,11 @@
                                     "description": "",
                                     "default": "RuntimeDefault"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "containerSecurityContext": {
                     "type": "object",
@@ -6484,9 +6856,11 @@
                                     "description": "",
                                     "default": "RuntimeDefault"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "startupProbe": {
                     "type": "object",
@@ -6531,7 +6905,8 @@
                             "description": "defines the seconds after the probe times out",
                             "default": 1
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "readinessProbe": {
                     "type": "object",
@@ -6576,7 +6951,8 @@
                             "description": "defines the seconds after the probe times out",
                             "default": 1
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "livenessProbe": {
                     "type": "object",
@@ -6621,7 +6997,8 @@
                             "description": "defines the seconds after the probe times out",
                             "default": 1
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "metrics": {
                     "type": "object",
@@ -6631,12 +7008,14 @@
                             "description": "Prometheus metrics endpoint",
                             "default": "/actuator/prometheus"
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "nodeSelector": {
                     "type": "object",
                     "description": "can be used to define on which nodes the Optimize pods should run",
-                    "default": {}
+                    "default": {},
+                    "additionalProperties": false
                 },
                 "tolerations": {
                     "type": "array",
@@ -6647,7 +7026,8 @@
                 "affinity": {
                     "type": "object",
                     "description": "can be used to define pod affinity or anti-affinity https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity",
-                    "default": {}
+                    "default": {},
+                    "additionalProperties": false
                 },
                 "resources": {
                     "type": "object",
@@ -6665,7 +7045,8 @@
                                     "description": "",
                                     "default": "1Gi"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "limits": {
                             "type": "object",
@@ -6680,9 +7061,11 @@
                                     "description": "",
                                     "default": "2Gi"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "configuration": {
                     "type": "string",
@@ -6703,7 +7086,8 @@
                 "dnsConfig": {
                     "type": "object",
                     "description": "https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config",
-                    "default": {}
+                    "default": {},
+                    "additionalProperties": false
                 },
                 "persistence": {
                     "type": "object",
@@ -6741,14 +7125,17 @@
                         "annotations": {
                             "type": "object",
                             "description": "can be used to define annotations to add to the persistent volume claim",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": false
                         },
                         "selector": {
                             "type": "object",
                             "description": "can be used to define a label selector for the persistent volume claim",
-                            "default": {}
+                            "default": {},
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "profiles": {
                     "type": "string",
@@ -6768,7 +7155,8 @@
                             "description": "if true, enables multitenancy in Optimize",
                             "default": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "caches": {
                     "type": "object",
@@ -6786,9 +7174,11 @@
                                     "description": "defines the minimum interval between fetches from the database for the cache",
                                     "default": 600000
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 }
             },
             "migration": {
@@ -6816,7 +7206,8 @@
                                 },
                                 "valueFrom": {
                                     "description": "Source for the environment variable's value",
-                                    "type": "object"
+                                    "type": "object",
+                                    "additionalProperties": false
                                 }
                             },
                             "required": [
@@ -6825,8 +7216,10 @@
                             "additionalProperties": false
                         }
                     }
-                }
-            }
+                },
+                "additionalProperties": false
+            },
+            "additionalProperties": false
         },
         "elasticsearch": {
             "type": "object",
@@ -6850,11 +7243,14 @@
                                             "description": "(DEPRECATED) Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: force (perform the adaptation always), disabled (do not perform adaptation)",
                                             "default": "{{ .Values.global.compatibility.openshift.adaptSecurityContext | default \"disabled\" }}"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "image": {
                     "type": "object",
@@ -6874,7 +7270,8 @@
                             "description": "(DEPRECATED) can be used to set image digest (overrides tag if set, e.g. \"sha256:abcd...\")",
                             "default": ""
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "master": {
                     "type": "object",
@@ -6897,7 +7294,8 @@
                                     "description": "(DEPRECATED)",
                                     "default": true
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "masterOnly": {
                             "type": "boolean",
@@ -6917,7 +7315,8 @@
                                     "description": "(DEPRECATED)",
                                     "default": "64Gi"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "resources": {
                             "type": "object",
@@ -6930,7 +7329,8 @@
                                             "description": "(DEPRECATED) request",
                                             "default": "2Gi"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 },
                                 "limits": {
                                     "type": "object",
@@ -6940,9 +7340,11 @@
                                             "description": "(DEPRECATED) memory limit",
                                             "default": "2Gi"
                                         }
-                                    }
+                                    },
+                                    "additionalProperties": false
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         },
                         "extraEnvVars": {
                             "type": "array",
@@ -6958,10 +7360,12 @@
                                         "type": "string",
                                         "description": "(DEPRECATED) env value"
                                     }
-                                }
+                                },
+                                "additionalProperties": false
                             }
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "sysctlImage": {
                     "type": "object",
@@ -6976,7 +7380,8 @@
                             "description": "(DEPRECATED)",
                             "default": "bitnamilegacy/os-shell"
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "data": {
                     "type": "object",
@@ -6986,7 +7391,8 @@
                             "description": "(DEPRECATED)",
                             "default": 0
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "coordinating": {
                     "type": "object",
@@ -6996,7 +7402,8 @@
                             "description": "(DEPRECATED)",
                             "default": 0
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "ingest": {
                     "type": "object",
@@ -7006,7 +7413,8 @@
                             "description": "(DEPRECATED)",
                             "default": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "metrics": {
                     "type": "object",
@@ -7019,9 +7427,11 @@
                                     "description": "(DEPRECATED)",
                                     "default": "bitnamilegacy/elasticsearch-exporter"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "volumePermissions": {
                     "type": "object",
@@ -7034,9 +7444,11 @@
                                     "description": "(DEPRECATED)",
                                     "default": "bitnamilegacy/os-shell"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "copyTlsCerts": {
                     "type": "object",
@@ -7049,11 +7461,14 @@
                                     "description": "(DEPRECATED)",
                                     "default": "bitnamilegacy/os-shell"
                                 }
-                            }
+                            },
+                            "additionalProperties": false
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 }
-            }
+            },
+            "additionalProperties": false
         },
         "prometheusServiceMonitor": {
             "type": "object",
@@ -7071,14 +7486,17 @@
                             "description": "",
                             "default": "metrics"
                         }
-                    }
+                    },
+                    "additionalProperties": false
                 },
                 "scrapeInterval": {
                     "type": "string",
                     "description": "can be set to configure the interval at which metrics should be scraped",
                     "default": "10s"
                 }
-            }
+            },
+            "additionalProperties": false
         }
-    }
+    },
+    "additionalProperties": false
 }

--- a/scripts/make-schema-strict/go.mod
+++ b/scripts/make-schema-strict/go.mod
@@ -1,0 +1,7 @@
+module camunda.com/makeschemastrict
+
+go 1.25.0
+
+toolchain go1.26.2
+
+require github.com/iancoleman/orderedmap v0.3.0

--- a/scripts/make-schema-strict/go.sum
+++ b/scripts/make-schema-strict/go.sum
@@ -1,0 +1,2 @@
+github.com/iancoleman/orderedmap v0.3.0 h1:5cbR2grmZR/DiVt+VJopEhtVs9YGInGIxAoMJn+Ichc=
+github.com/iancoleman/orderedmap v0.3.0/go.mod h1:XuLcCUkdL5owUCQeF2Ue9uuw1EptkJDkXXS7VoV7XGE=

--- a/scripts/make-schema-strict/main.go
+++ b/scripts/make-schema-strict/main.go
@@ -1,0 +1,187 @@
+// Command make-schema-strict post-processes a Helm chart values.schema.json
+// to inject "additionalProperties": false into every object schema that does
+// not already declare an explicit value for it. See:
+// https://github.com/camunda/camunda-platform-helm/issues/4564
+//
+// The transform is non-destructive: existing additionalProperties (whether
+// false, true, or a sub-schema like {type: string} for free-form maps such
+// as labels/annotations) are preserved as-is. Key ordering is preserved so
+// review diffs only show the injected lines.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/iancoleman/orderedmap"
+)
+
+func main() {
+	in := flag.String("i", "", "input file path, or - for stdin")
+	out := flag.String("o", "", "output file path, or - for stdout")
+	flag.Parse()
+
+	if *in == "" || *out == "" {
+		fmt.Fprintln(os.Stderr, "usage: make-schema-strict -i FILE -o FILE")
+		os.Exit(2)
+	}
+
+	raw, err := readInput(*in)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "read %s: %v\n", *in, err)
+		os.Exit(1)
+	}
+
+	root := orderedmap.New()
+	if err := json.Unmarshal(raw, &root); err != nil {
+		fmt.Fprintf(os.Stderr, "parse %s: %v\n", *in, err)
+		os.Exit(1)
+	}
+
+	strictifyMap(root)
+
+	pretty, err := json.MarshalIndent(root, "", "    ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "marshal: %v\n", err)
+		os.Exit(1)
+	}
+	pretty = append(pretty, '\n')
+
+	if err := writeOutput(*out, pretty); err != nil {
+		fmt.Fprintf(os.Stderr, "write %s: %v\n", *out, err)
+		os.Exit(1)
+	}
+}
+
+// makeStrict walks node, injecting additionalProperties: false into every
+// object schema that does not already declare it. Returns the (possibly
+// mutated) value so callers can replace it inside the parent container —
+// orderedmap stores values by value, so in-place mutation through the
+// `interface{}` returned by Get does not propagate.
+func makeStrict(node interface{}) interface{} {
+	switch v := node.(type) {
+	case *orderedmap.OrderedMap:
+		strictifyMap(v)
+		return v
+	case orderedmap.OrderedMap:
+		strictifyMap(&v)
+		return v
+	case []interface{}:
+		for i, elem := range v {
+			v[i] = makeStrict(elem)
+		}
+		return v
+	}
+	return node
+}
+
+func strictifyMap(m *orderedmap.OrderedMap) {
+	if isObjectSchema(m) {
+		if _, exists := m.Get("additionalProperties"); !exists {
+			m.Set("additionalProperties", false)
+		}
+	}
+
+	handled := map[string]bool{}
+
+	if v, ok := m.Get("properties"); ok {
+		handled["properties"] = true
+		m.Set("properties", recurseInOrderedMap(v))
+	}
+
+	if v, ok := m.Get("patternProperties"); ok {
+		handled["patternProperties"] = true
+		m.Set("patternProperties", recurseInOrderedMap(v))
+	}
+
+	if v, ok := m.Get("items"); ok {
+		handled["items"] = true
+		m.Set("items", makeStrict(v))
+	}
+
+	for _, comb := range []string{"allOf", "anyOf", "oneOf"} {
+		if v, ok := m.Get(comb); ok {
+			handled[comb] = true
+			m.Set(comb, makeStrict(v))
+		}
+	}
+
+	if v, ok := m.Get("not"); ok {
+		handled["not"] = true
+		m.Set("not", makeStrict(v))
+	}
+
+	// Generic fallback for definitions, $defs, and any other nested object
+	// container. Only recurse into structural types, not primitives.
+	for _, k := range m.Keys() {
+		if handled[k] {
+			continue
+		}
+		v, _ := m.Get(k)
+		switch v.(type) {
+		case orderedmap.OrderedMap, *orderedmap.OrderedMap, []interface{}:
+			m.Set(k, makeStrict(v))
+		}
+	}
+}
+
+// isObjectSchema returns true if m looks like a JSON Schema describing an
+// object — has properties, patternProperties, or explicit type: object.
+func isObjectSchema(m *orderedmap.OrderedMap) bool {
+	if _, ok := m.Get("properties"); ok {
+		return true
+	}
+	if _, ok := m.Get("patternProperties"); ok {
+		return true
+	}
+	if t, ok := m.Get("type"); ok {
+		if s, isStr := t.(string); isStr && s == "object" {
+			return true
+		}
+	}
+	return false
+}
+
+// recurseInOrderedMap walks each value of an inner ordered map (used for
+// properties and patternProperties, where each key maps to a sub-schema)
+// and returns the mutated map by value so the caller can store it back.
+func recurseInOrderedMap(v interface{}) interface{} {
+	inner, ok := asOrderedMap(v)
+	if !ok {
+		return v
+	}
+	for _, k := range inner.Keys() {
+		sub, _ := inner.Get(k)
+		inner.Set(k, makeStrict(sub))
+	}
+	return *inner
+}
+
+// asOrderedMap normalizes value vs pointer return from orderedmap.Get.
+func asOrderedMap(v interface{}) (*orderedmap.OrderedMap, bool) {
+	switch vv := v.(type) {
+	case *orderedmap.OrderedMap:
+		return vv, true
+	case orderedmap.OrderedMap:
+		return &vv, true
+	}
+	return nil, false
+}
+
+func readInput(path string) ([]byte, error) {
+	if path == "-" {
+		return io.ReadAll(os.Stdin)
+	}
+	return os.ReadFile(path)
+}
+
+func writeOutput(path string, data []byte) error {
+	if path == "-" {
+		_, err := os.Stdout.Write(data)
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}

--- a/scripts/make-schema-strict/main_test.go
+++ b/scripts/make-schema-strict/main_test.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/iancoleman/orderedmap"
+)
+
+func runStrict(t *testing.T, in string) string {
+	t.Helper()
+	root := orderedmap.New()
+	if err := json.Unmarshal([]byte(in), &root); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	makeStrict(root)
+	out, err := json.MarshalIndent(root, "", "    ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(out)
+}
+
+func TestStrictify(t *testing.T) {
+	cases := []struct {
+		name       string
+		in         string
+		mustHave   []string
+		mustNotHave []string
+	}{
+		{
+			name: "object with properties gets additionalProperties false",
+			in: `{
+                "type": "object",
+                "properties": {
+                    "foo": { "type": "string" }
+                }
+            }`,
+			mustHave: []string{`"additionalProperties": false`},
+		},
+		{
+			name: "explicit additionalProperties is preserved",
+			in: `{
+                "type": "object",
+                "properties": {
+                    "labels": {
+                        "type": "object",
+                        "additionalProperties": { "type": "string" }
+                    }
+                }
+            }`,
+			mustHave: []string{
+				`"additionalProperties": {`,
+				`"type": "string"`,
+			},
+			mustNotHave: []string{`"additionalProperties": false,\n        "type": "object"`},
+		},
+		{
+			name: "explicit true is preserved",
+			in: `{
+                "type": "object",
+                "properties": {
+                    "x": {
+                        "type": "object",
+                        "additionalProperties": true
+                    }
+                }
+            }`,
+			mustHave: []string{`"additionalProperties": true`},
+		},
+		{
+			name: "patternProperties triggers strictification",
+			in: `{
+                "patternProperties": {
+                    "^[a-z]+$": { "type": "string" }
+                }
+            }`,
+			mustHave: []string{`"additionalProperties": false`},
+		},
+		{
+			name: "nested objects are recursed",
+			in: `{
+                "type": "object",
+                "properties": {
+                    "outer": {
+                        "type": "object",
+                        "properties": {
+                            "inner": { "type": "string" }
+                        }
+                    }
+                }
+            }`,
+			mustHave: []string{
+				`"additionalProperties": false`,
+			},
+		},
+		{
+			name: "items array is recursed",
+			in: `{
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" }
+                    }
+                }
+            }`,
+			mustHave: []string{`"additionalProperties": false`},
+		},
+		{
+			name: "allOf composition is recursed",
+			in: `{
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "a": { "type": "string" }
+                        }
+                    }
+                ]
+            }`,
+			mustHave: []string{`"additionalProperties": false`},
+		},
+		{
+			name: "definitions block is recursed",
+			in: `{
+                "definitions": {
+                    "Pod": {
+                        "type": "object",
+                        "properties": {
+                            "name": { "type": "string" }
+                        }
+                    }
+                }
+            }`,
+			mustHave: []string{`"additionalProperties": false`},
+		},
+		{
+			name: "leaf type does not get additionalProperties",
+			in: `{
+                "type": "string"
+            }`,
+			mustNotHave: []string{`"additionalProperties"`},
+		},
+		{
+			name: "idempotent: running on already-strict schema is a no-op",
+			in: `{
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "foo": { "type": "string" }
+                }
+            }`,
+			mustHave:    []string{`"additionalProperties": false`},
+			mustNotHave: []string{`false,\n    "additionalProperties": false`},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := runStrict(t, tc.in)
+			for _, s := range tc.mustHave {
+				if !strings.Contains(out, s) {
+					t.Errorf("expected output to contain %q\n--- output ---\n%s", s, out)
+				}
+			}
+			for _, s := range tc.mustNotHave {
+				if strings.Contains(out, s) {
+					t.Errorf("expected output to NOT contain %q\n--- output ---\n%s", s, out)
+				}
+			}
+		})
+	}
+}
+
+func TestKeyOrderPreserved(t *testing.T) {
+	in := `{
+        "type": "object",
+        "description": "z-first",
+        "properties": {
+            "z_first": { "type": "string" },
+            "a_second": { "type": "string" }
+        }
+    }`
+	out := runStrict(t, in)
+	zIdx := strings.Index(out, `"z_first"`)
+	aIdx := strings.Index(out, `"a_second"`)
+	if zIdx < 0 || aIdx < 0 {
+		t.Fatalf("missing keys in output: %s", out)
+	}
+	if zIdx > aIdx {
+		t.Errorf("expected z_first before a_second, got order:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary

Pilots an automated solution for [#4564](https://github.com/camunda/camunda-platform-helm/issues/4564) on `camunda-platform-8.10`. A new `scripts/make-schema-strict` Go tool injects `"additionalProperties": false` into every object schema in `values.schema.json` that doesn't already declare an explicit value, so typos like `global.identity.keycloak.urll` fail at `helm install` time instead of being silently dropped.

The tool runs as a new step inside `make helm.schema-update`, after the existing `readme-generator` + `jq` merge with `values.schema.extra.json`. Existing flexible-key carve-outs (e.g. `global.ingress.annotations: { additionalProperties: { type: string } }`) are preserved. Key ordering is preserved so review diffs only show the injected lines.

The deployment-references repo already implements the same `make_schema_strict()` algorithm in [`internal-helm-deprecation-check/validate-unknown-keys.py`](https://github.com/camunda/camunda-deployment-references/blob/main/.github/actions/internal-helm-deprecation-check/validate-unknown-keys.py); this PR ports the strictification half into the chart-build pipeline so end users benefit at install time rather than only at deploy-time validation. Unlike the upstream version, this implementation is **non-destructive**: it only sets `additionalProperties: false` when the field is absent, so existing carve-outs survive.

## What changed

| File | Change |
|---|---|
| `scripts/make-schema-strict/{go.mod,go.sum,main.go,main_test.go}` | New Go tool with table-driven unit tests covering recursion through `properties`, `patternProperties`, `items`, `allOf`/`anyOf`/`oneOf`, `not`, and `definitions`/`$defs`; preservation of explicit `false`/`true`/object values; idempotency; key-order preservation |
| `Makefile` (`helm.schema-update`) | Adds `strict_versions` regex gate (currently `8.10` only) and a final `go run` step that mutates the merged schema in place |
| `charts/camunda-platform-8.10/values.schema.json` | Regenerated — 426 `additionalProperties: false` insertions, 4 pre-existing `additionalProperties: { type: string }` entries preserved |

## Verification

```bash
make helm.dependency-update chartPath=charts/camunda-platform-8.10
make helm.schema-update      chartPath=charts/camunda-platform-8.10

# Resolves the issue's reproducer
helm template c8 charts/camunda-platform-8.10 \
  --set global.identity.keycloak.urll=https://example.com
# → Error: ... global.identity.keycloak: Additional property urll is not allowed

# Tool unit tests
( cd scripts/make-schema-strict && go test ./... )
```

## Pilot scope and surfaced gaps

The strict step is gated to `camunda-platform-8.10` via the `strict_versions` regex in the Makefile. Extending to 8.8 and 8.9 is a deliberate follow-up.

`make helm.lint chartPath=charts/camunda-platform-8.10` now surfaces 22 real schema gaps where existing values aren't described — every one of them is a class of typo that was silently accepted before. **These should be addressed before merging this PR.** They split into three categories:

**Sub-chart pass-throughs** (probably need `additionalProperties: true` on the sub-chart root in `values.schema.extra.json`):
- `(root).common`
- `elasticsearch.extraConfig`
- `elasticsearch.master.resources.{requests,limits}.cpu`
- `identityKeycloak.extraVolumes`
- `identityKeycloak.ingress.annotations`

**Kubernetes-standard fields the umbrella schema doesn't model** (need explicit entries):
- `orchestration.affinity`
- `orchestration.ingress.grpc.labels`
- `global.ingress.labels`
- `global.gateway.{labels,annotations}`
- `*.resources.{requests,limits}.cpu` for connectors/console

**First-party features missing from `values.yaml` schema annotations** (need fixing in `values.yaml` so `readme-generator` picks them up):
- `global.multiregion`
- `global.testDeprecationFlags`
- `global.security.allowInsecureImages`
- `orchestration.profiles`
- `connectors.logging`, `webModeler.restapi.logging`
- `identity.logging.level."io.camunda.identity"` (dotted logger key — needs `patternProperties`)

## Test plan

- [ ] Decide scope: address all 22 gaps in this PR, or split into follow-up commits / PRs
- [ ] After gap fixes, confirm `make helm.lint chartPath=charts/camunda-platform-8.10` is clean
- [ ] Confirm `helm template` for each shipped overlay (`values.yaml`, `values-latest.yaml`, `values-enterprise.yaml`, `values-bitnami-legacy.yaml`) still renders
- [ ] Walk integration scenario YAMLs under `test/integration/scenarios/` for false-positive lockouts
- [ ] Re-run `make go.test chartPath=charts/camunda-platform-8.10` — golden output should not shift
- [ ] Decide cadence for extending the gate to 8.8 and 8.9