### PR TITLE
chore: fix broken links in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,7 +20,7 @@ Please make sure to follow our [Contributing Guide](../docs/contribution-and-col
 - [ ] In the repo's root dir, run `make go.update-golden-only`.
 - [ ] There is no other open [pull request](../pulls) for the same update/change.
 - [ ] Tests for charts are added (if needed).
-- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#pull-request-requirements) are updated (if needed).
+- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).
 
 **After opening the PR:**
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@
 
 ### Checklist
 
-Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).
+Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).
 
 <!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
 
@@ -20,7 +20,7 @@ Please make sure to follow our [Contributing Guide](../blob/main/docs/contributi
 - [ ] In the repo's root dir, run `make go.update-golden-only`.
 - [ ] There is no other open [pull request](../pulls) for the same update/change.
 - [ ] Tests for charts are added (if needed).
-- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).
+- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#documentation) are updated (if needed).
 
 **After opening the PR:**
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,7 +20,7 @@ Please make sure to follow our [Contributing Guide](../docs/contribution-and-col
 - [ ] In the repo's root dir, run `make go.update-golden-only`.
 - [ ] There is no other open [pull request](../pulls) for the same update/change.
 - [ ] Tests for charts are added (if needed).
-- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#documentation) are updated (if needed).
+- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#pull-request-requirements) are updated (if needed).
 
 **After opening the PR:**
 


### PR DESCRIPTION
### Which problem does the PR fix?

The PR template referenced `docs/contributing.md` (file does not exist) via a `../blob/main/...` relative path that resolves to a double `blob/main` URL on GitHub. Both links pointed to the wrong file.

### What's in this PR?

- Replaced `../blob/main/docs/contributing.md` → `../docs/contribution-and-collaboration.md` (correct relative path and correct filename)
- Same fix for the `#documentation` anchor variant

### Checklist

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [x] In-repo [documentation](../docs/contribution-and-collaboration.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?