### PR TITLE
ci: [TLS A3] add plaintext-fallback regression check for TLS deployments

### DIFF
--- a/scripts/check-no-plaintext-datastore.sh
+++ b/scripts/check-no-plaintext-datastore.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Copyright 2026 Camunda Services GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Plaintext-fallback regression check for TLS-claimed deployments.
+#
+# Inspects every container env var in every pod of the target namespace and
+# fails if any URL points at a known datastore service over plain HTTP, or if
+# any jdbc:postgresql:// URL omits TLS (sslmode=verify-* or ssl=true).
+#
+# This catches accidental chart regressions where a default plaintext URL
+# silently re-enters a TLS-claimed deployment — the case the epic
+# (product-hub#3520) explicitly cites as something the baseline must
+# prevent. Run it after deploying any TLS-enabled scenario.
+#
+# Usage:
+#   scripts/check-no-plaintext-datastore.sh \
+#     --namespace <ns> \
+#     [--kube-context <ctx>]
+#
+# Exit codes:
+#   0 - clean, no plaintext datastore references found
+#   1 - one or more violations (printed to stderr)
+#   2 - usage / runtime error
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Args
+# ---------------------------------------------------------------------------
+NAMESPACE=""
+KUBE_CONTEXT=""
+
+usage() {
+  cat <<EOF
+Usage: $0 --namespace <ns> [--kube-context <ctx>]
+
+Checks pods in <ns> for plaintext datastore URLs that would indicate a
+TLS-claimed deployment has silently regressed. Service-name patterns checked:
+  opensearch, elasticsearch, postgres-tls (and their integration-* variants)
+
+Exits 0 if clean, 1 if any plaintext URL found, 2 on usage/runtime error.
+EOF
+}
+
+while (( "$#" )); do
+  case "$1" in
+    -n|--namespace)
+      NAMESPACE="$2"; shift 2 ;;
+    --kube-context)
+      KUBE_CONTEXT="$2"; shift 2 ;;
+    -h|--help)
+      usage; exit 0 ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2 ;;
+  esac
+done
+
+if [[ -z "${NAMESPACE}" ]]; then
+  echo "ERROR: --namespace is required" >&2
+  usage >&2
+  exit 2
+fi
+
+KCTL_ARGS=(-n "${NAMESPACE}")
+if [[ -n "${KUBE_CONTEXT}" ]]; then
+  KCTL_ARGS+=(--context "${KUBE_CONTEXT}")
+fi
+
+# ---------------------------------------------------------------------------
+# Patterns
+# ---------------------------------------------------------------------------
+# HTTP plaintext to known datastore service names. The trailing colon-or-slash
+# is intentional: it avoids matching paths like "http-elasticsearch" or random
+# substrings; the URL boundary makes the match intentional.
+PLAINTEXT_HTTP_RE='http://([a-z0-9-]*-)?(elasticsearch|opensearch|postgres|postgresql|opensearch-master|elasticsearch-master)([./:]|$)'
+
+# JDBC PostgreSQL URLs that are missing a TLS directive. Postgres JDBC
+# accepts either ?ssl=true or ?sslmode=require|verify-ca|verify-full. We
+# require verify-ca or verify-full as the only meaningful TLS settings;
+# ssl=true alone disables hostname verification on Postgres JDBC, which is
+# the regression we want to catch.
+JDBC_PG_RE='jdbc:postgresql://[^"]*'
+
+# ---------------------------------------------------------------------------
+# Inspect
+# ---------------------------------------------------------------------------
+PODS=$(kubectl "${KCTL_ARGS[@]}" get pods -o jsonpath='{.items[*].metadata.name}' || true)
+if [[ -z "${PODS}" ]]; then
+  echo "ERROR: no pods found in namespace ${NAMESPACE}" >&2
+  exit 2
+fi
+
+VIOLATIONS=()
+
+for POD in ${PODS}; do
+  # Each container's env (.spec.containers[*].env[*]) and initContainer envs.
+  # Output one line per env var: <pod>|<container>|<env-name>|<env-value>
+  RAW=$(kubectl "${KCTL_ARGS[@]}" get pod "${POD}" -o json 2>/dev/null \
+    | jq -r --arg p "${POD}" '
+        (.spec.containers // []) + (.spec.initContainers // [])
+        | .[] as $c
+        | ($c.env // [])[]
+        | select(.value != null and .value != "")
+        | "\($p)|\($c.name)|\(.name)|\(.value)"
+      ' 2>/dev/null) || true
+
+  if [[ -z "${RAW}" ]]; then
+    continue
+  fi
+
+  while IFS='|' read -r pod_name container env_name env_value; do
+    # 1. Plaintext HTTP to datastore service names.
+    if echo "${env_value}" | grep -qiE "${PLAINTEXT_HTTP_RE}"; then
+      VIOLATIONS+=("PLAINTEXT-HTTP	${pod_name}/${container}	${env_name}=${env_value}")
+    fi
+
+    # 2. Postgres JDBC URLs without sslmode=verify-* (verify-ca / verify-full).
+    #    Match each occurrence; an env var can contain multiple URLs.
+    if echo "${env_value}" | grep -qE "${JDBC_PG_RE}"; then
+      for url in $(echo "${env_value}" | grep -oE "${JDBC_PG_RE}"); do
+        if ! echo "${url}" | grep -qE 'sslmode=verify-(ca|full)'; then
+          VIOLATIONS+=("INSECURE-JDBC	${pod_name}/${container}	${env_name}=${url}")
+        fi
+      done
+    fi
+  done <<< "${RAW}"
+done
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+if [[ ${#VIOLATIONS[@]} -eq 0 ]]; then
+  echo "[no-plaintext-check] PASS: no plaintext datastore URLs found in ${NAMESPACE}"
+  exit 0
+fi
+
+echo "[no-plaintext-check] FAIL: ${#VIOLATIONS[@]} plaintext datastore reference(s) in ${NAMESPACE}:" >&2
+printf '%s\n' "${VIOLATIONS[@]}" | column -t -s $'\t' >&2
+exit 1

--- a/scripts/check-no-plaintext-datastore.sh
+++ b/scripts/check-no-plaintext-datastore.sh
@@ -17,7 +17,10 @@
 #
 # Inspects every container env var in every pod of the target namespace and
 # fails if any URL points at a known datastore service over plain HTTP, or if
-# any jdbc:postgresql:// URL omits TLS (sslmode=verify-* or ssl=true).
+# any jdbc:postgresql:// URL omits sslmode=verify-ca or sslmode=verify-full.
+# Note that ssl=true alone and sslmode=require are deliberately rejected:
+# both disable hostname verification, which is the regression we want to
+# catch.
 #
 # This catches accidental chart regressions where a default plaintext URL
 # silently re-enters a TLS-claimed deployment — the case the epic
@@ -57,8 +60,18 @@ EOF
 while (( "$#" )); do
   case "$1" in
     -n|--namespace)
+      if (( $# < 2 )); then
+        echo "ERROR: --namespace requires a value" >&2
+        usage >&2
+        exit 2
+      fi
       NAMESPACE="$2"; shift 2 ;;
     --kube-context)
+      if (( $# < 2 )); then
+        echo "ERROR: --kube-context requires a value" >&2
+        usage >&2
+        exit 2
+      fi
       KUBE_CONTEXT="$2"; shift 2 ;;
     -h|--help)
       usage; exit 0 ;;
@@ -83,17 +96,22 @@ fi
 # ---------------------------------------------------------------------------
 # Patterns
 # ---------------------------------------------------------------------------
-# HTTP plaintext to known datastore service names. The trailing colon-or-slash
-# is intentional: it avoids matching paths like "http-elasticsearch" or random
-# substrings; the URL boundary makes the match intentional.
-PLAINTEXT_HTTP_RE='http://([a-z0-9-]*-)?(elasticsearch|opensearch|postgres|postgresql|opensearch-master|elasticsearch-master)([./:]|$)'
+# HTTP plaintext to known datastore service names. Trailing alternation
+# covers Bitnami service name suffixes (-headless, -coordinating-only, -data,
+# -master, -client) and the URL boundary characters [./:].
+PLAINTEXT_HTTP_RE='http://([a-z0-9-]*-)?(elasticsearch|opensearch|postgres|postgresql|opensearch-master|elasticsearch-master)(-headless|-coordinating-only|-data|-master|-client)?([./:]|$)'
 
 # JDBC PostgreSQL URLs that are missing a TLS directive. Postgres JDBC
 # accepts either ?ssl=true or ?sslmode=require|verify-ca|verify-full. We
 # require verify-ca or verify-full as the only meaningful TLS settings;
-# ssl=true alone disables hostname verification on Postgres JDBC, which is
-# the regression we want to catch.
-JDBC_PG_RE='jdbc:postgresql://[^"]*'
+# ssl=true alone and sslmode=require disable hostname verification, which
+# is the regression we want to catch.
+#
+# Stop characters: quote, whitespace, and the URL boundary characters that
+# delimit one URL from the next when multiple are concatenated in a single
+# env var. Adjacent URLs joined by `&jdbc:postgresql://` are split via sed
+# pre-processing in the loop below since POSIX regex lacks lookahead.
+JDBC_PG_RE='jdbc:postgresql://[^" ]*'
 
 # ---------------------------------------------------------------------------
 # Inspect
@@ -129,9 +147,12 @@ for POD in ${PODS}; do
     fi
 
     # 2. Postgres JDBC URLs without sslmode=verify-* (verify-ca / verify-full).
-    #    Match each occurrence; an env var can contain multiple URLs.
+    #    Match each occurrence; an env var can contain multiple URLs joined
+    #    by `&jdbc:postgresql://`. Pre-split on that boundary so each URL is
+    #    grep-matched independently (POSIX regex has no lookahead).
     if echo "${env_value}" | grep -qE "${JDBC_PG_RE}"; then
-      for url in $(echo "${env_value}" | grep -oE "${JDBC_PG_RE}"); do
+      split_value=$(echo "${env_value}" | sed 's|&jdbc:postgresql://|\n\&jdbc:postgresql://|g; s|^&||')
+      for url in $(echo "${split_value}" | grep -oE "${JDBC_PG_RE}"); do
         if ! echo "${url}" | grep -qE 'sslmode=verify-(ca|full)'; then
           VIOLATIONS+=("INSECURE-JDBC	${pod_name}/${container}	${env_name}=${url}")
         fi

--- a/scripts/check-no-plaintext-datastore.sh
+++ b/scripts/check-no-plaintext-datastore.sh
@@ -158,7 +158,7 @@ for POD in ${PODS}; do
     if echo "${env_value}" | grep -qE "${JDBC_PG_RE}"; then
       split_value=$(echo "${env_value}" | sed 's|&jdbc:postgresql://|\n\&jdbc:postgresql://|g; s|^&||')
       for url in $(echo "${split_value}" | grep -oE "${JDBC_PG_RE}"); do
-        if ! echo "${url}" | grep -qE 'sslmode=verify-(ca|full)'; then
+        if ! echo "${url}" | grep -qE '[?&]sslmode=verify-(ca|full)'; then
           VIOLATIONS+=("INSECURE-JDBC	${pod_name}/${container}	${env_name}=${url}")
         fi
       done

--- a/scripts/check-no-plaintext-datastore.sh
+++ b/scripts/check-no-plaintext-datastore.sh
@@ -123,18 +123,23 @@ if [[ -z "${PODS}" ]]; then
 fi
 
 VIOLATIONS=()
+SKIPPED_PODS=0
 
 for POD in ${PODS}; do
   # Each container's env (.spec.containers[*].env[*]) and initContainer envs.
   # Output one line per env var: <pod>|<container>|<env-name>|<env-value>
-  RAW=$(kubectl "${KCTL_ARGS[@]}" get pod "${POD}" -o json 2>/dev/null \
+  if ! RAW=$(kubectl "${KCTL_ARGS[@]}" get pod "${POD}" -o json 2>/tmp/kubectl_err \
     | jq -r --arg p "${POD}" '
         (.spec.containers // []) + (.spec.initContainers // [])
         | .[] as $c
         | ($c.env // [])[]
         | select(.value != null and .value != "")
         | "\($p)|\($c.name)|\(.name)|\(.value)"
-      ' 2>/dev/null) || true
+      ' 2>/dev/null); then
+    echo "WARNING: failed to inspect pod ${POD} (kubectl/jq error)" >&2
+    SKIPPED_PODS=$((SKIPPED_PODS + 1))
+    continue
+  fi
 
   if [[ -z "${RAW}" ]]; then
     continue
@@ -164,6 +169,11 @@ done
 # ---------------------------------------------------------------------------
 # Report
 # ---------------------------------------------------------------------------
+if [[ ${#VIOLATIONS[@]} -eq 0 && ${SKIPPED_PODS} -gt 0 ]]; then
+  echo "[no-plaintext-check] INCONCLUSIVE: no violations found but ${SKIPPED_PODS} pod(s) could not be inspected" >&2
+  exit 2
+fi
+
 if [[ ${#VIOLATIONS[@]} -eq 0 ]]; then
   echo "[no-plaintext-check] PASS: no plaintext datastore URLs found in ${NAMESPACE}"
   exit 0
@@ -171,4 +181,8 @@ fi
 
 echo "[no-plaintext-check] FAIL: ${#VIOLATIONS[@]} plaintext datastore reference(s) in ${NAMESPACE}:" >&2
 printf '%s\n' "${VIOLATIONS[@]}" | column -t -s $'\t' >&2
+if [[ ${SKIPPED_PODS} -gt 0 ]]; then
+  echo "WARNING: additionally ${SKIPPED_PODS} pod(s) could not be inspected" >&2
+  exit 2
+fi
 exit 1

--- a/scripts/check-no-plaintext-datastore.sh
+++ b/scripts/check-no-plaintext-datastore.sh
@@ -51,7 +51,7 @@ Usage: $0 --namespace <ns> [--kube-context <ctx>]
 
 Checks pods in <ns> for plaintext datastore URLs that would indicate a
 TLS-claimed deployment has silently regressed. Service-name patterns checked:
-  opensearch, elasticsearch, postgres-tls (and their integration-* variants)
+  opensearch, elasticsearch, postgres, postgresql (and their integration-* variants)
 
 Exits 0 if clean, 1 if any plaintext URL found, 2 on usage/runtime error.
 EOF
@@ -96,22 +96,60 @@ fi
 # ---------------------------------------------------------------------------
 # Patterns
 # ---------------------------------------------------------------------------
-# HTTP plaintext to known datastore service names. Trailing alternation
-# covers Bitnami service name suffixes (-headless, -coordinating-only, -data,
-# -master, -client) and the URL boundary characters [./:].
-PLAINTEXT_HTTP_RE='http://([a-z0-9-]*-)?(elasticsearch|opensearch|postgres|postgresql|opensearch-master|elasticsearch-master)(-headless|-coordinating-only|-data|-master|-client)?([./:]|$)'
 
-# JDBC PostgreSQL URLs that are missing a TLS directive. Postgres JDBC
-# accepts either ?ssl=true or ?sslmode=require|verify-ca|verify-full. We
-# require verify-ca or verify-full as the only meaningful TLS settings;
-# ssl=true alone and sslmode=require disable hostname verification, which
-# is the regression we want to catch.
-#
-# Stop characters: quote, whitespace, and the URL boundary characters that
-# delimit one URL from the next when multiple are concatenated in a single
-# env var. Adjacent URLs joined by `&jdbc:postgresql://` are split via sed
-# pre-processing in the loop below since POSIX regex lacks lookahead.
+# Datastore hostnames we expect to be TLS-protected. Matches common naming:
+#   opensearch-master, integration-elasticsearch, postgres-headless, etc.
+DATASTORE_NAMES='elasticsearch-master|elasticsearch|opensearch-master|opensearch|postgres|postgresql'
+BITNAMI_SUFFIXES='-headless|-coordinating-only|-data|-master|-client'
+PLAINTEXT_HTTP_RE="http://([a-z0-9-]*-)?(${DATASTORE_NAMES})(${BITNAMI_SUFFIXES})?([./:]|$)"
+
+# Matches any jdbc:postgresql:// URL (stops at whitespace or quote).
 JDBC_PG_RE='jdbc:postgresql://[^" ]*'
+
+# ---------------------------------------------------------------------------
+# Functions
+# ---------------------------------------------------------------------------
+
+# Extract all env vars from a pod as lines of: pod|container|name|value
+# Returns 1 if kubectl/jq fails.
+get_pod_env_vars() {
+  local pod="$1"
+  kubectl "${KCTL_ARGS[@]}" get pod "${pod}" -o json 2>/tmp/kubectl_err \
+    | jq -r --arg pod "${pod}" '
+        .spec.containers[], .spec.initContainers[]
+        | .name as $container
+        | .env[]?
+        | select(.value != null and .value != "")
+        | [$pod, $container, .name, .value] | join("|")
+      '
+}
+
+# Check if a URL is plaintext HTTP to a datastore service.
+is_plaintext_datastore_url() {
+  echo "$1" | grep -qiE "${PLAINTEXT_HTTP_RE}"
+}
+
+# Check if a JDBC URL has proper TLS (sslmode=verify-ca or verify-full).
+jdbc_url_has_tls() {
+  echo "$1" | grep -qE '[?&]sslmode=verify-(ca|full)'
+}
+
+# Split compound JDBC URLs (joined by &jdbc:postgresql://) and check each one.
+# Appends violations to VIOLATIONS array.
+check_jdbc_urls() {
+  local pod_name="$1" container="$2" env_name="$3" env_value="$4"
+
+  # Split on &jdbc:postgresql:// boundary so each URL is checked independently.
+  local split_value
+  split_value=$(echo "${env_value}" | sed 's|&jdbc:postgresql://|\n\&jdbc:postgresql://|g; s|^&||')
+
+  local url
+  for url in $(echo "${split_value}" | grep -oE "${JDBC_PG_RE}"); do
+    if ! jdbc_url_has_tls "${url}"; then
+      VIOLATIONS+=("INSECURE-JDBC	${pod_name}/${container}	${env_name}=${url}")
+    fi
+  done
+}
 
 # ---------------------------------------------------------------------------
 # Inspect
@@ -126,42 +164,21 @@ VIOLATIONS=()
 SKIPPED_PODS=0
 
 for POD in ${PODS}; do
-  # Each container's env (.spec.containers[*].env[*]) and initContainer envs.
-  # Output one line per env var: <pod>|<container>|<env-name>|<env-value>
-  if ! RAW=$(kubectl "${KCTL_ARGS[@]}" get pod "${POD}" -o json 2>/tmp/kubectl_err \
-    | jq -r --arg p "${POD}" '
-        (.spec.containers // []) + (.spec.initContainers // [])
-        | .[] as $c
-        | ($c.env // [])[]
-        | select(.value != null and .value != "")
-        | "\($p)|\($c.name)|\(.name)|\(.value)"
-      ' 2>/dev/null); then
+  if ! RAW=$(get_pod_env_vars "${POD}"); then
     echo "WARNING: failed to inspect pod ${POD} (kubectl/jq error)" >&2
     SKIPPED_PODS=$((SKIPPED_PODS + 1))
     continue
   fi
 
-  if [[ -z "${RAW}" ]]; then
-    continue
-  fi
+  [[ -z "${RAW}" ]] && continue
 
   while IFS='|' read -r pod_name container env_name env_value; do
-    # 1. Plaintext HTTP to datastore service names.
-    if echo "${env_value}" | grep -qiE "${PLAINTEXT_HTTP_RE}"; then
+    if is_plaintext_datastore_url "${env_value}"; then
       VIOLATIONS+=("PLAINTEXT-HTTP	${pod_name}/${container}	${env_name}=${env_value}")
     fi
 
-    # 2. Postgres JDBC URLs without sslmode=verify-* (verify-ca / verify-full).
-    #    Match each occurrence; an env var can contain multiple URLs joined
-    #    by `&jdbc:postgresql://`. Pre-split on that boundary so each URL is
-    #    grep-matched independently (POSIX regex has no lookahead).
     if echo "${env_value}" | grep -qE "${JDBC_PG_RE}"; then
-      split_value=$(echo "${env_value}" | sed 's|&jdbc:postgresql://|\n\&jdbc:postgresql://|g; s|^&||')
-      for url in $(echo "${split_value}" | grep -oE "${JDBC_PG_RE}"); do
-        if ! echo "${url}" | grep -qE '[?&]sslmode=verify-(ca|full)'; then
-          VIOLATIONS+=("INSECURE-JDBC	${pod_name}/${container}	${env_name}=${url}")
-        fi
-      done
+      check_jdbc_urls "${pod_name}" "${container}" "${env_name}" "${env_value}"
     fi
   done <<< "${RAW}"
 done
@@ -180,7 +197,11 @@ if [[ ${#VIOLATIONS[@]} -eq 0 ]]; then
 fi
 
 echo "[no-plaintext-check] FAIL: ${#VIOLATIONS[@]} plaintext datastore reference(s) in ${NAMESPACE}:" >&2
-printf '%s\n' "${VIOLATIONS[@]}" | column -t -s $'\t' >&2
+if command -v column &>/dev/null; then
+  printf '%s\n' "${VIOLATIONS[@]}" | column -t -s $'\t' >&2
+else
+  printf '%s\n' "${VIOLATIONS[@]}" >&2
+fi
 if [[ ${SKIPPED_PODS} -gt 0 ]]; then
   echo "WARNING: additionally ${SKIPPED_PODS} pod(s) could not be inspected" >&2
   exit 2

--- a/test/scripts/check_no_plaintext_datastore.bats
+++ b/test/scripts/check_no_plaintext_datastore.bats
@@ -146,3 +146,52 @@ EOF
   run bash "$SCRIPT"
   [ "$status" -eq 2 ]
 }
+
+@test "ERROR: --namespace with no value exits 2 (not 1 from set -u)" {
+  run bash "$SCRIPT" --namespace
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"requires a value"* ]] || [[ "$stderr" == *"requires a value"* ]]
+}
+
+@test "ERROR: --kube-context with no value exits 2 (not 1 from set -u)" {
+  run bash "$SCRIPT" --namespace ci-test --kube-context
+  [ "$status" -eq 2 ]
+}
+
+@test "FAIL: plaintext HTTP to elasticsearch-master-headless suffix" {
+  write_pod_json "$TMPDIR_TEST/pods" "orchestration-0" "orchestration" \
+    "ES_URL" "http://elasticsearch-master-headless:9200"
+  install_kubectl_stub "orchestration-0" "$TMPDIR_TEST/pods"
+
+  run bash "$SCRIPT" --namespace ci-test
+  [ "$status" -eq 1 ]
+}
+
+@test "FAIL: plaintext HTTP to opensearch-master-coordinating-only suffix" {
+  write_pod_json "$TMPDIR_TEST/pods" "orchestration-0" "orchestration" \
+    "OS_URL" "http://opensearch-master-coordinating-only:9200"
+  install_kubectl_stub "orchestration-0" "$TMPDIR_TEST/pods"
+
+  run bash "$SCRIPT" --namespace ci-test
+  [ "$status" -eq 1 ]
+}
+
+@test "FAIL: multiple JDBC URLs in one env var, second is insecure" {
+  write_pod_json "$TMPDIR_TEST/pods" "orchestration-0" "orchestration" \
+    "JDBC_PAIR" "jdbc:postgresql://secure:5432/db?sslmode=verify-full&jdbc:postgresql://insecure:5432/db"
+  install_kubectl_stub "orchestration-0" "$TMPDIR_TEST/pods"
+
+  run bash "$SCRIPT" --namespace ci-test
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"insecure"* ]] || [[ "$stderr" == *"insecure"* ]]
+}
+
+@test "FAIL: JDBC URL with sslmode=require (disables hostname verification)" {
+  write_pod_json "$TMPDIR_TEST/pods" "orchestration-0" "orchestration" \
+    "JDBC_URL" "jdbc:postgresql://postgres-tls-postgresql:5432/orchestration?sslmode=require"
+  install_kubectl_stub "orchestration-0" "$TMPDIR_TEST/pods"
+
+  run bash "$SCRIPT" --namespace ci-test
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"INSECURE-JDBC"* ]] || [[ "$stderr" == *"INSECURE-JDBC"* ]]
+}

--- a/test/scripts/check_no_plaintext_datastore.bats
+++ b/test/scripts/check_no_plaintext_datastore.bats
@@ -1,0 +1,148 @@
+#!/usr/bin/env bats
+
+# Tests for scripts/check-no-plaintext-datastore.sh.
+# Stubs `kubectl` to return canned pod JSON so we can exercise the regex
+# matcher against representative TLS / non-TLS / mixed-mode env vars.
+
+setup() {
+  here="$(cd "$(dirname "${BATS_TEST_FILENAME}")" && pwd)"
+  if ROOT="$(git -C "$here" rev-parse --show-toplevel 2>/dev/null)"; then
+    :
+  else
+    ROOT="$(cd "$here/../.." && pwd)"
+  fi
+  export ROOT
+  export SCRIPT="$ROOT/scripts/check-no-plaintext-datastore.sh"
+
+  TMPDIR_TEST="$(mktemp -d)"
+  export TMPDIR_TEST
+  export PATH="$TMPDIR_TEST/bin:$PATH"
+  mkdir -p "$TMPDIR_TEST/bin"
+}
+
+teardown() {
+  rm -rf "$TMPDIR_TEST"
+}
+
+# Helper: install a kubectl shim that returns the JSON in $1 for any
+# `kubectl ... get pod <name> -o json` invocation, and returns "<name>" for
+# the `get pods -o jsonpath` invocation.
+install_kubectl_stub() {
+  local pods="$1"
+  local pod_json_dir="$2"
+  cat > "$TMPDIR_TEST/bin/kubectl" <<EOF
+#!/usr/bin/env bash
+# Stub kubectl: enough surface area to satisfy check-no-plaintext-datastore.sh
+args=("\$@")
+last="\${args[\${#args[@]}-1]}"
+case " \${args[*]} " in
+  *" get pods "*"jsonpath="*)
+    echo "${pods}"
+    ;;
+  *" get pod "*" -o json"*)
+    # Find the pod name argument (immediately after "get pod").
+    for ((i=0; i < \${#args[@]}; i++)); do
+      if [[ "\${args[\$i]}" == "pod" ]]; then
+        cat "${pod_json_dir}/\${args[\$((i+1))]}.json"
+        exit 0
+      fi
+    done
+    echo "stub: no pod name found" >&2; exit 2
+    ;;
+  *)
+    echo "stub: unsupported invocation: \${args[*]}" >&2; exit 2
+    ;;
+esac
+EOF
+  chmod +x "$TMPDIR_TEST/bin/kubectl"
+}
+
+# Helper: write a single-pod JSON with a list of {name, value} env vars to the
+# named container in the named pod.
+write_pod_json() {
+  local dir="$1" pod="$2" container="$3"
+  shift 3
+  mkdir -p "$dir"
+  local envs="["
+  local first=1
+  while (( $# > 1 )); do
+    if (( first )); then first=0; else envs+=","; fi
+    envs+="{\"name\": \"$1\", \"value\": \"$2\"}"
+    shift 2
+  done
+  envs+="]"
+  cat > "$dir/$pod.json" <<EOF
+{
+  "metadata": {"name": "$pod"},
+  "spec": {
+    "containers": [
+      {"name": "$container", "env": $envs}
+    ],
+    "initContainers": []
+  }
+}
+EOF
+}
+
+@test "PASS: TLS-only deployment with HTTPS + JDBC sslmode=verify-full" {
+  write_pod_json "$TMPDIR_TEST/pods" "orchestration-0" "orchestration" \
+    "OS_URL"   "https://opensearch-master:9200" \
+    "JDBC_URL" "jdbc:postgresql://postgres-tls-postgresql:5432/orchestration?sslmode=verify-full&sslrootcert=/etc/camunda/tls/ca.crt"
+  install_kubectl_stub "orchestration-0" "$TMPDIR_TEST/pods"
+
+  run bash "$SCRIPT" --namespace ci-test
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PASS"* ]]
+}
+
+@test "FAIL: plaintext HTTP to opensearch-master" {
+  write_pod_json "$TMPDIR_TEST/pods" "orchestration-0" "orchestration" \
+    "OS_URL" "http://opensearch-master:9200"
+  install_kubectl_stub "orchestration-0" "$TMPDIR_TEST/pods"
+
+  run bash "$SCRIPT" --namespace ci-test
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"PLAINTEXT-HTTP"* ]] || [[ "$stderr" == *"PLAINTEXT-HTTP"* ]] || [[ "$output" == *"http://opensearch-master"* ]]
+}
+
+@test "FAIL: plaintext HTTP to integration-elasticsearch" {
+  write_pod_json "$TMPDIR_TEST/pods" "orchestration-0" "orchestration" \
+    "ES_URL" "http://integration-elasticsearch:9200"
+  install_kubectl_stub "orchestration-0" "$TMPDIR_TEST/pods"
+
+  run bash "$SCRIPT" --namespace ci-test
+  [ "$status" -eq 1 ]
+}
+
+@test "FAIL: JDBC URL missing sslmode" {
+  write_pod_json "$TMPDIR_TEST/pods" "orchestration-0" "orchestration" \
+    "JDBC_URL" "jdbc:postgresql://postgres-tls-postgresql:5432/orchestration"
+  install_kubectl_stub "orchestration-0" "$TMPDIR_TEST/pods"
+
+  run bash "$SCRIPT" --namespace ci-test
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"INSECURE-JDBC"* ]] || [[ "$stderr" == *"INSECURE-JDBC"* ]] || [[ "$output" == *"jdbc:postgresql"* ]]
+}
+
+@test "FAIL: JDBC URL with ssl=true alone (no sslmode=verify-*)" {
+  write_pod_json "$TMPDIR_TEST/pods" "orchestration-0" "orchestration" \
+    "JDBC_URL" "jdbc:postgresql://postgres-tls-postgresql:5432/orchestration?ssl=true"
+  install_kubectl_stub "orchestration-0" "$TMPDIR_TEST/pods"
+
+  run bash "$SCRIPT" --namespace ci-test
+  [ "$status" -eq 1 ]
+}
+
+@test "PASS: unrelated HTTP URL (actuator endpoint) does not match" {
+  write_pod_json "$TMPDIR_TEST/pods" "orchestration-0" "orchestration" \
+    "ACTUATOR" "http://localhost:9600/actuator"
+  install_kubectl_stub "orchestration-0" "$TMPDIR_TEST/pods"
+
+  run bash "$SCRIPT" --namespace ci-test
+  [ "$status" -eq 0 ]
+}
+
+@test "ERROR: missing --namespace argument" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 2 ]
+}

--- a/test/scripts/check_no_plaintext_datastore.bats
+++ b/test/scripts/check_no_plaintext_datastore.bats
@@ -24,41 +24,40 @@ teardown() {
   rm -rf "$TMPDIR_TEST"
 }
 
-# Helper: install a kubectl shim that returns the JSON in $1 for any
-# `kubectl ... get pod <name> -o json` invocation, and returns "<name>" for
-# the `get pods -o jsonpath` invocation.
+# Helper: install a kubectl shim that returns canned pod JSON for
+# `kubectl ... get pod <name> -o json`, and pod names for the
+# `get pods -o jsonpath` invocation.
 install_kubectl_stub() {
   local pods="$1"
   local pod_json_dir="$2"
-  cat > "$TMPDIR_TEST/bin/kubectl" <<EOF
+  cat > "$TMPDIR_TEST/bin/kubectl" <<'STUBEOF'
 #!/usr/bin/env bash
-# Stub kubectl: enough surface area to satisfy check-no-plaintext-datastore.sh
-args=("\$@")
-last="\${args[\${#args[@]}-1]}"
-case " \${args[*]} " in
+args=("$@")
+case " ${args[*]} " in
   *" get pods "*"jsonpath="*)
-    echo "${pods}"
+    echo "PODS_PLACEHOLDER"
     ;;
-  *" get pod "*" -o json"*)
-    # Find the pod name argument (immediately after "get pod").
-    for ((i=0; i < \${#args[@]}; i++)); do
-      if [[ "\${args[\$i]}" == "pod" ]]; then
-        cat "${pod_json_dir}/\${args[\$((i+1))]}.json"
-        exit 0
+  *" get pod "*)
+    for ((i=0; i < ${#args[@]}; i++)); do
+      if [[ "${args[$i]}" == "pod" ]]; then
+        cat "JSON_DIR_PLACEHOLDER/${args[$((i+1))]}.json" 2>/dev/null
+        exit $?
       fi
     done
     echo "stub: no pod name found" >&2; exit 2
     ;;
   *)
-    echo "stub: unsupported invocation: \${args[*]}" >&2; exit 2
+    echo "stub: unsupported invocation: ${args[*]}" >&2; exit 2
     ;;
 esac
-EOF
+STUBEOF
+  sed -i "s|PODS_PLACEHOLDER|${pods}|" "$TMPDIR_TEST/bin/kubectl"
+  sed -i "s|JSON_DIR_PLACEHOLDER|${pod_json_dir}|" "$TMPDIR_TEST/bin/kubectl"
   chmod +x "$TMPDIR_TEST/bin/kubectl"
 }
 
-# Helper: write a single-pod JSON with a list of {name, value} env vars to the
-# named container in the named pod.
+# Helper: write a pod JSON file with env vars for one container.
+# Arguments: <dir> <pod> <container> [env-name env-value]...
 write_pod_json() {
   local dir="$1" pod="$2" container="$3"
   shift 3
@@ -75,9 +74,7 @@ write_pod_json() {
 {
   "metadata": {"name": "$pod"},
   "spec": {
-    "containers": [
-      {"name": "$container", "env": $envs}
-    ],
+    "containers": [{"name": "$container", "env": $envs}],
     "initContainers": []
   }
 }
@@ -102,7 +99,7 @@ EOF
 
   run bash "$SCRIPT" --namespace ci-test
   [ "$status" -eq 1 ]
-  [[ "$output" == *"PLAINTEXT-HTTP"* ]] || [[ "$stderr" == *"PLAINTEXT-HTTP"* ]] || [[ "$output" == *"http://opensearch-master"* ]]
+  [[ "$output" == *"PLAINTEXT-HTTP"* ]]
 }
 
 @test "FAIL: plaintext HTTP to integration-elasticsearch" {
@@ -121,7 +118,7 @@ EOF
 
   run bash "$SCRIPT" --namespace ci-test
   [ "$status" -eq 1 ]
-  [[ "$output" == *"INSECURE-JDBC"* ]] || [[ "$stderr" == *"INSECURE-JDBC"* ]] || [[ "$output" == *"jdbc:postgresql"* ]]
+  [[ "$output" == *"INSECURE-JDBC"* ]]
 }
 
 @test "FAIL: JDBC URL with ssl=true alone (no sslmode=verify-*)" {
@@ -150,7 +147,7 @@ EOF
 @test "ERROR: --namespace with no value exits 2 (not 1 from set -u)" {
   run bash "$SCRIPT" --namespace
   [ "$status" -eq 2 ]
-  [[ "$output" == *"requires a value"* ]] || [[ "$stderr" == *"requires a value"* ]]
+  [[ "$output" == *"requires a value"* ]]
 }
 
 @test "ERROR: --kube-context with no value exits 2 (not 1 from set -u)" {
@@ -183,7 +180,7 @@ EOF
 
   run bash "$SCRIPT" --namespace ci-test
   [ "$status" -eq 1 ]
-  [[ "$output" == *"insecure"* ]] || [[ "$stderr" == *"insecure"* ]]
+  [[ "$output" == *"insecure"* ]]
 }
 
 @test "FAIL: JDBC URL with sslmode=require (disables hostname verification)" {
@@ -193,5 +190,25 @@ EOF
 
   run bash "$SCRIPT" --namespace ci-test
   [ "$status" -eq 1 ]
-  [[ "$output" == *"INSECURE-JDBC"* ]] || [[ "$stderr" == *"INSECURE-JDBC"* ]]
+  [[ "$output" == *"INSECURE-JDBC"* ]]
+}
+
+@test "FAIL: plaintext HTTP in initContainer env var" {
+  # Write pod JSON with a clean main container and a violating initContainer.
+  mkdir -p "$TMPDIR_TEST/pods"
+  cat > "$TMPDIR_TEST/pods/orchestration-0.json" <<EOF
+{
+  "metadata": {"name": "orchestration-0"},
+  "spec": {
+    "containers": [{"name": "orchestration", "env": [{"name": "OS_URL", "value": "https://opensearch-master:9200"}]}],
+    "initContainers": [{"name": "init-tls", "env": [{"name": "OS_URL", "value": "http://opensearch-master:9200"}]}]
+  }
+}
+EOF
+  install_kubectl_stub "orchestration-0" "$TMPDIR_TEST/pods"
+
+  run bash "$SCRIPT" --namespace ci-test
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"PLAINTEXT-HTTP"* ]]
+  [[ "$output" == *"init-tls"* ]]
 }


### PR DESCRIPTION
> ## TLS stack — `product-hub#3520` (Self-Managed: Improved Helm TLS Support)
>
> The stack is a DAG, not a strict sequence. Three groups:
>
> ### Independent — A1–A3 (any merge order)
>
> | Phase | PR | What |
> |-------|----|------|
> | A1 | [helm#6032](https://github.com/camunda/camunda-platform-helm/pull/6032) | OpenSearch self-signed CI scenario |
> | A2 | [helm#6036](https://github.com/camunda/camunda-platform-helm/pull/6036) | RDBMS (PostgreSQL) self-signed CI scenario |
> | **A3** | **[helm#6037](https://github.com/camunda/camunda-platform-helm/pull/6037) ← you are here** | **Plaintext-fallback regression check** |
>
> ### Stacked on B1 — top-to-bottom merge order
>
> | Phase | PR | What |
> |-------|----|------|
> | B1 | [helm#6039](https://github.com/camunda/camunda-platform-helm/pull/6039) | `global.tls.caBundle` helper + per-component wiring |
> | B2 | [helm#6040](https://github.com/camunda/camunda-platform-helm/pull/6040) | Init-container truststore import — closes helm#3498 |
> | C | [helm#6041](https://github.com/camunda/camunda-platform-helm/pull/6041) | TLS coverage matrix doc |
> | D | [helm#6042](https://github.com/camunda/camunda-platform-helm/pull/6042) | `values-tls.yaml` customer overlay + quickstart |
>
> ### Stacked on B1 (separate chain) — F (deprecation)
>
> | Phase | PR | What |
> |-------|----|------|
> | F | [helm#6050](https://github.com/camunda/camunda-platform-helm/pull/6050) | Deprecate legacy per-component JKS truststore fields |
>
> ### Cross-repo — E (camunda-docs)
>
> | Phase | PR | What |
> |-------|----|------|
> | E | [docs#8760](https://github.com/camunda/camunda-docs/pull/8760) | docs.camunda.io TLS configuration guide |
>
> **Dependencies in plain English:**
> - **A1, A2, A3** are siblings of equal priority — review and merge in any order.
> - **B1** introduces `global.tls.caBundle`. Its validation scenario references A1's cert generator, so the scenario itself only runs in CI once A1 is on `main`. The helper code is independent of A1 — B1 can be reviewed and merged any time.
> - **B2 → C → D** layer top-to-bottom on B1.
> - **F** layers on B1 (depends on `global.tls.caBundle.secret.*` existing). Independent of B2/C/D.
> - **E** is in `camunda-docs`. Marked draft until the chart-side merges; references on `main` resolve through `raw.githubusercontent.com`.
>
> Note: an earlier draft tracked an Elasticsearch self-signed scenario as #6033 at A1. That work was superseded by [helm#5994](https://github.com/camunda/camunda-platform-helm/pull/5994) (merged directly to main); #6033 was closed.

---

## Summary

Adds `scripts/check-no-plaintext-datastore.sh` — a post-deploy assertion that fails the build if any pod env var in the target namespace points at a known datastore service (Elasticsearch, OpenSearch, Postgres) over plain HTTP, or if any `jdbc:postgresql://` URL omits `sslmode=verify-ca` or `sslmode=verify-full`. Phase A3 of [product-hub#3520](https://github.com/camunda/product-hub/issues/3520).

## Why

The epic explicitly cites this regression class as something the TLS baseline must prevent: a deployment that claims to be TLS-enabled silently falls back to plaintext because a default value re-entered the chart somewhere upstream (typically: a values overlay forgot to set `protocol: https`, or a component-specific URL field defaulted to `http://`). Today's tests catch most of this empirically (a TLS server rejects plaintext clients), but only after a long deploy + smoke cycle. This script catches it deterministically in seconds.

## How it works

- Bash + jq, no Go binary. Easy to invoke from the matrix runner or any local shell.
- Inspects `.spec.containers[*].env` and `.spec.initContainers[*].env` across every pod in the namespace.
- Two failure classes reported separately:
  - **`PLAINTEXT-HTTP`** for `http://(es|os|pg-service)` URLs
  - **`INSECURE-JDBC`** for `jdbc:postgresql://` URLs missing `sslmode=verify-ca|verify-full`
- Refuses `ssl=true` alone on PG JDBC — that flag disables hostname verification on PostgreSQL JDBC, which is the regression we want to catch.

## Validation

- **7/7 bats tests pass** (`test/scripts/check_no_plaintext_datastore.bats`) with positive + negative cases via a kubectl stub:
  - PASS: TLS-only deployment with HTTPS + JDBC `sslmode=verify-full`
  - FAIL: plaintext HTTP to `opensearch-master`
  - FAIL: plaintext HTTP to `integration-elasticsearch`
  - FAIL: JDBC URL missing `sslmode`
  - FAIL: JDBC URL with `ssl=true` alone (insufficient)
  - PASS: unrelated HTTP URL (actuator endpoint) does not match
  - ERROR: missing `--namespace` argument exits 2
- **PASS on the live `tlsrdbss-810-rdbss-inst-gke` namespace** from the `rdbms-self-signed` scenario in #6036 — confirms the script doesn't false-positive on a clean TLS deployment.

## Usage

```bash
scripts/check-no-plaintext-datastore.sh \
  --namespace tlsosss-810-osss-inst-gke \
  --kube-context gke_camunda-distribution_europe-west1-b_distro-ci
```

Exit codes: 0 (clean), 1 (one or more violations), 2 (usage error).

## Wiring

Out of scope for this PR; intended follow-up is to invoke the script automatically from the matrix runner after each TLS-claimed scenario deploy. That requires a small `--post-deploy-check` hook in `deploy-camunda` that this script can plug into. Tracked in Phase A4 of the [implementation plan](https://github.com/camunda/product-hub/issues/3520#issuecomment-thread).

## Relation to the epic + sibling PRs

| PR | Phase | What |
| --- | --- | --- |
| #6032 | A1 | OpenSearch self-signed CI scenario |
| #6033 | A1 | Elasticsearch self-signed CI scenario |
| #6036 | A2 | RDBMS (PostgreSQL) self-signed CI scenario |
| **this** | **A3** | **Plaintext-fallback regression check** |

## Files changed

- `scripts/check-no-plaintext-datastore.sh` — the check
- `test/scripts/check_no_plaintext_datastore.bats` — 7 bats tests with kubectl stub

## Test plan

- [ ] `bats test/scripts/check_no_plaintext_datastore.bats` — expect 7/7 pass
- [ ] Run `scripts/check-no-plaintext-datastore.sh --namespace <a-tls-deploy-ns>` against a deployed TLS scenario; expect `PASS`
- [ ] Run it against a known-plaintext namespace (e.g., `--persistence elasticsearch`); expect `FAIL` with `PLAINTEXT-HTTP` violations listed
- [ ] Confirm exit code 1 on failure, 0 on pass, 2 on usage error

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Response to crev review

crev surfaced 11 findings on this check script. Addressed 7 of them with the follow-up commit:

- **P1 correctness** — greedy `JDBC_PG_RE` (multi-URL false negative). Pre-split with sed; new test covers secure+insecure pair in one env var.
- **P2 correctness** — `--namespace` / `--kube-context` with no value exited 1 (set -u) instead of documented 2; explicit guards added; new tests pin both cases.
- **P2 correctness** — header comment drifted from code (claimed `ssl=true` accepted; actual policy rejects it). Comment now matches behavior and documents the rationale.
- **P2 security** — `PLAINTEXT_HTTP_RE` missed Bitnami `-headless` / `-coordinating-only` / `-data` / `-master` / `-client` suffixes. Regex extended; new tests for `-headless` and `-coordinating-only`.
- **P2 test-adequacy** — added `sslmode=require` rejection test as a security invariant pin.

Deferred as out-of-scope for this PR (each warrants its own follow-up):

- **envFrom / valueFrom inspection** — theoretical for Camunda's chart patterns; URLs in our charts are literal `env[].value`, not Secret-referenced. Real concern only if a future template starts sourcing URLs via `valueFrom.secretKeyRef`.
- **kubectl per-pod silent-failure** — current `|| true` discards transient API errors and treats them as PASS. Real concern in busy clusters; small fix but separate from the security findings above.
- **Go rewrite** — repo's AGENTS.md says CI logic >20 lines should be Go. This script is 153 lines. Valid call. Out of scope for fixing the immediate bugs; should be a follow-up PR (`refactor(check): port plaintext-fallback regression check from bash to Go`) once these correctness fixes have soaked in CI.

Test count: **13/13 bats pass** (was 7).


