### PR TITLE
ci: simplify Slack notification message format

### DIFF
--- a/.github/workflows/notify-pr-activity.yml
+++ b/.github/workflows/notify-pr-activity.yml
@@ -13,9 +13,9 @@
 # Can be called from other repos via workflow_call — pass all pr_* inputs explicitly.
 #
 # Message format:
-#   ↗️ [helm] PR opened · by @author · review: @rev1 · +42/-7 — #123 feat: add support for X
-#   🎉 [helm] PR merged after 1d 4h · by @author · merged by @merger — #123 feat: add support for X
-#   ❌ [helm] PR closed without merge · by @author — #123 feat: add support for X
+#   ↗ [helm] #123 feat: add support for X — review: @rev1
+#   ✅ [helm] #123 merged after 1d 4h
+#   ❌ [helm] #123 feat: add support for X
 #
 # Notification logic is implemented in scripts/notify-pr-activity (Go).
 #

--- a/.github/workflows/notify-pr-activity.yml
+++ b/.github/workflows/notify-pr-activity.yml
@@ -6,16 +6,15 @@
 # Sends a message to #team-distribution-github (via distro-bot) when:
 #   - A PR is opened or converted from draft to ready for review
 #   - A PR is merged
-#   - A PR is closed without merge
 #
-# Draft PRs are skipped entirely.
+# Draft PRs and closed-without-merge PRs are skipped entirely.
+# Bot-authored PRs are suppressed unless labelled upgrade:major (renovate major bumps).
 #
 # Can be called from other repos via workflow_call — pass all pr_* inputs explicitly.
 #
 # Message format:
 #   ↗ [helm] #123 feat: add support for X — review: @rev1
 #   ✅ [helm] #123 merged after 1d 4h
-#   ❌ [helm] #123 feat: add support for X
 #
 # Notification logic is implemented in scripts/notify-pr-activity (Go).
 #
@@ -108,7 +107,8 @@ on:
 
 jobs:
   notify-slack:
-    # Skip draft PRs; only run for opened, ready_for_review, closed+merged, or closed+unmerged events.
+    # Skip draft PRs; only run for opened, ready_for_review, or closed (merged) events.
+    # Closed-without-merge suppression and bot filtering are handled in the Go script.
     # When called via workflow_call, the caller controls filtering via the pr_draft input.
     if: |
       (github.event_name == 'workflow_call' && inputs.pr_draft != 'true') ||

--- a/.github/workflows/triage-ai-issue.yml
+++ b/.github/workflows/triage-ai-issue.yml
@@ -471,23 +471,16 @@ jobs:
             ISSUE_URL="$GITHUB_SERVER_URL/$OWNER/$REPO/issues/$ISSUE_NUMBER"
             SHORT_REPO=$(echo "$REPO" | sed 's/camunda-platform-//')
 
-            # Pick an emoji based on kind
-            KIND_EMOJI=":label:"
-            case "${KIND:-unknown}" in
-              bug)             KIND_EMOJI=":bug:" ;;
-              chore)           KIND_EMOJI=":wrench:" ;;
-              docs)            KIND_EMOJI=":memo:" ;;
-              feature-request) KIND_EMOJI=":bulb:" ;;
-              internal)        KIND_EMOJI=":nut_and_bolt:" ;;
-              refactor)        KIND_EMOJI=":recycle:" ;;
-              research)        KIND_EMOJI=":microscope:" ;;
+            # Severity prefix for high/critical only; low/mid show no label
+            SEVERITY_PREFIX=""
+            case "$SEVERITY" in
+              high)     SEVERITY_PREFIX="⚠️ HIGH — " ;;
+              critical) SEVERITY_PREFIX="🚨 CRITICAL — " ;;
             esac
 
             SLACK_PAYLOAD=$(jq -n \
-              --arg emoji "$KIND_EMOJI" \
               --arg repo "$SHORT_REPO" \
-              --arg kind "${KIND:-unknown}" \
-              --arg severity "${SEVERITY_EMOJI} ${SEVERITY}" \
+              --arg severity_prefix "$SEVERITY_PREFIX" \
               --arg issue_url "$ISSUE_URL" \
               --arg issue_number "#${ISSUE_NUMBER}" \
               --arg title "$ISSUE_TITLE" \
@@ -496,7 +489,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ($emoji + " [" + $repo + "] " + $kind + " · " + $severity + " severity — <" + $issue_url + "|" + $issue_number + " " + $title + ">")
+                    "text": ("🎫 [" + $repo + "] <" + $issue_url + "|" + $issue_number + " " + $severity_prefix + $title + ">")
                   }
                 }]
               }')

