### PR TITLE
fix(matrix): exit non-zero when any matrix entry fails

### DIFF
--- a/scripts/deploy-camunda/cmd/matrix.go
+++ b/scripts/deploy-camunda/cmd/matrix.go
@@ -540,6 +540,28 @@ This command calls deploy.Execute() for each matrix entry.`,
 				fmt.Fprintln(os.Stdout, matrix.PrintRunSummary(results, time.Since(runStart), logDir))
 			}
 
+			// Surface per-entry failures via exit code even when stop-on-failure is
+			// disabled. Without this, a failed `helm upgrade --install` is logged
+			// as "Matrix entry failed" but the CLI still exits 0, which causes
+			// downstream CI steps (e.g. Playwright e2e) to run against a broken
+			// cluster and produce misleading test failures (HTTP 502 across the
+			// board) instead of clearly attributing the failure to the deploy.
+			if err == nil {
+				failed := 0
+				for _, r := range results {
+					if r.Error != nil {
+						failed++
+					}
+				}
+				if failed > 0 {
+					noun := "entry"
+					if failed != 1 {
+						noun = "entries"
+					}
+					err = fmt.Errorf("%d matrix %s failed", failed, noun)
+				}
+			}
+
 			return err
 		},
 	}

--- a/scripts/deploy-camunda/cmd/matrix.go
+++ b/scripts/deploy-camunda/cmd/matrix.go
@@ -546,21 +546,7 @@ This command calls deploy.Execute() for each matrix entry.`,
 			// downstream CI steps (e.g. Playwright e2e) to run against a broken
 			// cluster and produce misleading test failures (HTTP 502 across the
 			// board) instead of clearly attributing the failure to the deploy.
-			if err == nil {
-				failed := 0
-				for _, r := range results {
-					if r.Error != nil {
-						failed++
-					}
-				}
-				if failed > 0 {
-					noun := "entry"
-					if failed != 1 {
-						noun = "entries"
-					}
-					err = fmt.Errorf("%d matrix %s failed", failed, noun)
-				}
-			}
+			err = aggregateRunError(err, results)
 
 			return err
 		},
@@ -772,4 +758,28 @@ func validateChartRefFlags(chartRef, chartRefVersion string) error {
 	}
 
 	return nil
+}
+
+// aggregateRunError converts per-entry failures from matrix.Run into a
+// returned CLI error so the process exits non-zero. If runErr is already
+// non-nil (e.g. from --stop-on-failure), it is returned unchanged to
+// preserve the original error semantics. Factored out for unit testing.
+func aggregateRunError(runErr error, results []matrix.RunResult) error {
+	if runErr != nil {
+		return runErr
+	}
+	failed := 0
+	for _, r := range results {
+		if r.Error != nil {
+			failed++
+		}
+	}
+	if failed == 0 {
+		return nil
+	}
+	noun := "entry"
+	if failed != 1 {
+		noun = "entries"
+	}
+	return fmt.Errorf("%d matrix %s failed", failed, noun)
 }

--- a/scripts/deploy-camunda/cmd/matrix_test.go
+++ b/scripts/deploy-camunda/cmd/matrix_test.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"errors"
 	"strings"
 	"testing"
