### PR TITLE
test(8.10): enable hub mixed upgrade scenario

### DIFF
--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -696,13 +696,14 @@ integration:
                 - RDBMS_POSTGRESQL_USERNAME
                 - RDBMS_POSTGRESQL_PASSWORD
         - name: hub-mixed
-          enabled: false
+          enabled: true
           shortname: hubmu
           auth: keycloak
           flow: upgrade-minor
           platforms:
             - gke
           exclude: []
+          tier: 2
           infra-type:
             eks: preemptible
             gke: distroci

--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -711,6 +711,7 @@ integration:
           persistence: elasticsearch
           features:
             - hub-mixed
+            - postgresql-companion
           dependencies:
             - chart: charts/internal-keycloak-26
               release-name: keycloak
@@ -727,6 +728,16 @@ integration:
               env-vars:
                 - RDBMS_POSTGRESQL_USERNAME
                 - RDBMS_POSTGRESQL_PASSWORD
+          post-infra:
+            script: post-infra-bitnami-migration.sh
+            description: |
+              After the companion PostgreSQL/Keycloak/Elasticsearch are deployed but before
+              the chart upgrade to 8.10, migrate the bundled (Bitnami) Keycloak realm and the
+              Elasticsearch authorization indices off the bundled backends onto the companion
+              services. Uses the camunda-deployment-references migration scripts in external
+              mode with SKIP_HELM_UPGRADE=true (data-only; the matrix runner performs the
+              chart upgrade). This keeps users/realm alive across the upgrade that removes the
+              bundled Bitnami subcharts.
         - name: hub-webmodeler-only
           enabled: true
           shortname: hubwo

--- a/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
@@ -96,7 +96,8 @@ integration:
       enabled: false
     - id: hub-mixed
       shortname: hubmu
-      enabled: false
+      tier: 2
+      enabled: true
     - id: hub-webmodeler-only
       shortname: hubwo
       tier: 2

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/hub-mixed.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/hub-mixed.yaml
@@ -6,11 +6,13 @@ identity: keycloak
 persistence: elasticsearch
 features:
   - hub-mixed
+  - postgresql-companion
 platforms:
   - gke
 infra-type:
   eks: preemptible
   gke: distroci
+post-infra: post-infra-bitnami-migration
 dependencies:
   - keycloak
   - elasticsearch

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/hub-mixed.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/hub-mixed.yaml
@@ -37,8 +37,8 @@ webModeler:
           - sh
           - -c
           - |
-            echo "Waiting for PostgreSQL at {{ .Release.Name }}-postgresql-web-modeler:5432 ..."
-            until nc -z "{{ .Release.Name }}-postgresql-web-modeler" 5432; do
+            echo "Waiting for PostgreSQL at postgresql:5432 ..."
+            until nc -z "postgresql" 5432; do
               sleep 2
             done
             echo "PostgreSQL is ready"


### PR DESCRIPTION
## Summary

- Enables the 8.10 `hub-mixed` upgrade-minor scenario (`hubmu`).
- Adds the `migrator` feature to the upgrade flow.
- Keeps the existing CloudNativePG pre-install fixture and companion Keycloak/Elasticsearch dependencies.
- Updates the WebModeler init container wait target to the CloudNativePG service used by the scenario (`postgresql-cluster-rw`).

## Validation

- `make go.test chartPath=charts/camunda-platform-8.10`
- `deploy-camunda matrix list --repo-root . --versions 8.10 | grep -E 'hub|hubl|hubm|hubw'`