### PR TITLE
ci(links): add lychee-based global link validation workflow

### DIFF
--- a/.github/workflows/global-links.yaml
+++ b/.github/workflows/global-links.yaml
@@ -1,0 +1,78 @@
+name: "Chart - Validate All Documentation Links"
+
+# Lychee-based replacement for the bash composite at
+# .github/actions/validate-docs-links/. Tracked by issue #6218.
+#
+# This runs alongside the existing chart-validate-docs-links.yaml during the
+# migration window (see #6218 plan). On pull_request the lychee step is
+# soft-failing so PRs that touch unrelated Markdown are not blocked while we
+# clean up false positives; the scheduled run still hard-fails and opens a
+# tracking issue.
+#
+# Once the cron is green for a couple of cycles, drop the soft-fail and the
+# legacy chart-validate-docs-links.yaml workflow.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * *"  # Daily at 6 AM UTC.
+  pull_request:
+    paths:
+      - "**/*.md"
+      - "scripts/templates/**"
+      - "lychee-links.toml"
+      - ".github/workflows/global-links.yaml"
+
+permissions:
+  contents: read
+  issues: write  # only used by the scheduled-failure issue creation step.
+
+env:
+  IS_SCHEDULE: ${{ github.event_name == 'schedule' && 'true' || 'false' }}
+
+jobs:
+  lint:
+    name: links-check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+
+      - name: Compute today's cache key
+        run: echo "DATEOFDAY=$(date +%Y-%m-%d)" >> "$GITHUB_ENV"
+
+      - name: Lychee cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ env.DATEOFDAY }}
+          restore-keys: |
+            cache-lychee-
+
+      - name: Run lychee
+        id: lychee
+        # On pull_request, do not fail the job on broken links — surface them
+        # in the run summary instead. See file header for rationale.
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        with:
+          fail: true
+          args: >-
+            -c ./lychee-links.toml
+            --cache --max-cache-age 1d
+            --verbose --no-progress
+            '*.md'
+            './**/*.md'
+            './**/*.tpl'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Open tracking issue on scheduled failure
+        if: env.IS_SCHEDULE == 'true' && steps.lychee.outcome == 'failure'
+        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6
+        with:
+          title: "CI: scheduled link check found broken links"
+          content-filepath: ./lychee/out.md
+          labels: kind/chore,kind/docs

--- a/.github/workflows/global-links.yaml
+++ b/.github/workflows/global-links.yaml
@@ -23,17 +23,25 @@ on:
       - "lychee-links.toml"
       - ".github/workflows/global-links.yaml"
 
+# Cancel superseded PR runs (force-pushes), but let scheduled / dispatch runs
+# complete in order — they share a group keyed on github.ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+# Top-level least-privilege default. The optional `open-issue` job below
+# elevates only what it needs.
 permissions:
   contents: read
