### PR TITLE
chore(8.7): migrate ci-test-config integration block to composable scenario registry

### DIFF
--- a/charts/camunda-platform-8.7/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.7/test/ci-test-config.yaml
@@ -1,4 +1,21 @@
 # Used in the GitHub Actions unit test CI workflow.
+# auth can be the following values: basic, keycloak, oidc
+#
+# ─── `unit:` block: LIVE ─────────────────────────────────────────────────────
+# The `unit:` block below is still the source of truth for the unit test
+# workflow — read via yq in `.github/actions/test-type-vars/action.yaml`.
+# Edit freely.
+#
+# ─── `integration:` block: FROZEN SNAPSHOT (do not edit) ─────────────────────
+# As of 2026-06-08 the integration test matrix is sourced from the
+# composable scenario registry under `test/ci/registry/` (ADR 0093).
+# `deploy-camunda matrix run/list` auto-detects the registry via
+# `test/ci/registry/manifest.yaml`; the `integration:` block here is retained
+# only as the equivalence-test baseline (`TestRegistryEquivalence` in
+# `scripts/deploy-camunda/matrix/registry_equivalence_test.go`). Edit
+# registry files instead. Scheduled for deletion once 8.8 is migrated and the
+# matrix has held green on `main` for one full nightly cycle.
+# ─────────────────────────────────────────────────────────────────────────────
 unit:
   enabled: true
   matrix:

--- a/charts/camunda-platform-8.7/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.7/test/ci/registry-snapshot.yaml
@@ -1,0 +1,298 @@
+integration:
+  vars:
+    tasksBaseDir: ../../../test/integration/scenarios
+    valuesBaseDir: integration/scenarios
+    chartsBaseDir: ../../../..
+  case:
+    pr:
+      scenario:
+        - name: elasticsearch
+          enabled: true
+          shortname: eske
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          tier: 1
+          infra-type:
+            eks: preemptible
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          helmVersion: 3.20.2
+          skip-e2e: true
+        - name: enterprise-values
+          enabled: true
+          shortname: entv
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - enterprise
+          helmVersion: 3.20.2
+          skip-e2e: true
+        - name: keycloak-mt
+          enabled: true
+          shortname: kemt
+          auth: keycloak
+          flow: install,upgrade-patch
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            eks: preemptible
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          helmVersion: 3.20.2
+          skip-e2e: true
+        - name: keycloak-rba
+          enabled: true
+          shortname: kerba
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          helmVersion: 3.20.2
+          skip-e2e: true
+        - name: oidc
+          enabled: true
+          shortname: esoi
+          auth: oidc
+          flow: install,upgrade-patch
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            eks: preemptible
+            gke: distroci
+          persistence: elasticsearch
+          helmVersion: 3.20.2
+          skip-e2e: true
+          skip-it: true
+        - name: keycloak-original
+          enabled: true
+          shortname: keyc
+          auth: keycloak
+          flow: install,upgrade-patch
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            eks: preemptible
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          helmVersion: 3.20.2
+          skip-e2e: true
+        - name: opensearch-embedded
+          enabled: true
+          shortname: osem
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: opensearch-embedded
+          dependencies:
+            - chart: opensearch/opensearch
+              version: 2.31.0
+              release-name: opensearch
+              values-file: test/integration/companion-values/opensearch.yaml
+              repo-name: opensearch
+              repo-url: https://opensearch-project.github.io/helm-charts/
+        - name: component-persistence
+          enabled: true
+          shortname: cprst
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - persistence
+          skip-e2e: true
+        - name: shadow-e2e
+          enabled: true
+          shortname: shde2
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          skip-e2e: true
+        - name: keycloak-original
+          enabled: true
+          shortname: keyco
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          tier: 1
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          post-deploy:
+            script: post-deploy-keycloak-token-lifespan.sh
+            description: |
+              Increases Keycloak access token lifespan to 30 minutes and SSO
+              session idle timeout to 2 hours for E2E test stability.
+        - name: alwaysgreen
+          enabled: false
+          shortname: agrn
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: alwaysgreen
+          identity: keycloak
+          persistence: elasticsearch
+        - name: qa-elasticsearch
+          enabled: false
+          shortname: qael
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+            - eks
+          exclude: []
+          infra-type:
+            eks: preemptible
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          qa: true
+          image-tags: true
+          post-deploy:
+            script: post-deploy-keycloak-token-lifespan.sh
+            description: |
+              Increases Keycloak access token lifespan to 30 minutes and SSO
+              session idle timeout to 2 hours. Prevents session-expiry flakiness
+              in long-running E2E test flows (diagram building, process deployment)
+              when the cluster is under heavy load.
+        - name: qa-elasticsearch-rba
+          enabled: false
+          shortname: qarba
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - rba
+          qa: true
+          image-tags: true
+          post-deploy:
+            script: post-deploy-keycloak-token-lifespan.sh
+            description: |
+              Increases Keycloak access token lifespan to 30 minutes and SSO
+              session idle timeout to 2 hours for E2E test stability.
+        - name: qa-elasticsearch-mt
+          enabled: false
+          shortname: qamt
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - multitenancy
+          qa: true
+          image-tags: true
+          post-deploy:
+            script: post-deploy-keycloak-token-lifespan.sh
+            description: |
+              Increases Keycloak access token lifespan to 30 minutes and SSO
+              session idle timeout to 2 hours for E2E test stability.
+        - name: qa-license
+          enabled: false
+          shortname: lic
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - license
+          qa: true
+          image-tags: true
+          post-deploy:
+            script: post-deploy-keycloak-token-lifespan.sh
+            description: |
+              Increases Keycloak access token lifespan to 30 minutes and SSO
+              session idle timeout to 2 hours for E2E test stability.
+        - name: qa-opensearch
+          enabled: false
+          shortname: qaos
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: qa-workloads
+          identity: keycloak
+          persistence: opensearch-embedded
+          qa: true
+          image-tags: true
+          dependencies:
+            - chart: opensearch/opensearch
+              version: 2.31.0
+              release-name: opensearch
+              values-file: test/integration/companion-values/opensearch.yaml
+              repo-name: opensearch
+              repo-url: https://opensearch-project.github.io/helm-charts/
+          post-deploy:
+            script: post-deploy-keycloak-token-lifespan.sh
+            description: |
+              Increases Keycloak access token lifespan to 30 minutes and SSO
+              session idle timeout to 2 hours for E2E test stability.
+    nightly:
+      scenario: []

