### PR TITLE
test(8.10): drive Bitnami→companion migration from a post-infra hook before upgrade

### DIFF
--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -847,6 +847,16 @@ integration:
               values-file: test/integration/companion-values/elasticsearch-qa.yaml
               repo-name: elastic
               repo-url: https://helm.elastic.co
+          post-infra:
+            script: post-infra-bitnami-migration.sh
+            description: |
+              After the companion PostgreSQL/Keycloak/Elasticsearch are deployed but before
+              the chart upgrade to 8.10, migrate the bundled (Bitnami) Keycloak realm and the
+              Elasticsearch authorization indices off the bundled backends onto the companion
+              services. Uses the camunda-deployment-references migration scripts in external
+              mode with SKIP_HELM_UPGRADE=true (data-only; the matrix runner performs the
+              chart upgrade). This keeps users/realm alive across the upgrade that removes the
+              bundled Bitnami subcharts.
         - name: qa-elasticsearch
           enabled: false
           shortname: qael

--- a/charts/camunda-platform-8.10/test/ci/registry/hooks/post-infra-bitnami-migration.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/hooks/post-infra-bitnami-migration.yaml
@@ -1,0 +1,9 @@
+script: post-infra-bitnami-migration.sh
+description: |
+  After the companion PostgreSQL/Keycloak/Elasticsearch are deployed but before
+  the chart upgrade to 8.10, migrate the bundled (Bitnami) Keycloak realm and the
+  Elasticsearch authorization indices off the bundled backends onto the companion
+  services. Uses the camunda-deployment-references migration scripts in external
+  mode with SKIP_HELM_UPGRADE=true (data-only; the matrix runner performs the
+  chart upgrade). This keeps users/realm alive across the upgrade that removes the
+  bundled Bitnami subcharts.

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/qa-elasticsearch-upg-modular.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/qa-elasticsearch-upg-modular.yaml
@@ -12,6 +12,7 @@ infra-type:
   gke: qa-workloads
 qa: true
 image-tags: true
+post-infra: post-infra-bitnami-migration
 dependencies:
   - postgresql-qa
   - keycloak-qa

