### PR TITLE
ci: remove redundant branch-freshness check from PR conventions

### DIFF
--- a/.github/workflows/repo-pr-conventions.yaml
+++ b/.github/workflows/repo-pr-conventions.yaml
@@ -55,15 +55,3 @@ jobs:
           # merge commit, and it's easy to commit this by mistake. Enable this option
           # to also validate the commit message for one commit PRs.
           validateSingleCommit: true
-      - name: Checkout
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          fetch-depth: 0
-      - name: Ensure PR branch is up to date
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          (git rev-list --left-right --count origin/main...HEAD | grep -q "^0") \
-            || (echo "PR branch is not up to date with main. Please rebase or merge main into your branch." && exit 1) \
-            && echo "PR branch is up to date with main."


### PR DESCRIPTION
## Summary

- Removes the "Ensure PR branch is up to date" step from the Check PR Conventions workflow
- Removes the associated Checkout step that only existed to support it

## Why

The merge queue (ALLGREEN grouping, SQUASH method) already rebases onto main before merging. The workflow check creates a race condition: any commit landing on main between force-push and CI execution causes a spurious failure, requiring repeated rebases with no benefit.

Additionally, "Check PR Conventions" is not a required status check (only `CI Gate` and `license/cla` are), so the red X is purely noise that confuses contributors into unnecessary rebases.

## Evidence

PR #6036 failed this check immediately after a rebase because a commit landed on main during the ~10s between push and CI execution.