### PR TITLE
ci: deduplicate companion chart setup via reusable dependency profiles

### DIFF
--- a/charts/camunda-platform-8.10/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.10/test/ci-test-config.yaml
@@ -11,7 +11,7 @@ unit:
       packages: web-modeler
 
 # Used in the GitHub Actions integration test CI workflow.
-# 
+#
 # Scenarios support two configuration approaches:
 #
 # 1. Legacy (scenario name parsing - still supported):
@@ -44,6 +44,69 @@ integration:
           StatefulSet + PVC before the patch upgrade. Required because the
           target chart's PostgreSQL spec has immutable diffs vs the prior
           patch (PSQL 15→14 rollback path) — Helm cannot reconcile in place.
+  # Reusable companion-chart bundles. A scenario references these by name via
+  # its `profiles:` list (resolved into `dependencies` + `pre-install` at load
+  # time). This keeps the common Keycloak / Elasticsearch / OpenSearch /
+  # PostgreSQL companion setup declared once instead of repeated per scenario.
+  # Special scenarios (self-signed TLS, the rdbms 3-database bootstrap) keep
+  # their companion charts or pre-install hooks inline.
+  dependency-profiles:
+    keycloak:
+      dependencies:
+        - chart: charts/internal-keycloak-26
+          release-name: keycloak
+          values-file: test/integration/companion-values/keycloak.yaml
+    keycloak-qa:
+      dependencies:
+        - chart: charts/internal-keycloak-26
+          release-name: keycloak
+          values-file: test/integration/companion-values/keycloak-qa.yaml
+    elasticsearch:
+      dependencies:
+        - chart: elastic/elasticsearch
+          version: "8.5.1"
+          release-name: elasticsearch
+          repo-name: elastic
+          repo-url: https://helm.elastic.co
+          values-file: test/integration/companion-values/elasticsearch.yaml
+    elasticsearch-qa:
+      dependencies:
+        - chart: elastic/elasticsearch
+          version: "8.5.1"
+          release-name: elasticsearch
+          repo-name: elastic
+          repo-url: https://helm.elastic.co
+          values-file: test/integration/companion-values/elasticsearch-qa.yaml
+    opensearch:
+      dependencies:
+        - chart: opensearch/opensearch
+          version: "3.6.0"
+          release-name: opensearch
+          repo-name: opensearch
+          repo-url: https://opensearch-project.github.io/helm-charts/
+          values-file: test/integration/companion-values/opensearch.yaml
+    postgresql:
+      dependencies:
+        - chart: charts/internal-postgresql
+          release-name: postgresql
+          values-file: test/integration/companion-values/postgresql.yaml
+          env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
+    postgresql-qa:
+      dependencies:
+        - chart: charts/internal-postgresql
+          release-name: postgresql
+          values-file: test/integration/companion-values/postgresql-qa.yaml
+          env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
+    # CloudNativePG pre-install fixture shared by Keycloak-backed scenarios.
+    cnpg:
+      pre-install:
+        fixtures:
+          - postgresql-cluster.yaml
+        description: |
+          Provisions a CloudNativePG `Cluster` in the scenario
+          namespace, bootstrapped with `identity` and `webmodeler` databases. Required because Identity
+          and WebModeler need external databases now that no
+          bundled PostgreSQL subchart is deployed (8.10+).
   case:
     pr:
       # NOTE (5985): install-flow scenarios now use identity: keycloak with the
@@ -65,24 +128,7 @@ integration:
           identity: keycloak
           persistence: elasticsearch
           platforms: [gke]
-          pre-install:
-            fixtures:
-              - postgresql-cluster.yaml
-            description: |
-              Provisions a CloudNativePG `Cluster` in the scenario
-              namespace, bootstrapped with `identity` and `webmodeler` databases. Required because Identity
-              and WebModeler need external databases now that no
-              bundled PostgreSQL subchart is deployed (8.10+).
-          dependencies:
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak.yaml
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch.yaml
+          profiles: [keycloak, elasticsearch, cnpg]
         - name: opensearch
           enabled: true
           auth: keycloak
@@ -95,24 +141,7 @@ integration:
           infra-type:
             gke: distroci
           platforms: [gke]
-          pre-install:
-            fixtures:
-              - postgresql-cluster.yaml
-            description: |
-              Provisions a CloudNativePG `Cluster` in the scenario
-              namespace, bootstrapped with `identity` and `webmodeler` databases. Required because Identity
-              and WebModeler need external databases now that no
-              bundled PostgreSQL subchart is deployed (8.10+).
-          dependencies:
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak.yaml
-            - chart: opensearch/opensearch
-              version: "3.6.0"
-              release-name: opensearch
-              repo-name: opensearch
-              repo-url: https://opensearch-project.github.io/helm-charts/
-              values-file: test/integration/companion-values/opensearch.yaml
+          profiles: [keycloak, opensearch, cnpg]
         - name: opensearch-self-signed
           enabled: true
           shortname: osss
@@ -124,6 +153,7 @@ integration:
           infra-type:
             gke: distroci
           platforms: [gke]
+          profiles: [keycloak]
           pre-install:
             script: pre-install-opensearch-self-signed.sh
             description: |
@@ -133,9 +163,6 @@ integration:
               opensearch-jks Secrets consumed by the OpenSearch companion
               chart's TLS config.
           dependencies:
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak.yaml
             - chart: opensearch/opensearch
               version: "3.6.0"
               release-name: opensearch
@@ -198,13 +225,7 @@ integration:
           infra-type:
             gke: distroci
             eks: preemptible
-          dependencies:
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch.yaml
+          profiles: [elasticsearch]
         - name: oidc
           enabled: false
           exclude: [identity,console,orchestration-grpc]
@@ -220,17 +241,7 @@ integration:
           persistence: elasticsearch
           features: [postgresql-companion]
           platforms: [gke]
-          dependencies:
-            - chart: charts/internal-postgresql
-              release-name: postgresql
-              values-file: test/integration/companion-values/postgresql.yaml
-              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch.yaml
+          profiles: [postgresql, elasticsearch]
         - name: auth0
           # Auth0 OIDC scenario. The matrix runner provisions per-component
           # first-party clients via the Management API at runtime
