### PR TITLE
chore: add ADR 0093 for composable CI scenario registry

### DIFF
--- a/docs/adr/0093-adopt-composable-ci-scenario-registry-for-per-version-test-matrix.md
+++ b/docs/adr/0093-adopt-composable-ci-scenario-registry-for-per-version-test-matrix.md
@@ -1,0 +1,233 @@
+# Adopt a composable CI scenario registry for the per-version integration test matrix
+
+- Status: accepted
+- Date: 2026-06-01
+- Decision-makers: Distribution team
+
+## Context and Problem Statement
+
+The Camunda Helm chart's CI integration test matrix is defined by one
+`ci-test-config.yaml` per chart version at
+`charts/camunda-platform-{8.7,8.8,8.9,8.10}/test/ci-test-config.yaml`.
+Each file is an ordered list under `integration.case.pr` and
+`integration.case.nightly`. Each list item is an inline `CIScenario`
+blob mixing identity, persistence, platform/infra routing, flow
+selection, lifecycle hooks, companion-chart dependencies, skip policy,
+shortname, prefix key, and Helm version override. The 8.10 file is
+~1200 lines, ~30 lines per scenario.
+
+The 100-commit sample in
+[#6264](https://github.com/camunda/camunda-platform-helm/issues/6264)
+shows 11–16 edits per per-version file. Structurally independent
+changes (new scenarios, hook tweaks, infra routing, skip policy)
+collide as merge conflicts in the same ordered list — structural
+conflicts, not stale-branch artifacts.
+
+Three duplication pressures compound it:
+
+- **Inlined hooks** — identical `pre-install` fixtures and descriptions
+  copied across every CloudNativePG-using scenario.
+- **Inlined companion dependencies** — same `internal-keycloak-26` and
+  `elastic/elasticsearch 8.5.1` repo+values blocks copied across every
+  consumer; a single bump touches many scenarios × four files.
+- **`pr` vs `nightly`** — scheduling a scenario in both tiers requires
+  copying the full blob and toggling `enabled`.
+
+Precedent: `.github/config/permitted-flows.yaml` is loaded separately
+by `matrix/config.go` (`LoadPermittedFlows`, `FilterFlows`) and applied
+as a cross-cutting filter. This ADR generalizes that pattern.
+
+### Applicability by version
+
+Applies to all currently supported chart versions — **8.7, 8.8, 8.9,
+8.10**. Versions 8.3–8.6 remain on the legacy file until removed; they
+are not migrated.
+
+## Decision Drivers
+
+- **Conflict surface area.** Independent scenario or policy changes
+  must touch independent files. Primary motivation from #6264.
+- **Reviewability.** A scenario diff must show all relevant policy
+  without scrolling a 1200-line file; a hook or dependency change must
+  show its full blast radius via ID references.
+- **Migration safety.** `deploy-camunda matrix list/run` MUST
+  produce equivalent CI matrices during transition, enforced by the
+  equivalence test (item 5).
+- **Single source of truth.** While both layouts exist, exactly one is
+  hand-edited; the other is generated and CI-guarded against drift.
+- **Internal scope.** Registry is a CI-internal mechanism. MUST NOT
+  alter user-facing chart values, templates, golden files, or
+  `values.schema.json`. MUST NOT change the `CITestConfig` struct
+  consumed by `deploy-camunda matrix run`.
+
+## Considered Options
+
+- **Keep the monolithic file; rely on smaller PRs and rebase
+  discipline.** Rejected — conflict pattern is structural; process
+  cannot remove file-level adjacency.
+- **Sort each version's scenario list alphabetically by `name`.**
+  Rejected — reduces but does not eliminate adjacency; leaves hooks
+  and dependencies duplicated; breaks reviewer ordering.
+- **Split only `dependencies` into a shared file.** Rejected — removes
+  one duplication but leaves hooks, infra, identity, persistence, and
+  platforms coupled in the same ordered list.
+- **Composable registry; each concept its own file, referenced by ID
+  from a thin per-version manifest (chosen).** Independent concepts →
+  independent files. Composition becomes data, validated cross-file
+  at load time. Generalizes the `permitted-flows.yaml` precedent.
+
+## Decision Outcome
+
+A composable CI scenario registry rooted at `test/ci/registry/`
+becomes the source of truth for the integration test matrix. The
+legacy per-version `charts/<version>/test/ci-test-config.yaml` files
+remain as **generated compatibility artifacts** during migration and
+are removed once all four supported versions have migrated and held
+green for one full nightly cycle on `main`. The following constraints
+are normative:
+
+1. **Layout.** Single repo-global path with one subdirectory per
+   concern; files keyed by stable ID matching the filename stem:
+
+   ```text
+   test/ci/registry/
+     versions/<X.Y>.yaml       # per-version manifest: scenario refs grouped by schedule (pr | nightly), each with enabled, numeric tier, and optional field overrides
+     scenarios/<id>.yaml       # composition: refs to identity, persistence, flow, platforms, infra, e2e, hooks, deps, features; plus scenario scalars (shortname, prefix-key, helm-version-override)
+     identities/<id>.yaml      # keycloak | oidc | auth0 | basic | hybrid; references companion charts by `dependencies/<id>` ID, never inlines them
+     persistence/<id>.yaml     # elasticsearch | opensearch-embedded | opensearch-self-signed | rdbms | rdbms-self-signed
+     flows/<id>.yaml           # install | upgrade-patch | upgrade-minor | modular-upgrade-minor (owns pre-upgrade hook)
+     platforms/<id>.yaml       # gke | eks | openshift
+     infra/<id>.yaml           # distroci | preemptible | alwaysgreen — selects values-infra-<id>.yaml
+     hooks/<id>.yaml           # named pre-install / post-deploy LifecycleHook blocks
+     dependencies/<id>.yaml    # named ChartDependency entries (chart, version, repo, values-file)
+     features/<id>.yaml        # named feature toggles mapping to values/features/<id>.yaml (e.g. postgresql-companion, hub-pinned-images, migrator)
+     e2e/<id>.yaml             # smoke | full | skip-keycloak-dependent
+   ```
+
+   Registry lives at repo root, not under `charts/<version>/`, because
+   its purpose is cross-version sharing. ADR 0063 internalized test
+   artifacts within this repository; it did not constrain them to the
+   chart subtree.
+
+   A version manifest references scenario IDs only, grouped under
+   `pr:` and `nightly:` schedule lists. A scenario references
+   identity, persistence, flow, platforms, infra, e2e, hooks,
+   dependencies, and features by ID and owns its own scalars
+   (shortname, prefix key, Helm version override). Numeric `tier`
+   and `enabled` live on the version-manifest reference, not the
+   shared scenario file. Identities reference companion charts via
+   `dependencies/<id>` IDs; inline companion blocks in identity or
+   version files MUST NOT be permitted.
+
+   Version-scoped paths (values-layer files under `chart-full-setup/values/`,
+   hook manifests under `common/resources/`, hook scripts under
+   `pre-setup-scripts/`) are named by basename in registry files and
+   resolved by the loader against the version's
+   `charts/<X.Y>/test/integration/scenarios/` tree.
+
+2. **Loader.** `scripts/deploy-camunda/matrix/config.go` gains
+   `LoadRegistry(repoRoot, version string) (*CITestConfig, error)`,
+   which resolves a version manifest's ID references against the
+   registry and returns the existing `CITestConfig` struct. Legacy
+   `LoadCITestConfig(chartDir)` is retained until all four supported
+   versions have migrated, then removed.
+
+3. **Validation.** A new `RegistryValidator` enforces at load time:
+   - Every referenced ID resolves to a file on disk.
+   - IDs and shortnames are unique within scope.
+   - Per-version × platform × flow tuples do not duplicate.
+   - Version-scoped paths (hooks, dependency values-files, scenario
+     values-layer files, `features/<id>` → `values/features/<id>.yaml`)
+     resolve under the target version's tree.
+   - Version × platform × flow combinations are not denied by
+     `.github/config/permitted-flows.yaml`.
+
+   Existing `LifecycleHook.Validate` plain-filename rule is reused.
+
+4. **Per-version overrides.** Per-version scenario drift (e.g. 8.7
+   lacks `modular-upgrade-minor`; per-version values-file paths
+   differ) is expressed as field-level overrides on the scenario
+   reference in `versions/<X.Y>.yaml`. Listed fields override the
+   shared `scenarios/<id>.yaml`; absent fields inherit. Forking the
+   shared scenario file per version MUST NOT be permitted.
+
+   ```yaml
+   # versions/8.7.yaml
+   pr:
+     - id: orchestration-upgrade
+       tier: 1
+       enabled: true
+       flows: [upgrade-patch, upgrade-minor]   # drops modular-upgrade-minor for 8.7
+   nightly: []
+   ```
+
+5. **Equivalence test.** A Go test in
+   `scripts/deploy-camunda/matrix/` MUST, per active chart version,
+   load both the legacy `ci-test-config.yaml` and the registry and
+   assert the two `*CITestConfig` values are equal via `cmp.Diff`,
+   with explicit slice-order normalization for order-independent
+   fields (e.g. `platforms`, `flows`). Gates the per-version rollout
+   and remains until that version's legacy file is removed.
+
+6. **Migration order and source switch.** 8.10 migrates first
+   (highest churn); 8.9, 8.8, 8.7 follow after 8.10's equivalence
+   test holds green on `main` for one full nightly run. Each
+   migration is a single PR: registry files added, legacy
+   `ci-test-config.yaml` regenerated and committed for review-diff
+   visibility, equivalence test enabled. The loader picks the
+   registry when `test/ci/registry/versions/<X.Y>.yaml` exists and
+   falls back to `LoadCITestConfig` otherwise. No runtime flag.
+
+7. **Generated-file guard.** A new `make ci.registry-check`, invoked
+   from `make helm.lint-all`, regenerates each migrated version's
+   `ci-test-config.yaml` and fails if the working tree differs. The
+   generated file carries a header marker
+   (`# GENERATED FROM test/ci/registry — DO NOT EDIT`); the guard
+   uses it to detect direct edits and point at the corresponding
+   registry file. Unmigrated versions lack the marker and are skipped.
+
+First-landing PR: 8.10 registry migration. Follow-ups: 8.9, 8.8, 8.7
+migrations; removal of `LoadCITestConfig` and the legacy files;
+refactor of `scripts/deploy-camunda/matrix/runner.go` into
+concern-scoped packages; migration of scenario-specific behavior
+currently in `.github/workflows/test-integration-runner.yaml` into
+registry data.
+
+### Positive Consequences
+
+- Adding a scenario creates one `scenarios/<id>.yaml` and one
+  version-manifest line. Two unrelated scenario PRs collide only if
+  they touch the same scenario or the same shared policy file.
+- Editing a hook, dependency, identity, persistence, or infra mapping
+  touches one file; blast radius is visible via ID references.
+- Scenario review shows a composed document instead of a 30-line
+  inline blob in a 1200-line file.
+- `deploy-camunda matrix list/run` behavior is preserved; GHA
+  workflows and external callers continue to work unchanged.
+- The `permitted-flows.yaml` extraction precedent is generalized
+  rather than duplicated.
+
+### Negative Consequences
+
+- During migration each migrated version has two sources of truth
+  (registry + generated legacy file). The guard mitigates drift but
+  contributors editing the legacy file see CI failures until they
+  re-apply against the registry.
+- Reading a scenario's effective configuration means reading its
+  scenario file plus referenced identity, persistence, flow, hooks,
+  and dependency files. Multi-file composition replaces long inline
+  blobs as the cognitive cost.
+- New loader, validator, and equivalence test add maintenance surface
+  in `scripts/deploy-camunda/matrix/`.
+- Per-version field-level overrides (item 4) make drift between a
+  shared default and a version override invisible without rendering
+  the resolved scenario. The equivalence test catches it only during
+  the migration window; post-migration, confirm an override's effect
+  via `deploy-camunda matrix list`.
+
+## Links
+
+- Issue [#6264 — Reduce CI scenario merge conflicts with a composable scenario registry](https://github.com/camunda/camunda-platform-helm/issues/6264) — source problem statement and 100-commit evidence.
+- [ADR 0071](0071-implement-matrix-driven-ci-framework-for-testing-supported.md) — established the matrix-driven CI framework this registry restructures.
+- [ADR 0075](0075-rewrite-ci-shell-scripts-as-structured-go-clis-with-shared.md) — established the Go-CLI pattern (`deploy-camunda`) the registry loader extends.
+- [ADR 0063](0063-internalize-integration-test-values-within-the-helm-chart.md) — established the precedent for keeping CI test artifacts inside the chart repo; this ADR extends that direction to the matrix definition itself.

--- a/docs/adr/0093-adopt-composable-ci-scenario-registry-for-per-version-test-matrix.md
+++ b/docs/adr/0093-adopt-composable-ci-scenario-registry-for-per-version-test-matrix.md
@@ -76,7 +76,7 @@ are not migrated.
 
 A composable CI scenario registry rooted at `test/ci/registry/`
 becomes the source of truth for the integration test matrix. The
-legacy per-version `charts/<version>/test/ci-test-config.yaml` files
+legacy per-version `charts/camunda-platform-<X.Y>/test/ci-test-config.yaml` files
 remain as **generated compatibility artifacts** during migration and
 are removed once all four supported versions have migrated and held
 green for one full nightly cycle on `main`. The following constraints

--- a/docs/adr/0093-adopt-composable-ci-scenario-registry-for-per-version-test-matrix.md
+++ b/docs/adr/0093-adopt-composable-ci-scenario-registry-for-per-version-test-matrix.md
@@ -117,7 +117,7 @@ are normative:
    hook manifests under `common/resources/`, hook scripts under
    `pre-setup-scripts/`) are named by basename and resolved by the
    loader against the version's
-   `charts/<X.Y>/test/integration/scenarios/` tree.
+   `charts/camunda-platform-<X.Y>/test/integration/scenarios/` tree.
 
 2. **Loader.** `scripts/deploy-camunda/matrix/config.go` gains
    `LoadRegistry(repoRoot, version string) (*CITestConfig, error)`,

--- a/docs/adr/0093-adopt-composable-ci-scenario-registry-for-per-version-test-matrix.md
+++ b/docs/adr/0093-adopt-composable-ci-scenario-registry-for-per-version-test-matrix.md
@@ -33,10 +33,6 @@ Three duplication pressures compound it:
 - **`pr` vs `nightly`** — scheduling a scenario in both tiers requires
   copying the full blob and toggling `enabled`.
 
-Precedent: `.github/config/permitted-flows.yaml` is loaded separately
-by `matrix/config.go` (`LoadPermittedFlows`, `FilterFlows`) and applied
-as a cross-cutting filter. This ADR generalizes that pattern.
-
 ### Applicability by version
 
 Applies to all currently supported chart versions — **8.7, 8.8, 8.9,
@@ -109,24 +105,18 @@ are normative:
    artifacts within this repository; it did not constrain them to the
    chart subtree.
 
-   A version manifest references scenario IDs only, grouped under
-   `pr:` and `nightly:` schedule lists. A scenario references
-   identity, persistence, platforms, infra, e2e, hooks, dependencies,
-   and features by ID, and carries a plural `flows: [<flow-id>, …]`
-   list (one composition × multiple flows). The loader fans out one
-   registry scenario × N flows into N `CIScenario` entries with the
-   same composition and distinct singular `Flow` field, preserving
-   the existing `CITestConfig` struct unchanged. A scenario also owns
-   its own scalars (shortname, prefix key, Helm version override).
-   Numeric `tier` and `enabled` live on the version-manifest
-   reference, not the shared scenario file. Identities reference
-   companion charts via `dependencies/<id>` IDs; inline companion
-   blocks in identity or version files MUST NOT be permitted.
+   Scenario files carry a plural `flows: [<flow-id>, …]`. The loader
+   fans out one registry scenario × N flows into N `CIScenario`
+   entries with distinct singular `Flow`, preserving the existing
+   `CITestConfig` struct unchanged. Numeric `tier` and `enabled` live
+   on the version-manifest reference, not the shared scenario file.
+   Inline companion-chart blocks in identity or version files MUST
+   NOT be permitted; identities reference `dependencies/<id>` by ID.
 
    Version-scoped paths (values-layer files under `chart-full-setup/values/`,
    hook manifests under `common/resources/`, hook scripts under
-   `pre-setup-scripts/`) are named by basename in registry files and
-   resolved by the loader against the version's
+   `pre-setup-scripts/`) are named by basename and resolved by the
+   loader against the version's
    `charts/<X.Y>/test/integration/scenarios/` tree.
 
 2. **Loader.** `scripts/deploy-camunda/matrix/config.go` gains
