### PR TITLE
fix(ci): add OIDC mapping rule to grant demo OC Identity admin access in 8.8 keycloak scenarios

### DIFF
--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/identity/keycloak-external.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/identity/keycloak-external.yaml
@@ -119,14 +119,8 @@ orchestration:
         existingSecretKey: identity-migration-client-secret
   security:
     initialization:
-      mappingRules:
-        - mappingRuleID: demo-admin-mapping-rule
-          claimName: preferred_username
-          claimValue: demo
       defaultRoles:
         admin:
-          mappingRules:
-            - demo-admin-mapping-rule
           users:
             - demo
           clients:

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/identity/keycloak-external.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/identity/keycloak-external.yaml
@@ -119,8 +119,14 @@ orchestration:
         existingSecretKey: identity-migration-client-secret
   security:
     initialization:
+      mappingRules:
+        - mappingRuleID: demo-admin-mapping-rule
+          claimName: preferred_username
+          claimValue: demo
       defaultRoles:
         admin:
+          mappingRules:
+            - demo-admin-mapping-rule
           users:
             - demo
           clients:

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
@@ -246,8 +246,14 @@ connectors:
 orchestration:
   security:
     initialization:
+      mappingRules:
+        - mappingRuleID: demo-admin-mapping-rule
+          claimName: preferred_username
+          claimValue: demo
       defaultRoles:
         admin:
+          mappingRules:
+            - demo-admin-mapping-rule
           users:
             - demo
           clients:


### PR DESCRIPTION
## Summary

[Successful run using this branch](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25551211951) ✅ 

- In OIDC/Keycloak auth mode, `defaultRoles.admin.users: [demo]` was a no-op: the internal user store is only populated for basic auth (gated in `_application-unified.yaml`), so `demo` had no OC Identity admin access.
- `demo` was authenticated via Keycloak but received "You don't have access to this component" in OC Identity, causing `createOCUser()` to time out on the missing Roles tab.
- Added a `mappingRules` entry (`preferred_username=demo` → `demo-admin-mapping-rule`) and wired it into `defaultRoles.admin.mappingRules` in both `keycloak.yaml` and `keycloak-external.yaml`.

## Root Cause

The template in `_application-unified.yaml` gates the `users:` block:
```
{{- if eq (include "orchestration.authMethod" .) "basic" }}
users: ...
{{- end }}
```
For OIDC, OC Identity's internal user store is never populated, making `defaultRoles.admin.users: [demo]` silently ineffective. The correct mechanism is `mappingRules`, which matches JWT claims at login time.

## Nightly Run
Fixes: https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25475067831
SM Nightly Chrome 8.8 OpenSearch — "Login to /orchestration/identity and /operate fails after 5 attempts"

## Test Plan
- [x] `helm template` confirms `mapping-rules` and `default-roles.admin.mappingRules` appear in rendered config
- [x] `go test ./orchestration/...` passes (golden tests use basic auth, unaffected)
- [x] `make helm.lint` clean
- [ ] New nightly deployment with this fix should show `demo` reaching OC Identity admin tabs and smoke tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)