### PR TITLE
test(8.10): add RBA upgrade scenario for env-var → global flag

### DIFF
--- a/charts/camunda-platform-8.10/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.10/test/ci-test-config.yaml
@@ -131,6 +131,24 @@ integration:
           persistence: elasticsearch
           features: [rba]
           platforms: [gke]
+        - name: rba-upgrade
+          # Verifies that an installation using the legacy manual env-var
+          # configuration on the previous chart version still works after
+          # upgrading to a chart that exposes global.rba.enabled. The values
+          # file features/rba-upgrade.yaml deliberately keeps the manual env
+          # vars (no global.rba.enabled) to exercise the back-compat path.
+          enabled: false
+          exclude: []
+          shortname: rbaup
+          auth: keycloak
+          flow: upgrade-minor
+          infra-type:
+            gke: distroci
+            eks: preemptible
+          identity: keycloak
+          persistence: elasticsearch
+          features: [rba-upgrade, migrator]
+          platforms: [gke]
         - name: keycloak-original
           enabled: false
           exclude: []

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/rba-upgrade.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/rba-upgrade.yaml
@@ -1,0 +1,28 @@
+# RBA upgrade-compat feature: keeps the legacy (pre-global.rba.enabled) env-var
+# configuration so an upgrade-minor flow exercises the back-compat path —
+# Step 1 deploys the previous chart with manual env vars, Step 2 upgrades to
+# the new chart using the same values, confirming the manual env vars still
+# win and RBA stays enforced after the upgrade.
+orchestration:
+  env:
+    - name: CAMUNDA_TASKLIST_IDENTITY_RESOURCE_PERMISSIONS_ENABLED
+      value: 'true'
+    - name: CAMUNDA_OPERATE_IDENTITY_RESOURCEPERMISSIONSENABLED
+      value: 'true'
+    - name: CAMUNDA_DATABASE_SCHEMAMANAGER_VERSIONCHECKRESTRICTIONENABLED
+      value: "false"
+
+identityPostgresql:
+  enabled: true
+  auth:
+    existingSecret: "integration-test-credentials"
+    secretKeys:
+      adminPasswordKey: "identity-keycloak-postgresql-admin-password"
+      userPasswordKey: "identity-keycloak-postgresql-user-password"
+
+identity:
+  externalDatabase:
+    enabled: false
+  env:
+    - name: RESOURCE_PERMISSIONS_ENABLED
+      value: 'true'


### PR DESCRIPTION
## Summary

Adds a new `rba-upgrade` upgrade-minor CI scenario for 8.10 that tests the backward-compatibility path: a user with RBA configured via the legacy manual env vars (pre-`global.rba.enabled`) upgrading to the new chart should keep working without values-file changes.

- New `features/rba-upgrade.yaml` overlay keeps the legacy manual env-var configuration.
- New `rba-upgrade` scenario in `ci-test-config.yaml` (disabled by default — enable when ready for CI).

## Why disabled by default?

Same reason existing `keycloak-rba` scenario is disabled — needs manual enablement once stable upgrade infra is in place. This PR just lays the scaffolding so the test can be flipped on without code changes.

## Test plan

- [ ] When enabled, the `rba-upgrade` scenario runs the upgrade-minor flow with no workload restart loops and RBA still enforced after the upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)