### PR TITLE
chore(docs): add 8.10 deployment journey IA proposal

### DIFF
--- a/docs/user journeys/8.10/8.10 deployment journey.md
+++ b/docs/user journeys/8.10/8.10 deployment journey.md
@@ -1,0 +1,820 @@
+# Camunda 8.10 Self-Managed Documentation — Information Architecture Proposal
+
+**Audience.** Camunda Self-Managed PM, Documentation team, InfraEx team, Hub team, Tech Writers.
+
+**Status.** Draft proposal for review before 8.10 GA documentation freeze.
+
+**Scope.** The Self-Managed section of `docs.camunda.io` only (`/docs/next/self-managed/...`). The Components hub is out of scope by explicit instruction and continues to live at the top of the docs as a cross-cutting reference. APIs & Tools, Reference, and Guides top-level sections are also out of scope.
+
+**Outcome.** A journey-shaped sidebar that replaces the current 8.9 component-shaped structure, with every existing page mapped to a new location and content briefs for ~45 new pages the structure requires.
+
+---
+
+## Table of contents
+
+1. [Executive summary](#1-executive-summary)
+2. [The core shift](#2-the-core-shift)
+3. [What the deeper analysis revealed](#3-what-the-deeper-analysis-revealed)
+4. [Validation from competitor docs](#4-validation-from-competitor-docs)
+5. [The proposed sidebar (complete tree)](#5-the-proposed-sidebar-complete-tree)
+6. [Page-by-page migration tables](#6-page-by-page-migration-tables)
+7. [Cross-cutting patterns to adopt](#7-cross-cutting-patterns-to-adopt)
+8. [Suggested rollout sequence](#8-suggested-rollout-sequence)
+9. [Open questions to validate before publishing](#9-open-questions-to-validate-before-publishing)
+10. [Appendix A — Content briefs for new pages](#appendix-a--content-briefs-for-new-pages)
+11. [Appendix B — Rewrite guidance for existing pages](#appendix-b--rewrite-guidance-for-existing-pages)
+
+---
+
+## 1. Executive summary
+
+The 8.9 Self-Managed sidebar is organized around what Camunda ships (Quickstart, Reference Architecture, Deploy and manage, Concepts, Components, Upgrade). For 8.10, the customer journey has changed enough — Hub replaces Web Modeler + Console SM, Physical Tenants are introduced, Optimize binds 1:1 to a PT, Bitnami is removed, Helm v4 is required, three resilience tiers replace ad-hoc multi-region patterns — that a same-shaped sidebar would amplify the docs problems customers already flag.
+
+This proposal reorganizes Self-Managed around six top-level sections:
+
+1. **Quickstart** — fast, opinionated paths that get a developer or administrator to a running instance. No decisions required.
+2. **Deploy to production** — the action-ordered path from planning decisions to a production-shaped baseline. Contains two sub-phases: Plan your deployment and Deploy your baseline.
+3. **Architecture and concepts** — reference and concept material that users consult selectively, in any order, after or alongside the main deployment path. This includes reference architectures and deployment concepts (tenancy, availability & DR, process analytics, database topology).
+4. **Run and maintain** — ongoing operational concerns for a healthy deployment: upgrades, backups, monitoring, scaling, diagnostics, troubleshooting.
+5. **Components** — cross-cutting reference for individual Camunda components. Intentionally separate from the deployment journey.
+6. **Migrate** — the once-per-version upgrade path from 8.9 to 8.10.
+
+**Why the journey stops at Deploy your baseline.** Availability & DR, Tenancy & isolation, Process analytics, and Databases are placed in Architecture and concepts rather than as a third sequential phase after Deploy your baseline. These capabilities are not a linear next step: customers adopt them independently, in any order, at any time after the baseline is healthy. Presenting them as a sequential phase implies a linearity that doesn't match how customers evolve their deployments, and risks recreating the problem where one sidebar section becomes a catch-all for everything that doesn't fit elsewhere. Architecture and concepts is where they belong: standing reference material users reach for when they need it, not a mandatory phase they walk through in sequence.
+
+A **Migrate from 8.9 → 8.10** section sits alongside as the once-per-version stay-as-is upgrade path. Quickstart keeps its current dev/admin split as a forked side path at the top of the sidebar. Reference architectures live in Architecture and concepts — accessible as a cross-cutting resource from Deploy to production's planning phase, not buried at the bottom of a sequential journey.
+
+This shape is validated against three competitor docs:
+
+- **Temporal** organizes around verbs (Evaluate → Develop → Deploy → Self-host) with a three-bucket landing page (Plan / Operate / Protect data) that maps directly onto Deploy to production / Architecture and concepts / Run and maintain.
+- **CockroachDB** has the best comparison-table pattern for helping customers choose between resilience options — adopted for the reference architecture and concept pages.
+- **Confluent** has the most rigorous architecture-pattern template (When to use / When not to / Use cases / Implementation recommendations) — adopted for every option page in Architecture and concepts.
+
+The proposal closes by:
+
+- Specifying where every existing Self-Managed page moves (§6).
+- Listing the ~45 net new pages the structure requires, with one-paragraph content briefs (Appendix A).
+- Listing existing pages that need rewrites beyond a pure relocation, with change instructions (Appendix B).
+- Sequencing the rollout into three phases of independent risk and value (§8), so the team can ship the low-risk wins immediately (backup-promotion, OpenShift de-duplication, glossary extension) before the larger 8.10 restructure.
+
+---
+
+## 2. The core shift
+
+The 8.9 sidebar treats deployment as a series of categories the customer browses (here are the installation methods, here are the components, here are the upgrade paths). The 8.10 proposal treats deployment as a sequence of actions the customer takes — but only up to the point where a production-shaped baseline is running. After that, the sidebar branches into targeted reference and concept material rather than continuing a linear narrative. Concretely:
+
+| 8.9 sidebar shape | 8.10 sidebar shape |
+|---|---|
+| Quickstart · Reference architecture · Deploy and manage · Concepts · Components · Upgrade | Quickstart · Deploy to production · Architecture and concepts · Run and maintain · Components · Migrate |
+| Categories | Action path → reference split |
+| Browse everything | Guided path to baseline, then branch to reference |
+| Component-shaped | Journey-shaped to baseline; concept-shaped beyond |
+| Multiple unrelated entry points | One opinionated happy path to production, then selective reference |
+| Deployment target choice implicit in which page you click | Deployment target chosen explicitly in Plan your deployment |
+| Multi-region and availability buried under Concepts | First-class content in Architecture and concepts with three named tiers |
+| Backup & restore buried under Concepts | First-class Run and maintain entry |
+| "Operate" as a section name | "Run and maintain" — avoids confusion with the Operate application |
+
+**Where the main deployment journey ends.** The guided, action-ordered path in Deploy to production stops after Deploy your baseline. The sidebar then intentionally branches: customers who want to understand tenancy models, availability tiers, database topology options, or Optimize-per-PT consult Architecture and concepts — selectively, in any order, as their deployment needs evolve. Customers managing a running deployment go to Run and maintain. This split avoids two failure modes of the 8.9 sidebar: concepts buried inside operational sections (Backup & restore under Concepts), and operational pages buried inside concept sections. It also avoids recreating the "Concepts as catch-all" problem that this restructure is trying to fix.
+
+**Why deployment capabilities belong in Architecture and concepts.** Availability & DR, Tenancy & isolation, Process analytics, and Databases are capabilities customers adopt selectively, often months after the baseline is healthy, in whatever order their deployment needs dictate. Grouping them as a sequential phase after Deploy your baseline would misrepresent this: a phase implies a customer walks through it in order, then moves on. Placing them in Architecture and concepts makes clear they are standing reference material — consult when you need it, skip what doesn't apply.
+
+---
+
+## 3. What the deeper analysis revealed
+
+Reading the actual current `sidebars.js` (not just the landing page) surfaced several issues that wouldn't be visible from the docs page alone:
+
+1. **Backup & restore lives under `Concepts`.** It's the most critical Day-2 capability and it's filed inside a junk-drawer section labelled as a place for definitions. This single mis-filing accounts for a significant share of customer "I can't find the backup docs" complaints in support tickets.
+
+2. **`Concepts` mixes two unrelated things.** Genuine concepts (authentication, secondary storage, databases) sit alongside pure operations (backup, monitoring, troubleshooting, data purge, flow control). Splitting the section cleanly — concepts into Plan, operations into Day-2 — is half the structural value of this restructure.
+
+3. **OpenShift appears in two places under Helm cloud providers.** Once as a child of Amazon (ROSA), once standalone. This is confusing today, before any 8.10 changes.
+
+4. **`helm/operational-tasks/dual-region-operational-procedure` is in Operational tasks** but it's really Availability & DR → Tier 2 content. It's misfiled because today's sidebar has no Availability & DR section to host it.
+
+5. **Bitnami migration pages are in Operational tasks** but they're a one-time pre-Baseline activity tied to a Phase 0 dependency decision, not ongoing operations.
+
+6. **Multi-region today is one buried page** (`concepts/multi-region/dual-region`). The journey doc's three-tier framework (Tier 1 cold recovery / Tier 2 dual-region hot standby / Tier 3 three-region stretched) has no home in the current sidebar at all.
+
+7. **Reference architecture is thin** — three pages (Kubernetes, Containers, Manual) — but the journey doc's needs (Tier 2, Tier 3, multi-PT variants) require it to grow.
+
+8. **Three Helm install overview pages** (`helm/index`, `helm/install/index`, `helm/install/production/index`) all do landing-page duty at slightly different levels. One page would do the job.
+
+9. **`configure-multi-tenancy` is in Baseline → Configure** but in 8.10 with auto-created PTs, multi-tenancy is fundamentally a Tenancy & isolation topic, not a Baseline configure topic.
+
+10. **Generic Helm pages appear before provider-specific infrastructure pages.** The actual install order is: provision cluster → install Helm chart. The sidebar order today is the reverse, which forces administrators to read past content they can't use yet.
+
+---
+
+## 4. Validation from competitor docs
+
+The journey-shaped direction is convergent with industry practice. Three patterns are particularly worth adopting.
+
+### From Temporal
+
+Temporal's top-level docs IA is verb-shaped: Evaluate → Develop → Deploy to production → Self-host → Operate. On the Self-hosted landing page, content is grouped into three named buckets — "Plan and deploy your service" / "Operate your self-hosted service" / "Protect data and enable advanced features." This maps almost one-to-one onto Deploy to production / Run and maintain / Architecture and concepts — the same separation between action-oriented and reference-oriented content that this proposal adopts.
+
+Patterns to adopt:
+
+- **Three-bucket landing pages** for each major section.
+- **Production checklist as a named page**, not scattered guidance across multiple deployment guides.
+- **AI-friendly affordances** — "Copy for LLM" / "View as Markdown" buttons on every page. Temporal ships these. Confluent ships "Copy Markdown / Open as Markdown." Camunda doesn't yet, and it's an emerging best practice.
+
+### From CockroachDB
+
+CockroachDB's Data Resilience page has the cleanest "help me choose" pattern in any database docs site. The page opens with a single architectural diagram, a glossary block defining RPO/RTO, then two comparison tables ("Choose an HA strategy" / "Choose a DR strategy") with strategies as columns and trade-offs (RPO, RTO, write latency, recovery, fault tolerance, minimum regions) as rows.
+
+Patterns to adopt:
+
+- **"Choose your tier" comparison table** as the opening of Availability & DR — see Appendix A for the proposed Camunda version.
+- **Glossary block at the start of each major section** for the terms it introduces.
+- **One architectural diagram per section** showing the topology choices side by side.
+- **LTS markers in the version switcher** to make supported-version status visible at a glance.
+
+### From Confluent
+
+Confluent's Multi-Data Center Architectures page has the most rigorous architecture-pattern template. Every pattern (2-Cluster Active-Passive, Stretched Cluster 3-Data Center, etc.) uses the same sub-structure: Terms → Why use this? / Why not? → When to use? → When not to use? → Use cases (with industry anchors) → Implementation recommendations.
+
+Patterns to adopt:
+
+- **"When to use / When not to use" blocks** on every option page in Architecture and concepts (tenancy, availability, database topology).
+- **Industry-anchored use cases** — anchor abstract tier patterns to concrete businesses (Tier 1 = internal tooling; Tier 2 = regulated SaaS, payments, insurance; Tier 3 = banking, government).
+- **Memorable pattern names**, not generic tier numbers. The journey doc already uses these — "Cold recovery", "Dual-region hot standby", "Three-region stretched cluster" — and they should be primary sidebar labels, with "Tier 1/2/3" as parenthetical aliases.
+
+### Two anti-patterns to avoid
+
+Confluent's sidebar has 20+ top-level entries with very deep nesting (look at the ksqlDB tree). Customers visibly drown. The proposed Camunda Self-Managed sidebar sits at 10–12 top-level entries; that's the right ceiling.
+
+Temporal's Self-host landing page makes one risky design choice: "Choose a deployment approach (Docker, Kubernetes, or manual)" lives entirely inside one page, with no sidebar fan-out at all. That works for Temporal because all three paradigms are roughly equivalent. It would not work for Camunda because Helm-on-Kubernetes is the recommended production paradigm and ECS / manual are increasingly specialized. The Baseline → Install fan-out the proposal carries is the right shape.
+
+---
+
+## 5. The proposed sidebar (complete tree)
+
+**Paradigm notation:** Pages marked `[Kubernetes]`, `[Containers]`, or `[Manual]` contain tabs synced via Docusaurus `groupId="deployment-paradigm"`. Selecting a paradigm once persists the choice across all pages in the session. Pages with no badge are paradigm-agnostic.
+
+**Depth note:** The tree below shows section and page structure. Provider-specific leaf subpages (e.g., EKS with eksctl, AKS with Terraform), auth-provider leaf pages (Microsoft Entra, Generic OIDC), and last-level tier implementation pages are omitted for readability. They exist as children of the nodes shown.
+
+```
+Self-Managed
+│
+├─ Start here                                      (about-self-managed — rewritten)
+│
+├─ Quickstart
+│   ├─ Developer quickstart
+│   └─ Administrator quickstart
+│
+├─ Deploy to production
+│   ├─ Plan your deployment
+│   │   ├─ Choose your deployment target          [Kubernetes] [Containers] [Manual]
+│   │   ├─ Choose your resilience tier
+│   │   ├─ Choose your database strategy
+│   │   ├─ Choose your identity strategy
+│   │   └─ Reference architectures               (cross-link to Architecture and concepts)
+│   │
+│   ├─ Deploy your baseline
+│   │   ├─ Kubernetes — Cloud providers       (existing: deployment/helm/cloud-providers/)
+│   │   │   ├─ Amazon EKS
+│   │   │   ├─ Google GKE
+│   │   │   ├─ Microsoft AKS
+│   │   │   └─ Red Hat OpenShift
+│   │   ├─ Containers                         (existing: deployment/docker/ + deployment/containers/)
+│   │   │   ├─ Docker
+│   │   │   └─ Amazon ECS
+│   │   └─ Manual                             (existing: deployment/manual/install/)
+│   │       ├─ Install
+│   │       ├─ Manual installation with RDBMS
+│   │       └─ Amazon EC2
+│   └─ Production readiness checklist
+│
+├─ Architecture and concepts
+│   ├─ Reference architectures               (existing: reference-architecture/)
+│   │   ├─ Kubernetes                        (existing)
+│   │   ├─ Containers                        (existing)
+│   │   └─ Manual / VM                       (existing)
+│   ├─ Hub / Orchestration Cluster topology
+│   ├─ Tenancy and isolation
+│   │   ├─ Choose your isolation strength
+│   │   ├─ Logical tenants
+│   │   ├─ Physical tenants
+│   │   └─ Separate Orchestration Clusters
+│   ├─ Availability and DR
+│   │   ├─ Tier framework and RPO / RTO
+│   │   ├─ Tier 1 — Cold recovery
+│   │   ├─ Tier 2 — Dual-region hot standby
+│   │   └─ Tier 3 — Three-region stretched
+│   ├─ Process analytics
+│   │   ├─ Optimize per Physical Tenant
+│   │   ├─ Hub Business View / Agent Control
+│   │   ├─ Storage requirements
+│   │   └─ Sizing at PT scale
+│   ├─ Databases
+│   │   ├─ Operating Elasticsearch / OpenSearch
+│   │   ├─ Operating RDBMS
+│   │   ├─ Splitting databases per component
+│   │   ├─ Secondary storage concepts
+│   │   └─ Exporters
+│   └─ Authentication
+│       ├─ Authentication to Orchestration Cluster
+│       └─ Authentication to management components
+│
+├─ Run and maintain
+│   ├─ Upgrade your deployment
+│   ├─ Back up and restore
+│   │   ├─ Overview
+│   │   ├─ Elasticsearch / OpenSearch
+│   │   ├─ Relational databases
+│   │   └─ Backup Management API
+│   ├─ Monitoring
+│   │   ├─ Log levels
+│   │   ├─ Metrics
+│   │   └─ Per-PT metrics
+│   ├─ Scaling
+│   │   ├─ OC broker scaling
+│   │   ├─ Stateless Hub scaling
+│   │   └─ Adding Physical Tenants
+│   ├─ Flow control
+│   ├─ Data purge
+│   ├─ Audit log
+│   ├─ Document handling
+│   ├─ Credentials and secrets rotation
+│   ├─ Diagnostics
+│   └─ Troubleshooting
+│
+├─ Components
+│   ├─ Camunda Hub
+│   ├─ Orchestration cluster
+│   ├─ Connectors
+│   ├─ Optimize
+│   └─ Management Identity
+│
+└─ Migrate
+    ├─ Migrate from 8.9 to 8.10
+    │   ├─ At-a-glance: what changes
+    │   ├─ Prepare for upgrade
+    │   ├─ Web Modeler + Console SM → Camunda Hub
+    │   ├─ Helm v3 → v4 CLI swap
+    │   ├─ Run the upgrade
+    │   │   ├─ Helm upgrade (8.9 → 8.10)         [Kubernetes]
+    │   │   ├─ Manual upgrade                     [Manual]
+    │   │   └─ Component-by-component notes
+    │   └─ Catch up to baseline (post-upgrade, optional)
+    └─ Bitnami migration
+        ├─ Migrate to operators
+        ├─ Migrate to managed services
+        ├─ Alternatives
+        └─ Zero-downtime migration
+```
+
+---
+
+## 6. Page-by-page migration tables
+
+Every existing Self-Managed page is accounted for. The tables are grouped by current top-level section so the migration can be reviewed section by section against the live `sidebars.js`.
+
+Action key:
+- **Move** — page relocates with no substantive content change.
+- **Rename** — page relocates *and* gets a clearer title; URL changes.
+- **Merge** — page is absorbed into another page; URL removed (with redirect).
+- **Split** — page content fans across multiple new pages.
+- **Rewrite** — page stays but content is substantively rewritten (see Appendix B).
+- **Delete** — page removed, content not preserved.
+
+### 6.1 Quickstart
+
+| Current path | New location | Action |
+|---|---|---|
+| `self-managed/quickstart/overview` | `Start here` landing absorbs intro content | **Merge** |
+| `self-managed/quickstart/developer-quickstart` | `Quickstart → For developers` overview | Move |
+| `self-managed/quickstart/developer-quickstart/c8run/*` (4 pages) | `Quickstart → For developers → Camunda 8 Run` | Move |
+| `self-managed/quickstart/developer-quickstart/docker-compose/*` (4 pages) | `Quickstart → For developers → Docker Compose` | Move |
+| `self-managed/quickstart/administrator-quickstart` | `Quickstart → For administrators → Local with kind` | **Rename + reframe** — see Appendix B |
+
+### 6.2 Reference architecture (moves into Plan)
+
+| Current path | New location | Action |
+|---|---|---|
+| `self-managed/reference-architecture/reference-architecture` | `Architecture and concepts → Reference architectures` landing | **Rewrite** — see Appendix B |
+| `self-managed/reference-architecture/kubernetes` | `Architecture and concepts → Reference architectures → Kubernetes → Single-region` | **Rewrite** — see Appendix B (trim) |
+| `self-managed/reference-architecture/containers` | `Architecture and concepts → Reference architectures → Containers` | Move |
+| `self-managed/reference-architecture/manual` | `Architecture and concepts → Reference architectures → Manual / VM` | Move |
+| — (NEW) | `Architecture and concepts → Reference architectures → Kubernetes → Dual-region (Tier 2)` | **New** — see Appendix A |
+| — (NEW) | `Architecture and concepts → Reference architectures → Kubernetes → Three-region (Tier 3)` | **New** — see Appendix A |
+| — (NEW) | `Architecture and concepts → Reference architectures → Kubernetes → Multi-PT variant` | **New** — see Appendix A |
+
+### 6.3 Deploy and manage → Helm install pages
+
+| Current path | New location | Action |
+|---|---|---|
+| `self-managed/deployment/index` | Dissolved — paradigm choice lives in `Deploy to production → Plan your deployment → Choose your deployment target` | **Delete** (with redirect) |
+| `self-managed/deployment/helm/index` | `Deploy to production → Deploy your baseline → → 2. Install Camunda` (tab: Kubernetes) — merged 3-into-1; see Appendix B | **Merge** (3-into-1) — see Appendix B |
+| `self-managed/deployment/helm/install/index` | (merged) | **Merge** |
+| `self-managed/deployment/helm/install/quick-install` | `Quickstart → For administrators → Local with kind` (cross-link) | **Move** |
+| `self-managed/deployment/helm/install/production/index` | (merged) | **Merge** |
+| `self-managed/deployment/helm/install/helm-with-rdbms` | `Architecture and concepts → Databases → Operating RDBMS → Example end-to-end install` | **Move** — see §5 RDBMS dissolution note |
+| `self-managed/deployment/helm/chart-parameters` | Out of Baseline scope — link as reference from `Deploy to production → Deploy your baseline → Prepare installation configuration` pages | **Out of scope** |
+
+### 6.4 Deploy and manage → Helm Configure pages
+
+| Current path | New location | Action |
+|---|---|---|
+| `self-managed/deployment/helm/configure/index` | Dissolved — no configuration landing page in Baseline | **Delete** |
+| `.../configure/application-configs` | Out of Baseline scope — app configuration is a separate discussion | **Out of scope** |
+| `.../configure/pod-networking` | `Deploy to production → Deploy your baseline → Provision infrastructure → Kubernetes-specific configuration → Pod networking` `[Kubernetes]` | Move |
+| `.../configure/operator-based-infrastructure` | `Deploy to production → Plan your deployment → Choose your database strategy → Kubernetes operators` | **Rewrite** — see Appendix B |
+| `.../configure/enable-additional-components` | Out of Baseline scope — app configuration is a separate discussion | **Out of scope** |
+| `.../configure/data-retention` | `Run and maintain → Data purge` | Move |
+| `.../configure/registry-and-images/index` | `Deploy to production → Deploy your baseline → Provision infrastructure → Kubernetes-specific configuration → Registry & images` landing `[Kubernetes]` | Move |
+| `.../configure/registry-and-images/air-gapped-installation` | `… → Air-gapped installation` | Move |
+| `.../configure/registry-and-images/install-bitnami-enterprise-images` | `… → Bitnami Enterprise images` | Move |
+| `.../configure/database/index` | (dissolved) | **Delete** |
+| `.../configure/database/rdbms` | `Architecture and concepts → Databases → Operating RDBMS` landing | Move |
+| `.../configure/database/rdbms-jdbc-drivers` | `… → Operating RDBMS → JDBC drivers` | Move |
+| `.../configure/database/rdbms-search-and-result-limits` | `… → Operating RDBMS → Search & result limits` | Move |
+| `.../configure/database/rdbms-schema-management` | `… → Operating RDBMS → Schema management` | Move |
+| `.../configure/database/rdbms-troubleshooting` | `… → Operating RDBMS → Troubleshooting` | Move |
+| `.../configure/database/validate-rdbms` | `… → Operating RDBMS → Validate setup` | Move |
+| `.../configure/database/access-sql-liquibase-scripts` | `… → Operating RDBMS → Liquibase scripts` | Move |
+| `.../configure/database/non-sql` | `Architecture and concepts → Databases → Operating Elasticsearch / OpenSearch` landing | **Rewrite** — see Appendix B |
+| `.../configure/database/elasticsearch/using-external-elasticsearch` | `Architecture and concepts → Databases → Splitting databases per component → External Elasticsearch for OC` | Move |
+| `.../configure/database/using-external-opensearch` | `… → Splitting databases per component → External OpenSearch for OC` | Move |
+| `.../configure/database/configure-db-custom-headers` | `… → Operating ES/OS → Custom headers` | Move |
+| `.../configure/database/elasticsearch/prefix-elasticsearch-indices` | `… → Operating ES/OS → Index prefixes` | Move |
+| `.../configure/database/all-shards-failed` | `… → Operating ES/OS → Troubleshooting` | Move |
+| `.../configure/database/using-existing-postgres` | `… → Splitting databases per component → Hub Postgres on its own instance` | Move |
+| `.../configure/database/optimize/index` | `Architecture and concepts → Process analytics → Storage requirements` | **Merge** |
+| `.../configure/database/optimize/using-external-elasticsearch` | `… → Splitting databases per component → Optimize on external ES` | Move |
+| `.../configure/database/optimize/using-external-opensearch` | `… → Splitting databases per component → Optimize on external OS` | Move |
+| `.../configure/ingress/index` | `Deploy to production → Deploy your baseline → Provision infrastructure → Kubernetes-specific configuration → Ingress` landing `[Kubernetes]` | Move |
+| `.../configure/ingress/ingress-setup` | `… → Ingress setup` | Move |
+| `.../configure/ingress/accessing-components-without-ingress` | `… → Accessing components without ingress` | Move |
+| `.../configure/ingress/gateway-api-setup` | `… → Gateway API setup` | Move |
+| `.../configure/authentication-and-authorization/index` | `Deploy to production → Deploy your baseline → Set up authentication` landing | Move |
+| `.../authentication-and-authorization/basic-authentication` | `… → Basic authentication` | Move |
+| `.../authentication-and-authorization/custom-users-and-clients` | `… → Custom users and clients` | Move |
+| `.../authentication-and-authorization/internal-keycloak` | `… → Internal Keycloak` | Move |
+| `.../authentication-and-authorization/external-oidc-provider` | `… → External OIDC provider` landing | Move |
+| `.../authentication-and-authorization/microsoft-entra` | `… → External OIDC → Microsoft Entra` | Move |
+| `.../authentication-and-authorization/generic-oidc-provider` | `… → External OIDC → Generic OIDC provider` | Move |
+| `.../authentication-and-authorization/external-keycloak` | `… → External OIDC → External Keycloak` | Move |
+| `.../authentication-and-authorization/external-idp-via-internal-keycloak` | `… → External OIDC → External IdP via internal Keycloak` | Move |
+| `.../authentication-and-authorization/troubleshooting-oidc` | `… → External OIDC → Troubleshooting OIDC` | Move |
+| `.../authentication-and-authorization/jwt-token-claims` | `… → External OIDC → JWT token claims` | Move |
+| `.../configure/secret-management` | `Deploy to production → Deploy your baseline → Prepare installation configuration → Secret management` | Move |
+| `.../configure/running-custom-connectors` | Out of Baseline scope — app configuration is a separate discussion | **Out of scope** |
+| `.../configure/add-extra-manifests` | `Deploy to production → Deploy your baseline → Provision infrastructure → Kubernetes-specific configuration → Extra manifests` `[Kubernetes]` | Move |
+| `.../configure/license-key` | `Deploy to production → Deploy your baseline → Prepare installation configuration → License key` | Move |
+| `.../configure/configure-multi-tenancy` | `Architecture and concepts → Tenancy and isolation → Logical tenants` | **Rewrite** — see Appendix B |
+
+### 6.5 Deploy and manage → Helm Operational tasks
+
+| Current path | New location | Action |
+|---|---|---|
+| `.../operational-tasks/index` | (dissolved) | **Delete** |
+| `.../operational-tasks/migration-from-bitnami/index` | `Deploy to production → Deploy your baseline → Provision databases → Migrate from Bitnami subcharts` landing | Move |
+| `.../migration-from-bitnami/bitnami-to-operators` | `… → Migrate to operators` | Move |
+| `.../migration-from-bitnami/bitnami-to-managed-services` | `… → Migrate to managed services` | Move |
+| `.../migration-from-bitnami/alternatives` | `… → Alternatives` | Move |
+| `.../migration-from-bitnami/zero-downtime` | `… → Zero-downtime migration` | Move |
+| `.../operational-tasks/diagnostics` | `Run and maintain → Diagnostics` | Move |
+| `.../operational-tasks/dual-region-operational-procedure` | `Architecture and concepts → Availability and DR → Tier 2 → Operational procedure` | **Rewrite** — see Appendix B |
+| `.../operational-tasks/helm-v4` | `Deploy to production → Deploy your baseline → → Kubernetes with Helm → 2. Install Camunda with Helm → Helm v4 requirements` | **Promote** out of operational-tasks |
+| `.../operational-tasks/moving-helm-v3-to-v4` | `Migrate from 8.9 → 8.10 → Helm v3 → v4 CLI swap` | Move |
+
+### 6.6 Deploy and manage → Helm cloud providers
+
+| Current path | New location | Action |
+|---|---|---|
+| `.../cloud-providers/index` | (merged into Helm install overview) | **Merge** |
+| `.../cloud-providers/kind` | `Quickstart → For administrators → Local with kind` | Move |
+| `.../cloud-providers/amazon/amazon-eks/amazon-eks` | `Deploy to production → Deploy your baseline → → Kubernetes with Helm → 1. Provision your K8s cluster → AWS EKS` landing | Move |
+| `.../amazon-eks/eks-eksctl` | `… → AWS EKS → EKS with eksctl` | Move |
+| `.../amazon-eks/eks-terraform` | `… → AWS EKS → EKS with Terraform` | Move |
+| `.../amazon-eks/eks-helm` | `… → AWS EKS → EKS with Helm` (or merge into the unified Install page if the content is generic) | Move (or merge — see Appendix B) |
+| `.../amazon-eks/dual-region` | `Architecture and concepts → Availability and DR → Tier 2 → AWS EKS` | **Move** + rewrite intro |
+| `.../amazon-eks/irsa` | `… → AWS EKS → Troubleshooting & IRSA` | Move |
+| `.../amazon/openshift/terraform-setup` | `Deploy to production → Deploy your baseline → → Kubernetes with Helm → 1. Provision your K8s cluster → Red Hat OpenShift → ROSA on AWS` | **Move** + flatten the Amazon/OpenShift duplication |
+| `.../amazon/openshift/terraform-setup-dual-region` | `Architecture and concepts → Availability and DR → Tier 2 → ROSA on AWS` | Move |
+| `.../gcp/google-gke` | `Deploy to production → Deploy your baseline → → Kubernetes with Helm → 1. Provision your K8s cluster → Google GKE` | Move |
+| `.../azure/microsoft-aks/microsoft-aks` | `… → Azure AKS` landing | Move |
+| `.../azure/microsoft-aks/aks-terraform` | `… → Azure AKS → AKS with Terraform` | Move |
+| `.../azure/microsoft-aks/aks-helm` | `… → Azure AKS → AKS with Helm` (or merge into unified Install page) | Move (or merge) |
+| `.../openshift/redhat-openshift` | `… → Red Hat OpenShift → OpenShift (IPI / bare-metal)` | Move + flatten |
+| `.../openshift/redhat-openshift-dual-region` | `Architecture and concepts → Availability and DR → Tier 2 → Red Hat OpenShift` | Move |
+
+### 6.7 Deploy and manage → Containers & Manual
+
+| Current path | New location | Action |
+|---|---|---|
+| `self-managed/deployment/docker/docker` | `Deploy to production → Deploy your baseline → → Containers → Provision your container infrastructure → Docker` | Move |
+| `.../containers/cloud-providers/amazon/index` | `Deploy to production → Deploy your baseline → → Containers → Provision your container infrastructure → AWS ECS` landing | Move |
+| `.../containers/cloud-providers/amazon/aws-ecs` | `… → AWS ECS (single-region)` | Move |
+| `self-managed/deployment/manual/install` | `Deploy to production → Deploy your baseline → → Manual / VM → Install Camunda manually → Manual install` | Move |
+| `.../manual/rdbms/index` | `… → Manual install → Manual with RDBMS` landing | Move |
+| `.../manual/rdbms/rdbms-production-architecture` | `… → Manual with RDBMS → Production architecture` | Move |
+| `.../manual/rdbms/configuration` | `… → Manual with RDBMS → Configuration` | Move |
+| `.../manual/rdbms/operations` | `… → Manual with RDBMS → Operations` | Move |
+| `.../manual/cloud-providers/amazon/aws-ec2` | `Deploy to production → Deploy your baseline → → Manual / VM → Provision your VM (AWS EC2 manual)` | Move |
+
+### 6.8 Concepts (dissolves entirely)
+
+| Current path | New location | Action |
+|---|---|---|
+| `self-managed/concepts/authentication/authentication-to-orchestration-cluster` | `Deploy to production → Plan your deployment → Choose your identity strategy → Authentication concepts` | **Rewrite** — see Appendix B |
+| `self-managed/concepts/authentication/authentication-to-management-components` | `Deploy to production → Plan your deployment → Choose your identity strategy → Authentication concepts` (sibling sub-page) | **Rewrite** — see Appendix B |
+| `self-managed/concepts/secondary-storage/index` | `Architecture and concepts → Databases → Secondary storage concepts` | **Merge** with other secondary-storage pages |
+| `self-managed/concepts/secondary-storage/configuring-secondary-storage` | (merged) | **Merge** |
+| `self-managed/concepts/secondary-storage/no-secondary-storage` | (merged) | **Merge** |
+| `self-managed/concepts/secondary-storage/managing-secondary-storage` | (merged) | **Merge** |
+| `self-managed/concepts/secondary-storage/rdbms-benchmark-results` | `Architecture and concepts → Databases → Operating RDBMS → Benchmark results` | Move |
+| `self-managed/concepts/databases/overview` | `Deploy to production → Plan your deployment → Choose your database strategy → RDBMS vs ES/OS — comparison` | **Merge** |
+| `self-managed/concepts/databases/elasticsearch/elasticsearch-privileges` | `Architecture and concepts → Databases → Operating ES/OS → Privileges` | Move |
+| `… elasticsearch-without-cluster-privileges` | `… → Operating ES/OS → Privileges` (sub-page) | Move |
+| `… opensearch-privileges` | `… → Operating ES/OS → Privileges` (sub-page) | Move |
+| `… opensearch-without-cluster-privileges` | `… → Operating ES/OS → Privileges` (sub-page) | Move |
+| `self-managed/concepts/databases/relational-db/index` | `Architecture and concepts → Databases → Operating RDBMS` landing | Move |
+| `.../databases/relational-db/rdbms-setup-guide` | `… → Operating RDBMS → Setup guide` | Move |
+| `.../databases/relational-db/database-configuration` | `… → Operating RDBMS → Database configuration` | Move |
+| `.../databases/relational-db/rdbms-support-policy` | `… → Operating RDBMS → Support policy` | Move |
+| `self-managed/operational-guides/backup-restore/backup-and-restore` | `Run and maintain → Backups & restore → Overview` | **Rewrite** — see Appendix B |
+| `.../backup-restore/elasticsearch/es-backup` | `Run and maintain → Backups & restore → ES/OS → Backup` | Move |
+| `.../backup-restore/elasticsearch/es-restore` | `Run and maintain → Backups & restore → ES/OS → Restore` | Move |
+| `.../backup-restore/rdbms/rdbms-backup` | `Run and maintain → Backups & restore → Relational databases → Backup` | Move |
+| `.../backup-restore/rdbms/rdbms-restore` | `Run and maintain → Backups & restore → Relational databases → Restore` | Move |
+| `.../backup-restore/optimize-backup` | `Run and maintain → Backups & restore → Backup Management API → Optimize backup` | Move |
+| `.../backup-restore/webapps-backup` | `Run and maintain → Backups & restore → Backup Management API → Webapps backup` | Move |
+| `.../backup-restore/zeebe-backup-and-restore` | `Run and maintain → Backups & restore → Backup Management API → Zeebe backup and restore` | Move |
+| `self-managed/concepts/document-handling/getting-started` | `Run and maintain → Document handling — process flow` | Move |
+| `.../document-handling/configuration/index` | `Deploy to production → Deploy your baseline → Prepare installation configuration → Document handling — storage configuration` | **Split** (concept → Day-2, config → Baseline) |
+| `.../document-handling/configuration/camunda-8-run` | `Deploy to production → Deploy your baseline → Prepare installation configuration → Document handling → Camunda 8 Run` | Move |
+| `.../document-handling/configuration/docker` | `… → Docker` | Move |
+| `.../document-handling/configuration/helm` | `… → Helm` | Move |
+| `self-managed/concepts/audit-log/index` | `Run and maintain → Audit log` | Move |
+| `.../audit-log/configure-audit-log` | `Run and maintain → Audit log → Configure audit log` | Move |
+| `self-managed/concepts/exporters` | `Architecture and concepts → Databases → Exporters` | Move |
+| `self-managed/operational-guides/configure-flow-control/configure-flow-control` | `Run and maintain → Flow control` | Move |
+| `self-managed/operational-guides/monitoring/log-levels` | `Run and maintain → Monitoring → Log levels` | Move |
+| `self-managed/operational-guides/monitoring/metrics` | `Run and maintain → Monitoring → Metrics` | Move |
+| `self-managed/concepts/multi-region/dual-region` | `Architecture and concepts → Availability and DR → Tier 2 → Multi-region concept` | **Rewrite** — see Appendix B |
+| `self-managed/operational-guides/data-purge` | `Run and maintain → Data purge` | Move |
+| `self-managed/operational-guides/troubleshooting` | `Run and maintain → Troubleshooting` (also cross-linked from top-level Troubleshooting & FAQ) | Move |
+
+### 6.9 Upgrade → becomes Migrate from 8.9 → 8.10
+
+| Current path | New location | Action |
+|---|---|---|
+| `self-managed/upgrade/index` | `Migrate from 8.9 → 8.10 → At-a-glance: what changes` | **Rewrite** — see Appendix B |
+| `self-managed/upgrade/prepare-for-upgrade` | `Migrate from 8.9 → 8.10 → Prepare for upgrade` | Move |
+| `self-managed/upgrade/helm/index` | `Migrate from 8.9 → 8.10 → Run the upgrade → Helm upgrade` | Move |
+| `self-managed/upgrade/helm/880-to-890` | `Migrate from 8.9 → 8.10 → Run the upgrade → Helm upgrade → 8.9 → 8.10` | **Rename** (ship `890-to-8100`) |
+| `self-managed/upgrade/manual/index` | `Migrate from 8.9 → 8.10 → Run the upgrade → Manual upgrade` | Move |
+| `self-managed/upgrade/components/index` | `Migrate from 8.9 → 8.10 → Run the upgrade → Component-by-component → Overview` | Move |
+| `self-managed/upgrade/components/880-to-890` | `… → Component-by-component → Per-component (8.9 → 8.10)` | **Rename** (ship `890-to-8100`) |
+| `.../upgrade/components/database/changes-in-elasticsearch-8` | `… → Component-by-component → Elasticsearch 8 changes` | Move |
+| `.../upgrade/components/keycloak/keycloak-compatibility` | `… → Component-by-component → Keycloak compatibility` | Move |
+
+---
+
+## 7. Cross-cutting patterns to adopt
+
+These apply across multiple sections of the new sidebar rather than to any one page.
+
+**Comparison tables at the top of decision sections.** Every concept section in Architecture and concepts opens with a comparison table — Choose your tier, Choose your isolation strength — adapted from CockroachDB's "Choose an HA strategy" pattern. See Appendix A for the proposed Camunda Tier comparison.
+
+**"When to use / When not to use" blocks on every option page.** Adapted from Confluent's multi-DC architecture template. Below each tier, each tenancy model, each topology variant, customers get:
+- When to choose this (3–5 bullet points)
+- When NOT to choose this (3–5 bullet points, points to alternatives)
+- Use cases (industry-anchored: banking, telecom, regulated SaaS, internal tooling, etc.)
+- Implementation (per-target subpages)
+
+**Glossary extension, not duplication.** The existing `reference/glossary/` is extended with the 8.10 SM terms (Hub, OC, Physical Tenant, Logical Tenant, Mgmt Identity, OC Admin, default PT, Resilience Tier 1/2/3, RPO, RTO). No new SM-specific glossary is created. Each major Self-Managed section links to the glossary from its intro.
+
+**Industry-anchored use cases.** Abstract patterns get concrete customer-domain anchors: "Tier 1 — internal tooling, non-customer-facing workloads"; "Tier 2 — regulated SaaS, customer-facing process automation, payments"; "Tier 3 — banking, government, mission-critical orchestration." Danske Bank's 50-PT case (already documented internally) is a candidate to anchor the Process analytics sizing page.
+
+**Deployment-paradigm tabs on paradigm-specific pages.** Pages that differ meaningfully by deployment target use Docusaurus tabs with `groupId="deployment-paradigm"`. Selecting `[Kubernetes]`, `[Containers]`, or `[Manual]` once persists across all pages in the session. In this proposal, page names followed by one or more of those badges indicate where tabs appear. Pages with no badge are paradigm-agnostic. Cross-cutting pages that only apply to one paradigm carry a single badge (e.g., `[Kubernetes]`) as a static header label rather than a tab set. Resolves the SUPPORT-29189 class of issue (feature tagged for both SaaS and SM but only applying to SM, with the restriction buried).
+
+**AI-friendly affordances.** "Copy as Markdown" and "View as Markdown" buttons on every page (Temporal and Confluent both ship these). Pairs with `reference/mcp-docs/docs-mcp` which already exists, making Camunda docs first-class consumable by AI tools.
+
+**LTS markers in the version switcher.** Make 8.7 / 8.8 LTS status explicit in the version dropdown. The 8.8 retro surfaced this debate already; CockroachDB shows the pattern (`v25.4.10 LTS` / `v25.3.7` / `v25.2.19 LTS`).
+
+**Page-level affordances.** Standardize "View Page Source / Edit This Page / Report Doc Issue" across every page (some have this today, some don't). Pairs with the existing thumbs-up/thumbs-down PushFeedback widget.
+
+---
+
+## 8. Suggested rollout sequence
+
+Doing this all at once would be a disaster — too much movement, too many redirects, too much risk to inbound links and SEO. Sequencing by independent ROI:
+
+### Phase 1 — low risk, immediate value (ship before 8.10 GA)
+
+These are mis-filings and structural minor fixes that improve the docs without requiring the larger journey-shaped restructure.
+
+- Promote **Backups & restore** out of `Concepts` to a Run and maintain top-level entry.
+- Move troubleshooting, data purge, monitoring, flow control, audit log, and diagnostics into Run and maintain alongside it (even if the section name is provisional).
+- **Flatten the OpenShift duplication** — collapse the Amazon → OpenShift (ROSA) sub-tree into a single OpenShift entry with ROSA and IPI as siblings.
+- **Add the Production readiness checklist page.**
+- **Extend the existing glossary** with 8.10 SM terms (Hub, OC, PT, Mgmt Identity, …).
+- **Promote `application-configs` prominence** to address `product-hub#3562` Helm-vs-app-config confusion.
+- **Move `helm-v4` out of Operational tasks** to sit next to the Helm install instructions where new admins encounter it.
+- **Move kind out of Helm cloud-providers** to sit under Quickstart → For administrators.
+
+Each item is a small `sidebars.js` change. None requires content rewrites. None breaks 8.9 customer mental models. The full set could ship as a single reviewable PR.
+
+### Phase 2 — medium risk (ship with 8.10)
+
+These are the 8.10-tied changes that need to land when 8.10 ships.
+
+- Introduce the **Quickstart → Deploy to production → Architecture and concepts → Run and maintain → Components → Migrate** spine. The shape, not the full content — many pages still in their current form, just reorganized under the new labels.
+- Build out **Availability & DR** under Architecture and concepts with the CockroachDB-style tier table and the moved Tier 2 per-target pages (EKS dual-region, OpenShift dual-region, ROSA dual-region, ECS-coming placeholder).
+- Introduce the **Migrate** section with the Migrate from 8.9 → 8.10 sub-path, deprecating `Upgrade to Camunda 8.9` (with redirects).
+- Add **Physical Tenant** pages under Architecture and concepts → Tenancy and isolation.
+- Add **Optimize-per-PT** pages under Architecture and concepts → Process analytics.
+- **Restructure Deploy your baseline to the tab model** — collapse three paradigm sub-trees (Kubernetes with Helm / Containers / Manual) into three topic-oriented steps (Provision infrastructure / Prepare installation configuration / Install Hub / Install Orchestration Cluster), each with synced `[Kubernetes]` `[Containers]` `[Manual]` tabs. Cluster provisioning first, install second. Most impactful single structural change for K8s admins.
+- **Merge the three Helm install overview pages** into one Prepare installation configuration page (Kubernetes tab).
+
+### Phase 3 — higher risk (ship with 8.10.x)
+
+The full IA cleanup.
+
+- **Dissolve `Concepts` entirely.** Move all `concepts/databases/*` and `concepts/secondary-storage/*` content into Architecture and concepts → Databases. Move authentication concepts into Architecture and concepts → Authentication.
+- **Build out Databases's Operating-RDBMS and Operating-ES/OS sub-trees** by consolidating today's scattered DB pages.
+- **Build Reference architectures' Tier 2 / Tier 3 / multi-PT variants** (per the journey doc's open items).
+- Ship the **per-paradigm Document handling split** (concept → Run and maintain, configuration → Deploy to production → Deploy your baseline → Prepare installation configuration).
+- Adopt the **comparison-table + when-to-use / when-not-to** pattern as the consistent template across all Architecture and concepts option pages.
+
+This sequencing front-loads the wins customers feel immediately (backup discoverability, OpenShift de-duplication, glossary, production checklist) before any major IA shift, then lands the 8.10-tied changes when 8.10 ships, then completes the structural reorganization once 8.10 is stable.
+
+---
+
+## 9. Open questions to validate before publishing
+
+Carried forward from the journey doc and surfaced by this restructure:
+
+1. **Helm chart packaging.** Chart split (single chart + per-unit values files vs. separate Hub and Orchestration charts) is not decided. The sidebar structure works either way, but the page titles inside Baseline read differently. Owner: Hub team. Reference: Hub Helm refactor PR `camunda-platform-helm#5421`; broader Hub helm work paused pending Console-SM application-side removal.
+
+2. **OC-to-Hub registration UX.** In 8.10, adding/updating an OC in Hub is a values-file edit + Hub restart — no in-UI flow. The new "Register the OC in Hub" page documents this. If a UI flow lands in 8.11/8.12, the page needs a rewrite, not a structural change. Owner: Hub team.
+
+3. **Tier 3 RTO/RPO targets.** Multi-region docs PR `camunda-docs#8492` did not commit RTO/RPO numbers for Tier 3. The proposed Tier 3 page currently has these as TBD. Need committed targets before publishing customer-facing guidance. Owner: Resilience Tiers / multi-region docs team.
+
+4. **Hub Business View aggregation.** With Optimize 1:1 per PT and many PTs across many OCs, Hub may need to read from N Optimize instances backed by N ES backends. The proposed Process analytics → Hub Business View page documents this. Need to confirm whether the business view supports connecting across multiple Optimize/ES backends in 8.10, and if not, document per-PT-only scope as a known limitation. Owner: Hub team.
+
+5. **Per-PT credentials rotation.** No built-in rotation flow in 8.10. The proposed Run and maintain → Credentials and secrets rotation page is a manual runbook. Track for 8.11. Owner: SM team.
+
+6. **PT + Optimize scaling story.** The shared-ES stress point at large PT scale is the key concern. The proposed Process analytics → Sizing & ES sharding page needs concrete guidance before customer publication at >10 PTs. Owner: SM team + Optimize team.
+
+7. **Customer journey messaging.** This proposal takes the position that Hub-in-own-namespace is the Baseline default (resolving Thorben's question). Confirm for 8.10 customer-facing docs.
+
+8. **Reference architecture epic — `product-hub#3561` / 8.10 Docs Tracker.** Need to align the proposed Reference Architecture subtree (single-region / Tier 2 / Tier 3 / multi-PT) with the `camunda-deployment-references` repo plans.
+
+---
+
+## Appendix A — Content briefs for new pages
+
+For each new page the structure requires, what content should live there. Brief is intentionally concise (one to three sentences) — enough to scope the page, not enough to write it.
+
+### A.1 — Deploy to production: Plan your deployment
+
+**Production topology overview** (`Architecture and concepts → Deployment concepts → Hub / Orchestration Cluster topology`)
+The one-sentence statement: *One Hub, one or more Orchestration Clusters, one or more Physical Tenants per OC, and zero or more Optimize deployments per PT*. A simple SVG topology diagram. A short cross-dependency table: Hub knows OCs via its values file; each Optimize binds 1:1 to a PT; each Optimize needs its own Mgmt Identity app registration; Hub dashboards read from Optimize. A "why this shape" paragraph linking forward to Deploy your baseline. Half a screen of content total — the page's job is to make the mental model click in 30 seconds.
+
+**Choose your deployment target** (`Deploy to production → Plan your deployment → Choose your deployment target`)
+The paradigm picker. Three choices: Kubernetes with Helm (recommended for production), Containers (Docker, AWS ECS), Manual / VM. Short table of trade-offs. Recommendation paragraph: "Kubernetes with Helm is the recommended path for production; consider containers when K8s is unavailable; manual installs are typically for air-gapped or specialized environments." This choice persists throughout the docs via Docusaurus tab `groupId="deployment-paradigm"` — once a paradigm is selected, all tabbed pages default to that paradigm. Links forward to Reference architectures.
+
+**Reference architectures — Kubernetes → Dual-region (Tier 2)** (`Architecture and concepts → Reference architectures → Kubernetes → Dual-region (Tier 2)`)
+Architectural blueprint of a Tier 2 Camunda deployment on Kubernetes. Topology diagram showing two regions, one active OC, one standby OC, shared RDBMS with cross-region replication, Hub remaining single-region. Calls out the standing-secondary reachability requirement (Zeebe stalls if it can't reach the standby). Links to the Architecture and concepts → Availability and DR → Tier 2 concept page for adoption details.
+
+**Reference architectures — Kubernetes → Three-region (Tier 3)** (`Architecture and concepts → Reference architectures → Kubernetes → Three-region (Tier 3)`)
+Architectural blueprint of a Tier 3 Camunda deployment. Topology diagram showing three regions with quorum-based replication. Notes Tier 3 is RDBMS-only and Helm-only at 8.10 GA. Calls out the open RTO/RPO targets (TBD per `camunda-docs#8492`). Links to Architecture and concepts → Availability and DR → Tier 3 for adoption details.
+
+**Reference architectures — Kubernetes → Multi-PT variant** (`Architecture and concepts → Reference architectures → Kubernetes → Multi-PT variant`)
+Architectural blueprint of a single-region Camunda deployment with multiple Physical Tenants in a single OC. Topology diagram showing one OC pod hosting N PTs, each with its own partitions and DB schema/index prefix, with shared Connectors runtime. Links to Architecture and concepts → Tenancy and isolation → Physical tenants for adoption details.
+
+**Choose your database strategy — landing** (`Deploy to production → Plan your deployment → Choose your database strategy`)
+Frames the database decision as the second planning decision (after deployment target, because database options differ by platform — e.g., OpenSearch is AWS-centric). Introduces the three implementation options (managed services, K8s operators, alternatives). Sets the hard rule: something must be provisioned and reachable for Hub and for the OC before any Helm install — no in-chart Bitnami fallback. Includes an RDBMS vs ES/OS comparison table inline.
+
+**RDBMS vs ES/OS — comparison** (`Deploy to production → Plan your deployment → Choose your database strategy`)
+Cockroach-style comparison table. Columns: RDBMS, Elasticsearch/OpenSearch. Rows: Storage model, Multi-region support (Tier 2/3 = RDBMS only at 8.10), Optimize compatibility (ES/OS only), Operational tooling familiarity, Operational complexity, Backup story, Suggested for. Recommendation paragraph below: "If multi-region is on your roadmap, prefer RDBMS for the OC from day one."
+
+**Choose your identity strategy — landing** (`Deploy to production → Plan your deployment → Choose your identity strategy`)
+Frames the identity decision as the third planning decision (after deployment target and database, since OIDC provider availability and Keycloak operator options depend on both). Introduces the choice surface: external OIDC for production (Entra ID, Okta, …) vs basic auth for dev/eval. Notes Mgmt Identity stays as a separate component in 8.10, planned removal in 8.11. Links to Architecture and concepts → Authentication pages.
+
+**Management Identity vs OC Admin** (`Architecture and concepts → Authentication → Authentication to management components`)
+Explains the two distinct identity surfaces in 8.10: Mgmt Identity in the Hub namespace (Hub, Optimize) and OC Admin embedded in the Orchestration Cluster (Zeebe, Operate, Tasklist). Shows which components authenticate against which. Notes that each Optimize requires its own Mgmt Identity app registration. Diagram of the auth flows.
+
+**Choose your resilience tier** (`Deploy to production → Plan your deployment → Choose your resilience tier`)
+A single page, half a screen. Five-row table mapping forward needs to planning decisions:
+- Multi-region DR likely → prefer RDBMS for OC from day one
+- Many PTs likely → size OC partition counts conservatively
+- Optimize on roadmap → if OC is RDBMS, plan a separate ES/OS cluster
+- Strict per-tenant DB isolation → plan capacity that absorbs growth
+- Regulatory or per-team upgrade isolation → plan namespace naming for multi-OC scale
+
+Short opening paragraph: *These are decisions you don't have to make today, but knowing your direction now prevents painful re-architecture later.*
+
+### A.2 — Deploy to production: Deploy your baseline
+
+**Install Hub** (`Deploy to production → Deploy your baseline → Install Hub`)
+Explains the two-component shape (Hub separate from OC) and why it's the baseline default in 8.10. Per-paradigm definitions of "separately": K8s namespaces, ECS clusters, Docker Compose projects, separate VM groups. Covers the Hub-specific Helm values, the Helm v4 prerequisite callout, and the Hub release install command. Why this shape: it establishes 1-Hub → N-OCs topology immediately so growth (more OCs, more tenants) is additive rather than re-architecture. Tabs: [Kubernetes] [Containers] [Manual].
+
+**Install Orchestration Cluster** (`Deploy to production → Deploy your baseline → Install Orchestration Cluster`)
+Covers the OC-specific Helm values and the OC release install command. Includes the "Register the OC in Hub" step as the final sub-section: the values-file edit + Hub restart pattern that wires the new OC into Hub (no in-UI registration in 8.10). Cross-link to Reference architectures. Tabs: [Kubernetes] [Containers] [Manual].
+
+**Provision databases — landing** (`Deploy to production → Deploy your baseline → Provision databases`)
+Frames database provisioning as a hard prerequisite before any Helm install (no in-chart Bitnami fallback). Lists the three dependency types: PostgreSQL/RDBMS, Elasticsearch/OpenSearch, Keycloak. Suggests order: provision DB → provision IdP → run Helm. Cross-links to the Migrate → Bitnami migration sub-section for customers upgrading from 8.9.
+
+**Prepare installation configuration** (`Deploy to production → Deploy your baseline → Prepare installation configuration`)
+Single tabbed page ([Kubernetes] [Containers] [Manual]) covering license key and secret management — the configuration steps that must be complete before the install commands run. Helm v4 prerequisite appears as a callout on the Kubernetes tab. The page explains the two-release model (Hub + OC as separate releases) and links forward to Install Hub and Install Orchestration Cluster. Absorbs the three old overview pages (helm/index, helm/install/index, helm/install/production/index) on the Kubernetes tab.
+
+**Register the OC in Hub** (`Deploy to production → Deploy your baseline → Install Orchestration Cluster → Register the OC in Hub`)
+8.10-specific sub-section inside Install Orchestration Cluster. Documents the values-file edit + Hub restart pattern (no in-UI registration in 8.10). Shows the values structure for an OC entry, the OIDC config, and how to wire secrets. Calls out that adding subsequent OCs (see Architecture and concepts → Tenancy and isolation → Separate Orchestration Clusters) follows the same pattern. Flags the open question (UI flow planned for 8.11/8.12) so this page can evolve.
+
+**Production readiness checklist** (`Deploy to production → Deploy your baseline → Production readiness checklist`)
+Temporal-style checklist page. Sections: Scale and capacity (resource requests, broker partition counts, secondary storage sizing), Reliability (replication factor, backup configured, monitoring scrape configured), Security (TLS enabled, OIDC configured, secrets managed externally, license applied), Long-term maintainability (chart version pinned, upgrade plan documented, runbook recorded). Each item is a single line with a cross-link. This is the page a customer prints and walks through before going live.
+
+**Smoke test and exit criteria** (`Deploy to production → Deploy your baseline → Smoke test and exit criteria`)
+Defines what "baseline deployed" actually means. Concrete tests: deploy a test process from Hub Workspace to the default PT; complete it end-to-end; verify it appears in Operate. Exit criteria checklist: Hub UI reachable, Mgmt Identity healthy, OC brokers across 3 AZs (single-region), Operate/Tasklist reachable, exports flowing for the PT, OC visible in Hub's cluster list. Failing any item means a config issue to fix before considering baseline complete.
+
+### A.3 — Architecture and concepts
+
+
+**Availability & DR — Tier framework + RPO/RTO** (`Architecture and concepts → Deployment concepts → Availability and DR → Tier framework + RPO/RTO`)
+The Cockroach-style "Choose your tier" comparison table. Glossary block at top defining HA, DR, RPO, RTO (linking to the global glossary). Comparison table with columns Tier 1 / Tier 2 / Tier 3 and rows: RTO, RPO, Regions, Failover (manual / scripted / automated), Standby cost, Storage (RDBMS / RDBMS+ES), Supported targets at 8.10 GA, Best for. One topology diagram showing all three tiers side by side. Recommendation paragraph and a "How to pick" decision flow.
+
+**Tier 1 — Cold recovery (DR)** (`Architecture and concepts → Deployment concepts → Availability and DR → Tier 1 — Cold recovery`)
+Confluent-style page. Sections: When to use (cost-sensitive workloads, internal tooling, non-customer-facing automation, RTO 1–4h acceptable). When NOT to use (zero data loss requirement → Tier 2; automatic failover required → Tier 3). Use cases (internal tooling, dev/staging environments, batch processing). Implementation: per-target recovery runbooks (EKS, OpenShift, ECS, manual).
+
+**Tier 2 — Dual-region hot standby (HA + DR)** (`Architecture and concepts → Deployment concepts → Availability and DR → Tier 2 — Dual-region hot standby`)
+Confluent-style page. When to use (regulated SaaS, customer-facing process automation, payments, RTO ~15min, RPO 0). When NOT to use (manual 1-4h acceptable → Tier 1; want automatic quorum-based failover → Tier 3; on manual/Compose paradigms → not blueprinted at Tier 2 in 8.10). Use cases (banking transaction orchestration, insurance claims, healthcare workflows, supply chain). Implementation: per-target subpages (AWS EKS, Red Hat OpenShift, ROSA on AWS, AWS ECS coming, Operational procedure).
+
+**Tier 2 — AWS ECS placeholder** (`Architecture and concepts → Deployment concepts → Availability and DR → Tier 2 → AWS ECS`)
+Placeholder page for the coming-in-8.10.x Tier 2 ECS pattern. Notes "Coming in 8.10.x" prominently. Links to the equivalent EKS and OpenShift implementations as reference. The page exists so the sidebar structure is stable when ECS Tier 2 ships.
+
+**Tier 3 — Three-region stretched (HA)** (`Architecture and concepts → Deployment concepts → Availability and DR → Tier 3 — Three-region stretched`)
+Confluent-style page. When to use (mission-critical orchestration, near-zero RTO required, automatic quorum-based failover). When NOT to use (cost-constrained, fewer than three regions available, manual recovery is acceptable). Use cases (banking, government, healthcare critical systems). Implementation: Kubernetes with Helm (only target at 8.10 GA). Calls out the open RTO/RPO TBD per `camunda-docs#8492`.
+
+**Tenancy & isolation — Choose your isolation strength** (`Architecture and concepts → Tenancy and isolation → Choose your isolation strength`)
+Comparison table with three columns (Logical tenants / Physical tenants / Separate OC) and rows: What's isolated, Infra cost, Per-tenant IdP support, Per-tenant backup/restore, Per-tenant perf isolation, Operational complexity, Upgrade cadence flexibility, When to choose. Decision flow below. Cross-link forward to each per-option page.
+
+**Physical tenants — Concept** (`Architecture and concepts → Deployment concepts → Tenancy and isolation → Physical tenants → Concept`)
+New page introducing PTs as new in 8.10. Explains: each PT has its own partitions, its own RDBMS schema (or ES/OS index prefix), its own IdP assignment; a single Connectors runtime serves all PTs in an OC; PTs are addressed via `/v2/physical-tenants/{tenantId}/...`; every OC auto-creates a default PT. Diagram showing one OC pod with N PTs. Performance caveat: many PTs against shared ES degrades Optimize throughput (Danske Bank 50-PT stress point).
+
+**Physical tenants — Add a PT to existing OC** (`Architecture and concepts → Deployment concepts → Tenancy and isolation → Physical tenants → Add a PT to existing OC`)
+Procedure: provision schema/index prefix for the new PT → add the PT under `camunda.physical-tenants.*` in `orchestration-values.yaml` with storage binding and IdP assignment → rolling restart the OC → verify via `/v2/physical-tenants/{tenantId}/...`. Caveat callout: per-PT partition resize is disruptive — size partition counts conservatively if many PTs anticipated.
+
+**Physical tenants — Per-PT credentials & backups** (`Architecture and concepts → Deployment concepts → Tenancy and isolation → Physical tenants → Per-PT credentials and backups`)
+Documents the per-PT credentials and backup story in 8.10. No built-in per-PT rotation flow (rotate via the underlying IdP and propagate through `orchestration-values.yaml`). Per-PT backup/restore via the REST Management API (new in 8.10). Manual runbook for credential rotation as the interim solution before 8.11 lands automation.
+
+**Tenancy & isolation — Separate OC — When to add a second OC** (`Architecture and concepts → Deployment concepts → Tenancy and isolation → Separate Orchestration Clusters → When to add a second OC`)
+Confluent-style page on when separate OCs are the right choice over Logical or Physical tenants. When to use (regulatory boundary, independent upgrade cadence, independent region, business-unit hard separation). When NOT to use (cost-sensitive deployments — separate OCs are the highest-cost isolation level; soft data isolation is sufficient → Logical tenant; per-tenant perf isolation is sufficient → Physical tenant).
+
+**Tenancy & isolation — Separate OC — Multi-OC operations** (`Architecture and concepts → Deployment concepts → Tenancy and isolation → Separate Orchestration Clusters → Multi-OC operations`)
+Operational considerations when running N OCs against one Hub: per-OC monitoring, per-OC backup windows, per-OC chart-version pinning, OC-to-Hub registration via values file (cross-link to Baseline → Register the OC in Hub). Notes the Hub-restart-per-OC-onboarding limitation in 8.10.
+
+**Tenancy & isolation — Separate OC — Independent upgrade cadence** (`Architecture and concepts → Deployment concepts → Tenancy and isolation → Separate Orchestration Clusters → Independent upgrade cadence`)
+Documents the upgrade-cadence flexibility separate OCs provide. Hub ↔ OC version matrix, supported lag (Hub at 8.10 can drive OC at 8.9 within compatibility window — confirm), upgrade order per OC. Cross-link to Migrate from 8.9 → 8.10 → Run the upgrade.
+
+**Process analytics — Add Optimize per Physical Tenant** (`Architecture and concepts → Process analytics → Add Optimize per Physical Tenant`)
+Procedure: confirm ES/OS available for the PT → register a dedicated Mgmt Identity application for this Optimize instance → author `optimize-values-{pt-name}.yaml` → `helm install optimize-{pt-name} … -n camunda-oc` → verify in Hub. One Optimize per PT that needs analytics — explicitly notes the 1:1 binding. Repeat per PT.
+
+**Process analytics — Hub Business View / Agent Control** (`… → Hub Business View / Agent Control`)
+Documents the Hub dashboards' dependency on Optimize-transformed data. Notes the open question (does Hub Business View aggregate across multiple Optimize instances?). If aggregation isn't supported in 8.10, documents per-PT-only scope as a known limitation. Page evolves as the Hub team confirms.
+
+**Process analytics — Storage requirements** (`… → Storage requirements`)
+Optimize is ES/OS-only — no RDBMS support, none planned. Three patterns: OC on ES/OS (Optimize can share the OC's ES/OS); OC on RDBMS (Optimize needs a separate ES/OS cluster); per-PT ES sharding (high PT counts on shared ES). Partition-count quirk: Optimize's partition-count config must match the bound PT's partition count; mismatches cause silent ingestion gaps. Validate after every PT or Optimize change.
+
+**Process analytics — Mgmt Identity app registration per Optimize** (`… → Mgmt Identity app registration per Optimize`)
+Step-by-step: for each Optimize instance, register a dedicated Mgmt Identity application; configure the app's redirect URIs and secrets; wire the secrets into the Optimize values file. Calls out that N PTs with Optimize = N Mgmt Identity app registrations. Cross-link to Plan → Decide identity strategy.
+
+**Process analytics — Sizing & ES sharding at PT scale** (`… → Sizing & ES sharding at PT scale`)
+Sizing guide for ES under many-PT load. Large-scale PT deployment as anchor. Recommendations on when to shard Optimize across multiple ES clusters vs scale a single ES cluster. Open until SM team commits sizing numbers; this page initially documents the pattern and links to the sizing-numbers ticket.
+
+
+**Databases — Splitting databases per component — landing** (`… → Splitting databases per component`)
+Landing page for the four split-per-component sub-pages. Explains when splitting helps (independent backup windows, independent failover, regulatory boundaries, perf isolation). Pattern table mapping common requirements to recommended splits.
+
+### A.4 — Day-2 section
+
+
+**Upgrades** (`Run and maintain → Upgrades`)
+Distinguishes recurring operational upgrades from the once-per-version Migrate event. Documents the Hub ↔ OC compatibility matrix, Optimize ↔ OC ↔ PT version coupling, and the supported upgrade lag between components. Cross-link forward to Migrate from 8.9 → 8.10 for the next-version event when it happens.
+
+**Per-PT metrics** (`Run and maintain → Monitoring → Per-PT metrics`)
+New in 8.10: monitoring labels now include `physical-tenants` dimension. Documents the new labels, how they appear in Prometheus / Grafana / DataDog, sample queries for per-PT throughput and latency. No new monitoring infrastructure delivered with 8.10 — just per-PT labels added to existing metrics.
+
+**Scaling — OC broker scaling** (`Run and maintain → Scaling → OC broker scaling`)
+StatefulSet-based broker scaling per OC. When to scale, how to scale, rebalancing implications. Cross-link to existing Zeebe ops content.
+
+**Scaling — Stateless Hub scaling** (`Run and maintain → Scaling → Stateless Hub scaling`)
+Standard Deployment scaling for the stateless Hub component. Considerations: shared Postgres, no in-pod state, horizontal scaling factors.
+
+**Scaling — Adding PTs to an existing OC** (`Run and maintain → Scaling → Adding PTs to an existing OC`)
+8.10-specific operational task. Cross-link to Architecture and concepts → Tenancy and isolation → Physical tenants → Add a PT for the procedure. Documents the operational considerations: rolling restart timing, partition-count conservatism, secondary-storage provisioning ahead of time.
+
+
+
+**Credentials & secrets rotation** (`Run and maintain → Credentials & secrets rotation`)
+Manual runbook for credential rotation in 8.10. No built-in automation; rotate via the underlying IdP/secret-store and propagate through component values files. Per-component rotation steps: Hub Postgres, OC secondary storage, Optimize Mgmt Identity app, IdP client secrets. Tracks the 8.11 automation ticket.
+
+### A.5 — Migrate section
+
+**At-a-glance: what changes 8.9 → 8.10** (`Migrate from 8.9 → 8.10 → At-a-glance`)
+Single-page summary of what's forced at upgrade vs what's optional adoption. Per the existing migration journey doc (gdoc: "Camunda 8.10 SM — Migration User Journey"), use the stay-as-is framing: Helm v4 (forced), Bitnami subcharts removed (must migrate dependencies first), Web Modeler + Console SM → Hub values rewrite (forced or use migration tool), Physical Tenants (default auto-created — stay-as-is means no change), Optimize-per-PT (existing OC = 1 PT = 1 Optimize, no change). Recommend doing Bitnami migration as a separate 8.9 operation before the 8.10 upgrade.
+
+**Web Modeler + Console SM → Camunda Hub** (`Migrate from 8.9 → 8.10 → Web Modeler + Console SM → Camunda Hub`)
+Documents the 8.10 values rewrite. `webModeler.*` → `camundaHub.*`; Console keys move under `camundaHub.*`. Best path: the migration & validation tool (`product-hub#3563`) translates these automatically. Manual fallback documented inline. Cross-link to the chart-side PRs (`#5996`, `#5997`, `#5998`, `#5999`).
+
+**Catch up to Baseline (post-upgrade, optional)** (`Migrate from 8.9 → 8.10 → Catch up to Baseline`)
+Bridges from the stay-as-is upgrade to the journey's Baseline shape. Three optional follow-ups: split Hub and OC into separate namespaces (matches the new Baseline default); adopt Physical Tenants for per-tenant isolation; consider Resilience Tier upgrade. Each is a forward-link to the relevant Build your Baseline or Extend page. Explicit that these are NOT part of the upgrade; they are post-upgrade choices on the customer's own timeline.
+
+---
+
+## Appendix B — Rewrite guidance for existing pages
+
+For pages that need substantive content change beyond a pure relocation. Pages not listed here move as-is.
+
+### B.1 — Landing pages that get rewritten
+
+**`self-managed/about-self-managed` — Start here**
+Currently a list of cards for Quickstart, Installation Methods, Infrastructure, Reference Architecture, Components. Rewrite as Temporal-style three-bucket landing: a short intro (Self-Managed vs SaaS choice) → three named buckets ("Plan and build" / "Extend and operate" / "Migrate from a previous version") with 3–5 items each. Remove the per-cloud-provider link cards (those live under Plan → Reference architecture → Kubernetes blueprint now).
+
+**`self-managed/quickstart/administrator-quickstart` — Local with kind**
+Currently a mixed page covering admin-quickstart concepts and the kind procedure. Rewrite as a focused "Local with kind" page: prerequisites (kind, Docker, kubectl, Helm v4), single command to bring up the full SM stack locally, how to access Hub/Operate/Tasklist, what's intentionally not production-shaped about this setup, link forward to Plan when ready to deploy for real.
+
+**`self-managed/reference-architecture/reference-architecture` — Architecture diagrams landing**
+Currently a thin page introducing the three reference architectures. Rewrite as the picker page used during Plan → Decide deployment target → Architecture diagrams. Rename to "Architecture diagrams" throughout. Add: per-paradigm trade-off table; explicit positioning as architecture diagrams (not step-by-step install guides — those live in Baseline → Install now); cross-links forward to per-paradigm subpages.
+
+**`self-managed/reference-architecture/kubernetes` — Kubernetes single-region diagram**
+Currently a single beefy page covering single-region K8s topology. Trim: keep the single-region topology content; move any references to install steps out (those live in Baseline → Install now); add cross-links to the three new Kubernetes variant pages (Dual-region, Three-region, Multi-PT). Goal: this page becomes the canonical single-region architecture diagram, three new pages join it as siblings.
+
+**`self-managed/deployment/index`**
+Currently a list of deployment options (Helm, Docker, Manual). Delete with redirect to `Deploy to production → Plan your deployment → Choose your deployment target`. Paradigm choice is now made once in Plan and persists via Docusaurus tab `groupId`; a second picker page in Baseline is redundant.
+
+**Install Camunda — 3-into-1 merge + Option B tab model** (`helm/index` + `helm/install/index` + `helm/install/production/index`)
+Three current overview pages become one "Install Camunda" page with three paradigm tabs (`[Kubernetes]` `[Containers]` `[Manual]`) sharing `groupId="deployment-paradigm"`. Kubernetes tab structure: Helm v4 prerequisite → What the chart deploys (Hub + OC as two releases) → Quick install vs production install (absorbing today's `production/index` content) → Chart parameters reference link. Containers and Manual tabs cover their respective install flows. Redirect all three deprecated URLs to the unified page. Per-target infrastructure details (EKS, AKS, GKE, OpenShift) live in "1. Provision your infrastructure" sub-pages, not on this page.
+
+**`self-managed/upgrade/index` — Migrate from 8.9 → 8.10 At-a-glance**
+Currently a generic upgrade overview. Rewrite as the 8.10-specific at-a-glance page per the existing migration journey doc. Content per Appendix A → "At-a-glance: what changes 8.9 → 8.10". URL slug changes from `/upgrade/` to `/migrate/` with redirect. Existing 8.7 → 8.8 → 8.9 paths remain in their respective versioned docs per `camunda-docs#7617` Option 2.
+
+**`self-managed/operational-guides/backup-restore/backup-and-restore` — Backups & restore Overview**
+Currently the entry point to backup docs buried under Concepts. Rewrite minimally: reframe the intro to position this as a Day-2 capability, not a concept; add a "When to test your backups" callout (recommend monthly restore drills); cross-link to the relevant Availability & DR tier page. Content largely unchanged; positioning and prominence are the change.
+
+**`self-managed/concepts/multi-region/dual-region` — Multi-region concept (inside Tier 2)**
+Currently a standalone concept page buried under Concepts. Rewrite to be the conceptual underpinning of Tier 2: define dual-region patterns, explain the standing-secondary reachability requirement, describe the failover/failback flow at the concept level. Move per-target implementation steps out (they live under Tier 2 per-target pages now). Cross-link extensively to the per-target pages.
+
+**`helm/operational-tasks/dual-region-operational-procedure` — Operational procedure (inside Tier 2)**
+Currently misfiled under Operational tasks. Rewrite to be specifically the operational procedure page for Tier 2 — what to do when failover is needed, how to validate a healthy Tier 2 deployment, common failure modes. Cross-link from each per-target Tier 2 page (EKS, OpenShift, ROSA, ECS).
+
+### B.2 — Configuration pages that get reframed
+
+**`helm/configure/application-configs` — Application config vs deployment-tool values**
+Currently a single page documenting the `extraConfiguration` pattern. Rewrite to address the prominence issue from `product-hub#3562`: this is the page that clarifies the configuration responsibility split (Helm values for deployment concerns; application config for runtime behavior). Add an opening section "Where does X configuration go?" with a table mapping common config items to the right layer. Promote this page in the Common configuration sidebar order.
+
+**`helm/configure/operator-based-infrastructure` — Kubernetes operators (in Plan)**
+Currently a Configure page assumed by readers to be one of many config options. Rewrite as a Phase 0 decision page: this is one of three ways to provision your dependencies (alongside managed services and alternatives). Add the decision framing: "Choose this if you have K8s expertise and want operator-managed dependencies; choose managed services if you prefer cloud-provider-managed; choose alternatives if you have non-standard requirements." Cross-link to the Migration from Bitnami sub-section for customers upgrading.
+
+**`helm/configure/database/non-sql` — Operating Elasticsearch / OpenSearch (in Architecture and concepts)**
+Currently a configure-time page. Rewrite as the operating-ES/OS landing page in Architecture and concepts → Deployment concepts → Databases. Rename "non-sql" to "Elasticsearch / OpenSearch" throughout. Reframe content from "how to point at an ES/OS at install time" (move that to Deploy to production → Deploy your baseline → Provision databases) to "how to operate an ES/OS-backed Camunda deployment ongoing."
+
+**`helm/configure/configure-multi-tenancy` — Logical tenants (in Tenancy and isolation)**
+Currently positioned as a Helm config option. Rewrite as the Logical tenants page in Architecture and concepts → Deployment concepts → Tenancy and isolation. Reframe content from "how to enable multi-tenancy in Helm values" to "how to use logical tenants for soft data isolation, when to choose this over Physical tenants or Separate Orchestration Clusters." Cross-link to the Choose your isolation strength comparison.
+
+### B.3 — Concepts pages that get reframed
+
+**`concepts/authentication/authentication-to-orchestration-cluster` — Authentication concepts (OC half)**
+Currently a concept page on OC auth. Reframe for Architecture and concepts → Authentication context: position as one of the two distinct identity surfaces in 8.10 (the OC Admin half). Cross-link to the Management Identity vs OC Admin page in the same section. Trim implementation details (those live in Deploy to production → Deploy your baseline → Set up authentication).
+
+**`concepts/authentication/authentication-to-management-components` — Authentication concepts (Mgmt half)**
+Currently a concept page on Mgmt Identity auth. Reframe symmetrically with the OC half: position as the other identity surface (Mgmt Identity in the Hub namespace, used by Hub and Optimize). Cross-link to Management Identity vs OC Admin and to the per-Optimize app registration page in Architecture and concepts → Deployment concepts → Process analytics.
+
+### B.4 — Pages getting renamed (URL changes)
+
+| Old URL | New URL | Why |
+|---|---|---|
+| `self-managed/upgrade/...` | `self-managed/migrate/...` | "Migrate" matches the journey doc; "Upgrade" was ambiguous between once-per-version and recurring ops |
+| `self-managed/upgrade/helm/880-to-890` | `self-managed/migrate/run-the-upgrade/helm/890-to-8100` | New version target |
+| `self-managed/upgrade/components/880-to-890` | `self-managed/migrate/run-the-upgrade/components/890-to-8100` | New version target |
+| `helm/configure/database/non-sql` | `architecture-concepts/database-topology/operating-elasticsearch-opensearch` | Friendlier slug; new location |
+| `helm/configure/operator-based-infrastructure` | `deploy-to-production/plan/choose-database-strategy/kubernetes-operators` | New location |
+| `helm/configure/configure-multi-tenancy` | `architecture-concepts/tenancy-isolation/logical-tenants` | Reframed scope |
+| `concepts/multi-region/dual-region` | `architecture-concepts/availability-dr/tier-2/multi-region-concept` | New location |
+| `operational-guides/backup-restore/...` | `run-and-maintain/backups-restore/...` | New location |
+
+All old URLs get permanent (301) redirects to the new URLs to preserve inbound links and SEO.
+
+### B.5 — Pages staying but getting cross-link expansion
+
+Several existing pages stay in their current form but need new cross-links to and from the new structure:
+
+- `apis-tools/migration-manuals/migrate-to-810` — already exists, cross-link from the new Migrate from 8.9 → 8.10 section.
+- `reference/announcements-release-notes/8100/whats-new-in-810` — cross-link from At-a-glance and from the Start here landing.
+- `reference/supported-environments` — cross-link from Deploy to production → Plan your deployment → Choose your deployment target and Prepare installation configuration.
+- `reference/glossary` — cross-link from every section intro; extend with 8.10 SM terms per §7.
+- The various component reference pages (Hub, OC, Zeebe, etc.) — cross-link from relevant Deploy to production and Architecture and concepts pages but stay in the existing Components top-level.
+
+---
+
+## Closing note
+
+This proposal is a substantial restructure — 50+ page relocations, 45+ new pages, 15+ rewrites. The Phase 1 / Phase 2 / Phase 3 sequencing is designed so the team never has to land it all at once. Phase 1 alone (the low-risk Run and maintain promotions, OpenShift de-duplication, glossary extension, kind move, application-configs prominence) would meaningfully improve docs ahead of 8.10 GA with no IA risk.
+
+The next concrete artifact, if the team agrees with the direction, is a `sidebars.js` diff against `camunda/camunda-docs` for the Phase 1 changes only. That's a single reviewable PR independent from the larger 8.10 restructure — ship the wins now, iterate the rest.

--- a/docs/user journeys/8.10/8.10 deployment journey.md
+++ b/docs/user journeys/8.10/8.10 deployment journey.md
@@ -8,6 +8,8 @@
 
 **Outcome.** A journey-shaped sidebar that replaces the current 8.9 component-shaped structure, with every existing page mapped to a new location and content briefs for ~45 new pages the structure requires.
 
+**Framework.** This proposal applies the [Diátaxis](https://diataxis.fr/) documentation framework as its organizing principle. Diátaxis defines four distinct user needs — Tutorial (learn), How-to (do), Reference (look up), Explanation (understand) — and holds that each page should serve exactly one. The sidebar structure reflects this directly: *Deploy to production* and *Run and maintain* are how-to sections; *Concepts* is explanation; *Reference* is look-up. Diátaxis gives every placement decision a repeatable test ("what single need does this page serve?"), which replaces section-by-section debate and makes the structure defensible to new contributors.
+
 ---
 
 ## Table of contents
@@ -28,26 +30,27 @@
 
 ## 1. Executive summary
 
-The 8.9 Self-Managed sidebar is organized around what Camunda ships (Quickstart, Reference Architecture, Deploy and manage, Concepts, Components, Upgrade). For 8.10, the customer journey has changed enough — Hub replaces Web Modeler + Console SM, Physical Tenants are introduced, Optimize binds 1:1 to a PT, Bitnami is removed, Helm v4 is required, three resilience tiers replace ad-hoc multi-region patterns — that a same-shaped sidebar would amplify the docs problems customers already flag.
+The current Next (8.10 baseline) Self-Managed sidebar is organized around what Camunda ships (Quickstart, Reference Architecture, Deploy and manage, Concepts, Components, Upgrade). For 8.10, the customer journey has changed enough — Hub replaces Web Modeler + Console SM, Physical Tenants are introduced, Optimize binds 1:1 to a PT, Bitnami is removed, Helm v4 is required, three resilience tiers replace ad-hoc multi-region patterns — that a same-shaped sidebar would amplify the docs problems customers already flag.
 
-This proposal reorganizes Self-Managed around six top-level sections:
+This proposal reorganizes Self-Managed around seven top-level sections:
 
 1. **Quickstart** — fast, opinionated paths that get a developer or administrator to a running instance. No decisions required.
 2. **Deploy to production** — the action-ordered path from planning decisions to a production-shaped baseline. Contains two sub-phases: Plan your deployment and Deploy your baseline.
-3. **Architecture and concepts** — reference and concept material that users consult selectively, in any order, after or alongside the main deployment path. This includes reference architectures and deployment concepts (tenancy, availability & DR, process analytics, database topology).
-4. **Run and maintain** — ongoing operational concerns for a healthy deployment: upgrades, backups, monitoring, scaling, diagnostics, troubleshooting.
-5. **Components** — cross-cutting reference for individual Camunda components. Intentionally separate from the deployment journey.
-6. **Migrate** — the once-per-version upgrade path from 8.9 to 8.10.
+3. **Concepts** — explanatory material users consult when understanding a decision: tenancy models, availability tiers, database strategy trade-offs, identity model, network & security patterns (TLS strategy, secret management), Hub / OC topology. Each page answers "what is this and when should I use it".
+4. **Reference** — look-up material: architecture diagrams, topology blueprints, operating guides for databases, TLS configuration reference, secret key reference, glossary, chart parameters, supported environments. Each page answers "what is the exact value / configuration / shape".
+5. **Run and maintain** — ongoing operational concerns for a healthy deployment: upgrades, backups, monitoring, scaling, diagnostics, troubleshooting.
+6. **Components** — cross-cutting reference for individual Camunda components. Intentionally separate from the deployment journey.
+7. **Migrate** — the once-per-version upgrade path from 8.9 to 8.10.
 
-**Why the journey stops at Deploy your baseline.** Availability & DR, Tenancy & isolation, Process analytics, and Databases are placed in Architecture and concepts rather than as a third sequential phase after Deploy your baseline. These capabilities are not a linear next step: customers adopt them independently, in any order, at any time after the baseline is healthy. Presenting them as a sequential phase implies a linearity that doesn't match how customers evolve their deployments, and risks recreating the problem where one sidebar section becomes a catch-all for everything that doesn't fit elsewhere. Architecture and concepts is where they belong: standing reference material users reach for when they need it, not a mandatory phase they walk through in sequence.
+**Why the journey stops at Deploy your baseline.** Availability & DR, Tenancy & isolation, Process analytics, and Database strategy are placed in Concepts rather than as a third sequential phase after Deploy your baseline. These capabilities are not a linear next step: customers adopt them independently, in any order, at any time after the baseline is healthy. Presenting them as a sequential phase implies a linearity that doesn't match how customers evolve their deployments, and risks recreating the problem where one sidebar section becomes a catch-all for everything that doesn't fit elsewhere. Concepts is where they belong: standing explanatory material users reach for when they need to understand a decision, not a mandatory phase they walk through in sequence.
 
-A **Migrate from 8.9 → 8.10** section sits alongside as the once-per-version stay-as-is upgrade path. Quickstart keeps its current dev/admin split as a forked side path at the top of the sidebar. Reference architectures live in Architecture and concepts — accessible as a cross-cutting resource from Deploy to production's planning phase, not buried at the bottom of a sequential journey.
+A **Migrate from 8.9 → 8.10** section sits alongside as the once-per-version stay-as-is upgrade path. Quickstart keeps its current dev/admin split as a forked side path at the top of the sidebar. Reference architectures live in Reference — accessible as a cross-cutting resource from Deploy to production's planning phase, not buried at the bottom of a sequential journey.
 
 This shape is validated against three competitor docs:
 
-- **Temporal** organizes around verbs (Evaluate → Develop → Deploy → Self-host) with a three-bucket landing page (Plan / Operate / Protect data) that maps directly onto Deploy to production / Architecture and concepts / Run and maintain.
+- **Temporal** organizes around verbs (Evaluate → Develop → Deploy → Self-host) with a three-bucket landing page (Plan / Operate / Protect data) that maps directly onto Deploy to production / Concepts / Run and maintain.
 - **CockroachDB** has the best comparison-table pattern for helping customers choose between resilience options — adopted for the reference architecture and concept pages.
-- **Confluent** has the most rigorous architecture-pattern template (When to use / When not to / Use cases / Implementation recommendations) — adopted for every option page in Architecture and concepts.
+- **Confluent** has the most rigorous architecture-pattern template (When to use / When not to / Use cases / Implementation recommendations) — adopted for every option page in Concepts.
 
 The proposal closes by:
 
@@ -64,19 +67,20 @@ The 8.9 sidebar treats deployment as a series of categories the customer browses
 
 | 8.9 sidebar shape | 8.10 sidebar shape |
 |---|---|
-| Quickstart · Reference architecture · Deploy and manage · Concepts · Components · Upgrade | Quickstart · Deploy to production · Architecture and concepts · Run and maintain · Components · Migrate |
-| Categories | Action path → reference split |
-| Browse everything | Guided path to baseline, then branch to reference |
-| Component-shaped | Journey-shaped to baseline; concept-shaped beyond |
+| Quickstart · Reference architecture · Deploy and manage · Concepts · Components · Upgrade | Quickstart · Deploy to production · Concepts · Reference · Run and maintain · Components · Migrate |
+| Categories | Action path → explanation / reference split |
+| Browse everything | Guided path to baseline, then branch to explanation or look-up |
+| Component-shaped | Journey-shaped to baseline; Diátaxis-shaped beyond |
 | Multiple unrelated entry points | One opinionated happy path to production, then selective reference |
 | Deployment target choice implicit in which page you click | Deployment target chosen explicitly in Plan your deployment |
-| Multi-region and availability buried under Concepts | First-class content in Architecture and concepts with three named tiers |
+| Multi-region and availability buried under Concepts | First-class Concepts content with three named tiers |
 | Backup & restore buried under Concepts | First-class Run and maintain entry |
+| "Concepts" mixes explanations and look-up material | Concepts = explanation only; Reference = look-up only |
 | "Operate" as a section name | "Run and maintain" — avoids confusion with the Operate application |
 
-**Where the main deployment journey ends.** The guided, action-ordered path in Deploy to production stops after Deploy your baseline. The sidebar then intentionally branches: customers who want to understand tenancy models, availability tiers, database topology options, or Optimize-per-PT consult Architecture and concepts — selectively, in any order, as their deployment needs evolve. Customers managing a running deployment go to Run and maintain. This split avoids two failure modes of the 8.9 sidebar: concepts buried inside operational sections (Backup & restore under Concepts), and operational pages buried inside concept sections. It also avoids recreating the "Concepts as catch-all" problem that this restructure is trying to fix.
+**Where the main deployment journey ends.** The guided, action-ordered path in Deploy to production stops after Deploy your baseline. The sidebar then intentionally branches: customers who want to understand tenancy models, availability tiers, database strategy, or Optimize-per-PT go to Concepts; customers looking up architecture diagrams, database operating guides, or chart parameters go to Reference. Customers managing a running deployment go to Run and maintain. Each section now answers one question — understand, look up, or operate — and nothing is a catch-all.
 
-**Why deployment capabilities belong in Architecture and concepts.** Availability & DR, Tenancy & isolation, Process analytics, and Databases are capabilities customers adopt selectively, often months after the baseline is healthy, in whatever order their deployment needs dictate. Grouping them as a sequential phase after Deploy your baseline would misrepresent this: a phase implies a customer walks through it in order, then moves on. Placing them in Architecture and concepts makes clear they are standing reference material — consult when you need it, skip what doesn't apply.
+**Why deployment capabilities belong in Concepts.** Availability & DR, Tenancy & isolation, Process analytics, and Database strategy are capabilities customers adopt selectively, often months after the baseline is healthy, in whatever order their deployment needs dictate. Grouping them as a sequential phase after Deploy your baseline would misrepresent this: a phase implies a customer walks through it in order, then moves on. Placing them in Concepts makes clear they are standing explanatory material — consult when you need to understand a decision, skip what doesn't apply.
 
 ---
 
@@ -84,13 +88,13 @@ The 8.9 sidebar treats deployment as a series of categories the customer browses
 
 Reading the actual current `sidebars.js` (not just the landing page) surfaced several issues that wouldn't be visible from the docs page alone:
 
-1. **Backup & restore lives under `Concepts`.** It's the most critical Day-2 capability and it's filed inside a junk-drawer section labelled as a place for definitions. This single mis-filing accounts for a significant share of customer "I can't find the backup docs" complaints in support tickets.
+1. **Backup & restore lives under `Concepts`.** It's the most critical Day-2 capability and it's filed inside a junk-drawer section labelled as a place for definitions. Filing a critical Day-2 task inside a section labelled for definitions makes it hard to discover; the placement, not the content, is the problem.
 
 2. **`Concepts` mixes two unrelated things.** Genuine concepts (authentication, secondary storage, databases) sit alongside pure operations (backup, monitoring, troubleshooting, data purge, flow control). Splitting the section cleanly — concepts into Plan, operations into Day-2 — is half the structural value of this restructure.
 
-3. **OpenShift appears in two places under Helm cloud providers.** Once as a child of Amazon (ROSA), once standalone. This is confusing today, before any 8.10 changes.
+3. **OpenShift appears in two places under Helm cloud providers.** `ROSA` under Amazon (AWS-managed) and a standalone `Red Hat OpenShift` (self-hosted). They are distinct targets, but the shared naming is confusing; the fix is clarifying the labels — e.g. `Red Hat OpenShift (AWS-managed / ROSA)` and `Red Hat OpenShift (self-hosted)` — rather than merging the entries.
 
-4. **`helm/operational-tasks/dual-region-operational-procedure` is in Operational tasks** but it's really Availability & DR → Tier 2 content. It's misfiled because today's sidebar has no Availability & DR section to host it.
+4. **Dual-region content is split across concept, procedure, and per-target pages with no cross-navigation.** `concepts/multi-region/dual-region` (explanation), `operational-tasks/dual-region-operational-procedure` (how-to), and per-provider blueprints (reference) are each correctly placed in their own form — but the topic as a whole is hard to follow because nothing links them together.
 
 5. **Bitnami migration pages are in Operational tasks** but they're a one-time pre-Baseline activity tied to a Phase 0 dependency decision, not ongoing operations.
 
@@ -112,7 +116,7 @@ The journey-shaped direction is convergent with industry practice. Three pattern
 
 ### From Temporal
 
-Temporal's top-level docs IA is verb-shaped: Evaluate → Develop → Deploy to production → Self-host → Operate. On the Self-hosted landing page, content is grouped into three named buckets — "Plan and deploy your service" / "Operate your self-hosted service" / "Protect data and enable advanced features." This maps almost one-to-one onto Deploy to production / Run and maintain / Architecture and concepts — the same separation between action-oriented and reference-oriented content that this proposal adopts.
+Temporal's top-level docs IA is verb-shaped: Evaluate → Develop → Deploy to production → Self-host → Operate. On the Self-hosted landing page, content is grouped into three named buckets — "Plan and deploy your service" / "Operate your self-hosted service" / "Protect data and enable advanced features." This maps almost one-to-one onto Deploy to production / Run and maintain / Concepts + Reference — the same separation between action-oriented, explanatory, and look-up content that this proposal adopts.
 
 Patterns to adopt:
 
@@ -137,7 +141,7 @@ Confluent's Multi-Data Center Architectures page has the most rigorous architect
 
 Patterns to adopt:
 
-- **"When to use / When not to use" blocks** on every option page in Architecture and concepts (tenancy, availability, database topology).
+- **"When to use / When not to use" blocks** on every option page in Concepts (tenancy, availability, database strategy).
 - **Industry-anchored use cases** — anchor abstract tier patterns to concrete businesses (Tier 1 = internal tooling; Tier 2 = regulated SaaS, payments, insurance; Tier 3 = banking, government).
 - **Memorable pattern names**, not generic tier numbers. The journey doc already uses these — "Cold recovery", "Dual-region hot standby", "Three-region stretched cluster" — and they should be primary sidebar labels, with "Tier 1/2/3" as parenthetical aliases.
 
@@ -170,7 +174,8 @@ Self-Managed
 │   │   ├─ Choose your resilience tier
 │   │   ├─ Choose your database strategy
 │   │   ├─ Choose your identity strategy
-│   │   └─ Reference architectures               (cross-link to Architecture and concepts)
+│   │   ├─ Choose your network & security strategy
+│   │   └─ Reference architectures               (cross-link to Reference)
 │   │
 │   ├─ Deploy your baseline
 │   │   ├─ Kubernetes — Cloud providers       (existing: deployment/helm/cloud-providers/)
@@ -187,11 +192,7 @@ Self-Managed
 │   │       └─ Amazon EC2
 │   └─ Production readiness checklist
 │
-├─ Architecture and concepts
-│   ├─ Reference architectures               (existing: reference-architecture/)
-│   │   ├─ Kubernetes                        (existing)
-│   │   ├─ Containers                        (existing)
-│   │   └─ Manual / VM                       (existing)
+├─ Concepts                                  (Explanation — understand a decision)
 │   ├─ Hub / Orchestration Cluster topology
 │   ├─ Tenancy and isolation
 │   │   ├─ Choose your isolation strength
@@ -208,15 +209,31 @@ Self-Managed
 │   │   ├─ Hub Business View / Agent Control
 │   │   ├─ Storage requirements
 │   │   └─ Sizing at PT scale
+│   ├─ Database strategy
+│   │   ├─ Splitting databases per component
+│   │   └─ Secondary storage concepts
+│   ├─ Authentication
+│   │   ├─ Authentication to Orchestration Cluster
+│   │   └─ Authentication to management components
+│   └─ Network and security
+│       ├─ TLS strategy (cert-manager vs manual vs external)
+│       ├─ Secret management patterns (Vault / External Secrets / K8s native / IRSA)
+│       └─ Network policy strategy (least-privilege / Zero-Trust posture)
+│
+├─ Reference                                 (Look-up — find an exact value or shape)
+│   ├─ Reference architectures               (existing: reference-architecture/)
+│   │   ├─ Kubernetes                        (existing)
+│   │   ├─ Containers                        (existing)
+│   │   └─ Manual / VM                       (existing)
 │   ├─ Databases
 │   │   ├─ Operating Elasticsearch / OpenSearch
 │   │   ├─ Operating RDBMS
-│   │   ├─ Splitting databases per component
-│   │   ├─ Secondary storage concepts
 │   │   └─ Exporters
-│   └─ Authentication
-│       ├─ Authentication to Orchestration Cluster
-│       └─ Authentication to management components
+│   └─ Network and security
+│       ├─ TLS configuration reference
+│       ├─ Secret key reference
+│       ├─ Supported certificate providers
+│       └─ NetworkPolicy reference
 │
 ├─ Run and maintain
 │   ├─ Upgrade your deployment
@@ -294,13 +311,13 @@ Action key:
 
 | Current path | New location | Action |
 |---|---|---|
-| `self-managed/reference-architecture/reference-architecture` | `Architecture and concepts → Reference architectures` landing | **Rewrite** — see Appendix B |
-| `self-managed/reference-architecture/kubernetes` | `Architecture and concepts → Reference architectures → Kubernetes → Single-region` | **Rewrite** — see Appendix B (trim) |
-| `self-managed/reference-architecture/containers` | `Architecture and concepts → Reference architectures → Containers` | Move |
-| `self-managed/reference-architecture/manual` | `Architecture and concepts → Reference architectures → Manual / VM` | Move |
-| — (NEW) | `Architecture and concepts → Reference architectures → Kubernetes → Dual-region (Tier 2)` | **New** — see Appendix A |
-| — (NEW) | `Architecture and concepts → Reference architectures → Kubernetes → Three-region (Tier 3)` | **New** — see Appendix A |
-| — (NEW) | `Architecture and concepts → Reference architectures → Kubernetes → Multi-PT variant` | **New** — see Appendix A |
+| `self-managed/reference-architecture/reference-architecture` | `Reference → Reference architectures` landing | **Rewrite** — see Appendix B |
+| `self-managed/reference-architecture/kubernetes` | `Reference → Reference architectures → Kubernetes → Single-region` | **Rewrite** — see Appendix B (trim) |
+| `self-managed/reference-architecture/containers` | `Reference → Reference architectures → Containers` | Move |
+| `self-managed/reference-architecture/manual` | `Reference → Reference architectures → Manual / VM` | Move |
+| — (NEW) | `Reference → Reference architectures → Kubernetes → Dual-region (Tier 2)` | **New** — see Appendix A |
+| — (NEW) | `Reference → Reference architectures → Kubernetes → Three-region (Tier 3)` | **New** — see Appendix A |
+| — (NEW) | `Reference → Reference architectures → Kubernetes → Multi-PT variant` | **New** — see Appendix A |
 
 ### 6.3 Deploy and manage → Helm install pages
 
@@ -311,7 +328,7 @@ Action key:
 | `self-managed/deployment/helm/install/index` | (merged) | **Merge** |
 | `self-managed/deployment/helm/install/quick-install` | `Quickstart → For administrators → Local with kind` (cross-link) | **Move** |
 | `self-managed/deployment/helm/install/production/index` | (merged) | **Merge** |
-| `self-managed/deployment/helm/install/helm-with-rdbms` | `Architecture and concepts → Databases → Operating RDBMS → Example end-to-end install` | **Move** — see §5 RDBMS dissolution note |
+| `self-managed/deployment/helm/install/helm-with-rdbms` | `Reference → Databases → Operating RDBMS → Example end-to-end install` | **Move** — see §5 RDBMS dissolution note |
 | `self-managed/deployment/helm/chart-parameters` | Out of Baseline scope — link as reference from `Deploy to production → Deploy your baseline → Prepare installation configuration` pages | **Out of scope** |
 
 ### 6.4 Deploy and manage → Helm Configure pages
@@ -328,21 +345,21 @@ Action key:
 | `.../configure/registry-and-images/air-gapped-installation` | `… → Air-gapped installation` | Move |
 | `.../configure/registry-and-images/install-bitnami-enterprise-images` | `… → Bitnami Enterprise images` | Move |
 | `.../configure/database/index` | (dissolved) | **Delete** |
-| `.../configure/database/rdbms` | `Architecture and concepts → Databases → Operating RDBMS` landing | Move |
+| `.../configure/database/rdbms` | `Reference → Databases → Operating RDBMS` landing | Move |
 | `.../configure/database/rdbms-jdbc-drivers` | `… → Operating RDBMS → JDBC drivers` | Move |
 | `.../configure/database/rdbms-search-and-result-limits` | `… → Operating RDBMS → Search & result limits` | Move |
 | `.../configure/database/rdbms-schema-management` | `… → Operating RDBMS → Schema management` | Move |
 | `.../configure/database/rdbms-troubleshooting` | `… → Operating RDBMS → Troubleshooting` | Move |
 | `.../configure/database/validate-rdbms` | `… → Operating RDBMS → Validate setup` | Move |
 | `.../configure/database/access-sql-liquibase-scripts` | `… → Operating RDBMS → Liquibase scripts` | Move |
-| `.../configure/database/non-sql` | `Architecture and concepts → Databases → Operating Elasticsearch / OpenSearch` landing | **Rewrite** — see Appendix B |
-| `.../configure/database/elasticsearch/using-external-elasticsearch` | `Architecture and concepts → Databases → Splitting databases per component → External Elasticsearch for OC` | Move |
+| `.../configure/database/non-sql` | `Reference → Databases → Operating Elasticsearch / OpenSearch` landing | **Rewrite** — see Appendix B |
+| `.../configure/database/elasticsearch/using-external-elasticsearch` | `Concepts → Database strategy → Splitting databases per component → External Elasticsearch for OC` | Move |
 | `.../configure/database/using-external-opensearch` | `… → Splitting databases per component → External OpenSearch for OC` | Move |
 | `.../configure/database/configure-db-custom-headers` | `… → Operating ES/OS → Custom headers` | Move |
 | `.../configure/database/elasticsearch/prefix-elasticsearch-indices` | `… → Operating ES/OS → Index prefixes` | Move |
 | `.../configure/database/all-shards-failed` | `… → Operating ES/OS → Troubleshooting` | Move |
 | `.../configure/database/using-existing-postgres` | `… → Splitting databases per component → Hub Postgres on its own instance` | Move |
-| `.../configure/database/optimize/index` | `Architecture and concepts → Process analytics → Storage requirements` | **Merge** |
+| `.../configure/database/optimize/index` | `Concepts → Process analytics → Storage requirements` | **Merge** |
 | `.../configure/database/optimize/using-external-elasticsearch` | `… → Splitting databases per component → Optimize on external ES` | Move |
 | `.../configure/database/optimize/using-external-opensearch` | `… → Splitting databases per component → Optimize on external OS` | Move |
 | `.../configure/ingress/index` | `Deploy to production → Deploy your baseline → Provision infrastructure → Kubernetes-specific configuration → Ingress` landing `[Kubernetes]` | Move |
@@ -364,7 +381,7 @@ Action key:
 | `.../configure/running-custom-connectors` | Out of Baseline scope — app configuration is a separate discussion | **Out of scope** |
 | `.../configure/add-extra-manifests` | `Deploy to production → Deploy your baseline → Provision infrastructure → Kubernetes-specific configuration → Extra manifests` `[Kubernetes]` | Move |
 | `.../configure/license-key` | `Deploy to production → Deploy your baseline → Prepare installation configuration → License key` | Move |
-| `.../configure/configure-multi-tenancy` | `Architecture and concepts → Tenancy and isolation → Logical tenants` | **Rewrite** — see Appendix B |
+| `.../configure/configure-multi-tenancy` | `Concepts → Tenancy and isolation → Logical tenants` | **Rewrite** — see Appendix B |
 
 ### 6.5 Deploy and manage → Helm Operational tasks
 
@@ -377,7 +394,7 @@ Action key:
 | `.../migration-from-bitnami/alternatives` | `… → Alternatives` | Move |
 | `.../migration-from-bitnami/zero-downtime` | `… → Zero-downtime migration` | Move |
 | `.../operational-tasks/diagnostics` | `Run and maintain → Diagnostics` | Move |
-| `.../operational-tasks/dual-region-operational-procedure` | `Architecture and concepts → Availability and DR → Tier 2 → Operational procedure` | **Rewrite** — see Appendix B |
+| `.../operational-tasks/dual-region-operational-procedure` | `Concepts → Availability and DR → Tier 2 → Operational procedure` | **Rewrite** — see Appendix B |
 | `.../operational-tasks/helm-v4` | `Deploy to production → Deploy your baseline → → Kubernetes with Helm → 2. Install Camunda with Helm → Helm v4 requirements` | **Promote** out of operational-tasks |
 | `.../operational-tasks/moving-helm-v3-to-v4` | `Migrate from 8.9 → 8.10 → Helm v3 → v4 CLI swap` | Move |
 
@@ -391,16 +408,16 @@ Action key:
 | `.../amazon-eks/eks-eksctl` | `… → AWS EKS → EKS with eksctl` | Move |
 | `.../amazon-eks/eks-terraform` | `… → AWS EKS → EKS with Terraform` | Move |
 | `.../amazon-eks/eks-helm` | `… → AWS EKS → EKS with Helm` (or merge into the unified Install page if the content is generic) | Move (or merge — see Appendix B) |
-| `.../amazon-eks/dual-region` | `Architecture and concepts → Availability and DR → Tier 2 → AWS EKS` | **Move** + rewrite intro |
+| `.../amazon-eks/dual-region` | `Concepts → Availability and DR → Tier 2 → AWS EKS` | **Move** + rewrite intro |
 | `.../amazon-eks/irsa` | `… → AWS EKS → Troubleshooting & IRSA` | Move |
-| `.../amazon/openshift/terraform-setup` | `Deploy to production → Deploy your baseline → → Kubernetes with Helm → 1. Provision your K8s cluster → Red Hat OpenShift → ROSA on AWS` | **Move** + flatten the Amazon/OpenShift duplication |
-| `.../amazon/openshift/terraform-setup-dual-region` | `Architecture and concepts → Availability and DR → Tier 2 → ROSA on AWS` | Move |
+| `.../amazon/openshift/terraform-setup` | `Deploy to production → Deploy your baseline → Kubernetes with Helm → 1. Provision your K8s cluster → Red Hat OpenShift (AWS-managed / ROSA)` | **Move** + clarify label (distinct target from self-hosted OpenShift — do not merge) |
+| `.../amazon/openshift/terraform-setup-dual-region` | `Concepts → Availability and DR → Tier 2 → ROSA on AWS` | Move |
 | `.../gcp/google-gke` | `Deploy to production → Deploy your baseline → → Kubernetes with Helm → 1. Provision your K8s cluster → Google GKE` | Move |
 | `.../azure/microsoft-aks/microsoft-aks` | `… → Azure AKS` landing | Move |
 | `.../azure/microsoft-aks/aks-terraform` | `… → Azure AKS → AKS with Terraform` | Move |
 | `.../azure/microsoft-aks/aks-helm` | `… → Azure AKS → AKS with Helm` (or merge into unified Install page) | Move (or merge) |
 | `.../openshift/redhat-openshift` | `… → Red Hat OpenShift → OpenShift (IPI / bare-metal)` | Move + flatten |
-| `.../openshift/redhat-openshift-dual-region` | `Architecture and concepts → Availability and DR → Tier 2 → Red Hat OpenShift` | Move |
+| `.../openshift/redhat-openshift-dual-region` | `Concepts → Availability and DR → Tier 2 → Red Hat OpenShift` | Move |
 
 ### 6.7 Deploy and manage → Containers & Manual
 
@@ -422,17 +439,17 @@ Action key:
 |---|---|---|
 | `self-managed/concepts/authentication/authentication-to-orchestration-cluster` | `Deploy to production → Plan your deployment → Choose your identity strategy → Authentication concepts` | **Rewrite** — see Appendix B |
 | `self-managed/concepts/authentication/authentication-to-management-components` | `Deploy to production → Plan your deployment → Choose your identity strategy → Authentication concepts` (sibling sub-page) | **Rewrite** — see Appendix B |
-| `self-managed/concepts/secondary-storage/index` | `Architecture and concepts → Databases → Secondary storage concepts` | **Merge** with other secondary-storage pages |
+| `self-managed/concepts/secondary-storage/index` | `Concepts → Database strategy → Secondary storage concepts` | **Merge** with other secondary-storage pages |
 | `self-managed/concepts/secondary-storage/configuring-secondary-storage` | (merged) | **Merge** |
 | `self-managed/concepts/secondary-storage/no-secondary-storage` | (merged) | **Merge** |
 | `self-managed/concepts/secondary-storage/managing-secondary-storage` | (merged) | **Merge** |
-| `self-managed/concepts/secondary-storage/rdbms-benchmark-results` | `Architecture and concepts → Databases → Operating RDBMS → Benchmark results` | Move |
+| `self-managed/concepts/secondary-storage/rdbms-benchmark-results` | `Reference → Databases → Operating RDBMS → Benchmark results` | Move |
 | `self-managed/concepts/databases/overview` | `Deploy to production → Plan your deployment → Choose your database strategy → RDBMS vs ES/OS — comparison` | **Merge** |
-| `self-managed/concepts/databases/elasticsearch/elasticsearch-privileges` | `Architecture and concepts → Databases → Operating ES/OS → Privileges` | Move |
+| `self-managed/concepts/databases/elasticsearch/elasticsearch-privileges` | `Reference → Databases → Operating ES/OS → Privileges` | Move |
 | `… elasticsearch-without-cluster-privileges` | `… → Operating ES/OS → Privileges` (sub-page) | Move |
 | `… opensearch-privileges` | `… → Operating ES/OS → Privileges` (sub-page) | Move |
 | `… opensearch-without-cluster-privileges` | `… → Operating ES/OS → Privileges` (sub-page) | Move |
-| `self-managed/concepts/databases/relational-db/index` | `Architecture and concepts → Databases → Operating RDBMS` landing | Move |
+| `self-managed/concepts/databases/relational-db/index` | `Reference → Databases → Operating RDBMS` landing | Move |
 | `.../databases/relational-db/rdbms-setup-guide` | `… → Operating RDBMS → Setup guide` | Move |
 | `.../databases/relational-db/database-configuration` | `… → Operating RDBMS → Database configuration` | Move |
 | `.../databases/relational-db/rdbms-support-policy` | `… → Operating RDBMS → Support policy` | Move |
@@ -451,11 +468,11 @@ Action key:
 | `.../document-handling/configuration/helm` | `… → Helm` | Move |
 | `self-managed/concepts/audit-log/index` | `Run and maintain → Audit log` | Move |
 | `.../audit-log/configure-audit-log` | `Run and maintain → Audit log → Configure audit log` | Move |
-| `self-managed/concepts/exporters` | `Architecture and concepts → Databases → Exporters` | Move |
+| `self-managed/concepts/exporters` | `Reference → Databases → Exporters` | Move |
 | `self-managed/operational-guides/configure-flow-control/configure-flow-control` | `Run and maintain → Flow control` | Move |
 | `self-managed/operational-guides/monitoring/log-levels` | `Run and maintain → Monitoring → Log levels` | Move |
 | `self-managed/operational-guides/monitoring/metrics` | `Run and maintain → Monitoring → Metrics` | Move |
-| `self-managed/concepts/multi-region/dual-region` | `Architecture and concepts → Availability and DR → Tier 2 → Multi-region concept` | **Rewrite** — see Appendix B |
+| `self-managed/concepts/multi-region/dual-region` | `Concepts → Availability and DR → Tier 2 → Multi-region concept` | **Rewrite** — see Appendix B |
 | `self-managed/operational-guides/data-purge` | `Run and maintain → Data purge` | Move |
 | `self-managed/operational-guides/troubleshooting` | `Run and maintain → Troubleshooting` (also cross-linked from top-level Troubleshooting & FAQ) | Move |
 
@@ -479,7 +496,7 @@ Action key:
 
 These apply across multiple sections of the new sidebar rather than to any one page.
 
-**Comparison tables at the top of decision sections.** Every concept section in Architecture and concepts opens with a comparison table — Choose your tier, Choose your isolation strength — adapted from CockroachDB's "Choose an HA strategy" pattern. See Appendix A for the proposed Camunda Tier comparison.
+**Comparison tables at the top of decision sections.** Every section in Concepts opens with a comparison table — Choose your tier, Choose your isolation strength — adapted from CockroachDB's "Choose an HA strategy" pattern. See Appendix A for the proposed Camunda Tier comparison.
 
 **"When to use / When not to use" blocks on every option page.** Adapted from Confluent's multi-DC architecture template. Below each tier, each tenancy model, each topology variant, customers get:
 - When to choose this (3–5 bullet points)
@@ -524,11 +541,11 @@ Each item is a small `sidebars.js` change. None requires content rewrites. None 
 
 These are the 8.10-tied changes that need to land when 8.10 ships.
 
-- Introduce the **Quickstart → Deploy to production → Architecture and concepts → Run and maintain → Components → Migrate** spine. The shape, not the full content — many pages still in their current form, just reorganized under the new labels.
-- Build out **Availability & DR** under Architecture and concepts with the CockroachDB-style tier table and the moved Tier 2 per-target pages (EKS dual-region, OpenShift dual-region, ROSA dual-region, ECS-coming placeholder).
+- Introduce the **Quickstart → Deploy to production → Concepts → Reference → Run and maintain → Components → Migrate** spine. The shape, not the full content — many pages still in their current form, just reorganized under the new labels.
+- Build out **Availability & DR** under Concepts with the CockroachDB-style tier table and the moved Tier 2 per-target pages (EKS dual-region, OpenShift dual-region, ROSA dual-region, ECS-coming placeholder).
 - Introduce the **Migrate** section with the Migrate from 8.9 → 8.10 sub-path, deprecating `Upgrade to Camunda 8.9` (with redirects).
-- Add **Physical Tenant** pages under Architecture and concepts → Tenancy and isolation.
-- Add **Optimize-per-PT** pages under Architecture and concepts → Process analytics.
+- Add **Physical Tenant** pages under Concepts → Tenancy and isolation.
+- Add **Optimize-per-PT** pages under Concepts → Process analytics.
 - **Restructure Deploy your baseline to the tab model** — collapse three paradigm sub-trees (Kubernetes with Helm / Containers / Manual) into three topic-oriented steps (Provision infrastructure / Prepare installation configuration / Install Hub / Install Orchestration Cluster), each with synced `[Kubernetes]` `[Containers]` `[Manual]` tabs. Cluster provisioning first, install second. Most impactful single structural change for K8s admins.
 - **Merge the three Helm install overview pages** into one Prepare installation configuration page (Kubernetes tab).
 
@@ -536,11 +553,11 @@ These are the 8.10-tied changes that need to land when 8.10 ships.
 
 The full IA cleanup.
 
-- **Dissolve `Concepts` entirely.** Move all `concepts/databases/*` and `concepts/secondary-storage/*` content into Architecture and concepts → Databases. Move authentication concepts into Architecture and concepts → Authentication.
-- **Build out Databases's Operating-RDBMS and Operating-ES/OS sub-trees** by consolidating today's scattered DB pages.
-- **Build Reference architectures' Tier 2 / Tier 3 / multi-PT variants** (per the journey doc's open items).
+- **Dissolve the old `Concepts` section entirely.** Move all `concepts/databases/*` and `concepts/secondary-storage/*` content into Reference → Databases. Move authentication concepts into Concepts → Authentication.
+- **Build out Reference → Databases' Operating-RDBMS and Operating-ES/OS sub-trees** by consolidating today's scattered DB pages.
+- **Build Reference → Reference architectures' Tier 2 / Tier 3 / multi-PT variants** (per the journey doc's open items).
 - Ship the **per-paradigm Document handling split** (concept → Run and maintain, configuration → Deploy to production → Deploy your baseline → Prepare installation configuration).
-- Adopt the **comparison-table + when-to-use / when-not-to** pattern as the consistent template across all Architecture and concepts option pages.
+- Adopt the **comparison-table + when-to-use / when-not-to** pattern as the consistent template across all Concepts option pages.
 
 This sequencing front-loads the wins customers feel immediately (backup discoverability, OpenShift de-duplication, glossary, production checklist) before any major IA shift, then lands the 8.10-tied changes when 8.10 ships, then completes the structural reorganization once 8.10 is stable.
 
@@ -548,13 +565,15 @@ This sequencing front-loads the wins customers feel immediately (backup discover
 
 ## 9. Open questions to validate before publishing
 
+> **On approach:** The target sidebar tree is a direction to converge on, not a fixed plan to implement up front. Several questions below are structure-blocking — committing those sections before the answers land risks rework. The right model is iterative: ship Phase 1 now, let blocking questions resolve, then loop back and extend the structure. Each loop is a small PR, not a big-bang restructure.
+
 Carried forward from the journey doc and surfaced by this restructure:
 
 1. **Helm chart packaging.** Chart split (single chart + per-unit values files vs. separate Hub and Orchestration charts) is not decided. The sidebar structure works either way, but the page titles inside Baseline read differently. Owner: Hub team. Reference: Hub Helm refactor PR `camunda-platform-helm#5421`; broader Hub helm work paused pending Console-SM application-side removal.
 
 2. **OC-to-Hub registration UX.** In 8.10, adding/updating an OC in Hub is a values-file edit + Hub restart — no in-UI flow. The new "Register the OC in Hub" page documents this. If a UI flow lands in 8.11/8.12, the page needs a rewrite, not a structural change. Owner: Hub team.
 
-3. **Tier 3 RTO/RPO targets.** Multi-region docs PR `camunda-docs#8492` did not commit RTO/RPO numbers for Tier 3. The proposed Tier 3 page currently has these as TBD. Need committed targets before publishing customer-facing guidance. Owner: Resilience Tiers / multi-region docs team.
+3. **Tier 3 RTO/RPO targets.** Unresolved as of today. RTO/RPO targets for Tier 3 should live alongside the Tier 1 and Tier 2 content in Concepts → Availability and DR — the page exists in the proposed structure but the numbers are TBD. `camunda-docs#8492` is currently closed/held and is not a reliable source; committed targets are needed before this page can be published. Owner: Resilience Tiers / multi-region docs team.
 
 4. **Hub Business View aggregation.** With Optimize 1:1 per PT and many PTs across many OCs, Hub may need to read from N Optimize instances backed by N ES backends. The proposed Process analytics → Hub Business View page documents this. Need to confirm whether the business view supports connecting across multiple Optimize/ES backends in 8.10, and if not, document per-PT-only scope as a known limitation. Owner: Hub team.
 
@@ -574,20 +593,20 @@ For each new page the structure requires, what content should live there. Brief 
 
 ### A.1 — Deploy to production: Plan your deployment
 
-**Production topology overview** (`Architecture and concepts → Deployment concepts → Hub / Orchestration Cluster topology`)
+**Production topology overview** (`Concepts → Hub / Orchestration Cluster topology`)
 The one-sentence statement: *One Hub, one or more Orchestration Clusters, one or more Physical Tenants per OC, and zero or more Optimize deployments per PT*. A simple SVG topology diagram. A short cross-dependency table: Hub knows OCs via its values file; each Optimize binds 1:1 to a PT; each Optimize needs its own Mgmt Identity app registration; Hub dashboards read from Optimize. A "why this shape" paragraph linking forward to Deploy your baseline. Half a screen of content total — the page's job is to make the mental model click in 30 seconds.
 
 **Choose your deployment target** (`Deploy to production → Plan your deployment → Choose your deployment target`)
 The paradigm picker. Three choices: Kubernetes with Helm (recommended for production), Containers (Docker, AWS ECS), Manual / VM. Short table of trade-offs. Recommendation paragraph: "Kubernetes with Helm is the recommended path for production; consider containers when K8s is unavailable; manual installs are typically for air-gapped or specialized environments." This choice persists throughout the docs via Docusaurus tab `groupId="deployment-paradigm"` — once a paradigm is selected, all tabbed pages default to that paradigm. Links forward to Reference architectures.
 
-**Reference architectures — Kubernetes → Dual-region (Tier 2)** (`Architecture and concepts → Reference architectures → Kubernetes → Dual-region (Tier 2)`)
-Architectural blueprint of a Tier 2 Camunda deployment on Kubernetes. Topology diagram showing two regions, one active OC, one standby OC, shared RDBMS with cross-region replication, Hub remaining single-region. Calls out the standing-secondary reachability requirement (Zeebe stalls if it can't reach the standby). Links to the Architecture and concepts → Availability and DR → Tier 2 concept page for adoption details.
+**Reference architectures — Kubernetes → Dual-region (Tier 2)** (`Reference → Reference architectures → Kubernetes → Dual-region (Tier 2)`)
+Architectural blueprint of a Tier 2 Camunda deployment on Kubernetes. Topology diagram showing two regions, one active OC, one standby OC, shared RDBMS with cross-region replication, Hub remaining single-region. Calls out the standing-secondary reachability requirement (Zeebe stalls if it can't reach the standby). Links to the Concepts → Availability and DR → Tier 2 concept page for adoption details.
 
-**Reference architectures — Kubernetes → Three-region (Tier 3)** (`Architecture and concepts → Reference architectures → Kubernetes → Three-region (Tier 3)`)
-Architectural blueprint of a Tier 3 Camunda deployment. Topology diagram showing three regions with quorum-based replication. Notes Tier 3 is RDBMS-only and Helm-only at 8.10 GA. Calls out the open RTO/RPO targets (TBD per `camunda-docs#8492`). Links to Architecture and concepts → Availability and DR → Tier 3 for adoption details.
+**Reference architectures — Kubernetes → Three-region (Tier 3)** (`Reference → Reference architectures → Kubernetes → Three-region (Tier 3)`)
+Architectural blueprint of a Tier 3 Camunda deployment. Topology diagram showing three regions with quorum-based replication. Notes Tier 3 is RDBMS-only and Helm-only at 8.10 GA. Calls out the open RTO/RPO targets (TBD per `camunda-docs#8492`). Links to Concepts → Availability and DR → Tier 3 for adoption details.
 
-**Reference architectures — Kubernetes → Multi-PT variant** (`Architecture and concepts → Reference architectures → Kubernetes → Multi-PT variant`)
-Architectural blueprint of a single-region Camunda deployment with multiple Physical Tenants in a single OC. Topology diagram showing one OC pod hosting N PTs, each with its own partitions and DB schema/index prefix, with shared Connectors runtime. Links to Architecture and concepts → Tenancy and isolation → Physical tenants for adoption details.
+**Reference architectures — Kubernetes → Multi-PT variant** (`Reference → Reference architectures → Kubernetes → Multi-PT variant`)
+Architectural blueprint of a single-region Camunda deployment with multiple Physical Tenants in a single OC. Topology diagram showing one OC pod hosting N PTs, each with its own partitions and DB schema/index prefix, with shared Connectors runtime. Links to Concepts → Tenancy and isolation → Physical tenants for adoption details.
 
 **Choose your database strategy — landing** (`Deploy to production → Plan your deployment → Choose your database strategy`)
 Frames the database decision as the second planning decision (after deployment target, because database options differ by platform — e.g., OpenSearch is AWS-centric). Introduces the three implementation options (managed services, K8s operators, alternatives). Sets the hard rule: something must be provisioned and reachable for Hub and for the OC before any Helm install — no in-chart Bitnami fallback. Includes an RDBMS vs ES/OS comparison table inline.
@@ -596,9 +615,9 @@ Frames the database decision as the second planning decision (after deployment t
 Cockroach-style comparison table. Columns: RDBMS, Elasticsearch/OpenSearch. Rows: Storage model, Multi-region support (Tier 2/3 = RDBMS only at 8.10), Optimize compatibility (ES/OS only), Operational tooling familiarity, Operational complexity, Backup story, Suggested for. Recommendation paragraph below: "If multi-region is on your roadmap, prefer RDBMS for the OC from day one."
 
 **Choose your identity strategy — landing** (`Deploy to production → Plan your deployment → Choose your identity strategy`)
-Frames the identity decision as the third planning decision (after deployment target and database, since OIDC provider availability and Keycloak operator options depend on both). Introduces the choice surface: external OIDC for production (Entra ID, Okta, …) vs basic auth for dev/eval. Notes Mgmt Identity stays as a separate component in 8.10, planned removal in 8.11. Links to Architecture and concepts → Authentication pages.
+Frames the identity decision as the third planning decision (after deployment target and database, since OIDC provider availability and Keycloak operator options depend on both). Introduces the choice surface: external OIDC for production (Entra ID, Okta, …) vs basic auth for dev/eval. Notes Mgmt Identity stays as a separate component in 8.10, planned removal in 8.11. Links to Concepts → Authentication pages.
 
-**Management Identity vs OC Admin** (`Architecture and concepts → Authentication → Authentication to management components`)
+**Management Identity vs OC Admin** (`Concepts → Authentication → Authentication to management components`)
 Explains the two distinct identity surfaces in 8.10: Mgmt Identity in the Hub namespace (Hub, Optimize) and OC Admin embedded in the Orchestration Cluster (Zeebe, Operate, Tasklist). Shows which components authenticate against which. Notes that each Optimize requires its own Mgmt Identity app registration. Diagram of the auth flows.
 
 **Choose your resilience tier** (`Deploy to production → Plan your deployment → Choose your resilience tier`)
@@ -626,7 +645,7 @@ Frames database provisioning as a hard prerequisite before any Helm install (no 
 Single tabbed page ([Kubernetes] [Containers] [Manual]) covering license key and secret management — the configuration steps that must be complete before the install commands run. Helm v4 prerequisite appears as a callout on the Kubernetes tab. The page explains the two-release model (Hub + OC as separate releases) and links forward to Install Hub and Install Orchestration Cluster. Absorbs the three old overview pages (helm/index, helm/install/index, helm/install/production/index) on the Kubernetes tab.
 
 **Register the OC in Hub** (`Deploy to production → Deploy your baseline → Install Orchestration Cluster → Register the OC in Hub`)
-8.10-specific sub-section inside Install Orchestration Cluster. Documents the values-file edit + Hub restart pattern (no in-UI registration in 8.10). Shows the values structure for an OC entry, the OIDC config, and how to wire secrets. Calls out that adding subsequent OCs (see Architecture and concepts → Tenancy and isolation → Separate Orchestration Clusters) follows the same pattern. Flags the open question (UI flow planned for 8.11/8.12) so this page can evolve.
+8.10-specific sub-section inside Install Orchestration Cluster. Documents the values-file edit + Hub restart pattern (no in-UI registration in 8.10). Shows the values structure for an OC entry, the OIDC config, and how to wire secrets. Calls out that adding subsequent OCs (see Concepts → Tenancy and isolation → Separate Orchestration Clusters) follows the same pattern. Flags the open question (UI flow planned for 8.11/8.12) so this page can evolve.
 
 **Production readiness checklist** (`Deploy to production → Deploy your baseline → Production readiness checklist`)
 Temporal-style checklist page. Sections: Scale and capacity (resource requests, broker partition counts, secondary storage sizing), Reliability (replication factor, backup configured, monitoring scrape configured), Security (TLS enabled, OIDC configured, secrets managed externally, license applied), Long-term maintainability (chart version pinned, upgrade plan documented, runbook recorded). Each item is a single line with a cross-link. This is the page a customer prints and walks through before going live.
@@ -634,46 +653,46 @@ Temporal-style checklist page. Sections: Scale and capacity (resource requests, 
 **Smoke test and exit criteria** (`Deploy to production → Deploy your baseline → Smoke test and exit criteria`)
 Defines what "baseline deployed" actually means. Concrete tests: deploy a test process from Hub Workspace to the default PT; complete it end-to-end; verify it appears in Operate. Exit criteria checklist: Hub UI reachable, Mgmt Identity healthy, OC brokers across 3 AZs (single-region), Operate/Tasklist reachable, exports flowing for the PT, OC visible in Hub's cluster list. Failing any item means a config issue to fix before considering baseline complete.
 
-### A.3 — Architecture and concepts
+### A.3 — Concepts and Reference
 
 
-**Availability & DR — Tier framework + RPO/RTO** (`Architecture and concepts → Deployment concepts → Availability and DR → Tier framework + RPO/RTO`)
+**Availability & DR — Tier framework + RPO/RTO** (`Concepts → Availability and DR → Tier framework + RPO/RTO`)
 The Cockroach-style "Choose your tier" comparison table. Glossary block at top defining HA, DR, RPO, RTO (linking to the global glossary). Comparison table with columns Tier 1 / Tier 2 / Tier 3 and rows: RTO, RPO, Regions, Failover (manual / scripted / automated), Standby cost, Storage (RDBMS / RDBMS+ES), Supported targets at 8.10 GA, Best for. One topology diagram showing all three tiers side by side. Recommendation paragraph and a "How to pick" decision flow.
 
-**Tier 1 — Cold recovery (DR)** (`Architecture and concepts → Deployment concepts → Availability and DR → Tier 1 — Cold recovery`)
+**Tier 1 — Cold recovery (DR)** (`Concepts → Availability and DR → Tier 1 — Cold recovery`)
 Confluent-style page. Sections: When to use (cost-sensitive workloads, internal tooling, non-customer-facing automation, RTO 1–4h acceptable). When NOT to use (zero data loss requirement → Tier 2; automatic failover required → Tier 3). Use cases (internal tooling, dev/staging environments, batch processing). Implementation: per-target recovery runbooks (EKS, OpenShift, ECS, manual).
 
-**Tier 2 — Dual-region hot standby (HA + DR)** (`Architecture and concepts → Deployment concepts → Availability and DR → Tier 2 — Dual-region hot standby`)
+**Tier 2 — Dual-region hot standby (HA + DR)** (`Concepts → Availability and DR → Tier 2 — Dual-region hot standby`)
 Confluent-style page. When to use (regulated SaaS, customer-facing process automation, payments, RTO ~15min, RPO 0). When NOT to use (manual 1-4h acceptable → Tier 1; want automatic quorum-based failover → Tier 3; on manual/Compose paradigms → not blueprinted at Tier 2 in 8.10). Use cases (banking transaction orchestration, insurance claims, healthcare workflows, supply chain). Implementation: per-target subpages (AWS EKS, Red Hat OpenShift, ROSA on AWS, AWS ECS coming, Operational procedure).
 
-**Tier 2 — AWS ECS placeholder** (`Architecture and concepts → Deployment concepts → Availability and DR → Tier 2 → AWS ECS`)
+**Tier 2 — AWS ECS placeholder** (`Concepts → Availability and DR → Tier 2 → AWS ECS`)
 Placeholder page for the coming-in-8.10.x Tier 2 ECS pattern. Notes "Coming in 8.10.x" prominently. Links to the equivalent EKS and OpenShift implementations as reference. The page exists so the sidebar structure is stable when ECS Tier 2 ships.
 
-**Tier 3 — Three-region stretched (HA)** (`Architecture and concepts → Deployment concepts → Availability and DR → Tier 3 — Three-region stretched`)
+**Tier 3 — Three-region stretched (HA)** (`Concepts → Availability and DR → Tier 3 — Three-region stretched`)
 Confluent-style page. When to use (mission-critical orchestration, near-zero RTO required, automatic quorum-based failover). When NOT to use (cost-constrained, fewer than three regions available, manual recovery is acceptable). Use cases (banking, government, healthcare critical systems). Implementation: Kubernetes with Helm (only target at 8.10 GA). Calls out the open RTO/RPO TBD per `camunda-docs#8492`.
 
-**Tenancy & isolation — Choose your isolation strength** (`Architecture and concepts → Tenancy and isolation → Choose your isolation strength`)
+**Tenancy & isolation — Choose your isolation strength** (`Concepts → Tenancy and isolation → Choose your isolation strength`)
 Comparison table with three columns (Logical tenants / Physical tenants / Separate OC) and rows: What's isolated, Infra cost, Per-tenant IdP support, Per-tenant backup/restore, Per-tenant perf isolation, Operational complexity, Upgrade cadence flexibility, When to choose. Decision flow below. Cross-link forward to each per-option page.
 
-**Physical tenants — Concept** (`Architecture and concepts → Deployment concepts → Tenancy and isolation → Physical tenants → Concept`)
+**Physical tenants — Concept** (`Concepts → Tenancy and isolation → Physical tenants → Concept`)
 New page introducing PTs as new in 8.10. Explains: each PT has its own partitions, its own RDBMS schema (or ES/OS index prefix), its own IdP assignment; a single Connectors runtime serves all PTs in an OC; PTs are addressed via `/v2/physical-tenants/{tenantId}/...`; every OC auto-creates a default PT. Diagram showing one OC pod with N PTs. Performance caveat: many PTs against shared ES degrades Optimize throughput (Danske Bank 50-PT stress point).
 
-**Physical tenants — Add a PT to existing OC** (`Architecture and concepts → Deployment concepts → Tenancy and isolation → Physical tenants → Add a PT to existing OC`)
+**Physical tenants — Add a PT to existing OC** (`Concepts → Tenancy and isolation → Physical tenants → Add a PT to existing OC`)
 Procedure: provision schema/index prefix for the new PT → add the PT under `camunda.physical-tenants.*` in `orchestration-values.yaml` with storage binding and IdP assignment → rolling restart the OC → verify via `/v2/physical-tenants/{tenantId}/...`. Caveat callout: per-PT partition resize is disruptive — size partition counts conservatively if many PTs anticipated.
 
-**Physical tenants — Per-PT credentials & backups** (`Architecture and concepts → Deployment concepts → Tenancy and isolation → Physical tenants → Per-PT credentials and backups`)
+**Physical tenants — Per-PT credentials & backups** (`Concepts → Tenancy and isolation → Physical tenants → Per-PT credentials and backups`)
 Documents the per-PT credentials and backup story in 8.10. No built-in per-PT rotation flow (rotate via the underlying IdP and propagate through `orchestration-values.yaml`). Per-PT backup/restore via the REST Management API (new in 8.10). Manual runbook for credential rotation as the interim solution before 8.11 lands automation.
 
-**Tenancy & isolation — Separate OC — When to add a second OC** (`Architecture and concepts → Deployment concepts → Tenancy and isolation → Separate Orchestration Clusters → When to add a second OC`)
+**Tenancy & isolation — Separate OC — When to add a second OC** (`Concepts → Tenancy and isolation → Separate Orchestration Clusters → When to add a second OC`)
 Confluent-style page on when separate OCs are the right choice over Logical or Physical tenants. When to use (regulatory boundary, independent upgrade cadence, independent region, business-unit hard separation). When NOT to use (cost-sensitive deployments — separate OCs are the highest-cost isolation level; soft data isolation is sufficient → Logical tenant; per-tenant perf isolation is sufficient → Physical tenant).
 
-**Tenancy & isolation — Separate OC — Multi-OC operations** (`Architecture and concepts → Deployment concepts → Tenancy and isolation → Separate Orchestration Clusters → Multi-OC operations`)
+**Tenancy & isolation — Separate OC — Multi-OC operations** (`Concepts → Tenancy and isolation → Separate Orchestration Clusters → Multi-OC operations`)
 Operational considerations when running N OCs against one Hub: per-OC monitoring, per-OC backup windows, per-OC chart-version pinning, OC-to-Hub registration via values file (cross-link to Baseline → Register the OC in Hub). Notes the Hub-restart-per-OC-onboarding limitation in 8.10.
 
-**Tenancy & isolation — Separate OC — Independent upgrade cadence** (`Architecture and concepts → Deployment concepts → Tenancy and isolation → Separate Orchestration Clusters → Independent upgrade cadence`)
+**Tenancy & isolation — Separate OC — Independent upgrade cadence** (`Concepts → Tenancy and isolation → Separate Orchestration Clusters → Independent upgrade cadence`)
 Documents the upgrade-cadence flexibility separate OCs provide. Hub ↔ OC version matrix, supported lag (Hub at 8.10 can drive OC at 8.9 within compatibility window — confirm), upgrade order per OC. Cross-link to Migrate from 8.9 → 8.10 → Run the upgrade.
 
-**Process analytics — Add Optimize per Physical Tenant** (`Architecture and concepts → Process analytics → Add Optimize per Physical Tenant`)
+**Process analytics — Add Optimize per Physical Tenant** (`Concepts → Process analytics → Add Optimize per Physical Tenant`)
 Procedure: confirm ES/OS available for the PT → register a dedicated Mgmt Identity application for this Optimize instance → author `optimize-values-{pt-name}.yaml` → `helm install optimize-{pt-name} … -n camunda-oc` → verify in Hub. One Optimize per PT that needs analytics — explicitly notes the 1:1 binding. Repeat per PT.
 
 **Process analytics — Hub Business View / Agent Control** (`… → Hub Business View / Agent Control`)
@@ -692,6 +711,27 @@ Sizing guide for ES under many-PT load. Large-scale PT deployment as anchor. Rec
 **Databases — Splitting databases per component — landing** (`… → Splitting databases per component`)
 Landing page for the four split-per-component sub-pages. Explains when splitting helps (independent backup windows, independent failover, regulatory boundaries, perf isolation). Pattern table mapping common requirements to recommended splits.
 
+**Network and security — TLS strategy** (`Concepts → Network and security → TLS strategy`)
+Decision page: cert-manager (automated rotation, ACME/Let's Encrypt, Vault PKI) vs manual certificate provisioning (bring-your-own cert, organisational CA) vs external TLS termination at ingress/load-balancer. When-to-use / when-not-to table per option. Calls out the mTLS considerations between Hub and OC. Cross-link to Reference → Network and security → TLS configuration reference for the actual values.
+
+**Network and security — Secret management patterns** (`Concepts → Network and security → Secret management patterns`)
+Decision page: K8s native Secrets (simple, no rotation) vs External Secrets Operator (pulls from Vault/AWS SM/GCP SM, rotation support) vs Vault agent sidecar (fine-grained, complex) vs IRSA / Workload Identity (cloud-native, no static credentials on EKS/GKE/AKS). Trade-off table: ops complexity, rotation support, audit trail, cloud-portability. Calls out which Camunda components read secrets at startup vs runtime — matters for rotation strategy. IRSA section explains how to omit static AWS credential keys when IAM role-based auth is configured for the S3 document store. Cross-link to Reference → Network and security → Secret key reference. Tracks `product-hub#3388`.
+
+**Network and security — Network policy strategy** (`Concepts → Network and security → Network policy strategy`)
+Decision page: no NetworkPolicies (open cluster, simpler but over-permissive) vs opinionated least-privilege policies (shipped with the chart, enable via values) vs custom policies (bring-your-own, full control). Explains the Zero-Trust posture and what "least-privilege" means for Camunda's Hub ↔ OC ↔ dependencies topology. When-to-use table: regulated environments, multi-tenant clusters, and enterprise security baselines that require network segregation. Calls out that enabling policies restricts pod-to-pod traffic — deliberate allow-lists are required for any external integrations. Cross-link to Reference → Network and security → NetworkPolicy reference. Tracks `product-hub#3519`.
+
+**Network and security — TLS configuration reference** (`Reference → Network and security → TLS configuration reference`)
+Look-up page: all `global.tls.*` and component-level TLS values keys, accepted formats, cert/key/CA bundle paths, trust store configuration. Covers Hub TLS, OC TLS, and inter-component mTLS. Not a guide — purely a values reference with types and defaults.
+
+**Network and security — Secret key reference** (`Reference → Network and security → Secret key reference`)
+Look-up page: every Kubernetes Secret that Camunda expects at deploy time — name pattern, namespace, required keys, which component consumes it. Tabular format: Secret name | Component | Required keys | Notes. Includes an "IRSA / omit-when" column marking keys that must be absent when workload identity is active (S3 document store case). Designed to be pasted into a values file or secret-provisioning script. Tracks `product-hub#3388`.
+
+**Network and security — NetworkPolicy reference** (`Reference → Network and security → NetworkPolicy reference`)
+Look-up page: the full set of NetworkPolicy resources the chart ships, what each allows (ingress/egress, port, peer), and the values flag to enable them. Tabular: Policy name | Direction | Ports | Peers | Enable flag. Includes a "custom extensions" section for teams adding their own allow-rules on top of the chart's baseline. Tracks `product-hub#3519`.
+
+**Plan your deployment — Choose your network & security strategy** (`Deploy to production → Plan → Choose your network & security strategy`)
+Decision guide: TLS termination point (at ingress, at component, mTLS throughout), secret management approach, network policy posture. Feeds directly into the TLS setup and secret wiring steps in Deploy your baseline. Cross-links to Concepts → Network and security for explanatory depth.
+
 ### A.4 — Day-2 section
 
 
@@ -708,7 +748,7 @@ StatefulSet-based broker scaling per OC. When to scale, how to scale, rebalancin
 Standard Deployment scaling for the stateless Hub component. Considerations: shared Postgres, no in-pod state, horizontal scaling factors.
 
 **Scaling — Adding PTs to an existing OC** (`Run and maintain → Scaling → Adding PTs to an existing OC`)
-8.10-specific operational task. Cross-link to Architecture and concepts → Tenancy and isolation → Physical tenants → Add a PT for the procedure. Documents the operational considerations: rolling restart timing, partition-count conservatism, secondary-storage provisioning ahead of time.
+8.10-specific operational task. Cross-link to Concepts → Tenancy and isolation → Physical tenants → Add a PT for the procedure. Documents the operational considerations: rolling restart timing, partition-count conservatism, secondary-storage provisioning ahead of time.
 
 
 
@@ -721,7 +761,7 @@ Manual runbook for credential rotation in 8.10. No built-in automation; rotate v
 Single-page summary of what's forced at upgrade vs what's optional adoption. Per the existing migration journey doc (gdoc: "Camunda 8.10 SM — Migration User Journey"), use the stay-as-is framing: Helm v4 (forced), Bitnami subcharts removed (must migrate dependencies first), Web Modeler + Console SM → Hub values rewrite (forced or use migration tool), Physical Tenants (default auto-created — stay-as-is means no change), Optimize-per-PT (existing OC = 1 PT = 1 Optimize, no change). Recommend doing Bitnami migration as a separate 8.9 operation before the 8.10 upgrade.
 
 **Web Modeler + Console SM → Camunda Hub** (`Migrate from 8.9 → 8.10 → Web Modeler + Console SM → Camunda Hub`)
-Documents the 8.10 values rewrite. `webModeler.*` → `camundaHub.*`; Console keys move under `camundaHub.*`. Best path: the migration & validation tool (`product-hub#3563`) translates these automatically. Manual fallback documented inline. Cross-link to the chart-side PRs (`#5996`, `#5997`, `#5998`, `#5999`).
+Documents the 8.10 values rewrite. `webModeler.*` → `camundaHub.*`; Console keys move under `camundaHub.*`. Best path: the migration & validation tool (`product-hub#3563`) translates these automatically. Manual fallback documented inline. Cross-link to the chart-side PRs (references TBD — verify before publishing).
 
 **Catch up to Baseline (post-upgrade, optional)** (`Migrate from 8.9 → 8.10 → Catch up to Baseline`)
 Bridges from the stay-as-is upgrade to the journey's Baseline shape. Three optional follow-ups: split Hub and OC into separate namespaces (matches the new Baseline default); adopt Physical Tenants for per-tenant isolation; consider Resilience Tier upgrade. Each is a forward-link to the relevant Build your Baseline or Extend page. Explicit that these are NOT part of the upgrade; they are post-upgrade choices on the customer's own timeline.
@@ -753,7 +793,7 @@ Currently a list of deployment options (Helm, Docker, Manual). Delete with redir
 Three current overview pages become one "Install Camunda" page with three paradigm tabs (`[Kubernetes]` `[Containers]` `[Manual]`) sharing `groupId="deployment-paradigm"`. Kubernetes tab structure: Helm v4 prerequisite → What the chart deploys (Hub + OC as two releases) → Quick install vs production install (absorbing today's `production/index` content) → Chart parameters reference link. Containers and Manual tabs cover their respective install flows. Redirect all three deprecated URLs to the unified page. Per-target infrastructure details (EKS, AKS, GKE, OpenShift) live in "1. Provision your infrastructure" sub-pages, not on this page.
 
 **`self-managed/upgrade/index` — Migrate from 8.9 → 8.10 At-a-glance**
-Currently a generic upgrade overview. Rewrite as the 8.10-specific at-a-glance page per the existing migration journey doc. Content per Appendix A → "At-a-glance: what changes 8.9 → 8.10". URL slug changes from `/upgrade/` to `/migrate/` with redirect. Existing 8.7 → 8.8 → 8.9 paths remain in their respective versioned docs per `camunda-docs#7617` Option 2.
+Currently a generic upgrade overview. Rewrite as the 8.10-specific at-a-glance page per the existing migration journey doc. Content per Appendix A → "At-a-glance: what changes 8.9 → 8.10". URL slug changes from `/upgrade/` to `/migrate/` with redirect. Existing 8.7 → 8.8 → 8.9 paths remain in their respective versioned docs (reference TBD — verify versioning strategy decision before publishing).
 
 **`self-managed/operational-guides/backup-restore/backup-and-restore` — Backups & restore Overview**
 Currently the entry point to backup docs buried under Concepts. Rewrite minimally: reframe the intro to position this as a Day-2 capability, not a concept; add a "When to test your backups" callout (recommend monthly restore drills); cross-link to the relevant Availability & DR tier page. Content largely unchanged; positioning and prominence are the change.
@@ -772,31 +812,31 @@ Currently a single page documenting the `extraConfiguration` pattern. Rewrite to
 **`helm/configure/operator-based-infrastructure` — Kubernetes operators (in Plan)**
 Currently a Configure page assumed by readers to be one of many config options. Rewrite as a Phase 0 decision page: this is one of three ways to provision your dependencies (alongside managed services and alternatives). Add the decision framing: "Choose this if you have K8s expertise and want operator-managed dependencies; choose managed services if you prefer cloud-provider-managed; choose alternatives if you have non-standard requirements." Cross-link to the Migration from Bitnami sub-section for customers upgrading.
 
-**`helm/configure/database/non-sql` — Operating Elasticsearch / OpenSearch (in Architecture and concepts)**
-Currently a configure-time page. Rewrite as the operating-ES/OS landing page in Architecture and concepts → Deployment concepts → Databases. Rename "non-sql" to "Elasticsearch / OpenSearch" throughout. Reframe content from "how to point at an ES/OS at install time" (move that to Deploy to production → Deploy your baseline → Provision databases) to "how to operate an ES/OS-backed Camunda deployment ongoing."
+**`helm/configure/database/non-sql` — Operating Elasticsearch / OpenSearch (in Reference)**
+Currently a configure-time page. Rewrite as the operating-ES/OS landing page in Reference → Databases. Rename "non-sql" to "Elasticsearch / OpenSearch" throughout. Reframe content from "how to point at an ES/OS at install time" (move that to Deploy to production → Deploy your baseline → Provision databases) to "how to operate an ES/OS-backed Camunda deployment ongoing." Must include opinionated guidance on index retention periods, rollover intervals, replica counts, and shard sizing — the absence of this today causes oversharding and index unavailability in production. Tracks `product-hub#3518`.
 
 **`helm/configure/configure-multi-tenancy` — Logical tenants (in Tenancy and isolation)**
-Currently positioned as a Helm config option. Rewrite as the Logical tenants page in Architecture and concepts → Deployment concepts → Tenancy and isolation. Reframe content from "how to enable multi-tenancy in Helm values" to "how to use logical tenants for soft data isolation, when to choose this over Physical tenants or Separate Orchestration Clusters." Cross-link to the Choose your isolation strength comparison.
+Currently positioned as a Helm config option. Rewrite as the Logical tenants page in Concepts → Tenancy and isolation. Reframe content from "how to enable multi-tenancy in Helm values" to "how to use logical tenants for soft data isolation, when to choose this over Physical tenants or Separate Orchestration Clusters." Cross-link to the Choose your isolation strength comparison.
 
 ### B.3 — Concepts pages that get reframed
 
 **`concepts/authentication/authentication-to-orchestration-cluster` — Authentication concepts (OC half)**
-Currently a concept page on OC auth. Reframe for Architecture and concepts → Authentication context: position as one of the two distinct identity surfaces in 8.10 (the OC Admin half). Cross-link to the Management Identity vs OC Admin page in the same section. Trim implementation details (those live in Deploy to production → Deploy your baseline → Set up authentication).
+Currently a concept page on OC auth. Reframe for Concepts → Authentication context: position as one of the two distinct identity surfaces in 8.10 (the OC Admin half). Cross-link to the Management Identity vs OC Admin page in the same section. Trim implementation details (those live in Deploy to production → Deploy your baseline → Set up authentication).
 
 **`concepts/authentication/authentication-to-management-components` — Authentication concepts (Mgmt half)**
-Currently a concept page on Mgmt Identity auth. Reframe symmetrically with the OC half: position as the other identity surface (Mgmt Identity in the Hub namespace, used by Hub and Optimize). Cross-link to Management Identity vs OC Admin and to the per-Optimize app registration page in Architecture and concepts → Deployment concepts → Process analytics.
+Currently a concept page on Mgmt Identity auth. Reframe symmetrically with the OC half: position as the other identity surface (Mgmt Identity in the Hub namespace, used by Hub and Optimize). Cross-link to Management Identity vs OC Admin and to the per-Optimize app registration page in Concepts → Process analytics.
 
 ### B.4 — Pages getting renamed (URL changes)
 
 | Old URL | New URL | Why |
 |---|---|---|
 | `self-managed/upgrade/...` | `self-managed/migrate/...` | "Migrate" matches the journey doc; "Upgrade" was ambiguous between once-per-version and recurring ops |
-| `self-managed/upgrade/helm/880-to-890` | `self-managed/migrate/run-the-upgrade/helm/890-to-8100` | New version target |
-| `self-managed/upgrade/components/880-to-890` | `self-managed/migrate/run-the-upgrade/components/890-to-8100` | New version target |
+| `self-managed/upgrade/helm/880-to-890` | `self-managed/migrate/helm/890-to-8100` | New version target; `run-the-upgrade/` level dropped — decoupled from sidebar nesting |
+| `self-managed/upgrade/components/880-to-890` | `self-managed/migrate/components/890-to-8100` | New version target; `run-the-upgrade/` level dropped |
 | `helm/configure/database/non-sql` | `architecture-concepts/database-topology/operating-elasticsearch-opensearch` | Friendlier slug; new location |
-| `helm/configure/operator-based-infrastructure` | `deploy-to-production/plan/choose-database-strategy/kubernetes-operators` | New location |
+| `helm/configure/operator-based-infrastructure` | `deploy-to-production/plan/kubernetes-operators` | New location; `choose-database-strategy/` level dropped |
 | `helm/configure/configure-multi-tenancy` | `architecture-concepts/tenancy-isolation/logical-tenants` | Reframed scope |
-| `concepts/multi-region/dual-region` | `architecture-concepts/availability-dr/tier-2/multi-region-concept` | New location |
+| `concepts/multi-region/dual-region` | `architecture-concepts/availability-dr/multi-region-concept` | New location; `tier-2/` level dropped — sidebar nesting shouldn't dictate URL depth |
 | `operational-guides/backup-restore/...` | `run-and-maintain/backups-restore/...` | New location |
 
 All old URLs get permanent (301) redirects to the new URLs to preserve inbound links and SEO.
@@ -809,12 +849,12 @@ Several existing pages stay in their current form but need new cross-links to an
 - `reference/announcements-release-notes/8100/whats-new-in-810` — cross-link from At-a-glance and from the Start here landing.
 - `reference/supported-environments` — cross-link from Deploy to production → Plan your deployment → Choose your deployment target and Prepare installation configuration.
 - `reference/glossary` — cross-link from every section intro; extend with 8.10 SM terms per §7.
-- The various component reference pages (Hub, OC, Zeebe, etc.) — cross-link from relevant Deploy to production and Architecture and concepts pages but stay in the existing Components top-level.
+- The various component reference pages (Hub, OC, Zeebe, etc.) — cross-link from relevant Deploy to production, Concepts, and Reference pages but stay in the existing Components top-level.
 
 ---
 
 ## Closing note
 
-This proposal is a substantial restructure — 50+ page relocations, 45+ new pages, 15+ rewrites. The Phase 1 / Phase 2 / Phase 3 sequencing is designed so the team never has to land it all at once. Phase 1 alone (the low-risk Run and maintain promotions, OpenShift de-duplication, glossary extension, kind move, application-configs prominence) would meaningfully improve docs ahead of 8.10 GA with no IA risk.
+This proposal is a substantial restructure — 50+ page relocations, 45+ new pages, 15+ rewrites. Per-section owners and effort estimates are not yet assigned; that scoping discussion should happen once the team accepts the direction, before committing to Phase 2/3 for GA. The Phase 1 / Phase 2 / Phase 3 sequencing is designed so the team never has to land it all at once. Phase 1 alone (the low-risk Run and maintain promotions, OpenShift de-duplication, glossary extension, kind move, application-configs prominence) would meaningfully improve docs ahead of 8.10 GA with no IA risk.
 
-The next concrete artifact, if the team agrees with the direction, is a `sidebars.js` diff against `camunda/camunda-docs` for the Phase 1 changes only. That's a single reviewable PR independent from the larger 8.10 restructure — ship the wins now, iterate the rest.
+The next concrete artifact, once this proposal is approved by the docs team, is a `sidebars.js` diff against `camunda/camunda-docs` for the Phase 1 changes only — delivered as a navigable preview deploy so reviewers can test real journeys (e.g. "find how to back up", "set up dual-region on EKS") rather than reading a written tree. That's a single reviewable PR independent from the larger 8.10 restructure — ship the wins now, iterate the rest.

--- a/docs/user journeys/8.10/diagrams/journey-overview.md
+++ b/docs/user journeys/8.10/diagrams/journey-overview.md
@@ -1,0 +1,69 @@
+# Diagram: 8.10 Administrator Journey Overview
+
+The sidebar is action-ordered to a production baseline, then branches into reference and operations.
+
+```mermaid
+flowchart LR
+    QS(["Quickstart\n(dev / admin)\nnot prod-shaped"])
+
+    subgraph DTP["Deploy to production"]
+        direction TB
+        subgraph PLAN["Plan your deployment"]
+            direction TB
+            pDT["Choose deployment target"]
+            pRT["Choose resilience tier"]
+            pDB["Choose database strategy"]
+            pID["Choose identity strategy"]
+            pDT --> pRT --> pDB --> pID
+        end
+        subgraph BASE["Deploy your baseline"]
+            direction TB
+            b1["Kubernetes — Cloud providers\n(EKS / GKE / AKS / OpenShift)"]
+            b2["Containers (Docker / ECS)"]
+            b3["Manual / VM"]
+        end
+        bPROD["Production readiness checklist"]
+        PLAN --> BASE --> bPROD
+    end
+
+    subgraph ANC["Architecture and concepts\n(reference — consult in any order)"]
+        direction TB
+        aRA["Reference architectures"]
+        aHUB["Hub / OC topology"]
+        aTEN["Tenancy and isolation\n(Logical / Physical Tenant / Separate OC)"]
+        aADR["Availability & DR\n(Tier 1 / 2 / 3)"]
+        aANA["Process analytics"]
+        aDB["Databases"]
+        aAUT["Authentication"]
+    end
+
+    subgraph RNM["Run and maintain"]
+        direction TB
+        dUPG["Upgrades"]
+        dBAK["Backups & restore"]
+        dMON["Monitoring"]
+        dSCA["Scaling"]
+        dCRED["Credentials rotation"]
+        dTRB["Diagnostics & troubleshooting"]
+    end
+
+    MIG(["Migrate 8.9 → 8.10\n(once-per-version)"])
+    COMP(["Components\n(cross-reference)"])
+
+    QS -.->|"not prod-shaped"| BASE
+    DTP -.->|"consult as needed"| ANC
+    DTP --> RNM
+    MIG -->|"forced changes\n(Helm v4, Bitnami, Hub values)"| DTP
+    MIG -.->|"post-upgrade optional"| ANC
+```
+
+## 8.9 vs 8.10 sidebar shape
+
+| 8.9 | 8.10 |
+|---|---|
+| Categories to browse | Action path to baseline, then reference |
+| Quickstart · Ref Arch · Deploy & manage · Concepts · Components · Upgrade | Quickstart · Deploy to production · Architecture and concepts · Run and maintain · Components · Migrate |
+| Backup & restore buried under Concepts | Backup & restore top-level Run and maintain entry |
+| Multi-region buried as one Concepts page | First-class Availability & DR with Tier 1 / 2 / 3 |
+| Deployment target choice implicit | Deployment target chosen explicitly in Plan your deployment |
+| "Concepts" mixes definitions with operations | Concepts → Architecture and concepts; Operations → Run and maintain |

--- a/docs/user journeys/8.10/diagrams/journey-overview.md
+++ b/docs/user journeys/8.10/diagrams/journey-overview.md
@@ -26,15 +26,20 @@ flowchart LR
         PLAN --> BASE --> bPROD
     end
 
-    subgraph ANC["Architecture and concepts\n(reference — consult in any order)"]
+    subgraph CON["Concepts\n(explanation — understand a decision)"]
         direction TB
-        aRA["Reference architectures"]
         aHUB["Hub / OC topology"]
         aTEN["Tenancy and isolation\n(Logical / Physical Tenant / Separate OC)"]
         aADR["Availability & DR\n(Tier 1 / 2 / 3)"]
         aANA["Process analytics"]
-        aDB["Databases"]
+        aDB["Database strategy"]
         aAUT["Authentication"]
+    end
+
+    subgraph REF["Reference\n(look-up — find an exact value)"]
+        direction TB
+        aRA["Reference architectures"]
+        aDBR["Databases\n(Operating ES/OS, RDBMS, Exporters)"]
     end
 
     subgraph RNM["Run and maintain"]
@@ -51,19 +56,20 @@ flowchart LR
     COMP(["Components\n(cross-reference)"])
 
     QS -.->|"not prod-shaped"| BASE
-    DTP -.->|"consult as needed"| ANC
+    DTP -.->|"understand a decision"| CON
+    DTP -.->|"look something up"| REF
     DTP --> RNM
     MIG -->|"forced changes\n(Helm v4, Bitnami, Hub values)"| DTP
-    MIG -.->|"post-upgrade optional"| ANC
+    MIG -.->|"post-upgrade optional"| CON
 ```
 
 ## 8.9 vs 8.10 sidebar shape
 
 | 8.9 | 8.10 |
 |---|---|
-| Categories to browse | Action path to baseline, then reference |
-| Quickstart · Ref Arch · Deploy & manage · Concepts · Components · Upgrade | Quickstart · Deploy to production · Architecture and concepts · Run and maintain · Components · Migrate |
+| Categories to browse | Action path to baseline, then explanation / look-up split |
+| Quickstart · Ref Arch · Deploy & manage · Concepts · Components · Upgrade | Quickstart · Deploy to production · Concepts · Reference · Run and maintain · Components · Migrate |
 | Backup & restore buried under Concepts | Backup & restore top-level Run and maintain entry |
-| Multi-region buried as one Concepts page | First-class Availability & DR with Tier 1 / 2 / 3 |
+| Multi-region buried as one Concepts page | First-class Availability & DR with Tier 1 / 2 / 3 in Concepts |
 | Deployment target choice implicit | Deployment target chosen explicitly in Plan your deployment |
-| "Concepts" mixes definitions with operations | Concepts → Architecture and concepts; Operations → Run and maintain |
+| "Concepts" mixes definitions, operations, and look-up material | Concepts = explanation only; Reference = look-up only; Operations → Run and maintain |


### PR DESCRIPTION
## Summary

- Adds `docs/user journeys/8.10/8.10 deployment journey.md` — a journey-shaped sidebar IA proposal for the Self-Managed 8.10 docs
- Reorganizes the sidebar from component-shaped (browse) to phase-shaped (act): Plan → Build Baseline → Extend → Day-2 → Migrate
- Includes full page-by-page migration table for all existing Self-Managed pages
- Content briefs for ~45 net-new pages required by the new structure (Appendix A)
- Rewrite guidance for existing pages that need changes beyond relocation (Appendix B)
- Competitor analysis validating the structure (Temporal, CockroachDB, Confluent)
- Three-phase rollout sequence ordered by risk and independent value

## Test plan

- [ ] Review IA proposal with docs team
- [ ] Validate page migration tables against current `sidebars.js`
- [ ] Confirm scope with Hub team re: Hub/Console SM/Web Modeler consolidation
- [ ] Sign off before 8.10 GA documentation freeze

🤖 Generated with [Claude Code](https://claude.com/claude-code)