### PR TITLE
fix(ci): bump Keycloak PostgreSQL CPU for reliable startup on EKS

### DIFF
--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
@@ -213,11 +213,12 @@ identityKeycloak:
       persistence:
         enabled: true
       # Bump PG resources: request enough CPU to get guaranteed capacity.
-      # Right-sized for CI: CPU P99 61m (from 500m), memory P99 92Mi (from 256Mi).
+      # Right-sized for CI: CPU P99 61m, but startup (realm import) is burst-heavy.
+      # 250m ensures reliable startup on burstable EKS nodes (t-core-16-unstable).
       resources:
         requests:
-          cpu: 80m
-          memory: 125Mi
+          cpu: 250m
+          memory: 180Mi
         limits:
           cpu: 500m
           memory: 512Mi

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
@@ -193,11 +193,12 @@ identityKeycloak:
       # Use PVC for upgrade stability across pod replacements/restarts.
       persistence:
         enabled: true
-      # Right-sized for CI: CPU P99 61m (from 500m), memory P99 92Mi (from 256Mi).
+      # Right-sized for CI: CPU P99 61m, but startup (realm import) is burst-heavy.
+      # 250m ensures reliable startup on burstable EKS nodes (t-core-16-unstable).
       resources:
         requests:
-          cpu: 80m
-          memory: 125Mi
+          cpu: 250m
+          memory: 180Mi
         limits:
           cpu: 500m
           memory: 512Mi

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
@@ -208,11 +208,12 @@ identityKeycloak:
       persistence:
         enabled: true
       # Bump PG resources: request enough CPU to get guaranteed capacity.
-      # Right-sized for CI: CPU P99 61m (from 500m), memory P99 92Mi (from 256Mi).
+      # Right-sized for CI: CPU P99 61m, but startup (realm import) is burst-heavy.
+      # 250m ensures reliable startup on burstable EKS nodes (t-core-16-unstable).
       resources:
         requests:
-          cpu: 80m
-          memory: 125Mi
+          cpu: 250m
+          memory: 180Mi
         limits:
           cpu: 500m
           memory: 512Mi


### PR DESCRIPTION
## Summary
- Increases Keycloak PostgreSQL CPU request from 80m to 250m across 8.8, 8.9, and 8.10 charts
- Increases memory request from 125Mi to 180Mi for consistency

## Problem
The DocumentStore nightly workflows on EKS have been consistently failing since ~May 1:
- `SM Nightly DocumentStore 8.9-SNAPSHOT` — 6 consecutive failures
- `SM Nightly DocumentStore 8.10-SNAPSHOT` — 6 consecutive failures

**Root cause**: Commit `070bda698` (Apr 28) reduced Keycloak's PostgreSQL CPU from 500m to 80m based on GKE P99 steady-state data. However, the EKS nightlies run on `t-core-16-unstable` (burstable T-series) nodes where:
1. CPU request determines guaranteed baseline capacity
2. With only 80m, PostgreSQL gets minimal guaranteed CPU during startup
3. Realm import queries take too long, causing Keycloak to miss its startup probe window (125s)
4. The workflow's 5-minute Keycloak realm health check times out
5. Tests can't log in → all fail

**Evidence**: The long-lived `distribution-810-docstr-inst-eks` deployment (which uses a different issue: `ImagePullBackOff` for a non-existent Harbor image) confirmed pods are pinned to `t-core-16-unstable` nodes via `values-infra-eks-preemptible.yaml`.

## Why 250m?
- P99 steady-state: 61m (from 7-day GMP data on GKE)
- Startup burst: requires significantly more for realm import (parallel index creation, entity persist)
- 250m provides 3x safety margin over steady-state P99 while remaining 50% below original 500m
- Memory bumped from 125Mi → 180Mi (P99 was 92Mi, 2x safety margin)

## Validation
- Go unit tests pass for all three chart versions (8.8, 8.9, 8.10)
- The PR CI will exercise the EKS deployment via the `qadoc` matrix entry to confirm Keycloak starts reliably

## Affected Workflows
- `SM Nightly DocumentStore 8.8-SNAPSHOT`
- `SM Nightly DocumentStore 8.9-SNAPSHOT`
- `SM Nightly DocumentStore 8.10-SNAPSHOT`