### PR TITLE
docs: enforce rebase-only workflow in agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,6 +212,7 @@ helm template integration charts/camunda-platform-8.X \
 - Commit/PR titles: Conventional Commits.
 - Common types: `feat`, `fix`, `refactor`, `test`, `docs`, `style`, `build`, `ci`, `chore`, `perf`, `deps`.
 - Use present tense; keep subject under 120 characters.
+- **NEVER create merge commits.** Always use `git rebase` to incorporate upstream changes. If a branch needs to be updated from `main`, use `git rebase origin/main`, not `git merge`. Force-push with `--force-with-lease` after rebasing.
 
 ## Additional Agent Context
 - `CLAUDE.md` — thin redirect for Claude Code (redirects to this file, AGENTS.md)


### PR DESCRIPTION
## Summary

- Add explicit rules to `AGENTS.md` and `.github/AGENTS.md` prohibiting merge commits
- Instruct AI agents to always use `git rebase origin/main` (not `git merge`) when updating branches
- Specify `--force-with-lease` for safe force-pushing after rebase

This came up when an AI agent used `git merge origin/main` to update a PR branch, introducing a merge commit that had to be cleaned up manually.