### PR TITLE
ci: skip closed issues in triage workflows

### DIFF
--- a/.github/workflows/triage-ai-issue.yml
+++ b/.github/workflows/triage-ai-issue.yml
@@ -185,9 +185,17 @@ jobs:
             ISSUE_TITLE=$(echo "$ISSUE_DATA" | jq -r '.title')
             ISSUE_BODY=$(echo "$ISSUE_DATA" | jq -r '.body // ""')
             ISSUE_LABELS=$(echo "$ISSUE_DATA" | jq -r '.labels[].name' | tr '\n' ',' | sed 's/,$//')
+            ISSUE_STATE=$(echo "$ISSUE_DATA" | jq -r '.state')
 
             echo "📄 Title: $ISSUE_TITLE"
             echo "🏷️  Labels: ${ISSUE_LABELS:-none}"
+
+            # Skip closed issues: re-labeling a closed issue must not re-run triage
+            # or overwrite the project Status field (e.g. ✅ Done → 📋 Backlog).
+            if [[ "$ISSUE_STATE" == "closed" ]]; then
+              echo "⏭️  Skipping: issue is closed"
+              continue
+            fi
 
             # Check if already triaged or marked for manual review
             if echo "$ISSUE_LABELS" | grep -qi "TRIAGE:COMPLETED"; then

--- a/.github/workflows/triage-assign-urgency-to-issue.yml
+++ b/.github/workflows/triage-assign-urgency-to-issue.yml
@@ -142,6 +142,7 @@ jobs:
             repository(owner:\$owner,name:\$repo){
               issue(number:\$issueNumber){
                 id
+                state
                 issueType { name }
                 labels(first:100){ nodes { name } }
                 projectItems(first:100){
@@ -194,6 +195,15 @@ jobs:
 
           ISSUE_DATA='${{ steps.fetch_data.outputs.issue_data }}'
           PROJECT_DATA='${{ steps.fetch_data.outputs.project_data }}'
+
+          # Skip closed issues: re-labeling a closed issue must not re-run urgency
+          # calculation or overwrite its project Status field.
+          ISSUE_STATE=$(echo "$ISSUE_DATA" | jq -r '.state // empty')
+          if [[ "$ISSUE_STATE" == "CLOSED" ]]; then
+            echo "⏭️ Issue #${ISSUE_NUMBER} is closed; skipping urgency assignment"
+            echo "in_target_project=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           # Extract project information
           TARGET_PROJECT_NODE_ID=$(echo "$PROJECT_DATA" | jq -r '.id // empty')


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6140.

### What's in this PR?

`triage-ai-issue.yml` and `triage-assign-urgency-to-issue.yml` trigger on `issues.labeled` and processed any issue without checking its open/closed state. Re-labeling a closed issue therefore re-ran the AI triage pipeline and overwrote the project Status field, flipping `✅ Done` back to `📋 Backlog` (or `⏭️ Ready` via the urgency workflow).

This PR adds a state guard inside the per-issue loop of each workflow so closed issues are skipped before any labels are applied or Status mutations are performed.

- `triage-ai-issue.yml`: read `state` from the per-issue REST fetch; `continue` on `closed`.
- `triage-assign-urgency-to-issue.yml`: include `state` in the GraphQL query; in `Validate project membership`, short-circuit when `CLOSED` by setting `in_target_project=false` and exiting cleanly — all gated steps then skip.

Reproduction and affected-item list documented in #6140.

### Checklist

**Before opening the PR:**

- [x] There is no other open pull request for the same update/change.

**After opening the PR:**

- [ ] Did all checks/tests pass in the PR?