### PR TITLE
chore(8.8): migrate ci-test-config integration block to composable scenario registry

### DIFF
--- a/charts/camunda-platform-8.8/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.8/test/ci-test-config.yaml
@@ -1,4 +1,21 @@
-# Used in the GitHub Actions unit test CI workflow. auth can be the following values: basic, keycloak, oidc
+# Used in the GitHub Actions unit test CI workflow.
+# auth can be the following values: basic, keycloak, oidc
+#
+# ─── `unit:` block: LIVE ─────────────────────────────────────────────────────
+# The `unit:` block below is still the source of truth for the unit test
+# workflow — read via yq in `.github/actions/test-type-vars/action.yaml`.
+# Edit freely.
+#
+# ─── `integration:` block: FROZEN SNAPSHOT (do not edit) ─────────────────────
+# As of 2026-06-08 the integration test matrix is sourced from the
+# composable scenario registry under `test/ci/registry/` (ADR 0093).
+# `deploy-camunda matrix run/list` auto-detects the registry via
+# `test/ci/registry/manifest.yaml`; the `integration:` block here is retained
+# only as the equivalence-test baseline (`TestRegistryEquivalence` in
+# `scripts/deploy-camunda/matrix/registry_equivalence_test.go`). Edit
+# registry files instead. Scheduled for deletion once 8.7 is migrated and
+# the matrix has held green on `main` for one full nightly cycle.
+# ─────────────────────────────────────────────────────────────────────────────
 unit:
   enabled: true
   matrix:

