### PR TITLE
fix(ci): extend nightly matrix coverage for missing platform/flow combinations

### DIFF
--- a/charts/camunda-platform-8.10/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.10/test/ci-test-config.yaml
@@ -306,6 +306,15 @@ integration:
           persistence: elasticsearch
           qa: true
           platforms: [gke]
+        - name: qa-elasticsearch-upg
+          enabled: false
+          flow: modular-upgrade-minor
+          shortname: qaelupg
+          auth: keycloak
+          identity: keycloak
+          persistence: elasticsearch
+          qa: true
+          platforms: [gke]
         - name: qa-elasticsearch
           enabled: false
           flow: install
@@ -372,7 +381,7 @@ integration:
           persistence: elasticsearch
           features: [documentstore]
           qa: true
-          platforms: [gke]
+          platforms: [gke, eks]
         - name: qa-document-store-upg
           enabled: false
           flow: install
@@ -382,7 +391,7 @@ integration:
           persistence: elasticsearch
           features: [documentstore]
           qa: true
-          platforms: [gke]
+          platforms: [gke, eks]
         - name: qa-license
           enabled: false
           flow: install

--- a/charts/camunda-platform-8.7/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.7/test/ci-test-config.yaml
@@ -112,7 +112,7 @@ integration:
           identity: keycloak
           persistence: elasticsearch
           qa: true
-          platforms: [gke]
+          platforms: [gke, eks]
         - name: qa-elasticsearch-rba
           enabled: false
           flow: install

--- a/charts/camunda-platform-8.8/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.8/test/ci-test-config.yaml
@@ -278,7 +278,7 @@ integration:
           persistence: elasticsearch
           features: [documentstore]
           qa: true
-          platforms: [gke]
+          platforms: [gke, eks]
         - name: qa-elasticsearch-tasklist-v1
           enabled: false
           flow: install
@@ -332,6 +332,15 @@ integration:
         - name: qa-elasticsearch-upg
           enabled: false
           flow: install
+          shortname: qaelupg
+          auth: keycloak
+          identity: keycloak
+          persistence: elasticsearch
+          qa: true
+          platforms: [gke]
+        - name: qa-elasticsearch-upg
+          enabled: false
+          flow: modular-upgrade-minor
           shortname: qaelupg
           auth: keycloak
           identity: keycloak

--- a/charts/camunda-platform-8.9/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.9/test/ci-test-config.yaml
@@ -319,7 +319,7 @@ integration:
           persistence: elasticsearch
           features: [documentstore]
           qa: true
-          platforms: [gke]
+          platforms: [gke, eks]
         - name: qa-elasticsearch-tasklist-v1
           enabled: false
           flow: install
@@ -373,6 +373,15 @@ integration:
         - name: qa-elasticsearch-upg
           enabled: false
           flow: install
+          shortname: qaelupg
+          auth: keycloak
+          identity: keycloak
+          persistence: elasticsearch
+          qa: true
+          platforms: [gke]
+        - name: qa-elasticsearch-upg
+          enabled: false
+          flow: modular-upgrade-minor
           shortname: qaelupg
           auth: keycloak
           identity: keycloak
@@ -437,7 +446,7 @@ integration:
           persistence: elasticsearch
           features: [documentstore]
           qa: true
-          platforms: [gke]
+          platforms: [gke, eks]
         # kcor is referenced by .github/workflows/test-backward-compat.yaml's
         # compat-camunda-docker job (camunda/docker-build-helm-integration.yml).
         # The 8.10 chart already exposes keycloak-original under shortname `keorg`;


### PR DESCRIPTION
## Summary

Extends `ci-test-config.yaml` matrix coverage in chart versions 8.7, 8.8, 8.9, and 8.10 so that nightly scenarios scheduled by `c8-cross-component-e2e-tests` actually match an entry in `deploy-camunda matrix run`.

Without these entries, the nightly workflow either fails fast with `no matrix entries matched the filters` or silently leaves the deploy namespace empty (`No resources found in <ns>`), depending on the scenario.

## Per-version changes

| Version | Change |
|---|---|
| 8.7 | `qa-elasticsearch` (`qael`): `platforms: [gke]` → `[gke, eks]` |
| 8.8 | `qa-document-store` (`qadoc`): `platforms: [gke]` → `[gke, eks]`; added `qa-elasticsearch-upg` (`qaelupg`) entry with `flow: modular-upgrade-minor`, `platforms: [gke]` |
| 8.9 | `qa-document-store` and `qa-document-store-upg`: `platforms: [gke]` → `[gke, eks]`; added `qaelupg` `modular-upgrade-minor` entry |
| 8.10 | `qa-document-store` and `qa-document-store-upg`: `platforms: [gke]` → `[gke, eks]`; added `qaelupg` `modular-upgrade-minor` entry |

Note: 8.8 has no `qa-document-store-upg`/`qadocupg` entry because no corresponding nightly workflow exists (`c8-cross-component-e2e-tests` ships `playwright_sm_nightly_upgrade_minor_document_store_8_{9,10}.yml` but no `_8_8` variant).

## Failing nightly runs addressed

EKS docStore (Issue 1):
- [camunda/c8-cross-component-e2e-tests#2](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25352722101) (8.8 EKS qadoc)
- [camunda/c8-cross-component-e2e-tests#](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25353547615) (8.8 EKS qadoc)
- [camunda/c8-cross-component-e2e-tests#](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25362700031) (8.9 EKS qadocupg — was mislabeled 8.8 in initial triage)
- [camunda/c8-cross-component-e2e-tests#](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25362671541) (8.9 EKS qadocupg)
- [camunda/c8-cross-component-e2e-tests#](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25353522380) (8.10 EKS qadoc)

Missing matrix entries (Issue 2):
- [camunda/c8-cross-component-e2e-tests#](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25353545817) (8.7 EKS qael install)
- [camunda/c8-cross-component-e2e-tests#](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25360341016) (8.8 GKE qaelupg modular-upgrade-minor)
- [camunda/c8-cross-component-e2e-tests#](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25360225208) (8.9 GKE qaelupg modular-upgrade-minor)
- [camunda/c8-cross-component-e2e-tests#](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25360367229) (8.10 GKE qaelupg modular-upgrade-minor)

## Validation

```bash
cd scripts/deploy-camunda
go run . matrix list --include-disabled --scenario-filter "qa-document-store" \
  --shortname-filter "qadoc" --shortname-exact --flow-filter "install" \
  --versions "8.8,8.9,8.10" --platform "eks"
# Returns 3 entries (was 0 before this change)
```

Validation runs against this branch (triggered manually):
- DocumentStore 8.8/8.9/8.10 EKS: actions/runs/25370124665, 25370126434, 25370128425
- Upgrade Minor DocumentStore 8.9/8.10 EKS: actions/runs/25370130169, 25370132013
- Upgrade Minor 8.8/8.9/8.10 GKE (qaelupg): actions/runs/25370133969, 25370135765, 25370137675

## Cross-repo PRs

- `c8-cross-component-e2e-tests` shared CI action fixes: camunda/c8-cross-component-e2e-tests#2239
- `c8-cross-component-e2e-tests` SM-8.9 retry bump: camunda/c8-cross-component-e2e-tests#2240

This PR should land **first** (per repo convention — Helm gates the nightly matrix), then the E2E PRs.


