### PR TITLE
fix: support Orchestration gRPC TLS endpoints

### DIFF
--- a/charts/camunda-platform-8.10/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/common/_helpers.tpl
@@ -701,6 +701,21 @@ Zeebe templates.
   {{- end -}}
 {{- end -}}
 
+{{/*
+[camunda-platform] Returns true when the last orchestration.env entry for name has value true.
+*/}}
+{{- define "camundaPlatform.orchestrationEnvIsTrue" -}}
+  {{- $ctx := .context -}}
+  {{- $name := .name -}}
+  {{- $enabled := false -}}
+  {{- range $env := $ctx.Values.orchestration.env -}}
+    {{- if eq ($env.name | default "") $name -}}
+      {{- $enabled = (eq (lower (tpl (toString ($env.value | default "")) $ctx)) "true") -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $enabled -}}
+{{- end -}}
+
 
 {{/*
 ********************************************************************************

--- a/charts/camunda-platform-8.10/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/common/_helpers.tpl
@@ -682,7 +682,8 @@ Zeebe templates.
 {{ define "camundaPlatform.orchestrationHTTPInternalURL" }}
   {{- if .Values.orchestration.enabled -}}
     {{-
-      printf "http://%s%s"
+      printf "%s://%s%s"
+        (ternary "https" "http" (eq (include "camundaPlatform.orchestrationEnvIsTrue" (dict "context" . "name" "SERVER_SSL_ENABLED")) "true"))
         (include "orchestration.serviceNameHTTP" .)
         (.Values.orchestration.contextPath | default "")
     -}}
@@ -695,7 +696,8 @@ Zeebe templates.
 {{ define "camundaPlatform.orchestrationGRPCInternalURL" }}
   {{- if .Values.orchestration.enabled -}}
     {{-
-      printf "grpc://%s"
+      printf "%s://%s"
+        (ternary "grpcs" "grpc" (eq (include "camundaPlatform.orchestrationEnvIsTrue" (dict "context" . "name" "CAMUNDA_API_GRPC_SSL_ENABLED")) "true"))
         (include "orchestration.serviceNameGRPC" .)
     -}}
   {{- end -}}

--- a/charts/camunda-platform-8.10/templates/common/ingress-grpc.yaml
+++ b/charts/camunda-platform-8.10/templates/common/ingress-grpc.yaml
@@ -12,7 +12,11 @@ metadata:
       )
       "context" .
     ) | nindent 4 }}
-{{- with .Values.orchestration.ingress.grpc.annotations }}
+{{- $grpcAnnotations := .Values.orchestration.ingress.grpc.annotations -}}
+{{- if eq (include "camundaPlatform.orchestrationEnvIsTrue" (dict "context" . "name" "CAMUNDA_API_GRPC_SSL_ENABLED")) "true" -}}
+{{- $grpcAnnotations = mergeOverwrite (dict) $grpcAnnotations (dict "nginx.ingress.kubernetes.io/backend-protocol" "GRPCS") -}}
+{{- end -}}
+{{- with $grpcAnnotations }}
   annotations:
   {{- tpl (toYaml .) $ | nindent 4 }}
 {{- end }}

--- a/charts/camunda-platform-8.10/templates/common/ingress-http.yaml
+++ b/charts/camunda-platform-8.10/templates/common/ingress-http.yaml
@@ -72,7 +72,7 @@ spec:
             pathType: {{ .Values.global.ingress.pathType }}
           {{- end }}
         {{- /* Orchestration Cluster */ -}}
-          {{- if and .Values.orchestration.enabled .Values.orchestration.contextPath }}
+          {{- if and .Values.orchestration.enabled .Values.orchestration.contextPath (ne (include "camundaPlatform.orchestrationEnvIsTrue" (dict "context" . "name" "SERVER_SSL_ENABLED")) "true") }}
           # Orchestration.
           - backend:
               service:

