### PR TITLE
ci: generalize companion chart values environment substitution

### DIFF
--- a/charts/camunda-platform-8.10/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.10/test/ci-test-config.yaml
@@ -224,6 +224,7 @@ integration:
             - chart: charts/internal-postgresql
               release-name: postgresql
               values-file: test/integration/companion-values/postgresql.yaml
+              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
             - chart: elastic/elasticsearch
               version: "8.5.1"
               release-name: elasticsearch
@@ -497,6 +498,7 @@ integration:
             - chart: charts/internal-postgresql
               release-name: postgresql
               values-file: test/integration/companion-values/postgresql.yaml
+              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
             - chart: charts/internal-keycloak-26
               release-name: keycloak
               values-file: test/integration/companion-values/keycloak.yaml
@@ -806,6 +808,7 @@ integration:
             - chart: charts/internal-postgresql
               release-name: postgresql
               values-file: test/integration/companion-values/postgresql-qa.yaml
+              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
             - chart: charts/internal-keycloak-26
               release-name: keycloak
               values-file: test/integration/companion-values/keycloak-qa.yaml
@@ -832,6 +835,7 @@ integration:
             - chart: charts/internal-postgresql
               release-name: postgresql
               values-file: test/integration/companion-values/postgresql-qa.yaml
+              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
             - chart: charts/internal-keycloak-26
               release-name: keycloak
               values-file: test/integration/companion-values/keycloak-qa.yaml
@@ -858,6 +862,7 @@ integration:
             - chart: charts/internal-postgresql
               release-name: postgresql
               values-file: test/integration/companion-values/postgresql-qa.yaml
+              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
             - chart: charts/internal-keycloak-26
               release-name: keycloak
               values-file: test/integration/companion-values/keycloak-qa.yaml
@@ -884,6 +889,7 @@ integration:
             - chart: charts/internal-postgresql
               release-name: postgresql
               values-file: test/integration/companion-values/postgresql-qa.yaml
+              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
             - chart: charts/internal-keycloak-26
               release-name: keycloak
               values-file: test/integration/companion-values/keycloak-qa.yaml
@@ -911,6 +917,7 @@ integration:
             - chart: charts/internal-postgresql
               release-name: postgresql
               values-file: test/integration/companion-values/postgresql-qa.yaml
+              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
             - chart: charts/internal-keycloak-26
               release-name: keycloak
               values-file: test/integration/companion-values/keycloak-qa.yaml
@@ -938,6 +945,7 @@ integration:
             - chart: charts/internal-postgresql
               release-name: postgresql
               values-file: test/integration/companion-values/postgresql-qa.yaml
+              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
             - chart: charts/internal-keycloak-26
               release-name: keycloak
               values-file: test/integration/companion-values/keycloak-qa.yaml
@@ -964,6 +972,7 @@ integration:
             - chart: charts/internal-postgresql
               release-name: postgresql
               values-file: test/integration/companion-values/postgresql-qa.yaml
+              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
             - chart: charts/internal-keycloak-26
               release-name: keycloak
               values-file: test/integration/companion-values/keycloak-qa.yaml
@@ -990,6 +999,7 @@ integration:
             - chart: charts/internal-postgresql
               release-name: postgresql
               values-file: test/integration/companion-values/postgresql-qa.yaml
+              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
             - chart: charts/internal-keycloak-26
               release-name: keycloak
               values-file: test/integration/companion-values/keycloak-qa.yaml
@@ -1016,6 +1026,7 @@ integration:
             - chart: charts/internal-postgresql
               release-name: postgresql
               values-file: test/integration/companion-values/postgresql-qa.yaml
+              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
             - chart: charts/internal-keycloak-26
               release-name: keycloak
               values-file: test/integration/companion-values/keycloak-qa.yaml
@@ -1042,6 +1053,7 @@ integration:
             - chart: charts/internal-postgresql
               release-name: postgresql
               values-file: test/integration/companion-values/postgresql-qa.yaml
+              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
             - chart: charts/internal-keycloak-26
               release-name: keycloak
               values-file: test/integration/companion-values/keycloak-qa.yaml
@@ -1068,6 +1080,7 @@ integration:
             - chart: charts/internal-postgresql
               release-name: postgresql
               values-file: test/integration/companion-values/postgresql-qa.yaml
+              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
             - chart: charts/internal-keycloak-26
               release-name: keycloak
               values-file: test/integration/companion-values/keycloak-qa.yaml
