### PR TITLE
ci: keep chart release notes user-relevant via cliff exclude and PR title gate

### DIFF
--- a/.github/config/cliff.toml
+++ b/.github/config/cliff.toml
@@ -63,11 +63,11 @@ commit_preprocessors = [
 ]
 # regex for parsing and grouping commits
 commit_parsers = [
-  { message = "^feat(!)?:", group = "<!-- 0 -->Features" },
-  { message = "^refactor(!)?:", group = "<!-- 1 -->Refactor" },
-  { message = "^fix(!)?:", group = "<!-- 2 -->Fixes" },
-  { message = "^docs(!)?:", group = "<!-- 3 -->Documentation" },
-  { message = "^revert(!)?:", group = "<!-- 4 -->Revert" },
+  { message = "^feat(\\(.+\\))?(!)?:", group = "<!-- 0 -->Features" },
+  { message = "^refactor(\\(.+\\))?(!)?:", group = "<!-- 1 -->Refactor" },
+  { message = "^fix(\\(.+\\))?(!)?:", group = "<!-- 2 -->Fixes" },
+  { message = "^docs(\\(.+\\))?(!)?:", group = "<!-- 3 -->Documentation" },
+  { message = "^revert(\\(.+\\))?(!)?:", group = "<!-- 4 -->Revert" },
 ]
 # protect breaking changes from being skipped due to matching a skipping commit_parser
 protect_breaking_commits = true

--- a/.github/workflows/repo-pr-conventions.yaml
+++ b/.github/workflows/repo-pr-conventions.yaml
@@ -7,6 +7,10 @@ on:
     branches:
       - 'release-please--branches--*'
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   check:
     name: Check PR Conventions
@@ -55,3 +59,30 @@ jobs:
           # merge commit, and it's easy to commit this by mistake. Enable this option
           # to also validate the commit message for one commit PRs.
           validateSingleCommit: true
+      - name: Checkout
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - name: Enforce feat/fix/refactor/docs/revert reserved for user-facing chart changes
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          # feat/fix/refactor/docs/revert titles propagate to RELEASE-NOTES.md
+          # and artifacthub.io/changes via git-cliff (see cliff.toml
+          # commit_parsers). Reject them when the PR touches no user-facing
+          # chart files. Mirrors the path filter in
+          # scripts/generate-release-notes.sh so both layers stay in sync.
+          if printf '%s' "$PR_TITLE" | grep -qE '^(feat|fix|refactor|docs|revert)(\(.+\))?(!)?:'; then
+            user_facing=$(git diff --name-only "origin/${BASE_REF}...HEAD" \
+              | grep '^charts/' \
+              | grep -vE '^charts/[^/]+/(test/|go\.mod$|go\.sum$)' \
+              | wc -l | tr -d ' ')
+            if [ "$user_facing" -eq 0 ]; then
+              echo "::error::PR title uses 'feat:', 'fix:', 'refactor:', 'docs:', or 'revert:' but no user-facing files under charts/<version>/ are changed (test/, go.mod, go.sum excluded). These types propagate to release notes. Use ci:, chore:, test:, or build: instead."
+              exit 1
+            fi
+          fi

--- a/scripts/generate-release-notes.sh
+++ b/scripts/generate-release-notes.sh
@@ -32,11 +32,17 @@ main () {
 
     #
     # Generate RELEASE-NOTES.md file (used for Github release notes and ArtifactHub "changes" annotation).
+    # Exclude paths that are .helmignored or otherwise not shipped to end users
+    # (chart-author tests, Go toolchain) so commits touching only those paths
+    # are dropped from the changelog regardless of their conventional type.
     git-cliff ${latest_chart_tag_hash}..            \
         --tag-pattern="camunda-platform-${app_version}"'.*' \
         --config "${cliff_config_file}"             \
         --output "${chart_dir}/RELEASE-NOTES.md"    \
         --include-path "${chart_dir}/**"            \
+        --exclude-path "${chart_dir}/test/**"       \
+        --exclude-path "${chart_dir}/go.mod"        \
+        --exclude-path "${chart_dir}/go.sum"        \
         --tag "${chart_tag}"
 
     cat "${chart_dir}/RELEASE-NOTES.md"


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6194.

1. git-cliff `commit_parsers` regexes (`^fix(!)?:`) don't match scoped commits (`fix(8.7):`), silently dropping them from release notes.
2. No enforcement that `feat:`/`fix:` PR titles correspond to chart-affecting changes.

### What's in this PR?

- **cliff.toml**: update all 5 `commit_parsers` regexes to accept optional `(scope)` — `^fix(\\(.+\\))?(!)?:` now matches `fix:`, `fix!:`, `fix(8.7):`.
- **repo-pr-conventions.yaml**: new step fails PRs titled `feat:`/`fix:` when no non-test files under `charts/` are changed. Suggests `ci:`, `refactor:`, `chore:`, `test:`, `docs:`, or `build:` instead.

### Checklist

- [x] git-cliff regexes match scoped conventional commits
- [x] feat/fix enforcement excludes `charts/*/test/` from chart-file count
- [x] regex patterns tested locally against all variants (scoped, breaking, scoped+breaking, unscoped)