### PR TITLE
chore(deploy-camunda): strip digest overlay pins shadowed by --extra-values image overrides

### DIFF
--- a/scripts/deploy-camunda/deploy/digest_overlay.go
+++ b/scripts/deploy-camunda/deploy/digest_overlay.go
@@ -1,0 +1,146 @@
+package deploy
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"scripts/camunda-core/pkg/logging"
+
+	"gopkg.in/yaml.v3"
+)
+
+// neutralizeOverriddenDigests rewrites the chart-root digest overlay so that it
+// does not pin image.digest for any component whose image coordinates
+// (registry/repository/tag) are explicitly supplied via --extra-values without an
+// accompanying digest.
+//
+// Why this is needed: the chart image helper (camundaPlatform.imageByParams)
+// prefers digest over tag — whenever image.digest is non-empty the tag is never
+// consulted. The values chain applies the digest overlay before --extra-values,
+// but Helm's map merge only overrides keys the later file actually sets. So an
+// --extra-values file that sets registry/repository/tag (but no digest) leaves the
+// overlay's digest in place, and the helper silently renders
+// "<extra registry>/<extra repository>@<overlay digest>". In the monorepo nightly
+// this glues the Harbor repo onto a DockerHub snapshot digest, producing a
+// reference that does not exist and an ImagePullBackOff.
+//
+// Stripping the conflicting digest lets the helper fall through to the tag path so
+// the --extra-values override actually takes effect. Components not overridden by
+// --extra-values keep their digest pins. If an --extra-values file supplies its own
+// digest, that digest is preserved (it wins via the normal merge), so we do not
+// strip it.
+//
+// It returns the original overlay path unchanged when nothing needs stripping
+// (no extra-values image overrides, or none of them collide with a pinned digest).
+func neutralizeOverriddenDigests(overlayPath string, extraValues []string, tempDir string) (string, error) {
+	overlay, err := loadValuesDoc(overlayPath)
+	if err != nil {
+		return "", fmt.Errorf("reading digest overlay %q: %w", overlayPath, err)
+	}
+	if overlay == nil {
+		return overlayPath, nil
+	}
+
+	// Collect the dotted image-paths overridden by --extra-values: an image block
+	// that sets registry/repository/tag but does not pin its own digest.
+	overridden := map[string]bool{}
+	for _, f := range extraValues {
+		doc, readErr := loadValuesDoc(f)
+		if readErr != nil {
+			return "", fmt.Errorf("reading extra-values %q: %w", f, readErr)
+		}
+		walkImageBlocks(doc, func(path string, img map[string]any) {
+			if _, hasDigest := img["digest"]; hasDigest {
+				return // caller pinned an explicit digest — let it win via merge
+			}
+			if img["registry"] != nil || img["repository"] != nil || img["tag"] != nil {
+				overridden[path] = true
+			}
+		})
+	}
+	if len(overridden) == 0 {
+		return overlayPath, nil
+	}
+
+	// Strip the digest from any overlay image block the caller overrode.
+	changed := false
+	stripped := make([]string, 0, len(overridden))
+	walkImageBlocks(overlay, func(path string, img map[string]any) {
+		if !overridden[path] {
+			return
+		}
+		if _, ok := img["digest"]; ok {
+			delete(img, "digest")
+			changed = true
+			stripped = append(stripped, path)
+		}
+	})
+	if !changed {
+		return overlayPath, nil
+	}
+
+	sanitizedPath := filepath.Join(tempDir, "values-digest.sanitized.yaml")
+	if err := writeValuesDoc(sanitizedPath, overlay); err != nil {
+		return "", fmt.Errorf("writing sanitized digest overlay: %w", err)
+	}
+
+	sort.Strings(stripped)
+	logging.Logger.Warn().
+		Str("originalOverlay", overlayPath).
+		Strs("componentsOverridden", stripped).
+		Str("sanitizedOverlay", sanitizedPath).
+		Msg("Stripped digest overlay pins shadowed by --extra-values image overrides")
+
+	return sanitizedPath, nil
+}
+
+// walkImageBlocks recursively walks a values document and invokes fn for every
+// map node that contains an "image" sub-map, passing the dotted path of the
+// component owning the image (e.g. "orchestration", "webModeler.restapi") and the
+// image map itself. The image map is the live reference, so mutating it (e.g.
+// deleting "digest") edits the underlying document.
+func walkImageBlocks(node map[string]any, fn func(path string, img map[string]any)) {
+	walkImageBlocksRec("", node, fn)
+}
+
+func walkImageBlocksRec(path string, node map[string]any, fn func(path string, img map[string]any)) {
+	if img, ok := node["image"].(map[string]any); ok {
+		fn(path, img)
+	}
+	for key, val := range node {
+		child, ok := val.(map[string]any)
+		if !ok {
+			continue
+		}
+		childPath := key
+		if path != "" {
+			childPath = path + "." + key
+		}
+		walkImageBlocksRec(childPath, child, fn)
+	}
+}
+
+// loadValuesDoc reads a YAML file into a generic map. An empty document yields a
+// nil map and no error.
+func loadValuesDoc(path string) (map[string]any, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, err
+	}
+	return doc, nil
+}
+
+// writeValuesDoc marshals a generic map and writes it to path.
+func writeValuesDoc(path string, doc map[string]any) error {
+	out, err := yaml.Marshal(doc)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, out, 0o644)
+}

