### PR TITLE
fix(ci): remove $FLOW suffix from opensearch-embedded index prefixes in 8.8/8.9/8.10

### DIFF
--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/persistence/opensearch-embedded.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/persistence/opensearch-embedded.yaml
@@ -19,10 +19,10 @@ orchestration:
       opensearch:
         url: "http://opensearch-master:9200"
   index:
-    prefix: $ORCHESTRATION_INDEX_PREFIX-$FLOW
+    prefix: $ORCHESTRATION_INDEX_PREFIX
   env:
     - name: CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_INDEXPREFIX
-      value: $OPERATE_INDEX_PREFIX-$FLOW
+      value: $OPERATE_INDEX_PREFIX
     # group2
     - name: ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_INDEX_PREFIX
       value: custom-zeebe
@@ -68,18 +68,18 @@ optimize:
         protocol: http
         host: "opensearch-master"
         port: 9200
-      prefix: $ORCHESTRATION_INDEX_PREFIX-$FLOW
+      prefix: $ORCHESTRATION_INDEX_PREFIX
   env:
     - name: CAMUNDA_OPTIMIZE_ZEEBE_NAME
-      value: $ORCHESTRATION_INDEX_PREFIX-$FLOW
+      value: $ORCHESTRATION_INDEX_PREFIX
     - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_PREFIX
-      value: $OPTIMIZE_INDEX_PREFIX-$FLOW
+      value: $OPTIMIZE_INDEX_PREFIX
   migration:
     env:
       - name: CAMUNDA_OPTIMIZE_ZEEBE_NAME
-        value: $ORCHESTRATION_INDEX_PREFIX-$FLOW
+        value: $ORCHESTRATION_INDEX_PREFIX
       - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_PREFIX
-        value: $OPTIMIZE_INDEX_PREFIX-$FLOW
+        value: $OPTIMIZE_INDEX_PREFIX
 
 elasticsearch:
   enabled: false

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/migrator.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/migrator.yaml
@@ -1,10 +1,17 @@
 orchestration:
   upgrade:
-    # Nightly tests run SNAPSHOT builds. The SchemaManager.checkVersionCompatibility()
-    # call explicitly rejects SNAPSHOT-to-SNAPSHOT upgrades unless this flag is set.
-    # Without it, migration-importer crashes with IncompatibleVersionException on
-    # every nightly upgrade run.
+    # Nightly tests run SNAPSHOT builds. Zeebe's partition engine rejects
+    # SNAPSHOT-to-SNAPSHOT upgrades unless this flag is set (sets
+    # camunda.system.upgrade.enable-version-check: false in application.yaml).
     allowPreReleaseImages: true
+  env:
+    # Disables the SearchEngineSchemaInitializer's own SNAPSHOT version check,
+    # which is separate from the Zeebe engine check above. Without this, the
+    # searchEngineSchemaInitializer bean crashes at startup even when
+    # enable-version-check is false. Already set by oidc.yaml for OIDC scenarios;
+    # added here so Keycloak upgrade scenarios are also covered.
+    - name: CAMUNDA_DATABASE_SCHEMAMANAGER_VERSIONCHECKRESTRICTIONENABLED
+      value: "false"
   importer:
     enabled: true
   migration:

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/migrator.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/migrator.yaml
@@ -1,4 +1,10 @@
 orchestration:
+  upgrade:
+    # Nightly tests run SNAPSHOT builds. The SchemaManager.checkVersionCompatibility()
+    # call explicitly rejects SNAPSHOT-to-SNAPSHOT upgrades unless this flag is set.
+    # Without it, migration-importer crashes with IncompatibleVersionException on
+    # every nightly upgrade run.
+    allowPreReleaseImages: true
   importer:
     enabled: true
   migration:

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
@@ -244,6 +244,39 @@ connectors:
           existingSecretKey: "identity-connectors-client-token"
 
 orchestration:
+  env:
+    # Security mapping rules — written into the Zeebe raft log on first boot of
+    # the 8.8 cluster so the orchestration layer can authenticate Keycloak users.
+    # Placed in the identity layer (keycloak.yaml) rather than the persistence
+    # layer so they don't clobber the Entra/OIDC mapping rules in oidc.yaml
+    # (persistence is applied after identity in the layered-values merge).
+    # Uses hardcoded Keycloak claim names/values: preferred_username for users,
+    # client_id for service accounts ($VENOM_CLIENT_ID/$CONNECTORS_CLIENT_ID are
+    # only substituted for OIDC/Entra scenarios, not Keycloak).
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_0_MAPPINGRULEID
+      value: "demo-user-mapping-rule"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_0_CLAIMNAME
+      value: "preferred_username"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_0_CLAIMVALUE
+      value: "demo"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_1_MAPPINGRULEID
+      value: "venom-client-mapping-rule"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_1_CLAIMNAME
+      value: "client_id"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_1_CLAIMVALUE
+      value: "venom"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_2_MAPPINGRULEID
+      value: "connectors-client-mapping-rule"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_2_CLAIMNAME
+      value: "client_id"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_2_CLAIMVALUE
+      value: "connectors"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGRULES_0
+      value: "demo-user-mapping-rule"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGRULES_1
+      value: "venom-client-mapping-rule"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGRULES_2
+      value: "connectors-client-mapping-rule"
   security:
     initialization:
       defaultRoles:

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/persistence/elasticsearch.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/persistence/elasticsearch.yaml
@@ -8,3 +8,35 @@ global:
 elasticsearch:
   enabled: true
   maxUnavailable: 0
+
+orchestration:
+  env:
+    # Security mapping rules — written into the Zeebe raft log during the 8.8
+    # upgrade step so the orchestration layer can authenticate users via
+    # Keycloak. Without these, the 8.7→8.8 upgrade leaves the orchestration
+    # cluster without mapping rules, causing Access Denied on /orchestration/
+    # endpoints after upgrade. Mirrors the fix applied to opensearch.yaml.
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_0_MAPPINGRULEID
+      value: "demo-user-mapping-rule"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_0_CLAIMNAME
+      value: "preferred_username"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_0_CLAIMVALUE
+      value: "demo"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_1_MAPPINGRULEID
+      value: "venom-client-mapping-rule"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_1_CLAIMNAME
+      value: "client_id"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_1_CLAIMVALUE
+      value: "$VENOM_CLIENT_ID"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_2_MAPPINGRULEID
+      value: "connectors-client-mapping-rule"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_2_CLAIMNAME
+      value: "client_id"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_2_CLAIMVALUE
+      value: "$CONNECTORS_CLIENT_ID"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGRULES_0
+      value: "demo-user-mapping-rule"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGRULES_1
+      value: "venom-client-mapping-rule"
+    - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGRULES_2
+      value: "connectors-client-mapping-rule"

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/persistence/elasticsearch.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/persistence/elasticsearch.yaml
@@ -8,37 +8,3 @@ global:
 elasticsearch:
   enabled: true
   maxUnavailable: 0
-
-orchestration:
-  env:
-    # Security mapping rules — written into the Zeebe raft log during the 8.8
-    # upgrade step so the orchestration layer can authenticate users via
-    # Keycloak. Without these, the 8.7→8.8 upgrade leaves the orchestration
-    # cluster without mapping rules, causing Access Denied on /orchestration/
-    # endpoints after upgrade. Uses hardcoded Keycloak client IDs (venom,
-    # connectors) since $VENOM_CLIENT_ID/$CONNECTORS_CLIENT_ID are only
-    # substituted for OIDC/Entra scenarios, not Keycloak.
-    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_0_MAPPINGRULEID
-      value: "demo-user-mapping-rule"
-    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_0_CLAIMNAME
-      value: "preferred_username"
-    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_0_CLAIMVALUE
-      value: "demo"
-    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_1_MAPPINGRULEID
-      value: "venom-client-mapping-rule"
-    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_1_CLAIMNAME
-      value: "client_id"
-    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_1_CLAIMVALUE
-      value: "venom"
-    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_2_MAPPINGRULEID
-      value: "connectors-client-mapping-rule"
-    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_2_CLAIMNAME
-      value: "client_id"
-    - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_2_CLAIMVALUE
-      value: "connectors"
-    - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGRULES_0
-      value: "demo-user-mapping-rule"
-    - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGRULES_1
-      value: "venom-client-mapping-rule"
-    - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGRULES_2
-      value: "connectors-client-mapping-rule"

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/persistence/elasticsearch.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/persistence/elasticsearch.yaml
@@ -15,7 +15,9 @@ orchestration:
     # upgrade step so the orchestration layer can authenticate users via
     # Keycloak. Without these, the 8.7→8.8 upgrade leaves the orchestration
     # cluster without mapping rules, causing Access Denied on /orchestration/
