### PR TITLE
fix(ci): set Flow="install" in executeUpgradeOnly to match prior install index prefixes

### DIFF
--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -2222,6 +2222,7 @@ func executeUpgradeOnly(ctx context.Context, entry Entry, flags *config.RuntimeF
 	upgradeFlags := *flags
 	upgradeFlags.Selection.UpgradeFlow = true            // Ensure base-upgrade.yaml is included.
 	upgradeFlags.Deployment.DeleteNamespaceFirst = false // Namespace must already exist from prior install.
+	upgradeFlags.Deployment.Flow = "install"             // Must match the prior install's Flow so $FLOW in index prefixes resolves identically.
 	upgradeFlags.Deployment.ExtraHelmSets = mergeHelmSets(
 		flags.Deployment.ExtraHelmSets,
 		map[string]string{"orchestration.upgrade.allowPreReleaseImages": "true"},


### PR DESCRIPTION
## Summary

- Fixes `executeUpgradeOnly` (modular-upgrade-minor flow) to override `Deployment.Flow` to `"install"`, matching the existing pattern in `executeTwoStepUpgrade` (line 2151)
- Without this fix, `$FLOW` resolves to `"modular-upgrade-minor"` during the upgrade step, causing OpenSearch index prefix mismatches that break Operate and Optimize after upgrade

## Root Cause

The `opensearch-embedded.yaml` (and other OpenSearch persistence variants) use `$FLOW` in index prefixes:
```yaml
orchestration:
  index:
    prefix: $ORCHESTRATION_INDEX_PREFIX-$FLOW
```

During install, `$FLOW = "install"` so indices are created as `orch-...-install`. During the modular-upgrade-minor step, `$FLOW` was not overridden, resolving to `"modular-upgrade-minor"` — so all components looked for indices suffixed with `-modular-upgrade-minor` while the data lived in `-install` indices.

Elasticsearch scenarios were unaffected because `elasticsearch.yaml` does not use `$FLOW` in index prefixes.

## Impact

- Both 8.9 and 8.10 OpenSearch upgrade nightlies have been failing since May 5 (16+ consecutive failures)
- Affected runs: 25853585153 (8.10), 25853571393 (8.9)
- Symptom: Operate sidebar "Processes" link never renders (120s timeout) because Operate can't find data in OpenSearch

## Validation

Deployed `qaosupg` scenario on GKE (`matrix-89-qaosupg-inst-gke`):
1. Install step: all 13 pods Running, orchestration `searchEngineCheck: UP`
2. Upgrade step (with fix): `$FLOW` correctly resolved to `"install"`, all pods Running, orchestration `searchEngineCheck: UP`, `indicesCheck: UP`

## Change

One-line addition in `scripts/deploy-camunda/matrix/runner.go:2234`:
```go
upgradeFlags.Deployment.Flow = "install"  // Must match the prior install's Flow so $FLOW in index prefixes resolves identically.
```