### PR TITLE
ci: prevent image overrides for OCI chart deploys

### DIFF
--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -237,6 +237,11 @@ on:
         required: false
         default: false
         type: boolean
+      force-image-overrides:
+        description: '⚠️ DANGER: Bypass OCI artifact immutability guard and allow image version overrides even when helmChartVersion is set. Only use if you know what you are doing.'
+        required: false
+        default: false
+        type: boolean
       helm-version:
         description: "Helm version to install. Empty means use the pre-baked Helm from the CI runner image."
         required: false
@@ -577,6 +582,7 @@ jobs:
           TEST_QA: ${{ inputs.test-qa }}
           TEST_UPGRADE: ${{ inputs.test-upgrade }}
           TEST_IMAGE_TAGS: ${{ inputs.include-image-tags }}
+          FORCE_IMAGE_OVERRIDES: ${{ inputs.force-image-overrides }}
           TEST_VALUES_SCENARIO: "${{ inputs.scenario }}"
           VALUES_CONFIG: ${{ inputs.values-config }}
           HELM_CHART_VERSION: ${{ inputs.helmChartVersion }}
@@ -617,13 +623,26 @@ jobs:
             CHART_REF_ARGS+=(--chart-version "${HELM_CHART_VERSION}")
           fi
 
-          # Convert VALUES_CONFIG JSON to .env file for image tag substitution.
-          # The .env file is loaded by buildScenarioEnv() and provides values for
-          # $E2E_TESTS_*_IMAGE_TAG placeholders in base-image-tags.yaml.
+          FORCE_IMAGE_OVERRIDE_ARGS=()
+          if [[ "${FORCE_IMAGE_OVERRIDES}" == "true" ]]; then
+            echo "::warning::Bypassing OCI artifact immutability guard; image version overrides may be applied to helmChartVersion=${HELM_CHART_VERSION:-<none>}"
+            FORCE_IMAGE_OVERRIDE_ARGS=(--force-image-overrides)
+          fi
+
+          # Convert VALUES_CONFIG JSON to .env file. In OCI immutability mode,
+          # strip image tag keys so the released chart artifact remains the
+          # source of truth while non-image test config (index prefixes, etc.) stays available.
           ENV_FILE_ARGS=()
           if [[ -n "${VALUES_CONFIG:-}" && "${VALUES_CONFIG}" != "{}" ]]; then
-            echo "${VALUES_CONFIG}" | jq -r 'to_entries[] | "\(.key)=\(.value)"' > /tmp/values-config.env
-            ENV_FILE_ARGS=(--env-file /tmp/values-config.env)
+            if [[ -n "${HELM_CHART_VERSION:-}" && "${FORCE_IMAGE_OVERRIDES}" != "true" ]]; then
+              echo "::notice::OCI artifact immutability mode: stripping *_IMAGE_TAG values from values-config"
+              echo "${VALUES_CONFIG}" | jq -r 'to_entries[] | select((.key | endswith("_IMAGE_TAG")) | not) | "\(.key)=\(.value)"' > /tmp/values-config.env
+            else
+              echo "${VALUES_CONFIG}" | jq -r 'to_entries[] | "\(.key)=\(.value)"' > /tmp/values-config.env
+            fi
+            if [[ -s /tmp/values-config.env ]]; then
+              ENV_FILE_ARGS=(--env-file /tmp/values-config.env)
+            fi
           fi
 
           cd ./scripts/deploy-camunda
@@ -640,6 +659,7 @@ jobs:
             --skip-dependency-update=false \
             --timeout 20 \
             --extra-helm-set "global.host=${{ steps.setup.outputs.ingress-host }}" \
+            ${FORCE_IMAGE_OVERRIDE_ARGS[@]+"${FORCE_IMAGE_OVERRIDE_ARGS[@]}"} \
             ${ENV_FILE_ARGS[@]+"${ENV_FILE_ARGS[@]}"} \
             ${CHART_REF_ARGS[@]+"${CHART_REF_ARGS[@]}"} \
             ${EXTRA_HELM_ARGS[@]+"${EXTRA_HELM_ARGS[@]}"} \
