### PR TITLE
ci: scope Vault secrets to consuming steps instead of exportEnv: true

### DIFF
--- a/.github/actions/integration-test-setup/action.yaml
+++ b/.github/actions/integration-test-setup/action.yaml
@@ -88,6 +88,57 @@ outputs:
   legacy-ingress-arg:
     description: --set global.ingress.host=... for charts older than 8.10, empty otherwise
     value: ${{ steps.legacy-ingress.outputs.arg }}
+  NEXUS_USERNAME:
+    description: Nexus username (docker registry fallback)
+    value: ${{ steps.test-credentials-secret.outputs.NEXUS_USERNAME }}
+  NEXUS_PASSWORD:
+    description: Nexus password (docker registry fallback)
+    value: ${{ steps.test-credentials-secret.outputs.NEXUS_PASSWORD }}
+  TEST_DOCKER_USERNAME_CAMUNDA_CLOUD:
+    description: Harbor (registry.camunda.cloud) username
+    value: ${{ steps.test-credentials-secret.outputs.TEST_DOCKER_USERNAME_CAMUNDA_CLOUD }}
+  TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD:
+    description: Harbor (registry.camunda.cloud) password
+    value: ${{ steps.test-credentials-secret.outputs.TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD }}
+  TEST_DOCKER_USERNAME:
+    description: Docker Hub username
+    value: ${{ steps.test-credentials-secret.outputs.TEST_DOCKER_USERNAME }}
+  TEST_DOCKER_PASSWORD:
+    description: Docker Hub password
+    value: ${{ steps.test-credentials-secret.outputs.TEST_DOCKER_PASSWORD }}
+  ENTRA_APP_CLIENT_ID:
+    description: Entra app client id (OIDC scenarios)
+    value: ${{ steps.test-credentials-secret.outputs.ENTRA_APP_CLIENT_ID }}
+  ENTRA_APP_CLIENT_SECRET:
+    description: Entra app client secret (OIDC scenarios)
+    value: ${{ steps.test-credentials-secret.outputs.ENTRA_APP_CLIENT_SECRET }}
+  ENTRA_APP_OBJECT_ID:
+    description: Entra app object id (OIDC scenarios)
+    value: ${{ steps.test-credentials-secret.outputs.ENTRA_APP_OBJECT_ID }}
+  ENTRA_APP_DIRECTORY_ID:
+    description: Entra app directory id (OIDC scenarios)
+    value: ${{ steps.test-credentials-secret.outputs.ENTRA_APP_DIRECTORY_ID }}
+  AUTH0_DOMAIN:
+    description: Auth0 domain (auth0 scenarios)
+    value: ${{ steps.test-credentials-secret.outputs.AUTH0_DOMAIN }}
+  AUTH0_AUDIENCE:
+    description: Auth0 audience (auth0 scenarios)
+    value: ${{ steps.test-credentials-secret.outputs.AUTH0_AUDIENCE }}
+  AUTH0_MGMT_CLIENT_ID:
+    description: Auth0 management API client id (auth0 scenarios)
+    value: ${{ steps.test-credentials-secret.outputs.AUTH0_MGMT_CLIENT_ID }}
+  AUTH0_MGMT_CLIENT_SECRET:
+    description: Auth0 management API client secret (auth0 scenarios)
+    value: ${{ steps.test-credentials-secret.outputs.AUTH0_MGMT_CLIENT_SECRET }}
+  AUTH0_INITIAL_ADMIN_EMAIL:
+    description: Auth0 initial admin email (auth0 scenarios)
+    value: ${{ steps.test-credentials-secret.outputs.AUTH0_INITIAL_ADMIN_EMAIL }}
+  RDBMS_POSTGRESQL_USERNAME:
+    description: RDBMS PostgreSQL username (rdbms scenarios)
+    value: ${{ steps.test-credentials-secret.outputs.RDBMS_POSTGRESQL_USERNAME }}
+  RDBMS_POSTGRESQL_PASSWORD:
+    description: RDBMS PostgreSQL password (rdbms scenarios)
+    value: ${{ steps.test-credentials-secret.outputs.RDBMS_POSTGRESQL_PASSWORD }}
 
 # Secrets cannot be referenced directly inside a composite action.
 # Callers must forward the required secrets as environment variables using `env:` on the step.
@@ -179,7 +230,7 @@ runs:
           secret/data/products/distribution/ci DISTRO_CI_GCP_GKE_CLUSTER_LOCATION;
           secret/data/products/distribution/ci DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER;
           secret/data/products/distribution/ci DISTRO_CI_GCP_SERVICE_ACCOUNT;
-        exportEnv: true
+        exportEnv: false
 
     # ------------------------------------------------------------------
     # Cluster authentication
@@ -193,10 +244,10 @@ runs:
       env:
         GH_APP_ID:        ${{ env.GH_APP_ID }}
         GH_APP_KEY:       ${{ env.GH_APP_KEY }}
-        GKE_CLUSTER_NAME: ${{ env.DISTRO_CI_GCP_GKE_CLUSTER_NAME }}
-        GKE_CLUSTER_LOC:  ${{ env.DISTRO_CI_GCP_GKE_CLUSTER_LOCATION }}
-        GKE_WIP:          ${{ env.DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
-        GKE_SA:           ${{ env.DISTRO_CI_GCP_SERVICE_ACCOUNT }}
+        GKE_CLUSTER_NAME: ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_GKE_CLUSTER_NAME }}
+        GKE_CLUSTER_LOC:  ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_GKE_CLUSTER_LOCATION }}
+        GKE_WIP:          ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+        GKE_SA:           ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_SERVICE_ACCOUNT }}
         ROSA_URL:         ${{ env.ROSA_URL }}
         ROSA_USER:        ${{ env.ROSA_USER }}
         ROSA_PASS:        ${{ env.ROSA_PASS }}
@@ -238,8 +289,8 @@ runs:
     - name: CI Setup - Login to Docker Hub
       shell: bash
       env:
-        TEST_DOCKER_USERNAME: ${{ env.DISTRO_CI_DOCKER_USERNAME_DOCKERHUB || env.TEST_DOCKER_USERNAME }}
-        TEST_DOCKER_PASSWORD: ${{ env.DISTRO_CI_DOCKER_PASSWORD_DOCKERHUB || env.TEST_DOCKER_PASSWORD }}
+        TEST_DOCKER_USERNAME: ${{ env.DISTRO_CI_DOCKER_USERNAME_DOCKERHUB || steps.test-credentials-secret.outputs.TEST_DOCKER_USERNAME }}
+        TEST_DOCKER_PASSWORD: ${{ env.DISTRO_CI_DOCKER_PASSWORD_DOCKERHUB || steps.test-credentials-secret.outputs.TEST_DOCKER_PASSWORD }}
       run: |
         echo "${TEST_DOCKER_PASSWORD}" | helm registry login registry-1.docker.io -u "${TEST_DOCKER_USERNAME}" --password-stdin
 

--- a/.github/instructions/github-actions.instructions.md
+++ b/.github/instructions/github-actions.instructions.md
@@ -67,11 +67,14 @@ permissions:
 
 ### 2. Vault Secrets Import
 
