### PR TITLE
ci: forward extra-values file to install matrix run helm commands

### DIFF
--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -645,6 +645,17 @@ jobs:
             fi
           fi
 
+          # Apply workflow-supplied extra values (e.g. the run-built image tag) last
+          # so they override chart defaults. The "Pre-install scenario tweaks" step
+          # above tees ${{ inputs.extra-values }} to /tmp/extra-values-file.yaml.
+          # `matrix run` does not yet natively consume that file (see #6312), so
+          # forward it to every helm command via --extra-helm-arg=--values. Skip when
+          # empty/whitespace-only. Safe here because the install flow is single-step;
+          # the upgrade flow deliberately omits this (see the note in its deploy step).
+          if [[ -s /tmp/extra-values-file.yaml ]] && grep -q '[^[:space:]]' /tmp/extra-values-file.yaml; then
+            EXTRA_HELM_ARGS+=(--extra-helm-arg=--values=/tmp/extra-values-file.yaml)
+          fi
+
           cd ./scripts/deploy-camunda
           go run . matrix run \
             --repo-root "${GITHUB_WORKSPACE}" \
@@ -960,6 +971,15 @@ jobs:
               ENV_FILE_ARGS=(--env-file /tmp/values-config.env)
             fi
           fi
+
+          # NOTE: extra-values (e.g. the run-built image tag) are intentionally NOT
+          # forwarded for upgrade flows. `matrix run` runs upgrade as a two-step
+          # orchestration — Step 1 installs the previous released version, Step 2
+          # upgrades to the current chart — and --extra-helm-arg fans out to BOTH
+          # steps, which would inject the new image tag into the previous-version
+          # install and break the upgrade-from-stable baseline. Step-2-only / per-
+          # scenario injection is tracked in #6312. (The install flow, being single-
+          # step, forwards the file safely; see that step.)
 
           cd ./scripts/deploy-camunda
           go run . matrix run \


### PR DESCRIPTION
### Which problem does the PR fix?

Follow-up hotfix to #6312.

CI was deploying the chart-default Camunda image tag (e.g. `8.10-SNAPSHOT`)
instead of the image built in the triggering run. Example:
https://github.com/camunda/camunda/actions/runs/26873115272/job/79254408193 —
the run built and pushed `…/camunda:8.10.0-SNAPSHOT-mq54211-run26873115272-a1`
but the deploy summary shows `Docker Image used for Orchestration: …/camunda:8.10-SNAPSHOT`.

Root cause: the integration runner tees the workflow `extra-values` input (which
carries `orchestration.image.{registry,repository,tag}`) to a fixed path,
`/tmp/extra-values-file.yaml`, and a comment claimed `deploy-camunda matrix run`
would add it to the Helm values chain via `flags.Deployment.ExtraValues`. That
wiring was never implemented — `matrix run` has no `--extra-values` flag and never
reads the file, so the override was written and silently dropped.

### What's in this PR?

Forwards `/tmp/extra-values-file.yaml` to every Helm command via
`--extra-helm-arg=--values=/tmp/extra-values-file.yaml` in the **install**
matrix-run step of `test-integration-runner.yaml` (the flow that failed in the
linked run).

- Guarded on the file being non-empty / non-whitespace, so runs without
  `extra-values` are unaffected.
- Applied last in the values chain, so it overrides chart defaults — restoring
  the intended behavior with no Go change (lowest blast radius for the
  merge-queue/nightly deploy).

**Upgrade flows deliberately omit this** (documented inline in the upgrade deploy
step). `matrix run` runs upgrade as a two-step orchestration — Step 1 installs the
previous released version, Step 2 upgrades to the current chart — and
`--extra-helm-arg` fans out to **both** steps. Forwarding the run-built image tag
would inject it into the Step 1 previous-version install and break the
upgrade-from-stable baseline. Step-scoped (Step-2-only) / per-scenario injection
for upgrade flows is tracked in #6312.

Native `--extra-values` consumption in `matrix run`, plus per-scenario extra
values from the matrix perspective, is the proper follow-up in #6312. The
workaround comments reference #6312 so it's traceable to its replacement.

> Reviewed with `crev` (dry-run): the install-only scoping and the explicit
> upgrade-flow exclusion address both findings (no-op for non-OIDC upgrade
> scenarios; Step-1 contamination in two-step upgrades).
