### PR TITLE
fix(ci): add qaosupg modular-upgrade-minor entries for 8.9 and 8.10

### DIFF
--- a/charts/camunda-platform-8.10/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.10/test/ci-test-config.yaml
@@ -342,6 +342,15 @@ integration:
           persistence: opensearch
           qa: true
           platforms: [gke]
+        - name: qa-opensearch-upg
+          enabled: false
+          flow: modular-upgrade-minor
+          shortname: qaosupg
+          auth: keycloak
+          identity: keycloak
+          persistence: opensearch
+          qa: true
+          platforms: [gke]
         - name: qa-elasticsearch-mt
           enabled: false
           flow: install

--- a/charts/camunda-platform-8.9/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.9/test/ci-test-config.yaml
@@ -247,11 +247,20 @@ integration:
         # All disabled so they don't appear in the regular CI matrix; matrix run resolves
         # them via --shortname-filter + --include-disabled.
         #
-        # Note on duplicate shortnames: compat workflow reuses qaosupg/qaelmtupg across
-        # tasklist-v1 install scenarios and *-upg upgrade-minor scenarios. Both deploy
-        # via the same flow=install path here (compat workflow uses flow: install for
-        # both because modular-upgrade-minor requires real infra it doesn't provision).
-        # One entry per shortname covers both.
+        # Note on duplicate shortnames: matrix lookup is keyed by (shortname, flow), so
+        # the same shortname can appear on multiple rows when each row carries a distinct
+        # flow. Specifically:
+        #   - qaosupg / qaelmtupg are reused by the compat workflow across tasklist-v1
+        #     install scenarios and *-upg upgrade-minor scenarios. The compat workflow
+        #     uses flow=install for both (modular-upgrade-minor requires real infra it
+        #     doesn't provision), so for compat purposes one flow=install entry per
+        #     shortname is enough.
+        #   - The OpenSearch nightly upgrade-minor workflow additionally needs a
+        #     (qaosupg, flow=modular-upgrade-minor) row pointing at qa-opensearch-upg;
+        #     that row coexists with the compat entry because (shortname, flow) differs.
+        # When adding new dual-purpose shortnames, keep one row per (shortname, flow)
+        # pair and use shortname suffixes (e.g. qaosupg2) only when both rows would
+        # otherwise share the same flow.
         # ===========================================================================
         - name: qa-elasticsearch
           enabled: false

--- a/charts/camunda-platform-8.9/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.9/test/ci-test-config.yaml
@@ -407,6 +407,15 @@ integration:
           persistence: opensearch
           qa: true
           platforms: [gke]
+        - name: qa-opensearch-upg
+          enabled: false
+          flow: modular-upgrade-minor
+          shortname: qaosupg
+          auth: keycloak
+          identity: keycloak
+          persistence: opensearch
+          qa: true
+          platforms: [gke]
         - name: qa-elasticsearch-rba-upg
           enabled: false
           flow: install


### PR DESCRIPTION
## Problem

The SM Nightly Upgrade Minor OpenSearch workflows for 8.9 and 8.10 call `deploy-camunda` with:
- `--shortname-filter qaosupg`
- `--flow-filter modular-upgrade-minor`
- `--platform gke`

Only an install-flow entry existed for `qa-opensearch-upg`, causing:
```
Error: no matrix entries matched the filters (versions=[8.9], scenario-filter="qa-opensearch-upg", shortname-filter="qaosupg", flow-filter="modular-upgrade-minor", platform="gke"); check ci-test-config.yaml has an entry for this scenario+flow combination
```
and immediate exit code 1 — same root cause as PR #6064 fixed for `qaelupg`.

## Fix

Adds a `flow: modular-upgrade-minor` entry for `qa-opensearch-upg` in:
- `charts/camunda-platform-8.9/test/ci-test-config.yaml`
- `charts/camunda-platform-8.10/test/ci-test-config.yaml`

Mirrors the `qaelupg` pattern from #6064 (commit `319d56e`). 8.8 has no nightly OpenSearch upgrade-minor workflow, so no 8.8 change.

## Validation

```bash
go -C scripts/deploy-camunda run . matrix list --repo-root . --versions 8.9 --shortname-filter qaosupg --shortname-exact --flow-filter modular-upgrade-minor --platform gke --include-disabled
```
Returns 1 entry for both 8.9 and 8.10.

Upgrade step passed here https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25380811554

## Affected nightly runs

- SM Nightly 8.9 Upgrade Minor OpenSearch https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25380808860
-  SM Nightly 8.10 Upgrade Minor OpenSearch https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25380811554