--- a/charts/camunda-platform-8.10/templates/common/ingress-orchestration-http.yaml
+++ b/charts/camunda-platform-8.10/templates/common/ingress-orchestration-http.yaml
@@ -1,0 +1,53 @@
+{{- if and .Values.global.ingress.enabled (not .Values.global.ingress.external) .Values.orchestration.enabled .Values.orchestration.contextPath (eq (include "camundaPlatform.orchestrationEnvIsTrue" (dict "context" . "name" "SERVER_SSL_ENABLED")) "true") -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "camundaPlatform.fullname" . }}-orchestration-http
+  labels:
+    {{- include "common.tplvalues.merge-overwrite" (dict
+      "values" (list
+        (include "camundaPlatform.labels" .)
+        .Values.global.ingress.labels
+      )
+      "context" .
+    ) | nindent 4 }}
+  annotations:
+    {{- include "common.tplvalues.merge-overwrite" (dict
+      "values" (list
+        .Values.global.ingress.annotations
+        (dict "nginx.ingress.kubernetes.io/backend-protocol" "HTTPS")
+      )
+      "context" .
+    ) | nindent 4 }}
+spec:
+  ingressClassName: {{ .Values.global.ingress.className }}
+  rules:
+    {{- if .Values.global.host }}
+    - host: {{ tpl .Values.global.host $ }}
+      http:
+    {{- else }}
+    - http:
+    {{- end }}
+        paths:
+          - backend:
+              service:
+                name: {{ include "orchestration.serviceName" . }}
+                port:
+                  number: {{ .Values.orchestration.service.httpPort }}
+            path: {{ .Values.orchestration.contextPath }}
+            pathType: {{ .Values.global.ingress.pathType }}
+  {{- if .Values.global.ingress.tls.enabled }}
+  tls:
+    {{- if eq .Values.global.ingress.tls.secretName "-" }}
+    {{/* Use secretName: "-" to generate an empty TLS block for automatic certificate management. */}}
+    {{/* This is useful for environments like OpenShift where the Ingress Operator manages certificates automatically. */}}
+    - {}
+    {{- else }}
+    - hosts:
+        - {{ tpl .Values.global.host $ }}
+      {{- if .Values.global.ingress.tls.secretName }}
+      secretName: {{ .Values.global.ingress.tls.secretName }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/camunda-platform-8.10/templates/connectors/files/_application.yaml
+++ b/charts/camunda-platform-8.10/templates/connectors/files/_application.yaml
@@ -43,7 +43,7 @@ spring:
 camunda:
   client:
     rest-address: {{ include "camundaPlatform.orchestrationHTTPInternalURL" . }}
-    grpc-address: {{ include "camundaPlatform.orchestrationGRPCInternalURL" . | replace "grpc://" "http://" }}
+    grpc-address: {{ include "camundaPlatform.orchestrationGRPCInternalURL" . | replace "grpcs://" "https://" | replace "grpc://" "http://" }}
     worker:
       defaults:
         max-jobs-active: 32

--- a/charts/camunda-platform-8.10/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.10/test/ci-test-config.yaml
@@ -15,4 +15,3 @@ unit:
       packages: orchestration connectors optimize
     - name: Design
       packages: web-modeler
-

--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -36,6 +36,44 @@ integration:
               env-vars:
                 - RDBMS_POSTGRESQL_USERNAME
                 - RDBMS_POSTGRESQL_PASSWORD
+        - name: orchestration-tls
+          enabled: true
+          shortname: estls
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - orchestration-tls
+          dependencies:
+            - chart: charts/internal-keycloak-26
+              release-name: keycloak
+              values-file: test/integration/companion-values/keycloak.yaml
+            - chart: elastic/elasticsearch
+              version: 8.5.1
+              release-name: elasticsearch
+              values-file: test/integration/companion-values/elasticsearch.yaml
+              repo-name: elastic
+              repo-url: https://helm.elastic.co
+            - chart: charts/internal-postgresql
+              release-name: postgresql
+              values-file: test/integration/companion-values/postgresql.yaml
+              env-vars:
+                - RDBMS_POSTGRESQL_USERNAME
+                - RDBMS_POSTGRESQL_PASSWORD
+          pre-install:
+            script: pre-install-orchestration-tls.sh
+            description: |
+              Generates a self-signed certificate/key pair for the Orchestration
+              Cluster gRPC endpoint, creates the server TLS Secret, and creates
+              a truststore Secret consumed by Web Modeler restapi. The Identity/WebModeler
+              PostgreSQL database is provided by the `postgresql` companion dependency.
         - name: opensearch
           enabled: true
           shortname: oske

--- a/charts/camunda-platform-8.10/test/ci/registry/hooks/orchestration-tls.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/hooks/orchestration-tls.yaml
@@ -1,0 +1,6 @@
+script: pre-install-orchestration-tls.sh
+description: |
+  Generates a self-signed certificate/key pair for the Orchestration
+  Cluster gRPC endpoint, creates the server TLS Secret, and creates
+  a truststore Secret consumed by Web Modeler restapi. The Identity/WebModeler
+  PostgreSQL database is provided by the `postgresql` companion dependency.

--- a/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
@@ -17,6 +17,10 @@ integration:
       shortname: eske
       tier: 1
       enabled: true
+    - id: orchestration-tls
+      shortname: estls
+      tier: 2
+      enabled: true
     - id: opensearch
       shortname: oske
       tier: 2

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/orchestration-tls.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/orchestration-tls.yaml
@@ -1,0 +1,17 @@
+name: orchestration-tls
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - orchestration-tls
+platforms:
+  - gke
+infra-type:
+  gke: distroci
+pre-install: orchestration-tls
+dependencies:
+  - keycloak
+  - elasticsearch
+  - postgresql

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/orchestration-tls.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/orchestration-tls.yaml
@@ -30,7 +30,8 @@ webModeler:
           web-app: https://$CAMUNDA_HOSTNAME/orchestration
     javaOpts: >-
       -XX:MaxRAMPercentage=80.0
-      -Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/orchestration/truststore.jks
+      -Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/orchestration/truststore.p12
+      -Djavax.net.ssl.trustStoreType=PKCS12
       -Djavax.net.ssl.trustStorePassword=changeit
     extraVolumes:
       - name: orchestration-tls-truststore
@@ -94,7 +95,8 @@ connectors:
   env:
     - name: JAVA_TOOL_OPTIONS
       value: >-
-        -Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/orchestration/truststore.jks
+        -Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/orchestration/truststore.p12
+        -Djavax.net.ssl.trustStoreType=PKCS12
         -Djavax.net.ssl.trustStorePassword=changeit
   extraVolumes:
     - name: orchestration-tls-truststore

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/orchestration-tls.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/orchestration-tls.yaml
@@ -1,0 +1,112 @@
+orchestration:
+  env:
+    - name: CAMUNDA_API_GRPC_SSL_ENABLED
+      value: "true"
+    - name: CAMUNDA_API_GRPC_SSL_CERTIFICATE
+      value: /usr/local/camunda/certificates/orchestration/tls.crt
+    - name: CAMUNDA_API_GRPC_SSL_CERTIFICATEPRIVATEKEY
+      value: /usr/local/camunda/certificates/orchestration/tls.key
+    - name: SERVER_SSL_ENABLED
+      value: "true"
+    - name: SERVER_SSL_CERTIFICATE
+      value: /usr/local/camunda/certificates/orchestration/tls.crt
+    - name: SERVER_SSL_CERTIFICATEPRIVATEKEY
+      value: /usr/local/camunda/certificates/orchestration/tls.key
+  extraVolumes:
+    - name: orchestration-tls
+      secret:
+        secretName: orchestration-tls
+  extraVolumeMounts:
+    - name: orchestration-tls
+      mountPath: /usr/local/camunda/certificates/orchestration
+      readOnly: true
+
+webModeler:
+  restapi:
+    clusters:
+      - id: default-cluster
+        name: integration-zeebe
+        version: 8.10-SNAPSHOT
+        authentication: BEARER_TOKEN
+        authorizations:
+          enabled: true
+        url:
+          grpc: grpcs://integration-zeebe-gateway:26500
+          rest: https://integration-zeebe-gateway:8080/orchestration
+          web-app: https://$CAMUNDA_HOSTNAME/orchestration
+    javaOpts: >-
+      -XX:MaxRAMPercentage=80.0
+      -Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/orchestration/truststore.jks
+      -Djavax.net.ssl.trustStorePassword=changeit
+    extraVolumes:
+      - name: orchestration-tls-truststore
+        secret:
+          secretName: orchestration-tls-truststore
+    extraVolumeMounts:
+      - name: orchestration-tls-truststore
+        mountPath: /usr/local/camunda/certificates/orchestration
+        readOnly: true
+
+connectors:
+  configuration: |
+    server:
+      port: 8080
+      servlet:
+        context-path: "/connectors"
+
+    management:
+      context-path: /actuator
+      endpoints:
+        web:
+          exposure:
+            include: metrics,health,prometheus
+      endpoint:
+        health:
+          show-details: always
+          show-components: always
+          group:
+            readiness:
+              include:
+              - processDefinitionImport
+              - zeebeClient
+
+    camunda:
+      client:
+        rest-address: https://integration-zeebe-gateway:8080/orchestration
+        grpc-address: https://integration-zeebe-gateway:26500
+        worker:
+          defaults:
+            max-jobs-active: 32
+            stream-enabled: true
+        mode: selfManaged
+        auth:
+          issuer-url: "http://keycloak:80/auth/realms/camunda-platform"
+          client-id: "connectors"
+          client-secret: "\u0024{VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET}"
+          audience: "orchestration-api"
+      connector:
+        headless:
+          service-url: "integration-connectors-headless"
+        webhook:
+          enabled: true
+        polling:
+          enabled: true
+        agenticai:
+          enabled: true
+
+    logging:
+      level:
+        io.camunda.connector: INFO
+  env:
+    - name: JAVA_TOOL_OPTIONS
+      value: >-
+        -Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/orchestration/truststore.jks
+        -Djavax.net.ssl.trustStorePassword=changeit
+  extraVolumes:
+    - name: orchestration-tls-truststore
+      secret:
+        secretName: orchestration-tls-truststore
+  extraVolumeMounts:
+    - name: orchestration-tls-truststore
+      mountPath: /usr/local/camunda/certificates/orchestration
+      readOnly: true

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/orchestration-tls.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/orchestration-tls.yaml
@@ -6,12 +6,6 @@ orchestration:
       value: /usr/local/camunda/certificates/orchestration/tls.crt
     - name: CAMUNDA_API_GRPC_SSL_CERTIFICATEPRIVATEKEY
       value: /usr/local/camunda/certificates/orchestration/tls.key
-    - name: SERVER_SSL_ENABLED
-      value: "true"
-    - name: SERVER_SSL_CERTIFICATE
-      value: /usr/local/camunda/certificates/orchestration/tls.crt
-    - name: SERVER_SSL_CERTIFICATEPRIVATEKEY
-      value: /usr/local/camunda/certificates/orchestration/tls.key
   extraVolumes:
     - name: orchestration-tls
       secret:
@@ -32,7 +26,7 @@ webModeler:
           enabled: true
         url:
           grpc: grpcs://integration-zeebe-gateway:26500
-          rest: https://integration-zeebe-gateway:8080/orchestration
+          rest: http://integration-zeebe-gateway:8080/orchestration
           web-app: https://$CAMUNDA_HOSTNAME/orchestration
     javaOpts: >-
       -XX:MaxRAMPercentage=80.0
@@ -72,7 +66,7 @@ connectors:
 
     camunda:
       client:
-        rest-address: https://integration-zeebe-gateway:8080/orchestration
+        rest-address: http://integration-zeebe-gateway:8080/orchestration
         grpc-address: https://integration-zeebe-gateway:26500
         worker:
           defaults:

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/orchestration-tls.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/orchestration-tls.yaml
@@ -25,22 +25,9 @@ webModeler:
         authorizations:
           enabled: true
         url:
-          grpc: grpcs://integration-zeebe-gateway:26500
+          grpc: grpcs://grpc-$CAMUNDA_HOSTNAME
           rest: http://integration-zeebe-gateway:8080/orchestration
           web-app: https://$CAMUNDA_HOSTNAME/orchestration
-    javaOpts: >-
-      -XX:MaxRAMPercentage=80.0
-      -Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/orchestration/truststore.p12
-      -Djavax.net.ssl.trustStoreType=PKCS12
-      -Djavax.net.ssl.trustStorePassword=changeit
-    extraVolumes:
-      - name: orchestration-tls-truststore
-        secret:
-          secretName: orchestration-tls-truststore
-    extraVolumeMounts:
-      - name: orchestration-tls-truststore
-        mountPath: /usr/local/camunda/certificates/orchestration
-        readOnly: true
 
 connectors:
   configuration: |
@@ -68,7 +55,7 @@ connectors:
     camunda:
       client:
         rest-address: http://integration-zeebe-gateway:8080/orchestration
-        grpc-address: https://integration-zeebe-gateway:26500
+        grpc-address: https://grpc-$CAMUNDA_HOSTNAME
         worker:
           defaults:
             max-jobs-active: 32
@@ -92,17 +79,3 @@ connectors:
     logging:
       level:
         io.camunda.connector: INFO
-  env:
-    - name: JAVA_TOOL_OPTIONS
-      value: >-
-        -Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/orchestration/truststore.p12
-        -Djavax.net.ssl.trustStoreType=PKCS12
-        -Djavax.net.ssl.trustStorePassword=changeit
-  extraVolumes:
-    - name: orchestration-tls-truststore
-      secret:
-        secretName: orchestration-tls-truststore
-  extraVolumeMounts:
-    - name: orchestration-tls-truststore
-      mountPath: /usr/local/camunda/certificates/orchestration
-      readOnly: true

--- a/charts/camunda-platform-8.10/test/integration/scenarios/pre-setup-scripts/pre-install-orchestration-tls.sh
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/pre-setup-scripts/pre-install-orchestration-tls.sh
@@ -44,13 +44,13 @@ openssl req -x509 -nodes -newkey rsa:4096 \
   -extensions v3_req \
   2>/dev/null
 
-keytool -importcert \
-  -keystore "$WORK_DIR/truststore.jks" \
-  -storetype JKS \
-  -storepass "$KEYSTORE_PASSWORD" \
-  -alias orchestration-tls \
-  -file "$WORK_DIR/tls.crt" \
-  -noprompt 2>/dev/null
+openssl pkcs12 -export \
+  -in "$WORK_DIR/tls.crt" \
+  -inkey "$WORK_DIR/tls.key" \
+  -out "$WORK_DIR/truststore.p12" \
+  -password "pass:$KEYSTORE_PASSWORD" \
+  -name orchestration-tls \
+  2>/dev/null
 
 create_or_replace_secret() {
   local name="$1"
@@ -66,5 +66,5 @@ create_or_replace_secret "orchestration-tls" \
   --from-file="tls.key=$WORK_DIR/tls.key"
 
 create_or_replace_secret "orchestration-tls-truststore" \
-  --from-file="truststore.jks=$WORK_DIR/truststore.jks" \
+  --from-file="truststore.p12=$WORK_DIR/truststore.p12" \
   --from-literal="truststore-password=$KEYSTORE_PASSWORD"

--- a/charts/camunda-platform-8.10/test/integration/scenarios/pre-setup-scripts/pre-install-orchestration-tls.sh
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/pre-setup-scripts/pre-install-orchestration-tls.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+# under one or more contributor license agreements. Licensed under a proprietary license.
+
+set -euo pipefail
+
+NAMESPACE="${TEST_NAMESPACE:?TEST_NAMESPACE must be set}"
+RELEASE="${RELEASE_NAME:-integration}"
+CONTEXT_FLAG=""
+if [[ -n "${KUBE_CONTEXT:-}" ]]; then
+  CONTEXT_FLAG="--context ${KUBE_CONTEXT}"
+fi
+
+CERT_VALIDITY_DAYS=365
+KEYSTORE_PASSWORD="changeit"
+WORK_DIR=$(mktemp -d)
+trap '[[ -n "${WORK_DIR:-}" ]] && rm -rf "$WORK_DIR"' EXIT
+
+cat > "$WORK_DIR/san.cnf" <<EOF
+[req]
+distinguished_name = req_dn
+req_extensions = v3_req
+prompt = no
+
+[req_dn]
+CN = ${RELEASE}-zeebe-gateway
+
+[v3_req]
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = ${RELEASE}-zeebe-gateway
+DNS.2 = ${RELEASE}-zeebe-gateway.${NAMESPACE}.svc
+DNS.3 = ${RELEASE}-zeebe-gateway.${NAMESPACE}.svc.cluster.local
+DNS.4 = localhost
+IP.1 = 127.0.0.1
+EOF
+
+openssl req -x509 -nodes -newkey rsa:4096 \
+  -keyout "$WORK_DIR/tls.key" \
+  -out "$WORK_DIR/tls.crt" \
+  -days "$CERT_VALIDITY_DAYS" \
+  -config "$WORK_DIR/san.cnf" \
+  -extensions v3_req \
+  2>/dev/null
+
+keytool -importcert \
+  -keystore "$WORK_DIR/truststore.jks" \
+  -storetype JKS \
+  -storepass "$KEYSTORE_PASSWORD" \
+  -alias orchestration-tls \
+  -file "$WORK_DIR/tls.crt" \
+  -noprompt 2>/dev/null
+
+create_or_replace_secret() {
+  local name="$1"
+  shift
+  if kubectl ${CONTEXT_FLAG} -n "$NAMESPACE" get secret "$name" >/dev/null 2>&1; then
+    kubectl ${CONTEXT_FLAG} -n "$NAMESPACE" delete secret "$name" --ignore-not-found
+  fi
+  kubectl ${CONTEXT_FLAG} -n "$NAMESPACE" create secret generic "$name" "$@"
+}
+
+create_or_replace_secret "orchestration-tls" \
+  --from-file="tls.crt=$WORK_DIR/tls.crt" \
+  --from-file="tls.key=$WORK_DIR/tls.key"
+
+create_or_replace_secret "orchestration-tls-truststore" \
+  --from-file="truststore.jks=$WORK_DIR/truststore.jks" \
+  --from-literal="truststore-password=$KEYSTORE_PASSWORD"

--- a/charts/camunda-platform-8.10/test/unit/common/ingress_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/ingress_test.go
@@ -436,6 +436,25 @@ func (s *GrpcIngressTemplateTest) TestDifferentValuesInputs() {
 				s.Require().Contains(ingress.Labels, "app.kubernetes.io/name")
 			},
 		},
+		{
+			Name:                 "TestGrpcIngressUsesSecureBackendProtocolWhenOrchestrationGrpcTlsIsEnabled",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			ValuesFiles:          []string{filepath.Join(s.chartPath, "test/unit/common/testdata/values-orchestration-grpc-tls.yaml")},
+			Values: map[string]string{
+				"orchestration.enabled":                              "true",
+				"orchestration.ingress.grpc.enabled":                 "true",
+				"orchestration.ingress.grpc.annotations.custom\\.io": "kept",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				var ingress netv1.Ingress
+				helm.UnmarshalK8SYaml(t, output, &ingress)
+
+				s.Require().Equal("GRPCS", ingress.Annotations["nginx.ingress.kubernetes.io/backend-protocol"])
+				s.Require().Equal("kept", ingress.Annotations["custom.io"])
+			},
+		},
 	}
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)

--- a/charts/camunda-platform-8.10/test/unit/common/ingress_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/ingress_test.go
@@ -222,6 +222,99 @@ func (s *IngressTemplateTest) TestDifferentValuesInputs() {
 				s.Require().Equal("tls-secret", ingress.Spec.TLS[0].SecretName)
 			},
 		},
+		{
+			Name: "TestHttpIngressOmitsOrchestrationPathWithServerTLS",
+			Values: map[string]string{
+				"global.ingress.enabled":    "true",
+				"orchestration.enabled":     "true",
+				"orchestration.contextPath": "/orchestration",
+				"orchestration.env[0].name": "SERVER_SSL_ENABLED",
+			},
+			RenderTemplateExtraArgs: []string{
+				"--set-string", "orchestration.env[0].value=true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				require.NotContains(t, output, "path: /orchestration")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
+type OrchestrationHttpIngressTemplateTest struct {
+	suite.Suite
+	chartPath string
+	release   string
+	namespace string
+	templates []string
+	extraArgs []string
+}
+
+func TestOrchestrationHttpIngressTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../")
+	require.NoError(t, err)
+
+	suite.Run(t, &OrchestrationHttpIngressTemplateTest{
+		chartPath: chartPath,
+		release:   "camunda-platform-test",
+		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
+		templates: []string{"templates/common/ingress-orchestration-http.yaml"},
+	})
+}
+
+func (s *OrchestrationHttpIngressTemplateTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestOrchestrationHttpIngressWithServerTLS",
+			Values: map[string]string{
+				"global.ingress.enabled":                     "true",
+				"global.host":                                "camunda.example.com",
+				"global.ingress.tls.enabled":                 "true",
+				"global.ingress.annotations.test-annotation": "test-value",
+				"orchestration.enabled":                      "true",
+				"orchestration.contextPath":                  "/orchestration",
+				"orchestration.env[0].name":                  "SERVER_SSL_ENABLED",
+			},
+			RenderTemplateExtraArgs: []string{
+				"--set-string", "orchestration.env[0].value=true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				var ingress netv1.Ingress
+				helm.UnmarshalK8SYaml(t, output, &ingress)
+
+				require.Equal(t, "camunda-platform-test-orchestration-http", ingress.Name)
+				require.Equal(t, "HTTPS", ingress.Annotations["nginx.ingress.kubernetes.io/backend-protocol"])
+				require.Equal(t, "test-value", ingress.Annotations["test-annotation"])
+				require.Equal(t, "camunda.example.com", ingress.Spec.Rules[0].Host)
+				require.Equal(t, "/orchestration", ingress.Spec.Rules[0].HTTP.Paths[0].Path)
+				require.Equal(t, "camunda-platform-test-zeebe-gateway", ingress.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Name)
+				require.Equal(t, int32(8080), ingress.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Port.Number)
+				require.Equal(t, "camunda.example.com", ingress.Spec.TLS[0].Hosts[0])
+			},
+		},
+		{
+			Name: "TestOrchestrationHttpIngressDisabledWithoutServerTLS",
+			CaseTemplates: &testhelpers.CaseTemplate{
+				Templates: nil,
+			},
+			Values: map[string]string{
+				"global.ingress.enabled":    "true",
+				"orchestration.enabled":     "true",
+				"orchestration.contextPath": "/orchestration",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				require.NotContains(t, output, "name: camunda-platform-test-orchestration-http")
+			},
+		},
 	}
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)

