### PR TITLE
test(8.8): add RBA upgrade scenario for env-var → global flag

### DIFF
--- a/charts/camunda-platform-8.8/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.8/test/ci-test-config.yaml
@@ -95,6 +95,24 @@ integration:
           persistence: elasticsearch
           features: [rba]
           platforms: [gke]
+        - name: rba-upgrade
+          # Verifies the back-compat path: Step 1 deploys the previous chart
+          # version using the legacy manual env-var configuration, Step 2
+          # upgrades to this chart still using the same values. Confirms the
+          # manual env-var path keeps working after the global.rba.enabled
+          # flag lands.
+          enabled: false
+          exclude: []
+          shortname: rbaup
+          auth: keycloak
+          flow: upgrade-minor
+          infra-type:
+            gke: distroci
+            eks: preemptible
+          identity: keycloak
+          persistence: elasticsearch
+          features: [rba-upgrade, migrator]
+          platforms: [gke]
         - name: elasticsearch-self-signed-upgrade
           enabled: false
           exclude: []

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/rba-upgrade.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/rba-upgrade.yaml
@@ -1,0 +1,39 @@
+# RBA upgrade-compat feature: keeps the legacy (pre-global.rba.enabled) env-var
+# configuration so an upgrade-minor flow exercises the back-compat path —
+# Step 1 deploys the previous chart with manual env vars (8.7-style:
+# tasklist.env / operate.env / identity.env), Step 2 upgrades to the 8.8
+# chart still using the same values, confirming the manual env vars still
+# win and RBA stays enforced after the upgrade.
+tasklist:
+  env:
+    - name: CAMUNDA_TASKLIST_IDENTITY_RESOURCE_PERMISSIONS_ENABLED
+      value: 'true'
+
+operate:
+  env:
+    - name: CAMUNDA_OPERATE_IDENTITY_RESOURCEPERMISSIONSENABLED
+      value: 'true'
+
+orchestration:
+  env:
+    - name: CAMUNDA_TASKLIST_IDENTITY_RESOURCE_PERMISSIONS_ENABLED
+      value: 'true'
+    - name: CAMUNDA_OPERATE_IDENTITY_RESOURCEPERMISSIONSENABLED
+      value: 'true'
+    - name: CAMUNDA_DATABASE_SCHEMAMANAGER_VERSIONCHECKRESTRICTIONENABLED
+      value: "false"
+
+identityPostgresql:
+  enabled: true
+  auth:
+    existingSecret: "integration-test-credentials"
+    secretKeys:
+      adminPasswordKey: "identity-keycloak-postgresql-admin-password"
+      userPasswordKey: "identity-keycloak-postgresql-user-password"
+
+identity:
+  externalDatabase:
+    enabled: false
+  env:
+    - name: RESOURCE_PERMISSIONS_ENABLED
+      value: 'true'


### PR DESCRIPTION
Adds a disabled-by-default `rba-upgrade` upgrade-minor scenario for 8.8 covering the 8.7→8.8 upgrade path where the chart layout itself changes (separate tasklist/operate → unified orchestration). Sister to #6004 (8.10) and #6005 (8.9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)