### PR TITLE
test: validate crev escalation-assessor system

### DIFF
--- a/.github/escalation-policy.md
+++ b/.github/escalation-policy.md
@@ -1,0 +1,101 @@
+# Escalation Policy — camunda-platform-helm
+
+This document defines when a pull request requires human review beyond the AI review
+performed by `crev`. The escalation-assessor agent reads this file and computes a
+composite score to determine whether human sign-off is necessary.
+
+## Threshold
+
+```yaml
+threshold: 0.5
+```
+
+Score >= 0.5 triggers mandatory human review. Below that, AI review is sufficient
+for merge approval (subject to CI passing).
+
+## Hard Escalation Rules (NEVER violations = always escalate)
+
+Any violation of these rules triggers immediate human-review-required regardless of
+the composite score:
+
+### Breaking Changes
+- **NEVER** remove or rename an existing `values.yaml` field without a deprecation
+  notice and migration path — this is a breaking API change for users.
+- **NEVER** change the default value of an existing field in a way that alters runtime
+  behaviour for users who do not override it.
+
+### Security
+- **NEVER** add secrets or credentials as default values in `values.yaml`.
+- **NEVER** expose API keys, tokens, or passwords in ConfigMaps (must be Secrets).
+- **NEVER** use mutable action tags (e.g., `@v4`) in GitHub Actions workflows — must
+  be pinned to full commit SHAs.
+
+### Chart Integrity
+- **NEVER** hardcode image names or tags instead of using `camundaPlatform.imageByParams`.
+- **NEVER** manually edit `values-digest.yaml`.
+- **NEVER** approve changes that only apply to one chart version when the same fix is
+  clearly needed across multiple versions (8.8, 8.9, 8.10).
+
+## Deterministic Escalation Signals
+
+These are checked automatically and contribute to the composite score:
+
+### Golden File Mismatch (weight: 0.5)
+Template files changed without corresponding golden file updates in
+`test/unit/<component>/golden/`. This is a CI-blocking issue and indicates
+the author may not have run the test suite.
+
+### Cross-Version Scope (weight: 0.6)
+File paths span multiple chart versions (e.g., `charts/camunda-platform-8.9/` AND
+`charts/camunda-platform-8.10/`) without the PR description explicitly mentioning
+cross-version changes or backporting.
+
+### Security Surface (weight: 0.7)
+Changes touch any of:
+- `**/identity/**`
+- `**/auth/**`
+- Files containing `secret`, `token`, `password`, `credential`, `tls`, `certificate`
+- `**/security*/**`
+- Vault/secrets-related workflow steps
+
+### Breaking Change Indicators (weight: 0.6)
+- `values.yaml` field removals or renames (not additions)
+- Helper function signature changes (`define "foo.bar"`)
+- Changes to `values.schema.json` that tighten constraints
+
+## Statistical Escalation Signals
+
+### Novelty (weight: 0.4)
+How different is this change from patterns previously reviewed in this repo?
+High novelty (new subsystem, new integration pattern) warrants human attention.
+
+### Author Familiarity (weight: 0.3)
+First-time contributors or contributors who have never touched the changed
+subsystem warrant additional human oversight.
+
+### Model Uncertainty (weight: 0.5)
+When the AI review itself shows signs of uncertainty (hedging language, many
+specialist findings dropped by verifier, contradictory assessments), human
+review provides the needed ground truth.
+
+## AI-Only Review Acceptable When
+
+Human review may be skipped (score < threshold) when ALL of the following hold:
+- Change is purely additive (new files, new values fields with documentation)
+- No NEVER rules violated
+- Author has significant history in the changed subsystem
+- Change pattern matches previously-reviewed similar PRs
+- No security surfaces touched
+- Golden files are updated
+- Change is scoped to a single chart version OR explicitly describes cross-version intent
+- CI passes (helm lint, unit tests, golden file check)
+
+## Chart Design Principle Violations (always escalate at P1+)
+
+PRs that violate the chart design principles from `docs/index.md` always require
+human review because they represent architectural decisions:
+- Adding opinionated integrations (bundled monitoring, hard-coded security policies)
+- Exposing arbitrary/exhaustive application configuration
+- Bundling external component dependencies
+- Breaking the 1:1 mapping between application config and Helm values
+- Working around application-level bugs in the chart

--- a/charts/camunda-platform-8.10/templates/identity/configmap.yaml
+++ b/charts/camunda-platform-8.10/templates/identity/configmap.yaml
@@ -37,6 +37,11 @@ data:
         {{- end }}
         issuer-url: {{ include "camundaPlatform.authIssuerUrlWithFallback" . | quote }}
         backend-url: {{ include "camundaPlatform.authIssuerBackendUrl" . | quote }}
