### PR TITLE
docs(adr-91): clarify Tier 2 backport policy and add gateway examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,26 +207,6 @@ helm template integration charts/camunda-platform-8.X \
 # Should be exactly 1. If >1, there's a duplicate.
 ```
 
-## values.yaml Key Classification (ADR 91)
-
-Before adding a new `values.yaml` key, classify it. Full details in
-`docs/adr/0091-adopt-component-extraconfiguration-as-the-standard-application-configuration-mechanism.md`.
-
-**Tier 1 — Application behavior** (BLOCKED — use `<component>.extraConfiguration` instead):
-- Feature flags, toggles, log levels, Spring Boot properties, env vars controlling application logic.
-- Examples: `global.multitenancy.enabled`, `orchestration.security.authorizations.enabled`.
-- **No new Tier 1 keys may be added to any chart version.**
-
-**Tier 2 — Infrastructure and connectivity** (ALLOWED — add to `values.yaml`):
-- Kubernetes infrastructure: resources, affinity, serviceAccount, volumes, strategy.
-- Connectivity: external endpoints, credentials, TLS certificates, Gateway API wiring
-  (`global.gateway.name`, `global.gateway.namespace`, `global.gateway.tls.*`).
-- Cross-component coordination: shared auth config, service discovery wiring.
-- **Tier 2 keys may be backported to released (non-alpha) chart versions** because they
-  are additive, opt-in, and default to the prior behaviour.
-
-Quick test: *Does this control what the application does (Tier 1) or how/where it runs and connects (Tier 2)?*
-
 ## Commit and Branch Conventions
 - Branches: `issueId-description` (example `123-adding-bpel-support`).
 - Commit/PR titles: Conventional Commits.
@@ -241,6 +221,7 @@ Quick test: *Does this control what the application does (Tier 1) or how/where i
 - `STATE.md` — session continuity (gitignored, read on session start)
 - `helm-values-mcp/` — MCP server exposing chart values schema. Tools: `list_versions`, `list_components`, `search_configs`, `get_config_info`, `generate_values_example`.
 - `scripts/helm_unused_values/` — CLI to find values declared in `values.yaml` but never referenced in templates.
+- `docs/adr/0091-*.md` — **values.yaml key classification (Tier 1 vs Tier 2)**. Read the Quick Reference table at the top before proposing a new key or backport.
 
 ## Recommended Agent Workflow
 1. Select target chart version/component.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,26 @@ helm template integration charts/camunda-platform-8.X \
 # Should be exactly 1. If >1, there's a duplicate.
 ```
 
+## values.yaml Key Classification (ADR 91)
+
+Before adding a new `values.yaml` key, classify it. Full details in
+`docs/adr/0091-adopt-component-extraconfiguration-as-the-standard-application-configuration-mechanism.md`.
+
+**Tier 1 — Application behavior** (BLOCKED — use `<component>.extraConfiguration` instead):
+- Feature flags, toggles, log levels, Spring Boot properties, env vars controlling application logic.
+- Examples: `global.multitenancy.enabled`, `orchestration.security.authorizations.enabled`.
+- **No new Tier 1 keys may be added to any chart version.**
+
+**Tier 2 — Infrastructure and connectivity** (ALLOWED — add to `values.yaml`):
+- Kubernetes infrastructure: resources, affinity, serviceAccount, volumes, strategy.
+- Connectivity: external endpoints, credentials, TLS certificates, Gateway API wiring
+  (`global.gateway.name`, `global.gateway.namespace`, `global.gateway.tls.*`).
+- Cross-component coordination: shared auth config, service discovery wiring.
+- **Tier 2 keys may be backported to released (non-alpha) chart versions** because they
+  are additive, opt-in, and default to the prior behaviour.
+
+Quick test: *Does this control what the application does (Tier 1) or how/where it runs and connects (Tier 2)?*
+
 ## Commit and Branch Conventions
 - Branches: `issueId-description` (example `123-adding-bpel-support`).
 - Commit/PR titles: Conventional Commits.

--- a/docs/adr/0091-adopt-component-extraconfiguration-as-the-standard-application-configuration-mechanism.md
+++ b/docs/adr/0091-adopt-component-extraconfiguration-as-the-standard-application-configuration-mechanism.md
@@ -120,12 +120,18 @@ graph TD
 
 **Allowed** (Tier 2 — may add to `values.yaml`):
 - Kubernetes infrastructure: resources, affinity, serviceAccount, volumes, strategy
-- Connectivity: external endpoints, credentials, TLS certificates
+- Connectivity: external endpoints, credentials, TLS certificates, **Gateway API
+  wiring** (`global.gateway.name`, `global.gateway.namespace`, `global.gateway.tls.*`)
 - Cross-component coordination: shared auth config, service discovery wiring
+
+> **Backport policy:** Tier 2 keys may be added to any active chart version,
+> including released (non-alpha) lines, because they are additive, opt-in, and
+> default to the prior behaviour. Only Tier 1 additions are blocked on released
+> chart versions.
 
 ---
 