@@ -251,21 +262,7 @@ integration:
           identity: auth0
           persistence: elasticsearch
           platforms: [gke]
-          pre-install:
-            fixtures:
-              - postgresql-cluster.yaml
-            description: |
-              Provisions a CloudNativePG `Cluster` in the scenario
-              namespace, bootstrapped with `identity` and `webmodeler` databases. Required because Identity
-              and WebModeler need external databases now that no
-              bundled PostgreSQL subchart is deployed (8.10+).
-          dependencies:
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch.yaml
+          profiles: [elasticsearch, cnpg]
         - name: keycloak-mt
           enabled: false
           exclude: []
@@ -278,24 +275,7 @@ integration:
             gke: distroci
             eks: preemptible
           platforms: [gke]
-          pre-install:
-            fixtures:
-              - postgresql-cluster.yaml
-            description: |
-              Provisions a CloudNativePG `Cluster` in the scenario
-              namespace, bootstrapped with `identity` and `webmodeler` databases. Required because Identity
-              and WebModeler need external databases now that no
-              bundled PostgreSQL subchart is deployed (8.10+).
-          dependencies:
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak.yaml
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch.yaml
+          profiles: [keycloak, elasticsearch, cnpg]
         - name: keycloak-rba
           enabled: false
           exclude: []
@@ -309,24 +289,7 @@ integration:
           persistence: elasticsearch
           features: [rba]
           platforms: [gke]
-          pre-install:
-            fixtures:
-              - postgresql-cluster.yaml
-            description: |
-              Provisions a CloudNativePG `Cluster` in the scenario
-              namespace, bootstrapped with `identity` and `webmodeler` databases. Required because Identity
-              and WebModeler need external databases now that no
-              bundled PostgreSQL subchart is deployed (8.10+).
-          dependencies:
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak.yaml
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch.yaml
+          profiles: [keycloak, elasticsearch, cnpg]
         - name: keycloak-original
           enabled: false
           exclude: []
@@ -339,24 +302,7 @@ integration:
           identity: keycloak
           persistence: elasticsearch
           platforms: [gke]
-          pre-install:
-            fixtures:
-              - postgresql-cluster.yaml
-            description: |
-              Provisions a CloudNativePG `Cluster` in the scenario
-              namespace, bootstrapped with `identity` and `webmodeler` databases. Required because Identity
-              and WebModeler need external databases now that no
-              bundled PostgreSQL subchart is deployed (8.10+).
-          dependencies:
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak.yaml
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch.yaml
+          profiles: [keycloak, elasticsearch, cnpg]
         - name: keycloak-original
           enabled: true
           exclude: []
@@ -370,24 +316,7 @@ integration:
           identity: keycloak
           persistence: elasticsearch
           platforms: [gke]
-          pre-install:
-            fixtures:
-              - postgresql-cluster.yaml
-            description: |
-              Provisions a CloudNativePG `Cluster` in the scenario
-              namespace, bootstrapped with `identity` and `webmodeler` databases. Required because Identity
-              and WebModeler need external databases now that no
-              bundled PostgreSQL subchart is deployed (8.10+).
-          dependencies:
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak.yaml
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch.yaml
+          profiles: [keycloak, elasticsearch, cnpg]
         - name: gateway-keycloak
           enabled: true
           exclude: []
@@ -402,30 +331,13 @@ integration:
           persistence: elasticsearch
           features: [gateway]
           platforms: [gke]
-          pre-install:
-            fixtures:
-              - postgresql-cluster.yaml
-            description: |
-              Provisions a CloudNativePG `Cluster` in the scenario
-              namespace, bootstrapped with `identity` and `webmodeler` databases. Required because Identity
-              and WebModeler need external databases now that no
-              bundled PostgreSQL subchart is deployed (8.10+).
+          profiles: [keycloak, elasticsearch, cnpg]
           post-deploy:
             script: post-deploy-gateway-keycloak.sh
             description: |
               Applies the NGINX ProxySettingsPolicy that bumps gateway buffer
               sizes. Runs after helm install because the Gateway API CRD is only
               registered by the chart itself.
-          dependencies:
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak.yaml
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch.yaml
         - name: elasticsearch-arm
           enabled: false
           auth: keycloak
@@ -440,21 +352,7 @@ integration:
           persistence: elasticsearch
           features: [arm]
           platforms: [gke]
-          pre-install:
-            fixtures:
-              - postgresql-cluster.yaml
-            description: |
-              Provisions a CloudNativePG `Cluster` in the scenario
-              namespace, bootstrapped with `identity` and `webmodeler` databases. Required because Identity
-              and WebModeler need external databases now that no
-              bundled PostgreSQL subchart is deployed (8.10+).
-          dependencies:
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch.yaml
+          profiles: [elasticsearch, cnpg]
         - name: noSecondaryStorage
           enabled: true
           auth: keycloak
@@ -470,18 +368,7 @@ integration:
           platforms: [gke]
           infra-type:
             gke: distroci
-          pre-install:
-            fixtures:
-              - postgresql-cluster.yaml
-            description: |
-              Provisions a CloudNativePG `Cluster` in the scenario
-              namespace, bootstrapped with `identity` and `webmodeler` databases. Required because Identity
-              and WebModeler need external databases now that no
-              bundled PostgreSQL subchart is deployed (8.10+).
-          dependencies:
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak.yaml
+          profiles: [keycloak, cnpg]
         - name: documentstore
           enabled: true
           exclude: []
@@ -494,20 +381,7 @@ integration:
           platforms: [eks]
           infra-type:
             eks: preemptible
-          dependencies:
-            - chart: charts/internal-postgresql
-              release-name: postgresql
-              values-file: test/integration/companion-values/postgresql.yaml
-              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak.yaml
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch.yaml
+          profiles: [postgresql, keycloak, elasticsearch]
         - name: rdbms-self-signed
           enabled: true
           shortname: rdbss
@@ -520,6 +394,7 @@ integration:
           infra-type:
             gke: distroci
           platforms: [gke]
+          profiles: [keycloak, elasticsearch]
           pre-install:
             script: pre-install-rdbms-self-signed.sh
             description: |
@@ -529,16 +404,6 @@ integration:
               self-signed CA + server cert by default; the CA is exposed via
               the `postgresql-cluster-ca` secret and consumed by Camunda for
               `sslmode=verify-full` validation.
