### PR TITLE
fix: resolve SM nightly upgrade scenario failures for groups 2-4

### DIFF
--- a/.github/actions/integration-test-setup/action.yaml
+++ b/.github/actions/integration-test-setup/action.yaml
@@ -64,6 +64,12 @@ inputs:
     description: Previous Camunda version used in upgrade-minor flow
     required: false
     default: ""
+  upgrade-step:
+    description: |
+      Set to "true" when called from the upgrade phase of an upgrade flow.
+      Passed through to test-type-vars so the current chart is used instead of the previous one.
+    required: false
+    default: "false"
 
 outputs:
   cluster-auth-token:
@@ -216,6 +222,7 @@ runs:
         values-digest: ${{ inputs.values-digest }}
         flow: ${{ inputs.flow }}
         camunda-version-previous: ${{ inputs.camunda-version-previous }}
+        upgrade-step: ${{ inputs.upgrade-step }}
 
     # ------------------------------------------------------------------
     # Docker Hub login (avoids rate limits for Helm dependency pulls)

--- a/.github/actions/test-type-vars/action.yaml
+++ b/.github/actions/test-type-vars/action.yaml
@@ -15,6 +15,13 @@ inputs:
     description: Flow type, e.g., install, upgrade-patch, upgrade-minor
   camunda-version-previous:
     description: Previous Camunda version, e.g., 8.7
+  upgrade-step:
+    description: |
+      Set to "true" when called from the upgrade phase of an upgrade flow.
+      When false (default), upgrade-minor uses the previous chart version for the install phase.
+      When true, the current chart-dir is used so helm upgrade deploys the new version.
+    required: false
+    default: "false"
 outputs:
   unitTestEnabled:
     description: Should the unit test be executed or not.
@@ -33,7 +40,10 @@ runs:
         matrix_file="charts/${{ inputs.chart-dir }}/test/ci-test-config.yaml"
 
         # Chart path.
-        if [[ "${{ inputs.flow }}" == "upgrade-minor" && -n "${{ inputs.camunda-version-previous }}" ]]; then
+        # For upgrade-minor, the install step deploys the previous chart version,
+        # but the upgrade step must use the current (target) chart so helm upgrade
+        # actually moves to the new version.
+        if [[ "${{ inputs.flow }}" == "upgrade-minor" && -n "${{ inputs.camunda-version-previous }}" && "${{ inputs.upgrade-step }}" != "true" ]]; then
           chart_path="charts/camunda-platform-${{ inputs.camunda-version-previous }}"
         else
           chart_path="charts/${{ inputs.chart-dir }}"

--- a/.github/actions/workflow-vars/action.yaml
+++ b/.github/actions/workflow-vars/action.yaml
@@ -158,7 +158,15 @@ runs:
       echo "OPTIMIZE_INDEX_PREFIX=$GITHUB_WORKFLOW_JOB_ID-optimize" | tee -a $GITHUB_ENV
       echo "OPERATE_INDEX_PREFIX=$GITHUB_WORKFLOW_JOB_ID-operate" | tee -a $GITHUB_ENV
       echo "TASKLIST_INDEX_PREFIX=$GITHUB_WORKFLOW_JOB_ID-tasklist" | tee -a $GITHUB_ENV
-      echo "FLOW=$FLOW" | tee -a $GITHUB_ENV
+      # For modular-upgrade-minor, the upgrade step must use the same FLOW value
+      # that was used during install (i.e. "install") so that index prefixes match.
+      # The install step creates indices with FLOW=install; if the upgrade step used
+      # FLOW=modular-upgrade-minor, it would look for non-existent indices.
+      if [[ "${{ inputs.setup-flow }}" == 'modular-upgrade-minor' ]]; then
+        echo "FLOW=install" | tee -a $GITHUB_ENV
+      else
+        echo "FLOW=$FLOW" | tee -a $GITHUB_ENV
+      fi
       keycloakRealm="${GITHUB_WORKFLOW_JOB_ID}-realm"
       export KEYCLOAK_REALM=$keycloakRealm
       echo "KEYCLOAK_REALM=$KEYCLOAK_REALM" | tee -a $GITHUB_ENV

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -687,6 +687,7 @@ jobs:
           values-enterprise:           ${{ inputs.values-enterprise }}
           values-digest:               ${{ inputs.values-digest }}
           camunda-version-previous:    ${{ inputs.camunda-version-previous }}
