### PR TITLE
fix: normalize platform input to lowercase in workflow-vars action

### DIFF
--- a/.github/actions/workflow-vars/action.yaml
+++ b/.github/actions/workflow-vars/action.yaml
@@ -136,6 +136,7 @@ runs:
       echo NAMESPACE_PREFIX=$NAMESPACE_PREFIX | tee -a $GITHUB_ENV
 
       PLATFORM="${{ inputs.platform }}"
+      PLATFORM="${PLATFORM%%,*}"
       PLATFORM="${PLATFORM,,}"
       echo PLATFORM=$PLATFORM | tee -a $GITHUB_ENV
 

--- a/.github/actions/workflow-vars/action.yaml
+++ b/.github/actions/workflow-vars/action.yaml
@@ -53,8 +53,10 @@ runs:
       INFRA_CONFIG=".github/config/infra.yaml"
 
       # Extract first platform when a comma-separated list is passed (e.g. "gke,eks").
+      # Normalize to lowercase so callers can pass "GKE", "gke", "EKS", etc. interchangeably.
       PLATFORM="${{ inputs.platform }}"
       PLATFORM="${PLATFORM%%,*}"
+      PLATFORM="${PLATFORM,,}"
       if [[ -z "$PLATFORM" ]]; then
         echo "::error::platform input must not be empty"
         exit 1

--- a/.github/actions/workflow-vars/action.yaml
+++ b/.github/actions/workflow-vars/action.yaml
@@ -135,8 +135,9 @@ runs:
       fi
       echo NAMESPACE_PREFIX=$NAMESPACE_PREFIX | tee -a $GITHUB_ENV
 
-      PLATFORM=${{ inputs.platform }}
-      echo PLATFORM=${{ inputs.platform }} | tee -a $GITHUB_ENV
+      PLATFORM="${{ inputs.platform }}"
+      PLATFORM="${PLATFORM,,}"
+      echo PLATFORM=$PLATFORM | tee -a $GITHUB_ENV
 
       echo "Env vars:"
       # Namespace.
@@ -209,7 +210,7 @@ runs:
       fi
 
       # Deployment identifier.
-      TEST_IDENTIFIER="$(echo ${{ inputs.platform }}-${local_identifier} | sed 's/\./-/g')"
+      TEST_IDENTIFIER="$(echo ${PLATFORM}-${local_identifier} | sed 's/\./-/g')"
       if [[ "${{ inputs.setup-flow }}" == 'upgrade-patch' ]]; then
         TEST_IDENTIFIER="${TEST_IDENTIFIER}-upgp"
       fi


### PR DESCRIPTION
## Summary

- The `workflow-vars` action recently added a "Load infra config" step that reads platform-specific values from `.github/config/infra.yaml`, which uses lowercase keys (`gke`, `eks`, `rosa`).
- All nightly callers in `camunda/c8-cross-component-e2e-tests` pass `platform: GKE` (uppercase). The `yq` lookup is case-sensitive, so `.GKE` is not found and the step exits with error.
- Root error across all failing runs: `platform 'GKE' not found in .github/config/infra.yaml`
- A follow-up commit also fixes the `Set workflow vars` step, which re-assigned `PLATFORM` from the raw input (losing normalization across the step boundary) and used the raw expression in `TEST_IDENTIFIER`.

**Failing nightly runs (2025-05-01):**
- [SM Nightly Chrome 8.8-SNAPSHOT #25201552036](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25201552036)
- [SM Nightly Chrome 8.7-SNAPSHOT #25200854746](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25200854746)
- [SM Nightly MT 8.7-SNAPSHOT #25202469355](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25202469355)
- [SM Nightly RBA 8.7-SNAPSHOT #25197449362](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25197449362)

## Fix

Normalization applied consistently in both steps:
1. **`Load infra config`** — `PLATFORM="${PLATFORM,,}"` after the comma-split (guards the `yq` lookup)
2. **`Set workflow vars`** — same expansion before exporting to `$GITHUB_ENV` and before building `TEST_IDENTIFIER`

This makes the action accept `GKE`, `gke`, `EKS`, `eks`, etc. interchangeably, without requiring changes to the 29 caller sites in the e2e test repo.

## Test plan

- [ ] [SM Nightly Chrome 8.7-SNAPSHOT validation run #25214114998](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25214114998) — triggered against this branch, result pending
- [ ] Verify the failing nightly runs pass after this merges to `main`
- [ ] Confirm `platform: GKE` and `platform: gke` both resolve correctly against `infra.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)