@@ -883,6 +903,7 @@ jobs:
           TEST_QA: ${{ inputs.test-qa }}
           TEST_UPGRADE: ${{ inputs.test-upgrade }}
           TEST_IMAGE_TAGS: ${{ inputs.include-image-tags }}
+          FORCE_IMAGE_OVERRIDES: ${{ inputs.force-image-overrides }}
           TEST_VALUES_SCENARIO: "${{ inputs.scenario }}"
           VALUES_CONFIG: ${{ inputs.values-config }}
           HELM_CHART_VERSION: ${{ inputs.helmChartVersion }}
@@ -919,11 +940,25 @@ jobs:
             CHART_REF_ARGS+=(--chart-version "${HELM_CHART_VERSION}")
           fi
 
-          # Convert VALUES_CONFIG JSON to .env file for image tag substitution.
+          FORCE_IMAGE_OVERRIDE_ARGS=()
+          if [[ "${FORCE_IMAGE_OVERRIDES}" == "true" ]]; then
+            echo "::warning::Bypassing OCI artifact immutability guard; image version overrides may be applied to helmChartVersion=${HELM_CHART_VERSION:-<none>}"
+            FORCE_IMAGE_OVERRIDE_ARGS=(--force-image-overrides)
+          fi
+
+          # Convert VALUES_CONFIG JSON to .env file. In OCI immutability mode,
+          # strip image tag keys so the released chart artifact remains the source of truth.
           ENV_FILE_ARGS=()
           if [[ -n "${VALUES_CONFIG:-}" && "${VALUES_CONFIG}" != "{}" ]]; then
-            echo "${VALUES_CONFIG}" | jq -r 'to_entries[] | "\(.key)=\(.value)"' > /tmp/values-config.env
-            ENV_FILE_ARGS=(--env-file /tmp/values-config.env)
+            if [[ -n "${HELM_CHART_VERSION:-}" && "${FORCE_IMAGE_OVERRIDES}" != "true" ]]; then
+              echo "::notice::OCI artifact immutability mode: stripping *_IMAGE_TAG values from values-config"
+              echo "${VALUES_CONFIG}" | jq -r 'to_entries[] | select((.key | endswith("_IMAGE_TAG")) | not) | "\(.key)=\(.value)"' > /tmp/values-config.env
+            else
+              echo "${VALUES_CONFIG}" | jq -r 'to_entries[] | "\(.key)=\(.value)"' > /tmp/values-config.env
+            fi
+            if [[ -s /tmp/values-config.env ]]; then
+              ENV_FILE_ARGS=(--env-file /tmp/values-config.env)
+            fi
           fi
 
           cd ./scripts/deploy-camunda
@@ -940,6 +975,7 @@ jobs:
             --skip-dependency-update=false \
             --timeout 20 \
             --extra-helm-set "global.host=${{ steps.setup.outputs.ingress-host }}" \
+            ${FORCE_IMAGE_OVERRIDE_ARGS[@]+"${FORCE_IMAGE_OVERRIDE_ARGS[@]}"} \
             ${ENV_FILE_ARGS[@]+"${ENV_FILE_ARGS[@]}"} \
             ${CHART_REF_ARGS[@]+"${CHART_REF_ARGS[@]}"} \
             ${EXTRA_HELM_ARGS[@]+"${EXTRA_HELM_ARGS[@]}"} \

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -211,6 +211,11 @@ on:
         required: false
         default: false
         type: boolean
+      force-image-overrides:
+        description: '⚠️ DANGER: Bypass OCI artifact immutability guard and allow image version overrides even when helmChartVersion is set. Only use if you know what you are doing.'
+        required: false
+        default: false
+        type: boolean
       helm-version:
         description: "Helm version to install. Empty means use the pre-baked Helm from the CI runner image."
         required: false
