### PR TITLE
ci: ensure release-please PR passes merge queue after public release

### DIFF
--- a/.github/workflows/chart-release-chores.yaml
+++ b/.github/workflows/chart-release-chores.yaml
@@ -58,6 +58,8 @@ jobs:
             helm
             helm-ct
             yq
+      - name: Add Go bin directory to PATH
+        run: echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
       - name: Install readme-generator-for-helm
         run: |
           # renovate: datasource=npm depName=@bitnami/readme-generator-for-helm

--- a/.github/workflows/chart-release-public.yaml
+++ b/.github/workflows/chart-release-public.yaml
@@ -328,6 +328,9 @@ jobs:
     name: Post-Release
     needs: release
     runs-on: ubuntu-latest
+    outputs:
+      pr-number: ${{ steps.mark-published.outputs.pr_number }}
+      auto-merge-enabled: ${{ steps.auto-merge.outputs.enabled }}
     steps:
       - name: Import Vault secrets for Harbor
         uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
@@ -484,6 +487,71 @@ jobs:
                   text: |
                     :white_check_mark: *Helm Chart ${{ needs.release.outputs.version }}* released and auto-merge enabled for the release-please PR.
                     <${{ github.server_url }}/${{ github.repository }}/pull/${{ steps.mark-published.outputs.pr_number }}|View PR> · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow>
+
+  ensure-release-pr-merged:
+    name: Ensure release-please PR merges
+    needs: [release, post-release]
+    # The artifact is already published; this job only shepherds the release-please PR
+    # through the merge queue. A PR that does not merge is a `main`-sync gap, NOT a release
+    # failure: this job raises its own distinct alert and is deliberately excluded from
+    # `notify-on-failure` (below) so it never fires the "Chart Public Release Failed" alert.
+    if: ${{ !cancelled() && needs.post-release.outputs.auto-merge-enabled == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Import Vault secrets
+        id: secrets
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/distribution/ci GH_APP_ID_DISTRO_CI;
+            secret/data/products/distribution/ci GH_APP_PRIVATE_KEY_DISTRO_CI;
+            secret/data/products/distribution/ci SLACK_DISTRO_BOT_WEBHOOK;
+          exportEnv: true
+
+      - name: Generate GitHub token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
+        id: generate-github-token
+        with:
+          app_id: ${{ env.GH_APP_ID_DISTRO_CI }}
+          private_key: ${{ env.GH_APP_PRIVATE_KEY_DISTRO_CI }}
+
+      - name: Shepherd release-please PR through merge queue
+        id: merge-queue
+        continue-on-error: true
+        uses: camunda/infra-global-github-actions/ensure-pr-passes-merge-queue@aef5579dd1bf60ea2e8ccfabeb9aaa46fdeaecf8 # main
+        with:
+          pr-number: ${{ needs.post-release.outputs.pr-number }}
+          app-token: ${{ steps.generate-github-token.outputs.token }}
+          repository-owner: ${{ github.repository_owner }}
+          repository-name: ${{ github.event.repository.name }}
+          merge-method: squash
+          timeout-minutes: "90"
+          max-evictions: "3"
+
+      - name: Alert if release-please PR did not merge
+        if: ${{ steps.merge-queue.outputs.result != 'merged' }}
+        continue-on-error: true
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          webhook: ${{ steps.secrets.outputs.SLACK_DISTRO_BOT_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: |
+                    <!subteam^S05K9BK6RTK> :rotating_light:
+                    *Helm Chart ${{ needs.release.outputs.version }}* was published, but its release-please PR is *not merged* (merge-queue result: `${{ steps.merge-queue.outputs.result || 'unknown' }}`).
+                    Please merge it so `main` syncs with the released artifact.
+                    <${{ github.server_url }}/${{ github.repository }}/pull/${{ needs.post-release.outputs.pr-number }}|View PR> · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow>
 
   notify-on-failure:
     name: Notify on Failure

--- a/docs/reference/release-process.md
+++ b/docs/reference/release-process.md
@@ -116,8 +116,11 @@ The charts are built, linted, and tested on every push to the main branch. The r
 
 **After public release:**
 
-1. Merge the `release-please` PR to sync `main` with the released artifact.
-2. This triggers `chart-public-files.yaml` to update:
+1. The workflow enables auto-merge on the `release-please` PR, then shepherds it through the merge
+   queue (re-enabling auto-merge after evictions). If it still does not merge within the timeout, a
+   distinct Slack alert pings the distribution release manager to merge it manually — the release
+   itself is not treated as failed.
+2. Merging the `release-please` PR syncs `main` with the released artifact and triggers `chart-public-files.yaml` to update:
    - [Version matrix](https://helm.camunda.io/camunda-platform/version-matrix/) (component versions for each chart release).
    - Public values files at `helm.camunda.io/camunda-platform/values/`.
 
@@ -149,7 +152,7 @@ Use this process when a Helm Chart fix is needed (e.g. incorrect image tag, char
 
 5. **Trigger public release** — Manually trigger [`chart-release-public.yaml`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/chart-release-public.yaml) with the RC tag. This publishes the corrected chart to GitHub Releases and updates the Helm repo index.
 
-6. **Make sure the release-please PR is merged** — Auto-merge is attempted but best-effort; confirm the release-please PR was merged with the correct released version, and merge it manually if needed.
+6. **Make sure the release-please PR is merged** — The workflow shepherds the release-please PR through the merge queue and re-enables auto-merge after evictions. If it still does not merge within the timeout, a Slack alert pings the distribution release manager; merge it manually with the correct released version. The daily PR reminder also flags any published-but-unmerged release PR as a backstop.
 
 7. **Notify support** — Post a message in `#ask-support` using the support template below.
 


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6384

After `chart-release-public.yaml` publishes a release, the `post-release` job enables best-effort
auto-merge on the release-please PR and then exits. If the PR is later evicted from the merge queue,
stuck on a flaky required check, or auto-merge silently fails, nothing drives it to completion and
`main` stays out of sync with the released artifact (e.g. #6380).

### What's in this PR?

Adds a dedicated `ensure-release-pr-merged` job that runs only when auto-merge was enabled. It uses
the shared
[`ensure-pr-passes-merge-queue`](https://github.com/camunda/infra-global-github-actions/blob/main/ensure-pr-passes-merge-queue/README.md)
action to poll the PR + merge queue and re-enable auto-merge after evictions, reusing the
`post-release` GitHub App token (already has pull-request write).

The artifact is already published at this point, so an unmerged PR is a `main`-sync gap, not a
release failure. The job is therefore:

- excluded from `notify-on-failure`'s `needs`, with both steps `continue-on-error`, so it never
  fails the release or fires the "Chart Public Release Failed" alert;
- on a non-`merged` result, posts a distinct alert pinging the distribution release manager
  ("published but PR not merged, please merge to sync `main`") with the PR link.

`post-release` now exposes `pr-number` and `auto-merge-enabled` as job outputs for the new job, and
`docs/reference/release-process.md` is updated to describe the behaviour.

Pairs with #6379 (release-chores as a required check): the action will correctly wait for chores to
go green before the PR can merge.

Also fixes the `release-chores` check itself. Since #6359 moved release-notes/version-matrix
generation to the `release-tools` Go binary, `chart-release-chores.yaml` called `release-tools` by
name without putting `$(go env GOPATH)/bin` on `PATH`, so the first release-please run on the new
code failed with `release-tools: command not found` (#6380's "Generate release files" check).
Without this, making release-chores a required check (#6379) would block release-please PRs from
merging rather than shepherding them through.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

