### PR TITLE
fix: guard legacy ES exporter on global.elasticsearch.enabled

### DIFF
--- a/charts/camunda-platform-8.10/templates/orchestration/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/orchestration/_helpers.tpl
@@ -289,8 +289,8 @@ and
 
 {{- define "orchestration.hasLegacyElasticsearchExporter" -}}
 {{- and
-      (or 
-        (and .Values.orchestration.exporters.rdbms.enabled .Values.optimize.enabled)
+      (or
+        (and .Values.global.elasticsearch.enabled .Values.orchestration.exporters.rdbms.enabled .Values.optimize.enabled)
         (or
           (and .Values.global.elasticsearch.enabled .Values.orchestration.exporters.zeebe.enabled)
           (and (or .Values.global.elasticsearch.enabled .Values.optimize.database.elasticsearch.enabled) .Values.optimize.enabled)

--- a/charts/camunda-platform-8.10/test/unit/orchestration/configmap_unified_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/configmap_unified_test.go
@@ -494,6 +494,110 @@ func (s *ConfigmapTemplateTest) TestDifferentValuesInputsUnifiedRDBMS() {
 	testhelpers.RunTestCases(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
 
+func (s *ConfigmapTemplateTest) TestHasLegacyElasticsearchExporter() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestLegacyESExporterAbsentWhenRdbmsAndOptimizeButNoElasticsearch",
+			Values: map[string]string{
+				"global.elasticsearch.enabled":                                  "false",
+				"elasticsearch.enabled":                                         "false",
+				"global.opensearch.enabled":                                     "true",
+				"global.opensearch.url.host":                                    "opensearch.example.com",
+				"orchestration.exporters.rdbms.enabled":                         "true",
+				"orchestration.data.secondaryStorage.rdbms.url":                 "jdbc:postgresql://localhost:5432/camunda",
+				"orchestration.data.secondaryStorage.rdbms.username":            "camunda",
+				"orchestration.data.secondaryStorage.rdbms.secret.inlineSecret": "my-password",
+				"optimize.enabled":                                              "true",
+				"optimize.database.opensearch.enabled":                          "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.NotContains(t, output, "io.camunda.zeebe.exporter.ElasticsearchExporter",
+					"rdbms+optimize without elasticsearch must not render legacy ES exporter")
+			},
+		},
+		{
+			Name: "TestLegacyESExporterPresentWhenRdbmsAndOptimizeAndGlobalElasticsearch",
+			Values: map[string]string{
+				"orchestration.exporters.rdbms.enabled":                         "true",
+				"orchestration.data.secondaryStorage.rdbms.url":                 "jdbc:postgresql://localhost:5432/camunda",
+				"orchestration.data.secondaryStorage.rdbms.username":            "camunda",
+				"orchestration.data.secondaryStorage.rdbms.secret.inlineSecret": "my-password",
+				"optimize.enabled":                                              "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.Contains(t, output, "io.camunda.zeebe.exporter.ElasticsearchExporter",
+					"rdbms+optimize with global.elasticsearch.enabled must render legacy ES exporter")
+			},
+		},
+		{
+			Name: "TestLegacyESExporterPresentWhenRdbmsAndOptimizeDatabaseElasticsearchOnly",
+			Values: map[string]string{
+				"global.elasticsearch.enabled":                                  "false",
+				"elasticsearch.enabled":                                         "false",
+				"global.opensearch.enabled":                                     "true",
+				"global.opensearch.url.host":                                    "opensearch.example.com",
+				"orchestration.exporters.rdbms.enabled":                         "true",
+				"orchestration.data.secondaryStorage.rdbms.url":                 "jdbc:postgresql://localhost:5432/camunda",
+				"orchestration.data.secondaryStorage.rdbms.username":            "camunda",
+				"orchestration.data.secondaryStorage.rdbms.secret.inlineSecret": "my-password",
+				"optimize.enabled":                                              "true",
+				"optimize.database.elasticsearch.enabled":                       "true",
+				"optimize.database.elasticsearch.external":                      "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.Contains(t, output, "io.camunda.zeebe.exporter.ElasticsearchExporter",
+					"rdbms+optimize with optimize.database.elasticsearch.enabled must render legacy ES exporter")
+			},
+		},
+		{
+			Name: "TestLegacyESExporterAbsentForSupport32901CustomerConfig",
+			Values: map[string]string{
+				"global.elasticsearch.enabled":                                  "false",
+				"elasticsearch.enabled":                                         "false",
+				"global.opensearch.enabled":                                     "true",
+				"global.opensearch.url.host":                                    "opensearch.example.com",
+				"orchestration.exporters.rdbms.enabled":                         "true",
+				"orchestration.exporters.zeebe.enabled":                         "true",
+				"orchestration.data.secondaryStorage.rdbms.url":                 "jdbc:postgresql://localhost:5432/camunda",
+				"orchestration.data.secondaryStorage.rdbms.username":            "camunda",
+				"orchestration.data.secondaryStorage.rdbms.secret.inlineSecret": "my-password",
+				"optimize.enabled":                                              "true",
+				"optimize.database.opensearch.enabled":                          "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.NotContains(t, output, "io.camunda.zeebe.exporter.ElasticsearchExporter",
+					"SUPPORT-32901: rdbms+optimize+zeebe with OpenSearch must not render legacy ES exporter")
+				require.Contains(t, output, "io.camunda.zeebe.exporter.opensearch.OpensearchExporter",
+					"SUPPORT-32901: OS exporter must still render to feed Optimize")
+			},
+		},
+		{
+			Name: "TestLegacyESExporterAbsentWhenOnlyRdbmsNoOptimize",
+			Values: map[string]string{
+				"global.elasticsearch.enabled":                                  "false",
+				"elasticsearch.enabled":                                         "false",
+				"global.opensearch.enabled":                                     "true",
+				"global.opensearch.url.host":                                    "opensearch.example.com",
+				"orchestration.exporters.rdbms.enabled":                         "true",
+				"orchestration.data.secondaryStorage.rdbms.url":                 "jdbc:postgresql://localhost:5432/camunda",
+				"orchestration.data.secondaryStorage.rdbms.username":            "camunda",
+				"orchestration.data.secondaryStorage.rdbms.secret.inlineSecret": "my-password",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.NotContains(t, output, "io.camunda.zeebe.exporter.ElasticsearchExporter",
+					"rdbms without optimize must not render legacy ES exporter")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
 func (s *ConfigmapTemplateTest) TestMultiRegionInitialContactPoints() {
 	testCases := []testhelpers.TestCase{
 		{

--- a/charts/camunda-platform-8.10/test/unit/orchestration/configmap_unified_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/configmap_unified_test.go
@@ -500,7 +500,6 @@ func (s *ConfigmapTemplateTest) TestHasLegacyElasticsearchExporter() {
 			Name: "TestLegacyESExporterAbsentWhenRdbmsAndOptimizeButNoElasticsearch",
 			Values: map[string]string{
 				"global.elasticsearch.enabled":                                  "false",
-				"elasticsearch.enabled":                                         "false",
 				"global.opensearch.enabled":                                     "true",
 				"global.opensearch.url.host":                                    "opensearch.example.com",
 				"orchestration.exporters.rdbms.enabled":                         "true",
@@ -535,7 +534,6 @@ func (s *ConfigmapTemplateTest) TestHasLegacyElasticsearchExporter() {
 			Name: "TestLegacyESExporterPresentWhenRdbmsAndOptimizeDatabaseElasticsearchOnly",
 			Values: map[string]string{
 				"global.elasticsearch.enabled":                                  "false",
-				"elasticsearch.enabled":                                         "false",
 				"global.opensearch.enabled":                                     "true",
 				"global.opensearch.url.host":                                    "opensearch.example.com",
 				"orchestration.exporters.rdbms.enabled":                         "true",
@@ -556,7 +554,6 @@ func (s *ConfigmapTemplateTest) TestHasLegacyElasticsearchExporter() {
 			Name: "TestLegacyESExporterAbsentForSupport32901CustomerConfig",
 			Values: map[string]string{
 				"global.elasticsearch.enabled":                                  "false",
-				"elasticsearch.enabled":                                         "false",
 				"global.opensearch.enabled":                                     "true",
 				"global.opensearch.url.host":                                    "opensearch.example.com",
 				"orchestration.exporters.rdbms.enabled":                         "true",
@@ -579,7 +576,6 @@ func (s *ConfigmapTemplateTest) TestHasLegacyElasticsearchExporter() {
 			Name: "TestLegacyESExporterAbsentWhenOnlyRdbmsNoOptimize",
 			Values: map[string]string{
 				"global.elasticsearch.enabled":                                  "false",
-				"elasticsearch.enabled":                                         "false",
 				"global.opensearch.enabled":                                     "true",
 				"global.opensearch.url.host":                                    "opensearch.example.com",
 				"orchestration.exporters.rdbms.enabled":                         "true",

--- a/charts/camunda-platform-8.9/templates/orchestration/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/orchestration/_helpers.tpl
@@ -289,8 +289,8 @@ and
 
 {{- define "orchestration.hasLegacyElasticsearchExporter" -}}
 {{- and
-      (or 
-        (and .Values.orchestration.exporters.rdbms.enabled .Values.optimize.enabled)
+      (or
+        (and .Values.global.elasticsearch.enabled .Values.orchestration.exporters.rdbms.enabled .Values.optimize.enabled)
         (or
           (and .Values.global.elasticsearch.enabled .Values.orchestration.exporters.zeebe.enabled)
           (and (or .Values.global.elasticsearch.enabled .Values.optimize.database.elasticsearch.enabled) .Values.optimize.enabled)

--- a/charts/camunda-platform-8.9/test/unit/orchestration/configmap_unified_test.go
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/configmap_unified_test.go
@@ -513,6 +513,110 @@ func (s *ConfigmapTemplateTest) TestDifferentValuesInputsUnifiedRDBMS() {
 	testhelpers.RunTestCases(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
 
+func (s *ConfigmapTemplateTest) TestHasLegacyElasticsearchExporter() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestLegacyESExporterAbsentWhenRdbmsAndOptimizeButNoElasticsearch",
+			Values: map[string]string{
+				"global.elasticsearch.enabled":                                  "false",
+				"elasticsearch.enabled":                                         "false",
+				"global.opensearch.enabled":                                     "true",
+				"global.opensearch.url.host":                                    "opensearch.example.com",
+				"orchestration.exporters.rdbms.enabled":                         "true",
+				"orchestration.data.secondaryStorage.rdbms.url":                 "jdbc:postgresql://localhost:5432/camunda",
+				"orchestration.data.secondaryStorage.rdbms.username":            "camunda",
+				"orchestration.data.secondaryStorage.rdbms.secret.inlineSecret": "my-password",
+				"optimize.enabled":                                              "true",
+				"optimize.database.opensearch.enabled":                          "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.NotContains(t, output, "io.camunda.zeebe.exporter.ElasticsearchExporter",
+					"rdbms+optimize without elasticsearch must not render legacy ES exporter")
+			},
+		},
+		{
+			Name: "TestLegacyESExporterPresentWhenRdbmsAndOptimizeAndGlobalElasticsearch",
+			Values: map[string]string{
+				"orchestration.exporters.rdbms.enabled":                         "true",
+				"orchestration.data.secondaryStorage.rdbms.url":                 "jdbc:postgresql://localhost:5432/camunda",
+				"orchestration.data.secondaryStorage.rdbms.username":            "camunda",
+				"orchestration.data.secondaryStorage.rdbms.secret.inlineSecret": "my-password",
+				"optimize.enabled":                                              "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.Contains(t, output, "io.camunda.zeebe.exporter.ElasticsearchExporter",
+					"rdbms+optimize with global.elasticsearch.enabled must render legacy ES exporter")
+			},
+		},
+		{
+			Name: "TestLegacyESExporterPresentWhenRdbmsAndOptimizeDatabaseElasticsearchOnly",
+			Values: map[string]string{
+				"global.elasticsearch.enabled":                                  "false",
+				"elasticsearch.enabled":                                         "false",
+				"global.opensearch.enabled":                                     "true",
+				"global.opensearch.url.host":                                    "opensearch.example.com",
+				"orchestration.exporters.rdbms.enabled":                         "true",
+				"orchestration.data.secondaryStorage.rdbms.url":                 "jdbc:postgresql://localhost:5432/camunda",
+				"orchestration.data.secondaryStorage.rdbms.username":            "camunda",
+				"orchestration.data.secondaryStorage.rdbms.secret.inlineSecret": "my-password",
+				"optimize.enabled":                                              "true",
+				"optimize.database.elasticsearch.enabled":                       "true",
+				"optimize.database.elasticsearch.external":                      "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.Contains(t, output, "io.camunda.zeebe.exporter.ElasticsearchExporter",
+					"rdbms+optimize with optimize.database.elasticsearch.enabled must render legacy ES exporter")
+			},
+		},
+		{
+			Name: "TestLegacyESExporterAbsentForSupport32901CustomerConfig",
+			Values: map[string]string{
+				"global.elasticsearch.enabled":                                  "false",
+				"elasticsearch.enabled":                                         "false",
+				"global.opensearch.enabled":                                     "true",
+				"global.opensearch.url.host":                                    "opensearch.example.com",
+				"orchestration.exporters.rdbms.enabled":                         "true",
+				"orchestration.exporters.zeebe.enabled":                         "true",
+				"orchestration.data.secondaryStorage.rdbms.url":                 "jdbc:postgresql://localhost:5432/camunda",
+				"orchestration.data.secondaryStorage.rdbms.username":            "camunda",
+				"orchestration.data.secondaryStorage.rdbms.secret.inlineSecret": "my-password",
+				"optimize.enabled":                                              "true",
+				"optimize.database.opensearch.enabled":                          "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.NotContains(t, output, "io.camunda.zeebe.exporter.ElasticsearchExporter",
+					"SUPPORT-32901: rdbms+optimize+zeebe with OpenSearch must not render legacy ES exporter")
+				require.Contains(t, output, "io.camunda.zeebe.exporter.opensearch.OpensearchExporter",
+					"SUPPORT-32901: OS exporter must still render to feed Optimize")
+			},
+		},
+		{
+			Name: "TestLegacyESExporterAbsentWhenOnlyRdbmsNoOptimize",
+			Values: map[string]string{
+				"global.elasticsearch.enabled":                                  "false",
+				"elasticsearch.enabled":                                         "false",
+				"global.opensearch.enabled":                                     "true",
+				"global.opensearch.url.host":                                    "opensearch.example.com",
+				"orchestration.exporters.rdbms.enabled":                         "true",
+				"orchestration.data.secondaryStorage.rdbms.url":                 "jdbc:postgresql://localhost:5432/camunda",
+				"orchestration.data.secondaryStorage.rdbms.username":            "camunda",
+				"orchestration.data.secondaryStorage.rdbms.secret.inlineSecret": "my-password",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.NotContains(t, output, "io.camunda.zeebe.exporter.ElasticsearchExporter",
+					"rdbms without optimize must not render legacy ES exporter")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
 func (s *ConfigmapTemplateTest) TestMultiRegionInitialContactPoints() {
 	testCases := []testhelpers.TestCase{
 		{


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6240
Refs SUPPORT-32901

### What's in this PR?

The helper `orchestration.hasLegacyElasticsearchExporter` had a branch that fired on `rdbms.enabled AND optimize.enabled` with no `global.elasticsearch.enabled` guard. RDBMS+Optimize deployments using OpenSearch ended up with the legacy ES exporter injected into Zeebe broker config, causing broker boot failure with `UnknownHostException` for the non-existent ES service.

Changes:
- Gate the rdbms+optimize branch on `global.elasticsearch.enabled` in `orchestration.hasLegacyElasticsearchExporter` (4-line helper edit).
- Applied symmetrically to `camunda-platform-8.9` and `camunda-platform-8.10`.
- Added 5 regression cases per version in `test/unit/orchestration/configmap_unified_test.go`, including `TestLegacyESExporterAbsentForSupport32901CustomerConfig` covering the exact customer config (rdbms+optimize+zeebe+OpenSearch, ES disabled).

Branch A is now logically subsumed by branch C (`(or global.es.enabled optimize.database.elasticsearch.enabled) AND optimize.enabled`); retained for explicitness.

### Checklist

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open pull request for the same update/change.
- [x] Tests for charts are added.
- [ ] In-repo documentation are updated (not needed — internal helper, no values added).

**After opening the PR:**

- [x] Did you sign our CLA?
- [ ] Did all checks/tests pass in the PR?
