### PR TITLE
fix: add /admin route to Identity HTTPRoute when contextPath is set

### DIFF
--- a/charts/camunda-platform-8.10/templates/identity/httproute.yaml
+++ b/charts/camunda-platform-8.10/templates/identity/httproute.yaml
@@ -92,5 +92,15 @@ spec:
     - name: {{ template "identity.fullname" . }}
       namespace: {{ .Release.Namespace }}
       port: {{ .Values.identity.service.port }}
+  {{- if .Values.identity.contextPath }}
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /admin
+    backendRefs:
+    - name: {{ template "identity.fullname" . }}
+      namespace: {{ .Release.Namespace }}
+      port: {{ .Values.identity.service.port }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/camunda-platform-8.10/test/unit/identity/httproute_test.go
+++ b/charts/camunda-platform-8.10/test/unit/identity/httproute_test.go
@@ -125,6 +125,31 @@ func (s *HTTPRouteTemplateTest) TestDifferentValuesInputs() {
 			},
 		},
 		{
+			Name: "TestIdentityHTTPRouteAdminRouteAddedWithContextPath",
+			Values: map[string]string{
+				"global.gateway.enabled": "true",
+				"global.host":            "camunda.example.com",
+				"identity.enabled":       "true",
+				"identity.contextPath":   "/identity",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.Contains(t, output, "value: /admin")
+			},
+		},
+		{
+			Name: "TestIdentityHTTPRouteAdminRouteAbsentWithoutContextPath",
+			Values: map[string]string{
+				"global.gateway.enabled": "true",
+				"global.host":            "camunda.example.com",
+				"identity.enabled":       "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.NotContains(t, output, "value: /admin")
+			},
+		},
+		{
 			Name: "TestKeycloakHTTPRouteUsesSameNamespaceService",
 			Values: map[string]string{
 				"global.gateway.enabled":                "true",

--- a/charts/camunda-platform-8.9/templates/identity/httproute.yaml
+++ b/charts/camunda-platform-8.9/templates/identity/httproute.yaml
@@ -86,5 +86,15 @@ spec:
     - name: {{ template "identity.fullname" . }}
       namespace: {{ .Release.Namespace }}
       port: {{ .Values.identity.service.port }}
+  {{- if .Values.identity.contextPath }}
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /admin
+    backendRefs:
+    - name: {{ template "identity.fullname" . }}
+      namespace: {{ .Release.Namespace }}
+      port: {{ .Values.identity.service.port }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/camunda-platform-8.9/test/unit/identity/httproute_test.go
+++ b/charts/camunda-platform-8.9/test/unit/identity/httproute_test.go
@@ -142,6 +142,31 @@ func (s *HTTPRouteTemplateTest) TestDifferentValuesInputs() {
 			},
 		},
 		{
+			Name: "TestIdentityHTTPRouteAdminRouteAddedWithContextPath",
+			Values: map[string]string{
+				"global.gateway.enabled": "true",
+				"global.host":            "camunda.example.com",
+				"identity.enabled":       "true",
+				"identity.contextPath":   "/identity",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.Contains(t, output, "value: /admin")
+			},
+		},
+		{
+			Name: "TestIdentityHTTPRouteAdminRouteAbsentWithoutContextPath",
+			Values: map[string]string{
+				"global.gateway.enabled": "true",
+				"global.host":            "camunda.example.com",
+				"identity.enabled":       "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.NotContains(t, output, "value: /admin")
+			},
+		},
+		{
 			Name: "TestHTTPRouteWithAnnotations",
 			Values: map[string]string{
 				"global.gateway.enabled":                 "true",


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6372

When `identity.contextPath` is set (e.g. `/identity`) and Gateway API is enabled, navigating to `/identity` or `/identity/` results in a blank page with broken assets.

Root cause: Identity's `IdentityIndexController` redirects `/identity/` → `/admin/` (Spring-level 302). The Gateway had no route for `/admin/`, so the browser's redirect landed on a 404. This also broke the Camunda logo link in the Identity UI, because `getBasePathBeforeAdmin()` in the React frontend derives `BrowserRouter basename` from the pathname and fails when the app is never fully loaded at `/admin/`.

### What's in this PR?

Added a `PathPrefix /admin` rule to the Identity `HTTPRoute`, gated on `identity.contextPath` being non-empty. This ensures the Gateway routes `/admin/*` to the Identity service after the Spring-level redirect, allowing the SPA to bootstrap correctly.

Changes:
- `charts/camunda-platform-8.10/templates/identity/httproute.yaml` — add `/admin` PathPrefix rule
- `charts/camunda-platform-8.9/templates/identity/httproute.yaml` — same fix backported
- `charts/camunda-platform-8.10/test/unit/identity/httproute_test.go` — two new test cases
- `charts/camunda-platform-8.9/test/unit/identity/httproute_test.go` — same test cases backported

### Checklist

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?