### PR TITLE
fix(integration): add security mapping rules to 8.8 elasticsearch.yaml for upgrade path

### DIFF
--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/persistence/elasticsearch.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/persistence/elasticsearch.yaml
@@ -8,3 +8,35 @@ global:
 elasticsearch:
   enabled: true
   maxUnavailable: 0
+
+orchestration:
+  env:
+    # Security mapping rules — written into the Zeebe raft log during the 8.8
+    # upgrade step so the orchestration layer can authenticate users via
+    # Keycloak. Without these, the 8.7→8.8 upgrade leaves the orchestration
+    # cluster without mapping rules, causing Access Denied on /orchestration/
+    # endpoints after upgrade. Mirrors the fix applied to opensearch.yaml.
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_0_MAPPINGRULEID
+      value: "demo-user-mapping-rule"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_0_CLAIMNAME
+      value: "preferred_username"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_0_CLAIMVALUE
+      value: "demo"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_1_MAPPINGRULEID
+      value: "venom-client-mapping-rule"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_1_CLAIMNAME
+      value: "client_id"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_1_CLAIMVALUE
+      value: "$VENOM_CLIENT_ID"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_2_MAPPINGRULEID
+      value: "connectors-client-mapping-rule"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_2_CLAIMNAME
+      value: "client_id"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_2_CLAIMVALUE
+      value: "$CONNECTORS_CLIENT_ID"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGRULES_0
+      value: "demo-user-mapping-rule"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGRULES_1
+      value: "venom-client-mapping-rule"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGRULES_2
+      value: "connectors-client-mapping-rule"


### PR DESCRIPTION
## Problem

The **SM Nightly 8.8 Upgrade Minor** workflow has been failing since 2026-05-09 with two symptoms in `migration-path-user-flows.spec.ts`:

1. **Navigation login failures** — `Login (/orchestration/tasklist) failed after 5 attempts` and `Login (/orchestration/operate) failed after 5 attempts`. Login itself succeeds (Keycloak is reachable) but every request through the orchestration proxy is rejected with Access Denied, so the app banner never renders.

2. **Modeler deploy failures** — `getByText('Instance started!')` never appears. Modeler's REST call to deploy and run a process via Zeebe is also rejected by the same missing authorization.

Nightly run: https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25712879651/job/75501916967

## Root cause

The `elasticsearch.yaml` values file used in the 8.8 upgrade step was missing `CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_*` env vars. Without these, the orchestration security initialization writes no mapping rules to the Zeebe raft log. With no mapping rules, the orchestration layer cannot match JWT claims (e.g. `preferred_username=demo`) to security identities, so all authenticated requests return Access Denied.

This is the identical bug that was fixed for the OpenSearch path in `b958d0891` — that commit correctly described:

> Without [mapping rules], 8.9 detects "already initialized" and skips creating mapping rules, causing Access Denied on /orchestration/operate after the upgrade.

The same mechanism applies to the 8.7→8.8 Elasticsearch path: the 8.7 raft log has process data but no orchestration security metadata, so when 8.8 initializes without explicit mapping rule env vars the raft log ends up with no mapping rules.

## Fix

Mirror the `opensearch.yaml` fix: add the three mapping rules (`demo-user`, `venom-client`, `connectors-client`) and wire them to the admin default role via env var overrides on `orchestration.env`.

## Validation

- The last successful run (2026-05-08) had the same Keycloak+Elasticsearch scenario but without the `features: [migrator]` change that exposed the regression. Verifying with the next nightly run after merge.
- No chart templates or golden files changed; this is a CI integration values file only.

## Related
- `b958d0891` — identical fix for OpenSearch path
- `889b8b7e5` — added `features: [migrator]` to the Elasticsearch upgrade scenario (the change that exposed the missing mapping rules)