### PR TITLE
test(8.10): add shadow full E2E suite as parallel jobs in PR CI

### DIFF
--- a/.github/actions/playwright-e2e-tests/action.yaml
+++ b/.github/actions/playwright-e2e-tests/action.yaml
@@ -56,6 +56,10 @@ inputs:
     description: The scenario being tested (e.g., opensearch, keycloak-rba, keycloak-mt, multitenancy)
     required: false
     default: "elasticsearch"
+  run-smoke-tests:
+    description: If true, run only the smoke-tests project. If false, run the full-suite project.
+    required: false
+    default: "true"
 runs:
   using: composite
   steps:
@@ -199,7 +203,7 @@ runs:
           EXTRA_FLAGS="--mt"
         fi
 
-        ./run-e2e-tests.sh --absolute-chart-path "${ABSOLUTE_TEST_CHART_DIR}" --namespace "${TEST_NAMESPACE}" --run-smoke-tests --verbose ${EXTRA_FLAGS}
+        ./run-e2e-tests.sh --absolute-chart-path "${ABSOLUTE_TEST_CHART_DIR}" --namespace "${TEST_NAMESPACE}" ${{ inputs.run-smoke-tests == 'true' && '--run-smoke-tests' || '' }} --verbose ${EXTRA_FLAGS}
 
     - name: Upload blob report to GitHub Actions Artifacts
       if: ${{ !cancelled() }}

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -1039,6 +1039,82 @@ jobs:
           shard-index: ${{ matrix.shardIndex }}
           scenario: ${{ inputs.scenario }}
 
