### PR TITLE
fix: update console custom-properties Camunda URL to www.camunda.com

### DIFF
--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/base-qa.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/base-qa.yaml
@@ -158,7 +158,7 @@ camundaHub:
                       - description: "This is the main integration environment for the Camunda Platform."
                         links:
                           - name: "Camunda"
-                            url: "https://camunda.com"
+                            url: "https://www.camunda.com"
                           - name: "Camunda Docs"
                             url: "https://docs.camunda.io"
     env:

--- a/charts/camunda-platform-8.5/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch-mt.yaml
+++ b/charts/camunda-platform-8.5/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-qa-elasticsearch-mt.yaml
@@ -45,7 +45,7 @@ console:
                 - description: "This is the main integration environment for the Camunda Platform."
                   links:
                     - name: "Camunda"
-                      url: "https://camunda.com"
+                      url: "https://www.camunda.com"
                     - name: "Camunda Docs"
                       url: "https://docs.camunda.io"
   env:

--- a/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-oidc.yaml
+++ b/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values-integration-test-ingress-oidc.yaml
@@ -120,7 +120,7 @@ console:
                 - description: "This is the main integration environment for the Camunda Platform."
                   links:
                     - name: "Camunda"
-                      url: "https://camunda.com"
+                      url: "https://www.camunda.com"
                     - name: "Camunda Docs"
                       url: "https://docs.camunda.io"
   env:

--- a/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values/base-qa.yaml
+++ b/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values/base-qa.yaml
@@ -23,7 +23,7 @@ console:
                 - description: "This is the main integration environment for the Camunda Platform."
                   links:
                     - name: "Camunda"
-                      url: "https://camunda.com"
+                      url: "https://www.camunda.com"
                     - name: "Camunda Docs"
                       url: "https://docs.camunda.io"
   env:

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/base-qa.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/base-qa.yaml
@@ -92,7 +92,7 @@ console:
                 - description: "This is the main integration environment for the Camunda Platform."
                   links:
                     - name: "Camunda"
-                      url: "https://camunda.com"
+                      url: "https://www.camunda.com"
                     - name: "Camunda Docs"
                       url: "https://docs.camunda.io"
   env:

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/base-qa.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/base-qa.yaml
@@ -138,7 +138,7 @@ console:
                 - description: "This is the main integration environment for the Camunda Platform."
                   links:
                     - name: "Camunda"
-                      url: "https://camunda.com"
+                      url: "https://www.camunda.com"
                     - name: "Camunda Docs"
                       url: "https://docs.camunda.io"
   env:


### PR DESCRIPTION
## Summary

- `https://camunda.com` now redirects to `https://www.camunda.com`
- The E2E `assertCustomPropertyIsNavigated` uses Playwright's `toHaveURL()` which checks the **final URL after redirect**, causing the console custom-properties link test to fail across all supported versions
- Updated the `url` in `overrideConfiguration`/`extraConfiguration` from `https://camunda.com` → `https://www.camunda.com` in all affected scenario values files (8.5, 8.7 ×2, 8.8, 8.9, 8.10)

## Files changed

| Version | File |
|---------|------|
| 8.5 | `values-integration-test-ingress-qa-elasticsearch-mt.yaml` |
| 8.7 | `values/base-qa.yaml`, `values-integration-test-ingress-oidc.yaml` |
| 8.8 | `values/base-qa.yaml` |
| 8.9 | `values/base-qa.yaml` |
| 8.10 | `values/base-qa.yaml` |

## Related

> Note: The matching E2E test assertions in `c8-cross-component-e2e-tests` (SM-8.7, 8.8, 8.9, 8.10 `console-user-flows.spec.ts`) also assert `'https://camunda.com'` and will need a coordinated update.

## Test plan

- [ ] Nightly matrix re-run for affected chart versions shows console custom-properties link test passing
- [ ] E2E PR in `c8-cross-component-e2e-tests` updated to assert `https://www.camunda.com` and linked here

🤖 Generated with [Claude Code](https://claude.com/claude-code)