### PR TITLE
ci(8.7): add post-deploy hook to increase Keycloak token lifespan for E2E stability

### DIFF
--- a/charts/camunda-platform-8.7/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.7/test/ci-test-config.yaml
@@ -147,6 +147,11 @@ integration:
           platforms: [gke]
           infra-type:
             gke: distroci
+          post-deploy:
+            script: post-deploy-keycloak-token-lifespan.sh
+            description: |
+              Increases Keycloak access token lifespan to 30 minutes and SSO
+              session idle timeout to 2 hours for E2E test stability.
         # AlwaysGreen scenario — referenced by camunda/camunda's
         # docker-build-helm-integration.yml. Deploys onto dedicated alwaysgreen
         # GKE node pool (workload=alwaysgreen label + NoSchedule taint).
@@ -173,6 +178,13 @@ integration:
           infra-type:
             gke: qa-workloads
             eks: preemptible
+          post-deploy:
+            script: post-deploy-keycloak-token-lifespan.sh
+            description: |
+              Increases Keycloak access token lifespan to 30 minutes and SSO
+              session idle timeout to 2 hours. Prevents session-expiry flakiness
+              in long-running E2E test flows (diagram building, process deployment)
+              when the cluster is under heavy load.
         - name: qa-elasticsearch-rba
           enabled: false
           flow: install
@@ -186,6 +198,11 @@ integration:
           platforms: [gke]
           infra-type:
             gke: qa-workloads
+          post-deploy:
+            script: post-deploy-keycloak-token-lifespan.sh
+            description: |
+              Increases Keycloak access token lifespan to 30 minutes and SSO
+              session idle timeout to 2 hours for E2E test stability.
         - name: qa-elasticsearch-mt
           enabled: false
           flow: install
@@ -199,6 +216,11 @@ integration:
           platforms: [gke]
           infra-type:
             gke: qa-workloads
+          post-deploy:
+            script: post-deploy-keycloak-token-lifespan.sh
+            description: |
+              Increases Keycloak access token lifespan to 30 minutes and SSO
+              session idle timeout to 2 hours for E2E test stability.
         - name: qa-license
           enabled: false
           flow: install
@@ -212,6 +234,11 @@ integration:
           platforms: [gke]
           infra-type:
             gke: qa-workloads
+          post-deploy:
+            script: post-deploy-keycloak-token-lifespan.sh
+            description: |
+              Increases Keycloak access token lifespan to 30 minutes and SSO
+              session idle timeout to 2 hours for E2E test stability.
         - name: qa-opensearch
           enabled: false
           flow: install
@@ -224,6 +251,11 @@ integration:
           platforms: [gke]
           infra-type:
             gke: qa-workloads
+          post-deploy:
+            script: post-deploy-keycloak-token-lifespan.sh
+            description: |
+              Increases Keycloak access token lifespan to 30 minutes and SSO
+              session idle timeout to 2 hours for E2E test stability.
           dependencies:
             - chart: opensearch/opensearch
               version: "2.31.0"

