### PR TITLE
chore: drop renovate rules for EOL chart versions 8.6 and below

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -171,89 +171,6 @@
       ],
     },
     // Elasticsearch version constraints per chart version
-    {
-      description: 'Camunda 8.3: Limit Elasticsearch to 8.13.x',
-      matchDatasources: [
-        'docker',
-      ],
-      matchFileNames: [
-        'charts/camunda-platform-8.3/values.yaml',
-        'charts/camunda-platform-8.3/values-latest.yaml',
-      ],
-      matchPackageNames: [
-        '/.*elasticsearch.*/',
-      ],
-      allowedVersions: '~8.8.0',
-    },
-    {
-      matchDatasources: [
-        'helm',
-      ],
-      matchFileNames: [
-        'charts/camunda-platform-8.3/Chart.yaml',
-      ],
-      matchPackageNames: [
-        '/.*elasticsearch.*/',
-      ],
-      allowedVersions: '19.13.15',
-    },
-    // Limit Elasticsearch version to latest supported version in Camunda 8.4 chart.
-    // https://docs.camunda.io/docs/8.4/reference/supported-environments/#camunda-8-self-managed
-    {
-      matchDatasources: [
-        'docker',
-      ],
-      matchFileNames: [
-        'charts/camunda-platform-8.4/values.yaml',
-        'charts/camunda-platform-8.4/values-latest.yaml',
-      ],
-      matchPackageNames: [
-        '/.*elasticsearch.*/',
-      ],
-      allowedVersions: '~8.9.0',
-    },
-    {
-      matchDatasources: [
-        'helm',
-      ],
-      matchFileNames: [
-        'charts/camunda-platform-8.4/Chart.yaml',
-      ],
-      matchPackageNames: [
-        '/.*elasticsearch.*/',
-      ],
-      allowedVersions: '19.19.4',
-    },
-    // Limit Elasticsearch version to latest supported version in Camunda 8.5 chart.
-    // https://docs.camunda.io/docs/8.5/reference/supported-environments/#camunda-8-self-managed
-    {
-      matchDatasources: [
-        'docker',
-      ],
-      matchFileNames: [
-        'charts/camunda-platform-8.5/values.yaml',
-        'charts/camunda-platform-8.5/values-latest.yaml',
-      ],
-      matchPackageNames: [
-        '/.*elasticsearch.*/',
-      ],
-      allowedVersions: '~8.12.0',
-    },
-    // Limit Elasticsearch version to latest supported version in Camunda 8.6 chart.
-    // https://docs.camunda.io/docs/8.6/reference/supported-environments/#camunda-8-self-managed
-    {
-      matchDatasources: [
-        'docker',
-      ],
-      matchFileNames: [
-        'charts/camunda-platform-8.6/values.yaml',
-        'charts/camunda-platform-8.6/values-latest.yaml',
-      ],
-      matchPackageNames: [
-        '/.*elasticsearch.*/',
-      ],
-      allowedVersions: '~8.15.0',
-    },
     // Limit Elasticsearch version to latest supported version in Camunda 8.7 chart.
     // https://docs.camunda.io/docs/reference/supported-environments/#camunda-8-self-managed
     {
@@ -298,22 +215,6 @@
         'regex',
       ],
       matchFileNames: [
-        'charts/camunda-platform-8.3/Chart.yaml',
-        'charts/camunda-platform-8.3/values.yaml',
-        'charts/camunda-platform-8.3/values-latest.yaml',
-        'charts/camunda-platform-8.3/values-enterprise.yaml',
-        'charts/camunda-platform-8.4/Chart.yaml',
-        'charts/camunda-platform-8.4/values.yaml',
-        'charts/camunda-platform-8.4/values-latest.yaml',
-        'charts/camunda-platform-8.4/values-enterprise.yaml',
-        'charts/camunda-platform-8.5/Chart.yaml',
-        'charts/camunda-platform-8.5/values.yaml',
-        'charts/camunda-platform-8.5/values-latest.yaml',
-        'charts/camunda-platform-8.5/values-enterprise.yaml',
-        'charts/camunda-platform-8.6/Chart.yaml',
-        'charts/camunda-platform-8.6/values.yaml',
-        'charts/camunda-platform-8.6/values-latest.yaml',
-        'charts/camunda-platform-8.6/values-enterprise.yaml',
         'charts/camunda-platform-8.7/Chart.yaml',
         'charts/camunda-platform-8.7/values.yaml',
         'charts/camunda-platform-8.7/values-latest.yaml',
@@ -411,11 +312,21 @@
       automergeType: 'pr', // Merge via PR to respect GitHub settings
       ignoreTests: false, // Wait for all status checks to pass
     },
-    // This package name is used by the initContainer for keycloak in v8.5, and doesn't make sense to
+    // This package name is used by the initContainer for keycloak and doesn't make sense to
     // be processed by renovate because it requires helm templating to render the real image name.
     {
       "matchDepNames": ["{{ .Values.global.identity.image.registry }}/{{ .Values.global.identity.image.repository }}{{ if .Values.global.identity.image.digest }}"],
       "enabled": false
+    },
+    {
+      description: 'Disable all updates for out-of-support chart versions (8.6 and below).',
+      enabled: false,
+      matchFileNames: [
+        'charts/camunda-platform-8.3/**',
+        'charts/camunda-platform-8.4/**',
+        'charts/camunda-platform-8.5/**',
+        'charts/camunda-platform-8.6/**',
+      ],
     },
   ],
   customManagers: [


### PR DESCRIPTION
## Summary

- Remove ES version constraint rules for 8.3, 8.4, 8.5, 8.6
- Remove 8.3–8.6 entries from `camunda-platform-images` image group
- Add blanket `enabled: false` rule matching `charts/camunda-platform-8.{3,4,5,6}/**` to suppress PRs from broad manager `fileMatch` patterns

## Why

8.6 and below are out of support. Renovate should not create any update PRs for those chart directories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)