### PR TITLE
test(8.9,8.10): disable orchestration authorizations in upgrade-leg QA values

### DIFF
--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/base-upgrade.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/base-upgrade.yaml
@@ -8,3 +8,15 @@ orchestration:
   env:
     - name: CAMUNDA_DATABASE_SCHEMAMANAGER_VERSIONCHECKRESTRICTIONENABLED
       value: "false"
+  security:
+    # The 8.9 -> 8.10 minor upgrade leaves the orchestration authorization DB
+    # empty because `orchestration.security.initialization.*` only seeds on
+    # first install (empty DB), not on minor upgrades. With authorizations
+    # enabled by default, every migrated user (demo, lisa, bart) is blocked
+    # at the Operate component gate with "You don't have access to this
+    # component", which breaks the migration-path E2E suite.
+    # Keep authorizations off in the upgrade leg so the QA matrix continues
+    # to validate user-facing flows under the previous gating model. Remove
+    # this once the product seeds authorizations during minor upgrades.
+    authorizations:
+      enabled: false

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/base-upgrade.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/base-upgrade.yaml
@@ -8,3 +8,15 @@ orchestration:
   env:
     - name: CAMUNDA_DATABASE_SCHEMAMANAGER_VERSIONCHECKRESTRICTIONENABLED
       value: "false"
+  security:
+    # The 8.8 -> 8.9 minor upgrade leaves the orchestration authorization DB
+    # empty because `orchestration.security.initialization.*` only seeds on
+    # first install (empty DB), not on minor upgrades. With authorizations
+    # enabled by default in 8.9, every migrated user (demo, lisa, bart) is
+    # blocked at the Operate component gate with "You don't have access to
+    # this component", which breaks the migration-path E2E suite.
+    # Keep authorizations off in the upgrade leg so the QA matrix continues
+    # to validate user-facing flows under the 8.8 gating model. Remove this
+    # once the product seeds authorizations during minor upgrades.
+    authorizations:
+      enabled: false


### PR DESCRIPTION
## Summary

Disables `orchestration.security.authorizations` in the upgrade-leg QA values for the 8.9 and 8.10 charts, unblocking the `migration-path-user-flows.spec.ts` E2E suite that the SM Nightly Upgrade Minor (OpenSearch and Elasticsearch) workflows run after the `modular-upgrade-minor` flow.