--- a/charts/camunda-platform-8.8/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry-snapshot.yaml
@@ -1,0 +1,676 @@
+integration:
+  vars:
+    tasksBaseDir: ../../../test/integration/scenarios
+    valuesBaseDir: integration/scenarios
+    chartsBaseDir: ../../../..
+  case:
+    pr:
+      scenario:
+        - name: elasticsearch
+          enabled: true
+          shortname: eske
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          tier: 1
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          helmVersion: 3.20.2
+        - name: enterprise-values
+          enabled: false
+          shortname: entv
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - enterprise
+          helmVersion: 3.20.2
+        - name: upgrade-migration
+          enabled: false
+          shortname: eske-upgm
+          auth: keycloak
+          flow: upgrade-minor
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            eks: preemptible
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - migrator
+          helmVersion: 3.20.2
+        - name: elasticsearch-basic
+          enabled: false
+          shortname: esba
+          auth: basic
+          flow: install
+          platforms:
+            - gke
+          exclude:
+            - identity
+            - console
+            - orchestration-grpc
+          infra-type:
+            eks: preemptible
+            gke: distroci
+          identity: basic
+          persistence: elasticsearch
+          helmVersion: 3.20.2
+        - name: oidc
+          enabled: true
+          shortname: esoi
+          auth: oidc
+          flow: install,upgrade-minor
+          platforms:
+            - gke
+          exclude:
+            - identity
+            - console
+            - orchestration-grpc
+          tier: 2
+          infra-type:
+            eks: preemptible
+            gke: distroci
+          identity: oidc
+          persistence: elasticsearch
+          helmVersion: 3.20.2
+          skip-e2e: true
+          skip-it: true
+        - name: keycloak-mt
+          enabled: false
+          shortname: kemt
+          auth: keycloak
+          flow: upgrade-minor
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            eks: preemptible
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          helmVersion: 3.20.2
+          skip-e2e: true
+        - name: keycloak-rba
+          enabled: false
+          shortname: kerba
+          auth: keycloak
+          flow: upgrade-minor
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            eks: preemptible
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - rba
+          helmVersion: 3.20.2
+        - name: elasticsearch-self-signed-upgrade
+          enabled: false
+          shortname: esss
+          auth: keycloak
+          flow: upgrade-minor
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch-self-signed
+          features:
+            - migrator
+          pre-install:
+            script: pre-install-elasticsearch-self-signed-upgrade.sh
+            description: |
+              Generates a self-signed CA plus node certificate via openssl,
+              packages them into JKS keystore + truststore via keytool, and
+              creates the elasticsearch-tls-certs, elasticsearch-tls-passwords,
+              and elasticsearch-jks Secrets consumed by the Elasticsearch
+              StatefulSet's TLS config.
+        - name: keycloak-original
+          enabled: false
+          shortname: keyc
+          auth: keycloak
+          flow: upgrade-minor
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            eks: preemptible
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          helmVersion: 3.20.2
+        - name: elasticsearch
+          enabled: false
+          shortname: eshy
+          auth: hybrid
+          flow: install
+          platforms:
+            - gke
+          exclude:
+            - orchestration-grpc
+          infra-type:
+            gke: distroci
+          identity: hybrid
+          persistence: elasticsearch
+          helmVersion: 3.20.2
+          skip-e2e: true
+        - name: elasticsearch-arm
+          enabled: true
+          shortname: esarm
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            gke: arm
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - arm
+          helmVersion: 3.20.2
+          skip-e2e: true
+        - name: opensearch
+          enabled: true
+          shortname: oske
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: opensearch-embedded
+          helmVersion: 3.20.2
+          dependencies:
+            - chart: opensearch/opensearch
+              version: 2.31.0
+              release-name: opensearch
+              values-file: test/integration/companion-values/opensearch.yaml
+              repo-name: opensearch
+              repo-url: https://opensearch-project.github.io/helm-charts/
+        - name: documentstore
+          enabled: true
+          shortname: docstr
+          auth: keycloak
+          flow: ""
+          platforms:
+            - eks
+          exclude: []
+          tier: 2
+          infra-type:
+            eks: preemptible
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - documentstore
+          helmVersion: 3.20.2
+        - name: component-persistence
+          enabled: true
+          shortname: cprst
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - persistence
+            - migrator
+          helmVersion: 3.20.2
+        - name: keycloak-ldap
+          enabled: false
+          shortname: keldp
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - ldap
+          dependencies:
+            - chart: test/integration/companion-charts/openldap
+              release-name: openldap
+              values-file: test/integration/companion-values/openldap.yaml
+        - name: keycloak-original
+          enabled: true
+          shortname: keyco
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          tier: 1
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+        - name: alwaysgreen
+          enabled: false
+          shortname: agrn
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: alwaysgreen
+          identity: keycloak
+          persistence: elasticsearch
+        - name: keycloak-original
+          enabled: false
+          shortname: kcor
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+        - name: elasticsearch
+          enabled: false
+          shortname: es
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+        - name: qa-elasticsearch
+          enabled: false
+          shortname: qael
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          qa: true
+          image-tags: true
+        - name: qa-opensearch
+          enabled: false
+          shortname: qaos
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: opensearch-embedded
+          qa: true
+          image-tags: true
+          dependencies:
+            - chart: opensearch/opensearch
+              version: 2.31.0
+              release-name: opensearch
+              values-file: test/integration/companion-values/opensearch.yaml
+              repo-name: opensearch
+              repo-url: https://opensearch-project.github.io/helm-charts/
+        - name: qa-elasticsearch-rba
+          enabled: false
+          shortname: qaelrba
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - rba
+          qa: true
+          image-tags: true
+        - name: qa-elasticsearch-mt
+          enabled: false
+          shortname: qaelmt
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - multitenancy
+          qa: true
+          image-tags: true
+        - name: qa-license
+          enabled: false
+          shortname: lic
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - license
+          qa: true
+          image-tags: true
+        - name: qa-entra
+          enabled: false
+          shortname: qaen
+          auth: oidc
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: oidc
+          persistence: elasticsearch
+          qa: true
+          image-tags: true
+        - name: qa-document-store
+          enabled: false
+          shortname: qadoc
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+            - eks
+          exclude: []
+          infra-type:
+            eks: preemptible
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - documentstore
+          qa: true
+          image-tags: true
+        - name: qa-document-store-upg
+          enabled: false
+          shortname: qadocupg
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - documentstore
+          qa: true
+          image-tags: true
+        - name: qa-elasticsearch-tasklist-v1
+          enabled: false
+          shortname: qaeltlv1
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - tasklist-v1
+          qa: true
+          image-tags: true
+        - name: qa-opensearch-tasklist-v1
+          enabled: false
+          shortname: qaosupg
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: opensearch-embedded
+          features:
+            - tasklist-v1
+          qa: true
+          image-tags: true
+          dependencies:
+            - chart: opensearch/opensearch
+              version: 2.31.0
+              release-name: opensearch
+              values-file: test/integration/companion-values/opensearch.yaml
+              repo-name: opensearch
+              repo-url: https://opensearch-project.github.io/helm-charts/
+          prefix-key: qa-opensearch-upg
+        - name: qa-elasticsearch-rba-tasklist-v1
+          enabled: false
+          shortname: qaelrbaupg
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - rba
+            - tasklist-v1
+          qa: true
+          image-tags: true
+        - name: qa-elasticsearch-mt-tasklist-v1
+          enabled: false
+          shortname: qaelmtupg
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - multitenancy
+            - tasklist-v1
+          qa: true
+          image-tags: true
+        - name: qa-license-tasklist-v1
+          enabled: false
+          shortname: licupg
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - license
+            - tasklist-v1
+          qa: true
+          image-tags: true
+        - name: qa-elasticsearch-upg
+          enabled: false
+          shortname: qaelupg
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          qa: true
+          image-tags: true
+        - name: qa-elasticsearch-upg
+          enabled: false
+          shortname: qaelupg
+          auth: keycloak
+          flow: modular-upgrade-minor
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - migrator
+          qa: true
+          image-tags: true
+        - name: qa-elasticsearch-document-upg
+          enabled: false
+          shortname: qaeldocupg
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - documentstore
+          qa: true
+          image-tags: true
+        - name: qa-opensearch-upg
+          enabled: false
+          shortname: qaosupg2
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: opensearch-embedded
+          qa: true
+          image-tags: true
+          dependencies:
+            - chart: opensearch/opensearch
+              version: 2.31.0
+              release-name: opensearch
+              values-file: test/integration/companion-values/opensearch.yaml
+              repo-name: opensearch
+              repo-url: https://opensearch-project.github.io/helm-charts/
+        - name: qa-elasticsearch-rba-upg
+          enabled: false
+          shortname: qaelrbaup2
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - rba
+          qa: true
+          image-tags: true
+        - name: qa-elasticsearch-mt-upg
+          enabled: false
+          shortname: qaelmtup2
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - multitenancy
+          qa: true
+          image-tags: true
+        - name: qa-license-upg
+          enabled: false
+          shortname: licup2
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - license
+          qa: true
+          image-tags: true
+    nightly:
+      scenario: []
+  flows:
+    modular-upgrade-minor:
+      pre-upgrade:
+        script: pre-upgrade-minor.sh
+        description: |
+          Deletes the postgresql and postgresql-web-modeler StatefulSets to
+          handle immutable spec diffs across the 8.7→8.8 minor upgrade.
+          Helm recreates them with the new spec while keeping PVC data.
+    upgrade-minor:
+      pre-upgrade:
+        script: pre-upgrade-minor.sh
+        description: |
+          Deletes the postgresql and postgresql-web-modeler StatefulSets to
+          handle immutable spec diffs across the 8.7→8.8 minor upgrade.
+          Helm recreates them with the new spec while keeping PVC data.
+    upgrade-patch:
+      pre-upgrade:
+        script: pre-upgrade-patch.sh
+        description: |
+          Deletes orchestration StatefulSets and the postgresql-web-modeler
+          StatefulSet + PVC before the 8.7→8.8 patch upgrade. PostgreSQL 15→14
+          rollback requires fresh statefulset spec.

