### PR TITLE
fix: replace azure/setup-helm with inline install for cross-repo compat

### DIFF
--- a/.github/workflows/test-chart-version-template.yaml
+++ b/.github/workflows/test-chart-version-template.yaml
@@ -123,7 +123,7 @@ on:
         default: false
         type: boolean
       helm-version:
-        description: "Helm version to install via azure/setup-helm. Empty means use the pre-baked Helm from the CI runner image."
+        description: "Helm version to install. Empty means use the pre-baked Helm from the CI runner image."
         required: false
         default: ""
         type: string

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -228,7 +228,7 @@ on:
         default: false
         type: boolean
       helm-version:
-        description: "Helm version to install via azure/setup-helm. Empty means use the pre-baked Helm from the CI runner image."
+        description: "Helm version to install. Empty means use the pre-baked Helm from the CI runner image."
         required: false
         default: ""
         type: string
@@ -348,9 +348,17 @@ jobs:
 
       - name: CI Setup - Override Helm version
         if: steps.helm-resolve.outputs.needs-install == 'true'
-        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
-        with:
-          version: ${{ steps.helm-resolve.outputs.version }}
+        env:
+          HELM_VERSION: ${{ steps.helm-resolve.outputs.version }}
+        run: |
+          tarball="helm-v${HELM_VERSION}-linux-amd64.tar.gz"
+          curl -fsSL "https://get.helm.sh/${tarball}" -o "/tmp/${tarball}"
+          curl -fsSL "https://get.helm.sh/${tarball}.sha256sum" -o "/tmp/${tarball}.sha256sum"
+          (cd /tmp && sha256sum --check "${tarball}.sha256sum")
+          tar -xzf "/tmp/${tarball}" -C /tmp
+          mv /tmp/linux-amd64/helm /usr/local/bin/helm
+          rm -rf "/tmp/${tarball}" "/tmp/${tarball}.sha256sum" /tmp/linux-amd64
+          helm version --short
 
       - name: CI Setup - Shared integration test setup
         id: setup
@@ -746,9 +754,17 @@ jobs:
 
       - name: CI Setup - Override Helm version
         if: steps.helm-resolve.outputs.needs-install == 'true'
-        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
-        with:
-          version: ${{ steps.helm-resolve.outputs.version }}
+        env:
+          HELM_VERSION: ${{ steps.helm-resolve.outputs.version }}
+        run: |
+          tarball="helm-v${HELM_VERSION}-linux-amd64.tar.gz"
+          curl -fsSL "https://get.helm.sh/${tarball}" -o "/tmp/${tarball}"
+          curl -fsSL "https://get.helm.sh/${tarball}.sha256sum" -o "/tmp/${tarball}.sha256sum"
+          (cd /tmp && sha256sum --check "${tarball}.sha256sum")
+          tar -xzf "/tmp/${tarball}" -C /tmp
+          mv /tmp/linux-amd64/helm /usr/local/bin/helm
+          rm -rf "/tmp/${tarball}" "/tmp/${tarball}.sha256sum" /tmp/linux-amd64
+          helm version --short
 
       - name: CI Setup - Shared integration test setup
         id: setup

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -202,7 +202,7 @@ on:
         default: false
         type: boolean
       helm-version:
-        description: "Helm version to install via azure/setup-helm. Empty means use the pre-baked Helm from the CI runner image."
+        description: "Helm version to install. Empty means use the pre-baked Helm from the CI runner image."
         required: false
         default: ""
         type: string


### PR DESCRIPTION
## Summary

- Replaces `azure/setup-helm` action with inline `curl`+`tar`+`sha256sum` install from the official Helm release URL
- Fixes `startup_failure` on every cross-repo caller of the reusable integration workflow since #5918 merged

## Root Cause

PR #5918 introduced `azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2` in the runner workflow. This action is **not on the enterprise action allowlist** for `camunda/camunda`. When cross-repo callers (`docker-build-helm-integration.yml`, `camunda-helm-integration.yml`) invoke the reusable workflow, GitHub Actions validates all referenced actions against the **caller's** enterprise allowlist and rejects disallowed actions with `startup_failure`.

**Error from GH UI:**
> the action azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 is not allowed in camunda/camunda because all actions must be from a repository owned by your enterprise, created by GitHub, or match one of the patterns: [...]

## Fix

Replace both `azure/setup-helm` usages (install job + upgrade job) in the runner with an inline bash step that downloads the tarball, verifies its SHA256 checksum, and installs it:

```bash
tarball="helm-v${HELM_VERSION}-linux-amd64.tar.gz"
curl -fsSL "https://get.helm.sh/${tarball}" -o "/tmp/${tarball}"
curl -fsSL "https://get.helm.sh/${tarball}.sha256sum" -o "/tmp/${tarball}.sha256sum"
(cd /tmp && sha256sum --check "${tarball}.sha256sum")
tar -xzf "/tmp/${tarball}" -C /tmp
mv /tmp/linux-amd64/helm /usr/local/bin/helm
```

The existing "Resolve Helm version" step is unchanged — only the install mechanism changes. No external action dependency needed.

## Follow-up

#6171 tracks investigating adding `azure/setup-helm` to the enterprise allowlist so we can revert to the official action.

## Impact

- All cross-repo integration test workflows will recover from `startup_failure`
- Helm version override behavior is preserved (falls back to pre-baked version if no override specified)
- Downloaded binary is verified against Helm's published SHA256 checksum
- No changes to inputs, outputs, or calling conventions