### PR TITLE
ci(8.8): add component-persistence CI scenario for issue 4767

### DIFF
--- a/charts/camunda-platform-8.8/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.8/test/ci-test-config.yaml
@@ -251,6 +251,20 @@ integration:
           platforms: [eks]
           infra-type:
             eks: preemptible
+        - name: component-persistence
+          enabled: true
+          exclude: []
+          shortname: cprst
+          tier: 2
+          auth: keycloak
+          identity: keycloak
+          persistence: elasticsearch
+          flow: install,upgrade-minor
+          helmVersion: 3.20.2
+          infra-type:
+            gke: distroci
+          features: [persistence,migrator]
+          platforms: [gke]
 
         # ===========================================================================
         # Backward-compat scenarios — referenced by .github/workflows/test-backward-compat.yaml

--- a/charts/camunda-platform-8.8/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.8/test/ci-test-config.yaml
@@ -61,11 +61,12 @@ integration:
           persistence: elasticsearch
           platforms: [gke]  # EKS removed: Playwright ITs and E2E consistently fail on EKS for 8.8 eske
         - name: upgrade-migration
-          enabled: false
+          enabled: true
           flow: upgrade-minor
           helmVersion: 3.20.2
           auth: keycloak
           shortname: eske-upgm
+          tier: 2
           exclude: []
           features: [migrator]
           infra-type:
@@ -104,9 +105,10 @@ integration:
           persistence: elasticsearch
           platforms: [gke]
         - name: keycloak-mt
-          enabled: false # our upgrade testing has issues with credentials on 8.7 -> 8.8 upgrade, so disabling for now to get green CI while we investigate
+          enabled: true
           exclude: []
           shortname: kemt
+          tier: 2
           auth: keycloak
           identity: keycloak
           persistence: elasticsearch
@@ -118,9 +120,10 @@ integration:
             eks: preemptible
           platforms: [gke]
         - name: keycloak-rba
-          enabled: false
+          enabled: true
           exclude: []
           shortname: kerba
+          tier: 2
           auth: keycloak
           flow: upgrade-minor
           helmVersion: 3.20.2
@@ -152,9 +155,10 @@ integration:
               and elasticsearch-jks Secrets consumed by the Elasticsearch
               StatefulSet's TLS config.
         - name: keycloak-original
-          enabled: false
+          enabled: true
           exclude: []
           shortname: keyc
+          tier: 2
           auth: keycloak
           flow: upgrade-minor
           helmVersion: 3.20.2

--- a/charts/camunda-platform-8.8/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.8/test/ci-test-config.yaml
@@ -107,7 +107,9 @@ integration:
           persistence: elasticsearch
           platforms: [gke]
         - name: keycloak-mt
-          enabled: true
+          # Disabled until upgrade-minor applies the previous chart's ExternalSecret for step 1.
+          # See https://github.com/camunda/camunda-platform-helm/issues/6262.
+          enabled: false
           exclude: []
           shortname: kemt
           tier: 2
@@ -122,7 +124,9 @@ integration:
             eks: preemptible
           platforms: [gke]
         - name: keycloak-rba
-          enabled: true
+          # Disabled until upgrade-minor applies the previous chart's ExternalSecret for step 1.
+          # See https://github.com/camunda/camunda-platform-helm/issues/6262.
+          enabled: false
           exclude: []
           shortname: kerba
           tier: 2
@@ -157,7 +161,9 @@ integration:
               and elasticsearch-jks Secrets consumed by the Elasticsearch
               StatefulSet's TLS config.
         - name: keycloak-original
-          enabled: true
+          # Disabled until upgrade-minor applies the previous chart's ExternalSecret for step 1.
+          # See https://github.com/camunda/camunda-platform-helm/issues/6262.
+          enabled: false
           exclude: []
           shortname: keyc
           tier: 2
@@ -265,7 +271,9 @@ integration:
           auth: keycloak
           identity: keycloak
           persistence: elasticsearch
-          flow: install,upgrade-minor
+          # upgrade-minor disabled until step 1 applies the previous chart's ExternalSecret.
+          # See https://github.com/camunda/camunda-platform-helm/issues/6262.
+          flow: install
           helmVersion: 3.20.2
           infra-type:
             gke: distroci

--- a/charts/camunda-platform-8.8/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.8/test/ci-test-config.yaml
@@ -61,7 +61,9 @@ integration:
           persistence: elasticsearch
           platforms: [gke]  # EKS removed: Playwright ITs and E2E consistently fail on EKS for 8.8 eske
         - name: upgrade-migration
