### PR TITLE
test: bound agentwatch poll loop and stop leaking claude transcripts

### DIFF
--- a/scripts/deploy-camunda/agentwatch/agentwatch.go
+++ b/scripts/deploy-camunda/agentwatch/agentwatch.go
@@ -69,6 +69,32 @@ const (
 	DecisionAbort
 )
 
+// DefaultInterval is the per-tick poll interval used when Options.Interval
+// is zero.
+const DefaultInterval = 60 * time.Second
+
+// MinInterval is the recommended floor enforced by CLI callers on
+// Options.Interval. Each tick is a paid LLM call, so accidental fast
+// intervals (e.g. --interval 1) must not fire-hose the agent API. The
+// package itself does not clamp, to keep unit tests fast.
+const MinInterval = 15 * time.Second
+
+// DefaultMaxTicks bounds the loop when Options.MaxTicks is zero. At
+// DefaultInterval that is one hour of watching; any healthy install
+// finishes well before then.
+const DefaultMaxTicks = 60
+
+// DefaultMaxDuration is the wall-clock cap applied when Options.MaxDuration
+// is zero. Independent from MaxTicks so a stuck snapshot collection that
+// takes longer than expected cannot evade the bound.
+const DefaultMaxDuration = 30 * time.Minute
+
+// DefaultMaxErrors is the consecutive-error cap. After this many
+// snapshot/invoke/parse failures in a row, Watch exits with an error
+// rather than retrying forever — an offline agent CLI should not produce
+// an unbounded retry storm.
+const DefaultMaxErrors = 5
+
 // Options configures a Watch run.
 type Options struct {
 	// CLI is the agent CLI to invoke. Use DetectCLI to populate.
@@ -78,7 +104,8 @@ type Options struct {
 	// Prompt is the system-style instruction passed on every tick. If empty,
 	// DefaultPrompt is used.
 	Prompt string
-	// Interval between poll ticks. Defaults to 60s when zero.
+	// Interval between poll ticks. Defaults to DefaultInterval when zero
+	// and is clamped from below to MinInterval.
 	Interval time.Duration
 	// AbortConfidence is the confidence threshold at or above which an
 	// "abort" verdict triggers DecisionAbort. Below this threshold, abort
@@ -89,31 +116,55 @@ type Options struct {
 	// snapshot+verdict pairs to for the eval corpus. One file per tick,
 	// named by RFC3339 timestamp.
 	CorpusDir string
-	// MaxTicks bounds the loop for tests; zero means unbounded.
+	// MaxTicks bounds the poll loop. Defaults to DefaultMaxTicks when zero.
+	// Set to a negative value to disable the bound (test-only escape hatch).
 	MaxTicks int
-	// IsInstallComplete is consulted at the start of each tick. Returning
-	// true ends the loop with DecisionContinue. Typically set to a closure
-	// that runs `helm status` and checks for "deployed" status. Optional.
-	IsInstallComplete func(ctx context.Context) (bool, error)
+	// MaxDuration is the wall-clock cap applied to the entire Watch run.
+	// Defaults to DefaultMaxDuration when zero. Set to a negative value to
+	// disable (test-only).
+	MaxDuration time.Duration
+	// MaxErrors is the consecutive-error cap. Defaults to DefaultMaxErrors
+	// when zero. Set to a negative value to disable.
+	MaxErrors int
 }
 
 // Watch polls the cluster on a fixed interval, hands each snapshot to the
 // agent CLI, and returns the final decision and the last verdict it acted
 // on. The function returns when:
-//   - IsInstallComplete reports true (DecisionContinue, nil verdict).
+//   - The snapshot shows every pod Ready (DecisionContinue, last verdict).
 //   - The agent recommends abort with sufficient confidence (DecisionAbort).
-//   - MaxTicks is reached (DecisionContinue, last seen verdict).
+//   - MaxTicks is reached (DecisionContinue, last verdict).
+//   - MaxDuration elapses (DecisionContinue, last verdict, ctx.DeadlineExceeded).
+//   - MaxErrors consecutive failures (DecisionContinue, last verdict, error).
 //   - ctx is cancelled (returns ctx.Err()).
+//
+// Each tick is a paid LLM call; the bounds above are independent kill
+// switches so no single misconfiguration can produce an unbounded run.
 func Watch(ctx context.Context, opts Options) (Decision, *Verdict, error) {
 	if opts.CLI.Name == "" {
 		return DecisionContinue, nil, errors.New("agentwatch: Options.CLI is empty (call DetectCLI first)")
 	}
 	if opts.Interval <= 0 {
-		opts.Interval = 60 * time.Second
+		opts.Interval = DefaultInterval
+	}
+	if opts.MaxTicks == 0 {
+		opts.MaxTicks = DefaultMaxTicks
+	}
+	if opts.MaxDuration == 0 {
+		opts.MaxDuration = DefaultMaxDuration
+	}
+	if opts.MaxErrors == 0 {
+		opts.MaxErrors = DefaultMaxErrors
 	}
 	prompt := opts.Prompt
 	if prompt == "" {
 		prompt = DefaultPrompt
+	}
+
+	if opts.MaxDuration > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, opts.MaxDuration)
+		defer cancel()
 	}
 
 	logging.Logger.Info().
@@ -121,11 +172,23 @@ func Watch(ctx context.Context, opts Options) (Decision, *Verdict, error) {
 		Str("namespace", opts.Snapshot.Namespace).
 		Str("release", opts.Snapshot.Release).
 		Dur("interval", opts.Interval).
+		Int("maxTicks", opts.MaxTicks).
+		Dur("maxDuration", opts.MaxDuration).
+		Int("maxErrors", opts.MaxErrors).
 		Float64("abortConfidence", opts.AbortConfidence).
 		Msg("agentwatch: starting watch loop")
 
 	var lastVerdict *Verdict
 	tick := 0
+	consecutiveErrors := 0
+	recordFailure := func() error {
+		consecutiveErrors++
+		if opts.MaxErrors > 0 && consecutiveErrors >= opts.MaxErrors {
+			return fmt.Errorf("agentwatch: %d consecutive errors, giving up", consecutiveErrors)
+		}
+		return nil
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -133,19 +196,12 @@ func Watch(ctx context.Context, opts Options) (Decision, *Verdict, error) {
 		default:
 		}
 
-		if opts.IsInstallComplete != nil {
-			done, err := opts.IsInstallComplete(ctx)
-			if err != nil {
-				logging.Logger.Debug().Err(err).Msg("agentwatch: install-complete check errored; continuing")
-			} else if done {
-				logging.Logger.Info().Msg("agentwatch: install reported complete; exiting watch loop")
-				return DecisionContinue, lastVerdict, nil
-			}
-		}
-
 		snapshot, err := GatherSnapshot(ctx, opts.Snapshot)
 		if err != nil {
 			logging.Logger.Warn().Err(err).Msg("agentwatch: snapshot collection failed; will retry")
+			if capErr := recordFailure(); capErr != nil {
+				return DecisionContinue, lastVerdict, capErr
+			}
 			if !sleep(ctx, opts.Interval) {
 				return DecisionContinue, lastVerdict, ctx.Err()
 			}
@@ -154,6 +210,11 @@ func Watch(ctx context.Context, opts Options) (Decision, *Verdict, error) {
 				return DecisionContinue, lastVerdict, nil
 			}
 			continue
+		}
+
+		if snapshot.AllPodsReady() {
+			logging.Logger.Info().Msg("agentwatch: all pods Ready; exiting watch loop")
+			return DecisionContinue, lastVerdict, nil
 		}
 
 		snapshotBytes, err := snapshot.MarshalIndent()
@@ -165,6 +226,9 @@ func Watch(ctx context.Context, opts Options) (Decision, *Verdict, error) {
 		if err != nil {
 			logging.Logger.Warn().Err(err).Msg("agentwatch: agent invocation failed; will retry")
 			persistTick(opts.CorpusDir, snapshotBytes, verdictBytes, nil, err)
+			if capErr := recordFailure(); capErr != nil {
+				return DecisionContinue, lastVerdict, capErr
+			}
 			if !sleep(ctx, opts.Interval) {
 				return DecisionContinue, lastVerdict, ctx.Err()
 			}
@@ -182,6 +246,9 @@ func Watch(ctx context.Context, opts Options) (Decision, *Verdict, error) {
 				Str("rawHead", truncate(string(verdictBytes), 200)).
 				Msg("agentwatch: could not parse verdict; will retry")
 			persistTick(opts.CorpusDir, snapshotBytes, verdictBytes, nil, err)
+			if capErr := recordFailure(); capErr != nil {
+				return DecisionContinue, lastVerdict, capErr
+			}
 			if !sleep(ctx, opts.Interval) {
 				return DecisionContinue, lastVerdict, ctx.Err()
 			}
@@ -192,6 +259,7 @@ func Watch(ctx context.Context, opts Options) (Decision, *Verdict, error) {
 			continue
 		}
 
+		consecutiveErrors = 0
 		lastVerdict = &verdict
 		persistTick(opts.CorpusDir, snapshotBytes, verdictBytes, &verdict, nil)
 		decision := classify(verdict, opts.AbortConfidence)

--- a/scripts/deploy-camunda/agentwatch/agentwatch.go
+++ b/scripts/deploy-camunda/agentwatch/agentwatch.go
@@ -104,8 +104,10 @@ type Options struct {
 	// Prompt is the system-style instruction passed on every tick. If empty,
 	// DefaultPrompt is used.
 	Prompt string
-	// Interval between poll ticks. Defaults to DefaultInterval when zero
-	// and is clamped from below to MinInterval.
+	// Interval between poll ticks. Defaults to DefaultInterval when zero.
+	// CLI callers should clamp values below MinInterval to avoid agent-API
+	// fire-hosing; the package itself does not clamp, to keep unit tests
+	// fast.
 	Interval time.Duration
 	// AbortConfidence is the confidence threshold at or above which an
 	// "abort" verdict triggers DecisionAbort. Below this threshold, abort

--- a/scripts/deploy-camunda/agentwatch/agentwatch_test.go
+++ b/scripts/deploy-camunda/agentwatch/agentwatch_test.go
@@ -2,6 +2,10 @@ package agentwatch
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -338,6 +342,151 @@ func TestReplayReport_FormatLabelsRegressions(t *testing.T) {
 	if !strings.Contains(out, "Regressions: 1") {
 		t.Fatalf("expected Regressions: 1 in output, got:\n%s", out)
 	}
+}
+
+func TestSnapshot_AllPodsReady(t *testing.T) {
+	cases := []struct {
+		name string
+		pods string
+		want bool
+	}{
+		{
+			name: "empty pods field",
+			pods: "",
+			want: false,
+		},
+		{
+			name: "no items",
+			pods: `{"items":[]}`,
+			want: false,
+		},
+		{
+			name: "single running ready",
+			pods: `{"items":[{"status":{"phase":"Running","conditions":[{"type":"Ready","status":"True"}]}}]}`,
+			want: true,
+		},
+		{
+			name: "running but not ready",
+			pods: `{"items":[{"status":{"phase":"Running","conditions":[{"type":"Ready","status":"False"}]}}]}`,
+			want: false,
+		},
+		{
+			name: "running with no Ready condition",
+			pods: `{"items":[{"status":{"phase":"Running","conditions":[{"type":"Initialized","status":"True"}]}}]}`,
+			want: false,
+		},
+		{
+			name: "pending pod blocks readiness",
+			pods: `{"items":[
+				{"status":{"phase":"Running","conditions":[{"type":"Ready","status":"True"}]}},
+				{"status":{"phase":"Pending"}}
+			]}`,
+			want: false,
+		},
+		{
+			name: "succeeded job pod counts as ready",
+			pods: `{"items":[
+				{"status":{"phase":"Running","conditions":[{"type":"Ready","status":"True"}]}},
+				{"status":{"phase":"Succeeded"}}
+			]}`,
+			want: true,
+		},
+		{
+			name: "malformed JSON returns false",
+			pods: `not json at all`,
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			snap := Snapshot{Pods: json.RawMessage(tc.pods)}
+			if got := snap.AllPodsReady(); got != tc.want {
+				t.Fatalf("AllPodsReady = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWatch_MaxDurationStopsLoop(t *testing.T) {
+	// With a sub-second wall-clock cap and no real cluster, snapshot
+	// gathering will fail repeatedly. The MaxDuration timeout must close
+	// the loop and surface context.DeadlineExceeded.
+	opts := Options{
+		CLI: AgentCLI{Name: "claude", Path: "/nonexistent-but-required-by-validation"},
+		Snapshot: SnapshotOptions{
+			Namespace:      "definitely-does-not-exist-" + nowSuffix(),
+			SkipHelmStatus: true,
+			KubeContext:    "definitely-does-not-exist-context",
+		},
+		Interval:    10 * time.Millisecond,
+		MaxTicks:    -1, // disable tick bound to isolate duration check
+		MaxDuration: 200 * time.Millisecond,
+		MaxErrors:   -1, // disable error bound too
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	start := time.Now()
+	_, _, err := Watch(ctx, opts)
+	elapsed := time.Since(start)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context.DeadlineExceeded, got %v", err)
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("Watch should have stopped near MaxDuration; elapsed=%s", elapsed)
+	}
+}
+
+func TestWatch_MaxErrorsStopsRetryStorm(t *testing.T) {
+	opts := Options{
+		CLI: AgentCLI{Name: "claude", Path: "/nonexistent-but-required-by-validation"},
+		Snapshot: SnapshotOptions{
+			Namespace:      "definitely-does-not-exist-" + nowSuffix(),
+			SkipHelmStatus: true,
+			KubeContext:    "definitely-does-not-exist-context",
+		},
+		Interval:  10 * time.Millisecond,
+		MaxTicks:  -1,
+		MaxErrors: 2,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, _, err := Watch(ctx, opts)
+	if err == nil || !strings.Contains(err.Error(), "consecutive errors") {
+		t.Fatalf("expected consecutive-errors abort, got %v", err)
+	}
+}
+
+func TestCleanupClaudeSession_RemovesMatchingTranscript(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	projectDir := filepath.Join(home, ".claude", "projects", "-tmp-fake-cwd")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	keep := filepath.Join(projectDir, "00000000-0000-0000-0000-000000000000.jsonl")
+	target := filepath.Join(projectDir, "deadbeef-1234-5678-9abc-fedcba987654.jsonl")
+	if err := os.WriteFile(keep, []byte(`{"keep":true}`), 0o644); err != nil {
+		t.Fatalf("write keep: %v", err)
+	}
+	if err := os.WriteFile(target, []byte(`{"target":true}`), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	envelope := []byte(`{"type":"result","session_id":"deadbeef-1234-5678-9abc-fedcba987654","result":"..."}`)
+	cleanupClaudeSession(envelope)
+
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Fatalf("target transcript should have been removed; stat err=%v", err)
+	}
+	if _, err := os.Stat(keep); err != nil {
+		t.Fatalf("unrelated transcript should remain; got err=%v", err)
+	}
+}
+
+func TestCleanupClaudeSession_NoSessionIDIsSilent(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cleanupClaudeSession([]byte(`{"type":"result","result":"no session id"}`))
+	cleanupClaudeSession([]byte(`not even json`))
 }
 
 // jsonString is a tiny helper to embed an arbitrary string as a JSON string

--- a/scripts/deploy-camunda/agentwatch/agentwatch_test.go
+++ b/scripts/deploy-camunda/agentwatch/agentwatch_test.go
@@ -489,6 +489,32 @@ func TestCleanupClaudeSession_NoSessionIDIsSilent(t *testing.T) {
 	cleanupClaudeSession([]byte(`not even json`))
 }
 
+func TestCleanupClaudeSession_RejectsPathTraversalPayload(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Lay down a file outside ~/.claude/projects that a traversal payload
+	// would target: <home>/victim.jsonl. The cleanup must leave it alone.
+	victim := filepath.Join(home, "victim.jsonl")
+	if err := os.WriteFile(victim, []byte("untouched"), 0o644); err != nil {
+		t.Fatalf("write victim: %v", err)
+	}
+
+	for _, payload := range []string{
+		`{"session_id":"../../victim"}`,
+		`{"session_id":"../victim"}`,
+		`{"session_id":"/etc/passwd"}`,
+		`{"session_id":"deadbeef"}`,
+		`{"session_id":"not-a-uuid-at-all"}`,
+		`{"session_id":"DEADBEEF-1234-5678-9ABC-FEDCBA987654"}`, // uppercase → reject
+	} {
+		cleanupClaudeSession([]byte(payload))
+	}
+
+	if _, err := os.Stat(victim); err != nil {
+		t.Fatalf("traversal payload deleted out-of-tree file: %v", err)
+	}
+}
+
 // jsonString is a tiny helper to embed an arbitrary string as a JSON string
 // literal in test fixtures.
 func jsonString(s string) string {

--- a/scripts/deploy-camunda/agentwatch/cli.go
+++ b/scripts/deploy-camunda/agentwatch/cli.go
@@ -10,9 +10,12 @@ package agentwatch
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 )
 
 // AgentCLI describes a discovered local agent CLI.
@@ -102,11 +105,44 @@ func Invoke(ctx context.Context, cli AgentCLI, prompt string, snapshot []byte) (
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	if err := cmd.Run(); err != nil {
-		return stdout.Bytes(), fmt.Errorf("%s exited with error: %w; stderr: %s",
-			cli.Name, err, truncate(stderr.String(), 2000))
+	runErr := cmd.Run()
+	out := stdout.Bytes()
+	// Claude Code's -p mode persists a transcript at
+	// ~/.claude/projects/<cwd-hash>/<session_id>.jsonl on every invocation.
+	// Because agentwatch polls every Interval, an hour-long install can
+	// leave hundreds of throwaway sessions cluttering the user's history.
+	// Best-effort delete the file using session_id from the JSON envelope.
+	if cli.Name == "claude" {
+		cleanupClaudeSession(out)
 	}
-	return stdout.Bytes(), nil
+	if runErr != nil {
+		return out, fmt.Errorf("%s exited with error: %w; stderr: %s",
+			cli.Name, runErr, truncate(stderr.String(), 2000))
+	}
+	return out, nil
+}
+
+// cleanupClaudeSession parses the session_id from a Claude Code -p
+// --output-format json envelope and removes the matching transcript file.
+// All failures are silent: this is housekeeping, not correctness.
+func cleanupClaudeSession(raw []byte) {
+	var env struct {
+		SessionID string `json:"session_id"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil || env.SessionID == "" {
+		return
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return
+	}
+	matches, err := filepath.Glob(filepath.Join(home, ".claude", "projects", "*", env.SessionID+".jsonl"))
+	if err != nil {
+		return
+	}
+	for _, m := range matches {
+		_ = os.Remove(m)
+	}
 }
 
 // truncate trims s to at most n runes, appending an ellipsis when shortened.

--- a/scripts/deploy-camunda/agentwatch/cli.go
+++ b/scripts/deploy-camunda/agentwatch/cli.go
@@ -16,7 +16,14 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 )
+
+// claudeSessionIDPattern matches the UUID format Claude Code emits for
+// session identifiers. We validate before using session_id in filesystem
+// operations: filepath.Join calls filepath.Clean, so a crafted value
+// containing "../" would otherwise escape ~/.claude/projects/.
+var claudeSessionIDPattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 
 // AgentCLI describes a discovered local agent CLI.
 type AgentCLI struct {
@@ -130,6 +137,9 @@ func cleanupClaudeSession(raw []byte) {
 		SessionID string `json:"session_id"`
 	}
 	if err := json.Unmarshal(raw, &env); err != nil || env.SessionID == "" {
+		return
+	}
+	if !claudeSessionIDPattern.MatchString(env.SessionID) {
 		return
 	}
 	home, err := os.UserHomeDir()

--- a/scripts/deploy-camunda/agentwatch/snapshot.go
+++ b/scripts/deploy-camunda/agentwatch/snapshot.go
@@ -139,3 +139,50 @@ func runCmd(ctx context.Context, name string, args ...string) ([]byte, error) {
 func (s Snapshot) MarshalIndent() ([]byte, error) {
 	return json.MarshalIndent(s, "", "  ")
 }
+
+// AllPodsReady reports whether every pod in the snapshot has reached a
+// terminal-ready state: phase=Running with the Ready condition true, or
+// phase=Succeeded (e.g. one-shot Jobs). Returns false when no pods are
+// present, since an empty namespace means the install has not started.
+func (s Snapshot) AllPodsReady() bool {
+	if len(s.Pods) == 0 {
+		return false
+	}
+	var list struct {
+		Items []struct {
+			Status struct {
+				Phase      string `json:"phase"`
+				Conditions []struct {
+					Type   string `json:"type"`
+					Status string `json:"status"`
+				} `json:"conditions"`
+			} `json:"status"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(s.Pods, &list); err != nil {
+		return false
+	}
+	if len(list.Items) == 0 {
+		return false
+	}
+	for _, p := range list.Items {
+		switch p.Status.Phase {
+		case "Succeeded":
+			continue
+		case "Running":
+			ready := false
+			for _, c := range p.Status.Conditions {
+				if c.Type == "Ready" && c.Status == "True" {
+					ready = true
+					break
+				}
+			}
+			if !ready {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/scripts/deploy-camunda/cmd/watch.go
+++ b/scripts/deploy-camunda/cmd/watch.go
@@ -33,6 +33,8 @@ func newWatchCommand() *cobra.Command {
 		abortConfidence float64
 		corpusDir       string
 		maxTicks        int
+		maxDuration     time.Duration
+		maxErrors       int
 		logLevel        string
 		cliName         string
 	)
@@ -105,6 +107,15 @@ Typical use:
 				}
 			}()
 
+			interval := time.Duration(intervalSeconds) * time.Second
+			if interval > 0 && interval < agentwatch.MinInterval {
+				logging.Logger.Warn().
+					Dur("requested", interval).
+					Dur("floor", agentwatch.MinInterval).
+					Msg("agentwatch: --interval below floor; clamping to MinInterval to avoid agent-API fire-hose")
+				interval = agentwatch.MinInterval
+			}
+
 			opts := agentwatch.Options{
 				CLI: cli,
 				Snapshot: agentwatch.SnapshotOptions{
@@ -112,10 +123,12 @@ Typical use:
 					Release:     release,
 					KubeContext: kubeContext,
 				},
-				Interval:        time.Duration(intervalSeconds) * time.Second,
+				Interval:        interval,
 				AbortConfidence: abortConfidence,
 				CorpusDir:       corpusDir,
 				MaxTicks:        maxTicks,
+				MaxDuration:     maxDuration,
+				MaxErrors:       maxErrors,
 			}
 
 			decision, verdict, err := agentwatch.Watch(ctx, opts)
@@ -151,7 +164,12 @@ Typical use:
 		"Auto-abort when an 'abort' verdict has confidence at or above this value (0 disables auto-abort)")
 	cmd.Flags().StringVar(&corpusDir, "corpus-dir", "",
 		"Directory to persist snapshot+verdict pairs for the eval corpus (empty disables persistence)")
-	cmd.Flags().IntVar(&maxTicks, "max-ticks", 0, "Maximum number of poll ticks before exiting (0 = unbounded)")
+	cmd.Flags().IntVar(&maxTicks, "max-ticks", 0,
+		"Maximum number of poll ticks before exiting (0 = package default, negative = unbounded)")
+	cmd.Flags().DurationVar(&maxDuration, "max-duration", 0,
+		"Wall-clock cap for the entire watch run (0 = package default, e.g. 30m)")
+	cmd.Flags().IntVar(&maxErrors, "max-errors", 0,
+		"Consecutive snapshot/agent/parse errors tolerated before giving up (0 = package default)")
 	cmd.Flags().StringVarP(&logLevel, "log-level", "l", "info", "Log level")
 	cmd.Flags().StringVar(&cliName, "cli", "", "Agent CLI to use: opencode or claude (auto-detected if empty)")
 


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6151.

### What's in this PR?

`deploy-camunda watch` (agentwatch) had no default upper bound on its poll loop, so a closed terminal, finished install, or stuck snapshot could leave it spinning indefinitely — each tick a paid `claude -p` call. This PR adds defense-in-depth so a runaway is impossible by default, and stops the same loop from polluting `~/.claude/projects/` with throwaway transcripts.

**Behavior changes**

- `Watch` now exits when the snapshot reports every pod `Running+Ready` (or `Succeeded`). New `Snapshot.AllPodsReady()` parses pod phase/conditions directly from the kubectl JSON we already collect — no extra `helm status` round-trip.
- `Options.MaxDuration` (default `30m`) wraps the whole run in `context.WithTimeout`. Bug-class-agnostic wall-clock cap.
- `Options.MaxTicks` default raised from `0`/unbounded to `60`.
- `Options.MaxErrors` (default `5`) caps consecutive snapshot/invoke/parse failures, so an offline agent CLI or unreachable API cannot produce an unbounded retry storm.
- `--max-duration`, `--max-errors` flags added to `deploy-camunda watch`. Existing `--max-ticks` keeps its semantics; pass a negative value to disable.
- `cmd/watch.go` clamps `--interval` from below at `agentwatch.MinInterval` (`15s`) with a warning, preventing accidental `--interval 1` from fire-hosing the agent API. Package itself does not clamp, so unit tests stay fast.
- Dead `Options.IsInstallComplete` hook removed — no caller set it, and the new internal readiness check covers the same intent.

**Hygiene fix (separate commit)**

- After every `claude -p` invocation, parse `session_id` from the JSON envelope and remove the matching `~/.claude/projects/<cwd-hash>/<session_id>.jsonl` transcript. Best-effort, silent on failure. Snapshot + verdict already persist to `CorpusDir`, so transcripts add no diagnostic value.

**Tests**

- `TestSnapshot_AllPodsReady` — 8 cases: empty, no items, running+ready, running not ready, no Ready condition, mixed with pending, succeeded jobs, malformed JSON.
- `TestWatch_MaxDurationStopsLoop` — wall-clock cap triggers `context.DeadlineExceeded`.
- `TestWatch_MaxErrorsStopsRetryStorm` — consecutive-error cap surfaces a clear error.
- `TestCleanupClaudeSession_RemovesMatchingTranscript` + negative case — `session_id` glob matches only the intended file; missing/empty IDs are silent no-ops.

### Checklist

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`. — N/A (Go-only change, no chart templates affected).
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed). — Go unit tests under `scripts/deploy-camunda/agentwatch/`.
- [x] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed). — N/A; `AGENTS.md` claim "watcher exits automatically when all pods reach Running/Ready" is now actually true.

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)?
- [ ] Did all checks/tests pass in the PR?