--- a/charts/camunda-platform-8.8/test/ci/registry/dependencies/openldap.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/dependencies/openldap.yaml
@@ -1,0 +1,3 @@
+chart: test/integration/companion-charts/openldap
+release-name: openldap
+values-file: test/integration/companion-values/openldap.yaml

--- a/charts/camunda-platform-8.8/test/ci/registry/dependencies/opensearch.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/dependencies/opensearch.yaml
@@ -1,0 +1,6 @@
+chart: opensearch/opensearch
+version: 2.31.0
+release-name: opensearch
+values-file: test/integration/companion-values/opensearch.yaml
+repo-name: opensearch
+repo-url: https://opensearch-project.github.io/helm-charts/

--- a/charts/camunda-platform-8.8/test/ci/registry/hooks/elasticsearch-self-signed-upgrade.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/hooks/elasticsearch-self-signed-upgrade.yaml
@@ -1,0 +1,7 @@
+script: pre-install-elasticsearch-self-signed-upgrade.sh
+description: |
+  Generates a self-signed CA plus node certificate via openssl,
+  packages them into JKS keystore + truststore via keytool, and
+  creates the elasticsearch-tls-certs, elasticsearch-tls-passwords,
+  and elasticsearch-jks Secrets consumed by the Elasticsearch
+  StatefulSet's TLS config.

