### PR TITLE
ci: remove integration test --test-it infrastructure

### DIFF
--- a/.github/actions/generate-chart-matrix/action.yaml
+++ b/.github/actions/generate-chart-matrix/action.yaml
@@ -78,18 +78,28 @@ runs:
     - name: Get chart versions
       id: get-chart-versions
       uses: ./.github/actions/get-chart-versions
+    - name: Restore deploy-camunda binary
+      id: binary-cache
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      with:
+        path: ~/.local/bin/deploy-camunda
+        key: deploy-camunda-${{ runner.os }}-${{ hashFiles('scripts/deploy-camunda/**/*.go', 'scripts/deploy-camunda/go.sum') }}
     - name: Setup Go
+      if: steps.binary-cache.outputs.cache-hit != 'true'
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version-file: scripts/deploy-camunda/go.mod
         cache: true
         cache-dependency-path: scripts/deploy-camunda/go.sum
     - name: Build deploy-camunda
+      if: steps.binary-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
         mkdir -p "$HOME/.local/bin"
         (cd scripts/deploy-camunda && go build -o "$HOME/.local/bin/deploy-camunda" .)
-        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+    - name: Export deploy-camunda to PATH
+      shell: bash
+      run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
     - name: Generate matrix
       shell: bash
       id: set-chart-versions

--- a/.github/actions/generate-chart-matrix/action.yaml
+++ b/.github/actions/generate-chart-matrix/action.yaml
@@ -83,7 +83,7 @@ runs:
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: ~/.local/bin/deploy-camunda
-        key: deploy-camunda-${{ runner.os }}-${{ hashFiles('scripts/deploy-camunda/**/*.go', 'scripts/deploy-camunda/go.sum') }}
+        key: deploy-camunda-v2-${{ runner.os }}-${{ hashFiles('scripts/deploy-camunda/**/*.go', 'scripts/deploy-camunda/go.sum') }}
     - name: Setup Go
       if: steps.binary-cache.outputs.cache-hit != 'true'
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -96,10 +96,19 @@ runs:
       shell: bash
       run: |
         mkdir -p "$HOME/.local/bin"
-        (cd scripts/deploy-camunda && go build -o "$HOME/.local/bin/deploy-camunda" .)
+        # CGO_ENABLED=0 produces a static binary so it runs unchanged inside the
+        # ci-runner container used by downstream matrix jobs.
+        (cd scripts/deploy-camunda && CGO_ENABLED=0 go build -o "$HOME/.local/bin/deploy-camunda" .)
     - name: Export deploy-camunda to PATH
       shell: bash
       run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+    - name: Upload deploy-camunda binary
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      with:
+        name: deploy-camunda-binary
+        path: ~/.local/bin/deploy-camunda
+        if-no-files-found: error
+        retention-days: 1
     - name: Generate matrix
       shell: bash
       id: set-chart-versions

--- a/.github/workflows/renovate-config-check.yaml
+++ b/.github/workflows/renovate-config-check.yaml
@@ -29,9 +29,11 @@ jobs:
         args: renovate-config-validator
 
     - name: Set up Go
-      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version-file: scripts/renovate-config-check/go.mod
+        cache: true
+        cache-dependency-path: scripts/renovate-config-check/go.sum
 
     - name: Validate alpha versioning consistency
       working-directory: scripts/renovate-config-check

--- a/.github/workflows/test-chart-version-template.yaml
+++ b/.github/workflows/test-chart-version-template.yaml
@@ -117,11 +117,6 @@ on:
         required: false
         default: false
         type: boolean
-      skip-it:
-        description: "Skip integration (Playwright IT) tests for this scenario"
-        required: false
-        default: false
-        type: boolean
       helm-version:
         description: "Helm version to install. Empty means use the pre-baked Helm from the CI runner image."
         required: false
@@ -219,7 +214,6 @@ jobs:
       test-qa: ${{ inputs.test-qa }}
       test-upgrade: ${{ inputs.test-upgrade }}
       skip-e2e: ${{ inputs.skip-e2e }}
-      skip-it: ${{ inputs.skip-it }}
       helm-version: ${{ inputs.helm-version }}
       pr-head-sha: ${{ inputs.pr-head-sha }}
       camunda-version: ${{ inputs.camunda-version }}

--- a/.github/workflows/test-chart-version.yaml
+++ b/.github/workflows/test-chart-version.yaml
@@ -299,7 +299,6 @@ jobs:
       test-qa: ${{ matrix.qa == 'true' }}
       test-upgrade: ${{ matrix.upgrade == 'true' }}
       skip-e2e: ${{ matrix.skipE2E == 'true' }}
-      skip-it: ${{ matrix.skipIT == 'true' }}
       helm-version: ${{ matrix.helmVersion }}
       cached: ${{ matrix.cached == 'true' }}
       pr-head-sha: ${{ needs.init.outputs.pr-head-sha }}

