### PR TITLE
fix(8.10): trust caBundle CA in console via NODE_EXTRA_CA_CERTS + CRLF-safe init

### DIFF
--- a/charts/camunda-platform-8.10/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/common/_helpers.tpl
@@ -1259,24 +1259,6 @@ Usage (inside an env: list):
 {{- end -}}
 
 {{/*
-caBundleSslCertFileEnv
-SSL_CERT_FILE only — for components that already manage their own
-NODE_EXTRA_CA_CERTS via component-specific values (Console pins the env
-var to its own server cert path; injecting another NODE_EXTRA_CA_CERTS
-from this helper would emit a duplicate env name with last-wins
-behavior). Use this variant on those components.
-
-Usage (inside an env: list):
-  {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
-  {{- include "camundaPlatform.caBundleSslCertFileEnv" . | nindent 12 }}
-  {{- end }}
-*/}}
-{{- define "camundaPlatform.caBundleSslCertFileEnv" -}}
-- name: SSL_CERT_FILE
-  value: /etc/camunda/tls/ca.crt
-{{- end -}}
-
-{{/*
 caBundleInitContainer
 Emits an init container that builds a Java truststore (PKCS12-format JKS)
 combining the system $JAVA_HOME/lib/security/cacerts with the user CA
@@ -1366,7 +1348,10 @@ restricted SCC assign a namespace-range UID.
       # /var/camunda — readOnlyRootFilesystem is set on this container.
       WORK=/var/camunda/tls-truststore/work
       mkdir -p "$WORK"
+      # Strip trailing CR first so a CRLF (Windows-authored) PEM still matches
+      # the BEGIN/END markers and the split cert files stay LF-clean for keytool.
       awk 'BEGIN{n=0; out=""}
+           { sub(/\r$/, "") }
            /-----BEGIN CERTIFICATE-----/ {n++; out=sprintf("'"$WORK"'/cert-%02d.pem", n)}
            out!="" {print > out}
            /-----END CERTIFICATE-----/ {close(out); out=""}' \

--- a/charts/camunda-platform-8.10/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.10/templates/common/constraints.tpl
@@ -372,6 +372,19 @@ The following values inside your values.yaml need to be set but were not:
       {{- end }}
     {{- end }}
 
+    {{/* (4) Console (Node.js) pins NODE_EXTRA_CA_CERTS to its own
+           console.tls.certKeyFilename when caBundle is unset; once caBundle is
+           set, NODE_EXTRA_CA_CERTS points at the bundle instead, so a configured
+           certKeyFilename no longer contributes trust. */}}
+    {{- if and (eq (include "camundaHub.consoleEnabled" .) "true") (or .Values.camundaHub.console.tls.certKeyFilename .Values.console.tls.certKeyFilename) }}
+      {{- $warningMessage := printf "%s %s %s"
+          "[camunda][warning]"
+          "global.tls.caBundle is set, so Console's NODE_EXTRA_CA_CERTS now points at the CA bundle and console.tls.certKeyFilename is no longer used for trust."
+          "If that cert's CA must still be trusted, include it in the global.tls.caBundle bundle."
+      -}}
+      {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
+    {{- end }}
+
   {{- end }}
 
   {{/* Warn when webModeler pusher secret is auto-generated */}}

--- a/charts/camunda-platform-8.10/templates/console/deployment.yaml
+++ b/charts/camunda-platform-8.10/templates/console/deployment.yaml
@@ -95,15 +95,11 @@ spec:
               value: {{ printf "%s/%s" .Values.global.documentStore.type.gcp.mountPath .Values.global.documentStore.type.gcp.fileName | quote }}
             {{- end }}
           {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
-            {{- /* Node.js — SSL_CERT_FILE for libcurl init scripts in the
-                  image; NODE_EXTRA_CA_CERTS is set unconditionally above
-                  to Console's own server cert path, so we use the
-                  SSL_CERT_FILE-only variant here to avoid emitting a
-                  duplicate NODE_EXTRA_CA_CERTS env entry (Kubernetes
-                  treats duplicates as undefined / last-wins). The
-                  JAVA_TOOL_OPTIONS truststore env is omitted: Node
-                  ignores it. */ -}}
-            {{- include "camundaPlatform.caBundleSslCertFileEnv" . | nindent 12 }}
+            {{- /* Console is Node.js: it trusts custom CAs via NODE_EXTRA_CA_CERTS, NOT
+                  SSL_CERT_FILE (Node ignores the latter for its TLS client). Emit both
+                  via caBundleEnv. No duplicate NODE_EXTRA_CA_CERTS: the original (Console's
+                  own server cert) is gated out above with `ne hasCaBundle`. */ -}}
+            {{- include "camundaPlatform.caBundleEnv" . | nindent 12 }}
           {{- end }}
           {{- if (or .Values.camundaHub.console.env .Values.console.env) }}
             {{ (or .Values.camundaHub.console.env .Values.console.env) | toYaml | nindent 12 }}

--- a/charts/camunda-platform-8.10/test/unit/common/constraints_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/constraints_test.go
@@ -391,7 +391,6 @@ func (s *ConstraintTemplateTest) TestLegacyJksTruststoreFieldsRenderWithoutCrash
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
 
-
 func (s *ConstraintTemplateTest) TestGatewayConstraints() {
 	testCases := []testhelpers.TestCase{
 		{
@@ -439,6 +438,29 @@ func (s *ConstraintTemplateTest) TestBitnamiSubchartDeprecationWarnings() {
 			Values: map[string]string{
 				"global.elasticsearch.enabled":             "false",
 				"orchestration.data.secondaryStorage.type": "rdbms",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().Nil(err)
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
+func (s *ConstraintTemplateTest) TestCaBundleConsoleCertKeyFilenameWarningRendersOk() {
+	testCases := []testhelpers.TestCase{
+		{
+			// Exercises the constraints warning that fires when caBundle is set
+			// AND console.tls.certKeyFilename is configured (the latter no longer
+			// contributes trust). Asserts the warning path renders without crashing.
+			Name: "TestCaBundleWithConsoleCertKeyFilenameRendersOk",
+			Values: map[string]string{
+				"console.enabled":                           "true",
+				"identity.enabled":                          "true",
+				"orchestration.data.secondaryStorage.type":  "elasticsearch",
+				"global.tls.caBundle.secret.existingSecret": "camunda-ca-bundle",
+				"console.tls.certKeyFilename":               "tls.crt",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				s.Require().Nil(err)

--- a/charts/camunda-platform-8.10/test/unit/common/tls_secrets_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/tls_secrets_test.go
@@ -572,6 +572,27 @@ func (s *tlsSecretsTest) TestCaBundleChecksumAnnotationWebModeler() {
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
 
+func (s *tlsSecretsTest) TestCaBundleConsole() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name:     "caBundle injects SSL_CERT_FILE + NODE_EXTRA_CA_CERTS into Console (Node.js trusts custom CA via NODE_EXTRA_CA_CERTS)",
+			Template: "templates/console/deployment.yaml",
+			Values: map[string]string{
+				"console.enabled":                           "true",
+				"identity.enabled":                          "true",
+				"global.tls.caBundle.secret.existingSecret": "my-ca-bundle",
+			},
+			Expected: map[string]string{
+				"spec.template.spec.volumes[?(@.name=='ca-bundle')].secret.secretName":         "my-ca-bundle",
+				"spec.template.spec.containers[0].env[?(@.name=='SSL_CERT_FILE')].value":       "/etc/camunda/tls/ca.crt",
+				"spec.template.spec.containers[0].env[?(@.name=='NODE_EXTRA_CA_CERTS')].value": "/etc/camunda/tls/ca.crt",
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
 func TestTLSSecretsTestSuite(t *testing.T) {
 	suite.Run(t, new(tlsSecretsTest))
 }


### PR DESCRIPTION
### Which problem does the PR fix?

Two latent issues in the shipped 8.10 `global.tls.caBundle` feature, both surfaced by `crev` while backporting to 8.9/8.8 (#6365, #6366):

1. **Console cannot trust the CA bundle.** Console is Node.js and trusts custom CAs via `NODE_EXTRA_CA_CERTS`, **not** `SSL_CERT_FILE` (Node ignores the latter for its TLS client). The caBundle wiring gates out Console's original `NODE_EXTRA_CA_CERTS` when caBundle is active and adds only `SSL_CERT_FILE`, so Console's outbound HTTPS to CA-signed services (Keycloak/Identity) fails certificate validation.
2. **CRLF PEM bundles.** The init-container cert-splitter `awk` doesn't strip `\r`, so a Windows-authored (CRLF) CA bundle can produce non-LF-clean per-cert files for `keytool`.

### What's in this PR?

- `console/deployment.yaml`: use `caBundleEnv` (both `SSL_CERT_FILE` + `NODE_EXTRA_CA_CERTS`) instead of `caBundleSslCertFileEnv` — matching the websockets template. No duplicate `NODE_EXTRA_CA_CERTS` because the original (Console's own server cert) is already gated out with `ne hasCaBundle`.
- Remove the now-dead `caBundleSslCertFileEnv` helper (Console was its only caller).
- `common/_helpers.tpl`: the cert-splitter `awk` strips a trailing CR first.
- `constraints.tpl`: warn that `console.tls.certKeyFilename` no longer contributes trust once `global.tls.caBundle` is set.
- Adds `TestCaBundleConsole`; golden regenerated.

`helm.lint` clean; full `make go.test` green. The same fixes are already included in the 8.9 (#6365) and 8.8 (#6366) backports.

### Checklist

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open pull request for the same update/change.
- [x] Tests for charts are added (if needed).
- [ ] In-repo documentation are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)?
- [ ] Did all checks/tests pass in the PR?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
