### PR TITLE
chore: replace Bitnami image references with Soldevelo equivalents

### DIFF
--- a/charts/camunda-platform-8.3/test/unit/camunda/golden/elasticsearch-statefulset.golden.yaml
+++ b/charts/camunda-platform-8.3/test/unit/camunda/golden/elasticsearch-statefulset.golden.yaml
@@ -54,7 +54,7 @@ spec:
       initContainers:
         ## Image that performs the sysctl operation to modify Kernel settings (needed sometimes to avoid boot errors)
         - name: sysctl
-          image: docker.io/bitnamilegacy/os-shell:12-debian-12-r16
+          image: docker.io/soldevelo/os-shell:12-debian-12-r2
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash

--- a/charts/camunda-platform-8.4/test/unit/camunda/golden/elasticsearch-statefulset.golden.yaml
+++ b/charts/camunda-platform-8.4/test/unit/camunda/golden/elasticsearch-statefulset.golden.yaml
@@ -54,7 +54,7 @@ spec:
       initContainers:
         ## Image that performs the sysctl operation to modify Kernel settings (needed sometimes to avoid boot errors)
         - name: sysctl
-          image: docker.io/bitnamilegacy/os-shell:12-debian-12-r16
+          image: docker.io/soldevelo/os-shell:12-debian-12-r2
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash

--- a/charts/camunda-platform-8.5/test/unit/camunda/golden/elasticsearch-statefulset.golden.yaml
+++ b/charts/camunda-platform-8.5/test/unit/camunda/golden/elasticsearch-statefulset.golden.yaml
@@ -54,7 +54,7 @@ spec:
       initContainers:
         ## Image that performs the sysctl operation to modify Kernel settings (needed sometimes to avoid boot errors)
         - name: sysctl
-          image: docker.io/bitnamilegacy/os-shell:12-debian-12-r18
+          image: docker.io/soldevelo/os-shell:12-debian-12-r2
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash

--- a/charts/camunda-platform-8.6/test/unit/camunda/golden/elasticsearch-statefulset.golden.yaml
+++ b/charts/camunda-platform-8.6/test/unit/camunda/golden/elasticsearch-statefulset.golden.yaml
@@ -60,7 +60,7 @@ spec:
       initContainers:
         ## Image that performs the sysctl operation to modify Kernel settings (needed sometimes to avoid boot errors)
         - name: sysctl
-          image: docker.io/bitnamilegacy/os-shell:12-debian-12-r43
+          image: docker.io/soldevelo/os-shell:12-debian-12-r2
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash

--- a/charts/camunda-platform-8.7/test/unit/camunda/golden/elasticsearch-statefulset.golden.yaml
+++ b/charts/camunda-platform-8.7/test/unit/camunda/golden/elasticsearch-statefulset.golden.yaml
@@ -60,7 +60,7 @@ spec:
       initContainers:
         ## Image that performs the sysctl operation to modify Kernel settings (needed sometimes to avoid boot errors)
         - name: sysctl
-          image: docker.io/bitnamilegacy/os-shell:12-debian-12-r43
+          image: docker.io/soldevelo/os-shell:12-debian-12-r2
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash

--- a/charts/camunda-platform-8.8/test/unit/common/golden/elasticsearch-statefulset.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/common/golden/elasticsearch-statefulset.golden.yaml
@@ -60,7 +60,7 @@ spec:
       initContainers:
         ## Image that performs the sysctl operation to modify Kernel settings (needed sometimes to avoid boot errors)
         - name: sysctl
-          image: docker.io/bitnamilegacy/os-shell:12-debian-12-r43
+          image: docker.io/soldevelo/os-shell:12-debian-12-r2
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash

--- a/charts/camunda-platform-8.9/test/unit/common/golden/elasticsearch-statefulset.golden.yaml
+++ b/charts/camunda-platform-8.9/test/unit/common/golden/elasticsearch-statefulset.golden.yaml
@@ -60,7 +60,7 @@ spec:
       initContainers:
         ## Image that performs the sysctl operation to modify Kernel settings (needed sometimes to avoid boot errors)
         - name: sysctl
-          image: docker.io/bitnamilegacy/os-shell:12-debian-12-r43
+          image: docker.io/soldevelo/os-shell:12-debian-12-r2
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash


### PR DESCRIPTION
## Why this change

Bitnami changed its container image distribution model on August 28, 2025, and public images no longer receive ongoing updates or security fixes.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a fork of bitnami/containers that continues to provide actively maintained and publicly available images.

## Image replacements

- `bitnamilegacy/os-shell:12-debian-12-r16` → [`soldevelo/os-shell:12-debian-12-r2`](https://hub.docker.com/r/soldevelo/os-shell)
- `bitnamilegacy/os-shell:12-debian-12-r43` → [`soldevelo/os-shell:12-debian-12-r2`](https://hub.docker.com/r/soldevelo/os-shell)
- `bitnamilegacy/os-shell:12-debian-12-r18` → [`soldevelo/os-shell:12-debian-12-r2`](https://hub.docker.com/r/soldevelo/os-shell)