--- a/charts/camunda-platform-8.10/test/integration/scenarios/pre-setup-scripts/post-infra-bitnami-migration.sh
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/pre-setup-scripts/post-infra-bitnami-migration.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# post-infra hook — Bitnami → companion data migration for the 8.9→8.10 upgrade.
+#
+# Runs AFTER the upgrade scenario's companion charts (internal-postgresql →
+# Service "postgresql", internal-keycloak-26 → Service "keycloak") are deployed
+# and ready, but BEFORE the matrix runner upgrades the chart to 8.10 (which
+# removes the bundled Bitnami subcharts). It uses the official
+# camunda-deployment-references migration scripts in EXTERNAL target mode with
+# SKIP_HELM_UPGRADE=true, so the realm / Identity / Web Modeler databases are
+# moved off the bundled Bitnami backends onto the companion services while the
+# chart upgrade itself stays the runner's job.
+#
+# Env provided by the matrix lifecycle runner (see lifecycle_hook.go):
+#   NAMESPACE / TEST_NAMESPACE, RELEASE_NAME, KUBE_CONTEXT,
+#   RDBMS_POSTGRESQL_USERNAME, RDBMS_POSTGRESQL_PASSWORD
+#
+# Pin the migration tooling. Defaults to stable/8.9 — the branch that
+# camunda-deployment-references#2620 (KEYCLOAK_TARGET_MODE=external +
+# SKIP_HELM_UPGRADE) merges into, and where the migration tooling now lives
+# (it was removed from main). Pin to a tag/SHA once a release is cut.
+set -euo pipefail
+
+REF="${CAMUNDA_DEPLOYMENT_REFERENCES_REF:-stable/8.9}"
+REPO="${CAMUNDA_DEPLOYMENT_REFERENCES_REPO:-https://github.com/camunda/camunda-deployment-references.git}"
+NS="${NAMESPACE:-${TEST_NAMESPACE}}"
+RELEASE="${RELEASE_NAME:-integration}"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+echo "Cloning ${REPO}@${REF} ..."
+git clone --depth 1 --branch "${REF}" "${REPO}" "${workdir}/refs"
+migration_dir="${workdir}/refs/generic/kubernetes/migration"
+
+# --- Secrets the external-mode migration validates -------------------------
+# Identity and Web Modeler databases live on the shared "postgresql" companion
+# (internal-postgresql, RDBMS_POSTGRESQL_* credentials). Keycloak's realm DB
+# lives on the companion Keycloak's OWN bundled PostgreSQL ("keycloak-postgresql",
+# db/user "keycloak"), so the realm restore lands where the companion Keycloak
+# actually reads from. The migration looks up one secret per component.
+for secret in external-pg-identity external-pg-webmodeler; do
+    kubectl create secret generic "${secret}" -n "${NS}" \
+        --from-literal=password="${RDBMS_POSTGRESQL_PASSWORD}" \
+        --dry-run=client -o yaml | kubectl apply -f -
+done
+# Keycloak DB password = the companion Keycloak's bundled-PG password
+# (keycloak-qa.yaml: postgresql.auth.password). Read it from the companion's
+# own secret so the value is never hardcoded.
+kc_pg_pass="$(kubectl get secret keycloak-postgresql -n "${NS}" \
+    -o jsonpath='{.data.postgresql-password}' 2>/dev/null | base64 -d || true)"
+kubectl create secret generic external-pg-keycloak -n "${NS}" \
+    --from-literal=password="${kc_pg_pass}" \
+    --dry-run=client -o yaml | kubectl apply -f -
+
+# --- Migration configuration (external mode, data-only) --------------------
+export NAMESPACE="${NS}"
+export CAMUNDA_RELEASE_NAME="${RELEASE}"
+export AUTO_CONFIRM=true
+export SKIP_HELM_UPGRADE=true
+
+export PG_TARGET_MODE=external
+export KEYCLOAK_TARGET_MODE=external
+
+# The bundled Camunda 8.9 chart ships ONLY a Keycloak PostgreSQL (Bitnami
+# defaults: db "bitnami_keycloak", user "bn_keycloak"). Identity has no
+# dedicated PG (its data lives in Elasticsearch), and Web Modeler reinitialises
+# its schema on first boot — so only the Keycloak realm needs PG migration.
+export MIGRATE_KEYCLOAK=true
+export MIGRATE_IDENTITY=false
+export MIGRATE_WEBMODELER=false
+# Elasticsearch holds the orchestration data AND the 8.10 authorization records
+# (camunda-authorization/user/role/mapping-rule indices). They must move from
+# the bundled Bitnami ES to the companion ES, or post-upgrade users get
+# "you don't have access to this component" in Operate/Tasklist. Use warm
+# reindex (the only automated external-ES path) from the bundled ES.
+export MIGRATE_ELASTICSEARCH=true
+export ES_TARGET_MODE=external
+export ES_WARM_REINDEX=true
+export EXTERNAL_ES_HOST=elasticsearch-master
+export EXTERNAL_ES_PORT=9200
+# Index patterns to reindex. The bundled Camunda indices are unprefixed in this
+# scenario (camunda-authorization-*, camunda-user-*, operate-*, tasklist-*,
+# optimize-*, zeebe-*). camunda-* carries the authorization/user/role/mapping
+# records that gate Operate/Tasklist access after upgrade. The companion ES
+# allows reindex-from-remote via reindex.remote.whitelist (companion-values).
+export ES_INDEX_PREFIXES="camunda- operate- optimize- tasklist- zeebe-"
+
+# Keycloak realm DB: migrate the bundled source (bitnami_keycloak / bn_keycloak)
+# into the companion Keycloak's own bundled PostgreSQL (keycloak-postgresql,
+# db/user "keycloak") — which is exactly what the companion Keycloak reads from.
+export EXTERNAL_PG_KEYCLOAK_HOST=keycloak-postgresql
+export EXTERNAL_PG_KEYCLOAK_SECRET=external-pg-keycloak
+export KEYCLOAK_SOURCE_DB_NAME=bitnami_keycloak
+export KEYCLOAK_SOURCE_DB_USER=bn_keycloak
+export KEYCLOAK_DB_NAME=keycloak
+export KEYCLOAK_DB_USER=keycloak
+
+# Companion Keycloak ("keycloak" Service, /auth context path, internal HTTP:80).
+# The realm is restored into the companion Keycloak's own bundled PG
+# (keycloak-postgresql, configured above), which is exactly what this instance
+# reads from — so the migrated realm is served without any companion-values change.
+# Admin credentials are owned by the post-migration chart upgrade (the runner
+# wires global.identity.keycloak.auth from integration-test-credentials); the
+# data-only migration scripts do not consume a Keycloak admin secret.
+export EXTERNAL_KEYCLOAK_PROTOCOL=http
+export EXTERNAL_KEYCLOAK_HOST=keycloak
+export EXTERNAL_KEYCLOAK_PORT=80
+export EXTERNAL_KEYCLOAK_CONTEXT_PATH=/auth
+
+cd "${migration_dir}"
+# The phase scripts expect env.sh to have been sourced (it fills defaults such as
+# CAMUNDA_HELM_CHART_VERSION). Our overrides above are preserved because env.sh
+# assigns every variable with a ${VAR:-default} guard.
+# shellcheck disable=SC1091
+source ./env.sh
+bash 1-deploy-targets.sh --yes
+bash 2-backup.sh --yes
+bash 3-cutover.sh --yes
+
+# The companion Keycloak has been running against an empty realm; restart it so
+# it loads the realm just restored into its database, before the chart upgrade
+# points Camunda at it.
+echo "Restarting companion Keycloak to load the migrated realm ..."
+kubectl rollout restart deployment/keycloak -n "${NS}"
+kubectl rollout status deployment/keycloak -n "${NS}" --timeout=300s
+
+echo "post-infra migration complete — realm moved to companion Keycloak; chart upgrade to 8.10 is the runner's job."