@@ -192,12 +182,11 @@ are normative:
    uses it to detect direct edits and point at the corresponding
    registry file. Unmigrated versions lack the marker and are skipped.
 
-First-landing PR: 8.10 registry migration. Follow-ups: 8.9, 8.8, 8.7
+Follow-ups (not in the first-landing 8.10 PR): 8.9 / 8.8 / 8.7
 migrations; removal of `LoadCITestConfig` and the legacy files;
-refactor of `scripts/deploy-camunda/matrix/runner.go` into
-concern-scoped packages; migration of scenario-specific behavior
-currently in `.github/workflows/test-integration-runner.yaml` into
-registry data.
+`runner.go` split into concern-scoped packages; migration of
+scenario-specific behavior in `.github/workflows/test-integration-runner.yaml`
+into registry data.
 
 ### Positive Consequences
 

--- a/docs/adr/0093-adopt-composable-ci-scenario-registry-for-per-version-test-matrix.md
+++ b/docs/adr/0093-adopt-composable-ci-scenario-registry-for-per-version-test-matrix.md
@@ -9,12 +9,11 @@
 The Camunda Helm chart's CI integration test matrix is defined by one
 `ci-test-config.yaml` per chart version at
 `charts/camunda-platform-{8.7,8.8,8.9,8.10}/test/ci-test-config.yaml`.
