### PR TITLE
refactor(8.10): drop camundaPlatform.toYamlPretty helm v3 compat wrapper

### DIFF
--- a/charts/camunda-platform-8.10/templates/common/_utilz.tpl
+++ b/charts/camunda-platform-8.10/templates/common/_utilz.tpl
@@ -7,29 +7,6 @@ Utilities.
 */}}
 
 {{/*
-camundaPlatform.toYamlPretty
-A version-safe wrapper for toYamlPretty that falls back to toYaml on older Helm versions.
-toYamlPretty was introduced in Helm 3.17.0, so older versions will fail if it's used directly.
-
-This uses tpl to dynamically evaluate the template string at runtime, avoiding parse-time
-errors on older Helm versions that don't recognize toYamlPretty as a function.
-
-Usage:
-{{ include "camundaPlatform.toYamlPretty" (dict "value" . "context" $) }}
-
-Parameters:
-- value: The value to convert to YAML
-- context: The root context ($) needed for accessing Capabilities
-*/}}
-{{- define "camundaPlatform.toYamlPretty" -}}
-  {{- if semverCompare ">=3.17.0" .context.Capabilities.HelmVersion.Version -}}
-    {{- tpl "{{ toYamlPretty .value }}" (dict "value" .value) -}}
-  {{- else -}}
-    {{- toYaml .value -}}
-  {{- end -}}
-{{- end -}}
-
-{{/*
 camundaPlatform.manualMigrationRequired
 Fail with message when the old values file key is used and show the new key.
 

--- a/charts/camunda-platform-8.10/templates/orchestration/statefulset.yaml
+++ b/charts/camunda-platform-8.10/templates/orchestration/statefulset.yaml
@@ -304,15 +304,15 @@ spec:
       {{- end }}
       {{- with .Values.orchestration.nodeSelector | default .Values.global.nodeSelector }}
       nodeSelector:
-        {{- include "camundaPlatform.toYamlPretty" (dict "value" . "context" $) | nindent 8 }}
+        {{- toYamlPretty . | nindent 8 }}
       {{- end }}
       {{- with .Values.orchestration.affinity }}
       affinity:
-        {{- include "camundaPlatform.toYamlPretty" (dict "value" . "context" $) | nindent 8 }}
+        {{- toYamlPretty . | nindent 8 }}
       {{- end }}
       {{- with .Values.orchestration.tolerations }}
       tolerations:
-        {{- include "camundaPlatform.toYamlPretty" (dict "value" . "context" $) | nindent 8 }}
+        {{- toYamlPretty . | nindent 8 }}
       {{- end }}
   {{- if eq .Values.orchestration.persistenceType "disk" }}
   volumeClaimTemplates:


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6139

### What's in this PR?

Chart 15 / Camunda 8.10 targets Helm v4 only. The `camundaPlatform.toYamlPretty` helper was a version-safe wrapper that fell back to `toYaml` on Helm < 3.17.0 (where `toYamlPretty` didn't exist). With Helm v4 as the minimum requirement, this compatibility shim is dead weight.

Changes:
- **`charts/camunda-platform-8.10/templates/common/_utilz.tpl`** — removed the `camundaPlatform.toYamlPretty` define and its docstring (removes the `.context.Capabilities.HelmVersion.Version` semver check)
- **`charts/camunda-platform-8.10/templates/orchestration/statefulset.yaml`** — replaced the three wrapper call sites (`nodeSelector`, `affinity`, `tolerations`) with direct `toYamlPretty .` invocations

No behavior change for Helm v4 users. Older chart versions (8.7/8.8/8.9) are untouched.

### Checklist

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?