### PR TITLE
ci(8.9,8.10): ensure consistent index prefixes across OpenSearch upgrade steps

### DIFF
--- a/charts/camunda-platform-8.10/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.10/test/ci-test-config.yaml
@@ -492,6 +492,7 @@ integration:
           enabled: false
           flow: install
           shortname: qaosupg
+          prefix-key: qa-opensearch-upg
           auth: keycloak
           identity: keycloak
           persistence: opensearch-embedded
@@ -511,6 +512,7 @@ integration:
           enabled: false
           flow: modular-upgrade-minor
           shortname: qaosupg
+          prefix-key: qa-opensearch-upg
           auth: keycloak
           identity: keycloak
           persistence: opensearch-embedded

--- a/charts/camunda-platform-8.9/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.9/test/ci-test-config.yaml
@@ -454,6 +454,7 @@ integration:
           enabled: false
           flow: install
           shortname: qaosupg
+          prefix-key: qa-opensearch-upg
           auth: keycloak
           identity: keycloak
           persistence: opensearch-embedded

--- a/scripts/deploy-camunda/config/config.go
+++ b/scripts/deploy-camunda/config/config.go
@@ -355,18 +355,6 @@ func applyEnvOverrides(rc *RootConfig) {
 	if v := get("CAMUNDA_KEYCLOAK_REALM"); v != "" {
 		rc.KeycloakRealm = v
 	}
-	if v := get("CAMUNDA_OPTIMIZE_INDEX_PREFIX"); v != "" {
-		rc.OptimizeIndexPrefix = v
-	}
-	if v := get("CAMUNDA_ORCHESTRATION_INDEX_PREFIX"); v != "" {
-		rc.OrchestrationIndexPrefix = v
-	}
-	if v := get("CAMUNDA_TASKLIST_INDEX_PREFIX"); v != "" {
-		rc.TasklistIndexPrefix = v
-	}
-	if v := get("CAMUNDA_OPERATE_INDEX_PREFIX"); v != "" {
-		rc.OperateIndexPrefix = v
-	}
 	if v := get("CAMUNDA_HOSTNAME"); v != "" {
 		rc.IngressHost = v
 	}

--- a/scripts/deploy-camunda/deploy/helm_values.go
+++ b/scripts/deploy-camunda/deploy/helm_values.go
@@ -137,6 +137,9 @@ func getNestedString(m map[string]interface{}, keys ...string) string {
 // at the given path in the nested map, returning the "value" for the entry
 // whose "name" matches envName. Returns "" if not found.
 func findEnvValue(m map[string]interface{}, path []string, envName string) string {
+	if len(path) == 0 {
+		return ""
+	}
 	// Navigate to the array
 	current := m
 	for _, key := range path[:len(path)-1] {

--- a/scripts/deploy-camunda/deploy/helm_values.go
+++ b/scripts/deploy-camunda/deploy/helm_values.go
@@ -1,0 +1,179 @@
+package deploy
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// helmGetValuesTimeout is the maximum time allowed for a `helm get values` call.
+const helmGetValuesTimeout = 30 * time.Second
+
+// InstalledPrefixes holds index prefix values read from a live Helm release.
+// Zero-value fields indicate the prefix was not found or not set.
+type InstalledPrefixes struct {
+	OrchestrationIndexPrefix string
+	OperateIndexPrefix       string
+	OptimizeIndexPrefix      string
+	TasklistIndexPrefix      string
+}
+
+// GetInstalledValues runs `helm get values <release> -n <ns> -o yaml` and
+// returns the parsed user-supplied values as a nested map. Returns a nil map
+// (no error) if the release does not exist.
+func GetInstalledValues(ctx context.Context, namespace, release, kubeContext string) (map[string]interface{}, error) {
+	callCtx, cancel := context.WithTimeout(ctx, helmGetValuesTimeout)
+	defer cancel()
+
+	args := []string{"get", "values", release, "-n", namespace, "-o", "yaml"}
+	if kubeContext != "" {
+		args = append(args, "--kube-context", kubeContext)
+	}
+
+	cmd := exec.CommandContext(callCtx, "helm", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		stderrStr := strings.TrimSpace(stderr.String())
+		// Release not found is not an error — return nil map.
+		if strings.Contains(stderrStr, "not found") || strings.Contains(stderrStr, "release: not found") {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("helm get values %s -n %s failed: %w; stderr: %s",
+			release, namespace, err, truncateStr(stderrStr, 500))
+	}
+
+	out := bytes.TrimSpace(stdout.Bytes())
+	if len(out) == 0 {
+		return nil, nil
+	}
+
+	var vals map[string]interface{}
+	if err := yaml.Unmarshal(out, &vals); err != nil {
+		return nil, fmt.Errorf("failed to parse helm values YAML: %w", err)
+	}
+
+	return vals, nil
+}
+
+// ReadInstalledPrefixes extracts index prefix values from a live Helm release.
+// It reads `orchestration.index.prefix`, walks `orchestration.env[]` for the
+// operate secondary-storage prefix, and reads `optimize.database.opensearch.prefix`.
+// Returns a zero-value struct if the release doesn't exist or fields are absent.
+func ReadInstalledPrefixes(ctx context.Context, namespace, release, kubeContext string) (InstalledPrefixes, error) {
+	vals, err := GetInstalledValues(ctx, namespace, release, kubeContext)
+	if err != nil {
+		return InstalledPrefixes{}, err
+	}
+	if vals == nil {
+		return InstalledPrefixes{}, nil
+	}
+
+	var result InstalledPrefixes
+
+	// orchestration.index.prefix
+	result.OrchestrationIndexPrefix = getNestedString(vals, "orchestration", "index", "prefix")
+
+	// optimize.database.opensearch.prefix (also uses the orchestration prefix in OS scenarios)
+	result.OptimizeIndexPrefix = getNestedString(vals, "optimize", "database", "opensearch", "prefix")
+
+	// orchestration.env[] — find CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_INDEXPREFIX
+	result.OperateIndexPrefix = findEnvValue(vals, []string{"orchestration", "env"}, "CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_INDEXPREFIX")
+
+	// orchestration.env[] — find CAMUNDA_TASKLIST_OPENSEARCH_INDEXPREFIX (if present)
+	if tp := findEnvValue(vals, []string{"orchestration", "env"}, "CAMUNDA_TASKLIST_OPENSEARCH_INDEXPREFIX"); tp != "" {
+		result.TasklistIndexPrefix = tp
+	}
+
+	return result, nil
+}
+
+// getNestedString traverses a nested map by successive keys and returns the
+// leaf value as a string. Returns "" if any key is missing or the leaf is not
+// a string.
+func getNestedString(m map[string]interface{}, keys ...string) string {
+	current := m
+	for i, key := range keys {
+		v, ok := current[key]
+		if !ok {
+			return ""
+		}
+		if i == len(keys)-1 {
+			// Leaf — convert to string
+			switch s := v.(type) {
+			case string:
+				return s
+			default:
+				return ""
+			}
+		}
+		// Intermediate — must be a map
+		next, ok := v.(map[string]interface{})
+		if !ok {
+			return ""
+		}
+		current = next
+	}
+	return ""
+}
+
+// findEnvValue searches an env-style array ([]map with "name"/"value" keys)
+// at the given path in the nested map, returning the "value" for the entry
+// whose "name" matches envName. Returns "" if not found.
+func findEnvValue(m map[string]interface{}, path []string, envName string) string {
+	// Navigate to the array
+	current := m
+	for _, key := range path[:len(path)-1] {
+		v, ok := current[key]
+		if !ok {
+			return ""
+		}
+		next, ok := v.(map[string]interface{})
+		if !ok {
+			return ""
+		}
+		current = next
+	}
+
+	// Get the array
+	arrKey := path[len(path)-1]
+	arrRaw, ok := current[arrKey]
+	if !ok {
+		return ""
+	}
+
+	arr, ok := arrRaw.([]interface{})
+	if !ok {
+		return ""
+	}
+
+	// Search for the env var by name
+	for _, item := range arr {
+		entry, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _ := entry["name"].(string)
+		if name == envName {
+			val, _ := entry["value"].(string)
+			return val
+		}
+	}
+
+	return ""
+}
+
+// truncateStr truncates a string to maxLen characters, appending "..." if truncated.
+func truncateStr(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}

--- a/scripts/deploy-camunda/deploy/helm_values.go
+++ b/scripts/deploy-camunda/deploy/helm_values.go
@@ -43,7 +43,10 @@ func GetInstalledValues(ctx context.Context, namespace, release, kubeContext str
 	if err := cmd.Run(); err != nil {
 		stderrStr := strings.TrimSpace(stderr.String())
 		// Release not found is not an error — return nil map.
-		if strings.Contains(stderrStr, "not found") || strings.Contains(stderrStr, "release: not found") {
+		// Match Helm's specific error messages to avoid false positives from
+		// unrelated errors that happen to contain "not found".
+		if strings.Contains(stderrStr, "release: not found") ||
+			strings.Contains(stderrStr, fmt.Sprintf("release %q not found", release)) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("helm get values %s -n %s failed: %w; stderr: %s",

--- a/scripts/deploy-camunda/deploy/helm_values.go
+++ b/scripts/deploy-camunda/deploy/helm_values.go
@@ -76,6 +76,12 @@ func ReadInstalledPrefixes(ctx context.Context, namespace, release, kubeContext 
 		return InstalledPrefixes{}, nil
 	}
 
+	return readPrefixesFromMap(vals), nil
+}
+
+// readPrefixesFromMap extracts index prefix values from a parsed Helm values map.
+// Factored out from ReadInstalledPrefixes for direct unit testing.
+func readPrefixesFromMap(vals map[string]interface{}) InstalledPrefixes {
 	var result InstalledPrefixes
 
 	// orchestration.index.prefix
@@ -92,7 +98,7 @@ func ReadInstalledPrefixes(ctx context.Context, namespace, release, kubeContext 
 		result.TasklistIndexPrefix = tp
 	}
 
-	return result, nil
+	return result
 }
 
 // getNestedString traverses a nested map by successive keys and returns the

--- a/scripts/deploy-camunda/deploy/helm_values_test.go
+++ b/scripts/deploy-camunda/deploy/helm_values_test.go
@@ -1,0 +1,218 @@
+package deploy
+
+import (
+	"testing"
+)
+
+func TestGetNestedString(t *testing.T) {
+	tests := []struct {
+		name string
+		m    map[string]interface{}
+		keys []string
+		want string
+	}{
+		{
+			name: "simple one-level key",
+			m:    map[string]interface{}{"foo": "bar"},
+			keys: []string{"foo"},
+			want: "bar",
+		},
+		{
+			name: "two-level nested key",
+			m: map[string]interface{}{
+				"orchestration": map[string]interface{}{
+					"index": map[string]interface{}{
+						"prefix": "orch-eske-abcd1234",
+					},
+				},
+			},
+			keys: []string{"orchestration", "index", "prefix"},
+			want: "orch-eske-abcd1234",
+		},
+		{
+			name: "missing intermediate key",
+			m:    map[string]interface{}{"foo": "bar"},
+			keys: []string{"missing", "path"},
+			want: "",
+		},
+		{
+			name: "leaf is not a string",
+			m:    map[string]interface{}{"foo": 42},
+			keys: []string{"foo"},
+			want: "",
+		},
+		{
+			name: "empty map",
+			m:    map[string]interface{}{},
+			keys: []string{"foo"},
+			want: "",
+		},
+		{
+			name: "intermediate is not a map",
+			m:    map[string]interface{}{"foo": "not-a-map"},
+			keys: []string{"foo", "bar"},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getNestedString(tt.m, tt.keys...)
+			if got != tt.want {
+				t.Errorf("getNestedString() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindEnvValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		m       map[string]interface{}
+		path    []string
+		envName string
+		want    string
+	}{
+		{
+			name: "finds env var in array",
+			m: map[string]interface{}{
+				"orchestration": map[string]interface{}{
+					"env": []interface{}{
+						map[string]interface{}{"name": "FOO", "value": "bar"},
+						map[string]interface{}{"name": "CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_INDEXPREFIX", "value": "op-eske-abcd1234"},
+					},
+				},
+			},
+			path:    []string{"orchestration", "env"},
+			envName: "CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_INDEXPREFIX",
+			want:    "op-eske-abcd1234",
+		},
+		{
+			name: "env var not found",
+			m: map[string]interface{}{
+				"orchestration": map[string]interface{}{
+					"env": []interface{}{
+						map[string]interface{}{"name": "FOO", "value": "bar"},
+					},
+				},
+			},
+			path:    []string{"orchestration", "env"},
+			envName: "MISSING",
+			want:    "",
+		},
+		{
+			name:    "path does not exist",
+			m:       map[string]interface{}{},
+			path:    []string{"orchestration", "env"},
+			envName: "FOO",
+			want:    "",
+		},
+		{
+			name: "array is empty",
+			m: map[string]interface{}{
+				"orchestration": map[string]interface{}{
+					"env": []interface{}{},
+				},
+			},
+			path:    []string{"orchestration", "env"},
+			envName: "FOO",
+			want:    "",
+		},
+		{
+			name: "array contains non-map entries",
+			m: map[string]interface{}{
+				"orchestration": map[string]interface{}{
+					"env": []interface{}{
+						"not-a-map",
+						map[string]interface{}{"name": "TARGET", "value": "found"},
+					},
+				},
+			},
+			path:    []string{"orchestration", "env"},
+			envName: "TARGET",
+			want:    "found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findEnvValue(tt.m, tt.path, tt.envName)
+			if got != tt.want {
+				t.Errorf("findEnvValue() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReadInstalledPrefixes_ParsesRealisticValues(t *testing.T) {
+	// This tests the extraction logic with a realistic Helm values structure.
+	// We can't call GetInstalledValues (it shells out to helm), but we can
+	// test the parsing directly using the same map structure.
+	vals := map[string]interface{}{
+		"orchestration": map[string]interface{}{
+			"index": map[string]interface{}{
+				"prefix": "orch-qa-opensearch-upg-abc12345",
+			},
+			"env": []interface{}{
+				map[string]interface{}{
+					"name":  "CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_INDEXPREFIX",
+					"value": "op-qa-opensearch-upg-abc12345",
+				},
+				map[string]interface{}{
+					"name":  "CAMUNDA_TASKLIST_OPENSEARCH_INDEXPREFIX",
+					"value": "task-qa-opensearch-upg-abc12345",
+				},
+			},
+		},
+		"optimize": map[string]interface{}{
+			"database": map[string]interface{}{
+				"opensearch": map[string]interface{}{
+					"prefix": "opt-qa-opensearch-upg-abc12345",
+				},
+			},
+		},
+	}
+
+	// Directly test the parsing logic (same code as ReadInstalledPrefixes minus the helm call).
+	var result InstalledPrefixes
+	result.OrchestrationIndexPrefix = getNestedString(vals, "orchestration", "index", "prefix")
+	result.OptimizeIndexPrefix = getNestedString(vals, "optimize", "database", "opensearch", "prefix")
+	result.OperateIndexPrefix = findEnvValue(vals, []string{"orchestration", "env"}, "CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_INDEXPREFIX")
+	if tp := findEnvValue(vals, []string{"orchestration", "env"}, "CAMUNDA_TASKLIST_OPENSEARCH_INDEXPREFIX"); tp != "" {
+		result.TasklistIndexPrefix = tp
+	}
+
+	if result.OrchestrationIndexPrefix != "orch-qa-opensearch-upg-abc12345" {
+		t.Errorf("OrchestrationIndexPrefix = %q, want %q", result.OrchestrationIndexPrefix, "orch-qa-opensearch-upg-abc12345")
+	}
+	if result.OptimizeIndexPrefix != "opt-qa-opensearch-upg-abc12345" {
+		t.Errorf("OptimizeIndexPrefix = %q, want %q", result.OptimizeIndexPrefix, "opt-qa-opensearch-upg-abc12345")
+	}
+	if result.OperateIndexPrefix != "op-qa-opensearch-upg-abc12345" {
+		t.Errorf("OperateIndexPrefix = %q, want %q", result.OperateIndexPrefix, "op-qa-opensearch-upg-abc12345")
+	}
+	if result.TasklistIndexPrefix != "task-qa-opensearch-upg-abc12345" {
+		t.Errorf("TasklistIndexPrefix = %q, want %q", result.TasklistIndexPrefix, "task-qa-opensearch-upg-abc12345")
+	}
+}
+
+func TestTruncateStr(t *testing.T) {
+	tests := []struct {
+		s      string
+		maxLen int
+		want   string
+	}{
+		{"short", 10, "short"},
+		{"exactly10!", 10, "exactly10!"},
+		{"this is too long", 10, "this is to..."},
+		{"", 5, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.s, func(t *testing.T) {
+			got := truncateStr(tt.s, tt.maxLen)
+			if got != tt.want {
+				t.Errorf("truncateStr(%q, %d) = %q, want %q", tt.s, tt.maxLen, got, tt.want)
+			}
+		})
+	}
+}

--- a/scripts/deploy-camunda/deploy/helm_values_test.go
+++ b/scripts/deploy-camunda/deploy/helm_values_test.go
@@ -144,10 +144,7 @@ func TestFindEnvValue(t *testing.T) {
 	}
 }
 
-func TestReadInstalledPrefixes_ParsesRealisticValues(t *testing.T) {
-	// This tests the extraction logic with a realistic Helm values structure.
-	// We can't call GetInstalledValues (it shells out to helm), but we can
-	// test the parsing directly using the same map structure.
+func TestReadPrefixesFromMap_FullValues(t *testing.T) {
 	vals := map[string]interface{}{
 		"orchestration": map[string]interface{}{
 			"index": map[string]interface{}{
@@ -173,14 +170,7 @@ func TestReadInstalledPrefixes_ParsesRealisticValues(t *testing.T) {
 		},
 	}
 
-	// Directly test the parsing logic (same code as ReadInstalledPrefixes minus the helm call).
-	var result InstalledPrefixes
-	result.OrchestrationIndexPrefix = getNestedString(vals, "orchestration", "index", "prefix")
-	result.OptimizeIndexPrefix = getNestedString(vals, "optimize", "database", "opensearch", "prefix")
-	result.OperateIndexPrefix = findEnvValue(vals, []string{"orchestration", "env"}, "CAMUNDA_DATA_SECONDARYSTORAGE_OPENSEARCH_INDEXPREFIX")
-	if tp := findEnvValue(vals, []string{"orchestration", "env"}, "CAMUNDA_TASKLIST_OPENSEARCH_INDEXPREFIX"); tp != "" {
-		result.TasklistIndexPrefix = tp
-	}
+	result := readPrefixesFromMap(vals)
 
 	if result.OrchestrationIndexPrefix != "orch-qa-opensearch-upg-abc12345" {
 		t.Errorf("OrchestrationIndexPrefix = %q, want %q", result.OrchestrationIndexPrefix, "orch-qa-opensearch-upg-abc12345")
@@ -193,6 +183,49 @@ func TestReadInstalledPrefixes_ParsesRealisticValues(t *testing.T) {
 	}
 	if result.TasklistIndexPrefix != "task-qa-opensearch-upg-abc12345" {
 		t.Errorf("TasklistIndexPrefix = %q, want %q", result.TasklistIndexPrefix, "task-qa-opensearch-upg-abc12345")
+	}
+}
+
+func TestReadPrefixesFromMap_EmptyMap(t *testing.T) {
+	result := readPrefixesFromMap(map[string]interface{}{})
+
+	if result.OrchestrationIndexPrefix != "" {
+		t.Errorf("OrchestrationIndexPrefix should be empty, got %q", result.OrchestrationIndexPrefix)
+	}
+	if result.OptimizeIndexPrefix != "" {
+		t.Errorf("OptimizeIndexPrefix should be empty, got %q", result.OptimizeIndexPrefix)
+	}
+	if result.OperateIndexPrefix != "" {
+		t.Errorf("OperateIndexPrefix should be empty, got %q", result.OperateIndexPrefix)
+	}
+	if result.TasklistIndexPrefix != "" {
+		t.Errorf("TasklistIndexPrefix should be empty, got %q", result.TasklistIndexPrefix)
+	}
+}
+
+func TestReadPrefixesFromMap_PartialValues(t *testing.T) {
+	// ES scenario: only orchestration.index.prefix is set, no env vars for OS prefixes.
+	vals := map[string]interface{}{
+		"orchestration": map[string]interface{}{
+			"index": map[string]interface{}{
+				"prefix": "orch-eske-12345678",
+			},
+		},
+	}
+
+	result := readPrefixesFromMap(vals)
+
+	if result.OrchestrationIndexPrefix != "orch-eske-12345678" {
+		t.Errorf("OrchestrationIndexPrefix = %q, want %q", result.OrchestrationIndexPrefix, "orch-eske-12345678")
+	}
+	if result.OptimizeIndexPrefix != "" {
+		t.Errorf("OptimizeIndexPrefix should be empty for ES scenario, got %q", result.OptimizeIndexPrefix)
+	}
+	if result.OperateIndexPrefix != "" {
+		t.Errorf("OperateIndexPrefix should be empty for ES scenario, got %q", result.OperateIndexPrefix)
+	}
+	if result.TasklistIndexPrefix != "" {
+		t.Errorf("TasklistIndexPrefix should be empty for ES scenario, got %q", result.TasklistIndexPrefix)
 	}
 }
 

--- a/scripts/deploy-camunda/deploy/scenario.go
+++ b/scripts/deploy-camunda/deploy/scenario.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 
+	"scripts/camunda-core/pkg/logging"
 	"scripts/deploy-camunda/config"
 )
 
@@ -213,6 +214,19 @@ func keycloakVersionSuffix(host string) string {
 	return strings.ReplaceAll(version, "-", "_")
 }
 
+// ComputeExpectedOrchestrationPrefix returns the orchestration index prefix that
+// will be used when deploy.Execute() runs for the given scenario and flags. This
+// allows callers to validate the prefix against external state (e.g., a live Helm
+// release) before executing the deployment.
+func ComputeExpectedOrchestrationPrefix(scenario string, flags *config.RuntimeFlags) string {
+	if flags.Index.OrchestrationIndexPrefix != "" {
+		return flags.Index.OrchestrationIndexPrefix
+	}
+	normalizedScenario := normalizeIdentifierPart(scenario)
+	suffix := namespaceDerivedSuffix(flags.EffectiveNamespace())
+	return fmt.Sprintf("orch-%s-%s", normalizedScenario, suffix)
+}
+
 // PinScenarioPrefixes derives a deterministic suffix from the namespace and writes
 // index prefixes + Keycloak realm name into flags so that subsequent calls to
 // Execute() (which internally call generateScenarioContext) will reuse the same
@@ -252,6 +266,16 @@ func PinScenarioPrefixes(scenario string, flags *config.RuntimeFlags) error {
 			suffix,
 		)
 	}
+
+	logging.Logger.Info().
+		Str("scenario", scenario).
+		Str("namespace", effectiveNs).
+		Str("orchestrationPrefix", flags.Index.OrchestrationIndexPrefix).
+		Str("operatePrefix", flags.Index.OperateIndexPrefix).
+		Str("optimizePrefix", flags.Index.OptimizeIndexPrefix).
+		Str("tasklistPrefix", flags.Index.TasklistIndexPrefix).
+		Str("keycloakRealm", flags.Auth.KeycloakRealm).
+		Msg("Pinned scenario prefixes")
 
 	return nil
 }

--- a/scripts/deploy-camunda/deploy/scenario.go
+++ b/scripts/deploy-camunda/deploy/scenario.go
@@ -224,6 +224,12 @@ func ComputeExpectedOrchestrationPrefix(scenario string, flags *config.RuntimeFl
 	}
 	normalizedScenario := normalizeIdentifierPart(scenario)
 	suffix := namespaceDerivedSuffix(flags.EffectiveNamespace())
+	return orchestrationPrefix(normalizedScenario, suffix)
+}
+
+// orchestrationPrefix returns the canonical orchestration index prefix for a
+// given normalized scenario name and namespace-derived suffix.
+func orchestrationPrefix(normalizedScenario, suffix string) string {
 	return fmt.Sprintf("orch-%s-%s", normalizedScenario, suffix)
 }
 
@@ -249,7 +255,7 @@ func PinScenarioPrefixes(scenario string, flags *config.RuntimeFlags) error {
 		flags.Index.OptimizeIndexPrefix = fmt.Sprintf("opt-%s-%s", normalizedScenario, suffix)
 	}
 	if flags.Index.OrchestrationIndexPrefix == "" {
-		flags.Index.OrchestrationIndexPrefix = fmt.Sprintf("orch-%s-%s", normalizedScenario, suffix)
+		flags.Index.OrchestrationIndexPrefix = orchestrationPrefix(normalizedScenario, suffix)
 	}
 	if flags.Index.TasklistIndexPrefix == "" {
 		flags.Index.TasklistIndexPrefix = fmt.Sprintf("task-%s-%s", normalizedScenario, suffix)

--- a/scripts/deploy-camunda/deploy/scenario_test.go
+++ b/scripts/deploy-camunda/deploy/scenario_test.go
@@ -350,3 +350,66 @@ func TestGenerateCompactRealmName(t *testing.T) {
 		}
 	})
 }
+
+func TestComputeExpectedOrchestrationPrefix_UsesExistingFlag(t *testing.T) {
+	flags := &config.RuntimeFlags{
+		Deployment: config.DeploymentFlags{
+			Namespace: "matrix-89-eske-upgm",
+		},
+		Index: config.IndexPrefixFlags{
+			OrchestrationIndexPrefix: "already-pinned-prefix",
+		},
+	}
+
+	got := ComputeExpectedOrchestrationPrefix("some-scenario", flags)
+	if got != "already-pinned-prefix" {
+		t.Errorf("expected pinned prefix %q, got %q", "already-pinned-prefix", got)
+	}
+}
+
+func TestComputeExpectedOrchestrationPrefix_ComputesFromScenario(t *testing.T) {
+	flags := &config.RuntimeFlags{
+		Deployment: config.DeploymentFlags{
+			Namespace: "matrix-89-eske-upgm",
+		},
+	}
+
+	got := ComputeExpectedOrchestrationPrefix("elasticsearch", flags)
+	if got == "" {
+		t.Fatal("expected non-empty prefix, got empty")
+	}
+	if !startsWith(got, "orch-") {
+		t.Errorf("expected prefix to start with 'orch-', got %q", got)
+	}
+}
+
+func TestComputeExpectedOrchestrationPrefix_MatchesPinned(t *testing.T) {
+	// ComputeExpected should produce the same value as PinScenarioPrefixes.
+	namespace := "matrix-89-qaosupg-inst-gke"
+	scenario := "qa-opensearch-upg"
+
+	flags := &config.RuntimeFlags{
+		Deployment: config.DeploymentFlags{
+			Namespace: namespace,
+		},
+	}
+	if err := PinScenarioPrefixes(scenario, flags); err != nil {
+		t.Fatalf("PinScenarioPrefixes: %v", err)
+	}
+
+	freshFlags := &config.RuntimeFlags{
+		Deployment: config.DeploymentFlags{
+			Namespace: namespace,
+		},
+	}
+	computed := ComputeExpectedOrchestrationPrefix(scenario, freshFlags)
+
+	if computed != flags.Index.OrchestrationIndexPrefix {
+		t.Errorf("ComputeExpected=%q does not match Pinned=%q",
+			computed, flags.Index.OrchestrationIndexPrefix)
+	}
+}
+
+func startsWith(s, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}

--- a/scripts/deploy-camunda/deploy/values.go
+++ b/scripts/deploy-camunda/deploy/values.go
@@ -340,23 +340,6 @@ func buildScenarioEnv(scenarioCtx *ScenarioContext, flags *config.RuntimeFlags) 
 	}
 	envMap["OS_POOL_INDEX"] = osPoolIndex
 
-	// 3.5 Honor CAMUNDA_*_INDEX_PREFIX overrides from the env file (set in step 2 above).
-	// When present, these take precedence over scenario-derived prefixes, allowing a CI
-	// caller to pin a fixed index prefix across separate jobs (e.g., 8.8 install + 8.9
-	// upgrade) by passing the same CAMUNDA_*_INDEX_PREFIX value to both jobs.
-	if v := envMap["CAMUNDA_OPERATE_INDEX_PREFIX"]; v != "" {
-		envMap["OPERATE_INDEX_PREFIX"] = v
-	}
-	if v := envMap["CAMUNDA_ORCHESTRATION_INDEX_PREFIX"]; v != "" {
-		envMap["ORCHESTRATION_INDEX_PREFIX"] = v
-	}
-	if v := envMap["CAMUNDA_OPTIMIZE_INDEX_PREFIX"]; v != "" {
-		envMap["OPTIMIZE_INDEX_PREFIX"] = v
-	}
-	if v := envMap["CAMUNDA_TASKLIST_INDEX_PREFIX"]; v != "" {
-		envMap["TASKLIST_INDEX_PREFIX"] = v
-	}
-
 	// 4. Apply per-entry extra environment variables (e.g., VENOM_CLIENT_ID, CONNECTORS_CLIENT_ID).
 	for k, v := range flags.ExtraEnv {
 		envMap[k] = v

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -2407,7 +2407,11 @@ func executeUpgradeOnly(ctx context.Context, entry Entry, flags *config.RuntimeF
 		installed, err := deploy.ReadInstalledPrefixes(ctx, flags.EffectiveNamespace(), flags.Deployment.Release, flags.Test.KubeContext)
 		if err != nil {
 			logging.Logger.Warn().Err(err).Msg("Failed to read installed prefixes; skipping prefix validation")
-		} else if installed.OrchestrationIndexPrefix != "" && installed.OrchestrationIndexPrefix != expectedPrefix {
+		} else if installed.OrchestrationIndexPrefix == "" {
+			logging.Logger.Warn().
+				Str("expectedPrefix", expectedPrefix).
+				Msg("Prefix validation skipped: installed release has no orchestration prefix set (fresh install or ES-only scenario)")
+		} else if installed.OrchestrationIndexPrefix != expectedPrefix {
 			return fmt.Errorf(
 				"prefix mismatch: installed release has orchestration prefix %q but this upgrade would use %q — "+
 					"check that install and upgrade scenarios share the same prefix-key in ci-test-config.yaml",

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -1630,32 +1630,6 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions, entryIndex 
 	flags.ESPoolIndex = strconv.Itoa(entryIndex % numESPools)
 	flags.OSPoolIndex = strconv.Itoa(entryIndex % numOSPools)
 
-	// Honor explicit index prefix overrides from CAMUNDA_*_INDEX_PREFIX env vars.
-	// The matrix command skips the root PersistentPreRunE (which normally applies
-	// config/env merges), so these env vars must be applied here instead.
-	// This allows CI upgrade workflows to pin identical prefixes across separate
-	// install and upgrade jobs that run within the same workflow run.
-	if flags.Index.OperateIndexPrefix == "" {
-		if v := os.Getenv("CAMUNDA_OPERATE_INDEX_PREFIX"); v != "" {
-			flags.Index.OperateIndexPrefix = v
-		}
-	}
-	if flags.Index.OrchestrationIndexPrefix == "" {
-		if v := os.Getenv("CAMUNDA_ORCHESTRATION_INDEX_PREFIX"); v != "" {
-			flags.Index.OrchestrationIndexPrefix = v
-		}
-	}
-	if flags.Index.OptimizeIndexPrefix == "" {
-		if v := os.Getenv("CAMUNDA_OPTIMIZE_INDEX_PREFIX"); v != "" {
-			flags.Index.OptimizeIndexPrefix = v
-		}
-	}
-	if flags.Index.TasklistIndexPrefix == "" {
-		if v := os.Getenv("CAMUNDA_TASKLIST_INDEX_PREFIX"); v != "" {
-			flags.Index.TasklistIndexPrefix = v
-		}
-	}
-
 	// Wire companion chart dependencies from ci-test-config.yaml.
 	// Values file paths are resolved relative to the repo root.
 	// Chart references are resolved to absolute paths when they point to an
@@ -2422,6 +2396,29 @@ func executeUpgradeOnly(ctx context.Context, entry Entry, flags *config.RuntimeF
 		Str("namespace", flags.EffectiveNamespace()).
 		Str("chartPath", entry.ChartPath).
 		Msg("Upgrade-only flow: upgrading existing deployment (no install step)")
+
+	// --- Prefix consistency validation ---
+	// Read the orchestration index prefix from the live Helm release and compare
+	// against what this upgrade step will use. A mismatch means the install step
+	// used a different scenario/prefix-key and the upgrade will produce incorrect
+	// index names, causing data loss or auth failures after upgrade.
+	expectedPrefix := deploy.ComputeExpectedOrchestrationPrefix(entry.Scenario, flags)
+	if expectedPrefix != "" {
+		installed, err := deploy.ReadInstalledPrefixes(ctx, flags.EffectiveNamespace(), flags.Deployment.Release, flags.Test.KubeContext)
+		if err != nil {
+			logging.Logger.Warn().Err(err).Msg("Failed to read installed prefixes; skipping prefix validation")
+		} else if installed.OrchestrationIndexPrefix != "" && installed.OrchestrationIndexPrefix != expectedPrefix {
+			return fmt.Errorf(
+				"prefix mismatch: installed release has orchestration prefix %q but this upgrade would use %q — "+
+					"check that install and upgrade scenarios share the same prefix-key in ci-test-config.yaml",
+				installed.OrchestrationIndexPrefix, expectedPrefix)
+		} else {
+			logging.Logger.Info().
+				Str("installedPrefix", installed.OrchestrationIndexPrefix).
+				Str("expectedPrefix", expectedPrefix).
+				Msg("Prefix validation passed: installed and expected orchestration prefixes match")
+		}
+	}
 
 	// --- Pre-upgrade lifecycle hook ---
 	if err := runDeclarativePreUpgradeHook(ctx, flags, entry.PreUpgrade, opts.RepoRoot, entry.Version, entry.Flow); err != nil {


### PR DESCRIPTION
## Summary

- Add `prefix-key` to `qa-opensearch-*` entries in `ci-test-config.yaml` (8.9 + 8.10) so install and upgrade steps derive identical index prefixes regardless of scenario name differences
- Add a validation gate in `executeUpgradeOnly` that reads the installed prefix from the live Helm release and hard-errors if it mismatches the expected prefix — prevents silent data/auth failures
- Remove the deprecated `CAMUNDA_*_INDEX_PREFIX` env var workaround (step 3.5 in `buildScenarioEnv` and the fallback in `executeEntry`)

## Root Cause

The nightly OpenSearch upgrade flow uses different scenario names:
- **Install (8.9):** `qa-opensearch-tasklist-v1` → prefix `orch-qa-opensearch-tasklist-v1-<hash>`
- **Upgrade (8.10):** `qa-opensearch-upg` → prefix `orch-qa-opensearch-upg-<hash>`

Since index prefixes were derived from scenario names, the upgrade step computed different prefixes than what the install step wrote to OpenSearch, causing authentication and data lookup failures post-upgrade.

## Fix

1. **`prefix-key` in ci-test-config.yaml** — Both entries now declare `prefix-key: qa-opensearch-upg`, forcing consistent prefix derivation regardless of scenario name.

2. **Validation gate** — `executeUpgradeOnly` now reads `helm get values` from the live release, extracts the orchestration index prefix, and compares it against the computed expected prefix. On mismatch, it returns a clear error pointing to the fix (add/align `prefix-key`).

3. **Cleanup** — Removed the `CAMUNDA_*_INDEX_PREFIX` env var passthrough (a brittle workaround that relied on CI callers manually piping prefixes between jobs).

## Validation

- All Go unit tests pass (`deploy/...` package, chart 8.9, chart 8.10)
- `ReadInstalledPrefixes` verified against a live GKE cluster — correctly reads prefix values from a Helm release
- Validation gate tested: correctly allows matching prefixes, correctly blocks on mismatch
- `deploy-camunda matrix list` confirms `prefixKey: "qa-opensearch-upg"` on all relevant entries

## Files Changed

| File | Change |
|------|--------|
| `charts/camunda-platform-8.9/test/ci-test-config.yaml` | Add `prefix-key: qa-opensearch-upg` |
| `charts/camunda-platform-8.10/test/ci-test-config.yaml` | Add `prefix-key: qa-opensearch-upg` (2 entries) |
| `scripts/deploy-camunda/deploy/helm_values.go` | NEW — `ReadInstalledPrefixes`, `GetInstalledValues` |
| `scripts/deploy-camunda/deploy/helm_values_test.go` | NEW — unit tests |
| `scripts/deploy-camunda/deploy/scenario.go` | Add `ComputeExpectedOrchestrationPrefix`, logging |
| `scripts/deploy-camunda/deploy/scenario_test.go` | Add tests for `ComputeExpected` |
| `scripts/deploy-camunda/deploy/values.go` | Remove step 3.5 (`CAMUNDA_*` override) |
| `scripts/deploy-camunda/matrix/runner.go` | Add validation gate, remove env var fallback |