### PR TITLE
ci: add Required Check aggregator and default automerge to true

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,6 +18,14 @@
   separateMinorPatch: true,
   ignoreTests: false,
   prCreation: 'not-pending',
+  // Automerge is the default. The "Required Check" workflow aggregates all
+  // other PR checks into one stable status, so Renovate can wait on it.
+  // Major updates are excluded via packageRules below.
+  automerge: true,
+  // Use Renovate's PR-based automerge (not GitHub's platformAutomerge), since
+  // Renovate waits for all status checks before merging.
+  platformAutomerge: false,
+  automergeType: 'pr',
   prBodyNotes: [
     '{{#if isMajor}}:warning: THIS IS A MAJOR VERSION UPDATE :warning:{{/if}}',
     'Before merging, *always* check with the release notes if any other changes need to be done.',
@@ -384,6 +392,9 @@
       prCreation: 'immediate',
     },
     {
+      // Visibility labels for non-major updates in known automation paths.
+      // Automerge itself is now the global default (see top of file); this
+      // rule only adds labels.
       matchFileNames: [
         '.tool-versions',
         '.github/workflows/*',
@@ -396,12 +407,6 @@
         'automation/renovatebot',
         'kind/chore',
       ],
-      // Use Renovate's automerge (not GitHub's platformAutomerge)
-      // Renovate waits for all status checks by default, which works with dynamic checks per chart version
-      platformAutomerge: false,
-      automerge: true,
-      automergeType: 'pr', // Merge via PR to respect GitHub settings
-      ignoreTests: false, // Wait for all status checks to pass
     },
     // This package name is used by the initContainer for keycloak in v8.5, and doesn't make sense to
     // be processed by renovate because it requires helm templating to render the real image name.

--- a/.github/workflows/pr-enable-automerge.yaml
+++ b/.github/workflows/pr-enable-automerge.yaml
@@ -1,0 +1,26 @@
+# Auto-enables GitHub's native auto-merge on every non-draft PR. Once required
+# reviews are approved and required status checks are green (i.e. the
+# "Required Check" aggregator passes), the PR merges itself with no manual
+# click. Major Renovate updates set `automerge: false` in renovate.json5 and
+# do NOT use this path - they merge through Renovate-side rules anyway.
+name: "PR - Enable Auto-Merge"
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-automerge:
+    name: Enable auto-merge
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    steps:
+      - name: Enable auto-merge (squash)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/required-check.yaml
+++ b/.github/workflows/required-check.yaml
@@ -1,0 +1,33 @@
+# Single, stable status check that aggregates the result of every other PR
+# check on this commit. Branch protection should require only this one check
+# (instead of the dynamic matrix-generated check names from
+# test-chart-version.yaml, which differ per PR).
+name: "Required Check"
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  checks: read
+  statuses: read
+
+jobs:
+  required-check:
+    name: Required Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for all other PR checks
+        uses: poseidon/wait-for-status-checks@899c768d191b56eef585c18f8558da19e1f3e707 # v0.6.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Ignore self so this job does not wait on its own status.
+          ignore: "Required Check"
+          delay: "30"
+          interval: "30"
+          # Integration tests can take a while; allow plenty of headroom.
+          timeout: "7200"


### PR DESCRIPTION
## Summary

Two related quality-of-life changes for branch protection + merging:

1. **Add a single, stable `Required Check` status** (`.github/workflows/required-check.yaml`) that waits for every other PR check on the head SHA via [`poseidon/wait-for-status-checks`](https://github.com/poseidon/wait-for-status-checks) and reports one aggregate result. This unblocks branch protection: today, the matrix-driven jobs in `test-chart-version.yaml` produce different job names per PR (chart versions / scenarios / flows differ based on changed files), so listing them as required checks blocks merges whenever a PR doesn't generate that exact matrix entry. With this aggregator, branch protection only needs to require **`Required Check`**.
2. **Make automerge the default** so we don't have to remember to merge an already-green, already-approved PR:
   - In `.github/renovate.json5`, set `automerge: true` + `platformAutomerge: false` + `automergeType: 'pr'` at the root level. The existing major-update rule still overrides this to `automerge: false`, so major bumps continue to require a human.
   - Add `.github/workflows/pr-enable-automerge.yaml` which calls `gh pr merge --auto --squash` on every non-draft PR (`opened` / `reopened` / `ready_for_review`). Once required reviews approve and `Required Check` is green, GitHub merges the PR. The repo already uses `gh pr merge --auto` in `chart-release-public.yaml`, so the "Allow auto-merge" repo setting is already on.

## Manual follow-up after merge

In **Settings → Branches → main** (or the equivalent ruleset), update **Required status checks** so that the matrix-driven names from `test-chart-version.yaml` are removed and **`Required Check`** is the only matrix-related required check. Other always-on checks (e.g. `Repo - Pull Request Conventions`, `PR - Require Task Link`) can remain required as desired.

## Test plan

- [ ] Confirm this draft PR's `Required Check` job runs and waits for the other PR checks (matrix jobs from `test-chart-version.yaml` will trigger because `.github/workflows/` files changed).
- [ ] Confirm `Required Check` reports green once all the matrix jobs and other PR workflows finish green/skipped.
- [ ] Confirm the new `PR - Enable Auto-Merge` job runs on this PR and that the GitHub UI shows "Auto-merge enabled" once this PR is taken out of draft.
- [ ] After merge: open a tiny markdown-only follow-up PR to verify `Required Check` still appears and goes green on a non-chart PR.
- [ ] After merge: rerun Renovate's dependency dashboard refresh and verify a non-major PR shows "Automerge: Enabled" in its body.