### PR TITLE
fix(8.9): correct webModeler PVC claimName casing to match PVC template

### DIFF
--- a/charts/camunda-platform-8.9/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform-8.9/templates/web-modeler/deployment-restapi.yaml
@@ -175,7 +175,7 @@ spec:
             claimName: {{ .Values.webModeler.persistence.existingClaim }}
           {{- else if .Values.webModeler.persistence.enabled }}
           persistentVolumeClaim:
-            claimName: {{ include "camundaPlatform.fullname" . }}-webModeler-data
+            claimName: {{ include "camundaPlatform.fullname" . }}-webmodeler-data
           {{- else }}
           emptyDir: {}
           {{- end }}

--- a/charts/camunda-platform-8.9/test/unit/web-modeler/persistence_test.go
+++ b/charts/camunda-platform-8.9/test/unit/web-modeler/persistence_test.go
@@ -113,7 +113,7 @@ func (s *PersistenceTemplateTest) TestPersistenceConfiguration() {
 				s.Require().NotNil(tmpVolume, "tmp volume should exist")
 				s.Require().NotNil(tmpVolume.PersistentVolumeClaim, "should use PVC when persistence is enabled")
 				s.Require().Nil(tmpVolume.EmptyDir, "should not use emptyDir when persistence is enabled")
-				s.Require().Equal("camunda-platform-test-webModeler-data", tmpVolume.PersistentVolumeClaim.ClaimName)
+				s.Require().Equal("camunda-platform-test-webmodeler-data", tmpVolume.PersistentVolumeClaim.ClaimName)
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

- Fixes `deployment-restapi.yaml` PVC `claimName` casing from `webModeler-data` (capital M) to `webmodeler-data` (lowercase) to match the actual PVC created by `persistentvolumeclaim-restapi.yaml`
- Updates unit test assertion to match the corrected name

## Problem

The 8.9 chart's web-modeler deployment template references a PVC named `<release>-webModeler-data` but the PVC template creates it as `<release>-webmodeler-data`. This mismatch causes web-modeler-restapi pods to be stuck `Pending` when `webModeler.persistence.enabled=true`.

**Affected versions:** Chart 14.0.0, 14.0.1 (all released 8.9 versions)

The 8.8 chart (13.x) is not affected — it has correct lowercase casing and an explicit NOTE comment preventing regression.

## Upgrade Safety

| Scenario | Outcome |
|----------|---------|
| Fresh install on fixed chart | Works correctly |
| Upgrade from 8.8 → fixed 8.9 | Works — 8.8 PVC is already lowercase |
| Patch upgrade from buggy 8.9 → fixed 8.9 | Works — PVC template always created lowercase, pod can now find it |
| Edge case: manually created PVC with capital M as workaround | Use `webModeler.persistence.existingClaim` to point to your custom PVC |

## Related

- SUPPORT-30069
- Companion docs PR needed for upgrade warning (edge case)
- Companion PR for feat(8.9) persistence scenario (separate)