### PR TITLE
chore: add ci key to override namespace prefix

### DIFF
--- a/charts/camunda-platform-8.8/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.8/test/ci-test-config.yaml
@@ -424,6 +424,7 @@ integration:
           enabled: false
           flow: install
           shortname: qaosupg
+          prefix-key: qa-opensearch-upg
           auth: keycloak
           identity: keycloak
           persistence: opensearch-embedded

--- a/charts/camunda-platform-8.9/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.9/test/ci-test-config.yaml
@@ -556,6 +556,7 @@ integration:
           enabled: false
           flow: modular-upgrade-minor
           shortname: qaosupg
+          prefix-key: qa-opensearch-upg
           auth: keycloak
           identity: keycloak
           persistence: opensearch-embedded

--- a/scripts/deploy-camunda/deploy/scenario_test.go
+++ b/scripts/deploy-camunda/deploy/scenario_test.go
@@ -255,6 +255,50 @@ func TestCrossJobPrefixConsistency(t *testing.T) {
 	}
 }
 
+func TestPrefixKeyOverridesScenarioName(t *testing.T) {
+	// Simulate the cross-version upgrade issue: 8.8 uses scenario name
+	// "qa-opensearch-tasklist-v1" while 8.9 uses "qa-opensearch-upg".
+	// When prefix-key is used to pin both to "qa-opensearch-upg", the
+	// prefixes must match despite different scenario names.
+	namespace := "matrix-88-qaosupg-inst-gke"
+
+	// Job 1: install on 8.8 (scenario="qa-opensearch-tasklist-v1", prefix-key="qa-opensearch-upg")
+	installFlags := &config.RuntimeFlags{
+		Deployment: config.DeploymentFlags{
+			Namespace: namespace,
+			Scenarios: []string{"qa-opensearch-tasklist-v1"},
+		},
+	}
+	// PinScenarioPrefixes called with prefix-key value, not scenario name
+	if err := PinScenarioPrefixes("qa-opensearch-upg", installFlags); err != nil {
+		t.Fatalf("PinScenarioPrefixes (install): %v", err)
+	}
+
+	// Job 2: upgrade on 8.9 (scenario="qa-opensearch-upg", prefix-key="qa-opensearch-upg")
+	upgradeFlags := &config.RuntimeFlags{
+		Deployment: config.DeploymentFlags{
+			Namespace: namespace,
+			Scenarios: []string{"qa-opensearch-upg"},
+		},
+	}
+	if err := PinScenarioPrefixes("qa-opensearch-upg", upgradeFlags); err != nil {
+		t.Fatalf("PinScenarioPrefixes (upgrade): %v", err)
+	}
+
+	if installFlags.Index.OrchestrationIndexPrefix != upgradeFlags.Index.OrchestrationIndexPrefix {
+		t.Errorf("OrchestrationIndexPrefix mismatch: install=%q upgrade=%q",
+			installFlags.Index.OrchestrationIndexPrefix, upgradeFlags.Index.OrchestrationIndexPrefix)
+	}
+	if installFlags.Index.OptimizeIndexPrefix != upgradeFlags.Index.OptimizeIndexPrefix {
+		t.Errorf("OptimizeIndexPrefix mismatch: install=%q upgrade=%q",
+			installFlags.Index.OptimizeIndexPrefix, upgradeFlags.Index.OptimizeIndexPrefix)
+	}
+	if installFlags.Auth.KeycloakRealm != upgradeFlags.Auth.KeycloakRealm {
+		t.Errorf("KeycloakRealm mismatch: install=%q upgrade=%q",
+			installFlags.Auth.KeycloakRealm, upgradeFlags.Auth.KeycloakRealm)
+	}
+}
+
 func TestNormalizeIdentifierPart(t *testing.T) {
 	tests := []struct {
 		input string

--- a/scripts/deploy-camunda/matrix/config.go
+++ b/scripts/deploy-camunda/matrix/config.go
@@ -175,6 +175,14 @@ type CIScenario struct {
 	// Each dependency is deployed as a separate Helm release in the same namespace.
 	Dependencies []ChartDependency `yaml:"dependencies,omitempty"`
 
+	// PrefixKey, when set, overrides the scenario name for index prefix
+	// derivation. This ensures that two scenarios with different names but
+	// representing the same logical deployment (e.g., across chart versions)
+	// produce identical index prefixes. Without this, an install on version A
+	// (scenario name X) and an upgrade on version B (scenario name Y) would
+	// generate different prefixes, breaking the upgrade.
+	PrefixKey string `yaml:"prefix-key,omitempty"`
+
 	// PreInstall declares a fixture or script to run before helm install for
 	// this scenario. Replaces the legacy filename-derived discovery
 	// (pre-install-<scenario>.sh) with an explicit, reviewable reference.

--- a/scripts/deploy-camunda/matrix/matrix.go
+++ b/scripts/deploy-camunda/matrix/matrix.go
@@ -60,6 +60,11 @@ type Entry struct {
 	// HelmVersion, when non-empty, tells the integration workflow to install
 	// this Helm version via azure/setup-helm (overriding the pre-baked binary).
 	HelmVersion string `json:"helmVersion,omitempty"`
+
+	// PrefixKey overrides the scenario name for index prefix derivation.
+	// When set, generateScenarioContext uses this instead of Entry.Scenario
+	// to compute orchestration/optimize/tasklist/operate index prefixes.
+	PrefixKey string `json:"prefixKey,omitempty"`
 }
 
 // GenerateOptions controls matrix generation.
@@ -212,7 +217,8 @@ func Generate(repoRoot string, opts GenerateOptions) ([]Entry, error) {
 						PreInstall:   scenario.PreInstall,
 						PostDeploy:   scenario.PostDeploy,
 						PreUpgrade:   preUpgrade,
-						HelmVersion: scenario.HelmVersion,
+						HelmVersion:  scenario.HelmVersion,
+						PrefixKey:    scenario.PrefixKey,
 					})
 				}
 			}

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -1852,6 +1852,17 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions, entryIndex 
 	var deployErr error
 	var diag string
 
