### PR TITLE
test(8.9): use global.rba.enabled in RBA scenario

### DIFF
--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/rba.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/rba.yaml
@@ -1,11 +1,11 @@
 # Resource-Based Access (RBA) feature configuration for 8.9
 # Layer 6: Feature - Resource-Based Access control
+global:
+  rba:
+    enabled: true
+
 orchestration:
   env:
-    - name: CAMUNDA_TASKLIST_IDENTITY_RESOURCE_PERMISSIONS_ENABLED
-      value: 'true'
-    - name: CAMUNDA_OPERATE_IDENTITY_RESOURCEPERMISSIONSENABLED
-      value: 'true'
     - name: CAMUNDA_DATABASE_SCHEMAMANAGER_VERSIONCHECKRESTRICTIONENABLED
       value: "false"
 
@@ -20,6 +20,3 @@ identityPostgresql:
 identity:
   externalDatabase:
     enabled: false
-  env:
-    - name: RESOURCE_PERMISSIONS_ENABLED
-      value: 'true'


### PR DESCRIPTION
## Summary

Follow-up to the 8.9 chart PR (#5997). Replaces the manual env-var injection in the RBA scenario overlay with the new single global flag.

This PR is based on \`3831-rba-global-flag-8-9\`. Once that PR merges to main, this PR will auto-retarget to main.

## Test plan

- [ ] CI scenario \`features: [rba]\` for 8.9 still passes end-to-end with the new flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)