### PR TITLE
ci: remove sudo from playwright-e2e-tests container action

### DIFF
--- a/.github/actions/playwright-e2e-tests/action.yaml
+++ b/.github/actions/playwright-e2e-tests/action.yaml
@@ -73,9 +73,10 @@ runs:
         fi
         
         # Install gettext for envsubst command used by render-e2e-env.sh
+        # Note: no sudo — containers run as root, and sudo may not be installed.
         if command -v apt-get &> /dev/null; then
           install_packages() {
-            sudo apt-get update && sudo apt-get install -y gettext-base
+            apt-get update && apt-get install -y gettext-base
           }
 
           # Try up to 5 times with exponential backoff
@@ -88,14 +89,14 @@ runs:
 
             if [ $attempt -lt 5 ]; then
               echo "apt-get failed, cleaning cache and retrying in $((attempt * 30)) seconds..."
-              sudo rm -rf /var/lib/apt/lists/*
+              rm -rf /var/lib/apt/lists/*
               sleep $((attempt * 30))
 
               # On third attempt, try switching to a different mirror
               if [ $attempt -eq 3 ]; then
                 echo "Switching to alternative Ubuntu mirror..."
-                sudo sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list 2>/dev/null || true
-                sudo sed -i 's|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list 2>/dev/null || true
+                sed -i 's|http://archive.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list 2>/dev/null || true
+                sed -i 's|http://security.ubuntu.com|http://mirrors.edge.kernel.org|g' /etc/apt/sources.list 2>/dev/null || true
               fi
             else
               echo "All attempts failed"
@@ -123,7 +124,7 @@ runs:
       uses: camunda/infra-global-github-actions/common-tooling@b4808875a583e71eff5b3dd07bb50dafb92694a6 # main
       with:
         overwrite: "false"
-        build-essential-enabled: "true"
+        build-essential-enabled: "false"
         node-enabled: "true"
         yarn-enabled: "false"
         buildx-enabled: "false"


### PR DESCRIPTION
## Summary

- Remove `sudo` from all commands in the `playwright-e2e-tests` action's `Install system dependencies` step — the `playwright-runner` container runs as root, but `sudo` is not installed
- Disable `build-essential-enabled` in the `common-tooling` step — prevents the external action from running `sudo apt install build-essential`, which also fails in the container and is not needed for Playwright tests

## Root Cause

The `playwright-runner:latest` container (`ghcr.io/camunda/team-distribution/playwright-runner`) is launched with `--user root` but does not include the `sudo` package. When the action runs `sudo apt-get update`, it fails with `sudo: command not found`.

Two code paths triggered this:
1. Our `Install system dependencies` step (lines 74-94) — all `sudo` calls replaced with direct commands
2. The external `common-tooling` action — when `build-essential-enabled: "true"`, it runs `sudo apt install build-essential` internally. Changed to `"false"` since Playwright tests don't compile native npm modules

## Testing

- The `test-local-template.yaml` workflow is **not affected** — it runs on `gcp-core-8-release` self-hosted runners where `sudo` is available
- The `check-tools` guard (lines 110-116) skips the `common-tooling` step entirely if `helm` and `kubectl` are pre-installed, but the current `playwright-runner` image does not include them