--- a/charts/camunda-platform-8.8/test/ci/registry/manifest.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/manifest.yaml
@@ -1,0 +1,157 @@
+integration:
+  vars:
+    tasksBaseDir: ../../../test/integration/scenarios
+    valuesBaseDir: integration/scenarios
+    chartsBaseDir: ../../../..
+  flows:
+    modular-upgrade-minor:
+      pre-upgrade:
+        script: pre-upgrade-minor.sh
+        description: |
+          Deletes the postgresql and postgresql-web-modeler StatefulSets to
+          handle immutable spec diffs across the 8.7→8.8 minor upgrade.
+          Helm recreates them with the new spec while keeping PVC data.
+    upgrade-minor:
+      pre-upgrade:
+        script: pre-upgrade-minor.sh
+        description: |
+          Deletes the postgresql and postgresql-web-modeler StatefulSets to
+          handle immutable spec diffs across the 8.7→8.8 minor upgrade.
+          Helm recreates them with the new spec while keeping PVC data.
+    upgrade-patch:
+      pre-upgrade:
+        script: pre-upgrade-patch.sh
+        description: |
+          Deletes orchestration StatefulSets and the postgresql-web-modeler
+          StatefulSet + PVC before the 8.7→8.8 patch upgrade. PostgreSQL 15→14
+          rollback requires fresh statefulset spec.
+  scenarios:
+    - id: elasticsearch
+      shortname: eske
+      tier: 1
+      enabled: true
+    - id: enterprise-values
+      shortname: entv
+      tier: 2
+      enabled: false
+    - id: upgrade-migration
+      shortname: eske-upgm
+      tier: 2
+      enabled: false
+    - id: elasticsearch-basic
+      shortname: esba
+      enabled: false
+    - id: oidc
+      shortname: esoi
+      tier: 2
+      enabled: true
+    - id: keycloak-mt
+      shortname: kemt
+      tier: 2
+      enabled: false
+    - id: keycloak-rba
+      shortname: kerba
+      tier: 2
+      enabled: false
+    - id: elasticsearch-self-signed-upgrade
+      shortname: esss
+      enabled: false
+    - id: keycloak-original-upgrade-tier2
+      shortname: keyc
+      tier: 2
+      enabled: false
+    - id: elasticsearch-2
+      shortname: eshy
+      enabled: false
+    - id: elasticsearch-arm
+      shortname: esarm
+      tier: 2
+      enabled: true
+    - id: opensearch
+      shortname: oske
+      tier: 2
+      enabled: true
+    - id: documentstore
+      shortname: docstr
+      tier: 2
+      enabled: true
+    - id: component-persistence
+      shortname: cprst
+      tier: 2
+      enabled: true
+    - id: keycloak-ldap
+      shortname: keldp
+      enabled: false
+    - id: keycloak-original-install-tier1
+      shortname: keyco
+      tier: 1
+      enabled: true
+    - id: alwaysgreen
+      shortname: agrn
+      enabled: false
+    - id: keycloak-original-install
+      shortname: kcor
+      enabled: false
+    - id: elasticsearch-3
+      shortname: es
+      enabled: false
+    - id: qa-elasticsearch
+      shortname: qael
+      enabled: false
+    - id: qa-opensearch
+      shortname: qaos
+      enabled: false
+    - id: qa-elasticsearch-rba
+      shortname: qaelrba
+      enabled: false
+    - id: qa-elasticsearch-mt
+      shortname: qaelmt
+      enabled: false
+    - id: qa-license
+      shortname: lic
+      enabled: false
+    - id: qa-entra
+      shortname: qaen
+      enabled: false
+    - id: qa-document-store
+      shortname: qadoc
+      enabled: false
+    - id: qa-document-store-upg
+      shortname: qadocupg
+      enabled: false
+    - id: qa-elasticsearch-tasklist-v1
+      shortname: qaeltlv1
+      enabled: false
+    - id: qa-opensearch-tasklist-v1
+      shortname: qaosupg
+      enabled: false
+    - id: qa-elasticsearch-rba-tasklist-v1
+      shortname: qaelrbaupg
+      enabled: false
+    - id: qa-elasticsearch-mt-tasklist-v1
+      shortname: qaelmtupg
+      enabled: false
+    - id: qa-license-tasklist-v1
+      shortname: licupg
+      enabled: false
+    - id: qa-elasticsearch-upg-install
+      shortname: qaelupg
+      enabled: false
+    - id: qa-elasticsearch-upg-modular
+      shortname: qaelupg
+      enabled: false
+    - id: qa-elasticsearch-document-upg
+      shortname: qaeldocupg
+      enabled: false
+    - id: qa-opensearch-upg
+      shortname: qaosupg2
+      enabled: false
+    - id: qa-elasticsearch-rba-upg
+      shortname: qaelrbaup2
+      enabled: false
+    - id: qa-elasticsearch-mt-upg
+      shortname: qaelmtup2
+      enabled: false
+    - id: qa-license-upg
+      shortname: licup2
+      enabled: false

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/alwaysgreen.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/alwaysgreen.yaml
@@ -1,0 +1,10 @@
+name: alwaysgreen
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+platforms:
+  - gke
+infra-type:
+  gke: alwaysgreen

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/component-persistence.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/component-persistence.yaml
@@ -1,0 +1,14 @@
+name: component-persistence
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - persistence
+  - migrator
+platforms:
+  - gke
+infra-type:
+  gke: distroci
+helmVersion: 3.20.2

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/documentstore.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/documentstore.yaml
@@ -1,0 +1,13 @@
+name: documentstore
+auth: keycloak
+flows:
+  - ""
+identity: keycloak
+persistence: elasticsearch
+features:
+  - documentstore
+platforms:
+  - eks
+infra-type:
+  eks: preemptible
+helmVersion: 3.20.2

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/elasticsearch-2.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/elasticsearch-2.yaml
@@ -1,0 +1,14 @@
+name: elasticsearch
+auth: hybrid
+flows:
+  - install
+identity: hybrid
+persistence: elasticsearch
+platforms:
+  - gke
+exclude:
+  - orchestration-grpc
+infra-type:
+  gke: distroci
+helmVersion: 3.20.2
+skip-e2e: true

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/elasticsearch-3.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/elasticsearch-3.yaml
@@ -1,0 +1,10 @@
+name: elasticsearch
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+platforms:
+  - gke
+infra-type:
+  gke: distroci

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/elasticsearch-arm.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/elasticsearch-arm.yaml
@@ -1,0 +1,14 @@
+name: elasticsearch-arm
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - arm
+platforms:
+  - gke
+infra-type:
+  gke: arm
+helmVersion: 3.20.2
+skip-e2e: true

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/elasticsearch-basic.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/elasticsearch-basic.yaml
@@ -1,0 +1,16 @@
+name: elasticsearch-basic
+auth: basic
+flows:
+  - install
+identity: basic
+persistence: elasticsearch
+platforms:
+  - gke
+exclude:
+  - identity
+  - console
+  - orchestration-grpc
+infra-type:
+  eks: preemptible
+  gke: distroci
+helmVersion: 3.20.2

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/elasticsearch-self-signed-upgrade.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/elasticsearch-self-signed-upgrade.yaml
@@ -1,0 +1,13 @@
+name: elasticsearch-self-signed-upgrade
+auth: keycloak
+flows:
+  - upgrade-minor
+identity: keycloak
+persistence: elasticsearch-self-signed
+features:
+  - migrator
+platforms:
+  - gke
+infra-type:
+  gke: distroci
+pre-install: elasticsearch-self-signed-upgrade

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/elasticsearch.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/elasticsearch.yaml
@@ -1,0 +1,11 @@
+name: elasticsearch
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+platforms:
+  - gke
+infra-type:
+  gke: distroci
+helmVersion: 3.20.2

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/enterprise-values.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/enterprise-values.yaml
@@ -1,0 +1,13 @@
+name: enterprise-values
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - enterprise
+platforms:
+  - gke
+infra-type:
+  gke: distroci
+helmVersion: 3.20.2

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/keycloak-ldap.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/keycloak-ldap.yaml
@@ -1,0 +1,14 @@
+name: keycloak-ldap
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - ldap
+platforms:
+  - gke
+infra-type:
+  gke: distroci
+dependencies:
+  - openldap

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/keycloak-mt.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/keycloak-mt.yaml
@@ -1,0 +1,13 @@
+name: keycloak-mt
+auth: keycloak
+flows:
+  - upgrade-minor
+identity: keycloak
+persistence: elasticsearch
+platforms:
+  - gke
+infra-type:
+  eks: preemptible
+  gke: distroci
+helmVersion: 3.20.2
+skip-e2e: true

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/keycloak-original-install-tier1.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/keycloak-original-install-tier1.yaml
@@ -1,0 +1,10 @@
+name: keycloak-original
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+platforms:
+  - gke
+infra-type:
+  gke: distroci

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/keycloak-original-install.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/keycloak-original-install.yaml
@@ -1,0 +1,10 @@
+name: keycloak-original
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+platforms:
+  - gke
+infra-type:
+  gke: distroci

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/keycloak-original-upgrade-tier2.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/keycloak-original-upgrade-tier2.yaml
@@ -1,0 +1,12 @@
+name: keycloak-original
+auth: keycloak
+flows:
+  - upgrade-minor
+identity: keycloak
+persistence: elasticsearch
+platforms:
+  - gke
+infra-type:
+  eks: preemptible
+  gke: distroci
+helmVersion: 3.20.2

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/keycloak-rba.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/keycloak-rba.yaml
@@ -1,0 +1,14 @@
+name: keycloak-rba
+auth: keycloak
+flows:
+  - upgrade-minor
+identity: keycloak
+persistence: elasticsearch
+features:
+  - rba
+platforms:
+  - gke
+infra-type:
+  eks: preemptible
+  gke: distroci
+helmVersion: 3.20.2

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/oidc.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/oidc.yaml
@@ -1,0 +1,18 @@
+name: oidc
+auth: oidc
+flows:
+  - install,upgrade-minor
+identity: oidc
+persistence: elasticsearch
+platforms:
+  - gke
+exclude:
+  - identity
+  - console
+  - orchestration-grpc
+infra-type:
+  eks: preemptible
+  gke: distroci
+helmVersion: 3.20.2
+skip-e2e: true
+skip-it: true

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/opensearch.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/opensearch.yaml
@@ -1,0 +1,13 @@
+name: opensearch
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: opensearch-embedded
+platforms:
+  - gke
+infra-type:
+  gke: distroci
+helmVersion: 3.20.2
+dependencies:
+  - opensearch

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-document-store-upg.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-document-store-upg.yaml
@@ -1,0 +1,14 @@
+name: qa-document-store-upg
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - documentstore
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-document-store.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-document-store.yaml
@@ -1,0 +1,16 @@
+name: qa-document-store
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - documentstore
+platforms:
+  - gke
+  - eks
+infra-type:
+  eks: preemptible
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-elasticsearch-document-upg.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-elasticsearch-document-upg.yaml
@@ -1,0 +1,14 @@
+name: qa-elasticsearch-document-upg
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - documentstore
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-elasticsearch-mt-tasklist-v1.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-elasticsearch-mt-tasklist-v1.yaml
@@ -1,0 +1,15 @@
+name: qa-elasticsearch-mt-tasklist-v1
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - multitenancy
+  - tasklist-v1
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-elasticsearch-mt-upg.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-elasticsearch-mt-upg.yaml
@@ -1,0 +1,14 @@
+name: qa-elasticsearch-mt-upg
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - multitenancy
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-elasticsearch-mt.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-elasticsearch-mt.yaml
@@ -1,0 +1,14 @@
+name: qa-elasticsearch-mt
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - multitenancy
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-elasticsearch-rba-tasklist-v1.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-elasticsearch-rba-tasklist-v1.yaml
@@ -1,0 +1,15 @@
+name: qa-elasticsearch-rba-tasklist-v1
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - rba
+  - tasklist-v1
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-elasticsearch-rba-upg.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-elasticsearch-rba-upg.yaml
@@ -1,0 +1,14 @@
+name: qa-elasticsearch-rba-upg
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - rba
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-elasticsearch-rba.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-elasticsearch-rba.yaml
@@ -1,0 +1,14 @@
+name: qa-elasticsearch-rba
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - rba
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-elasticsearch-tasklist-v1.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-elasticsearch-tasklist-v1.yaml
@@ -1,0 +1,14 @@
+name: qa-elasticsearch-tasklist-v1
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - tasklist-v1
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-elasticsearch-upg-install.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-elasticsearch-upg-install.yaml
@@ -1,0 +1,12 @@
+name: qa-elasticsearch-upg
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-elasticsearch-upg-modular.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-elasticsearch-upg-modular.yaml
@@ -1,0 +1,14 @@
+name: qa-elasticsearch-upg
+auth: keycloak
+flows:
+  - modular-upgrade-minor
+identity: keycloak
+persistence: elasticsearch
+features:
+  - migrator
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-elasticsearch.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-elasticsearch.yaml
@@ -1,0 +1,12 @@
+name: qa-elasticsearch
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-entra.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-entra.yaml
@@ -1,0 +1,12 @@
+name: qa-entra
+auth: oidc
+flows:
+  - install
+identity: oidc
+persistence: elasticsearch
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-license-tasklist-v1.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-license-tasklist-v1.yaml
@@ -1,0 +1,15 @@
+name: qa-license-tasklist-v1
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - license
+  - tasklist-v1
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-license-upg.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-license-upg.yaml
@@ -1,0 +1,14 @@
+name: qa-license-upg
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - license
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-license.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-license.yaml
@@ -1,0 +1,14 @@
+name: qa-license
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - license
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-opensearch-tasklist-v1.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-opensearch-tasklist-v1.yaml
@@ -1,0 +1,17 @@
+name: qa-opensearch-tasklist-v1
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: opensearch-embedded
+features:
+  - tasklist-v1
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true
+prefix-key: qa-opensearch-upg
+dependencies:
+  - opensearch

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-opensearch-upg.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-opensearch-upg.yaml
@@ -1,0 +1,14 @@
+name: qa-opensearch-upg
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: opensearch-embedded
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true
+dependencies:
+  - opensearch

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-opensearch.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/qa-opensearch.yaml
@@ -1,0 +1,14 @@
+name: qa-opensearch
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: opensearch-embedded
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true
+dependencies:
+  - opensearch

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/upgrade-migration.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/upgrade-migration.yaml
@@ -1,0 +1,14 @@
+name: upgrade-migration
+auth: keycloak
+flows:
+  - upgrade-minor
+identity: keycloak
+persistence: elasticsearch
+features:
+  - migrator
+platforms:
+  - gke
+infra-type:
+  eks: preemptible
+  gke: distroci
+helmVersion: 3.20.2


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6300. Parent epic #6264. ADR 0093 §5 staged migration — 8.8 follows 8.9 (#6352, merged `7395b6786`).