-          dependencies:
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak.yaml
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch.yaml
         - name: rdbms-external
           enabled: false
           auth: keycloak
@@ -550,24 +415,7 @@ integration:
           identity: keycloak
           persistence: rdbms-external
           platforms: [gke]
-          pre-install:
-            fixtures:
-              - postgresql-cluster.yaml
-            description: |
-              Provisions a CloudNativePG `Cluster` in the scenario
-              namespace, bootstrapped with `identity` and `webmodeler` databases. Required because Identity
-              and WebModeler need external databases now that no
-              bundled PostgreSQL subchart is deployed (8.10+).
-          dependencies:
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak.yaml
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch.yaml
+          profiles: [keycloak, elasticsearch, cnpg]
         # rdbms: persistence layer points Camunda at an external PostgreSQL
         # cluster (postgresql-cluster-rw.<namespace>.svc.cluster.local). The
         # CloudNativePG `Cluster` + auth Secret are NOT part of the chart —
@@ -589,6 +437,7 @@ integration:
           identity: keycloak
           persistence: rdbms
           platforms: [gke]
+          profiles: [keycloak, elasticsearch]
           pre-install:
             fixtures:
               - postgresql-cluster.yaml
@@ -598,16 +447,6 @@ integration:
               `app` (RDBMS secondary storage backend) plus `identity` and
               `webmodeler` (Identity + WebModeler external databases needed
               when no bundled PostgreSQL is deployed).
-          dependencies:
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak.yaml
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch.yaml
         - name: hub-legacy
           enabled: true
           auth: keycloak
@@ -621,24 +460,7 @@ integration:
           platforms: [gke]
           infra-type:
             gke: distroci
-          pre-install:
-            fixtures:
-              - postgresql-cluster.yaml
-            description: |
-              Provisions a CloudNativePG `Cluster` in the scenario
-              namespace, bootstrapped with `identity` and `webmodeler` databases. Required because Identity
-              and WebModeler need external databases now that no
-              bundled PostgreSQL subchart is deployed (8.10+).
-          dependencies:
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak.yaml
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch.yaml
+          profiles: [keycloak, elasticsearch, cnpg]
         - name: shadow-e2e
           enabled: true
           shortname: shde2
@@ -651,24 +473,7 @@ integration:
           infra-type:
             gke: distroci
           skip-e2e: true  # Standard smoke tests skipped; full suite runs via c8e2e distributed runner
-          pre-install:
-            fixtures:
-              - postgresql-cluster.yaml
-            description: |
-              Provisions a CloudNativePG `Cluster` in the scenario
-              namespace, bootstrapped with `identity` and `webmodeler` databases. Required because Identity
-              and WebModeler need external databases now that no
-              bundled PostgreSQL subchart is deployed (8.10+).
-          dependencies:
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak.yaml
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch.yaml
+          profiles: [keycloak, elasticsearch, cnpg]
         - name: hub-legacy
           enabled: false
           auth: keycloak
@@ -682,24 +487,7 @@ integration:
           infra-type:
             gke: distroci
             eks: preemptible
-          pre-install:
-            fixtures:
-              - postgresql-cluster.yaml
-            description: |
-              Provisions a CloudNativePG `Cluster` in the scenario
-              namespace, bootstrapped with `identity` and `webmodeler` databases. Required because Identity
-              and WebModeler need external databases now that no
-              bundled PostgreSQL subchart is deployed (8.10+).
-          dependencies:
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak.yaml
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch.yaml
+          profiles: [keycloak, elasticsearch, cnpg]
         - name: hub-mixed
           enabled: false
           auth: keycloak
@@ -713,24 +501,7 @@ integration:
           infra-type:
             gke: distroci
             eks: preemptible
-          pre-install:
-            fixtures:
-              - postgresql-cluster.yaml
-            description: |
-              Provisions a CloudNativePG `Cluster` in the scenario
-              namespace, bootstrapped with `identity` and `webmodeler` databases. Required because Identity
-              and WebModeler need external databases now that no
-              bundled PostgreSQL subchart is deployed (8.10+).
-          dependencies:
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak.yaml
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch.yaml
+          profiles: [keycloak, elasticsearch, cnpg]
         - name: hub-external-db
           enabled: true
           auth: keycloak
@@ -744,6 +515,7 @@ integration:
           platforms: [gke]
           infra-type:
             gke: distroci
+          profiles: [keycloak, elasticsearch]
           pre-install:
             fixtures:
               - postgresql-cluster.yaml
@@ -752,16 +524,6 @@ integration:
               Provisions the standard CloudNativePG `Cluster` required by
               Identity, plus a standalone PostgreSQL pod for Web Modeler
               restapi to connect to via externalDatabase config.
-          dependencies:
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak.yaml
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch.yaml
         # Used by camunda/connectors FEATURE_BRANCH_HELM_TEST workflow (main/8.10).
         - name: keycloak-original
           enabled: true
@@ -774,24 +536,7 @@ integration:
           platforms: [gke]
           infra-type:
             gke: distroci
-          pre-install:
-            fixtures:
-              - postgresql-cluster.yaml
-            description: |
-              Provisions a CloudNativePG `Cluster` in the scenario
-              namespace, bootstrapped with `identity` and `webmodeler` databases. Required because Identity
-              and WebModeler need external databases now that no
-              bundled PostgreSQL subchart is deployed (8.10+).
-          dependencies:
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak.yaml
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch.yaml
+          profiles: [keycloak, elasticsearch, cnpg]
         # AlwaysGreen scenario — referenced by camunda/camunda's
         # docker-build-helm-integration.yml. Deploys onto dedicated alwaysgreen
         # GKE node pool (workload=alwaysgreen label + NoSchedule taint).
@@ -805,24 +550,7 @@ integration:
           identity: keycloak
           persistence: elasticsearch
           platforms: [gke]
-          pre-install:
-            fixtures:
-              - postgresql-cluster.yaml
-            description: |
-              Provisions a CloudNativePG `Cluster` in the scenario
-              namespace, bootstrapped with `identity` and `webmodeler` databases. Required because Identity
-              and WebModeler need external databases now that no
-              bundled PostgreSQL subchart is deployed (8.10+).
-          dependencies:
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak.yaml
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch.yaml
+          profiles: [keycloak, elasticsearch, cnpg]
         - name: qa-elasticsearch-upg
           enabled: false
           flow: install