@@ -1094,6 +1107,7 @@ integration:
             - chart: charts/internal-postgresql
               release-name: postgresql
               values-file: test/integration/companion-values/postgresql.yaml
+              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
             - chart: charts/internal-keycloak-26
               release-name: keycloak
               values-file: test/integration/companion-values/keycloak.yaml
@@ -1120,6 +1134,7 @@ integration:
             - chart: charts/internal-postgresql
               release-name: postgresql
               values-file: test/integration/companion-values/postgresql-qa.yaml
+              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
             - chart: charts/internal-keycloak-26
               release-name: keycloak
               values-file: test/integration/companion-values/keycloak-qa.yaml
@@ -1146,6 +1161,7 @@ integration:
             - chart: charts/internal-postgresql
               release-name: postgresql
               values-file: test/integration/companion-values/postgresql.yaml
+              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
             - chart: charts/internal-keycloak-26
               release-name: keycloak
               values-file: test/integration/companion-values/keycloak.yaml
@@ -1172,6 +1188,7 @@ integration:
             - chart: charts/internal-postgresql
               release-name: postgresql
               values-file: test/integration/companion-values/postgresql-qa.yaml
+              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
             - chart: charts/internal-keycloak-26
               release-name: keycloak
               values-file: test/integration/companion-values/keycloak-qa.yaml
@@ -1198,6 +1215,7 @@ integration:
             - chart: charts/internal-postgresql
               release-name: postgresql
               values-file: test/integration/companion-values/postgresql.yaml
+              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
             - chart: charts/internal-keycloak-26
               release-name: keycloak
               values-file: test/integration/companion-values/keycloak.yaml
@@ -1224,6 +1242,7 @@ integration:
             - chart: charts/internal-postgresql
               release-name: postgresql
               values-file: test/integration/companion-values/postgresql-qa.yaml
+              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
             - chart: charts/internal-keycloak-26
               release-name: keycloak
               values-file: test/integration/companion-values/keycloak-qa.yaml

