### PR TITLE
test(8.9): pin embedded OpenSearch companion chart to 2.17.1

### DIFF
--- a/charts/camunda-platform-8.9/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.9/test/ci-test-config.yaml
@@ -89,7 +89,7 @@ integration:
           platforms: [gke]
           dependencies:
             - chart: opensearch/opensearch
-              version: "3.6.0"
+              version: "2.17.1"
               release-name: opensearch
               repo-name: opensearch
               repo-url: https://opensearch-project.github.io/helm-charts/
@@ -307,7 +307,7 @@ integration:
           platforms: [gke]
           dependencies:
             - chart: opensearch/opensearch
-              version: "3.6.0"
+              version: "2.17.1"
               release-name: opensearch
               repo-name: opensearch
               repo-url: https://opensearch-project.github.io/helm-charts/
@@ -390,7 +390,7 @@ integration:
           platforms: [gke]
           dependencies:
             - chart: opensearch/opensearch
-              version: "3.6.0"
+              version: "2.17.1"
               release-name: opensearch
               repo-name: opensearch
               repo-url: https://opensearch-project.github.io/helm-charts/
@@ -471,7 +471,7 @@ integration:
           platforms: [gke]
           dependencies:
             - chart: opensearch/opensearch
-              version: "3.6.0"
+              version: "2.17.1"
               release-name: opensearch
               repo-name: opensearch
               repo-url: https://opensearch-project.github.io/helm-charts/
@@ -488,7 +488,7 @@ integration:
           platforms: [gke]
           dependencies:
             - chart: opensearch/opensearch
-              version: "3.6.0"
+              version: "2.17.1"
               release-name: opensearch
               repo-name: opensearch
               repo-url: https://opensearch-project.github.io/helm-charts/


### PR DESCRIPTION
## Context

After PR #6071 switched `qa-opensearch*` scenarios from a shared external OpenSearch to the embedded companion chart, run [25717954218](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25717954218) installed successfully but **7 Tasklist V1 e2e tests failed** with tasks never appearing in the UI. Every Tasklist task search returned HTTP 500.

## Root cause

The embedded companion chart was pinned to `opensearch/opensearch@3.6.0` (deploys OpenSearch 3.6.0). Camunda **8.9** is certified against OpenSearch **2.17.x**.

Tasklist V1's Painless sort in `io.camunda.tasklist.store.opensearch.TaskStoreOpenSearch.queryTasks` calls `doc['creationTime'].value.getMillis()`. On OS 3.x `doc[<date>].value` is `java.time.ZonedDateTime` — the Joda-style `getMillis()` is gone. Reproduced directly against the cluster:

```
search_phase_execution_exception: all shards failed
caused_by: illegal_argument_exception:
  dynamic method [java.time.ZonedDateTime, getMillis/0] not found
```

## Change

Pin the companion chart to `2.17.1` (latest `2.17.x`) in `charts/camunda-platform-8.9/test/ci-test-config.yaml` (5 dependency entries).

## Follow-ups (not in this PR)

- Tasklist V1 product fix is still required to support OS 3.x going forward (replace `getMillis()` with `.toInstant().toEpochMilli()`); needed for 8.10+ on OS 3.x.
- 8.7 / 8.8 charts have the same pin; review separately if they also exercise the Tasklist V1 + embedded-OS path.

## Validation

A nightly workflow will be dispatched against this branch using the same inputs as run 25717954218.