--- a/.github/workflows/test-chart-version.yaml
+++ b/.github/workflows/test-chart-version.yaml
@@ -191,8 +191,11 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: scripts/ci-result-cache/go.mod
-          cache: true
-          cache-dependency-path: scripts/ci-result-cache/go.sum
+          # Cache disabled: the previous setup-go invocation (in the
+          # generate-chart-matrix composite) already populated GOMODCACHE
+          # with overlapping packages. Restoring a second cache on top of
+          # the first triggers tar "File exists" errors.
+          cache: false
 
       - name: Annotate matrix with cache status
         id: annotate-cache

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -139,11 +139,6 @@ on:
         required: false
         default: false
         type: boolean
-      skip-it:
-        description: "Skip integration (Playwright IT) tests for this scenario (declared in ci-test-config.yaml)"
-        required: false
-        default: false
-        type: boolean
       pr-head-sha:
         description: "PR HEAD commit SHA for recording cache results"
         required: false

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -332,6 +332,16 @@ jobs:
       - name: CI Setup - Configure Git safe directory
         run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
+      - name: Download deploy-camunda binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: deploy-camunda-binary
+          path: ${{ runner.temp }}/bin
+      - name: Add deploy-camunda to PATH
+        run: |
+          chmod +x "${RUNNER_TEMP}/bin/deploy-camunda"
+          echo "${RUNNER_TEMP}/bin" >> "$GITHUB_PATH"
+
       - name: Configure curl and wget
         uses: ./.github/actions/setup-curl
 
@@ -515,11 +525,10 @@ jobs:
         run: |
           echo "Extra values from workflow:"
           echo "$EXTRA_VALUES" | tee /tmp/extra-values-file.yaml
-          cd ./scripts/deploy-camunda
-          go run . entra update-redirect-uris \
+          deploy-camunda entra update-redirect-uris \
             --ingress-host "$TEST_INGRESS_HOST" \
             --log-level info
-          go run . entra ensure-venom-app \
+          deploy-camunda entra ensure-venom-app \
             --namespace "$TEST_NAMESPACE" \
             --log-level info | tee /tmp/entra-output.txt
           # Capture VENOM_CLIENT_ID and CONNECTORS_CLIENT_ID from Go CLI stdout.
@@ -670,8 +679,7 @@ jobs:
             EXTRA_VALUES_ARGS=(--extra-values /tmp/extra-values-file.yaml)
           fi
 
-          cd ./scripts/deploy-camunda
-          go run . matrix run \
+          deploy-camunda matrix run \
             --repo-root "${GITHUB_WORKSPACE}" \
             --include-disabled \
             --scenario-filter "${{ inputs.scenario }}" \
@@ -787,6 +795,16 @@ jobs:
       - name: CI Setup - Configure Git safe directory
         run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
+      - name: Download deploy-camunda binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: deploy-camunda-binary
+          path: ${{ runner.temp }}/bin
+      - name: Add deploy-camunda to PATH
+        run: |
+          chmod +x "${RUNNER_TEMP}/bin/deploy-camunda"
+          echo "${RUNNER_TEMP}/bin" >> "$GITHUB_PATH"
+
       # Tools (golang, helm, kubectl, oc, task, yq, zbctl) are pre-installed in the CI runner container image
       # See: .github/docker/ci-runner/Dockerfile
       # The per-scenario helm-version input below can override the pre-baked helm when set in ci-test-config.yaml.
@@ -882,11 +900,10 @@ jobs:
         run: |
           echo "Extra values from workflow:"
           echo "$EXTRA_VALUES" | tee /tmp/extra-values-file.yaml
-          cd ./scripts/deploy-camunda
-          go run . entra update-redirect-uris \
+          deploy-camunda entra update-redirect-uris \
             --ingress-host "$TEST_INGRESS_HOST" \
             --log-level info
-          go run . entra ensure-venom-app \
+          deploy-camunda entra ensure-venom-app \
             --namespace "$TEST_NAMESPACE" \
             --log-level info | tee /tmp/entra-output.txt
           # Capture VENOM_CLIENT_ID and CONNECTORS_CLIENT_ID from Go CLI stdout.
@@ -1024,8 +1041,7 @@ jobs:
           # scenario injection is tracked in #6312. (The install flow, being single-
           # step, forwards the file safely; see that step.)
 
-          cd ./scripts/deploy-camunda
-          go run . matrix run \
+          deploy-camunda matrix run \
             --repo-root "${GITHUB_WORKSPACE}" \
             --include-disabled \
             --scenario-filter "${{ inputs.scenario }}" \
@@ -1456,6 +1472,16 @@ jobs:
       - name: CI Setup - Configure Git safe directory
         run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
+      - name: Download deploy-camunda binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: deploy-camunda-binary
+          path: ${{ runner.temp }}/bin
+      - name: Add deploy-camunda to PATH
+        run: |
+          chmod +x "${RUNNER_TEMP}/bin/deploy-camunda"
+          echo "${RUNNER_TEMP}/bin" >> "$GITHUB_PATH"
+
       - name: CI Setup - ℹ️ Set workflow vars for both install and upgrade ℹ️
         id: vars
         uses: ./.github/actions/workflow-vars
