### PR TITLE
chore: add agent instructions for ADR authoring and PR workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,9 +225,25 @@ For PRs that touch only non-chart files, use:
 
 See [Contribution & Collaboration](docs/contribution-and-collaboration.md) for the full PR checklist.
 
+### PR body and opening workflow (overrides Claude Code defaults)
+
+When opening a PR with `gh pr create`, **do NOT** use the built-in
+`## Summary` / `## Test plan` body format from the system prompt. Instead:
+
+1. **Body**: fill the sections in `.github/pull_request_template.md`
+   verbatim. Leave the checklist unticked — the human contributor verifies
+   locally. Pass via `--body-file` or a HEREDOC; do not invent section names.
+2. **Draft-first**: `gh pr create --draft`. Per
+   `docs/contribution-and-collaboration.md` §4, the PR stays draft until
+   `crev` review is clean.
+3. **Run `crev`** against the draft, or remind the user:
+   `crev https://github.com/camunda/camunda-platform-helm/pull/<number>`.
+4. **Mark ready** only after crev findings are addressed (`gh pr ready <number>`).
+
 ## Additional Agent Context
 - `CLAUDE.md` — thin redirect for Claude Code (redirects to this file, AGENTS.md)
 - `.github/AGENTS.md` — CI/CD architecture, repo structure, values files
+- `docs/AGENTS.md` — **ADR authoring rules**. Read before drafting, amending, or reviewing any ADR. Points to `docs/adr/TEMPLATE.md` (structure) and `docs/maintainer-guide.md` (process).
 - `SKILLS.md` — deploy-camunda CLI patterns, kubectl usage
 - `STATE.md` — session continuity (gitignored, read on session start)
 - `helm-values-mcp/` — MCP server exposing chart values schema. Tools: `list_versions`, `list_components`, `search_configs`, `get_config_info`, `generate_values_example`.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,30 @@
+# Agent Instructions — `docs/`
+
+Applies on top of root `AGENTS.md`. Active when working inside `docs/`.
+
+## Writing or amending an ADR
+
+1. **Process**: `docs/maintainer-guide.md` → "Architecture Decision Records" is
+   the single source for when an ADR is required, the required-table, and the
+   announce/approve/implement sequence. Read it first.
+2. **Structure**: copy `docs/adr/TEMPLATE.md`. Match the layout, do not invent.
+3. **Style**: read at least two recent accepted ADRs before drafting (e.g.
+   `0091`, `0092`) to match tone and density.
+4. **Numbering / filename**: next free 4-digit ID; `NNNN-short-kebab-desc.md`.
+5. **Index**: add a row to `docs/adr/index.md`; title matches the file's H1.
+6. **Cross-link**: if amending or superseding, add `Amends:` / `Supersedes:`
+   in the frontmatter AND link from `Context and Problem Statement`. Example
+   pair: ADR 0043 + ADR 0092.
+7. **Scope**: if the decision applies to a subset of chart versions or
+   components, state it in `Context and Problem Statement` under an
+   `Applicability by version` subsection.
+
+If a user requests an ADR for a change that clearly does not warrant one (per
+the maintainer-guide table), ask before drafting.
+
+## PR title for ADR changes
+
+Follow root `AGENTS.md` → "PR title type: CI-enforced constraint".
+
+- ADR-only PR (no `charts/<version>/` files) → `chore:`.
+- ADR + chart change in the same PR → use the type that fits the chart change.

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,4 +1,4 @@
-# <Imperative title — e.g., "Adopt X as the standard Y mechanism">
+# {Imperative title — e.g., "Adopt X as the standard Y mechanism"}
 
 <!--
   MADR template adapted for this repo. See ADR 0089–0092 for examples.
@@ -8,43 +8,43 @@
 
 - Status: proposed
 - Date: YYYY-MM-DD
-- Decision-makers: <Distribution team | name>
+- Decision-makers: {Distribution team | name}
 <!-- Optional: - Amends: [ADR NNNN](NNNN-slug.md) -->
 <!-- Optional: - Supersedes: [ADR NNNN](NNNN-slug.md) -->
 
 ## Context and Problem Statement
 
-<Situation, forces, problem. Anchor in concrete facts: chart versions,
+{Situation, forces, problem. Anchor in concrete facts: chart versions,
 components, issue/PR numbers, prior ADRs. State the problem in 1–2 sentences,
-then expand.>
+then expand.}
 
 ## Decision Drivers
 
