### PR TITLE
ci: add always-run repo-wide gofmt gate

### DIFF
--- a/.github/workflows/repo-go-format.yaml
+++ b/.github/workflows/repo-go-format.yaml
@@ -1,0 +1,36 @@
+name: Repo - Go Format
+
+# Repo-wide, always-run gofmt gate. Deliberately NOT path-filtered and NOT
+# scoped to a chart-version matrix: the per-version `make go.fmt` step in the
+# unit-test workflow only checks the chart(s) a PR touches, so formatting drift
+# in untouched versions (8.3-8.x) and in the standalone scripts/ modules
+# accumulated unnoticed. This job scans every tracked Go file in one shot
+# (gofmt is syntactic, so it needs no module context) and fails on any drift.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  gofmt:
+    name: gofmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Install Go (from .tool-versions)
+        uses: ./.github/actions/install-tool-versions
+        with:
+          tools: |
+            golang
+      - name: Check gofmt across all Go files
+        run: |
+          unformatted=$(gofmt -l $(git ls-files '*.go'))
+          if [ -n "$unformatted" ]; then
+            echo "::error::These Go files are not gofmt-clean. Run 'gofmt -w' on them (or 'make go.fmt') and commit:"
+            echo "$unformatted"
+            exit 1
+          fi
+          echo "All tracked Go files are gofmt-clean."


### PR DESCRIPTION
### Which problem does the PR fix?

Prevents the `gofmt` drift cleaned up in #6311 from silently returning. The existing `make go.fmt` runs only inside the unit-test workflow's **per-chart-version matrix**, so it checks just the chart(s) a PR touches — drift in untouched versions (8.3–8.x) and in the standalone `scripts/` modules accumulated unnoticed.

### What's in this PR?

A new always-run PR check (`Repo - Go Format`) that runs `gofmt -l` over **every tracked Go file in one pass** (gofmt is syntactic, so no per-module context is needed) and fails on any drift, listing the offending files. Not path-filtered, not version-scoped — it closes both blind spots.

**Stacked on #6311** (the cleanup). Merge #6311 first; the gate is green once the tree is gofmt-clean. Verified locally: the gate flags all 48 drifted files on current `main`, and passes on the #6311-cleaned tree.

`ci:`-typed because it only adds a `.github/` workflow (no chart files).

### Checklist

Please make sure to follow our [Contributing Guide](../blob/main/docs/contributing.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../blob/main/docs/contributing.md#documentation) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
