### PR TITLE
ci: restore skip-e2e/skip-it/test-qa inputs in test-integration-runner

### DIFF
--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -128,15 +128,18 @@ on:
         description: "Enable QA configuration"
         required: false
         default: false
+        type: boolean
       test-upgrade:
         description: "Enable upgrade flow configuration"
         required: false
         default: false
         type: boolean
+      skip-e2e:
         description: "Skip E2E (Playwright smoke) tests for this scenario (declared in ci-test-config.yaml)"
         required: false
         default: false
         type: boolean
+      skip-it:
         description: "Skip integration (Playwright IT) tests for this scenario (declared in ci-test-config.yaml)"
         required: false
         default: false


### PR DESCRIPTION
## Description

`Test - Chart Version` has been failing **repo-wide** since ~Jun 12 — startup failure with **0 jobs** ("workflow file may be broken", non-rerunnable) on every PR and on `main`'s own merge_group. The last green run was immediately before #6359 merged.

### Root cause

#6359 (`ci: consolidate release-pipeline bash into tested Go`, commit e94f96a90) included a mangled hunk in `.github/workflows/test-integration-runner.yaml` that dropped three lines from the `workflow_call.inputs` block:

- `type: boolean` on the `test-qa` input
- the `skip-e2e:` input key
- the `skip-it:` input key

With the `skip-e2e:`/`skip-it:` keys gone, their property blocks collapsed into `test-upgrade` as **duplicate `description`/`required`/`default`/`type` keys**, and `test-qa` lost its type.

GitHub validates the entire reusable-workflow tree at startup, and this runner is the leaf of the chain:

```
Test - Chart Version
  → test-chart-version-template
    → test-integration-template
      → test-integration-runner.yaml   ← corrupt
```

So the whole tree failed to compile → `startup_failure`, 0 jobs, on every PR + merge_group. This also blocks the merge queue on `main`.

### Fix

Restore the three deleted lines. Verified with `actionlint`:

```
$ actionlint .github/workflows/test-integration-runner.yaml   # no [syntax-check] errors
skip-e2e present: True   skip-it present: True   test-qa has type: True
```

## Related

- Regression source: #6359
- Unblocks all open PRs and the `main` merge queue (e.g. #6365)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