+        {{- if .Values.identity.auth.tokenValidation }}
+        token-validation:
+          audience: {{ .Values.identity.auth.tokenValidation.audience | default "camunda-identity" | quote }}
+          clock-skew: {{ .Values.identity.auth.tokenValidation.clockSkew | default "PT30S" | quote }}
+        {{- end }}
 
       {{- if ne (include "camundaPlatform.authIssuerType" .) "KEYCLOAK"}}
       initial-claim-name: {{ .Values.global.identity.auth.identity.initialClaimName }}

--- a/charts/camunda-platform-8.10/values.yaml
+++ b/charts/camunda-platform-8.10/values.yaml
@@ -824,6 +824,15 @@ identity:
     ## @param identity.image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
     pullSecrets: []
 
+  ## Token validation configuration for identity auth provider
+  ## @extra identity.auth.tokenValidation
+  auth:
+    tokenValidation:
+      ## @param identity.auth.tokenValidation.audience defines the expected audience claim for token validation
+      audience: "camunda-identity"
+      ## @param identity.auth.tokenValidation.clockSkew defines the allowed clock skew for token expiry validation (ISO 8601 duration)
+      clockSkew: "PT30S"
+
   ## Multitenancy configuration
   ## @extra identity.multitenancy
   multitenancy:

--- a/charts/camunda-platform-8.9/templates/identity/configmap.yaml
+++ b/charts/camunda-platform-8.9/templates/identity/configmap.yaml
@@ -37,6 +37,11 @@ data:
         {{- end }}
         issuer-url: {{ include "camundaPlatform.authIssuerUrlWithFallback" . | quote }}
         backend-url: {{ include "camundaPlatform.authIssuerBackendUrl" . | quote }}
+        {{- if .Values.identity.auth.tokenValidation }}
+        token-validation:
+          audience: {{ .Values.identity.auth.tokenValidation.audience | default "camunda-identity" | quote }}
+          clock-skew: {{ .Values.identity.auth.tokenValidation.clockSkew | default "PT30S" | quote }}
+        {{- end }}
 
       {{- if ne (include "camundaPlatform.authIssuerType" .) "KEYCLOAK"}}
       initial-claim-name: {{ .Values.global.identity.auth.identity.initialClaimName }}


### PR DESCRIPTION
## Summary

Test PR for validating `crev`'s new escalation-assessor system. **DO NOT MERGE.**

This PR deliberately exercises multiple escalation signals to test whether the escalation-assessor correctly identifies PRs requiring human review:

### Signals Expected to Fire

| Signal | Expected | Why |
|--------|----------|-----|
| `security_surface_touched` | `true` | Changes modify `identity/configmap.yaml` (auth token validation) |
| `cross_version_scope` | `true` | Changes touch both `charts/camunda-platform-8.9/` and `charts/camunda-platform-8.10/` without backport mention |
| `golden_file_mismatch` | `true` | Template changes made without corresponding golden file updates |
| `rule_violation_detected` | `false` | No explicit NEVER rule violated (new field addition, not removal) |
| `breaking_change_probability` | low | Additive change only |
| `novelty_score` | medium | Token validation is new but auth patterns are familiar |
| `author_familiarity_inverse` | varies | Depends on git history analysis |
| `model_self_uncertainty` | varies | Depends on AI review consistency |

### Expected Outcome

The composite escalation score should be **above threshold** (>= 0.5) due to:
- Security surface touched (weight 0.7 x 1.0 = 0.7)
- Cross-version scope (weight 0.6 x 1.0 = 0.6)
- Golden file mismatch (weight 0.5 x 1.0 = 0.5)

Normalized: (0.7 + 0.6 + 0.5) / 4.6 = ~0.39 from just binary signals, plus continuous signals should push above 0.5.

**Result: `human_review_required: true`** is the expected determination.

### Changes Made

1. **`.github/escalation-policy.md`** - New escalation policy document defining when human review is required
2. **`charts/camunda-platform-8.10/templates/identity/configmap.yaml`** - Added token validation to auth provider
3. **`charts/camunda-platform-8.9/templates/identity/configmap.yaml`** - Same change in 8.9 (cross-version)
4. **`charts/camunda-platform-8.10/values.yaml`** - Added `identity.auth.tokenValidation` values section

### Validation Steps

Running `crev --dump-context` and full review to validate:
1. Policy document discovery works (found at `.github/escalation-policy.md`)
2. Workspace injection places `ESCALATION-POLICY.md` alongside `RUBRIC.md`
3. Escalation-assessor agent produces valid structured output
4. GitHub label and commit status are posted correctly

---
_This is a test PR for the crev review tooling. Will be closed without merge after validation._