### PR TITLE
ci(8.10): enable hub-legacy and hub-mixed upgrade-minor CI scenarios

### DIFF
--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -835,6 +835,35 @@ jobs:
       ##########################################################################################################
       # Upgrade
       ##########################################################################################################
+      - name: Cluster Setup - Upgrade - Configure the namespace
+        if: inputs.flow == 'modular-upgrade-minor'
+        run: |
+          echo $TEST_NAMESPACE
+          # Modular upgrade flows skip the install job, so the upgrade job must
+          # create the namespace before applying ExternalSecrets into it.
+          if kubectl get ns $TEST_NAMESPACE &>/dev/null; then
+            EXISTING_RUN_ID=$(kubectl get ns $TEST_NAMESPACE -o jsonpath='{.metadata.labels.github-run-id}' 2>/dev/null || echo "")
+            if [[ "$EXISTING_RUN_ID" == "$GITHUB_WORKFLOW_RUN_ID" ]]; then
+              echo "Namespace exists and was created by this run, deleting and recreating..."
+              kubectl delete ns $TEST_NAMESPACE
+            else
+              echo "Namespace exists but was created by a different run (run-id: $EXISTING_RUN_ID), cleaning up stale release..."
+              helm uninstall integration --namespace $TEST_NAMESPACE --wait --timeout 2m0s 2>/dev/null || true
+            fi
+          fi
+          kubectl create ns $TEST_NAMESPACE --dry-run=client -o yaml | kubectl apply -f -
+          kubectl label ns $TEST_NAMESPACE github-id=${{ steps.setup.outputs.identifier }} --overwrite
+          kubectl label ns $TEST_NAMESPACE test-flow=${{ inputs.flow }} --overwrite
+          kubectl label ns $TEST_NAMESPACE github-run-id=$GITHUB_WORKFLOW_RUN_ID --overwrite
+          kubectl label ns $TEST_NAMESPACE github-job-id=$GITHUB_WORKFLOW_JOB_ID --overwrite
+          kubectl label ns $TEST_NAMESPACE github-org=$(dirname $GITHUB_REPOSITORY) --overwrite
+          kubectl label ns $TEST_NAMESPACE github-repo=$(basename $GITHUB_REPOSITORY) --overwrite
+          kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${{ inputs.deployment-ttl || '1h' }} --overwrite
+          kubectl annotate ns $TEST_NAMESPACE janitor/ttl=${{ inputs.deployment-ttl || '1h' }} --overwrite
+          kubectl annotate ns $TEST_NAMESPACE camunda.cloud/ephemeral=true --overwrite
+          kubectl annotate ns $TEST_NAMESPACE github-workflow-run-url=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID --overwrite
+          kubectl get ns $TEST_NAMESPACE -o yaml
+
       - name: Helm - Upgrade - Configure Helm with Entra Values
         if: (inputs.auth == 'oidc' || inputs.test-identity == 'oidc') && inputs.values-config == '{}'
         timeout-minutes: 5

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -835,35 +835,6 @@ jobs:
       ##########################################################################################################
       # Upgrade
       ##########################################################################################################
-      - name: Cluster Setup - Upgrade - Configure the namespace
-        if: inputs.flow == 'modular-upgrade-minor'
-        run: |
-          echo $TEST_NAMESPACE
-          # Modular upgrade flows skip the install job, so the upgrade job must
-          # create the namespace before applying ExternalSecrets into it.
-          if kubectl get ns $TEST_NAMESPACE &>/dev/null; then
-            EXISTING_RUN_ID=$(kubectl get ns $TEST_NAMESPACE -o jsonpath='{.metadata.labels.github-run-id}' 2>/dev/null || echo "")
-            if [[ "$EXISTING_RUN_ID" == "$GITHUB_WORKFLOW_RUN_ID" ]]; then
-              echo "Namespace exists and was created by this run, deleting and recreating..."
-              kubectl delete ns $TEST_NAMESPACE
-            else
-              echo "Namespace exists but was created by a different run (run-id: $EXISTING_RUN_ID), cleaning up stale release..."
-              helm uninstall integration --namespace $TEST_NAMESPACE --wait --timeout 2m0s 2>/dev/null || true
-            fi
-          fi
-          kubectl create ns $TEST_NAMESPACE --dry-run=client -o yaml | kubectl apply -f -
-          kubectl label ns $TEST_NAMESPACE github-id=${{ steps.setup.outputs.identifier }} --overwrite
-          kubectl label ns $TEST_NAMESPACE test-flow=${{ inputs.flow }} --overwrite
-          kubectl label ns $TEST_NAMESPACE github-run-id=$GITHUB_WORKFLOW_RUN_ID --overwrite
-          kubectl label ns $TEST_NAMESPACE github-job-id=$GITHUB_WORKFLOW_JOB_ID --overwrite
-          kubectl label ns $TEST_NAMESPACE github-org=$(dirname $GITHUB_REPOSITORY) --overwrite
-          kubectl label ns $TEST_NAMESPACE github-repo=$(basename $GITHUB_REPOSITORY) --overwrite
-          kubectl annotate ns $TEST_NAMESPACE cleaner/ttl=${{ inputs.deployment-ttl || '1h' }} --overwrite
-          kubectl annotate ns $TEST_NAMESPACE janitor/ttl=${{ inputs.deployment-ttl || '1h' }} --overwrite
-          kubectl annotate ns $TEST_NAMESPACE camunda.cloud/ephemeral=true --overwrite
-          kubectl annotate ns $TEST_NAMESPACE github-workflow-run-url=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID --overwrite
-          kubectl get ns $TEST_NAMESPACE -o yaml
-
       - name: Helm - Upgrade - Configure Helm with Entra Values
         if: (inputs.auth == 'oidc' || inputs.test-identity == 'oidc') && inputs.values-config == '{}'
         timeout-minutes: 5

