### PR TITLE
ci: stop OpenSearch index cleanup from crashing on unset ELASTICSEARCH_NAMESPACE

### DIFF
--- a/scripts/apply-ttl-to-elasticsearch-indexes.sh
+++ b/scripts/apply-ttl-to-elasticsearch-indexes.sh
@@ -84,6 +84,7 @@ TTL=""
 ES_URL="http://localhost:9200"
 ES_USER=""
 ES_PASS=""
+ELASTICSEARCH_NAMESPACE=""
 NAMESPACE=""
 DRY_RUN=0
 


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6034.

The CI step that runs \`scripts/apply-ttl-to-elasticsearch-indexes.sh\` against OpenSearch has been silently failing on every job because of a \`set -u\` violation in the script — orphan indices accumulate in the shared QA OpenSearch cluster, eventually causing Optimize schema mismatches on later runs that happen to hash into the same prefix.

### What's in this PR?

The script declares \`ES_USER=\"\"\` and \`ES_PASS=\"\"\` at lines 85–86 but does not initialise \`ELASTICSEARCH_NAMESPACE\`. That variable is only ever assigned inside the \`--elasticsearch-namespace\` branch of the argument parser. When the OpenSearch invocation passes \`--user\` / \`--pass\` directly (no \`--elasticsearch-namespace\`), line 147

\`\`\`bash
if [[ -z \"\$ES_PASS\" && -n \"\$ELASTICSEARCH_NAMESPACE\" ]]; then
\`\`\`

aborts under \`set -u\`. The CI step swallows the failure with \`|| echo \"Warning: ...\"\`, so the OpenSearch cleanup has never run.

Add a single \`ELASTICSEARCH_NAMESPACE=\"\"\` default alongside \`ES_USER\` / \`ES_PASS\`. The Elasticsearch invocation, which always passes \`--elasticsearch-namespace\`, is unaffected.

Validated locally:

| Invocation | Before | After |
|---|---|---|
| OpenSearch (no \`--elasticsearch-namespace\`) | \`line 147: ELASTICSEARCH_NAMESPACE: unbound variable\` | reaches the indices query |
| Elasticsearch (with \`--elasticsearch-namespace fake-ns\`) | \`Namespace not found or inaccessible: fake-ns\` (expected) | unchanged |

### Checklist

**Before opening the PR:**

- [x] No template/golden changes — \`make go.update-golden-only\` not required.
- [x] There is no other open pull request for the same update/change.
- [x] No tests added (the script has no tests yet; out of scope for this surgical fix).
- [ ] In-repo documentation are updated (if needed).

**After opening the PR:**

- [ ] Did all checks/tests pass in the PR?