--- a/charts/camunda-platform-8.7/test/ci/registry/dependencies/opensearch.yaml
+++ b/charts/camunda-platform-8.7/test/ci/registry/dependencies/opensearch.yaml
@@ -1,0 +1,6 @@
+chart: opensearch/opensearch
+version: 2.31.0
+release-name: opensearch
+values-file: test/integration/companion-values/opensearch.yaml
+repo-name: opensearch
+repo-url: https://opensearch-project.github.io/helm-charts/

--- a/charts/camunda-platform-8.7/test/ci/registry/hooks/keycloak-token-lifespan-2.yaml
+++ b/charts/camunda-platform-8.7/test/ci/registry/hooks/keycloak-token-lifespan-2.yaml
@@ -1,0 +1,6 @@
+script: post-deploy-keycloak-token-lifespan.sh
+description: |
+  Increases Keycloak access token lifespan to 30 minutes and SSO
+  session idle timeout to 2 hours. Prevents session-expiry flakiness
+  in long-running E2E test flows (diagram building, process deployment)
+  when the cluster is under heavy load.

--- a/charts/camunda-platform-8.7/test/ci/registry/hooks/keycloak-token-lifespan.yaml
+++ b/charts/camunda-platform-8.7/test/ci/registry/hooks/keycloak-token-lifespan.yaml
@@ -1,0 +1,4 @@
+script: post-deploy-keycloak-token-lifespan.sh
+description: |
+  Increases Keycloak access token lifespan to 30 minutes and SSO
+  session idle timeout to 2 hours for E2E test stability.

