### PR TITLE
test(8.10): enable hub legacy upgrade scenario

### DIFF
--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -680,6 +680,7 @@ integration:
           persistence: elasticsearch
           features:
             - hub-legacy
+            - postgresql-companion
           dependencies:
             - chart: charts/internal-keycloak-26
               release-name: keycloak
@@ -696,6 +697,16 @@ integration:
               env-vars:
                 - RDBMS_POSTGRESQL_USERNAME
                 - RDBMS_POSTGRESQL_PASSWORD
+          post-infra:
+            script: post-infra-bitnami-migration.sh
+            description: |
+              After the companion PostgreSQL/Keycloak/Elasticsearch are deployed but before
+              the chart upgrade to 8.10, migrate the bundled (Bitnami) Keycloak realm and the
+              Elasticsearch authorization indices off the bundled backends onto the companion
+              services. Uses the camunda-deployment-references migration scripts in external
+              mode with SKIP_HELM_UPGRADE=true (data-only; the matrix runner performs the
+              chart upgrade). This keeps users/realm alive across the upgrade that removes the
+              bundled Bitnami subcharts.
         - name: hub-mixed
           enabled: false
           shortname: hubmu

--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -665,13 +665,14 @@ integration:
                 - RDBMS_POSTGRESQL_USERNAME
                 - RDBMS_POSTGRESQL_PASSWORD
         - name: hub-legacy
-          enabled: false
+          enabled: true
           shortname: hublu
           auth: keycloak
           flow: upgrade-minor
           platforms:
             - gke
           exclude: []
+          tier: 2
           infra-type:
             eks: preemptible
             gke: distroci

--- a/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
@@ -93,7 +93,8 @@ integration:
       enabled: true
     - id: hub-legacy-upgrade
       shortname: hublu
-      enabled: false
+      tier: 2
+      enabled: true
     - id: hub-mixed
       shortname: hubmu
       enabled: false

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/hub-legacy-upgrade.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/hub-legacy-upgrade.yaml
@@ -6,11 +6,13 @@ identity: keycloak
 persistence: elasticsearch
 features:
   - hub-legacy
+  - postgresql-companion
 platforms:
   - gke
 infra-type:
   eks: preemptible
   gke: distroci
+post-infra: post-infra-bitnami-migration
 dependencies:
   - keycloak
   - elasticsearch


### PR DESCRIPTION
## Summary

- Enables the 8.10 `hub-legacy` upgrade-minor scenario (`hublu`).
- Keeps the existing CloudNativePG pre-install fixture and companion Keycloak/Elasticsearch dependencies.
- Leaves migrator disabled because 8.10 upgrade migrators are not part of this chart scenario set.

## Validation

- `make go.test chartPath=charts/camunda-platform-8.10`
- `deploy-camunda matrix list --repo-root . --versions 8.10 | grep -E 'hub|hubl|hubm|hubw'`