### PR TITLE
docs(8.10): document bitnami removal and add removal ADR

### DIFF
--- a/charts/camunda-platform-8.10/README.md
+++ b/charts/camunda-platform-8.10/README.md
@@ -6,6 +6,15 @@
 > No release-state migration is needed when switching the local CLI from v3 to v4
 > against an existing release — `helm` is client-side only and cluster state is unaffected.
 
+> [!IMPORTANT]
+> **Bundled infrastructure was removed in 8.10.** The chart no longer ships the Bitnami
+> Keycloak, PostgreSQL, or Elasticsearch subcharts. From 8.10 you bring your own externally
+> managed database, search engine, and identity provider. The removed keys
+> (`identityKeycloak`, `identityPostgresql`, `webModelerPostgresql`, `elasticsearch`) now make
+> `helm template` fail with a migration message. See the
+> [migration from Bitnami guide](https://docs.camunda.io/docs/self-managed/deployment/helm/operational-tasks/migration-from-bitnami/)
+> and its accompanying toolkit for moving each component to externally managed infrastructure.
+
 Please also refer to the [documentation](https://docs.camunda.io/docs/self-managed/setup/overview/) on how to use Helm charts.
 
 - [Architecture](#architecture)
@@ -186,25 +195,13 @@ Visit [using secrets in manual installation](https://docs.camunda.io/docs/8.0/se
 
 ### Elasticsearch
 
-Camunda 8 Helm chart has a dependency on the [Elasticsearch 8 Helm Chart](https://artifacthub.io/packages/helm/bitnami/elasticsearch). All variables related to Elasticsearch can be set under `elasticsearch`.
-
-> [!NOTE]
->
-> The default setup of the Elasticsearch 8 part of Camunda 8 uses nodes that have all roles (master, data, coordinating, and ingest).
-> For high-demand deployments, it's recommended to deploy the Elasticsearch master-eligible nodes as master-only nodes.
-
-| Section         | Parameter | Description                                                                 | Default |
-| --------------- | --------- | --------------------------------------------------------------------------- | ------- |
-| `elasticsearch` | `enabled` | If true, enables Elasticsearch deployment as part of the Camunda Helm chart | `true`  |
-
-**Example:**
-
-```yaml
-elasticsearch:
-  enabled: true
-  image:
-    tag: <YOUR_VERSION_HERE>
-```
+From 8.10 the chart no longer bundles Elasticsearch. Provision Elasticsearch (or OpenSearch)
+externally — a managed service or an operator such as
+[ECK](https://www.elastic.co/guide/en/cloud-on-k8s/current/index.html) — and point the chart
+at it via `orchestration.data.secondaryStorage.elasticsearch` (and
+`optimize.database.elasticsearch` for Optimize). See the
+[migration from Bitnami guide](https://docs.camunda.io/docs/self-managed/deployment/helm/operational-tasks/migration-from-bitnami/)
+for moving off the previously bundled Bitnami Elasticsearch.
 
 #### Elasticsearch Retention
 
@@ -212,52 +209,18 @@ Since moving to Elasticsearch 8, [Curator](https://github.com/elastic/curator) i
 
 ### Keycloak
 
-When Camunda 8 Identity component is enabled by default, and it depends on
-[Bitnami Keycloak chart](https://github.com/bitnami/charts/tree/main/bitnami/keycloak).
-Since Keycloak is a dependency for Identity, all variables related to Keycloak can be found in
-[bitnami/keycloak/values.yaml](https://github.com/bitnami/charts/blob/main/bitnami/keycloak/values.yaml)
-and can be set under `identityKeycloak`.
-
-| Section            | Parameter | Description                                                                  | Default |
-| ------------------ | --------- | ---------------------------------------------------------------------------- | ------- |
-| `identityKeycloak` | `enabled` | If true, enables Keycloak chart deployment as part of the Camunda Helm chart | `true`  |
-
-**Example:**
-
-```yaml
-identityKeycloak:
-  enabled: true
-```
+From 8.10 the chart no longer bundles Keycloak. The Identity component authenticates against
+an externally managed Keycloak (or any OIDC provider). Point the chart at your Keycloak via
+`global.identity.keycloak.url.*` and `global.identity.keycloak.auth.*`. See the
+[migration from Bitnami guide](https://docs.camunda.io/docs/self-managed/deployment/helm/operational-tasks/migration-from-bitnami/)
+for moving off the previously bundled Bitnami Keycloak.
 
 #### Keycloak Theme
 
-Camunda provides a custom theme for the login page used in all apps. The theme is copied from the Identity image.
-
-The theme is added to Keycloak by default. Helm replaces YAML lists wholesale rather than merging them
-across values files, so if you override any of `extraVolumes`, `initContainers`, or `extraVolumeMounts`
-in your own values file you must re-include the entries below alongside your additions.
-
-```yaml
-identity:
-  keycloak:
-    extraVolumes:
-      - name: camunda-theme
-        emptyDir:
-          sizeLimit: 10Mi
-    initContainers:
-      - name: copy-camunda-theme
-        image: >-
-          {{- $identityImageParams := (dict "base" .Values.global "overlay" .Values.global.identity) -}}
-          {{- include "camundaPlatform.imageByParams" $identityImageParams }}
-        imagePullPolicy: "{{ .Values.global.image.pullPolicy }}"
-        command: ["sh", "-c", "cp -a /app/keycloak-theme/* /mnt"]
-        volumeMounts:
-          - name: camunda-theme
-            mountPath: /mnt
-    extraVolumeMounts:
-      - name: camunda-theme
-        mountPath: /opt/bitnami/keycloak/themes/identity
-```
+Camunda ships a custom login theme inside the Identity image (at `/app/keycloak-theme`). To use
+it, copy the theme into your own Keycloak deployment — for example via an init container that
+mounts the Identity image's theme directory into your Keycloak themes path. The exact themes
+path depends on the Keycloak image you run.
 
 ## Development
 
@@ -265,7 +228,7 @@ For development purposes, you might want to deploy and test the charts without c
 To do this you can run the following:
 
 ```sh
- helm install camunda --atomic --debug ./charts/camunda-platform
+ helm install camunda --atomic --debug ./charts/camunda-platform-8.10
 ```
 
 - `--atomic if set, the installation process deletes the installation on failure. The --wait flag will be set automatically if --atomic is used`
@@ -276,46 +239,27 @@ To generate the resources/manifests without really installing them, you can use:
 
 - `--dry-run simulate an install`
 
-If you see errors like:
+If you see an error like:
 
 ```sh
-Error: found in Chart.yaml, but missing in charts/ directory: elasticsearch
+Error: found in Chart.yaml, but missing in charts/ directory: common
 ```
 
-Then you need to download the dependencies first.
-
-Run the following to add resolve the dependencies:
+then download the chart dependencies first:
 
 ```sh
-make helm.repos-add
+make helm.dependency-update chartPath=charts/camunda-platform-8.10
 ```
-
-After this, you can run: `make helm.dependency-update`, which will update and download the dependencies for all charts.
 
 The execution should look like this:
 
 ```text
-$ make helm.dependency-update
-helm dependency update charts/camunda-platform
+$ make helm.dependency-update chartPath=charts/camunda-platform-8.10
+helm dependency update charts/camunda-platform-8.10
 Hang tight while we grab the latest from your chart repositories...
-...Successfully got an update from the "camunda-platform" chart repository
-...Successfully got an update from the "bitnami" chart repository
 Update Complete. ⎈Happy Helming!⎈
-Saving 6 charts
-Dependency zeebe did not declare a repository. Assuming it exists in the charts directory
-Dependency zeebe-gateway did not declare a repository. Assuming it exists in the charts directory
-Dependency operate did not declare a repository. Assuming it exists in the charts directory
-Dependency tasklist did not declare a repository. Assuming it exists in the charts directory
-Dependency identity did not declare a repository. Assuming it exists in the charts directory
+Saving 1 charts
 Deleting outdated charts
-helm dependency update charts/camunda-platform/charts/identity
-Hang tight while we grab the latest from your chart repositories...
-...Successfully got an update from the "camunda-platform" chart repository
-...Successfully got an update from the "bitnami" chart repository
-Update Complete. ⎈Happy Helming!⎈
-Saving 2 charts
-Downloading keycloak from repo https://charts.bitnami.com/bitnami
-Downloading common from repo https://charts.bitnami.com/bitnami
 ```
 
 ## Releasing the Charts

--- a/docs/adr/0094-remove-bundled-bitnami-subcharts-from-the-8-10-chart.md
+++ b/docs/adr/0094-remove-bundled-bitnami-subcharts-from-the-8-10-chart.md
@@ -1,0 +1,75 @@
+# Remove bundled Bitnami subcharts from the 8.10 chart and migrate CI to companion charts
+
+- Status: accepted
+- Date: 2026-06-01
+- Decision-makers: Balázs
+
+## Context and Problem Statement
+
+Through 8.9 the Camunda Platform Helm chart bundled four Bitnami subcharts —
+`identityKeycloak`, `identityPostgresql`, `webModelerPostgresql`, and `elasticsearch` —
+so that a default install provisioned its own Keycloak, two PostgreSQL instances, and
+Elasticsearch. In mid-2025 Bitnami moved the underlying container images to an
+unmaintained `bitnamilegacy/*` namespace and stopped patching them. The chart therefore
+shipped unmaintained, unpatchable third-party infrastructure inside a product marketed as
+production-ready, and every release carried the resulting CVE exposure.
+
+This was addressed as a multi-release deprecation: 8.8 disabled the bundled subcharts by
+default, 8.9 became the migration runway (migration guide in
+`camunda-docs/.../migration-from-bitnami/` and a toolkit in
+`camunda-deployment-references/generic/kubernetes/migration/`), and 8.10 is the agreed
+removal target per [PDP #3554](https://github.com/camunda/product-hub/issues/3554) and
+EPIC [team-distribution#774](https://github.com/camunda/team-distribution/issues/774).
+[ADR-0083](0083-deprecate-bitnami-subcharts-in-camunda-platform-helm-chart.md) recorded the
+8.9 deprecation; this ADR records the 8.10 removal and the CI test migration that the
+removal forced (delivered in [#6146](https://github.com/camunda/camunda-platform-helm/pull/6146)).
+
+## Decision Drivers
+
+- **Supply-chain security:** the bundled images were unmaintained (`bitnamilegacy/*`); continuing to ship them meant continuing to ship unpatched CVEs.
+- **Contractual obligation, not a design choice:** removal is the settled end-state of the public 8.8 → 8.9 → 8.10 deprecation path, framed by PDP #3554. The question was how to remove cleanly, not whether to remove.
+- **Explicit Self-Managed ownership boundary:** from 8.10, Camunda owns the workload chart; the customer owns the database (PostgreSQL), search (Elasticsearch/OpenSearch), and identity provider (Keycloak/IdP). This shrinks the supported surface area.
+- **Test what we ship:** with no bundled infrastructure, CI scenarios must exercise the external-infrastructure path that the chart now mandates, not a bundled-subchart path that no longer exists.
+- **Ship the breaking change early:** the chart is in 8.10 alpha, so the breaking removal lands as early in the cycle as possible to give consumers maximum runway.
+
+## Considered Options
+
+- **Hard removal with constraint failures (chosen)** — drop the four subcharts and fail `helm template` for any still-set removed key, pointing at the migration guide.
+- **Soft deprecation shim into 8.10** — rejected: the deprecation window already spanned 8.8 and 8.9; another shim would defer the supply-chain fix and add the exact dual-code-path complexity the removal is meant to delete.
+- **Replace with new bundled charts (e.g. an in-house Keycloak/PostgreSQL)** — rejected as a product default: it recreates the "Camunda owns infrastructure it cannot patch" problem. Minimal in-repo charts are introduced for CI only (see below), not as a supported install path.
+
+For the test infrastructure that the removal invalidated:
+
+- **Per-run companion charts (chosen)** — each scenario deploys lightweight charts alongside the Camunda release: `internal-postgresql` and `internal-keycloak-26` (added in-repo for CI), the `elastic/elasticsearch` (ECK) chart, and a CloudNativePG (CNPG) cluster for RDBMS/self-signed scenarios.
+- **Keep relying on shared in-cluster CI services** — rejected: it re-couples tests to long-lived shared infrastructure (the ~107 GB Keycloak/ES/OS/PG footprint tracked for decommissioning in [team-distribution#796](https://github.com/camunda/team-distribution/issues/796)) and does not represent how a real 8.10 user wires external infrastructure.
+- **Keep the Bitnami subcharts for tests only** — rejected: it would retain a dependency on the exact unmaintained images the release is removing, and tests would not exercise the supported external-infra surface.
+
+## Decision Outcome
+
+The four Bitnami subcharts and their supporting values (`values-bitnami-legacy.yaml`,
+removed-key blocks) are removed from the 8.10 chart. The dual code paths that gated on the
+subcharts' `*.enabled` flags collapse to the external-infrastructure path; identity Keycloak
+helpers read from `global.identity.keycloak.url.*` and identity/web-modeler database helpers
+read from the respective `externalDatabase.*` only. `camundaPlatform.keyRemoved` guards make
+`helm template` fail with a migration-guide pointer when a removed key is still set.
+
+CI integration tests are rebuilt around per-run companion charts: minimal in-repo
+`internal-postgresql` and `internal-keycloak-26` charts, the ECK Elasticsearch chart, and a
+CNPG cluster pre-install fixture for RDBMS/self-signed scenarios; the matrix runner gains
+`processCompanionCharts` env substitution and version-gates the legacy Bitnami PG password
+extraction off for ≥8.10. Bundled-only unit suites and golden snapshots
+(`keycloak-statefulset`, `elasticsearch-statefulset`) and the external/self-signed scenario
+value files are deleted. The migration guide and toolkit are not re-authored; they are linked
+from the chart README and the upgrade documentation.
+
+### Positive Consequences
+
+- The chart no longer ships unmaintained third-party infrastructure; the recurring Bitnami CVE surface is eliminated.
+- The Self-Managed responsibility boundary is explicit and the template logic reads as an external-infrastructure-first chart rather than one with bundled fallbacks.
+- CI scenarios provision infrastructure the same way a real 8.10 deployment does, improving test fidelity, and the per-run model unblocks decommissioning the shared CI infrastructure (team-distribution#796).
+
+### Negative Consequences
+
+- Direct breaking change: any 8.10 consumer still setting a removed key gets a hard `helm template` failure and must migrate to externally managed infrastructure (downstream consumers tracked under the EPIC; e.g. `camunda/camunda#54089`).
+- Users who relied on the bundled subcharts for quick local/dev installs must now provision Keycloak, PostgreSQL, and Elasticsearch themselves (operator-based and companion examples are provided per [#5989](https://github.com/camunda/camunda-platform-helm/issues/5989)).
+- The CI test surface gains companion-chart wiring whose per-scenario duplication needs follow-up consolidation ([#6273](https://github.com/camunda/camunda-platform-helm/issues/6273)).

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -95,3 +95,4 @@
 | 91 | [Standardize `<component>.extraConfiguration` as the Application Configuration Mechanism](0091-adopt-component-extraconfiguration-as-the-standard-application-configuration-mechanism.md) |
 | 92 | [Allow opt-in deployment strategy for components with chart-managed RWO persistence](0092-allow-opt-in-deployment-strategy-for-components-with-chart-managed-rwo-persistence.md) |
 | 93 | [Adopt a composable CI scenario registry for the per-version integration test matrix](0093-adopt-composable-ci-scenario-registry-for-per-version-test-matrix.md) |
+| 94 | [Remove bundled Bitnami subcharts from the 8.10 chart and migrate CI to companion charts](0094-remove-bundled-bitnami-subcharts-from-the-8-10-chart.md) |


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #5988.

The 8.10 chart README still presented the bundled Bitnami Keycloak/Elasticsearch
subcharts as live dependencies (`helm repo add bitnami`, `identityKeycloak.enabled`,
`/opt/bitnami/...`), even though #6146 removed them. There was also no Architecture
Decision Record capturing why the subcharts were removed or why CI tests were migrated
to companion charts.

### What's in this PR?

Docs only — no template or rendered-output changes.

- Rewrite the 8.10 README prelude for the external-infrastructure model: a single
  canonical "bundled infrastructure removed in 8.10" statement + migration-guide link near
  the top, and reframed Elasticsearch / Keycloak / Development sections (drop the bundled
  Bitnami dependency text, `helm repo add bitnami` output, and the bundled-Keycloak theme
  example).
- Add **ADR-0092** documenting the removal rationale (unmaintained `bitnamilegacy/*`
  images, PDP #3554, explicit Self-Managed ownership boundary, hard removal over another
  shim) and the CI test migration to per-run companion charts (`internal-postgresql`,
  `internal-keycloak-26`, ECK, CNPG) instead of shared infra. Index updated.

The migration guide and toolkit are not re-authored (out of scope per the EPIC); they are
linked. The 8.9 → 8.10 upgrade page lives in `camunda-docs` and is tracked there.

### Checklist

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open pull request for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo documentation are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)?
- [ ] Did all checks/tests pass in the PR?
