### PR TITLE
feat(8.9): add component-persistence scenario and fix webModeler PVC casing for issue 4767

### DIFF
--- a/charts/camunda-platform-8.9/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform-8.9/templates/web-modeler/deployment-restapi.yaml
@@ -175,7 +175,7 @@ spec:
             claimName: {{ .Values.webModeler.persistence.existingClaim }}
           {{- else if .Values.webModeler.persistence.enabled }}
           persistentVolumeClaim:
-            claimName: {{ include "camundaPlatform.fullname" . }}-webModeler-data
+            claimName: {{ include "camundaPlatform.fullname" . }}-webmodeler-data
           {{- else }}
           emptyDir: {}
           {{- end }}

--- a/charts/camunda-platform-8.9/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.9/test/ci-test-config.yaml
@@ -213,6 +213,18 @@ integration:
           identity: keycloak
           persistence: rdbms
           platforms: [gke]
+        - name: component-persistence
+          enabled: true
+          exclude: []
+          shortname: cprst
+          auth: keycloak
+          identity: keycloak
+          persistence: elasticsearch
+          flow: install,upgrade-minor
+          infra-type:
+            gke: distroci
+          features: [persistence,migrator]
+          platforms: [gke]
     nightly:
       scenario:
         - name: elasticsearch

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/persistence.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/persistence.yaml
@@ -1,0 +1,36 @@
+# =============================================================================
+# Component Persistence Feature
+# =============================================================================
+# Layer 4: Optional feature - exercises persistent volume configuration on
+# Camunda components so the chart's PVC/StatefulSet templates are covered by
+# nightly CI. Tracks the regressions reported in:
+#   SUPPORT-30042 (Optimize PVC pending)
+#   SUPPORT-30069 (web-modeler PVC pending / install failure)
+#   SUPPORT-30094 (orchestration extraVolumeClaimTemplates rejected)
+# Used with: TEST_VALUES_FEATURES containing "persistence"
+# =============================================================================
+
+optimize:
+  enabled: true
+  persistence:
+    enabled: true
+    size: 1Gi
+
+webModeler:
+  persistence:
+    enabled: true
+    size: 1Gi
+    # Required to upgrade through a single-replica restapi Deployment when
+    # the chart-managed PVC is RWO (default). RollingUpdate would leave
+    # the new pod waiting for the old pod to release the volume.
+    deploymentStrategy: Recreate
+
+orchestration:
+  extraVolumeClaimTemplates:
+    - metadata:
+        name: extra-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi

--- a/charts/camunda-platform-8.9/test/unit/web-modeler/persistence_test.go
+++ b/charts/camunda-platform-8.9/test/unit/web-modeler/persistence_test.go
@@ -113,7 +113,7 @@ func (s *PersistenceTemplateTest) TestPersistenceConfiguration() {
 				s.Require().NotNil(tmpVolume, "tmp volume should exist")
 				s.Require().NotNil(tmpVolume.PersistentVolumeClaim, "should use PVC when persistence is enabled")
 				s.Require().Nil(tmpVolume.EmptyDir, "should not use emptyDir when persistence is enabled")
-				s.Require().Equal("camunda-platform-test-webModeler-data", tmpVolume.PersistentVolumeClaim.ClaimName)
+				s.Require().Equal("camunda-platform-test-webmodeler-data", tmpVolume.PersistentVolumeClaim.ClaimName)
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

Adds a `component-persistence` PR-section CI scenario for chart 8.9 that exercises persistent-volume code paths reported in support tickets, and fixes the SUPPORT-30069 root cause uncovered while validating it.

Tracks issue [#4767](https://github.com/camunda/camunda-platform-helm/issues/4767).

## ⚠ Landing order

**This PR must land *after* #6014** (the rollout fixes for 8.9/8.10). The scenario's `features/persistence.yaml` sets `webModeler.persistence.deploymentStrategy: Recreate`. That values key is introduced in #6014; without #6014 it is silently ignored, and the scenario's `flow: install,upgrade-minor` path will deadlock on the web-modeler-restapi RWO `Multi-Attach error` (red PR CI). With #6014 first, this PR's CI is green.

## Bug fixed (SUPPORT-30069)

`templates/web-modeler/deployment-restapi.yaml:178` referenced the web-modeler PVC as `webModeler-data` (capital M), but `templates/web-modeler/persistentvolumeclaim-restapi.yaml:5` creates it as `webmodeler-data` (all lowercase, intentionally — see the 8.8 chart's `NOTE` comment). When `webModeler.persistence.enabled=true`, the restapi pod referenced a non-existent PVC and was unschedulable.

8.8 has the correct casing on both ends; 8.10 has the same bug and is fixed in #6010.

## Changes

- **Fix** `templates/web-modeler/deployment-restapi.yaml`: claimName lowercase `webmodeler-data`.
- **Fix** `test/unit/web-modeler/persistence_test.go`: assertion updated from buggy `webModeler-data` to correct `webmodeler-data`.
- **Add** `test/integration/scenarios/chart-full-setup/values/features/persistence.yaml` — enables `optimize.persistence`, `webModeler.persistence`, `orchestration.extraVolumeClaimTemplates`, and sets `webModeler.persistence.deploymentStrategy: Recreate` (requires #6014).
- **Add** `component-persistence` scenario in `test/ci-test-config.yaml` under `case.pr.scenario` (PR-time runs), shortname `cprst`, identity keycloak, persistence elasticsearch, `flow: install,upgrade-minor`, features `[persistence,migrator]`, GKE only.

## Test plan

- [x] `make helm.lint chartPath=charts/camunda-platform-8.9` clean.
- [x] `make go.test chartPath=charts/camunda-platform-8.9` passes (including the corrected persistence_test).
- [x] **GKE 8.8→8.9 upgrade-minor flow validated end-to-end** with this PR rebased on #6014:
  - helm release `deployed`; all pods 1/1 Running.
  - PVCs preserved across upgrade: `optimize-data-{camunda,tmp}`, `webmodeler-data`, `extra-data-integration-zeebe-{0..2}`.
  - `kubectl get deploy integration-web-modeler-restapi -o jsonpath='{.spec.strategy.type}'` returns `Recreate`.

## Related PRs

- 8.7 scenario: #6007
- 8.8 scenario: #6008
- 8.10 scenario + casing fix: #6010 (same dependency on #6014)
- **chart fixes (must land first): #6014**
- docs: camunda/camunda-docs#8738

🤖 Generated with [Claude Code](https://claude.com/claude-code)
