### PR TITLE
chore(8.9): migrate ci-test-config integration block to composable scenario registry

### DIFF
--- a/charts/camunda-platform-8.9/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.9/test/ci-test-config.yaml
@@ -1,5 +1,21 @@
 # Used in the GitHub Actions unit test CI workflow.
 # auth can be the following values: basic, keycloak, oidc
+#
+# ─── `unit:` block: LIVE ─────────────────────────────────────────────────────
+# The `unit:` block below is still the source of truth for the unit test
+# workflow — read via yq in `.github/actions/test-type-vars/action.yaml`.
+# Edit freely.
+#
+# ─── `integration:` block: FROZEN SNAPSHOT (do not edit) ─────────────────────
+# As of 2026-06-08 the integration test matrix is sourced from the
+# composable scenario registry under `test/ci/registry/` (ADR 0093).
+# `deploy-camunda matrix run/list` auto-detects the registry via
+# `test/ci/registry/manifest.yaml`; the `integration:` block here is retained
+# only as the equivalence-test baseline (`TestRegistryEquivalence` in
+# `scripts/deploy-camunda/matrix/registry_equivalence_test.go`). Edit
+# registry files instead. Scheduled for deletion once 8.8, 8.7 are
+# migrated and the matrix has held green on `main` for one full nightly cycle.
+# ─────────────────────────────────────────────────────────────────────────────
 unit:
   enabled: true
   matrix:

