### PR TITLE
ci: fix renovate alpha-versioning regex and check-values sed compat

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -356,19 +356,16 @@
       prCreation: 'immediate',
     },
     {
-      description: 'Parse Camunda 8.9 and 8.10 image tags as semver so alpha updates work',
+      description: 'Parse Camunda 8.10 alpha image tags as semver so alpha updates work; alpha suffix is optional so GA tags also match',
       enabled: true,
       matchPackageNames: ['/.*camunda.*/'],
       matchDatasources: ['helmv3', 'helm-values', 'docker', 'regex'],
       matchFileNames: [
-        'charts/camunda-platform-8.9/Chart.yaml',
-        'charts/camunda-platform-8.9/values.yaml',
-        'charts/camunda-platform-8.9/values-latest.yaml',
         'charts/camunda-platform-8.10/Chart.yaml',
         'charts/camunda-platform-8.10/values.yaml',
         'charts/camunda-platform-8.10/values-latest.yaml',
       ],
-      versioning: 'regex:^(?<major>\\d+)(.(?<minor>\\d+))(.(?<patch>\\d+))(-(?<prerelease>alpha[1-9]))$',
+      versioning: 'regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(-(?<prerelease>alpha[1-9]))?$',
     },
     {
       enabled: true,

--- a/scripts/check-values-latest.sh
+++ b/scripts/check-values-latest.sh
@@ -103,7 +103,7 @@ validate_chart() {
     local chart_dir="$1"
     local chart_path="${REPO_ROOT}/charts/${chart_dir}"
     local chart_version
-    chart_version=$(echo "$chart_dir" | sed 's/camunda-platform-\([0-9]\+\.[0-9]\+\)/\1/')
+    chart_version=$(echo "$chart_dir" | sed -E 's/camunda-platform-([0-9]+\.[0-9]+).*/\1/')
     
     echo ""
     echo -e "${YELLOW}Validating ${chart_dir}...${NC}"
@@ -131,7 +131,7 @@ validate_chart() {
         
         # Extract the minor version from the tag (e.g., 8.7 from 8.7.16)
         local tag_minor_version
-        tag_minor_version=$(echo "$tag" | sed 's/^\([0-9]\+\.[0-9]\+\).*/\1/')
+        tag_minor_version=$(echo "$tag" | sed -E 's/^([0-9]+\.[0-9]+).*/\1/')
         
         # Only check if the tag matches the chart version
         if [[ "$tag_minor_version" == "$chart_version" ]]; then


### PR DESCRIPTION
### Which problem does the PR fix?

Renovate has been silently freezing patch bumps for Camunda images in `charts/camunda-platform-8.9/values-latest.yaml` for weeks. This blocks teammate's bitnami removal work because current image versions can't merge. Symptom: PRs like #6154 (`update camunda-platform-images (patch)`) sit stuck — approved but failing the `Check values-latest.yaml files` workflow because Renovate refuses to bump further.

Root cause: a `packageRule` in `.github/renovate.json5` applies a regex versioning to Camunda images in 8.9/8.10 chart files. The trailing alpha group was mandatory (`(-(?<prerelease>alpha[1-9]))$`, no `?`), so any GA tag like `8.9.25` fails the regex, gets `skipReason: invalid-value`, never produces an update candidate. Meanwhile `scripts/check-values-latest.sh` queries Docker Hub directly, sees newer tags exist, and fails CI — creating a deadlock.

### What's in this PR?

**`.github/renovate.json5`** — fix the alpha-versioning `packageRule`:

```diff
- description: 'Parse Camunda 8.9 and 8.10 image tags as semver so alpha updates work',
+ description: 'Parse Camunda 8.10 alpha image tags as semver so alpha updates work; alpha suffix is optional so GA tags also match',
  matchPackageNames: ['/.*camunda.*/'],
  matchFileNames: [
-   'charts/camunda-platform-8.9/Chart.yaml',
-   'charts/camunda-platform-8.9/values.yaml',
-   'charts/camunda-platform-8.9/values-latest.yaml',
    'charts/camunda-platform-8.10/Chart.yaml',
    'charts/camunda-platform-8.10/values.yaml',
    'charts/camunda-platform-8.10/values-latest.yaml',
  ],
- versioning: 'regex:^(?<major>\\d+)(.(?<minor>\\d+))(.(?<patch>\\d+))(-(?<prerelease>alpha[1-9]))$',
+ versioning: 'regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(-(?<prerelease>alpha[1-9]))?$',
```

Decisions and why:
- **Drop 8.9 from the rule's scope.** 8.9 is GA, has no alpha tags. Falls back to default `docker` versioning so `8.9.X` patch tags parse normally.
- **Make the alpha group optional** (`?`). Keeps 8.10 alpha cycle working (`8.10.0-alpha1` → `8.10.0-alpha2`) AND survives the future GA flip (`8.10.0-alpha9` → `8.10.0`) without re-introducing the same bug.
- **Escape literal dots** (`\\.`). Was previously matching any character. Cosmetic but correct.

**`scripts/check-values-latest.sh`** — fix BSD/macOS sed incompatibility:

```diff
- chart_version=$(echo "$chart_dir" | sed 's/camunda-platform-\([0-9]\+\.[0-9]\+\)/\1/')
+ chart_version=$(echo "$chart_dir" | sed -E 's/camunda-platform-([0-9]+\.[0-9]+).*/\1/')
```

GNU sed accepts `\+`; BSD sed (macOS default) does not. Switch to `-E` extended regex so local runs on Darwin produce the same `chart_version` and `tag_minor_version` as CI on Linux.

### Verification

Renovate config validator passes:

```bash
docker run --rm -v "$(pwd):/src" -w /src renovate/renovate renovate-config-validator .github/renovate.json5
```

Renovate dry-run against a personal fork confirms previously-skipped updates are now picked up:

| Dep                                | Before fix              | After fix                       |
| ---------------------------------- | ----------------------- | ------------------------------- |
| `camunda/connectors-bundle` (8.9)  | `updates: []` (skipped) | `8.9.3 → 8.9.4` (patch)         |
| `camunda/optimize` (8.9)           | `updates: []` (skipped) | `8.9.4 → 8.9.5` (patch)         |
| `camunda/camunda` (8.9)            | `updates: []` (skipped) | `8.9.4 → 8.9.5` (patch)         |
| `camunda/connectors-bundle` (8.10) | `8.10.0-alpha1` parsed  | `8.10.0-alpha1` still parsed    |

All branched under `renovate/patch-camunda-platform-images` as expected. 8.10 alpha entries continue to parse correctly with the now-optional alpha group.

### Checklist

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] No chart template changes, so `make go.update-golden-only` is not required.
- [x] No chart test changes needed (config-only change).
- [x] No in-repo documentation changes needed.

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

🤖 Generated with [Claude Code](https://claude.com/claude-code)