--- a/scripts/deploy-camunda/deploy/digest_overlay_test.go
+++ b/scripts/deploy-camunda/deploy/digest_overlay_test.go
@@ -1,0 +1,217 @@
+package deploy
+
+import (
+	"strings"
+	"testing"
+)
+
+// digestOverlay is a representative chart-root values-digest.yaml: every
+// component is pinned by digest, mirroring the real overlay shape (including the
+// nested webModeler.restapi block).
+const digestOverlay = `
+orchestration:
+  image:
+    repository: camunda/camunda
+    tag: 8.10-SNAPSHOT
+    digest: "sha256:orchestrationdigest"
+connectors:
+  image:
+    repository: camunda/connectors-bundle
+    tag: 8.10-SNAPSHOT
+    digest: "sha256:connectorsdigest"
+webModeler:
+  restapi:
+    image:
+      repository: camunda/web-modeler-restapi
+      tag: 8.10-SNAPSHOT
+      digest: "sha256:restapidigest"
+`
+
+// imageHasDigest reports whether <component path>.image in the given doc still
+// carries a digest key. path is dot-separated (e.g. "webModeler.restapi").
+func imageHasDigest(t *testing.T, doc map[string]any, path string) bool {
+	t.Helper()
+	node := doc
+	for _, seg := range strings.Split(path, ".") {
+		child, ok := node[seg].(map[string]any)
+		if !ok {
+			t.Fatalf("path %q: segment %q not a map", path, seg)
+		}
+		node = child
+	}
+	img, ok := node["image"].(map[string]any)
+	if !ok {
+		t.Fatalf("path %q: no image map", path)
+	}
+	_, has := img["digest"]
+	return has
+}
+
+func TestNeutralizeOverriddenDigests(t *testing.T) {
+	tests := []struct {
+		name         string
+		extraValues  string // contents of a single --extra-values file
+		wantChanged  bool   // expect a sanitized temp file (path differs from original)
+		wantStripped []string
+		wantKept     []string
+	}{
+		{
+			name: "tag override without digest strips that component only",
+			extraValues: `
+orchestration:
+  image:
+    registry: registry.camunda.cloud
+    repository: team-camunda/camunda
+    tag: 8.10.0-SNAPSHOT-mq-run-a1
+`,
+			wantChanged:  true,
+			wantStripped: []string{"orchestration"},
+			wantKept:     []string{"connectors", "webModeler.restapi"},
+		},
+		{
+			name: "explicit digest in extra-values is preserved (overlay untouched)",
+			extraValues: `
+orchestration:
+  image:
+    registry: registry.camunda.cloud
+    repository: team-camunda/camunda
+    digest: "sha256:callerpinneddigest"
+`,
+			wantChanged: false,
+			wantKept:    []string{"orchestration", "connectors", "webModeler.restapi"},
+		},
+		{
+			name: "repository-only override still strips digest",
+			extraValues: `
+connectors:
+  image:
+    repository: team-camunda/connectors-bundle
+`,
+			wantChanged:  true,
+			wantStripped: []string{"connectors"},
+			wantKept:     []string{"orchestration", "webModeler.restapi"},
+		},
+		{
+			name: "nested webModeler override strips only that path",
+			extraValues: `
+webModeler:
+  restapi:
+    image:
+      repository: team-camunda/web-modeler-restapi
+      tag: snapshot-a1
+`,
+			wantChanged:  true,
+			wantStripped: []string{"webModeler.restapi"},
+			wantKept:     []string{"orchestration", "connectors"},
+		},
+		{
+			name: "extra-values without any image override leaves overlay untouched",
+			extraValues: `
+global:
+  ingress:
+    enabled: true
+`,
+			wantChanged: false,
+			wantKept:    []string{"orchestration", "connectors", "webModeler.restapi"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			overlayPath := writeTempYAML(t, dir, "values-digest.yaml", digestOverlay)
+			extraPath := writeTempYAML(t, dir, "extra-values.yaml", tt.extraValues)
+
+			got, err := neutralizeOverriddenDigests(overlayPath, []string{extraPath}, dir)
+			if err != nil {
+				t.Fatalf("neutralizeOverriddenDigests: %v", err)
+			}
+
+			if tt.wantChanged {
+				if got == overlayPath {
+					t.Fatalf("expected a sanitized file, got original path %q", got)
+				}
+			} else {
+				if got != overlayPath {
+					t.Fatalf("expected original path unchanged, got %q", got)
+				}
+			}
+
+			doc := readYAMLMap(t, got)
+			for _, p := range tt.wantStripped {
+				if imageHasDigest(t, doc, p) {
+					t.Errorf("expected digest stripped at %q, but it is still present", p)
+				}
+			}
+			for _, p := range tt.wantKept {
+				if !imageHasDigest(t, doc, p) {
+					t.Errorf("expected digest kept at %q, but it was removed", p)
+				}
+			}
+		})
+	}
+}
+
+// TestNeutralizeOverriddenDigestsNoDigestInOverlay verifies that when the caller
+// overrides a component whose overlay block has no digest, the overlay is
+// returned unchanged (nothing to strip).
+func TestNeutralizeOverriddenDigestsNoDigestInOverlay(t *testing.T) {
+	dir := t.TempDir()
+	overlay := `
+orchestration:
+  image:
+    repository: camunda/camunda
+    tag: 8.10-SNAPSHOT
+`
+	extra := `
+orchestration:
+  image:
+    repository: team-camunda/camunda
+    tag: snapshot-a1
+`
+	overlayPath := writeTempYAML(t, dir, "values-digest.yaml", overlay)
+	extraPath := writeTempYAML(t, dir, "extra-values.yaml", extra)
+
+	got, err := neutralizeOverriddenDigests(overlayPath, []string{extraPath}, dir)
+	if err != nil {
+		t.Fatalf("neutralizeOverriddenDigests: %v", err)
+	}
+	if got != overlayPath {
+		t.Fatalf("expected original path unchanged, got %q", got)
+	}
+}
+
+// TestNeutralizeOverriddenDigestsMultipleExtraFiles verifies overrides are
+// aggregated across multiple --extra-values files.
+func TestNeutralizeOverriddenDigestsMultipleExtraFiles(t *testing.T) {
+	dir := t.TempDir()
+	overlayPath := writeTempYAML(t, dir, "values-digest.yaml", digestOverlay)
+	extra1 := writeTempYAML(t, dir, "extra1.yaml", `
+orchestration:
+  image:
+    tag: snapshot-a1
+`)
+	extra2 := writeTempYAML(t, dir, "extra2.yaml", `
+connectors:
+  image:
+    tag: snapshot-a1
+`)
+
+	got, err := neutralizeOverriddenDigests(overlayPath, []string{extra1, extra2}, dir)
+	if err != nil {
+		t.Fatalf("neutralizeOverriddenDigests: %v", err)
+	}
+	if got == overlayPath {
+		t.Fatal("expected a sanitized file")
+	}
+	doc := readYAMLMap(t, got)
+	if imageHasDigest(t, doc, "orchestration") {
+		t.Error("orchestration digest should be stripped")
+	}
+	if imageHasDigest(t, doc, "connectors") {
+		t.Error("connectors digest should be stripped")
+	}
+	if !imageHasDigest(t, doc, "webModeler.restapi") {
+		t.Error("webModeler.restapi digest should be kept")
+	}
+}

