### PR TITLE
test(8.10): add hub-pinned-images upgrade scenario

### DIFF
--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -799,6 +799,7 @@ integration:
           persistence: elasticsearch
           features:
             - hub-pinned-images
+            - postgresql-companion
           dependencies:
             - chart: charts/internal-keycloak-26
               release-name: keycloak
@@ -815,6 +816,16 @@ integration:
               env-vars:
                 - RDBMS_POSTGRESQL_USERNAME
                 - RDBMS_POSTGRESQL_PASSWORD
+          post-infra:
+            script: post-infra-bitnami-migration.sh
+            description: |
+              After the companion PostgreSQL/Keycloak/Elasticsearch are deployed but before
+              the chart upgrade to 8.10, migrate the bundled (Bitnami) Keycloak realm and the
+              Elasticsearch authorization indices off the bundled backends onto the companion
+              services. Uses the camunda-deployment-references migration scripts in external
+              mode with SKIP_HELM_UPGRADE=true (data-only; the matrix runner performs the
+              chart upgrade). This keeps users/realm alive across the upgrade that removes the
+              bundled Bitnami subcharts.
         - name: hub-external-db
           enabled: true
           shortname: hubdb

--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -783,6 +783,38 @@ integration:
               env-vars:
                 - RDBMS_POSTGRESQL_USERNAME
                 - RDBMS_POSTGRESQL_PASSWORD
+        - name: hub-pinned-images
+          enabled: true
+          shortname: hubpi
+          auth: keycloak
+          flow: upgrade-minor
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            eks: preemptible
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - hub-pinned-images
+          dependencies:
+            - chart: charts/internal-keycloak-26
+              release-name: keycloak
+              values-file: test/integration/companion-values/keycloak.yaml
+            - chart: elastic/elasticsearch
+              version: 8.5.1
+              release-name: elasticsearch
+              values-file: test/integration/companion-values/elasticsearch.yaml
+              repo-name: elastic
+              repo-url: https://helm.elastic.co
+            - chart: charts/internal-postgresql
+              release-name: postgresql
+              values-file: test/integration/companion-values/postgresql.yaml
+              env-vars:
+                - RDBMS_POSTGRESQL_USERNAME
+                - RDBMS_POSTGRESQL_PASSWORD
         - name: hub-external-db
           enabled: true
           shortname: hubdb

--- a/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
@@ -103,6 +103,10 @@ integration:
       shortname: hubwo
       tier: 2
       enabled: true
+    - id: hub-pinned-images
+      shortname: hubpi
+      tier: 2
+      enabled: true
     - id: hub-external-db
       shortname: hubdb
       tier: 2

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/hub-pinned-images.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/hub-pinned-images.yaml
@@ -6,11 +6,13 @@ identity: keycloak
 persistence: elasticsearch
 features:
   - hub-pinned-images
+  - postgresql-companion
 platforms:
   - gke
 infra-type:
   eks: preemptible
   gke: distroci
+post-infra: post-infra-bitnami-migration
 dependencies:
   - keycloak
   - elasticsearch

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/hub-pinned-images.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/hub-pinned-images.yaml
@@ -1,0 +1,17 @@
+name: hub-pinned-images
+auth: keycloak
+flows:
+  - upgrade-minor
+identity: keycloak
+persistence: elasticsearch
+features:
+  - hub-pinned-images
+platforms:
+  - gke
+infra-type:
+  eks: preemptible
+  gke: distroci
+dependencies:
+  - keycloak
+  - elasticsearch
+  - postgresql

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/hub-pinned-images.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/hub-pinned-images.yaml
@@ -1,0 +1,86 @@
+# Hub Pinned Images feature layer - simulates customer who pins image repositories.
+# Layer 6: Feature - Validates upgrade when customer explicitly sets image repos in 8.9 style.
+#
+# In 8.9, the default repos were camunda/web-modeler-restapi and camunda/web-modeler-websockets.
+# In 8.10, defaults changed to camunda/hub and camunda/hub-websockets.
+# Customers in airgapped/mirrored environments pin image repos explicitly.
+# This layer validates the chart handles explicit legacy repos correctly on upgrade.
+#
+# IMPORTANT: This scenario intentionally uses the NEW image repos (camunda/hub) to prove
+# that the shim correctly applies camundaHub overrides on top of legacy keys. Customers who
+# pin OLD repos (camunda/web-modeler-restapi) will get ImagePullBackOff - this validates
+# that the upgrade docs must warn about the image rename.
+
+camundaHub:
+  enabled: false
+
+console:
+  enabled: true
+  contextPath: "/"
+  image:
+    pullSecrets:
+      - name: index-docker-io
+      - name: registry-camunda-cloud
+    # Explicitly pin the console image repo (unchanged between 8.9 and 8.10)
+    repository: camunda/console
+
+webModeler:
+  enabled: true
+  contextPath: "/modeler"
+  image:
+    pullSecrets:
+      - name: index-docker-io
+      - name: registry-camunda-cloud
+  restapi:
+    image:
+      # Customer explicitly pins the image repo - must match 8.10 image name.
+      # In real life, customers who still have camunda/web-modeler-restapi will break.
+      # This test uses the correct new name to validate pinning works through the shim.
+      repository: camunda/hub
+    javaOpts: >-
+      -XX:MaxRAMPercentage=80.0
+      -XX:+TieredCompilation
+      -XX:TieredStopAtLevel=1
+      -XX:+UseG1GC
+      -XX:+UseStringDeduplication
+    initContainers:
+      - name: wait-for-postgresql
+        image: busybox:1.36
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+        command:
+          - sh
+          - -c
+          - |
+            echo "Waiting for PostgreSQL at postgresql:5432 ..."
+            until nc -z "postgresql" 5432; do
+              sleep 2
+            done
+            echo "PostgreSQL is ready"
+    startupProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      failureThreshold: 30
+      timeoutSeconds: 1
+    mail:
+      fromAddress: noreply@example.com
+    resources:
+      requests:
+        cpu: 400m
+        memory: 512Mi
+      limits:
+        memory: 1Gi
+  websockets:
+    image:
+      # Customer explicitly pins websockets image repo.
+      repository: camunda/hub-websockets
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        memory: 256Mi


### PR DESCRIPTION
## Summary

- Adds `hub-pinned-images` (`hubpi`) upgrade-minor scenario to the 8.10 CI matrix
- Simulates a customer who explicitly pins image repository names (common in airgapped/mirrored environments)
- Validates that explicit `webModeler.restapi.image.repository` and `webModeler.websockets.image.repository` overrides work correctly through the shim after upgrade

## Context

In 8.9→8.10, the default image repos changed:
- `camunda/web-modeler-restapi` → `camunda/hub`
- `camunda/web-modeler-websockets` → `camunda/hub-websockets`

Customers who pin repos will get `ImagePullBackOff` if they don't update their values. This scenario validates:
1. The shim correctly applies explicit repo overrides
2. The upgrade docs must warn about the rename

## Depends on

- #6187 (enables hub-legacy and hub-mixed upgrade scenarios)

Contributes to: camunda/product-hub#3411