-All secrets come from Vault. Use `hashicorp/vault-action` **before** any step that needs them:
+All secrets come from Vault. Use `hashicorp/vault-action` **before** any step that needs them.
+Always set `exportEnv: false` so the values are **not** written to the job-wide `$GITHUB_ENV`.
+Give the step an `id:` and pass each secret only into the specific step that consumes it, via
+`${{ steps.<id>.outputs.<NAME> }}`:
 
 ```yaml
 - name: Import Vault secrets
-  uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+  uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
   id: vault
   with:
     url: ${{ secrets.VAULT_ADDR }}
@@ -81,11 +84,31 @@ All secrets come from Vault. Use `hashicorp/vault-action` **before** any step th
     secrets: |
       secret/data/products/distribution/ci GH_APP_ID_DISTRO_CI;
       secret/data/products/distribution/ci GH_APP_PRIVATE_KEY_DISTRO_CI;
-    exportEnv: true
+    exportEnv: false
+
+# Consume in a GitHub Action via its `with:` inputs — no env var needed:
+- name: Generate GitHub token
+  uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
+  with:
+    app_id: ${{ steps.vault.outputs.GH_APP_ID_DISTRO_CI }}
+    private_key: ${{ steps.vault.outputs.GH_APP_PRIVATE_KEY_DISTRO_CI }}
+
+# Consume in a shell `run:` step via a step-scoped `env:` block:
+- name: Use a secret in a script
+  env:
+    GH_APP_ID_DISTRO_CI: ${{ steps.vault.outputs.GH_APP_ID_DISTRO_CI }}
+  run: |
+    echo "app id is ${GH_APP_ID_DISTRO_CI}"
 ```
 
-Reference exported env vars in subsequent steps as `${{ env.GH_APP_ID_DISTRO_CI }}` or
-directly in `run:` scripts (they are exported as shell env vars via `exportEnv: true`).
+Why `exportEnv: false`: the action default (`true`) injects every imported secret into
+`$GITHUB_ENV`, making it readable by **all** subsequent steps in the job — including
+third-party actions that have no need for it. Scoping each secret to its consumer keeps the
+blast radius minimal.
+
+For composite actions: secrets cannot be handed to the calling job via `$GITHUB_ENV` without
+leaking them job-wide. Expose them as the composite's `outputs:` and let the caller wire each
+consuming step's `env:` from `${{ steps.<setup-id>.outputs.<NAME> }}`.
 
 ### 3. Reusable Template Workflow Structure
 
@@ -257,6 +280,11 @@ jobs:
 
 9. **Skipping debug output** — add an info step (`echo "output: ${{ steps.id.outputs.val }}"`)
    after complex composite actions so failures are easier to diagnose.
+
+10. **`exportEnv: true` on `vault-action`** — the default injects every imported secret into
+    job-wide `$GITHUB_ENV`, exposing it to all subsequent steps (and any third-party action)
+    in the job. Always set `exportEnv: false` and consume via `${{ steps.<id>.outputs.<NAME> }}`
+    in the consuming step's `with:` input or a step-scoped `env:` block (see Pattern 2).
 
 ---
 

--- a/.github/instructions/github-actions.instructions.md
+++ b/.github/instructions/github-actions.instructions.md
@@ -285,6 +285,9 @@ jobs:
     job-wide `$GITHUB_ENV`, exposing it to all subsequent steps (and any third-party action)
     in the job. Always set `exportEnv: false` and consume via `${{ steps.<id>.outputs.<NAME> }}`
     in the consuming step's `with:` input or a step-scoped `env:` block (see Pattern 2).
+    **Exception:** the per-scenario mapping step in `integration-test-setup` keeps
+    `exportEnv: true` because the following `vault-secret-mapper` `go run` resolves the mapped
+    secrets through `os.Getenv`; `exportEnv: false` there would yield an empty Secret manifest.
 
 ---
 

--- a/.github/workflows/add-new-issue.yaml
+++ b/.github/workflows/add-new-issue.yaml
@@ -26,14 +26,14 @@ jobs:
           secrets: |
             secret/data/products/distribution/ci GH_APP_ID_DISTRO_CI;
             secret/data/products/distribution/ci GH_APP_PRIVATE_KEY_DISTRO_CI;
-          exportEnv: true
+          exportEnv: false
 
       - name: Generate GitHub token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
         id: generate-github-token
         with:
-          app_id: ${{ env.GH_APP_ID_DISTRO_CI }}
-          private_key: ${{ env.GH_APP_PRIVATE_KEY_DISTRO_CI }}
+          app_id: ${{ steps.vault-harbor.outputs.GH_APP_ID_DISTRO_CI }}
+          private_key: ${{ steps.vault-harbor.outputs.GH_APP_PRIVATE_KEY_DISTRO_CI }}
       
       - name: Add to Distribution Team project
         uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0

--- a/.github/workflows/build-ci-runner-image.yaml
+++ b/.github/workflows/build-ci-runner-image.yaml
@@ -184,14 +184,14 @@ jobs:
           secrets: |
             secret/data/products/distribution/ci GH_APP_ID_DISTRO_CI;
             secret/data/products/distribution/ci GH_APP_PRIVATE_KEY_DISTRO_CI;
-          exportEnv: true
+          exportEnv: false
 
       - name: Generate GitHub App token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
         id: generate-github-token
         with:
-          app_id: ${{ env.GH_APP_ID_DISTRO_CI }}
-          private_key: ${{ env.GH_APP_PRIVATE_KEY_DISTRO_CI }}
+          app_id: ${{ steps.vault-harbor.outputs.GH_APP_ID_DISTRO_CI }}
+          private_key: ${{ steps.vault-harbor.outputs.GH_APP_PRIVATE_KEY_DISTRO_CI }}
           repositories: '["team-distribution"]'
           permissions: '{"packages": "read"}'
 

--- a/.github/workflows/chart-build-dev.yaml
+++ b/.github/workflows/chart-build-dev.yaml
@@ -172,7 +172,7 @@ jobs:
           secrets: |
             secret/data/products/distribution/ci HARBOR_REGISTRY_USER;
             secret/data/products/distribution/ci HARBOR_REGISTRY_PASSWORD;
-          exportEnv: true
+          exportEnv: false
 
       - name: Install tools
         uses: ./.github/actions/install-tool-versions
@@ -210,6 +210,9 @@ jobs:
           /tmp/release-tools inject-values
 
       - name: Login to Harbor registry
+        env:
+          HARBOR_REGISTRY_USER: ${{ steps.secrets.outputs.HARBOR_REGISTRY_USER }}
+          HARBOR_REGISTRY_PASSWORD: ${{ steps.secrets.outputs.HARBOR_REGISTRY_PASSWORD }}
         run: |
           source "${GITHUB_WORKSPACE}/scripts/harbor-retry.sh"
           harbor_login
@@ -294,6 +297,9 @@ jobs:
 
       - name: Check if artifact already exists
         id: check-artifact
+        env:
+          HARBOR_REGISTRY_USER: ${{ steps.secrets.outputs.HARBOR_REGISTRY_USER }}
+          HARBOR_REGISTRY_PASSWORD: ${{ steps.secrets.outputs.HARBOR_REGISTRY_PASSWORD }}
         run: |
           source "${GITHUB_WORKSPACE}/scripts/harbor-retry.sh"
 
@@ -488,6 +494,8 @@ jobs:
         if: env.SKIP_BUILD == 'false'
         env:
           CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          HARBOR_REGISTRY_USER: ${{ steps.secrets.outputs.HARBOR_REGISTRY_USER }}
+          HARBOR_REGISTRY_PASSWORD: ${{ steps.secrets.outputs.HARBOR_REGISTRY_PASSWORD }}
         run: |
           source "${GITHUB_WORKSPACE}/scripts/harbor-retry.sh"
           OCI_REGISTRY="${HARBOR_REGISTRY_HOST}/${HARBOR_REGISTRY_PROJECT}"

--- a/.github/workflows/chart-chores.yaml
+++ b/.github/workflows/chart-chores.yaml
@@ -29,7 +29,7 @@ jobs:
           secrets: |
             secret/data/products/distribution/ci GH_APP_ID_DISTRO_CI;
             secret/data/products/distribution/ci GH_APP_PRIVATE_KEY_DISTRO_CI;
