### PR TITLE
test(8.9): honor RDBMS_POSTGRESQL_USERNAME for the role in postgresql-cluster fixture

### DIFF
--- a/charts/camunda-platform-8.9/test/integration/scenarios/common/resources/postgresql-cluster.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/common/resources/postgresql-cluster.yaml
@@ -15,9 +15,15 @@ metadata:
   namespace: $NAMESPACE
 spec:
   instances: 1
+  # The login role derives from $RDBMS_POSTGRESQL_USERNAME so it stays
+  # self-consistent with the JDBC user the chart connects as (rdbms values +
+  # the psql-create-db job both use $RDBMS_POSTGRESQL_USERNAME). Previously the
+  # role was hardcoded `app`, so any value other than `app` failed with
+  # "password authentication failed for user ...". In CI the var is `app`, so
+  # this renders identically.
   managed:
     roles:
-      - name: app
+      - name: $RDBMS_POSTGRESQL_USERNAME
         ensure: present
         superuser: true
         login: true


### PR DESCRIPTION
### Which problem does the PR fix?

Backport of #6293 to the 8.9 chart. A manual `deploy-camunda` run of an 8.9 RDBMS scenario fails with `password authentication failed for user "..."` unless `RDBMS_POSTGRESQL_USERNAME` happens to be exactly `app`.

### What's in this PR?

The 8.9 `postgresql-cluster` CNPG fixture hardcoded the managed login role to `app`, while the connection `Secret`, the `psql-create-db` job (`--username=$RDBMS_POSTGRESQL_USERNAME`), and `rdbms.yaml` (`username: ${RDBMS_POSTGRESQL_USERNAME}`) all use the variable. They only agree when the variable is literally `app`.

This derives the managed role name from `$RDBMS_POSTGRESQL_USERNAME`. The role is a superuser, so it accesses the default `app` database regardless of name. When the variable is `app` the fixture renders **byte-identical** to before, so CI is unchanged.

8.9 differs from 8.10: it creates databases via the `psql-create-db` job (not `postInitSQL`), so there's no `CREATE DATABASE ... OWNER` clause to update — only the managed role name.

**Validation:** `envsubst` render with `=app` (identical to before) and `=camunda` (role consistently `camunda`); `go test ./matrix/...` passes. Not GKE-validated for non-`app` values (no standing local 8.9 RDBMS deploy), but mirrors the GKE-validated 8.10 fix (#6293) and is a no-op when the var is `app` as CI uses.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
