### PR TITLE
ci(8.7,8.8,8.9,8.10): add alwaysgreen infra-type for monorepo AlwaysGreen workflow

### DIFF
--- a/charts/camunda-platform-8.10/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.10/test/ci-test-config.yaml
@@ -353,6 +353,19 @@ integration:
           identity: keycloak
           persistence: elasticsearch
           platforms: [gke]
+        # AlwaysGreen scenario — referenced by camunda/camunda's
+        # docker-build-helm-integration.yml. Deploys onto dedicated alwaysgreen
+        # GKE node pool (workload=alwaysgreen label + NoSchedule taint).
+        - name: alwaysgreen
+          enabled: false
+          flow: install
+          shortname: agrn
+          auth: keycloak
+          infra-type:
+            gke: alwaysgreen
+          identity: keycloak
+          persistence: elasticsearch
+          platforms: [gke]
         - name: qa-elasticsearch-upg
           enabled: false
           flow: install

--- a/charts/camunda-platform-8.10/test/integration/scenarios/infra/values-infra-alwaysgreen.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/infra/values-infra-alwaysgreen.yaml
@@ -1,0 +1,136 @@
+# GKE alwaysgreen nodes need nodeSelector and tolerations config.
+
+# Auth.
+identity:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+identityKeycloak:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+  postgresql:
+    primary:
+      nodeSelector:
+        workload: alwaysgreen
+      tolerations:
+      - effect: NoSchedule
+        key: workload
+        operator: Equal
+        value: alwaysgreen
+identityPostgresql:
+  primary:
+    nodeSelector:
+      workload: alwaysgreen
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: alwaysgreen
+
+# Camunda Hub.
+camundaHub:
+  console:
+    nodeSelector:
+      workload: alwaysgreen
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: alwaysgreen
+  webModeler:
+    restapi:
+      nodeSelector:
+        workload: alwaysgreen
+      tolerations:
+      - effect: NoSchedule
+        key: workload
+        operator: Equal
+        value: alwaysgreen
+    websockets:
+      nodeSelector:
+        workload: alwaysgreen
+      tolerations:
+      - effect: NoSchedule
+        key: workload
+        operator: Equal
+        value: alwaysgreen
+connectors:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+tasklist:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+operate:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+optimize:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+
+webModelerPostgresql:
+  primary:
+    nodeSelector:
+      workload: alwaysgreen
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: alwaysgreen
+
+# Zeebe.
+orchestration:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+zeebeGateway:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+
+# Elasticsearch.
+elasticsearch:
+  master:
+    nodeSelector:
+      workload: alwaysgreen
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: alwaysgreen

--- a/charts/camunda-platform-8.7/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.7/test/ci-test-config.yaml
@@ -144,6 +144,19 @@ integration:
           identity: keycloak
           persistence: elasticsearch
           platforms: [gke]
+        # AlwaysGreen scenario — referenced by camunda/camunda's
+        # docker-build-helm-integration.yml. Deploys onto dedicated alwaysgreen
+        # GKE node pool (workload=alwaysgreen label + NoSchedule taint).
+        - name: alwaysgreen
+          enabled: false
+          flow: install
+          shortname: agrn
+          auth: keycloak
+          infra-type:
+            gke: alwaysgreen
+          identity: keycloak
+          persistence: elasticsearch
+          platforms: [gke]
         - name: qa-elasticsearch
           enabled: false
           flow: install

--- a/charts/camunda-platform-8.7/test/integration/scenarios/infra/values-infra-alwaysgreen.yaml
+++ b/charts/camunda-platform-8.7/test/integration/scenarios/infra/values-infra-alwaysgreen.yaml
@@ -1,0 +1,144 @@
+# GKE alwaysgreen nodes need nodeSelector and tolerations config.
+
+# Auth.
+identity:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+identityKeycloak:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+  postgresql:
+    primary:
+      nodeSelector:
+        workload: alwaysgreen
+      tolerations:
+      - effect: NoSchedule
+        key: workload
+        operator: Equal
+        value: alwaysgreen
+identityPostgresql:
+  primary:
+    nodeSelector:
+      workload: alwaysgreen
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: alwaysgreen
+
+# Web Apps.
+console:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+connectors:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+tasklist:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+operate:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+optimize:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+
+# Web Modeler.
+webModeler:
+  restapi:
+    nodeSelector:
+      workload: alwaysgreen
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: alwaysgreen
+  webapp:
+    nodeSelector:
+      workload: alwaysgreen
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: alwaysgreen
+  websockets:
+    nodeSelector:
+      workload: alwaysgreen
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: alwaysgreen
+postgresql:
+  primary:
+    nodeSelector:
+      workload: alwaysgreen
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: alwaysgreen
+
+# Zeebe.
+zeebe:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+zeebeGateway:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+
+# Elasticsearch.
+elasticsearch:
+  master:
+    nodeSelector:
+      workload: alwaysgreen
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: alwaysgreen

--- a/charts/camunda-platform-8.8/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.8/test/ci-test-config.yaml
@@ -269,6 +269,19 @@ integration:
           identity: keycloak
           persistence: elasticsearch
           platforms: [gke]
+        # AlwaysGreen scenario — referenced by camunda/camunda's
+        # docker-build-helm-integration.yml. Deploys onto dedicated alwaysgreen
+        # GKE node pool (workload=alwaysgreen label + NoSchedule taint).
+        - name: alwaysgreen
+          enabled: false
+          flow: install
+          shortname: agrn
+          auth: keycloak
+          infra-type:
+            gke: alwaysgreen
+          identity: keycloak
+          persistence: elasticsearch
+          platforms: [gke]
         # kcor is referenced by .github/workflows/test-backward-compat.yaml's
         # compat-camunda-docker job (camunda/docker-build-helm-integration.yml).
         - name: keycloak-original

