### PR TITLE
ci: skip integration-tests when no chart changes detected

### DIFF
--- a/.github/workflows/test-chart-version.yaml
+++ b/.github/workflows/test-chart-version.yaml
@@ -234,6 +234,7 @@ jobs:
     # validated by AlwaysGreen before publishing. Only golden file updates are needed.
     if: >-
       ${{
+        needs.init.outputs.camunda-versions != '[]' &&
         !contains(github.head_ref, 'release-please--branches--') &&
         !(startsWith(github.head_ref, 'renovate/') && (
           contains(github.head_ref, 'camunda-platform-images') ||


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6185.

The CI Gate job (added in #6180) fails on PRs that don't touch chart files. When no chart changes are detected, `generate-chart-matrix.sh` emits `{"include":[]}`. GitHub Actions treats a matrix job with zero inclusions as `failure`, not `skipped`. The CI Gate aggregates all job results and fails when it sees this.

Other test jobs (`unit-testing`, `validation`, `kind-testing`) already guard against this with `needs.init.outputs.camunda-versions != '[]'`, but `integration-tests` was missing this check.

- Failing CI Gate run: https://github.com/camunda/camunda-platform-helm/actions/runs/26074515960
- Blocked PR: https://github.com/camunda/camunda-platform-helm/pull/6184

### What's in this PR?

Adds the same `camunda-versions != '[]'` guard to `integration-tests` `if:` condition, consistent with the other test jobs.

### Checklist

- [x] Fix is a 1-line addition matching existing pattern used by sibling jobs