@@ -1537,8 +1563,7 @@ jobs:
           ENTRA_APP_OBJECT_ID: ${{ steps.test-credentials-secret.outputs.ENTRA_APP_OBJECT_ID }}
           ENTRA_APP_DIRECTORY_ID: ${{ steps.test-credentials-secret.outputs.ENTRA_APP_DIRECTORY_ID }}
         run: |
-          cd ./scripts/deploy-camunda
-          go run . entra cleanup-venom-app \
+          deploy-camunda entra cleanup-venom-app \
             --namespace "$TEST_NAMESPACE" \
             --log-level info
 
@@ -1554,8 +1579,7 @@ jobs:
           AUTH0_MGMT_CLIENT_ID: ${{ steps.test-credentials-secret.outputs.AUTH0_MGMT_CLIENT_ID }}
           AUTH0_MGMT_CLIENT_SECRET: ${{ steps.test-credentials-secret.outputs.AUTH0_MGMT_CLIENT_SECRET }}
         run: |
-          cd ./scripts/deploy-camunda
-          go run . auth0 cleanup-clients \
+          deploy-camunda auth0 cleanup-clients \
             --namespace "$TEST_NAMESPACE" \
             --domain "$AUTH0_DOMAIN" \
             --log-level info

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -130,6 +130,15 @@ on:
         required: false
         default: false
         type: boolean
+      skip-it:
+        # Deprecated no-op: kept so existing external callers (camunda/camunda,
+        # camunda/identity, camunda/connectors, …) don't fail on unknown-input.
+        # The integration test runner was removed; remove this input once
+        # downstream repos stop passing it.
+        description: "Deprecated — no-op. The --test-it runner was removed."
+        required: false
+        default: false
+        type: boolean
       pr-head-sha:
         description: "PR HEAD commit SHA for recording cache results"
         required: false

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -130,11 +130,6 @@ on:
         required: false
         default: false
         type: boolean
-      skip-it:
-        description: "Skip integration (Playwright IT) tests for this scenario"
-        required: false
-        default: false
-        type: boolean
       pr-head-sha:
         description: "PR HEAD commit SHA for recording cache results"
         required: false
@@ -374,7 +369,6 @@ jobs:
       test-qa: ${{ inputs.test-qa }}
       test-upgrade: ${{ inputs.test-upgrade }}
       skip-e2e: ${{ inputs.skip-e2e }}
-      skip-it: ${{ inputs.skip-it }}
       pr-head-sha: ${{ inputs.pr-head-sha }}
       camunda-version: ${{ inputs.camunda-version }}
       camunda-helm-post-render: ${{ inputs.camunda-helm-post-render }}

--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -227,7 +227,6 @@ integration:
           features:
             - postgresql-companion
           skip-e2e: true
-          skip-it: true
           dependencies:
             - chart: charts/internal-postgresql
               release-name: postgresql
@@ -474,7 +473,6 @@ integration:
           features:
             - no-secondary-storage
           skip-e2e: true
-          skip-it: true
           dependencies:
             - chart: charts/internal-keycloak-26
               release-name: keycloak

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/no-secondary-storage.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/no-secondary-storage.yaml
@@ -11,7 +11,6 @@ platforms:
 infra-type:
   gke: distroci
 skip-e2e: true
-skip-it: true
 dependencies:
   - keycloak
   - postgresql

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/oidc.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/oidc.yaml
@@ -16,7 +16,6 @@ infra-type:
   eks: preemptible
   gke: distroci
 skip-e2e: true
-skip-it: true
 dependencies:
   - postgresql
   - elasticsearch

--- a/charts/camunda-platform-8.7/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.7/test/ci/registry-snapshot.yaml
@@ -85,7 +85,6 @@ integration:
           persistence: elasticsearch
           helmVersion: 3.20.2
           skip-e2e: true
-          skip-it: true
         - name: keycloak-original
           enabled: true
           shortname: keyc

--- a/charts/camunda-platform-8.7/test/ci/registry/scenarios/oidc.yaml
+++ b/charts/camunda-platform-8.7/test/ci/registry/scenarios/oidc.yaml
@@ -10,4 +10,3 @@ infra-type:
   gke: distroci
 helmVersion: 3.20.2
 skip-e2e: true
-skip-it: true

--- a/charts/camunda-platform-8.8/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry-snapshot.yaml
@@ -111,7 +111,6 @@ integration:
           persistence: elasticsearch
           helmVersion: 3.20.2
           skip-e2e: true
-          skip-it: true
         - name: keycloak-mt
           enabled: false
           shortname: kemt

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/oidc.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/oidc.yaml
@@ -15,4 +15,3 @@ infra-type:
   gke: distroci
 helmVersion: 3.20.2
 skip-e2e: true
-skip-it: true

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/arm.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/arm.yaml
@@ -23,6 +23,11 @@ webModelerPostgresql:
       storageClass: hyperdisk-balanced
 
 identityKeycloak:
