### PR TITLE
fix(ci): restore OCI install path broken by #6016

### DIFF
--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -494,33 +494,13 @@ jobs:
             fi
           fi
 
-      - name: Helm - Install (OCI)
+      - name: Helm - OCI Registry Login
         if: inputs.helmChartVersion != ''
-        env:
-          HELM_CHART_VERSION: ${{ inputs.helmChartVersion }}
         run: |
-          set -euo pipefail
-          # OCI install path: pull a published chart from Harbor and stash a marker
-          # for the matrix-run step. The matrix-run install path below skips itself
-          # when this OCI marker is present.
-          echo "Using OCI chart version: ${HELM_CHART_VERSION}"
           helm registry login registry.camunda.cloud \
             --username "${TEST_DOCKER_USERNAME_CAMUNDA_CLOUD}" \
             --password "${TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD}"
-
-          cd "${CI_TASKS_BASE_DIR}/chart-full-setup"
-          rm -f ./*.tgz
-          helm pull "oci://registry.camunda.cloud/team-distribution/camunda-platform" \
-            --version "${HELM_CHART_VERSION}" \
-            --destination .
-
-          echo "TEST_CHART_VERSION=${HELM_CHART_VERSION}" >> "$GITHUB_ENV"
-          # TODO(deploy-camunda): wire OCI chart deploy through `deploy-camunda matrix run`
-          # once it learns to install from a local .tgz. Until then, fall back to
-          # `helm install` here. This branch is currently unused by all active CI callers
-          # (every caller passes helmChartVersion: "").
-          echo "::error::OCI install path is not yet supported by deploy-camunda matrix run; this CI flow is currently inert."
-          exit 1
+          echo "TEST_CHART_VERSION=${{ inputs.helmChartVersion }}" >> "$GITHUB_ENV"
 
       - name: Helm - Install - 🌟 Install Camunda chart 🌟
         # For upgrade flows, the upgrade job runs the full two-step orchestration
@@ -528,7 +508,7 @@ jobs:
         # The install job only deploys for plain `install` flow; for upgrade-patch /
         # upgrade-minor it stops after pre-install setup so the upgrade job can take
         # over a clean (but pre-secret-configured) namespace.
-        if: inputs.helmChartVersion == '' && inputs.flow == 'install'
+        if: inputs.flow == 'install'
         env:
           TEST_CHART_FLOW: ${{ inputs.flow }}
           # CAMUNDA_HOSTNAME is required by layered values (e.g. base.yaml contains $CAMUNDA_HOSTNAME)
@@ -550,6 +530,7 @@ jobs:
           TEST_IMAGE_TAGS: ${{ inputs.include-image-tags }}
           TEST_VALUES_SCENARIO: "${{ inputs.scenario }}"
           VALUES_CONFIG: ${{ inputs.values-config }}
+          HELM_CHART_VERSION: ${{ inputs.helmChartVersion }}
         run: |
           set -euo pipefail
           CHART_VERSION="${CAMUNDA_HELM_DIR#camunda-platform-}"
@@ -579,6 +560,14 @@ jobs:
             done
           fi
 
+          # OCI chart override: when helmChartVersion is set, deploy from the published
+          # OCI artifact instead of the local git chart directory.
+          CHART_REF_ARGS=()
+          if [[ -n "${HELM_CHART_VERSION:-}" ]]; then
+            CHART_REF_ARGS+=(--chart-ref "oci://registry.camunda.cloud/team-distribution/camunda-platform")
+            CHART_REF_ARGS+=(--chart-version "${HELM_CHART_VERSION}")
+          fi
+
           cd ./scripts/deploy-camunda
           go run . matrix run \
             --repo-root "${GITHUB_WORKSPACE}" \
@@ -593,6 +582,7 @@ jobs:
             --skip-dependency-update=false \
             --timeout 20 \
             --extra-helm-set "global.host=${{ steps.setup.outputs.ingress-host }}" \
+            ${CHART_REF_ARGS[@]+"${CHART_REF_ARGS[@]}"} \
             ${EXTRA_HELM_ARGS[@]+"${EXTRA_HELM_ARGS[@]}"} \
             --log-level info
 
@@ -777,6 +767,13 @@ jobs:
         run: |
           kubectl -n "$TEST_NAMESPACE" apply -f /tmp/vault-mapped-secrets.yaml
 
+      - name: Helm - OCI Registry Login (Upgrade)
+        if: inputs.helmChartVersion != ''
+        run: |
+          helm registry login registry.camunda.cloud \
+            --username "${TEST_DOCKER_USERNAME_CAMUNDA_CLOUD}" \
+            --password "${TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD}"
+
       - name: Helm - Upgrade - 🌟 Upgrade Camunda chart 🌟
         env:
           TEST_CHART_FLOW: ${{ inputs.flow }}
@@ -796,6 +793,7 @@ jobs:
           TEST_IMAGE_TAGS: ${{ inputs.include-image-tags }}
           TEST_VALUES_SCENARIO: "${{ inputs.scenario }}"
           VALUES_CONFIG: ${{ inputs.values-config }}
+          HELM_CHART_VERSION: ${{ inputs.helmChartVersion }}
         run: |
           set -euo pipefail
           CHART_VERSION="${CAMUNDA_HELM_DIR#camunda-platform-}"
@@ -820,6 +818,15 @@ jobs:
             done
           fi
 
+          # OCI chart override: when helmChartVersion is set, upgrade to the published
+          # OCI artifact instead of the local git chart directory. Step 1 (installing
+          # the previous version) still uses the Helm repo — only Step 2 uses the OCI ref.
+          CHART_REF_ARGS=()
+          if [[ -n "${HELM_CHART_VERSION:-}" ]]; then
+            CHART_REF_ARGS+=(--chart-ref "oci://registry.camunda.cloud/team-distribution/camunda-platform")
+            CHART_REF_ARGS+=(--chart-version "${HELM_CHART_VERSION}")
+          fi
+
           cd ./scripts/deploy-camunda
           go run . matrix run \
             --repo-root "${GITHUB_WORKSPACE}" \
@@ -834,6 +841,7 @@ jobs:
             --skip-dependency-update=false \
             --timeout 20 \
             --extra-helm-set "global.host=${{ steps.setup.outputs.ingress-host }}" \
+            ${CHART_REF_ARGS[@]+"${CHART_REF_ARGS[@]}"} \
             ${EXTRA_HELM_ARGS[@]+"${EXTRA_HELM_ARGS[@]}"} \
             --log-level info
 

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -497,9 +497,9 @@ jobs:
       - name: Helm - OCI Registry Login
         if: inputs.helmChartVersion != ''
         run: |
-          helm registry login registry.camunda.cloud \
+          printf '%s' "${TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD}" | helm registry login registry.camunda.cloud \
             --username "${TEST_DOCKER_USERNAME_CAMUNDA_CLOUD}" \
-            --password "${TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD}"
+            --password-stdin
           echo "TEST_CHART_VERSION=${{ inputs.helmChartVersion }}" >> "$GITHUB_ENV"
 
       - name: Helm - Install - 🌟 Install Camunda chart 🌟
@@ -770,9 +770,9 @@ jobs:
       - name: Helm - OCI Registry Login (Upgrade)
         if: inputs.helmChartVersion != ''
         run: |
-          helm registry login registry.camunda.cloud \
+          printf '%s' "${TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD}" | helm registry login registry.camunda.cloud \
             --username "${TEST_DOCKER_USERNAME_CAMUNDA_CLOUD}" \
-            --password "${TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD}"
+            --password-stdin
 
       - name: Helm - Upgrade - 🌟 Upgrade Camunda chart 🌟
         env:

--- a/scripts/deploy-camunda/cmd/matrix.go
+++ b/scripts/deploy-camunda/cmd/matrix.go
@@ -201,6 +201,9 @@ Each entry gets its own namespace (<prefix>-<version>-<shortname>).
 Use --cleanup to automatically delete each entry's namespace after its deployment and tests complete.
 
 This command calls deploy.Execute() for each matrix entry.`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return validateChartRefFlags(chartRef, chartRefVersion)
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Create a signal-aware context so that Ctrl+C (SIGINT) and
 			// SIGTERM cancel the context, which propagates through
@@ -714,4 +717,37 @@ func resolveRepoRoot(flagValue string) string {
 	}
 
 	return ""
+}
+
+// validateChartRefFlags rejects inconsistent --chart-ref / --chart-version
+// combinations before any matrix entries run, so misconfiguration surfaces as
+// a clear CLI error rather than a confusing helm failure.
+//
+// Rules:
+//   - --chart-version requires --chart-ref (it has no meaning otherwise).
+//   - --chart-ref must be either an OCI reference (oci://...) or a path to a
+//     packaged chart (*.tgz). Bare directory paths are rejected because
+//     deploy-camunda already supports local-directory installs via the normal
+//     (non-overridden) chart path.
+//   - When --chart-ref is an OCI reference, --chart-version is required —
+//     otherwise helm would resolve to an arbitrary tag.
+func validateChartRefFlags(chartRef, chartRefVersion string) error {
+	if chartRef == "" {
+		if chartRefVersion != "" {
+			return fmt.Errorf("--chart-version requires --chart-ref")
+		}
+		return nil
+	}
+
+	isOCI := strings.HasPrefix(chartRef, "oci://")
+	isTGZ := strings.HasSuffix(chartRef, ".tgz")
+	if !isOCI && !isTGZ {
+		return fmt.Errorf("--chart-ref must be an OCI reference (oci://...) or a packaged chart (.tgz), got %q", chartRef)
+	}
+
+	if isOCI && chartRefVersion == "" {
+		return fmt.Errorf("--chart-version is required when --chart-ref is an OCI reference")
+	}
+
+	return nil
 }

--- a/scripts/deploy-camunda/cmd/matrix.go
+++ b/scripts/deploy-camunda/cmd/matrix.go
@@ -188,6 +188,8 @@ func newMatrixRunCommand() *cobra.Command {
 		namespaceOverride        string
 		shortnameExact           bool
 		tier                     int
+		chartRef                 string
+		chartRefVersion          string
 	)
 
 	cmd := &cobra.Command{
@@ -497,6 +499,8 @@ This command calls deploy.Execute() for each matrix entry.`,
 				ExtraHelmArgs:         extraHelmArgs,
 				ExtraHelmSets:         extraHelmSets,
 				NamespaceOverride:     namespaceOverride,
+				ChartRef:              chartRef,
+				ChartRefVersion:       chartRefVersion,
 				OnEntryStart: func(entry matrix.Entry, namespace string) {
 					if statusDisplay != nil {
 						statusDisplay.OnEntryStart(entry, namespace)
@@ -589,6 +593,8 @@ This command calls deploy.Execute() for each matrix entry.`,
 	f.StringArrayVar(&extraHelmArgs, "extra-helm-arg", nil, "Extra argument appended to every helm command (repeatable, e.g. --extra-helm-arg=--set-file=global.license.secret.inlineSecret=/tmp/license.txt)")
 	f.StringSliceVar(&extraHelmSets, "extra-helm-set", nil, "Extra helm --set key=value pair applied to every entry (comma-separated or repeatable, e.g. orchestration.upgrade.allowPreReleaseImages=true)")
 	f.StringVar(&namespaceOverride, "namespace-override", "", "Override the computed namespace for every entry. Use only with filters that narrow the run to a single entry (typically called from per-scenario CI workflows that pre-create the namespace).")
+	f.StringVar(&chartRef, "chart-ref", "", "Override chart source with an OCI reference or .tgz path (e.g., oci://registry.camunda.cloud/team-distribution/camunda-platform). Values are still resolved from the local repo via --repo-root.")
+	f.StringVar(&chartRefVersion, "chart-version", "", "Chart version to install from --chart-ref (e.g., 13-rc-latest). Only meaningful when --chart-ref is set.")
 	f.IntVar(&tier, "tier", 0, "Filter entries by tier (1=PR CI, 2=merge-queue only; 0=all)")
 
 	registerMatrixShortnameCompletion(cmd)

--- a/scripts/deploy-camunda/cmd/matrix_test.go
+++ b/scripts/deploy-camunda/cmd/matrix_test.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateChartRefFlags(t *testing.T) {
+	tests := []struct {
+		name            string
+		chartRef        string
+		chartRefVersion string
+		wantErr         string // substring; empty = expect success
+	}{
+		{
+			name:    "both empty is allowed",
+			wantErr: "",
+		},
+		{
+			name:            "version without ref is rejected",
+			chartRefVersion: "13-rc-latest",
+			wantErr:         "--chart-version requires --chart-ref",
+		},
+		{
+			name:            "OCI ref with version is allowed",
+			chartRef:        "oci://registry.camunda.cloud/team-distribution/camunda-platform",
+			chartRefVersion: "13-rc-latest",
+		},
+		{
+			name:     "OCI ref without version is rejected",
+			chartRef: "oci://registry.camunda.cloud/team-distribution/camunda-platform",
+			wantErr:  "--chart-version is required when --chart-ref is an OCI reference",
+		},
+		{
+			name:     "tgz ref without version is allowed",
+			chartRef: "/tmp/camunda-platform-13.4.0-rc.tgz",
+		},
+		{
+			name:            "tgz ref with version is allowed",
+			chartRef:        "/tmp/camunda-platform-13.4.0-rc.tgz",
+			chartRefVersion: "13.4.0-rc",
+		},
+		{
+			name:     "directory ref is rejected",
+			chartRef: "/tmp/camunda-platform-8.9",
+			wantErr:  "must be an OCI reference (oci://...) or a packaged chart (.tgz)",
+		},
+		{
+			name:     "bare chart name is rejected",
+			chartRef: "camunda/camunda-platform",
+			wantErr:  "must be an OCI reference (oci://...) or a packaged chart (.tgz)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateChartRefFlags(tt.chartRef, tt.chartRefVersion)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+			}
+		})
+	}
+}

--- a/scripts/deploy-camunda/matrix/matrix_test.go
+++ b/scripts/deploy-camunda/matrix/matrix_test.go
@@ -1669,14 +1669,15 @@ func TestExtractBitnamiPGPasswords_MappingConsistency(t *testing.T) {
 
 // --- ChartRef override tests ---
 
-func TestChartRefOverride_AppliedToFlags(t *testing.T) {
-	// Verify that when ChartRef is set in RunOptions, the chart-ref override
-	// logic correctly sets Chart, ChartVersion, and forces SkipDependencyUpdate.
-	// This simulates the logic in executeEntry() without calling deploy.Execute().
+func TestApplyChartRefOverride(t *testing.T) {
+	// Verify that applyChartRefOverride correctly mutates ChartFlags when
+	// RunOptions.ChartRef is set, and is a no-op when it is empty. This
+	// exercises the same helper that executeEntry calls in production.
 	tests := []struct {
 		name            string
 		chartRef        string
 		chartRefVersion string
+		wantApplied     bool
 		wantChart       string
 		wantVersion     string
 		wantSkipDep     bool
@@ -1685,6 +1686,7 @@ func TestChartRefOverride_AppliedToFlags(t *testing.T) {
 			name:            "OCI reference",
 			chartRef:        "oci://registry.camunda.cloud/team-distribution/camunda-platform",
 			chartRefVersion: "13-rc-latest",
+			wantApplied:     true,
 			wantChart:       "oci://registry.camunda.cloud/team-distribution/camunda-platform",
 			wantVersion:     "13-rc-latest",
 			wantSkipDep:     true,
@@ -1693,6 +1695,7 @@ func TestChartRefOverride_AppliedToFlags(t *testing.T) {
 			name:            "local tgz path",
 			chartRef:        "/tmp/oci-chart/camunda-platform-13.4.0-rc.tgz",
 			chartRefVersion: "",
+			wantApplied:     true,
 			wantChart:       "/tmp/oci-chart/camunda-platform-13.4.0-rc.tgz",
 			wantVersion:     "",
 			wantSkipDep:     true,
@@ -1701,6 +1704,7 @@ func TestChartRefOverride_AppliedToFlags(t *testing.T) {
 			name:            "empty chart-ref does not override",
 			chartRef:        "",
 			chartRefVersion: "",
+			wantApplied:     false,
 			wantChart:       "",
 			wantVersion:     "",
 			wantSkipDep:     false,
@@ -1714,31 +1718,28 @@ func TestChartRefOverride_AppliedToFlags(t *testing.T) {
 				ChartRefVersion: tt.chartRefVersion,
 			}
 
-			// Simulate the flags struct built in executeEntry().
-			flags := &config.ChartFlags{
+			chart := &config.ChartFlags{
 				ChartPath:            "/path/to/charts/camunda-platform-8.9",
 				SkipDependencyUpdate: false,
 			}
 
-			// Apply the chart-ref override logic (mirrors executeEntry).
-			if opts.ChartRef != "" {
-				flags.Chart = opts.ChartRef
-				flags.ChartVersion = opts.ChartRefVersion
-				flags.SkipDependencyUpdate = true
-			}
+			applied := applyChartRefOverride(chart, opts)
 
-			if flags.Chart != tt.wantChart {
-				t.Errorf("Chart = %q, want %q", flags.Chart, tt.wantChart)
+			if applied != tt.wantApplied {
+				t.Errorf("applyChartRefOverride returned %v, want %v", applied, tt.wantApplied)
 			}
-			if flags.ChartVersion != tt.wantVersion {
-				t.Errorf("ChartVersion = %q, want %q", flags.ChartVersion, tt.wantVersion)
+			if chart.Chart != tt.wantChart {
+				t.Errorf("Chart = %q, want %q", chart.Chart, tt.wantChart)
 			}
-			if flags.SkipDependencyUpdate != tt.wantSkipDep {
-				t.Errorf("SkipDependencyUpdate = %v, want %v", flags.SkipDependencyUpdate, tt.wantSkipDep)
+			if chart.ChartVersion != tt.wantVersion {
+				t.Errorf("ChartVersion = %q, want %q", chart.ChartVersion, tt.wantVersion)
+			}
+			if chart.SkipDependencyUpdate != tt.wantSkipDep {
+				t.Errorf("SkipDependencyUpdate = %v, want %v", chart.SkipDependencyUpdate, tt.wantSkipDep)
 			}
 			// ChartPath must always be preserved for values resolution.
-			if flags.ChartPath != "/path/to/charts/camunda-platform-8.9" {
-				t.Errorf("ChartPath should be preserved, got %q", flags.ChartPath)
+			if chart.ChartPath != "/path/to/charts/camunda-platform-8.9" {
+				t.Errorf("ChartPath should be preserved, got %q", chart.ChartPath)
 			}
 		})
 	}
@@ -1753,12 +1754,12 @@ func TestChartRefOverride_UpgradeStep1Unaffected(t *testing.T) {
 		ChartRefVersion: "13-rc-latest",
 	}
 
-	// Simulate: base flags have the chart-ref override applied (from executeEntry).
+	// Apply the override the same way executeEntry does.
 	baseFlags := &config.ChartFlags{
-		ChartPath:            "/path/to/charts/camunda-platform-8.9",
-		Chart:                opts.ChartRef,
-		ChartVersion:         opts.ChartRefVersion,
-		SkipDependencyUpdate: true,
+		ChartPath: "/path/to/charts/camunda-platform-8.9",
+	}
+	if !applyChartRefOverride(baseFlags, opts) {
+		t.Fatal("applyChartRefOverride returned false for non-empty ChartRef")
 	}
 
 	// Simulate what executeTwoStepUpgrade does for Step 1:

--- a/scripts/deploy-camunda/matrix/matrix_test.go
+++ b/scripts/deploy-camunda/matrix/matrix_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"scripts/camunda-core/pkg/versionmatrix"
 	"scripts/camunda-deployer/pkg/deployer"
 	"scripts/deploy-camunda/config"
 	"scripts/deploy-camunda/deploy"
@@ -1766,15 +1767,15 @@ func TestChartRefOverride_UpgradeStep1Unaffected(t *testing.T) {
 	// step1Flags := *flags
 	// step1Flags.Chart.Chart = versionmatrix.DefaultHelmChartRef
 	step1Flags := *baseFlags
-	step1Flags.Chart = "camunda/camunda-platform" // DefaultHelmChartRef
-	step1Flags.ChartVersion = "12.5.0"            // Previous version
-	step1Flags.ChartPath = ""                     // Use repo chart, not local path
-	step1Flags.SkipDependencyUpdate = true        // Repo charts don't need dep update
-	step1Flags.ChartRootOverlays = nil            // No overlays for Step 1
+	step1Flags.Chart = versionmatrix.DefaultHelmChartRef
+	step1Flags.ChartVersion = "12.5.0"     // Previous version
+	step1Flags.ChartPath = ""              // Use repo chart, not local path
+	step1Flags.SkipDependencyUpdate = true // Repo charts don't need dep update
+	step1Flags.ChartRootOverlays = nil     // No overlays for Step 1
 
 	// Step 1 should use the Helm repo ref, not the OCI override.
-	if step1Flags.Chart != "camunda/camunda-platform" {
-		t.Errorf("Step 1 Chart = %q, want %q (should not use ChartRef)", step1Flags.Chart, "camunda/camunda-platform")
+	if step1Flags.Chart != versionmatrix.DefaultHelmChartRef {
+		t.Errorf("Step 1 Chart = %q, want %q (should not use ChartRef)", step1Flags.Chart, versionmatrix.DefaultHelmChartRef)
 	}
 	if step1Flags.ChartVersion != "12.5.0" {
 		t.Errorf("Step 1 ChartVersion = %q, want %q", step1Flags.ChartVersion, "12.5.0")

--- a/scripts/deploy-camunda/matrix/matrix_test.go
+++ b/scripts/deploy-camunda/matrix/matrix_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"scripts/camunda-deployer/pkg/deployer"
+	"scripts/deploy-camunda/config"
 	"scripts/deploy-camunda/deploy"
 )
 
@@ -1663,5 +1664,127 @@ func TestExtractBitnamiPGPasswords_MappingConsistency(t *testing.T) {
 			}
 			allPaths[hp] = secretKey
 		}
+	}
+}
+
+// --- ChartRef override tests ---
+
+func TestChartRefOverride_AppliedToFlags(t *testing.T) {
+	// Verify that when ChartRef is set in RunOptions, the chart-ref override
+	// logic correctly sets Chart, ChartVersion, and forces SkipDependencyUpdate.
+	// This simulates the logic in executeEntry() without calling deploy.Execute().
+	tests := []struct {
+		name            string
+		chartRef        string
+		chartRefVersion string
+		wantChart       string
+		wantVersion     string
+		wantSkipDep     bool
+	}{
+		{
+			name:            "OCI reference",
+			chartRef:        "oci://registry.camunda.cloud/team-distribution/camunda-platform",
+			chartRefVersion: "13-rc-latest",
+			wantChart:       "oci://registry.camunda.cloud/team-distribution/camunda-platform",
+			wantVersion:     "13-rc-latest",
+			wantSkipDep:     true,
+		},
+		{
+			name:            "local tgz path",
+			chartRef:        "/tmp/oci-chart/camunda-platform-13.4.0-rc.tgz",
+			chartRefVersion: "",
+			wantChart:       "/tmp/oci-chart/camunda-platform-13.4.0-rc.tgz",
+			wantVersion:     "",
+			wantSkipDep:     true,
+		},
+		{
+			name:            "empty chart-ref does not override",
+			chartRef:        "",
+			chartRefVersion: "",
+			wantChart:       "",
+			wantVersion:     "",
+			wantSkipDep:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := RunOptions{
+				ChartRef:        tt.chartRef,
+				ChartRefVersion: tt.chartRefVersion,
+			}
+
+			// Simulate the flags struct built in executeEntry().
+			flags := &config.ChartFlags{
+				ChartPath:            "/path/to/charts/camunda-platform-8.9",
+				SkipDependencyUpdate: false,
+			}
+
+			// Apply the chart-ref override logic (mirrors executeEntry).
+			if opts.ChartRef != "" {
+				flags.Chart = opts.ChartRef
+				flags.ChartVersion = opts.ChartRefVersion
+				flags.SkipDependencyUpdate = true
+			}
+
+			if flags.Chart != tt.wantChart {
+				t.Errorf("Chart = %q, want %q", flags.Chart, tt.wantChart)
+			}
+			if flags.ChartVersion != tt.wantVersion {
+				t.Errorf("ChartVersion = %q, want %q", flags.ChartVersion, tt.wantVersion)
+			}
+			if flags.SkipDependencyUpdate != tt.wantSkipDep {
+				t.Errorf("SkipDependencyUpdate = %v, want %v", flags.SkipDependencyUpdate, tt.wantSkipDep)
+			}
+			// ChartPath must always be preserved for values resolution.
+			if flags.ChartPath != "/path/to/charts/camunda-platform-8.9" {
+				t.Errorf("ChartPath should be preserved, got %q", flags.ChartPath)
+			}
+		})
+	}
+}
+
+func TestChartRefOverride_UpgradeStep1Unaffected(t *testing.T) {
+	// Verify that when ChartRef is set, Step 1 of an upgrade flow still uses
+	// the DefaultHelmChartRef (from versionmatrix), not the ChartRef override.
+	// This is because executeTwoStepUpgrade creates step1Flags independently.
+	opts := RunOptions{
+		ChartRef:        "oci://registry.camunda.cloud/team-distribution/camunda-platform",
+		ChartRefVersion: "13-rc-latest",
+	}
+
+	// Simulate: base flags have the chart-ref override applied (from executeEntry).
+	baseFlags := &config.ChartFlags{
+		ChartPath:            "/path/to/charts/camunda-platform-8.9",
+		Chart:                opts.ChartRef,
+		ChartVersion:         opts.ChartRefVersion,
+		SkipDependencyUpdate: true,
+	}
+
+	// Simulate what executeTwoStepUpgrade does for Step 1:
+	// step1Flags := *flags
+	// step1Flags.Chart.Chart = versionmatrix.DefaultHelmChartRef
+	step1Flags := *baseFlags
+	step1Flags.Chart = "camunda/camunda-platform" // DefaultHelmChartRef
+	step1Flags.ChartVersion = "12.5.0"            // Previous version
+	step1Flags.ChartPath = ""                     // Use repo chart, not local path
+	step1Flags.SkipDependencyUpdate = true        // Repo charts don't need dep update
+	step1Flags.ChartRootOverlays = nil            // No overlays for Step 1
+
+	// Step 1 should use the Helm repo ref, not the OCI override.
+	if step1Flags.Chart != "camunda/camunda-platform" {
+		t.Errorf("Step 1 Chart = %q, want %q (should not use ChartRef)", step1Flags.Chart, "camunda/camunda-platform")
+	}
+	if step1Flags.ChartVersion != "12.5.0" {
+		t.Errorf("Step 1 ChartVersion = %q, want %q", step1Flags.ChartVersion, "12.5.0")
+	}
+
+	// Step 2 should inherit the ChartRef override from baseFlags.
+	step2Flags := *baseFlags
+	if step2Flags.Chart != opts.ChartRef {
+		t.Errorf("Step 2 Chart = %q, want %q (should inherit ChartRef)", step2Flags.Chart, opts.ChartRef)
+	}
+	if step2Flags.ChartVersion != opts.ChartRefVersion {
+		t.Errorf("Step 2 ChartVersion = %q, want %q", step2Flags.ChartVersion, opts.ChartRefVersion)
 	}
 }

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -192,6 +192,27 @@ type RunOptions struct {
 	ChartRefVersion string
 }
 
+// applyChartRefOverride mutates chart to point at opts.ChartRef (an OCI reference
+// or a local .tgz path) when set, and forces SkipDependencyUpdate so helm does
+// not try to run `dependency update` against an external/packaged chart.
+// ChartPath is left untouched so values-file resolution (scenario directory,
+// chart-root overlays) still uses the local repo. It returns true when the
+// override was applied. Centralizing this logic here lets executeEntry and
+// tests share a single code path.
+func applyChartRefOverride(chart *config.ChartFlags, opts RunOptions) bool {
+	if opts.ChartRef == "" {
+		return false
+	}
+	chart.Chart = opts.ChartRef
+	chart.ChartVersion = opts.ChartRefVersion
+	chart.SkipDependencyUpdate = true
+	logging.Logger.Info().
+		Str("chartRef", opts.ChartRef).
+		Str("chartVersion", opts.ChartRefVersion).
+		Msg("Using external chart reference (OCI/tgz) instead of local chart directory")
+	return true
+}
+
 // RunResult holds the result of a single matrix entry execution.
 type RunResult struct {
 	Entry       Entry
@@ -511,20 +532,27 @@ func formatDryRunOutput(entries []dryRunEntry, versions []string, opts RunOption
 
 			// Upgrade plan — show two-step upgrade details for two-step upgrade flows,
 			// or upgrade-only details for modular-upgrade-minor.
+			step2Target := "local chart"
+			if opts.ChartRef != "" {
+				step2Target = opts.ChartRef
+				if opts.ChartRefVersion != "" {
+					step2Target += "@" + opts.ChartRefVersion
+				}
+			}
 			if e.upgradeOnly && e.upgradeFromVersion != "" {
 				fmt.Fprintf(&b, "      %s %s %s → %s %s\n",
 					dryKey("upgrade:"),
 					dryDim("upgrade-only (no install step), expects"),
 					dryWarn(versionmatrix.DefaultHelmChartRef+"@"+e.upgradeFromVersion),
 					dryDim("already running, upgrading to"),
-					dryWarn("local chart"))
+					dryWarn(step2Target))
 			} else if !e.upgradeOnly && e.upgradeFromVersion != "" {
 				fmt.Fprintf(&b, "      %s %s %s → %s %s\n",
 					dryKey("upgrade:"),
 					dryDim("Step 1: install"),
 					dryWarn(versionmatrix.DefaultHelmChartRef+"@"+e.upgradeFromVersion),
 					dryDim("Step 2: upgrade to"),
-					dryWarn("local chart"))
+					dryWarn(step2Target))
 				// For upgrade-minor, Step 1 uses the previous version's values files.
 				// Show this explicitly so operators know values come from a different chart dir.
 				if e.step1ValuesFrom != "" {
@@ -1773,18 +1801,8 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions, entryIndex 
 	var diag string
 
 	// Override chart source when --chart-ref is set (OCI install path).
-	// This makes deploy.Execute() use the external chart reference (e.g., oci://registry.camunda.cloud/...)
-	// instead of the local chart directory. ChartPath is preserved for values file resolution
-	// (scenario directory, chart-root overlays) but not used as the helm install target.
-	if opts.ChartRef != "" {
-		flags.Chart.Chart = opts.ChartRef
-		flags.Chart.ChartVersion = opts.ChartRefVersion
-		flags.Chart.SkipDependencyUpdate = true
-		logging.Logger.Info().
-			Str("chartRef", opts.ChartRef).
-			Str("chartVersion", opts.ChartRefVersion).
-			Msg("Using external chart reference (OCI/tgz) instead of local chart directory")
-	}
+	// See applyChartRefOverride for details.
+	applyChartRefOverride(&flags.Chart, opts)
 
 	// Two-step upgrade flow: install old version first, then upgrade to current.
 	if versionmatrix.IsTwoStepUpgradeFlow(entry.Flow) {
@@ -2118,15 +2136,23 @@ func executeTwoStepUpgrade(ctx context.Context, entry Entry, flags *config.Runti
 		}
 	}
 
-	// --- Step 2: Upgrade to current on-disk chart ---
+	// --- Step 2: Upgrade to current on-disk chart (or external chart-ref when set) ---
 	if flags.OnPhase != nil {
 		flags.OnPhase("step-2")
 	}
-	logging.Logger.Info().
+	step2Log := logging.Logger.Info().
 		Str("step", "2/2").
-		Str("action", "upgrade").
-		Str("chartPath", entry.ChartPath).
-		Msg("Step 2: Upgrading to current chart version")
+		Str("action", "upgrade")
+	if opts.ChartRef != "" {
+		step2Log.
+			Str("chartRef", opts.ChartRef).
+			Str("chartVersion", opts.ChartRefVersion).
+			Msg("Step 2: Upgrading to chart from --chart-ref")
+	} else {
+		step2Log.
+			Str("chartPath", entry.ChartPath).
+			Msg("Step 2: Upgrading to current chart version")
+	}
 
 	// Clone flags for Step 2: upgrade from installed state to local chart.
 	step2Flags := *flags
@@ -2149,6 +2175,9 @@ func executeTwoStepUpgrade(ctx context.Context, entry Entry, flags *config.Runti
 	}
 
 	if err := deploy.Execute(ctx, &step2Flags); err != nil {
+		if opts.ChartRef != "" {
+			return fmt.Errorf("step 2: upgrade to %s@%s failed: %w", opts.ChartRef, opts.ChartRefVersion, err)
+		}
 		return fmt.Errorf("step 2: upgrade to local chart failed: %w", err)
 	}
 

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -180,6 +180,16 @@ type RunOptions struct {
 	// invoking matrix run, so the install lands in the same namespace.
 	// Only meaningful when filters narrow the run to a single entry.
 	NamespaceOverride string
+	// ChartRef, when non-empty, overrides the chart source for helm install/upgrade.
+	// This can be an OCI reference (e.g., "oci://registry.camunda.cloud/team-distribution/camunda-platform")
+	// or a path to a local .tgz file. When set, the matrix runner uses this as the
+	// chart argument for `helm upgrade --install` instead of the local chart directory.
+	// The local chart directory (entry.ChartPath) is still used for values file resolution
+	// (scenario layers, chart-root overlays). SkipDependencyUpdate is forced to true.
+	ChartRef string
+	// ChartRefVersion is the chart version to install from ChartRef (e.g., "13-rc-latest").
+	// Only meaningful when ChartRef is set. Passed as --version to helm.
+	ChartRefVersion string
 }
 
 // RunResult holds the result of a single matrix entry execution.
@@ -1761,6 +1771,20 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions, entryIndex 
 	// All code paths converge into a single result so cleanup runs exactly once.
 	var deployErr error
 	var diag string
+
+	// Override chart source when --chart-ref is set (OCI install path).
+	// This makes deploy.Execute() use the external chart reference (e.g., oci://registry.camunda.cloud/...)
+	// instead of the local chart directory. ChartPath is preserved for values file resolution
+	// (scenario directory, chart-root overlays) but not used as the helm install target.
+	if opts.ChartRef != "" {
+		flags.Chart.Chart = opts.ChartRef
+		flags.Chart.ChartVersion = opts.ChartRefVersion
+		flags.Chart.SkipDependencyUpdate = true
+		logging.Logger.Info().
+			Str("chartRef", opts.ChartRef).
+			Str("chartVersion", opts.ChartRefVersion).
+			Msg("Using external chart reference (OCI/tgz) instead of local chart directory")
+	}
 
 	// Two-step upgrade flow: install old version first, then upgrade to current.
 	if versionmatrix.IsTwoStepUpgradeFlow(entry.Flow) {

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -2176,7 +2176,11 @@ func executeTwoStepUpgrade(ctx context.Context, entry Entry, flags *config.Runti
 
 	if err := deploy.Execute(ctx, &step2Flags); err != nil {
 		if opts.ChartRef != "" {
-			return fmt.Errorf("step 2: upgrade to %s@%s failed: %w", opts.ChartRef, opts.ChartRefVersion, err)
+			target := opts.ChartRef
+			if opts.ChartRefVersion != "" {
+				target += "@" + opts.ChartRefVersion
+			}
+			return fmt.Errorf("step 2: upgrade to %s failed: %w", target, err)
 		}
 		return fmt.Errorf("step 2: upgrade to local chart failed: %w", err)
 	}


### PR DESCRIPTION
## Summary

Restores the `Helm - Install (OCI)` step in `.github/workflows/test-integration-runner.yaml`, which has been an unconditional `exit 1` since #6016 (merged 2026-05-04). Any caller passing a non-empty `helmChartVersion` — including ~20 RC-validation workflows in `c8-cross-component-e2e-tests` — currently fails before any deploy happens.

Closes #6086.

## What changed

Wires OCI chart deployment through `deploy-camunda matrix run` (the path #6016 left as a TODO) instead of falling back to a direct `helm install` in the workflow.

- **`scripts/deploy-camunda/matrix/runner.go`** — Add `RunOptions.ChartRef` / `ChartRefVersion`. New `applyChartRefOverride` helper, called from `executeEntry`, points `flags.Chart.Chart` at the external reference and forces `SkipDependencyUpdate`. `ChartPath` is left untouched so values-file resolution (scenario directory, chart-root overlays) still uses the local repo. Step 2 of `executeTwoStepUpgrade` now logs and reports the chart-ref when set; Step 1 explicitly resets to `versionmatrix.DefaultHelmChartRef` so the previous-version install is unaffected.
- **`scripts/deploy-camunda/cmd/matrix.go`** — New `--chart-ref` / `--chart-version` CLI flags on `matrix run`, plus a `PreRunE` that calls `validateChartRefFlags` (rejects `--chart-version` without `--chart-ref`, restricts `--chart-ref` to `oci://...` or `*.tgz`, and requires `--chart-version` for OCI refs).
- **`scripts/deploy-camunda/cmd/matrix_test.go` (new), `scripts/deploy-camunda/matrix/matrix_test.go`** — Tests for `validateChartRefFlags` and `applyChartRefOverride`. The override test calls the helper directly so it exercises the production code path.
- **`.github/workflows/test-integration-runner.yaml`** — Replace the inert `exit 1` stub with: helm OCI registry login, then invoke `deploy-camunda matrix run` with `--chart-ref oci://registry.camunda.cloud/team-distribution/camunda-platform --chart-version "${HELM_CHART_VERSION}"`. Gated on `inputs.helmChartVersion != '' && inputs.flow == 'install'`, so the source-tree nightly path (`helmChartVersion=''`) is untouched.

## Validation

**Pre-merge end-to-end validation is not possible from a fork branch.** GitHub Actions resolves reusable-workflow YAML at dispatch time from the literal `@<ref>` in the caller's `uses:` line. Both `c8-cross-component-e2e-tests` (`uses: camunda/camunda-platform-helm/...@main`) and the helm-repo callers thread a `camunda-helm-git-ref` input that only re-checks-out chart files inside the running workflow — it does not change which workflow YAML executes. So any branch dispatch still runs the broken `main` copy of `test-integration-runner.yaml`. Confirmed empirically: https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25486645667 (failed at the same `exit 1` from `main`).

What is validated locally:

- `go build ./...` and `go vet ./...` clean for `scripts/deploy-camunda/...`.
- `go test ./scripts/deploy-camunda/cmd/... ./scripts/deploy-camunda/matrix/...` — new tests pass; only pre-existing `TestLoadChartVersions` failure (unrelated to this PR, fails on `main` too).
- YAML syntactically valid (`python3 -c "import yaml; yaml.safe_load(...)"`).
- `inputs.helmChartVersion != ''` gating ensures the source-tree path used by `test-chart-version-nightly` is untouched.

## Post-merge plan

1. Re-dispatch the 7 originally-failing workflows on `c8-cross-component-e2e-tests@main`. Reporter to monitor and report back.
2. If the new step fails: open a follow-up; do not revert (the path is already 100% red).

## Failing runs this unblocks

| Run | Workflow |
|---|---|
| [25447148937](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25447148937) | SM On-Demand 8.8+ Install |
| [25447148914](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25447148914) | SM On-Demand License Key 8.8+ |
| [25447148916](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25447148916) | SM On-Demand DocumentStore 8.8+ |
| [25447148919](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25447148919) | SM On-Demand OpenSearch 8.8+ |
| [25447148940](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25447148940) | SM On-Demand 8.8 Upgrade Minor |
| [25447148982](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25447148982) | SM On-Demand MT 8.8+ |
| [25447149056](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25447149056) | SM On-Demand RBA 8.8+ |

## Reviewer

@eamonnmoloney — author of #6016, has full context on the deploy-camunda matrix-run rework.

