### PR TITLE
build: add post-infra lifecycle hook to the matrix deploy tooling

### DIFF
--- a/scripts/camunda-deployer/pkg/deployer/deployer.go
+++ b/scripts/camunda-deployer/pkg/deployer/deployer.go
@@ -129,5 +129,15 @@ func Deploy(ctx context.Context, o types.Options) error {
 		}
 	}
 
+	// Run post-infra hooks after the companion charts (external infrastructure)
+	// are deployed and ready, but before the main Camunda chart. This is the
+	// point to act on freshly-provisioned infrastructure — e.g. migrating data
+	// from a prior release's bundled backends onto the companion services.
+	for i, hook := range o.PostInfraHooks {
+		if err := hook(ctx); err != nil {
+			return fmt.Errorf("post-infra hook [%d] failed: %w", i, err)
+		}
+	}
+
 	return upgradeInstall(ctx, o)
 }

--- a/scripts/camunda-deployer/pkg/types/types.go
+++ b/scripts/camunda-deployer/pkg/types/types.go
@@ -80,6 +80,13 @@ type Options struct {
 	// deployed with helm upgrade --install --wait to ensure it is ready
 	// before the main chart deployment begins.
 	CompanionCharts []CompanionChart
+
+	// PostInfraHooks are functions called after all CompanionCharts are
+	// deployed and ready, but before the main Camunda chart is
+	// installed/upgraded. Used to act on freshly-provisioned infrastructure —
+	// e.g. migrating data from a prior release's bundled backends onto the
+	// companion services before the chart switches over to them.
+	PostInfraHooks []func(ctx context.Context) error
 }
 
 // CompanionChart represents a Helm chart that should be deployed as a

