### PR TITLE
ci: add schema update to renovate post-upgrade tasks

### DIFF
--- a/.github/workflows/renovate-post-upgrade.yaml
+++ b/.github/workflows/renovate-post-upgrade.yaml
@@ -112,10 +112,18 @@ jobs:
           else
             make helm.readme-update
           fi
+      - name: Update Schema
+        run: |
+          if [ -n "${CHANGED_CHARTS}" ]; then
+            chartPath="${CHANGED_CHARTS}" \
+              make helm.schema-update
+          else
+            make helm.schema-update
+          fi
       - name: Git pull
         run: git pull --rebase --autostash .
       - uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
         with:
           author_name: "renovate[bot]"
           author_email: "29139614+renovate[bot]@users.noreply.github.com"
-          message: "chore(deps): post upgrade tasks - go mod tidy and update golden files"
+          message: "chore(deps): post upgrade tasks - go mod tidy, update golden files, readme, and schema"

--- a/.github/workflows/renovate-post-upgrade.yaml
+++ b/.github/workflows/renovate-post-upgrade.yaml
@@ -14,6 +14,10 @@ on:
       - '**/go.mod'
       - '**/go.sum'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -126,4 +130,4 @@ jobs:
         with:
           author_name: "renovate[bot]"
           author_email: "29139614+renovate[bot]@users.noreply.github.com"
-          message: "chore(deps): post upgrade tasks - go mod tidy, update golden files, readme, and schema"
+          message: "chore(ci): post upgrade tasks - go mod tidy, update golden files, readme, and schema"

--- a/.github/workflows/renovate-post-upgrade.yaml
+++ b/.github/workflows/renovate-post-upgrade.yaml
@@ -16,7 +16,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -130,4 +130,4 @@ jobs:
         with:
           author_name: "renovate[bot]"
           author_email: "29139614+renovate[bot]@users.noreply.github.com"
-          message: "chore(ci): post upgrade tasks - go mod tidy, update golden files, readme, and schema"
+          message: "chore(deps): post upgrade tasks - go mod tidy, update golden files, readme, and schema"


### PR DESCRIPTION
## Summary

Adds `helm.schema-update` to `renovate-post-upgrade.yaml`, closing a gap that causes lint failures on all Renovate minor-update PRs that touch image tags.

## Background

There are two workflows responsible for keeping generated chart files in sync:

**`chart-chores.yaml`** — runs on normal PRs and auto-commits three updates:
1. `go.update-golden-only` — regenerates golden test snapshots
2. `helm.readme-update` — regenerates README tables from values.yaml
3. `helm.schema-update` — regenerates `values.schema.json` from values.yaml

**`renovate-post-upgrade.yaml`** — the Renovate-specific equivalent. It exists because `chart-chores.yaml` explicitly skips `renovate/*` branches (`if: !startsWith(github.head_ref, 'renovate/')`) to avoid race conditions where both workflows push commits to the same branch simultaneously.

The original intent (commit 8c94d974, Sep 2024) was that `renovate-post-upgrade.yaml` would mirror `chart-chores.yaml` for Renovate branches. However, when it was created it only included steps 1 and 2 — **`helm.schema-update` was never added**.

## The gap in practice

When Renovate bumps an image tag (e.g. `curlimages/curl: 8.19.0 → 8.20.0`), it updates `values.yaml`. That default value is also embedded in `values.schema.json`:

```json
"tag": {
    "type": "string",
    "description": "...",
    "default": "8.19.0"   ← not updated by Renovate
}
```

`renovate-post-upgrade.yaml` runs, correctly updates the golden file and README, but never touches the schema. The lint job then runs `make helm.schema-update`, diffs the output against what's committed, finds a mismatch, and fails.

Observed in camunda/camunda-platform-helm#6112.

## Fix

Add `helm.schema-update` as a step in `renovate-post-upgrade.yaml`, using the same conditional pattern already in place for golden files and README.

Two additional changes based on review feedback:

**`concurrency: cancel-in-progress: false`** — this workflow commits generated files back to the branch via `add-and-commit`. With `cancel-in-progress: true`, a second push to the same branch (e.g. Renovate rebasing) would kill an in-flight run before it reaches the commit step, silently dropping the schema update — the exact problem this PR fixes. Setting `false` serialises runs so each one always completes its write-back before the next begins.

**Commit message type stays `chore(deps):`** — the auto-generated commit describes post-upgrade tasks triggered by a dependency bump, not a change to CI infrastructure itself.

## Test plan

- [ ] Merge this PR
- [ ] Verify the next Renovate minor-updates PR that touches `values.yaml` passes `8.x - Validation / Lint` without manual schema fixup