### PR TITLE
ci: remove stale ExternalSecrets before upgrade to fix ESO race condition

### DIFF
--- a/.github/actions/cluster-setup-secrets/action.yaml
+++ b/.github/actions/cluster-setup-secrets/action.yaml
@@ -70,10 +70,21 @@ runs:
             ".github/config/external-secret/external-secret-certificates.yaml" \
             "$TEST_NAMESPACE"
 
+          # Remove any ExternalSecrets targeting integration-test-credentials that were
+          # applied by a previous chart version. Two Orphan ExternalSecrets targeting the
+          # same Secret cause ESO to overwrite each other's keys on reconcile, making the
+          # wait below time out in upgrade flows (e.g. 8.7 ES wipes 8.8 keys and vice-versa).
+          stale_es="$(kubectl get externalsecret -n "$TEST_NAMESPACE" -o json 2>/dev/null | \
+            jq -r '.items[] | select(.spec.target.name == "integration-test-credentials") | .metadata.name')"
+          if [[ -n "$stale_es" ]]; then
+            echo "🧹 Removing stale ExternalSecrets targeting integration-test-credentials: $(tr '\n' ' ' <<< "$stale_es")"
+            echo "$stale_es" | xargs kubectl delete externalsecret -n "$TEST_NAMESPACE" --ignore-not-found
+          fi
+
           # Apply external secret configuration for integration tests
           # Check for chart-specific external secret first (better approach)
           CHART_SPECIFIC_FILE="${CHART_PATH}/test/integration/external-secrets/external-secret-integration-test-credentials.yaml"
-          
+
           if [[ -f "$CHART_SPECIFIC_FILE" ]]; then
             echo "✅ Applying chart-specific external secret for integration tests: $CHART_SPECIFIC_FILE"
             apply_external_secret_with_retry "$CHART_SPECIFIC_FILE" "$TEST_NAMESPACE"
@@ -111,6 +122,14 @@ runs:
             "$TEST_NAMESPACE"
 
           # Apply integration test credentials (creates integration-test-credentials secret)
+          # Remove stale ExternalSecrets from previous chart versions first (same race fix as GKE).
+          stale_es="$(kubectl get externalsecret -n "$TEST_NAMESPACE" -o json 2>/dev/null | \
+            jq -r '.items[] | select(.spec.target.name == "integration-test-credentials") | .metadata.name')"
+          if [[ -n "$stale_es" ]]; then
+            echo "🧹 Removing stale ExternalSecrets targeting integration-test-credentials: $(tr '\n' ' ' <<< "$stale_es")"
+            echo "$stale_es" | xargs kubectl delete externalsecret -n "$TEST_NAMESPACE" --ignore-not-found
+          fi
+
           # Check for chart-specific vault external secret first
           CHART_SPECIFIC_VAULT_FILE="${CHART_PATH}/test/integration/external-secrets/external-secret-integration-test-credentials-vault.yaml"
 


### PR DESCRIPTION
## Summary

[Successful run with this branch](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/26768448557/job/78906285427) ✅ 

- In upgrade flows (e.g. 8.7→8.8), both the install and upgrade steps apply version-specific ExternalSecrets targeting the same `integration-test-credentials` Secret with `creationPolicy: Orphan`
- Two Orphan ExternalSecrets targeting the same Secret causes ESO's reconciler to overwrite each other's keys — whichever reconciles last wins, wiping the other's keys
- The `wait_for_secret_keys` check scans **all** ExternalSecrets in the namespace and expects **all** their keys to be present; when the 8.8 ES wipes the 8.7 keys (or vice-versa), the wait times out after 30 minutes
- Retrying the same run never recovers because ESO's `refreshInterval: 1h` prevents the overwritten ES from re-syncing within the retry window

**Fix**: before applying the current version's ExternalSecret, delete any pre-existing ExternalSecrets targeting `integration-test-credentials`. This ensures only one ES is active at a time, so `wait_for_secret_keys` only checks the current version's keys. The `integration-test-credentials` Secret itself is preserved (Orphan policy does not delete the Secret when the ExternalSecret is removed).

Applied to both the GKE/ROSA and EKS paths.

## Failing nightly run

https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/26755956934/job/78871096814

Observed: 30-minute timeout in "Cluster Setup - Upgrade - Configure TLS Certificates/Secrets" waiting for keys `operate-secret tasklist-secret optimize-secret connectors-secret console-secret zeebe-secret identity-*-client-password postgres-password` (all from the 8.7 ExternalSecret) — missing because the 8.8 ExternalSecret reconciled and replaced the Secret data.

## Test plan

- [ ] Trigger a fresh SM Nightly 8.8 Upgrade Minor run after this merges and confirm the upgrade step completes without timing out on `integration-test-credentials`