--- a/charts/camunda-platform-8.10/test/unit/common/testdata/values-orchestration-grpc-tls.yaml
+++ b/charts/camunda-platform-8.10/test/unit/common/testdata/values-orchestration-grpc-tls.yaml
@@ -1,0 +1,4 @@
+orchestration:
+  env:
+    - name: CAMUNDA_API_GRPC_SSL_ENABLED
+      value: "true"

--- a/charts/camunda-platform-8.10/test/unit/connectors/configmap_test.go
+++ b/charts/camunda-platform-8.10/test/unit/connectors/configmap_test.go
@@ -126,6 +126,20 @@ func (s *ConfigMapTemplateTest) TestDifferentValuesInputs() {
 				"configmapApplication.camunda.client.auth.client-id": "connectors",
 			},
 		},
+		{
+			Name:        "TestConnectorsShouldUseSecureGrpcAddressWhenOrchestrationGrpcTlsIsEnabled",
+			ValuesFiles: []string{filepath.Join(s.chartPath, "test/unit/connectors/testdata/values-orchestration-grpc-tls.yaml")},
+			Values: map[string]string{
+				"connectors.enabled":             "true",
+				"orchestration.contextPath":      "/orchestration",
+				"orchestration.service.grpcPort": "26600",
+				"orchestration.service.httpPort": "8090",
+			},
+			Expected: map[string]string{
+				"configmapApplication.camunda.client.grpc-address": "https://camunda-platform-test-zeebe-gateway:26600",
+				"configmapApplication.camunda.client.rest-address": "http://camunda-platform-test-zeebe-gateway:8090/orchestration",
+			},
+		},
 	}
 
 	testhelpers.RunTestCases(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)

--- a/charts/camunda-platform-8.10/test/unit/connectors/testdata/values-orchestration-grpc-tls.yaml
+++ b/charts/camunda-platform-8.10/test/unit/connectors/testdata/values-orchestration-grpc-tls.yaml
@@ -1,0 +1,4 @@
+orchestration:
+  env:
+    - name: CAMUNDA_API_GRPC_SSL_ENABLED
+      value: "true"

--- a/charts/camunda-platform-8.10/test/unit/testhelpers/testhelpers.go
+++ b/charts/camunda-platform-8.10/test/unit/testhelpers/testhelpers.go
@@ -157,8 +157,8 @@ func runTestCaseE(t *testing.T, chartPath, release, namespace string, templates 
 }
 
 // renderTemplate renders the specified Helm templates into a Kubernetes ConfigMap
-func renderTemplate(t *testing.T, chartPath, release string, namespace string, templates []string, values map[string]string) corev1.ConfigMap {
-	options := setupHelmOptions(namespace, values, nil, nil)
+func renderTemplate(t *testing.T, chartPath, release string, namespace string, templates []string, values map[string]string, valuesFiles []string) corev1.ConfigMap {
+	options := setupHelmOptions(namespace, values, valuesFiles, nil)
 
 	output := helm.RenderTemplate(t, options, chartPath, release, templates)
 	var configmap corev1.ConfigMap
@@ -170,7 +170,7 @@ func renderTemplate(t *testing.T, chartPath, release string, namespace string, t
 func RunTestCases(t *testing.T, chartPath, release, namespace string, templates []string, testCases []TestCase) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(tct *testing.T) {
-			configmap := renderTemplate(tct, chartPath, release, namespace, templates, tc.Values)
+			configmap := renderTemplate(tct, chartPath, release, namespace, templates, tc.Values, tc.ValuesFiles)
 			verifyConfigMap(tct, tc.Name, configmap, tc.Expected)
 		})
 	}

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/configmap_restapi_test.go
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/configmap_restapi_test.go
@@ -484,6 +484,39 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldConfigureClusterFromSa
 	}
 }
 
+func (s *configmapRestAPITemplateTest) TestContainerShouldUseSecureGrpcUrlWhenOrchestrationGrpcTlsIsEnabled() {
+	values := map[string]string{
+		"identity.enabled":                              "true",
+		"global.elasticsearch.enabled":                  "true",
+		"global.zeebeClusterName":                       "test-zeebe",
+		"global.ingress.enabled":                        "true",
+		"global.ingress.tls.enabled":                    "true",
+		"global.host":                                   "example.com",
+		"orchestration.contextPath":                     "/orchestration",
+		"orchestration.data.secondaryStorage.type":      "elasticsearch",
+		"orchestration.service.grpcPort":                "26600",
+		"orchestration.service.httpPort":                "8090",
+		"orchestration.security.authorizations.enabled": "false",
+	}
+	maps.Insert(values, maps.All(requiredValues))
+	options := &helm.Options{
+		SetValues:      values,
+		ValuesFiles:    []string{filepath.Join(s.chartPath, "test/unit/web-modeler/testdata/values-orchestration-grpc-tls.yaml")},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var configmap corev1.ConfigMap
+	var configmapApplication WebModelerRestAPIApplicationYAML
+	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	require.NoError(s.T(), err)
+
+	s.Require().Equal("grpcs://camunda-platform-test-zeebe-gateway:26600", configmapApplication.Camunda.Modeler.Clusters[0].Url.Grpc)
+	s.Require().Equal("http://camunda-platform-test-zeebe-gateway:8090/orchestration", configmapApplication.Camunda.Modeler.Clusters[0].Url.Rest)
+}
+
 func (s *configmapRestAPITemplateTest) TestContainerShouldUseClustersFromCustomConfiguration() {
 	// given
 	values := map[string]string{

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/testdata/values-orchestration-grpc-tls.yaml
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/testdata/values-orchestration-grpc-tls.yaml
@@ -1,0 +1,4 @@
+orchestration:
+  env:
+    - name: CAMUNDA_API_GRPC_SSL_ENABLED
+      value: "true"

--- a/charts/camunda-platform-8.8/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.8/templates/common/_helpers.tpl
@@ -588,8 +588,9 @@ Zeebe templates.
 */}}
 {{ define "camundaPlatform.orchestrationHTTPInternalURL" }}
   {{- if .Values.orchestration.enabled -}}
+    {{- $proto := ternary "https" "http" (eq (include "camundaPlatform.orchestrationEnvIsTrue" (dict "context" . "name" "SERVER_SSL_ENABLED")) "true") -}}
     {{-
-      printf "http://%s%s"
+      printf "%s://%s%s" $proto
         (include "orchestration.serviceNameHTTP" .)
         (.Values.orchestration.contextPath | default "")
     -}}
@@ -601,11 +602,27 @@ Zeebe templates.
 */}}
 {{ define "camundaPlatform.orchestrationGRPCInternalURL" }}
   {{- if .Values.orchestration.enabled -}}
+    {{- $proto := ternary "grpcs" "grpc" (eq (include "camundaPlatform.orchestrationEnvIsTrue" (dict "context" . "name" "CAMUNDA_API_GRPC_SSL_ENABLED")) "true") -}}
     {{-
-      printf "grpc://%s"
+      printf "%s://%s" $proto
         (include "orchestration.serviceNameGRPC" .)
     -}}
   {{- end -}}
+{{- end -}}
+
+{{/*
+[camunda-platform] Returns true when the last orchestration.env entry for name has value true.
+*/}}
+{{- define "camundaPlatform.orchestrationEnvIsTrue" -}}
+  {{- $ctx := .context -}}
+  {{- $name := .name -}}
+  {{- $enabled := false -}}
+  {{- range $env := $ctx.Values.orchestration.env -}}
+    {{- if eq ($env.name | default "") $name -}}
+      {{- $enabled = (eq (lower (tpl (toString ($env.value | default "")) $ctx)) "true") -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $enabled -}}
 {{- end -}}
 
 

--- a/charts/camunda-platform-8.8/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.8/templates/common/_helpers.tpl
@@ -589,7 +589,8 @@ Zeebe templates.
 {{ define "camundaPlatform.orchestrationHTTPInternalURL" }}
   {{- if .Values.orchestration.enabled -}}
     {{-
-      printf "http://%s%s"
+      printf "%s://%s%s"
+        (ternary "https" "http" (eq (include "camundaPlatform.orchestrationEnvIsTrue" (dict "context" . "name" "SERVER_SSL_ENABLED")) "true"))
         (include "orchestration.serviceNameHTTP" .)
         (.Values.orchestration.contextPath | default "")
     -}}
@@ -602,7 +603,8 @@ Zeebe templates.
 {{ define "camundaPlatform.orchestrationGRPCInternalURL" }}
   {{- if .Values.orchestration.enabled -}}
     {{-
-      printf "grpc://%s"
+      printf "%s://%s"
+        (ternary "grpcs" "grpc" (eq (include "camundaPlatform.orchestrationEnvIsTrue" (dict "context" . "name" "CAMUNDA_API_GRPC_SSL_ENABLED")) "true"))
         (include "orchestration.serviceNameGRPC" .)
     -}}
   {{- end -}}

--- a/charts/camunda-platform-8.8/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.8/templates/common/_helpers.tpl
@@ -588,9 +588,8 @@ Zeebe templates.
 */}}
 {{ define "camundaPlatform.orchestrationHTTPInternalURL" }}
   {{- if .Values.orchestration.enabled -}}
-    {{- $proto := ternary "https" "http" (eq (include "camundaPlatform.orchestrationEnvIsTrue" (dict "context" . "name" "SERVER_SSL_ENABLED")) "true") -}}
     {{-
-      printf "%s://%s%s" $proto
+      printf "http://%s%s"
         (include "orchestration.serviceNameHTTP" .)
         (.Values.orchestration.contextPath | default "")
     -}}
@@ -602,9 +601,8 @@ Zeebe templates.
 */}}
 {{ define "camundaPlatform.orchestrationGRPCInternalURL" }}
   {{- if .Values.orchestration.enabled -}}
-    {{- $proto := ternary "grpcs" "grpc" (eq (include "camundaPlatform.orchestrationEnvIsTrue" (dict "context" . "name" "CAMUNDA_API_GRPC_SSL_ENABLED")) "true") -}}
     {{-
-      printf "%s://%s" $proto
+      printf "grpc://%s"
         (include "orchestration.serviceNameGRPC" .)
     -}}
   {{- end -}}

--- a/charts/camunda-platform-8.8/templates/common/ingress-grpc.yaml
+++ b/charts/camunda-platform-8.8/templates/common/ingress-grpc.yaml
@@ -12,7 +12,11 @@ metadata:
       )
       "context" .
     ) | nindent 4 }}
-{{- with .Values.orchestration.ingress.grpc.annotations }}
+{{- $grpcAnnotations := .Values.orchestration.ingress.grpc.annotations -}}
+{{- if eq (include "camundaPlatform.orchestrationEnvIsTrue" (dict "context" . "name" "CAMUNDA_API_GRPC_SSL_ENABLED")) "true" -}}
+{{- $grpcAnnotations = mergeOverwrite (dict) $grpcAnnotations (dict "nginx.ingress.kubernetes.io/backend-protocol" "GRPCS") -}}
+{{- end -}}
+{{- with $grpcAnnotations }}
   annotations:
   {{- tpl (toYaml .) $ | nindent 4 }}
 {{- end }}

--- a/charts/camunda-platform-8.8/templates/common/ingress-http.yaml
+++ b/charts/camunda-platform-8.8/templates/common/ingress-http.yaml
@@ -72,7 +72,7 @@ spec:
             pathType: {{ .Values.global.ingress.pathType }}
           {{- end }}
         {{- /* Orchestration Cluster */ -}}
-          {{- if and .Values.orchestration.enabled .Values.orchestration.contextPath }}
+          {{- if and .Values.orchestration.enabled .Values.orchestration.contextPath (ne (include "camundaPlatform.orchestrationEnvIsTrue" (dict "context" . "name" "SERVER_SSL_ENABLED")) "true") }}
           # Orchestration.
           - backend:
               service:

--- a/charts/camunda-platform-8.8/templates/common/ingress-orchestration-http.yaml
+++ b/charts/camunda-platform-8.8/templates/common/ingress-orchestration-http.yaml
@@ -1,0 +1,53 @@
+{{- if and .Values.global.ingress.enabled (not .Values.global.ingress.external) .Values.orchestration.enabled .Values.orchestration.contextPath (eq (include "camundaPlatform.orchestrationEnvIsTrue" (dict "context" . "name" "SERVER_SSL_ENABLED")) "true") -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "camundaPlatform.fullname" . }}-orchestration-http
+  labels:
+    {{- include "common.tplvalues.merge-overwrite" (dict
+      "values" (list
+        (include "camundaPlatform.labels" .)
+        .Values.global.ingress.labels
+      )
+      "context" .
+    ) | nindent 4 }}
+  annotations:
+    {{- include "common.tplvalues.merge-overwrite" (dict
+      "values" (list
+        .Values.global.ingress.annotations
+        (dict "nginx.ingress.kubernetes.io/backend-protocol" "HTTPS")
+      )
+      "context" .
+    ) | nindent 4 }}
+spec:
+  ingressClassName: {{ .Values.global.ingress.className }}
+  rules:
+    {{- if .Values.global.ingress.host }}
+    - host: {{ tpl .Values.global.ingress.host $ }}
+      http:
+    {{- else }}
+    - http:
+    {{- end }}
+        paths:
+          - backend:
+              service:
+                name: {{ include "orchestration.serviceName" . }}
+                port:
+                  number: {{ .Values.orchestration.service.httpPort }}
+            path: {{ .Values.orchestration.contextPath }}
+            pathType: {{ .Values.global.ingress.pathType }}
+  {{- if .Values.global.ingress.tls.enabled }}
+  tls:
+    {{- if eq .Values.global.ingress.tls.secretName "-" }}
+    {{/* Use secretName: "-" to generate an empty TLS block for automatic certificate management. */}}
+    {{/* This is useful for environments like OpenShift where the Ingress Operator manages certificates automatically. */}}
+    - {}
+    {{- else }}
+    - hosts:
+        - {{ tpl .Values.global.ingress.host $ }}
+      {{- if .Values.global.ingress.tls.secretName }}
+      secretName: {{ .Values.global.ingress.tls.secretName }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/camunda-platform-8.8/templates/connectors/files/_application.yaml
+++ b/charts/camunda-platform-8.8/templates/connectors/files/_application.yaml
@@ -28,7 +28,7 @@ management:
 camunda:
   client:
     rest-address: {{ include "camundaPlatform.orchestrationHTTPInternalURL" . }}
-    grpc-address: {{ include "camundaPlatform.orchestrationGRPCInternalURL" . | replace "grpc://" "http://" }}
+    grpc-address: {{ include "camundaPlatform.orchestrationGRPCInternalURL" . | replace "grpcs://" "https://" | replace "grpc://" "http://" }}
     worker:
       defaults:
         max-jobs-active: 32

--- a/charts/camunda-platform-8.8/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.8/test/ci-test-config.yaml
@@ -15,4 +15,3 @@ unit:
       packages: orchestration connectors optimize
     - name: Design
       packages: web-modeler
-

--- a/charts/camunda-platform-8.8/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry-snapshot.yaml
@@ -20,6 +20,28 @@ integration:
           identity: keycloak
           persistence: elasticsearch
           helmVersion: 3.20.2
+        - name: orchestration-tls
+          enabled: true
+          shortname: estls
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - orchestration-tls
+          helmVersion: 3.20.2
+          pre-install:
+            script: pre-install-orchestration-tls.sh
+            description: |
+              Generates a self-signed certificate/key pair for the Orchestration
+              Cluster gRPC endpoint, creates the server TLS Secret, and creates
+              a truststore Secret consumed by Web Modeler restapi.
         - name: enterprise-values
           enabled: false
           shortname: entv

--- a/charts/camunda-platform-8.8/test/ci/registry/hooks/orchestration-tls.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/hooks/orchestration-tls.yaml
@@ -1,0 +1,5 @@
+script: pre-install-orchestration-tls.sh
+description: |
+  Generates a self-signed certificate/key pair for the Orchestration
+  Cluster gRPC endpoint, creates the server TLS Secret, and creates
+  a truststore Secret consumed by Web Modeler restapi.

--- a/charts/camunda-platform-8.8/test/ci/registry/manifest.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/manifest.yaml
@@ -30,6 +30,10 @@ integration:
       shortname: eske
       tier: 1
       enabled: true
+    - id: orchestration-tls
+      shortname: estls
+      tier: 2
+      enabled: true
     - id: enterprise-values
       shortname: entv
       tier: 2

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/orchestration-tls.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/orchestration-tls.yaml
@@ -1,0 +1,14 @@
+name: orchestration-tls
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - orchestration-tls
+platforms:
+  - gke
+infra-type:
+  gke: distroci
+helmVersion: 3.20.2
+pre-install: orchestration-tls

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/orchestration-tls.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/orchestration-tls.yaml
@@ -30,7 +30,8 @@ webModeler:
           web-app: https://$CAMUNDA_HOSTNAME/orchestration
     javaOpts: >-
       -XX:MaxRAMPercentage=80.0
-      -Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/orchestration/truststore.jks
+      -Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/orchestration/truststore.p12
+      -Djavax.net.ssl.trustStoreType=PKCS12
       -Djavax.net.ssl.trustStorePassword=changeit
     extraVolumes:
       - name: orchestration-tls-truststore
@@ -94,7 +95,8 @@ connectors:
   env:
     - name: JAVA_TOOL_OPTIONS
       value: >-
-        -Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/orchestration/truststore.jks
+        -Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/orchestration/truststore.p12
+        -Djavax.net.ssl.trustStoreType=PKCS12
         -Djavax.net.ssl.trustStorePassword=changeit
   extraVolumes:
     - name: orchestration-tls-truststore

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/orchestration-tls.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/orchestration-tls.yaml
@@ -6,12 +6,6 @@ orchestration:
       value: /usr/local/camunda/certificates/orchestration/tls.crt
     - name: CAMUNDA_API_GRPC_SSL_CERTIFICATEPRIVATEKEY
       value: /usr/local/camunda/certificates/orchestration/tls.key
-    - name: SERVER_SSL_ENABLED
-      value: "true"
-    - name: SERVER_SSL_CERTIFICATE
-      value: /usr/local/camunda/certificates/orchestration/tls.crt
-    - name: SERVER_SSL_CERTIFICATEPRIVATEKEY
-      value: /usr/local/camunda/certificates/orchestration/tls.key
   extraVolumes:
     - name: orchestration-tls
       secret:
@@ -32,7 +26,7 @@ webModeler:
           enabled: true
         url:
           grpc: grpcs://integration-zeebe-gateway:26500
-          rest: https://integration-zeebe-gateway:8080/orchestration
+          rest: http://integration-zeebe-gateway:8080/orchestration
           web-app: https://$CAMUNDA_HOSTNAME/orchestration
     javaOpts: >-
       -XX:MaxRAMPercentage=80.0
@@ -72,7 +66,7 @@ connectors:
 
     camunda:
       client:
-        rest-address: https://integration-zeebe-gateway:8080/orchestration
+        rest-address: http://integration-zeebe-gateway:8080/orchestration
         grpc-address: https://integration-zeebe-gateway:26500
         worker:
           defaults:

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/orchestration-tls.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/orchestration-tls.yaml
@@ -25,22 +25,9 @@ webModeler:
         authorizations:
           enabled: true
         url:
-          grpc: grpcs://integration-zeebe-gateway:26500
+          grpc: grpcs://grpc-$CAMUNDA_HOSTNAME
           rest: http://integration-zeebe-gateway:8080/orchestration
           web-app: https://$CAMUNDA_HOSTNAME/orchestration
-    javaOpts: >-
-      -XX:MaxRAMPercentage=80.0
-      -Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/orchestration/truststore.p12
-      -Djavax.net.ssl.trustStoreType=PKCS12
-      -Djavax.net.ssl.trustStorePassword=changeit
-    extraVolumes:
-      - name: orchestration-tls-truststore
-        secret:
-          secretName: orchestration-tls-truststore
-    extraVolumeMounts:
-      - name: orchestration-tls-truststore
-        mountPath: /usr/local/camunda/certificates/orchestration
-        readOnly: true
 
 connectors:
   configuration: |
@@ -68,7 +55,7 @@ connectors:
     camunda:
       client:
         rest-address: http://integration-zeebe-gateway:8080/orchestration
-        grpc-address: https://integration-zeebe-gateway:26500
+        grpc-address: https://grpc-$CAMUNDA_HOSTNAME
         worker:
           defaults:
             max-jobs-active: 32
@@ -92,17 +79,3 @@ connectors:
     logging:
       level:
         io.camunda.connector: INFO
-  env:
-    - name: JAVA_TOOL_OPTIONS
-      value: >-
-        -Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/orchestration/truststore.p12
-        -Djavax.net.ssl.trustStoreType=PKCS12
-        -Djavax.net.ssl.trustStorePassword=changeit
-  extraVolumes:
-    - name: orchestration-tls-truststore
-      secret:
-        secretName: orchestration-tls-truststore
-  extraVolumeMounts:
-    - name: orchestration-tls-truststore
-      mountPath: /usr/local/camunda/certificates/orchestration
-      readOnly: true

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/orchestration-tls.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/orchestration-tls.yaml
@@ -1,0 +1,112 @@
+orchestration:
+  env:
+    - name: CAMUNDA_API_GRPC_SSL_ENABLED
+      value: "true"
+    - name: CAMUNDA_API_GRPC_SSL_CERTIFICATE
+      value: /usr/local/camunda/certificates/orchestration/tls.crt
+    - name: CAMUNDA_API_GRPC_SSL_CERTIFICATEPRIVATEKEY
+      value: /usr/local/camunda/certificates/orchestration/tls.key
+    - name: SERVER_SSL_ENABLED
+      value: "true"
+    - name: SERVER_SSL_CERTIFICATE
+      value: /usr/local/camunda/certificates/orchestration/tls.crt
+    - name: SERVER_SSL_CERTIFICATEPRIVATEKEY
+      value: /usr/local/camunda/certificates/orchestration/tls.key
+  extraVolumes:
+    - name: orchestration-tls
+      secret:
+        secretName: orchestration-tls
+  extraVolumeMounts:
+    - name: orchestration-tls
+      mountPath: /usr/local/camunda/certificates/orchestration
+      readOnly: true
+
+webModeler:
+  restapi:
+    clusters:
+      - id: default-cluster
+        name: integration-zeebe
+        version: 8.8.24
+        authentication: BEARER_TOKEN
+        authorizations:
+          enabled: true
+        url:
+          grpc: grpcs://integration-zeebe-gateway:26500
+          rest: https://integration-zeebe-gateway:8080/orchestration
+          web-app: https://$CAMUNDA_HOSTNAME/orchestration
+    javaOpts: >-
+      -XX:MaxRAMPercentage=80.0
+      -Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/orchestration/truststore.jks
+      -Djavax.net.ssl.trustStorePassword=changeit
+    extraVolumes:
+      - name: orchestration-tls-truststore
+        secret:
+          secretName: orchestration-tls-truststore
+    extraVolumeMounts:
+      - name: orchestration-tls-truststore
+        mountPath: /usr/local/camunda/certificates/orchestration
+        readOnly: true
+
+connectors:
+  configuration: |
+    server:
+      port: 8080
+      servlet:
+        context-path: "/connectors"
+
+    management:
+      context-path: /actuator
+      endpoints:
+        web:
+          exposure:
+            include: metrics,health,prometheus
+      endpoint:
+        health:
+          show-details: always
+          show-components: always
+          group:
+            readiness:
+              include:
+              - processDefinitionImport
+              - zeebeClient
+
+    camunda:
+      client:
+        rest-address: https://integration-zeebe-gateway:8080/orchestration
+        grpc-address: https://integration-zeebe-gateway:26500
+        worker:
+          defaults:
+            max-jobs-active: 32
+            stream-enabled: true
+        mode: selfManaged
+        auth:
+          token-url: http://integration-keycloak/auth/realms/camunda-platform/protocol/openid-connect/token
+          client-id: "connectors"
+          client-secret: "\u0024{VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET}"
+          audience: "orchestration-api"
+      connector:
+        headless:
+          service-url: "integration-connectors-headless"
+        webhook:
+          enabled: true
+        polling:
+          enabled: true
+        agenticai:
+          enabled: true
+
+    logging:
+      level:
+        io.camunda.connector: INFO
+  env:
+    - name: JAVA_TOOL_OPTIONS
+      value: >-
+        -Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/orchestration/truststore.jks
+        -Djavax.net.ssl.trustStorePassword=changeit
+  extraVolumes:
+    - name: orchestration-tls-truststore
+      secret:
+        secretName: orchestration-tls-truststore
+  extraVolumeMounts:
+    - name: orchestration-tls-truststore
+      mountPath: /usr/local/camunda/certificates/orchestration
+      readOnly: true

--- a/charts/camunda-platform-8.8/test/integration/scenarios/pre-setup-scripts/pre-install-orchestration-tls.sh
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/pre-setup-scripts/pre-install-orchestration-tls.sh
@@ -44,13 +44,13 @@ openssl req -x509 -nodes -newkey rsa:4096 \
   -extensions v3_req \
   2>/dev/null
 
-keytool -importcert \
-  -keystore "$WORK_DIR/truststore.jks" \
-  -storetype JKS \
-  -storepass "$KEYSTORE_PASSWORD" \
-  -alias orchestration-tls \
-  -file "$WORK_DIR/tls.crt" \
-  -noprompt 2>/dev/null
+openssl pkcs12 -export \
+  -in "$WORK_DIR/tls.crt" \
+  -inkey "$WORK_DIR/tls.key" \
+  -out "$WORK_DIR/truststore.p12" \
+  -password "pass:$KEYSTORE_PASSWORD" \
+  -name orchestration-tls \
+  2>/dev/null
 
 create_or_replace_secret() {
   local name="$1"
@@ -66,5 +66,5 @@ create_or_replace_secret "orchestration-tls" \
   --from-file="tls.key=$WORK_DIR/tls.key"
 
 create_or_replace_secret "orchestration-tls-truststore" \
-  --from-file="truststore.jks=$WORK_DIR/truststore.jks" \
+  --from-file="truststore.p12=$WORK_DIR/truststore.p12" \
   --from-literal="truststore-password=$KEYSTORE_PASSWORD"

--- a/charts/camunda-platform-8.8/test/integration/scenarios/pre-setup-scripts/pre-install-orchestration-tls.sh
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/pre-setup-scripts/pre-install-orchestration-tls.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+# under one or more contributor license agreements. Licensed under a proprietary license.
+
+set -euo pipefail
+
+NAMESPACE="${TEST_NAMESPACE:?TEST_NAMESPACE must be set}"
+RELEASE="${RELEASE_NAME:-integration}"
+CONTEXT_FLAG=""
+if [[ -n "${KUBE_CONTEXT:-}" ]]; then
+  CONTEXT_FLAG="--context ${KUBE_CONTEXT}"
+fi
+
+CERT_VALIDITY_DAYS=365
+KEYSTORE_PASSWORD="changeit"
+WORK_DIR=$(mktemp -d)
+trap '[[ -n "${WORK_DIR:-}" ]] && rm -rf "$WORK_DIR"' EXIT
+
+cat > "$WORK_DIR/san.cnf" <<EOF
+[req]
+distinguished_name = req_dn
+req_extensions = v3_req
+prompt = no
+
+[req_dn]
+CN = ${RELEASE}-zeebe-gateway
+
+[v3_req]
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = ${RELEASE}-zeebe-gateway
+DNS.2 = ${RELEASE}-zeebe-gateway.${NAMESPACE}.svc
+DNS.3 = ${RELEASE}-zeebe-gateway.${NAMESPACE}.svc.cluster.local
+DNS.4 = localhost
+IP.1 = 127.0.0.1
+EOF
+
+openssl req -x509 -nodes -newkey rsa:4096 \
+  -keyout "$WORK_DIR/tls.key" \
+  -out "$WORK_DIR/tls.crt" \
+  -days "$CERT_VALIDITY_DAYS" \
+  -config "$WORK_DIR/san.cnf" \
+  -extensions v3_req \
+  2>/dev/null
+
+keytool -importcert \
+  -keystore "$WORK_DIR/truststore.jks" \
+  -storetype JKS \
+  -storepass "$KEYSTORE_PASSWORD" \
+  -alias orchestration-tls \
+  -file "$WORK_DIR/tls.crt" \
+  -noprompt 2>/dev/null
+
+create_or_replace_secret() {
+  local name="$1"
+  shift
+  if kubectl ${CONTEXT_FLAG} -n "$NAMESPACE" get secret "$name" >/dev/null 2>&1; then
+    kubectl ${CONTEXT_FLAG} -n "$NAMESPACE" delete secret "$name" --ignore-not-found
+  fi
+  kubectl ${CONTEXT_FLAG} -n "$NAMESPACE" create secret generic "$name" "$@"
+}
+
+create_or_replace_secret "orchestration-tls" \
+  --from-file="tls.crt=$WORK_DIR/tls.crt" \
+  --from-file="tls.key=$WORK_DIR/tls.key"
+
+create_or_replace_secret "orchestration-tls-truststore" \
+  --from-file="truststore.jks=$WORK_DIR/truststore.jks" \
+  --from-literal="truststore-password=$KEYSTORE_PASSWORD"

--- a/charts/camunda-platform-8.8/test/unit/common/ingress_test.go
+++ b/charts/camunda-platform-8.8/test/unit/common/ingress_test.go
@@ -488,6 +488,25 @@ func (s *GrpcIngressTemplateTest) TestDifferentValuesInputs() {
 				s.Require().Contains(ingress.Labels, "app.kubernetes.io/name")
 			},
 		},
+		{
+			Name:                 "TestGrpcIngressUsesSecureBackendProtocolWhenOrchestrationGrpcTlsIsEnabled",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			ValuesFiles:          []string{filepath.Join(s.chartPath, "test/unit/common/testdata/values-orchestration-grpc-tls.yaml")},
+			Values: map[string]string{
+				"orchestration.enabled":                              "true",
+				"orchestration.ingress.grpc.enabled":                 "true",
+				"orchestration.ingress.grpc.annotations.custom\\.io": "kept",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				var ingress netv1.Ingress
+				helm.UnmarshalK8SYaml(t, output, &ingress)
+
+				s.Require().Equal("GRPCS", ingress.Annotations["nginx.ingress.kubernetes.io/backend-protocol"])
+				s.Require().Equal("kept", ingress.Annotations["custom.io"])
+			},
+		},
 	}
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)