--- a/charts/camunda-platform-8.7/test/ci/registry/manifest.yaml
+++ b/charts/camunda-platform-8.7/test/ci/registry/manifest.yaml
@@ -1,0 +1,64 @@
+integration:
+  vars:
+    tasksBaseDir: ../../../test/integration/scenarios
+    valuesBaseDir: integration/scenarios
+    chartsBaseDir: ../../../..
+  scenarios:
+    - id: elasticsearch
+      shortname: eske
+      tier: 1
+      enabled: true
+    - id: enterprise-values
+      shortname: entv
+      tier: 2
+      enabled: true
+    - id: keycloak-mt
+      shortname: kemt
+      tier: 2
+      enabled: true
+    - id: keycloak-rba
+      shortname: kerba
+      tier: 2
+      enabled: true
+    - id: oidc
+      shortname: esoi
+      tier: 2
+      enabled: true
+    - id: keycloak-original-install-patch
+      shortname: keyc
+      tier: 2
+      enabled: true
+    - id: opensearch-embedded
+      shortname: osem
+      tier: 2
+      enabled: true
+    - id: component-persistence
+      shortname: cprst
+      tier: 2
+      enabled: true
+    - id: shadow-e2e
+      shortname: shde2
+      tier: 2
+      enabled: true
+    - id: keycloak-original-install
+      shortname: keyco
+      tier: 1
+      enabled: true
+    - id: alwaysgreen
+      shortname: agrn
+      enabled: false
+    - id: qa-elasticsearch
+      shortname: qael
+      enabled: false
+    - id: qa-elasticsearch-rba
+      shortname: qarba
+      enabled: false
+    - id: qa-elasticsearch-mt
+      shortname: qamt
+      enabled: false
+    - id: qa-license
+      shortname: lic
+      enabled: false
+    - id: qa-opensearch
+      shortname: qaos
+      enabled: false

--- a/charts/camunda-platform-8.7/test/ci/registry/scenarios/alwaysgreen.yaml
+++ b/charts/camunda-platform-8.7/test/ci/registry/scenarios/alwaysgreen.yaml
@@ -1,0 +1,10 @@
+name: alwaysgreen
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+platforms:
+  - gke
+infra-type:
+  gke: alwaysgreen

--- a/charts/camunda-platform-8.7/test/ci/registry/scenarios/component-persistence.yaml
+++ b/charts/camunda-platform-8.7/test/ci/registry/scenarios/component-persistence.yaml
@@ -1,0 +1,13 @@
+name: component-persistence
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - persistence
+platforms:
+  - gke
+infra-type:
+  gke: distroci
+skip-e2e: true

--- a/charts/camunda-platform-8.7/test/ci/registry/scenarios/elasticsearch.yaml
+++ b/charts/camunda-platform-8.7/test/ci/registry/scenarios/elasticsearch.yaml
@@ -1,0 +1,13 @@
+name: elasticsearch
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+platforms:
+  - gke
+infra-type:
+  eks: preemptible
+  gke: distroci
+helmVersion: 3.20.2
+skip-e2e: true

--- a/charts/camunda-platform-8.7/test/ci/registry/scenarios/enterprise-values.yaml
+++ b/charts/camunda-platform-8.7/test/ci/registry/scenarios/enterprise-values.yaml
@@ -1,0 +1,14 @@
+name: enterprise-values
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - enterprise
+platforms:
+  - gke
+infra-type:
+  gke: distroci
+helmVersion: 3.20.2
+skip-e2e: true

--- a/charts/camunda-platform-8.7/test/ci/registry/scenarios/keycloak-mt.yaml
+++ b/charts/camunda-platform-8.7/test/ci/registry/scenarios/keycloak-mt.yaml
@@ -1,0 +1,13 @@
+name: keycloak-mt
+auth: keycloak
+flows:
+  - install,upgrade-patch
+identity: keycloak
+persistence: elasticsearch
+platforms:
+  - gke
+infra-type:
+  eks: preemptible
+  gke: distroci
+helmVersion: 3.20.2
+skip-e2e: true