--- a/scripts/deploy-camunda/config/merge.go
+++ b/scripts/deploy-camunda/config/merge.go
@@ -251,6 +251,10 @@ type CompanionChart struct {
 	ReleaseName string
 	// ValuesFile is the absolute path to a values file. Empty means use chart defaults.
 	ValuesFile string
+	// EnvVars is the explicit allowlist of environment variable names to
+	// substitute in ValuesFile before deploying. Only these names are expanded;
+	// all other $-tokens are left intact. Empty means no substitution.
+	EnvVars []string
 	// RepoName is the Helm repository name to register before installing
 	// (e.g., "opensearch"). Empty means no repo registration is needed.
 	RepoName string

--- a/scripts/deploy-camunda/deploy/companion_values_test.go
+++ b/scripts/deploy-camunda/deploy/companion_values_test.go
@@ -10,10 +10,12 @@ import (
 	"scripts/deploy-camunda/config"
 )
 
-func TestProcessCompanionChartsSubstitutesValuesFilePlaceholders(t *testing.T) {
+func TestProcessCompanionChartsSubstitutesAllowlistedVars(t *testing.T) {
 	tmpDir := t.TempDir()
-	sourceFile := filepath.Join(tmpDir, "postgresql.yaml")
-	if err := os.WriteFile(sourceFile, []byte("auth:\n  username: \"$RDBMS_POSTGRESQL_USERNAME\"\n  password: \"$RDBMS_POSTGRESQL_PASSWORD\"\n"), 0o644); err != nil {
+	sourceFile := filepath.Join(tmpDir, "companion.yaml")
+	// A non-PostgreSQL variable name proves substitution is generic and not
+	// tied to the old $RDBMS_POSTGRESQL_ prefix. Both $VAR and ${VAR} forms.
+	if err := os.WriteFile(sourceFile, []byte("auth:\n  token: \"$MY_CUSTOM_TOKEN\"\n  alt: \"${MY_CUSTOM_TOKEN}\"\n"), 0o644); err != nil {
 		t.Fatalf("write source values: %v", err)
 	}
 
@@ -21,11 +23,11 @@ func TestProcessCompanionChartsSubstitutesValuesFilePlaceholders(t *testing.T) {
 		ChartRef:    "charts/internal-postgresql",
 		ReleaseName: "postgresql",
 		ValuesFile:  sourceFile,
+		EnvVars:     []string{"MY_CUSTOM_TOKEN"},
 	}}
 
 	processed, err := processCompanionCharts(context.Background(), charts, tmpDir, "", map[string]string{
-		"RDBMS_POSTGRESQL_USERNAME": "app",
-		"RDBMS_POSTGRESQL_PASSWORD": "ci-secret",
+		"MY_CUSTOM_TOKEN": "secret123",
 	})
 	if err != nil {
 		t.Fatalf("processCompanionCharts returned error: %v", err)
@@ -35,7 +37,7 @@ func TestProcessCompanionChartsSubstitutesValuesFilePlaceholders(t *testing.T) {
 		t.Fatalf("processed charts length = %d, want 1", len(processed))
 	}
 	if processed[0].ValuesFile == sourceFile {
-		t.Fatalf("processed values file should be written to a temp path, got source path %q", sourceFile)
+		t.Fatalf("processed values file should be written to a separate path, got source path %q", sourceFile)
 	}
 
 	content, err := os.ReadFile(processed[0].ValuesFile)
@@ -43,7 +45,7 @@ func TestProcessCompanionChartsSubstitutesValuesFilePlaceholders(t *testing.T) {
 		t.Fatalf("read processed values: %v", err)
 	}
 	got := string(content)
-	for _, want := range []string{"username: \"app\"", "password: \"ci-secret\""} {
+	for _, want := range []string{"token: \"secret123\"", "alt: \"secret123\""} {
 		if !strings.Contains(got, want) {
 			t.Errorf("processed values missing %q:\n%s", want, got)
 		}
@@ -53,8 +55,34 @@ func TestProcessCompanionChartsSubstitutesValuesFilePlaceholders(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read original values: %v", err)
 	}
-	if !strings.Contains(string(original), "$RDBMS_POSTGRESQL_PASSWORD") {
+	if !strings.Contains(string(original), "$MY_CUSTOM_TOKEN") {
 		t.Fatalf("source values file was modified:\n%s", original)
+	}
+}
+
+func TestProcessCompanionChartsMissingVarErrors(t *testing.T) {
+	tmpDir := t.TempDir()
+	sourceFile := filepath.Join(tmpDir, "postgresql.yaml")
+	if err := os.WriteFile(sourceFile, []byte("auth:\n  username: \"$RDBMS_POSTGRESQL_USERNAME\"\n"), 0o644); err != nil {
+		t.Fatalf("write source values: %v", err)
+	}
+
+	charts := []config.CompanionChart{{
+		ChartRef:    "charts/internal-postgresql",
+		ReleaseName: "postgresql",
+		ValuesFile:  sourceFile,
+		EnvVars:     []string{"RDBMS_POSTGRESQL_USERNAME", "RDBMS_POSTGRESQL_PASSWORD"},
+	}}
+
+	// Only USERNAME is present; PASSWORD is declared but missing from the env map.
+	_, err := processCompanionCharts(context.Background(), charts, tmpDir, "", map[string]string{
+		"RDBMS_POSTGRESQL_USERNAME": "app",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing declared variable, got nil")
+	}
+	if !strings.Contains(err.Error(), "RDBMS_POSTGRESQL_PASSWORD") {
+		t.Errorf("error should name the missing variable, got: %v", err)
 	}
 }
 
@@ -62,6 +90,7 @@ func TestProcessCompanionChartsKeepsChartsWithoutValuesFile(t *testing.T) {
 	charts := []config.CompanionChart{{
 		ChartRef:    "opensearch/opensearch",
 		ReleaseName: "opensearch",
+		EnvVars:     []string{"SOME_VAR"},
 	}}
 
 	processed, err := processCompanionCharts(context.Background(), charts, t.TempDir(), "", nil)
@@ -76,15 +105,17 @@ func TestProcessCompanionChartsKeepsChartsWithoutValuesFile(t *testing.T) {
 	}
 }
 
-func TestProcessCompanionChartsSkipsUnrelatedShellVariables(t *testing.T) {
+func TestProcessCompanionChartsPassesThroughWithoutEnvVars(t *testing.T) {
 	tmpDir := t.TempDir()
 	sourceFile := filepath.Join(tmpDir, "elasticsearch.yaml")
+	// Contains shell variables; with no EnvVars allowlist the file must be used
+	// verbatim (no processing, no copy).
 	if err := os.WriteFile(sourceFile, []byte("extraInitContainers:\n  - command:\n      - sh\n      - -c\n      - |\n        echo \"waiting ($n/$max)\"\n"), 0o644); err != nil {
 		t.Fatalf("write source values: %v", err)
 	}
 
 	charts := []config.CompanionChart{{
-		ChartRef:    "elasticsearch/elasticsearch",
+		ChartRef:    "elastic/elasticsearch",
 		ReleaseName: "elasticsearch",
 		ValuesFile:  sourceFile,
 	}}
@@ -95,5 +126,104 @@ func TestProcessCompanionChartsSkipsUnrelatedShellVariables(t *testing.T) {
 	}
 	if processed[0].ValuesFile != sourceFile {
 		t.Fatalf("ValuesFile = %q, want original source path %q", processed[0].ValuesFile, sourceFile)
+	}
+}
+
+func TestSubstituteCompanionEnvVarsLeavesUndeclaredTokensIntact(t *testing.T) {
+	content := strings.Join([]string{
+		`echo "waiting ($n/$max)"`,
+		`user: "$RDBMS_POSTGRESQL_USERNAME"`,
+		`alt: "${RDBMS_POSTGRESQL_USERNAME}"`,
+		`extra: "$RDBMS_POSTGRESQL_USERNAME_SUFFIX"`,
+	}, "\n")
+
+	got, err := substituteCompanionEnvVars(content, []string{"RDBMS_POSTGRESQL_USERNAME"}, map[string]string{
+		"RDBMS_POSTGRESQL_USERNAME": "app",
+	})
+	if err != nil {
+		t.Fatalf("substituteCompanionEnvVars returned error: %v", err)
+	}
+
+	// Declared variable is substituted in both forms.
+	for _, want := range []string{`user: "app"`, `alt: "app"`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing substituted %q:\n%s", want, got)
+		}
+	}
+	// Undeclared shell variables are left intact.
+	if !strings.Contains(got, "($n/$max)") {
+		t.Errorf("shell vars $n/$max were modified:\n%s", got)
+	}
+	// A longer name with the allowlisted name as a prefix is NOT partially replaced.
+	if !strings.Contains(got, `extra: "$RDBMS_POSTGRESQL_USERNAME_SUFFIX"`) {
+		t.Errorf("prefix-shadowed token was wrongly substituted:\n%s", got)
+	}
+}
+
+func TestSubstituteCompanionEnvVarsMissingVar(t *testing.T) {
+	_, err := substituteCompanionEnvVars(`token: "$A_TOKEN"`, []string{"A_TOKEN", "B_TOKEN"}, map[string]string{
+		"A_TOKEN": "x",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing variable, got nil")
+	}
+	if !strings.Contains(err.Error(), "B_TOKEN") {
+		t.Errorf("error should name missing B_TOKEN, got: %v", err)
+	}
+}
+
+func TestProcessCompanionChartsSharedBasenameNoCollision(t *testing.T) {
+	tmpDir := t.TempDir()
+	// Cross-product collision: release "alpha-beta" + "x.yaml" and release
+	// "alpha" + "beta-x.yaml" both flatten to "alpha-beta-x.yaml" under a
+	// release-name-only prefix. The loop-index prefix must keep them distinct.
+	dirA := filepath.Join(tmpDir, "a")
+	dirB := filepath.Join(tmpDir, "b")
+	for _, d := range []string{dirA, dirB} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+	}
+	fileA := filepath.Join(dirA, "x.yaml")
+	fileB := filepath.Join(dirB, "beta-x.yaml")
+	if err := os.WriteFile(fileA, []byte("token: \"$TOK\"\n"), 0o644); err != nil {
+		t.Fatalf("write a: %v", err)
+	}
+	if err := os.WriteFile(fileB, []byte("token: \"$TOK\"\n"), 0o644); err != nil {
+		t.Fatalf("write b: %v", err)
+	}
+
+	charts := []config.CompanionChart{
+		{ChartRef: "chart-a", ReleaseName: "alpha-beta", ValuesFile: fileA, EnvVars: []string{"TOK"}},
+		{ChartRef: "chart-b", ReleaseName: "alpha", ValuesFile: fileB, EnvVars: []string{"TOK"}},
+	}
+	processed, err := processCompanionCharts(context.Background(), charts, tmpDir, "", map[string]string{
+		"TOK": "v1",
+	})
+	if err != nil {
+		t.Fatalf("processCompanionCharts returned error: %v", err)
+	}
+	if processed[0].ValuesFile == processed[1].ValuesFile {
+		t.Fatalf("processed paths collided: %q", processed[0].ValuesFile)
+	}
+	for _, p := range processed {
+		content, err := os.ReadFile(p.ValuesFile)
+		if err != nil {
+			t.Fatalf("read %q: %v", p.ValuesFile, err)
+		}
+		if !strings.Contains(string(content), `token: "v1"`) {
+			t.Errorf("%q not substituted:\n%s", p.ValuesFile, content)
+		}
+	}
+}
+
+func TestSubstituteCompanionEnvVarsEmptyAllowlistNoOp(t *testing.T) {
+	content := `echo "($n/$max)"`
+	got, err := substituteCompanionEnvVars(content, nil, nil)
+	if err != nil {
+		t.Fatalf("substituteCompanionEnvVars returned error: %v", err)
+	}
+	if got != content {
+		t.Errorf("empty allowlist should be a no-op, got: %s", got)
 	}
 }

--- a/scripts/deploy-camunda/deploy/values.go
+++ b/scripts/deploy-camunda/deploy/values.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -182,7 +183,15 @@ func processCommonValues(ctx context.Context, scenarioPath, outputDir, envFile, 
 	return processedFiles, nil
 }
 
-func processCompanionCharts(ctx context.Context, charts []config.CompanionChart, outputDir, envFile string, envOverrides map[string]string) ([]config.CompanionChart, error) {
+// processCompanionCharts substitutes environment variables into companion
+// chart values files. Substitution is opt-in and allowlist-scoped: a chart is
+// processed only when it declares EnvVars, and only the names in that allowlist
+// are expanded. This keeps ordinary shell variables embedded in companion
+// values (e.g. $n, $max in Elasticsearch/OpenSearch init scripts) untouched and
+// avoids the previous service-specific content scan for $RDBMS_POSTGRESQL_.
+// envOverrides is deploy-camunda's isolated scenario env map; it is never the
+// process environment.
+func processCompanionCharts(_ context.Context, charts []config.CompanionChart, outputDir, _ string, envOverrides map[string]string) ([]config.CompanionChart, error) {
 	if len(charts) == 0 {
 		return nil, nil
 	}
@@ -192,30 +201,72 @@ func processCompanionCharts(ctx context.Context, charts []config.CompanionChart,
 	companionOutputDir := filepath.Join(outputDir, "companion-values")
 
 	for i, chart := range processed {
-		if chart.ValuesFile == "" {
+		if chart.ValuesFile == "" || len(chart.EnvVars) == 0 {
 			continue
 		}
 		content, err := os.ReadFile(chart.ValuesFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read companion values file %q: %w", chart.ValuesFile, err)
 		}
-		if !strings.Contains(string(content), "$RDBMS_POSTGRESQL_") && !strings.Contains(string(content), "${RDBMS_POSTGRESQL_") {
-			continue
-		}
-
-		outputPath, _, err := values.Process(ctx, chart.ValuesFile, values.Options{
-			OutputDir:    companionOutputDir,
-			Interactive:  false,
-			EnvFile:      envFile,
-			EnvOverrides: envOverrides,
-		})
+		substituted, err := substituteCompanionEnvVars(string(content), chart.EnvVars, envOverrides)
 		if err != nil {
 			return nil, fmt.Errorf("failed to process companion values file %q: %w", chart.ValuesFile, err)
+		}
+		if err := os.MkdirAll(companionOutputDir, 0o755); err != nil {
+			return nil, fmt.Errorf("failed to create companion values dir %q: %w", companionOutputDir, err)
+		}
+		// Prefix with the loop index (and release name for readability) so two
+		// companion charts whose values files share a basename cannot overwrite
+		// each other's processed output. The index guarantees uniqueness within
+		// this call regardless of release-name/basename concatenation.
+		outputPath := filepath.Join(companionOutputDir, fmt.Sprintf("%d-%s-%s", i, chart.ReleaseName, filepath.Base(chart.ValuesFile)))
+		if err := os.WriteFile(outputPath, []byte(substituted), 0o644); err != nil {
+			return nil, fmt.Errorf("failed to write companion values file %q: %w", outputPath, err)
 		}
 		processed[i].ValuesFile = outputPath
 	}
 
 	return processed, nil
+}
+
+// substituteCompanionEnvVars replaces only the allowlisted $VAR / ${VAR} tokens
+// in content using envMap. Any $-token whose name is not in allowlist is left
+// intact, so shell variables such as $n or $max survive untouched. It returns
+// an error naming every allowlisted variable that is missing from envMap, so a
+// misconfigured scenario fails early with a useful message.
+func substituteCompanionEnvVars(content string, allowlist []string, envMap map[string]string) (string, error) {
+	if len(allowlist) == 0 {
+		return content, nil
+	}
+
+	var missing []string
+	for _, name := range allowlist {
+		if _, ok := envMap[name]; !ok {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		return "", fmt.Errorf("missing required environment variable(s) for substitution: %s", strings.Join(missing, ", "))
+	}
+
+	// Sort longest-first so a name that is a prefix of another (e.g. FOO vs
+	// FOOBAR) cannot shadow it in the alternation. The trailing \b on the bare
+	// $VAR form already prevents partial matches, but ordering is cheap insurance.
+	names := append([]string(nil), allowlist...)
+	sort.Slice(names, func(i, j int) bool { return len(names[i]) > len(names[j]) })
+	quoted := make([]string, len(names))
+	for i, n := range names {
+		quoted[i] = regexp.QuoteMeta(n)
+	}
+	alt := strings.Join(quoted, "|")
+	re := regexp.MustCompile(`\$\{(?:` + alt + `)\}|\$(?:` + alt + `)\b`)
+
+	return re.ReplaceAllStringFunc(content, func(match string) string {
+		name := strings.TrimPrefix(match, "$")
+		name = strings.TrimPrefix(name, "{")
+		name = strings.TrimSuffix(name, "}")
+		return envMap[name]
+	}), nil
 }
 
 // generateDebugValuesFile creates a temporary values file with debug configuration

--- a/scripts/deploy-camunda/matrix/config.go
+++ b/scripts/deploy-camunda/matrix/config.go
@@ -214,6 +214,11 @@ type ChartDependency struct {
 	// ValuesFile is the path to a values file for the companion chart,
 	// relative to the repo root. Optional — omit to use chart defaults.
 	ValuesFile string `yaml:"values-file,omitempty" json:"values-file,omitempty"`
+	// EnvVars is the explicit allowlist of environment variable names to
+	// substitute in ValuesFile ($VAR / ${VAR}). Only these names are expanded;
+	// all other $-tokens (e.g. shell vars $n, $max in init scripts) are left
+	// intact. Empty means the values file is used verbatim.
+	EnvVars []string `yaml:"env-vars,omitempty" json:"env-vars,omitempty"`
 	// RepoName is the Helm repository name to register before installing
 	// the chart (e.g., "opensearch"). Required for repo-style chart refs;
 	// not needed for OCI or local paths.

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -1735,6 +1735,7 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions, entryIndex 
 				ChartRef:    chartRef,
 				Version:     version,
 				ReleaseName: dep.ReleaseName,
+				EnvVars:     dep.EnvVars,
 				RepoName:    dep.RepoName,
 				RepoURL:     dep.RepoURL,
 			}


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6261.

### What's in this PR?

Companion-chart values environment substitution was PostgreSQL-specific:
`processCompanionCharts` scanned raw YAML for a hardcoded `$RDBMS_POSTGRESQL_`
prefix before expanding, to avoid clobbering ordinary shell variables (`$n`,
`$max`) embedded in Elasticsearch/OpenSearch init scripts.

This replaces the content scan with an explicit, generic per-dependency allowlist:

- New `env-vars` field on a companion dependency (`ChartDependency` /
  `CompanionChart`). Listing variable names opts the values file into
  substitution; only those names are expanded.
- `processCompanionCharts` substitutes via a new `substituteCompanionEnvVars`
  helper — an allowlist-scoped regex (`$VAR` / `${VAR}`, word-boundary safe).
  Undeclared `$`-tokens (shell variables) are left intact; a declared variable
  missing from deploy-camunda's isolated scenario env map fails early with a
  clear error naming it.
- Charts without `env-vars` are passed through verbatim (preserves the
  Keycloak/Elasticsearch/OpenSearch companion behavior).
- Existing PostgreSQL companion scenarios in `ci-test-config.yaml` migrated to
  declare `env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]`.

Unit tests cover generic (non-PostgreSQL) substitution, missing-variable
failure, undeclared-shell-variable safety, prefix-shadow safety, and the
no-`env-vars` passthrough. Scope: 8.10 tooling + CI config only; no chart
templates change.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
