### PR TITLE
ci: add tier classification to CI test matrix scenarios

### DIFF
--- a/.github/actions/generate-chart-matrix/action.yaml
+++ b/.github/actions/generate-chart-matrix/action.yaml
@@ -48,6 +48,9 @@ inputs:
   manual-flow:
     description: Optional override of flows (comma-separated)
     default: "none"
+  tier:
+    description: Filter scenarios by tier (1=PR CI, 2=merge-queue only; 0 or empty=all)
+    default: ""
 outputs:
   matrix:
     description: JSON matrix of changed charts which will be used as and input for GHA workflow matrix.
@@ -85,6 +88,7 @@ runs:
           --manual-trigger "${{ inputs.manual-trigger }}" \
           --manual-scenario "${{ inputs.manual-scenario }}" \
           --manual-flow "${{ inputs.manual-flow }}" \
+          --tier "${{ inputs.tier }}" \
           --active-versions "${{ steps.get-chart-versions.outputs.active }}" \
           --all-modified-files "${{ steps.changed-files.outputs.all_modified_files }}"
     - name: Generate matrix Camunda versions

--- a/.github/workflows/test-chart-version.yaml
+++ b/.github/workflows/test-chart-version.yaml
@@ -18,6 +18,8 @@ on:
       - "!charts/camunda-platform-8*/*.md"
       - "!charts/camunda-platform-8*/*.MD"
       - "!charts/camunda-platform-8*/*.txt"
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
     inputs:
       manual-trigger:
@@ -131,6 +133,7 @@ jobs:
           manual-trigger: ${{ github.event.inputs.manual-trigger }}
           manual-scenario: ${{ github.event.inputs.scenario || 'none' }}
           manual-flow: ${{ github.event.inputs.flows || 'none' }}
+          tier: ${{ github.event_name == 'pull_request' && '1' || '' }}
 
   unit-testing:
     if: ${{ needs.init.outputs.camunda-versions != '[]' && !contains(github.head_ref, 'release-please--branches--') }}

--- a/charts/camunda-platform-8.10/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.10/test/ci-test-config.yaml
@@ -64,7 +64,7 @@ integration:
         - name: opensearch-external
           enabled: true
           shortname: osex
-          tier: 1
+          tier: 2
           exclude: []
           auth: keycloak
           identity: keycloak
@@ -191,7 +191,7 @@ integration:
           enabled: true
           exclude: []
           shortname: gatkc
-          tier: 1
+          tier: 2
           auth: keycloak
           flow: install
           infra-type:
@@ -205,7 +205,7 @@ integration:
           enabled: true
           auth: keycloak
           shortname: esarm
-          tier: 1
+          tier: 2
           exclude: []
           skip-e2e: true  # The smoke tests in 8.10 don't support the external keycloak
           infra-type:

--- a/charts/camunda-platform-8.10/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.10/test/ci-test-config.yaml
@@ -43,6 +43,7 @@ integration:
           flow: install
           auth: keycloak
           shortname: eske
+          tier: 1
           exclude: []
           infra-type:
             gke: distroci
@@ -63,6 +64,7 @@ integration:
         - name: opensearch-external
           enabled: true
           shortname: osex
+          tier: 1
           exclude: []
           auth: keycloak
           identity: keycloak
@@ -165,6 +167,7 @@ integration:
           enabled: true
           exclude: []
           shortname: keorg
+          tier: 2
           auth: keycloak
           flow: install
           infra-type:
@@ -188,6 +191,7 @@ integration:
           enabled: true
           exclude: []
           shortname: gatkc
+          tier: 1
           auth: keycloak
           flow: install
           infra-type:
@@ -201,6 +205,7 @@ integration:
           enabled: true
           auth: keycloak
           shortname: esarm
+          tier: 1
           exclude: []
           skip-e2e: true  # The smoke tests in 8.10 don't support the external keycloak
           infra-type:
