### PR TITLE
fix(test): drop --force from helm upgrade and remove obsolete sts pre-deletes for issue 4767

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ STATE.md
 **/.omc
 
 .claude/
+c8e2e-results/

--- a/charts/camunda-platform-8.8/test/integration/scenarios/pre-setup-scripts/pre-upgrade-minor.sh
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/pre-setup-scripts/pre-upgrade-minor.sh
@@ -12,7 +12,11 @@ if [[ -n "${KUBE_CONTEXT:-}" ]]; then
   CONTEXT_FLAG="--context ${KUBE_CONTEXT}"
 fi
 
-# Remove StatefulSets that commonly hit immutable-spec diffs between 8.7 and 8.8.
-# They are recreated by Helm with the new spec while keeping PVC data.
-kubectl ${CONTEXT_FLAG} delete sts -n "${TEST_NAMESPACE}" -l app.kubernetes.io/name=postgresql --ignore-not-found
-kubectl ${CONTEXT_FLAG} delete sts -n "${TEST_NAMESPACE}" -l app.kubernetes.io/name=postgresql-web-modeler --ignore-not-found
+# No StatefulSet pre-deletions are required for the 8.7 -> 8.8 upgrade.
+# The previous postgresql / postgresql-web-modeler deletions existed to
+# work around immutable-spec diffs surfaced when helm upgrade ran with
+# the --force flag (which uses helper.Replace -> HTTP PUT, requiring
+# byte-exact immutable-field equality after server defaulting). With
+# --force removed from the chart-upgrade Taskfile, helm uses strategic-
+# merge-patch, which only validates the diff'd fields and does not
+# require this pre-cleanup.


### PR DESCRIPTION
## Summary

Drops the unconditional `--force` flag from `chart-upgrade-taskfile.yaml`'s helm upgrade command and removes the now-obsolete `kubectl delete sts` lines from chart 8.8's `pre-upgrade-minor.sh`. Both existed to mask immutable-field rejection patterns introduced by `--force` itself.

Tracks issue [#4767](https://github.com/camunda/camunda-platform-helm/issues/4767).

## Why `--force` was problematic

`pkg/kube/client.go:712-718` in helm v3.20.2:

```go
if force {
    obj, err = helper.Replace(target.Namespace, target.Name, true, target.Object)
    if err != nil {
        return errors.Wrap(err, "failed to replace object")
    }
} else {
    patch, patchType, err := createPatch(target, currentObj, threeWayMergeForUnstructured)
    obj, err = helper.Patch(target.Namespace, target.Name, patchType, patch, nil)
}
```

`--force` routes helm through `helper.Replace` — an HTTP PUT of the rendered manifest. Replace requires byte-exact immutable-field equality between the new manifest and the post-server-defaulting live state. Strategic-merge-patch (the default) only validates the fields actually present in the diff. Under control-plane churn, server-defaulted fields (`volumeMode`, `dataSource`, etc.) on a StatefulSet's `volumeClaimTemplates` could reach Replace's validation differently, producing intermittent `UPGRADE FAILED: failed to replace object: ... spec: Forbidden` errors that were not deterministic.

## History

The `--force` flag was added in two stages:

1. **`18b94e451`** (2025-04-18, by Jesse Simpson): conditional `--force` for the 8.4→8.5 transition only, paired with a targeted `kubectl delete deployment integration-identity` to handle the Identity port-name immutability change. The pattern was: delete the specific resource that has an unfixable immutable change, then `helm upgrade --force --install` to recreate.

2. **`0a4f540f9`** (2025-10-03, mine): "Use --force on Helm upgrades to avoid immutable field conflicts when resources change." Removed the version-conditional logic and made `--force` apply to every upgrade-minor run. This was a convenience for adding new scenarios without per-version cleanup hooks, but it traded a precise mechanism for a broad one — and the broad mechanism intermittently fails under K8s control-plane churn.

Subsequently, the postgresql / postgresql-web-modeler `kubectl delete sts` lines were silently added to `pre-upgrade-minor.sh` in `b5ad9946e` (2026-03-13) as part of a values-convention refactor — to mask the same `--force`-induced Replace failures on Bitnami subchart StatefulSets that had immutable-spec diffs between 8.7 and 8.8 versions.

## Changes

- `test/integration/scenarios/lib/chart-upgrade-taskfile.yaml`: remove `--force` from both helm upgrade invocations (selection-composition path and legacy fallback path).
- `charts/camunda-platform-8.8/test/integration/scenarios/pre-setup-scripts/pre-upgrade-minor.sh`: remove the postgresql / postgresql-web-modeler `kubectl delete sts` lines, with a comment explaining why they're no longer needed.
- `.gitignore`: ignore `c8e2e-results/` produced by local `c8e2e test` runs.

## CI evidence

To exercise this change in real CI, **four upgrade-minor scenarios that had been disabled because of `--force`-induced flakiness were temporarily re-enabled on this branch**. All four passed cleanly:

```
8.8 - eske-upgm - upgrade-minor   pass   8m12s
8.8 - kemt      - upgrade-minor   pass   8m10s   (was disabled with comment "credentials issues on 8.7 -> 8.8 upgrade")
8.8 - kerba     - upgrade-minor   pass   7m54s
8.8 - keyc      - upgrade-minor   pass   8m53s
```

The scenario re-enables now ship in the companion PR **#6008** so this PR stays scoped to the helm-correctness change.

## Backward compatibility

- Customer-facing chart behavior: unchanged. This only modifies test infrastructure (the chart-test Taskfile and a CI-only pre-upgrade hook). Customers who run `helm upgrade --force` on their own setups (which is not standard practice) still get the same Replace path.
- Existing CI scenarios: the install path is unchanged. The upgrade-minor path now uses strategic-merge-patch instead of Replace, which is more lenient and the helm 3 default. All previously passing upgrade-minor scenarios continue to pass; previously disabled ones (see CI evidence above) now also pass.

## What this PR does *not* fix

- The `cprst` upgrade-minor flow on PR #6008 fails with `cannot patch ... spec: Forbidden` even after `--force` removal. That's a separate, real immutable change: the 8.7 chart on `main` has no persistence feature file, so step 1 install creates the SS without `extra-data` VCT, and step 2 8.8 upgrade tries to add it (forbidden). Resolved by landing #6007 first so 8.7's chart includes the matching `zeebe.extraVolumeClaimTemplates` feature file.

## Related PRs

- **#6007** — 8.7 persistence scenario (independent prereq for #6008).
- **#6008** — 8.8 component-persistence scenario + the upgrade-minor scenario re-enables verified above. Depends on this PR + #6007.
- #6009 / #6010 — 8.9 / 8.10 scenarios (depend on #6014, not on this PR).
- #6014 — orchestration chart fixes for 8.9 / 8.10.
- camunda-docs#8738 — persistence guide.

## Land order

This PR can land independently of all the others. After it lands, #6008 should be rebased on main to pick up the `--force` removal.