-  issues: write  # only used by the scheduled-failure issue creation step.
-
-env:
-  IS_SCHEDULE: ${{ github.event_name == 'schedule' && 'true' || 'false' }}
 
 jobs:
   lint:
     name: links-check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      lychee-outcome: ${{ steps.lychee.outcome }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -69,8 +77,34 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Open tracking issue on scheduled failure
-        if: env.IS_SCHEDULE == 'true' && steps.lychee.outcome == 'failure'
+      - name: Upload lychee report (for scheduled failures)
+        if: github.event_name == 'schedule' && steps.lychee.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: lychee-report
+          path: ./lychee/out.md
+          if-no-files-found: error
+          retention-days: 14
+
+  # Issue creation lives in a dedicated job so `issues: write` is granted only
+  # on scheduled runs, never on pull_request runs. Addresses the Copilot
+  # review comment on PR #6219.
+  open-issue:
+    name: open-tracking-issue
+    needs: [lint]
+    if: github.event_name == 'schedule' && needs.lint.outputs.lychee-outcome == 'failure'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Download lychee report
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: lychee-report
+          path: ./lychee
+
+      - name: Open tracking issue
         uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6
         with:
           title: "CI: scheduled link check found broken links"

--- a/lychee-links.toml
+++ b/lychee-links.toml
@@ -1,0 +1,40 @@
+# Lychee link-checker config — used by .github/workflows/global-links.yaml.
+# Reference: https://lychee.cli.rs/usage/config/
+
+# Network behaviour.
+max_concurrency = 24
+max_retries = 2
+retry_wait_time = 2
+timeout = 20
+
+# Accept these HTTP codes as valid (in addition to 2xx).
+# 401 / 403 / 429 typically mean "the server doesn't like CI traffic" rather
+# than a real broken link; rejecting them produces noise without value.
+accept = ["200..=299", "401", "403", "429"]
+
+# Skip URLs known to be unreliable on CI or that require auth.
+exclude = [
+  # Placeholders.
+  "^https?://example\\.(com|org|net)",
+  # Local-only.
+  "^https?://localhost",
+  "^https?://127\\.0\\.0\\.1",
+  # Auth-gated registries.
+  "^https?://registry\\.camunda\\.cloud",
+  # Camunda signup loop.
+  "^https?://signup\\.camunda\\.com",
+]
+
+exclude_mail = true
+exclude_loopback = true
+
+# Folders not worth scanning (build outputs, vendored content, generated sites).
+exclude_path = [
+  ".git",
+  "node_modules",
+  "helm-docs-site/build",
+  "helm-docs-site/.docusaurus",
+]
+
+# Quieter output for CI logs.
+no_progress = true


### PR DESCRIPTION
## Description

Adds a lychee-based global link-validation workflow at
`.github/workflows/global-links.yaml`, plus a `lychee-links.toml` config
at repo root.

Inspired by
[`camunda/camunda-deployment-references/.github/workflows/internal_global_links.yml`](https://github.com/camunda/camunda-deployment-references/blob/main/.github/workflows/internal_global_links.yml).

### Why

The existing `.github/workflows/chart-validate-docs-links.yaml` (bash +
curl composite) has three blind spots that #6216 / #6217 surfaced:

1. `pull_request` only fires when the workflow file itself is edited, so
   PRs that introduce broken links go through unchecked.
2. It only scans `charts/camunda-platform-<v>/` — so `version-matrix/`,
   `scripts/templates/`, `docs/`, top-level READMEs, ADRs, and
   `helm-docs-site/` are never validated.
3. It only matches `https://docs\.camunda\.` URLs; relative links,
   anchors, and external hosts are ignored.

### What's new

- **Lychee** ([`lycheeverse/lychee-action@v2.8.0`](https://github.com/lycheeverse/lychee-action))
  with markdown-aware extraction, a daily cache, and pinned by full SHA.
- Single TOML config (`lychee-links.toml`) for accept codes, retries,
  and excludes — no inline bash to maintain.
- Triggers:
  - `workflow_dispatch`
  - `schedule` (06:00 UTC, same as the legacy workflow)
  - `pull_request` on `**/*.md`, `scripts/templates/**`,
    `lychee-links.toml`, and the workflow itself.
- Scope: `'*.md'`, `'**/*.md'`, `'**/*.tpl'` — covers every Markdown
  file plus the gomplate templates under `scripts/templates/` (where
  the recent `install-bitnami-enterprise-images` 404 was hiding).
- Failure handling:
  - **PR**: the lychee step is `continue-on-error: true` so unrelated
    stale links elsewhere in the repo do not block doc PRs while we
    clean up. Broken links still show up red in the run summary.
  - **Schedule**: hard-fails and opens a tracking issue via
    `peter-evans/create-issue-from-file@v6` (labels
    `kind/chore,kind/docs`).

### Migration plan (per #6218)

1. **This PR**: land alongside the existing
   `chart-validate-docs-links.yaml` workflow — no removal yet.
2. After two clean cron cycles, drop the soft-fail in the PR job, then
   delete `.github/workflows/chart-validate-docs-links.yaml` and
   `.github/actions/validate-docs-links/`.

### Verification

- `yamllint` warnings are limited to repo-wide style preferences shared
  with the other workflows (no `---` document start, GitHub Actions'
  `on:` keyword); no real syntax errors.
- All third-party actions pinned by 40-char SHA with `# vX.Y.Z` comment,
  matching the supply-chain rule in `.github/instructions/code-review.instructions.md`.
- Will auto-run on this PR (touches `lychee-links.toml` and the new
  workflow), giving us a first real-world signal on false-positive
  count.

## Related

- Closes #6218
- Motivated by #6216 / #6217
- Reference: [camunda-deployment-references/.github/workflows/internal_global_links.yml](https://github.com/camunda/camunda-deployment-references/blob/main/.github/workflows/internal_global_links.yml)

## Definition of Done

- [x] Workflow + config added
- [x] Actions pinned by SHA
- [x] Documented migration path
- [ ] First scheduled run observed (post-merge follow-up)
