### PR TITLE
feat(qa): wire oidc-qa Entra overlay into integration scenarios

### DIFF
--- a/charts/camunda-platform-8.10/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.10/test/ci-test-config.yaml
@@ -106,6 +106,20 @@ integration:
           identity: oidc
           persistence: elasticsearch
           platforms: [gke]
+        - name: oidc-qa
+          enabled: false  # flip to true after first green Entra QA run
+          exclude: [identity,console,orchestration-grpc]
+          shortname: oidcqa
+          auth: oidc
+          flow: install
+          skip-e2e: true  # E2E suite is driven from c8-cross-component-e2e-tests OIDC nightly
+          skip-it: true   # ITs not authored for Entra real-user flow yet
+          infra-type:
+            gke: distroci
+          identity: oidc
+          persistence: elasticsearch
+          qa: true
+          platforms: [gke]
         - name: keycloak-mt
           enabled: false
           exclude: []

--- a/charts/camunda-platform-8.7/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.7/test/ci-test-config.yaml
@@ -72,6 +72,20 @@ integration:
             gke: distroci
             eks: preemptible
           platforms: [gke]
+        - name: oidc-qa
+          enabled: false  # flip to true after first green Entra QA run
+          shortname: oidcqa
+          exclude: []
+          auth: oidc
+          identity: oidc
+          persistence: elasticsearch
+          qa: true
+          flow: install
+          skip-e2e: true  # E2E suite is driven from c8-cross-component-e2e-tests OIDC nightly
+          skip-it: true   # ITs not authored for Entra real-user flow yet
+          infra-type:
+            gke: distroci
+          platforms: [gke]
         - name: keycloak-original
           enabled: true
           shortname: keyc

--- a/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values/identity/oidc-qa.yaml
+++ b/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values/identity/oidc-qa.yaml
@@ -1,0 +1,13 @@
+# QA OIDC auth overlay for 8.7 (Entra ID)
+# Layered on top of identity/oidc.yaml when QA mode is enabled.
+# Swaps the initial admin claim from a fixed Entra app object ID
+# ($ENTRA_APP_OBJECT_ID) to the QA test user's oid ($INITIAL_CLAIM_VALUE),
+# allowing real-user UI sign-in flows (TOTP MFA) instead of service-principal
+# token grants.
+
+global:
+  identity:
+    auth:
+      identity:
+        initialClaimName: oid
+        initialClaimValue: $INITIAL_CLAIM_VALUE

--- a/charts/camunda-platform-8.8/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.8/test/ci-test-config.yaml
@@ -69,6 +69,20 @@ integration:
           identity: oidc
           persistence: elasticsearch
           platforms: [gke]
+        - name: oidc-qa
+          enabled: false  # flip to true after first green Entra QA run
+          exclude: [identity,console,orchestration-grpc]
+          shortname: oidcqa
+          auth: oidc
+          flow: install
+          skip-e2e: true  # E2E suite is driven from c8-cross-component-e2e-tests OIDC nightly
+          skip-it: true   # ITs not authored for Entra real-user flow yet
+          infra-type:
+            gke: distroci
+          identity: oidc
+          persistence: elasticsearch
+          qa: true
+          platforms: [gke]
         - name: keycloak-mt
           enabled: false # our upgrade testing has issues with credentials on 8.7 -> 8.8 upgrade, so disabling for now to get green CI while we investigate
           exclude: []

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/identity/oidc-qa.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/identity/oidc-qa.yaml
@@ -1,0 +1,27 @@
+# QA OIDC auth overlay for 8.8 (Entra ID)
+# Layered on top of identity/oidc.yaml when QA mode is enabled.
+# Swaps the admin from a static Entra app object ID to the QA test user's `oid`
+# ($INITIAL_CLAIM_VALUE) so real-user UI sign-in flows (TOTP MFA) can drive the
+# end-to-end suite. Replaces the orchestration env mapping rules with a
+# structured defaultRoles.admin.users entry so the user is granted admin
+# directly rather than via a service-principal mapping rule.
+
+global:
+  identity:
+    auth:
+      identity:
+        initialClaimValue: $INITIAL_CLAIM_VALUE
+
+orchestration:
+  security:
+    initialization:
+      defaultRoles:
+        admin:
+          users:
+            - $INITIAL_CLAIM_VALUE
+  # Helm replaces arrays wholesale: re-declare orchestration.env without the
+  # mapping rules from identity/oidc.yaml so the QA test user, not a service
+  # principal, is the sole admin.
+  env:
+    - name: CAMUNDA_DATABASE_SCHEMAMANAGER_VERSIONCHECKRESTRICTIONENABLED
+      value: "false"

