### PR TITLE
test(8.10): honor RDBMS_POSTGRESQL_USERNAME for the role in postgresql-cluster fixture

### DIFF
--- a/charts/camunda-platform-8.10/test/integration/scenarios/common/resources/postgresql-cluster.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/common/resources/postgresql-cluster.yaml
@@ -15,16 +15,22 @@ metadata:
   namespace: $NAMESPACE
 spec:
   instances: 1
+  # The login role, its owned databases, and the connection secret all derive
+  # from $RDBMS_POSTGRESQL_USERNAME so any value stays self-consistent with the
+  # JDBC user the chart connects as. Previously the role/owner were hardcoded
+  # to `app` while the chart connected as $RDBMS_POSTGRESQL_USERNAME, so any
+  # value other than `app` failed with "password authentication failed for
+  # user ...". In CI the var is `app`, so this renders identically.
   bootstrap:
     initdb:
       database: app
-      owner: app
+      owner: $RDBMS_POSTGRESQL_USERNAME
       postInitSQL:
-        - CREATE DATABASE identity OWNER app
-        - CREATE DATABASE webmodeler OWNER app
+        - CREATE DATABASE identity OWNER $RDBMS_POSTGRESQL_USERNAME
+        - CREATE DATABASE webmodeler OWNER $RDBMS_POSTGRESQL_USERNAME
   managed:
     roles:
-      - name: app
+      - name: $RDBMS_POSTGRESQL_USERNAME
         ensure: present
         superuser: true
         login: true


### PR DESCRIPTION
### Which problem does the PR fix?

A manual `deploy-camunda` run of any scenario using the `postgresql-cluster` CNPG fixture fails with a confusing `FATAL: password authentication failed for user "..."` unless `RDBMS_POSTGRESQL_USERNAME` happens to be exactly `app`.

### What's in this PR?

The `postgresql-cluster.yaml` fixture hardcoded the login role, the app-db owner, and the `identity`/`webmodeler` database owners to `app`, while the connection `Secret` and the chart's JDBC user both derive from `$RDBMS_POSTGRESQL_USERNAME`. They only agree when that variable is literally `app` (which CI's vault provides), so a manual run with any other value brought all pods up but failed JDBC auth — the role the chart connected as simply didn't exist.

This derives the managed role name, the `initdb` owner, and the `CREATE DATABASE ... OWNER` clauses from `$RDBMS_POSTGRESQL_USERNAME`, so any value stays self-consistent with the JDBC user. When the variable is `app` the fixture renders **byte-identical** to before, so CI behavior is unchanged. An unset variable is still caught loudly upstream by the chart's required-env validation.

**Validation:**
- `envsubst` render: `RDBMS_POSTGRESQL_USERNAME=app` → identical to the old hardcoded fixture; `=camunda` → role/owner/DDL/secret all consistently `camunda`.
- `go test ./matrix/... ./deploy/...` pass (no test asserts the fixture's role content).
- **GKE `distro-ci`:** deployed `opensearch-self-signed-os-trust` with `RDBMS_POSTGRESQL_USERNAME=camunda` (the value that failed before this change) → `[PASS] 7m31s`, `web-modeler-restapi` and `identity` both `Running 1/1` / 0 restarts.

Note: an equivalent (simpler) `postgresql-cluster.yaml` exists in `charts/camunda-platform-8.9` with the same `name: app` hardcoding; left out of this PR to keep the diff version-scoped and because its bootstrap layout differs (no explicit `initdb` / DB-creation). Happy to follow up if wanted.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