--- a/scripts/camunda-deployer/pkg/deployer/deployer.go
+++ b/scripts/camunda-deployer/pkg/deployer/deployer.go
@@ -129,5 +129,15 @@ func Deploy(ctx context.Context, o types.Options) error {
 		}
 	}
 
+	// Run post-infra hooks after the companion charts (external infrastructure)
+	// are deployed and ready, but before the main Camunda chart. This is the
+	// point to act on freshly-provisioned infrastructure — e.g. migrating data
+	// from a prior release's bundled backends onto the companion services.
+	for i, hook := range o.PostInfraHooks {
+		if err := hook(ctx); err != nil {
+			return fmt.Errorf("post-infra hook [%d] failed: %w", i, err)
+		}
+	}
+
 	return upgradeInstall(ctx, o)
 }

--- a/scripts/camunda-deployer/pkg/types/types.go
+++ b/scripts/camunda-deployer/pkg/types/types.go
@@ -80,6 +80,13 @@ type Options struct {
 	// deployed with helm upgrade --install --wait to ensure it is ready
 	// before the main chart deployment begins.
 	CompanionCharts []CompanionChart
+
+	// PostInfraHooks are functions called after all CompanionCharts are
+	// deployed and ready, but before the main Camunda chart is
+	// installed/upgraded. Used to act on freshly-provisioned infrastructure —
+	// e.g. migrating data from a prior release's bundled backends onto the
+	// companion services before the chart switches over to them.
+	PostInfraHooks []func(ctx context.Context) error
 }
 
 // CompanionChart represents a Helm chart that should be deployed as a

