### PR TITLE
test(8.10): move auth method to global in all integration test identity values

### DIFF
--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/identity/basic.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/identity/basic.yaml
@@ -2,6 +2,9 @@
 # Layer 2: Auth method - Basic authentication (no identity provider)
 
 global:
+  security:
+    authentication:
+      method: basic
   exporter:
     zeebe:
       enabled: false
@@ -9,13 +12,7 @@ global:
 orchestration:
   security:
     authentication:
-      method: basic
       authenticationRefreshInterval: "PT30S"
 
 camundaHub:
   enabled: false
-
-connectors:
-  security:
-    authentication:
-      method: basic

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/identity/keycloak-external.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/identity/keycloak-external.yaml
@@ -62,6 +62,9 @@ global:
       #     existingSecret: "integration-test-credentials"
       #     existingSecretKey: "identity-connectors-client-token"
       ## END pre-install-upgrade.sh COMMENT
+  security:
+    authentication:
+      method: oidc
 
 identity:
   realm:
@@ -82,7 +85,6 @@ identityPostgresql:
 connectors:
   security:
     authentication:
-      method: oidc
       oidc:
         secret:
           existingSecret: "integration-test-credentials"
@@ -98,7 +100,6 @@ orchestration:
           clients:
             - venom
     authentication:
-      method: oidc
       authenticationRefreshInterval: "PT30S"
       oidc:
         redirectUrl: "https://{{ .Values.global.host }}/orchestration"

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
@@ -52,6 +52,9 @@ global:
       #     existingSecret: "integration-test-credentials"
       #     existingSecretKey: "identity-connectors-client-token"
       ## END pre-install-upgrade.sh COMMENT
+  security:
+    authentication:
+      method: oidc
 
 # -- Wait for Keycloak before starting Identity --------------------------------
 # Identity's /actuator/health returns 503 while Keycloak is not reachable,
@@ -264,17 +267,10 @@ optimize:
 connectors:
   security:
     authentication:
-      method: oidc
       oidc:
         secret:
           existingSecret: "integration-test-credentials"
           existingSecretKey: "identity-connectors-client-token"
-
-camundaHub:
-  webModeler:
-    security:
-      authentication:
-        method: oidc
 
 orchestration:
   security:
@@ -286,7 +282,6 @@ orchestration:
           clients:
             - venom
     authentication:
-      method: oidc
       authenticationRefreshInterval: "PT30S"
       oidc:
         redirectUrl: "https://{{ .Values.global.host }}/orchestration"

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/identity/oidc.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/identity/oidc.yaml
@@ -80,10 +80,6 @@ camundaHub:
     env:
       - name: CAMUNDA_IDENTITY_JWKS_URL
         value: https://login.microsoftonline.com/$ENTRA_APP_DIRECTORY_ID/discovery/v2.0/keys
-  webModeler:
-    security:
-      authentication:
-        method: oidc
 
 identityPostgresql:
   enabled: true
@@ -99,7 +95,6 @@ identityKeycloak:
 connectors:
   security:
     authentication:
-      method: oidc
       oidc:
         clientId: $ENTRA_APP_CLIENT_ID
         audience: $ENTRA_APP_CLIENT_ID
@@ -112,7 +107,6 @@ connectors:
 orchestration:
   security:
     authentication:
-      method: oidc
       unprotectedApi: false
       oidc:
         backwardsCompatibleAudiences:

--- a/charts/camunda-platform-8.10/test/unit/connectors/configmap_test.go
+++ b/charts/camunda-platform-8.10/test/unit/connectors/configmap_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -87,18 +86,9 @@ func (s *ConfigMapTemplateTest) TestDifferentValuesInputs() {
 				"global.security.authentication.method": "oidc",
 				"global.identity.auth.tokenUrl":         "http://camunda-keycloak/auth/realms/camunda-platform/protocol/openid-connect/token",
 			},
-			Verifier: func(t *testing.T, output string, err error) {
-				var configmap corev1.ConfigMap
-				var configmapApplication ConnectorsConfigYAML
-				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
-				if e != nil {
-					s.Fail("Failed to unmarshal yaml. error=", e)
-				}
-
-				// then
-				s.Require().Equal("http://camunda-keycloak/auth/realms/camunda-platform/protocol/openid-connect/token", configmapApplication.Camunda.Client.Auth.TokenUrl)
+			Expected: map[string]string{
+				"configmapApplication.camunda.client.auth.token-url": "http://camunda-keycloak/auth/realms/camunda-platform/protocol/openid-connect/token",
+				"configmapApplication.camunda.client.auth.client-id": "connectors",
 			},
 		},
 		{
@@ -109,18 +99,31 @@ func (s *ConfigMapTemplateTest) TestDifferentValuesInputs() {
 				"connectors.security.authentication.method": "oidc",
 				"global.identity.auth.tokenUrl":             "http://camunda-keycloak/auth/realms/camunda-platform/protocol/openid-connect/token",
 			},
-			Verifier: func(t *testing.T, output string, err error) {
-				var configmap corev1.ConfigMap
-				var configmapApplication ConnectorsConfigYAML
-				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-				e := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
-				if e != nil {
-					s.Fail("Failed to unmarshal yaml. error=", e)
-				}
-
-				// then
-				s.Require().Equal("http://camunda-keycloak/auth/realms/camunda-platform/protocol/openid-connect/token", configmapApplication.Camunda.Client.Auth.TokenUrl)
+			Expected: map[string]string{
+				"configmapApplication.camunda.client.auth.token-url": "http://camunda-keycloak/auth/realms/camunda-platform/protocol/openid-connect/token",
+				"configmapApplication.camunda.client.auth.client-id": "connectors",
+			},
+		},
+		{
+			Name: "TestConnectorsOIDCShouldInheritAuthMethodFromGlobal",
+			Values: map[string]string{
+				"connectors.enabled":                    "true",
+				"global.security.authentication.method": "oidc",
+			},
+			Expected: map[string]string{
+				"configmapApplication.camunda.client.auth.client-id": "connectors",
+			},
+		},
+		{
+			Name: "TestConnectorsOIDCComponentMethodShouldOverrideGlobal",
+			Values: map[string]string{
+				"connectors.enabled":                        "true",
+				"global.security.authentication.method":     "basic",
+				"connectors.security.authentication.method": "oidc",
+				"global.identity.auth.tokenUrl":             "http://camunda-keycloak/auth/realms/camunda-platform/protocol/openid-connect/token",
+			},
+			Expected: map[string]string{
+				"configmapApplication.camunda.client.auth.client-id": "connectors",
 			},
 		},
 	}

