### PR TITLE
ci: skip EOL chart versions in renovate post-upgrade tasks

### DIFF
--- a/.github/workflows/renovate-post-upgrade.yaml
+++ b/.github/workflows/renovate-post-upgrade.yaml
@@ -93,8 +93,9 @@ jobs:
           CHANGED_CHARTS=$(ct list-changed | tr '\n' ' ')
           echo "CHANGED_CHARTS=${CHANGED_CHARTS}" | tee -a $GITHUB_ENV
           # Build exclude pattern from supportExtended + endOfLife in charts/chart-versions.yaml.
-          EOL_VERSIONS=$(yq '.camundaVersions.supportExtended + .camundaVersions.endOfLife | join("|")' charts/chart-versions.yaml)
-          SUPPORTED_CHANGED=$(echo "${CHANGED_CHARTS}" | tr ' ' '\n' | grep -Ev "camunda-platform-(${EOL_VERSIONS})([^0-9]|$)" | tr '\n' ' ' | xargs || true)
+          # Dots are escaped (8\.6 not 8.6) so the regex matches literal version strings only.
+          EXCLUDED_VERSIONS=$(yq '.camundaVersions.supportExtended + .camundaVersions.endOfLife | map(. | sub("\.", "\\.")) | join("|")' charts/chart-versions.yaml)
+          SUPPORTED_CHANGED=$(echo "${CHANGED_CHARTS}" | tr ' ' '\n' | grep -Ev "camunda-platform-(${EXCLUDED_VERSIONS})([^0-9]|$)" | tr '\n' ' ' | xargs || true)
           echo "SUPPORTED_CHANGED=${SUPPORTED_CHANGED}" | tee -a $GITHUB_ENV
       - name: Run go mod tidy
         run: |

--- a/.github/workflows/renovate-post-upgrade.yaml
+++ b/.github/workflows/renovate-post-upgrade.yaml
@@ -86,7 +86,11 @@ jobs:
       #
       - name: Set vars
         run: |
-          echo "CHANGED_CHARTS=$(ct list-changed | tr '\n' ' ')" | tee -a $GITHUB_ENV
+          CHANGED_CHARTS=$(ct list-changed | tr '\n' ' ')
+          echo "CHANGED_CHARTS=${CHANGED_CHARTS}" | tee -a $GITHUB_ENV
+          # Filter out out-of-support versions (8.6 and below).
+          SUPPORTED_CHANGED=$(echo "${CHANGED_CHARTS}" | tr ' ' '\n' | grep -Ev 'camunda-platform-8\.[3-6]([^0-9]|$)' | tr '\n' ' ' | xargs || true)
+          echo "SUPPORTED_CHANGED=${SUPPORTED_CHANGED}" | tee -a $GITHUB_ENV
       - name: Run go mod tidy
         run: |
           set -euo pipefail
@@ -102,27 +106,24 @@ jobs:
           echo "✅ 'go mod tidy' completed successfully"
       - name: Update golden files
         run: |
-          if [ -n "${CHANGED_CHARTS}" ]; then
-            chartPath="${CHANGED_CHARTS}" \
-              make go.update-golden-only
+          if [ -n "${SUPPORTED_CHANGED}" ]; then
+            chartPath="${SUPPORTED_CHANGED}" make go.update-golden-only
           else
-            make go.update-golden-only
+            echo "No supported chart changes, skipping golden file update."
           fi
       - name: Update README
         run: |
-          if [ -n "${CHANGED_CHARTS}" ]; then
-            chartPath="${CHANGED_CHARTS}" \
-              make helm.readme-update
+          if [ -n "${SUPPORTED_CHANGED}" ]; then
+            chartPath="${SUPPORTED_CHANGED}" make helm.readme-update
           else
-            make helm.readme-update
+            echo "No supported chart changes, skipping README update."
           fi
       - name: Update Schema
         run: |
-          if [ -n "${CHANGED_CHARTS}" ]; then
-            chartPath="${CHANGED_CHARTS}" \
-              make helm.schema-update
+          if [ -n "${SUPPORTED_CHANGED}" ]; then
+            chartPath="${SUPPORTED_CHANGED}" make helm.schema-update
           else
-            make helm.schema-update
+            echo "No supported chart changes, skipping schema update."
           fi
       - name: Git pull
         run: git pull --rebase --autostash .

--- a/.github/workflows/renovate-post-upgrade.yaml
+++ b/.github/workflows/renovate-post-upgrade.yaml
@@ -84,6 +84,10 @@ jobs:
       #
       # Post Upgrade Tasks.
       #
+      # SUPPORTED_CHANGED = CHANGED_CHARTS minus out-of-support chart versions.
+      # The exclusion list is derived dynamically from charts/chart-versions.yaml
+      # (supportExtended + endOfLife), so updating that file is the only thing
+      # needed when a version transitions to end-of-support — no changes here.
       - name: Set vars
         run: |
           CHANGED_CHARTS=$(ct list-changed | tr '\n' ' ')

--- a/.github/workflows/renovate-post-upgrade.yaml
+++ b/.github/workflows/renovate-post-upgrade.yaml
@@ -88,8 +88,9 @@ jobs:
         run: |
           CHANGED_CHARTS=$(ct list-changed | tr '\n' ' ')
           echo "CHANGED_CHARTS=${CHANGED_CHARTS}" | tee -a $GITHUB_ENV
-          # Filter out out-of-support versions (8.6 and below).
-          SUPPORTED_CHANGED=$(echo "${CHANGED_CHARTS}" | tr ' ' '\n' | grep -Ev 'camunda-platform-8\.[3-6]([^0-9]|$)' | tr '\n' ' ' | xargs || true)
+          # Build exclude pattern from supportExtended + endOfLife in charts/chart-versions.yaml.
+          EOL_VERSIONS=$(yq '.camundaVersions.supportExtended + .camundaVersions.endOfLife | join("|")' charts/chart-versions.yaml)
+          SUPPORTED_CHANGED=$(echo "${CHANGED_CHARTS}" | tr ' ' '\n' | grep -Ev "camunda-platform-(${EOL_VERSIONS})([^0-9]|$)" | tr '\n' ' ' | xargs || true)
           echo "SUPPORTED_CHANGED=${SUPPORTED_CHANGED}" | tee -a $GITHUB_ENV
       - name: Run go mod tidy
         run: |


### PR DESCRIPTION
### Which problem does the PR fix?

Renovate's post-upgrade workflow (`renovate-post-upgrade.yaml`) was updating golden files, READMEs, and schemas for out-of-support chart versions (`supportExtended` + `endOfLife` in `charts/chart-versions.yaml`, currently 8.0–8.6). It also ran all three tasks unnecessarily when no chart files changed (e.g. a pure `actions/setup-go` bump), producing spurious commits touching EOL directories.

Observed in: https://github.com/camunda/camunda-platform-helm/pull/6236

### What's in this PR?

**`renovate-post-upgrade.yaml`**

- In `Set vars`, `SUPPORTED_CHANGED` is computed by reading `charts/chart-versions.yaml` via `yq` and filtering `CHANGED_CHARTS` to exclude versions listed under `supportExtended` and `endOfLife`. The variable is exported to `$GITHUB_ENV` so all subsequent steps share it.
- Golden file update, README update, and schema update steps now gate on `SUPPORTED_CHANGED` being non-empty. If empty (only EOL charts changed, or no chart files changed at all), each step skips with a log message.
- The exclusion list is **not hardcoded** — it is derived at runtime from `charts/chart-versions.yaml`. When a version moves to end-of-support, updating that file is the only change needed.

### Checklist

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).