--- a/charts/camunda-platform-8.8/test/unit/common/ingress_test.go
+++ b/charts/camunda-platform-8.8/test/unit/common/ingress_test.go
@@ -274,6 +274,99 @@ func (s *IngressTemplateTest) TestDifferentValuesInputs() {
 				s.Require().Equal("tls-secret", ingress.Spec.TLS[0].SecretName)
 			},
 		},
+		{
+			Name: "TestHttpIngressOmitsOrchestrationPathWithServerTLS",
+			Values: map[string]string{
+				"global.ingress.enabled":    "true",
+				"orchestration.enabled":     "true",
+				"orchestration.contextPath": "/orchestration",
+				"orchestration.env[0].name": "SERVER_SSL_ENABLED",
+			},
+			RenderTemplateExtraArgs: []string{
+				"--set-string", "orchestration.env[0].value=true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				require.NotContains(t, output, "path: /orchestration")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
+type OrchestrationHttpIngressTemplateTest struct {
+	suite.Suite
+	chartPath string
+	release   string
+	namespace string
+	templates []string
+	extraArgs []string
+}
+
+func TestOrchestrationHttpIngressTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../")
+	require.NoError(t, err)
+
+	suite.Run(t, &OrchestrationHttpIngressTemplateTest{
+		chartPath: chartPath,
+		release:   "camunda-platform-test",
+		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
+		templates: []string{"templates/common/ingress-orchestration-http.yaml"},
+	})
+}
+
+func (s *OrchestrationHttpIngressTemplateTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestOrchestrationHttpIngressWithServerTLS",
+			Values: map[string]string{
+				"global.ingress.enabled":                     "true",
+				"global.ingress.host":                        "camunda.example.com",
+				"global.ingress.tls.enabled":                 "true",
+				"global.ingress.annotations.test-annotation": "test-value",
+				"orchestration.enabled":                      "true",
+				"orchestration.contextPath":                  "/orchestration",
+				"orchestration.env[0].name":                  "SERVER_SSL_ENABLED",
+			},
+			RenderTemplateExtraArgs: []string{
+				"--set-string", "orchestration.env[0].value=true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				var ingress netv1.Ingress
+				helm.UnmarshalK8SYaml(t, output, &ingress)
+
+				require.Equal(t, "camunda-platform-test-orchestration-http", ingress.Name)
+				require.Equal(t, "HTTPS", ingress.Annotations["nginx.ingress.kubernetes.io/backend-protocol"])
+				require.Equal(t, "test-value", ingress.Annotations["test-annotation"])
+				require.Equal(t, "camunda.example.com", ingress.Spec.Rules[0].Host)
+				require.Equal(t, "/orchestration", ingress.Spec.Rules[0].HTTP.Paths[0].Path)
+				require.Equal(t, "camunda-platform-test-zeebe-gateway", ingress.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Name)
+				require.Equal(t, int32(8080), ingress.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Port.Number)
+				require.Equal(t, "camunda.example.com", ingress.Spec.TLS[0].Hosts[0])
+			},
+		},
+		{
+			Name: "TestOrchestrationHttpIngressDisabledWithoutServerTLS",
+			CaseTemplates: &testhelpers.CaseTemplate{
+				Templates: nil,
+			},
+			Values: map[string]string{
+				"global.ingress.enabled":    "true",
+				"orchestration.enabled":     "true",
+				"orchestration.contextPath": "/orchestration",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				require.NotContains(t, output, "name: camunda-platform-test-orchestration-http")
+			},
+		},
 	}
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)

--- a/charts/camunda-platform-8.8/test/unit/common/testdata/values-orchestration-grpc-tls.yaml
+++ b/charts/camunda-platform-8.8/test/unit/common/testdata/values-orchestration-grpc-tls.yaml
@@ -1,0 +1,4 @@
+orchestration:
+  env:
+    - name: CAMUNDA_API_GRPC_SSL_ENABLED
+      value: "true"

--- a/charts/camunda-platform-8.8/test/unit/connectors/configmap_test.go
+++ b/charts/camunda-platform-8.8/test/unit/connectors/configmap_test.go
@@ -124,6 +124,20 @@ func (s *ConfigMapTemplateTest) TestDifferentValuesInputs() {
 				"configmapApplication.camunda.client.auth.client-id": "connectors",
 			},
 		},
+		{
+			Name:        "TestConnectorsShouldUseSecureGrpcAddressWhenOrchestrationGrpcTlsIsEnabled",
+			ValuesFiles: []string{filepath.Join(s.chartPath, "test/unit/connectors/testdata/values-orchestration-grpc-tls.yaml")},
+			Values: map[string]string{
+				"connectors.enabled":             "true",
+				"orchestration.contextPath":      "/orchestration",
+				"orchestration.service.grpcPort": "26600",
+				"orchestration.service.httpPort": "8090",
+			},
+			Expected: map[string]string{
+				"configmapApplication.camunda.client.grpc-address": "https://camunda-platform-test-zeebe-gateway:26600",
+				"configmapApplication.camunda.client.rest-address": "http://camunda-platform-test-zeebe-gateway:8090/orchestration",
+			},
+		},
 	}
 
 	testhelpers.RunTestCases(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)

--- a/charts/camunda-platform-8.8/test/unit/connectors/testdata/values-orchestration-grpc-tls.yaml
+++ b/charts/camunda-platform-8.8/test/unit/connectors/testdata/values-orchestration-grpc-tls.yaml
@@ -1,0 +1,4 @@
+orchestration:
+  env:
+    - name: CAMUNDA_API_GRPC_SSL_ENABLED
+      value: "true"

--- a/charts/camunda-platform-8.8/test/unit/testhelpers/testhelpers.go
+++ b/charts/camunda-platform-8.8/test/unit/testhelpers/testhelpers.go
@@ -148,8 +148,8 @@ func runTestCaseE(t *testing.T, chartPath, release, namespace string, templates 
 }
 
 // renderTemplate renders the specified Helm templates into a Kubernetes ConfigMap
-func renderTemplate(t *testing.T, chartPath, release string, namespace string, templates []string, values map[string]string) corev1.ConfigMap {
-	options := setupHelmOptions(namespace, values, nil, nil)
+func renderTemplate(t *testing.T, chartPath, release string, namespace string, templates []string, values map[string]string, valuesFiles []string) corev1.ConfigMap {
+	options := setupHelmOptions(namespace, values, valuesFiles, nil)
 
 	output := helm.RenderTemplate(t, options, chartPath, release, templates)
 	var configmap corev1.ConfigMap
@@ -161,7 +161,7 @@ func renderTemplate(t *testing.T, chartPath, release string, namespace string, t
 func RunTestCases(t *testing.T, chartPath, release, namespace string, templates []string, testCases []TestCase) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(tct *testing.T) {
-			configmap := renderTemplate(tct, chartPath, release, namespace, templates, tc.Values)
+			configmap := renderTemplate(tct, chartPath, release, namespace, templates, tc.Values, tc.ValuesFiles)
 			verifyConfigMap(tct, tc.Name, configmap, tc.Expected)
 		})
 	}

--- a/charts/camunda-platform-8.8/test/unit/web-modeler/configmap_restapi_test.go
+++ b/charts/camunda-platform-8.8/test/unit/web-modeler/configmap_restapi_test.go
@@ -385,6 +385,39 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldConfigureClusterFromSa
 	}
 }
 