+  # Override chart-default tag 26.3.3 — its linux/arm64 manifest is missing
+  # in registry.camunda.cloud (digest 404 on sha256:1d18277a…), causing
+  # ImagePullBackOff on ARM nodes. 26.3.2 has an intact arm64 manifest.
+  image:
+    tag: "26.3.2"
   postgresql:
     primary:
       persistence:

--- a/charts/camunda-platform-8.9/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry-snapshot.yaml
@@ -110,7 +110,6 @@ integration:
           identity: oidc
           persistence: elasticsearch
           skip-e2e: true
-          skip-it: true
         - name: keycloak-mt
           enabled: true
           shortname: kemt
@@ -252,7 +251,6 @@ integration:
           features:
             - no-secondary-storage
           skip-e2e: true
-          skip-it: true
         - name: documentstore
           enabled: true
           shortname: docstr

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/no-secondary-storage.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/no-secondary-storage.yaml
@@ -11,4 +11,3 @@ platforms:
 infra-type:
   gke: distroci
 skip-e2e: true
-skip-it: true

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/oidc.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/oidc.yaml
@@ -14,4 +14,3 @@ infra-type:
   eks: preemptible
   gke: distroci
 skip-e2e: true
-skip-it: true

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/arm.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/arm.yaml
@@ -23,6 +23,11 @@ webModelerPostgresql:
       storageClass: hyperdisk-balanced
 
 identityKeycloak:
+  # Override chart-default tag 26.3.3 — its linux/arm64 manifest is missing
+  # in registry.camunda.cloud (digest 404 on sha256:1d18277a…), causing
+  # ImagePullBackOff on ARM nodes. 26.3.2 has an intact arm64 manifest.
+  image:
+    tag: "26.3.2"
   postgresql:
     primary:
       persistence:

--- a/charts/camunda-platform-8.9/values-enterprise.yaml
+++ b/charts/camunda-platform-8.9/values-enterprise.yaml
@@ -28,7 +28,7 @@ identityPostgresql:
   image:
     registry: registry.camunda.cloud
     repository: vendor-ee/postgresql
-    tag: 18.4.0-debian-12-r9
+    tag: 18.4.0-debian-12-r2
     pullSecrets:
       - name: registry-camunda-cloud
 
@@ -65,7 +65,7 @@ identityKeycloak:
     image:
       registry: registry.camunda.cloud
       repository: vendor-ee/postgresql
-      tag: 18.4.0-debian-12-r9
+      tag: 18.4.0-debian-12-r2
       pullSecrets:
         - name: registry-camunda-cloud
 
@@ -87,7 +87,7 @@ webModelerPostgresql:
   image:
     registry: registry.camunda.cloud
     repository: vendor-ee/postgresql
-    tag: 18.4.0-debian-12-r9
+    tag: 18.4.0-debian-12-r2
     pullSecrets:
       - name: registry-camunda-cloud
 