-          exportEnv: true
+          exportEnv: false
       #
       # Checkout.
       #
@@ -37,8 +37,8 @@ jobs:
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
         id: generate-github-token
         with:
-          app_id: ${{ env.GH_APP_ID_DISTRO_CI }}
-          private_key: ${{ env.GH_APP_PRIVATE_KEY_DISTRO_CI }}
+          app_id: ${{ steps.vault-harbor.outputs.GH_APP_ID_DISTRO_CI }}
+          private_key: ${{ steps.vault-harbor.outputs.GH_APP_PRIVATE_KEY_DISTRO_CI }}
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:

--- a/.github/workflows/chart-promote-rc.yaml
+++ b/.github/workflows/chart-promote-rc.yaml
@@ -65,14 +65,14 @@ jobs:
             secret/data/products/distribution/ci GH_APP_PRIVATE_KEY_DISTRO_CI;
             secret/data/products/distribution/ci HARBOR_REGISTRY_USER;
             secret/data/products/distribution/ci HARBOR_REGISTRY_PASSWORD;
-          exportEnv: true
+          exportEnv: false
 
       - name: Generate GitHub token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
         id: generate-github-token
         with:
-          app_id: ${{ env.GH_APP_ID_DISTRO_CI }}
-          private_key: ${{ env.GH_APP_PRIVATE_KEY_DISTRO_CI }}
+          app_id: ${{ steps.test-credentials-secret.outputs.GH_APP_ID_DISTRO_CI }}
+          private_key: ${{ steps.test-credentials-secret.outputs.GH_APP_PRIVATE_KEY_DISTRO_CI }}
 
       # "Parse dev tag" runs before the commit SHA is known, so build release-tools
       # here. The binary in /tmp survives the later checkout-at-SHA.
@@ -93,6 +93,8 @@ jobs:
         env:
           HARBOR_API: "https://${{ env.HARBOR_REGISTRY }}/api/v2.0"
           HARBOR_REPO: "projects/${{ env.HARBOR_PROJECT }}/repositories/camunda-platform"
+          HARBOR_REGISTRY_USER: ${{ steps.test-credentials-secret.outputs.HARBOR_REGISTRY_USER }}
+          HARBOR_REGISTRY_PASSWORD: ${{ steps.test-credentials-secret.outputs.HARBOR_REGISTRY_PASSWORD }}
         run: |
           input_tag="${{ inputs.dev-tag }}"
 
@@ -145,6 +147,9 @@ jobs:
           fi
 
       - name: Login to Harbor
+        env:
+          HARBOR_REGISTRY_USER: ${{ steps.test-credentials-secret.outputs.HARBOR_REGISTRY_USER }}
+          HARBOR_REGISTRY_PASSWORD: ${{ steps.test-credentials-secret.outputs.HARBOR_REGISTRY_PASSWORD }}
         run: |
           # Retrying registry login; harbor_helm_pull below also re-auths on 401.
           source "${GITHUB_WORKSPACE}/scripts/harbor-retry.sh"
@@ -158,6 +163,9 @@ jobs:
 
       - name: Pull and validate dev package
         id: package
+        env:
+          HARBOR_REGISTRY_USER: ${{ steps.test-credentials-secret.outputs.HARBOR_REGISTRY_USER }}
+          HARBOR_REGISTRY_PASSWORD: ${{ steps.test-credentials-secret.outputs.HARBOR_REGISTRY_PASSWORD }}
         run: |
           source "${GITHUB_WORKSPACE}/scripts/harbor-retry.sh"
           echo "Checking for package: ${{ steps.parse.outputs.resolved_tag }}"
@@ -274,6 +282,8 @@ jobs:
         env:
           HARBOR_API: "https://${{ env.HARBOR_REGISTRY }}/api/v2.0"
           HARBOR_REPO: "projects/${{ env.HARBOR_PROJECT }}/repositories/camunda-platform"
+          HARBOR_REGISTRY_USER: ${{ steps.test-credentials-secret.outputs.HARBOR_REGISTRY_USER }}
+          HARBOR_REGISTRY_PASSWORD: ${{ steps.test-credentials-secret.outputs.HARBOR_REGISTRY_PASSWORD }}
         run: |
           set -euo pipefail
           # Point {version}-rc and {major}-rc-latest at the dev artifact's digest,

--- a/.github/workflows/chart-release-artifact-verify.yaml
+++ b/.github/workflows/chart-release-artifact-verify.yaml
@@ -28,7 +28,7 @@ jobs:
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           secrets: |
             secret/data/products/distribution/ci SLACK_DISTRO_BOT_WEBHOOK;
-          exportEnv: true
+          exportEnv: false
       - name: Get chart versions
         id: get-chart-versions
         uses: ./.github/actions/get-chart-versions
@@ -136,7 +136,7 @@ jobs:
         if: failure()
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
-          webhook: ${{ env.SLACK_DISTRO_BOT_WEBHOOK }}
+          webhook: ${{ steps.test-credentials-secret.outputs.SLACK_DISTRO_BOT_WEBHOOK }}
           webhook-type: incoming-webhook
           payload: |
             blocks:

--- a/.github/workflows/chart-release-chores.yaml
+++ b/.github/workflows/chart-release-chores.yaml
@@ -35,14 +35,14 @@ jobs:
           secrets: |
             secret/data/products/distribution/ci GH_APP_ID_DISTRO_CI;
             secret/data/products/distribution/ci GH_APP_PRIVATE_KEY_DISTRO_CI;
-          exportEnv: true
+          exportEnv: false
       # Checkout.
       - name: Generate GitHub token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
         id: generate-github-token
         with:
-          app_id: ${{ env.GH_APP_ID_DISTRO_CI }}
-          private_key: ${{ env.GH_APP_PRIVATE_KEY_DISTRO_CI }}
+          app_id: ${{ steps.vault-harbor.outputs.GH_APP_ID_DISTRO_CI }}
+          private_key: ${{ steps.vault-harbor.outputs.GH_APP_PRIVATE_KEY_DISTRO_CI }}
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:

--- a/.github/workflows/chart-release-public.yaml
+++ b/.github/workflows/chart-release-public.yaml
@@ -130,12 +130,18 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Login to Harbor
+        env:
+          HARBOR_REGISTRY_USER: ${{ steps.vault-harbor.outputs.HARBOR_REGISTRY_USER }}
+          HARBOR_REGISTRY_PASSWORD: ${{ steps.vault-harbor.outputs.HARBOR_REGISTRY_PASSWORD }}
         run: |
           # Retrying registry login; harbor_helm_pull below also re-auths on 401.
           source "${GITHUB_WORKSPACE}/scripts/harbor-retry.sh"
           harbor_login
 
       - name: Pull RC package from Harbor
+        env:
+          HARBOR_REGISTRY_USER: ${{ steps.vault-harbor.outputs.HARBOR_REGISTRY_USER }}
+          HARBOR_REGISTRY_PASSWORD: ${{ steps.vault-harbor.outputs.HARBOR_REGISTRY_PASSWORD }}
         run: |
           source "${GITHUB_WORKSPACE}/scripts/harbor-retry.sh"
           mkdir -p .cr-release-packages

--- a/.github/workflows/chart-release-public.yaml
+++ b/.github/workflows/chart-release-public.yaml
@@ -55,14 +55,14 @@ jobs:
             secret/data/products/distribution/ci HARBOR_REGISTRY_PASSWORD;
             secret/data/products/distribution/ci GH_APP_ID_DISTRO_CI;
             secret/data/products/distribution/ci GH_APP_PRIVATE_KEY_DISTRO_CI;
-          exportEnv: true
+          exportEnv: false
 
       - name: Generate GitHub token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
         id: generate-github-token
         with:
-          app_id: ${{ env.GH_APP_ID_DISTRO_CI }}
-          private_key: ${{ env.GH_APP_PRIVATE_KEY_DISTRO_CI }}
+          app_id: ${{ steps.vault-harbor.outputs.GH_APP_ID_DISTRO_CI }}
+          private_key: ${{ steps.vault-harbor.outputs.GH_APP_PRIVATE_KEY_DISTRO_CI }}
 
       # "Parse RC tag" runs before the main checkout, so build release-tools here.
       # The binary in /tmp survives the later checkout.
@@ -83,6 +83,8 @@ jobs:
         env:
           HARBOR_API: "https://${{ env.HARBOR_REGISTRY }}/api/v2.0"
           HARBOR_REPO: "projects/${{ env.HARBOR_PROJECT }}/repositories/camunda-platform"
+          HARBOR_REGISTRY_USER: ${{ steps.vault-harbor.outputs.HARBOR_REGISTRY_USER }}
+          HARBOR_REGISTRY_PASSWORD: ${{ steps.vault-harbor.outputs.HARBOR_REGISTRY_PASSWORD }}
         run: |
           input_tag="${{ inputs.rc-tag }}"
 
@@ -343,14 +345,14 @@ jobs:
           secrets: |
             secret/data/products/distribution/ci GH_APP_ID_DISTRO_CI;
             secret/data/products/distribution/ci GH_APP_PRIVATE_KEY_DISTRO_CI;
-          exportEnv: true
+          exportEnv: false
 
       - name: Generate GitHub token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
         id: generate-github-token
         with:
-          app_id: ${{ env.GH_APP_ID_DISTRO_CI }}
-          private_key: ${{ env.GH_APP_PRIVATE_KEY_DISTRO_CI }}
+          app_id: ${{ steps.vault-harbor.outputs.GH_APP_ID_DISTRO_CI }}
+          private_key: ${{ steps.vault-harbor.outputs.GH_APP_PRIVATE_KEY_DISTRO_CI }}
 
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -513,14 +515,14 @@ jobs:
             secret/data/products/distribution/ci GH_APP_ID_DISTRO_CI;
             secret/data/products/distribution/ci GH_APP_PRIVATE_KEY_DISTRO_CI;
             secret/data/products/distribution/ci SLACK_DISTRO_BOT_WEBHOOK;
-          exportEnv: true
+          exportEnv: false
 
       - name: Generate GitHub token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
         id: generate-github-token
         with:
-          app_id: ${{ env.GH_APP_ID_DISTRO_CI }}
-          private_key: ${{ env.GH_APP_PRIVATE_KEY_DISTRO_CI }}
+          app_id: ${{ steps.secrets.outputs.GH_APP_ID_DISTRO_CI }}
+          private_key: ${{ steps.secrets.outputs.GH_APP_PRIVATE_KEY_DISTRO_CI }}
 
       - name: Shepherd release-please PR through merge queue
         id: merge-queue

--- a/.github/workflows/cleanup-namespace.yaml
+++ b/.github/workflows/cleanup-namespace.yaml
@@ -93,7 +93,7 @@ jobs:
             secret/data/products/distribution/ci DISTRO_CI_GCP_GKE_CLUSTER_LOCATION;
             secret/data/products/distribution/ci DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER;
             secret/data/products/distribution/ci DISTRO_CI_GCP_SERVICE_ACCOUNT;
-          exportEnv: true
+          exportEnv: false
 
       - name: CI Setup - Authenticate to cluster
         id: cluster-auth
@@ -104,10 +104,10 @@ jobs:
         env:
           GH_APP_ID:        ${{ secrets.GH_APP_ID_DISTRO_CI_MANAGE_GH_ENVS }}
           GH_APP_KEY:       ${{ secrets.GH_APP_PRIVATE_KEY_DISTRO_CI_MANAGE_GH_ENVS }}
-          GKE_CLUSTER_NAME: ${{ env.DISTRO_CI_GCP_GKE_CLUSTER_NAME }}
-          GKE_CLUSTER_LOC:  ${{ env.DISTRO_CI_GCP_GKE_CLUSTER_LOCATION }}
-          GKE_WIP:          ${{ env.DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          GKE_SA:           ${{ env.DISTRO_CI_GCP_SERVICE_ACCOUNT }}
+          GKE_CLUSTER_NAME: ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_GKE_CLUSTER_NAME }}
+          GKE_CLUSTER_LOC:  ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_GKE_CLUSTER_LOCATION }}
+          GKE_WIP:          ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GKE_SA:           ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_SERVICE_ACCOUNT }}
           ROSA_URL:         ${{ secrets[fromJson(steps.load-config.outputs.distro_config).secret.server-url] }}
           ROSA_USER:        ${{ secrets[fromJson(steps.load-config.outputs.distro_config).secret.username] }}
           ROSA_PASS:        ${{ secrets[fromJson(steps.load-config.outputs.distro_config).secret.password] }}

--- a/.github/workflows/cleanup-opensearch-entra.yaml
+++ b/.github/workflows/cleanup-opensearch-entra.yaml
@@ -37,7 +37,7 @@ jobs:
             secret/data/products/distribution/ci DISTRO_CI_GCP_GKE_CLUSTER_LOCATION;
             secret/data/products/distribution/ci DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER;
             secret/data/products/distribution/ci DISTRO_CI_GCP_SERVICE_ACCOUNT;
-          exportEnv: true
+          exportEnv: false
       - name: Configure curl and wget
         uses: ./.github/actions/setup-curl
       - name: Load infra config
@@ -53,11 +53,14 @@ jobs:
       - name: Authenticate to GKE
         uses: ./.github/actions/gke-login
         with:
-          cluster-name: ${{ env.DISTRO_CI_GCP_GKE_CLUSTER_NAME }}
-          cluster-location: ${{ env.DISTRO_CI_GCP_GKE_CLUSTER_LOCATION }}
-          workload-identity-provider: ${{ env.DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service-account: ${{ env.DISTRO_CI_GCP_SERVICE_ACCOUNT }}
+          cluster-name: ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_GKE_CLUSTER_NAME }}
+          cluster-location: ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_GKE_CLUSTER_LOCATION }}
+          workload-identity-provider: ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service-account: ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_SERVICE_ACCOUNT }}
       - name: get basicauth var
+        env:
+          OPENSEARCH_USERNAME: ${{ steps.test-credentials-secret.outputs.OPENSEARCH_USERNAME }}
+          OPENSEARCH_PASSWORD: ${{ steps.test-credentials-secret.outputs.OPENSEARCH_PASSWORD }}
         run: |
           echo "OPENSEARCH_BASIC_AUTH_BASE64=$(echo -n "${OPENSEARCH_USERNAME}:${OPENSEARCH_PASSWORD}" | base64)" >> $GITHUB_ENV
       - name: cleanup OpenSearch
@@ -250,6 +253,11 @@ jobs:
           fi
       - name: cleanup Entra
         shell: bash
