### PR TITLE
test(8.8): use global.rba.enabled in RBA scenario

### DIFF
--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/rba.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/rba.yaml
@@ -1,12 +1,11 @@
 # Resource-Based Access (RBA) feature configuration for 8.8
 # Layer 6: Feature - Resource-Based Access control
+global:
+  rba:
+    enabled: true
 
 orchestration:
   env:
-    - name: CAMUNDA_TASKLIST_IDENTITY_RESOURCE_PERMISSIONS_ENABLED
-      value: 'true'
-    - name: CAMUNDA_OPERATE_IDENTITY_RESOURCEPERMISSIONSENABLED
-      value: 'true'
     - name: CAMUNDA_DATABASE_SCHEMAMANAGER_VERSIONCHECKRESTRICTIONENABLED
       value: "false"
 
@@ -21,6 +20,3 @@ identityPostgresql:
 identity:
   externalDatabase:
     enabled: false
-  env:
-    - name: RESOURCE_PERMISSIONS_ENABLED
-      value: 'true'


### PR DESCRIPTION
Follow-up to the 8.8 chart PR (#5998). Replaces manual env-vars in the RBA scenario overlay with the new single global flag. Auto-retargets to main once #5998 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)