--- a/charts/camunda-platform-8.9/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry-snapshot.yaml
@@ -1,0 +1,702 @@
+integration:
+  vars:
+    tasksBaseDir: ../../../test/integration/scenarios
+    valuesBaseDir: integration/scenarios
+    chartsBaseDir: ../../../..
+  case:
+    pr:
+      scenario:
+        - name: elasticsearch
+          enabled: true
+          shortname: eske
+          auth: keycloak
+          flow: install,upgrade-minor
+          platforms:
+            - gke
+          exclude: []
+          tier: 1
+          infra-type:
+            eks: preemptible
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+        - name: enterprise-values
+          enabled: true
+          shortname: entv
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - enterprise
+        - name: opensearch
+          enabled: true
+          shortname: oske
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: opensearch-embedded
+          dependencies:
+            - chart: opensearch/opensearch
+              version: 3.6.0
+              release-name: opensearch
+              values-file: test/integration/companion-values/opensearch.yaml
+              repo-name: opensearch
+              repo-url: https://opensearch-project.github.io/helm-charts/
+        - name: elasticsearch-basic
+          enabled: false
+          shortname: esba
+          auth: basic
+          flow: install
+          platforms: []
+          exclude:
+            - identity
+            - console
+            - orchestration-grpc
+          infra-type:
+            eks: preemptible
+            gke: distroci
+          identity: basic
+          persistence: elasticsearch
+        - name: oidc
+          enabled: true
+          shortname: esoi
+          auth: oidc
+          flow: install,upgrade-minor
+          platforms:
+            - gke
+          exclude:
+            - identity
+            - console
+            - orchestration-grpc
+          tier: 2
+          infra-type:
+            eks: preemptible
+            gke: distroci
+          identity: oidc
+          persistence: elasticsearch
+          skip-e2e: true
+          skip-it: true
+        - name: keycloak-mt
+          enabled: true
+          shortname: kemt
+          auth: keycloak
+          flow: upgrade-minor
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            eks: preemptible
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+        - name: keycloak-rba
+          enabled: true
+          shortname: kerba
+          auth: keycloak
+          flow: upgrade-minor
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            eks: preemptible
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - rba
+        - name: keycloak-original
+          enabled: true
+          shortname: keorg
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            eks: preemptible
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+        - name: elasticsearch-self-signed
+          enabled: false
+          shortname: esss
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch-self-signed
+          pre-install:
+            script: pre-install-elasticsearch-self-signed.sh
+            description: |
+              Generates a self-signed CA plus node certificate via openssl,
+              packages them into JKS keystore + truststore via keytool, and
+              creates the elasticsearch-tls-certs, elasticsearch-tls-passwords,
+              and elasticsearch-jks Secrets consumed by the Elasticsearch
+              StatefulSet's TLS config.
+        - name: gateway-keycloak
+          enabled: true
+          shortname: gatkc
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            eks: preemptible
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - gateway
+          post-deploy:
+            fixtures:
+              - gateway-proxy-settings.yaml
+            description: |
+              Applies the NGINX ProxySettingsPolicy that bumps gateway buffer
+              sizes so the Camunda Gateway can carry Keycloak auth headers
+              without 502s. Runs after helm install because the Gateway API
+              CRD is only registered by the chart itself.
+        - name: elasticsearch-arm
+          enabled: true
+          shortname: esarm
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            gke: arm
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - arm
+        - name: noSecondaryStorage
+          enabled: true
+          shortname: nosec
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: no-elasticsearch
+          features:
+            - no-secondary-storage
+          skip-e2e: true
+          skip-it: true
+        - name: documentstore
+          enabled: true
+          shortname: docstr
+          auth: keycloak
+          flow: ""
+          platforms:
+            - eks
+          exclude: []
+          tier: 2
+          infra-type:
+            eks: preemptible
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - documentstore
+        - name: rdbms-external
+          enabled: false
+          shortname: rdbme
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: rdbms-external
+        - name: rdbms
+          enabled: true
+          shortname: rdbms
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: rdbms
+          pre-install:
+            fixtures:
+              - postgresql-cluster.yaml
+            description: |
+              Provisions a CloudNativePG `Cluster` plus auth Secret in the
+              scenario namespace. The CloudNativePG operator reconciles the
+              Cluster into a running PostgreSQL instance reachable as
+              postgresql-cluster-rw.<namespace>.svc.cluster.local — required
+              before helm install or the Camunda OrchestrationCluster pods
+              crash-loop trying to reach RDBMS.
+        - name: keycloak-original
+          enabled: true
+          shortname: keyco
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          tier: 1
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+        - name: alwaysgreen
+          enabled: false
+          shortname: agrn
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: alwaysgreen
+          identity: keycloak
+          persistence: elasticsearch
+        - name: qa-elasticsearch
+          enabled: false
+          shortname: qael
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          qa: true
+          image-tags: true
+        - name: qa-opensearch
+          enabled: false
+          shortname: qaos
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: opensearch-embedded
+          qa: true
+          image-tags: true
+          dependencies:
+            - chart: opensearch/opensearch
+              version: 3.6.0
+              release-name: opensearch
+              values-file: test/integration/companion-values/opensearch.yaml
+              repo-name: opensearch
+              repo-url: https://opensearch-project.github.io/helm-charts/
+        - name: qa-elasticsearch-rba
+          enabled: false
+          shortname: qaelrba
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - rba
+          qa: true
+          image-tags: true
+        - name: qa-elasticsearch-mt
+          enabled: false
+          shortname: qaelmt
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - multitenancy
+          qa: true
+          image-tags: true
+        - name: qa-license
+          enabled: false
+          shortname: lic
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - license
+          qa: true
+          image-tags: true
+        - name: qa-entra
+          enabled: false
+          shortname: qaen
+          auth: oidc
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: oidc
+          persistence: elasticsearch
+          qa: true
+          image-tags: true
+        - name: qa-document-store
+          enabled: false
+          shortname: qadoc
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+            - eks
+          exclude: []
+          infra-type:
+            eks: preemptible
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - documentstore
+          qa: true
+          image-tags: true
+        - name: qa-elasticsearch-tasklist-v1
+          enabled: false
+          shortname: qaeltlv1
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - tasklist-v1
+          qa: true
+          image-tags: true
+        - name: qa-opensearch-tasklist-v1
+          enabled: false
+          shortname: qaosupg
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: opensearch-embedded
+          features:
+            - tasklist-v1
+          qa: true
+          image-tags: true
+          dependencies:
+            - chart: opensearch/opensearch
+              version: 3.6.0
+              release-name: opensearch
+              values-file: test/integration/companion-values/opensearch.yaml
+              repo-name: opensearch
+              repo-url: https://opensearch-project.github.io/helm-charts/
+          prefix-key: qa-opensearch-upg
+        - name: qa-elasticsearch-rba-tasklist-v1
+          enabled: false
+          shortname: qaelrbaupg
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - rba
+            - tasklist-v1
+          qa: true
+          image-tags: true
+        - name: qa-elasticsearch-mt-tasklist-v1
+          enabled: false
+          shortname: qaelmtupg
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - multitenancy
+            - tasklist-v1
+          qa: true
+          image-tags: true
+        - name: qa-license-tasklist-v1
+          enabled: false
+          shortname: licupg
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - license
+            - tasklist-v1
+          qa: true
+          image-tags: true
+        - name: qa-elasticsearch-upg
+          enabled: false
+          shortname: qaelupg
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          qa: true
+          image-tags: true
+        - name: qa-elasticsearch-upg
+          enabled: false
+          shortname: qaelupg
+          auth: keycloak
+          flow: modular-upgrade-minor
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          qa: true
+          image-tags: true
+        - name: qa-elasticsearch-document-upg
+          enabled: false
+          shortname: qaeldocupg
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - documentstore
+          qa: true
+          image-tags: true
+        - name: qa-opensearch-upg
+          enabled: false
+          shortname: qaosupg2
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: opensearch-embedded
+          qa: true
+          image-tags: true
+          dependencies:
+            - chart: opensearch/opensearch
+              version: 3.6.0
+              release-name: opensearch
+              values-file: test/integration/companion-values/opensearch.yaml
+              repo-name: opensearch
+              repo-url: https://opensearch-project.github.io/helm-charts/
+        - name: qa-opensearch-upg
+          enabled: false
+          shortname: qaosupg
+          auth: keycloak
+          flow: modular-upgrade-minor
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: opensearch-embedded
+          qa: true
+          image-tags: true
+          dependencies:
+            - chart: opensearch/opensearch
+              version: 3.6.0
+              release-name: opensearch
+              values-file: test/integration/companion-values/opensearch.yaml
+              repo-name: opensearch
+              repo-url: https://opensearch-project.github.io/helm-charts/
+          prefix-key: qa-opensearch-upg
+        - name: qa-elasticsearch-rba-upg
+          enabled: false
+          shortname: qaelrbaup2
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - rba
+          qa: true
+          image-tags: true
+        - name: qa-elasticsearch-mt-upg
+          enabled: false
+          shortname: qaelmtup2
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - multitenancy
+          qa: true
+          image-tags: true
+        - name: qa-elasticsearch-mt-upg
+          enabled: false
+          shortname: qaelmtupg
+          auth: keycloak
+          flow: modular-upgrade-minor
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - multitenancy
+          qa: true
+          image-tags: true
+        - name: qa-license-upg
+          enabled: false
+          shortname: licup2
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - license
+          qa: true
+          image-tags: true
+        - name: qa-document-store-upg
+          enabled: false
+          shortname: qadocupg
+          auth: keycloak
+          flow: install,modular-upgrade-minor
+          platforms:
+            - gke
+            - eks
+          exclude: []
+          infra-type:
+            eks: preemptible
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - documentstore
+          qa: true
+          image-tags: true
+        - name: qa-document-store-upg
+          enabled: false
+          shortname: qadocupg
+          auth: keycloak
+          flow: modular-upgrade-minor
+          platforms:
+            - gke
+            - eks
+          exclude: []
+          infra-type:
+            eks: preemptible
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - documentstore
+          qa: true
+          image-tags: true
+        - name: keycloak-original
+          enabled: false
+          shortname: kcor
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+    nightly:
+      scenario: []
+  flows:
+    upgrade-patch:
+      pre-upgrade:
+        script: pre-upgrade-patch.sh
+        description: |
+          Deletes orchestration StatefulSets and the postgresql-web-modeler
+          StatefulSet + PVC before the patch upgrade. Required because the
+          target chart's PostgreSQL spec has immutable diffs vs the prior
+          patch (PSQL 15→14 rollback path) — Helm cannot reconcile in place.

