### PR TITLE
ci: make release-chores a required status check for release PRs

### DIFF
--- a/.github/workflows/chart-release-chores.yaml
+++ b/.github/workflows/chart-release-chores.yaml
@@ -139,3 +139,33 @@ jobs:
           author_name: "distro-ci[bot]"
           author_email: "122795778+distro-ci[bot]@users.noreply.github.com"
           message: "chore(release): update chart files + version matrix"
+
+  report-status:
+    name: "Report release-chores status"
+    if: always()
+    needs: [chores]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 1
+      - name: Get HEAD SHA after chores commit
+        id: head
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Post release-chores status
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          result="${{ needs.chores.result }}"
+          if [[ "$result" == "success" || "$result" == "skipped" ]]; then
+            state="success"
+            desc="Release chores completed (release notes, version matrix updated)."
+          else
+            state="failure"
+            desc="Release chores failed — release notes or version matrix may not be updated. Re-run the workflow."
+          fi
+          gh api "repos/${{ github.repository }}/statuses/${{ steps.head.outputs.sha }}" \
+            -f state="$state" \
+            -f context="release-chores" \
+            -f description="$desc"

--- a/.github/workflows/chart-release-chores.yaml
+++ b/.github/workflows/chart-release-chores.yaml
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  statuses: write
 
 jobs:
   chores:

--- a/.github/workflows/chart-release-chores.yaml
+++ b/.github/workflows/chart-release-chores.yaml
@@ -9,6 +9,10 @@ on:
       - '**/.release-please-config.json'
       - '**/.release-please-manifest.json'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/test-chart-version.yaml
+++ b/.github/workflows/test-chart-version.yaml
@@ -347,3 +347,30 @@ jobs:
             -f description="Contributor License Agreement is signed." \
             -f target_url="https://cla-assistant.io/${{ github.repository }}"
 
+  # Report release-chores status for non-release PRs and merge queue events.
+  # For release-please PRs, chart-release-chores.yaml owns this status.
+  # For all other PRs, chores are not applicable — report success immediately.
+  # For merge queue commits, chores were verified on the PR — re-report success.
+  report-release-chores-skip:
+    name: "Report release-chores status (skip)"
+    if: >-
+      ${{
+        github.event_name == 'merge_group' ||
+        (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please--'))
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report release-chores as not applicable
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            desc="Merge queue: release-chores verified on PR before queuing."
+          else
+            desc="Not a release PR — release-chores not required."
+          fi
+          gh api "repos/${{ github.repository }}/statuses/${{ github.sha }}" \
+            -f state="success" \
+            -f context="release-chores" \
+            -f description="$desc"
+


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6378

Release PRs (`chore(release):`) could be merged even when the `chart-release-chores` workflow failed or never completed. The chores workflow updates release notes and the version matrix — skipping it silently broke the release state and caused downstream release trains to pick up stale versions.

### What's in this PR?

Two workflow changes that together make `release-chores` a blockable status check:

**`chart-release-chores.yaml`**
- Adds `statuses: write` permission
- Adds a `report-status` job (`if: always()`) that runs after the `chores` job, checks out the branch ref to get the final HEAD SHA (post-commit, since chores pushes a commit), and posts a `release-chores` GitHub commit status — `success` if chores passed or was skipped, `failure` otherwise

**`test-chart-version.yaml`**
- Adds a `report-release-chores-skip` job that posts `release-chores: success` immediately for:
  - Non-release-please PRs (chores don't apply)
  - Merge queue commits (chores were already verified on the PR before queuing)
  - This ensures regular PRs are never blocked by the new required check

**Ruleset change (post-merge, not in this PR)**
After this PR merges, add `release-chores` to the required status checks in branch ruleset 639923 via `gh api PATCH`. This must happen after the workflows are live to avoid blocking all existing open PRs.

### Checklist

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?