+	// When prefix-key is set, pin index prefixes using the prefix-key instead of
+	// the scenario name. This ensures cross-version consistency: an install on 8.8
+	// (scenario name "qa-opensearch-tasklist-v1") and an upgrade on 8.9
+	// (scenario name "qa-opensearch-upg") produce identical prefixes when both
+	// declare the same prefix-key.
+	if entry.PrefixKey != "" {
+		if err := deploy.PinScenarioPrefixes(entry.PrefixKey, flags); err != nil {
+			return RunResult{Entry: entry, Namespace: namespace, KubeContext: kubeCtx, Error: fmt.Errorf("pin scenario prefixes (prefix-key=%s): %w", entry.PrefixKey, err)}
+		}
+	}
+
 	// Override chart source when --chart-ref is set (OCI install path).
 	// See applyChartRefOverride for details.
 	applyChartRefOverride(&flags.Chart, opts)


### PR DESCRIPTION
### Which problem does the PR fix?

closes https://github.com/camunda/camunda-platform-helm/issues/6232

Regarding the 8.8 and 8.9 [test failures](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/26269144722/job/77377363763) on opensearch upgrade-minor, I'm noticing that the prefix seems to be inconsistent between 8.8 (before upgrade) and 8.9 (after upgrade)

<img width="3181" height="682" alt="image" src="https://github.com/user-attachments/assets/a06a0faa-7c8e-4b1a-bae3-5a2053424495" />


[https://github.com/camunda/camunda-platform-helm/blob/77ff360ba0e8dd95766acdfd881c[…]bfa22bdc45/charts/camunda-platform-8.8/test/ci-test-config.yaml](https://github.com/camunda/camunda-platform-helm/blob/77ff360ba0e8dd95766acdfd881c73bfa22bdc45/charts/camunda-platform-8.8/test/ci-test-config.yaml#L436)
it looks like the prefix is coming from the name parameter in ci-test-config. so when QA requests to run qaosupg on 8.8 and upgrade to qaosupg on 8.9 , they are getting two different index prefixes.

[https://github.com/camunda/camunda-platform-helm/blob/77ff360ba0e8dd95766acdfd881c[…]bfa22bdc45/charts/camunda-platform-8.9/test/ci-test-config.yaml](https://github.com/camunda/camunda-platform-helm/blob/77ff360ba0e8dd95766acdfd881c73bfa22bdc45/charts/camunda-platform-8.9/test/ci-test-config.yaml#L567-L569)

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

### What's in this PR?

Make the prefix configurable instead of just using the name from `ci-test-config.yaml`

<!--
  Explain the contents of the PR.
  Give an overview of the implementation, which decisions were made, and why.
-->

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
