### PR TITLE
fix(ci): add modular-upgrade-minor entries for MT and DocumentStore upgrades

### DIFF
--- a/charts/camunda-platform-8.10/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.10/test/ci-test-config.yaml
@@ -380,6 +380,16 @@ integration:
           features: [multitenancy]
           qa: true
           platforms: [gke]
+        - name: qa-elasticsearch-mt-upg
+          enabled: false
+          flow: modular-upgrade-minor
+          shortname: qaelmtupg
+          auth: keycloak
+          identity: keycloak
+          persistence: elasticsearch
+          features: [multitenancy]
+          qa: true
+          platforms: [gke]
         - name: qa-elasticsearch-rba
           enabled: false
           flow: install
@@ -403,6 +413,16 @@ integration:
         - name: qa-document-store-upg
           enabled: false
           flow: install
+          shortname: qadocupg
+          auth: keycloak
+          identity: keycloak
+          persistence: elasticsearch
+          features: [documentstore]
+          qa: true
+          platforms: [gke, eks]
+        - name: qa-document-store-upg
+          enabled: false
+          flow: modular-upgrade-minor
           shortname: qadocupg
           auth: keycloak
           identity: keycloak

--- a/charts/camunda-platform-8.9/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.9/test/ci-test-config.yaml
@@ -456,6 +456,16 @@ integration:
           features: [multitenancy]
           qa: true
           platforms: [gke]
+        - name: qa-elasticsearch-mt-upg
+          enabled: false
+          flow: modular-upgrade-minor
+          shortname: qaelmtupg
+          auth: keycloak
+          identity: keycloak
+          persistence: elasticsearch
+          features: [multitenancy]
+          qa: true
+          platforms: [gke]
         - name: qa-license-upg
           enabled: false
           flow: install
@@ -469,6 +479,16 @@ integration:
         - name: qa-document-store-upg
           enabled: false
           flow: install
+          shortname: qadocupg
+          auth: keycloak
+          identity: keycloak
+          persistence: elasticsearch
+          features: [documentstore]
+          qa: true
+          platforms: [gke, eks]
+        - name: qa-document-store-upg
+          enabled: false
+          flow: modular-upgrade-minor
           shortname: qadocupg
           auth: keycloak
           identity: keycloak


### PR DESCRIPTION
## Summary
- Adds `modular-upgrade-minor` flow entries for `qa-elasticsearch-mt-upg` (shortname `qaelmtupg`) in 8.9 and 8.10
- Adds `modular-upgrade-minor` flow entries for `qa-document-store-upg` (shortname `qadocupg`) in 8.9 and 8.10

## Problem
The nightly upgrade workflows for MT and DocumentStore scenarios fail at the upgrade step with:
```
Error: no matrix entries matched the filters (versions=[8.9], scenario-filter="qa-elasticsearch-mt-upg", 
shortname-filter="qaelmtupg", flow-filter="modular-upgrade-minor", platform="gke")
```

The `ci-test-config.yaml` files had `install` flow entries for these scenarios (used by the compat workflow) but were missing the `modular-upgrade-minor` entries needed by the nightly upgrade workflows.

## Affected Nightly Workflows
- `playwright_sm_nightly_upgrade_minor_mt_8_9.yml`
- `playwright_sm_nightly_upgrade_minor_mt_8_10.yml`
- `playwright_sm_nightly_upgrade_minor_document_store_8_9.yml`
- `playwright_sm_nightly_upgrade_minor_document_store_8_10.yml`

## Validation
- `deploy-camunda matrix list` confirms all entries resolve correctly
- Go unit tests pass for both 8.9 and 8.10 charts