### PR TITLE
chore: document and unify PR title type conventions across AGENTS.md, docs, and CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,6 +220,7 @@ helm template integration charts/camunda-platform-8.X \
 For PRs that touch only non-chart files, use:
 - `chore:` — docs, AGENTS.md, CLAUDE.md, SKILLS.md, README, scripts
 - `ci:` — `.github/` workflows or actions
+- `build:` — Makefile, tooling, dependency, or other build-system changes
 - `test:` — test files only
 
 See [Contribution & Collaboration](docs/contribution-and-collaboration.md) for the full PR checklist.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,6 +214,16 @@ helm template integration charts/camunda-platform-8.X \
 - Use present tense; keep subject under 120 characters.
 - **NEVER create merge commits.** Always use `git rebase` to incorporate upstream changes. If a branch needs to be updated from `main`, use `git rebase origin/main`, not `git merge`. Force-push with `--force-with-lease` after rebasing.
 
+### PR title type: CI-enforced constraint
+`feat:`, `fix:`, `refactor:`, `docs:`, and `revert:` are **reserved for PRs that change user-facing chart files** (anything under `charts/<version>/` except `test/`, `go.mod`, `go.sum`). CI rejects these types when no such files are changed — they feed into `RELEASE-NOTES.md` and `artifacthub.io/changes`.
+
+For PRs that touch only non-chart files, use:
+- `chore:` — docs, AGENTS.md, CLAUDE.md, SKILLS.md, README, scripts
+- `ci:` — `.github/` workflows or actions
+- `test:` — test files only
+
+See [Contribution & Collaboration](docs/contribution-and-collaboration.md) for the full PR checklist.
+
 ## Additional Agent Context
 - `CLAUDE.md` — thin redirect for Claude Code (redirects to this file, AGENTS.md)
 - `.github/AGENTS.md` — CI/CD architecture, repo structure, values files

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,19 +18,6 @@ For community-maintained Camunda projects, please visit the [Camunda Community H
   - [Commit message header](#commit-message-header)
 - [CI](#ci)
 - [Integration Testing](#integration-testing)
-  - [Overview](#overview)
-  - [Scenarios](#scenarios)
-  - [The deploy-camunda CLI (alpha)](#the-deploy-camunda-cli-alpha)
-    - [Installation](#installation)
-    - [Basic Usage](#basic-usage)
-    - [Key Flags](#key-flags)
-    - [Configuration File](#configuration-file)
-    - [Environment Variables](#environment-variables)
-  - [Requirements](#requirements)
-    - [For Camunda Employees](#for-camunda-employees)
-    - [For Community Contributors](#for-community-contributors)
-  - [Running E2E Tests After Deployment](#running-e2e-tests-after-deployment)
-  - [Troubleshooting](#troubleshooting)
 
 ## Prerequisites
 
@@ -107,9 +94,9 @@ The `main` branch contains the current in-development state of the project. To w
    ```
 
 5. Implement the required changes on your branch and regularly push your
-   changes to the origin so that the CI can run. Code formatting, style, and
-   license header are fixed automatically by running Maven. Checkstyle
-   violations have to be fixed manually.
+   changes to the origin so that the CI can run. Run `make go.fmt` to format
+   Go code and `make go.addlicense-run chartPath=...` to add missing license
+   headers before committing.
 
    ```
    git commit -am 'feat: add BPEL execution support'
@@ -148,20 +135,25 @@ The commit header should match the following pattern:
 %{type}: %{description}
 ```
 
-The commit header should be kept short, preferably under 72 chars but we allow a max of 120 chars.
+The commit header must be under 120 characters.
 
 - `type` should be one of:
-  - `build`: Changes that affect the build system (e.g. Maven, Docker, etc)
-  - `ci`: Changes to our CI configuration files and scripts (e.g. GitHub Actions, etc)
-  - `deps`: A change to the external dependencies (was already used by Dependabot)
-  - `docs`: A change to the documentation
-  - `feat`: A new feature (both internal or user-facing)
-  - `fix`: A bug fix (both internal or user-facing)
+  - `build`: Changes that affect the build system (e.g. Go toolchain, Docker, Makefile)
+  - `cd`: Changes to continuous delivery configuration
+  - `ci`: Changes to CI configuration files and scripts (e.g. GitHub Actions)
+  - `chore`: Maintenance, housekeeping, or non-functional changes
+  - `deps`: A change to external dependencies
+  - `docs`: A documentation change — **only valid when chart files under `charts/<version>/` are also changed**; use `chore:` for docs-only PRs
+  - `feat`: A new chart feature — requires changes to user-facing chart files under `charts/<version>/`
+  - `fix`: A bug fix — requires changes to user-facing chart files under `charts/<version>/`
   - `perf`: A code change that improves performance
-  - `refactor`: A code change that does not change the behavior
+  - `refactor`: A code change that does not change behavior — requires changes to user-facing chart files under `charts/<version>/`
+  - `revert`: Reverts a previous commit — requires changes to user-facing chart files under `charts/<version>/`
   - `style`: A change to align the code with our style guide
-  - `test`: Adding missing tests or correcting existing tests
+  - `test`: Adding or correcting tests
 - `description`: short description of the change in present tense
+
+> **CI enforcement:** `feat:`, `fix:`, `refactor:`, `docs:`, and `revert:` are rejected by CI if no user-facing chart files are changed (files under `charts/<version>/` excluding `test/`, `go.mod`, `go.sum`). These types feed into release notes. For changes that only touch `docs/`, `AGENTS.md`, scripts, or CI config, use `chore:` or `ci:` instead.
 
 ## CI
 
@@ -169,264 +161,14 @@ CI is performed via GitHub Actions [workflow](.github/workflows).
 
 ## Integration Testing
 
-Integration tests verify that Helm charts can be deployed to Kubernetes and that services work correctly together. Unlike unit tests (which are expected for all contributions), **integration tests are primarily maintained by the Camunda team** and require access to Kubernetes infrastructure.
+Integration tests verify that Helm charts can be deployed to Kubernetes and that services work correctly together. **Integration tests are primarily maintained by the Camunda team** and require access to Kubernetes infrastructure.
 
 > [!NOTE]
 >
-> **For community contributors:** You are not expected to run integration tests. The CI pipeline handles this automatically. This section is provided for transparency and for those who want to understand or contribute to the testing infrastructure.
+> **For community contributors:** You are not expected to run integration tests. The CI pipeline handles this automatically.
 
-### Overview
+For full details on scenarios, the `deploy-camunda` CLI, and E2E test execution, see:
+- [`SKILLS.md`](SKILLS.md) — deploy-camunda CLI usage, kubectl patterns, E2E test workflow
+- [`docs/skills/reproducing-ci-e2e-failures.md`](docs/skills/reproducing-ci-e2e-failures.md) — reproducing CI failures locally
+- [`.github/AGENTS.md`](.github/AGENTS.md) — CI/CD architecture and workflow structure
 
-Integration tests deploy the Camunda Platform to a real Kubernetes cluster using predefined **scenarios**. Each scenario is a set of Helm values that configure a specific deployment topology (e.g., with Keycloak authentication, Elasticsearch, OpenSearch, multi-tenancy, etc.).
-
-The `deploy-camunda` CLI tool automates the deployment process, handling:
-- Helm values file preparation and merging
-- Unique identifier generation (Keycloak realms, Elasticsearch index prefixes)
-- Secret management and credential injection
-- Parallel deployment of multiple scenarios
-
-### Scenarios
-
-Scenarios are YAML values files located in each chart's test directory:
-
-```
-charts/<version>/test/integration/scenarios/chart-full-setup/
-```
-
-Files follow the naming convention: `values-integration-test-ingress-<scenario-name>.yaml`
-
-**Available scenarios include:**
-
-| Scenario | Description |
-|----------|-------------|
-| `keycloak-original` | Full deployment with Keycloak authentication and external elasticsearch |
-| `elasticsearch` | Deployment using Elasticsearch for data storage |
-| `opensearch` | Deployment using OpenSearch for data storage |
-| `multitenancy` | Multi-tenant configuration |
-| `qa-elasticsearch` | QA-specific configuration with custom image tags |
-| `qa-opensearch` | QA-specific OpenSearch configuration |
-
-Scenario files can reference environment variables (e.g., `$CAMUNDA_HOSTNAME`, `$E2E_TESTS_ZEEBE_IMAGE_TAG`) that are substituted at deployment time.
-
-### The deploy-camunda CLI (alpha)
-
-The `deploy-camunda` CLI is located at `scripts/deploy-camunda/` and provides a streamlined way to deploy Camunda Platform for integration testing.
-
-#### Installation
-
-From the repository root:
-
-```bash
-cd scripts/deploy-camunda
-go build -o deploy-camunda .
-```
-
-Or with make:
-```bash
-make install.dx-tooling
-```
-
-Or run directly:
-
-```bash
-go run scripts/deploy-camunda/main.go [flags]
-```
-
-#### Basic Usage
-
-```bash
-# Deploy a single scenario
-deploy-camunda --chart-path ./charts/camunda-platform-8.6 \
-  --namespace my-test-ns \
-  --release integration \
-  --scenario keycloak
-
-# Deploy multiple scenarios in parallel
-deploy-camunda --chart-path ./charts/camunda-platform-8.6 \
-  --namespace my-test-ns \
-  --release integration \
-  --scenario keycloak,elasticsearch
-```
-
-#### Key Flags
-
-| Flag | Short | Description |
-|------|-------|-------------|
-| `--chart-path` | | Path to the Camunda chart directory |
-| `--chart` | `-c` | Chart name (for remote charts) |
-| `--version` | `-v` | Chart version (requires `--chart`) |
-| `--namespace` | `-n` | Kubernetes namespace |
-| `--release` | `-r` | Helm release name |
-| `--scenario` | `-s` | Scenario name(s), comma-separated for parallel deployment |
-| `--scenario-path` | | Custom path to scenario files |
-| `--auth` | | Auth scenario (default: `keycloak`) |
-| `--platform` | | Target platform: `gke`, `rosa`, `eks` (default: `gke`) |
-| `--timeout` | | Helm deployment timeout in minutes (default: 5) |
-| `--delete-namespace` | | Delete namespace before deploying |
-| `--auto-generate-secrets` | | Generate random test secrets |
-| `--render-templates` | | Render manifests without installing |
-| `--extra-values` | | Additional values files to apply |
-| `--config` | `-F` | Path to config file |
-
-#### Configuration File
-
-Instead of passing flags every time, you can create a configuration file at `.camunda-deploy.yaml` (project-level) or `~/.config/camunda/deploy.yaml` (global).
-
-**Example configuration:**
-
-```yaml
-# Global defaults
-repoRoot: /path/to/camunda-platform-helm
-platform: gke
-logLevel: info
-
-# Keycloak settings (for Camunda internal infrastructure)
-keycloak:
-  host: keycloak.example.com
-  protocol: https
-
-# Named deployment profiles
-deployments:
-  local-test:
-    chartPath: ./charts/camunda-platform-8.6
-    namespace: camunda-test
-    release: integration
-    scenario: keycloak
-
-  qa-full:
-    chartPath: ./charts/camunda-platform-8.6
-    namespace: qa-integration
-    release: integration
-    scenario: qa-elasticsearch
-    valuesPreset: enterprise
-
-# Set the active deployment
-current: local-test
-```
-
-**Using deployment profiles:**
-
-```bash
-# List configured deployments
-deploy-camunda config list
-
-# Switch active deployment
-deploy-camunda config use qa-full
-
-# Show merged configuration
-deploy-camunda config show
-
-# Run with active deployment settings
-deploy-camunda
-```
-
-#### Environment Variables
-
-The CLI supports environment variable overrides with the `CAMUNDA_` prefix:
-
-| Variable | Description |
-|----------|-------------|
-| `CAMUNDA_CURRENT` | Active deployment profile |
-| `CAMUNDA_REPO_ROOT` | Repository root path |
-| `CAMUNDA_PLATFORM` | Target platform |
-| `CAMUNDA_HOSTNAME` | Ingress hostname |
-| `CAMUNDA_KEYCLOAK_HOST` | External Keycloak host |
-| `CAMUNDA_KEYCLOAK_REALM` | Keycloak realm name |
-
-You can also use a `.env` file (loaded automatically or via `--env-file`):
-
-```bash
-CAMUNDA_HOSTNAME=my-cluster.example.com
-DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD=secretpassword
-```
-
-### Requirements
-
-#### For Camunda Employees
-
-Internal integration tests use shared infrastructure:
-
-- **Kubernetes clusters**: GKE, EKS, or ROSA with appropriate permissions
-- **External Keycloak**: Shared Keycloak instance for authentication
-- **External Elasticsearch**: Shared Elasticsearch cluster
-- **Vault secrets**: Credentials managed via HashiCorp Vault
-- **Docker registry access**: Enterprise image pull secrets
-
-Contact the Platform team for access to shared infrastructure and required credentials.
-
-#### For Community Contributors
-
-To run integration tests independently, you need:
-
-1. **Kubernetes cluster**: Any Kubernetes cluster (minikube, kind, cloud provider)
-2. **Helm 4.x**: Same version as specified in `.tool-versions`
-3. **kubectl**: Configured to access your cluster
-4. **Docker registry secrets**: For pulling Camunda images (if using enterprise features)
-
-**Minimal local setup:**
-
-```bash
-# Create a kind cluster
-kind create cluster --name camunda-test
-
-# Deploy with auto-generated secrets (no external dependencies)
-go run scripts/deploy-camunda/main.go \
-  --chart-path ./charts/camunda-platform-8.6 \
-  --namespace camunda \
-  --release integration \
-  --scenario elasticsearch \
-  --auto-generate-secrets \
-  --skip-dependency-update=false
-```
-
-### Running E2E Tests After Deployment
-
-Once deployed, E2E tests can be run using the provided script:
-
-```bash
-./scripts/run-e2e-tests.sh \
-  --absolute-chart-path /path/to/charts/camunda-platform-8.6 \
-  --namespace my-test-ns
-```
-
-Additional flags:
-- `--opensearch`: Run OpenSearch-specific tests
-- `--mt`: Run multi-tenancy tests
-- `--rba`: Run role-based access tests
-- `--run-smoke-tests`: Run smoke tests only
-- `--verbose`: Show detailed output
-
-### Troubleshooting
-
-**Scenario not found:**
-
-The CLI provides helpful error messages listing available scenarios:
-
-```
-Scenario "invalid-name" not found
-
-Searched in: charts/camunda-platform-8.6/test/integration/scenarios/chart-full-setup
-Expected file: values-integration-test-ingress-invalid-name.yaml
-
-Available scenarios (10 found):
-  - keycloak
-  - elasticsearch
-  - opensearch
-  ...
-```
-
-**Helm timeout:**
-
-Increase the timeout for slower clusters:
-
-```bash
-deploy-camunda --timeout 15 ...
-```
-
-**Viewing rendered manifests:**
-
-Use `--render-templates` to inspect what would be deployed:
-
-```bash
-deploy-camunda --render-templates --render-output-dir ./rendered ...
-```

--- a/docs/contribution-and-collaboration.md
+++ b/docs/contribution-and-collaboration.md
@@ -69,8 +69,9 @@ PR titles must follow [Conventional Commits](https://www.conventionalcommits.org
 | Changed files | Correct type |
 |---|---|
 | Chart templates, values, helpers | `feat:` / `fix:` / `refactor:` |
-| `docs/`, `AGENTS.md`, `CLAUDE.md`, `SKILLS.md`, `README.md` | `chore:` |
+| `docs/`, `AGENTS.md`, `CLAUDE.md`, `SKILLS.md`, `README.md`, `scripts/` | `chore:` |
 | `.github/` workflows or actions | `ci:` |
+| Build tooling, dependency metadata, or other non-chart changes CI suggests as `build:` | `build:` |
 | Test files only (`test/`, `go.mod`, `go.sum`) | `test:` |
 | Mixed chart + docs/CI | Use the type matching the chart change |
 

--- a/docs/contribution-and-collaboration.md
+++ b/docs/contribution-and-collaboration.md
@@ -64,7 +64,7 @@ flowchart TD
 
 ### PR title type selection
 
-PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/). CI enforces an additional constraint: **`feat:`, `fix:`, `refactor:`, `docs:`, and `revert:` are reserved for PRs that change user-facing chart files** (anything under `charts/<version>/` excluding `test/`, `go.mod`, `go.sum`). These types propagate to `RELEASE-NOTES.md` and `artifacthub.io/changes` via `git-cliff`.
+PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/). CI enforces an additional constraint: **`feat:`, `fix:`, `refactor:`, `docs:`, and `revert:` are reserved for PRs that change user-facing chart files** (anything under `charts/<chart>/` excluding `test/`, `go.mod`, `go.sum`). These types propagate to `RELEASE-NOTES.md` and `artifacthub.io/changes` via `git-cliff`.
 
 | Changed files | Correct type |
 |---|---|

--- a/docs/contribution-and-collaboration.md
+++ b/docs/contribution-and-collaboration.md
@@ -62,7 +62,23 @@ flowchart TD
 
 ## Pull Request Requirements
 
-Every PR related to Helm chart changes must satisfy the following checklist before requesting review:
+### PR title type selection
+
+PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/). CI enforces an additional constraint: **`feat:`, `fix:`, `refactor:`, `docs:`, and `revert:` are reserved for PRs that change user-facing chart files** (anything under `charts/<version>/` excluding `test/`, `go.mod`, `go.sum`). These types propagate to `RELEASE-NOTES.md` and `artifacthub.io/changes` via `git-cliff`.
+
+| Changed files | Correct type |
+|---|---|
+| Chart templates, values, helpers | `feat:` / `fix:` / `refactor:` |
+| `docs/`, `AGENTS.md`, `CLAUDE.md`, `SKILLS.md`, `README.md` | `chore:` |
+| `.github/` workflows or actions | `ci:` |
+| Test files only (`test/`, `go.mod`, `go.sum`) | `test:` |
+| Mixed chart + docs/CI | Use the type matching the chart change |
+
+Using `docs:` for a docs-only PR will fail CI — use `chore:` instead.
+
+### Checklist
+
+Every PR must satisfy the following before requesting review:
 
 - [ ] **`crev` review** — run [`crev`](https://github.com/camunda/crev) against the PR and address or acknowledge all findings before requesting review.
 - [ ] **Configuration key classification** — if the PR adds a `values.yaml` key, confirm it is Tier 2, additive, opt-in, and non-breaking. See [Values YAML Policy](./policies/values-yaml-policy.md).


### PR DESCRIPTION
## Summary

- Documents the CI-enforced constraint: `feat:`, `fix:`, `refactor:`, `docs:`, and `revert:` require user-facing chart file changes — CI rejects them otherwise as these types feed into release notes
- Adds a type selection table to `AGENTS.md` so automated PRs pick the correct type
- Adds the same rule to `docs/contribution-and-collaboration.md` under a **PR title type selection** subsection
- Aligns `CONTRIBUTING.md` with the actual CI rules: adds missing types (`chore`, `cd`, `revert`), fixes subject length (single 120-char limit), fixes `build` type description (was referencing Maven), replaces stale 260-line integration testing section with pointers to `SKILLS.md` and `docs/skills/`

## Motivation

PR camunda/camunda-platform-helm#6209 failed CI with `docs:` on a docs-only change. The rule exists in the workflow (`repo-pr-conventions.yaml`) but was undocumented. Separately, `CONTRIBUTING.md` and `docs/contribution-and-collaboration.md` had overlapping but inconsistent commit type guidance.

## Test plan

- [ ] `Check PR Conventions` passes (title is `chore:`, no chart files changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)