+        env:
+          ENTRA_APP_DIRECTORY_ID: ${{ steps.test-credentials-secret.outputs.ENTRA_APP_DIRECTORY_ID }}
+          ENTRA_APP_CLIENT_ID: ${{ steps.test-credentials-secret.outputs.ENTRA_APP_CLIENT_ID }}
+          ENTRA_APP_CLIENT_SECRET: ${{ steps.test-credentials-secret.outputs.ENTRA_APP_CLIENT_SECRET }}
+          ENTRA_APP_OBJECT_ID: ${{ steps.test-credentials-secret.outputs.ENTRA_APP_OBJECT_ID }}
         run: |
           RESPONSE=$(curl -X POST \
             https://login.microsoftonline.com/${ENTRA_APP_DIRECTORY_ID}/oauth2/v2.0/token \

--- a/.github/workflows/closed-issue.yaml
+++ b/.github/workflows/closed-issue.yaml
@@ -27,14 +27,14 @@ jobs:
           secrets: |
             secret/data/products/distribution/ci GH_APP_ID_DISTRO_CI;
             secret/data/products/distribution/ci GH_APP_PRIVATE_KEY_DISTRO_CI;
-          exportEnv: true
+          exportEnv: false
 
       - name: Generate GitHub token
         id: generate-github-token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
         with:
-          app_id: ${{ env.GH_APP_ID_DISTRO_CI }}
-          private_key: ${{ env.GH_APP_PRIVATE_KEY_DISTRO_CI }}
+          app_id: ${{ steps.vault-harbor.outputs.GH_APP_ID_DISTRO_CI }}
+          private_key: ${{ steps.vault-harbor.outputs.GH_APP_PRIVATE_KEY_DISTRO_CI }}
 
       - name: Update Closed At field
         uses: github/update-project-action@af4f6083118f5080c89828b421ef598d1906fb60 # main

--- a/.github/workflows/notify-pr-activity.yml
+++ b/.github/workflows/notify-pr-activity.yml
@@ -145,12 +145,12 @@ jobs:
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           secrets: |
             secret/data/products/distribution/ci SLACK_DISTRO_BOT_WEBHOOK_GH;
-          exportEnv: true
+          exportEnv: false
 
       - name: Send Slack notification
         continue-on-error: true
         env:
-          SLACK_WEBHOOK: ${{ env.SLACK_DISTRO_BOT_WEBHOOK_GH }}
+          SLACK_WEBHOOK: ${{ steps.vault-secrets.outputs.SLACK_DISTRO_BOT_WEBHOOK_GH }}
           # Resolve from workflow_call inputs first, fall back to pull_request_target event
           GH_ACTION:        ${{ inputs.action        || github.event.action }}
           PR_REPO:          ${{ inputs.pr_repo        || github.event.repository.name }}

--- a/.github/workflows/renovate-post-upgrade.yaml
+++ b/.github/workflows/renovate-post-upgrade.yaml
@@ -39,7 +39,7 @@ jobs:
           secrets: |
             secret/data/products/distribution/ci GH_APP_ID_DISTRO_CI;
             secret/data/products/distribution/ci GH_APP_PRIVATE_KEY_DISTRO_CI;
-          exportEnv: true
+          exportEnv: false
       #
       # Checkout.
       #
@@ -47,8 +47,8 @@ jobs:
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
         id: generate-github-token
         with:
-          app_id: ${{ env.GH_APP_ID_DISTRO_CI }}
-          private_key: ${{ env.GH_APP_PRIVATE_KEY_DISTRO_CI }}
+          app_id: ${{ steps.vault-harbor.outputs.GH_APP_ID_DISTRO_CI }}
+          private_key: ${{ steps.vault-harbor.outputs.GH_APP_PRIVATE_KEY_DISTRO_CI }}
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           token: '${{ steps.generate-github-token.outputs.token }}'

--- a/.github/workflows/test-integration-cleanup-template.yaml
+++ b/.github/workflows/test-integration-cleanup-template.yaml
@@ -72,16 +72,16 @@ jobs:
           secret/data/products/distribution/ci DISTRO_CI_GCP_GKE_CLUSTER_LOCATION;
           secret/data/products/distribution/ci DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER;
           secret/data/products/distribution/ci DISTRO_CI_GCP_SERVICE_ACCOUNT;
-        exportEnv: true
+        exportEnv: false
     # TODO: Later, find a way to abstract the auth for different platforms.
     - name: Authenticate to GKE
       if: matrix.distro.platform == 'gke'
       uses: ./.github/actions/gke-login
       with:
-        cluster-name: ${{ env.DISTRO_CI_GCP_GKE_CLUSTER_NAME }}
-        cluster-location: ${{ env.DISTRO_CI_GCP_GKE_CLUSTER_LOCATION }}
-        workload-identity-provider: ${{ env.DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
-        service-account: ${{ env.DISTRO_CI_GCP_SERVICE_ACCOUNT }}
+        cluster-name: ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_GKE_CLUSTER_NAME }}
+        cluster-location: ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_GKE_CLUSTER_LOCATION }}
+        workload-identity-provider: ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+        service-account: ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_SERVICE_ACCOUNT }}
     - name: Authenticate to OpenShift
       if: matrix.distro.platform == 'rosa'
       uses: redhat-actions/oc-login@5eb45e848b168b6bf6b8fe7f1561003c12e3c99d # v1

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -476,8 +476,10 @@ jobs:
             --dry-run=client -o yaml | kubectl apply -f -
           fi
         env:
-          TEST_DOCKER_USERNAME_CAMUNDA_CLOUD: ${{ env.TEST_DOCKER_USERNAME_CAMUNDA_CLOUD || env.NEXUS_USERNAME }}
-          TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD: ${{ env.TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD || env.NEXUS_PASSWORD }}
+          TEST_DOCKER_USERNAME_CAMUNDA_CLOUD: ${{ steps.setup.outputs.TEST_DOCKER_USERNAME_CAMUNDA_CLOUD || steps.setup.outputs.NEXUS_USERNAME }}
+          TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD: ${{ steps.setup.outputs.TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD || steps.setup.outputs.NEXUS_PASSWORD }}
+          TEST_DOCKER_USERNAME: ${{ steps.setup.outputs.TEST_DOCKER_USERNAME }}
+          TEST_DOCKER_PASSWORD: ${{ steps.setup.outputs.TEST_DOCKER_PASSWORD }}
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -511,6 +513,10 @@ jobs:
             ${{ env.TEST_HELM_EXTRA_ARGS }}
             ${{ steps.setup.outputs.legacy-ingress-arg }}
             --set global.host=${{ steps.setup.outputs.ingress-host }}
+          ENTRA_APP_CLIENT_ID: ${{ steps.setup.outputs.ENTRA_APP_CLIENT_ID }}
+          ENTRA_APP_CLIENT_SECRET: ${{ steps.setup.outputs.ENTRA_APP_CLIENT_SECRET }}
+          ENTRA_APP_OBJECT_ID: ${{ steps.setup.outputs.ENTRA_APP_OBJECT_ID }}
+          ENTRA_APP_DIRECTORY_ID: ${{ steps.setup.outputs.ENTRA_APP_DIRECTORY_ID }}
         run: |
           echo "Extra values from workflow:"
           echo "$EXTRA_VALUES" | tee /tmp/extra-values-file.yaml
@@ -541,6 +547,9 @@ jobs:
 
       - name: Helm - OCI Registry Login
         if: inputs.helmChartVersion != ''
+        env:
+          TEST_DOCKER_USERNAME_CAMUNDA_CLOUD: ${{ steps.setup.outputs.TEST_DOCKER_USERNAME_CAMUNDA_CLOUD }}
+          TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD: ${{ steps.setup.outputs.TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD }}
         run: |
           export HARBOR_REGISTRY_HOST=registry.camunda.cloud
           export HARBOR_REGISTRY_USER="${TEST_DOCKER_USERNAME_CAMUNDA_CLOUD}"
@@ -581,6 +590,20 @@ jobs:
           TEST_VALUES_SCENARIO: "${{ inputs.scenario }}"
           VALUES_CONFIG: ${{ inputs.values-config }}
           HELM_CHART_VERSION: ${{ inputs.helmChartVersion }}
