### PR TITLE
chore: audit CI scenario matrix and index prefix coverage

### DIFF
--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -993,7 +993,7 @@ integration:
               repo-url: https://opensearch-project.github.io/helm-charts/
           prefix-key: qa-opensearch-upg
         - name: qa-opensearch-upg
-          enabled: false
+          enabled: true
           shortname: qaosupg
           auth: keycloak
           flow: modular-upgrade-minor
@@ -1092,7 +1092,7 @@ integration:
               repo-name: elastic
               repo-url: https://helm.elastic.co
         - name: qa-elasticsearch-mt-upg
-          enabled: false
+          enabled: true
           shortname: qaelmtupg
           auth: keycloak
           flow: modular-upgrade-minor
@@ -1290,7 +1290,7 @@ integration:
               repo-name: elastic
               repo-url: https://helm.elastic.co
         - name: qa-document-store-upg
-          enabled: false
+          enabled: true
           shortname: qadocupg
           auth: keycloak
           flow: modular-upgrade-minor
@@ -1323,7 +1323,7 @@ integration:
               repo-name: elastic
               repo-url: https://helm.elastic.co
         - name: qa-document-store-upg
-          enabled: false
+          enabled: true
           shortname: qadocupg
           auth: keycloak
           flow: modular-upgrade-minor

--- a/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
@@ -125,7 +125,7 @@ integration:
       enabled: false
     - id: qa-opensearch-upg-modular
       shortname: qaosupg
-      enabled: false
+      enabled: true
     - id: qa-elasticsearch-mt
       shortname: qaelmt
       enabled: false
@@ -134,7 +134,7 @@ integration:
       enabled: false
     - id: qa-elasticsearch-mt-upg-modular
       shortname: qaelmtupg
-      enabled: false
+      enabled: true
     - id: qa-elasticsearch-rba
       shortname: qaelrba
       enabled: false
@@ -152,10 +152,10 @@ integration:
       enabled: false
     - id: qa-document-store-upg-modular-gke
       shortname: qadocupg
-      enabled: false
+      enabled: true
     - id: qa-document-store-upg-modular-eks
       shortname: qadocupg
-      enabled: false
+      enabled: true
     - id: qa-license
       shortname: lic
       enabled: false

--- a/charts/camunda-platform-8.9/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry-snapshot.yaml
@@ -578,7 +578,7 @@ integration:
               repo-name: opensearch
               repo-url: https://opensearch-project.github.io/helm-charts/
         - name: qa-opensearch-upg
-          enabled: false
+          enabled: true
           shortname: qaosupg
           auth: keycloak
           flow: modular-upgrade-minor
@@ -682,7 +682,7 @@ integration:
           qa: true
           image-tags: true
         - name: qa-document-store-upg
-          enabled: false
+          enabled: true
           shortname: qadocupg
           auth: keycloak
           flow: modular-upgrade-minor

--- a/charts/camunda-platform-8.9/test/ci/registry/manifest.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/manifest.yaml
@@ -131,7 +131,7 @@ integration:
       enabled: false
     - id: qa-opensearch-upg-modular
       shortname: qaosupg
-      enabled: false
+      enabled: true
     - id: qa-elasticsearch-rba-upg
       shortname: qaelrbaup2
       enabled: false
@@ -149,7 +149,7 @@ integration:
       enabled: false
     - id: qa-document-store-upg-modular
       shortname: qadocupg
-      enabled: false
+      enabled: true
     - id: keycloak-original-install
       shortname: kcor
       enabled: false