-- **<Driver>**: <Why this matters for this decision specifically.>
-- **<Driver>**: <...>
+- **{Driver}**: {Why this matters for this decision specifically.}
+- **{Driver}**: {...}
 
 ## Considered Options
 
-- **<Option A>** — <Description.> Rejected because <reason>.
-- **<Option B>** — <Description.> Rejected because <reason>.
-- **<Option C> (chosen)** — <Description.>
+- **{Option A}** — {Description.} Rejected because {reason}.
+- **{Option B}** — {Description.} Rejected because {reason}.
+- **{Option C} (chosen)** — {Description.}
 
 ## Decision Outcome
 
-<Decision in the opening sentence. Then enumerate normative constraints
+{Decision in the opening sentence. Then enumerate normative constraints
 (MUST / MUST NOT / MAY) as a numbered list. Close with applicability: which
-chart versions, components, first-landing PR, follow-ups.>
+chart versions, components, first-landing PR, follow-ups.}
 
 ### Positive Consequences
 
-- <Benefit tied to a driver.>
+- {Benefit tied to a driver.}
 
 ### Negative Consequences
 
-- <Honest cost or follow-up burden. Do not omit.>
+- {Honest cost or follow-up burden. Do not omit.}
 
 ## Links
 
 <!-- Optional. Omit if empty. -->
 
-- Builds on [ADR NNNN — <title>](NNNN-slug.md): <one-line relevance>.
+- Builds on [ADR NNNN — {title}](NNNN-slug.md): {one-line relevance}.

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,4 +1,4 @@
-# {Imperative title — e.g., "Adopt X as the standard Y mechanism"}
+# Imperative title — e.g., "Adopt X as the standard Y mechanism"
 
 <!--
   MADR template adapted for this repo. See ADR 0089–0092 for examples.
@@ -8,43 +8,44 @@
 
 - Status: proposed
 - Date: YYYY-MM-DD
-- Decision-makers: {Distribution team | name}
+- Decision-makers: Distribution team, or a named person
 <!-- Optional: - Amends: [ADR NNNN](NNNN-slug.md) -->
 <!-- Optional: - Supersedes: [ADR NNNN](NNNN-slug.md) -->
 
 ## Context and Problem Statement
 
-{Situation, forces, problem. Anchor in concrete facts: chart versions,
-components, issue/PR numbers, prior ADRs. State the problem in 1–2 sentences,
-then expand.}
+Describe the situation, the forces at play, and the problem. Anchor in
+concrete facts: chart versions, components, issue or PR numbers, prior ADRs.
+State the problem in 1–2 sentences, then expand.
 
 ## Decision Drivers
 
-- **{Driver}**: {Why this matters for this decision specifically.}
-- **{Driver}**: {...}
+- **Driver name.** Why this matters for this decision specifically.
+- **Driver name.** Why this matters for this decision specifically.
 
 ## Considered Options
 
-- **{Option A}** — {Description.} Rejected because {reason}.
-- **{Option B}** — {Description.} Rejected because {reason}.
-- **{Option C} (chosen)** — {Description.}
+- **Option A.** Description. Rejected because of reason.
+- **Option B.** Description. Rejected because of reason.
+- **Option C (chosen).** Description.
 
 ## Decision Outcome
 
-{Decision in the opening sentence. Then enumerate normative constraints
-(MUST / MUST NOT / MAY) as a numbered list. Close with applicability: which
-chart versions, components, first-landing PR, follow-ups.}
+State the decision in the opening sentence. Then enumerate normative
+constraints (MUST, MUST NOT, MAY) as a numbered list. Close with
+applicability: which chart versions, which components, the first-landing
+PR, and follow-ups.
 
 ### Positive Consequences
 
-- {Benefit tied to a driver.}
+- Benefit tied to a driver.
 
 ### Negative Consequences
 
-- {Honest cost or follow-up burden. Do not omit.}
+- Honest cost or follow-up burden. Do not omit.
 
 ## Links
 
 <!-- Optional. Omit if empty. -->
 