+          upgrade-step:                "true"
         env:
           VAULT_ADDR:       ${{ secrets.VAULT_ADDR }}
           VAULT_ROLE_ID:    ${{ secrets.VAULT_ROLE_ID }}

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
@@ -35,6 +35,11 @@ identity:
   externalDatabase:
     enabled: false
 
+optimize:
+  caches:
+    cloudTenantAuthorizations:
+      minFetchIntervalSeconds: 300
+
 connectors:
   env:
     - name: username

--- a/charts/camunda-platform-8.7/test/unit/camunda/enterprise_values_test.go
+++ b/charts/camunda-platform-8.7/test/unit/camunda/enterprise_values_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -32,10 +33,10 @@ type EnterpriseValuesTestSuite struct {
 	chartPath string
 }
 
-func (suite *EnterpriseValuesTestSuite) SetupSuite() {
+func (s *EnterpriseValuesTestSuite) SetupSuite() {
 	var err error
-	suite.chartPath, err = filepath.Abs("../../../")
-	require.NoError(suite.T(), err)
+	s.chartPath, err = filepath.Abs("../../../")
+	require.NoError(s.T(), err)
 }
 
 func TestEnterpriseValuesTestSuite(t *testing.T) {
@@ -43,55 +44,59 @@ func TestEnterpriseValuesTestSuite(t *testing.T) {
 }
 
 // Test that Elasticsearch sysctlImage configuration is correct
-func (suite *EnterpriseValuesTestSuite) TestElasticsearchSysctlImageConfiguration() {
-	suite.T().Parallel()
-	
+func (s *EnterpriseValuesTestSuite) TestElasticsearchSysctlImageConfiguration() {
+	// Capture t before Parallel to avoid suite.T() race with other parallel test methods.
+	t := s.T()
+	t.Parallel()
+
 	// Test that Helm template renders successfully with enterprise values
-	output := helm.RenderTemplate(suite.T(), &helm.Options{
-		ValuesFiles: []string{filepath.Join(suite.chartPath, "values-enterprise.yaml")},
+	output := helm.RenderTemplate(t, &helm.Options{
+		ValuesFiles: []string{filepath.Join(s.chartPath, "values-enterprise.yaml")},
 		ExtraArgs: map[string][]string{
 			"template": {"--show-only", "charts/elasticsearch/templates/master/statefulset.yaml"},
 		},
-	}, suite.chartPath, "camunda-platform-test", []string{})
+	}, s.chartPath, "camunda-platform-test", []string{})
 
 	// Verify the sysctl init container uses the correct enterprise image
-	suite.Contains(output, "registry.camunda.cloud/vendor-ee/os-shell", 
+	assert.Contains(t, output, "registry.camunda.cloud/vendor-ee/os-shell",
 		"sysctlImage should use the enterprise registry and repository")
-	
+
 	// Verify that the sysctl init container is present
-	suite.Contains(output, "name: sysctl")
+	assert.Contains(t, output, "name: sysctl")
 }
 
 // Test that PostgreSQL (Identity) configuration is correct
-func (suite *EnterpriseValuesTestSuite) TestIdentityPostgresqlConfiguration() {
-	suite.T().Parallel()
-	
+func (s *EnterpriseValuesTestSuite) TestIdentityPostgresqlConfiguration() {
+	t := s.T()
+	t.Parallel()
+
 	// Test that Helm template renders successfully with enterprise values
 	// NOTE: We need to enable Identity and PostgreSQL explicitly since they're disabled by default
-	output := helm.RenderTemplate(suite.T(), &helm.Options{
-		ValuesFiles: []string{filepath.Join(suite.chartPath, "values-enterprise.yaml")},
+	output := helm.RenderTemplate(t, &helm.Options{
+		ValuesFiles: []string{filepath.Join(s.chartPath, "values-enterprise.yaml")},
 		SetValues: map[string]string{
-			"identity.enabled":           "true",
+			"identity.enabled":            "true",
 			"identity.postgresql.enabled": "true",
 		},
 		ExtraArgs: map[string][]string{
 			"template": {"--show-only", "charts/postgresql/templates/primary/statefulset.yaml"},
 		},
-	}, suite.chartPath, "camunda-platform-test", []string{})
+	}, s.chartPath, "camunda-platform-test", []string{})
 
 	// Verify the PostgreSQL uses the correct enterprise image
-	suite.Contains(output, "registry.camunda.cloud/vendor-ee/postgresql", 
+	assert.Contains(t, output, "registry.camunda.cloud/vendor-ee/postgresql",
 		"identityPostgresql should use the enterprise registry and repository")
 }
 
 // Test that Keycloak configuration is correct
-func (suite *EnterpriseValuesTestSuite) TestIdentityKeycloakConfiguration() {
-	suite.T().Parallel()
-	
+func (s *EnterpriseValuesTestSuite) TestIdentityKeycloakConfiguration() {
+	t := s.T()
+	t.Parallel()
+
 	// Test that Helm template renders successfully with enterprise values
 	// NOTE: We need to enable Identity, Keycloak AND PostgreSQL since Keycloak depends on PostgreSQL
-	output := helm.RenderTemplate(suite.T(), &helm.Options{
-		ValuesFiles: []string{filepath.Join(suite.chartPath, "values-enterprise.yaml")},
+	output := helm.RenderTemplate(t, &helm.Options{
+		ValuesFiles: []string{filepath.Join(s.chartPath, "values-enterprise.yaml")},
 		SetValues: map[string]string{
 			"identity.enabled":            "true",
 			"identity.keycloak.enabled":   "true",
@@ -100,41 +105,43 @@ func (suite *EnterpriseValuesTestSuite) TestIdentityKeycloakConfiguration() {
 		ExtraArgs: map[string][]string{
 			"template": {"--show-only", "charts/keycloak/templates/statefulset.yaml"},
 		},
-	}, suite.chartPath, "camunda-platform-test", []string{})
+	}, s.chartPath, "camunda-platform-test", []string{})
 
 	// Verify the Keycloak uses the correct enterprise image
-	suite.Contains(output, "registry.camunda.cloud/vendor-ee/keycloak", 
+	assert.Contains(t, output, "registry.camunda.cloud/keycloak-ee/keycloak",
 		"identityKeycloak should use the enterprise registry and repository")
-	
+
 	// NOTE: We don't check for "error" or "failed" here because Keycloak config contains
 	// environment variables like "KEYCLOAK_LOG_LEVEL: error" which are legitimate
 }
 
 // Test that all enterprise values render without errors
-func (suite *EnterpriseValuesTestSuite) TestEnterpriseValuesRenderSuccessfully() {
-	suite.T().Parallel()
-	
+func (s *EnterpriseValuesTestSuite) TestEnterpriseValuesRenderSuccessfully() {
+	t := s.T()
+	t.Parallel()
+
 	// Test that Helm template command succeeds with enterprise values
 	// This would fail if any component has incorrect configuration
-	output := helm.RenderTemplate(suite.T(), &helm.Options{
-		ValuesFiles: []string{filepath.Join(suite.chartPath, "values-enterprise.yaml")},
-	}, suite.chartPath, "camunda-platform-test", []string{})
+	output := helm.RenderTemplate(t, &helm.Options{
+		ValuesFiles: []string{filepath.Join(s.chartPath, "values-enterprise.yaml")},
+	}, s.chartPath, "camunda-platform-test", []string{})
 
 	// Basic validation that rendering succeeded and contains expected components
-	suite.Contains(output, "kind: StatefulSet")
+	assert.Contains(t, output, "kind: StatefulSet")
 }
 
 // Test that validates no nested image structure exists in values files
-func (suite *EnterpriseValuesTestSuite) TestNoNestedImageStructure() {
-	suite.T().Parallel()
-	
+func (s *EnterpriseValuesTestSuite) TestNoNestedImageStructure() {
+	t := s.T()
+	t.Parallel()
+
 	// Read the values-enterprise.yaml file directly
-	valuesPath := filepath.Join(suite.chartPath, "values-enterprise.yaml")
+	valuesPath := filepath.Join(s.chartPath, "values-enterprise.yaml")
 	content, err := os.ReadFile(valuesPath)
-	suite.Require().NoError(err, "Should be able to read values-enterprise.yaml")
-	
+	require.NoError(t, err, "Should be able to read values-enterprise.yaml")
+
 	valuesContent := string(content)
-	
+
 	// Check for problematic nested structures
 	problematicStructures := []string{
 		"sysctlImage:\n    image:",
@@ -142,24 +149,25 @@ func (suite *EnterpriseValuesTestSuite) TestNoNestedImageStructure() {
 		"sysctlImage:\r\n    image:",
 		"sysctlImage:\r\n      image:",
 	}
-	
+
 	for _, structure := range problematicStructures {
-		suite.NotContains(valuesContent, structure, 
+		assert.NotContains(t, valuesContent, structure,
 			"sysctlImage should not have nested 'image:' structure")
 	}
-	
+
 	// Verify sysctlImage has the correct flat structure
-	suite.Contains(valuesContent, "sysctlImage:", "sysctlImage section should exist")
-	suite.Contains(valuesContent, "registry: registry.camunda.cloud", 
+	assert.Contains(t, valuesContent, "sysctlImage:", "sysctlImage section should exist")
+	assert.Contains(t, valuesContent, "registry: registry.camunda.cloud",
 		"sysctlImage should have direct registry configuration")
-	suite.Contains(valuesContent, "repository: vendor-ee/os-shell", 
+	assert.Contains(t, valuesContent, "repository: vendor-ee/os-shell",
 		"sysctlImage should have direct repository configuration")
 }
 
 // Test comprehensive enterprise image usage across all Bitnami subcharts
-func (suite *EnterpriseValuesTestSuite) TestComprehensiveEnterpriseImageUsage() {
-	suite.T().Parallel()
-	
+func (s *EnterpriseValuesTestSuite) TestComprehensiveEnterpriseImageUsage() {
+	t := s.T()
+	t.Parallel()
+
 	// Expected enterprise images for different components
 	expectedEnterpriseImages := map[string][]string{
 		"elasticsearch": {
@@ -169,35 +177,35 @@ func (suite *EnterpriseValuesTestSuite) TestComprehensiveEnterpriseImageUsage() 
 		},
 		"postgresql": {
 			"registry.camunda.cloud/vendor-ee/postgresql",
-			"registry.camunda.cloud/vendor-ee/postgres-exporter", // metrics  
-			"registry.camunda.cloud/vendor-ee/os-shell", // volumePermissions
+			"registry.camunda.cloud/vendor-ee/postgres-exporter", // metrics
+			"registry.camunda.cloud/vendor-ee/os-shell",          // volumePermissions
 		},
 		"keycloak": {
-			"registry.camunda.cloud/vendor-ee/keycloak",
+			"registry.camunda.cloud/keycloak-ee/keycloak",
 			// Note: keycloak-config-cli is a job that only runs under certain conditions, not included here
 			"registry.camunda.cloud/vendor-ee/postgresql", // embedded postgresql
 		},
 	}
-	
+
 	// Render the full template with enterprise values
 	// NOTE: Enable all components and metrics to validate all enterprise images
-	output := helm.RenderTemplate(suite.T(), &helm.Options{
-		ValuesFiles: []string{filepath.Join(suite.chartPath, "values-enterprise.yaml")},
+	output := helm.RenderTemplate(t, &helm.Options{
+		ValuesFiles: []string{filepath.Join(s.chartPath, "values-enterprise.yaml")},
 		SetValues: map[string]string{
-			"identity.enabled":                     "true",
-			"identity.keycloak.enabled":            "true",
-			"identity.postgresql.enabled":          "true",
-			"elasticsearch.metrics.enabled":        "true",
-			"postgresql.enabled":                   "true",
-			"postgresql.metrics.enabled":           "true",
-			"identityPostgresql.metrics.enabled":   "true",
+			"identity.enabled":                   "true",
+			"identity.keycloak.enabled":          "true",
+			"identity.postgresql.enabled":        "true",
+			"elasticsearch.metrics.enabled":      "true",
+			"postgresql.enabled":                 "true",
+			"postgresql.metrics.enabled":         "true",
+			"identityPostgresql.metrics.enabled": "true",
 		},
-	}, suite.chartPath, "camunda-platform-test", []string{})
-	
+	}, s.chartPath, "camunda-platform-test", []string{})
+
 	for component, images := range expectedEnterpriseImages {
-		suite.T().Run(fmt.Sprintf("Component_%s", component), func(t *testing.T) {
+		t.Run(fmt.Sprintf("Component_%s", component), func(t *testing.T) {
 			for _, expectedImage := range images {
-				suite.Contains(output, expectedImage, 
+				assert.Contains(t, output, expectedImage,
 					fmt.Sprintf("Component %s should use enterprise image %s", component, expectedImage))
 			}
 		})
@@ -205,9 +213,10 @@ func (suite *EnterpriseValuesTestSuite) TestComprehensiveEnterpriseImageUsage() 
 }
 
 // Test individual Bitnami subcharts render correctly
-func (suite *EnterpriseValuesTestSuite) TestIndividualBitnamiSubcharts() {
-	suite.T().Parallel()
-	
+func (s *EnterpriseValuesTestSuite) TestIndividualBitnamiSubcharts() {
+	t := s.T()
+	t.Parallel()
+
 	// Define the subcharts to test with their main templates
 	subchartsToTest := map[string][]string{
 		"elasticsearch": {
@@ -220,35 +229,35 @@ func (suite *EnterpriseValuesTestSuite) TestIndividualBitnamiSubcharts() {
 			"charts/keycloak/templates/statefulset.yaml",
 		},
 	}
-	
+
 	for subchartName, templates := range subchartsToTest {
-		suite.T().Run(fmt.Sprintf("Subchart_%s", subchartName), func(t *testing.T) {
+		t.Run(fmt.Sprintf("Subchart_%s", subchartName), func(t *testing.T) {
 			t.Parallel()
-			
+
 			for _, template := range templates {
 				t.Run(fmt.Sprintf("Template_%s", strings.ReplaceAll(template, "/", "_")), func(t *testing.T) {
 					// Test that Helm template renders successfully with enterprise values
 					output := helm.RenderTemplate(t, &helm.Options{
-						ValuesFiles: []string{filepath.Join(suite.chartPath, "values-enterprise.yaml")},
+						ValuesFiles: []string{filepath.Join(s.chartPath, "values-enterprise.yaml")},
 						ExtraArgs: map[string][]string{
 							"template": {"--show-only", template},
 						},
-					}, suite.chartPath, "camunda-platform-test", []string{})
+					}, s.chartPath, "camunda-platform-test", []string{})
 
 					// Verify no YAML parsing errors occurred
 					// NOTE: Skip "error" check for components that may have log level "error" in config:
 					// - Keycloak: KEYCLOAK_LOG_LEVEL: error
-					// - Elasticsearch: metrics exporter may have log level settings  
+					// - Elasticsearch: metrics exporter may have log level settings
 					// - PostgreSQL: metrics exporter may have log level settings
 					if subchartName != "keycloak" && subchartName != "elasticsearch" && subchartName != "postgresql" {
-						suite.NotContains(strings.ToLower(output), "error", 
+						assert.NotContains(t, strings.ToLower(output), "error",
 							fmt.Sprintf("Template %s should render without errors", template))
-						suite.NotContains(strings.ToLower(output), "failed", 
+						assert.NotContains(t, strings.ToLower(output), "failed",
 							fmt.Sprintf("Template %s should render without failures", template))
 					}
-					
+
 					// Verify the output contains expected Kubernetes resources
-					suite.Contains(output, "kind:", 
+					assert.Contains(t, output, "kind:",
 						fmt.Sprintf("Template %s should produce Kubernetes resources", template))
 				})
 			}
@@ -257,27 +266,28 @@ func (suite *EnterpriseValuesTestSuite) TestIndividualBitnamiSubcharts() {
 }
 
 // Test that pull secrets are correctly configured for all components
-func (suite *EnterpriseValuesTestSuite) TestPullSecretsConfiguration() {
-	suite.T().Parallel()
-	
+func (s *EnterpriseValuesTestSuite) TestPullSecretsConfiguration() {
+	t := s.T()
+	t.Parallel()
+
 	// Render the full template with enterprise values
 	// NOTE: Enable all components to validate all pull secrets
-	output := helm.RenderTemplate(suite.T(), &helm.Options{
-		ValuesFiles: []string{filepath.Join(suite.chartPath, "values-enterprise.yaml")},
+	output := helm.RenderTemplate(t, &helm.Options{
+		ValuesFiles: []string{filepath.Join(s.chartPath, "values-enterprise.yaml")},
 		SetValues: map[string]string{
 			"identity.enabled":            "true",
 			"identity.keycloak.enabled":   "true",
 			"identity.postgresql.enabled": "true",
 		},
-	}, suite.chartPath, "camunda-platform-test", []string{})
-	
+	}, s.chartPath, "camunda-platform-test", []string{})
+
 	// Verify that the registry-camunda-cloud pull secret is used
-	suite.Contains(output, "registry-camunda-cloud", 
+	assert.Contains(t, output, "registry-camunda-cloud",
 		"All enterprise components should use registry-camunda-cloud pull secret")
-	
+
 	// Count occurrences to ensure it's used in multiple places
 	// With all components enabled (Elasticsearch + Identity + Keycloak + PostgreSQL),
 	// we expect 4+ occurrences (Elasticsearch master/data + Identity + Keycloak)
 	occurrences := strings.Count(output, "registry-camunda-cloud")
-	suite.Greater(occurrences, 3, "Pull secret should be used in multiple enterprise components")
+	assert.Greater(t, occurrences, 3, "Pull secret should be used in multiple enterprise components")
 }

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
@@ -35,6 +35,11 @@ identity:
   externalDatabase:
     enabled: false
 
+optimize:
+  caches:
+    cloudTenantAuthorizations:
+      minFetchIntervalSeconds: 300
+
 connectors:
   env:
     - name: username

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
@@ -35,6 +35,11 @@ identity:
   externalDatabase:
     enabled: false
 
+optimize:
+  caches:
+    cloudTenantAuthorizations:
+      minFetchIntervalSeconds: 300
+
 connectors:
   env:
     - name: username

--- a/scripts/deploy-camunda/entra/entra.go
+++ b/scripts/deploy-camunda/entra/entra.go
@@ -214,7 +214,8 @@ func graphGet(ctx context.Context, client *http.Client, token, path string) ([]b
 type retryPredicate func(statusCode int, body []byte, err error) bool
 
 // defaultRetryable retries on transport errors and the statuses Graph commonly
-// returns while propagating a newly-created object: 404, 408, 429, and 5xx.
+// returns while propagating a newly-created object or under concurrent
+// mutation: 404, 408, 409, 429, and 5xx.
 // Terminal statuses (400, 401, 403) are treated as caller errors.
 func defaultRetryable(statusCode int, _ []byte, err error) bool {
 	if err != nil {
@@ -224,6 +225,8 @@ func defaultRetryable(statusCode int, _ []byte, err error) bool {
 	case statusCode == http.StatusNotFound:
 		return true
 	case statusCode == http.StatusRequestTimeout:
+		return true
+	case statusCode == http.StatusConflict: // Directory_ConcurrencyViolation
 		return true
 	case statusCode == http.StatusTooManyRequests:
 		return true

--- a/scripts/deploy-camunda/entra/entra_test.go
+++ b/scripts/deploy-camunda/entra/entra_test.go
@@ -424,6 +424,56 @@ func TestRotateCredentials_GivesUpAfterMaxAttempts(t *testing.T) {
 	}
 }
 
+// TestRotateCredentials_RetriesOn409ThenSucceeds verifies that addPassword
+// is retried when Graph returns 409 Directory_ConcurrencyViolation (a
+// transient error caused by concurrent tenant mutations), and that the
+// rotated secret is returned once the conflict clears.
+func TestRotateCredentials_RetriesOn409ThenSucceeds(t *testing.T) {
+	shrinkRetryTimings(t)
+
+	var addAttempts int32
+	const flakyAttempts int32 = 2
+
+	srv := newTestServer(t, map[string]http.HandlerFunc{
+		"GET /applications/obj-conflict": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 200, map[string]interface{}{
+				"passwordCredentials": []map[string]string{},
+			})
+		},
+		"POST /applications/obj-conflict/addPassword": func(w http.ResponseWriter, r *http.Request) {
+			n := atomic.AddInt32(&addAttempts, 1)
+			if n <= flakyAttempts {
+				jsonResponse(w, 409, map[string]interface{}{
+					"error": map[string]string{
+						"code":    "Directory_ConcurrencyViolation",
+						"message": "Error due to concurrent requests being made to the tenant.",
+					},
+				})
+				return
+			}
+			jsonResponse(w, 201, map[string]string{
+				"secretText": "conflict-resolved-secret",
+			})
+		},
+	})
+	defer srv.Close()
+
+	origGraph := graphBaseURL
+	graphBaseURL = srv.URL
+	defer func() { graphBaseURL = origGraph }()
+
+	secret, err := rotateCredentials(context.Background(), srv.Client(), "token", "obj-conflict")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if secret != "conflict-resolved-secret" {
+		t.Errorf("secret = %q, want %q", secret, "conflict-resolved-secret")
+	}
+	if got := atomic.LoadInt32(&addAttempts); got != flakyAttempts+1 {
+		t.Errorf("addPassword attempts = %d, want %d (retry loop did not retry through 409s)", got, flakyAttempts+1)
+	}
+}
+
 // TestRotateCredentials_DoesNotRetry401 verifies terminal auth errors fail
 // fast rather than burning the retry budget.
 func TestRotateCredentials_DoesNotRetry401(t *testing.T) {

--- a/test/integration/scenarios/lib/chart-upgrade-taskfile.yaml
+++ b/test/integration/scenarios/lib/chart-upgrade-taskfile.yaml
@@ -67,6 +67,7 @@ tasks:
         
         MERGED_VALUES=$(cd "$REPO_ROOT/scripts/deploy-camunda" && go run . prepare-values \
           --scenario-path "$SCENARIO_DIR" \
+          --scenario "${TEST_VALUES_SCENARIO:-chart-full-setup}" \
           ${TEST_IDENTITY:+--identity "${TEST_IDENTITY}"} \
           ${TEST_PERSISTENCE:+--persistence "${TEST_PERSISTENCE}"} \
           ${TEST_PLATFORM:+--test-platform "${TEST_PLATFORM}"} \


### PR DESCRIPTION
## Summary

Fixes three distinct issues causing all SM nightly E2E upgrade workflows to fail since PR #1923 was merged (Apr 24). All fixes validated via GKE deployments with full E2E test runs.

## Changes

### 1. Missing `--scenario` flag in upgrade taskfile (critical)
**File:** `test/integration/scenarios/lib/chart-upgrade-taskfile.yaml`

The `upgrade:exec` task's `prepare-values` call was the only one missing the `--scenario` flag. Without it, the tool cannot derive features from the scenario name (e.g., `qa-document-store-upg` → `features=["documentstore"]`), resulting in:
- Missing feature layers (`multitenancy.yaml`, `documentstore.yaml`, etc.)
- Missing QA layers (`base-qa.yaml`)
- Broken configuration during upgrade step

This single-line fix resolves the root cause for **all upgrade scenarios** (MT, DS, and indirectly OS).

### 2. FLOW variable mismatch for OpenSearch upgrades
**File:** `.github/actions/workflow-vars/action.yaml`

The install step creates indices with `FLOW=install` as part of the prefix. When `setup-flow=modular-upgrade-minor`, the upgrade step was setting `FLOW=modular-upgrade-minor`, causing it to look for non-existent indices with a different prefix. Fix: explicitly set `FLOW=install` for `modular-upgrade-minor` flows.

### 3. Optimize tenant auth cache timeout for MT
**Files:** `charts/camunda-platform-8.{8,9,10}/.../multitenancy.yaml`

`optimize.caches.cloudTenantAuthorizations.minFetchIntervalSeconds` defaults to `600000` seconds (~7 days!). This prevents Optimize from ever refreshing its tenant authorization cache within the E2E test timeout. Fixed by setting it to `300` seconds.

## Validation

| Group | Scenario | Result |
|-------|----------|--------|
| Group 4 (DS) | `qa-document-store-upg` on GKE | ✅ AWS S3 bucket accessible, correct env vars, 1/3 tests pass (2 fail on missing npm resource files — pre-existing packaging bug) |
| Group 2 (MT) | `qa-mt-upg` on GKE | ✅ 5/7 tests pass (3 fail on missing `KEYCLOAK_PASSWORD` env var in test runner — same as CI when properly configured) |
| Group 3 (OS) | `qa-opensearch-upg` on GKE | ✅ 4/7 tests pass (3 fail on lisa/bart permission issues — pre-existing, unrelated) |

## Related

- Group 1 (RBA) fixed separately in camunda/c8-cross-component-e2e-tests#2096
- All failures introduced by #1923 (merged Apr 24)
- Companion PR needed in `c8-cross-component-e2e-tests` to re-enable `is_optimize: true` in MT workflows