### PR TITLE
fix(ci): add migrator feature to qa-elasticsearch-upg upgrade-minor scenario

### DIFF
--- a/charts/camunda-platform-8.8/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.8/test/ci-test-config.yaml
@@ -359,6 +359,7 @@ integration:
           auth: keycloak
           identity: keycloak
           persistence: elasticsearch
+          features: [migrator]
           qa: true
           platforms: [gke]
         - name: qa-elasticsearch-document-upg


### PR DESCRIPTION
## Summary

- The `qa-elasticsearch-upg` `modular-upgrade-minor` scenario was missing `features: [migrator]`, causing the Identity and data migration jobs to not run during the 8.7→8.8 upgrade in the nightly SM 8.8 Upgrade Minor workflow
- Without the Identity migrator, lisa and bart's 8.7 `Zeebe` role is not remapped to the 8.8 `Orchestration` role → Web Modeler returns "You do not have the permissions needed to deploy or run instances on the integration-zeebe cluster"
- Without the data migrator, completed 8.7 Zeebe task records are not migrated to the 8.8 Tasklist schema → `Zeebe_User_Task_Process` is not visible in Tasklist after upgrade

Failing nightly run: https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25419238655
Successful run after the fix: https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25482446833/job/74772187929

## Test plan

- [ ] Trigger SM On-Demand 8.8 Upgrade Minor from this branch and confirm `migration-path-user-flows.spec.ts` passes — specifically `Assert Lisa User Can Deploy Processes`, `Assert Bart User Can Deploy Processes`, and `Assert Most Common Flow User Flow With All Apps Process Migration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)