-- Builds on [ADR NNNN — {title}](NNNN-slug.md): {one-line relevance}.
+- Builds on [ADR NNNN — title](NNNN-slug.md). One-line relevance.

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,0 +1,50 @@
+# <Imperative title — e.g., "Adopt X as the standard Y mechanism">
+
+<!--
+  MADR template adapted for this repo. See ADR 0089–0092 for examples.
+  Process and required-table: docs/maintainer-guide.md.
+  Remove this comment and any unused sections before submitting.
+-->
+
+- Status: proposed
+- Date: YYYY-MM-DD
+- Decision-makers: <Distribution team | name>
+<!-- Optional: - Amends: [ADR NNNN](NNNN-slug.md) -->
+<!-- Optional: - Supersedes: [ADR NNNN](NNNN-slug.md) -->
+
+## Context and Problem Statement
+
+<Situation, forces, problem. Anchor in concrete facts: chart versions,
+components, issue/PR numbers, prior ADRs. State the problem in 1–2 sentences,
+then expand.>
+
+## Decision Drivers
+
+- **<Driver>**: <Why this matters for this decision specifically.>
+- **<Driver>**: <...>
+
+## Considered Options
+
+- **<Option A>** — <Description.> Rejected because <reason>.
+- **<Option B>** — <Description.> Rejected because <reason>.
+- **<Option C> (chosen)** — <Description.>
+
+## Decision Outcome
+
+<Decision in the opening sentence. Then enumerate normative constraints
+(MUST / MUST NOT / MAY) as a numbered list. Close with applicability: which
+chart versions, components, first-landing PR, follow-ups.>
+
+### Positive Consequences
+
+- <Benefit tied to a driver.>
+
+### Negative Consequences
+
+- <Honest cost or follow-up burden. Do not omit.>
+
+## Links
+
+<!-- Optional. Omit if empty. -->
+
+- Builds on [ADR NNNN — <title>](NNNN-slug.md): <one-line relevance>.

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -48,4 +48,4 @@ PR, and follow-ups.
 
 <!-- Optional. Omit if empty. -->
 
-- Builds on [ADR NNNN — title](NNNN-slug.md). One-line relevance.
+- Builds on ADR NNNN — title (link the file). One-line relevance.