### What's in this PR?

Migrate the `integration:` block of `charts/camunda-platform-8.8/test/ci-test-config.yaml` into the composable registry at `charts/camunda-platform-8.8/test/ci/registry/`. Same loader + equivalence-test scaffold landed in #6318 (8.10) and #6352 (8.9); zero translator code changes.

Translator re-run (`go test -tags=migrate -run=TestMigrate8_10 -chartDir=../../../charts/camunda-platform-8.8`) emits:

- **39 scenarios** under `scenarios/` (matches legacy row count).
- **1 hook**: `elasticsearch-self-signed-upgrade` (script `pre-install-elasticsearch-self-signed-upgrade.sh`; 8.8-unique vs 8.9's `elasticsearch-self-signed`).
- **2 deps**: `opensearch` (version `2.31.0` — 8.8 pin, not 8.9/8.10's `3.6.0`), `openldap` (local companion chart referenced by `keycloak-ldap`; not present in 8.9/8.10).
- **3 flow-level pre-upgrade scripts** in `integration.flows`: `upgrade-patch` (8.7→8.8 patch, PSQL 15→14 rollback), `upgrade-minor` (8.7→8.8 minor), `modular-upgrade-minor` (dormant alias — all referencing scenarios disabled — but kept so `matrix.Generate` flow-hook lookup resolves it).

Collision resolution by `assignScenarioIDs` (group-aware axis disambiguation):

- `keycloak-original` ×3 → `keycloak-original-upgrade-tier2` (keyc), `keycloak-original-install-tier1` (keyco), `keycloak-original-install` (kcor) — `{flow, tier}` subset.
- `elasticsearch` ×3 → `elasticsearch` (eske, tier 1), `elasticsearch-2` + `elasticsearch-3` (eshy hybrid + es compat). Axis-key disambiguation found no distinguishing non-empty subset for the latter two (both `flow=install`, neither tiered) → numeric fallback. Internal addressing only; shortname (`eshy` / `es`) carries human meaning.
- `qa-elasticsearch-upg` ×2 (install / modular-upgrade-minor) → `qa-elasticsearch-upg-install` + `qa-elasticsearch-upg-modular` (modular variant carries `features:[migrator]`) — `{flow}` subset.

Legacy `charts/camunda-platform-8.8/test/ci-test-config.yaml` frozen with the LIVE/FROZEN header pattern from 8.9 / 8.10. `unit:` block remains live — still read by `.github/actions/test-type-vars/action.yaml` via `yq`.

### Acceptance criteria (#6300)

- [x] `charts/camunda-platform-8.8/test/ci/registry/` populated with `manifest.yaml` + per-scenario + dedup'd `hooks/` + `dependencies/` files.
- [x] `TestRegistryEquivalence` extended to cover 8.8 (test auto-iterates every version with `HasRegistry(chartDir)` true); `cmp.Diff` empty.
- [x] Legacy `charts/camunda-platform-8.8/test/ci-test-config.yaml` frozen with header comment.
- [x] `deploy-camunda matrix list --versions 8.8` output byte-identical before/after (text + JSON).
- [ ] One full nightly cycle green on `main` before opening the 8.7 follow-up (#6301).

### Local verification

```
TestRegistryEquivalence            PASS (8.8, 8.9, 8.10)
matrix list --versions 8.8         BYTE-IDENTICAL (text + JSON)
make go.test chartPath=charts/camunda-platform-8.8   all packages PASS
make helm.lint chartPath=charts/camunda-platform-8.8 0 failed
```

### ADR 0093 §5 gate note

8.9 (#6352) merged 2026-06-08. The required full-nightly-green cycle on `main` since that merge has not yet elapsed. Opening as draft so review can proceed in parallel while the nightly bakes; will not mark ready until one full green cycle covering 8.9 has been observed.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?