--- a/charts/camunda-platform-8.9/test/ci/registry/dependencies/opensearch.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/dependencies/opensearch.yaml
@@ -1,0 +1,6 @@
+chart: opensearch/opensearch
+version: 3.6.0
+release-name: opensearch
+values-file: test/integration/companion-values/opensearch.yaml
+repo-name: opensearch
+repo-url: https://opensearch-project.github.io/helm-charts/

--- a/charts/camunda-platform-8.9/test/ci/registry/hooks/cnpg.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/hooks/cnpg.yaml
@@ -1,0 +1,9 @@
+fixtures:
+  - postgresql-cluster.yaml
+description: |
+  Provisions a CloudNativePG `Cluster` plus auth Secret in the
+  scenario namespace. The CloudNativePG operator reconciles the
+  Cluster into a running PostgreSQL instance reachable as
+  postgresql-cluster-rw.<namespace>.svc.cluster.local — required
+  before helm install or the Camunda OrchestrationCluster pods
+  crash-loop trying to reach RDBMS.

--- a/charts/camunda-platform-8.9/test/ci/registry/hooks/elasticsearch-self-signed.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/hooks/elasticsearch-self-signed.yaml
@@ -1,0 +1,7 @@
+script: pre-install-elasticsearch-self-signed.sh
+description: |
+  Generates a self-signed CA plus node certificate via openssl,
+  packages them into JKS keystore + truststore via keytool, and
+  creates the elasticsearch-tls-certs, elasticsearch-tls-passwords,
+  and elasticsearch-jks Secrets consumed by the Elasticsearch
+  StatefulSet's TLS config.