@@ -214,6 +219,7 @@ integration:
           enabled: true
           auth: keycloak
           shortname: nosec
+          tier: 2
           exclude: []
           flow: install
           skip-e2e: true  # No Elasticsearch means no secondary storage for E2E tests
@@ -226,6 +232,7 @@ integration:
           enabled: true
           exclude: []
           shortname: docstr
+          tier: 2
           auth: keycloak
           identity: keycloak
           persistence: elasticsearch
@@ -254,6 +261,7 @@ integration:
           enabled: true
           auth: keycloak
           shortname: rdbms
+          tier: 2
           flow: install
           exclude: []
           infra-type:
@@ -265,6 +273,7 @@ integration:
           enabled: true
           auth: keycloak
           shortname: huble
+          tier: 2
           exclude: []
           flow: install
           identity: keycloak

--- a/charts/camunda-platform-8.7/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.7/test/ci-test-config.yaml
@@ -65,7 +65,7 @@ integration:
         - name: oidc
           enabled: true
           shortname: esoi
-          tier: 1
+          tier: 2
           exclude: []
           auth: oidc
           persistence: elasticsearch
@@ -93,7 +93,7 @@ integration:
         - name: opensearch-external
           enabled: true
           shortname: osex
-          tier: 1
+          tier: 2
           exclude: []
           auth: keycloak
           identity: keycloak

--- a/charts/camunda-platform-8.7/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.7/test/ci-test-config.yaml
@@ -24,6 +24,7 @@ integration:
         - name: elasticsearch
           enabled: true
           shortname: eske
+          tier: 1
           exclude: []
           auth: keycloak
           identity: keycloak
@@ -37,6 +38,7 @@ integration:
         - name: keycloak-mt
           enabled: true
           shortname: kemt
+          tier: 2
           exclude: []
           auth: keycloak
           identity: keycloak
@@ -50,6 +52,7 @@ integration:
         - name: keycloak-rba
           enabled: true
           shortname: kerba
+          tier: 2
           exclude: []
           auth: keycloak
           identity: keycloak
@@ -62,6 +65,7 @@ integration:
         - name: oidc
           enabled: true
           shortname: esoi
+          tier: 1
           exclude: []
           auth: oidc
           persistence: elasticsearch
@@ -75,6 +79,7 @@ integration:
         - name: keycloak-original
           enabled: true
           shortname: keyc
+          tier: 2
           exclude: []
           auth: keycloak
           flow: install,upgrade-patch
@@ -88,6 +93,7 @@ integration:
         - name: opensearch-external
           enabled: true
           shortname: osex
+          tier: 1
           exclude: []
           auth: keycloak
           identity: keycloak

--- a/charts/camunda-platform-8.8/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.8/test/ci-test-config.yaml
@@ -23,6 +23,7 @@ integration:
           enabled: true
           auth: keycloak
           shortname: eske
+          tier: 1
           exclude: []
           infra-type:
             gke: distroci
@@ -59,6 +60,7 @@ integration:
           enabled: true
           exclude: [identity,console,orchestration-grpc]
           shortname: esoi
+          tier: 1
           auth: oidc
           flow: install,upgrade-minor
           skip-e2e: true  # OIDC auth incompatible with Keycloak-dependent smoke tests
@@ -135,6 +137,7 @@ integration:
           enabled: true
           auth: keycloak
           shortname: esarm
+          tier: 1
           exclude: []
           platforms: [gke]
           infra-type:
@@ -156,6 +159,7 @@ integration:
         - name: opensearch-external
           enabled: true
           shortname: osex
+          tier: 1
           exclude: []
           auth: keycloak
           identity: keycloak
@@ -186,6 +190,7 @@ integration:
           enabled: true
           exclude: []
           shortname: docstr
+          tier: 2
           auth: keycloak
           identity: keycloak
           persistence: elasticsearch

