### PR TITLE
fix: reduce Optimize tenant auth cache interval from 300s to 30s in MT QA scenarios

### DIFF
--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
@@ -38,7 +38,7 @@ identity:
 optimize:
   caches:
     cloudTenantAuthorizations:
-      minFetchIntervalSeconds: 300
+      minFetchIntervalSeconds: 30
 
 connectors:
   env:

--- a/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values/base-qa.yaml
+++ b/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values/base-qa.yaml
@@ -138,4 +138,4 @@ connectors:
 optimize:
   caches:
     cloudTenantAuthorizations:
-      minFetchIntervalSeconds: 300
+      minFetchIntervalSeconds: 30

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/base-qa.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/base-qa.yaml
@@ -5,7 +5,7 @@ optimize:
   enabled: true
   caches:
     cloudTenantAuthorizations:
-      minFetchIntervalSeconds: 300
+      minFetchIntervalSeconds: 30
 
 identity:
   firstUser:

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
@@ -38,7 +38,7 @@ identity:
 optimize:
   caches:
     cloudTenantAuthorizations:
-      minFetchIntervalSeconds: 300
+      minFetchIntervalSeconds: 30
 
 connectors:
   env:

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
@@ -38,7 +38,7 @@ identity:
 optimize:
   caches:
     cloudTenantAuthorizations:
-      minFetchIntervalSeconds: 300
+      minFetchIntervalSeconds: 30
 
 connectors:
   env:


### PR DESCRIPTION
## Summary

- Reduces `optimize.caches.cloudTenantAuthorizations.minFetchIntervalSeconds` from 300 to 30 in all MT QA scenario values files (8.7–8.10)
- With the original 300s setting, any race between beforeEach tenant assignment and Optimize's first cache fetch for a test user would cause the smoke test to see "no processes" for up to 5 minutes, exceeding the test timeout

## Root cause

In the SM-8.8 MT nightly scenario (`qaelmtupg`), the Playwright `beforeEach` assigns a fresh test user to the `<default>` tenant in Management Identity. However, if Optimize's `ccsm` profile had already cached the user's tenant authorizations as empty (e.g., during an earlier navigation), the 300s minimum refresh interval meant Optimize would not re-check Identity until 5 minutes later — well past the test's retry window.

Reducing to 30s gives a fast recovery path without hammering Identity on every request.

## Related PRs

- E2E test fix (tenant tab wait + 10-min IS_MT timeout): https://github.com/camunda/c8-cross-component-e2e-tests/pull/2329
- Failing nightly run: https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25650688415

## Test plan

- [ ] Trigger SM On-Demand 8.9 Upgrade Minor MT with this branch
- [ ] Confirm `8.8 - GKE - install / Run tests - chromium` passes
- [ ] Confirm the smoke test no longer enters an infinite process-not-found retry loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)