+          TEST_DOCKER_USERNAME_CAMUNDA_CLOUD: ${{ steps.setup.outputs.TEST_DOCKER_USERNAME_CAMUNDA_CLOUD }}
+          TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD: ${{ steps.setup.outputs.TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD }}
+          NEXUS_USERNAME: ${{ steps.setup.outputs.NEXUS_USERNAME }}
+          NEXUS_PASSWORD: ${{ steps.setup.outputs.NEXUS_PASSWORD }}
+          TEST_DOCKER_USERNAME: ${{ steps.setup.outputs.TEST_DOCKER_USERNAME }}
+          TEST_DOCKER_PASSWORD: ${{ steps.setup.outputs.TEST_DOCKER_PASSWORD }}
+          ENTRA_APP_CLIENT_ID: ${{ steps.setup.outputs.ENTRA_APP_CLIENT_ID }}
+          AUTH0_DOMAIN: ${{ steps.setup.outputs.AUTH0_DOMAIN }}
+          AUTH0_AUDIENCE: ${{ steps.setup.outputs.AUTH0_AUDIENCE }}
+          AUTH0_MGMT_CLIENT_ID: ${{ steps.setup.outputs.AUTH0_MGMT_CLIENT_ID }}
+          AUTH0_MGMT_CLIENT_SECRET: ${{ steps.setup.outputs.AUTH0_MGMT_CLIENT_SECRET }}
+          AUTH0_INITIAL_ADMIN_EMAIL: ${{ steps.setup.outputs.AUTH0_INITIAL_ADMIN_EMAIL }}
+          RDBMS_POSTGRESQL_USERNAME: ${{ steps.setup.outputs.RDBMS_POSTGRESQL_USERNAME }}
+          RDBMS_POSTGRESQL_PASSWORD: ${{ steps.setup.outputs.RDBMS_POSTGRESQL_PASSWORD }}
         run: |
           set -euo pipefail
           CHART_VERSION="${CAMUNDA_HELM_DIR#camunda-platform-}"
@@ -854,6 +877,10 @@ jobs:
             ${{ env.TEST_HELM_EXTRA_ARGS }}
             ${{ steps.setup.outputs.legacy-ingress-arg }}
             --set global.host=${{ steps.setup.outputs.ingress-host }}
+          ENTRA_APP_CLIENT_ID: ${{ steps.setup.outputs.ENTRA_APP_CLIENT_ID }}
+          ENTRA_APP_CLIENT_SECRET: ${{ steps.setup.outputs.ENTRA_APP_CLIENT_SECRET }}
+          ENTRA_APP_OBJECT_ID: ${{ steps.setup.outputs.ENTRA_APP_OBJECT_ID }}
+          ENTRA_APP_DIRECTORY_ID: ${{ steps.setup.outputs.ENTRA_APP_DIRECTORY_ID }}
         run: |
           echo "Extra values from workflow:"
           echo "$EXTRA_VALUES" | tee /tmp/extra-values-file.yaml
@@ -886,6 +913,9 @@ jobs:
 
       - name: Helm - OCI Registry Login (Upgrade)
         if: inputs.helmChartVersion != ''
+        env:
+          TEST_DOCKER_USERNAME_CAMUNDA_CLOUD: ${{ steps.setup.outputs.TEST_DOCKER_USERNAME_CAMUNDA_CLOUD }}
+          TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD: ${{ steps.setup.outputs.TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD }}
         run: |
           export HARBOR_REGISTRY_HOST=registry.camunda.cloud
           export HARBOR_REGISTRY_USER="${TEST_DOCKER_USERNAME_CAMUNDA_CLOUD}"
@@ -916,6 +946,20 @@ jobs:
           TEST_VALUES_SCENARIO: "${{ inputs.scenario }}"
           VALUES_CONFIG: ${{ inputs.values-config }}
           HELM_CHART_VERSION: ${{ inputs.helmChartVersion }}
+          TEST_DOCKER_USERNAME_CAMUNDA_CLOUD: ${{ steps.setup.outputs.TEST_DOCKER_USERNAME_CAMUNDA_CLOUD }}
+          TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD: ${{ steps.setup.outputs.TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD }}
+          NEXUS_USERNAME: ${{ steps.setup.outputs.NEXUS_USERNAME }}
+          NEXUS_PASSWORD: ${{ steps.setup.outputs.NEXUS_PASSWORD }}
+          TEST_DOCKER_USERNAME: ${{ steps.setup.outputs.TEST_DOCKER_USERNAME }}
+          TEST_DOCKER_PASSWORD: ${{ steps.setup.outputs.TEST_DOCKER_PASSWORD }}
+          ENTRA_APP_CLIENT_ID: ${{ steps.setup.outputs.ENTRA_APP_CLIENT_ID }}
+          AUTH0_DOMAIN: ${{ steps.setup.outputs.AUTH0_DOMAIN }}
+          AUTH0_AUDIENCE: ${{ steps.setup.outputs.AUTH0_AUDIENCE }}
+          AUTH0_MGMT_CLIENT_ID: ${{ steps.setup.outputs.AUTH0_MGMT_CLIENT_ID }}
+          AUTH0_MGMT_CLIENT_SECRET: ${{ steps.setup.outputs.AUTH0_MGMT_CLIENT_SECRET }}
+          AUTH0_INITIAL_ADMIN_EMAIL: ${{ steps.setup.outputs.AUTH0_INITIAL_ADMIN_EMAIL }}
+          RDBMS_POSTGRESQL_USERNAME: ${{ steps.setup.outputs.RDBMS_POSTGRESQL_USERNAME }}
+          RDBMS_POSTGRESQL_PASSWORD: ${{ steps.setup.outputs.RDBMS_POSTGRESQL_PASSWORD }}
         run: |
           set -euo pipefail
           CHART_VERSION="${CAMUNDA_HELM_DIR#camunda-platform-}"
@@ -1061,17 +1105,17 @@ jobs:
             secret/data/products/distribution/ci DISTRO_CI_GCP_GKE_CLUSTER_LOCATION;
             secret/data/products/distribution/ci DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER;
             secret/data/products/distribution/ci DISTRO_CI_GCP_SERVICE_ACCOUNT;
-          exportEnv: true
+          exportEnv: false
 
       - name: Run Playwright E2E Tests
         uses: ./.github/actions/playwright-e2e-tests
         env:
           GH_APP_ID:        ${{ secrets.GH_APP_ID_DISTRO_CI_MANAGE_GH_ENVS }}
           GH_APP_KEY:       ${{ secrets.GH_APP_PRIVATE_KEY_DISTRO_CI_MANAGE_GH_ENVS }}
-          GKE_CLUSTER_NAME: ${{ env.DISTRO_CI_GCP_GKE_CLUSTER_NAME }}
-          GKE_CLUSTER_LOC:  ${{ env.DISTRO_CI_GCP_GKE_CLUSTER_LOCATION }}
-          GKE_WIP:          ${{ env.DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          GKE_SA:           ${{ env.DISTRO_CI_GCP_SERVICE_ACCOUNT }}
+          GKE_CLUSTER_NAME: ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_GKE_CLUSTER_NAME }}
+          GKE_CLUSTER_LOC:  ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_GKE_CLUSTER_LOCATION }}
+          GKE_WIP:          ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GKE_SA:           ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_SERVICE_ACCOUNT }}
           ROSA_URL:         ${{ secrets[inputs.server-url] }}
           ROSA_USER:        ${{ secrets[inputs.username] }}
           ROSA_PASS:        ${{ secrets[inputs.password] }}
@@ -1136,17 +1180,17 @@ jobs:
             secret/data/products/distribution/ci DISTRO_CI_GCP_GKE_CLUSTER_LOCATION;
             secret/data/products/distribution/ci DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER;
             secret/data/products/distribution/ci DISTRO_CI_GCP_SERVICE_ACCOUNT;
