### PR TITLE
fix(8.9): remove duplicate Optimize env vars in OpenSearch CI values

### DIFF
--- a/charts/camunda-platform-8.9/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.9/test/ci-test-config.yaml
@@ -62,7 +62,7 @@ integration:
           persistence: elasticsearch
           platforms: [gke]  # EKS removed: external ES connectivity issues cause Zeebe pods to never become ready on EKS
         - name: opensearch
-          enabled: false
+          enabled: true
           auth: keycloak
           shortname: oske
           exclude: []

--- a/charts/camunda-platform-8.9/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.9/test/ci-test-config.yaml
@@ -67,6 +67,7 @@ integration:
           shortname: oske
           exclude: []
           identity: keycloak
+          persistence: opensearch
           infra-type:
             gke: distroci
             eks: preemptible

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/persistence/opensearch-external.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/persistence/opensearch-external.yaml
@@ -52,12 +52,6 @@ optimize:
       value: zeebe-$ORCHESTRATION_INDEX_PREFIX-$FLOW
     - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_PREFIX
       value: $OPTIMIZE_INDEX_PREFIX-$FLOW
-  migration:
-    env:
-      - name: CAMUNDA_OPTIMIZE_ZEEBE_NAME
-        value: zeebe-$ORCHESTRATION_INDEX_PREFIX-$FLOW
-      - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_PREFIX
-        value: $OPTIMIZE_INDEX_PREFIX-$FLOW
 
 elasticsearch:
   enabled: false

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/persistence/opensearch.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/persistence/opensearch.yaml
@@ -78,12 +78,6 @@ optimize:
       value: $ORCHESTRATION_INDEX_PREFIX-$FLOW
     - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_PREFIX
       value: $OPTIMIZE_INDEX_PREFIX-$FLOW
-  migration:
-    env:
-      - name: CAMUNDA_OPTIMIZE_ZEEBE_NAME
-        value: $ORCHESTRATION_INDEX_PREFIX-$FLOW
-      - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_PREFIX
-        value: $OPTIMIZE_INDEX_PREFIX-$FLOW
 
 elasticsearch:
   enabled: false


### PR DESCRIPTION
## Summary

- Closes part of #4255 (8.9 only — companion PRs: 8.8 #6011, 8.10 #6013).
- Drops the redundant `optimize.migration.env` block from `chart-full-setup` `opensearch.yaml` and `opensearch-external.yaml` persistence values. The same two env vars (`CAMUNDA_OPTIMIZE_ZEEBE_NAME`, `CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_PREFIX`) were defined under both `optimize.env` and `optimize.migration.env`, producing duplicate entries in the rendered Optimize migration init container.
- Enables the `oske` (bundled-OpenSearch + Keycloak) scenario in the PR CI matrix so future regressions on `opensearch.yaml` are caught at PR time.

## Why `optimize.migration.env` exists (and why we should not use it like we were)

`optimize.env` and `optimize.migration.env` are two separate hooks with different scopes:

| Field | Rendered into | Intended use |
|---|---|---|
| `optimize.env` | main `optimize` container **and** the migration init container | "set this everywhere" |
| `optimize.migration.env` | migration init container **only** (stacked after `optimize.env`) | "set this *only* during the migration step, or override an `optimize.env` value just for migration" |

`values.yaml` already states this:
> `optimize.migration.env` can be used to set extra environment variables in the app container. **(Note: there is no need to define this if `optimize.env` is defined.)**

Legitimate uses of `migration.env` are migration-specific things — a different log level for the migration run, migration-only batch/chunk tuning, JVM heap overrides for the migrator, skip-flags for specific migration paths, temporarily pointing migration at a different index/alias, etc.

What our CI persistence values were doing was *not* one of those — they were copy-pasting the same two `CAMUNDA_OPTIMIZE_*` vars into both hooks. That ends up rendering them twice in the init container's env list. Kubernetes silently keeps the last entry ("last wins"), and because both copies were identical, runtime behaviour was unaffected — but the manifest was wrong and confusing.

This PR removes only the duplicates; it does **not** change the template, and `optimize.migration.env` remains available for legitimate migration-only use.

## Root cause

The Optimize migration init container renders both `.Values.optimize.env` and `.Values.optimize.migration.env` (`templates/optimize/deployment.yaml`). The CI persistence values files listed identical entries under both keys, so each var was emitted twice in the init container's env list. The main `optimize` container only renders `optimize.env` and was already correct.

## Validation

### Static (every commit)
- `make helm.lint chartPath=charts/camunda-platform-8.9` PASS
- `make go.test chartPath=charts/camunda-platform-8.9` PASS
- `helm template ... | grep -c` for both vars returns `2` against `opensearch.yaml` and `opensearch-external.yaml`. Was `3` before.

### Live deploy on GKE (`distro-ci`, namespace `matrix-89-osex-inst-gke`)
External OpenSearch path:
```
$ deploy-camunda matrix run --versions 8.9 --shortname-filter osex \
    --flow-filter install --platform gke --delete-namespace --yes ...
[PASS] 8.9/opensearch-external (osex, flow=install)   2m29s

$ kubectl -n matrix-89-osex-inst-gke get deploy integration-optimize -o yaml \
    | grep -c "name: CAMUNDA_OPTIMIZE_ZEEBE_NAME"
2
$ kubectl -n matrix-89-osex-inst-gke get deploy integration-optimize -o yaml \
    | grep -c "name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_PREFIX"
2
```

### Live deploy on GKE (`distro-ci`, namespace `matrix-89-oske-inst-gke`)
Bundled-OpenSearch + Keycloak path — verifying the freshly-enabled `oske` PR scenario:
```
$ deploy-camunda matrix run --versions 8.9 --shortname-filter oske --include-disabled \
    --flow-filter install --platform gke --delete-namespace --yes ...
[PASS] 8.9/opensearch (oske, flow=install)   2m36s

$ kubectl -n matrix-89-oske-inst-gke get deploy integration-optimize -o yaml \
    | grep -c "name: CAMUNDA_OPTIMIZE_ZEEBE_NAME"
2
$ kubectl -n matrix-89-oske-inst-gke get deploy integration-optimize -o yaml \
    | grep -c "name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_PREFIX"
2
```

Both test namespaces have been deleted.

## Test plan

- [x] Static `helm template` shows 2 occurrences of each var (one per container)
- [x] `make helm.lint chartPath=charts/camunda-platform-8.9`
- [x] `make go.test chartPath=charts/camunda-platform-8.9`
- [x] Live deploy `osex` on GKE — env var count = 2 each
- [x] Live deploy `oske` on GKE — env var count = 2 each
- [x] Enable `oske` in PR matrix

Generated with [Claude Code](https://claude.com/claude-code)