--- a/docs/ci-scenario-matrix.md
+++ b/docs/ci-scenario-matrix.md
@@ -1,0 +1,109 @@
+---
+title: CI Scenario Matrix and Index-Prefix Coverage
+---
+
+# CI Scenario Matrix and Index-Prefix Coverage
+
+## Feature matrix
+
+One row per `(chart version x platform x scenario name x shortname)` exercised by a cron-triggered nightly workflow under `camunda/c8-cross-component-e2e-tests/.github/workflows/playwright_sm_nightly_*.yml`.
+
+- Scenarios live in the composable registry at `charts/camunda-platform-<v>/test/ci/registry/`: `manifest.yaml` lists each scenario (`id`, `shortname`, `tier`, `enabled`), and `scenarios/<id>.yaml` carries its `name`, `flows`, `identity`, `persistence`, `features`, `platforms`, and optional `prefix-key`.
+- **PR CI** is `enabled` when the scenario's `manifest.yaml` entry has `enabled: true`.
+- **Prefix-aligned** is `OK` for upgrade pairs covered by `TestUpgradePrefixCoverage`; install-only rows are `n/a`.
+- Each upgrade is split into two registry scenarios sharing one logical `name`/`shortname`: an `*-upg-install` leg (`flow: install`, the previous chart version's install) and an `*-upg-modular` leg (`flow: modular-upgrade-minor`). Legs whose logical index prefix must match across the two charts carry `prefix-key`.
+- This table is hand-maintained documentation that mirrors the external nightly repo. The gap-enablement and the upgrade prefix invariant below are the parts enforced by tests; the workflow-to-row mapping itself is not test-enforced (it depends on an external repo).
+
+| version | platform | scenario | shortname | flow | PR CI | nightly workflow | prefix-aligned |
+|---|---|---|---|---|---|---|---|
+| 8.7 | eks, gke | qa-elasticsearch | qael | install | disabled | `playwright_sm_nightly_tests_chrome_8_7.yml`, `playwright_sm_nightly_tests_edge_8_7.yml`, `playwright_sm_nightly_tests_firefox_8_7.yml` | n/a |
+| 8.7 | gke | qa-elasticsearch-mt | qamt | install | disabled | `playwright_sm_nightly_mt_8_7.yml` | n/a |
+| 8.7 | gke | qa-elasticsearch-rba | qarba | install | disabled | `playwright_sm_nightly_rba_8_7.yml` | n/a |
+| 8.7 | gke | qa-opensearch | qaos | install | disabled | `playwright_sm_nightly_tests_opensearch_8_7.yml` | n/a |
+| 8.8 | eks, gke | qa-document-store | qadoc | install | disabled | `playwright_sm_nightly_document_store_8_8.yml` | n/a |
+| 8.8 | gke | qa-elasticsearch-mt | qaelmt | install | disabled | `playwright_sm_nightly_mt_8_8.yml` | n/a |
+| 8.8 | gke | qa-elasticsearch-mt-upg | qaelmtup2 | install, modular-upgrade-minor | disabled | `playwright_sm_nightly_upgrade_minor_mt_8_9.yml` (`8-8-install`) | OK |
+| 8.8 | gke | qa-elasticsearch-upg | qaelupg | install, modular-upgrade-minor | disabled | `playwright_sm_nightly_tests_chrome_8_8.yml`, `playwright_sm_nightly_upgrade_minor_8_8.yml` (`8-8-plus-upgrade`) | OK |
+| 8.8 | gke | qa-opensearch-upg | qaosupg2 | install | disabled | `playwright_sm_nightly_tests_opensearch_8_8.yml` | n/a |
+| 8.9 | eks, gke | qa-document-store | qadoc | install | disabled | `playwright_sm_nightly_document_store_8_9.yml` | n/a |
+| 8.9 | eks, gke | qa-document-store-upg | qadocupg | modular-upgrade-minor | **enabled** | `playwright_sm_nightly_upgrade_minor_document_store_8_9.yml` (`8-9-upgrade`) | OK |
+| 8.9 | gke | qa-elasticsearch-mt-upg | qaelmtupg | modular-upgrade-minor | disabled | `playwright_sm_nightly_upgrade_minor_mt_8_9.yml` (`8-9-upgrade`) | OK |
+| 8.9 | gke | qa-elasticsearch-upg | qaelupg | install, modular-upgrade-minor | disabled | `playwright_sm_nightly_tests_chrome_8_9.yml`, `playwright_sm_nightly_upgrade_minor_8_9.yml` (`8-9-upgrade`) | OK |
+| 8.9 | gke | qa-opensearch-upg | qaosupg | modular-upgrade-minor | **enabled** | `playwright_sm_nightly_upgrade_minor_opensearch_8_9.yml` (`8-9-upgrade`) | OK |
+| 8.10 | eks, gke | qa-document-store | qadoc | install | disabled | `playwright_sm_nightly_document_store_8_10.yml` | n/a |
+| 8.10 | eks, gke | qa-document-store-upg | qadocupg | modular-upgrade-minor | **enabled** | `playwright_sm_nightly_upgrade_minor_document_store_8_10.yml` (`8-10-upgrade`) | OK |
+| 8.10 | gke | qa-elasticsearch-mt | qaelmt | install | disabled | `playwright_sm_nightly_mt_8_10.yml` | n/a |
+| 8.10 | gke | qa-elasticsearch-mt-upg | qaelmtupg | modular-upgrade-minor | **enabled** | `playwright_sm_nightly_upgrade_minor_mt_8_10.yml` (`8-10-upgrade`) | OK |
+| 8.10 | gke | qa-elasticsearch-rba | qaelrba | install | disabled | `playwright_sm_nightly_rba_8_10.yml` | n/a |
+| 8.10 | gke | qa-elasticsearch-upg | qaelupg | install, modular-upgrade-minor | disabled | `playwright_sm_nightly_tests_chrome_8_10.yml`, `playwright_sm_nightly_upgrade_minor_8_10.yml` (`8-10-upgrade`) | OK |
+| 8.10 | gke | qa-opensearch | qaos | install | disabled | `playwright_sm_nightly_tests_opensearch_8_10.yml` | n/a |
+| 8.10 | gke | qa-opensearch-upg | qaosupg | modular-upgrade-minor | **enabled** | `playwright_sm_nightly_upgrade_minor_opensearch_8_10.yml` (`8-10-upgrade`) | OK |
+
+The five **enabled** modular-upgrade-minor rows above are the issue #6172 coverage gaps that this change turned on; `TestIssue6172UpgradeGapsRunInPRCI` asserts each is generated into the matrix. Tier-1/tier-2 PR rows not exercised by cron nightlies are omitted; see each version's `ci/registry/manifest.yaml` for the full PR matrix. Some `*-upg-install` and tasklist-v1 install legs are also registered (disabled by default) — run `deploy-camunda matrix list --include-disabled --versions <v>` for the exhaustive list.
+
+## Index-prefix coverage
+
+Per `(version x persistence layer)`, which `$*_INDEX_PREFIX` placeholders appear in `charts/camunda-platform-<v>/test/integration/scenarios/chart-full-setup/values/persistence/<L>.yaml`. `Y` means referenced, `-` means the file exists but has no reference, and `n/a` means the file does not exist for this version.
+
+### 8.7
+
+| persistence | ORCH | OPERATE | TASKLIST | OPTIMIZE |
+|---|---|---|---|---|
+| elasticsearch | - | - | - | - |
+| elasticsearch-external | Y | Y | Y | Y |
+| elasticsearch-self-signed | - | - | - | - |
+| opensearch | Y | Y | Y | Y |
+| opensearch-embedded | Y | Y | Y | Y |
+| opensearch-external | Y | Y | Y | Y |
+| no-elasticsearch, rdbms*, elasticsearch-external-self-signed | n/a | n/a | n/a | n/a |
+
+### 8.8
+
+| persistence | ORCH | OPERATE | TASKLIST | OPTIMIZE |
+|---|---|---|---|---|
+| elasticsearch | - | - | - | - |
+| elasticsearch-external | Y | - | - | Y |
+| elasticsearch-self-signed | - | - | - | - |
+| elasticsearch-external-self-signed | Y | - | - | Y |
+| opensearch | Y | - | - | Y |
+| opensearch-embedded | Y | Y | - | Y |
+| opensearch-external | Y | - | - | Y |
+| no-elasticsearch, rdbms* | n/a | n/a | n/a | n/a |
+
+### 8.9, 8.10
+
+| persistence | ORCH | OPERATE | TASKLIST | OPTIMIZE |
+|---|---|---|---|---|
+| elasticsearch, elasticsearch-self-signed, no-elasticsearch, rdbms* | - | - | - | - |
+| elasticsearch-external | Y | - | - | Y |
+| opensearch | Y | - | - | Y |
+| opensearch-embedded | Y | Y | - | Y |
+| opensearch-external | Y | - | - | Y |
+| elasticsearch-external-self-signed | n/a | n/a | n/a | n/a |
+
+### Observations
+
+- `TASKLIST_INDEX_PREFIX` is consumed only on 8.7 for Tasklist's own indices. Zeebe import indices use `ORCHESTRATION_INDEX_PREFIX`.
+- `OPERATE_INDEX_PREFIX` is consumed only by `opensearch-embedded.yaml` in 8.8/8.9/8.10. It disambiguates `CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_INDEXPREFIX` from `global.opensearch.prefix`, which uses `ORCHESTRATION_INDEX_PREFIX`.
+- `ORCHESTRATION_INDEX_PREFIX` and `OPTIMIZE_INDEX_PREFIX` are consumed by every Elasticsearch/OpenSearch persistence layer that overrides defaults. Bundled `elasticsearch.yaml` and `elasticsearch-self-signed.yaml` rely on chart defaults and reference no prefix variables.
+
+The upgrade prefix invariant (install-step `$*_INDEX_PREFIX` placeholders ⊆ upgrade-step placeholders) and the issue #6172 gap enablement are enforced by [`upgrade_prefix_coverage_test.go`](../scripts/deploy-camunda/matrix/upgrade_prefix_coverage_test.go) — `TestUpgradePrefixCoverage` and `TestIssue6172UpgradeGapsRunInPRCI`. Both read enabled scenarios from the generated matrix (`matrix.Generate`) rather than parsing config directly, so they track the composable registry. Where an upgrade's install leg runs on a previous chart version that lacks one of the current version's layers (e.g. the `postgresql-companion` feature on 8.10 has no counterpart on 8.9), the prefix check skips that pair rather than failing — prefix alignment, not cross-version layer parity, is what it asserts.
+
+## Maintenance
+
+When the registry, persistence YAML, or a cross-component cron nightly changes:
+
+- Update the feature matrix above to reflect the new or removed row.
+- After editing any `manifest.yaml` / `scenarios/*.yaml`, regenerate the golden with `make go.update-registry-golden` and commit the updated `charts/<v>/test/ci/registry-snapshot.yaml`.
+- Keep `prefix-key` on upgrade legs whose install leg uses a different scenario name, so both charts generate the same logical index prefixes.
+
+Sources of truth:
+
+| Concern | Source |
+|---|---|
+| Which scenarios run on PR CI per version | `charts/camunda-platform-<v>/test/ci/registry/manifest.yaml` (`integration.scenarios[].enabled`) + `registry/scenarios/<id>.yaml` |
+| Which nightly E2E demands a `(version, platform, scenario, shortname, flow)` | `camunda/c8-cross-component-e2e-tests` repo, `.github/workflows/playwright_sm_nightly_*.yml` |
+| Which prefix variables a persistence layer references | `charts/camunda-platform-<v>/test/integration/scenarios/chart-full-setup/values/persistence/<L>.yaml` |
+| How prefix env-vars are generated | `scripts/deploy-camunda/deploy/scenario.go` `generateScenarioContext()` and `scripts/deploy-camunda/deploy/values.go` `buildScenarioEnv()` |
+
+See also: [Integration Test Scenario Resolution](./skills/integration-test-scenario-resolution.md), [GitHub Actions Workflows](./reference/github-actions-workflows.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,7 @@ Looking for end-user installation docs? See the [official Camunda docs](https://
 | [Code Style](./reference/code-style.md) | Helm, Go, and YAML style conventions |
 | [Testing](./reference/testing.md) | Unit tests, golden files, property tests, license headers |
 | [GitHub Actions Workflows](./reference/github-actions-workflows.md) | Overview of every CI/CD workflow |
+| [CI Scenario Matrix and Index-Prefix Coverage](./ci-scenario-matrix.md) | Nightly E2E scenario coverage and upgrade prefix compatibility |
 
 ## Skills & Runbooks
 

--- a/docs/reference/github-actions-workflows.md
+++ b/docs/reference/github-actions-workflows.md
@@ -4,6 +4,8 @@ title: GitHub Actions Workflows
 
 This repo has many [GitHub Actions workflows](https://github.com/camunda/camunda-platform-helm/tree/main/.github/workflows) for different aspects of the CI pipelines.
 
+> See also: [CI Scenario Matrix and Index-Prefix Coverage](../ci-scenario-matrix.md) — which registry scenarios are wired to which nightly E2E workflow, plus the index-prefix coverage matrix per chart version.
+
 - [Camunda Helm chart deployment](#camunda-helm-chart-deployment)
   - [Getting started](#getting-started)
   - [Workflow inputs](#workflow-inputs)

--- a/docs/skills/integration-test-scenario-resolution.md
+++ b/docs/skills/integration-test-scenario-resolution.md
@@ -13,6 +13,8 @@ title: "Skill: Integration Test Scenario Resolution"
 How the Go CLI (`deploy-camunda`) resolves Helm values files for each integration
 test scenario, from the CI config entry to the final `helm install -f` arguments.
 
+> See also: [CI Scenario Matrix and Index-Prefix Coverage](../ci-scenario-matrix.md) — feature matrix of which scenarios run in PR CI / nightly E2E per chart version, and index-prefix coverage per persistence layer.
+
 ---
 
 ## Table of Contents

--- a/helm-docs-site/sidebars.js
+++ b/helm-docs-site/sidebars.js
@@ -90,6 +90,11 @@ const sidebars = {
           id: 'reference/github-actions-workflows',
           label: 'GitHub Actions Workflows',
         },
+        {
+          type: 'doc',
+          id: 'ci-scenario-matrix',
+          label: 'CI Scenario Matrix',
+        },
       ],
     },
 

--- a/scripts/camunda-core/pkg/scenarios/scenarios.go
+++ b/scripts/camunda-core/pkg/scenarios/scenarios.go
@@ -433,6 +433,15 @@ type BuilderOverrides struct {
 	Upgrade      bool
 	ChartVersion string
 	ValuesConfig string // JSON config string; if it contains *_IMAGE_TAG keys, ImageTags is auto-enabled (only when ImageTagsSet is false)
+
+	// ChartDir, when non-empty, points at the chart's chart-full-setup directory.
+	// Setting it enables version-aware validation: BuildDeploymentConfig will run
+	// ValidateForChart, which verifies that every referenced layer (identity,
+	// persistence, features) has a YAML file on disk for that specific chart
+	// version. Callers that already validated layer existence elsewhere (or that
+	// are intentionally constructing configs for a different version's layout)
+	// can leave it empty and get the legacy behaviour.
+	ChartDir string
 }
 
 // BuildDeploymentConfig is the single canonical constructor for DeploymentConfig.
@@ -487,7 +496,56 @@ func BuildDeploymentConfig(scenario string, ov BuilderOverrides) (*DeploymentCon
 		return nil, fmt.Errorf("deployment config validation failed for scenario %q: %w", scenario, err)
 	}
 
+	if ov.ChartDir != "" {
+		if err := cfg.ValidateForChart(ov.ChartDir); err != nil {
+			return nil, fmt.Errorf("deployment config validation failed for scenario %q: %w", scenario, err)
+		}
+	}
+
 	return cfg, nil
+}
+
+// ValidateForChart verifies that every layer referenced by this config has a
+// YAML file on disk under chartFullSetupDir/values/. The plain Validate() only
+// checks that selections are members of the static allow-lists, but those
+// allow-lists are not version-aware: e.g. "elasticsearch-external-self-signed"
+// is accepted by Validate() but only exists as a file on chart 8.8 today.
+// Without this check, a typo or version-mismatched selection passes validation
+// and then fails much later inside helm template with a vaguer error.
+//
+// This is opt-in via BuilderOverrides.ChartDir to avoid changing behaviour for
+// existing callers that do not pass a chart directory.
+func (c *DeploymentConfig) ValidateForChart(chartFullSetupDir string) error {
+	valuesDir := filepath.Join(chartFullSetupDir, ValuesDir)
+	if _, err := os.Stat(valuesDir); err != nil {
+		return fmt.Errorf("values directory not found under chart-full-setup: %s", valuesDir)
+	}
+
+	checks := []struct {
+		dir   string
+		name  string
+		label string
+	}{
+		{IdentityDir, c.Identity, "identity"},
+		{PersistenceDir, c.Persistence, "persistence"},
+		{PlatformDir, c.Platform, "platform"},
+	}
+	for _, ck := range checks {
+		if ck.name == "" {
+			continue
+		}
+		p := filepath.Join(valuesDir, ck.dir, ck.name+".yaml")
+		if _, err := os.Stat(p); err != nil {
+			return fmt.Errorf("%s %q has no values file at %s (chart version may not support this selection)", ck.label, ck.name, p)
+		}
+	}
+	for _, f := range c.Features {
+		p := filepath.Join(valuesDir, FeaturesDir, f+".yaml")
+		if _, err := os.Stat(p); err != nil {
+			return fmt.Errorf("feature %q has no values file at %s (chart version may not support this feature)", f, p)
+		}
+	}
+	return nil
 }
 
 func valuesConfigHasImageTags(valuesConfig string) bool {

--- a/scripts/camunda-core/pkg/scenarios/validate_for_chart_test.go
+++ b/scripts/camunda-core/pkg/scenarios/validate_for_chart_test.go
@@ -1,0 +1,113 @@
+package scenarios
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateForChart(t *testing.T) {
+	chartDir := t.TempDir()
+	mustMkdir := func(p string) {
+		t.Helper()
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite := func(p string) {
+		t.Helper()
+		if err := os.WriteFile(p, []byte("# fixture"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	valuesDir := filepath.Join(chartDir, ValuesDir)
+	mustMkdir(filepath.Join(valuesDir, IdentityDir))
+	mustMkdir(filepath.Join(valuesDir, PersistenceDir))
+	mustMkdir(filepath.Join(valuesDir, PlatformDir))
+	mustMkdir(filepath.Join(valuesDir, FeaturesDir))
+	mustWrite(filepath.Join(valuesDir, IdentityDir, "keycloak.yaml"))
+	mustWrite(filepath.Join(valuesDir, PersistenceDir, "elasticsearch.yaml"))
+	mustWrite(filepath.Join(valuesDir, PlatformDir, "gke.yaml"))
+	mustWrite(filepath.Join(valuesDir, FeaturesDir, "documentstore.yaml"))
+
+	t.Run("all layers present", func(t *testing.T) {
+		cfg := &DeploymentConfig{Identity: "keycloak", Persistence: "elasticsearch", Platform: "gke", Features: []string{"documentstore"}}
+		if err := cfg.ValidateForChart(chartDir); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("missing persistence file", func(t *testing.T) {
+		cfg := &DeploymentConfig{Identity: "keycloak", Persistence: "no-elasticsearch", Platform: "gke"}
+		err := cfg.ValidateForChart(chartDir)
+		if err == nil {
+			t.Fatal("expected error for missing persistence file")
+		}
+		if !strings.Contains(err.Error(), "persistence") {
+			t.Errorf("expected error to mention persistence, got %q", err.Error())
+		}
+	})
+
+	t.Run("missing feature file", func(t *testing.T) {
+		cfg := &DeploymentConfig{Identity: "keycloak", Persistence: "elasticsearch", Platform: "gke", Features: []string{"rba"}}
+		err := cfg.ValidateForChart(chartDir)
+		if err == nil {
+			t.Fatal("expected error for missing feature file")
+		}
+		if !strings.Contains(err.Error(), "feature") {
+			t.Errorf("expected error to mention feature, got %q", err.Error())
+		}
+	})
+
+	t.Run("missing values directory", func(t *testing.T) {
+		cfg := &DeploymentConfig{Identity: "keycloak", Persistence: "elasticsearch", Platform: "gke"}
+		err := cfg.ValidateForChart(t.TempDir())
+		if err == nil {
+			t.Fatal("expected error for missing values directory")
+		}
+	})
+}
+
+func TestBuildDeploymentConfig_WithChartDir(t *testing.T) {
+	chartDir := t.TempDir()
+	valuesDir := filepath.Join(chartDir, ValuesDir)
+	for _, d := range []string{IdentityDir, PersistenceDir, PlatformDir, FeaturesDir} {
+		if err := os.MkdirAll(filepath.Join(valuesDir, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, f := range []string{
+		filepath.Join(valuesDir, IdentityDir, "keycloak.yaml"),
+		filepath.Join(valuesDir, PersistenceDir, "elasticsearch.yaml"),
+		filepath.Join(valuesDir, PlatformDir, "gke.yaml"),
+	} {
+		if err := os.WriteFile(f, []byte("# fixture"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Run("validates layer files when ChartDir is set", func(t *testing.T) {
+		_, err := BuildDeploymentConfig("elasticsearch", BuilderOverrides{
+			Identity:    "keycloak",
+			Persistence: "no-elasticsearch", // file does not exist in tmp chart
+			Platform:    "gke",
+			ChartDir:    chartDir,
+		})
+		if err == nil {
+			t.Fatal("expected error when ChartDir validation finds a missing layer")
+		}
+	})
+
+	t.Run("no validation when ChartDir is empty (legacy behaviour)", func(t *testing.T) {
+		_, err := BuildDeploymentConfig("elasticsearch", BuilderOverrides{
+			Identity:    "keycloak",
+			Persistence: "no-elasticsearch",
+			Platform:    "gke",
+		})
+		if err != nil {
+			t.Fatalf("did not expect error without ChartDir, got %v", err)
+		}
+	})
+}

--- a/scripts/deploy-camunda/cmd/prepare_values.go
+++ b/scripts/deploy-camunda/cmd/prepare_values.go
@@ -231,6 +231,7 @@ func runPrepareValuesLayered(pv *prepareValuesFlags, scenarioDir, outputDir stri
 		Upgrade:      pv.upgradeFlow,
 		ChartVersion: pv.chartVersion,
 		ValuesConfig: pv.valuesConfig,
+		ChartDir:     scenarioDir,
 	})
 	if err != nil {
 		return err

--- a/scripts/deploy-camunda/cmd/prepare_values_test.go
+++ b/scripts/deploy-camunda/cmd/prepare_values_test.go
@@ -19,6 +19,13 @@ func writeTempFile(t *testing.T, dir, name, content string) string {
 	return p
 }
 
+func writeMinimalLayerFiles(t *testing.T, scenarioDir string) {
+	t.Helper()
+	writeTempFile(t, scenarioDir, "values/identity/keycloak.yaml", "{}\n")
+	writeTempFile(t, scenarioDir, "values/persistence/elasticsearch.yaml", "{}\n")
+	writeTempFile(t, scenarioDir, "values/platform/gke.yaml", "{}\n")
+}
+
 func captureStdout(t *testing.T, fn func() error) (string, error) {
 	t.Helper()
 	oldStdout := os.Stdout
@@ -84,6 +91,7 @@ func TestRunPrepareValues_LayeredPath(t *testing.T) {
 elasticsearch:
   enabled: true
 `)
+	writeMinimalLayerFiles(t, scenarioDir)
 
 	pv := &prepareValuesFlags{
 		scenarioPath: scenarioDir,
@@ -112,7 +120,7 @@ elasticsearch:
 	if readErr != nil {
 		t.Fatalf("failed to read output file: %v", readErr)
 	}
-	if !strings.Contains(string(data), `tag: "8.9.0"`) {
+	if !strings.Contains(string(data), `tag: 8.9.0`) {
 		t.Errorf("output file missing expected content, got:\n%s", string(data))
 	}
 }
@@ -237,6 +245,7 @@ func TestRunPrepareValues_ImageTagsAutoEnabled(t *testing.T) {
   image:
     tag: "$E2E_TESTS_ORCHESTRATION_IMAGE_TAG"
 `)
+	writeMinimalLayerFiles(t, scenarioDir)
 
 	pv := &prepareValuesFlags{
 		scenarioPath: scenarioDir,
@@ -276,6 +285,7 @@ func TestRunPrepareValues_ImageTagsNotAutoEnabledWithoutTagKeys(t *testing.T) {
   image:
     tag: "$E2E_TESTS_ORCHESTRATION_IMAGE_TAG"
 `)
+	writeMinimalLayerFiles(t, scenarioDir)
 
 	pv := &prepareValuesFlags{
 		scenarioPath: scenarioDir,

--- a/scripts/deploy-camunda/deploy/values.go
+++ b/scripts/deploy-camunda/deploy/values.go
@@ -716,6 +716,7 @@ func prepareScenarioValues(ctx context.Context, scenarioCtx *ScenarioContext, fl
 			ImageTags:    flags.Selection.ImageTags,
 			Upgrade:      flags.Selection.UpgradeFlow,
 			ChartVersion: flags.Chart.ChartVersion,
+			ChartDir:     effectiveScenarioDir,
 		})
 		if err != nil {
 			os.RemoveAll(tempDir)

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -314,6 +314,7 @@ func dryRun(entries []Entry, opts RunOptions) []RunResult {
 				QA:          entry.QA || opts.UseQA,
 				ImageTags:   effectiveImageTags(entry, opts),
 				Upgrade:     entry.Upgrade,
+				ChartDir:    scenarioDir,
 			})
 			if buildErr != nil {
 				results = append(results, RunResult{
@@ -638,6 +639,7 @@ func coverageReport(entries []Entry, opts RunOptions) []RunResult {
 				QA:          entry.QA || opts.UseQA,
 				ImageTags:   effectiveImageTags(entry, opts),
 				Upgrade:     entry.Upgrade,
+				ChartDir:    filepath.Join(entry.ChartPath, "test/integration/scenarios/chart-full-setup"),
 			})
 			if buildErr != nil {
 				results = append(results, RunResult{

--- a/scripts/deploy-camunda/matrix/upgrade_prefix_coverage_test.go
+++ b/scripts/deploy-camunda/matrix/upgrade_prefix_coverage_test.go
@@ -1,0 +1,252 @@
+package matrix
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"scripts/camunda-core/pkg/scenarios"
+	"scripts/camunda-core/pkg/versionmatrix"
+)
+
+// These tests deliver the CI-coverage guarantees of issue #6172 against the
+// composable registry (charts/<v>/test/ci/registry/). They were originally
+// written for the pre-refactor monolithic ci-test-config.yaml; here they are
+// re-expressed to source scenarios from the generated matrix (Generate) so they
+// stay correct after the registry migration that removed LoadCITestConfig.
+
+var indexPrefixPlaceholder = regexp.MustCompile(`\$([A-Z][A-Z0-9_]*)_INDEX_PREFIX`)
+
+// gapRequirement identifies a scenario row that issue #6172 requires to run in
+// PR CI. Matching is by generated matrix Entry fields (Scenario is the
+// scenario's logical name), not the registry id.
+type gapRequirement struct {
+	version   string
+	platform  string
+	scenario  string
+	shortname string
+	flow      string
+}
+
+// TestIssue6172UpgradeGapsRunInPRCI asserts that the modular-upgrade-minor
+// coverage gaps identified in issue #6172 (OpenSearch / DocStore / multitenancy
+// upgrades on 8.9 and 8.10) are enabled in the composable registry and therefore
+// generated into the CI matrix. The matrix is generated with the default
+// (enabled-only) options, so a matching row existing here means the scenario is
+// enabled — closing the gap that earlier left these upgrade paths untested on
+// chart PRs.
+func TestIssue6172UpgradeGapsRunInPRCI(t *testing.T) {
+	entries := generateEnabledMatrix(t)
+	required := []gapRequirement{
+		{version: "8.9", platform: "gke", scenario: "qa-opensearch-upg", shortname: "qaosupg", flow: "modular-upgrade-minor"},
+		{version: "8.9", platform: "eks", scenario: "qa-document-store-upg", shortname: "qadocupg", flow: "modular-upgrade-minor"},
+		{version: "8.10", platform: "gke", scenario: "qa-opensearch-upg", shortname: "qaosupg", flow: "modular-upgrade-minor"},
+		{version: "8.10", platform: "eks", scenario: "qa-document-store-upg", shortname: "qadocupg", flow: "modular-upgrade-minor"},
+		{version: "8.10", platform: "gke", scenario: "qa-elasticsearch-mt-upg", shortname: "qaelmtupg", flow: "modular-upgrade-minor"},
+	}
+
+	for _, req := range required {
+		req := req
+		t.Run(fmt.Sprintf("v%s/%s/%s", req.version, req.platform, req.scenario), func(t *testing.T) {
+			if !gapEntryPresent(entries, req) {
+				t.Fatalf("issue #6172 requires this upgrade scenario enabled in the registry, "+
+					"but no matching enabled matrix row was generated: %+v", req)
+			}
+		})
+	}
+}
+
+// TestUpgradePrefixCoverage enforces issue #6172 acceptance criterion 4: for
+// every enabled scenario whose flow is an upgrade flow, the set of
+// $*_INDEX_PREFIX placeholders referenced by the install-step layered values is
+// a subset of those referenced by the upgrade-step values.
+//
+// Failure mode this guards against: install creates indices named by the
+// install-side prefix; upgrade reads from a different prefix; result is empty
+// indices after upgrade (PR #6160 was the 8.8 OpenSearch instance of this bug).
+func TestUpgradePrefixCoverage(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+
+	var upgrades []Entry
+	for _, e := range generateEnabledMatrix(t) {
+		if isUpgradeFlow(e.Flow) {
+			upgrades = append(upgrades, e)
+		}
+	}
+	if len(upgrades) == 0 {
+		t.Fatal("no enabled upgrade-flow scenarios found in the generated matrix")
+	}
+
+	for _, e := range upgrades {
+		e := e
+		t.Run(fmt.Sprintf("v%s/%s/%s/%s", e.Version, e.Shortname, e.Flow, platformOrDefault(e)), func(t *testing.T) {
+			checkUpgradePrefixSubset(t, repoRoot, e)
+		})
+	}
+}
+
+func checkUpgradePrefixSubset(t *testing.T, repoRoot string, e Entry) {
+	t.Helper()
+
+	currentDir := scenarioFullSetupDir(repoRoot, e.Version)
+
+	// upgrade-patch installs and upgrades within the same chart version.
+	// upgrade-minor / modular-upgrade-minor install with the previous version.
+	installDir := currentDir
+	if e.Flow != "upgrade-patch" {
+		prev, err := versionmatrix.PreviousAppVersion(e.Version)
+		if err != nil {
+			t.Fatalf("previous app version for %s: %v", e.Version, err)
+		}
+		installDir = scenarioFullSetupDir(repoRoot, prev)
+	}
+
+	cfg, err := scenarios.BuildDeploymentConfig(e.Scenario, scenarios.BuilderOverrides{
+		Identity:    e.Identity,
+		Persistence: e.Persistence,
+		Platform:    platformOrDefault(e),
+		Features:    e.Features,
+		Flow:        e.Flow,
+	})
+	if err != nil {
+		t.Fatalf("build deployment config for %s/%s: %v", e.Version, e.Scenario, err)
+	}
+
+	// A layer present on the current version may not exist on the previous
+	// version (or vice versa). Skip rather than fail in that case — this test
+	// asserts prefix alignment, not cross-version layer parity.
+	if err := cfg.ValidateForChart(installDir); err != nil {
+		t.Skipf("install-step layer missing under %s: %v", installDir, err)
+	}
+	if err := cfg.ValidateForChart(currentDir); err != nil {
+		t.Skipf("upgrade-step layer missing under %s: %v", currentDir, err)
+	}
+
+	installCfg := *cfg
+	installCfg.Upgrade = false
+	installPaths, err := installCfg.ResolvePaths(installDir)
+	if err != nil {
+		t.Fatalf("resolve install-step paths: %v", err)
+	}
+
+	upgradeCfg := *cfg
+	upgradeCfg.Upgrade = true
+	upgradePaths, err := upgradeCfg.ResolvePaths(currentDir)
+	if err != nil {
+		t.Fatalf("resolve upgrade-step paths: %v", err)
+	}
+
+	installSet, err := collectIndexPrefixes(installPaths)
+	if err != nil {
+		t.Fatalf("collect install-step prefixes: %v", err)
+	}
+	upgradeSet, err := collectIndexPrefixes(upgradePaths)
+	if err != nil {
+		t.Fatalf("collect upgrade-step prefixes: %v", err)
+	}
+
+	if installOnly := prefixDiff(installSet, upgradeSet); len(installOnly) > 0 {
+		t.Errorf("install-step references %v but upgrade-step does not — indices created by install will be invisible to the upgraded version", installOnly)
+	}
+	if upgradeOnly := prefixDiff(upgradeSet, installSet); len(upgradeOnly) > 0 {
+		t.Logf("note: upgrade-step references %v not used at install-step (likely dead env-var generation)", upgradeOnly)
+	}
+}
+
+func generateEnabledMatrix(t *testing.T) []Entry {
+	t.Helper()
+	entries, err := Generate(findRepoRoot(t), GenerateOptions{
+		Versions: []string{"8.7", "8.8", "8.9", "8.10"},
+	})
+	if err != nil {
+		t.Fatalf("generate matrix: %v", err)
+	}
+	return entries
+}
+
+func gapEntryPresent(entries []Entry, req gapRequirement) bool {
+	for _, e := range entries {
+		if e.Version == req.version &&
+			e.Scenario == req.scenario &&
+			e.Shortname == req.shortname &&
+			e.Flow == req.flow &&
+			platformOrDefault(e) == req.platform {
+			return true
+		}
+	}
+	return false
+}
+
+func isUpgradeFlow(flow string) bool {
+	switch flow {
+	case "upgrade-patch", "upgrade-minor", "modular-upgrade-minor":
+		return true
+	}
+	return false
+}
+
+func platformOrDefault(e Entry) string {
+	p := strings.ToLower(e.Platform)
+	if p == "" {
+		return "gke"
+	}
+	return p
+}
+
+func scenarioFullSetupDir(repoRoot, version string) string {
+	return filepath.Join(repoRoot, "charts", "camunda-platform-"+version,
+		"test", "integration", "scenarios", "chart-full-setup")
+}
+
+// collectIndexPrefixes walks each YAML file via yaml.v3 node traversal and
+// returns the set of *_INDEX_PREFIX placeholder names referenced in scalar
+// values (so commented-out lines are ignored).
+func collectIndexPrefixes(paths []string) (map[string]struct{}, error) {
+	set := map[string]struct{}{}
+	for _, p := range paths {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", p, err)
+		}
+		var root yaml.Node
+		if err := yaml.Unmarshal(data, &root); err != nil {
+			return nil, fmt.Errorf("parse %s: %w", p, err)
+		}
+		walkScalarNodes(&root, func(s string) {
+			for _, m := range indexPrefixPlaceholder.FindAllStringSubmatch(s, -1) {
+				set[m[1]+"_INDEX_PREFIX"] = struct{}{}
+			}
+		})
+	}
+	return set, nil
+}
+
+func walkScalarNodes(n *yaml.Node, fn func(string)) {
+	if n == nil {
+		return
+	}
+	if n.Kind == yaml.ScalarNode {
+		fn(n.Value)
+		return
+	}
+	for _, c := range n.Content {
+		walkScalarNodes(c, fn)
+	}
+}
+
+func prefixDiff(a, b map[string]struct{}) []string {
+	var out []string
+	for k := range a {
+		if _, ok := b[k]; !ok {
+			out = append(out, k)
+		}
+	}
+	sort.Strings(out)
+	return out
+}


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6172.

### What's in this PR?

- `docs/ci-scenario-matrix.md` — PR scenarios per version, cross-component nightly inventory, index-prefix coverage matrix, known gaps.
- `TestUpgradePrefixCoverage` — asserts install-step prefix vars ⊆ upgrade-step prefix vars for every enabled upgrade scenario.
- `DeploymentConfig.ValidateForChart` — opt-in version-aware layer-file existence check.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?