### PR TITLE
ci: add OpenSearch template cleanup to per-test and nightly workflows

### DIFF
--- a/.github/workflows/cleanup-opensearch-entra.yaml
+++ b/.github/workflows/cleanup-opensearch-entra.yaml
@@ -84,6 +84,102 @@ jobs:
           #Exclude prefixes from `KEEP_PREFIXES`array
           EXCLUSIONS=$(printf -- ",-%s*" "${KEEP_PREFIXES[@]}" | cut -c2-)
           curl -L -X DELETE ${OPENSEARCH_HOST}/*,${EXCLUSIONS} -H "Authorization: Basic $OPENSEARCH_BASIC_AUTH_BASE64"
+      - name: cleanup OpenSearch templates
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          OPENSEARCH_HOST="${INFRA_OPENSEARCH_ENDPOINT}"
+          AUTH_HEADER="Authorization: Basic $OPENSEARCH_BASIC_AUTH_BASE64"
+          CURL_OPTS=(-L --silent --show-error --connect-timeout 10 --max-time 120 --retry 2 --retry-delay 5 --retry-connrefused)
+
+          ALL_NS=$(kubectl get namespaces -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n')
+          HEX_PREFIXES=($(echo "$ALL_NS" | grep -oP '[a-f0-9]{6}(?=(-upgp|-upgm)?$)' || true))
+          NUM_PREFIXES=($(echo "$ALL_NS" | grep -oP '\d+$' || true))
+          KEEP_PREFIXES=($(printf '%s\n' "${HEX_PREFIXES[@]}" "${NUM_PREFIXES[@]}" | sort -u))
+
+          is_kept_prefix() {
+            local name="$1"
+            for pfx in "${KEEP_PREFIXES[@]}"; do
+              if [[ "$name" == "${pfx}-"* ]]; then
+                return 0
+              fi
+            done
+            return 1
+          }
+
+          total_v2=0 total_comp=0 total_legacy=0
+
+          v2_templates=$(curl "${CURL_OPTS[@]}" -H "$AUTH_HEADER" "${OPENSEARCH_HOST}/_index_template" \
+            | jq -r '.index_templates[]?.name // empty | select(startswith(".") | not)') || true
+          if [[ -n "$v2_templates" ]]; then
+            orphan_prefixes=()
+            while IFS= read -r tpl; do
+              [[ -z "$tpl" ]] && continue
+              if ! is_kept_prefix "$tpl"; then
+                pfx="${tpl%%-*}"
+                orphan_prefixes+=("$pfx")
+              fi
+            done <<< "$v2_templates"
+            unique_orphans=($(printf '%s\n' "${orphan_prefixes[@]}" | sort -u))
+            for pfx in "${unique_orphans[@]}"; do
+              http_code=$(curl "${CURL_OPTS[@]}" -H "$AUTH_HEADER" -o /dev/null -w "%{http_code}" -X DELETE "${OPENSEARCH_HOST}/_index_template/${pfx}-*") || true
+              if [[ "$http_code" =~ ^2 ]]; then
+                echo "Deleted V2 index templates for prefix ${pfx}"
+                ((total_v2++)) || true
+              else
+                echo "Warning: Failed to delete V2 index templates for prefix ${pfx} (HTTP ${http_code})"
+              fi
+            done
+          fi
+
+          comp_templates=$(curl "${CURL_OPTS[@]}" -H "$AUTH_HEADER" "${OPENSEARCH_HOST}/_component_template" \
+            | jq -r '.component_templates[]?.name // empty | select(startswith(".") | not)') || true
+          if [[ -n "$comp_templates" ]]; then
+            orphan_prefixes=()
+            while IFS= read -r tpl; do
+              [[ -z "$tpl" ]] && continue
+              if ! is_kept_prefix "$tpl"; then
+                pfx="${tpl%%-*}"
+                orphan_prefixes+=("$pfx")
+              fi
+            done <<< "$comp_templates"
+            unique_orphans=($(printf '%s\n' "${orphan_prefixes[@]}" | sort -u))
+            for pfx in "${unique_orphans[@]}"; do
+              http_code=$(curl "${CURL_OPTS[@]}" -H "$AUTH_HEADER" -o /dev/null -w "%{http_code}" -X DELETE "${OPENSEARCH_HOST}/_component_template/${pfx}-*") || true
+              if [[ "$http_code" =~ ^2 ]]; then
+                echo "Deleted component templates for prefix ${pfx}"
+                ((total_comp++)) || true
+              else
+                echo "Warning: Failed to delete component templates for prefix ${pfx} (HTTP ${http_code})"
+              fi
+            done
+          fi
+
+          legacy_templates=$(curl "${CURL_OPTS[@]}" -H "$AUTH_HEADER" "${OPENSEARCH_HOST}/_template" \
+            | jq -r 'keys[] | select(startswith(".") | not)') || true
+          if [[ -n "$legacy_templates" ]]; then
+            orphan_prefixes=()
+            while IFS= read -r tpl; do
+              [[ -z "$tpl" ]] && continue
+              if ! is_kept_prefix "$tpl"; then
+                pfx="${tpl%%-*}"
+                orphan_prefixes+=("$pfx")
+              fi
+            done <<< "$legacy_templates"
+            unique_orphans=($(printf '%s\n' "${orphan_prefixes[@]}" | sort -u))
+            for pfx in "${unique_orphans[@]}"; do
+              http_code=$(curl "${CURL_OPTS[@]}" -H "$AUTH_HEADER" -o /dev/null -w "%{http_code}" -X DELETE "${OPENSEARCH_HOST}/_template/${pfx}-*") || true
+              if [[ "$http_code" =~ ^2 ]]; then
+                echo "Deleted legacy templates for prefix ${pfx}"
+                ((total_legacy++)) || true
+              else
+                echo "Warning: Failed to delete legacy templates for prefix ${pfx} (HTTP ${http_code})"
+              fi
+            done
+          fi
+
+          echo "OS template cleanup complete: v2_prefixes=${total_v2} component_prefixes=${total_comp} legacy_prefixes=${total_legacy}"
       - name: update ISM policy
         shell: bash
         run: |

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -1155,10 +1155,9 @@ jobs:
             secret/data/products/distribution/ci DISTRO_CI_GCP_GKE_CLUSTER_LOCATION;
             secret/data/products/distribution/ci DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER;
             secret/data/products/distribution/ci DISTRO_CI_GCP_SERVICE_ACCOUNT;
+            secret/data/products/distribution/ci DISTRO_AWS_OPENSEARCH_USERNAME | OPENSEARCH_USERNAME;
+            secret/data/products/distribution/ci DISTRO_AWS_OPENSEARCH_PASSWORD | OPENSEARCH_PASSWORD;
           exportEnv: true
-
-      # Tools (golang, helm, kubectl, oc, task, yq) are pre-installed in the CI runner container image
-      # See: .github/docker/ci-runner/Dockerfile
 
       - name: CI Setup - Authenticate to cluster
         id: cluster-auth
@@ -1312,3 +1311,83 @@ jobs:
           fi
 
           echo "ES template cleanup complete: v2_index=${deleted_index} component=${deleted_component} legacy=${deleted_legacy} failures=${failed}"
+
+      - name: CI Cleanup - Delete OpenSearch templates for this CI run
+        if: always()
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${OPENSEARCH_USERNAME:-}" || -z "${OPENSEARCH_PASSWORD:-}" ]]; then
+            echo "OpenSearch credentials not available. Skipping OS template cleanup."
+            exit 0
+          fi
+
+          OS_URL="${OPENSEARCH_PROTOCOL}://${OPENSEARCH_HOST}:${OPENSEARCH_PORT}"
+
+          HEX_PREFIX="${TEST_NAMESPACE##*-}"
+          if [[ "$HEX_PREFIX" == "upgm" || "$HEX_PREFIX" == "upgp" ]]; then
+            HEX_PREFIX="$(echo "$TEST_NAMESPACE" | sed "s/-${HEX_PREFIX}\$//" | sed 's/.*-//')"
+          fi
+
+          if ! [[ "$HEX_PREFIX" =~ ^[0-9a-f]{6}$ ]]; then
+            echo "Warning: Could not extract a valid 6-char hex prefix from namespace '${TEST_NAMESPACE}' (got '${HEX_PREFIX}'). Skipping OS template cleanup."
+            exit 0
+          fi
+
+          echo "Cleaning up OS templates with hex prefix: ${HEX_PREFIX}"
+
+          CURL_AUTH=(-u "${OPENSEARCH_USERNAME}:${OPENSEARCH_PASSWORD}")
+          CURL_OPTS=(--silent --show-error --connect-timeout 10 --max-time 60 --retry 2 --retry-delay 2 --retry-connrefused)
+
+          deleted_index=0
+          deleted_component=0
+          deleted_legacy=0
+          failed=0
+
+          v2_templates=$(curl "${CURL_OPTS[@]}" "${CURL_AUTH[@]}" "${OS_URL}/_index_template" | jq -r --arg pfx "$HEX_PREFIX" '.index_templates[]?.name // empty | select(startswith($pfx + "-"))') || true
+          if [[ -n "$v2_templates" ]]; then
+            echo "Found $(echo "$v2_templates" | wc -l | tr -d ' ') V2 index templates to delete"
+            http_code=$(curl "${CURL_OPTS[@]}" "${CURL_AUTH[@]}" -o /dev/null -w "%{http_code}" -X DELETE "${OS_URL}/_index_template/${HEX_PREFIX}-*") || true
+            if [[ "$http_code" =~ ^2 ]]; then
+              deleted_index=$(echo "$v2_templates" | wc -l | tr -d ' ')
+              echo "Deleted ${deleted_index} V2 index templates"
+            else
+              echo "Warning: Failed to delete V2 index templates (HTTP ${http_code})"
+              ((failed++)) || true
+            fi
+          else
+            echo "No V2 index templates found for prefix ${HEX_PREFIX}"
+          fi
+
+          comp_templates=$(curl "${CURL_OPTS[@]}" "${CURL_AUTH[@]}" "${OS_URL}/_component_template" | jq -r --arg pfx "$HEX_PREFIX" '.component_templates[]?.name // empty | select(startswith($pfx + "-"))') || true
+          if [[ -n "$comp_templates" ]]; then
+            echo "Found $(echo "$comp_templates" | wc -l | tr -d ' ') component templates to delete"
+            http_code=$(curl "${CURL_OPTS[@]}" "${CURL_AUTH[@]}" -o /dev/null -w "%{http_code}" -X DELETE "${OS_URL}/_component_template/${HEX_PREFIX}-*") || true
+            if [[ "$http_code" =~ ^2 ]]; then
+              deleted_component=$(echo "$comp_templates" | wc -l | tr -d ' ')
+              echo "Deleted ${deleted_component} component templates"
+            else
+              echo "Warning: Failed to delete component templates (HTTP ${http_code})"
+              ((failed++)) || true
+            fi
+          else
+            echo "No component templates found for prefix ${HEX_PREFIX}"
+          fi
+
+          legacy_templates=$(curl "${CURL_OPTS[@]}" "${CURL_AUTH[@]}" "${OS_URL}/_template" | jq -r --arg pfx "$HEX_PREFIX" 'keys[] | select(startswith($pfx + "-"))') || true
+          if [[ -n "$legacy_templates" ]]; then
+            echo "Found $(echo "$legacy_templates" | wc -l | tr -d ' ') legacy templates to delete"
+            http_code=$(curl "${CURL_OPTS[@]}" "${CURL_AUTH[@]}" -o /dev/null -w "%{http_code}" -X DELETE "${OS_URL}/_template/${HEX_PREFIX}-*") || true
+            if [[ "$http_code" =~ ^2 ]]; then
+              deleted_legacy=$(echo "$legacy_templates" | wc -l | tr -d ' ')
+              echo "Deleted ${deleted_legacy} legacy templates"
+            else
+              echo "Warning: Failed to delete legacy templates (HTTP ${http_code})"
+              ((failed++)) || true
+            fi
+          else
+            echo "No legacy templates found for prefix ${HEX_PREFIX}"
+          fi
+
+          echo "OS template cleanup complete: v2_index=${deleted_index} component=${deleted_component} legacy=${deleted_legacy} failures=${failed}"


### PR DESCRIPTION
## Summary

- Add per-test OpenSearch template cleanup step to the integration test runner cleanup job, mirroring the existing Elasticsearch template cleanup
- Add nightly OpenSearch template cleanup step to `cleanup-opensearch-entra.yaml` as a safety net for orphaned templates
- Add `OPENSEARCH_USERNAME`/`OPENSEARCH_PASSWORD` Vault imports to the cleanup job (previously missing, causing silent failures of OS index cleanup too)

Closes #6067

## Context

109K+ stale V2 index templates accumulated on AWS OpenSearch because:
1. Per-test OS index cleanup was broken (`OPENSEARCH_USERNAME`/`OPENSEARCH_PASSWORD` never imported in cleanup job) — fixed here and in #6035
2. No per-test OS template cleanup existed at all (only ES had one)
3. Nightly cleanup only handled indices, not templates

The in-cluster OpenSearch pools were unaffected because they have a CronJob (`ci-cleanup-opensearch.sh`) that already handles all three template types.

A one-time manual purge of all 109K+ stale templates was performed on 2026-05-07 to restore AWS OpenSearch to a clean state. This PR prevents re-accumulation.

## Changes

### Per-test cleanup (`test-integration-runner.yaml`)
- Added `DISTRO_AWS_OPENSEARCH_USERNAME`/`PASSWORD` to the cleanup job's Vault import (these were missing — the existing OS index cleanup on lines 1210/1219 was silently failing)
- Added new "Delete OpenSearch templates for this CI run" step after the ES template cleanup step
- Deletes V2 index templates, component templates, and legacy templates matching `${HEX_PREFIX}-*`
- Handles both `-upgm` and `-upgp` namespace suffixes

### Nightly cleanup (`cleanup-opensearch-entra.yaml`)
- Added "cleanup OpenSearch templates" step between index cleanup and ISM policy update
- Lists all non-system templates, identifies orphan prefixes not matching any active namespace, deletes by wildcard per prefix
- Acts as a safety net for any templates missed by per-test cleanup

## Test plan

- [ ] Verify `actionlint` passes with no new errors (confirmed locally — only pre-existing SC2207/SC2086 warnings)
- [ ] Verify YAML parses correctly (confirmed locally via `python3 yaml.safe_load`)
- [ ] Monitor next qaos CI run for "OS template cleanup complete" log lines in the cleanup job
- [ ] Monitor next nightly run (1 AM UTC) for template cleanup output