-          exportEnv: true
+          exportEnv: false
 
       - name: Run full E2E suite (shadow)
         uses: ./.github/actions/playwright-e2e-tests
         env:
           GH_APP_ID:        ${{ secrets.GH_APP_ID_DISTRO_CI_MANAGE_GH_ENVS }}
           GH_APP_KEY:       ${{ secrets.GH_APP_PRIVATE_KEY_DISTRO_CI_MANAGE_GH_ENVS }}
-          GKE_CLUSTER_NAME: ${{ env.DISTRO_CI_GCP_GKE_CLUSTER_NAME }}
-          GKE_CLUSTER_LOC:  ${{ env.DISTRO_CI_GCP_GKE_CLUSTER_LOCATION }}
-          GKE_WIP:          ${{ env.DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          GKE_SA:           ${{ env.DISTRO_CI_GCP_SERVICE_ACCOUNT }}
+          GKE_CLUSTER_NAME: ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_GKE_CLUSTER_NAME }}
+          GKE_CLUSTER_LOC:  ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_GKE_CLUSTER_LOCATION }}
+          GKE_WIP:          ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GKE_SA:           ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_SERVICE_ACCOUNT }}
           ROSA_URL:         ${{ secrets[inputs.server-url] }}
           ROSA_USER:        ${{ secrets[inputs.username] }}
           ROSA_PASS:        ${{ secrets[inputs.password] }}
@@ -1216,17 +1260,17 @@ jobs:
             secret/data/products/distribution/ci DISTRO_CI_GCP_GKE_CLUSTER_LOCATION;
             secret/data/products/distribution/ci DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER;
             secret/data/products/distribution/ci DISTRO_CI_GCP_SERVICE_ACCOUNT;
-          exportEnv: true
+          exportEnv: false
 
       - name: Run Playwright E2E Tests
         uses: ./.github/actions/playwright-e2e-tests
         env:
           GH_APP_ID:        ${{ secrets.GH_APP_ID_DISTRO_CI_MANAGE_GH_ENVS }}
           GH_APP_KEY:       ${{ secrets.GH_APP_PRIVATE_KEY_DISTRO_CI_MANAGE_GH_ENVS }}
-          GKE_CLUSTER_NAME: ${{ env.DISTRO_CI_GCP_GKE_CLUSTER_NAME }}
-          GKE_CLUSTER_LOC:  ${{ env.DISTRO_CI_GCP_GKE_CLUSTER_LOCATION }}
-          GKE_WIP:          ${{ env.DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          GKE_SA:           ${{ env.DISTRO_CI_GCP_SERVICE_ACCOUNT }}
+          GKE_CLUSTER_NAME: ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_GKE_CLUSTER_NAME }}
+          GKE_CLUSTER_LOC:  ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_GKE_CLUSTER_LOCATION }}
+          GKE_WIP:          ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GKE_SA:           ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_SERVICE_ACCOUNT }}
           ROSA_URL:         ${{ secrets[inputs.server-url] }}
           ROSA_USER:        ${{ secrets[inputs.username] }}
           ROSA_PASS:        ${{ secrets[inputs.password] }}
@@ -1455,7 +1499,7 @@ jobs:
             secret/data/products/distribution/ci ENTRA_APP_CLIENT_SECRET;
             secret/data/products/distribution/ci ENTRA_APP_OBJECT_ID;
             secret/data/products/distribution/ci ENTRA_APP_DIRECTORY_ID;
-          exportEnv: true
+          exportEnv: false
 
       - name: CI Setup - Authenticate to cluster
         id: cluster-auth
@@ -1466,10 +1510,10 @@ jobs:
         env:
           GH_APP_ID:        ${{ secrets.GH_APP_ID_DISTRO_CI_MANAGE_GH_ENVS }}
           GH_APP_KEY:       ${{ secrets.GH_APP_PRIVATE_KEY_DISTRO_CI_MANAGE_GH_ENVS }}
-          GKE_CLUSTER_NAME: ${{ env.DISTRO_CI_GCP_GKE_CLUSTER_NAME }}
-          GKE_CLUSTER_LOC:  ${{ env.DISTRO_CI_GCP_GKE_CLUSTER_LOCATION }}
-          GKE_WIP:          ${{ env.DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          GKE_SA:           ${{ env.DISTRO_CI_GCP_SERVICE_ACCOUNT }}
+          GKE_CLUSTER_NAME: ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_GKE_CLUSTER_NAME }}
+          GKE_CLUSTER_LOC:  ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_GKE_CLUSTER_LOCATION }}
+          GKE_WIP:          ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GKE_SA:           ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_SERVICE_ACCOUNT }}
           ROSA_URL:         ${{ secrets[inputs.server-url] }}
           ROSA_USER:        ${{ secrets[inputs.username] }}
           ROSA_PASS:        ${{ secrets[inputs.password] }}
@@ -1488,6 +1532,11 @@ jobs:
       - name: CI Cleanup - Delete venom Entra app registration
         if: always() && (inputs.auth == 'oidc' || inputs.scenario == 'oidc' || inputs.test-identity == 'oidc')
         continue-on-error: true
+        env:
+          ENTRA_APP_CLIENT_ID: ${{ steps.test-credentials-secret.outputs.ENTRA_APP_CLIENT_ID }}
+          ENTRA_APP_CLIENT_SECRET: ${{ steps.test-credentials-secret.outputs.ENTRA_APP_CLIENT_SECRET }}
+          ENTRA_APP_OBJECT_ID: ${{ steps.test-credentials-secret.outputs.ENTRA_APP_OBJECT_ID }}
+          ENTRA_APP_DIRECTORY_ID: ${{ steps.test-credentials-secret.outputs.ENTRA_APP_DIRECTORY_ID }}
         run: |
           cd ./scripts/deploy-camunda
           go run . entra cleanup-venom-app \
@@ -1499,11 +1548,12 @@ jobs:
         # per-component first-party clients in the tenant via
         # `auth0 ensure-clients`; namespace deletion does not touch the
         # tenant, so without this step orphans accumulate across PR runs.
-        # AUTH0_DOMAIN / AUTH0_MGMT_CLIENT_ID / AUTH0_MGMT_CLIENT_SECRET
-        # are already exported to $GITHUB_ENV by the integration-test-setup
-        # action's vault mapping.
         if: always() && inputs.scenario == 'auth0'
         continue-on-error: true
+        env:
+          AUTH0_DOMAIN: ${{ steps.test-credentials-secret.outputs.AUTH0_DOMAIN }}
+          AUTH0_MGMT_CLIENT_ID: ${{ steps.test-credentials-secret.outputs.AUTH0_MGMT_CLIENT_ID }}
+          AUTH0_MGMT_CLIENT_SECRET: ${{ steps.test-credentials-secret.outputs.AUTH0_MGMT_CLIENT_SECRET }}
         run: |
           cd ./scripts/deploy-camunda
           go run . auth0 cleanup-clients \
@@ -1513,6 +1563,9 @@ jobs:
 
       - name: CI Cleanup
         if: always() && inputs.always-delete-namespace
+        env:
+          OPENSEARCH_USERNAME: ${{ steps.test-credentials-secret.outputs.OPENSEARCH_USERNAME }}
+          OPENSEARCH_PASSWORD: ${{ steps.test-credentials-secret.outputs.OPENSEARCH_PASSWORD }}
         run: |
           kubectl annotate ns $TEST_NAMESPACE test-flow=${{ inputs.flow }} --overwrite || true
           kubectl annotate ns $TEST_NAMESPACE build-failed=true --overwrite || true
@@ -1535,6 +1588,9 @@ jobs:
       - name: CI Cleanup - Delete OpenSearch templates for this CI run
         if: always()
         continue-on-error: true