--- a/charts/camunda-platform-8.9/test/ci/registry/hooks/gateway-proxy-settings.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/hooks/gateway-proxy-settings.yaml
@@ -1,0 +1,7 @@
+fixtures:
+  - gateway-proxy-settings.yaml
+description: |
+  Applies the NGINX ProxySettingsPolicy that bumps gateway buffer
+  sizes so the Camunda Gateway can carry Keycloak auth headers
+  without 502s. Runs after helm install because the Gateway API
+  CRD is only registered by the chart itself.

--- a/charts/camunda-platform-8.9/test/ci/registry/manifest.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/manifest.yaml
@@ -1,0 +1,151 @@
+integration:
+  vars:
+    tasksBaseDir: ../../../test/integration/scenarios
+    valuesBaseDir: integration/scenarios
+    chartsBaseDir: ../../../..
+  flows:
+    upgrade-patch:
+      pre-upgrade:
+        script: pre-upgrade-patch.sh
+        description: |
+          Deletes orchestration StatefulSets and the postgresql-web-modeler
+          StatefulSet + PVC before the patch upgrade. Required because the
+          target chart's PostgreSQL spec has immutable diffs vs the prior
+          patch (PSQL 15→14 rollback path) — Helm cannot reconcile in place.
+  scenarios:
+    - id: elasticsearch
+      shortname: eske
+      tier: 1
+      enabled: true
+    - id: enterprise-values
+      shortname: entv
+      tier: 2
+      enabled: true
+    - id: opensearch
+      shortname: oske
+      tier: 2
+      enabled: true
+    - id: elasticsearch-basic
+      shortname: esba
+      enabled: false
+    - id: oidc
+      shortname: esoi
+      tier: 2
+      enabled: true
+    - id: keycloak-mt
+      shortname: kemt
+      tier: 2
+      enabled: true
+    - id: keycloak-rba
+      shortname: kerba
+      tier: 2
+      enabled: true
+    - id: keycloak-original-install-tier2
+      shortname: keorg
+      tier: 2
+      enabled: true
+    - id: elasticsearch-self-signed
+      shortname: esss
+      enabled: false
+    - id: gateway-keycloak
+      shortname: gatkc
+      tier: 2
+      enabled: true
+    - id: elasticsearch-arm
+      shortname: esarm
+      tier: 2
+      enabled: true
+    - id: no-secondary-storage
+      shortname: nosec
+      tier: 2
+      enabled: true
+    - id: documentstore
+      shortname: docstr
+      tier: 2
+      enabled: true
+    - id: rdbms-external
+      shortname: rdbme
+      enabled: false
+    - id: rdbms
+      shortname: rdbms
+      tier: 2
+      enabled: true
+    - id: keycloak-original-install-tier1
+      shortname: keyco
+      tier: 1
+      enabled: true
+    - id: alwaysgreen
+      shortname: agrn
+      enabled: false
+    - id: qa-elasticsearch
+      shortname: qael
+      enabled: false
+    - id: qa-opensearch
+      shortname: qaos
+      enabled: false
+    - id: qa-elasticsearch-rba
+      shortname: qaelrba
+      enabled: false
+    - id: qa-elasticsearch-mt
+      shortname: qaelmt
+      enabled: false
+    - id: qa-license
+      shortname: lic
+      enabled: false
+    - id: qa-entra
+      shortname: qaen
+      enabled: false
+    - id: qa-document-store
+      shortname: qadoc
+      enabled: false
+    - id: qa-elasticsearch-tasklist-v1
+      shortname: qaeltlv1
+      enabled: false
+    - id: qa-opensearch-tasklist-v1
+      shortname: qaosupg
+      enabled: false
+    - id: qa-elasticsearch-rba-tasklist-v1
+      shortname: qaelrbaupg
+      enabled: false
+    - id: qa-elasticsearch-mt-tasklist-v1
+      shortname: qaelmtupg
+      enabled: false
+    - id: qa-license-tasklist-v1
+      shortname: licupg
+      enabled: false
+    - id: qa-elasticsearch-upg-install
+      shortname: qaelupg
+      enabled: false
+    - id: qa-elasticsearch-upg-modular
+      shortname: qaelupg
+      enabled: false
+    - id: qa-elasticsearch-document-upg
+      shortname: qaeldocupg
+      enabled: false
+    - id: qa-opensearch-upg-install
+      shortname: qaosupg2
+      enabled: false
+    - id: qa-opensearch-upg-modular
+      shortname: qaosupg
+      enabled: false
+    - id: qa-elasticsearch-rba-upg
+      shortname: qaelrbaup2
+      enabled: false
+    - id: qa-elasticsearch-mt-upg-install
+      shortname: qaelmtup2
+      enabled: false
+    - id: qa-elasticsearch-mt-upg-modular
+      shortname: qaelmtupg
+      enabled: false
+    - id: qa-license-upg
+      shortname: licup2
+      enabled: false
+    - id: qa-document-store-upg-install-modular
+      shortname: qadocupg
+      enabled: false
+    - id: qa-document-store-upg-modular
+      shortname: qadocupg
+      enabled: false
+    - id: keycloak-original-install
+      shortname: kcor
+      enabled: false

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/alwaysgreen.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/alwaysgreen.yaml
@@ -1,0 +1,10 @@
+name: alwaysgreen
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+platforms:
+  - gke
+infra-type:
+  gke: alwaysgreen

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/documentstore.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/documentstore.yaml
@@ -1,0 +1,12 @@
+name: documentstore
+auth: keycloak
+flows:
+  - ""
+identity: keycloak
+persistence: elasticsearch
+features:
+  - documentstore
+platforms:
+  - eks
+infra-type:
+  eks: preemptible

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/elasticsearch-arm.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/elasticsearch-arm.yaml
@@ -1,0 +1,12 @@
+name: elasticsearch-arm
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - arm
+platforms:
+  - gke
+infra-type:
+  gke: arm

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/elasticsearch-basic.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/elasticsearch-basic.yaml
@@ -1,0 +1,13 @@
+name: elasticsearch-basic
+auth: basic
+flows:
+  - install
+identity: basic
+persistence: elasticsearch
+exclude:
+  - identity
+  - console
+  - orchestration-grpc
+infra-type:
+  eks: preemptible
+  gke: distroci

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/elasticsearch-self-signed.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/elasticsearch-self-signed.yaml
@@ -1,0 +1,11 @@
+name: elasticsearch-self-signed
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch-self-signed
+platforms:
+  - gke
+infra-type:
+  gke: distroci
+pre-install: elasticsearch-self-signed

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/elasticsearch.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/elasticsearch.yaml
@@ -1,0 +1,11 @@
+name: elasticsearch
+auth: keycloak
+flows:
+  - install,upgrade-minor
+identity: keycloak
+persistence: elasticsearch
+platforms:
+  - gke
+infra-type:
+  eks: preemptible
+  gke: distroci

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/enterprise-values.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/enterprise-values.yaml
@@ -1,0 +1,12 @@
+name: enterprise-values
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - enterprise
+platforms:
+  - gke
+infra-type:
+  gke: distroci

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/gateway-keycloak.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/gateway-keycloak.yaml
@@ -1,0 +1,14 @@
+name: gateway-keycloak
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - gateway
+platforms:
+  - gke
+infra-type:
+  eks: preemptible
+  gke: distroci
+post-deploy: gateway-proxy-settings

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/keycloak-mt.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/keycloak-mt.yaml
@@ -1,0 +1,11 @@
+name: keycloak-mt
+auth: keycloak
+flows:
+  - upgrade-minor
+identity: keycloak
+persistence: elasticsearch
+platforms:
+  - gke
+infra-type:
+  eks: preemptible
+  gke: distroci

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/keycloak-original-install-tier1.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/keycloak-original-install-tier1.yaml
@@ -1,0 +1,10 @@
+name: keycloak-original
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+platforms:
+  - gke
+infra-type:
+  gke: distroci

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/keycloak-original-install-tier2.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/keycloak-original-install-tier2.yaml
@@ -1,0 +1,11 @@
+name: keycloak-original
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+platforms:
+  - gke
+infra-type:
+  eks: preemptible
+  gke: distroci

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/keycloak-original-install.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/keycloak-original-install.yaml
@@ -1,0 +1,10 @@
+name: keycloak-original
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+platforms:
+  - gke
+infra-type:
+  gke: distroci

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/keycloak-rba.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/keycloak-rba.yaml
@@ -1,0 +1,13 @@
+name: keycloak-rba
+auth: keycloak
+flows:
+  - upgrade-minor
+identity: keycloak
+persistence: elasticsearch
+features:
+  - rba
+platforms:
+  - gke
+infra-type:
+  eks: preemptible
+  gke: distroci

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/no-secondary-storage.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/no-secondary-storage.yaml
@@ -1,0 +1,14 @@
+name: noSecondaryStorage
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: no-elasticsearch
+features:
+  - no-secondary-storage
+platforms:
+  - gke
+infra-type:
+  gke: distroci
+skip-e2e: true
+skip-it: true

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/oidc.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/oidc.yaml
@@ -1,0 +1,17 @@
+name: oidc
+auth: oidc
+flows:
+  - install,upgrade-minor
+identity: oidc
+persistence: elasticsearch
+platforms:
+  - gke
+exclude:
+  - identity
+  - console
+  - orchestration-grpc
+infra-type:
+  eks: preemptible
+  gke: distroci
+skip-e2e: true
+skip-it: true

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/opensearch.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/opensearch.yaml
@@ -1,0 +1,12 @@
+name: opensearch
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: opensearch-embedded
+platforms:
+  - gke
+infra-type:
+  gke: distroci
+dependencies:
+  - opensearch

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-document-store-upg-install-modular.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-document-store-upg-install-modular.yaml
@@ -1,0 +1,16 @@
+name: qa-document-store-upg
+auth: keycloak
+flows:
+  - install,modular-upgrade-minor
+identity: keycloak
+persistence: elasticsearch
+features:
+  - documentstore
+platforms:
+  - gke
+  - eks
+infra-type:
+  eks: preemptible
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-document-store-upg-modular.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-document-store-upg-modular.yaml
@@ -1,0 +1,16 @@
+name: qa-document-store-upg
+auth: keycloak
+flows:
+  - modular-upgrade-minor
+identity: keycloak
+persistence: elasticsearch
+features:
+  - documentstore
+platforms:
+  - gke
+  - eks
+infra-type:
+  eks: preemptible
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-document-store.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-document-store.yaml
@@ -1,0 +1,16 @@
+name: qa-document-store
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - documentstore
+platforms:
+  - gke
+  - eks
+infra-type:
+  eks: preemptible
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-elasticsearch-document-upg.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-elasticsearch-document-upg.yaml
@@ -1,0 +1,14 @@
+name: qa-elasticsearch-document-upg
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - documentstore
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-elasticsearch-mt-tasklist-v1.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-elasticsearch-mt-tasklist-v1.yaml
@@ -1,0 +1,15 @@
+name: qa-elasticsearch-mt-tasklist-v1
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - multitenancy
+  - tasklist-v1
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-elasticsearch-mt-upg-install.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-elasticsearch-mt-upg-install.yaml
@@ -1,0 +1,14 @@
+name: qa-elasticsearch-mt-upg
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - multitenancy
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-elasticsearch-mt-upg-modular.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-elasticsearch-mt-upg-modular.yaml
@@ -1,0 +1,14 @@
+name: qa-elasticsearch-mt-upg
+auth: keycloak
+flows:
+  - modular-upgrade-minor
+identity: keycloak
+persistence: elasticsearch
+features:
+  - multitenancy
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-elasticsearch-mt.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-elasticsearch-mt.yaml
@@ -1,0 +1,14 @@
+name: qa-elasticsearch-mt
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - multitenancy
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-elasticsearch-rba-tasklist-v1.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-elasticsearch-rba-tasklist-v1.yaml
@@ -1,0 +1,15 @@
+name: qa-elasticsearch-rba-tasklist-v1
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - rba
+  - tasklist-v1
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-elasticsearch-rba-upg.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-elasticsearch-rba-upg.yaml
@@ -1,0 +1,14 @@
+name: qa-elasticsearch-rba-upg
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - rba
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-elasticsearch-rba.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-elasticsearch-rba.yaml
@@ -1,0 +1,14 @@
+name: qa-elasticsearch-rba
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - rba
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-elasticsearch-tasklist-v1.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-elasticsearch-tasklist-v1.yaml
@@ -1,0 +1,14 @@
+name: qa-elasticsearch-tasklist-v1
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - tasklist-v1
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-elasticsearch-upg-install.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-elasticsearch-upg-install.yaml
@@ -1,0 +1,12 @@
+name: qa-elasticsearch-upg
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-elasticsearch-upg-modular.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-elasticsearch-upg-modular.yaml
@@ -1,0 +1,12 @@
+name: qa-elasticsearch-upg
+auth: keycloak
+flows:
+  - modular-upgrade-minor
+identity: keycloak
+persistence: elasticsearch
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-elasticsearch.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-elasticsearch.yaml
@@ -1,0 +1,12 @@
+name: qa-elasticsearch
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-entra.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-entra.yaml
@@ -1,0 +1,12 @@
+name: qa-entra
+auth: oidc
+flows:
+  - install
+identity: oidc
+persistence: elasticsearch
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-license-tasklist-v1.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-license-tasklist-v1.yaml
@@ -1,0 +1,15 @@
+name: qa-license-tasklist-v1
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - license
+  - tasklist-v1
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-license-upg.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-license-upg.yaml
@@ -1,0 +1,14 @@
+name: qa-license-upg
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - license
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-license.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-license.yaml
@@ -1,0 +1,14 @@
+name: qa-license
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - license
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-opensearch-tasklist-v1.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-opensearch-tasklist-v1.yaml
@@ -1,0 +1,17 @@
+name: qa-opensearch-tasklist-v1
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: opensearch-embedded
+features:
+  - tasklist-v1
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true
+prefix-key: qa-opensearch-upg
+dependencies:
+  - opensearch

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-opensearch-upg-install.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-opensearch-upg-install.yaml
@@ -1,0 +1,14 @@
+name: qa-opensearch-upg
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: opensearch-embedded
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true
+dependencies:
+  - opensearch

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-opensearch-upg-modular.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-opensearch-upg-modular.yaml
@@ -1,0 +1,15 @@
+name: qa-opensearch-upg
+auth: keycloak
+flows:
+  - modular-upgrade-minor
+identity: keycloak
+persistence: opensearch-embedded
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true
+prefix-key: qa-opensearch-upg
+dependencies:
+  - opensearch

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-opensearch.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/qa-opensearch.yaml
@@ -1,0 +1,14 @@
+name: qa-opensearch
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: opensearch-embedded
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true
+dependencies:
+  - opensearch

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/rdbms-external.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/rdbms-external.yaml
@@ -1,0 +1,10 @@
+name: rdbms-external
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: rdbms-external
+platforms:
+  - gke
+infra-type:
+  gke: distroci

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/rdbms.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/rdbms.yaml
@@ -1,0 +1,11 @@
+name: rdbms
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: rdbms
+platforms:
+  - gke
+infra-type:
+  gke: distroci
+pre-install: cnpg