--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -665,13 +665,14 @@ integration:
                 - RDBMS_POSTGRESQL_USERNAME
                 - RDBMS_POSTGRESQL_PASSWORD
         - name: hub-legacy
-          enabled: false
+          enabled: true
           shortname: hublu
           auth: keycloak
           flow: upgrade-minor
           platforms:
             - gke
           exclude: []
+          tier: 2
           infra-type:
             eks: preemptible
             gke: distroci
@@ -696,13 +697,14 @@ integration:
                 - RDBMS_POSTGRESQL_USERNAME
                 - RDBMS_POSTGRESQL_PASSWORD
         - name: hub-mixed
-          enabled: false
+          enabled: true
           shortname: hubmu
           auth: keycloak
           flow: upgrade-minor
           platforms:
             - gke
           exclude: []
+          tier: 2
           infra-type:
             eks: preemptible
             gke: distroci

--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -668,7 +668,7 @@ integration:
           enabled: true
           shortname: hublu
           auth: keycloak
-          flow: modular-upgrade-minor
+          flow: upgrade-minor
           platforms:
             - gke
           exclude: []
@@ -710,7 +710,7 @@ integration:
           enabled: true
           shortname: hubmu
           auth: keycloak
-          flow: modular-upgrade-minor
+          flow: upgrade-minor
           platforms:
             - gke
           exclude: []

--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -668,7 +668,7 @@ integration:
           enabled: true
           shortname: hublu
           auth: keycloak
-          flow: upgrade-minor
+          flow: modular-upgrade-minor
           platforms:
             - gke
           exclude: []
@@ -696,11 +696,21 @@ integration:
               env-vars:
                 - RDBMS_POSTGRESQL_USERNAME
                 - RDBMS_POSTGRESQL_PASSWORD
+          post-infra:
+            script: post-infra-bitnami-migration.sh
+            description: |
+              After the companion PostgreSQL/Keycloak/Elasticsearch are deployed but before
+              the chart upgrade to 8.10, migrate the bundled (Bitnami) Keycloak realm and the
+              Elasticsearch authorization indices off the bundled backends onto the companion
+              services. Uses the camunda-deployment-references migration scripts in external
+              mode with SKIP_HELM_UPGRADE=true (data-only; the matrix runner performs the
+              chart upgrade). This keeps users/realm alive across the upgrade that removes the
+              bundled Bitnami subcharts.
         - name: hub-mixed
           enabled: true
           shortname: hubmu
           auth: keycloak
-          flow: upgrade-minor
+          flow: modular-upgrade-minor
           platforms:
             - gke
           exclude: []
@@ -728,6 +738,16 @@ integration:
               env-vars:
                 - RDBMS_POSTGRESQL_USERNAME
                 - RDBMS_POSTGRESQL_PASSWORD
+          post-infra:
+            script: post-infra-bitnami-migration.sh
+            description: |
+              After the companion PostgreSQL/Keycloak/Elasticsearch are deployed but before
+              the chart upgrade to 8.10, migrate the bundled (Bitnami) Keycloak realm and the
+              Elasticsearch authorization indices off the bundled backends onto the companion
+              services. Uses the camunda-deployment-references migration scripts in external
+              mode with SKIP_HELM_UPGRADE=true (data-only; the matrix runner performs the
+              chart upgrade). This keeps users/realm alive across the upgrade that removes the
+              bundled Bitnami subcharts.
         - name: hub-external-db
           enabled: true
           shortname: hubdb