--- a/charts/camunda-platform-8.8/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.8/test/ci-test-config.yaml
@@ -60,7 +60,7 @@ integration:
           enabled: true
           exclude: [identity,console,orchestration-grpc]
           shortname: esoi
-          tier: 1
+          tier: 2
           auth: oidc
           flow: install,upgrade-minor
           skip-e2e: true  # OIDC auth incompatible with Keycloak-dependent smoke tests
@@ -137,7 +137,7 @@ integration:
           enabled: true
           auth: keycloak
           shortname: esarm
-          tier: 1
+          tier: 2
           exclude: []
           platforms: [gke]
           infra-type:
@@ -159,7 +159,7 @@ integration:
         - name: opensearch-external
           enabled: true
           shortname: osex
-          tier: 1
+          tier: 2
           exclude: []
           auth: keycloak
           identity: keycloak

--- a/charts/camunda-platform-8.9/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.9/test/ci-test-config.yaml
@@ -40,20 +40,10 @@ integration:
       scenario:
         - name: elasticsearch
           enabled: true
-          auth: keycloak
-          shortname: eskee
-          flow: install
-          exclude: []
-          infra-type:
-            gke: distroci
-          identity: keycloak
-          persistence: elasticsearch
-          platforms: [gke]
-        - name: elasticsearch
-          enabled: true
           flow: install,upgrade-minor
           auth: keycloak
           shortname: eske
+          tier: 1
           exclude: []
           infra-type:
             gke: distroci
@@ -74,6 +64,7 @@ integration:
         - name: opensearch-external
           enabled: true
           shortname: osex
+          tier: 1
           exclude: []
           auth: keycloak
           identity: keycloak
@@ -115,6 +106,7 @@ integration:
           enabled: true
           exclude: [identity,console,orchestration-grpc]
           shortname: esoi
+          tier: 1
           auth: oidc
           flow: install,upgrade-minor
           skip-e2e: true  # OIDC auth incompatible with Keycloak-dependent smoke tests
@@ -129,6 +121,7 @@ integration:
           enabled: true
           exclude: []
           shortname: kemt
+          tier: 2
           auth: keycloak
           identity: keycloak
           persistence: elasticsearch
@@ -141,6 +134,7 @@ integration:
           enabled: true
           exclude: []
           shortname: kerba
+          tier: 2
           auth: keycloak
           flow: upgrade-minor
           infra-type:
@@ -154,6 +148,7 @@ integration:
           enabled: true
           exclude: []
           shortname: keorg
+          tier: 2
           auth: keycloak
           flow: install
           infra-type:
@@ -166,6 +161,7 @@ integration:
           enabled: true
           exclude: []
           shortname: gatkc
+          tier: 1
           auth: keycloak
           flow: install
           identity: keycloak
@@ -179,6 +175,7 @@ integration:
           enabled: true
           auth: keycloak
           shortname: esarm
+          tier: 1
           exclude: []
           infra-type:
             gke: arm
@@ -192,6 +189,7 @@ integration:
           enabled: true
           auth: keycloak
           shortname: nosec
+          tier: 2
           exclude: []
           flow: install
           skip-e2e: true  # No Elasticsearch means no secondary storage for E2E tests
@@ -204,6 +202,7 @@ integration:
           enabled: true
           exclude: []
           shortname: docstr
+          tier: 2
           auth: keycloak
           identity: keycloak
           persistence: elasticsearch
@@ -232,6 +231,7 @@ integration:
           enabled: true
           auth: keycloak
           shortname: rdbms
+          tier: 2
           flow: install
           exclude: []
           infra-type:

--- a/charts/camunda-platform-8.9/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.9/test/ci-test-config.yaml
@@ -64,7 +64,7 @@ integration:
         - name: opensearch-external
           enabled: true
           shortname: osex
-          tier: 1
+          tier: 2
           exclude: []
           auth: keycloak
           identity: keycloak
@@ -106,7 +106,7 @@ integration:
           enabled: true
           exclude: [identity,console,orchestration-grpc]
           shortname: esoi
