### PR TITLE
ci(8.8): add LDAP multi-group-mapper reproduction scenario

### DIFF
--- a/charts/camunda-platform-8.8/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.8/test/ci-test-config.yaml
@@ -280,6 +280,30 @@ integration:
             gke: distroci
           features: [persistence,migrator]
           platforms: [gke]
+        - name: keycloak-ldap
+          # Disabled: reproducing the regression requires manual post-deploy
+          # steps (configure group mappers via KC Admin API, trigger sync, verify
+          # token). There is no E2E test that automates this flow yet. Enable
+          # only for manual investigation of Keycloak #45256.
+          #
+          # Bug: multiple LDAP group mappers with LDAP_ONLY mode +
+          # GET_GROUPS_FROM_USER_MEMBEROF_ATTRIBUTE cause cross-mapper group
+          # deletion during user sync (KC 26.x regression).
+          # Ref: SUPPORT-32686, https://github.com/keycloak/keycloak/issues/45256
+          enabled: false
+          shortname: keldp
+          auth: keycloak
+          flow: install
+          identity: keycloak
+          persistence: elasticsearch
+          features: [ldap]
+          platforms: [gke]
+          infra-type:
+            gke: distroci
+          dependencies:
+            - chart: test/integration/companion-charts/openldap
+              release-name: openldap
+              values-file: test/integration/companion-values/openldap.yaml
 
         # ===========================================================================
         # Backward-compat scenarios — referenced by .github/workflows/test-backward-compat.yaml

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/ldap.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/ldap.yaml
@@ -1,0 +1,158 @@
+# LDAP multi-group-mapper feature configuration for 8.8
+# Layer 4: Feature - LDAP federation with multiple group mappers
+#
+# Purpose: Reproduce Keycloak #45256 regression where multiple LDAP group
+# mappers using GET_GROUPS_FROM_USER_MEMBEROF_ATTRIBUTE strategy only show
+# groups from one mapper on users/tokens after Keycloak 26.2.6+.
+#
+# Reproduction result (Keycloak 26.3.3 on GKE):
+#   - mode: LDAP_ONLY  -> testuser gets 2/4 groups (REGRESSION)
+#   - mode: READ_ONLY  -> testuser gets 4/4 groups (correct)
+#
+# Root cause: In LDAP_ONLY mode, each mapper's sync resolves group memberships
+# scoped to its own groups.dn. With dropNonExistingGroupsDuringSync=true,
+# mapper A removes groups from mapper B's scope (they appear "non-existing"
+# from A's perspective), and vice versa. The last mapper to sync wins.
+#
+# Trigger conditions (ALL required):
+#   1. Multiple LDAP group mappers with different groups.dn
+#   2. mode: LDAP_ONLY (READ_ONLY is unaffected)
+#   3. drop.non.existing.groups.during.sync: true
+#   4. user.roles.retrieve.strategy: GET_GROUPS_FROM_USER_MEMBEROF_ATTRIBUTE
+#
+# Customer workaround: Switch mode from LDAP_ONLY to READ_ONLY.
+#
+# Requires: OpenLDAP companion chart deployed in the same namespace
+# (release name "openldap", service "openldap:389").
+#
+# Ref: SUPPORT-32686, https://github.com/keycloak/keycloak/issues/45256
+
+identityKeycloak:
+  keycloakConfigCli:
+    enabled: true
+    configuration:
+      ldap-federation.json: |
+        {
+          "realm": "camunda-platform",
+          "components": {
+            "org.keycloak.storage.UserStorageProvider": [
+              {
+                "name": "openldap-federation",
+                "providerId": "ldap",
+                "config": {
+                  "vendor": ["other"],
+                  "connectionUrl": ["ldap://openldap:389"],
+                  "bindDn": ["cn=admin,dc=test,dc=local"],
+                  "bindCredential": ["adminpassword"],
+                  "usersDn": ["ou=Users,dc=test,dc=local"],
+                  "usernameLDAPAttribute": ["uid"],
+                  "rdnLDAPAttribute": ["cn"],
+                  "uuidLDAPAttribute": ["entryUUID"],
+                  "userObjectClasses": ["inetOrgPerson"],
+                  "editMode": ["READ_ONLY"],
+                  "searchScope": ["1"],
+                  "pagination": ["false"],
+                  "importEnabled": ["true"],
+                  "syncRegistrations": ["false"],
+                  "trustEmail": ["true"],
+                  "enabled": ["true"],
+                  "priority": ["0"],
+                  "cachePolicy": ["DEFAULT"],
+                  "batchSizeForSync": ["1000"],
+                  "fullSyncPeriod": ["-1"],
+                  "changedSyncPeriod": ["-1"]
+                },
+                "subComponents": {
+                  "org.keycloak.storage.ldap.mappers.LDAPStorageMapper": [
+                    {
+                      "name": "username",
+                      "providerId": "user-attribute-ldap-mapper",
+                      "config": {
+                        "ldap.attribute": ["uid"],
+                        "user.model.attribute": ["username"],
+                        "read.only": ["true"],
+                        "always.read.value.from.ldap": ["true"],
+                        "is.mandatory.in.ldap": ["true"]
+                      }
+                    },
+                    {
+                      "name": "email",
+                      "providerId": "user-attribute-ldap-mapper",
+                      "config": {
+                        "ldap.attribute": ["mail"],
+                        "user.model.attribute": ["email"],
+                        "read.only": ["true"],
+                        "always.read.value.from.ldap": ["true"],
+                        "is.mandatory.in.ldap": ["false"]
+                      }
+                    },
+                    {
+                      "name": "first name",
+                      "providerId": "user-attribute-ldap-mapper",
+                      "config": {
+                        "ldap.attribute": ["givenName"],
+                        "user.model.attribute": ["firstName"],
+                        "read.only": ["true"],
+                        "always.read.value.from.ldap": ["true"],
+                        "is.mandatory.in.ldap": ["true"]
+                      }
+                    },
+                    {
+                      "name": "last name",
+                      "providerId": "user-attribute-ldap-mapper",
+                      "config": {
+                        "ldap.attribute": ["sn"],
+                        "user.model.attribute": ["lastName"],
+                        "read.only": ["true"],
+                        "always.read.value.from.ldap": ["true"],
+                        "is.mandatory.in.ldap": ["true"]
+                      }
+                    },
+                    {
+                      "name": "app-groups-mapper",
+                      "providerId": "group-ldap-mapper",
+                      "config": {
+                        "groups.dn": ["ou=AppGroups,dc=test,dc=local"],
+                        "group.name.ldap.attribute": ["cn"],
+                        "group.object.classes": ["groupOfNames"],
+                        "preserve.group.inheritance": ["false"],
+                        "ignore.missing.groups": ["false"],
+                        "membership.ldap.attribute": ["member"],
+                        "membership.attribute.type": ["DN"],
+                        "membership.user.ldap.attribute": ["cn"],
+                        "groups.ldap.filter": [],
+                        "mode": ["READ_ONLY"],
+                        "user.roles.retrieve.strategy": ["GET_GROUPS_FROM_USER_MEMBEROF_ATTRIBUTE"],
+                        "memberof.ldap.attribute": ["memberOf"],
+                        "mapped.group.attributes": [],
+                        "drop.non.existing.groups.during.sync": ["true"],
+                        "groups.path": ["/app-groups"]
+                      }
+                    },
+                    {
+                      "name": "infra-groups-mapper",
+                      "providerId": "group-ldap-mapper",
+                      "config": {
+                        "groups.dn": ["ou=InfraGroups,dc=test,dc=local"],
+                        "group.name.ldap.attribute": ["cn"],
+                        "group.object.classes": ["groupOfNames"],
+                        "preserve.group.inheritance": ["false"],
+                        "ignore.missing.groups": ["false"],
+                        "membership.ldap.attribute": ["member"],
+                        "membership.attribute.type": ["DN"],
+                        "membership.user.ldap.attribute": ["cn"],
+                        "groups.ldap.filter": [],
+                        "mode": ["READ_ONLY"],
+                        "user.roles.retrieve.strategy": ["GET_GROUPS_FROM_USER_MEMBEROF_ATTRIBUTE"],
+                        "memberof.ldap.attribute": ["memberOf"],
+                        "mapped.group.attributes": [],
+                        "drop.non.existing.groups.during.sync": ["true"],
+                        "groups.path": ["/infra-groups"]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }

--- a/test/integration/companion-charts/openldap/Chart.yaml
+++ b/test/integration/companion-charts/openldap/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: openldap
+description: Minimal OpenLDAP for CI integration testing (memberOf overlay enabled)
+type: application
+version: 0.1.0
+appVersion: "2.6"
+# Purpose: Reproduce Keycloak #45256 — a regression in KC 26.x where multiple
+# LDAP group mappers with GET_GROUPS_FROM_USER_MEMBEROF_ATTRIBUTE strategy and
+# LDAP_ONLY mode cause cross-mapper group deletion during user sync.
+#
+# The memberOf overlay mimics Active Directory's automatic memberOf attribute
+# maintenance, which is required to trigger the regression code path in
+# Keycloak's UserRolesRetrieveStrategy.GetRolesFromUserMemberOfAttribute.
+#
+# Ref: SUPPORT-32686, https://github.com/keycloak/keycloak/issues/45256

--- a/test/integration/companion-charts/openldap/templates/configmap-config.yaml
+++ b/test/integration/companion-charts/openldap/templates/configmap-config.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-config-ldif
+  labels:
+    app.kubernetes.io/name: openldap
+    app.kubernetes.io/instance: {{ .Release.Name }}
+data:
+  # Enable the memberOf overlay module.
+  # This LDIF is loaded against cn=config during bootstrap (not the main DIT).
+  # It causes OpenLDAP to automatically maintain memberOf attributes on user
+  # entries when groups (groupOfNames) are modified — mimicking Active Directory behavior.
+  03-memberOf.ldif: |
+    dn: cn=module,cn=config
+    cn: module
+    objectClass: olcModuleList
+    olcModuleLoad: memberof
+
+    dn: olcOverlay=memberof,olcDatabase={1}mdb,cn=config
+    objectClass: olcOverlayConfig
+    objectClass: olcMemberOf
+    olcOverlay: memberof
+    olcMemberOfDangling: ignore
+    olcMemberOfGroupOC: groupOfNames
+    olcMemberOfMemberAD: member
+    olcMemberOfMemberOfAD: memberOf

--- a/test/integration/companion-charts/openldap/templates/configmap.yaml
+++ b/test/integration/companion-charts/openldap/templates/configmap.yaml
@@ -1,0 +1,82 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-seed-ldif
+  labels:
+    app.kubernetes.io/name: openldap
+    app.kubernetes.io/instance: {{ .Release.Name }}
+data:
+  # All seed data in one file to avoid Kubernetes ConfigMap symlink issues
+  # with osixia/openldap's bootstrap script processing hidden directories.
+  #
+  # Data layout mirrors a typical enterprise AD with groups in separate OUs:
+  #   ou=Users        — test users (testuser, testuser2)
+  #   ou=AppGroups    — application-level groups (Keycloak group mapper A scope)
+  #   ou=InfraGroups  — infrastructure groups (Keycloak group mapper B scope)
+  #
+  # testuser is a member of ALL 4 groups (2 per OU). The memberOf overlay
+  # automatically populates testuser.memberOf with all 4 group DNs.
+  #
+  # Expected behavior: testuser should see all 4 groups in their JWT token.
+  # Regression (KC 26.x, LDAP_ONLY mode): testuser only sees groups from the
+  # last mapper that synced (2/4 groups).
+  seed.ldif: |
+    # Organizational Units
+    dn: ou=Users,{{ .Values.baseDN }}
+    objectClass: organizationalUnit
+    ou: Users
+
+    dn: ou=AppGroups,{{ .Values.baseDN }}
+    objectClass: organizationalUnit
+    ou: AppGroups
+
+    dn: ou=InfraGroups,{{ .Values.baseDN }}
+    objectClass: organizationalUnit
+    ou: InfraGroups
+
+    # Test users
+    dn: cn=testuser,ou=Users,{{ .Values.baseDN }}
+    objectClass: inetOrgPerson
+    objectClass: organizationalPerson
+    objectClass: person
+    cn: testuser
+    sn: User
+    givenName: Test
+    uid: testuser
+    mail: testuser@test.local
+    userPassword: testpassword
+
+    dn: cn=testuser2,ou=Users,{{ .Values.baseDN }}
+    objectClass: inetOrgPerson
+    objectClass: organizationalPerson
+    objectClass: person
+    cn: testuser2
+    sn: User2
+    givenName: Test2
+    uid: testuser2
+    mail: testuser2@test.local
+    userPassword: testpassword
+
+    # Application groups (ou=AppGroups) — Mapper A scope
+    dn: cn=app-admin,ou=AppGroups,{{ .Values.baseDN }}
+    objectClass: groupOfNames
+    cn: app-admin
+    member: cn=testuser,ou=Users,{{ .Values.baseDN }}
+
+    dn: cn=app-viewer,ou=AppGroups,{{ .Values.baseDN }}
+    objectClass: groupOfNames
+    cn: app-viewer
+    member: cn=testuser,ou=Users,{{ .Values.baseDN }}
+    member: cn=testuser2,ou=Users,{{ .Values.baseDN }}
+
+    # Infrastructure groups (ou=InfraGroups) — Mapper B scope
+    dn: cn=infra-admin,ou=InfraGroups,{{ .Values.baseDN }}
+    objectClass: groupOfNames
+    cn: infra-admin
+    member: cn=testuser,ou=Users,{{ .Values.baseDN }}
+
+    dn: cn=infra-viewer,ou=InfraGroups,{{ .Values.baseDN }}
+    objectClass: groupOfNames
+    cn: infra-viewer
+    member: cn=testuser,ou=Users,{{ .Values.baseDN }}
+    member: cn=testuser2,ou=Users,{{ .Values.baseDN }}

--- a/test/integration/companion-charts/openldap/templates/deployment.yaml
+++ b/test/integration/companion-charts/openldap/templates/deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app.kubernetes.io/name: openldap
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: openldap
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: openldap
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: openldap
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "--copy-service"
+            - "--loglevel"
+            - "debug"
+          ports:
+            - name: ldap
+              containerPort: 389
+              protocol: TCP
+          env:
+            - name: LDAP_ORGANISATION
+              value: {{ .Values.organisation | quote }}
+            - name: LDAP_DOMAIN
+              value: {{ .Values.domain | quote }}
+            - name: LDAP_ADMIN_PASSWORD
+              value: {{ .Values.adminPassword | quote }}
+            - name: LDAP_CONFIG_PASSWORD
+              value: {{ .Values.configPassword | quote }}
+            - name: LDAP_REMOVE_CONFIG_AFTER_SETUP
+              value: "false"
+          volumeMounts:
+            # Config-level LDIF: memberOf overlay setup (subPath avoids K8s symlink issues)
+            - name: config-ldif
+              mountPath: /container/service/slapd/assets/config/bootstrap/ldif/03-memberOf.ldif
+              subPath: 03-memberOf.ldif
+            # Data LDIF: seed users and groups (subPath avoids K8s symlink issues)
+            - name: seed-ldif
+              mountPath: /container/service/slapd/assets/config/bootstrap/ldif/custom/seed.ldif
+              subPath: seed.ldif
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          readinessProbe:
+            tcpSocket:
+              port: 389
+            initialDelaySeconds: 15
+            periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: 389
+            initialDelaySeconds: 20
+            periodSeconds: 10
+      volumes:
+        - name: config-ldif
+          configMap:
+            name: {{ .Release.Name }}-config-ldif
+        - name: seed-ldif
+          configMap:
+            name: {{ .Release.Name }}-seed-ldif

--- a/test/integration/companion-charts/openldap/templates/service.yaml
+++ b/test/integration/companion-charts/openldap/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app.kubernetes.io/name: openldap
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 389
+      protocol: TCP
+      name: ldap
+  selector:
+    app.kubernetes.io/name: openldap
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/test/integration/companion-charts/openldap/values.yaml
+++ b/test/integration/companion-charts/openldap/values.yaml
@@ -1,0 +1,30 @@
+# OpenLDAP companion chart values for CI testing.
+# Deploys a single-replica OpenLDAP with memberOf overlay enabled,
+# pre-seeded with test users and groups for multi-mapper regression testing.
+
+image:
+  repository: osixia/openldap
+  tag: "1.5.0"
+  pullPolicy: IfNotPresent
+
+# LDAP admin credentials
+adminPassword: "adminpassword"
+# Config admin password (cn=admin,cn=config)
+configPassword: "configpassword"
+
+# Base DN for the directory
+baseDN: "dc=test,dc=local"
+organisation: "Test"
+domain: "test.local"
+
+# Service configuration
+service:
+  port: 389
+
+resources:
+  requests:
+    cpu: "100m"
+    memory: "128Mi"
+  limits:
+    cpu: "500m"
+    memory: "256Mi"

--- a/test/integration/companion-values/openldap.yaml
+++ b/test/integration/companion-values/openldap.yaml
@@ -1,0 +1,40 @@
+# CI values for the OpenLDAP companion chart.
+# Minimal single-replica deployment with memberOf overlay enabled.
+# Used to reproduce Keycloak multi-group-mapper regression (SUPPORT-32686).
+#
+# Deployed as a separate Helm release by deploy-camunda before the main
+# Camunda chart. Referenced from ci-test-config.yaml dependencies.
+#
+# The chart seeds 2 users and 4 groups across 2 OUs (ou=AppGroups, ou=InfraGroups).
+# The memberOf overlay auto-maintains memberOf attributes on users, mimicking
+# Active Directory behavior required to trigger Keycloak #45256.
+#
+# To reproduce the regression after deployment:
+#   1. Configure 2 LDAP group mappers in Keycloak (one per OU)
+#   2. Set mode=LDAP_ONLY, drop.non.existing.groups.during.sync=true,
+#      user.roles.retrieve.strategy=GET_GROUPS_FROM_USER_MEMBEROF_ATTRIBUTE
+#   3. Trigger full user sync — testuser will only have groups from one mapper
+#
+# Ref: https://github.com/keycloak/keycloak/issues/45256
+
+image:
+  repository: osixia/openldap
+  tag: "1.5.0"
+  pullPolicy: IfNotPresent
+
+adminPassword: "adminpassword"
+configPassword: "configpassword"
+baseDN: "dc=test,dc=local"
+organisation: "Test"
+domain: "test.local"
+
+service:
+  port: 389
+
+resources:
+  requests:
+    cpu: "100m"
+    memory: "128Mi"
+  limits:
+    cpu: "500m"
+    memory: "256Mi"


### PR DESCRIPTION
## Summary

- Add OpenLDAP companion chart and `keycloak-ldap` CI scenario (disabled) to reproduce Keycloak [#45256](https://github.com/keycloak/keycloak/issues/45256)
- Regression confirmed on GKE with Keycloak 26.3.3: multiple LDAP group mappers with `LDAP_ONLY` mode cause cross-mapper group deletion during user sync
- **Exhaustive testing (25+ scenarios on KC 26.3.3, 10+ on KC EE 26.5.6, AD + OpenLDAP)** confirms READ_ONLY mode is NOT affected
- **Default group mapper mode is `LDAP_ONLY`** — customers likely have this without realizing

## Context

Users of Keycloak with multiple LDAP group mappers (e.g., separate AD OUs for different group categories) lose group memberships after upgrading to Keycloak 26.x. This is tracked upstream as [keycloak/keycloak#45256](https://github.com/keycloak/keycloak/issues/45256).

## Critical Discovery: Default Mode is LDAP_ONLY

```
KC ServerInfo → group-ldap-mapper → mode:
  defaultValue: "LDAP_ONLY"     ← THIS IS THE BUG TRIGGER
  options: ["LDAP_ONLY", "IMPORT", "READ_ONLY"]
```

When customers create group mappers via the Admin UI without changing the Mode dropdown, they get `LDAP_ONLY` — the broken mode. They may report "mode=READ_ONLY" when actually referring to the **federation** `editMode` (a different setting).

**Valid group mapper modes** (NOT the federation `editMode`):
| Mode | Behavior | Multi-mapper safe? |
|------|----------|-------------------|
| `LDAP_ONLY` (DEFAULT) | Groups only in LDAP; KC removes other mappers' groups during sync | **NO** |
| `IMPORT` | Groups imported once on user create; never re-resolved | **NO** (0 groups on 2nd sync) |
| `READ_ONLY` | Groups resolved from LDAP memberOf on every access | **YES — always correct** |

Note: `WRITABLE` is NOT a valid group mapper mode in KC 26 (only valid for federation `editMode`). Setting it via API causes `IllegalArgumentException` at runtime.

## Exhaustive Reproduction Testing

Tested on GKE with:
- `quay.io/keycloak/keycloak:26.3.3` (vanilla OSS)
- `docker.io/camunda/keycloak:26.3.3` (Camunda OSS with PR #39903 backport)
- `registry.camunda.cloud/keycloak-ee/keycloak:26.5.6` (Camunda Enterprise)

Results are identical across all three images.

### Setup — OpenLDAP
- OpenLDAP with memberOf overlay (mimics AD)
- 2 users: `testuser` (member of 4 groups), `testuser2` (member of 2 groups)
- 4 groups across 2 OUs: `ou=AppGroups` (app-admin, app-viewer) and `ou=InfraGroups` (infra-admin, infra-viewer)
- Expected result: `testuser` JWT should contain all 4 groups

### Setup — Samba Active Directory
- `nowsci/samba-domain:latest` (domain `TESTCORP.LOCAL`)
- `testuser2` is member of `app-viewer` (OU=AppGroups) and `infra-viewer` (OU=InfraGroups)
- Native AD `memberOf` back-links (not OpenLDAP overlay)
- Expected result: `testuser2` should see 2 groups

### Configurations that FAIL

| Scenario | Backend | Mapper Mode | Strategy | dropNonExisting | groups.path | Result |
|----------|---------|-------------|----------|-----------------|-------------|--------|
| S1 | OpenLDAP | LDAP_ONLY | memberOf | true | `/` | 2/4 :x: |
| J | OpenLDAP | LDAP_ONLY | memberOf | true | `/` | 2/4 :x: |
| L | OpenLDAP | LDAP_ONLY | memberOf | true | `/` | 2/4 :x: |
| P | OpenLDAP | Mixed (RO + LDAP_ONLY) | memberOf | true | `/` | 2/4 :x: |
| T | OpenLDAP | IMPORT | memberOf | true | `/` | 0/4 :x: |
| AD-1 | Samba AD | LDAP_ONLY | memberOf | true | `/` | 1/2 :x: |
| AD-2 | Samba AD | IMPORT (2nd sync) | memberOf | true | `/` | 0/2 :x: |

### Configurations that PASS

| Scenario | Backend | Mapper Mode | Strategy | dropNonExisting | groups.path | Notes |
|----------|---------|-------------|----------|-----------------|-------------|-------|
| S2 | OpenLDAP | READ_ONLY | memberOf | true | `/` | Standard config |
| S3 | OpenLDAP | READ_ONLY | memberOf | true | `/` | importEnabled=false |
| S4 | OpenLDAP | READ_ONLY | LOAD_GROUPS_BY_MEMBER | true | `/` | Alt strategy |
| S5 | OpenLDAP | READ_ONLY | memberOf | true | `/` | preserveInheritance=false |
| S6 | OpenLDAP | READ_ONLY | memberOf | false | `/` | dropNonExisting=false |
| S7 | OpenLDAP | READ_ONLY | memberOf | true | `/` | federation editMode=WRITABLE |
| A | OpenLDAP | READ_ONLY | memberOf | true | `/` | Login BETWEEN mapper syncs |
| B | OpenLDAP | READ_ONLY | memberOf | true | scoped | Distinct paths |
| **D** | **OpenLDAP** | **LDAP_ONLY** | **memberOf** | **true** | **scoped** | **PASS with distinct paths!** |
| AD-3 | Samba AD | READ_ONLY | memberOf | true | `/` | 2/2 correct :white_check_mark: |
| AD-4 | Samba AD | READ_ONLY + preserveInheritance=true | memberOf | true | `/` | 2/2 :white_check_mark: |
| AD-5 | Samba AD | READ_ONLY (editMode=WRITABLE) | memberOf | true | `/` | 2/2 :white_check_mark: |

### KC EE 26.5.6 Extended Testing (Multi-Tenant + Clustered)

Tested on `registry.camunda.cloud/keycloak-ee/keycloak:26.5.6`:

| Test | Configuration | Result |
|------|--------------|--------|
| S2 rerun | 1 federation, 2 mappers, READ_ONLY, memberOf, drop=true, path=/ | :white_check_mark: 4/4 |
| Rapid sync | 5 rounds of group sync + user sync in quick succession | :white_check_mark: 4/4 |
| Changed sync | `triggerChangedUsersSync` after full sync | :white_check_mark: 4/4 |
| Multi-tenant | 4 federations x 2 mappers (8 total), unique group names per tenant | :white_check_mark: 4/4 per tenant |
| Same-named groups | 4 federations x 2 mappers, shared name across tenants | :white_check_mark: 6/6 per tenant |
| Group obliteration | Group sync removes 14-15 cross-tenant groups → immediate login | :white_check_mark: All groups restored |
| importEnabled=false | No local user cache, 2 mappers | :white_check_mark: 4/4 |
| LOAD_GROUPS_BY_MEMBER | Alternative strategy, 2 mappers | :white_check_mark: 4/4 |
| Token claim | OIDC mapper, login after group sync destroys KC groups | :white_check_mark: 4 groups in JWT |
| **Clustered KC** | 2 replicas + PostgreSQL, separate Infinispan caches | :white_check_mark: 4/4 |
| **Cross-pod cache** | Group sync on Pod A, login on Pod B | :white_check_mark: 4/4 |
| **Periodic sync** | fullSyncPeriod=10, changedSyncPeriod=10, observe 5+ cycles | :white_check_mark: Stable |

### Samba AD Comprehensive Mode Matrix

Tested on Samba AD (`TESTCORP.LOCAL`) with KC EE 26.5.6 clustered:

| Mapper A Mode | Mapper B Mode | Federation editMode | Result | Status |
|--------------|--------------|--------------------|---------|----|
| READ_ONLY | READ_ONLY | READ_ONLY | 2/2 | :white_check_mark: |
| LDAP_ONLY | LDAP_ONLY | READ_ONLY | 1/2 (last mapper only) | :x: |
| IMPORT | IMPORT (1st sync) | READ_ONLY | 2/2 (fresh import) | :white_check_mark: |
| IMPORT | IMPORT (2nd sync) | READ_ONLY | 0/2 | :x: |
| IMPORT | IMPORT (noDrop=false, 2nd sync) | READ_ONLY | 0/2 | :x: |
| READ_ONLY | READ_ONLY | WRITABLE | 2/2 | :white_check_mark: |

**IMPORT mode finding:** First sync (fresh user import) works correctly. Second sync fails because:
1. Group entity removal by cross-mapper `dropNonExisting` deletes group objects
2. `onImportUserFromLDAP` only assigns groups on `isCreate=true` — existing users never get re-assigned
3. `proxy()` in IMPORT mode returns raw delegate (no LDAP resolution) — KC-local state is used as-is

## Root Cause Analysis

Two bugs in `GroupLDAPStorageMapper.java`:

### Bug 1: `dropNonExistingKcGroups` (group sync)

```java
// Line 341 — removes ALL KC groups at groups.path not in THIS mapper's LDAP
getAllKcGroups(realm, parent)
    .filter(kcGroup -> !visitedGroupIds.contains(kcGroup.getId()))
    .forEach(kcGroup -> realm.removeGroup(kcGroup));  // Destroys sibling mapper groups!
```

### Bug 2: `getGroupsStream` in LDAP_ONLY delegate (user resolution)

```java
// Line 713 — only returns THIS mapper's LDAP groups, ignores delegate chain
if (config.isTopLevelGroupsPath() && config.getMode() == LDAPGroupMapperMode.LDAP_ONLY) {
    return ldapGroupMappings;  // Loses all groups from inner delegate (other mappers)
}
```

**READ_ONLY avoids both bugs** because its delegate ALWAYS chains via `super.getGroupsStream()` and resolves from LDAP memberOf on every access — so even when group entities are removed, user memberships are re-resolved correctly.

## Key Findings

1. **`LDAP_ONLY` mode is the confirmed regression trigger** — AND it's the server default for new mappers
2. **`READ_ONLY` mode is NEVER affected** (tested on OpenLDAP, Samba AD, single instance, clustered, CE, EE)
3. **Using distinct `groups.path` is a workaround** that fixes even LDAP_ONLY mode
4. **PR #39903 does NOT change behavior** vs vanilla KC 26.3.3
5. **Clustered KC (2 replicas + PostgreSQL) does NOT reproduce READ_ONLY failure**
6. **No upstream fix exists** — issue #45256 is still open, marked "help wanted", no PR submitted

## Workarounds (validated on GKE)

| # | Workaround | Impact | Validated |
|---|-----------|--------|-----------|
| 1 | **Switch mapper mode to `READ_ONLY`** | Minimal — loses KC-to-LDAP group write-back | All scenarios pass |
| 2 | Use distinct `groups.path` (e.g., `/AppGroups`) | Requires creating parent groups in KC | Fixes even LDAP_ONLY |
| 3 | Set `drop.non.existing.groups.during.sync: false` | May leave stale groups in KC | Tested, works |

**Recommendation: Workaround #1 (READ_ONLY mode) — immediate, no restart needed.**

## Changes

### OpenLDAP companion chart (`test/integration/companion-charts/openldap/`)
- Deployment, Service, ConfigMaps for `osixia/openldap:1.5.0`
- memberOf overlay enabled via config LDIF (mimics Active Directory behavior)
- Seed data: 2 users, 4 groups across 2 OUs (AppGroups, InfraGroups)

### LDAP feature values (`values/features/ldap.yaml`)
- keycloakConfigCli realm JSON with LDAP federation + 2 group-ldap-mappers
- Each mapper scoped to a different `groups.dn` with `GET_GROUPS_FROM_USER_MEMBEROF_ATTRIBUTE`

### CI scenario (`ci-test-config.yaml`)
- New `keycloak-ldap` scenario (shortname `keldp`), **disabled** — for manual reproduction only
- Uses companion chart dependency mechanism

## Conclusion: Why READ_ONLY Cannot Be Reproduced as Failing

After analyzing all 8 comments on [keycloak/keycloak#45256](https://github.com/keycloak/keycloak/issues/45256) and the source code:

### No upstream reporter actually uses READ_ONLY mode

| Reporter | Mode stated | Backend | Federation editMode |
|----------|------------|---------|---------------------|
| docholiday/bit-nstmn | **`LDAP_ONLY`** (explicitly) | Microsoft AD | `UNSYNCED` |
| jitkang | "LDAP_ONLY and IMPORT" (explicitly) | AWS Managed AD + FreeIPA | not stated |
| big-bug-ant | not stated ("imported in KC 19") | OpenLDAP 2.4.46 | not stated |

**Not a single reporter claims to use `READ_ONLY` mapper mode.** They all use `LDAP_ONLY` (the server default).

### The code proves READ_ONLY is structurally immune

The bug is in `GroupLDAPStorageMapper.java` line 713, inside the `LDAPGroupMappingsUserDelegate.getGroupsStream()`:

```java
@Override
public Stream<GroupModel> getGroupsStream() {
    Stream<GroupModel> ldapGroupMappings = getLDAPGroupMappingsConverted();
    if (config.isTopLevelGroupsPath() && config.getMode() == LDAPGroupMapperMode.LDAP_ONLY) {
        // LDAP_ONLY: returns ONLY this mapper's groups — breaks delegate chain!
        return ldapGroupMappings;
    } else {
        // READ_ONLY: merges this mapper's groups with super (which chains to other mappers)
        return Stream.concat(ldapGroupMappings, super.getGroupsStream());
    }
}
```

When multiple group mappers exist, KC wraps the user in a **chain of delegates**:
```
UserModel → Mapper_B's Delegate → Mapper_A's Delegate → DB User
```

**In `READ_ONLY` mode** (the `else` branch):
- Mapper B's delegate: `concat(B_LDAP_groups, super.getGroupsStream())`
- `super` calls Mapper A's delegate: `concat(A_LDAP_groups, DB_groups)`
- Final: ALL groups from ALL mappers → **always correct**

**In `LDAP_ONLY` mode with `groups.path=/`** (the `if` branch):
- Mapper B's delegate: returns `B_LDAP_groups` **only**
- `super.getGroupsStream()` is **never called** → Mapper A's groups are invisible
- Final: only the last-applied mapper's groups → **broken**

### This explains ALL observations

1. **Original reporter has `dropNonExisting: Off`** — yet still sees the issue. Because Bug #2 (delegate chain) operates at user resolution time, completely independent of group sync.

2. **KC developer (vramik) couldn't reproduce** — because their test used **distinct `groups.path`** (`/AppGroups`, `/DeptGroups`). When path ≠ `/`, `isTopLevelGroupsPath()` returns `false`, so code always takes the `else` branch (which chains correctly). Same reason our Scenario D passes.

3. **`READ_ONLY` can never be affected** — the condition `config.getMode() == LDAPGroupMapperMode.LDAP_ONLY` is never true for READ_ONLY, so it always takes the `else` branch that preserves the delegate chain.

4. **"Last mapper wins"** — because the outermost delegate's `getGroupsStream()` returns only its own LDAP groups without calling `super`, the inner delegates (earlier mappers) are unreachable.


## Testing
- Scenario is `enabled: false` — no CI impact
- Manually verified on GKE namespace `inc-32686-ldap-repro` across **35+ configurations**
- Tested on vanilla KC 26.3.3, Camunda KC 26.3.3, and **KC EE 26.5.6**
- Tested on **both OpenLDAP and Samba Active Directory**
- Multi-tenant architecture (4 federations x 2 mappers) validated on EE image
- **Clustered KC** (2 replicas + PostgreSQL + Infinispan) validated — no stale cache issues