--- a/scripts/deploy-camunda/cmd/matrix.go
+++ b/scripts/deploy-camunda/cmd/matrix.go
@@ -145,7 +145,6 @@ func newMatrixRunCommand() *cobra.Command {
 		repoRoot                 string
 		dryRun                   bool
 		coverage                 bool
-		testIT                   bool
 		testE2E                  bool
 		testAll                  bool
 		stopOnFailure            bool
@@ -283,7 +282,6 @@ This command calls deploy.Execute() for each matrix entry.`,
 					SkipDependencyUpdate: &skipDependencyUpdate,
 					HelmTimeout:          &helmTimeout,
 					// Tests
-					TestIT:  &testIT,
 					TestE2E: &testE2E,
 					TestAll: &testAll,
 					// Kube contexts
@@ -483,7 +481,6 @@ This command calls deploy.Execute() for each matrix entry.`,
 				NamespacePrefix:       namespacePrefix,
 				Platform:              platform,
 				MaxParallel:           maxParallel,
-				TestIT:                testIT,
 				TestE2E:               testE2E,
 				TestAll:               testAll,
 				RepoRoot:              repoRoot,
@@ -574,9 +571,8 @@ This command calls deploy.Execute() for each matrix entry.`,
 	f.StringVar(&repoRoot, "repo-root", "", "Repository root path (or set repoRoot in config)")
 	f.BoolVar(&dryRun, "dry-run", false, "Log what would be deployed without actually deploying")
 	f.BoolVar(&coverage, "coverage", false, "Show a layer-breakdown report of what is tested in the matrix (no deployment)")
-	f.BoolVar(&testIT, "test-it", false, "Run integration tests after each deployment")
 	f.BoolVar(&testE2E, "test-e2e", false, "Run e2e tests after each deployment")
-	f.BoolVar(&testAll, "test-all", false, "Run both integration and e2e tests after each deployment")
+	f.BoolVar(&testAll, "test-all", false, "Run all e2e tests after each deployment")
 	f.BoolVar(&stopOnFailure, "stop-on-failure", false, "Stop the run on the first failure")
 	f.StringVar(&namespacePrefix, "namespace-prefix", "matrix", "Prefix for generated namespaces")
 	f.BoolVar(&cleanup, "cleanup", false, "Delete each entry's namespace after its deployment and tests complete")

--- a/scripts/deploy-camunda/cmd/root.go
+++ b/scripts/deploy-camunda/cmd/root.go
@@ -252,9 +252,8 @@ func NewRootCommand() *cobra.Command {
 	f.StringVar(&flags.Test.OutputTestEnvPath, "output-test-env-path", ".env.test", "Path for the test .env file output (for multi-scenario: used as base, e.g., .env.test.{scenario})")
 
 	// Test execution flags
-	f.BoolVar(&flags.Test.RunIntegrationTests, "test-it", false, "Run integration tests after deployment")
 	f.BoolVar(&flags.Test.RunE2ETests, "test-e2e", false, "Run e2e tests after deployment")
-	f.BoolVar(&flags.Test.RunAllTests, "test-all", false, "Run both integration and e2e tests after deployment")
+	f.BoolVar(&flags.Test.RunAllTests, "test-all", false, "Run all e2e tests after deployment")
 	f.StringVar(&flags.Test.KubeContext, "kube-context", "", "Kubernetes context to use for deployment")
 	f.StringVar(&flags.Test.TestExclude, "test-exclude", "", "Pipe-separated regex of test suites to exclude (passed as --grep-invert to Playwright)")
 	f.BoolVar(&flags.Secrets.UseVaultBackedSecrets, "use-vault-backed-secrets", false, "Use vault-backed external secrets (selects -vault.yaml suffix files)")

--- a/scripts/deploy-camunda/config/config.go
+++ b/scripts/deploy-camunda/config/config.go
@@ -92,7 +92,6 @@ type DeploySpecConfig struct {
 	ExtraValues              []string `mapstructure:"extraValues" yaml:"extraValues,omitempty"`
 	ScenarioRoot             string   `mapstructure:"scenarioRoot" yaml:"scenarioRoot,omitempty"`
 	ValuesPreset             string   `mapstructure:"valuesPreset" yaml:"valuesPreset,omitempty"`
-	RunIntegrationTests      *bool    `mapstructure:"runIntegrationTests" yaml:"runIntegrationTests,omitempty"`
 	RunE2ETests              *bool    `mapstructure:"runE2ETests" yaml:"runE2ETests,omitempty"`
 
 	// Selection + composition model fields (alternative to Scenario)
@@ -129,7 +128,6 @@ type MatrixConfig struct {
 	HelmTimeout   *int  `mapstructure:"helmTimeout" yaml:"helmTimeout,omitempty"`
 
 	// Tests
-	TestIT  *bool `mapstructure:"testIT" yaml:"testIT,omitempty"`
 	TestE2E *bool `mapstructure:"testE2E" yaml:"testE2E,omitempty"`
 	TestAll *bool `mapstructure:"testAll" yaml:"testAll,omitempty"`
 
@@ -460,10 +458,6 @@ func applyMatrixEnvOverrides(m *MatrixConfig, get func(string) string) {
 	}
 	if v := get("CAMUNDA_MATRIX_UPGRADE_FROM_VERSION"); v != "" {
 		m.UpgradeFromVersion = v
-	}
-	if v := get("CAMUNDA_MATRIX_TEST_IT"); v != "" {
-		b := parseBool(v)
-		m.TestIT = &b
 	}
 	if v := get("CAMUNDA_MATRIX_TEST_E2E"); v != "" {
 		b := parseBool(v)

--- a/scripts/deploy-camunda/config/matrix_merge.go
+++ b/scripts/deploy-camunda/config/matrix_merge.go
@@ -93,7 +93,6 @@ type MatrixRunFlags struct {
 	HelmTimeout          *int
 
 	// Tests
-	TestIT  *bool
 	TestE2E *bool
 	TestAll *bool
 
@@ -210,7 +209,6 @@ func ApplyMatrixRunConfig(rc *RootConfig, changedFlags map[string]bool, f *Matri
 	MergeStringField(f.LogLevel, m.LogLevel, rc.LogLevel, changedFlags, "log-level")
 
 	// --- Tests ---
-	MergeBoolField(f.TestIT, m.TestIT, nil, changedFlags, "test-it")
 	MergeBoolField(f.TestE2E, m.TestE2E, nil, changedFlags, "test-e2e")
 	MergeBoolField(f.TestAll, m.TestAll, nil, changedFlags, "test-all")
 

--- a/scripts/deploy-camunda/config/matrix_merge_test.go
+++ b/scripts/deploy-camunda/config/matrix_merge_test.go
@@ -10,7 +10,7 @@ func newMatrixRunFlags() (*MatrixRunFlags, *string, *string, *string, *string, *
 	var (
 		versions                                      []string
 		includeDisabled, dryRun, coverage, stopOnFail bool
-		cleanup, deleteNS, skipDep, testIT, testE2E   bool
+		cleanup, deleteNS, skipDep, testE2E           bool
 		testAll, useVault, ensureReg, ensureHub       bool
 		maxParallel, helmTimeout                      int
 		scenarioFilter, shortnameFilter, flowFilter   string
@@ -26,7 +26,7 @@ func newMatrixRunFlags() (*MatrixRunFlags, *string, *string, *string, *string, *
 		DryRun: &dryRun, Coverage: &coverage, StopOnFailure: &stopOnFail, Cleanup: &cleanup,
 		DeleteNamespace: &deleteNS, NamespacePrefix: &namespacePrefix, MaxParallel: &maxParallel,
 		LogLevel: &logLevel, SkipDependencyUpdate: &skipDep, HelmTimeout: &helmTimeout,
-		TestIT: &testIT, TestE2E: &testE2E, TestAll: &testAll,
+		TestE2E: &testE2E, TestAll: &testAll,
 		KubeContext: &kubeContext, KubeContextGKE: &kubeGKE, KubeContextEKS: &kubeEKS,
 		IngressBaseDomain: &ingress, IngressBaseDomainGKE: &ingressGKE, IngressBaseDomainEKS: &ingressEKS,
 		UseVaultBackedSecrets: &useVault,

--- a/scripts/deploy-camunda/config/merge.go
+++ b/scripts/deploy-camunda/config/merge.go
@@ -114,13 +114,12 @@ type DebugFlags struct {
 
 // TestFlags holds test execution configuration.
 type TestFlags struct {
-	RunIntegrationTests bool   // Run integration tests after deployment
-	RunE2ETests         bool   // Run e2e tests after deployment
-	RunAllTests         bool   // Run both integration and e2e tests after deployment
-	TestExclude         string // Pipe-separated regex for test suites to exclude (passed as --grep-invert to Playwright)
-	OutputTestEnv       bool   // Generate .env file for E2E tests after deployment
-	OutputTestEnvPath   string // Path for the test .env file output
-	KubeContext         string
+	RunE2ETests       bool   // Run e2e tests after deployment
+	RunAllTests       bool   // Run all e2e tests after deployment
+	TestExclude       string // Pipe-separated regex for test suites to exclude (passed as --grep-invert to Playwright)
+	OutputTestEnv     bool   // Generate .env file for E2E tests after deployment
+	OutputTestEnvPath string // Path for the test .env file output
+	KubeContext       string
 }
 
 // SelectionFlags holds selection + composition model flags.
@@ -240,10 +239,6 @@ type RuntimeFlags struct {
 	// show fine-grained progress. Nil disables the callback.
 	OnPhase func(phase string)
 
-	// ITOutputWriter, when non-nil, replaces os.Stdout/os.Stderr for
-	// integration test script output. Used by the matrix runner to redirect
-	// IT output to a per-entry log file instead of polluting the terminal.
-	ITOutputWriter io.Writer
 	// E2EOutputWriter, when non-nil, replaces os.Stdout/os.Stderr for
 	// e2e test script output. Used by the matrix runner to redirect
 	// e2e output to a per-entry log file instead of polluting the terminal.
@@ -382,7 +377,6 @@ func ApplyActiveDeployment(rc *RootConfig, active string, flags *RuntimeFlags) e
 	MergeBoolField(&flags.Deployment.RenderTemplates, dep.RenderTemplates, rc.RenderTemplates, changed, "render-templates")
 
 	// Test execution flags
-	MergeBoolField(&flags.Test.RunIntegrationTests, dep.RunIntegrationTests, rc.RunIntegrationTests, changed, "test-it")
 	MergeBoolField(&flags.Test.RunE2ETests, dep.RunE2ETests, rc.RunE2ETests, changed, "test-e2e")
 
 	// Selection + composition model fields
@@ -463,7 +457,6 @@ func applyRootDefaults(rc *RootConfig, flags *RuntimeFlags) error {
 	MergeBoolField(&flags.Deployment.RenderTemplates, nil, rc.RenderTemplates, changed, "render-templates")
 
 	// Test execution flags
-	MergeBoolField(&flags.Test.RunIntegrationTests, nil, rc.RunIntegrationTests, changed, "test-it")
 	MergeBoolField(&flags.Test.RunE2ETests, nil, rc.RunE2ETests, changed, "test-e2e")
 
 	// Selection + composition model fields

--- a/scripts/deploy-camunda/deploy/test.go
+++ b/scripts/deploy-camunda/deploy/test.go
@@ -34,13 +34,12 @@ func (e *TestError) Unwrap() error {
 
 // TestResult holds the result of a test execution.
 type TestResult struct {
-	Type   string // "integration" or "e2e"
+	Type   string // "e2e"
 	Error  error
 	Output string // Captured stdout+stderr from the test script.
 }
 
 // RunTests executes tests after deployment based on flags.
-// Tests are run in parallel if both --test-it and --test-e2e (or --test-all) are specified.
 //
 // On failure, the returned error is a *TestError containing the captured output
 // from the test scripts. Callers can use errors.As to extract it.
@@ -62,7 +61,7 @@ func RunTests(ctx context.Context, flags *config.RuntimeFlags, namespace string)
 
 	// Bound total post-deployment test runtime so matrix entries cannot hang
 	// indefinitely after Helm has already completed.
-	// Keep this well above Helm timeout because integration tests (DNS + ingress
+	// Keep this well above Helm timeout because e2e tests (DNS + ingress
 	// readiness + Playwright retries) can legitimately run much longer on
 	// upgrade-minor flows for 8.9.
 	testTimeout := 30 * time.Minute
@@ -317,7 +316,7 @@ func findRepoRoot(chartPath string) string {
 		}
 
 		// Check for scripts directory (specific to this repo)
-		if _, err := os.Stat(filepath.Join(dir, "scripts", "run-integration-tests.sh")); err == nil {
+		if _, err := os.Stat(filepath.Join(dir, "scripts", "run-e2e-tests.sh")); err == nil {
 			return dir
 		}
 

--- a/scripts/deploy-camunda/matrix/config.go
+++ b/scripts/deploy-camunda/matrix/config.go
@@ -187,7 +187,6 @@ type CIScenario struct {
 	// When set, these prevent the corresponding test types from running for this scenario,
 	// replacing hardcoded shortname-based skip logic in both the Go CLI and GHA workflows.
 	SkipE2E bool `yaml:"skip-e2e,omitempty"`
-	SkipIT  bool `yaml:"skip-it,omitempty"`
 
 	// Profiles names reusable dependency profiles (see
 	// integration.dependency-profiles) to expand into this scenario's

--- a/scripts/deploy-camunda/matrix/matrix.go
+++ b/scripts/deploy-camunda/matrix/matrix.go
@@ -38,7 +38,6 @@ type Entry struct {
 
 	// Test skip flags — declarative controls from ci-test-config.yaml.
 	SkipE2E bool `json:"skipE2E,omitempty"`
-	SkipIT  bool `json:"skipIT,omitempty"`
 
 	// Dependencies specifies companion charts to deploy before the main Camunda chart.
 	Dependencies []ChartDependency `json:"dependencies,omitempty"`
@@ -217,7 +216,6 @@ func Generate(repoRoot string, opts GenerateOptions) ([]Entry, error) {
 						Upgrade:      scenario.Upgrade,
 						Enterprise:   scenario.Enterprise,
 						SkipE2E:      scenario.SkipE2E,
-						SkipIT:       scenario.SkipIT,
 						Dependencies: append([]ChartDependency(nil), scenario.Dependencies...),
 						PreInstall:   scenario.PreInstall,
 						PostInfra:    scenario.PostInfra,

--- a/scripts/deploy-camunda/matrix/registry.go
+++ b/scripts/deploy-camunda/matrix/registry.go
@@ -62,7 +62,6 @@ type registryScenario struct {
 	Enterprise  bool              `yaml:"enterprise,omitempty"`
 	HelmVersion string            `yaml:"helmVersion,omitempty"`
 	SkipE2E     bool              `yaml:"skip-e2e,omitempty"`
-	SkipIT      bool              `yaml:"skip-it,omitempty"`
 	PrefixKey   string            `yaml:"prefix-key,omitempty"`
 
 	PreInstallID  string   `yaml:"pre-install,omitempty"`
@@ -217,7 +216,6 @@ func LoadRegistry(chartDir string) (*CITestConfig, error) {
 				Enterprise:   rscn.Enterprise,
 				HelmVersion:  rscn.HelmVersion,
 				SkipE2E:      rscn.SkipE2E,
-				SkipIT:       rscn.SkipIT,
 				Dependencies: append([]ChartDependency(nil), deps...),
 				PrefixKey:    rscn.PrefixKey,
 				PreInstall:   preInstall,

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -1590,7 +1590,6 @@ func PrintRunSummary(results []RunResult, wallClock time.Duration, logDir string
 					baseName := entryLogFileName(r.Entry)
 					fmt.Fprintf(&b, "    %s\n", dryKey("Logs:"))
 					fmt.Fprintf(&b, "      deploy:  %s\n", filepath.Join(logDir, baseName+".deploy.log"))
-					fmt.Fprintf(&b, "      it:      %s\n", filepath.Join(logDir, baseName+".it.log"))
 					fmt.Fprintf(&b, "      e2e:     %s\n", filepath.Join(logDir, baseName+".e2e.log"))
 				}
 			}

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -201,14 +201,13 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) RunResult {
 			UseVaultBackedSecrets: useVault,
 		},
 		Test: config.TestFlags{
-			KubeContext:         kubeCtx,
-			TestExclude:         testExclude,
-			RunIntegrationTests: (opts.TestIT || opts.TestAll) && !entry.SkipIT,
-			RunE2ETests:         (opts.TestE2E || opts.TestAll) && !entry.SkipE2E,
-			// Do NOT propagate RunAllTests here — RunE2ETests/RunIntegrationTests already
-			// encode the full decision (including skip-e2e/skip-it from ci-test-config.yaml).
-			// Setting RunAllTests would bypass the skip logic in deploy/test.go which ORs
-			// RunAllTests with each individual flag.
+			KubeContext: kubeCtx,
+			TestExclude: testExclude,
+			RunE2ETests: (opts.TestE2E || opts.TestAll) && !entry.SkipE2E,
+			// Do NOT propagate RunAllTests here — RunE2ETests already encodes
+			// the full decision (including skip-e2e from ci-test-config.yaml).
+			// Setting RunAllTests would bypass the skip logic in deploy/test.go
+			// which ORs RunAllTests with RunE2ETests.
 			RunAllTests: false,
 		},
 		// Selection + Composition: pass explicit layer overrides from ci-test-config.yaml.
@@ -249,12 +248,6 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) RunResult {
 	// This keeps output out of the terminal so the status table stays clean.
 	if opts.LogDir != "" {
 		baseName := entryLogFileName(entry)
-		if itFile, err := os.Create(filepath.Join(opts.LogDir, baseName+".it.log")); err != nil {
-			logging.Logger.Warn().Err(err).Msg("Failed to create IT log file, output will go to terminal")
-		} else {
-			defer itFile.Close()
-			flags.ITOutputWriter = itFile
-		}
 		if e2eFile, err := os.Create(filepath.Join(opts.LogDir, baseName+".e2e.log")); err != nil {
 			logging.Logger.Warn().Err(err).Msg("Failed to create e2e log file, output will go to terminal")
 		} else {

--- a/scripts/deploy-camunda/matrix/runner_options.go
+++ b/scripts/deploy-camunda/matrix/runner_options.go
@@ -27,11 +27,9 @@ type RunOptions struct {
 	// 0 or 1 means sequential execution (default). Values > 1 enable parallel execution
 	// with at most MaxParallel entries running simultaneously.
 	MaxParallel int
-	// TestIT runs integration tests after each deployment.
-	TestIT bool
 	// TestE2E runs e2e tests after each deployment.
 	TestE2E bool
-	// TestAll runs both integration and e2e tests after each deployment.
+	// TestAll runs all e2e tests after each deployment.
 	TestAll bool
 	// RepoRoot is the repository root path.
 	RepoRoot string

--- a/scripts/deploy-camunda/matrix/runner_upgrade.go
+++ b/scripts/deploy-camunda/matrix/runner_upgrade.go
@@ -183,8 +183,7 @@ func executeTwoStepUpgrade(ctx context.Context, entry Entry, flags *config.Runti
 	// Step 1 installs the previously released chart; caller --extra-values
 	// (e.g. per-PR image tag) belongs to Step 2 only.
 	step1Flags.Deployment.ExtraValues = nil
-	step1Flags.Test.RunIntegrationTests = false // Don't run tests after Step 1.
-	step1Flags.Test.RunE2ETests = false
+	step1Flags.Test.RunE2ETests = false // Don't run tests after Step 1.
 	step1Flags.Test.RunAllTests = false
 	step1Flags.Deployment.DeleteNamespaceFirst = flags.Deployment.DeleteNamespaceFirst // Only delete on Step 1.
 

--- a/scripts/generate-chart-matrix.jq
+++ b/scripts/generate-chart-matrix.jq
@@ -86,7 +86,6 @@ def yaml_block($version; $version_prev):
     "    qa: \($e.qa // false)\n" +
     "    upgrade: \($e.upgrade // false)\n" +
     "    skipE2E: \($e.skipE2E // false)\n" +
-    "    skipIT: \($e.skipIT // false)\n" +
     "    helmVersion: \"\($e.helmVersion // "")\"";
 
 # Tag each input entry with its original CLI position so group_by can be


### PR DESCRIPTION
## Summary

- Removes the `--test-it` CLI flag, `RunIntegrationTests`/`ITOutputWriter`/`TestIT`/`SkipIT` config fields, and IT log file creation from the `deploy-camunda` CLI and matrix runner
- Removes `skip-it` workflow inputs from all CI workflow templates (`test-integration-runner`, `test-integration-template`, `test-chart-version-template`, `test-chart-version`)
- Removes `skip-it` entries from `ci-test-config.yaml` (8.7–8.10) and `skipIT` handling from `generate-chart-matrix.sh`

## Motivation

The IT test runner was built into the Helm repo but is no longer used — all post-deployment testing now goes through E2E/Playwright. This dead code adds confusion and maintenance burden.

## What's Kept

- All E2E/Playwright infrastructure (`--test-e2e`, `skip-e2e`, `run-e2e-tests.sh`, Playwright GHA jobs)
- `integration-test-credentials` K8s secret handling (used by PG password extraction)
- `values-integration-test-ingress-*.yaml` file patterns (used by the values layer system)
- Entra OIDC app registration (used by E2E tests)

Closes #5764