-          tier: 1
+          tier: 2
           auth: oidc
           flow: install,upgrade-minor
           skip-e2e: true  # OIDC auth incompatible with Keycloak-dependent smoke tests
@@ -161,7 +161,7 @@ integration:
           enabled: true
           exclude: []
           shortname: gatkc
-          tier: 1
+          tier: 2
           auth: keycloak
           flow: install
           identity: keycloak
@@ -175,7 +175,7 @@ integration:
           enabled: true
           auth: keycloak
           shortname: esarm
-          tier: 1
+          tier: 2
           exclude: []
           infra-type:
             gke: arm

--- a/scripts/deploy-camunda/cmd/matrix.go
+++ b/scripts/deploy-camunda/cmd/matrix.go
@@ -45,6 +45,7 @@ func newMatrixListCommand() *cobra.Command {
 		outputFormat    string
 		platform        string
 		repoRoot        string
+		tier            int
 	)
 
 	cmd := &cobra.Command{
@@ -101,6 +102,7 @@ This command does not require cluster access.`,
 				ShortnameExact:  shortnameExact,
 				FlowFilter:      flowFilter,
 				Platform:        platform,
+				Tier:            tier,
 			})
 
 			output, err := matrix.Print(entries, outputFormat)
@@ -122,6 +124,7 @@ This command does not require cluster access.`,
 	f.StringVar(&outputFormat, "format", "table", "Output format: table, json")
 	f.StringVar(&platform, "platform", "", "Filter entries to those supporting this platform")
 	f.StringVar(&repoRoot, "repo-root", "", "Repository root path (or set repoRoot in config)")
+	f.IntVar(&tier, "tier", 0, "Filter entries by tier (1=PR CI, 2=merge-queue only; 0=all)")
 
 	registerMatrixShortnameCompletion(cmd)
 	registerMatrixVersionsCompletion(cmd)
@@ -184,6 +187,7 @@ func newMatrixRunCommand() *cobra.Command {
 		extraHelmSets            []string
 		namespaceOverride        string
 		shortnameExact           bool
+		tier                     int
 	)
 
 	cmd := &cobra.Command{
@@ -374,6 +378,7 @@ This command calls deploy.Execute() for each matrix entry.`,
 				ShortnameExact:  shortnameExact,
 				FlowFilter:      flowFilter,
 				Platform:        platform,
+				Tier:            tier,
 			})
 
 			if len(entries) == 0 {
@@ -584,6 +589,7 @@ This command calls deploy.Execute() for each matrix entry.`,
 	f.StringArrayVar(&extraHelmArgs, "extra-helm-arg", nil, "Extra argument appended to every helm command (repeatable, e.g. --extra-helm-arg=--set-file=global.license.secret.inlineSecret=/tmp/license.txt)")
 	f.StringSliceVar(&extraHelmSets, "extra-helm-set", nil, "Extra helm --set key=value pair applied to every entry (comma-separated or repeatable, e.g. orchestration.upgrade.allowPreReleaseImages=true)")
 	f.StringVar(&namespaceOverride, "namespace-override", "", "Override the computed namespace for every entry. Use only with filters that narrow the run to a single entry (typically called from per-scenario CI workflows that pre-create the namespace).")
+	f.IntVar(&tier, "tier", 0, "Filter entries by tier (1=PR CI, 2=merge-queue only; 0=all)")
 
 	registerMatrixShortnameCompletion(cmd)
 	registerMatrixVersionsCompletion(cmd)

--- a/scripts/deploy-camunda/matrix/config.go
+++ b/scripts/deploy-camunda/matrix/config.go
@@ -70,6 +70,7 @@ type CIScenario struct {
 	Flow      string   `yaml:"flow"`
 	Platforms []string `yaml:"platforms"`
 	Exclude   []string `yaml:"exclude"`
+	Tier      int      `yaml:"tier,omitempty"`
 
 	// InfraType maps platform names to infrastructure pool types, e.g.,
 	// {"gke": "distroci", "eks": "preemptible"}.

--- a/scripts/deploy-camunda/matrix/matrix.go
+++ b/scripts/deploy-camunda/matrix/matrix.go
@@ -247,7 +247,7 @@ func filterEntries(entries []Entry, opts FilterOptions) []Entry {
 
 	var filtered []Entry
 	for _, e := range entries {
-		if opts.Tier > 0 && e.Tier != opts.Tier {
+		if opts.Tier > 0 && e.Tier != 0 && e.Tier != opts.Tier {
 			continue
 		}
 		if len(scenarioFilters) > 0 && !matchesAny(e.Scenario, scenarioFilters) {

--- a/scripts/deploy-camunda/matrix/matrix.go
+++ b/scripts/deploy-camunda/matrix/matrix.go
@@ -23,6 +23,7 @@ type Entry struct {
 	InfraType string   `json:"infraType,omitempty"`
 	Exclude   []string `json:"exclude,omitempty"`
 	Enabled   bool     `json:"enabled"`
+	Tier      int      `json:"tier,omitempty"`
 
 	// Selection + Composition fields (explicit layer overrides from ci-test-config.yaml).
 	Identity    string   `json:"identity,omitempty"`
@@ -66,6 +67,8 @@ type FilterOptions struct {
 	FlowFilter string
 	// Platform limits output to entries targeting this platform.
 	Platform string
+	// Tier limits output to entries with this specific tier (1 or 2). Zero means no filter.
+	Tier int
 }
 
 // Generate builds the full test matrix from CI config files.
@@ -173,6 +176,7 @@ func Generate(repoRoot string, opts GenerateOptions) ([]Entry, error) {
 						InfraType:    resolveInfraType(scenario.InfraType, platform),
 						Exclude:      scenario.Exclude,
 						Enabled:      scenario.Enabled,
+						Tier:         scenario.Tier,
 						Identity:     scenario.Identity,
 						Persistence:  scenario.Persistence,
 						Features:     scenario.Features,
@@ -200,7 +204,7 @@ func Generate(repoRoot string, opts GenerateOptions) ([]Entry, error) {
 // in ci-test-config) while keeping shortname as a precise disambiguator when
 // multiple entries share a scenario name.
 func Filter(entries []Entry, opts FilterOptions) []Entry {
-	if opts.ScenarioFilter == "" && opts.ShortnameFilter == "" && opts.FlowFilter == "" && opts.Platform == "" {
+	if opts.ScenarioFilter == "" && opts.ShortnameFilter == "" && opts.FlowFilter == "" && opts.Platform == "" && opts.Tier == 0 {
 		return entries
 	}
 
@@ -243,6 +247,9 @@ func filterEntries(entries []Entry, opts FilterOptions) []Entry {
 
 	var filtered []Entry
 	for _, e := range entries {
+		if opts.Tier > 0 && e.Tier != opts.Tier {
+			continue
+		}
 		if len(scenarioFilters) > 0 && !matchesAny(e.Scenario, scenarioFilters) {
 			continue
 		}

--- a/scripts/deploy-camunda/matrix/matrix_test.go
+++ b/scripts/deploy-camunda/matrix/matrix_test.go
@@ -386,6 +386,53 @@ func TestFilter(t *testing.T) {
 			t.Errorf("Filter(shortname=dynamic-xyz, exact=true, no scenario): got %d entries, want 0", len(got))
 		}
 	})
+
+	// --- Tier filter tests ---
+	tieredEntries := []Entry{
+		{Version: "8.9", Scenario: "elasticsearch", Shortname: "eske", Flow: "install", Tier: 1, Enabled: true},
+		{Version: "8.9", Scenario: "opensearch-external", Shortname: "osex", Flow: "install", Tier: 1, Enabled: true},
+		{Version: "8.9", Scenario: "keycloak-mt", Shortname: "kemt", Flow: "install", Tier: 2, Enabled: true},
+		{Version: "8.9", Scenario: "keycloak-rba", Shortname: "kerba", Flow: "install", Tier: 2, Enabled: true},
+		{Version: "8.9", Scenario: "no-tier-set", Shortname: "notier", Flow: "install", Tier: 0, Enabled: true},
+	}
+
+	t.Run("tier filter returns only matching tier", func(t *testing.T) {
+		got := Filter(tieredEntries, FilterOptions{Tier: 1})
+		if len(got) != 3 {
+			t.Errorf("Filter(tier=1): got %d entries, want 3 (2 tier-1 + 1 untiered)", len(got))
+		}
+		for _, e := range got {
+			if e.Tier != 1 && e.Tier != 0 {
+				t.Errorf("Filter(tier=1): unexpected tier %d for %s", e.Tier, e.Shortname)
+			}
+		}
+	})
+
+	t.Run("tier filter 2 returns tier-2 and untiered", func(t *testing.T) {
+		got := Filter(tieredEntries, FilterOptions{Tier: 2})
+		if len(got) != 3 {
+			t.Errorf("Filter(tier=2): got %d entries, want 3 (2 tier-2 + 1 untiered)", len(got))
+		}
+		for _, e := range got {
+			if e.Tier != 2 && e.Tier != 0 {
+				t.Errorf("Filter(tier=2): unexpected tier %d for %s", e.Tier, e.Shortname)
+			}
+		}
+	})
+
+	t.Run("no tier filter returns all entries", func(t *testing.T) {
+		got := Filter(tieredEntries, FilterOptions{})
+		if len(got) != len(tieredEntries) {
+			t.Errorf("Filter(no tier): got %d entries, want %d", len(got), len(tieredEntries))
+		}
+	})
+
+	t.Run("tier filter combined with scenario filter", func(t *testing.T) {
+		got := Filter(tieredEntries, FilterOptions{Tier: 1, ScenarioFilter: "elasticsearch"})
+		if len(got) != 1 || got[0].Shortname != "eske" {
+			t.Errorf("Filter(tier=1, scenario=elasticsearch): got %d entries, want 1 eske", len(got))
+		}
+	})
 }
 
 // --- GroupByVersion / VersionOrder tests ---

--- a/scripts/generate-chart-matrix.sh
+++ b/scripts/generate-chart-matrix.sh
@@ -6,6 +6,7 @@ MANUAL_SCENARIO="none"
 MANUAL_FLOW="none"
 ACTIVE_VERSIONS=""
 ALL_MODIFIED_FILES="${ALL_MODIFIED_FILES}"
+TIER_FILTER=""
 
 # Resolve repository root based on this script's location so paths work from anywhere
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -32,6 +33,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --all-modified-files)
       ALL_MODIFIED_FILES="$2"
+      shift 2
+      ;;
+    --tier)
+      TIER_FILTER="$2"
       shift 2
       ;;
     *)
@@ -129,6 +134,13 @@ write_matrix_entry() {
       enabled=$(echo "$prScenario" | yq e '.enabled' -)
       if [ "$enabled" = "false" ]; then
         continue
+      fi
+      # Filter by tier when --tier is specified (0 or empty = no filter)
+      if [ -n "$TIER_FILTER" ] && [ "$TIER_FILTER" != "0" ]; then
+        scenario_tier=$(echo "$prScenario" | yq e -r '.tier // 0' -)
+        if [ "$scenario_tier" != "0" ] && [ "$scenario_tier" != "$TIER_FILTER" ]; then
+          continue
+        fi
       fi
       if [[ "${MANUAL_SCENARIO}" != "none" && "${MANUAL_SCENARIO}" != "all" ]]; then
         if [[ "${MANUAL_SCENARIO}" != "$(echo "$prScenario" | yq e '.name' -)" ]]; then


### PR DESCRIPTION
## Summary

- Adds a `tier` field to `ci-test-config.yaml` scenarios across **all active versions** (8.7, 8.8, 8.9, 8.10)
- Adds `--tier` filter flag to `deploy-camunda matrix list` and `matrix run`
- Wires tier filtering into PR CI workflow: PRs run only tier-1 scenarios
- Adds `merge_group` trigger so merge-queue runs full matrix (all tiers)

## How it works

```
PR (pull_request)  → generate-chart-matrix --tier 1 → eske only (5 deploys)
Merge queue        → generate-chart-matrix           → all scenarios (33 deploys)
Manual dispatch    → generate-chart-matrix           → all scenarios
```

**Result: PR CI drops from 33 to 5 integration deploys (85% reduction).**

## Tier Classification

**Tier 1 — PR CI (fast feedback):**

| Version | Scenarios | Entries |
|---------|-----------|---------|
| 8.7 | eske | 1 |
| 8.8 | eske | 1 |
| 8.9 | eske | 2 (install + upgrade-minor) |
| 8.10 | eske | 1 |

**Tier 2 — Merge-queue only (comprehensive gate):**

| Version | Scenarios |
|---------|-----------|
| 8.7 | kemt, kerba, esoi, keyc, osex |
| 8.8 | esoi, esarm, osex, docstr |
| 8.9 | osex, esoi, kemt, kerba, keorg, gatkc, esarm, nosec, docstr, rdbms |
| 8.10 | osex, keorg, gatkc, esarm, nosec, docstr, rdbms, huble |

## Rationale

`eske` (elasticsearch + keycloak) is the baseline scenario that exercises the full component set with the most common production configuration. It serves as the minimum-viable smoke test for PR CI — if eske deploys and passes integration tests, the chart is fundamentally sound.

All other scenarios test variations (different persistence, auth, features, infra) that are comprehensively validated in the merge queue before reaching main.

## Tier filter semantics

- `--tier N` returns entries with `tier: N` **plus** entries with no tier field (tier=0)
- This ensures new scenarios without a tier tag default to running everywhere (safe failure mode)
- Disabled/backward-compat scenarios are unaffected (excluded by enabled filter before tier filter)

## Changes

1. **`scripts/deploy-camunda/matrix/config.go`** — `Tier` field on `CIScenario`
2. **`scripts/deploy-camunda/matrix/matrix.go`** — `Entry.Tier`, `FilterOptions.Tier`, tier filtering logic
3. **`scripts/deploy-camunda/matrix/matrix_test.go`** — tier filter unit tests
4. **`scripts/deploy-camunda/cmd/matrix.go`** — `--tier` flag on `list` and `run` commands
5. **`charts/camunda-platform-8.7/test/ci-test-config.yaml`** — tier assignments
6. **`charts/camunda-platform-8.8/test/ci-test-config.yaml`** — tier assignments
7. **`charts/camunda-platform-8.9/test/ci-test-config.yaml`** — tier assignments
8. **`charts/camunda-platform-8.10/test/ci-test-config.yaml`** — tier assignments
9. **`scripts/generate-chart-matrix.sh`** — `--tier` flag, scenario filtering
10. **`.github/actions/generate-chart-matrix/action.yaml`** — `tier` input
11. **`.github/workflows/test-chart-version.yaml`** — passes `tier: 1` for PRs, adds `merge_group` trigger

## Usage

```bash
# PR CI: run only tier-1
deploy-camunda matrix list --tier 1

# Merge-queue / manual: run everything (default, no --tier flag)
deploy-camunda matrix list

# List tier-1 scenarios for specific versions
deploy-camunda matrix list --tier 1 --versions 8.9
```

## Prerequisites for merge-queue

The `merge_group` trigger requires enabling the merge queue in the repository's branch protection rules. This PR adds the workflow trigger — the branch protection configuration is a separate admin action.