+        env:
+          OPENSEARCH_USERNAME: ${{ steps.test-credentials-secret.outputs.OPENSEARCH_USERNAME }}
+          OPENSEARCH_PASSWORD: ${{ steps.test-credentials-secret.outputs.OPENSEARCH_PASSWORD }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -597,6 +597,9 @@ jobs:
           TEST_DOCKER_USERNAME: ${{ steps.setup.outputs.TEST_DOCKER_USERNAME }}
           TEST_DOCKER_PASSWORD: ${{ steps.setup.outputs.TEST_DOCKER_PASSWORD }}
           ENTRA_APP_CLIENT_ID: ${{ steps.setup.outputs.ENTRA_APP_CLIENT_ID }}
+          ENTRA_APP_CLIENT_SECRET: ${{ steps.setup.outputs.ENTRA_APP_CLIENT_SECRET }}
+          ENTRA_APP_OBJECT_ID: ${{ steps.setup.outputs.ENTRA_APP_OBJECT_ID }}
+          ENTRA_APP_DIRECTORY_ID: ${{ steps.setup.outputs.ENTRA_APP_DIRECTORY_ID }}
           AUTH0_DOMAIN: ${{ steps.setup.outputs.AUTH0_DOMAIN }}
           AUTH0_AUDIENCE: ${{ steps.setup.outputs.AUTH0_AUDIENCE }}
           AUTH0_MGMT_CLIENT_ID: ${{ steps.setup.outputs.AUTH0_MGMT_CLIENT_ID }}
@@ -953,6 +956,9 @@ jobs:
           TEST_DOCKER_USERNAME: ${{ steps.setup.outputs.TEST_DOCKER_USERNAME }}
           TEST_DOCKER_PASSWORD: ${{ steps.setup.outputs.TEST_DOCKER_PASSWORD }}
           ENTRA_APP_CLIENT_ID: ${{ steps.setup.outputs.ENTRA_APP_CLIENT_ID }}
+          ENTRA_APP_CLIENT_SECRET: ${{ steps.setup.outputs.ENTRA_APP_CLIENT_SECRET }}
+          ENTRA_APP_OBJECT_ID: ${{ steps.setup.outputs.ENTRA_APP_OBJECT_ID }}
+          ENTRA_APP_DIRECTORY_ID: ${{ steps.setup.outputs.ENTRA_APP_DIRECTORY_ID }}
           AUTH0_DOMAIN: ${{ steps.setup.outputs.AUTH0_DOMAIN }}
           AUTH0_AUDIENCE: ${{ steps.setup.outputs.AUTH0_AUDIENCE }}
           AUTH0_MGMT_CLIENT_ID: ${{ steps.setup.outputs.AUTH0_MGMT_CLIENT_ID }}

--- a/.github/workflows/test-local-template.yaml
+++ b/.github/workflows/test-local-template.yaml
@@ -45,7 +45,7 @@ jobs:
           secrets: |
             secret/data/products/distribution/ci DOCKERHUB_USERNAME | TEST_DOCKER_USERNAME;
             secret/data/products/distribution/ci DOCKERHUB_PASSWORD | TEST_DOCKER_PASSWORD;
-          exportEnv: true
+          exportEnv: false
       - name: Install common software tooling
         uses: camunda/infra-global-github-actions/common-tooling@b4808875a583e71eff5b3dd07bb50dafb92694a6 # main
         with:
@@ -67,6 +67,9 @@ jobs:
             kubectl
             task
       - name: Docker Hub login
+        env:
+          TEST_DOCKER_USERNAME: ${{ steps.test-credentials-secret.outputs.TEST_DOCKER_USERNAME }}
+          TEST_DOCKER_PASSWORD: ${{ steps.test-credentials-secret.outputs.TEST_DOCKER_PASSWORD }}
         run: |
           echo "${TEST_DOCKER_PASSWORD}" | docker login -u "${TEST_DOCKER_USERNAME}" --password-stdin
       - name: CI Setup - Set test type vars
@@ -83,6 +86,8 @@ jobs:
       - name: Create Docker login secret
         env:
           TEST_CREATE_DOCKER_LOGIN_SECRET: "TRUE"
+          TEST_DOCKER_USERNAME: ${{ steps.test-credentials-secret.outputs.TEST_DOCKER_USERNAME }}
+          TEST_DOCKER_PASSWORD: ${{ steps.test-credentials-secret.outputs.TEST_DOCKER_PASSWORD }}
         run: |
           kubectl create namespace ${{ env.TEST_NAMESPACE }}
           # Docker Hub pull secret (replaces legacy `task docker-login --taskfile lib/init-seed-taskfile.yaml`).

--- a/.github/workflows/triage-ai-issue.yml
+++ b/.github/workflows/triage-ai-issue.yml
@@ -80,14 +80,14 @@ jobs:
             secret/data/products/distribution/ci GH_APP_PRIVATE_KEY_DISTRO_CI;
             secret/data/products/distribution/ci GLEAN_API_TOKEN;
             secret/data/products/distribution/ci SLACK_DISTRO_BOT_WEBHOOK_GH;
-          exportEnv: true
+          exportEnv: false
 
       - name: Generate GitHub token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a  # v2
         id: generate-github-token
         with:
-          app_id: ${{ env.GH_APP_ID_DISTRO_CI }}
-          private_key: ${{ env.GH_APP_PRIVATE_KEY_DISTRO_CI }}
+          app_id: ${{ steps.vault-secrets.outputs.GH_APP_ID_DISTRO_CI }}
+          private_key: ${{ steps.vault-secrets.outputs.GH_APP_PRIVATE_KEY_DISTRO_CI }}
 
       - name: Set GitHub token
         run: |
@@ -169,6 +169,9 @@ jobs:
 
       - name: Triage issues
         if: steps.fetch_issues.outputs.has_issues == 'true'
+        env:
+          GLEAN_API_TOKEN: ${{ steps.vault-secrets.outputs.GLEAN_API_TOKEN }}
+          SLACK_DISTRO_BOT_WEBHOOK_GH: ${{ steps.vault-secrets.outputs.SLACK_DISTRO_BOT_WEBHOOK_GH }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/triage-assign-urgency-to-issue.yml
+++ b/.github/workflows/triage-assign-urgency-to-issue.yml
@@ -102,14 +102,14 @@ jobs:
           secrets: |
             secret/data/products/distribution/ci GH_APP_ID_DISTRO_CI;
             secret/data/products/distribution/ci GH_APP_PRIVATE_KEY_DISTRO_CI;
-          exportEnv: true
+          exportEnv: false
 
       - name: Generate GitHub token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a  # v2
         id: generate-github-token
         with:
-          app_id: ${{ env.GH_APP_ID_DISTRO_CI }}
-          private_key: ${{ env.GH_APP_PRIVATE_KEY_DISTRO_CI }}
+          app_id: ${{ steps.vault-secrets.outputs.GH_APP_ID_DISTRO_CI }}
+          private_key: ${{ steps.vault-secrets.outputs.GH_APP_PRIVATE_KEY_DISTRO_CI }}
 
       - name: Set GitHub token
         run: |


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #5740

`vault-action` used `exportEnv: true` (default) across ~20 workflows + the `integration-test-setup` composite, leaking every imported secret into job-wide `$GITHUB_ENV` instead of only the step that needs it.

### What's in this PR?

- All vault imports → `exportEnv: false`; each secret passed per-consumer via `${{ steps.<id>.outputs.<NAME> }}` (`with:` input or step-scoped `env:`).
- Composite exposes the always-on CI creds as `outputs:`, wired per-step in `test-integration-runner.yaml` install/upgrade (incl. the `deploy-camunda` steps that read them via `os.Getenv`).
- `github-actions.instructions.md` Vault example rewritten to the scoped pattern.

**Exception:** per-scenario mapping step keeps `exportEnv: true` — dynamic secret names, consumed by `vault-secret-mapper`.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