@@ -836,20 +564,7 @@ integration:
           platforms: [gke]
           infra-type:
             gke: qa-workloads
-          dependencies:
-            - chart: charts/internal-postgresql
-              release-name: postgresql
-              values-file: test/integration/companion-values/postgresql-qa.yaml
-              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak-qa.yaml
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch-qa.yaml
+          profiles: [postgresql-qa, keycloak-qa, elasticsearch-qa]
         - name: qa-elasticsearch-upg
           enabled: false
           flow: modular-upgrade-minor
@@ -863,20 +578,7 @@ integration:
           platforms: [gke]
           infra-type:
             gke: qa-workloads
-          dependencies:
-            - chart: charts/internal-postgresql
-              release-name: postgresql
-              values-file: test/integration/companion-values/postgresql-qa.yaml
-              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak-qa.yaml
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch-qa.yaml
+          profiles: [postgresql-qa, keycloak-qa, elasticsearch-qa]
         - name: qa-elasticsearch
           enabled: false
           flow: install
@@ -890,20 +592,7 @@ integration:
           platforms: [gke]
           infra-type:
             gke: qa-workloads
-          dependencies:
-            - chart: charts/internal-postgresql
-              release-name: postgresql
-              values-file: test/integration/companion-values/postgresql-qa.yaml
-              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak-qa.yaml
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch-qa.yaml
+          profiles: [postgresql-qa, keycloak-qa, elasticsearch-qa]
         - name: qa-opensearch
           enabled: false
           flow: install
@@ -917,20 +606,7 @@ integration:
           platforms: [gke]
           infra-type:
             gke: qa-workloads
-          dependencies:
-            - chart: charts/internal-postgresql
-              release-name: postgresql
-              values-file: test/integration/companion-values/postgresql-qa.yaml
-              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak-qa.yaml
-            - chart: opensearch/opensearch
-              version: "3.6.0"
-              release-name: opensearch
-              repo-name: opensearch
-              repo-url: https://opensearch-project.github.io/helm-charts/
-              values-file: test/integration/companion-values/opensearch.yaml
+          profiles: [postgresql-qa, keycloak-qa, opensearch]
         - name: qa-opensearch-upg
           enabled: false
           flow: install
@@ -945,20 +621,7 @@ integration:
           platforms: [gke]
           infra-type:
             gke: qa-workloads
-          dependencies:
-            - chart: charts/internal-postgresql
-              release-name: postgresql
-              values-file: test/integration/companion-values/postgresql-qa.yaml
-              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak-qa.yaml
-            - chart: opensearch/opensearch
-              version: "3.6.0"
-              release-name: opensearch
-              repo-name: opensearch
-              repo-url: https://opensearch-project.github.io/helm-charts/
-              values-file: test/integration/companion-values/opensearch.yaml
+          profiles: [postgresql-qa, keycloak-qa, opensearch]
         - name: qa-opensearch-upg
           enabled: false
           flow: modular-upgrade-minor
@@ -973,20 +636,7 @@ integration:
           platforms: [gke]
           infra-type:
             gke: qa-workloads
-          dependencies:
-            - chart: charts/internal-postgresql
-              release-name: postgresql
-              values-file: test/integration/companion-values/postgresql-qa.yaml
-              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak-qa.yaml
-            - chart: opensearch/opensearch
-              version: "3.6.0"
-              release-name: opensearch
-              repo-name: opensearch
-              repo-url: https://opensearch-project.github.io/helm-charts/
-              values-file: test/integration/companion-values/opensearch.yaml
+          profiles: [postgresql-qa, keycloak-qa, opensearch]
         - name: qa-elasticsearch-mt
           enabled: false
           flow: install
@@ -1000,20 +650,7 @@ integration:
           platforms: [gke]
           infra-type:
             gke: qa-workloads
-          dependencies:
-            - chart: charts/internal-postgresql
-              release-name: postgresql
-              values-file: test/integration/companion-values/postgresql-qa.yaml
-              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak-qa.yaml
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch-qa.yaml
+          profiles: [postgresql-qa, keycloak-qa, elasticsearch-qa]
         - name: qa-elasticsearch-mt-upg
           enabled: false
           flow: install
@@ -1027,20 +664,7 @@ integration:
           platforms: [gke]
           infra-type:
             gke: qa-workloads
-          dependencies:
-            - chart: charts/internal-postgresql
-              release-name: postgresql
-              values-file: test/integration/companion-values/postgresql-qa.yaml
-              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak-qa.yaml
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch-qa.yaml
+          profiles: [postgresql-qa, keycloak-qa, elasticsearch-qa]
         - name: qa-elasticsearch-mt-upg
           enabled: false
           flow: modular-upgrade-minor
@@ -1054,20 +678,7 @@ integration:
           platforms: [gke]
           infra-type:
             gke: qa-workloads
-          dependencies:
-            - chart: charts/internal-postgresql
-              release-name: postgresql
-              values-file: test/integration/companion-values/postgresql-qa.yaml
-              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak-qa.yaml
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch-qa.yaml
+          profiles: [postgresql-qa, keycloak-qa, elasticsearch-qa]
         - name: qa-elasticsearch-rba
           enabled: false
           flow: install
@@ -1081,20 +692,7 @@ integration:
           platforms: [gke]
           infra-type:
             gke: qa-workloads
-          dependencies:
-            - chart: charts/internal-postgresql
-              release-name: postgresql
-              values-file: test/integration/companion-values/postgresql-qa.yaml
-              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak-qa.yaml
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch-qa.yaml
+          profiles: [postgresql-qa, keycloak-qa, elasticsearch-qa]
         - name: qa-document-store
           enabled: false
           flow: install
@@ -1108,20 +706,7 @@ integration:
           platforms: [gke]
           infra-type:
             gke: qa-workloads
-          dependencies:
-            - chart: charts/internal-postgresql
-              release-name: postgresql
-              values-file: test/integration/companion-values/postgresql-qa.yaml
-              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak-qa.yaml
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch-qa.yaml
+          profiles: [postgresql-qa, keycloak-qa, elasticsearch-qa]
         - name: qa-document-store
           enabled: false
           flow: install