--- a/scripts/deploy-camunda/deploy/values.go
+++ b/scripts/deploy-camunda/deploy/values.go
@@ -885,6 +885,19 @@ func prepareScenarioValues(ctx context.Context, scenarioCtx *ScenarioContext, fl
 		}
 		overlayPath := filepath.Join(flags.Chart.ChartPath, "values-"+overlay+".yaml")
 		if _, statErr := os.Stat(overlayPath); statErr == nil {
+			// The digest overlay pins image.digest, which the chart image helper
+			// prefers over tag. If --extra-values overrides a component's image
+			// coordinates (without its own digest), strip that component's digest
+			// from the overlay so the override actually takes effect instead of
+			// being silently shadowed. See neutralizeOverriddenDigests.
+			if overlay == "digest" && len(flags.Deployment.ExtraValues) > 0 {
+				sanitized, sanErr := neutralizeOverriddenDigests(overlayPath, flags.Deployment.ExtraValues, tempDir)
+				if sanErr != nil {
+					os.RemoveAll(tempDir)
+					return nil, fmt.Errorf("failed to sanitize digest overlay: %w", sanErr)
+				}
+				overlayPath = sanitized
+			}
 			chartRootOverlayFiles = append(chartRootOverlayFiles, overlayPath)
 			logging.Logger.Info().
 				Str("overlay", overlay).


### PR DESCRIPTION
### Which problem does the PR fix?

Nightly Helm integration installs can fail with `ImagePullBackOff` on the
orchestration (Zeebe) pods even though the image was built and pushed
successfully. Observed on the monorepo-driven nightly:
https://github.com/camunda/camunda/actions/runs/26928331705/job/79443999919
(`8.10 / alwaysgreen (agrn)`, flow=install).

Root cause is a digest-vs-tag collision in the values merge, not Harbor and not
the chart templates:

- `charts/camunda-platform-<ver>/values-digest.yaml` pins `image.digest` for
  every component.
- The chart helper `camundaPlatform.imageByParams` (`templates/common/_helpers.tpl`)
  prefers `digest` over `tag` — when a digest is set, the tag is never used.
- `deploy-camunda` applies the digest overlay **before** `--extra-values`, but
  Helm's map merge only overrides keys the later file actually sets. The
  monorepo injects the freshly-built orchestration image via `--extra-values`
  as `registry`/`repository`/`tag` (no digest), so the overlay's stale digest
  survives the merge.
- The helper then renders `<extra registry>/<extra repository>@<overlay digest>`,
  i.e. the Harbor repo `registry.camunda.cloud/team-camunda/camunda` glued onto a
  DockerHub snapshot digest (`sha256:d744…`). That reference does not exist in
  Harbor → `NotFound` → `ImagePullBackOff` → `helm --wait` timeout → failed install.

The pushed image is fine — it exists in Harbor under `sha256:adf925…` (the build
job's `containerimage.digest`); nothing ever published `d744…` there.

### What's in this PR?

`deploy-camunda` now sanitizes the chart-root digest overlay before use. For any
component whose image coordinates are overridden via `--extra-values` **without**
an explicit digest, that component's `digest` is stripped from a temp copy of the
overlay, so the override actually takes effect (helper falls through to the tag
path). This makes the documented "`--extra-values` wins" precedence
(`deploy/chain.go`) true for images.

Design notes:

- **Surgical** — only components actually overridden lose their pin; everything
  else keeps its digest pin. In a monorepo nightly only `orchestration` is
  stripped; `console`/`connectors`/`optimize`/`identity` stay pinned.
- **Honors explicit digests** — an `image.digest` supplied in `--extra-values` is
  preserved and wins via the normal merge (we only strip when the override has no
  digest).
- **No precedence churn** — the overlay keeps its chain position; only its
  content is edited, mirroring the existing `sanitizeEnvFileForOCIImmutability`
  pattern.
- **Generic nesting** — a recursive walk handles nested image blocks
  (`webModeler.restapi`, `webModeler.websockets`) without hardcoding component
  names.
- OCI-immutability mode (`--chart-ref`) is unaffected: it already resolves no
  chart-root overlays, so there is nothing to sanitize.

New unit tests cover: tag-only override, repository-only override, explicit
digest preserved, nested webModeler override, no-image-override no-op, overlay
without a digest, and aggregation across multiple `--extra-values` files.

A complementary one-line unblock on the monorepo side (set `orchestration.image.digest: ""`
in the injected extra-values) can land immediately; this PR is the durable guard
so the class of failure cannot recur for any chart version.

### Checklist

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open pull request for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo documentation are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
