### PR TITLE
ci: sanitise extra-values comment to prevent shell injection in integration runner

### DIFF
--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -647,7 +647,7 @@ jobs:
 
           # Apply workflow-supplied extra values (e.g. the run-built image tag) last
           # so they override chart defaults. The "Pre-install scenario tweaks" step
-          # above tees ${{ inputs.extra-values }} to /tmp/extra-values-file.yaml.
+          # above tees the workflow's extra-values input to /tmp/extra-values-file.yaml.
           # `matrix run` does not yet natively consume that file (see #6312), so
           # forward it to every helm command via --extra-helm-arg=--values. Skip when
           # empty/whitespace-only. Safe here because the install flow is single-step;


### PR DESCRIPTION
### Which problem does the PR fix?

The Helm chart integration-test install step fails with exit code 127 before the chart is ever deployed, e.g. [camunda/camunda run 26884180252](https://github.com/camunda/camunda/actions/runs/26884180252/job/79293231653):

```
/__w/_temp/….sh: line 62: image:: command not found
##[error]Process completed with exit code 127.
```

Root cause is a shell-injection bug in `test-integration-runner.yaml`. The install deploy step interpolates the GitHub expression `${{ inputs.extra-values }}` directly into a `run:` **comment**. When `extra-values` is multi-line YAML (the normal case — it carries the run-built orchestration image tag), GitHub pastes it verbatim into the rendered script:

```bash
# above tees orchestration:        # <- only this first line stays commented
  image:                            # <- these become bare shell lines
    registry: registry.camunda.cloud
    ...
```

bash then tries to execute `image:` as a command → `image:: command not found` → the step exits 127, before `matrix run` runs.

### What's in this PR?

Sanitise the comment so no `${{ }}` expression is expanded into the script body — reference the input by name in prose instead. The actual data path is unchanged and already safe: the value is passed via the `EXTRA_VALUES` env var and tee'd to `/tmp/extra-values-file.yaml`, then forwarded with `--extra-helm-arg=--values`. This is the only `${{ }}` interpolation in a `run:` script body in this workflow; all other uses are within `env:` mappings, which handle multi-line values safely.

One-line diff, no behavior change beyond removing the failure.