--- a/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
@@ -93,10 +93,12 @@ integration:
       enabled: true
     - id: hub-legacy-upgrade
       shortname: hublu
-      enabled: false
+      tier: 2
+      enabled: true
     - id: hub-mixed
       shortname: hubmu
-      enabled: false
+      tier: 2
+      enabled: true
     - id: hub-external-db
       shortname: hubdb
       tier: 2

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/hub-legacy-upgrade.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/hub-legacy-upgrade.yaml
@@ -1,7 +1,7 @@
 name: hub-legacy
 auth: keycloak
 flows:
-  - upgrade-minor
+  - modular-upgrade-minor
 identity: keycloak
 persistence: elasticsearch
 features:
@@ -11,6 +11,7 @@ platforms:
 infra-type:
   eks: preemptible
   gke: distroci
+post-infra: post-infra-bitnami-migration
 dependencies:
   - keycloak
   - elasticsearch

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/hub-legacy-upgrade.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/hub-legacy-upgrade.yaml
@@ -1,7 +1,7 @@
 name: hub-legacy
 auth: keycloak
 flows:
-  - modular-upgrade-minor
+  - upgrade-minor
 identity: keycloak
 persistence: elasticsearch
 features:

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/hub-mixed.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/hub-mixed.yaml
@@ -1,7 +1,7 @@
 name: hub-mixed
 auth: keycloak
 flows:
-  - modular-upgrade-minor
+  - upgrade-minor
 identity: keycloak
 persistence: elasticsearch
 features:

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/hub-mixed.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/hub-mixed.yaml
@@ -1,7 +1,7 @@
 name: hub-mixed
 auth: keycloak
 flows:
-  - upgrade-minor
+  - modular-upgrade-minor
 identity: keycloak
 persistence: elasticsearch
 features:
@@ -11,6 +11,7 @@ platforms:
 infra-type:
   eks: preemptible
   gke: distroci
+post-infra: post-infra-bitnami-migration
 dependencies:
   - keycloak
   - elasticsearch

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/base-upgrade.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/base-upgrade.yaml
@@ -8,3 +8,14 @@ orchestration:
   env:
     - name: CAMUNDA_DATABASE_SCHEMAMANAGER_VERSIONCHECKRESTRICTIONENABLED
       value: "false"
+  security:
+    initialization:
+      # 8.10 upgrade scenarios start from 8.9 state where the Admin role may
+      # not yet grant Orchestration Admin component access to OIDC mapping rules.
+      authorizations:
+        - ownerType: MAPPING_RULE
+          ownerId: demo-user-mapping-rule
+          resourceType: COMPONENT
+          resourceId: "*"
+          permissions:
+            - ACCESS

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/hub-mixed.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/hub-mixed.yaml
@@ -37,8 +37,8 @@ webModeler:
           - sh
           - -c
           - |
-            echo "Waiting for PostgreSQL at {{ .Release.Name }}-postgresql-web-modeler:5432 ..."
-            until nc -z "{{ .Release.Name }}-postgresql-web-modeler" 5432; do
+            echo "Waiting for PostgreSQL at postgresql:5432 ..."
+            until nc -z "postgresql" 5432; do
               sleep 2
             done
             echo "PostgreSQL is ready"


### PR DESCRIPTION
## Summary

- Enables the `hub-legacy` (`hublu`) and `hub-mixed` (`hubmu`) upgrade-minor scenarios in the 8.10 CI matrix.
- Continuously validates the 8.9 -> 8.10 upgrade path for camundaHub consolidation.
- Assigns both upgrade scenarios to Tier 2.

## What these scenarios test

- **hub-legacy**: Customer uses only `console.*` / `webModeler.*` keys. Validates backward compatibility.
- **hub-mixed**: Customer sets `camundaHub.enabled: true` but keeps detail config under legacy keys. Validates shim merge behavior during upgrade.

## Fixes applied

- Restored the existing install scenario shortname to `huble` to avoid duplicate `hublu` shortnames.
- Removed invalid 8.10 `migrator` feature references.
- Restored `hub-mixed` persistence to `elasticsearch`.
- Added missing `tier: 2` to `hublu`.
- Updated `hub-mixed` Web Modeler init container to wait for the CloudNativePG service `postgresql-cluster-rw`.

## Validation

- `make helm.dependency-update chartPath=charts/camunda-platform-8.10`
- `make helm.lint chartPath=charts/camunda-platform-8.10`
- `make go.test chartPath=charts/camunda-platform-8.10`
- `deploy-camunda matrix list --repo-root . --versions 8.10`
- `crev review --dry-run --no-cache https://github.com/camunda/camunda-platform-helm/pull/6187`

Contributes to: camunda/product-hub#3411