### PR TITLE
fix(8.10): route QA image-tag overrides through legacy webModeler/console keys

### DIFF
--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/base-image-tags.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/base-image-tags.yaml
@@ -6,21 +6,19 @@ orchestration:
 optimize:
   image:
     tag: "$E2E_TESTS_OPTIMIZE_IMAGE_TAG"
-camundaHub:
-  webModeler:
-    restapi:
-      image:
-        tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
-    websockets:
-      image:
-        tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
-  console:
+webModeler:
+  restapi:
     image:
-      tag: "$E2E_TESTS_CONSOLE_IMAGE_TAG"
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+  websockets:
+    image:
+      tag: "$E2E_TESTS_WEBMODELER_IMAGE_TAG"
+console:
+  image:
+    tag: "$E2E_TESTS_CONSOLE_IMAGE_TAG"
 identity:
   image:
     tag: "$E2E_TESTS_IDENTITY_IMAGE_TAG"
 connectors:
   image:
     tag: "$E2E_TESTS_CONNECTORS_IMAGE_TAG"
-


### PR DESCRIPTION
## Summary

- Unblocks all nine SM 8.10 nightly workflows in `c8-cross-component-e2e-tests`, which have been failing with `INSTALLATION FAILED: context deadline exceeded` because web-modeler `restapi`/`websockets` pods render as `%!s(<nil>):SNAPSHOT` and stick in `InvalidImageName`.
- Root cause: the 8.10 webModeler image helpers do `or .Values.camundaHub.webModeler.X.image .Values.webModeler.X.image`, designed so empty `camundaHub.*.image` maps fall through to legacy defaults (which carry `repository: camunda/hub` / `camunda/hub-websockets`). The QA scenario override `base-image-tags.yaml` populated only `tag` under `camundaHub.webModeler.{restapi,websockets}.image`, making that branch non-empty and shadowing the legacy `repository`. The Go template's `printf "%s%s%s:%s"` then rendered `nil` for the repository.
- Fix: move tag overrides to the legacy `webModeler.{restapi,websockets}.image.tag` and `console.image.tag` keys so `camundaHub.*.image` stays empty and the helpers fall through to defaults. Console moves for consistency only — its template uses `mustMergeOverwrite` so it was unaffected at runtime.
- This is the surgical fix. A follow-up PR should switch the webModeler `_helpers.tpl` from `or` to `mustMergeOverwrite` (mirroring console's pattern) so partial `camundaHub.*` overrides can no longer shadow legacy defaults wholesale — that requires golden-file regeneration and is out of scope here.

## Failing nightlies covered

All on 2026-04-29 (`upgrade_minor_*_8_10` had been failing for 3 days):

- `playwright_sm_nightly_document_store_8_10`
- `playwright_sm_nightly_mt_8_10`
- `playwright_sm_nightly_rba_8_10`
- `playwright_sm_nightly_tests_chrome_8_10`
- `playwright_sm_nightly_tests_opensearch_8_10`
- `playwright_sm_nightly_upgrade_minor_8_10`
- `playwright_sm_nightly_upgrade_minor_document_store_8_10`
- `playwright_sm_nightly_upgrade_minor_mt_8_10`
- `playwright_sm_nightly_upgrade_minor_opensearch_8_10`

Sample evidence (`gh run view 25090315172`):

```
Error: INSTALLATION FAILED: context deadline exceeded
integration-web-modeler-restapi-...    0/1   InvalidImageName   0   20m
Failed to apply default image tag "%!s(<nil>):SNAPSHOT": couldn't parse image name
```

## Test plan

- [x] `make helm.lint chartPath=charts/camunda-platform-8.10` — passes
- [x] `make go.test chartPath=charts/camunda-platform-8.10` — all unit packages pass; no golden regeneration needed (no golden file exercises the `camundaHub.*.image.*` override path)
- [ ] `deploy-camunda matrix run --repo-root . --versions 8.10 --shortname qaelupg` on GKE — confirm web-modeler pods reach Ready and `kubectl describe` shows a resolved image string (not `%!s(<nil>)`)
- [ ] Re-trigger `playwright_sm_nightly_tests_chrome_8_10.yml` and one upgrade-minor workflow; confirm Helm install completes and Playwright proceeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Linked Issue

Closes #6029
