### PR TITLE
chore: codify HOW-only comment policy for agents

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,12 @@
+# GitHub Copilot — Repository Instructions
+
+Follow the root `AGENTS.md` and the path-scoped guides in `.github/instructions/`.
+
+## Comments
+
+Write comments only to explain non-obvious **how**. Never add reasoning, rationale,
+"why", or narration comments. Rationale and decisions belong in an ADR under `docs/adr/`,
+authored by a human — never create or edit ADRs automatically. Keep only required
+structured comments: Apache license headers, `## @param`/`## @extra` values docs, the
+`{{- /* NOTE */ -}}` helper convention, and lint/build pragmas (`//nolint`, `//go:build`,
+`# yamllint disable`).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,8 +5,9 @@ Follow the root `AGENTS.md` and the path-scoped guides in `.github/instructions/
 ## Comments
 
 Write comments only to explain non-obvious **how**. Never add reasoning, rationale,
-"why", or narration comments. Rationale and decisions belong in an ADR under `docs/adr/`,
-authored by a human — never create or edit ADRs automatically. Keep only required
+"why", or narration comments. Architectural rationale belongs in an ADR under `docs/adr/`,
+authored by a human — never create or edit ADRs proactively. Tactical rationale (bug-fix
+defaults, timeouts, label choices) goes in the PR body or commit message. Keep only required
 structured comments: Apache license headers, `## @param`/`## @extra` values docs, the
 `{{- /* NOTE */ -}}` helper convention, and lint/build pragmas (`//nolint`, `//go:build`,
-`# yamllint disable`).
+`# yamllint disable`, `# yamllint disable-line`, `# shellcheck disable`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Use this file as the practical guide. For architecture and CI context, also read
 - NEVER assume templates are identical across chart versions — always check the target version first.
 - NEVER edit golden files by hand — use `make go.update-golden-only chartPath=...`.
 - NEVER implement CI logic (>20 lines) in bash — use Go scripts in `scripts/` with unit tests.
-- NEVER write reasoning/"why"/narration comments — comments explain only non-obvious HOW. Rationale and decisions belong in an ADR under `docs/adr/`, human-authored; agents NEVER create or edit ADRs automatically or unprompted. Keep only required structured comments: Apache license headers, `## @param`/`## @extra`, the `{{- /* NOTE */ -}}` helper convention, and lint/build pragmas (`//nolint`, `//go:build`, `# yamllint disable`).
+- NEVER write reasoning/"why"/narration comments — comments explain only non-obvious HOW. Architectural rationale belongs in an ADR under `docs/adr/`, human-authored; tactical rationale (bug-fix defaults, timeouts, label choices) goes in the PR body or commit message. Agents NEVER create or edit ADRs proactively. Keep only required structured comments: Apache license headers, `## @param`/`## @extra`, the `{{- /* NOTE */ -}}` helper convention, and lint/build pragmas (`//nolint`, `//go:build`, `# yamllint disable`, `# yamllint disable-line`, `# shellcheck disable`).
 - ALWAYS run `make helm.dependency-update chartPath=...` before testing/linting a chart.
 - ALWAYS keep diffs small and version-scoped.
 - ALWAYS preserve existing patterns before introducing new abstractions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ Use this file as the practical guide. For architecture and CI context, also read
 - NEVER assume templates are identical across chart versions — always check the target version first.
 - NEVER edit golden files by hand — use `make go.update-golden-only chartPath=...`.
 - NEVER implement CI logic (>20 lines) in bash — use Go scripts in `scripts/` with unit tests.
+- NEVER write reasoning/"why"/narration comments — comments explain only non-obvious HOW. Rationale and decisions belong in an ADR under `docs/adr/`, human-authored; agents NEVER create or edit ADRs automatically or unprompted. Keep only required structured comments: Apache license headers, `## @param`/`## @extra`, the `{{- /* NOTE */ -}}` helper convention, and lint/build pragmas (`//nolint`, `//go:build`, `# yamllint disable`).
 - ALWAYS run `make helm.dependency-update chartPath=...` before testing/linting a chart.
 - ALWAYS keep diffs small and version-scoped.
 - ALWAYS preserve existing patterns before introducing new abstractions.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -23,8 +23,7 @@ If a user requests an ADR for a change that clearly does not warrant one (per
 the maintainer-guide table), ask before drafting.
 
 Never author or amend an ADR proactively — only when a human explicitly asks.
-Rationale that would otherwise become a "why" code comment is a candidate ADR:
-surface it to the human; do not write the ADR (or the comment) yourself.
+If you notice rationale that would otherwise become a "why" code comment, surface it to the human as a candidate ADR; only draft/amend the ADR if explicitly asked.
 
 ## PR title for ADR changes
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -22,6 +22,10 @@ Applies on top of root `AGENTS.md`. Active when working inside `docs/`.
 If a user requests an ADR for a change that clearly does not warrant one (per
 the maintainer-guide table), ask before drafting.
 
+Never author or amend an ADR proactively — only when a human explicitly asks.
+Rationale that would otherwise become a "why" code comment is a candidate ADR:
+surface it to the human; do not write the ADR (or the comment) yourself.
+
 ## PR title for ADR changes
 
 Follow root `AGENTS.md` → "PR title type: CI-enforced constraint".


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6393

Agents add "why"/reasoning/narration comments to code; the repo's instruction files didn't forbid it (the `github-actions.instructions.md` guide was itself introduced with such boilerplate). Rationale belongs in ADRs, not code comments.

### What's in this PR?

- `AGENTS.md` Critical Rules: `NEVER` write reasoning/"why"/narration comments — HOW-only; rationale → ADR (`docs/adr/`), human-authored; agents never auto-create/edit ADRs. Carve-outs for required structured comments (license headers, `## @param`, `{{- /* NOTE */ -}}`, lint/build pragmas).
- `.github/copilot-instructions.md` (new): same rule, repo-wide for Copilot.
- `docs/AGENTS.md`: agents never proactively author ADRs.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
