### PR TITLE
ci: install helm in promote-rc workflow to support 8.10 chart

### DIFF
--- a/.github/workflows/chart-promote-rc.yaml
+++ b/.github/workflows/chart-promote-rc.yaml
@@ -175,6 +175,7 @@ jobs:
         uses: ./.github/actions/install-tool-versions
         with:
           tools: |
+            helm
             yq
 
       - name: Pull and validate dev package


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes #6333

### What's in this PR?

The `Install tools` step in `chart-promote-rc.yaml` only installed `yq` from asdf, so the `helm` command in step 13 ("Pre-populate version matrix from dev package") resolved to the runner's system Helm 3.x. The 8.10 chart's `constraints.tpl` fails with `[camunda][error] Camunda chart 15.x requires Helm CLI v4` when run with Helm 3, and since that error goes to `/dev/null` (`2>/dev/null` in the pipeline), the script exits silently via `set -euo pipefail`.

Added `helm` to the tools list so asdf provides Helm 4.1.4 (from `.tool-versions`), matching `chart-release-chores.yaml`.

### Checklist

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?