+func (s *configmapRestAPITemplateTest) TestContainerShouldUseSecureGrpcUrlWhenOrchestrationGrpcTlsIsEnabled() {
+	values := map[string]string{
+		"identity.enabled":                              "true",
+		"webModelerPostgresql.enabled":                  "false",
+		"global.zeebeClusterName":                       "test-zeebe",
+		"global.ingress.enabled":                        "true",
+		"global.ingress.tls.enabled":                    "true",
+		"global.ingress.host":                           "example.com",
+		"orchestration.contextPath":                     "/orchestration",
+		"orchestration.data.secondaryStorage.type":      "elasticsearch",
+		"orchestration.service.grpcPort":                "26600",
+		"orchestration.service.httpPort":                "8090",
+		"orchestration.security.authorizations.enabled": "false",
+	}
+	maps.Insert(values, maps.All(requiredValues))
+	options := &helm.Options{
+		SetValues:      values,
+		ValuesFiles:    []string{filepath.Join(s.chartPath, "test/unit/web-modeler/testdata/values-orchestration-grpc-tls.yaml")},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var configmap corev1.ConfigMap
+	var configmapApplication WebModelerRestAPIApplicationYAML
+	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	require.NoError(s.T(), err)
+
+	s.Require().Equal("grpcs://camunda-platform-test-zeebe-gateway:26600", configmapApplication.Camunda.Modeler.Clusters[0].Url.Grpc)
+	s.Require().Equal("http://camunda-platform-test-zeebe-gateway:8090/orchestration", configmapApplication.Camunda.Modeler.Clusters[0].Url.Rest)
+}
+
 func (s *configmapRestAPITemplateTest) TestContainerShouldUseClustersFromCustomConfiguration() {
 	// given
 	values := map[string]string{

--- a/charts/camunda-platform-8.8/test/unit/web-modeler/configmap_restapi_test.go
+++ b/charts/camunda-platform-8.8/test/unit/web-modeler/configmap_restapi_test.go
@@ -385,45 +385,6 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldConfigureClusterFromSa
 	}
 }
 
-func (s *configmapRestAPITemplateTest) TestContainerShouldConfigureClusterInternalUrlsWithTls() {
-	// given
-	values := map[string]string{
-		"identity.enabled":                              "true",
-		"webModelerPostgresql.enabled":                  "false",
-		"global.zeebeClusterName":                       "test-zeebe",
-		"global.identity.auth.enabled":                  "true",
-		"orchestration.contextPath":                     "/orchestration",
-		"orchestration.security.authorizations.enabled": "false",
-		"orchestration.env[0].name":                     "CAMUNDA_API_GRPC_SSL_ENABLED",
-		"orchestration.env[1].name":                     "SERVER_SSL_ENABLED",
-	}
-	stringValues := map[string]string{
-		"orchestration.env[0].value": "true",
-		"orchestration.env[1].value": "true",
-	}
-	maps.Insert(values, maps.All(requiredValues))
-	options := &helm.Options{
-		SetValues:      values,
-		SetStrValues:   stringValues,
-		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
-	}
-
-	// when
-	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
-	var configmap corev1.ConfigMap
-	var configmapApplication WebModelerRestAPIApplicationYAML
-	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
-	if err != nil {
-		s.Fail("Failed to unmarshal yaml. error=", err)
-	}
-
-	// then
-	s.Require().Equal("grpcs://camunda-platform-test-zeebe-gateway:26500", configmapApplication.Camunda.Modeler.Clusters[0].Url.Grpc)
-	s.Require().Equal("https://camunda-platform-test-zeebe-gateway:8080/orchestration", configmapApplication.Camunda.Modeler.Clusters[0].Url.Rest)
-}
-
 func (s *configmapRestAPITemplateTest) TestContainerShouldUseClustersFromCustomConfiguration() {
 	// given
 	values := map[string]string{

--- a/charts/camunda-platform-8.8/test/unit/web-modeler/configmap_restapi_test.go
+++ b/charts/camunda-platform-8.8/test/unit/web-modeler/configmap_restapi_test.go
@@ -385,6 +385,45 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldConfigureClusterFromSa
 	}
 }
 
+func (s *configmapRestAPITemplateTest) TestContainerShouldConfigureClusterInternalUrlsWithTls() {
+	// given
+	values := map[string]string{
+		"identity.enabled":                              "true",
+		"webModelerPostgresql.enabled":                  "false",
+		"global.zeebeClusterName":                       "test-zeebe",
+		"global.identity.auth.enabled":                  "true",
+		"orchestration.contextPath":                     "/orchestration",
+		"orchestration.security.authorizations.enabled": "false",
+		"orchestration.env[0].name":                     "CAMUNDA_API_GRPC_SSL_ENABLED",
+		"orchestration.env[1].name":                     "SERVER_SSL_ENABLED",
+	}
+	stringValues := map[string]string{
+		"orchestration.env[0].value": "true",
+		"orchestration.env[1].value": "true",
+	}
+	maps.Insert(values, maps.All(requiredValues))
+	options := &helm.Options{
+		SetValues:      values,
+		SetStrValues:   stringValues,
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var configmap corev1.ConfigMap
+	var configmapApplication WebModelerRestAPIApplicationYAML
+	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	if err != nil {
+		s.Fail("Failed to unmarshal yaml. error=", err)
+	}
+
+	// then
+	s.Require().Equal("grpcs://camunda-platform-test-zeebe-gateway:26500", configmapApplication.Camunda.Modeler.Clusters[0].Url.Grpc)
+	s.Require().Equal("https://camunda-platform-test-zeebe-gateway:8080/orchestration", configmapApplication.Camunda.Modeler.Clusters[0].Url.Rest)
+}
+
 func (s *configmapRestAPITemplateTest) TestContainerShouldUseClustersFromCustomConfiguration() {
 	// given
 	values := map[string]string{

--- a/charts/camunda-platform-8.8/test/unit/web-modeler/testdata/values-orchestration-grpc-tls.yaml
+++ b/charts/camunda-platform-8.8/test/unit/web-modeler/testdata/values-orchestration-grpc-tls.yaml
@@ -1,0 +1,4 @@
+orchestration:
+  env:
+    - name: CAMUNDA_API_GRPC_SSL_ENABLED
+      value: "true"

--- a/charts/camunda-platform-8.9/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/common/_helpers.tpl
@@ -649,7 +649,8 @@ Zeebe templates.
 {{ define "camundaPlatform.orchestrationHTTPInternalURL" }}
   {{- if .Values.orchestration.enabled -}}
     {{-
-      printf "http://%s%s"
+      printf "%s://%s%s"
+        (ternary "https" "http" (eq (include "camundaPlatform.orchestrationEnvIsTrue" (dict "context" . "name" "SERVER_SSL_ENABLED")) "true"))
         (include "orchestration.serviceNameHTTP" .)
         (.Values.orchestration.contextPath | default "")
     -}}
@@ -662,7 +663,8 @@ Zeebe templates.
 {{ define "camundaPlatform.orchestrationGRPCInternalURL" }}
   {{- if .Values.orchestration.enabled -}}
     {{-
-      printf "grpc://%s"
+      printf "%s://%s"
+        (ternary "grpcs" "grpc" (eq (include "camundaPlatform.orchestrationEnvIsTrue" (dict "context" . "name" "CAMUNDA_API_GRPC_SSL_ENABLED")) "true"))
         (include "orchestration.serviceNameGRPC" .)
     -}}
   {{- end -}}

--- a/charts/camunda-platform-8.9/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/common/_helpers.tpl
@@ -668,6 +668,21 @@ Zeebe templates.
   {{- end -}}
 {{- end -}}
 
+{{/*
+[camunda-platform] Returns true when the last orchestration.env entry for name has value true.
+*/}}
+{{- define "camundaPlatform.orchestrationEnvIsTrue" -}}
+  {{- $ctx := .context -}}
+  {{- $name := .name -}}
+  {{- $enabled := false -}}
+  {{- range $env := $ctx.Values.orchestration.env -}}
+    {{- if eq ($env.name | default "") $name -}}
+      {{- $enabled = (eq (lower (tpl (toString ($env.value | default "")) $ctx)) "true") -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $enabled -}}
+{{- end -}}
+
 
 {{/*
 ********************************************************************************

--- a/charts/camunda-platform-8.9/templates/common/ingress-grpc.yaml
+++ b/charts/camunda-platform-8.9/templates/common/ingress-grpc.yaml
@@ -12,7 +12,11 @@ metadata:
       )
       "context" .
     ) | nindent 4 }}
-{{- with .Values.orchestration.ingress.grpc.annotations }}
+{{- $grpcAnnotations := .Values.orchestration.ingress.grpc.annotations -}}
+{{- if eq (include "camundaPlatform.orchestrationEnvIsTrue" (dict "context" . "name" "CAMUNDA_API_GRPC_SSL_ENABLED")) "true" -}}
+{{- $grpcAnnotations = mergeOverwrite (dict) $grpcAnnotations (dict "nginx.ingress.kubernetes.io/backend-protocol" "GRPCS") -}}
+{{- end -}}
+{{- with $grpcAnnotations }}
   annotations:
   {{- tpl (toYaml .) $ | nindent 4 }}
 {{- end }}

--- a/charts/camunda-platform-8.9/templates/common/ingress-http.yaml
+++ b/charts/camunda-platform-8.9/templates/common/ingress-http.yaml
@@ -72,7 +72,7 @@ spec:
             pathType: {{ .Values.global.ingress.pathType }}
           {{- end }}
         {{- /* Orchestration Cluster */ -}}
-          {{- if and .Values.orchestration.enabled .Values.orchestration.contextPath }}
+          {{- if and .Values.orchestration.enabled .Values.orchestration.contextPath (ne (include "camundaPlatform.orchestrationEnvIsTrue" (dict "context" . "name" "SERVER_SSL_ENABLED")) "true") }}
           # Orchestration.
           - backend:
               service:

--- a/charts/camunda-platform-8.9/templates/common/ingress-orchestration-http.yaml
+++ b/charts/camunda-platform-8.9/templates/common/ingress-orchestration-http.yaml
@@ -1,0 +1,53 @@
+{{- if and .Values.global.ingress.enabled (not .Values.global.ingress.external) .Values.orchestration.enabled .Values.orchestration.contextPath (eq (include "camundaPlatform.orchestrationEnvIsTrue" (dict "context" . "name" "SERVER_SSL_ENABLED")) "true") -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "camundaPlatform.fullname" . }}-orchestration-http
+  labels:
+    {{- include "common.tplvalues.merge-overwrite" (dict
+      "values" (list
+        (include "camundaPlatform.labels" .)
+        .Values.global.ingress.labels
+      )
+      "context" .
+    ) | nindent 4 }}
+  annotations:
+    {{- include "common.tplvalues.merge-overwrite" (dict
+      "values" (list
+        .Values.global.ingress.annotations
+        (dict "nginx.ingress.kubernetes.io/backend-protocol" "HTTPS")
+      )
+      "context" .
+    ) | nindent 4 }}
+spec:
+  ingressClassName: {{ .Values.global.ingress.className }}
+  rules:
+    {{- if or .Values.global.ingress.host .Values.global.host }}
+    - host: {{ or (tpl .Values.global.ingress.host $) (tpl .Values.global.host $) }}
+      http:
+    {{- else }}
+    - http:
+    {{- end }}
+        paths:
+          - backend:
+              service:
+                name: {{ include "orchestration.serviceName" . }}
+                port:
+                  number: {{ .Values.orchestration.service.httpPort }}
+            path: {{ .Values.orchestration.contextPath }}
+            pathType: {{ .Values.global.ingress.pathType }}
+  {{- if .Values.global.ingress.tls.enabled }}
+  tls:
+    {{- if eq .Values.global.ingress.tls.secretName "-" }}
+    {{/* Use secretName: "-" to generate an empty TLS block for automatic certificate management. */}}
+    {{/* This is useful for environments like OpenShift where the Ingress Operator manages certificates automatically. */}}
+    - {}
+    {{- else }}
+    - hosts:
+        - {{ or (tpl .Values.global.ingress.host $) (tpl .Values.global.host $) }}
+      {{- if .Values.global.ingress.tls.secretName }}
+      secretName: {{ .Values.global.ingress.tls.secretName }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/camunda-platform-8.9/templates/connectors/files/_application.yaml
+++ b/charts/camunda-platform-8.9/templates/connectors/files/_application.yaml
@@ -43,7 +43,7 @@ spring:
 camunda:
   client:
     rest-address: {{ include "camundaPlatform.orchestrationHTTPInternalURL" . }}
-    grpc-address: {{ include "camundaPlatform.orchestrationGRPCInternalURL" . | replace "grpc://" "http://" }}
+    grpc-address: {{ include "camundaPlatform.orchestrationGRPCInternalURL" . | replace "grpcs://" "https://" | replace "grpc://" "http://" }}
     worker:
       defaults:
         max-jobs-active: 32

--- a/charts/camunda-platform-8.9/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.9/test/ci-test-config.yaml
@@ -15,4 +15,3 @@ unit:
       packages: orchestration connectors optimize
     - name: Design
       packages: web-modeler
-

--- a/charts/camunda-platform-8.9/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry-snapshot.yaml
@@ -20,6 +20,28 @@ integration:
             gke: distroci
           identity: keycloak
           persistence: elasticsearch
+        - name: orchestration-tls
+          enabled: true
+          shortname: estls
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - orchestration-tls
+          helmVersion: 3.20.2
+          pre-install:
+            script: pre-install-orchestration-tls.sh
+            description: |
+              Generates a self-signed certificate/key pair for the Orchestration
+              Cluster gRPC endpoint, creates the server TLS Secret, and creates
+              a truststore Secret consumed by Web Modeler restapi.
         - name: enterprise-values
           enabled: true
           shortname: entv

--- a/charts/camunda-platform-8.9/test/ci/registry/hooks/orchestration-tls.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/hooks/orchestration-tls.yaml
@@ -1,0 +1,5 @@
+script: pre-install-orchestration-tls.sh
+description: |
+  Generates a self-signed certificate/key pair for the Orchestration
+  Cluster gRPC endpoint, creates the server TLS Secret, and creates
+  a truststore Secret consumed by Web Modeler restapi.

--- a/charts/camunda-platform-8.9/test/ci/registry/manifest.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/manifest.yaml
@@ -17,6 +17,10 @@ integration:
       shortname: eske
       tier: 1
       enabled: true
+    - id: orchestration-tls
+      shortname: estls
+      tier: 2
+      enabled: true
     - id: enterprise-values
       shortname: entv
       tier: 2

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/orchestration-tls.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/orchestration-tls.yaml
@@ -1,0 +1,14 @@
+name: orchestration-tls
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - orchestration-tls
+platforms:
+  - gke
+infra-type:
+  gke: distroci
+helmVersion: 3.20.2
+pre-install: orchestration-tls

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/orchestration-tls.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/orchestration-tls.yaml
@@ -30,7 +30,8 @@ webModeler:
           web-app: https://$CAMUNDA_HOSTNAME/orchestration
     javaOpts: >-
       -XX:MaxRAMPercentage=80.0
-      -Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/orchestration/truststore.jks
+      -Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/orchestration/truststore.p12
+      -Djavax.net.ssl.trustStoreType=PKCS12
       -Djavax.net.ssl.trustStorePassword=changeit
     extraVolumes:
       - name: orchestration-tls-truststore
@@ -94,7 +95,8 @@ connectors:
   env:
     - name: JAVA_TOOL_OPTIONS
       value: >-
-        -Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/orchestration/truststore.jks
+        -Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/orchestration/truststore.p12
+        -Djavax.net.ssl.trustStoreType=PKCS12
         -Djavax.net.ssl.trustStorePassword=changeit
   extraVolumes:
     - name: orchestration-tls-truststore

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/orchestration-tls.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/orchestration-tls.yaml
@@ -1,0 +1,112 @@
+orchestration:
+  env:
+    - name: CAMUNDA_API_GRPC_SSL_ENABLED
+      value: "true"
+    - name: CAMUNDA_API_GRPC_SSL_CERTIFICATE
+      value: /usr/local/camunda/certificates/orchestration/tls.crt
+    - name: CAMUNDA_API_GRPC_SSL_CERTIFICATEPRIVATEKEY
+      value: /usr/local/camunda/certificates/orchestration/tls.key
+    - name: SERVER_SSL_ENABLED
+      value: "true"
+    - name: SERVER_SSL_CERTIFICATE
+      value: /usr/local/camunda/certificates/orchestration/tls.crt
+    - name: SERVER_SSL_CERTIFICATEPRIVATEKEY
+      value: /usr/local/camunda/certificates/orchestration/tls.key
+  extraVolumes:
+    - name: orchestration-tls
+      secret:
+        secretName: orchestration-tls
+  extraVolumeMounts:
+    - name: orchestration-tls
+      mountPath: /usr/local/camunda/certificates/orchestration
+      readOnly: true
+
+webModeler:
+  restapi:
+    clusters:
+      - id: default-cluster
+        name: integration-zeebe
+        version: 8.9.5
+        authentication: BEARER_TOKEN
+        authorizations:
+          enabled: true
+        url:
+          grpc: grpcs://integration-zeebe-gateway:26500
+          rest: https://integration-zeebe-gateway:8080/orchestration
+          web-app: https://$CAMUNDA_HOSTNAME/orchestration
+    javaOpts: >-
+      -XX:MaxRAMPercentage=80.0
+      -Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/orchestration/truststore.jks
+      -Djavax.net.ssl.trustStorePassword=changeit
+    extraVolumes:
+      - name: orchestration-tls-truststore
+        secret:
+          secretName: orchestration-tls-truststore
+    extraVolumeMounts:
+      - name: orchestration-tls-truststore
+        mountPath: /usr/local/camunda/certificates/orchestration
+        readOnly: true
+
+connectors:
+  configuration: |
+    server:
+      port: 8080
+      servlet:
+        context-path: "/connectors"
+
+    management:
+      context-path: /actuator
+      endpoints:
+        web:
+          exposure:
+            include: metrics,health,prometheus
+      endpoint:
+        health:
+          show-details: always
+          show-components: always
+          group:
+            readiness:
+              include:
+              - processDefinitionImport
+              - zeebeClient
+
+    camunda:
+      client:
+        rest-address: https://integration-zeebe-gateway:8080/orchestration
+        grpc-address: https://integration-zeebe-gateway:26500
+        worker:
+          defaults:
+            max-jobs-active: 32
+            stream-enabled: true
+        mode: selfManaged
+        auth:
+          token-url: http://integration-keycloak/auth/realms/camunda-platform/protocol/openid-connect/token
+          client-id: "connectors"
+          client-secret: "\u0024{VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET}"
+          audience: "orchestration-api"
+      connector:
+        headless:
+          service-url: "integration-connectors-headless"
+        webhook:
+          enabled: true
+        polling:
+          enabled: true
+        agenticai:
+          enabled: true
+
+    logging:
+      level:
+        io.camunda.connector: INFO
+  env:
+    - name: JAVA_TOOL_OPTIONS
+      value: >-
+        -Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/orchestration/truststore.jks
+        -Djavax.net.ssl.trustStorePassword=changeit
+  extraVolumes:
+    - name: orchestration-tls-truststore
+      secret:
+        secretName: orchestration-tls-truststore
+  extraVolumeMounts:
+    - name: orchestration-tls-truststore
+      mountPath: /usr/local/camunda/certificates/orchestration
+      readOnly: true

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/orchestration-tls.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/orchestration-tls.yaml
@@ -6,12 +6,6 @@ orchestration:
       value: /usr/local/camunda/certificates/orchestration/tls.crt
     - name: CAMUNDA_API_GRPC_SSL_CERTIFICATEPRIVATEKEY
       value: /usr/local/camunda/certificates/orchestration/tls.key
-    - name: SERVER_SSL_ENABLED
-      value: "true"
-    - name: SERVER_SSL_CERTIFICATE
-      value: /usr/local/camunda/certificates/orchestration/tls.crt
-    - name: SERVER_SSL_CERTIFICATEPRIVATEKEY
-      value: /usr/local/camunda/certificates/orchestration/tls.key
   extraVolumes:
     - name: orchestration-tls
       secret:
@@ -32,7 +26,7 @@ webModeler:
           enabled: true
         url:
           grpc: grpcs://integration-zeebe-gateway:26500
-          rest: https://integration-zeebe-gateway:8080/orchestration
+          rest: http://integration-zeebe-gateway:8080/orchestration
           web-app: https://$CAMUNDA_HOSTNAME/orchestration
     javaOpts: >-
       -XX:MaxRAMPercentage=80.0
@@ -72,7 +66,7 @@ connectors:
 
     camunda:
       client:
-        rest-address: https://integration-zeebe-gateway:8080/orchestration
+        rest-address: http://integration-zeebe-gateway:8080/orchestration
         grpc-address: https://integration-zeebe-gateway:26500
         worker:
           defaults:

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/orchestration-tls.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/orchestration-tls.yaml
@@ -25,22 +25,9 @@ webModeler:
         authorizations:
           enabled: true
         url:
-          grpc: grpcs://integration-zeebe-gateway:26500
+          grpc: grpcs://grpc-$CAMUNDA_HOSTNAME
           rest: http://integration-zeebe-gateway:8080/orchestration
           web-app: https://$CAMUNDA_HOSTNAME/orchestration
-    javaOpts: >-
-      -XX:MaxRAMPercentage=80.0
-      -Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/orchestration/truststore.p12
-      -Djavax.net.ssl.trustStoreType=PKCS12
-      -Djavax.net.ssl.trustStorePassword=changeit
-    extraVolumes:
-      - name: orchestration-tls-truststore
-        secret:
-          secretName: orchestration-tls-truststore
-    extraVolumeMounts:
-      - name: orchestration-tls-truststore
-        mountPath: /usr/local/camunda/certificates/orchestration
-        readOnly: true
 
 connectors:
   configuration: |
@@ -68,7 +55,7 @@ connectors:
     camunda:
       client:
         rest-address: http://integration-zeebe-gateway:8080/orchestration
-        grpc-address: https://integration-zeebe-gateway:26500
+        grpc-address: https://grpc-$CAMUNDA_HOSTNAME
         worker:
           defaults:
             max-jobs-active: 32
@@ -92,17 +79,3 @@ connectors:
     logging:
       level:
         io.camunda.connector: INFO
-  env:
-    - name: JAVA_TOOL_OPTIONS
-      value: >-
-        -Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/orchestration/truststore.p12
-        -Djavax.net.ssl.trustStoreType=PKCS12
-        -Djavax.net.ssl.trustStorePassword=changeit
-  extraVolumes:
-    - name: orchestration-tls-truststore
-      secret:
-        secretName: orchestration-tls-truststore
-  extraVolumeMounts:
-    - name: orchestration-tls-truststore
-      mountPath: /usr/local/camunda/certificates/orchestration
-      readOnly: true

--- a/charts/camunda-platform-8.9/test/integration/scenarios/pre-setup-scripts/pre-install-orchestration-tls.sh
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/pre-setup-scripts/pre-install-orchestration-tls.sh
@@ -44,13 +44,13 @@ openssl req -x509 -nodes -newkey rsa:4096 \
   -extensions v3_req \
   2>/dev/null
 
-keytool -importcert \
-  -keystore "$WORK_DIR/truststore.jks" \
-  -storetype JKS \
-  -storepass "$KEYSTORE_PASSWORD" \
-  -alias orchestration-tls \
-  -file "$WORK_DIR/tls.crt" \
-  -noprompt 2>/dev/null
+openssl pkcs12 -export \
+  -in "$WORK_DIR/tls.crt" \
+  -inkey "$WORK_DIR/tls.key" \
+  -out "$WORK_DIR/truststore.p12" \
+  -password "pass:$KEYSTORE_PASSWORD" \
+  -name orchestration-tls \
+  2>/dev/null
 
 create_or_replace_secret() {
   local name="$1"
@@ -66,5 +66,5 @@ create_or_replace_secret "orchestration-tls" \
   --from-file="tls.key=$WORK_DIR/tls.key"
 
 create_or_replace_secret "orchestration-tls-truststore" \
-  --from-file="truststore.jks=$WORK_DIR/truststore.jks" \
+  --from-file="truststore.p12=$WORK_DIR/truststore.p12" \
   --from-literal="truststore-password=$KEYSTORE_PASSWORD"

--- a/charts/camunda-platform-8.9/test/integration/scenarios/pre-setup-scripts/pre-install-orchestration-tls.sh
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/pre-setup-scripts/pre-install-orchestration-tls.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+# under one or more contributor license agreements. Licensed under a proprietary license.
+
+set -euo pipefail
+
+NAMESPACE="${TEST_NAMESPACE:?TEST_NAMESPACE must be set}"
+RELEASE="${RELEASE_NAME:-integration}"
+CONTEXT_FLAG=""
+if [[ -n "${KUBE_CONTEXT:-}" ]]; then
+  CONTEXT_FLAG="--context ${KUBE_CONTEXT}"
+fi
+
+CERT_VALIDITY_DAYS=365
+KEYSTORE_PASSWORD="changeit"
+WORK_DIR=$(mktemp -d)
+trap '[[ -n "${WORK_DIR:-}" ]] && rm -rf "$WORK_DIR"' EXIT
+
+cat > "$WORK_DIR/san.cnf" <<EOF
+[req]
+distinguished_name = req_dn
+req_extensions = v3_req
+prompt = no
+
+[req_dn]
+CN = ${RELEASE}-zeebe-gateway
+
+[v3_req]
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = ${RELEASE}-zeebe-gateway
+DNS.2 = ${RELEASE}-zeebe-gateway.${NAMESPACE}.svc
+DNS.3 = ${RELEASE}-zeebe-gateway.${NAMESPACE}.svc.cluster.local
+DNS.4 = localhost
+IP.1 = 127.0.0.1
+EOF
+
+openssl req -x509 -nodes -newkey rsa:4096 \
+  -keyout "$WORK_DIR/tls.key" \
+  -out "$WORK_DIR/tls.crt" \
+  -days "$CERT_VALIDITY_DAYS" \
+  -config "$WORK_DIR/san.cnf" \
+  -extensions v3_req \
+  2>/dev/null
+
+keytool -importcert \
+  -keystore "$WORK_DIR/truststore.jks" \
+  -storetype JKS \
+  -storepass "$KEYSTORE_PASSWORD" \
+  -alias orchestration-tls \
+  -file "$WORK_DIR/tls.crt" \
+  -noprompt 2>/dev/null
+
+create_or_replace_secret() {
+  local name="$1"
+  shift
+  if kubectl ${CONTEXT_FLAG} -n "$NAMESPACE" get secret "$name" >/dev/null 2>&1; then
+    kubectl ${CONTEXT_FLAG} -n "$NAMESPACE" delete secret "$name" --ignore-not-found
+  fi
+  kubectl ${CONTEXT_FLAG} -n "$NAMESPACE" create secret generic "$name" "$@"
+}
+
+create_or_replace_secret "orchestration-tls" \
+  --from-file="tls.crt=$WORK_DIR/tls.crt" \
+  --from-file="tls.key=$WORK_DIR/tls.key"
+
+create_or_replace_secret "orchestration-tls-truststore" \
+  --from-file="truststore.jks=$WORK_DIR/truststore.jks" \
+  --from-literal="truststore-password=$KEYSTORE_PASSWORD"

--- a/charts/camunda-platform-8.9/test/unit/common/ingress_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/ingress_test.go
@@ -547,6 +547,25 @@ func (s *GrpcIngressTemplateTest) TestDifferentValuesInputs() {
 				s.Require().Contains(ingress.Labels, "app.kubernetes.io/name")
 			},
 		},
+		{
+			Name:                 "TestGrpcIngressUsesSecureBackendProtocolWhenOrchestrationGrpcTlsIsEnabled",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			ValuesFiles:          []string{filepath.Join(s.chartPath, "test/unit/common/testdata/values-orchestration-grpc-tls.yaml")},
+			Values: map[string]string{
+				"orchestration.enabled":                              "true",
+				"orchestration.ingress.grpc.enabled":                 "true",
+				"orchestration.ingress.grpc.annotations.custom\\.io": "kept",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				var ingress netv1.Ingress
+				helm.UnmarshalK8SYaml(t, output, &ingress)
+
+				s.Require().Equal("GRPCS", ingress.Annotations["nginx.ingress.kubernetes.io/backend-protocol"])
+				s.Require().Equal("kept", ingress.Annotations["custom.io"])
+			},
+		},
 	}
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)

--- a/charts/camunda-platform-8.9/test/unit/common/ingress_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/ingress_test.go
@@ -333,6 +333,99 @@ func (s *IngressTemplateTest) TestDifferentValuesInputs() {
 				s.Require().Empty(ingress.Spec.Rules[0].Host)
 			},
 		},
+		{
+			Name: "TestHttpIngressOmitsOrchestrationPathWithServerTLS",
+			Values: map[string]string{
+				"global.ingress.enabled":    "true",
+				"orchestration.enabled":     "true",
+				"orchestration.contextPath": "/orchestration",
+				"orchestration.env[0].name": "SERVER_SSL_ENABLED",
+			},
+			RenderTemplateExtraArgs: []string{
+				"--set-string", "orchestration.env[0].value=true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				require.NotContains(t, output, "path: /orchestration")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
+type OrchestrationHttpIngressTemplateTest struct {
+	suite.Suite
+	chartPath string
+	release   string
+	namespace string
+	templates []string
+	extraArgs []string
+}
+
+func TestOrchestrationHttpIngressTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../")
+	require.NoError(t, err)
+
+	suite.Run(t, &OrchestrationHttpIngressTemplateTest{
+		chartPath: chartPath,
+		release:   "camunda-platform-test",
+		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
+		templates: []string{"templates/common/ingress-orchestration-http.yaml"},
+	})
+}
+
+func (s *OrchestrationHttpIngressTemplateTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestOrchestrationHttpIngressWithServerTLS",
+			Values: map[string]string{
+				"global.ingress.enabled":                     "true",
+				"global.host":                                "camunda.example.com",
+				"global.ingress.tls.enabled":                 "true",
+				"global.ingress.annotations.test-annotation": "test-value",
+				"orchestration.enabled":                      "true",
+				"orchestration.contextPath":                  "/orchestration",
+				"orchestration.env[0].name":                  "SERVER_SSL_ENABLED",
+			},
+			RenderTemplateExtraArgs: []string{
+				"--set-string", "orchestration.env[0].value=true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				var ingress netv1.Ingress
+				helm.UnmarshalK8SYaml(t, output, &ingress)
+
+				require.Equal(t, "camunda-platform-test-orchestration-http", ingress.Name)
+				require.Equal(t, "HTTPS", ingress.Annotations["nginx.ingress.kubernetes.io/backend-protocol"])
+				require.Equal(t, "test-value", ingress.Annotations["test-annotation"])
+				require.Equal(t, "camunda.example.com", ingress.Spec.Rules[0].Host)
+				require.Equal(t, "/orchestration", ingress.Spec.Rules[0].HTTP.Paths[0].Path)
+				require.Equal(t, "camunda-platform-test-zeebe-gateway", ingress.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Name)
+				require.Equal(t, int32(8080), ingress.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Port.Number)
+				require.Equal(t, "camunda.example.com", ingress.Spec.TLS[0].Hosts[0])
+			},
+		},
+		{
+			Name: "TestOrchestrationHttpIngressDisabledWithoutServerTLS",
+			CaseTemplates: &testhelpers.CaseTemplate{
+				Templates: nil,
+			},
+			Values: map[string]string{
+				"global.ingress.enabled":    "true",
+				"orchestration.enabled":     "true",
+				"orchestration.contextPath": "/orchestration",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				require.NotContains(t, output, "name: camunda-platform-test-orchestration-http")
+			},
+		},
 	}
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)

--- a/charts/camunda-platform-8.9/test/unit/common/testdata/values-orchestration-grpc-tls.yaml
+++ b/charts/camunda-platform-8.9/test/unit/common/testdata/values-orchestration-grpc-tls.yaml
@@ -1,0 +1,4 @@
+orchestration:
+  env:
+    - name: CAMUNDA_API_GRPC_SSL_ENABLED
+      value: "true"

--- a/charts/camunda-platform-8.9/test/unit/connectors/configmap_test.go
+++ b/charts/camunda-platform-8.9/test/unit/connectors/configmap_test.go
@@ -126,6 +126,20 @@ func (s *ConfigMapTemplateTest) TestDifferentValuesInputs() {
 				"configmapApplication.camunda.client.auth.client-id": "connectors",
 			},
 		},
