### PR TITLE
fix: correct enterprise Elasticsearch image tag to existing 8.19.15

### DIFF
--- a/charts/camunda-platform-8.5/values-enterprise.yaml
+++ b/charts/camunda-platform-8.5/values-enterprise.yaml
@@ -104,7 +104,7 @@ elasticsearch:
   image:
     registry: registry.camunda.cloud
     repository: vendor-ee/elasticsearch
-    tag: 8.19.13
+    tag: 8.19.15
     pullSecrets:
       - name: registry-camunda-cloud
 

--- a/charts/camunda-platform-8.6/values-enterprise.yaml
+++ b/charts/camunda-platform-8.6/values-enterprise.yaml
@@ -113,7 +113,7 @@ elasticsearch:
   image:
     registry: registry.camunda.cloud
     repository: vendor-ee/elasticsearch
-    tag: 8.19.13
+    tag: 8.19.15
     pullSecrets:
       - name: registry-camunda-cloud
 

--- a/charts/camunda-platform-8.7/values-enterprise.yaml
+++ b/charts/camunda-platform-8.7/values-enterprise.yaml
@@ -104,7 +104,7 @@ elasticsearch:
   image:
     registry: registry.camunda.cloud
     repository: vendor-ee/elasticsearch
-    tag: 8.19.13
+    tag: 8.19.15
     pullSecrets:
       - name: registry-camunda-cloud
 

--- a/charts/camunda-platform-8.8/values-enterprise.yaml
+++ b/charts/camunda-platform-8.8/values-enterprise.yaml
@@ -109,7 +109,7 @@ elasticsearch:
   image:
     registry: registry.camunda.cloud
     repository: vendor-ee/elasticsearch
-    tag: 8.19.13
+    tag: 8.19.15
     pullSecrets:
       - name: registry-camunda-cloud
 

--- a/charts/camunda-platform-8.9/values-enterprise.yaml
+++ b/charts/camunda-platform-8.9/values-enterprise.yaml
@@ -109,7 +109,7 @@ elasticsearch:
   image:
     registry: registry.camunda.cloud
     repository: vendor-ee/elasticsearch
-    tag: 8.19.13
+    tag: 8.19.15
     pullSecrets:
       - name: registry-camunda-cloud
 


### PR DESCRIPTION
### Which problem does the PR fix?

The enterprise values files pin `vendor-ee/elasticsearch:8.19.13`, a tag that **does not exist** in the `registry.camunda.cloud` Harbor proxy (which mirrors the Broadcom-hosted Bitnami catalog). `8.19.13` is a gap in that catalog — `8.19.12`, `8.19.14`, and `8.19.15` exist, but `8.19.13` was never published.

Any deploy of the enterprise values therefore fails with `ImagePullBackOff` on the Elasticsearch StatefulSet, which in turn blocks Operate/Optimize/Tasklist startup and makes `helm install --wait` hit `context deadline exceeded`.

This was surfaced by the new `enterprise-values` (`entv`) install scenario added in #6215, which is the first CI path that actually *deploys* these values:
- Failing merge-queue run: https://github.com/camunda/camunda-platform-helm/actions/runs/26842333631
- Error: `Failed to pull image "registry.camunda.cloud/vendor-ee/elasticsearch:8.19.13": ... manifest ... not found`

Root cause: the automated patch-updates PR #5518 bumped `8.19.12 -> 8.19.13`. It went unnoticed because `values-enterprise.yaml` was only exercised by `helm template` unit tests, which never pull images.

### What's in this PR?

Bumps `vendor-ee/elasticsearch` from the non-existent `8.19.13` to `8.19.15` — the highest tag verified present in the proxy (`docker manifest inspect` confirms `8.19.15` resolves as a multi-arch manifest) — in every chart version that still bundles the Bitnami Elasticsearch subchart:

- `charts/camunda-platform-8.5/values-enterprise.yaml`
- `charts/camunda-platform-8.6/values-enterprise.yaml`
- `charts/camunda-platform-8.7/values-enterprise.yaml`
- `charts/camunda-platform-8.8/values-enterprise.yaml`
- `charts/camunda-platform-8.9/values-enterprise.yaml`

`8.10` is unaffected — bundled Bitnami subcharts were dropped in #6146, so it has no `values-enterprise.yaml`.

Validation:
- `helm template` of 8.7 enterprise values now renders `registry.camunda.cloud/vendor-ee/elasticsearch:8.19.15`.
- 8.7 `TestEnterpriseValues` unit suite passes (the tests assert the image *repository*, not the tag, so no test changes were required).
- No golden files reference the tag.

**Dependency:** #6215 (the `entv` shadow E2E scenario) depends on this fix to get past the Elasticsearch install. This should merge first.

> Follow-up worth considering: Renovate's datasource (Bitnami on docker.io) lists tags the camunda Harbor proxy does not mirror, so this class of bad bump can recur. Pinning the ES image's datasource/registry in `renovate.json` to the proxy would prevent it.

### Checklist

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open pull request for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo documentation are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