> ⚠️ **This is a CI-side workaround, not a product fix.** The real bug is in the orchestration component: `orchestration.security.initialization.*` only seeds the authorization DB on first install (empty DB) and there is no migration step that backfills authorization rows on minor upgrades. With `authorizations.enabled: true` by default in 8.9+, every pre-existing user is locked out post-upgrade. This PR keeps the migration-path E2E suite green until the orchestration team ships a real authorization migration. See [Follow-up](#follow-up).

## Root cause

The 8.9 chart enables `orchestration.security.authorizations.enabled: true` by default (carried over into 8.10). The orchestration authorization DB is seeded only by `orchestration.security.initialization.*` at application start **on an empty DB** — there is no migration step that backfills authorization rows when an existing previous-minor DB is upgraded.

In the `qa-opensearch-upg` / `qa-elasticsearch-upg` nightly scenarios with `flow: modular-upgrade-minor`:

1. The previous-minor (8.8 / 8.9) install creates a DB with no orchestration authorization rows (8.8 didn't have this layer; 8.9's seeding ran but its rows aren't re-applied on upgrade).
2. On upgrade to 8.9 / 8.10, the orchestration startup sees a non-empty DB and skips initialization.
3. With authorizations enabled, Operate's component-level gate denies every migrated user (`demo`, `lisa`, `bart`) — they all hit "You don't have access to this component" when navigating to **Processes** in Operate.
4. The Playwright migration-path tests (`Assert Demo/Lisa/Bart User Can Deploy Processes`, `Assert Most Common Flow User Flow With All Apps Process Migration`) fail in `clickProcessesTab` because the `Processes` link is never rendered in the sidenav.

Identity-side roles are preserved correctly across the upgrade — the `Assert Users Persist in Management Identity With Correct Roles` test still passes — confirming this is not an Identity/Keycloak regression.

Screenshot evidence captured from the failing run artifact (Demo user, same wall for Lisa/Bart):

> Operate · "You don't have access to this component" — "It looks like you don't have the necessary permissions to access this component. Please contact your cluster admin to request access."

## Changes

- `charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/base-upgrade.yaml` — add `orchestration.security.authorizations.enabled: false`.
- `charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/base-upgrade.yaml` — same.

Both files are consumed **only** by upgrade flows (`flow: modular-upgrade-minor`, `flow: modular-upgrade-patch`), so the install-leg matrix is unchanged. No chart-template change, no golden snapshot impact.

## Failing nightly runs addressed

All four upgrade-leg failures listed under "Not addressed by this PR (tracked separately)" in [camunda/c8-cross-component-e2e-tests#2351](https://github.com/camunda/c8-cross-component-e2e-tests/pull/2351):

- https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25900863592 — SM Nightly 8.9 Upgrade Minor OpenSearch
- https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25903825339
- https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25902868501
- https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25902869435
- https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/25901163069

## Validation

### Local

- `yq` parses both files; `orchestration.security.authorizations.enabled` resolves to `false`.
- `helm template` with the QA upgrade-leg value stack (`base.yaml` + `base-qa.yaml` + `base-upgrade.yaml` + `identity/keycloak.yaml`) renders the orchestration configmap with:
  ```yaml
  authorizations:
    enabled: false
  ```
  for both `charts/camunda-platform-8.9` and `charts/camunda-platform-8.10`.

### CI

| Workflow | Run | Result | Notes |
|---|---|---|---|
| Test - Chart Version (PR auto-trigger, tier 1) | [25914814794](https://github.com/camunda/camunda-platform-helm/actions/runs/25914814794) | ✅ success | All 45 jobs green, including `8.9 - eske - upgrade-minor - pr - gke` (install + upgrade-minor + Playwright e2e after upgrade on Elasticsearch+Keycloak). Validates the same `base-upgrade.yaml` override on the same orchestration auth code path — the seeding gap is persistence-agnostic. |

### Coverage gap (intentional)

The original failing scenarios are `qa-opensearch-upg` / `qa-elasticsearch-upg` with `flow: modular-upgrade-minor`, which live under `integration.case.nightly` in `ci-test-config.yaml`. The scheduled nightly workflow (`test-chart-version-nightly.yaml`) is the only path that exercises them, and it has no `workflow_dispatch` trigger. The dispatchable `test-chart-version.yaml` only enumerates `case.pr` scenarios, where every `qa-*-upg` entry is `enabled: false`.

End-to-end OpenSearch+migration-path validation will be confirmed by the next scheduled nightly run after merge. Reviewers who want pre-merge OpenSearch coverage can run `c8e2e test --target SM-8.9 --file-pattern migration-path-user-flows --follow` against an upgrade cluster pinned to this branch, or temporarily add `workflow_dispatch:` to `test-chart-version-nightly.yaml` for an on-demand run.

## Follow-up

This override is a workaround, not a fix. Remove it once the orchestration component supplies one of:

1. A real authorization migration step that backfills rows for pre-existing users on minor upgrades, **or**
2. Idempotent seeding (`initialization.*` upserts on every start instead of gating on "empty DB"), **or**
3. A Flyway/Liquibase-style schema migration that adds default authorizations when upgrading from a minor without that layer.

The override is scoped to `base-upgrade.yaml` only, so customer-facing chart defaults and the install-leg test matrix are unaffected — it just allows the migration-path E2E suite to keep validating user-facing flows under the previous gating model until the product seeds authorizations on minor upgrades.