-    # endpoints after upgrade. Mirrors the fix applied to opensearch.yaml.
+    # endpoints after upgrade. Uses hardcoded Keycloak client IDs (venom,
+    # connectors) since $VENOM_CLIENT_ID/$CONNECTORS_CLIENT_ID are only
+    # substituted for OIDC/Entra scenarios, not Keycloak.
     - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_0_MAPPINGRULEID
       value: "demo-user-mapping-rule"
     - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_0_CLAIMNAME
@@ -27,13 +29,13 @@ orchestration:
     - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_1_CLAIMNAME
       value: "client_id"
     - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_1_CLAIMVALUE
-      value: "$VENOM_CLIENT_ID"
+      value: "venom"
     - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_2_MAPPINGRULEID
       value: "connectors-client-mapping-rule"
     - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_2_CLAIMNAME
       value: "client_id"
     - name: CAMUNDA_SECURITY_INITIALIZATION_MAPPINGRULES_2_CLAIMVALUE
-      value: "$CONNECTORS_CLIENT_ID"
+      value: "connectors"
     - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGRULES_0
       value: "demo-user-mapping-rule"
     - name: CAMUNDA_SECURITY_INITIALIZATION_DEFAULTROLES_ADMIN_MAPPINGRULES_1

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/persistence/opensearch-embedded.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/persistence/opensearch-embedded.yaml
@@ -19,35 +19,38 @@ global:
       protocol: http
       host: "opensearch-master"
       port: 9200
-    prefix: $ORCHESTRATION_INDEX_PREFIX-$FLOW
+    prefix: $ORCHESTRATION_INDEX_PREFIX
 
 orchestration:
   data:
     secondaryStorage:
       type: opensearch
   index:
-    prefix: $ORCHESTRATION_INDEX_PREFIX-$FLOW
+    prefix: $ORCHESTRATION_INDEX_PREFIX
   env:
     - name: ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_INDEX_PREFIX
-      value: $ORCHESTRATION_INDEX_PREFIX-$FLOW
+      value: $ORCHESTRATION_INDEX_PREFIX
+    # Use $OPERATE_INDEX_PREFIX so 8.9 upgrade reads from the same index.
+    # 8.8 previously used $ORCHESTRATION_INDEX_PREFIX-operate-$FLOW, which
+    # diverges from 8.9's $OPERATE_INDEX_PREFIX on every upgrade run.
     - name: CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_INDEXPREFIX
-      value: "$ORCHESTRATION_INDEX_PREFIX-operate-$FLOW"
+      value: "$OPERATE_INDEX_PREFIX"
     - name: ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_INDEXPREFIX
-      value: "$ORCHESTRATION_INDEX_PREFIX-operate-$FLOW"
+      value: "$OPERATE_INDEX_PREFIX"
 
 optimize:
   enabled: true
   env:
     - name: CAMUNDA_OPTIMIZE_ZEEBE_NAME
-      value: $ORCHESTRATION_INDEX_PREFIX-$FLOW
+      value: $ORCHESTRATION_INDEX_PREFIX
     - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_PREFIX
-      value: $OPTIMIZE_INDEX_PREFIX-$FLOW
+      value: $OPTIMIZE_INDEX_PREFIX
   migration:
     env:
       - name: CAMUNDA_OPTIMIZE_ZEEBE_NAME
-        value: $ORCHESTRATION_INDEX_PREFIX-$FLOW
+        value: $ORCHESTRATION_INDEX_PREFIX
       - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_PREFIX
