### PR TITLE
test(ci): add entv tier-2 integration scenario for enterprise values on 8.10

### DIFF
--- a/SKILLS.md
+++ b/SKILLS.md
@@ -731,7 +731,7 @@ awk '/shortname:/{s=$2} /enabled:/{e=$2} /tier:/{t=$2; print s, e, "tier", t}' \
 | 8.7  | `kemt`, `kerba`, `esoi`, `keyc`, `osem` |
 | 8.8  | `esoi`, `esarm`, `osem`, `docstr` |
 | 8.9  | `osem`, `esoi`, `kemt`, `kerba`, `keorg`, `gatkc`, `esarm`, `nosec`, `docstr`, `rdbms` |
-| 8.10 | `osem`, `keorg`, `gatkc`, `esarm`, `nosec`, `docstr`, `rdbms`, `huble` |
+| 8.10 | `osem`, `keorg`, `gatkc`, `esarm`, `nosec`, `docstr`, `rdbms`, `huble`, `entv` |
 
 `osex` (external AWS OpenSearch, #6119) and `oske` (Bitnami OpenSearch subchart, #6121) are defined but currently disabled.
 
@@ -748,7 +748,7 @@ awk '/shortname:/{s=$2} /enabled:/{e=$2} /tier:/{t=$2; print s, e, "tier", t}' \
 | `esarm` | ARM Elasticsearch |
 | `docstr` | document store feature |
 | `huble` | hub-legacy feature |
-| `entv` | enterprise values overlay (`values-enterprise.yaml`; tier-1 on 8.10 initially, tier-2 once validated) |
+| `entv` | enterprise values overlay (`values-enterprise.yaml`) |
 
 ### Select Scenarios
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -748,6 +748,7 @@ awk '/shortname:/{s=$2} /enabled:/{e=$2} /tier:/{t=$2; print s, e, "tier", t}' \
 | `esarm` | ARM Elasticsearch |
 | `docstr` | document store feature |
 | `huble` | hub-legacy feature |
+| `entv` | enterprise values overlay (`values-enterprise.yaml`; tier-1 on 8.10 initially, tier-2 once validated) |
 
 ### Select Scenarios
 
@@ -762,6 +763,7 @@ Default: tier-1 on every affected version. Add tier-2 entries only when the diff
 | Document store feature 8.8+ | `eske` + `docstr` per version |
 | Hub change on 8.10 | `eske` + `huble` |
 | `_helpers.tpl` change | tier-1 all versions + `nosec`, `docstr` |
+| `values-enterprise.yaml` or enterprise image tags | `entv` on each affected version |
 
 **Skip the matrix** for `.github/workflows/*` (run `actionlint`), `scripts/` Go tooling (`make go.test`), Dockerfile-only (`hadolint`, `docker build --target`), compose-only (`docker compose config`), docs-only.
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -763,7 +763,7 @@ Default: tier-1 on every affected version. Add tier-2 entries only when the diff
 | Document store feature 8.8+ | `eske` + `docstr` per version |
 | Hub change on 8.10 | `eske` + `huble` |
 | `_helpers.tpl` change | tier-1 all versions + `nosec`, `docstr` |
-| `values-enterprise.yaml` or enterprise image tags | `entv` on each affected version |
+| `values-enterprise.yaml` or enterprise image tags | `entv` on each version where it is defined (8.10 only until backports land) |
 
 **Skip the matrix** for `.github/workflows/*` (run `actionlint`), `scripts/` Go tooling (`make go.test`), Dockerfile-only (`hadolint`, `docker build --target`), compose-only (`docker compose config`), docs-only.
 

--- a/charts/camunda-platform-8.10/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.10/test/ci-test-config.yaml
@@ -24,7 +24,7 @@ unit:
 #      identity: keycloak        # Explicit: keycloak, keycloak-external, oidc, basic, hybrid
 #      persistence: elasticsearch # Explicit: elasticsearch, opensearch, rdbms, rdbms-oracle
 #      platform: gke             # Explicit: gke, eks, openshift
-#      features: [multitenancy]  # Explicit: multitenancy, rba, documentstore
+#      features: [multitenancy]  # Explicit: any filename (without .yaml) from test/integration/scenarios/chart-full-setup/values/features/
 #      qa: true                  # Enable QA config
 #      upgrade: false            # Enable upgrade flow config
 #
@@ -71,7 +71,7 @@ integration:
             gke: distroci
           identity: keycloak
           persistence: elasticsearch
-          features: [enterprise]
+          features: [enterprise]  # symlink: values/features/enterprise.yaml -> values-enterprise.yaml
           platforms: [gke]
         - name: opensearch
           enabled: false  # Disabled: Bitnami OpenSearch subchart is unstable in CI; tracked in #6121

--- a/charts/camunda-platform-8.10/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.10/test/ci-test-config.yaml
@@ -63,7 +63,7 @@ integration:
         - name: enterprise-values
           enabled: true
           shortname: entv
-          tier: 1
+          tier: 2
           auth: keycloak
           flow: install
           exclude: []

--- a/charts/camunda-platform-8.10/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.10/test/ci-test-config.yaml
@@ -60,6 +60,19 @@ integration:
           identity: keycloak
           persistence: elasticsearch
           platforms: [gke]  # EKS removed: external ES connectivity issues cause Zeebe pods to never become ready on EKS
+        - name: enterprise-values
+          enabled: true
+          shortname: entv
+          tier: 1
+          auth: keycloak
+          flow: install
+          exclude: []
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          features: [enterprise]
+          platforms: [gke]
         - name: opensearch
           enabled: false  # Disabled: Bitnami OpenSearch subchart is unstable in CI; tracked in #6121
           auth: keycloak

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/enterprise.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/enterprise.yaml
@@ -1,0 +1,1 @@
+../../../../../../values-enterprise.yaml


### PR DESCRIPTION
## Summary

Closes #6220 (partial — 8.10 only; backports to 8.9/8.8/8.7 follow in separate PRs).

- Adds `features/enterprise.yaml` as a symlink to `values-enterprise.yaml` in the 8.10 scenario values directory, enabling it as a composable feature layer with no content duplication.
- Adds the `entv` (enterprise-values) scenario to `charts/camunda-platform-8.10/test/ci-test-config.yaml` at **tier 2**, so it runs in the merge queue and validates enterprise images before any PR merges.
- Updates `SKILLS.md` variant decoder and tier-2 shortname table.

The scenario mirrors the `eske` baseline (Elasticsearch + Keycloak, GKE distroci) with `values-enterprise.yaml` layered on top. The `registry-camunda-cloud` pull secret is already created by the CI runner — no workflow changes required.

The scenario was initially added at tier 1 on this PR to confirm it works end-to-end. The tier-1 run passed (all enterprise images pulled from `registry.camunda.cloud`, all pods healthy, ES cluster GREEN). The scenario was then promoted to tier 2 in the same branch before merge.

## Test plan

- [x] `entv` tier-1 run on this PR passed — all enterprise images resolved, full install succeeded on GKE
- [x] All 8.10 unit tests pass (`make go.test chartPath=charts/camunda-platform-8.10`)
- [ ] `entv` runs as tier-2 (merge queue) on subsequent PRs touching `values-enterprise.yaml` or enterprise-related templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)