### PR TITLE
chore: block Elasticsearch 9 major upgrade in 8.8 and 8.9 charts

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -186,6 +186,22 @@
       ],
       allowedVersions: '~8.17.0',
     },
+    // Limit Elasticsearch version to 8.x in Camunda 8.8 and 8.9 charts (Bitnami subchart removed in 8.10).
+    {
+      matchDatasources: [
+        'docker',
+      ],
+      matchFileNames: [
+        'charts/camunda-platform-8.8/values.yaml',
+        'charts/camunda-platform-8.8/values-latest.yaml',
+        'charts/camunda-platform-8.9/values.yaml',
+        'charts/camunda-platform-8.9/values-latest.yaml',
+      ],
+      matchPackageNames: [
+        '/.*elasticsearch.*/',
+      ],
+      allowedVersions: '<9.0.0',
+    },
     // Limit alpha chart version to alpha tags only.
     {
       enabled: true,

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -194,13 +194,15 @@
       matchFileNames: [
         'charts/camunda-platform-8.8/values.yaml',
         'charts/camunda-platform-8.8/values-latest.yaml',
+        'charts/camunda-platform-8.8/values-enterprise.yaml',
         'charts/camunda-platform-8.9/values.yaml',
         'charts/camunda-platform-8.9/values-latest.yaml',
+        'charts/camunda-platform-8.9/values-enterprise.yaml',
       ],
       matchPackageNames: [
         '/.*elasticsearch.*/',
       ],
-      allowedVersions: '<9.0.0',
+      allowedVersions: '>=8.0.0 <9.0.0',
     },
     // Limit alpha chart version to alpha tags only.
     {


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6257 — Renovate proposes an ES 8→9 major bump for `8.8` and `8.9` charts that still carry the Bitnami Elasticsearch subchart. The Bitnami subchart is removed in `8.10`, so a major ES version change must never land on `8.7`–`8.9`.

### What's in this PR?

Adds a Renovate `packageRule` that constrains `allowedVersions: '<9.0.0'` for all `.*elasticsearch.*` docker images in `charts/camunda-platform-8.8` and `charts/camunda-platform-8.9` values files. Mirrors the existing `~8.17.0` cap already in place for `8.7`.

### Checklist

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?