### PR TITLE
ci: add CI Gate job to block merging PRs with failed CI

### DIFF
--- a/.github/workflows/test-chart-version.yaml
+++ b/.github/workflows/test-chart-version.yaml
@@ -227,6 +227,31 @@ jobs:
       skip-it: ${{ matrix.skipIT == 'true' }}
       helm-version: ${{ matrix.helmVersion }}
 
+  # Aggregation gate job that fails if any CI job fails.
+  # Add this job's name ("CI Gate") to the ruleset's required status checks
+  # so the merge queue will not merge PRs with broken CI.
+  ci-gate:
+    name: "CI Gate"
+    if: always()
+    needs: [unit-testing, validation, kind-testing, integration-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check job results
+        run: |
+          results=(
+            "${{ needs.unit-testing.result }}"
+            "${{ needs.validation.result }}"
+            "${{ needs.kind-testing.result }}"
+            "${{ needs.integration-tests.result }}"
+          )
+          for result in "${results[@]}"; do
+            if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
+              echo "::error::Required job reported: $result"
+              exit 1
+            fi
+          done
+          echo "All required jobs passed (or were skipped)."
+
   # Report license/cla commit status on merge queue commits.
   # The CLA bot only reports on pull_request events; the merge queue creates
   # ephemeral commits that never receive the status. This job bridges that gap

--- a/.github/workflows/test-chart-version.yaml
+++ b/.github/workflows/test-chart-version.yaml
@@ -233,12 +233,13 @@ jobs:
   ci-gate:
     name: "CI Gate"
     if: always()
-    needs: [unit-testing, validation, kind-testing, integration-tests]
+    needs: [init, unit-testing, validation, kind-testing, integration-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Check job results
         run: |
           results=(
+            "${{ needs.init.result }}"
             "${{ needs.unit-testing.result }}"
             "${{ needs.validation.result }}"
             "${{ needs.kind-testing.result }}"


### PR DESCRIPTION
## Summary

- Adds a `CI Gate` aggregation job that depends on `unit-testing`, `validation`, `kind-testing`, and `integration-tests`
- Fails if any dependency reported `failure` or `cancelled` (skipped jobs are allowed)
- Once `CI Gate` is added to the ruleset's required status checks, the merge queue will stop merging PRs whose CI is broken

## Problem

The merge queue currently only requires the `license/cla` status check. The `report-cla-status` job satisfies this immediately on `merge_group` events, meaning PRs merge regardless of whether actual tests pass.

## How it works

```yaml
ci-gate:
  name: "CI Gate"
  if: always()
  needs: [unit-testing, validation, kind-testing, integration-tests]
```

The job uses `if: always()` so it runs even when dependencies are skipped (which is expected for Renovate image PRs and release-please branches). It only fails on `failure` or `cancelled`.

## Required follow-up

After merging this PR, add `CI Gate` to the ruleset's required status checks (ruleset ID `639923`). Without that step, the gate job exists but isn't enforced.