### PR TITLE
chore: add Helm-only re-release process to release-process.md

### DIFF
--- a/docs/reference/release-process.md
+++ b/docs/reference/release-process.md
@@ -120,6 +120,58 @@ The charts are built, linted, and tested on every push to the main branch. The r
    - [Version matrix](https://helm.camunda.io/camunda-platform/version-matrix/) (component versions for each chart release).
    - Public values files at `helm.camunda.io/camunda-platform/values/`.
 
+## Helm-Only Re-Release (Without Release Train)
+
+Use this process when a Helm Chart fix is needed (e.g. incorrect image tag, chart misconfiguration) that does not require a full release train. No application components are re-released.
+
+### When to Use
+
+- A released Helm Chart contains an error (e.g. wrong image tag, misconfigured value).
+- The fix is limited to the Helm Chart — no new application component versions are involved.
+- A full release train would be overkill.
+
+### Prerequisites
+
+- The fix is already merged to `main` (via Renovatebot automerge or a manual PR).
+- The dev build workflow (`chart-build-dev.yaml`) has run successfully and produced a new dev package.
+
+### Steps
+
+1. **Promote a new RC** — Manually trigger `chart-promote-rc.yaml` with the latest dev tag (e.g. `{chart-major}-dev-latest`). This creates a new RC tag (e.g. `{chart-major}-rc-latest`).
+
+2. **Notify QA** — Ping `@qa-automated-release-manager` in `#c8-release-announcements` requesting a Helm Chart release test against the RC tag.
+   - QA inputs: Branch = `main`, Directory = `camunda-platform-{CAMUNDA_VERSION}`.
+   - Do not specify individual component versions when testing an OCI tag — use the RC tag directly.
+
+3. **Await QA sign-off** — Wait for QA to confirm all test runs passed.
+
+4. **Trigger public release** — Manually trigger `chart-release-public.yaml` with the RC tag. This publishes the corrected chart to GitHub Releases and updates the Helm repo index.
+
+5. **Make sure the release-please PR is merged** — Should be automated — just confirm the release-please PR was merged with the correct released version.
+
+6. **Notify support** — Post a message in `#ask-support` using the template below.
+
+### Notes
+
+- **Chart versioning:** re-running with no chart changes defaults release-please to a minor version bump.
+- If the fix is not yet in the dev package, manually trigger `chart-build-dev.yaml` (individual component version inputs can be overridden).
+- This process is for Self-Managed only — no SaaS rollout is involved.
+
+### #ask-support Notification Template
+
+```
+Hi team,
+
+We have released a Helm Chart correction for Camunda {CAMUNDA_VERSION} (Self-Managed only — no release train).
+
+*Reason:* {BRIEF_DESCRIPTION_OF_THE_FIX}
+
+*What's new in this release:*
+- Camunda Platform (Helm) {CAMUNDA_VERSION}-{HELM_VERSION} (https://github.com/camunda/camunda-platform-helm/releases/tag/camunda-platform-{CAMUNDA_VERSION}-{HELM_VERSION})
+
+@distribution-release-manager
+```
+
 ## Release Process Flowchart
 
 ```mermaid

--- a/docs/reference/release-process.md
+++ b/docs/reference/release-process.md
@@ -133,28 +133,28 @@ Use this process when a Helm Chart fix is needed (e.g. incorrect image tag, char
 ### Prerequisites
 
 - The fix is already merged to `main` (via Renovatebot automerge or a manual PR).
-- The dev build workflow (`chart-build-dev.yaml`) has run successfully and produced a new dev package.
 
 ### Steps
 
-1. **Promote a new RC** — Manually trigger `chart-promote-rc.yaml` with the latest dev tag (e.g. `{chart-major}-dev-latest`). This creates a new RC tag (e.g. `{chart-major}-rc-latest`).
+1. **Trigger a dev build** — Manually trigger `chart-build-dev.yaml` if the automatic post-merge build has not yet produced a package, or if you need to pin specific component image versions rather than taking the latest. Individual component version inputs can be overridden in the workflow dispatch form.
 
-2. **Notify QA** — Ping `@qa-automated-release-manager` in `#c8-release-announcements` requesting a Helm Chart release test against the RC tag.
+2. **Promote a new RC** — Manually trigger `chart-promote-rc.yaml` with the dev tag produced in Step 1 (e.g. `{version}-dev-{sha}` or `{chart-major}-dev-latest`). This creates a new RC tag (e.g. `{chart-major}-rc-latest`).
+
+3. **Notify QA** — Ping `@qa-automated-release-manager` in `#c8-release-announcements` requesting a Helm Chart release test against the RC tag.
    - QA inputs: Branch = `main`, Directory = `camunda-platform-{CAMUNDA_VERSION}`.
    - Do not specify individual component versions when testing an OCI tag — use the RC tag directly.
 
-3. **Await QA sign-off** — Wait for QA to confirm all test runs passed.
+4. **Await QA sign-off** — Wait for QA to confirm all test runs passed.
 
-4. **Trigger public release** — Manually trigger `chart-release-public.yaml` with the RC tag. This publishes the corrected chart to GitHub Releases and updates the Helm repo index.
+5. **Trigger public release** — Manually trigger `chart-release-public.yaml` with the RC tag. This publishes the corrected chart to GitHub Releases and updates the Helm repo index.
 
-5. **Make sure the release-please PR is merged** — Should be automated — just confirm the release-please PR was merged with the correct released version.
+6. **Make sure the release-please PR is merged** — Should be automated — just confirm the release-please PR was merged with the correct released version.
 
-6. **Notify support** — Post a message in `#ask-support` using the template below.
+7. **Notify support** — Post a message in `#ask-support` using the template below.
 
 ### Notes
 
 - **Chart versioning:** re-running with no chart changes defaults release-please to a minor version bump.
-- If the fix is not yet in the dev package, manually trigger `chart-build-dev.yaml` (individual component version inputs can be overridden).
 - This process is for Self-Managed only — no SaaS rollout is involved.
 
 ### #ask-support Notification Template

--- a/docs/reference/release-process.md
+++ b/docs/reference/release-process.md
@@ -136,9 +136,9 @@ Use this process when a Helm Chart fix is needed (e.g. incorrect image tag, char
 
 ### Steps
 
-1. **Trigger a dev build** — Manually trigger `chart-build-dev.yaml` if the automatic post-merge build has not yet produced a package, or if you need to pin specific component image versions rather than taking the latest. Individual component version inputs can be overridden in the workflow dispatch form.
+1. **Trigger a dev build** — Manually trigger [`chart-build-dev.yaml`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/chart-build-dev.yaml) if the automatic post-merge build has not yet produced a package, or if you need to pin specific component image versions rather than taking the latest. Individual component version inputs can be overridden in the workflow dispatch form.
 
-2. **Promote a new RC** — Manually trigger `chart-promote-rc.yaml` with the dev tag produced in Step 1 (e.g. `{version}-dev-{sha}` or `{chart-major}-dev-latest`). This creates a new RC tag (e.g. `{chart-major}-rc-latest`).
+2. **Promote a new RC** — Manually trigger [`chart-promote-rc.yaml`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/chart-promote-rc.yaml) with the dev tag produced in Step 1 (e.g. `{version}-dev-{sha}` or `{chart-major}-dev-latest`). This creates a new RC tag (e.g. `{chart-major}-rc-latest`).
 
 3. **Notify QA** — Ping `@qa-automated-release-manager` in `#c8-release-announcements` requesting a Helm Chart release test against the RC tag.
    - QA inputs: Branch = `main`, Directory = `camunda-platform-{CAMUNDA_VERSION}`.
@@ -146,15 +146,15 @@ Use this process when a Helm Chart fix is needed (e.g. incorrect image tag, char
 
 4. **Await QA sign-off** — Wait for QA to confirm all test runs passed.
 
-5. **Trigger public release** — Manually trigger `chart-release-public.yaml` with the RC tag. This publishes the corrected chart to GitHub Releases and updates the Helm repo index.
+5. **Trigger public release** — Manually trigger [`chart-release-public.yaml`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/chart-release-public.yaml) with the RC tag. This publishes the corrected chart to GitHub Releases and updates the Helm repo index.
 
-6. **Make sure the release-please PR is merged** — Should be automated — just confirm the release-please PR was merged with the correct released version.
+6. **Make sure the release-please PR is merged** — Auto-merge is attempted but best-effort; confirm the release-please PR was merged with the correct released version, and merge it manually if needed.
 
 7. **Notify support** — Post a message in `#ask-support` using the template below.
 
 ### Notes
 
-- **Chart versioning:** re-running with no chart changes defaults release-please to a minor version bump.
+- **Chart versioning:** the release version is determined by the workflows — [`chart-build-dev.yaml`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/chart-build-dev.yaml) derives the version from a release-please dry-run (falling back to the current `Chart.yaml` version), and [`chart-promote-rc.yaml`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/chart-promote-rc.yaml) forces `--release-as` to the version parsed from the selected dev tag.
 - This process is for Self-Managed only — no SaaS rollout is involved.
 
 ### #ask-support Notification Template


### PR DESCRIPTION
## Summary

- Adds `## Helm-Only Re-Release (Without Release Train)` section to `docs/release-process.md`
- Documents the lightweight process for releasing a Helm Chart fix without a full release train
- Covers when to use it, prerequisites, step-by-step process, notes, and an `#ask-support` notification template

🤖 Generated with [Claude Code](https://claude.com/claude-code)