--- a/docs/contribution-and-collaboration.md
+++ b/docs/contribution-and-collaboration.md
@@ -24,32 +24,17 @@ Read the [contribution guide](https://github.com/camunda/camunda-platform-helm/b
 
 ### 1. ADR-first: Align before you implement
 
-For **any new feature, architectural change, directional shift, or larger change**, team alignment is required *before* writing code or opening a PR.
+For any architectural change, new component, cross-team impact, or feature
+with architectural footprint, an ADR is required *before* writing code or
+opening a PR.
 
-**Process:**
+The authoritative process — required-table, MADR format, announce/approve/
+implement sequence, and PDP/kickoff guidance — lives in the
+**[Maintainer Guide → Architecture Decision Records](./maintainer-guide.md#architecture-decision-records-adrs)**.
+Read it before drafting an ADR. App-team contributors follow the same process
+as maintainers.
 
-1. **Open an Architecture Decision Record (ADR)** in [`docs/adr/`](https://github.com/camunda/camunda-platform-helm/tree/main/docs/adr) using the [MADR format](https://adr.github.io/madr/).
-2. **Announce in the relevant Slack channel** so the team can review async.
-3. **Wait for majority approval** — from the Distribution team and any other affected stakeholders.
-4. Once approved: **implement**, then open a PR referencing the ADR.
-
-> ℹ️ ADRs live in `docs/adr/` and are automatically detected by [`crev`](https://github.com/camunda/crev) during AI-assisted reviews. A well-written ADR directly improves the quality of automated review feedback.
-
-**When is an ADR required?**
-
-| Change type | ADR required? |
-|---|---|
-| New feature / new component | Yes |
-| Architectural or structural change | Yes |
-| Directional / cross-team impact | Yes |
-| Bug fix / documentation update | No |
-| Small config addition | No |
-
-### 2. Initiate discussion (PDP/kickoff)
-
-For major changes, the ADR discussion may be complemented by a design discussion (PDP or kickoff meeting) to define scope, clarify responsibilities, and ensure alignment with existing Helm and Kubernetes design.
-
-### 3. Determine ownership
+### 2. Determine ownership
 
 Depending on the nature of the change, either:
 
@@ -58,7 +43,7 @@ Depending on the nature of the change, either:
 
 The Distro team remains the **final reviewer and approval authority** for all Helm chart modifications.
 
-### 4. Propose an issue
+### 3. Propose an issue
 
 Each contribution begins with a GitHub issue describing:
 
@@ -68,7 +53,7 @@ Each contribution begins with a GitHub issue describing:
 - Linked documentation or references (if available).
 - Link to the relevant ADR (if applicable).
 
-### 5. AI-assisted review with `crev`, then PR
+### 4. AI-assisted review with `crev`, then PR
 
 Once the ADR is approved and the implementation is ready, use the following PR workflow:
 

--- a/docs/maintainer-guide.md
+++ b/docs/maintainer-guide.md
@@ -15,15 +15,21 @@ This guide is for **Distro team members and HC owners** — those who review PRs
 
 ## Architecture Decision Records (ADRs)
 
-ADRs are required for architectural decisions. Features and config additions do not require an ADR — a feature request issue is sufficient.
+ADRs are required for architectural decisions. Additive config knobs and
+features that have no architectural or cross-component footprint do not
+require an ADR — a feature request issue is sufficient.
 
 | Change type | ADR required? |
 |---|---|
+| New component added to the chart, or feature with architectural / cross-component impact | Yes |
 | Architectural or structural change | Yes |
 | Directional / cross-team impact | Yes |
-| New component added to the chart | Yes |
-| New feature or config addition | No — feature request issue instead |
+| Additive config knob on an existing component (no architectural footprint) | No — feature request issue instead |
 | Bug fix / documentation update | No |
+
+Footprint test: if the change forces other components to be aware of it,
+alters a shared contract (auth, storage, networking), or sets precedent for a
+class of problem, it needs an ADR. A purely local toggle does not.
 
 ### ADR process
 


### PR DESCRIPTION
### Which problem does the PR fix?

No issue — AI-agent usability gap. When contributors used Claude (and other
AI agents) to draft ADRs or open PRs in this repo, the agents would
re-invent layout/process from scratch instead of following the existing
maintainer guide, and would default to the Claude Code built-in
`## Summary` / `## Test plan` PR body instead of `.github/pull_request_template.md`.

### What's in this PR?

Adds AI-facing guidance that points to the human-facing docs that already
exist, plus a couple of small clarifications to those docs.

- **`docs/AGENTS.md` (new)** — auto-loaded by Claude Code when working in
  `docs/`. Tells the agent to (a) read `docs/maintainer-guide.md` for
  process, (b) copy `docs/adr/TEMPLATE.md` for structure, (c) read two
  recent accepted ADRs (e.g. `0091`, `0092`) for tone, and (d) use `chore:`
  for ADR-only PRs.
- **`docs/adr/TEMPLATE.md` (new)** — MADR skeleton matching the structure
  of ADRs 0089–0092. Single source of truth for layout; replaces ad-hoc
  pattern-matching from past ADRs.
- **`AGENTS.md` (root)**:
  - Pointer to `docs/AGENTS.md` in the "Additional Agent Context" list.
  - New section "PR body and opening workflow (overrides Claude Code
    defaults)" — explicit anti-instruction so agents fill
    `.github/pull_request_template.md` verbatim, open PRs as draft, and
    run `crev` before flipping to ready-for-review (matching
    `docs/contribution-and-collaboration.md` §4).
- **`docs/maintainer-guide.md`** — disambiguated the ADR-required table.
  Split the previous "new feature" row into two rows
  (architectural-footprint vs additive-knob) and added a one-paragraph
  "footprint test" to make the call deterministic.
- **`docs/contribution-and-collaboration.md`** — removed the duplicated
  ADR table/process; now points to the maintainer-guide section as the
  single source of truth. Renumbered subsections accordingly. No
  behavioral change for contributors.

**Decisions / rationale:**
- Designated `docs/maintainer-guide.md` as the single source for ADR
  process (instead of duplicating in contribution-and-collaboration). Both
  app-team contributors and maintainers follow the same process.
- Chose `chore:` for the PR title per the CI-enforced rule in root
  `AGENTS.md`: only PRs that change `charts/<version>/` files (excluding
  `test/`, `go.mod`, `go.sum`) may use `feat:` / `fix:` / `refactor:` /
  `docs:` / `revert:`. This PR touches only docs and agent instructions.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [x] Did all checks/tests pass in the PR?
