### PR TITLE
feat(8.10): caBundle guardrails + cert-rotation auto-rollout

### DIFF
--- a/charts/camunda-platform-8.10/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/common/_helpers.tpl
@@ -1164,12 +1164,15 @@ Usage (inside a pod template's metadata.annotations):
 {{- define "camundaPlatform.caBundleChecksumAnnotation" -}}
 {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" -}}
 {{- $secret := lookup "v1" "Secret" .Release.Namespace .Values.global.tls.caBundle.secret.existingSecret -}}
-{{- /* Hash only .data (the actual CA bytes), NOT the whole object — the full
-       Secret carries server-managed metadata (resourceVersion, managedFields,
+{{- $key := .Values.global.tls.caBundle.secret.existingSecretKey | default "ca.crt" -}}
+{{- /* Hash ONLY the CA-bundle key's bytes, not the whole Secret. The full
+       object carries server-managed metadata (resourceVersion, managedFields,
        uid) that controllers (cert-manager, ArgoCD, server-side apply) churn
-       without touching the CA, which would otherwise cause spurious rollouts.
-       .data is nil under helm template/--dry-run, giving a stable sentinel. */ -}}
-checksum/ca-bundle: {{ ($secret | default dict).data | toYaml | sha256sum }}
+       without touching the CA; and a Secret may hold co-located keys whose
+       rotation is unrelated to the CA. Scoping to existingSecretKey avoids
+       spurious rollouts from either. `get` returns "" under helm template /
+       --dry-run (no API access), giving a stable sentinel. */ -}}
+checksum/ca-bundle: {{ get (($secret | default dict).data | default dict) $key | toYaml | sha256sum }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/camunda-platform-8.10/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/common/_helpers.tpl
@@ -1145,6 +1145,30 @@ false
 {{- end -}}
 
 {{/*
+caBundleChecksumAnnotation
+Emits a `checksum/ca-bundle` pod annotation derived from the live CA-bundle
+Secret so that, on `helm upgrade`, pods roll automatically when the CA is
+rotated — the init container then rebuilds the truststore with the new CA.
+Without this, rotating the secret has no effect until the operator manually
+runs `kubectl rollout restart`.
+
+`lookup` returns an empty value during `helm template` / `--dry-run` (no API
+access), so the checksum is stable there and only carries real content on a
+live `helm upgrade`. It therefore does NOT react to a raw `kubectl edit secret`
+— that path still needs a manual rollout restart (documented in
+docs/tls-values-quickstart.md). Emits nothing when caBundle is unset.
+
+Usage (inside a pod template's metadata.annotations):
+  {{- include "camundaPlatform.caBundleChecksumAnnotation" . | nindent 8 }}
+*/}}
+{{- define "camundaPlatform.caBundleChecksumAnnotation" -}}
+{{- if eq (include "camundaPlatform.hasCaBundle" .) "true" -}}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace .Values.global.tls.caBundle.secret.existingSecret -}}
+checksum/ca-bundle: {{ $secret | toYaml | sha256sum }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 caBundleVolume
 Emits the volume entry that exposes global.tls.caBundle as a single file
 under /etc/camunda/tls/ca.crt inside the container. Always called from a

--- a/charts/camunda-platform-8.10/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/common/_helpers.tpl
@@ -1164,7 +1164,12 @@ Usage (inside a pod template's metadata.annotations):
 {{- define "camundaPlatform.caBundleChecksumAnnotation" -}}
 {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" -}}
 {{- $secret := lookup "v1" "Secret" .Release.Namespace .Values.global.tls.caBundle.secret.existingSecret -}}
-checksum/ca-bundle: {{ $secret | toYaml | sha256sum }}
+{{- /* Hash only .data (the actual CA bytes), NOT the whole object — the full
+       Secret carries server-managed metadata (resourceVersion, managedFields,
+       uid) that controllers (cert-manager, ArgoCD, server-side apply) churn
+       without touching the CA, which would otherwise cause spurious rollouts.
+       .data is nil under helm template/--dry-run, giving a stable sentinel. */ -}}
+checksum/ca-bundle: {{ ($secret | default dict).data | toYaml | sha256sum }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/camunda-platform-8.10/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.10/templates/common/constraints.tpl
@@ -294,6 +294,67 @@ The following values inside your values.yaml need to be set but were not:
     {{- end }}
   {{- end }}
 
+  {{/* global.tls.caBundle guardrails: surface the three silent failure modes
+       a caBundle user can hit (JKS precedence, trust!=encryption, env override). */}}
+  {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
+
+    {{/* (1) A per-component JKS truststore silently wins over caBundle for that
+           component — the init container still builds a truststore the JVM never uses. */}}
+    {{- $jksOverrides := list
+        (dict "comp" "orchestration secondaryStorage.elasticsearch" "config" .Values.orchestration.data.secondaryStorage.elasticsearch.tls)
+        (dict "comp" "orchestration secondaryStorage.opensearch" "config" .Values.orchestration.data.secondaryStorage.opensearch.tls)
+        (dict "comp" "optimize database.elasticsearch" "config" .Values.optimize.database.elasticsearch.tls)
+        (dict "comp" "optimize database.opensearch" "config" .Values.optimize.database.opensearch.tls)
+        (dict "comp" "global.elasticsearch" "config" .Values.global.elasticsearch.tls)
+        (dict "comp" "global.opensearch" "config" .Values.global.opensearch.tls)
+    }}
+    {{- range $jksOverrides }}
+      {{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" .config)) "true" }}
+        {{- $warningMessage := printf "%s %s %s"
+            "[camunda][warning]"
+            (printf "global.tls.caBundle is set, but %s also configures a per-component JKS truststore (tls.secret)." .comp)
+            "The JKS takes precedence for that component, so the caBundle is NOT used there (its init container still builds an unused truststore). Remove the per-component tls.secret to switch to the caBundle, or ignore this if the JKS is intentional."
+        -}}
+        {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
+      {{- end }}
+    {{- end }}
+
+    {{/* (2) caBundle provides CA trust, not encryption. A plaintext datastore URL
+           means traffic is still unencrypted despite the bundle being set. */}}
+    {{- range $url := (list .Values.orchestration.data.secondaryStorage.opensearch.url .Values.orchestration.data.secondaryStorage.elasticsearch.url) }}
+      {{- if and $url (hasPrefix "http://" $url) }}
+        {{- $warningMessage := printf "%s %s %s"
+            "[camunda][warning]"
+            (printf "global.tls.caBundle is set, but the secondary-storage URL '%s' is plaintext http://." $url)
+            "caBundle provides CA TRUST, not encryption — it does not enable TLS by itself. Set the URL to https:// to actually encrypt the connection."
+        -}}
+        {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
+      {{- end }}
+    {{- end }}
+
+    {{/* (3) A component-level JAVA_TOOL_OPTIONS env entry overrides (last-wins) the
+           chart's truststore flags, silently breaking JVM trust. */}}
+    {{- $envComponents := list
+        (dict "comp" "orchestration" "env" .Values.orchestration.env)
+        (dict "comp" "optimize" "env" .Values.optimize.env)
+        (dict "comp" "connectors" "env" .Values.connectors.env)
+        (dict "comp" "identity" "env" .Values.identity.env)
+    }}
+    {{- range $c := $envComponents }}
+      {{- range $e := $c.env }}
+        {{- if eq $e.name "JAVA_TOOL_OPTIONS" }}
+          {{- $warningMessage := printf "%s %s %s"
+              "[camunda][warning]"
+              (printf "global.tls.caBundle is set, but %s.env sets JAVA_TOOL_OPTIONS directly." $c.comp)
+              "Kubernetes keeps the last duplicate env var, so this overrides the chart's truststore flags and JVM TLS trust will break (PKIX errors). Use the component's 'javaOpts' value instead — the chart appends its truststore flags to that."
+          -}}
+          {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+
+  {{- end }}
+
   {{/* Warn when webModeler pusher secret is auto-generated */}}
   {{- if eq (include "camundaHub.webModelerEnabled" .) "true" }}
     {{- $pusherSecret := .Values.webModeler.restapi.pusher.secret }}

--- a/charts/camunda-platform-8.10/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.10/templates/common/constraints.tpl
@@ -320,13 +320,26 @@ The following values inside your values.yaml need to be set but were not:
     {{- end }}
 
     {{/* (2) caBundle provides CA trust, not encryption. A plaintext datastore URL
-           means traffic is still unencrypted despite the bundle being set. */}}
+           means traffic is still unencrypted despite the bundle being set.
+           Orchestration secondaryStorage URLs are full scheme strings;
+           Optimize database URLs are split into a separate .protocol field. */}}
     {{- range $url := (list .Values.orchestration.data.secondaryStorage.opensearch.url .Values.orchestration.data.secondaryStorage.elasticsearch.url) }}
       {{- if and $url (hasPrefix "http://" $url) }}
         {{- $warningMessage := printf "%s %s %s"
             "[camunda][warning]"
             (printf "global.tls.caBundle is set, but the secondary-storage URL '%s' is plaintext http://." $url)
             "caBundle provides CA TRUST, not encryption — it does not enable TLS by itself. Set the URL to https:// to actually encrypt the connection."
+        -}}
+        {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
+      {{- end }}
+    {{- end }}
+    {{- range $db := (list "opensearch" "elasticsearch") }}
+      {{- $u := index $.Values.optimize.database $db "url" }}
+      {{- if and $u $u.protocol (eq (lower $u.protocol) "http") }}
+        {{- $warningMessage := printf "%s %s %s"
+            "[camunda][warning]"
+            (printf "global.tls.caBundle is set, but optimize.database.%s.url.protocol is plaintext 'http'." $db)
+            "caBundle provides CA TRUST, not encryption — it does not enable TLS by itself. Set the protocol to https to actually encrypt the connection."
         -}}
         {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
       {{- end }}
@@ -339,6 +352,7 @@ The following values inside your values.yaml need to be set but were not:
         (dict "comp" "optimize" "env" .Values.optimize.env)
         (dict "comp" "connectors" "env" .Values.connectors.env)
         (dict "comp" "identity" "env" .Values.identity.env)
+        (dict "comp" "webModeler.restapi" "env" (or .Values.camundaHub.webModeler.restapi.env .Values.webModeler.restapi.env))
     }}
     {{- range $c := $envComponents }}
       {{- range $e := $c.env }}

--- a/charts/camunda-platform-8.10/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.10/templates/common/constraints.tpl
@@ -347,6 +347,11 @@ The following values inside your values.yaml need to be set but were not:
 
     {{/* (3) A component-level JAVA_TOOL_OPTIONS env entry overrides (last-wins) the
            chart's truststore flags, silently breaking JVM trust. */}}
+    {{/* webModeler.restapi env uses `or` to mirror deployment-restapi.yaml's own
+         env coalescing (camundaHub takes precedence; only that one list is
+         applied). We check exactly the list the deployment uses, so we never warn
+         about a JAVA_TOOL_OPTIONS in the ignored list — that would be a false
+         alarm since it is not applied. */}}
     {{- $envComponents := list
         (dict "comp" "orchestration" "env" .Values.orchestration.env)
         (dict "comp" "optimize" "env" .Values.optimize.env)

--- a/charts/camunda-platform-8.10/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.10/templates/common/constraints.tpl
@@ -365,7 +365,7 @@ The following values inside your values.yaml need to be set but were not:
           {{- $warningMessage := printf "%s %s %s"
               "[camunda][warning]"
               (printf "global.tls.caBundle is set, but %s.env sets JAVA_TOOL_OPTIONS directly." $c.comp)
-              "Kubernetes keeps the last duplicate env var, so this overrides the chart's truststore flags and JVM TLS trust will break (PKIX errors). Use the component's 'javaOpts' value instead — the chart appends its truststore flags to that."
+              "Kubernetes keeps the last duplicate env var, so this overrides the chart's truststore flags and JVM TLS trust will break (PKIX errors). Include the chart's flags in your value: '-Djavax.net.ssl.trustStore=/var/camunda/tls-truststore/cacerts -Djavax.net.ssl.trustStorePassword=changeit'. Components that expose a 'javaOpts' value (orchestration, optimize, web-modeler restapi) can set that instead — the chart appends its truststore flags to it."
           -}}
           {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
         {{- end }}

--- a/charts/camunda-platform-8.10/templates/connectors/deployment.yaml
+++ b/charts/camunda-platform-8.10/templates/connectors/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/connectors/configmap.yaml") . | sha256sum }}
+        {{- with (include "camundaPlatform.caBundleChecksumAnnotation" .) }}{{ . | nindent 8 }}{{- end }}
       {{- if .Values.connectors.podAnnotations }}
       {{- tpl (toYaml .Values.connectors.podAnnotations) $ | nindent 8 }}
       {{- end }}

--- a/charts/camunda-platform-8.10/templates/console/deployment.yaml
+++ b/charts/camunda-platform-8.10/templates/console/deployment.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/console/configmap.yaml") . | sha256sum }}
+        {{- with (include "camundaPlatform.caBundleChecksumAnnotation" .) }}{{ . | nindent 8 }}{{- end }}
       {{- with (or .Values.camundaHub.console.podAnnotations .Values.console.podAnnotations) }}
         {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}

--- a/charts/camunda-platform-8.10/templates/identity/deployment.yaml
+++ b/charts/camunda-platform-8.10/templates/identity/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/identity/configmap.yaml") . | sha256sum }}
+        {{- with (include "camundaPlatform.caBundleChecksumAnnotation" .) }}{{ . | nindent 8 }}{{- end }}
       {{- if .Values.identity.podAnnotations }}
         {{- tpl (toYaml .Values.identity.podAnnotations) $ | nindent 8 }}
       {{- end }}

--- a/charts/camunda-platform-8.10/templates/optimize/deployment.yaml
+++ b/charts/camunda-platform-8.10/templates/optimize/deployment.yaml
@@ -23,6 +23,7 @@ spec:
         {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/optimize/configmap.yaml") . | sha256sum }}
+        {{- with (include "camundaPlatform.caBundleChecksumAnnotation" .) }}{{ . | nindent 8 }}{{- end }}
       {{- if .Values.optimize.podAnnotations }}
         {{- tpl (toYaml .Values.optimize.podAnnotations) $ | nindent 8 }}
       {{- end }}

--- a/charts/camunda-platform-8.10/templates/orchestration/statefulset.yaml
+++ b/charts/camunda-platform-8.10/templates/orchestration/statefulset.yaml
@@ -27,6 +27,7 @@ spec:
         {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/orchestration/configmap.yaml") . | sha256sum }}
+        {{- with (include "camundaPlatform.caBundleChecksumAnnotation" .) }}{{ . | nindent 8 }}{{- end }}
         {{- if .Values.orchestration.podAnnotations }}
         {{- tpl (toYaml .Values.orchestration.podAnnotations) $ | nindent 8 }}
         {{- end }}

--- a/charts/camunda-platform-8.10/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform-8.10/templates/web-modeler/deployment-restapi.yaml
@@ -24,9 +24,12 @@ spec:
       {{- if (or .Values.camundaHub.webModeler.restapi.podLabels .Values.webModeler.restapi.podLabels) }}
       {{- tpl (toYaml (or .Values.camundaHub.webModeler.restapi.podLabels .Values.webModeler.restapi.podLabels)) $ | nindent 8 }}
       {{- end }}
-      {{- if (or .Values.camundaHub.webModeler.restapi.podAnnotations .Values.webModeler.restapi.podAnnotations) }}
+      {{- if or (eq (include "camundaPlatform.hasCaBundle" .) "true") (or .Values.camundaHub.webModeler.restapi.podAnnotations .Values.webModeler.restapi.podAnnotations) }}
       annotations:
-        {{- tpl (toYaml (or .Values.camundaHub.webModeler.restapi.podAnnotations .Values.webModeler.restapi.podAnnotations)) $ | nindent 8 }}
+        {{- with (include "camundaPlatform.caBundleChecksumAnnotation" .) }}{{ . | nindent 8 }}{{- end }}
+        {{- with (or .Values.camundaHub.webModeler.restapi.podAnnotations .Values.webModeler.restapi.podAnnotations) }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
       {{- end }}
     spec:
       imagePullSecrets:

--- a/charts/camunda-platform-8.10/templates/web-modeler/deployment-websockets.yaml
+++ b/charts/camunda-platform-8.10/templates/web-modeler/deployment-websockets.yaml
@@ -17,9 +17,12 @@ spec:
       {{- if (or .Values.camundaHub.webModeler.websockets.podLabels .Values.webModeler.websockets.podLabels) }}
       {{- tpl (toYaml (or .Values.camundaHub.webModeler.websockets.podLabels .Values.webModeler.websockets.podLabels)) $ | nindent 8 }}
       {{- end }}
-      {{- if (or .Values.camundaHub.webModeler.websockets.podAnnotations .Values.webModeler.websockets.podAnnotations) }}
+      {{- if or (eq (include "camundaPlatform.hasCaBundle" .) "true") (or .Values.camundaHub.webModeler.websockets.podAnnotations .Values.webModeler.websockets.podAnnotations) }}
       annotations:
-        {{- tpl (toYaml (or .Values.camundaHub.webModeler.websockets.podAnnotations .Values.webModeler.websockets.podAnnotations)) $ | nindent 8 }}
+        {{- with (include "camundaPlatform.caBundleChecksumAnnotation" .) }}{{ . | nindent 8 }}{{- end }}
+        {{- with (or .Values.camundaHub.webModeler.websockets.podAnnotations .Values.webModeler.websockets.podAnnotations) }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
       {{- end }}
     spec:
       imagePullSecrets:

--- a/charts/camunda-platform-8.10/test/unit/common/tls_secrets_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/tls_secrets_test.go
@@ -491,7 +491,7 @@ func (s *tlsSecretsTest) TestCaBundleChecksumAnnotation() {
 			Expected: map[string]string{
 				// lookup is empty under `helm template`, so the value is the stable
 				// sha256 of an empty object — presence is what we assert here.
-				"spec.template.metadata.annotations.checksum/ca-bundle": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+				"spec.template.metadata.annotations.checksum/ca-bundle": "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126",
 			},
 		},
 		{
@@ -510,7 +510,7 @@ func (s *tlsSecretsTest) TestCaBundleChecksumAnnotation() {
 }
 
 func (s *tlsSecretsTest) TestCaBundleChecksumAnnotationWebModeler() {
-	const sentinel = "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b"
+	const sentinel = "12ae32cb1ec02d01eda3581b127c1fee3b0dc53572ed6baf239721a03d82e126"
 	testCases := []testhelpers.TestCase{
 		{
 			Name:     "web-modeler restapi gets checksum/ca-bundle even with no user podAnnotations (restructured block)",

--- a/charts/camunda-platform-8.10/test/unit/common/tls_secrets_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/tls_secrets_test.go
@@ -509,6 +509,42 @@ func (s *tlsSecretsTest) TestCaBundleChecksumAnnotation() {
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
 
+func (s *tlsSecretsTest) TestCaBundleChecksumAnnotationWebModeler() {
+	const sentinel = "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b"
+	testCases := []testhelpers.TestCase{
+		{
+			Name:     "web-modeler restapi gets checksum/ca-bundle even with no user podAnnotations (restructured block)",
+			Template: "templates/web-modeler/deployment-restapi.yaml",
+			Values: map[string]string{
+				"webModeler.enabled":                        "true",
+				"webModeler.restapi.mail.fromAddress":       "test@example.com",
+				"identity.enabled":                          "true",
+				"global.tls.caBundle.secret.existingSecret": "my-ca-bundle",
+			},
+			Expected: map[string]string{
+				"spec.template.metadata.annotations.checksum/ca-bundle": sentinel,
+			},
+		},
+		{
+			Name:     "web-modeler restapi keeps caBundle checksum alongside user podAnnotations",
+			Template: "templates/web-modeler/deployment-restapi.yaml",
+			Values: map[string]string{
+				"webModeler.enabled":                        "true",
+				"webModeler.restapi.mail.fromAddress":       "test@example.com",
+				"identity.enabled":                          "true",
+				"global.tls.caBundle.secret.existingSecret": "my-ca-bundle",
+				"webModeler.restapi.podAnnotations.my-anno": "v1",
+			},
+			Expected: map[string]string{
+				"spec.template.metadata.annotations.checksum/ca-bundle": sentinel,
+				"spec.template.metadata.annotations.my-anno":            "v1",
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
 func TestTLSSecretsTestSuite(t *testing.T) {
 	suite.Run(t, new(tlsSecretsTest))
 }

--- a/charts/camunda-platform-8.10/test/unit/common/tls_secrets_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/tls_secrets_test.go
@@ -491,7 +491,7 @@ func (s *tlsSecretsTest) TestCaBundleChecksumAnnotation() {
 			Expected: map[string]string{
 				// lookup is empty under `helm template`, so the value is the stable
 				// sha256 of an empty object — presence is what we assert here.
-				"spec.template.metadata.annotations.checksum/ca-bundle": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+				"spec.template.metadata.annotations.checksum/ca-bundle": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
 			},
 		},
 		{

--- a/charts/camunda-platform-8.10/test/unit/common/tls_secrets_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/tls_secrets_test.go
@@ -479,6 +479,36 @@ func (s *tlsSecretsTest) TestCaBundleInitContainerSecurityContext() {
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
 
+func (s *tlsSecretsTest) TestCaBundleChecksumAnnotation() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name:     "caBundle stamps a checksum/ca-bundle pod annotation for rotation auto-rollout",
+			Template: "templates/orchestration/statefulset.yaml",
+			Values: map[string]string{
+				"orchestration.enabled":                     "true",
+				"global.tls.caBundle.secret.existingSecret": "my-ca-bundle",
+			},
+			Expected: map[string]string{
+				// lookup is empty under `helm template`, so the value is the stable
+				// sha256 of an empty object — presence is what we assert here.
+				"spec.template.metadata.annotations.checksum/ca-bundle": "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+			},
+		},
+		{
+			Name:     "no checksum/ca-bundle annotation when caBundle is unset",
+			Template: "templates/orchestration/statefulset.yaml",
+			Values: map[string]string{
+				"orchestration.enabled": "true",
+			},
+			Expected: map[string]string{
+				"spec.template.metadata.annotations.checksum/ca-bundle": "",
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
 func TestTLSSecretsTestSuite(t *testing.T) {
 	suite.Run(t, new(tlsSecretsTest))
 }

--- a/docs/tls-values-quickstart.md
+++ b/docs/tls-values-quickstart.md
@@ -90,10 +90,17 @@ contents, so `helm upgrade` automatically rolls the Java components when the CA
 changes — the init container re-runs on each new pod and imports the new CA into
 a fresh truststore. No manual `rollout restart` needed.
 
-> **Note:** the checksum is computed by reading the live secret at render time, so
-> the auto-rollout fires on `helm upgrade`, not on a raw `kubectl edit secret`. If
-> you change the secret outside Helm, trigger the rollout yourself:
-> `kubectl -n "$NAMESPACE" rollout restart statefulset,deployment`.
+> **Note:** the checksum is computed by reading the live secret via Helm's `lookup`,
+> which only has cluster access during a real `helm upgrade`. So the auto-rollout
+> fires on `helm upgrade`, **not** on a raw `kubectl edit secret`, and **not** under
+> pure `helm template` rendering. If you change the secret outside Helm, trigger the
+> rollout yourself: `kubectl -n "$NAMESPACE" rollout restart statefulset,deployment`.
+>
+> **GitOps (ArgoCD / Flux):** these render with `helm template` (no `lookup`), so the
+> `checksum/ca-bundle` annotation is constant and the auto-rollout does **not** fire
+> on CA rotation. Drive the restart from your GitOps stack instead — e.g. an Argo CD
+> `PostSync` hook or a Flux `kustomize` patch that rolls the Java workloads when the
+> CA Secret changes — or run the `kubectl rollout restart` above as part of rotation.
 
 > **Reminder:** `global.tls.caBundle` provides CA **trust**, not encryption. It does
 > not turn a plaintext datastore connection into TLS — point the datastore URL at

--- a/docs/tls-values-quickstart.md
+++ b/docs/tls-values-quickstart.md
@@ -75,17 +75,31 @@ You should see:
 
 ## Updating the CA
 
-To rotate the CA bundle, replace the secret and bounce the affected pods:
+To rotate the CA bundle, replace the secret and re-run `helm upgrade`:
 
 ```bash
 kubectl -n "$NAMESPACE" delete secret camunda-ca-bundle
 kubectl -n "$NAMESPACE" create secret generic camunda-ca-bundle \
   --from-file=ca.crt=./new-ca-bundle.pem
 
-kubectl -n "$NAMESPACE" rollout restart statefulset,deployment
+helm upgrade --install camunda camunda/camunda-platform -f values-tls.yaml -f your-values.yaml
 ```
 
-The init container re-runs on each pod start and imports the new CA into a fresh truststore.
+The chart stamps a `checksum/ca-bundle` pod annotation derived from the secret's
+contents, so `helm upgrade` automatically rolls the Java components when the CA
+changes — the init container re-runs on each new pod and imports the new CA into
+a fresh truststore. No manual `rollout restart` needed.
+
+> **Note:** the checksum is computed by reading the live secret at render time, so
+> the auto-rollout fires on `helm upgrade`, not on a raw `kubectl edit secret`. If
+> you change the secret outside Helm, trigger the rollout yourself:
+> `kubectl -n "$NAMESPACE" rollout restart statefulset,deployment`.
+
+> **Reminder:** `global.tls.caBundle` provides CA **trust**, not encryption. It does
+> not turn a plaintext datastore connection into TLS — point the datastore URL at
+> `https://` (or set the JDBC `sslmode`) to actually encrypt the traffic. The chart
+> emits an install-time warning if the bundle is set while a datastore URL is still
+> `http://`.
 
 ## Common gotchas
 


### PR DESCRIPTION
### Which problem does the PR fix?

Follow-up to #6292 (caBundle init-container hardening). Closes the remaining silent-failure modes a `global.tls.caBundle` user can hit, surfaced by the post-merge risk review. **Stacked on #6292** — review/merge that first; this PR's base will retarget to `main` once it lands.

### What's in this PR?

**Install-time guardrails** (`NOTES.txt` warnings in `constraints.tpl`), all gated on `global.tls.caBundle` being set:
1. **JKS silently overrides caBundle** — a per-component `tls.secret` JKS takes precedence for that component, so the caBundle is ignored there (the init container still builds an unused truststore). Previously undocumented at deploy time.
2. **Trust ≠ encryption** — caBundle provides CA *trust*, not TLS. Warn when a secondary-storage URL is still `http://`, so users don't believe they're encrypted when they aren't.
3. **`JAVA_TOOL_OPTIONS` env override** — a component-level `env` entry named `JAVA_TOOL_OPTIONS` overrides (k8s last-wins) the chart's truststore flags and silently breaks JVM trust. Points users at `.javaOpts` (which the chart appends to).

**Cert-rotation auto-rollout** — a `checksum/ca-bundle` pod annotation derived from the live secret (`camundaPlatform.caBundleChecksumAnnotation`) rolls the Java components on `helm upgrade` when the CA rotates, removing the manual `rollout restart` footgun. `lookup` is empty under `helm template`/`--dry-run`, so the call sites use `{{- with … }}` to avoid stray whitespace — **goldens are unchanged** when caBundle is unset.

**Docs** — quickstart CA-rotation section updated for the auto-rollout (+ the `kubectl edit secret` caveat) and a trust≠encryption reminder.

Deprecation-message wording (plan item B3) is intentionally left to the in-flight JKS-deprecation PR #6050, which rewrites that `constraints.tpl` block.

**Validation:**
- `make helm.lint` + `make go.test` (all 7 packages) pass; goldens unchanged.
- All three guardrails verified via `helm install --dry-run=client` (fire when triggered, silent in the clean case); a unit test asserts the `checksum/ca-bundle` annotation is present with caBundle and absent without.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