--- a/charts/camunda-platform-8.7/test/ci/registry/scenarios/keycloak-original-install-patch.yaml
+++ b/charts/camunda-platform-8.7/test/ci/registry/scenarios/keycloak-original-install-patch.yaml
@@ -1,0 +1,13 @@
+name: keycloak-original
+auth: keycloak
+flows:
+  - install,upgrade-patch
+identity: keycloak
+persistence: elasticsearch
+platforms:
+  - gke
+infra-type:
+  eks: preemptible
+  gke: distroci
+helmVersion: 3.20.2
+skip-e2e: true

--- a/charts/camunda-platform-8.7/test/ci/registry/scenarios/keycloak-original-install.yaml
+++ b/charts/camunda-platform-8.7/test/ci/registry/scenarios/keycloak-original-install.yaml
@@ -1,0 +1,11 @@
+name: keycloak-original
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+platforms:
+  - gke
+infra-type:
+  gke: distroci
+post-deploy: keycloak-token-lifespan

--- a/charts/camunda-platform-8.7/test/ci/registry/scenarios/keycloak-rba.yaml
+++ b/charts/camunda-platform-8.7/test/ci/registry/scenarios/keycloak-rba.yaml
@@ -1,0 +1,12 @@
+name: keycloak-rba
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+platforms:
+  - gke
+infra-type:
+  gke: distroci
+helmVersion: 3.20.2
+skip-e2e: true

--- a/charts/camunda-platform-8.7/test/ci/registry/scenarios/oidc.yaml
+++ b/charts/camunda-platform-8.7/test/ci/registry/scenarios/oidc.yaml
@@ -1,0 +1,13 @@
+name: oidc
+auth: oidc
+flows:
+  - install,upgrade-patch
+persistence: elasticsearch
+platforms:
+  - gke
+infra-type:
+  eks: preemptible
+  gke: distroci
+helmVersion: 3.20.2
+skip-e2e: true
+skip-it: true

--- a/charts/camunda-platform-8.7/test/ci/registry/scenarios/opensearch-embedded.yaml
+++ b/charts/camunda-platform-8.7/test/ci/registry/scenarios/opensearch-embedded.yaml
@@ -1,0 +1,12 @@
+name: opensearch-embedded
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: opensearch-embedded
+platforms:
+  - gke
+infra-type:
+  gke: distroci
+dependencies:
+  - opensearch

--- a/charts/camunda-platform-8.7/test/ci/registry/scenarios/qa-elasticsearch-mt.yaml
+++ b/charts/camunda-platform-8.7/test/ci/registry/scenarios/qa-elasticsearch-mt.yaml
@@ -1,0 +1,15 @@
+name: qa-elasticsearch-mt
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - multitenancy
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true
+post-deploy: keycloak-token-lifespan

--- a/charts/camunda-platform-8.7/test/ci/registry/scenarios/qa-elasticsearch-rba.yaml
+++ b/charts/camunda-platform-8.7/test/ci/registry/scenarios/qa-elasticsearch-rba.yaml
@@ -1,0 +1,15 @@
+name: qa-elasticsearch-rba
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - rba
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true
+post-deploy: keycloak-token-lifespan

--- a/charts/camunda-platform-8.7/test/ci/registry/scenarios/qa-elasticsearch.yaml
+++ b/charts/camunda-platform-8.7/test/ci/registry/scenarios/qa-elasticsearch.yaml
@@ -1,0 +1,15 @@
+name: qa-elasticsearch
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+platforms:
+  - gke
+  - eks
+infra-type:
+  eks: preemptible
+  gke: qa-workloads
+qa: true
+image-tags: true
+post-deploy: keycloak-token-lifespan-2

--- a/charts/camunda-platform-8.7/test/ci/registry/scenarios/qa-license.yaml
+++ b/charts/camunda-platform-8.7/test/ci/registry/scenarios/qa-license.yaml
@@ -1,0 +1,15 @@
+name: qa-license
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+features:
+  - license
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true
+post-deploy: keycloak-token-lifespan

