### PR TITLE
test(8.7): use global.rba.enabled in RBA scenario

### DIFF
--- a/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values/features/rba.yaml
+++ b/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values/features/rba.yaml
@@ -1,17 +1,5 @@
 # Resource-Based Access (RBA) feature configuration for 8.7
 # Layer 4: Feature - Resource-Based Access control
-
-tasklist:
-  env:
-    - name: CAMUNDA_TASKLIST_IDENTITY_RESOURCE_PERMISSIONS_ENABLED
-      value: 'true'
-
-operate:
-  env:
-    - name: CAMUNDA_OPERATE_IDENTITY_RESOURCEPERMISSIONSENABLED
-      value: 'true'
-
-identity:
-  env:
-    - name: RESOURCE_PERMISSIONS_ENABLED
-      value: 'true'
+global:
+  rba:
+    enabled: true


### PR DESCRIPTION
Follow-up to the 8.7 chart PR (#5999). Replaces manual per-component env-vars in the RBA scenario overlay with the new single global flag. Auto-retargets to main once #5999 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)