### PR TITLE
ci: fix compat namespace collisions and ExternalSecrets timeout

### DIFF
--- a/.github/actions/cluster-setup-secrets/action.yaml
+++ b/.github/actions/cluster-setup-secrets/action.yaml
@@ -76,7 +76,7 @@ runs:
           for secret in $(kubectl get externalsecret -n $TEST_NAMESPACE -o jsonpath='{.items[*].metadata.name}'); do
             echo "⏳ Waiting for ExternalSecret: $secret"
             kubectl get externalsecret/"$secret" -n $TEST_NAMESPACE
-            kubectl wait --for=condition=Ready externalsecret/"$secret" -n $TEST_NAMESPACE --timeout=300s
+            kubectl wait --for=condition=Ready externalsecret/"$secret" -n $TEST_NAMESPACE --timeout=600s
           done
 
         else
@@ -121,7 +121,7 @@ runs:
           for secret in $(kubectl get externalsecret -n $TEST_NAMESPACE -o jsonpath='{.items[*].metadata.name}'); do
             echo "⏳ Waiting for ExternalSecret: $secret"
             kubectl get externalsecret/"$secret" -n $TEST_NAMESPACE
-            kubectl wait --for=condition=Ready externalsecret/"$secret" -n $TEST_NAMESPACE --timeout=300s
+            kubectl wait --for=condition=Ready externalsecret/"$secret" -n $TEST_NAMESPACE --timeout=600s
           done
         fi
 

--- a/.github/actions/workflow-vars/action.yaml
+++ b/.github/actions/workflow-vars/action.yaml
@@ -97,6 +97,19 @@ runs:
       echo "OS_POOL_INDEX=${OS_POOL_INDEX}" | tee -a $GITHUB_ENV
       echo "os-pool-index=${OS_POOL_INDEX}" >> $GITHUB_OUTPUT
 
+      # K8s caps namespace length at 63. Reserve room for the hash (-XXXXXX, 7 chars) and the flow
+      # suffix (-upgp/-upgm, 5 chars) BEFORE appending them, so on long scenario names the hash and
+      # flow tag survive instead of being silently truncated off — otherwise namespaces stop being
+      # unique per run and concurrent or back-to-back runs collide.
+      RESERVED_SUFFIX_LEN=0
+      if [[ "${{ inputs.deployment-ttl }}" == '' ]]; then
+        RESERVED_SUFFIX_LEN=$((RESERVED_SUFFIX_LEN + 7))
+      fi
+      case "${{ inputs.setup-flow }}" in
+        upgrade-patch|upgrade-minor) RESERVED_SUFFIX_LEN=$((RESERVED_SUFFIX_LEN + 5)) ;;
+      esac
+      TEST_NAMESPACE="$(printf '%s' "$TEST_NAMESPACE" | head -c $((63 - RESERVED_SUFFIX_LEN)) | sed 's/-$//')"
+
       if [[ "${{ inputs.deployment-ttl }}" == '' ]]; then
         TEST_NAMESPACE="${TEST_NAMESPACE}-${GITHUB_WORKFLOW_JOB_ID}"
       fi

--- a/.github/workflows/test-backward-compat.yaml
+++ b/.github/workflows/test-backward-compat.yaml
@@ -87,11 +87,11 @@ jobs:
           - name: qa-elasticsearch-tasklist-v1
             shortname: qaeltlv1
           - name: qa-opensearch-tasklist-v1
-            shortname: qaosupg
+            shortname: qaostlv1
           - name: qa-elasticsearch-rba-tasklist-v1
             shortname: qaelrbaupg
           - name: qa-elasticsearch-mt-tasklist-v1
-            shortname: qaelmtupg
+            shortname: qaelmttl
             e2e-enabled: false
           - name: qa-license-tasklist-v1
             shortname: licupg

--- a/scripts/camunda-core/pkg/kube/platforms.go
+++ b/scripts/camunda-core/pkg/kube/platforms.go
@@ -175,7 +175,7 @@ func applySecretsForEKS(ctx context.Context, client *Client, repoRoot, chartPath
 	return nil
 }
 