--- a/charts/camunda-platform-8.7/test/ci/registry/scenarios/qa-opensearch.yaml
+++ b/charts/camunda-platform-8.7/test/ci/registry/scenarios/qa-opensearch.yaml
@@ -1,0 +1,15 @@
+name: qa-opensearch
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: opensearch-embedded
+platforms:
+  - gke
+infra-type:
+  gke: qa-workloads
+qa: true
+image-tags: true
+post-deploy: keycloak-token-lifespan
+dependencies:
+  - opensearch

--- a/charts/camunda-platform-8.7/test/ci/registry/scenarios/shadow-e2e.yaml
+++ b/charts/camunda-platform-8.7/test/ci/registry/scenarios/shadow-e2e.yaml
@@ -1,0 +1,11 @@
+name: shadow-e2e
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+platforms:
+  - gke
+infra-type:
+  gke: distroci
+skip-e2e: true


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6301. Final per-version data migration of [ADR 0093](https://github.com/camunda/camunda-platform-helm/blob/main/docs/adr/0093-adopt-composable-ci-scenario-registry-for-per-version-test-matrix.md). Parent epic #6264. Independent of #6300 / #6299 per epic policy update 2026-06-08 — only #6302 (legacy-loader removal) requires all four versions migrated + one nightly green on `main`.

### What's in this PR?

Re-runs the translator (`scripts/deploy-camunda/matrix/registry_migrate_test.go`, build tag `migrate`) against `charts/camunda-platform-8.7/test/ci-test-config.yaml` and freezes the legacy `integration:` block as the `TestRegistryEquivalence` baseline. **Zero translator / loader / workflow changes** — all 8.7-shape needs were already covered by refinements landed in #6318 (8.10) and #6352 (8.9).

Registry contents under `charts/camunda-platform-8.7/test/ci/registry/`:

- **16 scenarios** under `scenarios/`. Includes the two `keycloak-original` rows disambiguated by `{flow}` axis subset (`assignScenarioIDs`): `keycloak-original-install-patch.yaml` (keyc, `install,upgrade-patch`, tier 2) and `keycloak-original-install.yaml` (keyco, `install`, tier 1).
- **1 dependency**: `opensearch` (v2.31.0) — referenced by `opensearch-embedded` and `qa-opensearch`. No `openldap` (8.8-only).
- **2 hooks**: `keycloak-token-lifespan` (5 scenarios; short E2E-stability description) and `keycloak-token-lifespan-2` (1 scenario, `qa-elasticsearch`, longer "Prevents session-expiry flakiness…" description). Content-hash dedup emits both files distinct.
- **No `integration.flows:` block** — 8.7 has no flow-level pre-upgrade scripts; `manifest.Integration.Flows` `omitempty` drops the key cleanly.

Frozen `charts/camunda-platform-8.7/test/ci-test-config.yaml` with the same LIVE/FROZEN header pattern used on 8.10 / 8.9 (date `2026-06-08`). `unit:` block remains LIVE (still read by `.github/actions/test-type-vars/action.yaml` via yq).

Snapshot at `charts/camunda-platform-8.7/test/ci/registry-snapshot.yaml` (298 lines, 8675 bytes) regenerated via `make go.update-registry-golden`.

8.7 uses separate per-component template directories (8.8+ unified to `templates/orchestration/`) — orthogonal to registry migration.

### Verification

- `TestRegistryEquivalence/8.7` PASS (8.10 / 8.9 still PASS).
- `make go.test chartPath=charts/camunda-platform-8.7` — all packages PASS.
- `make helm.lint chartPath=charts/camunda-platform-8.7` — 0 failed.
- `deploy-camunda matrix list --versions 8.7` byte-identical text + JSON pre/post (JSON sha256 `38a5ebb9c7b3c9edf9fffe45bb8996857ac5384dd4d5d26d4fb095148607c4f0`).

### Title prefix

`chore(8.7):` because CI restricts `refactor:` / `feat:` / `fix:` / `docs:` / `revert:` to PRs touching user-facing chart files. All chart changes here are under `test/ci/registry/`.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?