### PR TITLE
ci: report license/cla status on merge queue commits

### DIFF
--- a/.github/workflows/merge-queue-cla-status.yaml
+++ b/.github/workflows/merge-queue-cla-status.yaml
@@ -1,0 +1,30 @@
+name: "Merge Queue - Report CLA Status"
+
+# The CLA assistant only reports the "license/cla" commit status on pull_request
+# events. The merge queue creates ephemeral merge commits that never receive this
+# status, causing the queue to block with "Waiting for status to be reported."
+#
+# This workflow bridges the gap by reporting the status on merge_group commits.
+# This is safe because CLA is already verified before a PR can enter the queue.
+
+on:
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  statuses: write
+
+jobs:
+  report-cla:
+    name: "license/cla"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report license/cla status
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "repos/${{ github.repository }}/statuses/${{ github.event.merge_group.head_sha }}" \
+            -f state=success \
+            -f context=license/cla \
+            -f description="Contributor License Agreement is signed." \
+            -f target_url="https://cla-assistant.io/camunda/camunda-platform-helm?pullRequest="


### PR DESCRIPTION
## Summary

- The merge queue is broken: the `license/cla` commit status is never reported on merge queue commits because the CLA bot only runs on `pull_request` events
- This adds a lightweight workflow that triggers on `merge_group` events and reports `license/cla` as success (CLA is already verified before entering the queue)
- Unblocks PR #5993 and all future merge queue entries

## Context

The merge queue ruleset requires `license/cla` as a status check. The CLA assistant only reports this status on PR HEAD commits, never on the ephemeral merge commits created by the merge queue. This causes every entry to block indefinitely with "Expected — Waiting for status to be reported."

Recent PRs have been admin-merged (bypassing the queue) because of this issue. This fix restores merge queue functionality.

## Note

This PR itself needs admin-merge (bypass queue) since the queue is broken without it.