### PR TITLE
fix(8.8): add missing qa-document-store-upg backward-compat scenario

### DIFF
--- a/charts/camunda-platform-8.10/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.10/test/ci-test-config.yaml
@@ -535,7 +535,7 @@ integration:
             eks: preemptible
         - name: qa-document-store-upg
           enabled: false
-          flow: install
+          flow: install,modular-upgrade-minor
           shortname: qadocupg
           auth: keycloak
           identity: keycloak

--- a/charts/camunda-platform-8.8/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.8/test/ci-test-config.yaml
@@ -407,6 +407,19 @@ integration:
           infra-type:
             gke: qa-workloads
             eks: preemptible
+        - name: qa-document-store-upg
+          enabled: false
+          flow: install
+          shortname: qadocupg
+          auth: keycloak
+          identity: keycloak
+          persistence: elasticsearch
+          features: [documentstore]
+          qa: true
+          image-tags: true
+          platforms: [gke]
+          infra-type:
+            gke: qa-workloads
         - name: qa-elasticsearch-tasklist-v1
           enabled: false
           flow: install

--- a/charts/camunda-platform-8.9/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.9/test/ci-test-config.yaml
@@ -637,7 +637,7 @@ integration:
             gke: qa-workloads
         - name: qa-document-store-upg
           enabled: false
-          flow: install
+          flow: install,modular-upgrade-minor
           shortname: qadocupg
           auth: keycloak
           identity: keycloak


### PR DESCRIPTION
## Summary

- Adds `qa-document-store-upg` (shortname: `qadocupg`) backward-compat entry to 8.8's `ci-test-config.yaml`
- The upgrade DS 8.9 nightly installs version 8.8 with shortname `qadocupg`, but no matching entry existed — causing `no matrix entries matched` errors from `deploy-camunda matrix run`
- Mirrors the existing `qadocupg` entries in 8.9 and 8.10 configs

## Context

The `c8-cross-component-e2e-tests` nightly workflow `playwright_sm_nightly_upgrade_minor_document_store_8_9.yml` performs a two-step deploy:
1. Install 8.8 with `scenario=qa-document-store, shortname=qadocupg, flow=install`
2. Upgrade to 8.9 with `scenario=qa-document-store-upg, shortname=qadocupg, flow=modular-upgrade-minor`

Step 1 failed because 8.8 had no `qadocupg` entry. This PR adds it.

## Validation

```
$ deploy-camunda matrix list --repo-root . --versions 8.8 --include-disabled --shortname-filter qadocupg --platform gke

VER    SCENARIO                  SHORT      FLOW     PLATFORM  IDENTITY   PERSISTENCE    FEATURES
8.8    qa-document-store-upg     qadocupg   install  gke       keycloak   elasticsearch  documentstore
```

## Companion PR

Depends on companion PR in `c8-cross-component-e2e-tests` that switches nightly workflows from `platform: eks` to `platform: gke`.