### PR TITLE
fix(ci): resolve common values dir as scenario sibling

### DIFF
--- a/scripts/deploy-camunda/deploy/values.go
+++ b/scripts/deploy-camunda/deploy/values.go
@@ -25,7 +25,20 @@ import (
 // Returns the list of processed file paths in the output directory.
 func processCommonValues(ctx context.Context, scenarioPath, outputDir, envFile, platform string, envOverrides map[string]string) ([]string, error) {
 	// Common directory is a sibling to the scenario directory
-	commonDir := filepath.Join(filepath.Dir(scenarioPath), "..", "common")
+	// (e.g. scenarios/chart-full-setup → scenarios/common). The previous
+	// implementation went `Dir(scenarioPath) + ".." + "common"`, which walked
+	// one level too high (test/integration/common, which doesn't exist), so
+	// os.Stat failed and every common values file was silently skipped.
+	// That regressed nightlies after the install path switched from Taskfile
+	// setup.exec (which listed the common files explicitly via -f) to
+	// deploy-camunda matrix run (which relies on this auto-discovery): the
+	// most damaging loss was global.image.pullSecrets from
+	// common/values-integration-test-pull-secrets.yaml. Without it, components
+	// that don't set their own pullSecrets (orchestration in particular) fell
+	// back to anonymous Docker Hub pulls, hit the rate limit on shared GKE
+	// node IPs, sat in ImagePullBackOff, and never reached Ready — which is
+	// what produced the sustained 502s through the orchestration ingress.
+	commonDir := filepath.Join(filepath.Dir(scenarioPath), "common")
 
 	logging.Logger.Debug().
 		Str("scenarioPath", scenarioPath).

--- a/scripts/deploy-camunda/deploy/values_test.go
+++ b/scripts/deploy-camunda/deploy/values_test.go
@@ -1,0 +1,124 @@
+package deploy
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestProcessCommonValues_FindsSiblingCommonDir guards against a regression of
+// the silent-skip bug that killed OpenSearch nightlies in May 2026.
+//
+// scenarios/chart-full-setup is the scenario; scenarios/common is its sibling.
+// The previous implementation went one directory too high, computing the
+// non-existent test/integration/common, which made os.Stat fail and silently
+// drop every common values file (including the one that sets
+// CAMUNDA_SYSTEM_UPGRADE_ENABLEVERSIONCHECK=false on orchestration). On
+// SNAPSHOT installs that kept the orchestration StatefulSet NotReady and the
+// ingress returned 502s.
+func TestProcessCommonValues_FindsSiblingCommonDir(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Mirror the real layout: <root>/scenarios/{chart-full-setup, common}/
+	scenariosDir := filepath.Join(tmp, "scenarios")
+	scenarioPath := filepath.Join(scenariosDir, "chart-full-setup")
+	commonDir := filepath.Join(scenariosDir, "common")
+
+	if err := os.MkdirAll(scenarioPath, 0o755); err != nil {
+		t.Fatalf("setup scenario dir: %v", err)
+	}
+	if err := os.MkdirAll(commonDir, 0o755); err != nil {
+		t.Fatalf("setup common dir: %v", err)
+	}
+
+	// values-integration-test.yaml is in the predefined CommonValuesFiles list
+	// (deployer.CommonValuesFiles); processCommonValues must pick it up.
+	srcFile := filepath.Join(commonDir, "values-integration-test.yaml")
+	const srcBody = `orchestration:
+  env:
+    - name: CAMUNDA_SYSTEM_UPGRADE_ENABLEVERSIONCHECK
+      value: "false"
+`
+	if err := os.WriteFile(srcFile, []byte(srcBody), 0o644); err != nil {
+		t.Fatalf("write source common values file: %v", err)
+	}
+
+	outputDir := filepath.Join(tmp, "out")
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		t.Fatalf("setup output dir: %v", err)
+	}
+
+	files, err := processCommonValues(context.Background(), scenarioPath, outputDir, "", "", nil)
+	if err != nil {
+		t.Fatalf("processCommonValues returned error: %v", err)
+	}
+
+	if len(files) == 0 {
+		t.Fatalf("expected at least one processed common values file, got 0")
+	}
+
+	found := false
+	for _, f := range files {
+		if filepath.Base(f) == "values-integration-test.yaml" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected values-integration-test.yaml to be picked up; got %v", files)
+	}
+}
+
+// TestProcessCommonValues_RealChartLayout exercises the fix against the actual
+// chart layout in this repo, so a regression of the path-resolution bug shows
+// up immediately on `go test ./deploy/...` instead of waiting for a nightly.
+func TestProcessCommonValues_RealChartLayout(t *testing.T) {
+	// Walk up from the test working directory to the repo root by looking for
+	// a sentinel that's only at the repo root (charts/ + a known chart dir).
+	// Test cwd is scripts/deploy-camunda/deploy, so the root is 3 levels up.
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	repoRoot := wd
+	for i := 0; i < 8; i++ {
+		if _, err := os.Stat(filepath.Join(repoRoot, "charts", "camunda-platform-8.9")); err == nil {
+			break
+		}
+		parent := filepath.Dir(repoRoot)
+		if parent == repoRoot {
+			break // reached filesystem root
+		}
+		repoRoot = parent
+	}
+
+	scenarioPath := filepath.Join(repoRoot, "charts", "camunda-platform-8.9",
+		"test", "integration", "scenarios", "chart-full-setup")
+	if _, err := os.Stat(scenarioPath); err != nil {
+		t.Skipf("chart-full-setup scenario not found at %s — skipping", scenarioPath)
+	}
+
+	outputDir := t.TempDir()
+
+	files, err := processCommonValues(context.Background(), scenarioPath, outputDir, "", "gke", nil)
+	if err != nil {
+		t.Fatalf("processCommonValues returned error: %v", err)
+	}
+
+	if len(files) == 0 {
+		t.Fatalf("expected common values files for chart-full-setup; got 0 (path-resolution regression?)")
+	}
+
+	hasIntegrationTest := false
+	for _, f := range files {
+		base := filepath.Base(f)
+		if base == "values-integration-test.yaml" {
+			hasIntegrationTest = true
+			break
+		}
+	}
+	if !hasIntegrationTest {
+		t.Fatalf("expected values-integration-test.yaml in processed common files, got %v", files)
+	}
+}


### PR DESCRIPTION
## What broke and why

`processCommonValues` (added in #5880) is supposed to load shared values
files from `scenarios/common/` before every integration test run — things
like pull secrets and base image settings that every scenario needs.

It computed the path to that directory like this:

```
scenarioPath = "scenarios/chart-full-setup"
commonDir    = filepath.Dir(scenarioPath) + ".." + "common"
             = "scenarios"               + ".." + "common"
             = "test/integration/common"   ← does not exist
```

`filepath.Dir("scenarios/chart-full-setup")` returns `"scenarios"`, then
appending `".."` walks **one level too high** to `"test/integration"`, and
finally appending `"common"` gives `"test/integration/common"` — a path that
does not exist. `os.Stat` returned `ENOENT`, the function logged a debug-level
`"common directory not found - skipping"` and silently dropped every file
under `scenarios/common/`.

The correct path is the sibling of the scenario directory:

```
commonDir = filepath.Dir(scenarioPath) + "common"
          = "scenarios"                + "common"
          = "scenarios/common"           ← exists, contains the shared files
```

The actual directory layout on disk:

```
test/integration/scenarios/
├── chart-full-setup/   ← scenarioPath points here
├── common/             ← should be resolved as a sibling
│   ├── values-integration-test.yaml
│   ├── values-integration-test-pull-secrets.yaml
│   ├── gke/
│   └── eks/
├── infra/
└── pre-setup-scripts/
```

## Why it was silent for so long

The bug was latent while CI used the old Taskfile `setup.exec` path, which
listed the common files explicitly via `-f` flags. It surfaced after #6016
switched CI to `deploy-camunda matrix run`, which relies entirely on
`processCommonValues` for auto-discovery.

## What the missing files cost

The most damaging dropped file was
`common/values-integration-test-pull-secrets.yaml`, which sets:

```yaml
global:
  image:
    pullSecrets:
      - name: index-docker-io
```

Without it, components that don't set their own pull secrets — orchestration
in particular — fell back to anonymous Docker Hub pulls. On shared GKE node
IPs that hit the 100-pulls-per-6h rate limit, pods sat in `ImagePullBackOff`
indefinitely. `helm install --wait --timeout 1200s` expired, the namespace
was left half-deployed, and the orchestration ingress had no healthy backends,
returning sustained HTTP 502s on every endpoint the E2E tests tried to reach.

## The fix

Remove the spurious `".."` segment:

```go
// Before
commonDir := filepath.Join(filepath.Dir(scenarioPath), "..", "common")

// After
commonDir := filepath.Join(filepath.Dir(scenarioPath), "common")
```

## Verification

Confirmed by rendering the orchestration StatefulSet with and without the fix:

| | `imagePullSecrets` |
|---|---|
| Before (broken) | `[]` |
| After (fixed) | `[{name: index-docker-io}]` |

New unit tests in `deploy/values_test.go` cover the fix:
- `TestProcessCommonValues_FindsSiblingCommonDir` — synthetic temp dir mirroring `scenarios/{chart-full-setup,common}`; fails without the fix, passes with it
- `TestProcessCommonValues_RealChartLayout` — runs against the real `charts/camunda-platform-8.9` layout; asserts `values-integration-test.yaml` is among the discovered files

`go test ./scripts/deploy-camunda/deploy/...` clean.

Re-ran the failing OpenSearch 8.9 nightly scenario against this branch — orchestration reached Ready and E2E tests no longer received 502s:
https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25484907436

🤖 Generated with [Claude Code](https://claude.com/claude-code)