-Each file is an ordered list under `integration.case.pr` and
-`integration.case.nightly`. Each list item is an inline `CIScenario`
-blob mixing identity, persistence, platform/infra routing, flow
-selection, lifecycle hooks, companion-chart dependencies, skip policy,
-shortname, prefix key, and Helm version override. The 8.10 file is
-~1200 lines, ~30 lines per scenario.
+Each file is an ordered list under
+`integration.case.pr.scenario`; each list item is a ~30-line inline
+`CIScenario` blob mixing identity, persistence, platform/infra,
+flow, tier, lifecycle hooks, dependencies, and scenario scalars.
+The 8.10 file is ~1200 lines.
 
 The 100-commit sample in
 [#6264](https://github.com/camunda/camunda-platform-helm/issues/6264)
@@ -23,21 +22,18 @@ changes (new scenarios, hook tweaks, infra routing, skip policy)
 collide as merge conflicts in the same ordered list — structural
 conflicts, not stale-branch artifacts.
 
-Three duplication pressures compound it:
+Two duplication pressures compound it:
 
 - **Inlined hooks** — identical `pre-install` fixtures and descriptions
   copied across every CloudNativePG-using scenario.
 - **Inlined companion dependencies** — same `internal-keycloak-26` and
   `elastic/elasticsearch 8.5.1` repo+values blocks copied across every
   consumer; a single bump touches many scenarios × four files.
-- **`pr` vs `nightly`** — scheduling a scenario in both tiers requires
-  copying the full blob and toggling `enabled`.
 
 ### Applicability by version
 
 Applies to all currently supported chart versions — **8.7, 8.8, 8.9,
-8.10**. Versions 8.3–8.6 remain on the legacy file until removed; they
-are not migrated.
+8.10**.
 
 ## Decision Drivers
 
@@ -47,10 +43,10 @@ are not migrated.
   without scrolling a 1200-line file; a hook or dependency change must
   show its full blast radius via ID references.
 - **Migration safety.** `deploy-camunda matrix list/run` MUST
-  produce equivalent CI matrices during transition, enforced by the
-  equivalence test (item 5).
-- **Single source of truth.** While both layouts exist, exactly one is
-  hand-edited; the other is generated and CI-guarded against drift.
+  produce a matrix equivalent to the pre-migration one at the
+  migration cut, enforced by the equivalence test (item 4).
+- **Single source of truth.** Post-migration, only the registry is
+  edited; the legacy file is a frozen snapshot with a header comment.
 - **Internal scope.** Registry is a CI-internal mechanism. MUST NOT
   alter user-facing chart values, templates, golden files, or
   `values.schema.json`. MUST NOT change the `CITestConfig` struct
@@ -61,126 +57,90 @@ are not migrated.
 - **Keep the monolithic file; rely on smaller PRs and rebase
   discipline.** Rejected — conflict pattern is structural; process
   cannot remove file-level adjacency.
-- **Sort each version's scenario list alphabetically by `name`.**
-  Rejected — reduces but does not eliminate adjacency; leaves hooks
-  and dependencies duplicated; breaks reviewer ordering.
-- **Split only `dependencies` into a shared file.** Rejected — removes
-  one duplication but leaves hooks, infra, identity, persistence, and
-  platforms coupled in the same ordered list.
-- **Composable registry; each concept its own file, referenced by ID
-  from a thin per-version manifest (chosen).** Independent concepts →
-  independent files. Composition becomes data, validated cross-file
-  at load time. Generalizes the `permitted-flows.yaml` precedent.
+- **Full composable registry; identity, persistence, flows,
+  platforms, infra, features, and e2e each extracted into their own
+  subdirectory alongside scenarios, hooks, and dependencies.**
+  Rejected — scenario-specific, not cited in #6264 as duplication
+  sources; extracting them imposes multi-file reads without removing
+  conflict surface.
+- **Cross-version composable registry; one repo-global tree shared
+  by 8.7/8.8/8.9/8.10 with per-version field overrides.** Rejected —
+  version divergence collapses shared defaults into per-version
+  overrides, and the override layer becomes the new
+  single-point-of-conflict.
+- **Scenarios into their own files, plus hooks and dependencies
+  extracted; everything else inline (chosen).** Targets exactly the
+  duplication sources #6264 cites — the ordered scenario list and
+  the inlined hooks/dependencies. Layout in item 1.
 
 ## Decision Outcome
 
-A composable CI scenario registry rooted at `test/ci/registry/`
-becomes the source of truth for the integration test matrix. The
-legacy per-version `charts/camunda-platform-<X.Y>/test/ci-test-config.yaml` files
-remain as **generated compatibility artifacts** during migration and
-are removed once all four supported versions have migrated and held
-green for one full nightly cycle on `main`. The following constraints
-are normative:
+A composable CI scenario registry at
+`charts/camunda-platform-<X.Y>/test/ci/registry/` becomes the source
+of truth for that version's integration test matrix. `deploy-camunda`
+reads the registry directly once migrated; the legacy
+`ci-test-config.yaml` is frozen as the pre-migration snapshot for
+item 4 and is deleted once all four versions have migrated and held
+green for one nightly cycle on `main`. Normative constraints:
 
-1. **Layout.** Single repo-global path with one subdirectory per
-   concern; files keyed by stable ID matching the filename stem:
+1. **Layout.** Thin manifest plus `scenarios/`, `hooks/`,
+   `dependencies/` subdirectories; files keyed by stable ID:
 
    ```text
-   test/ci/registry/
-     versions/<X.Y>.yaml       # per-version manifest: scenario refs grouped by schedule (pr | nightly), each with enabled, numeric tier, and optional field overrides
-     scenarios/<id>.yaml       # composition: refs to identity, persistence, flows, platforms, infra, e2e, hooks, deps, features; plus scenario scalars (shortname, prefix-key, helm-version-override)
-     identities/<id>.yaml      # keycloak | oidc | auth0 | basic | hybrid; references companion charts by `dependencies/<id>` ID, never inlines them
-     persistence/<id>.yaml     # elasticsearch | opensearch-embedded | opensearch-self-signed | rdbms | rdbms-self-signed
-     flows/<id>.yaml           # install | upgrade-patch | upgrade-minor | modular-upgrade-minor (owns pre-upgrade hook)
-     platforms/<id>.yaml       # gke | eks | openshift
-     infra/<id>.yaml           # distroci | preemptible | alwaysgreen — selects values-infra-<id>.yaml
+   charts/camunda-platform-<X.Y>/test/ci/registry/
+     manifest.yaml             # ordered list of scenario IDs with numeric tier and enabled
+     scenarios/<id>.yaml       # one scenario per file; inlines all `CIScenario` fields (identity, persistence, platforms, infra-type, features, shortname, prefix-key, helmVersion, skip-e2e, skip-it, qa, image-tags, upgrade, enterprise) except `flow`, `pre-install`, `post-deploy`, and `dependencies`
      hooks/<id>.yaml           # named pre-install / post-deploy LifecycleHook blocks
      dependencies/<id>.yaml    # named ChartDependency entries (chart, version, repo, values-file)
-     features/<id>.yaml        # named feature toggles mapping to values/features/<id>.yaml (e.g. postgresql-companion, hub-pinned-images, migrator)
-     e2e/<id>.yaml             # smoke | full | skip-keycloak-dependent
    ```
 
-   Registry lives at repo root, not under `charts/<version>/`, because
-   its purpose is cross-version sharing. ADR 0063 internalized test
-   artifacts within this repository; it did not constrain them to the
-   chart subtree.
+   Registry lives under the version's chart subtree, matching the
+   ADR 0063 precedent.
 
    Scenario files carry a plural `flows: [<flow-id>, …]`. The loader
-   fans out one registry scenario × N flows into N `CIScenario`
-   entries with distinct singular `Flow`, preserving the existing
-   `CITestConfig` struct unchanged. Numeric `tier` and `enabled` live
-   on the version-manifest reference, not the shared scenario file.
-   Inline companion-chart blocks in identity or version files MUST
-   NOT be permitted; identities reference `dependencies/<id>` by ID.
+   fans out one scenario × N flows into N `CIScenario` entries with
+   distinct singular `Flow`, preserving the existing `CITestConfig`
+   struct unchanged. Inline companion-chart blocks MUST NOT be
+   permitted; identity sections reference `dependencies/<id>` by ID.
 
-   Version-scoped paths (values-layer files under `chart-full-setup/values/`,
-   hook manifests under `common/resources/`, hook scripts under
-   `pre-setup-scripts/`) are named by basename and resolved by the
-   loader against the version's
-   `charts/camunda-platform-<X.Y>/test/integration/scenarios/` tree.
+   Values-layer files (under `chart-full-setup/values/`), hook
+   manifests (`common/resources/`), and hook scripts
+   (`pre-setup-scripts/`) are named by basename and resolved against
+   the same version's `test/integration/scenarios/` tree.
 
 2. **Loader.** `scripts/deploy-camunda/matrix/config.go` gains
-   `LoadRegistry(repoRoot, version string) (*CITestConfig, error)`,
-   which resolves a version manifest's ID references against the
+   `LoadRegistry(chartDir string) (*CITestConfig, error)`, which
+   resolves the manifest's ID references against the colocated
    registry and returns the existing `CITestConfig` struct. Legacy
-   `LoadCITestConfig(chartDir)` is retained until all four supported
-   versions have migrated, then removed.
+   `LoadCITestConfig` is retained until all four supported versions
+   have migrated, then removed.
 
 3. **Validation.** A new `RegistryValidator` enforces at load time:
-   - Every referenced ID resolves to a file on disk.
-   - IDs and shortnames are unique within scope.
-   - Per-version × platform × flow tuples do not duplicate.
-   - Version-scoped paths (hooks, dependency values-files, scenario
-     values-layer files, `features/<id>` → `values/features/<id>.yaml`)
-     resolve under the target version's tree.
-   - Version × platform × flow combinations are not denied by
+   - Every referenced hook and dependency ID resolves to a file.
+   - Scenario IDs and shortnames are unique.
+   - Platform × flow tuples do not duplicate.
+   - Referenced basenames (hook manifests, hook scripts, dependency
+     values-files, scenario values-layer files, feature values-files)
+     resolve under `test/integration/scenarios/`.
+   - Platform × flow combinations are not denied by
      `.github/config/permitted-flows.yaml`.
 
-   Existing `LifecycleHook.Validate` plain-filename rule is reused.
+4. **Equivalence test (one-shot, in the migration PR).** A Go test
+   in `scripts/deploy-camunda/matrix/` loads both the legacy
+   `ci-test-config.yaml` and the registry and asserts the two
+   `*CITestConfig` values equal via `cmp.Diff`, with slice-order
+   normalization for order-independent fields and the post-fan-out
+   scenario list. Proves the migration cut; not a long-running
+   invariant. Post-migration regressions caught by the nightly
+   integration suite.
 
-4. **Per-version overrides.** Per-version scenario drift (e.g. 8.7
-   lacks `modular-upgrade-minor`; per-version values-file paths
-   differ) is expressed as field-level overrides on the scenario
-   reference in `versions/<X.Y>.yaml`. Listed fields override the
-   shared `scenarios/<id>.yaml`; absent fields inherit. Forking the
-   shared scenario file per version MUST NOT be permitted.
-
-   ```yaml
-   # versions/8.7.yaml
-   pr:
-     - id: orchestration-upgrade
-       tier: 1
-       enabled: true
-       flows: [upgrade-patch, upgrade-minor]   # drops modular-upgrade-minor for 8.7
-   nightly: []
-   ```
-
-5. **Equivalence test.** A Go test in
-   `scripts/deploy-camunda/matrix/` MUST, per active chart version,
-   load both the legacy `ci-test-config.yaml` and the registry and
-   assert the two `*CITestConfig` values are equal via `cmp.Diff`,
-   with explicit slice-order normalization for order-independent
-   fields (`Platforms`) and for the post-fan-out scenario list itself
-   (registry-derived scenarios are emitted in fan-out order, legacy
-   scenarios in file order). Gates the per-version rollout and remains
-   until that version's legacy file is removed.
-
-6. **Migration order and source switch.** 8.10 migrates first
-   (highest churn); 8.9, 8.8, 8.7 follow after 8.10's equivalence
-   test holds green on `main` for one full nightly run. Each
-   migration is a single PR: registry files added, legacy
-   `ci-test-config.yaml` regenerated and committed for review-diff
-   visibility, equivalence test enabled. The loader picks the
-   registry when `test/ci/registry/versions/<X.Y>.yaml` exists and
-   falls back to `LoadCITestConfig` otherwise. No runtime flag.
-
-7. **Generated-file guard.** A new `make ci.registry-check`, invoked
-   from `make helm.lint-all`, regenerates each migrated version's
-   `ci-test-config.yaml` and fails if the working tree differs. The
-   generated file carries a header marker
-   (`# GENERATED FROM test/ci/registry — DO NOT EDIT`); the guard
-   uses it to detect direct edits and point at the corresponding
-   registry file. Unmigrated versions lack the marker and are skipped.
+5. **Migration order and source switch.** 8.10 migrates first
+   (highest churn); 8.9, 8.8, 8.7 follow after 8.10 holds green on
+   `main` for one full nightly run. Each migration is a single PR:
+   registry files added, equivalence test (item 4) green, legacy
+   file frozen with header comment. At runtime the loader picks the
+   registry when `<chartDir>/test/ci/registry/manifest.yaml` exists,
+   else falls back to `LoadCITestConfig`. No runtime flag.
 
 Follow-ups (not in the first-landing 8.10 PR): 8.9 / 8.8 / 8.7
 migrations; removal of `LoadCITestConfig` and the legacy files;
@@ -191,34 +151,25 @@ into registry data.
 ### Positive Consequences
 
 - Adding a scenario creates one `scenarios/<id>.yaml` and one
-  version-manifest line. Two unrelated scenario PRs collide only if
-  they touch the same scenario or the same shared policy file.
-- Editing a hook, dependency, identity, persistence, or infra mapping
-  touches one file; blast radius is visible via ID references.
-- Scenario review shows a composed document instead of a 30-line
-  inline blob in a 1200-line file.
+  manifest line. Two unrelated scenario PRs collide only if they
+  touch the same scenario or the same shared file.
+- Editing a hook or dependency touches one file; blast radius
+  visible via ID references back to consuming scenarios.
+- Scenario review shows a focused `scenarios/<id>.yaml` instead of
+  a blob in a 1200-line file.
 - `deploy-camunda matrix list/run` behavior is preserved; GHA
   workflows and external callers continue to work unchanged.
-- The `permitted-flows.yaml` extraction precedent is generalized
-  rather than duplicated.
 
 ### Negative Consequences
 
-- During migration each migrated version has two sources of truth
-  (registry + generated legacy file). The guard mitigates drift but
-  contributors editing the legacy file see CI failures until they
-  re-apply against the registry.
+- Frozen legacy file mitigated only by header comment, not a CI
+  guard; regressions surface in the nightly integration run, not at
+  PR time.
 - Reading a scenario's effective configuration means reading its
-  scenario file plus referenced identity, persistence, flow, hooks,
-  and dependency files. Multi-file composition replaces long inline
-  blobs as the cognitive cost.
+  file plus referenced hook and dependency files; two-hop
+  composition replaces long inline blobs as the cognitive cost.
 - New loader, validator, and equivalence test add maintenance surface
   in `scripts/deploy-camunda/matrix/`.
-- Per-version field-level overrides (item 4) make drift between a
-  shared default and a version override invisible without rendering
-  the resolved scenario. The equivalence test catches it only during
-  the migration window; post-migration, confirm an override's effect
-  via `deploy-camunda matrix list`.
 
 ## Links
 

--- a/docs/adr/0093-adopt-composable-ci-scenario-registry-for-per-version-test-matrix.md
+++ b/docs/adr/0093-adopt-composable-ci-scenario-registry-for-per-version-test-matrix.md
@@ -92,7 +92,7 @@ are normative:
    ```text
    test/ci/registry/
      versions/<X.Y>.yaml       # per-version manifest: scenario refs grouped by schedule (pr | nightly), each with enabled, numeric tier, and optional field overrides
-     scenarios/<id>.yaml       # composition: refs to identity, persistence, flow, platforms, infra, e2e, hooks, deps, features; plus scenario scalars (shortname, prefix-key, helm-version-override)
+     scenarios/<id>.yaml       # composition: refs to identity, persistence, flows, platforms, infra, e2e, hooks, deps, features; plus scenario scalars (shortname, prefix-key, helm-version-override)
      identities/<id>.yaml      # keycloak | oidc | auth0 | basic | hybrid; references companion charts by `dependencies/<id>` ID, never inlines them
      persistence/<id>.yaml     # elasticsearch | opensearch-embedded | opensearch-self-signed | rdbms | rdbms-self-signed
      flows/<id>.yaml           # install | upgrade-patch | upgrade-minor | modular-upgrade-minor (owns pre-upgrade hook)
@@ -111,13 +111,17 @@ are normative:
 
    A version manifest references scenario IDs only, grouped under
    `pr:` and `nightly:` schedule lists. A scenario references
-   identity, persistence, flow, platforms, infra, e2e, hooks,
-   dependencies, and features by ID and owns its own scalars
-   (shortname, prefix key, Helm version override). Numeric `tier`
-   and `enabled` live on the version-manifest reference, not the
-   shared scenario file. Identities reference companion charts via
-   `dependencies/<id>` IDs; inline companion blocks in identity or
-   version files MUST NOT be permitted.
+   identity, persistence, platforms, infra, e2e, hooks, dependencies,
+   and features by ID, and carries a plural `flows: [<flow-id>, …]`
+   list (one composition × multiple flows). The loader fans out one
+   registry scenario × N flows into N `CIScenario` entries with the
+   same composition and distinct singular `Flow` field, preserving
+   the existing `CITestConfig` struct unchanged. A scenario also owns
+   its own scalars (shortname, prefix key, Helm version override).
+   Numeric `tier` and `enabled` live on the version-manifest
+   reference, not the shared scenario file. Identities reference
+   companion charts via `dependencies/<id>` IDs; inline companion
+   blocks in identity or version files MUST NOT be permitted.
 
    Version-scoped paths (values-layer files under `chart-full-setup/values/`,
    hook manifests under `common/resources/`, hook scripts under
@@ -166,8 +170,10 @@ are normative:
    load both the legacy `ci-test-config.yaml` and the registry and
    assert the two `*CITestConfig` values are equal via `cmp.Diff`,
    with explicit slice-order normalization for order-independent
-   fields (e.g. `platforms`, `flows`). Gates the per-version rollout
-   and remains until that version's legacy file is removed.
+   fields (`Platforms`) and for the post-fan-out scenario list itself
+   (registry-derived scenarios are emitted in fan-out order, legacy
+   scenarios in file order). Gates the per-version rollout and remains
+   until that version's legacy file is removed.
 
 6. **Migration order and source switch.** 8.10 migrates first
    (highest churn); 8.9, 8.8, 8.7 follow after 8.10's equivalence

--- a/docs/adr/0093-adopt-composable-ci-scenario-registry-for-per-version-test-matrix.md
+++ b/docs/adr/0093-adopt-composable-ci-scenario-registry-for-per-version-test-matrix.md
@@ -18,7 +18,7 @@ shortname, prefix key, and Helm version override. The 8.10 file is
 
 The 100-commit sample in
 [#6264](https://github.com/camunda/camunda-platform-helm/issues/6264)
-shows 11–16 edits per per-version file. Structurally independent
+shows 11–16 edits per version file. Structurally independent
 changes (new scenarios, hook tweaks, infra routing, skip policy)
 collide as merge conflicts in the same ordered list — structural
 conflicts, not stale-branch artifacts.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -94,3 +94,4 @@
 | 90 | [Adopt Docusaurus as the dedicated documentation platform for Helm chart project knowledge](0090-adopt-docusaurus-as-the-dedicated-documentation-platform.md) |
 | 91 | [Standardize `<component>.extraConfiguration` as the Application Configuration Mechanism](0091-adopt-component-extraconfiguration-as-the-standard-application-configuration-mechanism.md) |
 | 92 | [Allow opt-in deployment strategy for components with chart-managed RWO persistence](0092-allow-opt-in-deployment-strategy-for-components-with-chart-managed-rwo-persistence.md) |
+| 93 | [Adopt a composable CI scenario registry for the per-version integration test matrix](0093-adopt-composable-ci-scenario-registry-for-per-version-test-matrix.md) |


### PR DESCRIPTION
### Which problem does the PR fix?

Refs #6264. This PR records the decision only; implementation (loader,
validator, registry files, equivalence test, per-version migrations)
lands in follow-up PRs and keeps #6264 open until 8.10/8.9/8.8/8.7
have all migrated.

### What's in this PR?

Adds ADR 0093 (status: accepted) proposing a composable CI scenario
registry rooted at `test/ci/registry/` as the source of truth for the
integration test matrix across chart versions 8.7–8.10.

The current per-version `charts/<version>/test/ci-test-config.yaml`
files (8.10 is ~1200 lines, ~30 lines per inline scenario) concentrate
unrelated changes into one ordered list. The 100-commit sample in
#6264 shows 11–16 edits per file with structurally independent PRs
colliding as merge conflicts. Three duplication pressures compound it:
inlined lifecycle hooks, inlined companion-chart dependencies, and
`pr`/`nightly` blob duplication.

The ADR splits the matrix into one file per concern, keyed by stable ID:

```text
test/ci/registry/
  versions/<X.Y>.yaml       # per-version manifest: refs grouped by pr|nightly schedule, numeric tier, optional field overrides
  scenarios/<id>.yaml       # composition: refs to identity, persistence, flow, platforms, infra, e2e, hooks, deps, features
  identities/<id>.yaml      # keycloak | oidc | auth0 | basic | hybrid (companion charts referenced via dependencies/<id>)
  persistence/<id>.yaml     # elasticsearch | opensearch-* | rdbms | rdbms-self-signed
  flows/<id>.yaml           # install | upgrade-patch | upgrade-minor | modular-upgrade-minor
  platforms/<id>.yaml       # gke | eks | openshift
  infra/<id>.yaml           # distroci | preemptible | alwaysgreen
  hooks/<id>.yaml           # named pre-install / post-deploy LifecycleHook blocks
  dependencies/<id>.yaml    # named ChartDependency entries
  features/<id>.yaml        # named feature toggles -> values/features/<id>.yaml
  e2e/<id>.yaml             # smoke | full | skip-keycloak-dependent
```

Normative constraints in the ADR:

1. Layout — repo-global `test/ci/registry/`; version-scoped paths (hooks, dependency values-files, feature values, scenario values-layer files) resolved against the loading version's chart subtree.
2. Loader — new `LoadRegistry(repoRoot, version)` in `scripts/deploy-camunda/matrix/config.go` returning the existing `*CITestConfig`; legacy `LoadCITestConfig` retained until all four versions migrated.
3. Validation — `RegistryValidator` enforces ID resolution, shortname uniqueness, no duplicate version×platform×flow tuples, version-scoped path resolution, and `permitted-flows.yaml` compliance.
4. Per-version overrides — field-level overrides on the scenario reference in `versions/<X.Y>.yaml`; forking the shared scenario file per version is prohibited.
5. Equivalence test — Go test asserts `cmp.Diff` equality of `*CITestConfig` from legacy file vs registry per version, with slice-order normalization for order-independent fields.
6. Migration order — 8.10 first (highest churn); 8.9 / 8.8 / 8.7 follow after 8.10 holds green for one full nightly run. Loader selects registry vs legacy by file presence; no runtime flag.
7. Generated-file guard — new `make ci.registry-check` invoked from `make helm.lint-all`; regenerated file carries `# GENERATED FROM test/ci/registry — DO NOT EDIT` header marker.

Scope: ADR-only PR. No chart files change. Builds on ADR 0071 (matrix CI framework), ADR 0075 (Go CLI pattern), ADR 0063 (in-repo test artifacts).

### Checklist

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?