### PR TITLE
fix: remove obsolete backup.webapps workaround when RDBMS is enabled

### DIFF
--- a/charts/camunda-platform-8.10/templates/orchestration/files/_application.yaml
+++ b/charts/camunda-platform-8.10/templates/orchestration/files/_application.yaml
@@ -40,11 +40,6 @@ management:
     base-path: {{ include "camundaPlatform.joinpath" (list .Values.orchestration.contextPath) | quote }}
 
 camunda:
-  {{- if .Values.orchestration.exporters.rdbms.enabled }}
-  backup:
-    webapps:
-      enabled: false
-  {{- end }}
   license:
     key: "${VALUES_ORCHESTRATION_LICENSE_KEY}"
   {{- if eq (include "orchestration.hasAzureDocumentStore" .) "true" }}

--- a/charts/camunda-platform-8.9/templates/orchestration/files/_application.yaml
+++ b/charts/camunda-platform-8.9/templates/orchestration/files/_application.yaml
@@ -40,11 +40,6 @@ management:
     base-path: {{ include "camundaPlatform.joinpath" (list .Values.orchestration.contextPath) | quote }}
 
 camunda:
-  {{- if .Values.orchestration.exporters.rdbms.enabled }}
-  backup:
-    webapps:
-      enabled: false
-  {{- end }}
   license:
     key: "${VALUES_ORCHESTRATION_LICENSE_KEY}"
   {{- if eq (include "orchestration.hasAzureDocumentStore" .) "true" }}


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #4676

### What's in this PR?

Removes the `backup.webapps.enabled: false` block that the orchestration `application.yaml` rendered whenever RDBMS was enabled (8.9 + 8.10).

It was a workaround for an old app constraint. camunda/camunda#39723 (merged, shipped in both 8.9 and 8.10) moved that decision into the app based on the secondary-storage type, so the flag is now a no-op and can go.

No exporter changes: for RDBMS the app already auto-installs the RdbmsExporter and skips the CamundaExporter, which the chart's existing logic mirrors — so it stays as-is.

### Verification

- `make go.test` passes for 8.9 and 8.10 with no golden changes.
- Deployed the `rdbms` scenario (8.10) on GKE: orchestration pods Running, rendered config has no `backup`/`webapps`, RDBMS secondary storage healthy.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
