### PR TITLE
fix(8.10): align camunda hub service account gating

### DIFF
--- a/charts/camunda-platform-8.10/templates/console/serviceaccount.yaml
+++ b/charts/camunda-platform-8.10/templates/console/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq (include "camundaHub.consoleEnabled" .) "true") .Values.console.serviceAccount.enabled -}}
+{{- if and (eq (include "camundaHub.consoleEnabled" .) "true") (or .Values.camundaHub.console.serviceAccount.enabled .Values.console.serviceAccount.enabled) -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/camunda-platform-8.10/templates/web-modeler/serviceaccount.yaml
+++ b/charts/camunda-platform-8.10/templates/web-modeler/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq (include "camundaHub.webModelerEnabled" .) "true") .Values.webModeler.serviceAccount.enabled -}}
+{{- if and (eq (include "camundaHub.webModelerEnabled" .) "true") (or .Values.camundaHub.webModeler.serviceAccount.enabled .Values.webModeler.serviceAccount.enabled) -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/camunda-platform-8.10/test/unit/console/service_test.go
+++ b/charts/camunda-platform-8.10/test/unit/console/service_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	appsv1 "k8s.io/api/apps/v1"
 	coreV1 "k8s.io/api/core/v1"
 )
 
@@ -68,8 +69,8 @@ func (s *ServiceTest) TestDifferentValuesInputs() {
 		}, {
 			Name: "TestContainerServiceAnnotations",
 			Values: map[string]string{
-				"identity.enabled":                "true",
-				"console.enabled":                 "true",
+				"identity.enabled": "true",
+				"console.enabled":  "true",
 				"camundaHub.console.service.annotations.foo": "bar",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
@@ -83,4 +84,39 @@ func (s *ServiceTest) TestDifferentValuesInputs() {
 	}
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
+func (s *ServiceTest) TestLegacyServiceAccountEnabledOverrideDoesNotBreakDeploymentReference() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"console.enabled":                           "true",
+			"identity.enabled":                          "true",
+			"console.serviceAccount.enabled":            "false",
+			"camundaHub.console.serviceAccount.enabled": "true",
+			"global.elasticsearch.enabled":              "true",
+		},
+	}
+	templates := []string{
+		"templates/console/serviceaccount.yaml",
+		"templates/console/deployment.yaml",
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, templates)
+
+	var serviceAccount coreV1.ServiceAccount
+	var deployment appsv1.Deployment
+	for _, object := range strings.Split(output, "---") {
+		if strings.Contains(object, "kind: ServiceAccount") {
+			helm.UnmarshalK8SYaml(s.T(), object, &serviceAccount)
+		}
+		if strings.Contains(object, "kind: Deployment") {
+			helm.UnmarshalK8SYaml(s.T(), object, &deployment)
+		}
+	}
+
+	// then
+	s.Require().NotEmpty(serviceAccount.Name)
+	s.Require().Equal(serviceAccount.Name, deployment.Spec.Template.Spec.ServiceAccountName)
 }

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/service_test.go
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/service_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	appsv1 "k8s.io/api/apps/v1"
 	coreV1 "k8s.io/api/core/v1"
 )
 
@@ -59,11 +60,11 @@ func (s *ServiceTest) TestDifferentValuesInputs() {
 		{
 			Name: "TestContainerSetGlobalAnnotations",
 			Values: map[string]string{
-				"identity.enabled":                    "true",
-				"webModeler.enabled":                  "true",
+				"identity.enabled":   "true",
+				"webModeler.enabled": "true",
 				"camundaHub.webModeler.restapi.mail.fromAddress": "example@example.com",
-				"global.annotations.foo":              "bar",
-				"global.elasticsearch.enabled":        "true",
+				"global.annotations.foo":                         "bar",
+				"global.elasticsearch.enabled":                   "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var service coreV1.Service
@@ -75,11 +76,11 @@ func (s *ServiceTest) TestDifferentValuesInputs() {
 		}, {
 			Name: "TestContainerServiceAnnotations",
 			Values: map[string]string{
-				"identity.enabled":                                       "true",
-				"webModeler.enabled":                                     "true",
+				"identity.enabled":   "true",
+				"webModeler.enabled": "true",
 				"camundaHub.webModeler.restapi.mail.fromAddress":                    "example@example.com",
 				"camundaHub.webModeler." + s.component + ".service.annotations.foo": "bar",
-				"global.elasticsearch.enabled":                           "true",
+				"global.elasticsearch.enabled":                                      "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var service coreV1.Service
@@ -92,4 +93,40 @@ func (s *ServiceTest) TestDifferentValuesInputs() {
 	}
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
+func (s *ServiceTest) TestLegacyServiceAccountEnabledOverrideDoesNotBreakDeploymentReference() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"identity.enabled":                               "true",
+			"webModeler.enabled":                             "true",
+			"webModeler.serviceAccount.enabled":              "false",
+			"camundaHub.webModeler.serviceAccount.enabled":   "true",
+			"camundaHub.webModeler.restapi.mail.fromAddress": "example@example.com",
+			"global.elasticsearch.enabled":                   "true",
+		},
+	}
+	templates := []string{
+		"templates/web-modeler/serviceaccount.yaml",
+		"templates/web-modeler/deployment-" + s.component + ".yaml",
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, templates)
+
+	var serviceAccount coreV1.ServiceAccount
+	var deployment appsv1.Deployment
+	for _, object := range strings.Split(output, "---") {
+		if strings.Contains(object, "kind: ServiceAccount") {
+			helm.UnmarshalK8SYaml(s.T(), object, &serviceAccount)
+		}
+		if strings.Contains(object, "kind: Deployment") {
+			helm.UnmarshalK8SYaml(s.T(), object, &deployment)
+		}
+	}
+
+	// then
+	s.Require().NotEmpty(serviceAccount.Name)
+	s.Require().Equal(serviceAccount.Name, deployment.Spec.Template.Spec.ServiceAccountName)
 }


### PR DESCRIPTION
## Summary

- Aligns Console and WebModeler ServiceAccount manifests with the same merged camundaHub/legacy enablement logic used by the deployment ServiceAccount name helpers.
- Adds regression coverage for the mismatch flagged by crev after #6223: `camundaHub.*.serviceAccount.enabled=true` with legacy `*.serviceAccount.enabled=false` must render a ServiceAccount that matches the pod reference.

## Validation

- `make helm.lint chartPath=charts/camunda-platform-8.10`
- `make go.test chartPath=charts/camunda-platform-8.10`

Follow-up to #6223.