--- a/scripts/deploy-camunda/config/merge.go
+++ b/scripts/deploy-camunda/config/merge.go
@@ -193,6 +193,14 @@ type RuntimeFlags struct {
 	// may not yet exist or may be recreated by DeleteNamespaceFirst.
 	PreInstallHooks []func(ctx context.Context) error
 
+	// PostInfraHooks are functions called by the deployer after companion
+	// charts (the external infrastructure: PostgreSQL, Elasticsearch, Keycloak,
+	// …) are deployed and ready, but before the main Camunda chart is
+	// installed/upgraded. Used to act on freshly-provisioned infrastructure —
+	// e.g. migrating data from a prior release's bundled backends onto the
+	// companion services before the chart switches over to them.
+	PostInfraHooks []func(ctx context.Context) error
+
 	// PostDeployHooks are functions called by the deployer after helm
 	// upgrade/install completes successfully but before the deployment result
 	// is returned. Used to apply scenario-specific resources whose CRDs are

--- a/scripts/deploy-camunda/deploy/deploy.go
+++ b/scripts/deploy-camunda/deploy/deploy.go
@@ -313,6 +313,7 @@ func executeDeployment(ctx context.Context, prepared *PreparedScenario, flags *c
 		SetPairs:              flags.Deployment.ExtraHelmSets,
 		PreInstallHooks:       flags.PreInstallHooks,
 		CompanionCharts:       toDeployerCompanionCharts(prepared.CompanionCharts),
+		PostInfraHooks:        flags.PostInfraHooks,
 	}
 
 	// Log deployment options (redact sensitive fields)

--- a/scripts/deploy-camunda/matrix/config.go
+++ b/scripts/deploy-camunda/matrix/config.go
@@ -215,6 +215,13 @@ type CIScenario struct {
 	// (pre-install-<scenario>.sh) with an explicit, reviewable reference.
 	PreInstall *LifecycleHook `yaml:"pre-install,omitempty"`
 
+	// PostInfra declares a fixture or script to run after the scenario's
+	// companion charts (external infrastructure) are deployed and ready, but
+	// before the main Camunda chart is installed/upgraded. Used to act on
+	// freshly-provisioned infrastructure — e.g. migrating data from a prior
+	// release's bundled backends onto the companion services.
+	PostInfra *LifecycleHook `yaml:"post-infra,omitempty"`
+
 	// PostDeploy declares a fixture or script to run after helm install
 	// completes successfully. Used for resources whose CRDs are only
 	// installed by the chart itself (e.g., the Gateway API

--- a/scripts/deploy-camunda/matrix/lifecycle_hook.go
+++ b/scripts/deploy-camunda/matrix/lifecycle_hook.go
@@ -103,6 +103,7 @@ type hookKind string
 
 const (
 	hookPreInstall hookKind = "pre-install"
+	hookPostInfra  hookKind = "post-infra"
 	hookPostDeploy hookKind = "post-deploy"
 	hookPreUpgrade hookKind = "pre-upgrade"
 )
@@ -185,6 +186,16 @@ func registerDeclarativeHook(flags *config.RuntimeFlags, hook *LifecycleHook, ki
 // for pre-install registrations.
 func registerDeclarativePreInstallHook(flags *config.RuntimeFlags, hook *LifecycleHook, repoRoot, appVersion, scenario string) error {
 	return registerDeclarativeHook(flags, hook, hookPreInstall, &flags.PreInstallHooks, repoRoot, appVersion, scenario)
+}
+
+// registerDeclarativePostInfraHook is a thin shim that pins the slot and kind
+// for post-infra registrations. The hook runs after companion charts (the
+// external infrastructure: PostgreSQL, Elasticsearch, Keycloak, …) are deployed
+// and ready, but before the main Camunda chart is installed/upgraded. Use it to
+// act on freshly-provisioned infrastructure — e.g. migrating data from a prior
+// release's bundled backends onto the companion services.
+func registerDeclarativePostInfraHook(flags *config.RuntimeFlags, hook *LifecycleHook, repoRoot, appVersion, scenario string) error {
+	return registerDeclarativeHook(flags, hook, hookPostInfra, &flags.PostInfraHooks, repoRoot, appVersion, scenario)
 }
 
 // registerDeclarativePostDeployHook is a thin shim that pins the slot and kind

--- a/scripts/deploy-camunda/matrix/matrix.go
+++ b/scripts/deploy-camunda/matrix/matrix.go
@@ -48,6 +48,11 @@ type Entry struct {
 	// without re-loading ci-test-config.yaml.
 	PreInstall *LifecycleHook `json:"preInstall,omitempty"`
 
+	// PostInfra declares a fixture or script to run after companion charts
+	// (external infrastructure) are deployed but before the main Camunda chart.
+	// Carried from CIScenario.PostInfra.
+	PostInfra *LifecycleHook `json:"postInfra,omitempty"`
+
 	// PostDeploy declares a fixture or script to run after helm install
 	// completes successfully. Carried from CIScenario.PostDeploy.
 	PostDeploy *LifecycleHook `json:"postDeploy,omitempty"`
@@ -215,6 +220,7 @@ func Generate(repoRoot string, opts GenerateOptions) ([]Entry, error) {
 						SkipIT:       scenario.SkipIT,
 						Dependencies: append([]ChartDependency(nil), scenario.Dependencies...),
 						PreInstall:   scenario.PreInstall,
+						PostInfra:    scenario.PostInfra,
 						PostDeploy:   scenario.PostDeploy,
 						PreUpgrade:   preUpgrade,
 						HelmVersion:  scenario.HelmVersion,

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -542,6 +542,9 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) RunResult {
 		if err := registerDeclarativePreInstallHook(flags, entry.PreInstall, opts.RepoRoot, entry.Version, entry.Scenario); err != nil {
 			return RunResult{Entry: entry, Namespace: namespace, Error: err}
 		}
+		if err := registerDeclarativePostInfraHook(flags, entry.PostInfra, opts.RepoRoot, entry.Version, entry.Scenario); err != nil {
+			return RunResult{Entry: entry, Namespace: namespace, Error: err}
+		}
 	}
 	if !isTwoStepUpgrade {
 		if err := registerDeclarativePostDeployHook(flags, entry.PostDeploy, opts.RepoRoot, entry.Version, entry.Scenario); err != nil {

--- a/scripts/deploy-camunda/matrix/runner_upgrade.go
+++ b/scripts/deploy-camunda/matrix/runner_upgrade.go
@@ -279,6 +279,13 @@ func executeTwoStepUpgrade(ctx context.Context, entry Entry, flags *config.Runti
 		}
 	}
 
+	// --- Post-infra lifecycle hook (Step 2 of two-step upgrade) ---
+	// Registered against step2Flags so it fires after Step 2's companion charts
+	// are deployed but before the target chart upgrade.
+	if err := registerDeclarativePostInfraHook(&step2Flags, entry.PostInfra, opts.RepoRoot, entry.Version, entry.Scenario); err != nil {
+		return err
+	}
+
 	// --- Post-deploy lifecycle hook (Step 2 of two-step upgrade) ---
 	// Registered against step2Flags so it fires after the upgrade succeeds.
 	if err := registerDeclarativePostDeployHook(&step2Flags, entry.PostDeploy, opts.RepoRoot, entry.Version, entry.Scenario); err != nil {
@@ -377,6 +384,13 @@ func executeUpgradeOnly(ctx context.Context, entry Entry, flags *config.RuntimeF
 	// Upgrade-only flows reuse an existing namespace, but scenario pre-install
 	// fixtures may still be required before the target chart can start.
 	if err := registerDeclarativePreInstallHook(&upgradeFlags, entry.PreInstall, opts.RepoRoot, entry.Version, entry.Scenario); err != nil {
+		return err
+	}
+	// Post-infra hook: runs after the upgrade's companion charts are deployed
+	// but before the target chart upgrade. This is where a Bitnami→companion
+	// data migration runs, so the upgraded chart finds its data on the
+	// companion services.
+	if err := registerDeclarativePostInfraHook(&upgradeFlags, entry.PostInfra, opts.RepoRoot, entry.Version, entry.Scenario); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
### Which problem does the PR fix?

The matrix deploy tooling had two declarative lifecycle hooks — `pre-install`
(before the namespace/chart) and `post-deploy` (after the chart) — plus the
flow-level `pre-upgrade`. There was **no hook that runs once the companion
charts (external infrastructure: PostgreSQL, Elasticsearch, Keycloak, …) are
deployed and ready, but before the main Camunda chart**.

That gap blocks a real scenario: standing up companion infra as **migration
targets** and moving data from a prior release's bundled (Bitnami) backends
onto them *before* the chart upgrade switches over — so the upgraded chart
finds its realm/data on the external infrastructure. (This is the Helm-CI side
of exercising the `camunda-deployment-references` Bitnami→external migration
scripts; see Related.)

### What's in this PR?

A new **`post-infra`** declarative lifecycle hook:

- **deployer** (`types.Options` + `deployer.Deploy`): runs `PostInfraHooks`
  after the companion-charts loop and before `upgradeInstall` (the main chart).
- **`config.RuntimeFlags.PostInfraHooks`**, wired through `deploy.Execute` into
  the deployer options.
- **matrix**: `CIScenario.PostInfra` / `Entry.PostInfra` (yaml key `post-infra`,
  same `LifecycleHook` shape as the others: `script` xor `fixtures` + required
  `description`); carried onto the `Entry`; `registerDeclarativePostInfraHook`
  mirrors the existing pre-install/post-deploy shims. Registered on the install
  path, the upgrade-only (`modular-upgrade-minor`) path, and Step 2 of two-step
  upgrades.
- **`TestLifecycleFixtures`** now also validates `post-infra` script/fixture
  references and descriptions.

Ordering inside the deployer is now: namespace/secrets → `pre-install` hooks →
companion charts → **`post-infra` hooks** → main chart install/upgrade →
`post-deploy` hooks.

This is the hook mechanism only — no scenario uses it yet. The migration
wiring (a `post-infra` script that drives the references scripts against the
companions) lands in a follow-up.

### Validation

- `go build ./...` (deploy-camunda + camunda-deployer), `go test ./matrix/...`
  and `./pkg/deployer/...`, `gofmt` — all pass locally.

### Related

- camunda/camunda-deployment-references#2620 — adds `KEYCLOAK_TARGET_MODE=external`
  and `SKIP_HELM_UPGRADE` (data-only cutover) so a CI harness can migrate Bitnami
  data onto external/companion infra and own the chart upgrade. The follow-up
  Helm-CI PR will add a `post-infra` migration script that uses both.

### Checklist

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open pull request for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo documentation are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)?
- [ ] Did all checks/tests pass in the PR?
