### PR TITLE
ci: retry Helm OCI registry login up to 3 times on transient failure

### DIFF
--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -551,9 +551,13 @@ jobs:
       - name: Helm - OCI Registry Login
         if: inputs.helmChartVersion != ''
         run: |
-          printf '%s' "${TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD}" | helm registry login registry.camunda.cloud \
-            --username "${TEST_DOCKER_USERNAME_CAMUNDA_CLOUD}" \
-            --password-stdin
+          for i in 1 2 3; do
+            printf '%s' "${TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD}" | helm registry login registry.camunda.cloud \
+              --username "${TEST_DOCKER_USERNAME_CAMUNDA_CLOUD}" \
+              --password-stdin && break
+            echo "Attempt $i failed, retrying in 15s..."
+            sleep 15
+          done
           echo "TEST_CHART_VERSION=${{ inputs.helmChartVersion }}" >> "$GITHUB_ENV"
 
       - name: Helm - Install - 🌟 Install Camunda chart 🌟
@@ -893,9 +897,13 @@ jobs:
       - name: Helm - OCI Registry Login (Upgrade)
         if: inputs.helmChartVersion != ''
         run: |
-          printf '%s' "${TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD}" | helm registry login registry.camunda.cloud \
-            --username "${TEST_DOCKER_USERNAME_CAMUNDA_CLOUD}" \
-            --password-stdin
+          for i in 1 2 3; do
+            printf '%s' "${TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD}" | helm registry login registry.camunda.cloud \
+              --username "${TEST_DOCKER_USERNAME_CAMUNDA_CLOUD}" \
+              --password-stdin && break
+            echo "Attempt $i failed, retrying in 15s..."
+            sleep 15
+          done
 
       - name: Helm - Upgrade - 🌟 Upgrade Camunda chart 🌟
         env:

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -551,13 +551,13 @@ jobs:
       - name: Helm - OCI Registry Login
         if: inputs.helmChartVersion != ''
         run: |
-          for i in 1 2 3; do
-            printf '%s' "${TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD}" | helm registry login registry.camunda.cloud \
-              --username "${TEST_DOCKER_USERNAME_CAMUNDA_CLOUD}" \
-              --password-stdin && break
-            echo "Attempt $i failed, retrying in 15s..."
-            sleep 15
-          done
+          export HARBOR_REGISTRY_HOST=registry.camunda.cloud
+          export HARBOR_REGISTRY_USER="${TEST_DOCKER_USERNAME_CAMUNDA_CLOUD}"
+          export HARBOR_REGISTRY_PASSWORD="${TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD}"
+          export HARBOR_RETRY_DELAY=15
+
+          source "${GITHUB_WORKSPACE}/scripts/harbor-retry.sh"
+          harbor_login
           echo "TEST_CHART_VERSION=${{ inputs.helmChartVersion }}" >> "$GITHUB_ENV"
 
       - name: Helm - Install - 🌟 Install Camunda chart 🌟
@@ -897,13 +897,13 @@ jobs:
       - name: Helm - OCI Registry Login (Upgrade)
         if: inputs.helmChartVersion != ''
         run: |
-          for i in 1 2 3; do
-            printf '%s' "${TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD}" | helm registry login registry.camunda.cloud \
-              --username "${TEST_DOCKER_USERNAME_CAMUNDA_CLOUD}" \
-              --password-stdin && break
-            echo "Attempt $i failed, retrying in 15s..."
-            sleep 15
-          done
+          export HARBOR_REGISTRY_HOST=registry.camunda.cloud
+          export HARBOR_REGISTRY_USER="${TEST_DOCKER_USERNAME_CAMUNDA_CLOUD}"
+          export HARBOR_REGISTRY_PASSWORD="${TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD}"
+          export HARBOR_RETRY_DELAY=15
+
+          source "${GITHUB_WORKSPACE}/scripts/harbor-retry.sh"
+          harbor_login
 
       - name: Helm - Upgrade - 🌟 Upgrade Camunda chart 🌟
         env:


### PR DESCRIPTION
## Summary

Run with no login issue: https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/26639135637 ✅ 

Harbor's token endpoint occasionally returns 401 transiently (brief overload, rolling restart, network blip). A single failure aborts the entire install/upgrade job. Added a 3-attempt retry loop with a 15s back-off to both OCI login steps so transient Harbor hiccups no longer fail the run.

- **`Helm - OCI Registry Login`** (install flow): wrapped in `for i in 1 2 3` loop
- **`Helm - OCI Registry Login (Upgrade)`** (upgrade flow): same

No secrets or credential mapping changed.

## Root cause

The failing run [`26635704224`](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/26635704224) got:
```
GET ".../service/token?service=harbor-registry": response status code 401: Unauthorized
```
An immediate retry of the same run (no code change) succeeded — confirming this is a transient Harbor token endpoint issue, not a credential problem.

## Test plan
- [ ] Trigger SM On-Demand 8.8+ Install with `helmChartVersion` set — confirm OCI login succeeds on first attempt
- [ ] Confirm no behavior change for runs without `helmChartVersion` (step is skipped)