### PR TITLE
test(ci): add entv tier-2 integration scenario for enterprise values on 8.7

### DIFF
--- a/SKILLS.md
+++ b/SKILLS.md
@@ -728,7 +728,7 @@ awk '/shortname:/{s=$2} /enabled:/{e=$2} /tier:/{t=$2; print s, e, "tier", t}' \
 
 | Version | Shortnames |
 |---|---|
-| 8.7  | `kemt`, `kerba`, `esoi`, `keyc`, `osem` |
+| 8.7  | `kemt`, `kerba`, `esoi`, `keyc`, `osem`, `entv` |
 | 8.8  | `esoi`, `esarm`, `osem`, `docstr` |
 | 8.9  | `osem`, `esoi`, `kemt`, `kerba`, `keorg`, `gatkc`, `esarm`, `nosec`, `docstr`, `rdbms` |
 | 8.10 | `osem`, `keorg`, `gatkc`, `esarm`, `nosec`, `docstr`, `rdbms`, `huble`, `entv` |

--- a/charts/camunda-platform-8.7/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.7/test/ci-test-config.yaml
@@ -36,6 +36,21 @@ integration:
             gke: distroci
             eks: preemptible
           platforms: [gke]  # EKS removed: Playwright ITs fail due to pods not recovering on EKS (newly exposed by ExternalSecrets fix)
+        - name: enterprise-values
+          enabled: true
+          shortname: entv
+          tier: 2
+          auth: keycloak
+          flow: install
+          exclude: []
+          helmVersion: 3.20.2
+          skip-e2e: true  # 8.7 web-modeler-restapi has a known unresponsiveness bug
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          features: [enterprise]  # symlink: values/features/enterprise.yaml -> values-enterprise.yaml
+          platforms: [gke]
         - name: keycloak-mt
           enabled: true
           shortname: kemt

--- a/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values/features/enterprise.yaml
+++ b/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values/features/enterprise.yaml
@@ -1,0 +1,1 @@
+../../../../../../values-enterprise.yaml


### PR DESCRIPTION
## Summary

Backport of #6222 to chart version 8.7. Part of #6220.

- Adds `features/enterprise.yaml` as a symlink to `values-enterprise.yaml` in the 8.7 scenario values directory.
- Adds the `entv` (enterprise-values) scenario to `charts/camunda-platform-8.7/test/ci-test-config.yaml` at tier 2, so it runs in the merge queue and validates enterprise images before any PR merges.
- Updates `SKILLS.md` tier-2 shortname table for 8.7.

The scenario mirrors the `eske` baseline (Elasticsearch + Keycloak, GKE distroci) with `values-enterprise.yaml` layered on top. Includes `helmVersion: 3.20.2` and `skip-e2e: true` consistent with other 8.7 tier-2 scenarios (known web-modeler-restapi unresponsiveness bug). The `registry-camunda-cloud` pull secret is already created by the CI runner — no workflow changes required.

## Test plan

- [ ] `entv` scenario appears in `deploy-camunda matrix list --versions 8.7 --shortname-filter entv`
- [ ] CI runs the `entv` integration test and it passes (all pods healthy, no ImagePullBackOff)
- [ ] All 8.7 unit tests pass (`make go.test chartPath=charts/camunda-platform-8.7`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)