--- a/charts/camunda-platform-8.9/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.9/test/ci-test-config.yaml
@@ -107,6 +107,20 @@ integration:
           identity: oidc
           persistence: elasticsearch
           platforms: [gke]
+        - name: oidc-qa
+          enabled: false  # flip to true after first green Entra QA run
+          exclude: [identity,console,orchestration-grpc]
+          shortname: oidcqa
+          auth: oidc
+          flow: install
+          skip-e2e: true  # E2E suite is driven from c8-cross-component-e2e-tests OIDC nightly
+          skip-it: true   # ITs not authored for Entra real-user flow yet
+          infra-type:
+            gke: distroci
+          identity: oidc
+          persistence: elasticsearch
+          qa: true
+          platforms: [gke]
         - name: keycloak-mt
           enabled: true
           exclude: []

--- a/scripts/camunda-core/pkg/scenarios/scenarios.go
+++ b/scripts/camunda-core/pkg/scenarios/scenarios.go
@@ -127,6 +127,15 @@ func (c *DeploymentConfig) ResolvePaths(scenariosDir string) ([]string, error) {
 		if _, err := os.Stat(identityPath); err == nil {
 			files = append(files, identityPath)
 		}
+		// QA-specific identity overlay (e.g., oidc-qa.yaml) layered on top of the
+		// base identity file when QA mode is on. Lets QA swap test users / claim
+		// values without forking the whole identity overlay.
+		if c.QA {
+			qaIdentityPath := filepath.Join(valuesDir, IdentityDir, c.Identity+"-qa.yaml")
+			if _, err := os.Stat(qaIdentityPath); err == nil {
+				files = append(files, qaIdentityPath)
+			}
+		}
 	}
 
 	// Layer 4: Persistence selection