-- **No new Tier 1 keys shall be added to the Helm chart.** New application features that require Tier 1 configuration must use `<component>.extraConfiguration` exclusively. New features that require Tier 2 configuration (connectivity, infrastructure, cross-component coordination) may introduce new `values.yaml` keys subject to the Tier 2 classification defined above. **This rule applies to all active chart versions from the date this ADR is accepted.**
+- **No new Tier 1 keys shall be added to the Helm chart.** New application features that require Tier 1 configuration must use `<component>.extraConfiguration` exclusively. New features that require Tier 2 configuration (connectivity, infrastructure, cross-component coordination) may introduce new `values.yaml` keys subject to the Tier 2 classification defined above. **This rule applies to all active chart versions from the date this ADR is accepted.** Tier 2 additions are also permitted as backports to released (non-alpha) chart lines because they are additive, opt-in, and default to prior behaviour — only Tier 1 additions are blocked on released lines.
 - All existing application-specific keys in values.yaml are deprecated as of Camunda 8.10, with documented migration hints mapping each deprecated key to the equivalent extraConfiguration pattern.
 - Removal is targeted for Camunda 8.11. The keys in scope for removal are all Tier 1 values.yaml entries — those that configure application behavior rather than Tier 2 infrastructure, connectivity, or cross-component coordination concerns. Sequencing and any version-specific exceptions are tracked in product-hub#3562.
 - `<component>.configuration` (full application config file override) remains available as an advanced escape hatch for operators who intentionally want to take full control of the application configuration file. It is not the recommended path and is not part of the standard mechanism.

--- a/docs/adr/0091-adopt-component-extraconfiguration-as-the-standard-application-configuration-mechanism.md
+++ b/docs/adr/0091-adopt-component-extraconfiguration-as-the-standard-application-configuration-mechanism.md
@@ -4,6 +4,21 @@
 - Date: 2026-05-06
 - Decision-makers: Distribution team
 
+## Quick Reference
+
+**Proposing a new `values.yaml` key?** Classify it first:
+
+| Tier | What it controls | Rule | Backportable? |
+|------|-----------------|------|---------------|
+| **Tier 1** — app behavior | Feature flags, toggles, log levels, Spring Boot properties, env vars controlling application logic | **BLOCKED** — use `<component>.extraConfiguration` instead | No |
+| **Tier 2** — infra & connectivity | Kubernetes infrastructure (resources, affinity, volumes), connectivity (endpoints, TLS, **Gateway API wiring**: `global.gateway.name`, `global.gateway.namespace`, `global.gateway.tls.*`), cross-component coordination (shared auth config, service discovery) | **Allowed** — add to `values.yaml` | Yes — additive, opt-in, defaults to prior behaviour |
+
+Quick test: *Does this control what the application **does** (Tier 1) or **how/where** it runs and connects (Tier 2)?*
+
+Full classification details, examples, and rationale are in [Configuration Classification](#configuration-classification) below.
+
+---
+
 ## Context and Problem Statement
 
 The Camunda Helm chart historically added abstraction layers over application-level configuration to simplify inconsistent component setups (e.g., log levels, feature flags, resource permission toggles). Over time, this produced a third configuration layer sitting between the application's native config and Kubernetes deployment concerns. Critically, these Helm-level parameters were not a 1:1 mapping to native application properties — they were a simplified abstraction that required its own Helm-specific documentation and did not transfer to other deployment methods such as ECS, Docker, or Jar. Instead of having a single configuration reference for all deployment methods, operators were required to learn a Helm-specific configuration layer on top of the application's own.

--- a/docs/contribution-and-collaboration.md
+++ b/docs/contribution-and-collaboration.md
@@ -159,7 +159,7 @@ PRs are automatically reviewed by [`crev`](https://github.com/camunda/crev), an 
 - A **commit status** (`crev/escalation`) indicating whether human review is required.
 - A **label** (`human-review-required` or `ai-review-sufficient`) based on the escalation score.
 
-The escalation decision is governed by the [escalation policy](/.github/escalation-policy.md). PRs that touch security surfaces, span multiple chart versions, or violate hard rules always require human review. Routine additive changes by familiar authors may be approved with AI review alone.
+The escalation decision is governed by the [escalation policy](https://github.com/camunda/camunda-platform-helm/blob/main/.github/escalation-policy.md). PRs that touch security surfaces, span multiple chart versions, or violate hard rules always require human review. Routine additive changes by familiar authors may be approved with AI review alone.
 
 Contributors should treat the `human-review-required` label as a signal that the Distro team must approve before merge.
 


### PR DESCRIPTION
## Summary

Addresses a false-positive from automated tooling that flagged \`global.gateway.name\` and \`global.gateway.namespace\` on #6174 as violating the ADR 91 no-new-keys rule. Also surfaces the classification rules in \`AGENTS.md\` so agents have the context without reading the full ADR.

**ADR 91 changes:**
- Adds Gateway API wiring keys as an explicit Tier 2 **connectivity** example in the Allowed quick-reference
- Adds a callout box making the Tier 2 backport policy explicit: Tier 2 keys are permitted on released (non-alpha) chart lines; only Tier 1 additions are blocked there
- Extends the main constraint sentence with the same backport distinction

**AGENTS.md changes:**
- Adds a `## values.yaml Key Classification (ADR 91)` section with the Tier 1/2 rules, examples, and backport policy in one place agents can read without opening the full ADR

## Test plan

- [ ] Docs-only change — no chart templates or test code modified
- [ ] Text reviewed for accuracy against existing ADR definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)