+		{
+			Name:        "TestConnectorsShouldUseSecureGrpcAddressWhenOrchestrationGrpcTlsIsEnabled",
+			ValuesFiles: []string{filepath.Join(s.chartPath, "test/unit/connectors/testdata/values-orchestration-grpc-tls.yaml")},
+			Values: map[string]string{
+				"connectors.enabled":             "true",
+				"orchestration.contextPath":      "/orchestration",
+				"orchestration.service.grpcPort": "26600",
+				"orchestration.service.httpPort": "8090",
+			},
+			Expected: map[string]string{
+				"configmapApplication.camunda.client.grpc-address": "https://camunda-platform-test-zeebe-gateway:26600",
+				"configmapApplication.camunda.client.rest-address": "http://camunda-platform-test-zeebe-gateway:8090/orchestration",
+			},
+		},
 	}
 
 	testhelpers.RunTestCases(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)

--- a/charts/camunda-platform-8.9/test/unit/connectors/testdata/values-orchestration-grpc-tls.yaml
+++ b/charts/camunda-platform-8.9/test/unit/connectors/testdata/values-orchestration-grpc-tls.yaml
@@ -1,0 +1,4 @@
+orchestration:
+  env:
+    - name: CAMUNDA_API_GRPC_SSL_ENABLED
+      value: "true"

