### PR TITLE
chore: guard deploy-camunda matrix --chart-ref against multi-version runs

### DIFF
--- a/scripts/deploy-camunda/cmd/matrix.go
+++ b/scripts/deploy-camunda/cmd/matrix.go
@@ -399,6 +399,12 @@ This command calls deploy.Execute() for each matrix entry.`,
 				return nil
 			}
 
+			// An external --chart-ref artifact corresponds to a single Camunda
+			// version, so it must not be applied across a multi-version matrix.
+			if err := validateChartRefVersionSpan(chartRef, entries); err != nil {
+				return err
+			}
+
 			// Block e2e runs with many entries — Playwright spawns a browser per test
 			// which can exhaust machine resources fast.
 			const e2eWarnThreshold = 5
@@ -761,6 +767,33 @@ func validateChartRefFlags(chartRef, chartRefVersion string) error {
 		return fmt.Errorf("--chart-version is required when --chart-ref is an OCI reference")
 	}
 
+	return nil
+}
+
+// validateChartRefVersionSpan rejects a --chart-ref override that would span
+// more than one chart version. An external chart artifact (OCI ref or .tgz)
+// corresponds to a single Camunda version, so applying it across multiple
+// resolved matrix versions would install the wrong chart on every entry but the
+// matching one. Multiple entries that share one version (scenarios/flows) are
+// allowed — that is the normal RC-validation workflow.
+func validateChartRefVersionSpan(chartRef string, entries []matrix.Entry) error {
+	if chartRef == "" {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	order := []string{}
+	for _, e := range entries {
+		if _, ok := seen[e.Version]; !ok {
+			seen[e.Version] = struct{}{}
+			order = append(order, e.Version)
+		}
+	}
+	if len(order) > 1 {
+		return fmt.Errorf(
+			"--chart-ref applies a single external chart artifact, but the resolved matrix spans %d versions (%s); "+
+				"narrow the run to one version with --versions (e.g. --versions %s)",
+			len(order), strings.Join(order, ", "), order[0])
+	}
 	return nil
 }
 

--- a/scripts/deploy-camunda/cmd/matrix_test.go
+++ b/scripts/deploy-camunda/cmd/matrix_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"strings"
 	"testing"
+
+	"scripts/deploy-camunda/matrix"
 )
 
 func TestValidateChartRefFlags(t *testing.T) {
@@ -55,6 +57,67 @@ func TestValidateChartRefFlags(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := validateChartRefFlags(tt.chartRef, tt.chartRefVersion)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+			}
+		})
+	}
+}
+
+func TestValidateChartRefVersionSpan(t *testing.T) {
+	entriesFor := func(versions ...string) []matrix.Entry {
+		out := make([]matrix.Entry, 0, len(versions))
+		for _, v := range versions {
+			out = append(out, matrix.Entry{Version: v})
+		}
+		return out
+	}
+
+	tests := []struct {
+		name     string
+		chartRef string
+		entries  []matrix.Entry
+		wantErr  string // substring; empty = expect success
+	}{
+		{
+			name:    "no chart-ref allows any version span",
+			entries: entriesFor("8.8", "8.9", "8.10"),
+		},
+		{
+			name:     "single version single entry is allowed",
+			chartRef: "oci://registry.camunda.cloud/team-distribution/camunda-platform",
+			entries:  entriesFor("8.10"),
+		},
+		{
+			name:     "single version multiple entries is allowed",
+			chartRef: "oci://registry.camunda.cloud/team-distribution/camunda-platform",
+			entries:  entriesFor("8.10", "8.10", "8.10"),
+		},
+		{
+			name:     "multiple versions are rejected",
+			chartRef: "oci://registry.camunda.cloud/team-distribution/camunda-platform",
+			entries:  entriesFor("8.8", "8.9"),
+			wantErr:  "spans 2 versions (8.8, 8.9)",
+		},
+		{
+			name:     "empty entries with chart-ref does not panic",
+			chartRef: "oci://registry.camunda.cloud/team-distribution/camunda-platform",
+			entries:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateChartRefVersionSpan(tt.chartRef, tt.entries)
 			if tt.wantErr == "" {
 				if err != nil {
 					t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6089.

The global `--chart-ref` / `--chart-version` flags on `deploy-camunda matrix run` apply one external OCI/`.tgz` chart source to every resolved matrix entry. An OCI chart artifact (e.g. `13-rc-latest`) corresponds to a single Camunda version, so applying it across `8.8,8.9,8.10` entries installs the wrong chart on every entry but the matching one. There was no guard against this misuse; it is latent today only because every CI caller filters to a single fully-pinned entry.

### What's in this PR?

Adds a `validateChartRefVersionSpan` guard in `scripts/deploy-camunda/cmd/matrix.go`, run after the matrix is resolved (post-`Filter`), before the run starts. When `--chart-ref` is set and the resolved entries span more than one distinct chart version, it fails fast with a clear message:

```
--chart-ref applies a single external chart artifact, but the resolved matrix spans 2 versions (8.9, 8.10); narrow the run to one version with --versions (e.g. --versions 8.9)
```

Design notes:
- The guard keys on **distinct chart version**, not entry count. An OCI artifact maps to exactly one Camunda version, but legitimately spans many scenarios/flows of that one version — the normal RC-validation workflow (e.g. all tier-1 8.10 scenarios against `13-rc-latest`). Guarding on ">1 entry" (as the issue's Option 2 suggested) would wrongly block that; guarding on ">1 version" blocks only the broken case.
- Kept separate from the existing `validateChartRefFlags` (`PreRunE`, flag-shape checks): the version span is unknown until entries are resolved, so the entry-set check must run after `matrix.Generate`/`Filter`.
- No flag rename, no env vars, no per-entry config, no new command — those alternatives from the issue were rejected (per-entry config conflates an ephemeral release target with durable scenario identity; env vars are a cosmetic relabel; a separate command would duplicate matrix orchestration and undo #6087).

No behavior change for any existing CI flow (all single-version, single-entry).

Verified: `go build`, `go vet`, gofmt clean, `go test ./cmd/...` (24 pass incl. new `TestValidateChartRefVersionSpan`); negative dry-run (`--versions 8.9,8.10`) errors as above, positive dry-run (`--versions 8.10`, 14 entries) passes.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
