### PR TITLE
fix(8.8): render es: connection in Optimize configmap for OpenSearch scenarios

### DIFF
--- a/charts/camunda-platform-8.8/templates/optimize/configmap.yaml
+++ b/charts/camunda-platform-8.8/templates/optimize/configmap.yaml
@@ -25,12 +25,16 @@ data:
       name: {{ .Values.global.opensearch.prefix | quote }}
       {{- end }}
 
-    {{- if .Values.global.elasticsearch.enabled }}
     es:
       connection:
         nodes:
+        {{- if .Values.global.elasticsearch.enabled }}
           - host: {{ include "camundaPlatform.elasticsearchHost" . | quote }}
             httpPort: {{ .Values.global.elasticsearch.url.port }}
+        {{- else if .Values.global.opensearch.enabled }}
+          - host: {{ include "camundaPlatform.opensearchHost" . | quote }}
+            httpPort: {{ .Values.global.opensearch.url.port }}
+        {{- end }}
       {{- if .Values.global.elasticsearch.external }}
       security:
         username: {{ .Values.global.elasticsearch.auth.username | quote }}
@@ -39,7 +43,6 @@ data:
           enabled: "true"
         {{- end }}
       {{- end }}
-    {{- end }}
 
     spring:
       servlet:

--- a/charts/camunda-platform-8.8/test/unit/optimize/configmap_test.go
+++ b/charts/camunda-platform-8.8/test/unit/optimize/configmap_test.go
@@ -81,6 +81,32 @@ func (s *ConfigMapTemplateTest) TestDifferentValuesInputs() {
 				s.Require().Equal("custom-prefix", configmapApplication.Zeebe.Name)
 			},
 		},
+		{
+			Name:                 "TestOpenSearchNodeRenderedInEsSection",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values: map[string]string{
+				"optimize.enabled":             "true",
+				"elasticsearch.enabled":        "false",
+				"global.elasticsearch.enabled": "false",
+				"global.opensearch.enabled":    "true",
+				"global.opensearch.url.host":   "my-opensearch",
+				"global.opensearch.url.port":   "9200",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				var configmapApplication OptimizeConfigYAML
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				e := yaml.Unmarshal([]byte(configmap.Data["environment-config.yaml"]), &configmapApplication)
+				if e != nil {
+					s.Fail("Failed to unmarshal yaml. error=", e)
+				}
+
+				s.Require().Len(configmapApplication.Es.Connection.Nodes, 1)
+				s.Require().Equal("my-opensearch", configmapApplication.Es.Connection.Nodes[0].Host)
+				s.Require().Equal(9200, configmapApplication.Es.Connection.Nodes[0].HttpPort)
+			},
+		},
 	}
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)

--- a/charts/camunda-platform-8.8/test/unit/optimize/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/optimize/golden/configmap.golden.yaml
@@ -19,6 +19,7 @@ data:
       enabled: true
       partitionCount: 3
       name: "zeebe-record"
+
     es:
       connection:
         nodes:

--- a/charts/camunda-platform-8.8/test/unit/optimize/types.go
+++ b/charts/camunda-platform-8.8/test/unit/optimize/types.go
@@ -3,6 +3,7 @@ package optimize
 type OptimizeConfigYAML struct {
 	Container ContainerYAML `yaml:"container"`
 	Zeebe     ZeebeYAML     `yaml:"zeebe"`
+	Es        EsYAML        `yaml:"es"`
 }
 
 type ContainerYAML struct {
@@ -11,4 +12,17 @@ type ContainerYAML struct {
 
 type ZeebeYAML struct {
 	Name string `yaml:"name"`
+}
+
+type EsYAML struct {
+	Connection EsConnectionYAML `yaml:"connection"`
+}
+
+type EsConnectionYAML struct {
+	Nodes []EsNodeYAML `yaml:"nodes"`
+}
+
+type EsNodeYAML struct {
+	Host     string `yaml:"host"`
+	HttpPort int    `yaml:"httpPort"`
 }


### PR DESCRIPTION
## Summary

- Renders the `es:` connection section in Optimize's `environment-config.yaml` for OpenSearch scenarios, aligning 8.8 with what 8.9 and 8.10 already do.
- When `global.opensearch.enabled` is true, the `es.connection.nodes` now points to the OpenSearch host/port instead of being omitted entirely.

## Root Cause

The `es:` section was gated by `{{- if .Values.global.elasticsearch.enabled }}`, meaning it was never rendered for OpenSearch deployments. Without this section in the configmap, Optimize falls back to the default `es.connection.nodes[0].host: localhost` from its bundled `service-config.yaml`.

Optimize uses the `es:` connection config internally even when the database backend is OpenSearch (for legacy compatibility in schema initialization and import index management). When this config points to localhost, Optimize silently fails to initialize properly.

In 8.9 and 8.10, this was already fixed — the `es:` section always renders, pointing to the correct backend (ES or OS depending on which is enabled).

## Evidence

- SM Nightly Chrome 8.8-SNAPSHOT OpenSearch consistently fails `createReportForProcess` (3/4 recent runs)
- Same test passes on Elasticsearch in 2.2 minutes
- 8.10 OpenSearch passes (has this fix already)
- Template comparison shows 8.9/8.10 use `{{- else if .Values.global.opensearch.enabled }}` fallback while 8.8 did not

## Testing

- `make helm.lint chartPath=charts/camunda-platform-8.8` — passes
- `make go.test chartPath=charts/camunda-platform-8.8` — all packages pass
- `helm template` with OpenSearch values renders correctly:
  ```yaml
  es:
    connection:
      nodes:
        - host: "opensearch.example.com"
          httpPort: 443
  ```

## Related

- E2E test fix PR: https://github.com/camunda/c8-cross-component-e2e-tests/pull/2100
- Note: 8.9 OpenSearch also fails despite having this chart fix. That failure is likely an application-level issue in the Optimize 8.9-SNAPSHOT build (same chart template, same import code as 8.10, but different runtime behavior).