-const externalSecretsReadyTimeout = 300 * time.Second
+const externalSecretsReadyTimeout = 600 * time.Second
 
 func copySecretBetweenNamespaces(ctx context.Context, client *Client, srcNamespace, secretName, destNamespace string) error {
 	logging.Logger.Debug().


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6025.

Three CI flakes that have been hitting `main` and PR runs:

- `INSTALLATION FAILED: release: already exists` / `cannot re-use a name that is still in use` on `Compat: e2e 8.8+` matrix jobs `qaelmtupg` and `qaosupg`
- `error: timed out waiting for the condition on externalsecrets/<release>-helm-existing-secrets-8-{7,8}` on most per-version `gke - install` jobs whenever many CI jobs start at the same time
- `Error: INSTALLATION FAILED: create: failed to create: namespaces "<truncated>" not found` on long-named scenarios such as `Compat: e2e 8.8+ upgrade-minor (89-qaeldocupg)`

### What's in this PR?

**1. Compat duplicate shortnames** (`.github/workflows/test-backward-compat.yaml`)

`compat-e2e-8-8-plus` had the same `shortname` on two scenarios:

- `qa-opensearch-tasklist-v1` and `qa-opensearch-upg` both used `qaosupg`
- `qa-elasticsearch-mt-tasklist-v1` and `qa-elasticsearch-mt-upg` both used `qaelmtupg`

`namespace-prefix` and `identifier` are derived from `${{ matrix.scenario.shortname }}`, so two matrix entries sharing a shortname produce the same `TEST_NAMESPACE` within a single run. GitHub Actions does not deduplicate matrix entries by display name — it runs both jobs concurrently. Confirmed in the failing run: jobs `73707080537` and `73707082292` (display name `Compat: e2e 8.8+ (88-qaosupg) / ... - qaosupg`) started 2 seconds apart and resolved to the identical `TEST_NAMESPACE` `bc88p88qaosupg--pr-compat-88p-88-qaosupg-25146378430-qaosupg-ef`. Whichever job ran `helm install` second hit `release: already exists`. Renamed the `*-tasklist-v1` variants to `qaostlv1` and `qaelmttl`, following the existing `qa-elasticsearch-tasklist-v1` → `qaeltlv1` pattern. The `*-upg` variants keep their names so any external references (Slack alerts, dashboards) remain stable.

**2. Namespace truncation losing the unique hash** (`.github/actions/workflow-vars/action.yaml`)

`workflow-vars` builds `TEST_NAMESPACE`, then appends a 6-char `-XXXXXX` hash and (for `upgrade-patch` / `upgrade-minor`) a 5-char `-upgp` / `-upgm` suffix, then `head -c 63` to satisfy the K8s namespace limit. For long scenario names (e.g. `Compat: e2e 8.8+ upgrade-minor (89-qaeldocupg)`, base length 82) the hash and the flow tag get silently chopped off. Different runs of the same scenario then resolve to the same truncated namespace, which is a) not unique per run and b) doesn't match what was actually created. Reserve the 7+5 suffix bytes before the truncation so the hash and flow tag always survive. Hash and pool-index computations still use the full base, so per-scenario routing and cross-run uniqueness are preserved.

Validated locally — the failing scenario now produces distinct namespaces per run:

| run_id | namespace |
|---|---|
| `25146378430` | `bc88pupgmin89qaeldocupg--pr-compat-88p-upgmin-89-qaeldoc-970d2e` |
| `25146374183` | `bc88pupgmin89qaeldocupg--pr-compat-88p-upgmin-89-qaeldoc-31edb3` |

Short scenarios (e.g. `qael`) are unchanged: their base already fits under the limit, so the reservation is a no-op.

**3. ExternalSecrets readiness timeout** (`.github/actions/cluster-setup-secrets/action.yaml`, `scripts/camunda-core/pkg/kube/platforms.go`)

`kubectl wait --timeout=300s` and the Go deployer constant `externalSecretsReadyTimeout = 300 * time.Second` were both hitting their ceiling on runs where many jobs hit the ESO operator at the same time — the operator processes the queue, just not fast enough for 300s. Bumped both to 600s; behaviour unchanged on the happy path, just a longer ceiling under load.

### Checklist

**Before opening the PR:**

- [x] No template/golden changes — `make go.update-golden-only` not required.
- [x] There is no other open pull request for the same update/change.
- [x] Tests for charts are added (if needed). The Go change is a constant; no test asserts on the value.
- [ ] In-repo documentation are updated (if needed).

**After opening the PR:**

- [ ] Did all checks/tests pass in the PR?