@@ -1135,20 +720,7 @@ integration:
           platforms: [eks]
           infra-type:
             eks: preemptible
-          dependencies:
-            - chart: charts/internal-postgresql
-              release-name: postgresql
-              values-file: test/integration/companion-values/postgresql.yaml
-              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak.yaml
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch.yaml
+          profiles: [postgresql, keycloak, elasticsearch]
         - name: qa-document-store-upg
           enabled: false
           flow: install
@@ -1162,20 +734,7 @@ integration:
           platforms: [gke]
           infra-type:
             gke: qa-workloads
-          dependencies:
-            - chart: charts/internal-postgresql
-              release-name: postgresql
-              values-file: test/integration/companion-values/postgresql-qa.yaml
-              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak-qa.yaml
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch-qa.yaml
+          profiles: [postgresql-qa, keycloak-qa, elasticsearch-qa]
         - name: qa-document-store-upg
           enabled: false
           flow: install
@@ -1189,20 +748,7 @@ integration:
           platforms: [eks]
           infra-type:
             eks: preemptible
-          dependencies:
-            - chart: charts/internal-postgresql
-              release-name: postgresql
-              values-file: test/integration/companion-values/postgresql.yaml
-              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak.yaml
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch.yaml
+          profiles: [postgresql, keycloak, elasticsearch]
         - name: qa-document-store-upg
           enabled: false
           flow: modular-upgrade-minor
@@ -1216,20 +762,7 @@ integration:
           platforms: [gke]
           infra-type:
             gke: qa-workloads
-          dependencies:
-            - chart: charts/internal-postgresql
-              release-name: postgresql
-              values-file: test/integration/companion-values/postgresql-qa.yaml
-              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak-qa.yaml
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch-qa.yaml
+          profiles: [postgresql-qa, keycloak-qa, elasticsearch-qa]
         - name: qa-document-store-upg
           enabled: false
           flow: modular-upgrade-minor
@@ -1243,20 +776,7 @@ integration:
           platforms: [eks]
           infra-type:
             eks: preemptible
-          dependencies:
-            - chart: charts/internal-postgresql
-              release-name: postgresql
-              values-file: test/integration/companion-values/postgresql.yaml
-              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak.yaml
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch.yaml
+          profiles: [postgresql, keycloak, elasticsearch]
         - name: qa-license
           enabled: false
           flow: install
@@ -1270,17 +790,4 @@ integration:
           platforms: [gke]
           infra-type:
             gke: qa-workloads
-          dependencies:
-            - chart: charts/internal-postgresql
-              release-name: postgresql
-              values-file: test/integration/companion-values/postgresql-qa.yaml
-              env-vars: [RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD]
-            - chart: charts/internal-keycloak-26
-              release-name: keycloak
-              values-file: test/integration/companion-values/keycloak-qa.yaml
-            - chart: elastic/elasticsearch
-              version: "8.5.1"
-              release-name: elasticsearch
-              repo-name: elastic
-              repo-url: https://helm.elastic.co
-              values-file: test/integration/companion-values/elasticsearch-qa.yaml
+          profiles: [postgresql-qa, keycloak-qa, elasticsearch-qa]

--- a/scripts/deploy-camunda/matrix/config.go
+++ b/scripts/deploy-camunda/matrix/config.go
@@ -62,7 +62,22 @@ type CITestConfig struct {
 		// e.g. pre-upgrade scripts shared by all scenarios using a given flow.
 		// Keys are flow strings such as "upgrade-patch", "upgrade-minor".
 		Flows map[string]*FlowHooks `yaml:"flows,omitempty"`
+		// DependencyProfiles are reusable companion-chart bundles keyed by name.
+		// Scenarios reference them via Profiles; ResolveProfiles expands the
+		// references into each scenario's Dependencies and PreInstall at load
+		// time, so common companion setup is declared once instead of repeated
+		// in every scenario.
+		DependencyProfiles map[string]DependencyProfile `yaml:"dependency-profiles,omitempty"`
 	} `yaml:"integration"`
+}
+
+// DependencyProfile is a reusable bundle of companion-chart dependencies and an
+// optional pre-install hook, referenced by name from a scenario's Profiles list.
+// PreInstall, when set, must use fixtures (not a script) so profiles compose
+// cleanly across scenarios.
+type DependencyProfile struct {
+	Dependencies []ChartDependency `yaml:"dependencies,omitempty"`
+	PreInstall   *LifecycleHook    `yaml:"pre-install,omitempty"`
 }
 
 // LifecycleHook declares a fixture or shell script that runs at a defined