--- a/scripts/camunda-core/pkg/scenarios/scenarios_test.go
+++ b/scripts/camunda-core/pkg/scenarios/scenarios_test.go
@@ -607,6 +607,95 @@ func TestDeploymentConfigResolvePaths(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("qa mode layers identity-qa.yaml overlay when present", func(t *testing.T) {
+		oidcPath := filepath.Join(tmpDir, "values", "identity", "oidc.yaml")
+		oidcQAPath := filepath.Join(tmpDir, "values", "identity", "oidc-qa.yaml")
+		if err := os.WriteFile(oidcPath, []byte("# oidc"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(oidcQAPath, []byte("# oidc qa"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			os.Remove(oidcPath)
+			os.Remove(oidcQAPath)
+		})
+
+		config := &DeploymentConfig{
+			Identity:    "oidc",
+			Persistence: "elasticsearch",
+			Platform:    "gke",
+			QA:          true,
+		}
+		paths, err := config.ResolvePaths(tmpDir)
+		if err != nil {
+			t.Fatalf("ResolvePaths() error = %v", err)
+		}
+
+		// Expected order: base.yaml, base-qa.yaml, oidc.yaml, oidc-qa.yaml, elasticsearch.yaml, gke.yaml
+		expectedSuffixes := []string{
+			"values/base.yaml",
+			"values/base-qa.yaml",
+			"values/identity/oidc.yaml",
+			"values/identity/oidc-qa.yaml",
+			"values/persistence/elasticsearch.yaml",
+			"values/platform/gke.yaml",
+		}
+		if len(paths) != len(expectedSuffixes) {
+			t.Fatalf("Expected %d paths, got %d: %v", len(expectedSuffixes), len(paths), paths)
+		}
+		for i, suffix := range expectedSuffixes {
+			if !containsSuffix(paths[i], suffix) {
+				t.Errorf("paths[%d] = %q, want suffix %q", i, paths[i], suffix)
+			}
+		}
+	})
+
+	t.Run("non-qa with identity-qa.yaml present does not layer it", func(t *testing.T) {
+		oidcPath := filepath.Join(tmpDir, "values", "identity", "oidc.yaml")
+		oidcQAPath := filepath.Join(tmpDir, "values", "identity", "oidc-qa.yaml")
+		if err := os.WriteFile(oidcPath, []byte("# oidc"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(oidcQAPath, []byte("# oidc qa"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			os.Remove(oidcPath)
+			os.Remove(oidcQAPath)
+		})
+
+		config := &DeploymentConfig{
+			Identity:    "oidc",
+			Persistence: "elasticsearch",
+			Platform:    "gke",
+		}
+		paths, err := config.ResolvePaths(tmpDir)
+		if err != nil {
+			t.Fatalf("ResolvePaths() error = %v", err)
+		}
+
+		for _, p := range paths {
+			if containsSuffix(p, "oidc-qa.yaml") {
+				t.Errorf("non-QA scenario should not include oidc-qa.yaml, but found: %q", p)
+			}
+		}
+	})
+
+	t.Run("qa mode without identity-qa.yaml present skips overlay silently", func(t *testing.T) {
+		// keycloak-qa.yaml does NOT exist in fixtures — qa with keycloak should still resolve cleanly.
+		config := MapScenarioToConfig("qa-elasticsearch")
+		paths, err := config.ResolvePaths(tmpDir)
+		if err != nil {
+			t.Fatalf("ResolvePaths() error = %v", err)
+		}
+		for _, p := range paths {
+			if containsSuffix(p, "keycloak-qa.yaml") {
+				t.Errorf("keycloak-qa.yaml does not exist; should not appear in paths: %q", p)
+			}
+		}
+	})
 }
 
 func TestExpandImports(t *testing.T) {


### PR DESCRIPTION
## Summary
- Layer `values/identity/<identity>-qa.yaml` on top of the base identity overlay when a ci-test scenario sets `qa: true`. Without this, the `oidc-qa.yaml` files in 8.9/8.10 were orphaned (zero references in the codebase).
- New `oidc-qa.yaml` overlay for **8.7** and **8.8** — swap the static `\$ENTRA_APP_OBJECT_ID` admin claim for the QA test user's `\$INITIAL_CLAIM_VALUE` so a real-user UI sign-in (TOTP MFA) can drive the suite. 8.8 also re-declares `orchestration.env` to drop the service-principal mapping rules so the user becomes admin via `defaultRoles.admin.users`.
- New disabled `oidc-qa` CI scenario in `ci-test-config.yaml` for **8.7 / 8.8 / 8.9 / 8.10** (`qa: true`, `identity: oidc`, `persistence: elasticsearch`); flip `enabled: true` after the first green Entra QA run.

Issue: #3845

## Cross-repo dependency
Companion PR in `c8-cross-component-e2e-tests` adds the `auth=oidc` plumbing to the 8.7 reusable workflow + a TOTP login fixture + nightly OIDC workflows. Needs to land alongside this PR for the `qa-entra` scenario name to flow through to deploys.

## Test plan
- [x] `make helm.lint chartPath=charts/camunda-platform-8.7` and `8.8` — clean
- [x] `make go.test chartPath=charts/camunda-platform-8.7` and `8.8` — clean
- [x] `go test ./scripts/camunda-core/pkg/scenarios/...` — new `qa mode layers identity-qa.yaml overlay` tests pass; non-QA path unaffected
- [x] `deploy-camunda matrix list --include-disabled --scenario-filter oidc-qa` shows entries for 8.7, 8.8, 8.9, 8.10
- [ ] Live GKE deploy with `--identity oidc --qa` to confirm Identity / Orchestration come up against Entra and JWKS fetch succeeds
- [ ] After first green nightly OIDC run from the e2e repo, flip `enabled: true` on the four `oidc-qa` ci-test scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)