### PR TITLE
ci: include PR title in merged Slack notification

### DIFF
--- a/scripts/notify-pr-activity/main.go
+++ b/scripts/notify-pr-activity/main.go
@@ -131,7 +131,7 @@ func buildMessage() string {
 		if err1 == nil && err2 == nil {
 			duration = formatDuration(createdAt, mergedAt)
 		}
-		numLink := fmt.Sprintf("<%s|%s>", prURL, prNum)
+		numLink := fmt.Sprintf("<%s|%s %s>", prURL, prNum, prTitle)
 		return fmt.Sprintf("✅ [%s] %s merged after %s", repo, numLink, duration)
 
 	default:


### PR DESCRIPTION
## Summary

Updates the Slack notification message format for merged PRs to include the full PR title instead of just the number.

## Changes

- Modified `scripts/notify-pr-activity/main.go` to include PR title in the merged notification link

## Before

```
✅ [helm] #6200 merged after 5d 20h
```

## After

```
✅ [helm] #6200 feat: add support for X merged after 5d 20h
```

## Testing

- All existing unit tests pass
- The change mirrors the format already used for "opened" PR notifications

Fixes the issue where merged PR notifications only showed the PR number, making it harder to understand what was merged without clicking through.