### PR TITLE
ci: remove run_attempt from namespace hash to fix re-run failed jobs

### DIFF
--- a/.github/actions/workflow-vars/action.yaml
+++ b/.github/actions/workflow-vars/action.yaml
@@ -147,8 +147,11 @@ runs:
     
       # NOTE: We should use the matrix job id var once it's available.
       # https://github.com/orgs/community/discussions/40291
-      # NOTE we are using a hash here rather than a random value so that the namepsace is deterministic
-      GITHUB_WORKFLOW_JOB_ID=$(echo -n "$TEST_NAMESPACE-${{ github.run_id }}-${{ github.run_attempt }}" | sha256sum | head -c 6)
+      # NOTE we are using a hash here rather than a random value so that the namespace is deterministic.
+      # We intentionally exclude github.run_attempt so that retried jobs ("re-run failed jobs")
+      # compute the same namespace as the original install job. The install step already handles
+      # stale state via `helm uninstall || true` and the cleanup job removes indices/namespaces.
+      GITHUB_WORKFLOW_JOB_ID=$(echo -n "$TEST_NAMESPACE-${{ github.run_id }}" | sha256sum | head -c 6)
       # Workflow.
       echo "GITHUB_WORKFLOW_JOB_ID=$GITHUB_WORKFLOW_JOB_ID" | tee -a $GITHUB_ENV
       echo "GITHUB_WORKFLOW_RUN_ID=${{ github.run_id }}" | tee -a $GITHUB_ENV
@@ -157,11 +160,11 @@ runs:
       # The hash includes TEST_NAMESPACE (which is scenario-specific) so different
       # scenarios within the same CI run are distributed across pools.
       # Pool counts are read from .github/config/infra.yaml.
-      ES_POOL_INDEX=$(( 16#$(echo -n "${TEST_NAMESPACE}-${{ github.run_id }}-${{ github.run_attempt }}" | sha256sum | head -c 8) % INFRA_ES_POOLS ))
+      ES_POOL_INDEX=$(( 16#$(echo -n "${TEST_NAMESPACE}-${{ github.run_id }}" | sha256sum | head -c 8) % INFRA_ES_POOLS ))
       echo "ES_POOL_INDEX=${ES_POOL_INDEX}" | tee -a $GITHUB_ENV
       echo "es-pool-index=${ES_POOL_INDEX}" >> $GITHUB_OUTPUT
 
-      OS_POOL_INDEX=$(( 16#$(echo -n "${TEST_NAMESPACE}-${{ github.run_id }}-${{ github.run_attempt }}" | sha256sum | head -c 8) % INFRA_OS_POOLS ))
+      OS_POOL_INDEX=$(( 16#$(echo -n "${TEST_NAMESPACE}-${{ github.run_id }}" | sha256sum | head -c 8) % INFRA_OS_POOLS ))
       echo "OS_POOL_INDEX=${OS_POOL_INDEX}" | tee -a $GITHUB_ENV
       echo "os-pool-index=${OS_POOL_INDEX}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Summary

- Removes `github.run_attempt` from the hash computation for `GITHUB_WORKFLOW_JOB_ID`, `ES_POOL_INDEX`, and `OS_POOL_INDEX` in the `workflow-vars` action
- Fixes "re-run failed jobs" permanently failing with `namespace not found` when only the E2E job is retried

## Problem

When "re-run failed jobs" is triggered in GitHub Actions:
1. Previously-succeeded jobs (install) are NOT re-executed — GitHub replays their cached results from the prior attempt
2. Only the failed job (E2E) is actually re-run with the incremented `GITHUB_RUN_ATTEMPT`

Since both jobs independently compute the namespace from `sha256("...-$GITHUB_RUN_ATTEMPT")`, they get different namespace hashes. The E2E job looks for a namespace that was never created.

**Evidence**: [camunda/connectors run 23741033212](https://github.com/camunda/connectors/actions/runs/23741033212) — attempts 3 and 4 both failed with:
```
Error: namespace 'camunda-id-connectors-int-23741033212-qaes-037b92' not found
Error: namespace 'camunda-id-connectors-int-23741033212-qaes-2d198a' not found
```
While the install job (cached from attempt 2) created namespace `...-c92c0b`.

## Fix

Remove `github.run_attempt` from all hash inputs. The `run_id` alone provides uniqueness per workflow trigger. Existing mitigations handle stale state from prior attempts:
- Install step runs `helm uninstall || true` before installing
- Cleanup job (runs `if: always()`) removes namespaces and expires ES indices

## Risk Assessment

| Concern | Mitigation |
|---------|-----------|
| Retry finds dirty namespace from failed attempt | `helm uninstall || true` at start of install |
| Stale ES indices from prior attempt | Cleanup job sets 1s TTL on matching indices |
| Concurrent runs collide | Different `run_id` → different hash (no collision) |