--- a/charts/camunda-platform-8.9/test/unit/testhelpers/testhelpers.go
+++ b/charts/camunda-platform-8.9/test/unit/testhelpers/testhelpers.go
@@ -160,8 +160,8 @@ func runTestCaseE(t *testing.T, chartPath, release, namespace string, templates 
 }
 
 // renderTemplate renders the specified Helm templates into a Kubernetes ConfigMap
-func renderTemplate(t *testing.T, chartPath, release string, namespace string, templates []string, values map[string]string) corev1.ConfigMap {
-	options := setupHelmOptions(namespace, values, nil, nil)
+func renderTemplate(t *testing.T, chartPath, release string, namespace string, templates []string, values map[string]string, valuesFiles []string) corev1.ConfigMap {
+	options := setupHelmOptions(namespace, values, valuesFiles, nil)
 
 	output := helm.RenderTemplate(t, options, chartPath, release, templates)
 	var configmap corev1.ConfigMap
@@ -173,7 +173,7 @@ func renderTemplate(t *testing.T, chartPath, release string, namespace string, t
 func RunTestCases(t *testing.T, chartPath, release, namespace string, templates []string, testCases []TestCase) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(tct *testing.T) {
-			configmap := renderTemplate(tct, chartPath, release, namespace, templates, tc.Values)
+			configmap := renderTemplate(tct, chartPath, release, namespace, templates, tc.Values, tc.ValuesFiles)
 			verifyConfigMap(tct, tc.Name, configmap, tc.Expected)
 		})
 	}

--- a/charts/camunda-platform-8.9/test/unit/web-modeler/configmap_restapi_test.go
+++ b/charts/camunda-platform-8.9/test/unit/web-modeler/configmap_restapi_test.go
@@ -531,6 +531,39 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldConfigureClusterFromSa
 	}
 }
 
+func (s *configmapRestAPITemplateTest) TestContainerShouldUseSecureGrpcUrlWhenOrchestrationGrpcTlsIsEnabled() {
+	values := map[string]string{
+		"identity.enabled":                              "true",
+		"webModelerPostgresql.enabled":                  "false",
+		"global.zeebeClusterName":                       "test-zeebe",
+		"global.ingress.enabled":                        "true",
+		"global.ingress.tls.enabled":                    "true",
+		"global.ingress.host":                           "example.com",
+		"orchestration.contextPath":                     "/orchestration",
+		"orchestration.data.secondaryStorage.type":      "elasticsearch",
+		"orchestration.service.grpcPort":                "26600",
+		"orchestration.service.httpPort":                "8090",
+		"orchestration.security.authorizations.enabled": "false",
+	}
+	maps.Insert(values, maps.All(requiredValues))
+	options := &helm.Options{
+		SetValues:      values,
+		ValuesFiles:    []string{filepath.Join(s.chartPath, "test/unit/web-modeler/testdata/values-orchestration-grpc-tls.yaml")},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var configmap corev1.ConfigMap
+	var configmapApplication WebModelerRestAPIApplicationYAML
+	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	require.NoError(s.T(), err)
+
+	s.Require().Equal("grpcs://camunda-platform-test-zeebe-gateway:26600", configmapApplication.Camunda.Modeler.Clusters[0].Url.Grpc)
+	s.Require().Equal("http://camunda-platform-test-zeebe-gateway:8090/orchestration", configmapApplication.Camunda.Modeler.Clusters[0].Url.Rest)
+}
+
 func (s *configmapRestAPITemplateTest) TestContainerShouldUseClustersFromCustomConfiguration() {
 	// given
 	values := map[string]string{

--- a/charts/camunda-platform-8.9/test/unit/web-modeler/testdata/values-orchestration-grpc-tls.yaml
+++ b/charts/camunda-platform-8.9/test/unit/web-modeler/testdata/values-orchestration-grpc-tls.yaml
@@ -1,0 +1,4 @@
+orchestration:
+  env:
+    - name: CAMUNDA_API_GRPC_SSL_ENABLED
+      value: "true"


### PR DESCRIPTION
## Summary

- Support Orchestration REST and gRPC TLS independently across 8.8, 8.9, and 8.10.
- Render chart-generated Web Modeler and Connectors gRPC defaults with secure schemes when `CAMUNDA_API_GRPC_SSL_ENABLED=true`, while keeping REST on HTTP unless `SERVER_SSL_ENABLED=true`.
- Route the public Orchestration gRPC ingress to the backend with `nginx.ingress.kubernetes.io/backend-protocol: GRPCS` when the in-chart Orchestration gRPC server has TLS enabled.
- Keep the existing REST-TLS ingress split so `/orchestration` can use HTTPS upstream when `SERVER_SSL_ENABLED=true` without changing the shared HTTP ingress backends.
- Update `orchestration-tls` (`estls`) scenario values to match the SUPPORT-33090 customer shape: REST over HTTP, gRPC over TLS.

## Why

- SUPPORT-33090 clarified that the customer enables gRPC TLS with `CAMUNDA_API_GRPC_SSL_ENABLED=true` while leaving REST plaintext with `SERVER_SSL_ENABLED=false`.
- The chart previously treated internal Orchestration gRPC defaults as plaintext, and the gRPC ingress used `GRPC` upstream even when the in-chart Orchestration gRPC server expected TLS.
- Web Modeler expects `grpcs://` for secure gRPC, while Connectors/Camunda client expects the secure gRPC endpoint as `https://`.

## Notes

- Explicit user overrides still win:
  - `webModeler.restapi.clusters`
  - `connectors.configuration`
- The 8.10 `opensearch-self-signed-os-trust` / `osot` matrix entry is kept from the rebased branch using its dedicated `opensearch-self-signed-os-trust` persistence and pre-install wrapper.

## Local Validation

- `go test ./common/... ./connectors/... ./web-modeler/...` in 8.8 unit test dir.
- `go test ./common/... ./connectors/... ./web-modeler/...` in 8.9 unit test dir.
- `go test ./common/... ./connectors/... ./web-modeler/...` in 8.10 unit test dir.
- `make go.test chartPath=charts/camunda-platform-8.8`
- `make go.test chartPath=charts/camunda-platform-8.9`
- `make go.test chartPath=charts/camunda-platform-8.10`
- `make helm.lint chartPath=charts/camunda-platform-8.8`
- `make helm.lint chartPath=charts/camunda-platform-8.9`
- `make helm.lint chartPath=charts/camunda-platform-8.10`
- `go test ./matrix/...` from `scripts/deploy-camunda`.
- `deploy-camunda matrix list --repo-root . --versions 8.10 --scenario-filter opensearch-self-signed-os-trust --shortname-filter osot --shortname-exact --flow-filter install --platform gke` returns one `osot` entry.

## GKE Validation

- Deployed updated 8.8 `estls` scenario to GKE namespace `matrix-88-estls-inst-gke`:
  - `deploy-camunda matrix run --repo-root . --versions 8.8 --shortname-filter estls --shortname-exact --platform gke --ingress-base-domain-gke ci.distro.ultrawombat.com --delete-namespace --timeout 30 --yes --ensure-docker-registry`
- `deploy-camunda watch --namespace matrix-88-estls-inst-gke --release integration --interval 15` confirmed the Helm release is deployed and all pods are Ready.
- Live gRPC ingress `integration-camunda-platform-grpc` has `nginx.ingress.kubernetes.io/backend-protocol: GRPCS`.
- Live combined HTTP ingress routes `/orchestration -> integration-zeebe-gateway:8080`.
- Live Connectors ConfigMap renders:
  - `rest-address: http://integration-zeebe-gateway:8080/orchestration`
  - `grpc-address: https://integration-zeebe-gateway:26500`
- Live Web Modeler REST API ConfigMap renders:
  - `grpc: grpcs://integration-zeebe-gateway:26500`
  - `rest: http://integration-zeebe-gateway:8080/orchestration`
  - `web-app: https://matrix-88-estls-inst-gke.ci.distro.ultrawombat.com/orchestration`
- `https://matrix-88-estls-inst-gke.ci.distro.ultrawombat.com/orchestration/identity` returns `HTTP/2 401` with `www-authenticate: Bearer`, not a TLS protocol mismatch page.
- `MINOR_VERSION=SM-8.8 npx playwright test --project=chromium tests/SM-8.8/smoke-tests.spec.ts --workers=1 --trace on` passed with 3 passed and 4 skipped.

## CI Validation

- Pushed commit `6a9545d66` to refresh PR CI after rebasing on the updated branch.
- `test-chart-version.yaml` workflow dispatch currently does not expose `orchestration-tls` as a selectable scenario, so no narrower manual GKE workflow run was triggered from the workflow UI inputs.