@@ -174,8 +189,17 @@ type CIScenario struct {
 	SkipE2E bool `yaml:"skip-e2e,omitempty"`
 	SkipIT  bool `yaml:"skip-it,omitempty"`
 
+	// Profiles names reusable dependency profiles (see
+	// integration.dependency-profiles) to expand into this scenario's
+	// Dependencies and PreInstall. Profiles are applied in list order, before
+	// any scenario-inline Dependencies. Special scenarios may omit Profiles and
+	// declare Dependencies/PreInstall directly.
+	Profiles []string `yaml:"profiles,omitempty"`
+
 	// Dependencies specifies companion charts to deploy before the main Camunda chart.
 	// Each dependency is deployed as a separate Helm release in the same namespace.
+	// After ResolveProfiles, this holds the fully-expanded list (profile
+	// dependencies first, then any inline entries).
 	Dependencies []ChartDependency `yaml:"dependencies,omitempty"`
 
 	// PrefixKey, when set, overrides the scenario name for index prefix
@@ -240,7 +264,129 @@ func LoadCITestConfig(chartDir string) (*CITestConfig, error) {
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("failed to parse ci-test-config.yaml from %s: %w", chartDir, err)
 	}
+	if err := ResolveProfiles(&cfg); err != nil {
+		return nil, fmt.Errorf("failed to resolve dependency profiles in %s: %w", chartDir, err)
+	}
 	return &cfg, nil
+}
+
+// ResolveProfiles expands every scenario's Profiles into its Dependencies and
+// PreInstall, in place. Profile dependencies are placed first, in profile-list
+// order, followed by any scenario-inline Dependencies. A profile pre-install
+// fixture is merged into the scenario PreInstall (fixtures are unioned). The
+// resolution is deterministic so that matrix list/run output is unchanged from
+// the equivalent fully-inlined config. Returns an error for an unknown profile
+// reference or a pre-install mode conflict.
+func ResolveProfiles(cfg *CITestConfig) error {
+	if cfg == nil {
+		return nil
+	}
+	profiles := cfg.Integration.DependencyProfiles
+	// Iterate by index over each backing slice directly so the in-place writes
+	// in resolveScenarioProfiles are obviously reaching the real structs.
+	for i := range cfg.Integration.Case.PR.Scenarios {
+		if err := resolveScenarioProfiles(&cfg.Integration.Case.PR.Scenarios[i], profiles); err != nil {
+			return err
+		}
+	}
+	for i := range cfg.Integration.Case.Nightly.Scenarios {
+		if err := resolveScenarioProfiles(&cfg.Integration.Case.Nightly.Scenarios[i], profiles); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// resolveScenarioProfiles expands a single scenario's Profiles in place.
+func resolveScenarioProfiles(s *CIScenario, profiles map[string]DependencyProfile) error {
+	if len(s.Profiles) == 0 {
+		return nil
+	}
+	var deps []ChartDependency
+	for _, name := range s.Profiles {
+		p, ok := profiles[name]
+		if !ok {
+			return fmt.Errorf("scenario %q references unknown dependency profile %q", s.Name, name)
+		}
+		for _, d := range p.Dependencies {
+			// Deep-copy EnvVars so two scenarios expanding the same profile do
+			// not alias one slice (mirrors the fixtures copy in
+			// mergeProfilePreInstall).
+			if len(d.EnvVars) > 0 {
+				d.EnvVars = append([]string(nil), d.EnvVars...)
+			}
+			deps = append(deps, d)
+		}
+		merged, err := mergeProfilePreInstall(s.Name, name, s.PreInstall, p.PreInstall)
+		if err != nil {
+			return err
+		}
+		s.PreInstall = merged
+	}
+	// Scenario-inline dependencies follow the profile-derived ones.
+	deps = append(deps, s.Dependencies...)
+	s.Dependencies = deps
+	// Clear Profiles so ResolveProfiles is idempotent: a second call must not
+	// re-expand and double the already-resolved dependencies.
+	s.Profiles = nil
+	return nil
+}
+
+// mergeProfilePreInstall folds a profile's pre-install hook into the scenario's
+// current pre-install. Profiles may only contribute fixtures; the result unions
+// fixtures. Merging into a scenario script pre-install (or a profile declaring a
+// script) is a conflict.
+func mergeProfilePreInstall(scenario, profile string, existing, add *LifecycleHook) (*LifecycleHook, error) {
+	if add == nil {
+		return existing, nil
+	}
+	if add.Script != "" {
+		return nil, fmt.Errorf("scenario %q: dependency profile %q pre-install must use fixtures, not script", scenario, profile)
+	}
+	if existing == nil {
+		clone := *add
+		clone.Fixtures = append([]string(nil), add.Fixtures...)
+		return &clone, nil
+	}
+	if existing.Script != "" {
+		return nil, fmt.Errorf("scenario %q: cannot merge fixtures from dependency profile %q into a script pre-install", scenario, profile)
+	}
+	// Concatenate descriptions so no profile's rationale is silently dropped
+	// when two fixture-contributing hooks merge.
+	desc := existing.Description
+	if add.Description != "" {
+		if desc != "" {
+			desc += "\n" + add.Description
+		} else {
+			desc = add.Description
+		}
+	}
+	// Ordering: existing fixtures (the scenario inline hook, or the accumulator
+	// from earlier profiles in list order) come first, then this profile's, so
+	// multiple fixture-contributing profiles yield profile-list order. Duplicate
+	// fixture names are dropped (first occurrence wins) so e.g. an inline
+	// postgresql-cluster.yaml plus a profile that also provides it does not
+	// apply the same manifest twice.
+	merged := &LifecycleHook{
+		Fixtures:    dedupeStrings(append(append([]string(nil), existing.Fixtures...), add.Fixtures...)),
+		Description: desc,
+	}
+	return merged, nil
+}
+
+// dedupeStrings returns s with duplicate values removed, preserving first-seen
+// order.
+func dedupeStrings(s []string) []string {
+	seen := make(map[string]bool, len(s))
+	out := s[:0]
+	for _, v := range s {
+		if seen[v] {
+			continue
+		}
+		seen[v] = true
+		out = append(out, v)
+	}
+	return out
 }
 
 // PermittedFlows holds the parsed content of .github/config/permitted-flows.yaml.

--- a/scripts/deploy-camunda/matrix/config_test.go
+++ b/scripts/deploy-camunda/matrix/config_test.go
@@ -15,6 +15,7 @@
 package matrix
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -262,5 +263,275 @@ integration:
 	}
 	if cfg.Integration.Flows != nil {
 		t.Errorf("flows: want nil when omitted")
+	}
+}
+
+// profileTestConfig is a representative config exercising dependency profiles:
+// two companion profiles plus a fixtures-only cnpg profile.
+const profileTestConfig = `
+integration:
+  dependency-profiles:
+    keycloak:
+      dependencies:
+        - chart: charts/internal-keycloak-26
+          release-name: keycloak
+          values-file: test/integration/companion-values/keycloak.yaml
+    elasticsearch:
+      dependencies:
+        - chart: elastic/elasticsearch
+          version: "8.5.1"
+          release-name: elasticsearch
+          repo-name: elastic
+          repo-url: https://helm.elastic.co
+          values-file: test/integration/companion-values/elasticsearch.yaml
+    cnpg:
+      pre-install:
+        fixtures: [postgresql-cluster.yaml]
+        description: |
+          Provisions a CloudNativePG Cluster + auth Secret.
+  case:
+    pr:
+      scenario:
+        - name: %s
+`
+
+func loadAndResolve(t *testing.T, src string) *CITestConfig {
+	t.Helper()
+	var cfg CITestConfig
+	if err := yaml.Unmarshal([]byte(src), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if err := ResolveProfiles(&cfg); err != nil {
+		t.Fatalf("ResolveProfiles: %v", err)
+	}
+	return &cfg
+}
+
+func TestResolveProfiles_ExpandsDependenciesInOrder(t *testing.T) {
+	scenario := `elasticsearch
+          enabled: true
+          shortname: eske
+          profiles: [keycloak, elasticsearch, cnpg]`
+	cfg := loadAndResolve(t, fmt.Sprintf(profileTestConfig, scenario))
+
+	deps := cfg.Integration.Case.PR.Scenarios[0].Dependencies
+	gotCharts := make([]string, len(deps))
+	for i, d := range deps {
+		gotCharts[i] = d.Chart
+	}
+	want := []string{"charts/internal-keycloak-26", "elastic/elasticsearch"}
+	if len(gotCharts) != len(want) {
+		t.Fatalf("dependencies: got %v, want %v", gotCharts, want)
+	}
+	for i := range want {
+		if gotCharts[i] != want[i] {
+			t.Errorf("dependency[%d] chart: got %q, want %q", i, gotCharts[i], want[i])
+		}
+	}
+	// The remote ES dependency keeps its repo metadata after expansion.
+	if deps[1].RepoURL != "https://helm.elastic.co" || deps[1].Version != "8.5.1" {
+		t.Errorf("es dependency lost metadata: %+v", deps[1])
+	}
+	// cnpg profile contributed the pre-install fixture.
+	pi := cfg.Integration.Case.PR.Scenarios[0].PreInstall
+	if pi == nil || len(pi.Fixtures) != 1 || pi.Fixtures[0] != "postgresql-cluster.yaml" {
+		t.Fatalf("pre-install fixtures: got %+v", pi)
+	}
+}
+
+func TestResolveProfiles_UnknownProfileErrors(t *testing.T) {
+	scenario := `bad
+          enabled: true
+          shortname: bad
+          profiles: [keycloak, nope]`
+	var cfg CITestConfig
+	if err := yaml.Unmarshal([]byte(fmt.Sprintf(profileTestConfig, scenario)), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	err := ResolveProfiles(&cfg)
+	if err == nil {
+		t.Fatal("expected error for unknown profile, got nil")
+	}
+	if !strings.Contains(err.Error(), "nope") {
+		t.Errorf("error should name the unknown profile, got: %v", err)
+	}
+}
+
+func TestResolveProfiles_ScriptPreInstallConflicts(t *testing.T) {
+	// A scenario with a script pre-install cannot also pull cnpg fixtures.
+	scenario := `conflict
+          enabled: true
+          shortname: cflt
+          profiles: [cnpg]
+          pre-install:
+            script: pre-install-custom.sh
+            description: custom`
+	var cfg CITestConfig
+	if err := yaml.Unmarshal([]byte(fmt.Sprintf(profileTestConfig, scenario)), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	err := ResolveProfiles(&cfg)
+	if err == nil {
+		t.Fatal("expected conflict error, got nil")
+	}
+	if !strings.Contains(err.Error(), "script pre-install") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveProfiles_InlineDependenciesAppendedAfterProfiles(t *testing.T) {
+	scenario := `mixed
+          enabled: true
+          shortname: mix
+          profiles: [keycloak]
+          dependencies:
+            - chart: charts/extra
+              release-name: extra`
+	cfg := loadAndResolve(t, fmt.Sprintf(profileTestConfig, scenario))
+	deps := cfg.Integration.Case.PR.Scenarios[0].Dependencies
+	if len(deps) != 2 || deps[0].Chart != "charts/internal-keycloak-26" || deps[1].Chart != "charts/extra" {
+		t.Fatalf("expected profile dep then inline dep, got %+v", deps)
+	}
+}
+
+func TestResolveProfiles_Idempotent(t *testing.T) {
+	scenario := `idem
+          enabled: true
+          shortname: idem
+          profiles: [keycloak, elasticsearch, cnpg]`
+	src := fmt.Sprintf(profileTestConfig, scenario)
+	var cfg CITestConfig
+	if err := yaml.Unmarshal([]byte(src), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if err := ResolveProfiles(&cfg); err != nil {
+		t.Fatalf("ResolveProfiles (1): %v", err)
+	}
+	first := len(cfg.Integration.Case.PR.Scenarios[0].Dependencies)
+	// Second call must not re-expand the already-resolved dependencies.
+	if err := ResolveProfiles(&cfg); err != nil {
+		t.Fatalf("ResolveProfiles (2): %v", err)
+	}
+	second := len(cfg.Integration.Case.PR.Scenarios[0].Dependencies)
+	if first != 2 || second != first {
+		t.Fatalf("not idempotent: first=%d second=%d (want 2, 2)", first, second)
+	}
+}
+
+func TestResolveProfiles_MergesTwoFixtureDescriptions(t *testing.T) {
+	src := `
+integration:
+  dependency-profiles:
+    fx-a:
+      pre-install:
+        fixtures: [a.yaml]
+        description: AAA
+    fx-b:
+      pre-install:
+        fixtures: [b.yaml]
+        description: BBB
+  case:
+    pr:
+      scenario:
+        - name: two
+          enabled: true
+          shortname: two
+          profiles: [fx-a, fx-b]
+`
+	cfg := loadAndResolve(t, src)
+	pi := cfg.Integration.Case.PR.Scenarios[0].PreInstall
+	if pi == nil {
+		t.Fatal("pre-install: nil")
+	}
+	if len(pi.Fixtures) != 2 || pi.Fixtures[0] != "a.yaml" || pi.Fixtures[1] != "b.yaml" {
+		t.Errorf("fixtures: got %v, want [a.yaml b.yaml]", pi.Fixtures)
+	}
+	if !strings.Contains(pi.Description, "AAA") || !strings.Contains(pi.Description, "BBB") {
+		t.Errorf("description dropped a profile's text: %q", pi.Description)
+	}
+}
+
+func TestResolveProfiles_InlinePreInstallMergesBeforeProfileFixtures(t *testing.T) {
+	// Documented ordering: a scenario's own inline pre-install fixtures come
+	// before a fixture-contributing profile's. Locks the contract noted in
+	// mergeProfilePreInstall.
+	src := `
+integration:
+  dependency-profiles:
+    fx-p:
+      pre-install:
+        fixtures: [profile.yaml]
+        description: from profile
+  case:
+    pr:
+      scenario:
+        - name: combo
+          enabled: true
+          shortname: combo
+          profiles: [fx-p]
+          pre-install:
+            fixtures: [inline.yaml]
+            description: from scenario
+`
+	cfg := loadAndResolve(t, src)
+	pi := cfg.Integration.Case.PR.Scenarios[0].PreInstall
+	if pi == nil {
+		t.Fatal("pre-install: nil")
+	}
+	if len(pi.Fixtures) != 2 || pi.Fixtures[0] != "inline.yaml" || pi.Fixtures[1] != "profile.yaml" {
+		t.Errorf("fixtures: got %v, want [inline.yaml profile.yaml] (inline first)", pi.Fixtures)
+	}
+	if !strings.Contains(pi.Description, "from scenario") || !strings.Contains(pi.Description, "from profile") {
+		t.Errorf("description dropped text: %q", pi.Description)
+	}
+}
+
+func TestResolveProfiles_DeduplicatesMergedFixtures(t *testing.T) {
+	// Inline and profile both provide postgresql-cluster.yaml — the merged hook
+	// must list it once, not apply the same manifest twice.
+	src := `
+integration:
+  dependency-profiles:
+    fx-p:
+      pre-install:
+        fixtures: [postgresql-cluster.yaml]
+        description: from profile
+  case:
+    pr:
+      scenario:
+        - name: dup
+          enabled: true
+          shortname: dup
+          profiles: [fx-p]
+          pre-install:
+            fixtures: [postgresql-cluster.yaml]
+            description: from scenario
+`
+	cfg := loadAndResolve(t, src)
+	pi := cfg.Integration.Case.PR.Scenarios[0].PreInstall
+	if pi == nil || len(pi.Fixtures) != 1 || pi.Fixtures[0] != "postgresql-cluster.yaml" {
+		t.Fatalf("fixtures: got %+v, want exactly [postgresql-cluster.yaml]", pi)
+	}
+}
+
+func TestResolveProfiles_NoProfilesUnchanged(t *testing.T) {
+	// Backward compatibility: a scenario with only inline dependencies and no
+	// profiles resolves unchanged.
+	src := `
+integration:
+  case:
+    pr:
+      scenario:
+        - name: inline
+          enabled: true
+          shortname: inl
+          dependencies:
+            - chart: charts/internal-keycloak-26
+              release-name: keycloak
+`
+	cfg := loadAndResolve(t, src)
+	deps := cfg.Integration.Case.PR.Scenarios[0].Dependencies
+	if len(deps) != 1 || deps[0].Chart != "charts/internal-keycloak-26" {
+		t.Fatalf("inline deps changed: %+v", deps)
 	}
 }

--- a/scripts/deploy-camunda/matrix/lifecycle_hook_test.go
+++ b/scripts/deploy-camunda/matrix/lifecycle_hook_test.go
@@ -56,9 +56,9 @@ var preSetupScriptAllowlist = map[string]bool{
 //	                                (8.10) via envsubst+kubectl, not via the
 //	                                runner's declarative fixtures pipeline.
 var commonResourcesAllowlist = map[string]bool{
-	"postgres-createdb-job.yaml":    true,
-	"postgresql-cluster-tls.yaml":   true,
-	"gateway-proxy-settings.yaml":   true,
+	"postgres-createdb-job.yaml":  true,
+	"postgresql-cluster-tls.yaml": true,
+	"gateway-proxy-settings.yaml": true,
 }
 
 // TestLifecycleFixtures asserts the integrity of the declarative lifecycle
@@ -189,6 +189,16 @@ func validateLifecycleFixturesForVersion(t *testing.T, repoRoot, version string,
 		collect("scenario "+scn.Name+" (PR pre-install)", scn.PreInstall)
 		collect("scenario "+scn.Name+" (PR post-deploy)", scn.PostDeploy)
 		addScenarioFlows(scn)
+	}
+	for _, scn := range cfg.Integration.Case.Nightly.Scenarios {
+		collect("scenario "+scn.Name+" (nightly pre-install)", scn.PreInstall)
+		collect("scenario "+scn.Name+" (nightly post-deploy)", scn.PostDeploy)
+		addScenarioFlows(scn)
+	}
+	// Validate dependency-profile pre-install fixtures directly, so a typo in a
+	// profile not yet referenced by any scenario is still caught.
+	for profName, prof := range cfg.Integration.DependencyProfiles {
+		collect("dependency-profile "+profName+" (pre-install)", prof.PreInstall)
 	}
 	for flowName, hooks := range cfg.Integration.Flows {
 		if !knownFlows[flowName] {


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6273 

### What's in this PR?

After #6146 dropped the bundled Bitnami subcharts, `ci-test-config.yaml` repeated
the same companion `dependencies:` blocks (37× Keycloak, 34× Elasticsearch, 19×
PostgreSQL) and the same CloudNativePG `pre-install` fixture (19×) across
scenarios.

This introduces reusable named dependency profiles:

- An `integration.dependency-profiles` map defines each companion bundle once:
  `keycloak[-qa]`, `elasticsearch[-qa]`, `opensearch`, `postgresql[-qa]`, and a
  `cnpg` pre-install profile.
- Scenarios reference them via `profiles: [...]`. `ResolveProfiles` (run at
  config load) expands profile dependencies (in list order, before any inline
  deps) and merges the `cnpg` pre-install fixture into the scenario. `Generate()`
  and the matrix runner are untouched.
- Special scenarios stay explicit: `opensearch-self-signed` (TLS values + script),
  `rdbms-self-signed` (script), `rdbms` (custom 3-database CNPG bootstrap).
- `ci-test-config.yaml`: 1220 → 735 lines.

Resolution is deterministic: `deploy-camunda matrix list --include-disabled
--format json` is byte-identical before and after, so matrix list/run behavior
is unchanged.

Unit tests cover profile expansion order, unknown-profile error, `cnpg`
pre-install merge, script/fixtures conflict, and inline-only backward
compatibility.

> Stacked on #6287 — the `env-vars` allowlist it adds is reused by the
> `postgresql` profiles. Base is the #6287 branch; it retargets to `main` once
> that merges. Review/merge #6287 first.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
