### PR TITLE
ci(8.8): add LDAP multi-group-mapper reproduction scenario

### DIFF
--- a/charts/camunda-platform-8.8/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.8/test/ci-test-config.yaml
@@ -201,6 +201,21 @@ integration:
           persistence: elasticsearch
           features: [documentstore]
           platforms: [eks]
+        - name: keycloak-ldap
+          enabled: false
+          shortname: keldp
+          auth: keycloak
+          flow: install
+          identity: keycloak
+          persistence: elasticsearch
+          features: [ldap]
+          platforms: [gke]
+          infra-type:
+            gke: distroci
+          dependencies:
+            - chart: test/integration/companion-charts/openldap
+              release-name: openldap
+              values-file: test/integration/companion-values/openldap.yaml
 
         # ===========================================================================
         # Backward-compat scenarios — referenced by .github/workflows/test-backward-compat.yaml

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/ldap.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/ldap.yaml
@@ -1,0 +1,139 @@
+# LDAP multi-group-mapper feature configuration for 8.8
+# Layer 4: Feature - LDAP federation with multiple group mappers
+#
+# Purpose: Reproduce Keycloak #45256 regression where multiple LDAP group
+# mappers using GET_GROUPS_FROM_USER_MEMBEROF_ATTRIBUTE strategy only show
+# groups from one mapper on users/tokens after Keycloak 26.2.6+.
+#
+# Requires: OpenLDAP companion chart deployed in the same namespace
+# (release name "openldap", service "openldap:389").
+
+identityKeycloak:
+  keycloakConfigCli:
+    enabled: true
+    configuration:
+      ldap-federation.json: |
+        {
+          "realm": "camunda-platform",
+          "components": {
+            "org.keycloak.storage.UserStorageProvider": [
+              {
+                "name": "openldap-federation",
+                "providerId": "ldap",
+                "config": {
+                  "vendor": ["other"],
+                  "connectionUrl": ["ldap://openldap:389"],
+                  "bindDn": ["cn=admin,dc=test,dc=local"],
+                  "bindCredential": ["adminpassword"],
+                  "usersDn": ["ou=Users,dc=test,dc=local"],
+                  "usernameLDAPAttribute": ["uid"],
+                  "rdnLDAPAttribute": ["cn"],
+                  "uuidLDAPAttribute": ["entryUUID"],
+                  "userObjectClasses": ["inetOrgPerson"],
+                  "editMode": ["READ_ONLY"],
+                  "searchScope": ["1"],
+                  "pagination": ["false"],
+                  "importEnabled": ["true"],
+                  "syncRegistrations": ["false"],
+                  "trustEmail": ["true"],
+                  "enabled": ["true"],
+                  "priority": ["0"],
+                  "cachePolicy": ["DEFAULT"],
+                  "batchSizeForSync": ["1000"],
+                  "fullSyncPeriod": ["-1"],
+                  "changedSyncPeriod": ["-1"]
+                },
+                "subComponents": {
+                  "org.keycloak.storage.ldap.mappers.LDAPStorageMapper": [
+                    {
+                      "name": "username",
+                      "providerId": "user-attribute-ldap-mapper",
+                      "config": {
+                        "ldap.attribute": ["uid"],
+                        "user.model.attribute": ["username"],
+                        "read.only": ["true"],
+                        "always.read.value.from.ldap": ["true"],
+                        "is.mandatory.in.ldap": ["true"]
+                      }
+                    },
+                    {
+                      "name": "email",
+                      "providerId": "user-attribute-ldap-mapper",
+                      "config": {
+                        "ldap.attribute": ["mail"],
+                        "user.model.attribute": ["email"],
+                        "read.only": ["true"],
+                        "always.read.value.from.ldap": ["true"],
+                        "is.mandatory.in.ldap": ["false"]
+                      }
+                    },
+                    {
+                      "name": "first name",
+                      "providerId": "user-attribute-ldap-mapper",
+                      "config": {
+                        "ldap.attribute": ["givenName"],
+                        "user.model.attribute": ["firstName"],
+                        "read.only": ["true"],
+                        "always.read.value.from.ldap": ["true"],
+                        "is.mandatory.in.ldap": ["true"]
+                      }
+                    },
+                    {
+                      "name": "last name",
+                      "providerId": "user-attribute-ldap-mapper",
+                      "config": {
+                        "ldap.attribute": ["sn"],
+                        "user.model.attribute": ["lastName"],
+                        "read.only": ["true"],
+                        "always.read.value.from.ldap": ["true"],
+                        "is.mandatory.in.ldap": ["true"]
+                      }
+                    },
+                    {
+                      "name": "app-groups-mapper",
+                      "providerId": "group-ldap-mapper",
+                      "config": {
+                        "groups.dn": ["ou=AppGroups,dc=test,dc=local"],
+                        "group.name.ldap.attribute": ["cn"],
+                        "group.object.classes": ["groupOfNames"],
+                        "preserve.group.inheritance": ["false"],
+                        "ignore.missing.groups": ["false"],
+                        "membership.ldap.attribute": ["member"],
+                        "membership.attribute.type": ["DN"],
+                        "membership.user.ldap.attribute": ["cn"],
+                        "groups.ldap.filter": [],
+                        "mode": ["READ_ONLY"],
+                        "user.roles.retrieve.strategy": ["GET_GROUPS_FROM_USER_MEMBEROF_ATTRIBUTE"],
+                        "memberof.ldap.attribute": ["memberOf"],
+                        "mapped.group.attributes": [],
+                        "drop.non.existing.groups.during.sync": ["true"],
+                        "groups.path": ["/app-groups"]
+                      }
+                    },
+                    {
+                      "name": "infra-groups-mapper",
+                      "providerId": "group-ldap-mapper",
+                      "config": {
+                        "groups.dn": ["ou=InfraGroups,dc=test,dc=local"],
+                        "group.name.ldap.attribute": ["cn"],
+                        "group.object.classes": ["groupOfNames"],
+                        "preserve.group.inheritance": ["false"],
+                        "ignore.missing.groups": ["false"],
+                        "membership.ldap.attribute": ["member"],
+                        "membership.attribute.type": ["DN"],
+                        "membership.user.ldap.attribute": ["cn"],
+                        "groups.ldap.filter": [],
+                        "mode": ["READ_ONLY"],
+                        "user.roles.retrieve.strategy": ["GET_GROUPS_FROM_USER_MEMBEROF_ATTRIBUTE"],
+                        "memberof.ldap.attribute": ["memberOf"],
+                        "mapped.group.attributes": [],
+                        "drop.non.existing.groups.during.sync": ["true"],
+                        "groups.path": ["/infra-groups"]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }

--- a/scripts/deploy-camunda/agentwatch/agentwatch_test.go
+++ b/scripts/deploy-camunda/agentwatch/agentwatch_test.go
@@ -75,6 +75,41 @@ func TestParseVerdict_RejectsInvalidAction(t *testing.T) {
 	}
 }
 
+func TestParseVerdict_OpencodeNDJSON(t *testing.T) {
+	// opencode run --format json emits newline-delimited JSON events.
+	// The verdict text is in {"type":"text","part":{"text":"..."}} events.
+	raw := []byte(`{"type":"step_start","timestamp":1778579787017,"sessionID":"ses_abc","part":{"id":"prt_1","messageID":"msg_1","sessionID":"ses_abc","type":"step-start"}}
+{"type":"text","timestamp":1778579787124,"sessionID":"ses_abc","part":{"id":"prt_2","messageID":"msg_1","sessionID":"ses_abc","type":"text","text":"` + "```json\\n{\\\"diagnosis\\\":\\\"pod OOMKilled\\\",\\\"causal_chain\\\":[\\\"memory limit 256Mi\\\"],\\\"confidence\\\":0.88,\\\"recommended_action\\\":\\\"abort\\\"}\\n```" + `","time":{"start":1778579787018,"end":1778579787122}}}
+{"type":"step_finish","timestamp":1778579787192,"sessionID":"ses_abc","part":{"id":"prt_3","reason":"stop","messageID":"msg_1","sessionID":"ses_abc","type":"step-finish"}}`)
+	v, err := ParseVerdict(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v.Diagnosis != "pod OOMKilled" {
+		t.Fatalf("expected diagnosis 'pod OOMKilled', got %q", v.Diagnosis)
+	}
+	if v.Confidence != 0.88 {
+		t.Fatalf("expected confidence 0.88, got %v", v.Confidence)
+	}
+	if v.RecommendedAction != ActionAbort {
+		t.Fatalf("expected abort, got %q", v.RecommendedAction)
+	}
+}
+
+func TestParseVerdict_OpencodeNDJSONNoFence(t *testing.T) {
+	// opencode sometimes returns the JSON without code fences.
+	raw := []byte(`{"type":"step_start","timestamp":1,"sessionID":"s","part":{"type":"step-start"}}
+{"type":"text","timestamp":2,"sessionID":"s","part":{"type":"text","text":"{\"diagnosis\":\"all healthy\",\"causal_chain\":[],\"confidence\":0.95,\"recommended_action\":\"wait\"}"}}
+{"type":"step_finish","timestamp":3,"sessionID":"s","part":{"type":"step-finish"}}`)
+	v, err := ParseVerdict(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v.RecommendedAction != ActionWait {
+		t.Fatalf("expected wait, got %q", v.RecommendedAction)
+	}
+}
+
 func TestParseVerdict_RejectsConfidenceOutOfRange(t *testing.T) {
 	raw := []byte(`{"diagnosis":"x","confidence":1.5,"recommended_action":"wait"}`)
 	if _, err := ParseVerdict(raw); err == nil {
@@ -203,12 +238,12 @@ func TestClassify(t *testing.T) {
 
 func TestSupportedCLIs_StableOrder(t *testing.T) {
 	got := SupportedCLIs()
-	if len(got) < 2 || got[0] != "claude" || got[1] != "opencode" {
-		t.Fatalf("expected [claude opencode ...], got %v", got)
+	if len(got) < 2 || got[0] != "opencode" || got[1] != "claude" {
+		t.Fatalf("expected [opencode claude ...], got %v", got)
 	}
 	// Ensure callers can't mutate the package's internal slice.
 	got[0] = "tampered"
-	if SupportedCLIs()[0] != "claude" {
+	if SupportedCLIs()[0] != "opencode" {
 		t.Fatal("SupportedCLIs returns shared slice; callers can mutate package state")
 	}
 }
@@ -224,6 +259,24 @@ func TestBuildArgs_Opencode(t *testing.T) {
 	args := buildArgs(AgentCLI{Name: "opencode", Path: "/usr/bin/opencode"}, "be helpful")
 	if !contains(args, "run") || !contains(args, "be helpful") {
 		t.Fatalf("unexpected opencode args: %v", args)
+	}
+}
+
+func TestResolveCLI_EmptyFallsBackToDetect(t *testing.T) {
+	// When name is empty, ResolveCLI should behave like DetectCLI.
+	cli, err := ResolveCLI("")
+	if err != nil {
+		t.Skipf("no agent CLI on PATH (expected in CI): %v", err)
+	}
+	if cli.Name == "" || cli.Path == "" {
+		t.Fatal("ResolveCLI returned empty CLI for empty name")
+	}
+}
+
+func TestResolveCLI_NonExistentErrors(t *testing.T) {
+	_, err := ResolveCLI("nonexistent-agent-cli-xyz")
+	if err == nil {
+		t.Fatal("expected error for non-existent CLI name")
 	}
 }
 

--- a/scripts/deploy-camunda/agentwatch/cli.go
+++ b/scripts/deploy-camunda/agentwatch/cli.go
@@ -25,7 +25,7 @@ type AgentCLI struct {
 
 // supportedCLIs lists the agent CLIs we know how to invoke, in preference
 // order. Detection picks the first one found on PATH.
-var supportedCLIs = []string{"claude", "opencode"}
+var supportedCLIs = []string{"opencode", "claude"}
 
 // ErrNoAgentCLI is returned when neither supported CLI is installed.
 var ErrNoAgentCLI = errors.New(
@@ -42,6 +42,20 @@ func DetectCLI() (AgentCLI, error) {
 		}
 	}
 	return AgentCLI{}, ErrNoAgentCLI
+}
+
+// ResolveCLI returns an AgentCLI for the given name. If name is empty, it
+// falls back to DetectCLI (auto-detection). If a name is provided but the
+// binary cannot be found on PATH, an error is returned.
+func ResolveCLI(name string) (AgentCLI, error) {
+	if name == "" {
+		return DetectCLI()
+	}
+	path, err := exec.LookPath(name)
+	if err != nil {
+		return AgentCLI{}, fmt.Errorf("agent CLI %q not found on PATH: %w", name, err)
+	}
+	return AgentCLI{Name: name, Path: path}, nil
 }
 
 // buildArgs returns the command-line args for invoking the given CLI in

--- a/scripts/deploy-camunda/agentwatch/verdict.go
+++ b/scripts/deploy-camunda/agentwatch/verdict.go
@@ -1,6 +1,8 @@
 package agentwatch
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -152,14 +154,81 @@ func unwrapEnvelope(raw []byte) ([]byte, bool) {
 		return []byte(claude.Result), true
 	}
 
-	// Shape 2: opencode run --format json returns
-	//   {"output":"<assistant text>"} or similar.
-	var opencode struct {
+	// Shape 2: opencode run --format json returns a single JSON envelope
+	//   {"output":"<assistant text>"}.
+	var opencodeSingle struct {
 		Output string `json:"output"`
 	}
-	if err := json.Unmarshal(raw, &opencode); err == nil && opencode.Output != "" {
-		return []byte(opencode.Output), true
+	if err := json.Unmarshal(raw, &opencodeSingle); err == nil && opencodeSingle.Output != "" {
+		return []byte(opencodeSingle.Output), true
+	}
+
+	// Shape 3: opencode run --format json (current versions) emits NDJSON —
+	// newline-delimited JSON events. The assistant text lives in events with
+	// type "text", inside part.text. Concatenate all text parts to form the
+	// full response, then strip markdown code fences.
+	if text, ok := unwrapOpencodeNDJSON(raw); ok {
+		return []byte(text), true
 	}
 
 	return nil, false
+}
+
+// unwrapOpencodeNDJSON parses a stream of newline-delimited JSON events from
+// opencode's --format json output and extracts the concatenated assistant text.
+// Events have the shape: {"type":"text","part":{"text":"..."},...}
+func unwrapOpencodeNDJSON(raw []byte) (string, bool) {
+	scanner := bufio.NewScanner(bytes.NewReader(raw))
+	scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024) // allow large lines
+
+	var textParts []string
+	foundText := false
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var event struct {
+			Type string `json:"type"`
+			Part struct {
+				Text string `json:"text"`
+			} `json:"part"`
+		}
+		if err := json.Unmarshal(line, &event); err != nil {
+			continue
+		}
+		if event.Type == "text" && event.Part.Text != "" {
+			textParts = append(textParts, event.Part.Text)
+			foundText = true
+		}
+	}
+
+	if !foundText {
+		return "", false
+	}
+
+	text := strings.Join(textParts, "")
+	// Strip markdown code fences (```json ... ```) that the agent often wraps around JSON.
+	text = stripCodeFences(text)
+	return text, true
+}
+
+// stripCodeFences removes markdown code fences from text, handling both
+// ```json\n...\n``` and ```\n...\n``` patterns.
+func stripCodeFences(s string) string {
+	s = strings.TrimSpace(s)
+	// Try to strip opening fence
+	if strings.HasPrefix(s, "```") {
+		// Find end of opening fence line
+		if idx := strings.Index(s, "\n"); idx != -1 {
+			s = s[idx+1:]
+		}
+	}
+	// Strip closing fence
+	if strings.HasSuffix(s, "```") {
+		s = s[:len(s)-3]
+	}
+	return strings.TrimSpace(s)
 }

--- a/scripts/deploy-camunda/cmd/watch.go
+++ b/scripts/deploy-camunda/cmd/watch.go
@@ -34,6 +34,7 @@ func newWatchCommand() *cobra.Command {
 		corpusDir       string
 		maxTicks        int
 		logLevel        string
+		cliName         string
 	)
 
 	cmd := &cobra.Command{
@@ -66,7 +67,7 @@ Typical use:
 				return fmt.Errorf("--namespace is required")
 			}
 
-			cli, err := agentwatch.DetectCLI()
+			cli, err := agentwatch.ResolveCLI(cliName)
 			if err != nil {
 				return err
 			}
@@ -152,6 +153,7 @@ Typical use:
 		"Directory to persist snapshot+verdict pairs for the eval corpus (empty disables persistence)")
 	cmd.Flags().IntVar(&maxTicks, "max-ticks", 0, "Maximum number of poll ticks before exiting (0 = unbounded)")
 	cmd.Flags().StringVarP(&logLevel, "log-level", "l", "info", "Log level")
+	cmd.Flags().StringVar(&cliName, "cli", "", "Agent CLI to use: opencode or claude (auto-detected if empty)")
 
 	cmd.AddCommand(newWatchReplayCommand())
 
@@ -166,8 +168,9 @@ Typical use:
 // confidence threshold.
 func newWatchReplayCommand() *cobra.Command {
 	var (
-		strict   bool
-		logLevel string
+		strict      bool
+		logLevel    string
+		replayCLI   string
 	)
 	cmd := &cobra.Command{
 		Use:   "replay <corpus-dir>",
@@ -180,7 +183,7 @@ func newWatchReplayCommand() *cobra.Command {
 			}); err != nil {
 				return err
 			}
-			cli, err := agentwatch.DetectCLI()
+			cli, err := agentwatch.ResolveCLI(replayCLI)
 			if err != nil {
 				return err
 			}
@@ -203,5 +206,6 @@ func newWatchReplayCommand() *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&strict, "strict", true, "Exit non-zero if any verdict action class regresses")
 	cmd.Flags().StringVarP(&logLevel, "log-level", "l", "warn", "Log level (replay is noisy at info)")
+	cmd.Flags().StringVar(&replayCLI, "cli", "", "Agent CLI to use: opencode or claude (auto-detected if empty)")
 	return cmd
 }

--- a/test/integration/companion-charts/openldap/Chart.yaml
+++ b/test/integration/companion-charts/openldap/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: openldap
+description: Minimal OpenLDAP for CI integration testing (memberOf overlay enabled)
+type: application
+version: 0.1.0
+appVersion: "2.6"

--- a/test/integration/companion-charts/openldap/templates/configmap-config.yaml
+++ b/test/integration/companion-charts/openldap/templates/configmap-config.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-config-ldif
+  labels:
+    app.kubernetes.io/name: openldap
+    app.kubernetes.io/instance: {{ .Release.Name }}
+data:
+  # Enable the memberOf overlay module.
+  # This LDIF is loaded against cn=config during bootstrap (not the main DIT).
+  # It causes OpenLDAP to automatically maintain memberOf attributes on user
+  # entries when groups (groupOfNames) are modified — mimicking Active Directory behavior.
+  03-memberOf.ldif: |
+    dn: cn=module,cn=config
+    cn: module
+    objectClass: olcModuleList
+    olcModuleLoad: memberof
+
+    dn: olcOverlay=memberof,olcDatabase={1}mdb,cn=config
+    objectClass: olcOverlayConfig
+    objectClass: olcMemberOf
+    olcOverlay: memberof
+    olcMemberOfDangling: ignore
+    olcMemberOfGroupOC: groupOfNames
+    olcMemberOfMemberAD: member
+    olcMemberOfMemberOfAD: memberOf

--- a/test/integration/companion-charts/openldap/templates/configmap.yaml
+++ b/test/integration/companion-charts/openldap/templates/configmap.yaml
@@ -1,0 +1,70 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-seed-ldif
+  labels:
+    app.kubernetes.io/name: openldap
+    app.kubernetes.io/instance: {{ .Release.Name }}
+data:
+  # All seed data in one file to avoid Kubernetes ConfigMap symlink issues
+  # with osixia/openldap's bootstrap script processing hidden directories.
+  seed.ldif: |
+    # Organizational Units
+    dn: ou=Users,{{ .Values.baseDN }}
+    objectClass: organizationalUnit
+    ou: Users
+
+    dn: ou=AppGroups,{{ .Values.baseDN }}
+    objectClass: organizationalUnit
+    ou: AppGroups
+
+    dn: ou=InfraGroups,{{ .Values.baseDN }}
+    objectClass: organizationalUnit
+    ou: InfraGroups
+
+    # Test users
+    dn: cn=testuser,ou=Users,{{ .Values.baseDN }}
+    objectClass: inetOrgPerson
+    objectClass: organizationalPerson
+    objectClass: person
+    cn: testuser
+    sn: User
+    givenName: Test
+    uid: testuser
+    mail: testuser@test.local
+    userPassword: testpassword
+
+    dn: cn=testuser2,ou=Users,{{ .Values.baseDN }}
+    objectClass: inetOrgPerson
+    objectClass: organizationalPerson
+    objectClass: person
+    cn: testuser2
+    sn: User2
+    givenName: Test2
+    uid: testuser2
+    mail: testuser2@test.local
+    userPassword: testpassword
+
+    # Application groups (ou=AppGroups) — Mapper A scope
+    dn: cn=app-admin,ou=AppGroups,{{ .Values.baseDN }}
+    objectClass: groupOfNames
+    cn: app-admin
+    member: cn=testuser,ou=Users,{{ .Values.baseDN }}
+
+    dn: cn=app-viewer,ou=AppGroups,{{ .Values.baseDN }}
+    objectClass: groupOfNames
+    cn: app-viewer
+    member: cn=testuser,ou=Users,{{ .Values.baseDN }}
+    member: cn=testuser2,ou=Users,{{ .Values.baseDN }}
+
+    # Infrastructure groups (ou=InfraGroups) — Mapper B scope
+    dn: cn=infra-admin,ou=InfraGroups,{{ .Values.baseDN }}
+    objectClass: groupOfNames
+    cn: infra-admin
+    member: cn=testuser,ou=Users,{{ .Values.baseDN }}
+
+    dn: cn=infra-viewer,ou=InfraGroups,{{ .Values.baseDN }}
+    objectClass: groupOfNames
+    cn: infra-viewer
+    member: cn=testuser,ou=Users,{{ .Values.baseDN }}
+    member: cn=testuser2,ou=Users,{{ .Values.baseDN }}

--- a/test/integration/companion-charts/openldap/templates/deployment.yaml
+++ b/test/integration/companion-charts/openldap/templates/deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app.kubernetes.io/name: openldap
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: openldap
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: openldap
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: openldap
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "--copy-service"
+            - "--loglevel"
+            - "debug"
+          ports:
+            - name: ldap
+              containerPort: 389
+              protocol: TCP
+          env:
+            - name: LDAP_ORGANISATION
+              value: {{ .Values.organisation | quote }}
+            - name: LDAP_DOMAIN
+              value: {{ .Values.domain | quote }}
+            - name: LDAP_ADMIN_PASSWORD
+              value: {{ .Values.adminPassword | quote }}
+            - name: LDAP_CONFIG_PASSWORD
+              value: {{ .Values.configPassword | quote }}
+            - name: LDAP_REMOVE_CONFIG_AFTER_SETUP
+              value: "false"
+          volumeMounts:
+            # Config-level LDIF: memberOf overlay setup (subPath avoids K8s symlink issues)
+            - name: config-ldif
+              mountPath: /container/service/slapd/assets/config/bootstrap/ldif/03-memberOf.ldif
+              subPath: 03-memberOf.ldif
+            # Data LDIF: seed users and groups (subPath avoids K8s symlink issues)
+            - name: seed-ldif
+              mountPath: /container/service/slapd/assets/config/bootstrap/ldif/custom/seed.ldif
+              subPath: seed.ldif
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          readinessProbe:
+            tcpSocket:
+              port: 389
+            initialDelaySeconds: 15
+            periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: 389
+            initialDelaySeconds: 20
+            periodSeconds: 10
+      volumes:
+        - name: config-ldif
+          configMap:
+            name: {{ .Release.Name }}-config-ldif
+        - name: seed-ldif
+          configMap:
+            name: {{ .Release.Name }}-seed-ldif

--- a/test/integration/companion-charts/openldap/templates/service.yaml
+++ b/test/integration/companion-charts/openldap/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app.kubernetes.io/name: openldap
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 389
+      protocol: TCP
+      name: ldap
+  selector:
+    app.kubernetes.io/name: openldap
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/test/integration/companion-charts/openldap/values.yaml
+++ b/test/integration/companion-charts/openldap/values.yaml
@@ -1,0 +1,30 @@
+# OpenLDAP companion chart values for CI testing.
+# Deploys a single-replica OpenLDAP with memberOf overlay enabled,
+# pre-seeded with test users and groups for multi-mapper regression testing.
+
+image:
+  repository: osixia/openldap
+  tag: "1.5.0"
+  pullPolicy: IfNotPresent
+
+# LDAP admin credentials
+adminPassword: "adminpassword"
+# Config admin password (cn=admin,cn=config)
+configPassword: "configpassword"
+
+# Base DN for the directory
+baseDN: "dc=test,dc=local"
+organisation: "Test"
+domain: "test.local"
+
+# Service configuration
+service:
+  port: 389
+
+resources:
+  requests:
+    cpu: "100m"
+    memory: "128Mi"
+  limits:
+    cpu: "500m"
+    memory: "256Mi"

--- a/test/integration/companion-values/openldap.yaml
+++ b/test/integration/companion-values/openldap.yaml
@@ -1,0 +1,28 @@
+# CI values for the OpenLDAP companion chart.
+# Minimal single-replica deployment with memberOf overlay enabled.
+# Used to reproduce Keycloak multi-group-mapper regression (SUPPORT-32686).
+#
+# Deployed as a separate Helm release by deploy-camunda before the main
+# Camunda chart. Referenced from ci-test-config.yaml dependencies.
+
+image:
+  repository: osixia/openldap
+  tag: "1.5.0"
+  pullPolicy: IfNotPresent
+
+adminPassword: "adminpassword"
+configPassword: "configpassword"
+baseDN: "dc=test,dc=local"
+organisation: "Test"
+domain: "test.local"
+
+service:
+  port: 389
+
+resources:
+  requests:
+    cpu: "100m"
+    memory: "128Mi"
+  limits:
+    cpu: "500m"
+    memory: "256Mi"


### PR DESCRIPTION
## Summary

- Add OpenLDAP companion chart and `keycloak-ldap` CI scenario (disabled) to reproduce Keycloak [#45256](https://github.com/keycloak/keycloak/issues/45256) — a regression in KC 26.x where multiple LDAP group mappers with `GET_GROUPS_FROM_USER_MEMBEROF_ATTRIBUTE` strategy cause cross-mapper group deletion during user sync
- Fix `deploy-camunda watch` to support opencode CLI (NDJSON parsing, `--cli` flag, preference order swap)

## Context — SUPPORT-32686

Customers using Keycloak with multiple LDAP group mappers (e.g., separate AD OUs for different group categories) lose group memberships after upgrading to Keycloak 26.x. This is tracked upstream as [keycloak/keycloak#45256](https://github.com/keycloak/keycloak/issues/45256).

### Reproduction confirmed on GKE (Keycloak 26.3.3)

| Mapper Mode | Groups in JWT | Status |
|------------|--------------|--------|
| `LDAP_ONLY` | 2/4 (only last-synced mapper's groups) | **REGRESSION** |
| `READ_ONLY` | 4/4 (all groups correct) | OK |

**Trigger conditions** (all required):
1. Multiple LDAP group mappers on the same federation with different `groups.dn`
2. `mode: LDAP_ONLY`
3. `drop.non.existing.groups.during.sync: true`
4. `user.roles.retrieve.strategy: GET_GROUPS_FROM_USER_MEMBEROF_ATTRIBUTE`

**Customer workaround**: Switch mapper mode from `LDAP_ONLY` to `READ_ONLY`. Impact is minimal if LDAP/AD is the sole authority for group management (typical enterprise pattern) — the only difference is that group assignments made via Keycloak Admin Console won't propagate back to LDAP.

## Changes

### OpenLDAP companion chart (`test/integration/companion-charts/openldap/`)
- Deployment, Service, ConfigMaps for osixia/openldap:1.5.0
- memberOf overlay enabled via config LDIF (mimics Active Directory behavior)
- Seed data: 2 users, 4 groups across 2 OUs (AppGroups, InfraGroups)

### LDAP feature values (`values/features/ldap.yaml`)
- keycloakConfigCli realm JSON with LDAP federation + 2 group-ldap-mappers
- Each mapper scoped to a different `groups.dn` with `GET_GROUPS_FROM_USER_MEMBEROF_ATTRIBUTE`

### CI scenario (`ci-test-config.yaml`)
- New `keycloak-ldap` scenario (shortname `keldp`), **disabled** — for manual reproduction only
- Uses companion chart dependency mechanism

### deploy-camunda watch fixes
- Swap CLI preference to opencode-first (claude second)
- Add `ResolveCLI()` for explicit `--cli` flag selection on watch and replay
- Parse opencode NDJSON format (verdict text in `{"type":"text","part":{"text":"..."}}` events)
- Strip markdown code fences from agent responses

## Testing
- All 22 agentwatch Go tests pass
- Regression reproduced on GKE namespace `inc-32686-ldap-repro`
- Scenario is `enabled: false` — no CI impact