### PR TITLE
test(8.9): disable secondary-storage exporter in noSecondaryStorage scenario

### DIFF
--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/no-secondary-storage.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/no-secondary-storage.yaml
@@ -1,36 +1,18 @@
-# Resource-Based Access (RBA) feature configuration for 8.9
-# Layer 4: Feature - Resource-Based Access control
+# No-secondary-storage feature configuration for 8.9
+# Layer 4: Feature - No secondary storage (no Elasticsearch/OpenSearch backend)
+#
+# Composed with persistence/no-elasticsearch.yaml. Optimize requires a
+# secondary-storage backend, so it is disabled here.
+optimize:
+  enabled: false
+
+identity:
+  clients: null
+
+# base.yaml sets orchestration.data.secondaryStorage.type=elasticsearch for the
+# normal scenarios; clear it here so the chart helpers fall back to
+# global.noSecondaryStorage and skip the Camunda exporter / web-app profiles.
 orchestration:
   data:
     secondaryStorage:
-      elasticsearch:
-        auth:
-          username: elastic
-          secret:
-            existingSecret: infra-credentials
-            existingSecretKey: elasticsearch-password
-  index:
-    prefix: $ORCHESTRATION_INDEX_PREFIX-$FLOW
-
-optimize:
-  enabled: true
-  contextPath: "/optimize"
-  database:
-    elasticsearch:
-      enabled: true
-      external: true
-      prefix: $ORCHESTRATION_INDEX_PREFIX-$FLOW
-      auth:
-        username: elastic
-        secret:
-          existingSecret: infra-credentials
-          existingSecretKey: elasticsearch-password
-      url:
-        protocol: https
-        host: elasticsearch-21-6-3-pool-${ES_POOL_INDEX}.ci.distro.ultrawombat.com
-        port: 443
-  env:
-    - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_PREFIX
-      value: $OPTIMIZE_INDEX_PREFIX-$FLOW
-    - name: CAMUNDA_OPTIMIZE_ZEEBE_NAME
-      value: $ORCHESTRATION_INDEX_PREFIX-$FLOW
+      type: null


### PR DESCRIPTION
### Which problem does the PR fix?

The `8.9 - nosec - install - gke` (`noSecondaryStorage`) integration scenario fails **consistently** in merge-queue / PR CI — `helm upgrade --install ... --wait --timeout 1200s` ends with `context deadline exceeded`. Seen e.g. in runs [26999716632](https://github.com/camunda/camunda-platform-helm/actions/runs/26999716632) and [26998647996](https://github.com/camunda/camunda-platform-helm/actions/runs/26998647996).

Root cause: `charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/no-secondary-storage.yaml` was a copy-paste of an RBA/Elasticsearch config (its header even read *"Resource-Based Access (RBA) feature configuration"*). It **enabled** ES secondary storage and Optimize — the opposite of what the scenario needs.

`base.yaml` sets `orchestration.data.secondaryStorage.type: elasticsearch`, and the feature file never cleared it, so the `orchestration.secondaryStorage` helper returned `elasticsearch` instead of `none` and `orchestration.hasCamundaExporter` stayed `true`. The brokers loaded the Camunda/Elasticsearch exporter, could not reach the absent Elasticsearch, retried schema init indefinitely (`Failed to open exporter 'camundaexporter'` / `SchemaManager` retries), never opened `:9600`, failed the startup probe 30×, restarted 3×, and Helm timed out.

### What's in this PR?

Replaces the 8.9 `no-secondary-storage.yaml` feature file with the same shape as the working 8.10 file:

- `optimize.enabled: false` — Optimize requires a secondary-storage backend.
- `identity.clients: null` — drop clients for disabled apps.
- `orchestration.data.secondaryStorage.type: null` — clears the `elasticsearch` value set by `base.yaml` so the chart helpers fall back to `global.noSecondaryStorage` → `none` and skip the Camunda exporter / web-app profiles.

This is a test-scenario values file only — no user-facing chart templates, `values.yaml`, or golden snapshots change.

**Verification**

- `helm template` (8.9, nosec layers): `orchestration.data.secondaryStorage.type` flips `elasticsearch` → `none`, and `zeebe.broker.exporters` goes from `{elasticsearch, camundaexporter}` → `{}`.
- GKE `deploy-camunda matrix run --versions 8.9 --shortname-filter nosec --platform gke`: **success in 3m18s** (was a consistent 1200s timeout). All 3 `integration-zeebe` brokers `1/1 Running`, `0` restarts, `0` exporter/schema errors in broker logs.

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

🤖 Generated with [Claude Code](https://claude.com/claude-code)