--- a/charts/camunda-platform-8.7/test/integration/scenarios/pre-setup-scripts/post-deploy-keycloak-token-lifespan.sh
+++ b/charts/camunda-platform-8.7/test/integration/scenarios/pre-setup-scripts/post-deploy-keycloak-token-lifespan.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+# Copyright 2025 Camunda Services GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Increases Keycloak realm token lifespans for CI/E2E testing stability.
+#
+# The default access token lifespan (5 min) can expire during long-running
+# E2E test flows (diagram building, process deployment) when the cluster is
+# under heavy load. This script patches the camunda-platform realm to use
+# 30-minute access tokens and 2-hour SSO sessions, eliminating session
+# expiry as a source of test flakiness.
+#
+# Usage (called automatically by deploy-camunda as a post-deploy hook):
+#   export TEST_NAMESPACE=<namespace>
+#   export KUBE_CONTEXT=<context>           # optional
+#   export RELEASE_NAME=<release>           # optional, defaults to "integration"
+#   bash post-deploy-keycloak-token-lifespan.sh
+#
+# Prerequisites: kubectl, curl, jq
+#
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+NAMESPACE="${TEST_NAMESPACE:?TEST_NAMESPACE must be set}"
+RELEASE="${RELEASE_NAME:-integration}"
+CONTEXT_FLAG=""
+if [[ -n "${KUBE_CONTEXT:-}" ]]; then
+  CONTEXT_FLAG="--context ${KUBE_CONTEXT}"
+fi
+
+REALM="camunda-platform"
+# 30-minute access tokens (default: 5 min) — long enough for any E2E test flow.
+ACCESS_TOKEN_LIFESPAN=1800
+# 2-hour SSO session idle timeout (default: 30 min).
+SSO_SESSION_IDLE_TIMEOUT=7200
+# 12-hour SSO session max (default: 10 hours).
+SSO_SESSION_MAX_LIFESPAN=43200
+
+echo "[keycloak-token-lifespan] Patching realm '${REALM}' in namespace ${NAMESPACE}..."
+
+# ---------------------------------------------------------------------------
+# 1. Get Keycloak admin password from K8s secret
+# ---------------------------------------------------------------------------
+KEYCLOAK_PASSWORD=$(kubectl ${CONTEXT_FLAG} -n "${NAMESPACE}" get secret integration-test-credentials \
+  -o jsonpath='{.data.identity-keycloak-admin-password}' | base64 -d)
+
+if [[ -z "${KEYCLOAK_PASSWORD}" ]]; then
+  echo "[keycloak-token-lifespan] ERROR: Could not retrieve Keycloak admin password from secret"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Port-forward to Keycloak and obtain admin token
+# ---------------------------------------------------------------------------
+LOCAL_PORT=18080
+kubectl ${CONTEXT_FLAG} -n "${NAMESPACE}" port-forward "svc/${RELEASE}-keycloak" "${LOCAL_PORT}:80" &
+PF_PID=$!
+trap 'kill $PF_PID 2>/dev/null || true' EXIT
+
+# Wait for port-forward to be ready
+for i in $(seq 1 30); do
+  if curl -sf "http://localhost:${LOCAL_PORT}/auth/" >/dev/null 2>&1; then
+    break
+  fi
+  if [[ $i -eq 30 ]]; then
+    echo "[keycloak-token-lifespan] ERROR: Port-forward to Keycloak not ready after 30s"
+    exit 1
+  fi
+  sleep 1
+done
+
+KEYCLOAK_URL="http://localhost:${LOCAL_PORT}/auth"
+
+# Get admin access token
+TOKEN_RESPONSE=$(curl -sf -X POST "${KEYCLOAK_URL}/realms/master/protocol/openid-connect/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "username=admin" \
+  -d "password=${KEYCLOAK_PASSWORD}" \
+  -d "grant_type=password" \
+  -d "client_id=admin-cli")
+
+ADMIN_TOKEN=$(echo "${TOKEN_RESPONSE}" | jq -r '.access_token')
+
+if [[ -z "${ADMIN_TOKEN}" || "${ADMIN_TOKEN}" == "null" ]]; then
+  echo "[keycloak-token-lifespan] ERROR: Failed to obtain admin token"
+  echo "${TOKEN_RESPONSE}"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Patch realm token/session lifespans
+# ---------------------------------------------------------------------------
+HTTP_CODE=$(curl -sf -o /dev/null -w "%{http_code}" -X PUT \
+  "${KEYCLOAK_URL}/admin/realms/${REALM}" \
+  -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"accessTokenLifespan\": ${ACCESS_TOKEN_LIFESPAN},
+    \"ssoSessionIdleTimeout\": ${SSO_SESSION_IDLE_TIMEOUT},
+    \"ssoSessionMaxLifespan\": ${SSO_SESSION_MAX_LIFESPAN}
+  }")
+
+if [[ "${HTTP_CODE}" == "204" ]]; then
+  echo "[keycloak-token-lifespan] Successfully patched realm '${REALM}':"
+  echo "  accessTokenLifespan:    ${ACCESS_TOKEN_LIFESPAN}s (30 min)"
+  echo "  ssoSessionIdleTimeout:  ${SSO_SESSION_IDLE_TIMEOUT}s (2 hours)"
+  echo "  ssoSessionMaxLifespan:  ${SSO_SESSION_MAX_LIFESPAN}s (12 hours)"
+else
+  echo "[keycloak-token-lifespan] WARNING: Realm patch returned HTTP ${HTTP_CODE}"
+  echo "  This is non-fatal — E2E tests have re-login handling as a fallback."
+fi


### PR DESCRIPTION
## Summary

- Adds a post-deploy script (`post-deploy-keycloak-token-lifespan.sh`) that increases Keycloak realm token/session lifespans after deployment
- Configures it as a `post-deploy:` hook on all 8.7 QA scenarios and the `keyco` backward-compat scenario

## Problem

The default Keycloak access token lifespan (5 min) can expire during long-running E2E test flows when the GKE cluster is under heavy load. When the token expires, the Web Modeler frontend redirects to the Keycloak login page mid-test, breaking the deploy/run flow.

This manifests as the **Timer Event User Flow** test consistently failing with:
```
Error: Failed to click start process after 3 attempts: TimeoutError: locator.apply: Timeout 30000ms exceeded.
  waiting for getByRole('button', { name: 'Deploy & run', exact: true })
    navigated to ".../modeler/login-callback?..."
```

## Fix

The post-deploy script:
1. Retrieves the Keycloak admin password from the `integration-test-credentials` K8s secret
2. Port-forwards to the Keycloak service
3. Patches the `camunda-platform` realm via Admin API to set:
   - `accessTokenLifespan`: 5 min → **30 min**
   - `ssoSessionIdleTimeout`: 30 min → **2 hours**
   - `ssoSessionMaxLifespan`: 10 hours → **12 hours**

## Coordinated Fix

This is the **preventive** fix (belt). The companion **recovery** fix (suspenders) is in the E2E repo:
- https://github.com/camunda/c8-cross-component-e2e-tests/pull/2367 — adds `handleSessionExpiry()` to detect and re-login when Keycloak session expires mid-test

Together these two fixes make the Timer Event test resilient to session expiry regardless of cluster load.

## Validation

- `TestLifecycleFixtures` — PASS (validates script references and hook declarations)
- `make go.test chartPath=charts/camunda-platform-8.7` — all 12 packages PASS
- E2E fix validated on GKE (2 runs, Timer Event passed) in PR #2367