### PR TITLE
fix(ci): use hardcoded Keycloak client IDs in 8.8 elasticsearch mapping rules

### DIFF
--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/migrator.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/migrator.yaml
@@ -1,10 +1,17 @@
 orchestration:
   upgrade:
-    # Nightly tests run SNAPSHOT builds. The SchemaManager.checkVersionCompatibility()
-    # call explicitly rejects SNAPSHOT-to-SNAPSHOT upgrades unless this flag is set.
-    # Without it, migration-importer crashes with IncompatibleVersionException on
-    # every nightly upgrade run.
+    # Nightly tests run SNAPSHOT builds. Zeebe's partition engine rejects
+    # SNAPSHOT-to-SNAPSHOT upgrades unless this flag is set (sets
+    # camunda.system.upgrade.enable-version-check: false in application.yaml).
     allowPreReleaseImages: true
+  env:
+    # Disables the SearchEngineSchemaInitializer's own SNAPSHOT version check,
+    # which is separate from the Zeebe engine check above. Without this, the
+    # searchEngineSchemaInitializer bean crashes at startup even when
+    # enable-version-check is false. Already set by oidc.yaml for OIDC scenarios;
+    # added here so Keycloak upgrade scenarios are also covered.
+    - name: CAMUNDA_DATABASE_SCHEMAMANAGER_VERSIONCHECKRESTRICTIONENABLED
+      value: "false"
   importer:
     enabled: true
   migration:

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/migrator.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/migrator.yaml
@@ -1,4 +1,10 @@
 orchestration:
+  upgrade:
+    # Nightly tests run SNAPSHOT builds. The SchemaManager.checkVersionCompatibility()
+    # call explicitly rejects SNAPSHOT-to-SNAPSHOT upgrades unless this flag is set.
+    # Without it, migration-importer crashes with IncompatibleVersionException on
+    # every nightly upgrade run.
+    allowPreReleaseImages: true
   importer:
     enabled: true
   migration:

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
@@ -244,6 +244,39 @@ connectors:
           existingSecretKey: "identity-connectors-client-token"
 
 orchestration:
+  env:
+    # Security mapping rules — written into the Zeebe raft log on first boot of
+    # the 8.8 cluster so the orchestration layer can authenticate Keycloak users.
+    # Placed in the identity layer (keycloak.yaml) rather than the persistence
+    # layer so they don't clobber the Entra/OIDC mapping rules in oidc.yaml
+    # (persistence is applied after identity in the layered-values merge).
+    # Uses hardcoded Keycloak claim names/values: preferred_username for users,
+    # client_id for service accounts ($VENOM_CLIENT_ID/$CONNECTORS_CLIENT_ID are
+    # only substituted for OIDC/Entra scenarios, not Keycloak).
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_0_MAPPINGRULEID
+      value: "demo-user-mapping-rule"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_0_CLAIMNAME
+      value: "preferred_username"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_0_CLAIMVALUE
+      value: "demo"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_1_MAPPINGRULEID
+      value: "venom-client-mapping-rule"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_1_CLAIMNAME
+      value: "client_id"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_1_CLAIMVALUE
+      value: "venom"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_2_MAPPINGRULEID
+      value: "connectors-client-mapping-rule"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_2_CLAIMNAME
+      value: "client_id"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_2_CLAIMVALUE
+      value: "connectors"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGRULES_0
+      value: "demo-user-mapping-rule"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGRULES_1
+      value: "venom-client-mapping-rule"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGRULES_2
+      value: "connectors-client-mapping-rule"
   security:
     initialization:
       defaultRoles:

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/persistence/elasticsearch.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/persistence/elasticsearch.yaml
@@ -8,37 +8,3 @@ global:
 elasticsearch:
   enabled: true
   maxUnavailable: 0