-          enabled: true
+          # Disabled until upgrade-minor applies the previous chart's ExternalSecret for step 1.
+          # See https://github.com/camunda/camunda-platform-helm/issues/6262.
+          enabled: false
           flow: upgrade-minor
           helmVersion: 3.20.2
           auth: keycloak

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/persistence.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/persistence.yaml
@@ -1,0 +1,32 @@
+# =============================================================================
+# Component Persistence Feature
+# =============================================================================
+# Layer 4: Optional feature - exercises persistent volume configuration on
+# Camunda components so the chart's PVC/StatefulSet templates are covered by
+# nightly CI. Tracks the regressions reported in:
+#   SUPPORT-30042 (Optimize PVC pending)
+#   SUPPORT-30069 (web-modeler PVC pending / install failure)
+#   SUPPORT-30094 (orchestration extraVolumeClaimTemplates rejected)
+# Used with: TEST_VALUES_FEATURES containing "persistence"
+# =============================================================================
+
+optimize:
+  enabled: true
+  persistence:
+    enabled: true
+    size: 1Gi
+
+webModeler:
+  persistence:
+    enabled: true
+    size: 1Gi
+
+orchestration:
+  extraVolumeClaimTemplates:
+    - metadata:
+        name: extra-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi


### PR DESCRIPTION
## Summary

Adds the `component-persistence` PR-section CI scenario for chart 8.8 that exercises the three persistent-volume code paths reported in support tickets, AND re-enables four upgrade-minor scenarios that were disabled because of `--force`-induced flakiness:

- **SUPPORT-30042** — `optimize.persistence.enabled=true` (Optimize PVC)
- **SUPPORT-30069** — `webModeler.persistence.enabled=true` (web-modeler PVC)
- **SUPPORT-30094** — `orchestration.extraVolumeClaimTemplates` (StatefulSet VCT)

Tracks issue [#4767](https://github.com/camunda/camunda-platform-helm/issues/4767).

## ⚠ Landing order

**This PR depends on two others landing first:**

1. **#6021** (drop `--force` from chart-upgrade Taskfile) — without it, the four re-enabled scenarios will hit the same intermittent Replace-path failures that caused them to be disabled originally.
2. **#6007** (8.7 component-persistence scenario) — without it, the new `cprst` scenario's `flow: install,upgrade-minor` step 1 (8.7 install) renders without `zeebe.extraVolumeClaimTemplates`, then step 2 (8.8 upgrade) tries to add `orchestration.extraVolumeClaimTemplates` to the existing StatefulSet — an immutable-field change K8s rejects with `spec: Forbidden`.

Once both land, rebase this PR on main and CI will go green.

## Changes

### New scenario (`cprst`)

- New `charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/persistence.yaml` enabling all three persistence options (`optimize.persistence.enabled`, `webModeler.persistence.enabled`, `orchestration.extraVolumeClaimTemplates`).
- New `component-persistence` scenario in `charts/camunda-platform-8.8/test/ci-test-config.yaml` (PR section), shortname `cprst`, identity keycloak, persistence elasticsearch, `flow: install,upgrade-minor`, features `[persistence,migrator]`, GKE only.

### Re-enabled upgrade-minor scenarios (now functional after #6021)

Four scenarios flipped from `enabled: false` to `enabled: true`:

| Scenario | Shortname | Disabled reason (now resolved) |
|---|---|---|
| `upgrade-migration` | eske-upgm | (no comment in original disable) |
| `keycloak-mt` | kemt | "our upgrade testing has issues with credentials on 8.7 -> 8.8 upgrade, so disabling for now to get green CI while we investigate" |
| `keycloak-rba` | kerba | (no comment) |
| `keycloak-original` | keyc | (no comment) |

The "credentials issues" attributed to `kemt` were almost certainly the `--force`-induced Replace failures masquerading as something else. With `--force` removed by #6021, all four pass cleanly. Verified in CI on PR #6021's branch (which had these same re-enables for verification):

```
8.8 - eske-upgm - upgrade-minor   pass   8m12s
8.8 - kemt      - upgrade-minor   pass   8m10s
8.8 - kerba     - upgrade-minor   pass   7m54s
8.8 - keyc      - upgrade-minor   pass   8m53s
```

## Test plan

- [x] `make helm.lint chartPath=charts/camunda-platform-8.8` clean.
- [x] `make go.test chartPath=charts/camunda-platform-8.8` passes.
- [x] GKE install validated for `cprst` (`distro-ci`, namespace `cprst-88`):
  - `integration-camunda-platform-optimize-data-{camunda,tmp}` PVCs Bound.
  - `integration-camunda-platform-webmodeler-data` PVC Bound.
  - `extra-data-integration-zeebe-{0..2}` PVCs Bound.
  - All components 1/1 Running.
- [x] **GKE 8.7 → 8.8 upgrade-minor flow validated end-to-end** when both 8.7 and 8.8 charts include their respective persistence feature files (i.e., the post-#6007-landing state):
  - 8.7 install with persistence: `extra-data-integration-zeebe-{0..2}` Bound, all components 1/1 Running.
  - 8.8 helm upgrade with persistence: same SS UID, same PVC UIDs preserved across the upgrade, helm `deployed`.
- [x] Four re-enabled scenarios verified passing on the `--force`-removed Taskfile in CI (PR #6021).

## Related PRs

- **#6021** — drop `--force` (must land first).
- **#6007** — 8.7 scenario (must land first).
- 8.9: #6009.
- 8.10: #6010.
- chart fixes for 8.9/8.10: #6014.
- docs: camunda/camunda-docs#8738.