+  # Shadow job: runs the full E2E suite for the dedicated 'shadow-e2e' scenario.
+  # Tier 2 (merge queue only). Non-blocking during observation period.
+  shadow-e2e-full-suite:
+    name: "[shadow] Full e2e - ${{ inputs.shortname }}"
+    needs: [install]
+    runs-on: gcp-core-32-longrunning-big-ssd
+    container:
+      image: ghcr.io/camunda/team-distribution/playwright-runner:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --ipc=host --user root
+    defaults:
+      run:
+        shell: bash
+    if: ${{ inputs.test-enabled && inputs.scenario == 'shadow-e2e' }}
+    continue-on-error: true
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
+      deployments: write
+      packages: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: camunda/camunda-platform-helm
+          ref: ${{ inputs.camunda-helm-git-ref }}
+
+      - name: Import Vault secrets
+        id: test-credentials-secret
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/distribution/ci DISTRO_CI_GCP_GKE_CLUSTER_NAME;
+            secret/data/products/distribution/ci DISTRO_CI_GCP_GKE_CLUSTER_LOCATION;
+            secret/data/products/distribution/ci DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER;
+            secret/data/products/distribution/ci DISTRO_CI_GCP_SERVICE_ACCOUNT;
+          exportEnv: true
+
+      - name: Run full E2E suite (shadow)
+        uses: ./.github/actions/playwright-e2e-tests
+        env:
+          GH_APP_ID:        ${{ secrets.GH_APP_ID_DISTRO_CI_MANAGE_GH_ENVS }}
+          GH_APP_KEY:       ${{ secrets.GH_APP_PRIVATE_KEY_DISTRO_CI_MANAGE_GH_ENVS }}
+          GKE_CLUSTER_NAME: ${{ env.DISTRO_CI_GCP_GKE_CLUSTER_NAME }}
+          GKE_CLUSTER_LOC:  ${{ env.DISTRO_CI_GCP_GKE_CLUSTER_LOCATION }}
+          GKE_WIP:          ${{ env.DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GKE_SA:           ${{ env.DISTRO_CI_GCP_SERVICE_ACCOUNT }}
+          ROSA_URL:         ${{ secrets[inputs.server-url] }}
+          ROSA_USER:        ${{ secrets[inputs.username] }}
+          ROSA_PASS:        ${{ secrets[inputs.password] }}
+          CI_DEPLOYMENT_TTL: ${{ env.CI_DEPLOYMENT_TTL }}
+        with:
+          camunda-helm-git-ref: ${{ inputs.camunda-helm-git-ref }}
+          camunda-helm-dir: ${{ inputs.camunda-helm-dir }}
+          camunda-helm-upgrade-version: ${{ inputs.camunda-helm-upgrade-version }}
+          flow: ${{ inputs.flow }}
+          distro-platform: ${{ inputs.distro-platform }}
+          infra-type: ${{ inputs.infra-type }}
+          identifier: ${{ inputs.identifier }}
+          namespace-prefix: ${{ inputs.namespace-prefix }}
+          deployment-ttl: ${{ env.CI_DEPLOYMENT_TTL }}
+          auth: ${{ inputs.auth }}
+          auth-data: ${{ inputs.auth-data }}
+          exclude: ${{ inputs.exclude }}
+          test-stage: after-install
+          shard-index: "1"
+          scenario: ${{ inputs.scenario }}
+          run-smoke-tests: "false"
+
   playwright-e2e-tests-after-upgrade:
     name: Playwright e2e after upgrade - ${{ inputs.flow }} on ${{ inputs.distro-platform }} - ${{ inputs.shortname }} (${{ matrix.shardIndex }} of ${{ matrix.shardTotal }})
     needs: [upgrade]
@@ -1248,7 +1324,7 @@ jobs:
 
   cleanup:
     name: Cleanup - ${{ inputs.flow }} on ${{ inputs.distro-platform }} - ${{ inputs.shortname }}
-    needs: [merge-e2e-reports]
+    needs: [merge-e2e-reports, shadow-e2e-full-suite]
     if: ${{ always() && (contains(needs.*.result, 'success') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled')) }}
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -1097,6 +1097,7 @@ jobs:
           ROSA_USER:        ${{ secrets[inputs.username] }}
           ROSA_PASS:        ${{ secrets[inputs.password] }}
           CI_DEPLOYMENT_TTL: ${{ env.CI_DEPLOYMENT_TTL }}
+          PLAYWRIGHT_POD_RETRY_MAX_ATTEMPTS: "1"
         with:
           camunda-helm-git-ref: ${{ inputs.camunda-helm-git-ref }}
           camunda-helm-dir: ${{ inputs.camunda-helm-dir }}

--- a/charts/camunda-platform-8.10/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.10/test/ci-test-config.yaml
@@ -348,6 +348,18 @@ integration:
           platforms: [gke]
           infra-type:
             gke: distroci
+        - name: shadow-e2e
+          enabled: true
+          shortname: shde2
+          tier: 2
+          auth: keycloak
+          flow: install
+          identity: keycloak
+          persistence: elasticsearch
+          platforms: [gke]
+          infra-type:
+            gke: distroci
+          skip-e2e: true  # Standard smoke tests skipped; full suite runs via c8e2e distributed runner
         - name: hub-legacy
           enabled: false
           auth: keycloak

--- a/charts/camunda-platform-8.10/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.10/test/ci-test-config.yaml
@@ -272,6 +272,7 @@ integration:
         - name: rdbms-self-signed
           enabled: true
           shortname: rdbss
+          tier: 2
           exclude: []
           auth: keycloak
           identity: keycloak

--- a/charts/camunda-platform-8.10/test/e2e/playwright.config.ts
+++ b/charts/camunda-platform-8.10/test/e2e/playwright.config.ts
@@ -37,13 +37,39 @@ export default defineConfig({
       testMatch: ["**/smoke-tests.spec.{ts,js}"],
     },
     {
+      name: "full-suite-setup",
+      testMatch: ["**/test-setup.spec.{ts,js}"],
+      use: {
+        extraHTTPHeaders: {
+          "X-Test-Tasklist-Version": "v2",
+        },
+      },
+    },
+    {
       name: "full-suite",
+      dependencies: ["full-suite-setup"],
       testMatch: ["**/*.spec.{ts,js}"],
+      // cluster-variables requires Vault-managed secrets not available in PR CI.
+      // test-setup is run via the full-suite-setup dependency, not directly.
+      testIgnore: ["**/cluster-variables.spec.{ts,js}", "**/test-setup.spec.{ts,js}"],
+      // Match the E2E repo's chromium-v2 project behavior:
+      // - @tasklistV1: These tests require Tasklist v1 mode with RBA enabled
+      //   (CAMUNDA_TASKLIST_IDENTITY_RESOURCE_PERMISSIONS_ENABLED=true), which
+      //   is not deployed in standard PR CI scenarios. Also excludes all Optimize
+      //   tests (under 'Optimize User Flow Tests @tasklistV1' describe) which
+      //   require long Optimize warm-up not available on fresh clusters.
+      // - Connector Secrets/Custom Tags/Properties: Require QA-specific config.
+      grep: /^(?!.*(@tasklistV1|Connector Secrets User Flow|Custom Tags|Custom Properties)).*$/,
+      use: {
+        extraHTTPHeaders: {
+          "X-Test-Tasklist-Version": "v2",
+        },
+      },
     },
   ],
   fullyParallel: true,
   retries: 2,
-  timeout: 10 * 60 * 1000, // no test should take more than 3 minutes (failing fast is important so that we can run our tests on each PR)
+  timeout: 12 * 60 * 1000, // match E2E repo timeout (12 minutes); test.slow() triples this
   workers: "100%",
   //workers: process.env.CI == "true" ? 1 : "50%",
   use: {


### PR DESCRIPTION
## Summary

- Adds **separate parallel jobs** that run the full E2E suite (~78 tests) on their own machines for 8.10 PR CI
- Existing smoke test jobs remain the blocking gate (zero behavior change)
- Shadow jobs have `continue-on-error: true` — never block the workflow
- After 2-3 weeks of stable data, a follow-up PR promotes the full suite to blocking

## How It Works

```
After install/upgrade completes:

  Job: "Playwright e2e after install"             --> BLOCKING (smoke, ~4 tests, ~5 min)
  Job: "[shadow] Full e2e after install"          --> NON-BLOCKING (full suite, ~78 tests, ~17 min)
                                                      (separate machine, continue-on-error: true)
```

Both jobs start simultaneously after deploy. They run on separate runners so no resource contention.
For 8.8/8.9: shadow jobs are skipped (condition is false). Zero change.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/test-integration-runner.yaml` | Two new shadow jobs (after-install + after-upgrade) with `continue-on-error: true`, gated on 8.10 |
| `.github/actions/playwright-e2e-tests/action.yaml` | New `run-smoke-tests` input (default: true); existing callers unchanged |
| `charts/camunda-platform-8.10/test/e2e/playwright.config.ts` | `testIgnore` + `grep` exclusions on `full-suite` project |

## Exclusions in full-suite project

- **File excluded**: `cluster-variables.spec.ts` — requires Vault secret
- **Tests excluded via grep**: `Connector Secrets User Flow`, `Custom Tags`, `Custom Properties` — require QA config

## Validation

4 independent eske deployments on GKE, full suite with exclusions: **78/78 pass rate (100%)** across all runs. Avg duration ~17 min. All flaky tests self-heal with retries=2.

## Monitoring

In the workflow graph, look for the jobs prefixed with **[shadow]**:
- Green = full suite passed
- Orange (continue-on-error) = full suite failed but workflow still green

## Related

- #6164 — Separate PR for local `deploy-camunda --test-e2e` (Go changes, depends on this PR)

## Rollout Plan

1. **This PR**: Merge shadow jobs — zero risk, separate machines, never blocks
2. **2-3 weeks**: Monitor shadow job results across real PRs
3. **Follow-up PR**: Remove shadow jobs, change existing smoke jobs to run full suite