-
-orchestration:
-  env:
-    # Security mapping rules — written into the Zeebe raft log during the 8.8
-    # upgrade step so the orchestration layer can authenticate users via
-    # Keycloak. Without these, the 8.7→8.8 upgrade leaves the orchestration
-    # cluster without mapping rules, causing Access Denied on /orchestration/
-    # endpoints after upgrade. Uses hardcoded Keycloak client IDs (venom,
-    # connectors) since $VENOM_CLIENT_ID/$CONNECTORS_CLIENT_ID are only
-    # substituted for OIDC/Entra scenarios, not Keycloak.
-    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_0_MAPPINGRULEID
-      value: "demo-user-mapping-rule"
-    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_0_CLAIMNAME
-      value: "preferred_username"
-    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_0_CLAIMVALUE
-      value: "demo"
-    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_1_MAPPINGRULEID
-      value: "venom-client-mapping-rule"
-    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_1_CLAIMNAME
-      value: "client_id"
-    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_1_CLAIMVALUE
-      value: "venom"
-    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_2_MAPPINGRULEID
-      value: "connectors-client-mapping-rule"
-    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_2_CLAIMNAME
-      value: "client_id"
-    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_2_CLAIMVALUE
-      value: "connectors"
-    - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGRULES_0
-      value: "demo-user-mapping-rule"
-    - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGRULES_1
-      value: "venom-client-mapping-rule"
-    - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGRULES_2
-      value: "connectors-client-mapping-rule"

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/persistence/elasticsearch.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/persistence/elasticsearch.yaml
@@ -15,7 +15,9 @@ orchestration:
     # upgrade step so the orchestration layer can authenticate users via
     # Keycloak. Without these, the 8.7→8.8 upgrade leaves the orchestration
     # cluster without mapping rules, causing Access Denied on /orchestration/
-    # endpoints after upgrade. Mirrors the fix applied to opensearch.yaml.
+    # endpoints after upgrade. Uses hardcoded Keycloak client IDs (venom,
+    # connectors) since $VENOM_CLIENT_ID/$CONNECTORS_CLIENT_ID are only
+    # substituted for OIDC/Entra scenarios, not Keycloak.
     - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_0_MAPPINGRULEID
       value: "demo-user-mapping-rule"
     - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_0_CLAIMNAME
@@ -27,13 +29,13 @@ orchestration:
     - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_1_CLAIMNAME
       value: "client_id"
     - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_1_CLAIMVALUE
-      value: "$VENOM_CLIENT_ID"
+      value: "venom"
     - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_2_MAPPINGRULEID
       value: "connectors-client-mapping-rule"
     - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_2_CLAIMNAME
       value: "client_id"
     - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_2_CLAIMVALUE
-      value: "$CONNECTORS_CLIENT_ID"
+      value: "connectors"
     - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGRULES_0
       value: "demo-user-mapping-rule"
     - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGRULES_1


### PR DESCRIPTION
## Summary

[Successful upgrade from 8.7 to 8.8 run using this branch](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25742870006) ✅ 

Nightly upgrade fom 8.7 to 8.8 flow is currently now working. 

- `$VENOM_CLIENT_ID` and `$CONNECTORS_CLIENT_ID` are only substituted by the deploy-camunda runner for OIDC/Entra scenarios (via `entra.IsOIDCEntry`)
- For the Keycloak-based `qa-elasticsearch-upg` scenario, these variables resolve to **empty strings** during `envsubst`
- This caused `CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_*_CLAIMVALUE = ""` to be written to the Zeebe 8.8 raft log on first startup, causing zeebe-2 to crash in CrashLoopBackOff during the rolling upgrade
- The StatefulSet rolling update stalls at zeebe-2, leaving zeebe-0/1 on the old 8.7 config, which cascades to migration-importer CrashLoopBackOff and migration-identity job stuck in Init

Fix: Replace `$VENOM_CLIENT_ID` → `"venom"` and `$CONNECTORS_CLIENT_ID` → `"connectors"` — the literal Keycloak client IDs configured in `base-qa.yaml` and `values.yaml` defaults.

## Root cause chain

1. PR #6129 added mapping rules to `elasticsearch.yaml` (merged) ✅
2. But those rules used `$VENOM_CLIENT_ID`/`$CONNECTORS_CLIENT_ID` which aren't set for Keycloak scenarios
3. Empty claimValues → Zeebe 8.8 broker 2 crashes during raft log initialization
4. Rolling upgrade stalls → all downstream (importer, identity migration) fail

## Test plan
- [ ] Re-trigger `SM Nightly 8.8 Upgrade Minor` from this branch
- [ ] Verify `integration-zeebe-2` starts successfully and rolling upgrade completes
- [ ] Verify `integration-zeebe-migration-importer` runs without CrashLoopBackOff
- [ ] Verify `migration-path-user-flows.spec.ts` passes all 7 tests

Nightly run that exposed this: https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25731226897

🤖 Generated with [Claude Code](https://claude.com/claude-code)