### PR TITLE
ci: handle script-only PRs and empty matrix in chart-version workflow

### DIFF
--- a/.github/workflows/test-chart-version.yaml
+++ b/.github/workflows/test-chart-version.yaml
@@ -232,6 +232,8 @@ jobs:
   integration-tests:
     # Skip integration tests for Renovate image/digest PRs - these images are already
     # validated by AlwaysGreen before publishing. Only golden file updates are needed.
+    # Also skip on empty matrix; without this gate the matrix produces zero jobs and
+    # report-cla-status.needs.integration-tests resolves as a failed dependency on merge_group.
     if: >-
       ${{
         needs.init.outputs.camunda-versions != '[]' &&

--- a/scripts/generate-chart-matrix.sh
+++ b/scripts/generate-chart-matrix.sh
@@ -267,16 +267,19 @@ else
   # Use empty string for exclude_pattern if no exclusion is needed
   # Note: We use ';;' as delimiter to avoid conflicts with '|' in regex patterns
   BUILD_ALL_TRIGGERS=(
-    '\.github/(workflows|actions);;.github/workflows or .github/actions'
+    '\.github/(workflows|actions);;;;.github/workflows or .github/actions'
     '\.github/config;;\.github/config/release-please;;.github/config (excluding release-please)'
     # Anchor required: tj-actions/changed-files with dir_names:true emits the
     # bare token "scripts" so unanchored "scripts/" misses top-level helper changes.
-    '(^|[[:space:]])scripts(/|$|[[:space:]]);;scripts/ (any helper script)'
+    '(^|[[:space:]])scripts(/|$|[[:space:]]);;;;scripts/ (any helper script)'
   )
 
   build_all_triggered=false
   for trigger in "${BUILD_ALL_TRIGGERS[@]}"; do
-    IFS=';;' read -r pattern exclude_pattern description <<< "$trigger"
+    pattern="${trigger%%;;*}"
+    rest="${trigger#*;;}"
+    exclude_pattern="${rest%%;;*}"
+    description="${rest#*;;}"
     if echo "${ALL_MODIFIED_FILES}" | grep -qE "$pattern"; then
       # Check exclusion pattern if specified
       if [ -n "$exclude_pattern" ] && echo "${ALL_MODIFIED_FILES}" | grep -qE "$exclude_pattern"; then

--- a/scripts/generate-chart-matrix.sh
+++ b/scripts/generate-chart-matrix.sh
@@ -269,7 +269,9 @@ else
   BUILD_ALL_TRIGGERS=(
     '\.github/(workflows|actions);;.github/workflows or .github/actions'
     '\.github/config;;\.github/config/release-please;;.github/config (excluding release-please)'
-    'scripts/deploy-camunda/;;scripts/deploy-camunda/'
+    # Anchor required: tj-actions/changed-files with dir_names:true emits the
+    # bare token "scripts" so unanchored "scripts/" misses top-level helper changes.
+    '(^|[[:space:]])scripts(/|$|[[:space:]]);;scripts/ (any helper script)'
   )
 
   build_all_triggered=false

--- a/test/scripts/generate_chart_matrix.bats
+++ b/test/scripts/generate_chart_matrix.bats
@@ -70,18 +70,60 @@ get_first_version() {
 }
 
 
-@test "non-chart changes produce an empty matrix and succeed" {
-  export GITHUB_OUTPUT="$TMPDIR_TEST/github_output"
-  : > "$GITHUB_OUTPUT"
-
-  # Simulate a PR that only changes tooling/scripts paths, not charts.
+@test "scripts/ change triggers all chart versions" {
+  # Regression for #6108: a top-level scripts/ change is invoked by chart tests
+  # (e.g. apply-ttl-to-elasticsearch-indexes.sh) and must rebuild every version.
   run bash "$ROOT/scripts/generate-chart-matrix.sh" \
     --manual-trigger none \
     --active-versions "$AV" \
-    --all-modified-files "scripts/camunda-core"
+    --all-modified-files "scripts/apply-ttl-to-elasticsearch-indexes.sh"
+  assert_success
+  run bash -c 'yq -o=json ".matrix | [.[] | .version] | unique | sort" matrix_versions.txt | jq -c'
+  assert_success
+  expected="$(printf '%s\n' $AV | jq -R . | jq -s -c 'sort')"
+  assert_output "$expected"
+}
+
+@test "bare 'scripts' dir name (dir_names:true output) triggers all chart versions" {
+  # tj-actions/changed-files with dir_names:true collapses scripts/<file> to
+  # the bare token "scripts"; the BUILD_ALL_TRIGGERS regex must catch that too.
+  run bash "$ROOT/scripts/generate-chart-matrix.sh" \
+    --manual-trigger none \
+    --active-versions "$AV" \
+    --all-modified-files "scripts"
+  assert_success
+  run bash -c 'yq -o=json ".matrix | [.[] | .version] | unique | sort" matrix_versions.txt | jq -c'
+  assert_success
+  expected="$(printf '%s\n' $AV | jq -R . | jq -s -c 'sort')"
+  assert_output "$expected"
+}
+
+@test "unrelated path produces an empty matrix and succeeds" {
+  export GITHUB_OUTPUT="$TMPDIR_TEST/github_output"
+  : > "$GITHUB_OUTPUT"
+
+  # A docs-only path matches no BUILD_ALL_TRIGGER and no chart path.
+  run bash "$ROOT/scripts/generate-chart-matrix.sh" \
+    --manual-trigger none \
+    --active-versions "$AV" \
+    --all-modified-files "README.md"
   assert_success
 
   # The script should emit an empty JSON matrix for downstream jobs to skip.
+  run bash -c 'grep -E "^matrix=\{\\\"include\\\":\[\]\}$" "$GITHUB_OUTPUT"'
+  assert_success
+}
+
+@test "name containing 'scripts' substring does not trigger all chart versions" {
+  export GITHUB_OUTPUT="$TMPDIR_TEST/github_output"
+  : > "$GITHUB_OUTPUT"
+
+  # Anchored regex must not match e.g. "myscripts" or "descripts/foo".
+  run bash "$ROOT/scripts/generate-chart-matrix.sh" \
+    --manual-trigger none \
+    --active-versions "$AV" \
+    --all-modified-files "myscripts/foo.sh"
+  assert_success
   run bash -c 'grep -E "^matrix=\{\\\"include\\\":\[\]\}$" "$GITHUB_OUTPUT"'
   assert_success
 }


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6108.

### What's in this PR?

Two changes that together unblock the merge queue for PRs that only touch
`scripts/*` files outside `scripts/deploy-camunda/`:

1. **`scripts/generate-chart-matrix.sh`** — broaden `BUILD_ALL_TRIGGERS` so any
   `scripts/` change rebuilds every chart version. The narrow
   `scripts/deploy-camunda/` trigger missed scripts like
   `apply-ttl-to-elasticsearch-indexes.sh` that are invoked by
   `.github/workflows/test-integration-runner.yaml`. The new pattern handles
   both the bare top-level dir name (`scripts`, emitted by
   `tj-actions/changed-files` when `dir_names: true`) and full `scripts/...`
   paths, while still rejecting unrelated names like `myscripts` or
   `descripts/foo`.

2. **`.github/workflows/test-chart-version.yaml`** — add the same
   `camunda-versions != '[]'` gate to `integration-tests` that already guards
   `unit-testing`, `validation`, and `kind-testing`. Without it the matrix
   evaluated to zero entries when no chart was affected, no job key
   materialized, and `report-cla-status.needs.integration-tests` resolved as a
   failed dependency — flipping the workflow conclusion to `failure` even
   though every visible check was success or skipped.

3. **`test/scripts/generate_chart_matrix.bats`** — replace the previous
   "non-chart changes produce an empty matrix" test with four tests covering
   the new behavior: a top-level `scripts/<file>` change triggers all chart
   versions, the bare `scripts` token (dir_names:true output) does the same,
   an unrelated path (`README.md`) still produces an empty matrix, and a
   substring like `myscripts/foo.sh` does not falsely trigger.

### Repro of the original failure

PR #6035 (a one-file change to `scripts/apply-ttl-to-elasticsearch-indexes.sh`)
landed in the merge queue; `Test - Chart Version` reported failure
([run 25559156499](https://github.com/camunda/camunda-platform-helm/actions/runs/25559156499))
without any individual job failure.

### Checklist

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only` — N/A (workflow + bash + bats only).
- [x] There is no other open pull request for the same update/change.
- [x] Tests for charts are added (if needed) — bats unit tests updated.
- [ ] In-repo documentation is updated (if needed) — N/A.

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)?
- [ ] Did all checks/tests pass in the PR?