--- a/scripts/deploy-camunda/matrix/registry_migrate_test.go
+++ b/scripts/deploy-camunda/matrix/registry_migrate_test.go
@@ -144,7 +144,8 @@ func hashJSON(v any) string {
 //   - Single-fixture: when the fixture is `postgresql-cluster.yaml`, return
 //     `cnpg` — the fixture always provisions all three databases (`app`,
 //     `identity`, `webmodeler`), so a single slug covers all use cases.
-//     Other fixtures keep the `-self-signed` / `-default` derivation.
+//     Other fixtures: `-self-signed` when the description names a
+//     self-signed CA, otherwise the bare fixture basename.
 //   - Multi-fixture: when `postgresql-cluster.yaml` is one of the fixtures,
 //     extend the `cnpg-` family using the other fixture basenames (with any
 //     `postgresql` segments trimmed). Otherwise join basenames with `-`.
@@ -168,7 +169,7 @@ func hookSlug(h *LifecycleHook) string {
 		case strings.Contains(h.Description, "self-signed CA"):
 			return base + "-self-signed"
 		default:
-			return base + "-default"
+			return base
 		}
 	}
 	if len(h.Fixtures) > 1 {
@@ -281,10 +282,23 @@ func sanitize(s string) string {
 
 // flowSlug maps full flow names to short, human-readable suffixes used in
 // scenario IDs when a scenario name collides across multiple flow values.
-// Unknown flows are emitted with hyphens stripped so they still produce a
-// valid slug; the empty flow returns the empty string (callers treat that
-// as "this scenario does not contribute to the flow axis").
+// Comma-joined flows (e.g. "install,modular-upgrade-minor" on 8.9
+// qa-document-store-upg) split on `,`, slug each part, and rejoin with `-`
+// so the slug stays filesystem-safe. Unknown flows are emitted with hyphens
+// stripped so they still produce a valid slug; the empty flow returns the
+// empty string (callers treat that as "this scenario does not contribute to
+// the flow axis").
 func flowSlug(f string) string {
+	if strings.Contains(f, ",") {
+		parts := strings.Split(f, ",")
+		out := make([]string, 0, len(parts))
+		for _, p := range parts {
+			if s := flowSlug(strings.TrimSpace(p)); s != "" {
+				out = append(out, s)
+			}
+		}
+		return strings.Join(out, "-")
+	}
 	switch f {
 	case "":
 		return ""


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6299. Second-version landing of ADR 0093's per-version composable scenario registry, gated on the 8.10 landing (#6318) holding green on `main`.

8.9 was the second-highest CI scenario churn version (12/100 sampled commits per epic #6264). Same registry layout + loader switch as 8.10; reuses the loader/validator/equivalence-test scaffold landed in #6318.

### What's in this PR?

- Emit `charts/camunda-platform-8.9/test/ci/registry/`: `manifest.yaml` + 41 `scenarios/<id>.yaml` + 3 `hooks/<id>.yaml` (`cnpg`, `elasticsearch-self-signed`, `gateway-proxy-settings`) + 1 `dependencies/<id>.yaml` (`opensearch`) + `registry-snapshot.yaml`.
- Loader auto-detects via `matrix.go:137` `HasRegistry` switch — no new runtime code.
- Freeze the legacy `integration:` block of `charts/camunda-platform-8.9/test/ci-test-config.yaml` with the LIVE/FROZEN header pattern used on 8.10. `unit:` block remains LIVE (read by `.github/actions/test-type-vars/action.yaml`).
- Translator (`scripts/deploy-camunda/matrix/registry_migrate_test.go`, build tag `migrate`) refinements driven by 8.9's data shape:
  - Drop the `-default` filler on the single-fixture catch-all so 8.9's `gateway-proxy-settings.yaml` hook emits as `gateway-proxy-settings`, not `gateway-proxy-settings-default`.
  - `flowSlug` now splits comma-joined flows (e.g. `install,modular-upgrade-minor` on `qa-document-store-upg`) on `,`, slugs each part, rejoins with `-`. Without this guard the disambiguated scenario ID would land as a filename containing a literal comma.

Both refinements generalize to 8.8 / 8.7 without further per-version edits.

### Verification

- `TestRegistryEquivalence` green (`go test -count=1 -run TestRegistryEquivalence ./scripts/deploy-camunda/matrix/`).
- Full matrix package green (`go test -count=1 ./scripts/deploy-camunda/matrix/...`).
- `make go.test chartPath=charts/camunda-platform-8.9` green.
- `make helm.lint chartPath=charts/camunda-platform-8.9` green.
- Byte-identical parity: `deploy-camunda matrix list --versions 8.9 --format json` produces the same output with and without `charts/camunda-platform-8.9/test/ci/` present.

### Merge gating

Per ADR 0093 §5: do not merge until one full nightly integration cycle holds green on `main` (gates the 8.8 follow-up #6300).

### Checklist

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open pull request for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo documentation are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?