+
+	"scripts/deploy-camunda/matrix"
 )
 
 func TestValidateChartRefFlags(t *testing.T) {
@@ -66,6 +69,74 @@ func TestValidateChartRefFlags(t *testing.T) {
 			}
 			if !strings.Contains(err.Error(), tt.wantErr) {
 				t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+			}
+		})
+	}
+}
+
+func TestAggregateRunError(t *testing.T) {
+	preExisting := errors.New("stopping on failure: helm failed")
+	entryErr := errors.New("helm upgrade --install failed: exit status 1")
+
+	tests := []struct {
+		name    string
+		runErr  error
+		results []matrix.RunResult
+		wantErr string // substring; empty = expect nil
+	}{
+		{
+			name:    "no results no error",
+			results: nil,
+			wantErr: "",
+		},
+		{
+			name: "all entries succeeded",
+			results: []matrix.RunResult{
+				{Entry: matrix.Entry{Version: "8.9"}, Namespace: "ns-a"},
+				{Entry: matrix.Entry{Version: "8.9"}, Namespace: "ns-b"},
+			},
+			wantErr: "",
+		},
+		{
+			name: "single entry failed",
+			results: []matrix.RunResult{
+				{Entry: matrix.Entry{Version: "8.9"}, Namespace: "ns-a", Error: entryErr},
+			},
+			wantErr: "1 matrix entry failed",
+		},
+		{
+			name: "multiple entries failed",
+			results: []matrix.RunResult{
+				{Entry: matrix.Entry{Version: "8.8"}, Namespace: "ns-a", Error: entryErr},
+				{Entry: matrix.Entry{Version: "8.9"}, Namespace: "ns-b", Error: entryErr},
+				{Entry: matrix.Entry{Version: "8.9"}, Namespace: "ns-c"},
+			},
+			wantErr: "2 matrix entries failed",
+		},
+		{
+			name:   "preserves pre-existing run error",
+			runErr: preExisting,
+			results: []matrix.RunResult{
+				{Entry: matrix.Entry{Version: "8.9"}, Namespace: "ns-a", Error: entryErr},
+			},
+			wantErr: "stopping on failure: helm failed",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := aggregateRunError(tc.runErr, tc.results)
+			if tc.wantErr == "" {
+				if got != nil {
+					t.Fatalf("expected nil error, got %v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(got.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got %q", tc.wantErr, got.Error())
 			}
 		})
 	}


### PR DESCRIPTION
## Root cause

In e2e on-demand run [25671188636 / job 75371116433](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25671188636/job/75371116433), the **install job conclusion was `success`** even though the deploy-camunda CLI had logged:

```
14:05:16 WARN  [cmd:helm] Error: context deadline exceeded
14:05:30 ERROR Matrix entry failed  error="helm upgrade --install failed: exit status 1"
              command="helm upgrade --install integration … --wait --timeout 1200s …"
              flow=install scenario=qa-opensearch-tasklist-v1 version=8.9
```

Because the install step (which runs `go run . matrix run`) reported success, the subsequent **Playwright e2e** step ran against a half-deployed cluster (`gke-qaosupg-c962-8-9-qaosupg`) and produced **50+ misleading failures** with HTTP 502 across unrelated specs (cluster-variables, optimize-api, login flows).

### Why the CLI exits 0

`matrix.Run` in [`matrix/runner.go`](../blob/main/scripts/deploy-camunda/matrix/runner.go) logs `Matrix entry failed` for each failed entry, but only **returns** an error when `StopOnFailure=true`. Both the serial path (line 873-877) and the parallel path (line 953-959) return `nil` otherwise, so the CLI in [`cmd/matrix.go`](../blob/main/scripts/deploy-camunda/cmd/matrix.go) returns `nil` and the process exits 0.

The triggering workflow [`test-integration-runner.yaml`](../blob/main/.github/workflows/test-integration-runner.yaml#L535) wraps the call with `set -euo pipefail`, so a non-zero exit *would* correctly fail the GitHub Actions step (and cleanup is in a separate `if: always()` step, so it still runs).

## Fix

After `matrix.Run` returns, if any entry has `Error != nil`, override the returned `err` so the CLI exits non-zero. This is the minimal behavioral fix that doesn't touch library semantics, keeps the existing summary output intact, and applies whether or not `--stop-on-failure` is set.

```go
if err == nil {
    failed := 0
    for _, r := range results {
        if r.Error != nil {
            failed++
        }
    }
    if failed > 0 {
        err = fmt.Errorf("%d matrix %s failed", failed, noun)
    }
}
```

## Impact

After this change, a failing `helm upgrade --install` in any matrix entry fails the install job fast. Dependent Playwright e2e jobs (which `needs:` the install job) are then **skipped** rather than running against a broken cluster — surfacing the real install-time failure clearly and saving runner time + signal noise.

## Evidence of the pattern

The same symptom (cluster-wide 502 in tests after a silent helm install failure) was observed in three consecutive failing `SM On-Demand OpenSearch 8.8+` runs on `main` today (2026-05-11 12:30, 12:49, 12:50 UTC) — all symptoms of cluster install failures being reported as successes.

## Validation

Dispatched the same failing workflow against this branch with identical inputs (except `helmRepositoryBranchAndDirName=fix/matrix-runner-fail-on-entry-error,camunda-platform-8.9,4h`):

- Validation run: https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25677585547

**Result: behavior change confirmed** ✅

| Job | Before (run 25671188636) | After (run 25677585547) |
|---|---|---|
| `install for install on gke - qaosupg` | `success` (silently swallowed `helm upgrade --install` failure) | **`failure`** — exits non-zero on `context deadline exceeded` |
| `Playwright e2e after install` | `failure` (50× misleading HTTP 502 across unrelated specs) | **`skipped`** (correctly gated on install success) |
| `Cleanup` | `success` | `success` (still runs via `if: always()`) |

Same underlying `helm upgrade --install` `context deadline exceeded` reproduced on the same cluster type; this time the install job correctly surfaces it as a failure and dependent test jobs are skipped instead of producing misleading noise.