--- a/charts/camunda-platform-8.8/test/integration/scenarios/infra/values-infra-alwaysgreen.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/infra/values-infra-alwaysgreen.yaml
@@ -1,0 +1,144 @@
+# GKE alwaysgreen nodes need nodeSelector and tolerations config.
+
+# Auth.
+identity:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+identityKeycloak:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+  postgresql:
+    primary:
+      nodeSelector:
+        workload: alwaysgreen
+      tolerations:
+      - effect: NoSchedule
+        key: workload
+        operator: Equal
+        value: alwaysgreen
+identityPostgresql:
+  primary:
+    nodeSelector:
+      workload: alwaysgreen
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: alwaysgreen
+
+# Web Apps.
+console:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+connectors:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+tasklist:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+operate:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+optimize:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+
+# Web Modeler.
+webModeler:
+  restapi:
+    nodeSelector:
+      workload: alwaysgreen
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: alwaysgreen
+  webapp:
+    nodeSelector:
+      workload: alwaysgreen
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: alwaysgreen
+  websockets:
+    nodeSelector:
+      workload: alwaysgreen
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: alwaysgreen
+webModelerPostgresql:
+  primary:
+    nodeSelector:
+      workload: alwaysgreen
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: alwaysgreen
+
+# Zeebe.
+orchestration:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+zeebeGateway:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+
+# Elasticsearch.
+elasticsearch:
+  master:
+    nodeSelector:
+      workload: alwaysgreen
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: alwaysgreen

--- a/charts/camunda-platform-8.9/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.9/test/ci-test-config.yaml
@@ -321,6 +321,19 @@ integration:
           identity: keycloak
           persistence: elasticsearch
           platforms: [gke]
+        # AlwaysGreen scenario — referenced by camunda/camunda's
+        # docker-build-helm-integration.yml. Deploys onto dedicated alwaysgreen
+        # GKE node pool (workload=alwaysgreen label + NoSchedule taint).
+        - name: alwaysgreen
+          enabled: false
+          flow: install
+          shortname: agrn
+          auth: keycloak
+          infra-type:
+            gke: alwaysgreen
+          identity: keycloak
+          persistence: elasticsearch
+          platforms: [gke]
         - name: qa-elasticsearch
           enabled: false
           flow: install

--- a/charts/camunda-platform-8.9/test/integration/scenarios/infra/values-infra-alwaysgreen.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/infra/values-infra-alwaysgreen.yaml
@@ -1,0 +1,136 @@
+# GKE alwaysgreen nodes need nodeSelector and tolerations config.
+
+# Auth.
+identity:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+identityKeycloak:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+  postgresql:
+    primary:
+      nodeSelector:
+        workload: alwaysgreen
+      tolerations:
+      - effect: NoSchedule
+        key: workload
+        operator: Equal
+        value: alwaysgreen
+identityPostgresql:
+  primary:
+    nodeSelector:
+      workload: alwaysgreen
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: alwaysgreen
+
+# Web Apps.
+console:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+connectors:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+tasklist:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+operate:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+optimize:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+
+# Web Modeler.
+webModeler:
+  restapi:
+    nodeSelector:
+      workload: alwaysgreen
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: alwaysgreen
+  websockets:
+    nodeSelector:
+      workload: alwaysgreen
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: alwaysgreen
+webModelerPostgresql:
+  primary:
+    nodeSelector:
+      workload: alwaysgreen
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: alwaysgreen
+
+# Zeebe.
+orchestration:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+zeebeGateway:
+  nodeSelector:
+    workload: alwaysgreen
+  tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: alwaysgreen
+
+# Elasticsearch.
+elasticsearch:
+  master:
+    nodeSelector:
+      workload: alwaysgreen
+    tolerations:
+    - effect: NoSchedule
+      key: workload
+      operator: Equal
+      value: alwaysgreen


### PR DESCRIPTION
## Summary

- Adds `values-infra-alwaysgreen.yaml` for chart versions 8.7, 8.8, 8.9, and 8.10, scheduling all Camunda pods onto GKE nodes labeled `workload: alwaysgreen` with a matching `NoSchedule` toleration.
- Configures the `kcor` scenario (disabled, used via `--include-disabled`) with `infra-type: {gke: alwaysgreen}` in each version's `ci-test-config.yaml`.

## Context

The `camunda/camunda` monorepo's `docker-build-helm-integration.yml` workflow (AlwaysGreen) references `scenario: keycloak-original` / `shortname: kcor`. This PR provides the infra values file and scenario entry needed to deploy those workloads onto the dedicated `alwaysgreen` GKE node pool.

**Depends on:** [camunda/camunda#52954](https://github.com/camunda/camunda/pull/52954) (references this branch temporarily via `@move-ag-nodes-onto-always-green`; will revert to `@main` after this merges).

## Validation

- `deploy-camunda matrix list --include-disabled --versions 8.7,8.8,8.9,8.10` shows `kcor` with `alwaysgreen` infra-type for all versions.
- `TestLifecycleFixtures` and `TestGenerateWithIncludeDisabled` matrix tests pass.
- Helm template rendering with the new infra file produces correct `nodeSelector` and `tolerations` (14 occurrences, matching `distroci` parity).