### PR TITLE
test(8.10): add hub-webmodeler-only scenario for console-disabled upgrade

### DIFF
--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -726,6 +726,39 @@ integration:
               env-vars:
                 - RDBMS_POSTGRESQL_USERNAME
                 - RDBMS_POSTGRESQL_PASSWORD
+        - name: hub-webmodeler-only
+          enabled: true
+          shortname: hubwo
+          auth: keycloak
+          flow: upgrade-minor
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            eks: preemptible
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - hub-webmodeler-only
+          skip-e2e: true
+          dependencies:
+            - chart: charts/internal-keycloak-26
+              release-name: keycloak
+              values-file: test/integration/companion-values/keycloak.yaml
+            - chart: elastic/elasticsearch
+              version: 8.5.1
+              release-name: elasticsearch
+              values-file: test/integration/companion-values/elasticsearch.yaml
+              repo-name: elastic
+              repo-url: https://helm.elastic.co
+            - chart: charts/internal-postgresql
+              release-name: postgresql
+              values-file: test/integration/companion-values/postgresql.yaml
+              env-vars:
+                - RDBMS_POSTGRESQL_USERNAME
+                - RDBMS_POSTGRESQL_PASSWORD
         - name: hub-external-db
           enabled: true
           shortname: hubdb

--- a/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
@@ -97,6 +97,10 @@ integration:
     - id: hub-mixed
       shortname: hubmu
       enabled: false
+    - id: hub-webmodeler-only
+      shortname: hubwo
+      tier: 2
+      enabled: true
     - id: hub-external-db
       shortname: hubdb
       tier: 2

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/hub-webmodeler-only.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/hub-webmodeler-only.yaml
@@ -1,0 +1,18 @@
+name: hub-webmodeler-only
+auth: keycloak
+flows:
+  - upgrade-minor
+identity: keycloak
+persistence: elasticsearch
+features:
+  - hub-webmodeler-only
+platforms:
+  - gke
+skip-e2e: true
+infra-type:
+  eks: preemptible
+  gke: distroci
+dependencies:
+  - keycloak
+  - elasticsearch
+  - postgresql

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/hub-webmodeler-only.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/hub-webmodeler-only.yaml
@@ -1,0 +1,71 @@
+# Hub WebModeler-Only feature layer - simulates customer who never enabled Console SM.
+# Layer 6: Feature - Validates upgrade when only webModeler is deployed (no Console).
+#
+# Many customers only used Web Modeler and never enabled Console Self-Managed.
+# After upgrade to 8.10, the camundaHub shim must correctly handle the case where
+# console.enabled is false. No Console pod should be deployed.
+#
+# This tests that:
+# - camundaHub.consoleEnabled returns "false" when console.enabled=false and camundaHub.enabled=false
+# - No console Deployment/Service/ConfigMap is rendered
+# - WebModeler restapi and websockets deploy correctly in isolation
+# - The deprecation warning fires ONLY for webModeler.enabled (not for console.enabled since it's false)
+
+camundaHub:
+  enabled: false
+
+console:
+  enabled: false
+
+webModeler:
+  enabled: true
+  contextPath: "/modeler"
+  image:
+    pullSecrets:
+      - name: index-docker-io
+      - name: registry-camunda-cloud
+  restapi:
+    javaOpts: >-
+      -XX:MaxRAMPercentage=80.0
+      -XX:+TieredCompilation
+      -XX:TieredStopAtLevel=1
+      -XX:+UseG1GC
+      -XX:+UseStringDeduplication
+    initContainers:
+      - name: wait-for-postgresql
+        image: busybox:1.36
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+        command:
+          - sh
+          - -c
+          - |
+            echo "Waiting for PostgreSQL at postgresql:5432 ..."
+            until nc -z "postgresql" 5432; do
+              sleep 2
+            done
+            echo "PostgreSQL is ready"
+    startupProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      failureThreshold: 30
+      timeoutSeconds: 1
+    mail:
+      fromAddress: noreply@example.com
+    resources:
+      requests:
+        cpu: 400m
+        memory: 512Mi
+      limits:
+        memory: 1Gi
+  websockets:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        memory: 256Mi

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/hub-webmodeler-only.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/hub-webmodeler-only.yaml
@@ -1,0 +1,59 @@
+# Hub WebModeler-Only feature layer - customer who never enabled Console SM.
+# When used in an upgrade-minor flow, this ensures Step 1 (8.9) also deploys
+# without Console, matching the customer's actual 8.9 configuration.
+
+console:
+  enabled: false
+
+webModeler:
+  enabled: true
+  contextPath: "/modeler"
+  image:
+    pullSecrets:
+      - name: index-docker-io
+      - name: registry-camunda-cloud
+  restapi:
+    javaOpts: >-
+      -XX:MaxRAMPercentage=80.0
+      -XX:+TieredCompilation
+      -XX:TieredStopAtLevel=1
+      -XX:+UseG1GC
+      -XX:+UseStringDeduplication
+    initContainers:
+      - name: wait-for-postgresql
+        image: busybox:1.36
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+        command:
+          - sh
+          - -c
+          - |
+            echo "Waiting for PostgreSQL at {{ .Release.Name }}-postgresql-web-modeler:5432 ..."
+            until nc -z "{{ .Release.Name }}-postgresql-web-modeler" 5432; do
+              sleep 2
+            done
+            echo "PostgreSQL is ready"
+    startupProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      failureThreshold: 30
+      timeoutSeconds: 1
+    mail:
+      fromAddress: noreply@example.com
+    resources:
+      requests:
+        cpu: 400m
+        memory: 512Mi
+      limits:
+        memory: 1Gi
+  websockets:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        memory: 256Mi


### PR DESCRIPTION
## Summary

- Adds `hub-webmodeler-only` (`hubwo`) upgrade-minor scenario to the 8.10 CI matrix
- Simulates a customer who only used Web Modeler and never enabled Console SM
- Validates that the 8.9→8.10 upgrade works correctly when `console.enabled: false`

## What it tests

Many customers only deployed Web Modeler without Console SM. After upgrade:
- `camundaHub.consoleEnabled` must return `false` (no Console pods deployed)
- Web Modeler deploys and functions correctly in isolation
- Deprecation warning fires only for `webModeler.enabled`, not for disabled Console

## Includes

- `8.10/values/features/hub-webmodeler-only.yaml` — 8.10 feature layer
- `8.9/values/features/hub-webmodeler-only.yaml` — 8.9 feature layer (so Step 1 also skips Console)
- CI test config entry with upgrade-minor flow

## Depends on

- #6187 (enables hub-legacy and hub-mixed upgrade scenarios)

Contributes to: camunda/product-hub#3411