--- a/docs/contribution-and-collaboration.md
+++ b/docs/contribution-and-collaboration.md
@@ -3,94 +3,173 @@ id: contribution-and-collaboration
 title: Contribution & Collaboration
 ---
 
-The Camunda Helm chart is the integration point between the Camunda application components and Kubernetes. All contributors — internal app teams and external open-source contributors — follow the same contribution process and the same rules.
+The Camunda Helm chart is the integration point between the Camunda application components and Kubernetes. To maintain consistency, reliability, and ownership boundaries, contributions from application teams should follow a structured collaboration process. This ensures all configuration, feature, and bug-fix changes align with established review, testing, and documentation standards.
 
-For HC owners and Distro team members (reviewers, release managers, ADR authors): see the [Maintainer Guide](./maintainer-guide.md). For technical setup (cloning, toolchain, local builds): see [CONTRIBUTING.md](https://github.com/camunda/camunda-platform-helm/blob/main/CONTRIBUTING.md).
+## When App Teams Should Contribute Independently
+
+App teams are expected to contribute directly when changes primarily affect their application configuration, such as:
+
+- Adjustments to the ConfigMap or application-specific configuration fields.
+- Additions of new configuration properties to `values.yaml` or related templates.
+  - **Note:** With 8.9+, applications should be configured per default via the [`<component>.extraConfiguration`](https://docs.camunda.io/docs/next/self-managed/deployment/helm/configure/application-configs/#componentnameextraconfiguration) key.
+- Adding or updating secret references (for example, credential or endpoint configurations).
+
+Larger architectural or user-facing changes, such as new components or features that affect multiple components, should always be designed and implemented in collaboration with the Distribution team.
+
+:::note
+Read the [contribution guide](https://github.com/camunda/camunda-platform-helm/blob/main/CONTRIBUTING.md) to learn how to contribute.
+:::
+
+## General Collaboration Workflow
+
+### 1. ADR-first: Align before you implement
+
+For **any new feature, architectural change, directional shift, or larger change**, team alignment is required *before* writing code or opening a PR.
+
+**Process:**
+
+1. **Open an Architecture Decision Record (ADR)** in [`docs/adr/`](https://github.com/camunda/camunda-platform-helm/tree/main/docs/adr) using the [MADR format](https://adr.github.io/madr/).
+2. **Announce in the relevant Slack channel** so the team can review async.
+3. **Wait for majority approval** — from the Distribution team and any other affected stakeholders.
+4. Once approved: **implement**, then open a PR referencing the ADR.
+
+> ℹ️ ADRs live in `docs/adr/` and are automatically detected by [`crev`](https://github.com/camunda/crev) during AI-assisted reviews. A well-written ADR directly improves the quality of automated review feedback.
+
+**When is an ADR required?**
+
+| Change type | ADR required? |
+|---|---|
+| New feature / new component | Yes |
+| Architectural or structural change | Yes |
+| Directional / cross-team impact | Yes |
+| Bug fix / documentation update | No |
+| Small config addition | No |
+
+### 2. Initiate discussion (PDP/kickoff)
+
+For major changes, the ADR discussion may be complemented by a design discussion (PDP or kickoff meeting) to define scope, clarify responsibilities, and ensure alignment with existing Helm and Kubernetes design.
+
+### 3. Determine ownership
+
+Depending on the nature of the change, either:
+
+- The Distro team implements the change directly.
+- The app team member creates the implementation, while the Distro team acts as reviewer and owner of Helm-related concerns.
+
+The Distro team remains the **final reviewer and approval authority** for all Helm chart modifications.
+
+### 4. Propose an issue
+
+Each contribution begins with a GitHub issue describing:
+
+- Context and motivation.
+- The configuration or feature change.
+- Expected impact on existing values or manifests.
+- Linked documentation or references (if available).
+- Link to the relevant ADR (if applicable).
+
+### 5. AI-assisted review with `crev`, then PR
+
+Once the ADR is approved and the implementation is ready, use the following PR workflow:
+
+1. **Open your PR as a draft.**
+2. **Run [`crev`](https://github.com/camunda/crev) against your PR:**
+   ```bash
+   crev https://github.com/camunda/camunda-platform-helm/pull/<your-pr-number>
+   ```
+   `crev` automatically reads the ADR corpus in `docs/adr/`, this governance doc, and any escalation policy defined in `.github/escalation-policy.md`.
+3. **Read and respond to the review findings.** Address blockers before requesting human review.
+4. **Fix findings** — iterate until the AI review is clean or findings are intentionally accepted with explanation.
+5. **If the review output seems off or misses context**, add clarifying context directly in the PR description for the agents. Reference the [helm-repo-specific agent context](https://github.com/camunda/crev/blob/main/cmd/crev/review.go#L733) to understand what documents `crev` uses.
+6. **Mark the PR ready for review** once the crev report is satisfactory.
+7. The Distro team participates during design review and functional validation stages to ensure chart consistency.
+
+> ℹ️ `crev` detects ADRs (`docs/adr/**/*.md`), governance documents (`docs/contribution-and-collaboration.md`, `CONTRIBUTING.md`, etc.), and escalation policies. Keeping these files accurate directly improves AI review quality and reduces back-and-forth with human reviewers.
 
 ---
 
-## How to Contribute
+## Contribution Policy
 
-All contributions start with a GitHub issue — scope must be agreed before a PR is opened.
+### Configuration documentation
 
-```mermaid
-flowchart TD
-    Start([Contribution idea]) --> Type{What kind?}
+Before adding or modifying any configuration in the Helm chart, contributors must ensure the change is properly documented.
 
-    Type -- "Bug fix or\nsmall improvement" --> Issue1[Open bug/improvement issue]
-    Issue1 --> Confirm[Distro team confirms scope]
-    Confirm --> Impl1[Implement]
-    Impl1 --> PR([Open PR])
+Ideally, the configuration property should already be reflected in the user documentation.
+At minimum, a GitHub issue must describe the property clearly — its purpose, effect, default behavior, and any important constraints.
 
-    Type -- "New feature or\nconfig addition" --> Issue2[Open feature request issue]
-    Issue2 --> Approve[Distro team approves]
-    Approve --> Keys{Adds values.yaml key?}
-    Keys -- Yes --> Classify[Classify key: Tier 1 or Tier 2\nsee Values YAML Policy]
-    Keys -- No --> Impl2[Implement]
-    Classify --> Impl2
-    Impl2 --> PR
+This requirement serves as a **hard contribution criterion**.
 
-    Type -- "Architectural or\ndirectional change" --> Maintainer[See Maintainer Guide\nrequires ADR by HC owner]
-```
+Self-Managed engineers review documentation clarity as part of the code review process. Through this step, reviewers also deepen understanding of how the application integrates with its Helm configuration.
 
-### Contribution rules
+:::note
+Configuration values represent the main handover point between the application and the Helm chart. Clear, accurate documentation ensures maintainability and shared understanding across teams.
+:::
 
-1. **Open an issue first.** Scope must be agreed with the Distro team before a PR is opened. Unsolicited PRs without a linked issue may be closed.
-2. **Get approval before implementing.** For features and config additions, wait for explicit Distro team approval on the issue.
-3. **Application behavior config goes in `extraConfiguration`, not `values.yaml`.** A new feature toggle, log level, or Spring Boot property must use `<component>.extraConfiguration`. See [Values YAML Policy](./policies/values-yaml-policy.md).
-4. **Document before you merge.** The configuration property must be reflected in user documentation or, at minimum, clearly described in the issue. See [Ticket & Label Policy](./policies/ticket-and-label.md) for issue requirements.
-5. **Follow `values.yaml` conventions.** Variable names begin with a lowercase letter and use camelCase; every defined property must be documented. See [Code Style](./reference/code-style.md).
-6. **New applications must meet minimal requirements** — enable/disable flag, env block, and TLS block:
+### Helm documentation
 
-```yaml
-<appName>:
-  enabled: false
+The `values.yaml` file follows [Helm's best practices](https://helm.sh/docs/chart_best_practices/values/). This means:
 
-  env: {}
+- Variable names should begin with a lowercase letter, and words should be separated using camelCase.
+- Every defined property in `values.yaml` should be documented.
+- The documentation string should begin with the name of the property that it describes, followed by at least a one-sentence description.
+- We use [bitnami/readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm) to generate the Helm chart values docs from the values file. Ensure to follow the same convention as the tool.
 
-  tls:
-    enabled: false
-    existingSecret: ""
-    jks:
-      secret:
-        existingSecret: ""
-        existingSecretKey: ""
-        inlineSecret: ""
-```
+### New applications: minimal requirements
+
+To ensure consistency and operational reliability across all components shipped within the Camunda Platform Helm chart, any new application introduced into the chart must meet a set of minimal, mandatory requirements:
+
+- **Enable/Disable flag (`enabled`):** Allows users to explicitly opt-in to running the component, avoids accidental deployments, and ensures backward compatibility in chart upgrades.
+- **Environment Variable Configuration:** Allows users to configure runtime behavior without modifying template files.
+  ```yaml
+  <appName>:
+    env: {}
+  ```
+- **TLS / Java Keystore (JKS) Integration:** Provides consistent TLS behavior across all chart components and ensures secure communication patterns are applied uniformly.
+  ```yaml
+  <appName>:
+    tls:
+      enabled: false
+      existingSecret: ""
+      jks:
+        secret:
+          existingSecret: ""
+          existingSecretKey: ""
+          inlineSecret: ""
+  ```
 
 ---
 
 ## Pull Request Requirements
 
-### PR title type selection
+Every pull request (PR) related to Helm chart changes must adhere to the following checklist:
 
-PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/). CI enforces an additional constraint: **`feat:`, `fix:`, `refactor:`, `docs:`, and `revert:` are reserved for PRs that change user-facing chart files** (anything under `charts/<chart>/` excluding `test/`, `go.mod`, `go.sum`). These types propagate to `RELEASE-NOTES.md` and `artifacthub.io/changes` via `git-cliff`.
+- **ADR or team alignment:** For new features, architectural changes, or direction shifts — an ADR must exist and have team approval before the PR is opened.
+- **Linked issue:** Every PR must reference a clearly described GitHub issue.
+- **`crev` review completed:** Run `crev` against the PR before marking it ready for review. Address or acknowledge all findings.
+- **Unit tests:** Changes should include or update corresponding unit tests where applicable.
+- **Documentation updates:** User or technical documentation must reflect configuration or behavior changes.
+- **Passing CI:** All CI checks must pass successfully before merge.
+- **Code review:** At least one formal human review must be completed and approved.
+- **Atomic changes:** Aim for small, focused PRs that address a single issue or configuration change to simplify review and reduce merge complexity.
 
-| Changed files | Correct type |
-|---|---|
-| Chart templates, values, helpers | `feat:` / `fix:` / `refactor:` |
-| `docs/`, `AGENTS.md`, `CLAUDE.md`, `SKILLS.md`, `README.md`, `scripts/` | `chore:` |
-| `.github/` workflows or actions | `ci:` |
-| Build tooling, dependency metadata, or other non-chart changes CI suggests as `build:` | `build:` |
-| Test files only (`test/`, `go.mod`, `go.sum`) | `test:` |
-| Mixed chart + docs/CI | Use the type matching the chart change |
+### Automated AI review and escalation
 
-Using `docs:` for a docs-only PR will fail CI — use `chore:` instead.
+PRs are automatically reviewed by [`crev`](https://github.com/camunda/crev), an AI code-review tool with domain-specific knowledge of the Camunda Helm charts. After review, `crev` posts:
 
-### Checklist
+- A **commit status** (`crev/escalation`) indicating whether human review is required.
+- A **label** (`human-review-required` or `ai-review-sufficient`) based on the escalation score.
 
-Every PR must satisfy the following before requesting review:
+The escalation decision is governed by the [escalation policy](https://github.com/camunda/camunda-platform-helm/blob/main/.github/escalation-policy.md). PRs that touch security surfaces, span multiple chart versions, or violate hard rules always require human review. Routine additive changes by familiar authors may be approved with AI review alone.
 
-- [ ] **`crev` review** — run [`crev`](https://github.com/camunda/crev) against the PR and address or acknowledge all findings before requesting review.
-- [ ] **Configuration key classification** — if the PR adds a `values.yaml` key, confirm it is Tier 2, additive, opt-in, and non-breaking. See [Values YAML Policy](./policies/values-yaml-policy.md).
-- [ ] **Unit tests** — changes include or update corresponding unit tests. See [Testing Guide](./reference/testing.md).
-- [ ] **Documentation updates** — user or technical documentation reflects configuration or behavior changes.
-- [ ] **Passing CI** — the following required checks must pass: `Test - Chart Version / CI Gate` and `license/cla`.
-- [ ] **Atomic changes** — the PR is small and focused on a single issue or config change.
+Contributors should treat the `human-review-required` label as a signal that the Distro team must approve before merge.
 
 ### Helm version
 
-Use the exact Helm version pinned in [`.tool-versions`](https://github.com/camunda/camunda-platform-helm/blob/main/.tool-versions). Install via asdf:
+To have a smooth contribution experience, before working on a new PR make sure to use the exact Helm version that's currently used in the repo.
+
+The Helm version is set in the [`.tool-versions`](https://github.com/camunda/camunda-platform-helm/blob/main/.tool-versions) file, so you can use the [asdf version manager](https://github.com/asdf-vm/asdf) to install Helm locally or just install the same version manually.
+
+To install the Helm version that's used in this repo using asdf, in the repo root, run:
 
 ```bash
 make tools.asdf-install
@@ -100,10 +179,132 @@ make tools.asdf-install
 
 ## Tests
 
-Tests are written in Go using the [Terratest framework](https://terratest.gruntwork.io/) and live under `test/` in each chart directory. Run all tests with:
+:::note
+For more details about Helm chart testing, read the blog post: [Advanced Test Practices For Helm Charts](https://medium.com/@zelldon91/advanced-test-practices-for-helm-charts-587caeeb4cb).
+:::
 
-```bash
-make go.test
+In order to make sure that the Helm charts work properly and that further development doesn't break anything, we have introduced tests for the Helm charts.
+
+The tests are written in Go, using the [Terratest framework](https://terratest.gruntwork.io/).
+
+We separate our tests into two parts, with different targets and goals.
+
+- **Template tests (unit tests)** verify the general structure. Is it YAML-conformant, does it have the right value/structure if set, do the default values not change or are they set at all?
+- **Integration tests** verify whether the charts can be installed and used. This means: are the manifests accepted by the K8s API, and do they work? Can the services reach each other and are they working?
+
+For new contributions it is expected to write new unit tests, but no integration tests. We keep the count of integration tests to a minimum, and the knowledge for writing them is not expected for contributors.
+
+Tests can be found in the chart directory under `test/`. For each component we have a sub-directory in the `test/` directory.
+
+To run the tests, execute `make go.test` at the repository root.
+
+### Unit tests
+
+As mentioned earlier, we expect unit tests on new contributions. The unit tests (template tests) are divided into two parts: golden file tests and explicit property tests. In this section we explain when which test type should be used.
+
+#### Golden files
+
+We write new golden file tests for default values, where we can compare a complete manifest with its properties.
+
+Most of the golden file tests are part of `goldenfiles_test.go` in the corresponding sub-chart testing directory. For an example see `/test/zeebe/goldenfiles_test.go`.
+
+If the complete manifest can be enabled by a toggle, we also write a golden file test. This test is part of a `<manifestFileName>_test.go` file. The `<manifestFileName>` corresponds to the template filename in the sub-chart templates dir.
+
+For example, the Prometheus `templates/service-monitor.yaml` can be enabled by a toggle, so we write a golden file test in `test/servicemonitor_test.go`.
+
+To generate the golden files, run `go.test-golden-updated` at the repository root. This will add a new golden file in a `golden` sub-dir and run the corresponding test. The golden files should be named related to the manifest.
+
+#### Properties tests
+
+For things that are not enabled or set by default, we write a property test. Here we directly set the specific property/variable and verify that the Helm chart can be rendered and the property is set correctly on the object.
+
+This kind of test should be part of a `<manifestFileName>_test.go` file. The `<manifestFileName>` corresponds to the template filename in the sub-chart templates dir.
+
+For example, for the Zeebe StatefulSet manifest we have the test `test/zeebe/statefulset_test.go` under the zeebe sub-dir.
+
+It is always helpful to check existing tests to get a better understanding of how to write new tests, so do not hesitate to read and copy from them.
+
+### Test license headers
+
+Make sure that new Go tests contain the Apache license headers, otherwise the CI license check will fail.
+
+For adding and checking the license we use [addlicense](https://github.com/google/addlicense). To install it locally, run `make go.addlicense-install`. Afterward, you can run `make go.addlicense-run` to add the missing license header to a new Go file.
+
+---
+
+## Backporting Policy
+
+Backports exist to deliver critical fixes and stability improvements to actively supported Camunda Helm chart releases, while minimizing regression risk and avoiding surprising changes for users.
+
+**Golden rule:** If upgrading to a patch release changes a user's deployment in an unexpected way, the backport failed.
+
+Backporting must only be performed within actively supported versions as defined by the [Standard and Extended Support Periods](https://confluence.camunda.com/spaces/HAN/pages/245400921/Standard+and+Extended+Support+Periods).
+
+### Quick decision flow
+
+```
+graph TD
+  Start([Backport candidate]) --> V{Supported version?}
+  V -- No --> End([Archive: not supported])
+  V -- Yes --> R{New key in values.yaml?}
+  R -- Yes --> Reject([Reject: structural change])
+  R -- No --> M{Rendered output changes?}
+  M -- Yes --> B{Fixes documented bug?}
+  B -- No --> Reject
+  B -- Yes --> Approval([Maintainer approval])
+  M -- No --> Test{Golden tests match?}
+  Test -- No --> Reject
+  Test -- Yes --> Approval
 ```
 
-For full details on test types (golden files, property tests), license headers, and how to run a single test, see [Testing Guide](./reference/testing.md).
+### What we backport
+
+We backport only changes that are safe and predictable:
+
+- **Vital:** security fixes and "won't install / won't start" problems.
+- **Functional:** logic/template fixes or documentation fixes that do not change the chart API.
+
+### What we do not backport
+
+We reject backports that are likely to surprise users:
+
+- **Structural:** anything that adds/changes the config surface (especially new keys/toggles in `values.yaml`) or big dependency upgrades.
+- **Anything requiring manual intervention:** if users must run commands or edit/delete resources, it's a migration and must wait for a minor/major release.
+- **Unexpected manifest changes:** if the rendered output changes in places unrelated to the bug fix, it's blocked.
+
+### General backporting guidance
+
+- Backports must be minimal and focused on corrective action. Prefer smaller PRs targeting specific issues.
+- All backports should maintain consistent behavior across supported versions to ensure predictability during upgrades.
+- Each backport PR should include clear labeling (for example, `backport/<release>`) and link to the original fix or discussion for traceability.
+- Backported changes follow the same testing and documentation requirements as any mainline contribution. CI must pass and any altered functionality must be covered by tests.
+
+### Backporting commits in subdirectory versioning
+
+#### `format-patch`
+
+`git format-patch` will export the git commits to a series of patch files that can be applied to a different branch or a different sub-directory.
+
+To export the last 3 commits as patch files, run:
+
+```bash
+git format-patch HEAD^3
+```
+
+New files will be created starting with `0001-`, `0002-`, etc.
+
+#### Applying patch files without AI
+
+Suppose you have a patch file `0001-refactor-web-modeler-make-webapp-memory-config-dynam.patch` that you want to apply to the `charts/camunda-platform-8.7` directory:
+
+```bash
+git apply -p3 --directory=charts/camunda-platform-8.7 0001-refactor-web-modeler-make-webapp-memory-config-dynam.patch
+```
+
+In many cases, this will apply cleanly. If the command does not work, you can try using OpenCode or your editor's AI integration.
+
+#### Applying patch files with AI
+
+If you have an AI tool integrated into your IDE, a query you can use is:
+
+> I have exported commits as patch files starting with `000*.patch` using `git format-patch`. Please apply the patch to the `charts/camunda-platform-8.7` directory.

--- a/scripts/notify-pr-activity/main.go
+++ b/scripts/notify-pr-activity/main.go
@@ -91,20 +91,16 @@ func buildMessage() string {
 	prURL := mustEnv("PR_URL")
 	prNum := "#" + mustEnv("PR_NUMBER")
 	prTitle := mustEnv("PR_TITLE")
-	author := "@" + mustEnv("PR_AUTHOR")
 
 	link := fmt.Sprintf("<%s|%s %s>", prURL, prNum, prTitle)
 
 	switch action {
 	case "opened", "ready_for_review":
-		size := fmt.Sprintf("+%s/-%s", mustEnv("PR_ADDITIONS"), mustEnv("PR_DELETIONS"))
 		reviewers := parseReviewers(os.Getenv("PR_REVIEWERS_JSON"))
-		reviewText := ""
 		if reviewers != "" {
-			reviewText = " · review: " + reviewers
+			return fmt.Sprintf("↗ [%s] %s — review: %s", repo, link, reviewers)
 		}
-		return fmt.Sprintf(":arrow_heading_up: [%s] PR opened · by %s%s · %s — %s",
-			repo, author, reviewText, size, link)
+		return fmt.Sprintf("↗ [%s] %s", repo, link)
 
 	case "closed":
 		merged := os.Getenv("PR_MERGED") == "true"
@@ -115,11 +111,10 @@ func buildMessage() string {
 			if err1 == nil && err2 == nil {
 				duration = formatDuration(createdAt, mergedAt)
 			}
-			return fmt.Sprintf(":tada: [%s] PR merged after %s · by %s — %s",
-				repo, duration, author, link)
+			numLink := fmt.Sprintf("<%s|%s>", prURL, prNum)
+			return fmt.Sprintf("✅ [%s] %s merged after %s", repo, numLink, duration)
 		}
-		return fmt.Sprintf(":x: [%s] PR closed without merge · by %s — %s",
-			repo, author, link)
+		return fmt.Sprintf("❌ [%s] %s", repo, link)
 
 	default:
 		fmt.Fprintf(os.Stderr, "error: unhandled action %q\n", action)
@@ -160,28 +155,10 @@ func sendSlack(webhook, message string) error {
 	return nil
 }
 
-// hasLabel reports whether the JSON label array contains a label with the given name.
-// The array has the shape [{"name":"automerge",...},...]
-func hasLabel(labelsJSON, name string) bool {
-	var labels []struct {
-		Name string `json:"name"`
-	}
-	if err := json.Unmarshal([]byte(labelsJSON), &labels); err != nil {
-		return false
-	}
-	for _, l := range labels {
-		if l.Name == name {
-			return true
-		}
-	}
-	return false
-}
-
 func main() {
-	// Renovate PRs labelled "automerge" are handled automatically and generate no useful signal.
-	// Renovate PRs without "automerge" (e.g. major updates) still need human attention — notify those.
-	if os.Getenv("PR_AUTHOR") == "renovate[bot]" && hasLabel(os.Getenv("PR_LABELS_JSON"), "automerge") {
-		fmt.Println("ℹ️  Skipping Slack notification: automerge Renovate PR.")
+	// Suppress notifications for all bot authors (e.g. renovate[bot], dependabot[bot]).
+	if strings.HasSuffix(os.Getenv("PR_AUTHOR"), "[bot]") {
+		fmt.Println("ℹ️  Skipping Slack notification: bot author.")
 		return
 	}
 

--- a/scripts/notify-pr-activity/main.go
+++ b/scripts/notify-pr-activity/main.go
@@ -85,6 +85,23 @@ func parseReviewers(raw string) string {
 	return strings.Join(names, ", ")
 }
 
+// hasLabel returns true if PR_LABELS_JSON contains a label with the given name.
+func hasLabel(name string) bool {
+	raw := os.Getenv("PR_LABELS_JSON")
+	var labels []struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal([]byte(raw), &labels); err != nil {
+		return false
+	}
+	for _, l := range labels {
+		if l.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
 func buildMessage() string {
 	action := mustEnv("GH_ACTION")
 	repo := shortRepo(mustEnv("PR_REPO"))
@@ -104,17 +121,18 @@ func buildMessage() string {
 
 	case "closed":
 		merged := os.Getenv("PR_MERGED") == "true"
-		if merged {
-			createdAt, err1 := time.Parse(timeLayout, mustEnv("PR_CREATED_AT"))
-			mergedAt, err2 := time.Parse(timeLayout, mustEnv("PR_MERGED_AT"))
-			duration := "unknown"
-			if err1 == nil && err2 == nil {
-				duration = formatDuration(createdAt, mergedAt)
-			}
-			numLink := fmt.Sprintf("<%s|%s>", prURL, prNum)
-			return fmt.Sprintf("✅ [%s] %s merged after %s", repo, numLink, duration)
+		if !merged {
+			// Closed without merge: no notification.
+			return ""
 		}
-		return fmt.Sprintf("❌ [%s] %s", repo, link)
+		createdAt, err1 := time.Parse(timeLayout, mustEnv("PR_CREATED_AT"))
+		mergedAt, err2 := time.Parse(timeLayout, mustEnv("PR_MERGED_AT"))
+		duration := "unknown"
+		if err1 == nil && err2 == nil {
+			duration = formatDuration(createdAt, mergedAt)
+		}
+		numLink := fmt.Sprintf("<%s|%s>", prURL, prNum)
+		return fmt.Sprintf("✅ [%s] %s merged after %s", repo, numLink, duration)
 
 	default:
 		fmt.Fprintf(os.Stderr, "error: unhandled action %q\n", action)
@@ -156,14 +174,19 @@ func sendSlack(webhook, message string) error {
 }
 
 func main() {
-	// Suppress notifications for all bot authors (e.g. renovate[bot], dependabot[bot]).
-	if strings.HasSuffix(os.Getenv("PR_AUTHOR"), "[bot]") {
-		fmt.Println("ℹ️  Skipping Slack notification: bot author.")
+	// Suppress notifications for bot authors, unless it's a renovate major-version update.
+	if strings.HasSuffix(os.Getenv("PR_AUTHOR"), "[bot]") && !hasLabel("upgrade:major") {
+		fmt.Println("ℹ️  Skipping Slack notification: bot author (non-major update).")
 		return
 	}
 
 	webhook := mustEnv("SLACK_WEBHOOK")
 	message := buildMessage()
+
+	if message == "" {
+		fmt.Println("ℹ️  Skipping Slack notification: no message to send (e.g. closed without merge).")
+		return
+	}
 
 	fmt.Printf("📣 Sending Slack notification: %s\n", message)
 

--- a/scripts/notify-pr-activity/main_test.go
+++ b/scripts/notify-pr-activity/main_test.go
@@ -1,0 +1,126 @@
+// Copyright 2025 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func setEnv(t *testing.T, kvs map[string]string) {
+	t.Helper()
+	for k, v := range kvs {
+		t.Setenv(k, v)
+	}
+}
+
+func baseEnv(action string) map[string]string {
+	return map[string]string{
+		"GH_ACTION": action,
+		"PR_REPO":   "camunda-platform-helm",
+		"PR_URL":    "https://github.com/camunda/camunda-platform-helm/pull/1",
+		"PR_NUMBER": "1",
+		"PR_TITLE":  "feat: something",
+	}
+}
+
+// TestBuildMessage_Opened checks that opened PRs produce a non-empty message.
+func TestBuildMessage_Opened(t *testing.T) {
+	setEnv(t, baseEnv("opened"))
+	t.Setenv("PR_REVIEWERS_JSON", "[]")
+	msg := buildMessage()
+	if msg == "" {
+		t.Fatal("expected non-empty message for opened PR")
+	}
+}
+
+// TestBuildMessage_ClosedMerged checks that merged PRs produce a non-empty message.
+func TestBuildMessage_ClosedMerged(t *testing.T) {
+	env := baseEnv("closed")
+	env["PR_MERGED"] = "true"
+	env["PR_CREATED_AT"] = "2025-01-01T10:00:00Z"
+	env["PR_MERGED_AT"] = "2025-01-01T14:00:00Z"
+	setEnv(t, env)
+	msg := buildMessage()
+	if msg == "" {
+		t.Fatal("expected non-empty message for merged PR")
+	}
+}
+
+// TestBuildMessage_ClosedUnmerged_Empty checks that closed-without-merge PRs produce no message.
+func TestBuildMessage_ClosedUnmerged_Empty(t *testing.T) {
+	env := baseEnv("closed")
+	env["PR_MERGED"] = "false"
+	setEnv(t, env)
+	msg := buildMessage()
+	if msg != "" {
+		t.Fatalf("expected empty message for unmerged closed PR, got: %q", msg)
+	}
+}
+
+// TestHasLabel_Present checks that hasLabel returns true when label is present.
+func TestHasLabel_Present(t *testing.T) {
+	t.Setenv("PR_LABELS_JSON", `[{"name":"upgrade:major"},{"name":"dependencies"}]`)
+	if !hasLabel("upgrade:major") {
+		t.Fatal("expected hasLabel to return true for upgrade:major")
+	}
+}
+
+// TestHasLabel_Absent checks that hasLabel returns false when label is absent.
+func TestHasLabel_Absent(t *testing.T) {
+	t.Setenv("PR_LABELS_JSON", `[{"name":"dependencies"}]`)
+	if hasLabel("upgrade:major") {
+		t.Fatal("expected hasLabel to return false when label absent")
+	}
+}
+
+// TestHasLabel_Empty checks that hasLabel returns false for an empty label list.
+func TestHasLabel_Empty(t *testing.T) {
+	t.Setenv("PR_LABELS_JSON", `[]`)
+	if hasLabel("upgrade:major") {
+		t.Fatal("expected hasLabel to return false for empty labels")
+	}
+}
+
+// TestFormatDuration verifies the duration formatting helper.
+func TestFormatDuration(t *testing.T) {
+	base := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	cases := []struct {
+		addHours int
+		want     string
+	}{
+		{0, "< 1h"},
+		{3, "3h"},
+		{25, "1d 1h"},
+		{48, "2d"},
+	}
+	for _, c := range cases {
+		got := formatDuration(base, base.Add(time.Duration(c.addHours)*time.Hour))
+		if got != c.want {
+			t.Errorf("addHours=%d: got %q, want %q", c.addHours, got, c.want)
+		}
+	}
+}
+
+// TestParseReviewers checks the reviewer JSON parsing helper.
+func TestParseReviewers(t *testing.T) {
+	os.Setenv("PR_REVIEWERS_JSON", `[{"login":"alice"},{"login":"bob"}]`)
+	got := parseReviewers(`[{"login":"alice"},{"login":"bob"}]`)
+	want := "@alice, @bob"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Goal: Making GH notifications less noisy.

- **notify-pr-activity**: single emoji per event (↗/✅/❌), drop diff counts (`+42/-7`) and `by @author`, suppress all `[bot]` authors (previously only `renovate[bot]` + automerge)
- **triage-ai-issue**: replace per-kind emoji variable with single 🎫; prepend `⚠️ HIGH` / `🚨 CRITICAL` for high/critical severity only; remove kind field from message

## Message formats after change

**PR activity:**
```
↗ [helm] #783 feat: add dedicated node pool — review: @hamza-m-masood
✅ [helm] #783 merged after 3h
❌ [helm] #5843 deps: update module github.com/jackc/pgx
```

**Issue triage:**
```
🎫 [helm] #6183 bug: zeebeGateway tag not linked to zeebe when unset in 8.6/8.7
🎫 [helm] #6192 ⚠️ HIGH — ci(8.10): Add RDBMS nightly E2E and upgrade-minor scenario coverage
```

## Test plan
- [ ] Trigger a PR open/merge/close event and verify Slack message format
- [ ] Trigger issue triage on a high/critical issue and verify severity prefix appears
- [ ] Trigger issue triage on a low/mid issue and verify no severity prefix
- [ ] Verify a `dependabot[bot]` PR produces no Slack notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)