### PR TITLE
build: link zeebeGateway tag to zeebe when unset in values-injector

### DIFF
--- a/scripts/values-injector/internal/injector/injector_test.go
+++ b/scripts/values-injector/internal/injector/injector_test.go
@@ -131,6 +131,34 @@ func TestMergeImageTags86_SingleComponent(t *testing.T) {
 	}
 }
 
+func TestMergeImageTags86_ZeebeOverrideAlsoUpdatesGateway(t *testing.T) {
+	overrides := &chartcomponents.ValuesYAML86{
+		Zeebe: &chartcomponents.ComponentImage{
+			Image: chartcomponents.ImageTag{Tag: "8.6.99"},
+		},
+		ZeebeGateway: &chartcomponents.ComponentImage{
+			Image: chartcomponents.ImageTag{Tag: "8.6.99"},
+		},
+	}
+
+	result, err := MergeImageTags86(sampleValues86, overrides)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Both zeebe and zeebeGateway tags should be updated
+	lines := strings.Split(result, "\n")
+	updatedCount := 0
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "tag: 8.6.99" {
+			updatedCount++
+		}
+	}
+	if updatedCount != 2 {
+		t.Errorf("expected both zeebe and zeebeGateway tags to be 8.6.99, found %d occurrences", updatedCount)
+	}
+}
+
 func TestMergeImageTags86_MultipleComponents(t *testing.T) {
 	overrides := &chartcomponents.ValuesYAML86{
 		Console: &chartcomponents.ComponentImage{

--- a/scripts/values-injector/main.go
+++ b/scripts/values-injector/main.go
@@ -80,6 +80,8 @@ func buildOverrides86() *chartcomponents.ValuesYAML86 {
 		overrides.ZeebeGateway = &chartcomponents.ComponentImage{
 			Image: chartcomponents.ImageTag{Tag: tag},
 		}
+	} else if overrides.Zeebe != nil {
+		overrides.ZeebeGateway = overrides.Zeebe
 	}
 	if tag := os.Getenv("OPERATE_IMAGE_TAG"); tag != "" {
 		overrides.Operate = &chartcomponents.ComponentImage{

--- a/scripts/values-injector/main_test.go
+++ b/scripts/values-injector/main_test.go
@@ -1,0 +1,60 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+)
+
+func TestBuildOverrides86_ZeebeLinksToGateway(t *testing.T) {
+	t.Setenv("ZEEBE_IMAGE_TAG", "8.7.99")
+
+	overrides := buildOverrides86()
+
+	if overrides.Zeebe == nil {
+		t.Fatal("expected Zeebe override to be set")
+	}
+	if overrides.ZeebeGateway == nil {
+		t.Fatal("expected ZeebeGateway override to be set when ZEEBE_IMAGE_TAG is provided")
+	}
+	if overrides.ZeebeGateway.Image.Tag != "8.7.99" {
+		t.Errorf("expected ZeebeGateway tag to be 8.7.99, got %s", overrides.ZeebeGateway.Image.Tag)
+	}
+}
+
+func TestBuildOverrides86_ExplicitGatewayOverridesLink(t *testing.T) {
+	t.Setenv("ZEEBE_IMAGE_TAG", "8.7.99")
+	t.Setenv("ZEEBE_GATEWAY_IMAGE_TAG", "8.7.50")
+
+	overrides := buildOverrides86()
+
+	if overrides.ZeebeGateway == nil {
+		t.Fatal("expected ZeebeGateway override to be set")
+	}
+	if overrides.ZeebeGateway.Image.Tag != "8.7.50" {
+		t.Errorf("expected explicit gateway tag 8.7.50, got %s", overrides.ZeebeGateway.Image.Tag)
+	}
+}
+
+func TestBuildOverrides86_NoZeebeNoGateway(t *testing.T) {
+	overrides := buildOverrides86()
+
+	if overrides.Zeebe != nil {
+		t.Error("expected Zeebe override to be nil")
+	}
+	if overrides.ZeebeGateway != nil {
+		t.Error("expected ZeebeGateway override to be nil")
+	}
+}

--- a/scripts/values-injector/main_test.go
+++ b/scripts/values-injector/main_test.go
@@ -20,6 +20,7 @@ import (
 
 func TestBuildOverrides86_ZeebeLinksToGateway(t *testing.T) {
 	t.Setenv("ZEEBE_IMAGE_TAG", "8.7.99")
+	t.Setenv("ZEEBE_GATEWAY_IMAGE_TAG", "")
 
 	overrides := buildOverrides86()
 
@@ -49,6 +50,9 @@ func TestBuildOverrides86_ExplicitGatewayOverridesLink(t *testing.T) {
 }
 
 func TestBuildOverrides86_NoZeebeNoGateway(t *testing.T) {
+	t.Setenv("ZEEBE_IMAGE_TAG", "")
+	t.Setenv("ZEEBE_GATEWAY_IMAGE_TAG", "")
+
 	overrides := buildOverrides86()
 
 	if overrides.Zeebe != nil {


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6183.

During the 8.7 chart 12.9.0 release, the Build Dev workflow was triggered with `zeebe-image-tag: 8.7.29` but without `zeebe-gateway-image-tag`. Since `buildOverrides86` treats these as independent overrides, `zeebe.image.tag` was updated to `8.7.29` while `zeebeGateway.image.tag` stayed at `8.7.28`. Both use `camunda/zeebe`, so the version matrix and release notes ended up with two zeebe entries.

Zeebe and zeebeGateway have never had intentionally different tags in the 8.7 chart history.

- Build Dev run: https://github.com/camunda/camunda-platform-helm/actions/runs/25487761802
- Promote RC run: https://github.com/camunda/camunda-platform-helm/actions/runs/25488763286
- Release PR: https://github.com/camunda/camunda-platform-helm/pull/6088

### What's in this PR?

When `ZEEBE_GATEWAY_IMAGE_TAG` is not set but `ZEEBE_IMAGE_TAG` is, the values-injector now links the gateway override to the zeebe override. An explicit `ZEEBE_GATEWAY_IMAGE_TAG` still takes precedence.

Affects charts 8.6 and 8.7 only (8.8+ uses unified `orchestration`).

### Checklist

- [x] Tests added for the linkage behavior (`main_test.go` and `injector_test.go`)
- [x] All existing tests pass