--- a/scripts/deploy-camunda/config/merge.go
+++ b/scripts/deploy-camunda/config/merge.go
@@ -193,6 +193,14 @@ type RuntimeFlags struct {
 	// may not yet exist or may be recreated by DeleteNamespaceFirst.
 	PreInstallHooks []func(ctx context.Context) error
 
+	// PostInfraHooks are functions called by the deployer after companion
+	// charts (the external infrastructure: PostgreSQL, Elasticsearch, Keycloak,
+	// …) are deployed and ready, but before the main Camunda chart is
+	// installed/upgraded. Used to act on freshly-provisioned infrastructure —
+	// e.g. migrating data from a prior release's bundled backends onto the
+	// companion services before the chart switches over to them.
+	PostInfraHooks []func(ctx context.Context) error
+
 	// PostDeployHooks are functions called by the deployer after helm
 	// upgrade/install completes successfully but before the deployment result
 	// is returned. Used to apply scenario-specific resources whose CRDs are

--- a/scripts/deploy-camunda/deploy/deploy.go
+++ b/scripts/deploy-camunda/deploy/deploy.go
@@ -313,6 +313,7 @@ func executeDeployment(ctx context.Context, prepared *PreparedScenario, flags *c
 		SetPairs:              flags.Deployment.ExtraHelmSets,
 		PreInstallHooks:       flags.PreInstallHooks,
 		CompanionCharts:       toDeployerCompanionCharts(prepared.CompanionCharts),
+		PostInfraHooks:        flags.PostInfraHooks,
 	}
 
 	// Log deployment options (redact sensitive fields)

--- a/scripts/deploy-camunda/matrix/config.go
+++ b/scripts/deploy-camunda/matrix/config.go
@@ -215,6 +215,13 @@ type CIScenario struct {
 	// (pre-install-<scenario>.sh) with an explicit, reviewable reference.
 	PreInstall *LifecycleHook `yaml:"pre-install,omitempty"`
 
+	// PostInfra declares a fixture or script to run after the scenario's
+	// companion charts (external infrastructure) are deployed and ready, but
+	// before the main Camunda chart is installed/upgraded. Used to act on
+	// freshly-provisioned infrastructure — e.g. migrating data from a prior
+	// release's bundled backends onto the companion services.
+	PostInfra *LifecycleHook `yaml:"post-infra,omitempty"`
+
 	// PostDeploy declares a fixture or script to run after helm install
 	// completes successfully. Used for resources whose CRDs are only
 	// installed by the chart itself (e.g., the Gateway API

--- a/scripts/deploy-camunda/matrix/lifecycle_hook.go
+++ b/scripts/deploy-camunda/matrix/lifecycle_hook.go
@@ -103,6 +103,7 @@ type hookKind string
 
 const (
 	hookPreInstall hookKind = "pre-install"
+	hookPostInfra  hookKind = "post-infra"
 	hookPostDeploy hookKind = "post-deploy"
 	hookPreUpgrade hookKind = "pre-upgrade"
 )
@@ -185,6 +186,16 @@ func registerDeclarativeHook(flags *config.RuntimeFlags, hook *LifecycleHook, ki
 // for pre-install registrations.
 func registerDeclarativePreInstallHook(flags *config.RuntimeFlags, hook *LifecycleHook, repoRoot, appVersion, scenario string) error {
 	return registerDeclarativeHook(flags, hook, hookPreInstall, &flags.PreInstallHooks, repoRoot, appVersion, scenario)
+}
+
+// registerDeclarativePostInfraHook is a thin shim that pins the slot and kind
+// for post-infra registrations. The hook runs after companion charts (the
+// external infrastructure: PostgreSQL, Elasticsearch, Keycloak, …) are deployed
+// and ready, but before the main Camunda chart is installed/upgraded. Use it to
+// act on freshly-provisioned infrastructure — e.g. migrating data from a prior
+// release's bundled backends onto the companion services.
+func registerDeclarativePostInfraHook(flags *config.RuntimeFlags, hook *LifecycleHook, repoRoot, appVersion, scenario string) error {
+	return registerDeclarativeHook(flags, hook, hookPostInfra, &flags.PostInfraHooks, repoRoot, appVersion, scenario)
 }
 
 // registerDeclarativePostDeployHook is a thin shim that pins the slot and kind

--- a/scripts/deploy-camunda/matrix/matrix.go
+++ b/scripts/deploy-camunda/matrix/matrix.go
@@ -48,6 +48,11 @@ type Entry struct {
 	// without re-loading ci-test-config.yaml.
 	PreInstall *LifecycleHook `json:"preInstall,omitempty"`
 
+	// PostInfra declares a fixture or script to run after companion charts
+	// (external infrastructure) are deployed but before the main Camunda chart.
+	// Carried from CIScenario.PostInfra.
+	PostInfra *LifecycleHook `json:"postInfra,omitempty"`
+
 	// PostDeploy declares a fixture or script to run after helm install
 	// completes successfully. Carried from CIScenario.PostDeploy.
 	PostDeploy *LifecycleHook `json:"postDeploy,omitempty"`
@@ -215,6 +220,7 @@ func Generate(repoRoot string, opts GenerateOptions) ([]Entry, error) {
 						SkipIT:       scenario.SkipIT,
 						Dependencies: append([]ChartDependency(nil), scenario.Dependencies...),
 						PreInstall:   scenario.PreInstall,
+						PostInfra:    scenario.PostInfra,
 						PostDeploy:   scenario.PostDeploy,
 						PreUpgrade:   preUpgrade,
 						HelmVersion:  scenario.HelmVersion,

--- a/scripts/deploy-camunda/matrix/registry.go
+++ b/scripts/deploy-camunda/matrix/registry.go
@@ -66,6 +66,7 @@ type registryScenario struct {
 	PrefixKey   string            `yaml:"prefix-key,omitempty"`
 
 	PreInstallID  string   `yaml:"pre-install,omitempty"`
+	PostInfraID   string   `yaml:"post-infra,omitempty"`
 	PostDeployID  string   `yaml:"post-deploy,omitempty"`
 	DependencyIDs []string `yaml:"dependencies,omitempty"`
 }
@@ -170,6 +171,10 @@ func LoadRegistry(chartDir string) (*CITestConfig, error) {
 		if err != nil {
 			return nil, err
 		}
+		postInfra, err := loadHook(rscn.PostInfraID, entry.ID)
+		if err != nil {
+			return nil, err
+		}
 		postDeploy, err := loadHook(rscn.PostDeployID, entry.ID)
 		if err != nil {
 			return nil, err
@@ -216,6 +221,7 @@ func LoadRegistry(chartDir string) (*CITestConfig, error) {
 				Dependencies: append([]ChartDependency(nil), deps...),
 				PrefixKey:    rscn.PrefixKey,
 				PreInstall:   preInstall,
+				PostInfra:    postInfra,
 				PostDeploy:   postDeploy,
 			})
 		}

--- a/scripts/deploy-camunda/matrix/registry_validator.go
+++ b/scripts/deploy-camunda/matrix/registry_validator.go
@@ -136,6 +136,7 @@ func (v *RegistryValidator) Validate(cfg *CITestConfig) error {
 	for _, scn := range cfg.Integration.Case.PR.Scenarios {
 		label := fmt.Sprintf("scenario %q (shortname %q, flow %q)", scn.Name, scn.Shortname, scn.Flow)
 		checkHook(label+" pre-install", scn.PreInstall)
+		checkHook(label+" post-infra", scn.PostInfra)
 		checkHook(label+" post-deploy", scn.PostDeploy)
 		for _, feat := range scn.Features {
 			checkFeature(label, feat)
@@ -176,6 +177,7 @@ func (v *RegistryValidator) Validate(cfg *CITestConfig) error {
 	for _, scn := range cfg.Integration.Case.Nightly.Scenarios {
 		label := fmt.Sprintf("nightly scenario %q (shortname %q, flow %q)", scn.Name, scn.Shortname, scn.Flow)
 		checkHook(label+" pre-install", scn.PreInstall)
+		checkHook(label+" post-infra", scn.PostInfra)
 		checkHook(label+" post-deploy", scn.PostDeploy)
 	}
 

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -542,6 +542,9 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) RunResult {
 		if err := registerDeclarativePreInstallHook(flags, entry.PreInstall, opts.RepoRoot, entry.Version, entry.Scenario); err != nil {
 			return RunResult{Entry: entry, Namespace: namespace, Error: err}
 		}
+		if err := registerDeclarativePostInfraHook(flags, entry.PostInfra, opts.RepoRoot, entry.Version, entry.Scenario); err != nil {
+			return RunResult{Entry: entry, Namespace: namespace, Error: err}
+		}
 	}
 	if !isTwoStepUpgrade {
 		if err := registerDeclarativePostDeployHook(flags, entry.PostDeploy, opts.RepoRoot, entry.Version, entry.Scenario); err != nil {

--- a/scripts/deploy-camunda/matrix/runner_upgrade.go
+++ b/scripts/deploy-camunda/matrix/runner_upgrade.go
@@ -279,6 +279,13 @@ func executeTwoStepUpgrade(ctx context.Context, entry Entry, flags *config.Runti
 		}
 	}
 
+	// --- Post-infra lifecycle hook (Step 2 of two-step upgrade) ---
+	// Registered against step2Flags so it fires after Step 2's companion charts
+	// are deployed but before the target chart upgrade.
+	if err := registerDeclarativePostInfraHook(&step2Flags, entry.PostInfra, opts.RepoRoot, entry.Version, entry.Scenario); err != nil {
+		return err
+	}
+
 	// --- Post-deploy lifecycle hook (Step 2 of two-step upgrade) ---
 	// Registered against step2Flags so it fires after the upgrade succeeds.
 	if err := registerDeclarativePostDeployHook(&step2Flags, entry.PostDeploy, opts.RepoRoot, entry.Version, entry.Scenario); err != nil {
@@ -377,6 +384,13 @@ func executeUpgradeOnly(ctx context.Context, entry Entry, flags *config.RuntimeF
 	// Upgrade-only flows reuse an existing namespace, but scenario pre-install
 	// fixtures may still be required before the target chart can start.
 	if err := registerDeclarativePreInstallHook(&upgradeFlags, entry.PreInstall, opts.RepoRoot, entry.Version, entry.Scenario); err != nil {
+		return err
+	}
+	// Post-infra hook: runs after the upgrade's companion charts are deployed
+	// but before the target chart upgrade. This is where a Bitnami→companion
+	// data migration runs, so the upgraded chart finds its data on the
+	// companion services.
+	if err := registerDeclarativePostInfraHook(&upgradeFlags, entry.PostInfra, opts.RepoRoot, entry.Version, entry.Scenario); err != nil {
 		return err
 	}
 

--- a/test/integration/companion-values/elasticsearch-qa.yaml
+++ b/test/integration/companion-values/elasticsearch-qa.yaml
@@ -24,6 +24,9 @@ esConfig:
     network.host: 0.0.0.0
     xpack.security.enabled: false
     xpack.security.http.ssl.enabled: false
+    # Allow _reindex-from-remote to pull data from the source (bundled Bitnami)
+    # Elasticsearch during the Bitnami→companion migration.
+    reindex.remote.whitelist: "*:9200"
     xpack.security.transport.ssl.enabled: false
 
 extraEnvs:

--- a/test/integration/companion-values/elasticsearch.yaml
+++ b/test/integration/companion-values/elasticsearch.yaml
@@ -46,6 +46,10 @@ esConfig:
     network.host: 0.0.0.0
     xpack.security.enabled: false
     xpack.security.http.ssl.enabled: false
+    # Allow _reindex-from-remote to pull data from the source (bundled Bitnami)
+    # Elasticsearch during the Bitnami→companion migration (upgrade-minor flows).
+    # Harmless for install scenarios, which never issue a remote reindex.
+    reindex.remote.whitelist: "*:9200"
     xpack.security.transport.ssl.enabled: false
 
 extraEnvs:


### PR DESCRIPTION
### Which problem does the PR fix?

Completes the Helm-CI side of the 8.9→8.10 Bitnami-removal upgrade: it makes the
nightly actually exercise the **real** Bitnami→external migration scripts, so we
verify a customer on bundled (Bitnami) Keycloak/PostgreSQL in 8.9 can reach 8.10
with their realm/users intact — instead of testing a synthetic "already external"
topology.

### What's in this PR?

Wires the `qa-elasticsearch-upg` **`modular-upgrade-minor`** scenario to a
**`post-infra`** lifecycle hook (added in #6342):

- `pre-setup-scripts/post-infra-bitnami-migration.sh` — clones
  `camunda-deployment-references`, creates the external-target secrets, and runs
  the migration scripts in **external mode** with **`SKIP_HELM_UPGRADE=true`**.
  It migrates the bundled Keycloak realm (PostgreSQL) and the Elasticsearch data
  (warm reindex) onto the companion services (`postgresql` / `keycloak` /
  companion ES), then returns so the matrix runner performs the chart upgrade to
  8.10 pointing at the companions. Identity and Web Modeler need no PG migration —
  Identity's data lives in Elasticsearch, and Web Modeler reinitialises its schema
  on boot — so only the Keycloak realm DB + ES data move.
- `ci-test-config.yaml` — the `post-infra:` declaration on the scenario.

Sequence: install 8.9 + bundled Bitnami → deploy companions → **post-infra hook
migrates data onto companions** → runner upgrades to 8.10 → e2e verifies.

### Status — DRAFT

- `go test ./matrix/...` (incl. `TestLifecycleFixtures`, which validates the
  hook script reference + description + orphan check) passes; the script is
  `bash -n` clean and executable; the config parses.
- **Pinned to `stable/8.9`:** the references repo is pinned via
  `CAMUNDA_DEPLOYMENT_REFERENCES_REF` (default `stable/8.9`) — the branch
  camunda/camunda-deployment-references#2620 merges into, and where the migration
  tooling now lives (it was removed from `main`). Once #2620 merges, this hook
  runs against the merged tooling with no further change; pin to a tag/SHA when a
  release is cut.
- **Not yet GKE-validated.** Open wiring item noted inline in the hook script:
  the companion Keycloak (`keycloak-qa`) must read the realm from the companion
  PostgreSQL the migration restores into (align companion-values).

### Related / stacking

- Stacked on **#6342** (the `post-infra` lifecycle hook mechanism) — merge that first.
- Depends on **camunda/camunda-deployment-references#2620** (`KEYCLOAK_TARGET_MODE=external`
  + `SKIP_HELM_UPGRADE`) — merge that before this can go green.

### Checklist

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open pull request for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo documentation are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)?
- [ ] Did all checks/tests pass in the PR?
