### PR TITLE
test: support opencode CLI in deploy-camunda watch command

### DIFF
--- a/scripts/deploy-camunda/agentwatch/agentwatch_test.go
+++ b/scripts/deploy-camunda/agentwatch/agentwatch_test.go
@@ -75,6 +75,41 @@ func TestParseVerdict_RejectsInvalidAction(t *testing.T) {
 	}
 }
 
+func TestParseVerdict_OpencodeNDJSON(t *testing.T) {
+	// opencode run --format json emits newline-delimited JSON events.
+	// The verdict text is in {"type":"text","part":{"text":"..."}} events.
+	raw := []byte(`{"type":"step_start","timestamp":1778579787017,"sessionID":"ses_abc","part":{"id":"prt_1","messageID":"msg_1","sessionID":"ses_abc","type":"step-start"}}
+{"type":"text","timestamp":1778579787124,"sessionID":"ses_abc","part":{"id":"prt_2","messageID":"msg_1","sessionID":"ses_abc","type":"text","text":"` + "```json\\n{\\\"diagnosis\\\":\\\"pod OOMKilled\\\",\\\"causal_chain\\\":[\\\"memory limit 256Mi\\\"],\\\"confidence\\\":0.88,\\\"recommended_action\\\":\\\"abort\\\"}\\n```" + `","time":{"start":1778579787018,"end":1778579787122}}}
+{"type":"step_finish","timestamp":1778579787192,"sessionID":"ses_abc","part":{"id":"prt_3","reason":"stop","messageID":"msg_1","sessionID":"ses_abc","type":"step-finish"}}`)
+	v, err := ParseVerdict(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v.Diagnosis != "pod OOMKilled" {
+		t.Fatalf("expected diagnosis 'pod OOMKilled', got %q", v.Diagnosis)
+	}
+	if v.Confidence != 0.88 {
+		t.Fatalf("expected confidence 0.88, got %v", v.Confidence)
+	}
+	if v.RecommendedAction != ActionAbort {
+		t.Fatalf("expected abort, got %q", v.RecommendedAction)
+	}
+}
+
+func TestParseVerdict_OpencodeNDJSONNoFence(t *testing.T) {
+	// opencode sometimes returns the JSON without code fences.
+	raw := []byte(`{"type":"step_start","timestamp":1,"sessionID":"s","part":{"type":"step-start"}}
+{"type":"text","timestamp":2,"sessionID":"s","part":{"type":"text","text":"{\"diagnosis\":\"all healthy\",\"causal_chain\":[],\"confidence\":0.95,\"recommended_action\":\"wait\"}"}}
+{"type":"step_finish","timestamp":3,"sessionID":"s","part":{"type":"step-finish"}}`)
+	v, err := ParseVerdict(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v.RecommendedAction != ActionWait {
+		t.Fatalf("expected wait, got %q", v.RecommendedAction)
+	}
+}
+
 func TestParseVerdict_RejectsConfidenceOutOfRange(t *testing.T) {
 	raw := []byte(`{"diagnosis":"x","confidence":1.5,"recommended_action":"wait"}`)
 	if _, err := ParseVerdict(raw); err == nil {
@@ -203,12 +238,12 @@ func TestClassify(t *testing.T) {
 
 func TestSupportedCLIs_StableOrder(t *testing.T) {
 	got := SupportedCLIs()
-	if len(got) < 2 || got[0] != "claude" || got[1] != "opencode" {
-		t.Fatalf("expected [claude opencode ...], got %v", got)
+	if len(got) < 2 || got[0] != "opencode" || got[1] != "claude" {
+		t.Fatalf("expected [opencode claude ...], got %v", got)
 	}
 	// Ensure callers can't mutate the package's internal slice.
 	got[0] = "tampered"
-	if SupportedCLIs()[0] != "claude" {
+	if SupportedCLIs()[0] != "opencode" {
 		t.Fatal("SupportedCLIs returns shared slice; callers can mutate package state")
 	}
 }
@@ -224,6 +259,24 @@ func TestBuildArgs_Opencode(t *testing.T) {
 	args := buildArgs(AgentCLI{Name: "opencode", Path: "/usr/bin/opencode"}, "be helpful")
 	if !contains(args, "run") || !contains(args, "be helpful") {
 		t.Fatalf("unexpected opencode args: %v", args)
+	}
+}
+
+func TestResolveCLI_EmptyFallsBackToDetect(t *testing.T) {
+	// When name is empty, ResolveCLI should behave like DetectCLI.
+	cli, err := ResolveCLI("")
+	if err != nil {
+		t.Skipf("no agent CLI on PATH (expected in CI): %v", err)
+	}
+	if cli.Name == "" || cli.Path == "" {
+		t.Fatal("ResolveCLI returned empty CLI for empty name")
+	}
+}
+
+func TestResolveCLI_NonExistentErrors(t *testing.T) {
+	_, err := ResolveCLI("nonexistent-agent-cli-xyz")
+	if err == nil {
+		t.Fatal("expected error for non-existent CLI name")
 	}
 }
 

--- a/scripts/deploy-camunda/agentwatch/cli.go
+++ b/scripts/deploy-camunda/agentwatch/cli.go
@@ -25,7 +25,7 @@ type AgentCLI struct {
 
 // supportedCLIs lists the agent CLIs we know how to invoke, in preference
 // order. Detection picks the first one found on PATH.
-var supportedCLIs = []string{"claude", "opencode"}
+var supportedCLIs = []string{"opencode", "claude"}
 
 // ErrNoAgentCLI is returned when neither supported CLI is installed.
 var ErrNoAgentCLI = errors.New(
@@ -42,6 +42,20 @@ func DetectCLI() (AgentCLI, error) {
 		}
 	}
 	return AgentCLI{}, ErrNoAgentCLI
+}
+
+// ResolveCLI returns an AgentCLI for the given name. If name is empty, it
+// falls back to DetectCLI (auto-detection). If a name is provided but the
+// binary cannot be found on PATH, an error is returned.
+func ResolveCLI(name string) (AgentCLI, error) {
+	if name == "" {
+		return DetectCLI()
+	}
+	path, err := exec.LookPath(name)
+	if err != nil {
+		return AgentCLI{}, fmt.Errorf("agent CLI %q not found on PATH: %w", name, err)
+	}
+	return AgentCLI{Name: name, Path: path}, nil
 }
 
 // buildArgs returns the command-line args for invoking the given CLI in

--- a/scripts/deploy-camunda/agentwatch/cli.go
+++ b/scripts/deploy-camunda/agentwatch/cli.go
@@ -51,6 +51,16 @@ func ResolveCLI(name string) (AgentCLI, error) {
 	if name == "" {
 		return DetectCLI()
 	}
+	supported := false
+	for _, s := range supportedCLIs {
+		if name == s {
+			supported = true
+			break
+		}
+	}
+	if !supported {
+		return AgentCLI{}, fmt.Errorf("unsupported agent CLI %q; supported: %v", name, supportedCLIs)
+	}
 	path, err := exec.LookPath(name)
 	if err != nil {
 		return AgentCLI{}, fmt.Errorf("agent CLI %q not found on PATH: %w", name, err)

--- a/scripts/deploy-camunda/agentwatch/verdict.go
+++ b/scripts/deploy-camunda/agentwatch/verdict.go
@@ -1,6 +1,8 @@
 package agentwatch
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -152,14 +154,81 @@ func unwrapEnvelope(raw []byte) ([]byte, bool) {
 		return []byte(claude.Result), true
 	}
 
-	// Shape 2: opencode run --format json returns
-	//   {"output":"<assistant text>"} or similar.
-	var opencode struct {
+	// Shape 2: opencode run --format json returns a single JSON envelope
+	//   {"output":"<assistant text>"}.
+	var opencodeSingle struct {
 		Output string `json:"output"`
 	}
-	if err := json.Unmarshal(raw, &opencode); err == nil && opencode.Output != "" {
-		return []byte(opencode.Output), true
+	if err := json.Unmarshal(raw, &opencodeSingle); err == nil && opencodeSingle.Output != "" {
+		return []byte(opencodeSingle.Output), true
+	}
+
+	// Shape 3: opencode run --format json (current versions) emits NDJSON —
+	// newline-delimited JSON events. The assistant text lives in events with
+	// type "text", inside part.text. Concatenate all text parts to form the
+	// full response, then strip markdown code fences.
+	if text, ok := unwrapOpencodeNDJSON(raw); ok {
+		return []byte(text), true
 	}
 
 	return nil, false
+}
+
+// unwrapOpencodeNDJSON parses a stream of newline-delimited JSON events from
+// opencode's --format json output and extracts the concatenated assistant text.
+// Events have the shape: {"type":"text","part":{"text":"..."},...}
+func unwrapOpencodeNDJSON(raw []byte) (string, bool) {
+	scanner := bufio.NewScanner(bytes.NewReader(raw))
+	scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024) // allow large lines
+
+	var textParts []string
+	foundText := false
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var event struct {
+			Type string `json:"type"`
+			Part struct {
+				Text string `json:"text"`
+			} `json:"part"`
+		}
+		if err := json.Unmarshal(line, &event); err != nil {
+			continue
+		}
+		if event.Type == "text" && event.Part.Text != "" {
+			textParts = append(textParts, event.Part.Text)
+			foundText = true
+		}
+	}
+
+	if !foundText {
+		return "", false
+	}
+
+	text := strings.Join(textParts, "")
+	// Strip markdown code fences (```json ... ```) that the agent often wraps around JSON.
+	text = stripCodeFences(text)
+	return text, true
+}
+
+// stripCodeFences removes markdown code fences from text, handling both
+// ```json\n...\n``` and ```\n...\n``` patterns.
+func stripCodeFences(s string) string {
+	s = strings.TrimSpace(s)
+	// Try to strip opening fence
+	if strings.HasPrefix(s, "```") {
+		// Find end of opening fence line
+		if idx := strings.Index(s, "\n"); idx != -1 {
+			s = s[idx+1:]
+		}
+	}
+	// Strip closing fence
+	if strings.HasSuffix(s, "```") {
+		s = s[:len(s)-3]
+	}
+	return strings.TrimSpace(s)
 }

--- a/scripts/deploy-camunda/agentwatch/verdict.go
+++ b/scripts/deploy-camunda/agentwatch/verdict.go
@@ -205,6 +205,9 @@ func unwrapOpencodeNDJSON(raw []byte) (string, bool) {
 		}
 	}
 
+	if err := scanner.Err(); err != nil {
+		return "", false
+	}
 	if !foundText {
 		return "", false
 	}

--- a/scripts/deploy-camunda/cmd/watch.go
+++ b/scripts/deploy-camunda/cmd/watch.go
@@ -34,6 +34,7 @@ func newWatchCommand() *cobra.Command {
 		corpusDir       string
 		maxTicks        int
 		logLevel        string
+		cliName         string
 	)
 
 	cmd := &cobra.Command{
@@ -66,7 +67,7 @@ Typical use:
 				return fmt.Errorf("--namespace is required")
 			}
 
-			cli, err := agentwatch.DetectCLI()
+			cli, err := agentwatch.ResolveCLI(cliName)
 			if err != nil {
 				return err
 			}
@@ -152,6 +153,7 @@ Typical use:
 		"Directory to persist snapshot+verdict pairs for the eval corpus (empty disables persistence)")
 	cmd.Flags().IntVar(&maxTicks, "max-ticks", 0, "Maximum number of poll ticks before exiting (0 = unbounded)")
 	cmd.Flags().StringVarP(&logLevel, "log-level", "l", "info", "Log level")
+	cmd.Flags().StringVar(&cliName, "cli", "", "Agent CLI to use: opencode or claude (auto-detected if empty)")
 
 	cmd.AddCommand(newWatchReplayCommand())
 
@@ -166,8 +168,9 @@ Typical use:
 // confidence threshold.
 func newWatchReplayCommand() *cobra.Command {
 	var (
-		strict   bool
-		logLevel string
+		strict      bool
+		logLevel    string
+		replayCLI   string
 	)
 	cmd := &cobra.Command{
 		Use:   "replay <corpus-dir>",
@@ -180,7 +183,7 @@ func newWatchReplayCommand() *cobra.Command {
 			}); err != nil {
 				return err
 			}
-			cli, err := agentwatch.DetectCLI()
+			cli, err := agentwatch.ResolveCLI(replayCLI)
 			if err != nil {
 				return err
 			}
@@ -203,5 +206,6 @@ func newWatchReplayCommand() *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&strict, "strict", true, "Exit non-zero if any verdict action class regresses")
 	cmd.Flags().StringVarP(&logLevel, "log-level", "l", "warn", "Log level (replay is noisy at info)")
+	cmd.Flags().StringVar(&replayCLI, "cli", "", "Agent CLI to use: opencode or claude (auto-detected if empty)")
 	return cmd
 }


### PR DESCRIPTION
## Summary

- Add opencode NDJSON output parsing for `deploy-camunda watch` verdict extraction
- Add `--cli` flag to explicitly select agent CLI (opencode or claude)
- Swap default CLI preference order to opencode-first

## Changes

### `agentwatch/cli.go`
- Swap `supportedCLIs` preference order to `["opencode", "claude"]`
- Add `ResolveCLI(name string)` — resolves a specific CLI by name, falls back to auto-detection when empty

### `agentwatch/verdict.go`
- Add `unwrapOpencodeNDJSON()` — parses opencode's streaming NDJSON format where verdict text lives in `{"type":"text","part":{"text":"..."}}` events
- Add `stripCodeFences()` — removes markdown code fences (```` ```json ... ``` ````) that agents wrap around JSON responses

### `cmd/watch.go`
- Add `--cli` flag to both `watch` and `watch replay` subcommands
- Use `ResolveCLI(cliName)` instead of `DetectCLI()`

## Testing

All 22 agentwatch tests pass, including new tests:
- `TestParseVerdict_OpencodeNDJSON` — NDJSON with code-fenced JSON
- `TestParseVerdict_OpencodeNDJSONNoFence` — NDJSON without fences
- `TestResolveCLI_EmptyFallsBackToDetect`
- `TestResolveCLI_NonExistentErrors`
- `TestSupportedCLIs_StableOrder` — updated for new preference order