### PR TITLE
fix(8.8): add missing kcor backward-compat scenario to ci-test-config

### DIFF
--- a/charts/camunda-platform-8.8/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.8/test/ci-test-config.yaml
@@ -221,6 +221,16 @@ integration:
           identity: keycloak
           persistence: elasticsearch
           platforms: [gke]
+        # kcor is referenced by .github/workflows/test-backward-compat.yaml's
+        # compat-camunda-docker job (camunda/docker-build-helm-integration.yml).
+        - name: keycloak-original
+          enabled: false
+          flow: install
+          shortname: kcor
+          auth: keycloak
+          identity: keycloak
+          persistence: elasticsearch
+          platforms: [gke]
         # `es` is the test-integration-template default shortname; used by the
         # compat-camunda-simple job (camunda/camunda-helm-integration.yml).
         - name: elasticsearch


### PR DESCRIPTION
## Summary
- Adds a disabled `keycloak-original` / `kcor` entry to `charts/camunda-platform-8.8/test/ci-test-config.yaml` so the `camunda/camunda` monorepo's `docker-build-helm-integration.yml` workflow can resolve this scenario for 8.8 deployments.

## Problem
The `docker-build-helm-integration.yml` workflow invokes `deploy-camunda matrix run` with `--shortname-filter kcor --scenario-filter keycloak-original` for chart version 8.8, but no matching entry existed in `ci-test-config.yaml`. This caused the deploy step to fail with:
```
Error: no matrix entries matched the filters (versions=[8.8], scenario-filter="keycloak-original",
shortname-filter="kcor", flow-filter="install", platform="gke")
```
See: https://github.com/camunda/camunda/actions/runs/25437767048/job/74621893424

## Fix
Added a disabled `keycloak-original` entry with shortname `kcor`, mirroring the entry already present in the 8.9 config (line 566). The entry is `enabled: false` so it doesn't appear in the regular PR CI matrix — the compat workflow resolves it via `--include-disabled`.

## Verification
- `deploy-camunda matrix list --include-disabled --versions 8.8` now shows the `kcor` entry
- `deploy-camunda matrix run --dry-run` resolves the correct values layers
- All Go unit tests pass (`make go.test chartPath=charts/camunda-platform-8.8`)