### PR TITLE
deps: update actions/setup-go action to v6

### DIFF
--- a/.github/workflows/test-chart-version.yaml
+++ b/.github/workflows/test-chart-version.yaml
@@ -186,7 +186,7 @@ jobs:
       # and will be routed to a fast-path job, skipping the full GKE deploy+test cycle.
       - name: Setup Go for cache annotation
         if: github.event_name == 'merge_group' && steps.resolve-pr-sha.outputs.pr-head-sha != ''
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: scripts/ci-result-cache/go.mod
           cache: true

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -1358,7 +1358,7 @@ jobs:
           ref: ${{ inputs.camunda-helm-git-ref }}
 
       - name: Setup Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: scripts/ci-result-cache/go.mod
           cache: true


### PR DESCRIPTION
### Which problem does the PR fix?

Cherry-pick of the workflow-only commit from #6236, excluding the post-upgrade golden file changes that touched out-of-support chart versions (8.3–8.6). Closes #6236.

### What's in this PR?

- `.github/workflows/test-chart-version.yaml` — `actions/setup-go` v5 → v6
- `.github/workflows/test-integration-runner.yaml` — `actions/setup-go` v5 → v6

### Checklist

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).