--- a/charts/camunda-platform-8.10/test/unit/orchestration/configmap_unified_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/configmap_unified_test.go
@@ -106,6 +106,26 @@ func (s *ConfigmapTemplateTest) TestDifferentValuesInputsUnified() {
 			},
 		},
 		{
+			Name: "TestApplicationYamlShouldInheritAuthMethodFromGlobal",
+			Values: map[string]string{
+				"global.security.authentication.method": "oidc",
+			},
+			Expected: map[string]string{
+				"configmapApplication.camunda.security.authentication.method":         "oidc",
+				"configmapApplication.camunda.security.authentication.oidc.client-id": "orchestration",
+			},
+		},
+		{
+			Name: "TestApplicationYamlComponentMethodShouldOverrideGlobal",
+			Values: map[string]string{
+				"global.security.authentication.method":        "basic",
+				"orchestration.security.authentication.method": "oidc",
+			},
+			Expected: map[string]string{
+				"configmapApplication.camunda.security.authentication.method": "oidc",
+			},
+		},
+		{
 			Name: "TestApplicationYamlNoWebAppProfilesWhenNoSecondaryStorageEnabled",
 			Values: map[string]string{
 				"global.noSecondaryStorage":                    "true",
@@ -137,9 +157,9 @@ func (s *ConfigmapTemplateTest) TestDifferentValuesInputsUnifiedOpenSearchAWS() 
 		{
 			Name: "TestApplicationYamlShouldContainOpenSearchAwsEnabledViaSecondaryStorage",
 			Values: map[string]string{
-				"global.opensearch.enabled":                                         "true",
-				"global.opensearch.url.host":                                        "opensearch.example.com",
-				"orchestration.data.secondaryStorage.opensearch.aws.enabled":         "true",
+				"global.opensearch.enabled":                                  "true",
+				"global.opensearch.url.host":                                 "opensearch.example.com",
+				"orchestration.data.secondaryStorage.opensearch.aws.enabled": "true",
 			},
 			Expected: map[string]string{
 				"configmapApplication.camunda.data.secondary-storage.opensearch.aws-enabled": "true",
@@ -175,8 +195,8 @@ func (s *ConfigmapTemplateTest) TestDifferentValuesInputsUnifiedElasticsearchAWS
 		{
 			Name: "TestApplicationYamlShouldContainElasticsearchAwsEnabledViaSecondaryStorage",
 			Values: map[string]string{
-				"global.elasticsearch.enabled":                                            "true",
-				"orchestration.data.secondaryStorage.elasticsearch.aws.enabled":            "true",
+				"global.elasticsearch.enabled":                                  "true",
+				"orchestration.data.secondaryStorage.elasticsearch.aws.enabled": "true",
 			},
 			Expected: map[string]string{
 				"configmapApplication.camunda.data.secondary-storage.elasticsearch.aws-enabled": "true",


### PR DESCRIPTION
## Summary

Mirrors the 8.8 cleanup from #6020 for 8.10. Moves `security.authentication.method` to `global.security.authentication.method` in the four identity scenario values files and drops the now-redundant component-level `method:` keys.

- `basic.yaml`: added `global.security.authentication.method: basic`; removed `method: basic` from `orchestration` and removed the `connectors.security.authentication` block entirely.
- `keycloak.yaml`: added `global.security.authentication.method: oidc`; removed `method: oidc` from `connectors`, removed the entire `camundaHub.webModeler.security.authentication` block, and removed `method: oidc` from `orchestration`.
- `keycloak-external.yaml`: added `global.security.authentication.method: oidc`; removed `method: oidc` from `connectors` and `orchestration`.
- `oidc.yaml`: `global.security.authentication.method: oidc` was already present; removed the `connectors`, `camundaHub.webModeler`, and `orchestration` component-level `method:` duplicates.
- `hybrid.yaml`: intentionally untouched — it deliberately sets different methods per component.

Closes part of #6060. Companion PR for 8.9 is #6099. Related to #5456.

## Test plan

- [x] \`make go.test chartPath=charts/camunda-platform-8.10\` passes locally (all packages OK).
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)