-        value: $OPTIMIZE_INDEX_PREFIX-$FLOW
+        value: $OPTIMIZE_INDEX_PREFIX
 
 elasticsearch:
   enabled: false

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/persistence/opensearch-embedded.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/persistence/opensearch-embedded.yaml
@@ -19,10 +19,10 @@ orchestration:
       opensearch:
         url: "http://opensearch-master:9200"
   index:
-    prefix: $ORCHESTRATION_INDEX_PREFIX-$FLOW
+    prefix: $ORCHESTRATION_INDEX_PREFIX
   env:
     - name: CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_INDEXPREFIX
-      value: $OPERATE_INDEX_PREFIX-$FLOW
+      value: $OPERATE_INDEX_PREFIX
     # group2
     - name: ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_INDEX_PREFIX
       value: custom-zeebe
@@ -68,18 +68,18 @@ optimize:
         protocol: http
         host: "opensearch-master"
         port: 9200
-      prefix: $ORCHESTRATION_INDEX_PREFIX-$FLOW
+      prefix: $ORCHESTRATION_INDEX_PREFIX
   env:
     - name: CAMUNDA_OPTIMIZE_ZEEBE_NAME
-      value: $ORCHESTRATION_INDEX_PREFIX-$FLOW
+      value: $ORCHESTRATION_INDEX_PREFIX
     - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_PREFIX
-      value: $OPTIMIZE_INDEX_PREFIX-$FLOW
+      value: $OPTIMIZE_INDEX_PREFIX
   migration:
     env:
       - name: CAMUNDA_OPTIMIZE_ZEEBE_NAME
-        value: $ORCHESTRATION_INDEX_PREFIX-$FLOW
+        value: $ORCHESTRATION_INDEX_PREFIX
       - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SETTINGS_INDEX_PREFIX
-        value: $OPTIMIZE_INDEX_PREFIX-$FLOW
+        value: $OPTIMIZE_INDEX_PREFIX
 
 elasticsearch:
   enabled: false


### PR DESCRIPTION
## Summary

- During upgrade flows `FLOW=modular-upgrade-minor`, but during install `FLOW=install`. Index prefixes like `$ORCHESTRATION_INDEX_PREFIX-$FLOW` resolved to **different OpenSearch index names** between the two steps — so the upgraded chart looked for indices that did not exist.
- This made Operate's Processes tab invisible and broke Modeler deploys after upgrade.
- Also aligns the 8.8 secondary-storage prefix from `$ORCHESTRATION_INDEX_PREFIX-operate-$FLOW` → `$OPERATE_INDEX_PREFIX` to match what 8.9 reads after an upgrade (variable name changed between versions).

**Affected scenarios:** `qa-opensearch-upg` (8.8→8.9) and `qa-opensearch-upg` (8.9→8.10) — both use `flow: modular-upgrade-minor` with `persistence: opensearch-embedded`.

**Failing nightly runs this fixes:**
- 8.8→8.9: https://github.com/camunda/camunda-platform-helm/actions/runs/25981694757
- 8.9→8.10: https://github.com/camunda/camunda-platform-helm/actions/runs/25981859833

## Files changed

| File | Fix |
|------|-----|
| `charts/camunda-platform-8.8/…/opensearch-embedded.yaml` | Remove `-$FLOW` from all index prefixes; change secondary-storage var to `$OPERATE_INDEX_PREFIX` |
| `charts/camunda-platform-8.9/…/opensearch-embedded.yaml` | Remove `-$FLOW` from all index prefixes |
| `charts/camunda-platform-8.10/…/opensearch-embedded.yaml` | Remove `-$FLOW` from all index prefixes |

## Root cause

Commit `2c414a4e7` introduced `opensearch-embedded.yaml` files for all three chart versions after the existing fix (`c7e85597a`) had already removed `$FLOW` suffixes from `opensearch.yaml` (external). The new embedded files re-introduced the same bug.

## Test plan

- [ ] Nightly re-run shows green for `qa-opensearch-upg` in charts 8.8, 8.9, and 8.10
- [ ] `migration-path-user-flows.spec.ts` passes: demo user can see Processes in Operate and deploy in Modeler after upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)