@@ -385,6 +390,7 @@ jobs:
       always-delete-namespace: ${{ inputs.always-delete-namespace }}
       initialClaimValue: ${{ inputs.initialClaimValue }}
       include-image-tags: ${{ inputs.include-image-tags }}
+      force-image-overrides: ${{ inputs.force-image-overrides }}
   print-outputs:
     name: Print outputs
     runs-on: ubuntu-latest

--- a/scripts/deploy-camunda/cmd/matrix.go
+++ b/scripts/deploy-camunda/cmd/matrix.go
@@ -181,6 +181,7 @@ func newMatrixRunCommand() *cobra.Command {
 		ensureDockerHub          bool
 		useLatest                bool
 		useQA                    bool
+		forceImageOverrides      bool
 		yes                      bool
 		logDir                   string
 		extraHelmArgs            []string
@@ -499,6 +500,7 @@ This command calls deploy.Execute() for each matrix entry.`,
 				EnsureDockerHub:       ensureDockerHub,
 				UseLatest:             useLatest,
 				UseQA:                 useQA,
+				ForceImageOverrides:   forceImageOverrides,
 				ExtraHelmArgs:         extraHelmArgs,
 				ExtraHelmSets:         extraHelmSets,
 				NamespaceOverride:     namespaceOverride,
@@ -600,6 +602,7 @@ This command calls deploy.Execute() for each matrix entry.`,
 	f.BoolVar(&ensureDockerHub, "ensure-docker-hub", false, "Ensure Docker Hub registry pull secret is created in each entry's namespace")
 	f.BoolVar(&useLatest, "use-latest", false, "Use values-latest.yaml from each chart root instead of values-digest.yaml")
 	f.BoolVar(&useQA, "use-qa", false, "Force the base-qa layer to be included for all entries, regardless of per-scenario qa config")
+	f.BoolVar(&forceImageOverrides, "force-image-overrides", false, "Bypass OCI immutability guard: allow image version overrides even when --chart-ref is set")
 	f.BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompts (e.g., e2e threshold warning)")
 	f.StringVar(&logDir, "log-dir", "", "Write logs to this directory and show a live status table (auto-generated when running in a TTY)")
 	f.StringArrayVar(&extraHelmArgs, "extra-helm-arg", nil, "Extra argument appended to every helm command (repeatable, e.g. --extra-helm-arg=--set-file=global.license.secret.inlineSecret=/tmp/license.txt)")

--- a/scripts/deploy-camunda/cmd/matrix.go
+++ b/scripts/deploy-camunda/cmd/matrix.go
@@ -602,7 +602,7 @@ This command calls deploy.Execute() for each matrix entry.`,
 	f.BoolVar(&ensureDockerHub, "ensure-docker-hub", false, "Ensure Docker Hub registry pull secret is created in each entry's namespace")
 	f.BoolVar(&useLatest, "use-latest", false, "Use values-latest.yaml from each chart root instead of values-digest.yaml")
 	f.BoolVar(&useQA, "use-qa", false, "Force the base-qa layer to be included for all entries, regardless of per-scenario qa config")
-	f.BoolVar(&forceImageOverrides, "force-image-overrides", false, "Bypass OCI immutability guard: allow image version overrides even when --chart-ref is set")
+	f.BoolVar(&forceImageOverrides, "force-image-overrides", false, "Bypass OCI immutability guard: allow Go-layer image overlays (base-image-tags, chart-root overlays) even when --chart-ref is set. Note: env-file IMAGE_TAG keys stripped at the workflow layer are not restored by this flag.")
 	f.BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompts (e.g., e2e threshold warning)")
 	f.StringVar(&logDir, "log-dir", "", "Write logs to this directory and show a live status table (auto-generated when running in a TTY)")
 	f.StringArrayVar(&extraHelmArgs, "extra-helm-arg", nil, "Extra argument appended to every helm command (repeatable, e.g. --extra-helm-arg=--set-file=global.license.secret.inlineSecret=/tmp/license.txt)")

--- a/scripts/deploy-camunda/matrix/matrix_test.go
+++ b/scripts/deploy-camunda/matrix/matrix_test.go
@@ -1193,6 +1193,54 @@ func TestSanitizeEnvFileForOCIImmutability(t *testing.T) {
 
 // --- resolveUseVaultBackedSecrets tests ---
 
+func TestOCIImmutabilityForceOverridesRestoresDigest(t *testing.T) {
+	chartPath := t.TempDir()
+	for _, name := range []string{"values-digest.yaml", "values-enterprise.yaml", "values-latest.yaml"} {
+		if err := os.WriteFile(filepath.Join(chartPath, name), []byte("# test\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	// ForceImageOverrides: true + ImageTags: false -> digest overlay should be restored
+	entry := Entry{Enterprise: true, ImageTags: false}
+	opts := RunOptions{ChartRef: "oci://registry.camunda.cloud/team-distribution/camunda-platform", ForceImageOverrides: true}
+	got := resolveChartRootOverlaysQuiet(chartPath, entry, opts)
+	expected := "enterprise,digest"
+	if strings.Join(got, ",") != expected {
+		t.Fatalf("resolveChartRootOverlaysQuiet() = %v, want [enterprise, digest] when force-overrides restores non-image-tags path", got)
+	}
+}
+
+func TestSanitizeEnvFileAllImageTags(t *testing.T) {
+	// All keys are IMAGE_TAG -> result should be empty path (no temp file needed)
+	envFile := filepath.Join(t.TempDir(), "values.env")
+	content := "E2E_TESTS_OPTIMIZE_IMAGE_TAG=8.8-SNAPSHOT\nE2E_TESTS_OPERATE_IMAGE_TAG=8.8-SNAPSHOT\n"
+	if err := os.WriteFile(envFile, []byte(content), 0o644); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+
+	got, cleanup, err := sanitizeEnvFileForOCIImmutability(envFile, RunOptions{ChartRef: "oci://registry.camunda.cloud/team-distribution/camunda-platform"})
+	if err != nil {
+		t.Fatalf("sanitizeEnvFileForOCIImmutability() error = %v", err)
+	}
+	defer cleanup()
+	if got != "" {
+		t.Fatalf("sanitizeEnvFileForOCIImmutability() = %q, want empty path when all keys are image tags", got)
+	}
+}
+
+func TestSanitizeEnvFileNoEnvFile(t *testing.T) {
+	// OCI mode with no env file -> should short-circuit cleanly
+	got, cleanup, err := sanitizeEnvFileForOCIImmutability("", RunOptions{ChartRef: "oci://registry.camunda.cloud/team-distribution/camunda-platform"})
+	if err != nil {
+		t.Fatalf("sanitizeEnvFileForOCIImmutability() error = %v", err)
+	}
+	defer cleanup()
+	if got != "" {
+		t.Fatalf("sanitizeEnvFileForOCIImmutability() = %q, want empty string for no env file", got)
+	}
+}
+
 func TestResolveUseVaultBackedSecrets(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/scripts/deploy-camunda/matrix/matrix_test.go
+++ b/scripts/deploy-camunda/matrix/matrix_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 	"time"
 
-	"scripts/camunda-core/pkg/versionmatrix"
 	"gopkg.in/yaml.v3"
+	"scripts/camunda-core/pkg/versionmatrix"
 
 	"scripts/camunda-deployer/pkg/deployer"
 	"scripts/deploy-camunda/config"
@@ -1131,6 +1131,63 @@ func TestResolveEnvFile(t *testing.T) {
 				t.Errorf("resolveEnvFile(opts, %q) = %q, want %q", tt.version, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestOCIImmutabilityDisablesImageOverrides(t *testing.T) {
+	chartPath := t.TempDir()
+	for _, name := range []string{"values-digest.yaml", "values-enterprise.yaml", "values-latest.yaml"} {
+		if err := os.WriteFile(filepath.Join(chartPath, name), []byte("# test\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	entry := Entry{Enterprise: true, ImageTags: true}
+	ociOpts := RunOptions{ChartRef: "oci://registry.camunda.cloud/team-distribution/camunda-platform", UseLatest: true}
+	if got := effectiveImageTags(entry, ociOpts); got {
+		t.Fatalf("effectiveImageTags() = true, want false in OCI immutability mode")
+	}
+	if got := resolveChartRootOverlaysQuiet(chartPath, entry, ociOpts); len(got) != 0 {
+		t.Fatalf("resolveChartRootOverlaysQuiet() = %v, want no overlays in OCI immutability mode", got)
+	}
+
+	forcedOpts := RunOptions{ChartRef: ociOpts.ChartRef, ForceImageOverrides: true, UseLatest: true}
+	if got := effectiveImageTags(entry, forcedOpts); !got {
+		t.Fatalf("effectiveImageTags() = false, want true when OCI immutability bypass is enabled")
+	}
+	if got := resolveChartRootOverlaysQuiet(chartPath, entry, forcedOpts); strings.Join(got, ",") != "enterprise" {
+		t.Fatalf("resolveChartRootOverlaysQuiet() = %v, want [enterprise] when bypass preserves image-tags", got)
+	}
+}
+
+func TestSanitizeEnvFileForOCIImmutability(t *testing.T) {
+	envFile := filepath.Join(t.TempDir(), "values.env")
+	content := "E2E_TESTS_OPTIMIZE_IMAGE_TAG=8.8-SNAPSHOT\nOPERATE_INDEX_PREFIX=test-run\nTASKLIST_INDEX_PREFIX=test-tasklist\n"
+	if err := os.WriteFile(envFile, []byte(content), 0o644); err != nil {
+		t.Fatalf("write env file: %v", err)
+	}
+
+	got, cleanup, err := sanitizeEnvFileForOCIImmutability(envFile, RunOptions{ChartRef: "oci://registry.camunda.cloud/team-distribution/camunda-platform"})
+	if err != nil {
+		t.Fatalf("sanitizeEnvFileForOCIImmutability() error = %v", err)
+	}
+	defer cleanup()
+	if got == "" || got == envFile {
+		t.Fatalf("sanitizeEnvFileForOCIImmutability() = %q, want sanitized temp file", got)
+	}
+
+	data, err := os.ReadFile(got)
+	if err != nil {
+		t.Fatalf("read sanitized env file: %v", err)
+	}
+	text := string(data)
+	if strings.Contains(text, "E2E_TESTS_OPTIMIZE_IMAGE_TAG") {
+		t.Fatalf("sanitized env file still contains image tag key: %s", text)
+	}
+	for _, key := range []string{"OPERATE_INDEX_PREFIX", "TASKLIST_INDEX_PREFIX"} {
+		if !strings.Contains(text, key+"=") {
+			t.Fatalf("sanitized env file missing %s: %s", key, text)
+		}
 	}
 }
 

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -232,6 +232,8 @@ func effectiveImageTags(entry Entry, opts RunOptions) bool {
 
 func resolveChartRootOverlays(entry Entry, opts RunOptions) []string {
 	if ociImmutabilityMode(opts) {
+		// OCI artifacts bake all image versions; skip overlays that would
+		// override them (includes enterprise sub-chart image pins).
 		return nil
 	}
 
@@ -600,7 +602,7 @@ func resolveStep1ValuesFromQuiet(entry Entry) string {
 
 // resolveChartRootOverlaysQuiet returns the list of chart-root overlays that exist on disk.
 // This is a dry-run helper — best-effort, silently filters to existing files only.
-// enterprise is composable (changes registry/repo, not tags).
+// enterprise adds registry/repo config and sub-chart image pins (Keycloak, PostgreSQL).
 // digest, latest, and image-tags are mutually exclusive for image version resolution:
 //   - image-tags (SNAPSHOT tags from env) takes priority over digest/latest
 //   - useLatest selects values-latest.yaml instead of values-digest.yaml
@@ -609,6 +611,11 @@ func resolveStep1ValuesFromQuiet(entry Entry) string {
 func resolveChartRootOverlaysQuiet(chartPath string, entry Entry, opts RunOptions) []string {
 	if chartPath == "" {
 		return nil
+	}
+	if ociImmutabilityMode(opts) {
+		logging.Logger.Warn().
+			Str("chartRef", opts.ChartRef).
+			Msg("OCI immutability mode: skipping chart-root image overlays (dry-run)")
 	}
 	overlays := resolveChartRootOverlays(entry, opts)
 	// Filter to only overlays whose files exist on disk.
@@ -1578,10 +1585,10 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions, entryIndex 
 	kubeCtx := resolveKubeContext(opts, platform)
 	envFile := resolveEnvFile(opts, entry.Version)
 	envFile, cleanupEnvFile, err := sanitizeEnvFileForOCIImmutability(envFile, opts)
+	defer cleanupEnvFile() // safe: cleanup is always a valid no-op func even on error
 	if err != nil {
 		return RunResult{Entry: entry, Namespace: namespace, KubeContext: kubeCtx, Error: err}
 	}
-	defer cleanupEnvFile()
 	useVault := resolveUseVaultBackedSecrets(opts, platform)
 
 	// Compute the scenario directory. deploy.Execute uses this to resolve

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -191,6 +191,11 @@ type RunOptions struct {
 	// ChartRefVersion is the chart version to install from ChartRef (e.g., "13-rc-latest").
 	// Only meaningful when ChartRef is set. Passed as --version to helm.
 	ChartRefVersion string
+	// ForceImageOverrides bypasses the OCI immutability guard. By default, an
+	// external chart reference is deployed with the image versions baked into
+	// that chart artifact, without chart-root image overlays or image-tag env
+	// substitutions from the local git checkout.
+	ForceImageOverrides bool
 }
 
 // applyChartRefOverride mutates chart to point at opts.ChartRef (an OCI reference
@@ -212,6 +217,91 @@ func applyChartRefOverride(chart *config.ChartFlags, opts RunOptions) bool {
 		Str("chartVersion", opts.ChartRefVersion).
 		Msg("Using external chart reference (OCI/tgz) instead of local chart directory")
 	return true
+}
+
+func ociImmutabilityMode(opts RunOptions) bool {
+	return opts.ChartRef != "" && !opts.ForceImageOverrides
+}
+
+func effectiveImageTags(entry Entry, opts RunOptions) bool {
+	if ociImmutabilityMode(opts) {
+		return false
+	}
+	return entry.ImageTags
+}
+
+func resolveChartRootOverlays(entry Entry, opts RunOptions) []string {
+	if ociImmutabilityMode(opts) {
+		return nil
+	}
+
+	var overlays []string
+	if entry.Enterprise {
+		overlays = append(overlays, "enterprise")
+	}
+	if !effectiveImageTags(entry, opts) {
+		if opts.UseLatest {
+			overlays = append(overlays, "latest")
+		} else {
+			overlays = append(overlays, "digest")
+		}
+	}
+	return overlays
+}
+
+func sanitizeEnvFileForOCIImmutability(envFile string, opts RunOptions) (string, func(), error) {
+	cleanup := func() {}
+	if !ociImmutabilityMode(opts) || envFile == "" {
+		return envFile, cleanup, nil
+	}
+
+	values, err := env.ReadFile(envFile)
+	if err != nil {
+		return "", cleanup, fmt.Errorf("read env file for OCI immutability guard: %w", err)
+	}
+
+	filtered := make(map[string]string, len(values))
+	removed := make([]string, 0)
+	for key, value := range values {
+		if strings.HasSuffix(key, "_IMAGE_TAG") {
+			removed = append(removed, key)
+			continue
+		}
+		filtered[key] = value
+	}
+	if len(removed) == 0 {
+		return envFile, cleanup, nil
+	}
+
+	sort.Strings(removed)
+	logging.Logger.Warn().
+		Str("chartRef", opts.ChartRef).
+		Strs("removedKeys", removed).
+		Msg("OCI immutability mode: removing image tag env overrides")
+
+	if len(filtered) == 0 {
+		return "", cleanup, nil
+	}
+
+	file, err := os.CreateTemp("", "deploy-camunda-oci-env-*.env")
+	if err != nil {
+		return "", cleanup, fmt.Errorf("create sanitized env file for OCI immutability guard: %w", err)
+	}
+	defer file.Close()
+
+	keys := make([]string, 0, len(filtered))
+	for key := range filtered {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if _, err := fmt.Fprintf(file, "%s=%s\n", key, strconv.Quote(filtered[key])); err != nil {
+			_ = os.Remove(file.Name())
+			return "", cleanup, fmt.Errorf("write sanitized env file for OCI immutability guard: %w", err)
+		}
+	}
+
+	return file.Name(), func() { _ = os.Remove(file.Name()) }, nil
 }
 
 // RunResult holds the result of a single matrix entry execution.
@@ -389,7 +479,7 @@ func dryRun(entries []Entry, opts RunOptions) []RunResult {
 				InfraType:   entry.InfraType,
 				Flow:        entry.Flow,
 				QA:          entry.QA || opts.UseQA,
-				ImageTags:   entry.ImageTags,
+				ImageTags:   effectiveImageTags(entry, opts),
 				Upgrade:     entry.Upgrade,
 			})
 			if buildErr != nil {
@@ -431,7 +521,7 @@ func dryRun(entries []Entry, opts RunOptions) []RunResult {
 				preUpgradeScript:     resolvePreUpgradeScriptQuiet(opts.RepoRoot, entry),
 				upgradeOnly:          versionmatrix.IsUpgradeOnlyFlow(entry.Flow),
 				step1ValuesFrom:      resolveStep1ValuesFromQuiet(entry),
-				chartRootOverlays:    resolveChartRootOverlaysQuiet(entry.ChartPath, entry, opts.UseLatest),
+				chartRootOverlays:    resolveChartRootOverlaysQuiet(entry.ChartPath, entry, opts),
 			})
 			results = append(results, RunResult{Entry: entry, Namespace: namespace, KubeContext: kubeCtx})
 		}
@@ -514,22 +604,13 @@ func resolveStep1ValuesFromQuiet(entry Entry) string {
 // digest, latest, and image-tags are mutually exclusive for image version resolution:
 //   - image-tags (SNAPSHOT tags from env) takes priority over digest/latest
 //   - useLatest selects values-latest.yaml instead of values-digest.yaml
+//   - OCI immutability mode selects no chart-root overlays
 //   - digest is the CI default when neither image-tags nor useLatest is active
-func resolveChartRootOverlaysQuiet(chartPath string, entry Entry, useLatest bool) []string {
+func resolveChartRootOverlaysQuiet(chartPath string, entry Entry, opts RunOptions) []string {
 	if chartPath == "" {
 		return nil
 	}
-	var overlays []string
-	if entry.Enterprise {
-		overlays = append(overlays, "enterprise")
-	}
-	if !entry.ImageTags {
-		if useLatest {
-			overlays = append(overlays, "latest")
-		} else {
-			overlays = append(overlays, "digest")
-		}
-	}
+	overlays := resolveChartRootOverlays(entry, opts)
 	// Filter to only overlays whose files exist on disk.
 	var existing []string
 	for _, name := range overlays {
@@ -717,7 +798,7 @@ func coverageReport(entries []Entry, opts RunOptions) []RunResult {
 				InfraType:   entry.InfraType,
 				Flow:        entry.Flow,
 				QA:          entry.QA || opts.UseQA,
-				ImageTags:   entry.ImageTags,
+				ImageTags:   effectiveImageTags(entry, opts),
 				Upgrade:     entry.Upgrade,
 			})
 			if buildErr != nil {
@@ -1496,6 +1577,11 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions, entryIndex 
 	platform := resolvePlatform(opts, entry)
 	kubeCtx := resolveKubeContext(opts, platform)
 	envFile := resolveEnvFile(opts, entry.Version)
+	envFile, cleanupEnvFile, err := sanitizeEnvFileForOCIImmutability(envFile, opts)
+	if err != nil {
+		return RunResult{Entry: entry, Namespace: namespace, KubeContext: kubeCtx, Error: err}
+	}
+	defer cleanupEnvFile()
 	useVault := resolveUseVaultBackedSecrets(opts, platform)
 
 	// Compute the scenario directory. deploy.Execute uses this to resolve
@@ -1535,18 +1621,12 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions, entryIndex 
 			//   - useLatest selects values-latest.yaml instead of values-digest.yaml
 			//   - digest is the CI default when neither image-tags nor useLatest is active
 			ChartRootOverlays: func() []string {
-				var overlays []string
-				if entry.Enterprise {
-					overlays = append(overlays, "enterprise")
+				if ociImmutabilityMode(opts) {
+					logging.Logger.Warn().
+						Str("chartRef", opts.ChartRef).
+						Msg("OCI immutability mode: skipping chart-root image overlays")
 				}
-				if !entry.ImageTags {
-					if opts.UseLatest {
-						overlays = append(overlays, "latest")
-					} else {
-						overlays = append(overlays, "digest")
-					}
-				}
-				return overlays
+				return resolveChartRootOverlays(entry, opts)
 			}(),
 		},
 		Deployment: config.DeploymentFlags{
@@ -1622,7 +1702,7 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions, entryIndex 
 			Features:    entry.Features,
 			InfraType:   entry.InfraType,
 			QA:          entry.QA || opts.UseQA,
-			ImageTags:   entry.ImageTags,
+			ImageTags:   effectiveImageTags(entry, opts),
 			UpgradeFlow: entry.Upgrade,
 		},
 	}


### PR DESCRIPTION
## Summary

- Add an OCI immutability guard to `deploy-camunda matrix run`.
- When `--chart-ref` is set, deploy the chart artifact with its baked-in image versions by default.
- Suppress all image-version override sources in OCI mode:
  - `base-image-tags.yaml`
  - `values-digest.yaml`
  - `values-latest.yaml`
  - `values-enterprise.yaml`
  - `*_IMAGE_TAG` keys from env files
- Add `--force-image-overrides` as an explicit escape hatch for advanced debugging.

## Root Cause

`helmChartVersion` is intended to test the immutable OCI chart artifact as released, but the SM workflow path could still override image versions from local git checkout state.

This happened through multiple independent paths:
- `image-tags: true` in `ci-test-config.yaml` forced `base-image-tags.yaml`
- `VALUES_CONFIG` always carried `E2E_TESTS_*_IMAGE_TAG` values
- `ChartRootOverlays` could still add `values-digest.yaml` or `values-latest.yaml`

This regressed the OCI artifact validation flow seen in:
- https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/26567031163/job/78264242368

## Related

- Follow-up to #6253
- Related to #6097

## Validation

- `go test ./matrix ./cmd` from `scripts/deploy-camunda`
- Dry-run with `--chart-ref ... --chart-version 13.10.0-rc` shows no image override layers
- Dry-run with `--force-image-overrides` restores image override behavior intentionally
