### PR TITLE
feat(8.7): add component-persistence CI scenario for issue 4767

### DIFF
--- a/charts/camunda-platform-8.7/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.7/test/ci-test-config.yaml
@@ -128,6 +128,20 @@ integration:
               repo-name: opensearch
               repo-url: https://opensearch-project.github.io/helm-charts/
               values-file: test/integration/companion-values/opensearch.yaml
+        - name: component-persistence
+          enabled: true
+          tier: 2
+          exclude: []
+          shortname: cprst
+          auth: keycloak
+          identity: keycloak
+          persistence: elasticsearch
+          flow: install
+          skip-e2e: true  # 8.7 web-modeler-restapi has a known unresponsiveness bug
+          infra-type:
+            gke: distroci
+          features: [persistence]
+          platforms: [gke]
 
         # ===========================================================================
         # Backward-compat scenarios — referenced by .github/workflows/test-backward-compat.yaml

--- a/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values/features/persistence.yaml
+++ b/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values/features/persistence.yaml
@@ -1,0 +1,23 @@
+# =============================================================================
+# Component Persistence Feature
+# =============================================================================
+# Layer 4: Optional feature - exercises persistent volume configuration on
+# Camunda components so the chart's PVC/StatefulSet templates are covered by
+# nightly CI. Tracks the regressions reported in:
+#   SUPPORT-30094 (zeebe extraVolumeClaimTemplates rejected by API)
+# Used with: TEST_VALUES_FEATURES containing "persistence"
+#
+# Note: 8.7 predates the unified orchestration component and the
+# optimize.persistence / webModeler.persistence keys (added in 8.8). This
+# scenario only covers the StatefulSet extraVolumeClaimTemplates path on 8.7.
+# =============================================================================
+
+zeebe:
+  extraVolumeClaimTemplates:
+    - metadata:
+        name: extra-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi


### PR DESCRIPTION
## Summary

Adds a `component-persistence` PR-section CI scenario for chart 8.7 so the StatefulSet `volumeClaimTemplates` path stays covered by CI.

Tracks GitHub issue [#4767](https://github.com/camunda/camunda-platform-helm/issues/4767) and Jira ticket SUPPORT-30094.

## Why this is 8.7-only-partial

Chart 8.7 predates the unified orchestration component and the `optimize.persistence` / `webModeler.persistence` values keys (added in 8.8). For 8.7 the only piece of the issue applicable is `zeebe.extraVolumeClaimTemplates`. Companion PRs for 8.8/8.9/8.10 add the Optimize and web-modeler PVC coverage and an `upgrade-minor` flow.

## Why this PR is a hard prereq for #6008

The 8.8 PR (#6008) defines a `cprst` scenario with `flow: install,upgrade-minor`. The matrix runner's `upgrade-minor` flow runs:

- **Step 1** — install the previous version's chart (8.7 chart from this branch), reading 8.7's `features/persistence.yaml`.
- **Step 2** — `helm upgrade` to the current version's chart (8.8), reading 8.8's `features/persistence.yaml`.

Both steps need to render a StatefulSet with the same `volumeClaimTemplates` shape — otherwise step 2 tries to add an `extra-data` VCT to an existing SS that was created without it, and K8s rejects the change as a `spec: Forbidden` immutable-field violation.

This PR puts the matching `zeebe.extraVolumeClaimTemplates` feature into the 8.7 chart so step 1 produces a SS with the `extra-data` VCT already present. Without this PR landed first, #6008's `cprst upgrade-minor` job fails deterministically.

## Changes

- New `charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values/features/persistence.yaml` setting `zeebe.extraVolumeClaimTemplates` to a 1Gi `extra-data` template.
- New `component-persistence` entry in `charts/camunda-platform-8.7/test/ci-test-config.yaml` (PR section), shortname `cprst`, identity keycloak, persistence elasticsearch, flow install, features `[persistence]`, GKE only. `skip-e2e: true` to match other 8.7 entries (web-modeler-restapi unresponsiveness bug).

## Test plan

- [x] `make helm.lint chartPath=charts/camunda-platform-8.7` clean.
- [x] `make go.test chartPath=charts/camunda-platform-8.7` passes.
- [x] GKE validation (`distro-ci`, namespace `cprst-87`):
  - `deploy-camunda --chart-path ./charts/camunda-platform-8.7 --identity keycloak --persistence elasticsearch --features persistence --auto-generate-secrets` completes successfully.
  - `integration-zeebe` StatefulSet has both `data` and `extra-data` volumeClaimTemplates.
  - `extra-data-integration-zeebe-{0..2}` PVCs Bound (1Gi each).
  - All target components reach 1/1 Running.

## Related PRs

- **#6008** — 8.8 scenario (depends on this PR).
- 8.9: #6009.
- 8.10: #6010.
- chart fixes for 8.9/8.10: #6014.
- helm-correctness: #6021 (drop `--force`).
- docs: camunda/camunda-docs#8738.
