### PR TITLE
build(deploy-camunda): secrets & env UX overhaul

### DIFF
--- a/SKILLS.md
+++ b/SKILLS.md
@@ -26,6 +26,17 @@ cd scripts/deploy-camunda && go build -o deploy-camunda . && mv deploy-camunda $
 
 ### Pre-Flight Checklist
 
+> **Shortcut:** `deploy-camunda doctor` runs the checks below automatically and prints a
+> ✓/✗ checklist (config resolved, kube-context reachable, docker creds present, every var
+> in the vault mapping, the scenario's values, and companion charts set). It only flags
+> vars you must supply — deploy-computed ones like `CAMUNDA_HOSTNAME`/`KEYCLOAK_REALM` are
+> recognized as satisfied. `deploy-camunda doctor --fix` prompts for anything missing and
+> writes it to `.env`. First-time setup? `deploy-camunda config init` scaffolds config +
+> `.env` (including Postgres/RDBMS dev creds) and ends with the same checklist. See
+> `scripts/deploy-camunda/README.md` for the full secrets/env model. A direct
+> `deploy-camunda` run also fails fast on missing inputs before touching the cluster
+> (bypass with `--skip-preflight`); matrix entries do too.
+
 Before deploying, verify these requirements. Skipping any of these is the most common source
 of wasted time (pods stuck in `ImagePullBackOff`, missing ingress, helm errors):
 

--- a/scripts/deploy-camunda/README.md
+++ b/scripts/deploy-camunda/README.md
@@ -1,0 +1,164 @@
+# deploy-camunda — secrets & environment model
+
+`deploy-camunda` deploys Camunda 8 Self-Managed scenarios and runs the CI matrix.
+This document covers the part that trips people up most: **where secrets and
+environment variables come from, and how to make sure they're set before you
+deploy.** For the full command reference and operational patterns, see
+[`../../SKILLS.md`](../../SKILLS.md).
+
+## TL;DR — first run
+
+```bash
+deploy-camunda config init      # interactive: scaffolds .camunda-deploy.yaml + .env, ends with a checklist
+deploy-camunda doctor           # re-run the checklist any time
+deploy-camunda config env       # show the effective env and where each value came from (secrets masked)
+```
+
+A normal `deploy-camunda` run now runs the same preflight automatically and
+**fails fast** if a required input is missing — before creating a namespace or
+calling helm — so you no longer wait for an `ImagePullBackOff` to discover a
+missing credential. Pass `--skip-preflight` to bypass, or `--interactive`
+(default) to be prompted for missing scenario variables instead.
+
+## Where values come from (precedence)
+
+For configuration fields (chart, namespace, platform, kube-context, …):
+
+```
+CLI flags  >  active deployment in config file  >  root config  >  built-in defaults
+```
+
+The config file is resolved in this order (first that exists wins):
+
+1. `--config <path>` if given
+2. `.camunda-deploy.yaml` in the current directory
+3. `.camunda-deploy.yaml` in the repo root
+4. `~/.config/camunda/deploy.yaml`
+
+`CAMUNDA_*` environment variables override config-file values (e.g.
+`CAMUNDA_PLATFORM`, `CAMUNDA_LOG_LEVEL`).
+
+For **environment variables** substituted into scenario values files
+(`$VAR` / `${VAR}` placeholders) and packed into secrets:
+
+```
+process environment  <  .env file  <  per-entry overrides (ExtraEnv)
+```
+
+Later layers win. `deploy-camunda config env --show-origin` prints exactly which
+layer each variable resolved from. The `.env` file is read without mutating your
+shell, and `config init` / `--interactive` / `--auto-generate-secrets` write back
+to it format-preservingly (comments and ordering are kept).
+
+> Never commit `.env`. Generate it on demand (`config init`, `--auto-generate-secrets`,
+> or `scripts/render-e2e-env.sh`).
+
+## Secrets
+
+### Docker registry credentials
+
+Required when pods pull images (`--ensure-docker-registry`, and
+`--ensure-docker-hub` for Docker Hub). Resolution order:
+
+- **Harbor:** `--docker-username/--docker-password`, then `HARBOR_USERNAME`/`HARBOR_PASSWORD`,
+  then `TEST_DOCKER_USERNAME_CAMUNDA_CLOUD`/`TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD`,
+  then `NEXUS_USERNAME`/`NEXUS_PASSWORD`.
+- **Docker Hub:** `--dockerhub-username/--dockerhub-password`, then
+  `DOCKERHUB_USERNAME`/`DOCKERHUB_PASSWORD`, then `TEST_DOCKER_USERNAME`/`TEST_DOCKER_PASSWORD`.
+
+`deploy-camunda doctor` reports these as ✓/✗ and only fails when the matching
+`--ensure-docker-*` flag makes the pull secret mandatory.
+
+### Vault secret mapping
+
+`--vault-secret-mapping` (or the `vaultSecretMapping` config field) lists which
+env vars get packed into a Kubernetes `Secret`. Format:
+
+```
+vault/path VAR1,VAR2 | ALIAS1,ALIAS2;
+vault/path VAR3;
+```
+
+- Unset vars are **omitted with a warning** (the Secret simply lacks those keys).
+  Pass `--strict-secrets` to fail instead — useful in CI so an incomplete Secret
+  never ships and surfaces later as a crashing pod.
+- `deploy-camunda doctor` lists any mapping vars that are currently unset.
+
+The mapping used by `--auto-generate-secrets` / `config init` is data, not code:
+edit [`deploy/data/test-secret-mapping.yaml`](deploy/data/test-secret-mapping.yaml)
+to change which variables are scaffolded — no need to touch Go.
+
+## Commands for setup & inspection
+
+| Command | Purpose |
+| --- | --- |
+| `config init` | Interactive first-run setup (config profile, docker creds, test secrets, **Postgres/RDBMS dev creds**) ending in a checklist. `--non-interactive` just verifies + prints. |
+| `doctor [--fix]` | Read-only preflight checklist: config, kube-context reachability, docker creds, vault-mapping vars, scenario `$PLACEHOLDER`s, companion vars. `--fix` prompts for missing vars and writes them to `.env`. Exits non-zero on any ✗. |
+| `config env [--show-origin] [--unmask]` | Effective env table with source per key; secrets masked unless `--unmask`. |
+| `config set/get/list/use/create` | Manage deployment profiles in the config file. |
+
+## Companion charts (matrix scenarios)
+
+Some scenarios deploy companion charts (e.g. an external PostgreSQL) whose values
+files require their own env vars — `RDBMS_POSTGRESQL_USERNAME` /
+`RDBMS_POSTGRESQL_PASSWORD` for the `elasticsearch`/`rdbms` family, for example.
+These are declared per scenario as `dependencies` in `ci-test-config.yaml` (each
+with an `envVars` allowlist) and are substituted into the companion values file
+at deploy time. The preflight validates them too (the "companion env vars"
+check), so a missing `RDBMS_POSTGRESQL_*` is reported up front rather than
+failing partway through value preparation. `config init` offers to scaffold
+local `RDBMS_POSTGRESQL_USERNAME`/`RDBMS_POSTGRESQL_PASSWORD` dev credentials, and
+`doctor --fix` will prompt for any that are still missing.
+
+### Deploy-computed variables are not "missing"
+
+Some `$PLACEHOLDER`s in scenario values are filled in by the deploy machinery
+itself, not by you: `CAMUNDA_HOSTNAME` (from the ingress subdomain + base
+domain), `KEYCLOAK_REALM`, the `*_INDEX_PREFIX` vars, `FLOW`, and
+`KEYCLOAK_EXT_*`. The preflight evaluates placeholders against the **same
+environment the deploy will build** (`buildScenarioEnv`), so these are correctly
+recognized as satisfied and never flagged — only variables you actually need to
+provide are reported.
+
+`VENOM_CLIENT_ID` and `CONNECTORS_CLIENT_ID` are also deploy-supplied: they
+default to the Keycloak mapping-rule client IDs `venom` / `connectors`, mirroring
+the workflow env defaults in
+[`test-integration-runner.yaml`](../../.github/workflows/test-integration-runner.yaml)
+so local keycloak deploys match CI. OIDC/Entra entries override them with the
+provisioned app GUIDs (via per-entry `ExtraEnv`), and your process env / `.env`
+override the defaults too. Without this, keycloak + Elasticsearch scenarios would
+fail locally on the `$VENOM_CLIENT_ID` / `$CONNECTORS_CLIENT_ID` placeholders that
+live in the persistence/identity values layers.
+
+### Layered values are scanned in full
+
+A scenario's values are composed from layers — `base` + `identity/<id>` +
+`persistence/<backend>` + `platform/<p>` + `features/<f>`. The preflight resolves
+the **same layered set** the deploy composes (via the scenario's deployment
+config) and scans every layer for placeholders, not just the top-level scenario
+file. A `$VAR` introduced by a persistence or identity layer (e.g.
+`$VENOM_CLIENT_ID` in `values/persistence/elasticsearch.yaml`) is therefore caught
+up front rather than surfacing mid-deploy as a `failed to process layered values
+file` error.
+
+## Matrix runs
+
+Each matrix entry runs the fail-fast preflight at the start of its deploy (the
+runner's own pre-dispatch docker login and kube-context warmup still happen; the
+preflight's cluster reachability probe is skipped to avoid duplicate network
+calls). A missing scenario or companion variable fails that entry immediately
+with the full list. Set the required vars in your `.env` (or environment) — see
+the companion-chart vars above for `rdbms`/`elasticsearch` scenarios.
+
+`matrix run` inherits the **active `config init` deployment profile** for its
+shared infra fields — `ingressBaseDomain`, `kubeContext`, `platform`, `repoRoot`,
+`envFile`. Precedence is: CLI flag > `matrix:` config block > root config >
+active deployment profile. So once `config init` has set your base domain and
+context, you don't need to repeat `--ingress-base-domain-gke` / `--kube-context`
+on every matrix run. (Without a base domain the deploy can't compute
+`CAMUNDA_HOSTNAME`, which is why an unconfigured matrix run flagged it.)
+
+**Preview before deploying:** `matrix run --dry-run` now prints a per-entry
+preflight checklist (secrets/env/companion vars), so you can confirm an entry
+will pass — including computed vars like `CAMUNDA_HOSTNAME` — without touching a
+cluster.

--- a/scripts/deploy-camunda/cmd/config.go
+++ b/scripts/deploy-camunda/cmd/config.go
@@ -18,6 +18,8 @@ func newConfigCommand() *cobra.Command {
 		Short: "Manage deploy-camunda configuration and active deployment",
 	}
 
+	configCmd.AddCommand(newInitCommand())
+	configCmd.AddCommand(newEnvCommand())
 	configCmd.AddCommand(newListCommand())
 	configCmd.AddCommand(newShowCommand())
 	configCmd.AddCommand(newUseCommand())

--- a/scripts/deploy-camunda/cmd/config_env.go
+++ b/scripts/deploy-camunda/cmd/config_env.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"fmt"
+	"text/tabwriter"
+
+	"scripts/deploy-camunda/config"
+	"scripts/deploy-camunda/deploy"
+	"scripts/prepare-helm-values/pkg/values"
+
+	"github.com/spf13/cobra"
+)
+
+// newEnvCommand creates `config env`: prints the effective environment a deploy
+// would see and which layer each value came from, with secret values masked.
+// Mirrors `git config --show-origin`.
+func newEnvCommand() *cobra.Command {
+	var showOrigin bool
+	var unmask bool
+
+	cmd := &cobra.Command{
+		Use:   "env",
+		Short: "Show the effective deploy environment and where each value came from",
+		Long: `Print the environment variables a deploy would resolve, layered as
+process-env → .env file → per-entry overrides, annotated with the winning
+source per key. Secret-looking values (key/secret/password/token) are masked
+unless --unmask is passed.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var flags config.RuntimeFlags
+			if _, _, err := config.LoadAndMerge(configFile, true, &flags); err != nil {
+				return err
+			}
+
+			entries := deploy.EnvProvenance(&flags)
+			out := cmd.OutOrStdout()
+			w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+			if showOrigin {
+				fmt.Fprintln(w, "NAME\tORIGIN\tVALUE")
+			} else {
+				fmt.Fprintln(w, "NAME\tVALUE")
+			}
+			for _, e := range entries {
+				val := e.Value
+				if !unmask && values.IsSecretName(e.Name) {
+					val = "***"
+				}
+				if showOrigin {
+					fmt.Fprintf(w, "%s\t%s\t%s\n", e.Name, e.Origin, val)
+				} else {
+					fmt.Fprintf(w, "%s\t%s\n", e.Name, val)
+				}
+			}
+			return w.Flush()
+		},
+	}
+
+	cmd.Flags().BoolVar(&showOrigin, "show-origin", true, "Show which layer each value came from")
+	cmd.Flags().BoolVar(&unmask, "unmask", false, "Show secret values in clear text (key/secret/password/token)")
+	return cmd
+}

--- a/scripts/deploy-camunda/cmd/config_env.go
+++ b/scripts/deploy-camunda/cmd/config_env.go
@@ -12,8 +12,9 @@ import (
 )
 
 // newEnvCommand creates `config env`: prints the effective environment a deploy
-// would see and which layer each value came from, with secret values masked.
-// Mirrors `git config --show-origin`.
+// would see, with secret values masked. Default output is two machine-parseable
+// columns (NAME, VALUE); --show-origin adds an ORIGIN column, mirroring
+// `git config` (plain by default, origin column only when asked).
 func newEnvCommand() *cobra.Command {
 	var showOrigin bool
 	var unmask bool
@@ -55,7 +56,7 @@ unless --unmask is passed.`,
 		},
 	}
 
-	cmd.Flags().BoolVar(&showOrigin, "show-origin", true, "Show which layer each value came from")
+	cmd.Flags().BoolVar(&showOrigin, "show-origin", false, "Add an ORIGIN column showing which layer each value came from")
 	cmd.Flags().BoolVar(&unmask, "unmask", false, "Show secret values in clear text (key/secret/password/token)")
 	return cmd
 }

--- a/scripts/deploy-camunda/cmd/config_init.go
+++ b/scripts/deploy-camunda/cmd/config_init.go
@@ -19,6 +19,7 @@ import (
 	"scripts/prepare-helm-values/pkg/env"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 // newInitCommand creates the `config init` wizard: an interactive first-run
@@ -77,7 +78,7 @@ checklist without prompting.`,
 			}
 			if err := config.CreateDeployment(cfgRes.Path, name); err != nil {
 				// Already-exists is fine — we'll update it in place.
-				if !strings.Contains(err.Error(), "already exists") {
+				if !errors.Is(err, config.ErrDeploymentExists) {
 					return err
 				}
 				fmt.Fprintf(out, "  profile %q already exists — updating it\n", name)
@@ -246,14 +247,45 @@ func promptLine(ctx context.Context, out io.Writer, r *bufio.Reader, label, def 
 }
 
 func promptSecret(ctx context.Context, out io.Writer, r *bufio.Reader, label string) (string, error) {
-	// Note: input is not hidden (matches existing env.Prompt behavior); we simply
-	// never echo the value back afterwards.
 	fmt.Fprintf(out, "%s: ", label)
+	// On a real terminal, read with echo disabled so the secret never appears on
+	// screen or in scrollback. Piped/redirected input (tests, scripts) has
+	// nothing to hide and falls back to the buffered line reader.
+	stdinFd := int(os.Stdin.Fd())
+	if r.Buffered() == 0 && term.IsTerminal(stdinFd) {
+		secret, err := readSecretCtx(ctx, stdinFd)
+		fmt.Fprintln(out)
+		return secret, err
+	}
 	line, err := readLineCtx(ctx, r)
 	if err != nil {
 		return "", err
 	}
 	return strings.TrimSpace(line), nil
+}
+
+// readSecretCtx reads an echo-suppressed line from the terminal fd, aborting if
+// ctx is cancelled. Like readLineCtx, the parked term.ReadPassword goroutine is
+// an accepted leak for this single-run CLI.
+func readSecretCtx(ctx context.Context, fd int) (string, error) {
+	type res struct {
+		b   []byte
+		err error
+	}
+	ch := make(chan res, 1)
+	go func() {
+		b, err := term.ReadPassword(fd)
+		ch <- res{b, err}
+	}()
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	case rr := <-ch:
+		if rr.err != nil && !errors.Is(rr.err, io.EOF) {
+			return "", rr.err
+		}
+		return strings.TrimSpace(string(rr.b)), nil
+	}
 }
 
 func promptYesNo(ctx context.Context, out io.Writer, r *bufio.Reader, label string, def bool) (bool, error) {

--- a/scripts/deploy-camunda/cmd/config_init.go
+++ b/scripts/deploy-camunda/cmd/config_init.go
@@ -1,0 +1,300 @@
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"scripts/camunda-core/pkg/logging"
+	"scripts/deploy-camunda/config"
+	"scripts/deploy-camunda/deploy"
+	"scripts/prepare-helm-values/pkg/env"
+
+	"github.com/spf13/cobra"
+)
+
+// newInitCommand creates the `config init` wizard: an interactive first-run
+// setup that scaffolds a config file deployment, optional docker credentials,
+// and test secrets in .env, then ends with a doctor checklist. Mirrors
+// `gh auth login` / `supabase init`.
+func newInitCommand() *cobra.Command {
+	var nonInteractive bool
+	var envFile string
+
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Interactively scaffold deploy-camunda config and .env",
+		Long: `Guide first-time setup of deploy-camunda.
+
+Prompts for a deployment profile (platform, kube-context, ingress base domain,
+repo root), optionally captures Harbor credentials into .env, optionally
+scaffolds the random test secrets, then runs the doctor preflight so you finish
+with a ✓/✗ checklist instead of guessing what is missing.
+
+Use --non-interactive in CI to ensure a config file exists and print the
+checklist without prompting.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+			defer stop()
+
+			if err := logging.Setup(logging.Options{
+				LevelString:  "info",
+				ColorEnabled: logging.IsTerminal(os.Stdout.Fd()),
+			}); err != nil {
+				return err
+			}
+
+			cfgRes, err := config.ResolvePath(configFile)
+			if err != nil {
+				return err
+			}
+			out := cmd.OutOrStdout()
+
+			if nonInteractive {
+				if !cfgRes.Found {
+					return fmt.Errorf("no config file found at %s; run `deploy-camunda config init` interactively to create one", cfgRes.Path)
+				}
+				fmt.Fprintf(out, "Using config: %s\n", cfgRes.Path)
+				return runDoctorAfterInit(ctx, cfgRes)
+			}
+
+			reader := bufio.NewReader(cmd.InOrStdin())
+			fmt.Fprintf(out, "deploy-camunda setup — config: %s\n\n", cfgRes.Path)
+
+			// 1. Deployment profile.
+			name, err := promptLine(ctx, out, reader, "Deployment profile name", "local")
+			if err != nil {
+				return err
+			}
+			if err := config.CreateDeployment(cfgRes.Path, name); err != nil {
+				// Already-exists is fine — we'll update it in place.
+				if !strings.Contains(err.Error(), "already exists") {
+					return err
+				}
+				fmt.Fprintf(out, "  profile %q already exists — updating it\n", name)
+			}
+
+			repoDefault, _ := config.DetectRepoRoot()
+			fields := []struct {
+				key, prompt, def string
+				choices          []string
+			}{
+				{"platform", "Platform", "gke", config.DeployPlatforms},
+				{"kubeContext", "Kube context", currentKubeContext(), nil},
+				{"ingressBaseDomain", "Ingress base domain", config.ValidIngressBaseDomains[0], config.ValidIngressBaseDomains},
+				{"repoRoot", "Repo root", repoDefault, nil},
+			}
+			for _, f := range fields {
+				if len(f.choices) > 0 {
+					fmt.Fprintf(out, "  (options: %s)\n", strings.Join(f.choices, ", "))
+				}
+				val, err := promptLine(ctx, out, reader, f.prompt, f.def)
+				if err != nil {
+					return err
+				}
+				if strings.TrimSpace(val) == "" {
+					continue
+				}
+				if err := config.SetValue(cfgRes.Path, name+"."+f.key, val); err != nil {
+					return err
+				}
+			}
+			if err := config.WriteCurrentOnly(cfgRes.Path, name); err != nil {
+				return err
+			}
+			fmt.Fprintf(out, "Saved profile %q (now active) to %s\n\n", name, cfgRes.Path)
+
+			// 2. Docker (Harbor) credentials → .env.
+			if yes, err := promptYesNo(ctx, out, reader, "Store Harbor docker credentials in .env now?", false); err != nil {
+				return err
+			} else if yes {
+				user, err := promptLine(ctx, out, reader, "Harbor username (env HARBOR_USERNAME)", "")
+				if err != nil {
+					return err
+				}
+				pass, err := promptSecret(ctx, out, reader, "Harbor password (env HARBOR_PASSWORD)")
+				if err != nil {
+					return err
+				}
+				updates := map[string]string{}
+				if strings.TrimSpace(user) != "" {
+					updates["HARBOR_USERNAME"] = user
+				}
+				if strings.TrimSpace(pass) != "" {
+					updates["HARBOR_PASSWORD"] = pass
+				}
+				if len(updates) > 0 {
+					if err := env.AppendMultiple(envFile, updates); err != nil {
+						return fmt.Errorf("failed to write docker credentials to %s: %w", envFile, err)
+					}
+					fmt.Fprintf(out, "  wrote %d credential(s) to %s\n\n", len(updates), envFile)
+				}
+			}
+
+			// 3. Test secrets scaffold.
+			if yes, err := promptYesNo(ctx, out, reader, "Generate random test secrets into .env?", false); err != nil {
+				return err
+			} else if yes {
+				names, err := deploy.ScaffoldTestSecrets(envFile)
+				if err != nil {
+					return fmt.Errorf("failed to scaffold test secrets: %w", err)
+				}
+				fmt.Fprintf(out, "  ensured %d test secret(s) in %s\n\n", len(names), envFile)
+			}
+
+			// 3b. Companion (Postgres/RDBMS) dev credentials. Scenarios in the
+			// elasticsearch/rdbms family substitute these into the companion
+			// PostgreSQL values; for a fresh local deploy any value works.
+			if yes, err := promptYesNo(ctx, out, reader, "Generate local Postgres/RDBMS dev credentials into .env? (needed by elasticsearch/rdbms scenarios)", false); err != nil {
+				return err
+			} else if yes {
+				existing, _ := env.ReadFile(envFile)
+				updates := map[string]string{}
+				if existing["RDBMS_POSTGRESQL_USERNAME"] == "" {
+					updates["RDBMS_POSTGRESQL_USERNAME"] = "camunda"
+				}
+				if existing["RDBMS_POSTGRESQL_PASSWORD"] == "" {
+					pw, err := deploy.RandomSecret()
+					if err != nil {
+						return err
+					}
+					updates["RDBMS_POSTGRESQL_PASSWORD"] = pw
+				}
+				if len(updates) > 0 {
+					if err := env.AppendMultiple(envFile, updates); err != nil {
+						return fmt.Errorf("failed to write RDBMS credentials to %s: %w", envFile, err)
+					}
+					fmt.Fprintf(out, "  wrote %d RDBMS credential(s) to %s\n\n", len(updates), envFile)
+				} else {
+					fmt.Fprintf(out, "  RDBMS credentials already present in %s\n\n", envFile)
+				}
+			}
+
+			// 4. Finish with the doctor checklist.
+			fmt.Fprintln(out, "Running doctor preflight…")
+			return runDoctorAfterInit(ctx, cfgRes)
+		},
+	}
+
+	cmd.Flags().BoolVar(&nonInteractive, "non-interactive", false, "Don't prompt; require an existing config and just run doctor")
+	cmd.Flags().StringVar(&envFile, "env-file", ".env", "Path to the .env file to write secrets/credentials into")
+	return cmd
+}
+
+// runDoctorAfterInit loads the freshly-written config and prints a preflight
+// checklist, reusing the same Preflight engine as the doctor command. It never
+// returns an error for failing checks — init is advisory — but surfaces them.
+func runDoctorAfterInit(ctx context.Context, cfgRes *config.ConfigResolution) error {
+	var f config.RuntimeFlags
+	if _, _, err := config.LoadAndMerge(configFile, true, &f); err != nil {
+		return err
+	}
+	report := deploy.Preflight(ctx, &f, deploy.PreflightOptions{
+		ConfigPath:           cfgRes.Path,
+		ConfigFound:          true, // a config file exists by the time we run the checklist
+		SkipKubeReachability: false,
+	})
+	var buf bytes.Buffer
+	report.Render(&buf)
+	fmt.Print(buf.String())
+	if !report.OK() {
+		fmt.Println("\nSome checks need attention — re-run `deploy-camunda doctor` after fixing them.")
+	} else {
+		fmt.Println("\nAll checks passed — you're ready to deploy.")
+	}
+	return nil
+}
+
+// currentKubeContext returns the active kubectl context, or "" if unavailable.
+func currentKubeContext() string {
+	contexts, err := getKubeContexts()
+	if err != nil || len(contexts) == 0 {
+		return ""
+	}
+	// getKubeContexts lists all; current-context is a separate lookup.
+	if out, err := exec.Command("kubectl", "config", "current-context").Output(); err == nil {
+		return strings.TrimSpace(string(out))
+	}
+	return ""
+}
+
+// promptLine asks for a value with an optional default, honoring ctx cancellation.
+func promptLine(ctx context.Context, out io.Writer, r *bufio.Reader, label, def string) (string, error) {
+	if def != "" {
+		fmt.Fprintf(out, "%s [%s]: ", label, def)
+	} else {
+		fmt.Fprintf(out, "%s: ", label)
+	}
+	line, err := readLineCtx(ctx, r)
+	if err != nil {
+		return "", err
+	}
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return def, nil
+	}
+	return line, nil
+}
+
+func promptSecret(ctx context.Context, out io.Writer, r *bufio.Reader, label string) (string, error) {
+	// Note: input is not hidden (matches existing env.Prompt behavior); we simply
+	// never echo the value back afterwards.
+	fmt.Fprintf(out, "%s: ", label)
+	line, err := readLineCtx(ctx, r)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(line), nil
+}
+
+func promptYesNo(ctx context.Context, out io.Writer, r *bufio.Reader, label string, def bool) (bool, error) {
+	suffix := "y/N"
+	if def {
+		suffix = "Y/n"
+	}
+	fmt.Fprintf(out, "%s [%s]: ", label, suffix)
+	line, err := readLineCtx(ctx, r)
+	if err != nil {
+		return false, err
+	}
+	line = strings.ToLower(strings.TrimSpace(line))
+	if line == "" {
+		return def, nil
+	}
+	return line == "y" || line == "yes", nil
+}
+
+// readLineCtx reads a line, returning ctx.Err() if the context is cancelled
+// (e.g. Ctrl+C) before input arrives.
+func readLineCtx(ctx context.Context, r *bufio.Reader) (string, error) {
+	type res struct {
+		line string
+		err  error
+	}
+	ch := make(chan res, 1)
+	go func() {
+		line, err := r.ReadString('\n')
+		ch <- res{line, err}
+	}()
+	select {
+	case <-ctx.Done():
+		fmt.Println()
+		return "", ctx.Err()
+	case rr := <-ch:
+		// EOF with content (e.g. piped input without a trailing newline, or the
+		// final answer) is a normal end-of-input, not an error.
+		if errors.Is(rr.err, io.EOF) {
+			return rr.line, nil
+		}
+		return rr.line, rr.err
+	}
+}

--- a/scripts/deploy-camunda/cmd/config_init.go
+++ b/scripts/deploy-camunda/cmd/config_init.go
@@ -64,7 +64,7 @@ checklist without prompting.`,
 					return fmt.Errorf("no config file found at %s; run `deploy-camunda config init` interactively to create one", cfgRes.Path)
 				}
 				fmt.Fprintf(out, "Using config: %s\n", cfgRes.Path)
-				return runDoctorAfterInit(ctx, cfgRes)
+				return runDoctorAfterInit(ctx, out, cfgRes)
 			}
 
 			reader := bufio.NewReader(cmd.InOrStdin())
@@ -181,7 +181,7 @@ checklist without prompting.`,
 
 			// 4. Finish with the doctor checklist.
 			fmt.Fprintln(out, "Running doctor preflight…")
-			return runDoctorAfterInit(ctx, cfgRes)
+			return runDoctorAfterInit(ctx, out, cfgRes)
 		},
 	}
 
@@ -193,7 +193,7 @@ checklist without prompting.`,
 // runDoctorAfterInit loads the freshly-written config and prints a preflight
 // checklist, reusing the same Preflight engine as the doctor command. It never
 // returns an error for failing checks — init is advisory — but surfaces them.
-func runDoctorAfterInit(ctx context.Context, cfgRes *config.ConfigResolution) error {
+func runDoctorAfterInit(ctx context.Context, out io.Writer, cfgRes *config.ConfigResolution) error {
 	var f config.RuntimeFlags
 	if _, _, err := config.LoadAndMerge(configFile, true, &f); err != nil {
 		return err
@@ -205,11 +205,11 @@ func runDoctorAfterInit(ctx context.Context, cfgRes *config.ConfigResolution) er
 	})
 	var buf bytes.Buffer
 	report.Render(&buf)
-	fmt.Print(buf.String())
+	fmt.Fprint(out, buf.String())
 	if !report.OK() {
-		fmt.Println("\nSome checks need attention — re-run `deploy-camunda doctor` after fixing them.")
+		fmt.Fprintln(out, "\nSome checks need attention — re-run `deploy-camunda doctor` after fixing them.")
 	} else {
-		fmt.Println("\nAll checks passed — you're ready to deploy.")
+		fmt.Fprintln(out, "\nAll checks passed — you're ready to deploy.")
 	}
 	return nil
 }
@@ -280,6 +280,10 @@ func readLineCtx(ctx context.Context, r *bufio.Reader) (string, error) {
 		line string
 		err  error
 	}
+	// Buffered so this goroutine's send never blocks: on ctx cancellation the
+	// ReadString stays parked (bufio reads aren't context-aware) until stdin
+	// yields a newline/EOF or the process exits — an accepted leak for this
+	// single-run CLI.
 	ch := make(chan res, 1)
 	go func() {
 		line, err := r.ReadString('\n')

--- a/scripts/deploy-camunda/cmd/config_init_test.go
+++ b/scripts/deploy-camunda/cmd/config_init_test.go
@@ -1,0 +1,135 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestConfigInitWizard(t *testing.T) {
+	// Hermetic + fast: no kubectl on PATH so kube probes fail immediately rather
+	// than waiting on a network timeout.
+	t.Setenv("PATH", "")
+
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, ".camunda-deploy.yaml")
+
+	// Point the shared config path at our temp file and restore afterward.
+	prev := configFile
+	configFile = cfgPath
+	t.Cleanup(func() { configFile = prev })
+
+	// Scripted answers: name, platform, kube-context(default), ingress(default),
+	// repo-root, then "no" to docker creds and "no" to test secrets.
+	input := strings.Join([]string{
+		"testprofile",
+		"eks",
+		"", // kube context → default (empty, no kubectl)
+		"", // ingress base domain → default
+		"/tmp/repo",
+		"n", // docker creds
+		"n", // test secrets
+		"n", // RDBMS dev credentials
+	}, "\n") + "\n"
+
+	cmd := newInitCommand()
+	cmd.SetIn(strings.NewReader(input))
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--env-file", filepath.Join(tmp, ".env")})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init wizard returned error: %v\noutput:\n%s", err, out.String())
+	}
+
+	raw, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("config file not written: %v", err)
+	}
+	var data map[string]any
+	if err := yaml.Unmarshal(raw, &data); err != nil {
+		t.Fatalf("config file is not valid YAML: %v", err)
+	}
+
+	if data["current"] != "testprofile" {
+		t.Errorf("current = %v, want testprofile", data["current"])
+	}
+	deployments, ok := data["deployments"].(map[string]any)
+	if !ok {
+		t.Fatalf("deployments map missing: %#v", data)
+	}
+	profile, ok := deployments["testprofile"].(map[string]any)
+	if !ok {
+		t.Fatalf("testprofile missing: %#v", deployments)
+	}
+	if profile["platform"] != "eks" {
+		t.Errorf("platform = %v, want eks", profile["platform"])
+	}
+	if profile["repoRoot"] != "/tmp/repo" {
+		t.Errorf("repoRoot = %v, want /tmp/repo", profile["repoRoot"])
+	}
+}
+
+func TestConfigInitScaffoldsRDBMS(t *testing.T) {
+	t.Setenv("PATH", "")
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, ".camunda-deploy.yaml")
+	envPath := filepath.Join(tmp, ".env")
+	prev := configFile
+	configFile = cfgPath
+	t.Cleanup(func() { configFile = prev })
+
+	input := strings.Join([]string{
+		"local", // profile name
+		"gke",   // platform
+		"",      // kube context
+		"",      // ingress base domain
+		tmp,     // repo root
+		"n",     // docker creds
+		"n",     // test secrets
+		"y",     // RDBMS dev credentials → scaffold
+	}, "\n") + "\n"
+
+	cmd := newInitCommand()
+	cmd.SetIn(strings.NewReader(input))
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--env-file", envPath})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init wizard error: %v\n%s", err, out.String())
+	}
+
+	data, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatalf(".env not written: %v", err)
+	}
+	got := string(data)
+	for _, key := range []string{"RDBMS_POSTGRESQL_USERNAME", "RDBMS_POSTGRESQL_PASSWORD"} {
+		if !strings.Contains(got, key) {
+			t.Errorf(".env missing %s; content:\n%s", key, got)
+		}
+	}
+}
+
+func TestConfigInitNonInteractiveRequiresConfig(t *testing.T) {
+	t.Setenv("PATH", "")
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, ".camunda-deploy.yaml")
+	prev := configFile
+	configFile = cfgPath
+	t.Cleanup(func() { configFile = prev })
+
+	cmd := newInitCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--non-interactive"})
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error when --non-interactive and no config exists")
+	}
+}

--- a/scripts/deploy-camunda/cmd/config_init_test.go
+++ b/scripts/deploy-camunda/cmd/config_init_test.go
@@ -72,6 +72,13 @@ func TestConfigInitWizard(t *testing.T) {
 	if profile["repoRoot"] != "/tmp/repo" {
 		t.Errorf("repoRoot = %v, want /tmp/repo", profile["repoRoot"])
 	}
+
+	// The doctor-after-init checklist must reach the cobra output writer (not
+	// bare os.Stdout), otherwise it is invisible to callers capturing output.
+	// The "config file" check line is rendered by report.Render into `out`.
+	if got := out.String(); !strings.Contains(got, "config file") {
+		t.Errorf("doctor checklist not captured in command output; got:\n%s", got)
+	}
 }
 
 func TestConfigInitScaffoldsRDBMS(t *testing.T) {

--- a/scripts/deploy-camunda/cmd/doctor.go
+++ b/scripts/deploy-camunda/cmd/doctor.go
@@ -1,0 +1,119 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"scripts/camunda-core/pkg/logging"
+	"scripts/deploy-camunda/config"
+	"scripts/deploy-camunda/deploy"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// newDoctorCommand creates the `doctor` subcommand: a read-only preflight that
+// reports whether the secrets/env setup a deploy needs is in place, with a
+// remediation hint for anything missing. Mirrors `flyctl doctor`.
+func newDoctorCommand() *cobra.Command {
+	var skipKube bool
+	var fix bool
+
+	cmd := &cobra.Command{
+		Use:   "doctor",
+		Short: "Diagnose deploy setup: config, kube-context, docker creds, required secrets/env",
+		Long: `Run read-only preflight checks and print a ✓/✗ checklist.
+
+Resolves config and .env exactly as a deploy would, then verifies the kube
+context is reachable, docker credentials are present, every variable in the
+vault secret mapping is set, and every $PLACEHOLDER in the selected scenario's
+values is satisfied — so a missing input surfaces here instead of mid-deploy.
+
+Exits non-zero if any required check fails.`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+			defer stop()
+
+			if err := logging.Setup(logging.Options{
+				LevelString:  flags.LogLevel,
+				ColorEnabled: logging.IsTerminal(os.Stdout.Fd()),
+			}); err != nil {
+				return err
+			}
+
+			// Record explicitly-set flags so config merge won't clobber them.
+			flags.ChangedFlags = make(map[string]bool)
+			cmd.Flags().Visit(func(f *pflag.Flag) {
+				flags.ChangedFlags[f.Name] = true
+			})
+
+			_, cfgRes, err := config.LoadAndMerge(configFile, true, &flags)
+			if err != nil {
+				return err
+			}
+			if flags.Chart.RepoRoot == "" {
+				if detected, _ := config.DetectRepoRoot(); detected != "" {
+					flags.Chart.RepoRoot = detected
+				}
+			}
+
+			report := deploy.Preflight(ctx, &flags, deploy.PreflightOptions{
+				ConfigPath:           cfgRes.Path,
+				ConfigFound:          cfgRes.Found,
+				SkipKubeReachability: skipKube,
+			})
+
+			var buf bytes.Buffer
+			report.Render(&buf)
+			fmt.Fprint(os.Stdout, buf.String())
+
+			// --fix: prompt for the missing vars, persist to .env, and re-check.
+			if fix && !report.OK() {
+				if n, err := deploy.ResolveMissingInteractively(ctx, report, &flags); err != nil {
+					return err
+				} else if n > 0 {
+					report = deploy.Preflight(ctx, &flags, deploy.PreflightOptions{
+						ConfigPath:           cfgRes.Path,
+						ConfigFound:          cfgRes.Found,
+						SkipKubeReachability: skipKube,
+					})
+					var after bytes.Buffer
+					report.Render(&after)
+					fmt.Fprintf(os.Stdout, "\nAfter --fix:\n%s", after.String())
+				}
+			}
+
+			if !report.OK() {
+				return fmt.Errorf("preflight failed: fix the ✗ checks above (run `deploy-camunda doctor --fix` to be prompted, or `deploy-camunda config init`)")
+			}
+			return nil
+		},
+	}
+
+	// Inputs that scope the checks. Bound to the shared flags struct so config
+	// merging fills in anything not passed explicitly.
+	f := cmd.Flags()
+	f.StringVar(&flags.Chart.ChartPath, "chart-path", "", "Path to the Camunda chart directory")
+	f.StringVarP(&flags.Chart.Chart, "chart", "c", "", "Chart name")
+	f.StringVarP(&flags.Chart.ChartVersion, "version", "v", "", "Chart version")
+	f.StringVarP(&flags.Deployment.Scenario, "scenario", "s", "", "Scenario to check (comma-separated for multiple)")
+	f.StringVar(&flags.Deployment.ScenarioPath, "scenario-path", "", "Path to scenario files")
+	f.StringVar(&flags.Test.KubeContext, "kube-context", "", "Kubernetes context to check")
+	f.StringVar(&flags.EnvFile, "env-file", "", "Path to .env file (defaults to .env in current dir)")
+	f.StringVar(&flags.Secrets.VaultSecretMapping, "vault-secret-mapping", "", "Vault secret mapping content")
+	f.StringVar(&flags.Docker.DockerUsername, "docker-username", "", "Harbor registry username")
+	f.StringVar(&flags.Docker.DockerPassword, "docker-password", "", "Harbor registry password")
+	f.BoolVar(&flags.Docker.EnsureDockerRegistry, "ensure-docker-registry", false, "Treat Harbor pull secret as required")
+	f.BoolVar(&flags.Docker.EnsureDockerHub, "ensure-docker-hub", false, "Treat Docker Hub pull secret as required")
+	f.StringVarP(&flags.LogLevel, "log-level", "l", "info", "Log level")
+	f.BoolVar(&skipKube, "skip-kube-check", false, "Skip the cluster reachability probe")
+	f.BoolVar(&fix, "fix", false, "Prompt for missing variables and write them to the .env file")
+
+	return cmd
+}

--- a/scripts/deploy-camunda/cmd/root.go
+++ b/scripts/deploy-camunda/cmd/root.go
@@ -79,6 +79,12 @@ func NewRootCommand() *cobra.Command {
 				if cmd.Name() == "auth0" || (cmd.Parent() != nil && cmd.Parent().Name() == "auth0") {
 					return nil
 				}
+				// doctor runs its own config load + preflight; skip the deploy
+				// PersistentPreRunE so its strict Validate doesn't reject a
+				// diagnostic run with no chart/namespace/release set.
+				if cmd.Name() == "doctor" {
+					return nil
+				}
 				if cmd.Name() == "completion" ||
 					cmd.Name() == cobra.ShellCompRequestCmd ||
 					cmd.Name() == cobra.ShellCompNoDescRequestCmd {
@@ -215,8 +221,10 @@ func NewRootCommand() *cobra.Command {
 	f.StringVar(&flags.Deployment.Flow, "flow", "install", "Flow type")
 	f.StringVar(&flags.EnvFile, "env-file", "", "Path to .env file (defaults to .env in current dir)")
 	f.BoolVar(&flags.Interactive, "interactive", true, "Enable interactive prompts for missing variables")
+	f.BoolVar(&flags.SkipPreflight, "skip-preflight", false, "Skip the fail-fast secrets/env preflight run before deploying")
 	f.StringVar(&flags.Secrets.VaultSecretMapping, "vault-secret-mapping", "", "Vault secret mapping content")
 	f.BoolVar(&flags.Secrets.AutoGenerateSecrets, "auto-generate-secrets", false, "Auto-generate certain secrets for testing purposes")
+	f.BoolVar(&flags.Secrets.StrictSecrets, "strict-secrets", false, "Fail if any env var in the vault secret mapping is unset (instead of silently omitting it)")
 	f.BoolVar(&flags.Deployment.DeleteNamespaceFirst, "delete-namespace", false, "Delete the namespace first, then deploy")
 	f.StringVar(&flags.Docker.DockerUsername, "docker-username", "", "Harbor registry username")
 	f.StringVar(&flags.Docker.DockerPassword, "docker-password", "", "Harbor registry password")
@@ -538,6 +546,7 @@ func Execute() error {
 	rootCmd.AddCommand(newEntraCommand())
 	rootCmd.AddCommand(newWatchCommand())
 	rootCmd.AddCommand(newAuth0Command())
+	rootCmd.AddCommand(newDoctorCommand())
 
 	err := rootCmd.Execute()
 	if err != nil {

--- a/scripts/deploy-camunda/cmd/root.go
+++ b/scripts/deploy-camunda/cmd/root.go
@@ -114,6 +114,11 @@ func NewRootCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			// Hand the resolved config path to the preflight via flags.
+			if cfgRes != nil {
+				flags.ConfigPath = cfgRes.Path
+				flags.ConfigFound = cfgRes.Found
+			}
 
 			// Auto-detect repoRoot from CWD if not set by CLI or config.
 			// Soft fallback — repoRoot is optional for deploy, so errors are non-fatal.

--- a/scripts/deploy-camunda/config/config.go
+++ b/scripts/deploy-camunda/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -629,6 +630,10 @@ func GetValue(cfgPath, key string) (string, error) {
 	return formatValue(val), nil
 }
 
+// ErrDeploymentExists is returned by CreateDeployment when the named deployment
+// is already present. Callers match it with errors.Is to take an update path.
+var ErrDeploymentExists = errors.New("deployment already exists")
+
 // CreateDeployment creates a new empty deployment configuration.
 func CreateDeployment(cfgPath, name string) error {
 	content, err := os.ReadFile(cfgPath)
@@ -655,7 +660,7 @@ func CreateDeployment(cfgPath, name string) error {
 
 	// Check if deployment already exists
 	if _, exists := deployments[name]; exists {
-		return fmt.Errorf("deployment %q already exists", name)
+		return fmt.Errorf("deployment %q: %w", name, ErrDeploymentExists)
 	}
 
 	// Create empty deployment

--- a/scripts/deploy-camunda/config/matrix_merge.go
+++ b/scripts/deploy-camunda/config/matrix_merge.go
@@ -1,5 +1,7 @@
 package config
 
+import "strings"
+
 // MergeIntField applies the matrix/root value to target when the CLI flag was
 // not explicitly set by the user. Pointer-typed config values (nil = unset)
 // allow distinguishing "not configured" from zero.
@@ -147,11 +149,44 @@ type MatrixRunFlags struct {
 // For per-platform maps (KubeContexts, IngressBaseDomains, VaultBackedSecrets) and
 // per-version maps (EnvFiles), config values are merged into the already-assembled maps
 // (keys from CLI flags take precedence over config keys).
+// activeDeployment returns the active deployment profile, honoring `current`
+// and auto-selecting when exactly one profile exists (mirrors the selection in
+// ApplyActiveDeployment). Returns nil when no profile applies.
+func activeDeployment(rc *RootConfig) *DeploymentConfig {
+	if rc == nil || len(rc.Deployments) == 0 {
+		return nil
+	}
+	name := rc.Current
+	if strings.TrimSpace(name) == "" && len(rc.Deployments) == 1 {
+		for n := range rc.Deployments {
+			name = n
+		}
+	}
+	if dep, ok := rc.Deployments[name]; ok {
+		return &dep
+	}
+	return nil
+}
+
 func ApplyMatrixRunConfig(rc *RootConfig, changedFlags map[string]bool, f *MatrixRunFlags) {
 	if rc == nil {
 		return
 	}
 	m := &rc.Matrix
+
+	// Fall back to the active deployment profile for shared infra fields so a
+	// profile created by `config init` (which writes deployments.<name>.*) also
+	// configures the matrix — not just single deploys. Precedence stays:
+	// CLI flag > matrix block (m.*) > root (rc.*) > active deployment profile.
+	rcPlatform, rcRepoRoot := rc.Platform, rc.RepoRoot
+	rcKubeContext, rcIngressBaseDomain, rcEnvFile := rc.KubeContext, rc.IngressBaseDomain, rc.EnvFile
+	if dep := activeDeployment(rc); dep != nil {
+		rcPlatform = FirstNonEmpty(rc.Platform, dep.Platform)
+		rcRepoRoot = FirstNonEmpty(rc.RepoRoot, dep.RepoRoot)
+		rcKubeContext = FirstNonEmpty(rc.KubeContext, dep.KubeContext)
+		rcIngressBaseDomain = FirstNonEmpty(rc.IngressBaseDomain, dep.IngressBaseDomain)
+		rcEnvFile = FirstNonEmpty(rc.EnvFile, dep.EnvFile)
+	}
 
 	// --- Filtering & generation ---
 	MergeStringSliceField(f.Versions, m.Versions, nil)
@@ -159,8 +194,8 @@ func ApplyMatrixRunConfig(rc *RootConfig, changedFlags map[string]bool, f *Matri
 	MergeStringField(f.ScenarioFilter, m.ScenarioFilter, "", changedFlags, "scenario-filter")
 	MergeStringField(f.ShortnameFilter, m.ShortnameFilter, "", changedFlags, "shortname-filter")
 	MergeStringField(f.FlowFilter, m.FlowFilter, "", changedFlags, "flow-filter")
-	MergeStringField(f.Platform, m.Platform, rc.Platform, changedFlags, "platform")
-	MergeStringField(f.RepoRoot, m.RepoRoot, rc.RepoRoot, changedFlags, "repo-root")
+	MergeStringField(f.Platform, m.Platform, rcPlatform, changedFlags, "platform")
+	MergeStringField(f.RepoRoot, m.RepoRoot, rcRepoRoot, changedFlags, "repo-root")
 
 	// --- Execution ---
 	MergeStringField(f.NamespacePrefix, m.NamespacePrefix, "", changedFlags, "namespace-prefix")
@@ -181,14 +216,14 @@ func ApplyMatrixRunConfig(rc *RootConfig, changedFlags map[string]bool, f *Matri
 
 	// --- Kube contexts ---
 	// Scalar fallbacks (default context for all platforms)
-	MergeStringField(f.KubeContext, m.KubeContext, rc.KubeContext, changedFlags, "kube-context")
+	MergeStringField(f.KubeContext, m.KubeContext, rcKubeContext, changedFlags, "kube-context")
 	// Per-platform map: merge config map into the CLI-assembled map
 	if f.KubeContexts != nil {
 		MergeStringMapField(f.KubeContexts, m.KubeContexts)
 	}
 
 	// --- Ingress base domains ---
-	MergeStringField(f.IngressBaseDomain, m.IngressBaseDomain, rc.IngressBaseDomain, changedFlags, "ingress-base-domain")
+	MergeStringField(f.IngressBaseDomain, m.IngressBaseDomain, rcIngressBaseDomain, changedFlags, "ingress-base-domain")
 	if f.IngressBaseDomains != nil {
 		MergeStringMapField(f.IngressBaseDomains, m.IngressBaseDomains)
 	}
@@ -200,7 +235,7 @@ func ApplyMatrixRunConfig(rc *RootConfig, changedFlags map[string]bool, f *Matri
 	}
 
 	// --- Env files ---
-	MergeStringField(f.EnvFile, m.EnvFile, rc.EnvFile, changedFlags, "env-file")
+	MergeStringField(f.EnvFile, m.EnvFile, rcEnvFile, changedFlags, "env-file")
 	if f.EnvFiles != nil {
 		MergeStringMapField(f.EnvFiles, m.EnvFiles)
 	}

--- a/scripts/deploy-camunda/config/matrix_merge_test.go
+++ b/scripts/deploy-camunda/config/matrix_merge_test.go
@@ -1,0 +1,113 @@
+package config
+
+import "testing"
+
+// allStringPtrs returns a MatrixRunFlags with every *string/*int/*bool field
+// pointing at fresh zero values, so ApplyMatrixRunConfig can dereference them
+// without nil panics. Tests then inspect the ones they care about.
+func newMatrixRunFlags() (*MatrixRunFlags, *string, *string, *string, *string, *string) {
+	var platform, repoRoot, kubeContext, ingress, envFile string
+	var (
+		versions                                      []string
+		includeDisabled, dryRun, coverage, stopOnFail bool
+		cleanup, deleteNS, skipDep, testIT, testE2E   bool
+		testAll, useVault, ensureReg, ensureHub       bool
+		maxParallel, helmTimeout                      int
+		scenarioFilter, shortnameFilter, flowFilter   string
+		namespacePrefix, logLevel                     string
+		kubeGKE, kubeEKS, ingressGKE, ingressEKS      string
+		dockerUser, dockerPass, hubUser, hubPass      string
+		keycloakHost, keycloakProto, upgradeFrom      string
+	)
+	f := &MatrixRunFlags{
+		Versions: &versions, IncludeDisabled: &includeDisabled,
+		ScenarioFilter: &scenarioFilter, ShortnameFilter: &shortnameFilter, FlowFilter: &flowFilter,
+		Platform: &platform, RepoRoot: &repoRoot,
+		DryRun: &dryRun, Coverage: &coverage, StopOnFailure: &stopOnFail, Cleanup: &cleanup,
+		DeleteNamespace: &deleteNS, NamespacePrefix: &namespacePrefix, MaxParallel: &maxParallel,
+		LogLevel: &logLevel, SkipDependencyUpdate: &skipDep, HelmTimeout: &helmTimeout,
+		TestIT: &testIT, TestE2E: &testE2E, TestAll: &testAll,
+		KubeContext: &kubeContext, KubeContextGKE: &kubeGKE, KubeContextEKS: &kubeEKS,
+		IngressBaseDomain: &ingress, IngressBaseDomainGKE: &ingressGKE, IngressBaseDomainEKS: &ingressEKS,
+		UseVaultBackedSecrets: &useVault,
+		EnvFile:               &envFile,
+		DockerUsername:        &dockerUser, DockerPassword: &dockerPass,
+		EnsureDockerRegistry: &ensureReg, DockerHubUsername: &hubUser, DockerHubPassword: &hubPass,
+		EnsureDockerHub: &ensureHub,
+		KeycloakHost:    &keycloakHost, KeycloakProtocol: &keycloakProto,
+		UpgradeFromVersion: &upgradeFrom,
+	}
+	return f, &platform, &kubeContext, &ingress, &repoRoot, &envFile
+}
+
+func TestApplyMatrixRunConfigUsesActiveDeploymentProfile(t *testing.T) {
+	rc := &RootConfig{
+		Current: "local",
+		Deployments: map[string]DeploymentConfig{
+			"local": {InfraConfig: InfraConfig{
+				Platform:          "gke",
+				KubeContext:       "gke-ctx-from-profile",
+				IngressBaseDomain: "ci.distro.ultrawombat.com",
+				RepoRoot:          "/repo/root",
+				EnvFile:           ".env.profile",
+			}},
+		},
+	}
+
+	f, platform, kubeContext, ingress, repoRoot, envFile := newMatrixRunFlags()
+	ApplyMatrixRunConfig(rc, map[string]bool{}, f)
+
+	if *ingress != "ci.distro.ultrawombat.com" {
+		t.Errorf("ingress = %q, want profile value", *ingress)
+	}
+	if *kubeContext != "gke-ctx-from-profile" {
+		t.Errorf("kubeContext = %q, want profile value", *kubeContext)
+	}
+	if *platform != "gke" {
+		t.Errorf("platform = %q, want gke", *platform)
+	}
+	if *repoRoot != "/repo/root" {
+		t.Errorf("repoRoot = %q, want /repo/root", *repoRoot)
+	}
+	if *envFile != ".env.profile" {
+		t.Errorf("envFile = %q, want .env.profile", *envFile)
+	}
+}
+
+func TestApplyMatrixRunConfigPrecedenceOverProfile(t *testing.T) {
+	rc := &RootConfig{
+		Current: "local",
+		Deployments: map[string]DeploymentConfig{
+			"local": {InfraConfig: InfraConfig{IngressBaseDomain: "profile.example.com", KubeContext: "profile-ctx"}},
+		},
+	}
+	rc.IngressBaseDomain = "root.example.com" // root beats profile
+	rc.Matrix.KubeContext = "matrix-ctx"      // matrix block beats profile
+
+	f, _, kubeContext, ingress, _, _ := newMatrixRunFlags()
+	ApplyMatrixRunConfig(rc, map[string]bool{}, f)
+
+	if *ingress != "root.example.com" {
+		t.Errorf("ingress = %q, want root value (root beats profile)", *ingress)
+	}
+	if *kubeContext != "matrix-ctx" {
+		t.Errorf("kubeContext = %q, want matrix value (matrix block beats profile)", *kubeContext)
+	}
+}
+
+func TestApplyMatrixRunConfigCLIFlagBeatsProfile(t *testing.T) {
+	rc := &RootConfig{
+		Current: "local",
+		Deployments: map[string]DeploymentConfig{
+			"local": {InfraConfig: InfraConfig{IngressBaseDomain: "profile.example.com"}},
+		},
+	}
+
+	f, _, _, ingress, _, _ := newMatrixRunFlags()
+	*ingress = "cli.example.com" // user passed --ingress-base-domain
+	ApplyMatrixRunConfig(rc, map[string]bool{"ingress-base-domain": true}, f)
+
+	if *ingress != "cli.example.com" {
+		t.Errorf("ingress = %q, want cli value (explicit flag wins)", *ingress)
+	}
+}

--- a/scripts/deploy-camunda/config/merge.go
+++ b/scripts/deploy-camunda/config/merge.go
@@ -190,10 +190,9 @@ type RuntimeFlags struct {
 	ConfigFound bool
 
 	// SkipPreflight disables the fail-fast secrets/env preflight that
-	// deploy.Execute runs before any cluster mutation. The matrix runner sets
-	// this true because it performs its own pre-dispatch docker login and
-	// kube-context warmup; direct deploys leave it false so missing inputs
-	// surface up front rather than mid-deploy.
+	// deploy.Execute runs before any cluster mutation. Set via --skip-preflight
+	// as an escape hatch; both direct deploys and matrix entries leave it false
+	// so missing inputs surface up front rather than mid-deploy.
 	SkipPreflight bool
 
 	// ChangedFlags tracks which CLI flags were explicitly set by the user.

--- a/scripts/deploy-camunda/config/merge.go
+++ b/scripts/deploy-camunda/config/merge.go
@@ -100,6 +100,9 @@ type SecretsFlags struct {
 	VaultSecretMapping    string
 	AutoGenerateSecrets   bool
 	UseVaultBackedSecrets bool
+	// StrictSecrets makes vault-secret generation fail if any mapped env var is
+	// unset, instead of silently omitting it from the rendered Secret.
+	StrictSecrets bool
 }
 
 // DebugFlags holds JVM debug configuration.
@@ -179,6 +182,13 @@ type RuntimeFlags struct {
 	LogLevel    string
 	EnvFile     string
 	Interactive bool
+
+	// SkipPreflight disables the fail-fast secrets/env preflight that
+	// deploy.Execute runs before any cluster mutation. The matrix runner sets
+	// this true because it performs its own pre-dispatch docker login and
+	// kube-context warmup; direct deploys leave it false so missing inputs
+	// surface up front rather than mid-deploy.
+	SkipPreflight bool
 
 	// ChangedFlags tracks which CLI flags were explicitly set by the user.
 	// When populated, merge functions will not overwrite these flags with

--- a/scripts/deploy-camunda/config/merge.go
+++ b/scripts/deploy-camunda/config/merge.go
@@ -183,6 +183,12 @@ type RuntimeFlags struct {
 	EnvFile     string
 	Interactive bool
 
+	// ConfigPath is the config file path resolved during flag merging (honoring
+	// --config); ConfigFound reports whether it exists on disk. Consumed by the
+	// fail-fast preflight's config-file check.
+	ConfigPath  string
+	ConfigFound bool
+
 	// SkipPreflight disables the fail-fast secrets/env preflight that
 	// deploy.Execute runs before any cluster mutation. The matrix runner sets
 	// this true because it performs its own pre-dispatch docker login and

--- a/scripts/deploy-camunda/deploy/data/test-secret-mapping.yaml
+++ b/scripts/deploy-camunda/deploy/data/test-secret-mapping.yaml
@@ -1,0 +1,35 @@
+# Vault secret mapping scaffolded by --auto-generate-secrets and `config init`.
+#
+# This file is the single source of truth for which environment variables are
+# packed into the test Secret. Edit it directly (no recompile needed beyond a
+# rebuild of the embedding binary) instead of the old hardcoded string in
+# secrets.go. All variables share one vault path, so the path is declared once.
+#
+# generateTestSecrets random-fills the four DISTRO_QA_E2E_TESTS_* values when
+# they are unset; the remaining IDP_*/OPENAI_* values are read from the
+# environment (whatever is set is included; unset ones are skipped — run
+# `deploy-camunda doctor` to see which are missing).
+path: ci/path
+vars:
+  - DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD
+  - DISTRO_QA_E2E_TESTS_IDENTITY_SECONDUSER_PASSWORD
+  - DISTRO_QA_E2E_TESTS_IDENTITY_THIRDUSER_PASSWORD
+  - DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET
+  - IDP_AWS_ACCESSKEY
+  - IDP_AWS_BUCKET_NAME
+  - IDP_AWS_REGION
+  - IDP_AWS_SECRETKEY
+  - IDP_GCP_SERVICE_ACCOUNT
+  - IDP_GCP_VERTEX_BUCKET_NAME
+  - IDP_GCP_VERTEX_PROJECT_ID
+  - IDP_GCP_DOCUMENT_AI_PROJECT_ID
+  - IDP_GCP_DOCUMENT_AI_PROCESSOR_ID
+  - IDP_GCP_DOCUMENT_AI_REGION
+  - IDP_GCP_VERTEX_REGION
+  - IDP_AZURE_DOCUMENT_INTELLIGENCE_KEY
+  - IDP_AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT
+  - IDP_AZURE_AI_FOUNDRY_ENDPOINT
+  - IDP_AZURE_AI_FOUNDRY_KEY
+  - IDP_AZURE_OPEN_AI_ENDPOINT
+  - IDP_AZURE_OPEN_AI_KEY
+  - OPENAI_API_KEY

--- a/scripts/deploy-camunda/deploy/data/test-secret-mapping.yaml
+++ b/scripts/deploy-camunda/deploy/data/test-secret-mapping.yaml
@@ -1,9 +1,10 @@
 # Vault secret mapping scaffolded by --auto-generate-secrets and `config init`.
 #
 # This file is the single source of truth for which environment variables are
-# packed into the test Secret. Edit it directly (no recompile needed beyond a
-# rebuild of the embedding binary) instead of the old hardcoded string in
-# secrets.go. All variables share one vault path, so the path is declared once.
+# packed into the test Secret, replacing the old hardcoded string in secrets.go.
+# It is baked into the binary via //go:embed at compile time, so any edit here
+# only takes effect after rebuilding deploy-camunda. All variables share one
+# vault path, so the path is declared once.
 #
 # generateTestSecrets random-fills the four DISTRO_QA_E2E_TESTS_* values when
 # they are unset; the remaining IDP_*/OPENAI_* values are read from the

--- a/scripts/deploy-camunda/deploy/deploy.go
+++ b/scripts/deploy-camunda/deploy/deploy.go
@@ -1,6 +1,7 @@
 package deploy
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -16,8 +17,69 @@ import (
 	"scripts/deploy-camunda/config"
 )
 
+// runFailFastPreflight runs the secrets/env preflight before a deploy and
+// returns an error when a required input is missing. It skips the cluster
+// reachability probe (the deploy will contact the cluster regardless) to avoid
+// adding a network round-trip to every run. In interactive mode it downgrades a
+// failure to a warning, because the downstream values.Process step prompts for
+// missing scenario placeholders; non-interactive runs fail fast.
+func runFailFastPreflight(ctx context.Context, flags *config.RuntimeFlags) error {
+	if flags.SkipPreflight {
+		return nil
+	}
+	configPath, found := "", false
+	if cfgRes, err := config.ResolvePath(""); err == nil && cfgRes != nil {
+		configPath, found = cfgRes.Path, cfgRes.Found
+	}
+	report := Preflight(ctx, flags, PreflightOptions{
+		ConfigPath:           configPath,
+		ConfigFound:          found,
+		SkipKubeReachability: true,
+	})
+	if report.OK() {
+		return nil
+	}
+
+	// Interactive runs: prompt for the missing vars, persist them, and re-check
+	// before deciding. Non-interactive runs (the matrix) fail fast with the list.
+	if flags.Interactive {
+		var buf bytes.Buffer
+		report.Render(&buf)
+		logging.Logger.Info().Msgf("preflight found missing inputs:\n%s", buf.String())
+		if n, err := ResolveMissingInteractively(ctx, report, flags); err != nil {
+			return err
+		} else if n > 0 {
+			report = Preflight(ctx, flags, PreflightOptions{
+				ConfigPath:           configPath,
+				ConfigFound:          found,
+				SkipKubeReachability: true,
+			})
+			if report.OK() {
+				return nil
+			}
+		}
+		// Still not satisfied (or nothing entered). Some missing vars may still be
+		// resolvable by the downstream interactive values.Process prompt, so warn
+		// and continue rather than blocking.
+		var after bytes.Buffer
+		report.Render(&after)
+		logging.Logger.Warn().Msgf("preflight still has issues (continuing — downstream prompts may resolve scenario vars):\n%s", after.String())
+		return nil
+	}
+
+	var buf bytes.Buffer
+	report.Render(&buf)
+	return fmt.Errorf("preflight failed before deploy:\n%s\nfix the above, or re-run with --interactive (to be prompted) or --skip-preflight", buf.String())
+}
+
 // Execute performs the actual Camunda deployment based on the provided flags.
 func Execute(ctx context.Context, flags *config.RuntimeFlags) error {
+	// Fail-fast: validate secrets/env before any cluster mutation so a missing
+	// credential surfaces here rather than as an ImagePullBackOff minutes later.
+	if err := runFailFastPreflight(ctx, flags); err != nil {
+		return err
+	}
+
 	// Check if we're deploying multiple scenarios in parallel
 	if len(flags.Deployment.Scenarios) > 1 {
 		return executeParallelDeployments(ctx, flags)

--- a/scripts/deploy-camunda/deploy/deploy.go
+++ b/scripts/deploy-camunda/deploy/deploy.go
@@ -27,9 +27,13 @@ func runFailFastPreflight(ctx context.Context, flags *config.RuntimeFlags) error
 	if flags.SkipPreflight {
 		return nil
 	}
-	configPath, found := "", false
-	if cfgRes, err := config.ResolvePath(""); err == nil && cfgRes != nil {
-		configPath, found = cfgRes.Path, cfgRes.Found
+	// Prefer the path resolved by the root command; fall back to auto-discovery
+	// for callers that don't populate it (e.g. tests).
+	configPath, found := flags.ConfigPath, flags.ConfigFound
+	if configPath == "" {
+		if cfgRes, err := config.ResolvePath(""); err == nil && cfgRes != nil {
+			configPath, found = cfgRes.Path, cfgRes.Found
+		}
 	}
 	report := Preflight(ctx, flags, PreflightOptions{
 		ConfigPath:           configPath,

--- a/scripts/deploy-camunda/deploy/embed.go
+++ b/scripts/deploy-camunda/deploy/embed.go
@@ -22,6 +22,13 @@ type testSecretMappingDoc struct {
 // is emitted as one comma-keyed entry ("<path> VAR1,VAR2,...") rather than
 // repeating the path per variable. The result is consumed by
 // vault-secret-mapper, whose parser accepts comma-separated keys.
+// TestSecretMapping exposes the embedded vault_secret_mapping string to callers
+// outside this package (the matrix runner). It returns the same mapping
+// prepareScenarioValues resolves at deploy time.
+func TestSecretMapping() (string, error) {
+	return embeddedTestSecretMapping()
+}
+
 func embeddedTestSecretMapping() (string, error) {
 	var doc testSecretMappingDoc
 	if err := yaml.Unmarshal(testSecretMappingYAML, &doc); err != nil {

--- a/scripts/deploy-camunda/deploy/embed.go
+++ b/scripts/deploy-camunda/deploy/embed.go
@@ -1,0 +1,34 @@
+package deploy
+
+import (
+	_ "embed"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed data/test-secret-mapping.yaml
+var testSecretMappingYAML []byte
+
+// testSecretMappingDoc is the parsed shape of data/test-secret-mapping.yaml.
+type testSecretMappingDoc struct {
+	Path string   `yaml:"path"`
+	Vars []string `yaml:"vars"`
+}
+
+// embeddedTestSecretMapping builds the vault_secret_mapping string from the
+// embedded data file. All variables share a single vault path, so the mapping
+// is emitted as one comma-keyed entry ("<path> VAR1,VAR2,...") rather than
+// repeating the path per variable. The result is consumed by
+// vault-secret-mapper, whose parser accepts comma-separated keys.
+func embeddedTestSecretMapping() (string, error) {
+	var doc testSecretMappingDoc
+	if err := yaml.Unmarshal(testSecretMappingYAML, &doc); err != nil {
+		return "", fmt.Errorf("parse embedded test-secret-mapping.yaml: %w", err)
+	}
+	if doc.Path == "" || len(doc.Vars) == 0 {
+		return "", fmt.Errorf("embedded test-secret-mapping.yaml: path and vars are required")
+	}
+	return fmt.Sprintf("%s %s;", doc.Path, strings.Join(doc.Vars, ",")), nil
+}

--- a/scripts/deploy-camunda/deploy/embed_test.go
+++ b/scripts/deploy-camunda/deploy/embed_test.go
@@ -1,0 +1,55 @@
+package deploy
+
+import (
+	"sort"
+	"testing"
+
+	"scripts/vault-secret-mapper/pkg/mapper"
+)
+
+// oldHardcodedMapping is the literal that previously lived in secrets.go. The
+// embedded data file must produce the exact same set of required env vars.
+const oldHardcodedMapping = "" +
+	"ci/path DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD;" +
+	"ci/path DISTRO_QA_E2E_TESTS_IDENTITY_SECONDUSER_PASSWORD;" +
+	"ci/path DISTRO_QA_E2E_TESTS_IDENTITY_THIRDUSER_PASSWORD;" +
+	"ci/path DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET;" +
+	"ci/path IDP_AWS_ACCESSKEY;" +
+	"ci/path IDP_AWS_BUCKET_NAME;" +
+	"ci/path IDP_AWS_REGION;" +
+	"ci/path IDP_AWS_SECRETKEY;" +
+	"ci/path IDP_GCP_SERVICE_ACCOUNT;" +
+	"ci/path IDP_GCP_VERTEX_BUCKET_NAME;" +
+	"ci/path IDP_GCP_VERTEX_PROJECT_ID;" +
+	"ci/path IDP_GCP_DOCUMENT_AI_PROJECT_ID;" +
+	"ci/path IDP_GCP_DOCUMENT_AI_PROCESSOR_ID;" +
+	"ci/path IDP_GCP_DOCUMENT_AI_REGION;" +
+	"ci/path IDP_GCP_VERTEX_REGION;" +
+	"ci/path IDP_AZURE_DOCUMENT_INTELLIGENCE_KEY;" +
+	"ci/path IDP_AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT;" +
+	"ci/path IDP_AZURE_AI_FOUNDRY_ENDPOINT;" +
+	"ci/path IDP_AZURE_AI_FOUNDRY_KEY;" +
+	"ci/path IDP_AZURE_OPEN_AI_ENDPOINT;" +
+	"ci/path IDP_AZURE_OPEN_AI_KEY;" +
+	"ci/path OPENAI_API_KEY;"
+
+func TestEmbeddedMappingMatchesLegacy(t *testing.T) {
+	got, err := embeddedTestSecretMapping()
+	if err != nil {
+		t.Fatalf("embeddedTestSecretMapping: %v", err)
+	}
+
+	gotVars := mapper.RequiredEnvVars(got)
+	wantVars := mapper.RequiredEnvVars(oldHardcodedMapping)
+	sort.Strings(gotVars)
+	sort.Strings(wantVars)
+
+	if len(gotVars) != len(wantVars) {
+		t.Fatalf("var count mismatch: got %d, want %d\ngot:  %v\nwant: %v", len(gotVars), len(wantVars), gotVars, wantVars)
+	}
+	for i := range wantVars {
+		if gotVars[i] != wantVars[i] {
+			t.Errorf("var[%d] = %q, want %q", i, gotVars[i], wantVars[i])
+		}
+	}
+}

--- a/scripts/deploy-camunda/deploy/preflight.go
+++ b/scripts/deploy-camunda/deploy/preflight.go
@@ -135,17 +135,28 @@ func effectiveEnv(flags *config.RuntimeFlags) map[string]string {
 func scenarioDeployEnv(flags *config.RuntimeFlags, baseEnv map[string]string) map[string]string {
 	scenario := firstScenario(flags)
 	if scenario == "" || flags.Chart.ChartPath == "" {
-		return baseEnv
+		return withScenarioSeeds(baseEnv)
 	}
 	scenarioCtx, err := generateScenarioContext(scenario, flags)
 	if err != nil || scenarioCtx == nil {
-		return baseEnv
+		return withScenarioSeeds(baseEnv)
 	}
 	env, err := buildScenarioEnv(scenarioCtx, flags)
 	if err != nil || env == nil {
-		return baseEnv
+		return withScenarioSeeds(baseEnv)
 	}
 	return env
+}
+
+// withScenarioSeeds returns a new map of baseEnv overlaid on scenarioEnvSeeds(),
+// so a fallback env carries the same low-precedence seeds buildScenarioEnv adds
+// at step 0. baseEnv is not mutated.
+func withScenarioSeeds(baseEnv map[string]string) map[string]string {
+	merged := scenarioEnvSeeds()
+	for k, v := range baseEnv {
+		merged[k] = v
+	}
+	return merged
 }
 
 // firstScenario returns the first scenario name from flags, honoring both the
@@ -283,11 +294,20 @@ func checkVaultMapping(flags *config.RuntimeFlags, envMap map[string]string) Che
 	if len(missing) == 0 {
 		return Check{Name: "vault secret mapping", Status: StatusOK, Detail: fmt.Sprintf("all %d mapped vars set", len(present))}
 	}
+	// Severity mirrors the deploy: --strict-secrets (mapper.GenerateStrict)
+	// hard-fails on unset mapped vars; the default mapper.Generate omits them
+	// with a warning.
+	status := StatusWarn
+	remediation := "set the listed vars in your .env or environment (the generated Secret silently drops unset keys)"
+	if flags.Secrets.StrictSecrets {
+		status = StatusFail
+		remediation = "set the listed vars — --strict-secrets makes any unset mapped var a hard error"
+	}
 	return Check{
 		Name:        "vault secret mapping",
-		Status:      StatusFail,
+		Status:      status,
 		Detail:      fmt.Sprintf("%d/%d vars unset: %s", len(missing), len(required), strings.Join(missing, ", ")),
-		Remediation: "set the listed vars in your .env or environment (the generated Secret silently drops unset keys)",
+		Remediation: remediation,
 		Missing:     missing,
 	}
 }

--- a/scripts/deploy-camunda/deploy/preflight.go
+++ b/scripts/deploy-camunda/deploy/preflight.go
@@ -1,0 +1,511 @@
+// Package deploy preflight.go implements a self-diagnosing check of the
+// secrets/environment setup a deployment needs, mirroring tools like
+// `flyctl doctor` and `gh auth status`. The same checks back both the
+// standalone `deploy-camunda doctor` command and the fail-fast guard that runs
+// before any cluster mutation, so a missing credential surfaces up front with a
+// remediation hint instead of mid-deploy as an ImagePullBackOff or a
+// `kubectl apply` parse error.
+package deploy
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"scripts/camunda-core/pkg/scenarios"
+	"scripts/camunda-core/pkg/utils"
+	"scripts/deploy-camunda/config"
+	"scripts/prepare-helm-values/pkg/env"
+	"scripts/prepare-helm-values/pkg/placeholders"
+	"scripts/vault-secret-mapper/pkg/mapper"
+)
+
+// CheckStatus is the outcome of a single preflight check.
+type CheckStatus string
+
+const (
+	StatusOK   CheckStatus = "ok"   // requirement satisfied
+	StatusWarn CheckStatus = "warn" // not satisfied, but not strictly required for this run
+	StatusFail CheckStatus = "fail" // required and missing — a deploy would fail
+)
+
+// Check is the result of one preflight probe.
+type Check struct {
+	Name        string
+	Status      CheckStatus
+	Detail      string   // human-readable summary of what was found
+	Remediation string   // how to fix it, shown when Status != StatusOK
+	Missing     []string // env var names this check found unset (for aggregation)
+}
+
+// Report is the collected result of all preflight checks.
+type Report struct {
+	Checks []Check
+}
+
+// OK reports whether no check failed (warnings are tolerated).
+func (r *Report) OK() bool {
+	for _, c := range r.Checks {
+		if c.Status == StatusFail {
+			return false
+		}
+	}
+	return true
+}
+
+// MissingEnv returns the sorted union of env var names reported missing by any
+// check, so callers can prompt for or report them all at once.
+func (r *Report) MissingEnv() []string {
+	seen := map[string]struct{}{}
+	for _, c := range r.Checks {
+		for _, m := range c.Missing {
+			seen[m] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for m := range seen {
+		out = append(out, m)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// PreflightOptions tunes the preflight run.
+type PreflightOptions struct {
+	// ConfigPath is the config file path resolved by the caller (config.ResolvePath).
+	ConfigPath string
+	// ConfigFound reports whether ConfigPath exists on disk.
+	ConfigFound bool
+	// SkipKubeReachability skips the network round-trip that pings the cluster
+	// (used in tests and when only static checks are wanted).
+	SkipKubeReachability bool
+}
+
+// Preflight runs all secrets/env checks against the merged flags and returns a
+// Report. It has no side effects: it never writes files, mutates the process
+// environment, or contacts the cluster beyond an optional read-only readiness
+// ping. Sources are resolved exactly as a deploy would see them — process
+// environment overlaid with the configured .env file.
+func Preflight(ctx context.Context, flags *config.RuntimeFlags, opts PreflightOptions) *Report {
+	r := &Report{}
+	// baseEnv is process env + .env + ExtraEnv. deployEnv additionally includes the
+	// variables the deploy machinery computes per scenario (CAMUNDA_HOSTNAME,
+	// KEYCLOAK_REALM, the *_INDEX_PREFIX vars, FLOW, KEYCLOAK_EXT_*), so scenario
+	// and companion placeholder checks don't false-positive on values the deploy
+	// supplies itself. Vault-mapping and docker checks use baseEnv — those vars are
+	// never deploy-computed.
+	baseEnv := effectiveEnv(flags)
+	deployEnv := scenarioDeployEnv(flags, baseEnv)
+
+	r.Checks = append(r.Checks, checkConfigFile(opts))
+	r.Checks = append(r.Checks, checkKubeContext(ctx, flags, opts))
+	r.Checks = append(r.Checks, checkDockerCredentials(flags, baseEnv)...)
+	r.Checks = append(r.Checks, checkVaultMapping(flags, baseEnv))
+	r.Checks = append(r.Checks, checkScenarioEnv(flags, deployEnv))
+	r.Checks = append(r.Checks, checkCompanionEnv(flags, deployEnv))
+
+	return r
+}
+
+// effectiveEnv reproduces the env layering buildScenarioEnv uses for presence
+// checks, sharing one source of truth with EnvProvenance.
+func effectiveEnv(flags *config.RuntimeFlags) map[string]string {
+	m := map[string]string{}
+	for _, e := range EnvProvenance(flags) {
+		m[e.Name] = e.Value
+	}
+	return m
+}
+
+// scenarioDeployEnv returns the environment a deploy would actually resolve for
+// the first configured scenario — baseEnv plus the variables buildScenarioEnv
+// computes (ingress hostname, Keycloak realm, index prefixes, flow). It reuses
+// the same pure functions the deploy uses (generateScenarioContext +
+// buildScenarioEnv), so the preflight cannot disagree with reality about which
+// variables the user must supply. Falls back to baseEnv when no scenario/chart
+// is configured or the computation fails. Computed variable names are identical
+// across scenarios, so one representative scenario suffices.
+func scenarioDeployEnv(flags *config.RuntimeFlags, baseEnv map[string]string) map[string]string {
+	scenario := firstScenario(flags)
+	if scenario == "" || flags.Chart.ChartPath == "" {
+		return baseEnv
+	}
+	scenarioCtx, err := generateScenarioContext(scenario, flags)
+	if err != nil || scenarioCtx == nil {
+		return baseEnv
+	}
+	env, err := buildScenarioEnv(scenarioCtx, flags)
+	if err != nil || env == nil {
+		return baseEnv
+	}
+	return env
+}
+
+// firstScenario returns the first scenario name from flags, honoring both the
+// parsed Scenarios slice and a comma-separated Scenario string.
+func firstScenario(flags *config.RuntimeFlags) string {
+	if len(flags.Deployment.Scenarios) > 0 {
+		return flags.Deployment.Scenarios[0]
+	}
+	for _, s := range strings.Split(flags.Deployment.Scenario, ",") {
+		if t := strings.TrimSpace(s); t != "" {
+			return t
+		}
+	}
+	return ""
+}
+
+// presence partitions names into those set to a non-empty value and those unset.
+func presence(envMap map[string]string, names []string) (present, missing []string) {
+	for _, n := range names {
+		if v, ok := envMap[n]; ok && v != "" {
+			present = append(present, n)
+		} else {
+			missing = append(missing, n)
+		}
+	}
+	return present, missing
+}
+
+// firstNonEmptyEnv returns the explicit flag value if set, else the first
+// non-empty value among the named env vars (resolved through envMap so .env
+// entries count).
+func firstNonEmptyEnv(envMap map[string]string, flagVal string, names ...string) string {
+	if flagVal != "" {
+		return flagVal
+	}
+	vals := make([]string, 0, len(names))
+	for _, n := range names {
+		vals = append(vals, envMap[n])
+	}
+	return utils.FirstNonEmpty(vals...)
+}
+
+func checkConfigFile(opts PreflightOptions) Check {
+	if opts.ConfigFound {
+		return Check{Name: "config file", Status: StatusOK, Detail: opts.ConfigPath}
+	}
+	detail := "no config file found"
+	if opts.ConfigPath != "" {
+		detail = fmt.Sprintf("not found at %s", opts.ConfigPath)
+	}
+	return Check{
+		Name:        "config file",
+		Status:      StatusWarn,
+		Detail:      detail + " (relying on flags/env)",
+		Remediation: "run `deploy-camunda config init` to scaffold one",
+	}
+}
+
+func checkKubeContext(ctx context.Context, flags *config.RuntimeFlags, opts PreflightOptions) Check {
+	kubeCtx := flags.Test.KubeContext
+	if kubeCtx == "" {
+		if out, err := exec.CommandContext(ctx, "kubectl", "config", "current-context").Output(); err == nil {
+			kubeCtx = strings.TrimSpace(string(out))
+		}
+	}
+	if kubeCtx == "" {
+		return Check{
+			Name:        "kube context",
+			Status:      StatusFail,
+			Detail:      "no context set and no current-context configured",
+			Remediation: "pass --kube-context or run `kubectl config use-context <ctx>`",
+		}
+	}
+	if opts.SkipKubeReachability {
+		return Check{Name: "kube context", Status: StatusOK, Detail: kubeCtx + " (reachability not checked)"}
+	}
+	// Read-only readiness ping; short timeout so an unreachable cluster doesn't hang.
+	probe := exec.CommandContext(ctx, "kubectl", "--context", kubeCtx, "get", "--raw=/readyz", "--request-timeout=5s")
+	if err := probe.Run(); err != nil {
+		return Check{
+			Name:        "kube context",
+			Status:      StatusWarn,
+			Detail:      fmt.Sprintf("%s set but not reachable", kubeCtx),
+			Remediation: "check VPN/Teleport login and that the context points at a live cluster",
+		}
+	}
+	return Check{Name: "kube context", Status: StatusOK, Detail: kubeCtx + " (reachable)"}
+}
+
+// checkDockerCredentials validates Harbor (and optionally Docker Hub) creds
+// using the same flag/env fallback chain as camunda-core/pkg/docker. The checks
+// only fail when the corresponding --ensure-docker-* flag makes the pull secret
+// mandatory; otherwise an absence is a warning.
+func checkDockerCredentials(flags *config.RuntimeFlags, envMap map[string]string) []Check {
+	var checks []Check
+
+	harborUser := firstNonEmptyEnv(envMap, flags.Docker.DockerUsername, "HARBOR_USERNAME", "TEST_DOCKER_USERNAME_CAMUNDA_CLOUD", "NEXUS_USERNAME")
+	harborPass := firstNonEmptyEnv(envMap, flags.Docker.DockerPassword, "HARBOR_PASSWORD", "TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD", "NEXUS_PASSWORD")
+	checks = append(checks, dockerCredCheck(
+		"docker creds (Harbor)", harborUser, harborPass, flags.Docker.EnsureDockerRegistry,
+		"set --docker-username/--docker-password or HARBOR_USERNAME/HARBOR_PASSWORD (or TEST_DOCKER_*_CAMUNDA_CLOUD)"))
+
+	// Only probe Docker Hub when its pull secret is requested.
+	if flags.Docker.EnsureDockerHub {
+		hubUser := firstNonEmptyEnv(envMap, flags.Docker.DockerHubUsername, "DOCKERHUB_USERNAME", "TEST_DOCKER_USERNAME")
+		hubPass := firstNonEmptyEnv(envMap, flags.Docker.DockerHubPassword, "DOCKERHUB_PASSWORD", "TEST_DOCKER_PASSWORD")
+		checks = append(checks, dockerCredCheck(
+			"docker creds (Docker Hub)", hubUser, hubPass, true,
+			"set --dockerhub-username/--dockerhub-password or DOCKERHUB_USERNAME/DOCKERHUB_PASSWORD"))
+	}
+
+	return checks
+}
+
+func dockerCredCheck(name, user, pass string, required bool, remediation string) Check {
+	if user != "" && pass != "" {
+		return Check{Name: name, Status: StatusOK, Detail: "present"}
+	}
+	status := StatusWarn
+	detail := "not set (pull secret not requested)"
+	if required {
+		status = StatusFail
+		detail = "missing — required by --ensure-docker-* (pods would ImagePullBackOff)"
+	}
+	return Check{Name: name, Status: status, Detail: detail, Remediation: remediation}
+}
+
+func checkVaultMapping(flags *config.RuntimeFlags, envMap map[string]string) Check {
+	mapping := flags.Secrets.VaultSecretMapping
+	if strings.TrimSpace(mapping) == "" {
+		return Check{Name: "vault secret mapping", Status: StatusOK, Detail: "no mapping configured"}
+	}
+	required := mapper.RequiredEnvVars(mapping)
+	present, missing := presence(envMap, required)
+	if len(missing) == 0 {
+		return Check{Name: "vault secret mapping", Status: StatusOK, Detail: fmt.Sprintf("all %d mapped vars set", len(present))}
+	}
+	return Check{
+		Name:        "vault secret mapping",
+		Status:      StatusFail,
+		Detail:      fmt.Sprintf("%d/%d vars unset: %s", len(missing), len(required), strings.Join(missing, ", ")),
+		Remediation: "set the listed vars in your .env or environment (the generated Secret silently drops unset keys)",
+		Missing:     missing,
+	}
+}
+
+// checkScenarioEnv scans the values file(s) for the selected scenario(s) and
+// reports any $PLACEHOLDER env vars that are unset. Resolution failures are a
+// soft warning rather than a hard fail so `doctor` is still useful when no
+// scenario/chart is configured yet.
+func checkScenarioEnv(flags *config.RuntimeFlags, envMap map[string]string) Check {
+	scenarioList := flags.Deployment.Scenarios
+	if len(scenarioList) == 0 && flags.Deployment.Scenario != "" {
+		for _, s := range strings.Split(flags.Deployment.Scenario, ",") {
+			if t := strings.TrimSpace(s); t != "" {
+				scenarioList = append(scenarioList, t)
+			}
+		}
+	}
+	if len(scenarioList) == 0 || flags.Chart.ChartPath == "" {
+		return Check{Name: "scenario env vars", Status: StatusOK, Detail: "no scenario/chart configured to scan"}
+	}
+
+	scenarioDir := flags.Deployment.ScenarioPath
+	if scenarioDir == "" {
+		scenarioDir = filepath.Join(flags.Chart.ChartPath, "test/integration/scenarios/chart-full-setup")
+	}
+
+	required := map[string]struct{}{}
+	var unresolved []string
+	for _, scenario := range scenarioList {
+		files, err := scenarioLayerFiles(flags, scenarioDir, scenario)
+		if err != nil || len(files) == 0 {
+			unresolved = append(unresolved, scenario)
+			continue
+		}
+		for _, valuesFile := range files {
+			content, err := os.ReadFile(valuesFile)
+			if err != nil {
+				continue
+			}
+			for _, p := range placeholders.Find(string(content)) {
+				required[p] = struct{}{}
+			}
+		}
+	}
+
+	if len(required) == 0 {
+		if len(unresolved) > 0 {
+			return Check{
+				Name:        "scenario env vars",
+				Status:      StatusWarn,
+				Detail:      "could not resolve values for: " + strings.Join(unresolved, ", "),
+				Remediation: "check --scenario/--scenario-path and --chart-path",
+			}
+		}
+		return Check{Name: "scenario env vars", Status: StatusOK, Detail: "no placeholders in scenario values"}
+	}
+
+	names := make([]string, 0, len(required))
+	for n := range required {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	_, missing := presence(envMap, names)
+	if len(missing) == 0 {
+		return Check{Name: "scenario env vars", Status: StatusOK, Detail: fmt.Sprintf("all %d scenario vars set", len(names))}
+	}
+	return Check{
+		Name:        "scenario env vars",
+		Status:      StatusFail,
+		Detail:      fmt.Sprintf("%d unset: %s", len(missing), strings.Join(missing, ", ")),
+		Remediation: "set the listed vars (run with --interactive to be prompted, or `deploy-camunda config init`)",
+		Missing:     missing,
+	}
+}
+
+// scenarioLayerFiles returns the full set of layered values files a deploy would
+// compose for a scenario — base + identity + persistence + platform + infra +
+// features + … — mirroring the resolution in prepareScenarioValues
+// (values.go ≈ L708). Placeholders ($VAR) live across these layers, not only in
+// the top-level scenario file: e.g. $VENOM_CLIENT_ID / $CONNECTORS_CLIENT_ID live
+// in values/persistence/elasticsearch.yaml. Scanning only the single resolved
+// file made the preflight false-negative on those, letting a deploy pass
+// preflight and then fail in prepareScenarioValues. Selection overrides come from
+// flags exactly as the deploy applies them; with none set, BuildDeploymentConfig
+// derives identity/persistence from the scenario name. Falls back to the single
+// resolved scenario file when the directory is not layered.
+func scenarioLayerFiles(flags *config.RuntimeFlags, scenarioDir, scenario string) ([]string, error) {
+	if !scenarios.HasLayeredValues(scenarioDir) {
+		f, err := scenarios.ResolvePath(scenarioDir, scenario)
+		if err != nil {
+			return nil, err
+		}
+		return []string{f}, nil
+	}
+	platform := flags.Selection.TestPlatform
+	if platform == "" {
+		platform = flags.Deployment.Platform
+	}
+	deployConfig, err := scenarios.BuildDeploymentConfig(scenario, scenarios.BuilderOverrides{
+		Identity:     flags.Selection.Identity,
+		Persistence:  flags.Selection.Persistence,
+		Platform:     platform,
+		Features:     flags.Selection.Features,
+		InfraType:    flags.Selection.InfraType,
+		Flow:         flags.Deployment.Flow,
+		QA:           flags.Selection.QA,
+		ImageTags:    flags.Selection.ImageTags,
+		Upgrade:      flags.Selection.UpgradeFlow,
+		ChartVersion: flags.Chart.ChartVersion,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return deployConfig.ResolvePaths(scenarioDir)
+}
+
+// checkCompanionEnv validates the env vars that companion chart values files
+// need for substitution. It mirrors substituteCompanionEnvVars exactly: a chart
+// contributes requirements only when it has both a values file and a non-empty
+// EnvVars allowlist, and a variable counts as present when its key exists
+// (empty is allowed). The matrix runner populates flags.CompanionCharts from a
+// scenario's dependencies; without this check the substitution would otherwise
+// fail mid-prepare with the same missing-var error.
+func checkCompanionEnv(flags *config.RuntimeFlags, envMap map[string]string) Check {
+	required := map[string]struct{}{}
+	for _, c := range flags.CompanionCharts {
+		if c.ValuesFile == "" {
+			continue
+		}
+		for _, n := range c.EnvVars {
+			if n != "" {
+				required[n] = struct{}{}
+			}
+		}
+	}
+	if len(required) == 0 {
+		return Check{Name: "companion env vars", Status: StatusOK, Detail: "no companion charts requiring env vars"}
+	}
+
+	names := make([]string, 0, len(required))
+	for n := range required {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	var missing []string
+	for _, n := range names {
+		if _, ok := envMap[n]; !ok {
+			missing = append(missing, n)
+		}
+	}
+	if len(missing) == 0 {
+		return Check{Name: "companion env vars", Status: StatusOK, Detail: fmt.Sprintf("all %d companion vars set", len(names))}
+	}
+	return Check{
+		Name:        "companion env vars",
+		Status:      StatusFail,
+		Detail:      fmt.Sprintf("%d unset: %s", len(missing), strings.Join(missing, ", ")),
+		Remediation: "set the listed vars in your .env (RDBMS_POSTGRESQL_* are scaffolded by `deploy-camunda config init`, or use `doctor --fix`)",
+		Missing:     missing,
+	}
+}
+
+// ResolveMissingInteractively prompts for each variable the report flagged as
+// missing, persisting answers to the configured .env file (default ".env") and
+// into the process environment so an in-process deploy picks them up
+// immediately. Returns the number of variables resolved. Intended for
+// human-driven runs (interactive deploys, `doctor --fix`); the matrix runs
+// non-interactively and never calls this. Reuses env.Prompt (context-aware) and
+// env.AppendMultiple (format-preserving, concurrency-safe).
+func ResolveMissingInteractively(ctx context.Context, report *Report, flags *config.RuntimeFlags) (int, error) {
+	missing := report.MissingEnv()
+	if len(missing) == 0 {
+		return 0, nil
+	}
+	envFile := flags.EnvFile
+	if envFile == "" {
+		envFile = ".env"
+	}
+	updates := map[string]string{}
+	for _, name := range missing {
+		val, err := env.Prompt(ctx, name, "")
+		if err != nil {
+			// No more input available (EOF, e.g. non-interactive stdin): stop
+			// prompting and persist whatever was entered so far. Context
+			// cancellation (Ctrl+C) and other errors propagate.
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return len(updates), err
+		}
+		if strings.TrimSpace(val) == "" {
+			continue
+		}
+		os.Setenv(name, val)
+		updates[name] = val
+	}
+	if len(updates) > 0 {
+		if err := env.AppendMultiple(envFile, updates); err != nil {
+			return len(updates), fmt.Errorf("failed to persist resolved vars to %s: %w", envFile, err)
+		}
+	}
+	return len(updates), nil
+}
+
+// Render writes the report as an aligned ✓/✗ checklist to w.
+func (r *Report) Render(w *bytes.Buffer) {
+	symbol := map[CheckStatus]string{StatusOK: "✓", StatusWarn: "!", StatusFail: "✗"}
+	width := 0
+	for _, c := range r.Checks {
+		if len(c.Name) > width {
+			width = len(c.Name)
+		}
+	}
+	for _, c := range r.Checks {
+		fmt.Fprintf(w, "%s %-*s  %s\n", symbol[c.Status], width, c.Name, c.Detail)
+		if c.Status != StatusOK && c.Remediation != "" {
+			fmt.Fprintf(w, "  %-*s  → %s\n", width, "", c.Remediation)
+		}
+	}
+}

--- a/scripts/deploy-camunda/deploy/preflight.go
+++ b/scripts/deploy-camunda/deploy/preflight.go
@@ -1,10 +1,5 @@
-// Package deploy preflight.go implements a self-diagnosing check of the
-// secrets/environment setup a deployment needs, mirroring tools like
-// `flyctl doctor` and `gh auth status`. The same checks back both the
-// standalone `deploy-camunda doctor` command and the fail-fast guard that runs
-// before any cluster mutation, so a missing credential surfaces up front with a
-// remediation hint instead of mid-deploy as an ImagePullBackOff or a
-// `kubectl apply` parse error.
+// Package deploy preflight.go runs the secrets/environment checks that back
+// both `deploy-camunda doctor` and the fail-fast guard in deploy.Execute.
 package deploy
 
 import (
@@ -101,10 +96,16 @@ func Preflight(ctx context.Context, flags *config.RuntimeFlags, opts PreflightOp
 	// and companion placeholder checks don't false-positive on values the deploy
 	// supplies itself. Vault-mapping and docker checks use baseEnv — those vars are
 	// never deploy-computed.
+	// Resolve the chart path first: doctor skips root.go's PersistentPreRunE, so
+	// the check both validates the path and rewrites flags.Chart.ChartPath to the
+	// resolved directory the scenario checks below depend on.
+	chartCheck := checkChartPath(flags)
+
 	baseEnv := effectiveEnv(flags)
 	deployEnv := scenarioDeployEnv(flags, baseEnv)
 
 	r.Checks = append(r.Checks, checkConfigFile(opts))
+	r.Checks = append(r.Checks, chartCheck)
 	r.Checks = append(r.Checks, checkKubeContext(ctx, flags, opts))
 	r.Checks = append(r.Checks, checkDockerCredentials(flags, baseEnv)...)
 	r.Checks = append(r.Checks, checkVaultMapping(flags, baseEnv))
@@ -310,6 +311,36 @@ func checkVaultMapping(flags *config.RuntimeFlags, envMap map[string]string) Che
 		Remediation: remediation,
 		Missing:     missing,
 	}
+}
+
+// checkChartPath resolves the configured chart path the same way root.go's
+// PersistentPreRunE does — a relative path is joined against repoRoot — and
+// fails when it does not resolve to a directory. On success it rewrites
+// flags.Chart.ChartPath to the resolved path so the scenario/companion checks
+// scan the same directory a deploy would.
+func checkChartPath(flags *config.RuntimeFlags) Check {
+	path := strings.TrimSpace(flags.Chart.ChartPath)
+	if path == "" {
+		return Check{Name: "chart path", Status: StatusOK, Detail: "no chart configured"}
+	}
+	if !filepath.IsAbs(path) && flags.Chart.RepoRoot != "" {
+		if _, err := os.Stat(path); err != nil {
+			resolved := filepath.Join(flags.Chart.RepoRoot, path)
+			if fi, err := os.Stat(resolved); err == nil && fi.IsDir() {
+				path = resolved
+			}
+		}
+	}
+	if fi, err := os.Stat(path); err != nil || !fi.IsDir() {
+		return Check{
+			Name:        "chart path",
+			Status:      StatusFail,
+			Detail:      fmt.Sprintf("%q does not exist or is not a directory", path),
+			Remediation: "set --repo-root/--chart/--version or --chart-path to a valid chart directory",
+		}
+	}
+	flags.Chart.ChartPath = path
+	return Check{Name: "chart path", Status: StatusOK, Detail: path}
 }
 
 // checkScenarioEnv scans the values file(s) for the selected scenario(s) and

--- a/scripts/deploy-camunda/deploy/preflight_test.go
+++ b/scripts/deploy-camunda/deploy/preflight_test.go
@@ -1,0 +1,439 @@
+package deploy
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"scripts/deploy-camunda/config"
+)
+
+func TestPresence(t *testing.T) {
+	envMap := map[string]string{"SET": "v", "EMPTY": ""}
+	present, missing := presence(envMap, []string{"SET", "EMPTY", "ABSENT"})
+	if len(present) != 1 || present[0] != "SET" {
+		t.Errorf("present = %v, want [SET]", present)
+	}
+	if len(missing) != 2 || missing[0] != "EMPTY" || missing[1] != "ABSENT" {
+		t.Errorf("missing = %v, want [EMPTY ABSENT]", missing)
+	}
+}
+
+func TestFirstNonEmptyEnv(t *testing.T) {
+	envMap := map[string]string{"B": "fromB", "C": "fromC"}
+	if got := firstNonEmptyEnv(envMap, "flag", "A", "B"); got != "flag" {
+		t.Errorf("flag should win, got %q", got)
+	}
+	if got := firstNonEmptyEnv(envMap, "", "A", "B", "C"); got != "fromB" {
+		t.Errorf("first non-empty env should win, got %q", got)
+	}
+	if got := firstNonEmptyEnv(envMap, "", "A", "Z"); got != "" {
+		t.Errorf("none set should be empty, got %q", got)
+	}
+}
+
+func TestCheckVaultMapping(t *testing.T) {
+	tests := []struct {
+		name    string
+		mapping string
+		envMap  map[string]string
+		want    CheckStatus
+		missing int
+	}{
+		{"no mapping", "", nil, StatusOK, 0},
+		{"all set", "ci/path A;ci/path B;", map[string]string{"A": "1", "B": "2"}, StatusOK, 0},
+		{"some missing", "ci/path A;ci/path B;", map[string]string{"A": "1"}, StatusFail, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flags := &config.RuntimeFlags{}
+			flags.Secrets.VaultSecretMapping = tt.mapping
+			c := checkVaultMapping(flags, tt.envMap)
+			if c.Status != tt.want {
+				t.Errorf("status = %q, want %q (detail: %s)", c.Status, tt.want, c.Detail)
+			}
+			if len(c.Missing) != tt.missing {
+				t.Errorf("missing = %v, want %d entries", c.Missing, tt.missing)
+			}
+		})
+	}
+}
+
+func TestCheckDockerCredentials(t *testing.T) {
+	// Not required → warn; required + missing → fail; present → ok.
+	cases := []struct {
+		name     string
+		flags    config.DockerFlags
+		envMap   map[string]string
+		wantHead CheckStatus // status of the Harbor check (always first)
+	}{
+		{"absent not required", config.DockerFlags{}, nil, StatusWarn},
+		{"absent but required", config.DockerFlags{EnsureDockerRegistry: true}, nil, StatusFail},
+		{"present via flags", config.DockerFlags{DockerUsername: "u", DockerPassword: "p", EnsureDockerRegistry: true}, nil, StatusOK},
+		{"present via env", config.DockerFlags{EnsureDockerRegistry: true}, map[string]string{"HARBOR_USERNAME": "u", "HARBOR_PASSWORD": "p"}, StatusOK},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			flags := &config.RuntimeFlags{Docker: tt.flags}
+			checks := checkDockerCredentials(flags, tt.envMap)
+			if len(checks) == 0 {
+				t.Fatal("expected at least the Harbor check")
+			}
+			if checks[0].Status != tt.wantHead {
+				t.Errorf("Harbor status = %q, want %q (detail: %s)", checks[0].Status, tt.wantHead, checks[0].Detail)
+			}
+		})
+	}
+}
+
+func TestCheckScenarioEnv(t *testing.T) {
+	dir := t.TempDir()
+	// Legacy single-file scenario fixture (prefix matches scenarios.ValuesFilePrefix).
+	scenarioFile := filepath.Join(dir, "values-integration-test-ingress-doctortest.yaml")
+	if err := os.WriteFile(scenarioFile, []byte("license:\n  key: ${DOCTOR_LICENSE}\nfoo: $DOCTOR_FOO\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	base := func() *config.RuntimeFlags {
+		f := &config.RuntimeFlags{}
+		f.Chart.ChartPath = dir // non-empty so the scan runs
+		f.Deployment.ScenarioPath = dir
+		f.Deployment.Scenario = "doctortest"
+		return f
+	}
+
+	t.Run("no chart configured is OK", func(t *testing.T) {
+		c := checkScenarioEnv(&config.RuntimeFlags{}, nil)
+		if c.Status != StatusOK {
+			t.Errorf("status = %q, want ok", c.Status)
+		}
+	})
+
+	t.Run("all placeholders set", func(t *testing.T) {
+		c := checkScenarioEnv(base(), map[string]string{"DOCTOR_LICENSE": "x", "DOCTOR_FOO": "y"})
+		if c.Status != StatusOK {
+			t.Errorf("status = %q, want ok (detail: %s)", c.Status, c.Detail)
+		}
+	})
+
+	t.Run("missing placeholders fail", func(t *testing.T) {
+		c := checkScenarioEnv(base(), map[string]string{"DOCTOR_FOO": "y"})
+		if c.Status != StatusFail {
+			t.Fatalf("status = %q, want fail (detail: %s)", c.Status, c.Detail)
+		}
+		if len(c.Missing) != 1 || c.Missing[0] != "DOCTOR_LICENSE" {
+			t.Errorf("missing = %v, want [DOCTOR_LICENSE]", c.Missing)
+		}
+	})
+
+	t.Run("unresolvable scenario warns", func(t *testing.T) {
+		f := base()
+		f.Deployment.Scenario = "does-not-exist"
+		c := checkScenarioEnv(f, nil)
+		if c.Status != StatusWarn {
+			t.Errorf("status = %q, want warn (detail: %s)", c.Status, c.Detail)
+		}
+	})
+}
+
+// TestCheckScenarioEnvScansLayeredFiles guards the fix for placeholders that
+// live only in a non-base layer (identity/persistence/feature). The deploy
+// composes the full layered set, so a $VAR in values/persistence/elasticsearch.yaml
+// (e.g. $VENOM_CLIENT_ID) must be detected by the preflight; scanning only the
+// top-level scenario file made it false-negative and let the deploy fail later
+// in prepareScenarioValues.
+func TestCheckScenarioEnvScansLayeredFiles(t *testing.T) {
+	dir := t.TempDir()
+	valuesDir := filepath.Join(dir, "values")
+	persistenceDir := filepath.Join(valuesDir, "persistence")
+	if err := os.MkdirAll(persistenceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// base.yaml makes the dir "layered"; the placeholder lives only in the
+	// persistence layer, never in base.
+	if err := os.WriteFile(filepath.Join(valuesDir, "base.yaml"), []byte("global:\n  test: true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(persistenceDir, "elasticsearch.yaml"), []byte("foo:\n  bar: $LAYERED_ONLY_VAR\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	flags := func() *config.RuntimeFlags {
+		f := &config.RuntimeFlags{}
+		f.Chart.ChartPath = dir
+		f.Deployment.ScenarioPath = dir
+		f.Deployment.Scenario = "elasticsearch"
+		// Selection drives ResolvePaths to include the persistence layer, exactly
+		// as the matrix populates it per entry.
+		f.Selection.Identity = "keycloak"
+		f.Selection.Persistence = "elasticsearch"
+		f.Selection.TestPlatform = "gke"
+		return f
+	}
+
+	t.Run("layered placeholder flagged when unset", func(t *testing.T) {
+		c := checkScenarioEnv(flags(), map[string]string{})
+		if c.Status != StatusFail {
+			t.Fatalf("status = %q, want fail (detail: %s)", c.Status, c.Detail)
+		}
+		if len(c.Missing) != 1 || c.Missing[0] != "LAYERED_ONLY_VAR" {
+			t.Errorf("missing = %v, want [LAYERED_ONLY_VAR]", c.Missing)
+		}
+	})
+
+	t.Run("layered placeholder satisfied when set", func(t *testing.T) {
+		c := checkScenarioEnv(flags(), map[string]string{"LAYERED_ONLY_VAR": "x"})
+		if c.Status != StatusOK {
+			t.Errorf("status = %q, want ok (detail: %s)", c.Status, c.Detail)
+		}
+	})
+}
+
+// TestBuildScenarioEnvSeedsKeycloakClientIDs guards the local↔CI parity defaults
+// that mirror test-integration-runner.yaml's workflow env (VENOM_CLIENT_ID=venom,
+// CONNECTORS_CLIENT_ID=connectors). Without them, keycloak elasticsearch
+// scenarios fail locally on the $VENOM_CLIENT_ID/$CONNECTORS_CLIENT_ID
+// placeholders. flags.ExtraEnv (used by OIDC/Entra) must still override.
+func TestBuildScenarioEnvSeedsKeycloakClientIDs(t *testing.T) {
+	ctx := &ScenarioContext{}
+	t.Run("seeds keycloak defaults", func(t *testing.T) {
+		env, err := buildScenarioEnv(ctx, &config.RuntimeFlags{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if env["VENOM_CLIENT_ID"] != "venom" {
+			t.Errorf("VENOM_CLIENT_ID = %q, want venom", env["VENOM_CLIENT_ID"])
+		}
+		if env["CONNECTORS_CLIENT_ID"] != "connectors" {
+			t.Errorf("CONNECTORS_CLIENT_ID = %q, want connectors", env["CONNECTORS_CLIENT_ID"])
+		}
+	})
+
+	t.Run("ExtraEnv (OIDC) overrides the seed", func(t *testing.T) {
+		f := &config.RuntimeFlags{ExtraEnv: map[string]string{"VENOM_CLIENT_ID": "entra-guid"}}
+		env, err := buildScenarioEnv(ctx, f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if env["VENOM_CLIENT_ID"] != "entra-guid" {
+			t.Errorf("VENOM_CLIENT_ID = %q, want entra-guid (ExtraEnv must win)", env["VENOM_CLIENT_ID"])
+		}
+	})
+}
+
+func TestCheckCompanionEnv(t *testing.T) {
+	withCharts := func(charts ...config.CompanionChart) *config.RuntimeFlags {
+		return &config.RuntimeFlags{CompanionCharts: charts}
+	}
+	pg := config.CompanionChart{
+		ReleaseName: "postgresql",
+		ValuesFile:  "/repo/test/integration/companion-values/postgresql.yaml",
+		EnvVars:     []string{"RDBMS_POSTGRESQL_USERNAME", "RDBMS_POSTGRESQL_PASSWORD"},
+	}
+
+	t.Run("no companion charts is OK", func(t *testing.T) {
+		if c := checkCompanionEnv(withCharts(), nil); c.Status != StatusOK {
+			t.Errorf("status = %q, want ok", c.Status)
+		}
+	})
+
+	t.Run("chart without env vars is OK", func(t *testing.T) {
+		c := checkCompanionEnv(withCharts(config.CompanionChart{ReleaseName: "os", ValuesFile: "/x.yaml"}), nil)
+		if c.Status != StatusOK {
+			t.Errorf("status = %q, want ok", c.Status)
+		}
+	})
+
+	t.Run("missing companion vars fail", func(t *testing.T) {
+		c := checkCompanionEnv(withCharts(pg), map[string]string{"RDBMS_POSTGRESQL_USERNAME": "u"})
+		if c.Status != StatusFail {
+			t.Fatalf("status = %q, want fail (detail: %s)", c.Status, c.Detail)
+		}
+		if len(c.Missing) != 1 || c.Missing[0] != "RDBMS_POSTGRESQL_PASSWORD" {
+			t.Errorf("missing = %v, want [RDBMS_POSTGRESQL_PASSWORD]", c.Missing)
+		}
+	})
+
+	t.Run("present (even empty) is OK, matching substitution semantics", func(t *testing.T) {
+		// substituteCompanionEnvVars treats an existing-but-empty key as present.
+		c := checkCompanionEnv(withCharts(pg), map[string]string{
+			"RDBMS_POSTGRESQL_USERNAME": "u",
+			"RDBMS_POSTGRESQL_PASSWORD": "",
+		})
+		if c.Status != StatusOK {
+			t.Errorf("status = %q, want ok (empty value should count as present)", c.Status)
+		}
+	})
+}
+
+func TestScenarioDeployEnvResolvesComputedVars(t *testing.T) {
+	dir := t.TempDir()
+	// Scenario values file that references a deploy-computed var.
+	scenarioFile := filepath.Join(dir, "values-integration-test-ingress-hosttest.yaml")
+	if err := os.WriteFile(scenarioFile, []byte("ingress:\n  host: ${CAMUNDA_HOSTNAME}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	base := func() *config.RuntimeFlags {
+		f := &config.RuntimeFlags{}
+		f.Chart.ChartPath = dir
+		f.Deployment.ScenarioPath = dir
+		f.Deployment.Scenario = "hosttest"
+		f.Deployment.Scenarios = []string{"hosttest"}
+		return f
+	}
+
+	t.Run("CAMUNDA_HOSTNAME satisfied when ingress resolvable", func(t *testing.T) {
+		f := base()
+		f.Ingress.IngressSubdomain = "matrix-810-eske-inst-gke"
+		f.Ingress.IngressBaseDomain = "ci.distro.ultrawombat.com"
+
+		// scenarioDeployEnv must include the computed CAMUNDA_HOSTNAME.
+		env := scenarioDeployEnv(f, effectiveEnv(f))
+		if env["CAMUNDA_HOSTNAME"] == "" {
+			t.Fatalf("CAMUNDA_HOSTNAME not computed; env keys present? %v", env["CAMUNDA_HOSTNAME"])
+		}
+		// And the scenario check (which Preflight feeds deployEnv) must pass.
+		if c := checkScenarioEnv(f, env); c.Status != StatusOK {
+			t.Errorf("scenario env status = %q, want ok (detail: %s)", c.Status, c.Detail)
+		}
+	})
+
+	t.Run("CAMUNDA_HOSTNAME still flagged when ingress unresolvable", func(t *testing.T) {
+		f := base() // no ingress flags → ResolveIngressHostname == ""
+		env := scenarioDeployEnv(f, effectiveEnv(f))
+		if env["CAMUNDA_HOSTNAME"] != "" {
+			t.Fatalf("CAMUNDA_HOSTNAME should be empty without ingress flags, got %q", env["CAMUNDA_HOSTNAME"])
+		}
+		c := checkScenarioEnv(f, env)
+		if c.Status != StatusFail || len(c.Missing) != 1 || c.Missing[0] != "CAMUNDA_HOSTNAME" {
+			t.Errorf("want fail with [CAMUNDA_HOSTNAME], got status=%q missing=%v", c.Status, c.Missing)
+		}
+	})
+}
+
+func TestReportOKAndMissingEnv(t *testing.T) {
+	r := &Report{Checks: []Check{
+		{Name: "a", Status: StatusOK},
+		{Name: "b", Status: StatusWarn},
+		{Name: "c", Status: StatusFail, Missing: []string{"Z", "A"}},
+		{Name: "d", Status: StatusFail, Missing: []string{"A"}},
+	}}
+	if r.OK() {
+		t.Error("OK() should be false when a check failed")
+	}
+	got := r.MissingEnv()
+	if len(got) != 2 || got[0] != "A" || got[1] != "Z" {
+		t.Errorf("MissingEnv() = %v, want sorted union [A Z]", got)
+	}
+
+	clean := &Report{Checks: []Check{{Name: "a", Status: StatusOK}, {Name: "b", Status: StatusWarn}}}
+	if !clean.OK() {
+		t.Error("OK() should be true with only ok/warn checks")
+	}
+}
+
+func TestRunFailFastPreflight(t *testing.T) {
+	// A vault mapping with an unset var makes the preflight fail.
+	failing := func() *config.RuntimeFlags {
+		f := &config.RuntimeFlags{}
+		f.Test.KubeContext = "test-ctx" // OK without reachability probe
+		f.Secrets.VaultSecretMapping = "ci/path DEFINITELY_UNSET_VAR_XYZ;"
+		return f
+	}
+
+	t.Run("skip bypasses entirely", func(t *testing.T) {
+		f := failing()
+		f.SkipPreflight = true
+		if err := runFailFastPreflight(context.Background(), f); err != nil {
+			t.Errorf("SkipPreflight should bypass, got %v", err)
+		}
+	})
+
+	t.Run("non-interactive fails fast", func(t *testing.T) {
+		f := failing()
+		f.Interactive = false
+		if err := runFailFastPreflight(context.Background(), f); err == nil {
+			t.Error("expected fail-fast error for missing vault var")
+		}
+	})
+
+	t.Run("interactive downgrades to warning", func(t *testing.T) {
+		f := failing()
+		f.Interactive = true
+		if err := runFailFastPreflight(context.Background(), f); err != nil {
+			t.Errorf("interactive should not hard-fail, got %v", err)
+		}
+	})
+}
+
+func TestResolveMissingInteractively(t *testing.T) {
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, ".env")
+
+	// Scripted stdin. env.Prompt creates a fresh bufio.Reader per call, which
+	// buffers ahead on piped (non-TTY) input — so multi-line piping only feeds
+	// the first prompt reliably. That's a non-interactive artifact (real TTY use
+	// is line-buffered and feeds each prompt); the test validates the
+	// persist-and-set mechanism with a single missing var.
+	stdinPath := filepath.Join(dir, "stdin")
+	if err := os.WriteFile(stdinPath, []byte("supersecret\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(stdinPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	oldStdin := os.Stdin
+	os.Stdin = f
+	t.Cleanup(func() {
+		os.Stdin = oldStdin
+		os.Unsetenv("RDBMS_POSTGRESQL_PASSWORD")
+	})
+
+	report := &Report{Checks: []Check{{
+		Name:    "companion env vars",
+		Status:  StatusFail,
+		Missing: []string{"RDBMS_POSTGRESQL_PASSWORD"},
+	}}}
+	flags := &config.RuntimeFlags{}
+	flags.EnvFile = envFile
+
+	n, err := ResolveMissingInteractively(context.Background(), report, flags)
+	if err != nil {
+		t.Fatalf("ResolveMissingInteractively: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("resolved = %d, want 1", n)
+	}
+
+	data, err := os.ReadFile(envFile)
+	if err != nil {
+		t.Fatalf(".env not written: %v", err)
+	}
+	if !strings.Contains(string(data), "RDBMS_POSTGRESQL_PASSWORD") {
+		t.Errorf(".env missing RDBMS_POSTGRESQL_PASSWORD; content:\n%s", string(data))
+	}
+	if os.Getenv("RDBMS_POSTGRESQL_PASSWORD") == "" {
+		t.Error("process env RDBMS_POSTGRESQL_PASSWORD not set")
+	}
+}
+
+func TestPreflightSmoke(t *testing.T) {
+	flags := &config.RuntimeFlags{}
+	flags.Test.KubeContext = "test-ctx" // avoids shelling out to kubectl current-context
+	r := Preflight(context.Background(), flags, PreflightOptions{
+		ConfigPath:           "/tmp/x.yaml",
+		ConfigFound:          true,
+		SkipKubeReachability: true,
+	})
+	if r == nil || len(r.Checks) == 0 {
+		t.Fatal("expected a populated report")
+	}
+	if !r.OK() {
+		t.Errorf("clean smoke run should be OK; checks: %+v", r.Checks)
+	}
+}

--- a/scripts/deploy-camunda/deploy/preflight_test.go
+++ b/scripts/deploy-camunda/deploy/preflight_test.go
@@ -204,6 +204,10 @@ func TestCheckScenarioEnvScansLayeredFiles(t *testing.T) {
 // scenarios fail locally on the $VENOM_CLIENT_ID/$CONNECTORS_CLIENT_ID
 // placeholders. flags.ExtraEnv (used by OIDC/Entra) must still override.
 func TestBuildScenarioEnvSeedsKeycloakClientIDs(t *testing.T) {
+	// Isolate from any real .env in the checkout: buildScenarioEnv now defaults
+	// EnvFile to ".env" in CWD, which would otherwise leak local values over the
+	// seed-override assertions below.
+	t.Chdir(t.TempDir())
 	ctx := &ScenarioContext{}
 	t.Run("seeds keycloak defaults", func(t *testing.T) {
 		env, err := buildScenarioEnv(ctx, &config.RuntimeFlags{})
@@ -226,6 +230,41 @@ func TestBuildScenarioEnvSeedsKeycloakClientIDs(t *testing.T) {
 		}
 		if env["VENOM_CLIENT_ID"] != "entra-guid" {
 			t.Errorf("VENOM_CLIENT_ID = %q, want entra-guid (ExtraEnv must win)", env["VENOM_CLIENT_ID"])
+		}
+	})
+}
+
+func TestCheckChartPath(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("no chart configured is OK", func(t *testing.T) {
+		if c := checkChartPath(&config.RuntimeFlags{}); c.Status != StatusOK {
+			t.Errorf("status = %q, want ok", c.Status)
+		}
+	})
+
+	t.Run("nonexistent path fails red", func(t *testing.T) {
+		f := &config.RuntimeFlags{}
+		f.Chart.ChartPath = filepath.Join(dir, "does-not-exist")
+		if c := checkChartPath(f); c.Status != StatusFail {
+			t.Errorf("status = %q, want fail", c.Status)
+		}
+	})
+
+	t.Run("relative path resolves against repoRoot", func(t *testing.T) {
+		chart := filepath.Join(dir, "charts", "camunda-platform-8.10")
+		if err := os.MkdirAll(chart, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		f := &config.RuntimeFlags{}
+		f.Chart.RepoRoot = dir
+		f.Chart.ChartPath = filepath.Join("charts", "camunda-platform-8.10")
+		c := checkChartPath(f)
+		if c.Status != StatusOK {
+			t.Fatalf("status = %q, want ok", c.Status)
+		}
+		if f.Chart.ChartPath != chart {
+			t.Errorf("ChartPath = %q, want resolved %q", f.Chart.ChartPath, chart)
 		}
 	})
 }

--- a/scripts/deploy-camunda/deploy/preflight_test.go
+++ b/scripts/deploy-camunda/deploy/preflight_test.go
@@ -38,18 +38,25 @@ func TestCheckVaultMapping(t *testing.T) {
 	tests := []struct {
 		name    string
 		mapping string
+		strict  bool
 		envMap  map[string]string
 		want    CheckStatus
 		missing int
 	}{
-		{"no mapping", "", nil, StatusOK, 0},
-		{"all set", "ci/path A;ci/path B;", map[string]string{"A": "1", "B": "2"}, StatusOK, 0},
-		{"some missing", "ci/path A;ci/path B;", map[string]string{"A": "1"}, StatusFail, 1},
+		{"no mapping", "", false, nil, StatusOK, 0},
+		{"all set", "ci/path A;ci/path B;", false, map[string]string{"A": "1", "B": "2"}, StatusOK, 0},
+		// Non-strict: the mapper omits unset vars from the Secret, so a missing
+		// var is a warning, not a deploy-blocker.
+		{"some missing non-strict warns", "ci/path A;ci/path B;", false, map[string]string{"A": "1"}, StatusWarn, 1},
+		// Strict: mapper.GenerateStrict hard-fails on unset vars, so the preflight
+		// must too.
+		{"some missing strict fails", "ci/path A;ci/path B;", true, map[string]string{"A": "1"}, StatusFail, 1},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			flags := &config.RuntimeFlags{}
 			flags.Secrets.VaultSecretMapping = tt.mapping
+			flags.Secrets.StrictSecrets = tt.strict
 			c := checkVaultMapping(flags, tt.envMap)
 			if c.Status != tt.want {
 				t.Errorf("status = %q, want %q (detail: %s)", c.Status, tt.want, c.Detail)
@@ -336,11 +343,13 @@ func TestReportOKAndMissingEnv(t *testing.T) {
 }
 
 func TestRunFailFastPreflight(t *testing.T) {
-	// A vault mapping with an unset var makes the preflight fail.
+	// A strict vault mapping with an unset var makes the preflight hard-fail
+	// (non-strict would only warn — see TestCheckVaultMapping).
 	failing := func() *config.RuntimeFlags {
 		f := &config.RuntimeFlags{}
 		f.Test.KubeContext = "test-ctx" // OK without reachability probe
 		f.Secrets.VaultSecretMapping = "ci/path DEFINITELY_UNSET_VAR_XYZ;"
+		f.Secrets.StrictSecrets = true
 		return f
 	}
 

--- a/scripts/deploy-camunda/deploy/provenance.go
+++ b/scripts/deploy-camunda/deploy/provenance.go
@@ -1,0 +1,64 @@
+package deploy
+
+import (
+	"os"
+	"sort"
+	"strings"
+
+	"scripts/deploy-camunda/config"
+	"scripts/prepare-helm-values/pkg/env"
+)
+
+// EnvVar is one effective environment variable and the layer it came from.
+type EnvVar struct {
+	Name   string
+	Value  string
+	Origin string // "process-env", ".env (<path>)", or "extra-env"
+}
+
+// EnvProvenance returns the effective environment a deploy would see, in the
+// same layering buildScenarioEnv uses, annotated with the winning source per
+// key. Later layers override earlier ones: process env → .env file → per-entry
+// ExtraEnv. The result is sorted by name. Values are returned unmasked; callers
+// are responsible for masking secrets in human-facing output (see
+// values.IsSecretName).
+func EnvProvenance(flags *config.RuntimeFlags) []EnvVar {
+	value := map[string]string{}
+	origin := map[string]string{}
+
+	for _, e := range os.Environ() {
+		if k, v, ok := strings.Cut(e, "="); ok {
+			value[k] = v
+			origin[k] = "process-env"
+		}
+	}
+
+	envFile := flags.EnvFile
+	if envFile == "" {
+		envFile = ".env"
+	}
+	if dotenv, err := env.ReadFile(envFile); err == nil {
+		src := ".env (" + envFile + ")"
+		for k, v := range dotenv {
+			value[k] = v
+			origin[k] = src
+		}
+	}
+
+	for k, v := range flags.ExtraEnv {
+		value[k] = v
+		origin[k] = "extra-env"
+	}
+
+	names := make([]string, 0, len(value))
+	for k := range value {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+
+	out := make([]EnvVar, 0, len(names))
+	for _, n := range names {
+		out = append(out, EnvVar{Name: n, Value: value[n], Origin: origin[n]})
+	}
+	return out
+}

--- a/scripts/deploy-camunda/deploy/provenance_test.go
+++ b/scripts/deploy-camunda/deploy/provenance_test.go
@@ -1,0 +1,56 @@
+package deploy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"scripts/deploy-camunda/config"
+)
+
+func TestEnvProvenance(t *testing.T) {
+	// A process var that .env will override, and one only in the process.
+	t.Setenv("PROV_OVERRIDDEN", "from-process")
+	t.Setenv("PROV_PROCESS_ONLY", "p")
+
+	dir := t.TempDir()
+	envFile := filepath.Join(dir, ".env")
+	if err := os.WriteFile(envFile, []byte("PROV_OVERRIDDEN=from-dotenv\nPROV_DOTENV_ONLY=d\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	flags := &config.RuntimeFlags{
+		EnvFile:  envFile,
+		ExtraEnv: map[string]string{"PROV_EXTRA": "e", "PROV_OVERRIDDEN": "from-extra"},
+	}
+
+	got := map[string]EnvVar{}
+	for _, e := range EnvProvenance(flags) {
+		got[e.Name] = e
+	}
+
+	cases := []struct {
+		name       string
+		wantValue  string
+		wantOrigin string
+	}{
+		{"PROV_PROCESS_ONLY", "p", "process-env"},
+		{"PROV_DOTENV_ONLY", "d", ".env (" + envFile + ")"},
+		{"PROV_EXTRA", "e", "extra-env"},
+		// extra-env is the last layer, so it wins over both process and .env.
+		{"PROV_OVERRIDDEN", "from-extra", "extra-env"},
+	}
+	for _, c := range cases {
+		e, ok := got[c.name]
+		if !ok {
+			t.Errorf("%s missing from provenance", c.name)
+			continue
+		}
+		if e.Value != c.wantValue {
+			t.Errorf("%s value = %q, want %q", c.name, e.Value, c.wantValue)
+		}
+		if e.Origin != c.wantOrigin {
+			t.Errorf("%s origin = %q, want %q", c.name, e.Origin, c.wantOrigin)
+		}
+	}
+}

--- a/scripts/deploy-camunda/deploy/secrets.go
+++ b/scripts/deploy-camunda/deploy/secrets.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 
 	"scripts/camunda-core/pkg/logging"
 	"scripts/deploy-camunda/config"
@@ -26,19 +27,24 @@ import (
 //
 // The returned map also contains `vault_secret_mapping` so the caller can feed
 // it into mapper.Generate without touching the process environment.
-func generateTestSecrets(envFile string, existingEnv map[string]string) (map[string]string, error) {
-	text := func() (string, error) {
-		const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-		result := make([]byte, 32)
-		for i := range result {
-			num, err := rand.Int(rand.Reader, big.NewInt(int64(len(chars))))
-			if err != nil {
-				return "", fmt.Errorf("crypto/rand failed: %w", err)
-			}
-			result[i] = chars[num.Int64()]
+// RandomSecret returns a cryptographically-random 32-character alphanumeric
+// string, suitable for scaffolding local dev credentials (e.g. the `config init`
+// wizard's Postgres password). Shared with generateTestSecrets.
+func RandomSecret() (string, error) {
+	const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	result := make([]byte, 32)
+	for i := range result {
+		num, err := rand.Int(rand.Reader, big.NewInt(int64(len(chars))))
+		if err != nil {
+			return "", fmt.Errorf("crypto/rand failed: %w", err)
 		}
-		return string(result), nil
+		result[i] = chars[num.Int64()]
 	}
+	return string(result), nil
+}
+
+func generateTestSecrets(envFile string, existingEnv map[string]string) (map[string]string, error) {
+	text := RandomSecret
 
 	firstUserPwd, err := text()
 	if err != nil {
@@ -71,30 +77,13 @@ func generateTestSecrets(envFile string, existingEnv map[string]string) (map[str
 		}
 	}
 
-	// Add vault secret mapping.
-	secrets["vault_secret_mapping"] = "" +
-		"ci/path DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD;" +
-		"ci/path DISTRO_QA_E2E_TESTS_IDENTITY_SECONDUSER_PASSWORD;" +
-		"ci/path DISTRO_QA_E2E_TESTS_IDENTITY_THIRDUSER_PASSWORD;" +
-		"ci/path DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET;" +
-		"ci/path IDP_AWS_ACCESSKEY;" +
-		"ci/path IDP_AWS_BUCKET_NAME;" +
-		"ci/path IDP_AWS_REGION;" +
-		"ci/path IDP_AWS_SECRETKEY;" +
-		"ci/path IDP_GCP_SERVICE_ACCOUNT;" +
-		"ci/path IDP_GCP_VERTEX_BUCKET_NAME;" +
-		"ci/path IDP_GCP_VERTEX_PROJECT_ID;" +
-		"ci/path IDP_GCP_DOCUMENT_AI_PROJECT_ID;" +
-		"ci/path IDP_GCP_DOCUMENT_AI_PROCESSOR_ID;" +
-		"ci/path IDP_GCP_DOCUMENT_AI_REGION;" +
-		"ci/path IDP_GCP_VERTEX_REGION;" +
-		"ci/path IDP_AZURE_DOCUMENT_INTELLIGENCE_KEY;" +
-		"ci/path IDP_AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT;" +
-		"ci/path IDP_AZURE_AI_FOUNDRY_ENDPOINT;" +
-		"ci/path IDP_AZURE_AI_FOUNDRY_KEY;" +
-		"ci/path IDP_AZURE_OPEN_AI_ENDPOINT;" +
-		"ci/path IDP_AZURE_OPEN_AI_KEY;" +
-		"ci/path OPENAI_API_KEY;"
+	// Add vault secret mapping (loaded from the embedded data file so the var
+	// list is editable as data instead of a recompiled string literal).
+	mapping, err := embeddedTestSecretMapping()
+	if err != nil {
+		return nil, err
+	}
+	secrets["vault_secret_mapping"] = mapping
 
 	// Persist to .env file
 	targetEnvFile := envFile
@@ -118,6 +107,35 @@ func generateTestSecrets(envFile string, existingEnv map[string]string) (map[str
 	}
 
 	return secrets, nil
+}
+
+// ScaffoldTestSecrets generates the random test secrets (identity user
+// passwords + Keycloak client secret) and persists them to envFile, preserving
+// any values that already exist. It is the exported entry point used by the
+// `config init` wizard so first-time setup yields a working .env without the
+// caller having to run a full deploy with --auto-generate-secrets. Returns the
+// names of the secret keys now present in the file.
+func ScaffoldTestSecrets(envFile string) ([]string, error) {
+	if envFile == "" {
+		envFile = ".env"
+	}
+	existing, err := env.ReadFile(envFile)
+	if err != nil {
+		return nil, err
+	}
+	secrets, err := generateTestSecrets(envFile, existing)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(secrets))
+	for k := range secrets {
+		if k == "vault_secret_mapping" {
+			continue
+		}
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names, nil
 }
 
 // renderTestEnvFile generates the E2E test .env file by calling render-e2e-env.sh.

--- a/scripts/deploy-camunda/deploy/values.go
+++ b/scripts/deploy-camunda/deploy/values.go
@@ -373,8 +373,21 @@ func generateDebugValuesFile(outputDir string, flags *config.RuntimeFlags) (stri
 // overrides. The returned map is used as values.Options.EnvOverrides so that
 // parallel calls to values.Process never touch (or race on) the real process env.
 func buildScenarioEnv(scenarioCtx *ScenarioContext, flags *config.RuntimeFlags) (map[string]string, error) {
+	// 0. Seed mapping-rule client ID defaults for Keycloak. These mirror the
+	// workflow-level env defaults in .github/workflows/test-integration-runner.yaml
+	// ("VENOM_CLIENT_ID: venom" / "CONNECTORS_CLIENT_ID: connectors"), which make
+	// keycloak scenarios deploy in CI without anyone supplying these. Local
+	// deploy-camunda runs otherwise lack them and fail in prepareScenarioValues
+	// on the $VENOM_CLIENT_ID/$CONNECTORS_CLIENT_ID placeholders in the
+	// persistence/identity layers. Seeded at the lowest precedence: the process
+	// environment and .env (steps 1–2) override them, and OIDC/Entra entries
+	// override with the real app GUIDs via flags.ExtraEnv (step 4).
+	envMap := map[string]string{
+		"VENOM_CLIENT_ID":      "venom",
+		"CONNECTORS_CLIENT_ID": "connectors",
+	}
+
 	// 1. Snapshot the current process environment as the baseline.
-	envMap := make(map[string]string)
 	for _, entry := range os.Environ() {
 		if k, v, ok := strings.Cut(entry, "="); ok {
 			envMap[k] = v
@@ -834,7 +847,11 @@ func prepareScenarioValues(ctx context.Context, scenarioCtx *ScenarioContext, fl
 		if mapping == "" {
 			mapping = envMap["vault_secret_mapping"]
 		}
-		if err := mapper.Generate(mapping, "vault-mapped-secrets", vaultSecretPath, envMap); err != nil {
+		generate := mapper.Generate
+		if flags.Secrets.StrictSecrets {
+			generate = mapper.GenerateStrict
+		}
+		if err := generate(mapping, "vault-mapped-secrets", vaultSecretPath, envMap); err != nil {
 			os.RemoveAll(tempDir) // Cleanup on error
 			return nil, fmt.Errorf("failed to generate vault secrets: %w", err)
 		}

--- a/scripts/deploy-camunda/deploy/values.go
+++ b/scripts/deploy-camunda/deploy/values.go
@@ -372,6 +372,16 @@ func generateDebugValuesFile(outputDir string, flags *config.RuntimeFlags) (stri
 // the process environment, loading the .env file, and applying scenario-specific
 // overrides. The returned map is used as values.Options.EnvOverrides so that
 // parallel calls to values.Process never touch (or race on) the real process env.
+// scenarioEnvSeeds returns the lowest-precedence client-ID defaults seeded into
+// the scenario env (see buildScenarioEnv step 0). Both buildScenarioEnv and the
+// preflight fallback (scenarioDeployEnv) read from here.
+func scenarioEnvSeeds() map[string]string {
+	return map[string]string{
+		"VENOM_CLIENT_ID":      "venom",
+		"CONNECTORS_CLIENT_ID": "connectors",
+	}
+}
+
 func buildScenarioEnv(scenarioCtx *ScenarioContext, flags *config.RuntimeFlags) (map[string]string, error) {
 	// 0. Seed mapping-rule client ID defaults for Keycloak. These mirror the
 	// workflow-level env defaults in .github/workflows/test-integration-runner.yaml
@@ -382,10 +392,7 @@ func buildScenarioEnv(scenarioCtx *ScenarioContext, flags *config.RuntimeFlags) 
 	// persistence/identity layers. Seeded at the lowest precedence: the process
 	// environment and .env (steps 1–2) override them, and OIDC/Entra entries
 	// override with the real app GUIDs via flags.ExtraEnv (step 4).
-	envMap := map[string]string{
-		"VENOM_CLIENT_ID":      "venom",
-		"CONNECTORS_CLIENT_ID": "connectors",
-	}
+	envMap := scenarioEnvSeeds()
 
 	// 1. Snapshot the current process environment as the baseline.
 	for _, entry := range os.Environ() {
@@ -394,15 +401,19 @@ func buildScenarioEnv(scenarioCtx *ScenarioContext, flags *config.RuntimeFlags) 
 		}
 	}
 
-	// 2. Overlay .env file values (without modifying the process environment).
-	if flags.EnvFile != "" {
-		dotenvMap, err := env.ReadFile(flags.EnvFile)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read env file %q: %w", flags.EnvFile, err)
-		}
-		for k, v := range dotenvMap {
-			envMap[k] = v
-		}
+	// 2. Overlay .env file values (without modifying the process environment),
+	// defaulting to ".env" when unset to match EnvProvenance and the root.go
+	// loader. env.ReadFile returns an empty map (not an error) for an absent file.
+	envFile := flags.EnvFile
+	if envFile == "" {
+		envFile = ".env"
+	}
+	dotenvMap, err := env.ReadFile(envFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read env file %q: %w", envFile, err)
+	}
+	for k, v := range dotenvMap {
+		envMap[k] = v
 	}
 
 	// 3. Apply scenario-specific overrides.

--- a/scripts/deploy-camunda/go.mod
+++ b/scripts/deploy-camunda/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.24
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
+	golang.org/x/term v0.44.0
 	gopkg.in/yaml.v3 v3.0.1
 	scripts/camunda-core v0.0.0
 	scripts/camunda-deployer v0.0.0
@@ -60,7 +61,6 @@ require (
 	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
-	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -1,6 +1,7 @@
 package matrix
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -362,7 +363,81 @@ func dryRun(entries []Entry, opts RunOptions) []RunResult {
 
 	// Print clean dry-run output.
 	fmt.Fprintln(os.Stdout, formatDryRunOutput(resolved, versions, opts))
+
+	// Run the secrets/env preflight per entry so `--dry-run` can confirm a real
+	// run would pass before anything is deployed. Reuses the same engine and
+	// companion-chart wiring as the live path, so the result matches reality.
+	printDryRunPreflight(resolved, opts)
 	return results
+}
+
+// printDryRunPreflight runs deploy.Preflight for each resolved dry-run entry and
+// prints a per-entry ✓/✗ checklist. The cluster reachability probe is skipped
+// (dry-run shouldn't hit the network); everything else matches what the live
+// deploy would validate.
+func printDryRunPreflight(resolved []dryRunEntry, opts RunOptions) {
+	if len(resolved) == 0 {
+		return
+	}
+	configPath, configFound := "", false
+	if cfgRes, err := config.ResolvePath(""); err == nil && cfgRes != nil {
+		configPath, configFound = cfgRes.Path, cfgRes.Found
+	}
+
+	fmt.Fprintln(os.Stdout, "\n=== Preflight (secrets/env validation) ===")
+	for _, dre := range resolved {
+		flags := &config.RuntimeFlags{
+			EnvFile: dre.envFile,
+			Chart: config.ChartFlags{
+				ChartPath: dre.entry.ChartPath,
+				RepoRoot:  opts.RepoRoot,
+			},
+			Deployment: config.DeploymentFlags{
+				Scenario:     dre.entry.Scenario,
+				Scenarios:    []string{dre.entry.Scenario},
+				ScenarioPath: filepath.Join(dre.entry.ChartPath, "test/integration/scenarios/chart-full-setup"),
+				Platform:     dre.platform,
+				Flow:         dre.entry.Flow,
+			},
+			Ingress: config.IngressFlags{IngressHostname: dre.ingressHost},
+			Auth:    config.AuthFlags{Auth: dre.entry.Auth},
+			Test:    config.TestFlags{KubeContext: dre.kubeCtx},
+			// Selection drives the layered values resolution so the scenario-env
+			// check scans the same persistence/identity/feature layers the deploy
+			// composes (where placeholders like $VENOM_CLIENT_ID live).
+			Selection: config.SelectionFlags{
+				Identity:     dre.identity,
+				Persistence:  dre.persistence,
+				TestPlatform: dre.platform,
+				Features:     dre.features,
+				InfraType:    dre.infraType,
+			},
+			Docker: config.DockerFlags{
+				DockerUsername:       opts.DockerUsername,
+				DockerPassword:       opts.DockerPassword,
+				EnsureDockerRegistry: dre.ensureDockerRegistry,
+				DockerHubUsername:    opts.DockerHubUsername,
+				DockerHubPassword:    opts.DockerHubPassword,
+				EnsureDockerHub:      dre.ensureDockerHub,
+			},
+			CompanionCharts: companionChartsForEntry(dre.entry, opts.RepoRoot),
+		}
+
+		report := deploy.Preflight(context.Background(), flags, deploy.PreflightOptions{
+			ConfigPath:           configPath,
+			ConfigFound:          configFound,
+			SkipKubeReachability: true,
+		})
+
+		status := "OK"
+		if !report.OK() {
+			status = "NEEDS ATTENTION"
+		}
+		fmt.Fprintf(os.Stdout, "\n%s (%s) — %s\n", dre.entry.Scenario, dre.namespace, status)
+		var buf bytes.Buffer
+		report.Render(&buf)
+		fmt.Fprint(os.Stdout, buf.String())
+	}
 }
 
 // Style helpers for dry-run output. These wrap logging.Emphasize so colors

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -18,6 +18,41 @@ import (
 	"scripts/prepare-helm-values/pkg/env"
 )
 
+// companionChartsForEntry builds the companion chart list for a matrix entry
+// from its ci-test-config dependencies. Values file paths are resolved relative
+// to the repo root; chart references are resolved to absolute paths when they
+// point at an existing local directory, otherwise passed through as remote
+// repo/chart names. Shared by the deploy path (executeEntry) and the dry-run
+// preflight so both see the same companion env-var requirements.
+func companionChartsForEntry(entry Entry, repoRoot string) []config.CompanionChart {
+	if len(entry.Dependencies) == 0 {
+		return nil
+	}
+	charts := make([]config.CompanionChart, 0, len(entry.Dependencies))
+	for _, dep := range entry.Dependencies {
+		chartRef := dep.Chart
+		version := dep.Version
+		localChartPath := filepath.Join(repoRoot, dep.Chart)
+		if info, err := os.Stat(localChartPath); err == nil && info.IsDir() {
+			chartRef = localChartPath
+			version = "" // --version is only meaningful for remote charts
+		}
+		cc := config.CompanionChart{
+			ChartRef:    chartRef,
+			Version:     version,
+			ReleaseName: dep.ReleaseName,
+			EnvVars:     dep.EnvVars,
+			RepoName:    dep.RepoName,
+			RepoURL:     dep.RepoURL,
+		}
+		if dep.ValuesFile != "" {
+			cc.ValuesFile = filepath.Join(repoRoot, dep.ValuesFile)
+		}
+		charts = append(charts, cc)
+	}
+	return charts
+}
+
 // executeEntry deploys a single matrix entry by constructing RuntimeFlags and calling deploy.Execute().
 // The flow determines the execution strategy:
 //   - Two-step upgrade (upgrade-patch, upgrade-minor): Step 1 installs old version, Step 2 upgrades.
@@ -84,6 +119,13 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) RunResult {
 		LogLevel:    logLevel,
 		Interactive: false,
 		EnvFile:     envFile,
+		// Leave SkipPreflight false so deploy.Execute's fail-fast preflight runs
+		// per entry. By this point flags.CompanionCharts is populated from the
+		// entry's dependencies, so the preflight catches missing companion vars
+		// (e.g. RDBMS_POSTGRESQL_*) and any unset scenario placeholders up front —
+		// with a clear remediation — instead of failing deep in value prep. The
+		// kube reachability probe is skipped in that path, so this adds no network
+		// round-trip on top of the runner's existing docker login + context warmup.
 		Chart: config.ChartFlags{
 			ChartPath:            entry.ChartPath,
 			SkipDependencyUpdate: opts.SkipDependencyUpdate,
@@ -183,33 +225,7 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) RunResult {
 	}
 
 	// Wire companion chart dependencies from ci-test-config.yaml.
-	// Values file paths are resolved relative to the repo root.
-	// Chart references are resolved to absolute paths when they point to an
-	// existing local directory under the repo root; otherwise they are passed
-	// through as-is as remote repo/chart names.
-	if len(entry.Dependencies) > 0 {
-		for _, dep := range entry.Dependencies {
-			chartRef := dep.Chart
-			version := dep.Version
-			localChartPath := filepath.Join(opts.RepoRoot, dep.Chart)
-			if info, err := os.Stat(localChartPath); err == nil && info.IsDir() {
-				chartRef = localChartPath
-				version = "" // --version is only meaningful for remote charts
-			}
-			cc := config.CompanionChart{
-				ChartRef:    chartRef,
-				Version:     version,
-				ReleaseName: dep.ReleaseName,
-				EnvVars:     dep.EnvVars,
-				RepoName:    dep.RepoName,
-				RepoURL:     dep.RepoURL,
-			}
-			if dep.ValuesFile != "" {
-				cc.ValuesFile = filepath.Join(opts.RepoRoot, dep.ValuesFile)
-			}
-			flags.CompanionCharts = append(flags.CompanionCharts, cc)
-		}
-	}
+	flags.CompanionCharts = append(flags.CompanionCharts, companionChartsForEntry(entry, opts.RepoRoot)...)
 
 	// Wire phase reporting: deploy.Execute and RunTests call flags.OnPhase,
 	// which we forward to the matrix-level OnPhaseChange callback.

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -227,6 +227,16 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) RunResult {
 	// Wire companion chart dependencies from ci-test-config.yaml.
 	flags.CompanionCharts = append(flags.CompanionCharts, companionChartsForEntry(entry, opts.RepoRoot)...)
 
+	// Populate the vault secret mapping up front so the fail-fast preflight sees
+	// it; prepareScenarioValues otherwise resolves it only after preflight runs.
+	if flags.Secrets.AutoGenerateSecrets {
+		if mapping, err := deploy.TestSecretMapping(); err == nil {
+			flags.Secrets.VaultSecretMapping = mapping
+		} else {
+			logging.Logger.Warn().Err(err).Msg("Could not load embedded vault secret mapping for preflight validation")
+		}
+	}
+
 	// Wire phase reporting: deploy.Execute and RunTests call flags.OnPhase,
 	// which we forward to the matrix-level OnPhaseChange callback.
 	if opts.OnPhaseChange != nil {

--- a/scripts/prepare-helm-values/pkg/values/processor.go
+++ b/scripts/prepare-helm-values/pkg/values/processor.go
@@ -264,9 +264,13 @@ func Process(ctx context.Context, valuesFile string, opts Options) (string, stri
 // IsSecretName reports whether an environment variable name looks like it holds
 // a secret value (key, secret, password, or token), so callers can mask it in
 // human-facing output. The heuristic is intentionally simple and case-insensitive.
+// The "KEYCLOAK" token is stripped before the "KEY" check so KEYCLOAK_* hostnames
+// and realms (not secrets) are not masked; KEYCLOAK_*_SECRET/_PASSWORD still match
+// the other checks.
 func IsSecretName(name string) bool {
 	upper := strings.ToUpper(name)
-	return strings.Contains(upper, "KEY") ||
+	deKeycloaked := strings.ReplaceAll(upper, "KEYCLOAK", "")
+	return strings.Contains(deKeycloaked, "KEY") ||
 		strings.Contains(upper, "SECRET") ||
 		strings.Contains(upper, "PASSWORD") ||
 		strings.Contains(upper, "TOKEN")

--- a/scripts/prepare-helm-values/pkg/values/processor.go
+++ b/scripts/prepare-helm-values/pkg/values/processor.go
@@ -157,8 +157,7 @@ func Process(ctx context.Context, valuesFile string, opts Options) (string, stri
 		for _, p := range ph {
 			if val, ok := getVal(p); ok {
 				displayVal := val
-				upper := strings.ToUpper(p)
-				if strings.Contains(upper, "KEY") || strings.Contains(upper, "SECRET") || strings.Contains(upper, "PASSWORD") || strings.Contains(upper, "TOKEN") {
+				if IsSecretName(p) {
 					displayVal = "***"
 				}
 				logging.Logger.Info().Str("var", p).Str("value", displayVal).Msg("")
@@ -260,6 +259,17 @@ func Process(ctx context.Context, valuesFile string, opts Options) (string, stri
 	}
 	logging.Logger.Debug().Int("bytes", len(content)).Str("output-path", outputPath).Msg("Successfully wrote bytes to")
 	return outputPath, content, nil
+}
+
+// IsSecretName reports whether an environment variable name looks like it holds
+// a secret value (key, secret, password, or token), so callers can mask it in
+// human-facing output. The heuristic is intentionally simple and case-insensitive.
+func IsSecretName(name string) bool {
+	upper := strings.ToUpper(name)
+	return strings.Contains(upper, "KEY") ||
+		strings.Contains(upper, "SECRET") ||
+		strings.Contains(upper, "PASSWORD") ||
+		strings.Contains(upper, "TOKEN")
 }
 
 // IsMissingEnv returns (true, names) if err is a MissingEnvError.

--- a/scripts/prepare-helm-values/pkg/values/processor_test.go
+++ b/scripts/prepare-helm-values/pkg/values/processor_test.go
@@ -7,6 +7,34 @@ import (
 	"testing"
 )
 
+func TestIsSecretName(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		// Genuine secrets — masked.
+		{"OPENAI_API_KEY", true},
+		{"IDP_AWS_ACCESSKEY", true},
+		{"KEYCLOAK_CLIENTS_SECRET", true},
+		{"KEYCLOAK_ADMIN_PASSWORD", true},
+		{"SOME_TOKEN", true},
+		{"my_password", true},
+		// KEYCLOAK_* hostnames/realms/protocols — NOT secrets, must stay visible.
+		{"KEYCLOAK_REALM", false},
+		{"KEYCLOAK_HOST", false},
+		{"KEYCLOAK_EXT_HOST_8_10", false},
+		{"KEYCLOAK_EXT_PROTOCOL_8_10", false},
+		{"CAMUNDA_HOSTNAME", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsSecretName(tc.name); got != tc.want {
+				t.Errorf("IsSecretName(%q) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestProcessImageTags_NoFileSpecified(t *testing.T) {
 	opts := Options{
 		ImageTagsFile: "",

--- a/scripts/vault-secret-mapper/main.go
+++ b/scripts/vault-secret-mapper/main.go
@@ -18,6 +18,7 @@ func main() {
 	mapping := flag.String("mapping", "", "Vault secret mapping content (multi-line, semicolon-terminated entries)")
 	secretName := flag.String("secret-name", "vault-mapped-secrets", "Kubernetes Secret name to generate")
 	outputPath := flag.String("output", "", "Path to write the generated Secret YAML")
+	strict := flag.Bool("strict", false, "Fail if any mapped env var is unset, instead of omitting it from the Secret")
 	flag.Parse()
 
 	if *outputPath == "" {
@@ -27,7 +28,11 @@ func main() {
 		exitWithError("missing required flag: --mapping")
 	}
 
-	if err := mapper.Generate(*mapping, *secretName, *outputPath); err != nil {
+	generate := mapper.Generate
+	if *strict {
+		generate = mapper.GenerateStrict
+	}
+	if err := generate(*mapping, *secretName, *outputPath); err != nil {
 		exitWithError("%v", err)
 	}
 }

--- a/scripts/vault-secret-mapper/pkg/mapper/mapper.go
+++ b/scripts/vault-secret-mapper/pkg/mapper/mapper.go
@@ -23,10 +23,25 @@ type Metadata struct {
 	Labels map[string]string `yaml:"labels"`
 }
 
+// Generate renders a Kubernetes Secret from the mapping. Environment variables
+// that are unset or empty are skipped with a warning (the resulting Secret
+// simply omits those keys). Use GenerateStrict to fail instead.
 func Generate(mapping, secretName, outputPath string, envOverrides ...map[string]string) error {
+	return generate(mapping, secretName, outputPath, false, envOverrides...)
+}
+
+// GenerateStrict behaves like Generate but returns an error if any variable
+// referenced by the mapping is unset or empty, so CI can refuse to ship an
+// incomplete Secret rather than discovering the gap when a pod crashes.
+func GenerateStrict(mapping, secretName, outputPath string, envOverrides ...map[string]string) error {
+	return generate(mapping, secretName, outputPath, true, envOverrides...)
+}
+
+func generate(mapping, secretName, outputPath string, strict bool, envOverrides ...map[string]string) error {
 	logging.Logger.Debug().
 		Str("secretName", secretName).
 		Str("outputPath", outputPath).
+		Bool("strict", strict).
 		Msg("Generating secret from mapping")
 
 	// Parse the mapping and derive env var names to include in the Secret
@@ -53,19 +68,25 @@ func Generate(mapping, secretName, outputPath string, envOverrides ...map[string
 
 	// Collect non-empty env vars
 	stringData := make(map[string]string)
+	var missing []string
 	for _, name := range envVarNames {
 		if name == "" {
 			continue
 		}
 		val := lookupEnv(name)
 		if val == "" {
-			// Skip empty values to avoid creating empty keys
-			logging.Logger.Debug().Str("var", name).Msg("Environment variable empty or missing, skipping")
+			// The Secret would silently omit this key — warn so it isn't
+			// discovered later as a missing env var inside a crashing pod.
+			missing = append(missing, name)
+			logging.Logger.Warn().Str("var", name).Msg("Environment variable empty or missing, omitting from secret")
 			continue
 		}
 		stringData[name] = val
 	}
-	logging.Logger.Info().Int("mappedCount", len(stringData)).Msg("Mapped environment variables to secret")
+	if len(missing) > 0 && strict {
+		return fmt.Errorf("strict mode: %d mapped variable(s) unset or empty: %s", len(missing), strings.Join(missing, ", "))
+	}
+	logging.Logger.Info().Int("mappedCount", len(stringData)).Int("missing", len(missing)).Msg("Mapped environment variables to secret")
 
 	// Build Labels
 	labels := map[string]string{
@@ -98,6 +119,15 @@ func Generate(mapping, secretName, outputPath string, envOverrides ...map[string
 	}
 
 	return nil
+}
+
+// RequiredEnvVars returns the de-duplicated list of environment variable names
+// referenced by the given vault-secret mapping, in declaration order. This is
+// exactly the set that Generate attempts to read from the environment, exposed
+// so that preflight tooling can validate their presence before a deployment
+// rather than discovering an incomplete Secret at runtime.
+func RequiredEnvVars(mapping string) []string {
+	return dedupePreserveOrder(parseMapping(mapping))
 }
 
 // parseMapping extracts the env var names from the provided mapping.

--- a/scripts/vault-secret-mapper/pkg/mapper/mapper_test.go
+++ b/scripts/vault-secret-mapper/pkg/mapper/mapper_test.go
@@ -1,0 +1,93 @@
+package mapper
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestRequiredEnvVars(t *testing.T) {
+	tests := []struct {
+		name    string
+		mapping string
+		want    []string
+	}{
+		{
+			name:    "empty mapping",
+			mapping: "",
+			want:    []string{},
+		},
+		{
+			name:    "single entry single var",
+			mapping: "ci/path OPENAI_API_KEY;",
+			want:    []string{"OPENAI_API_KEY"},
+		},
+		{
+			name:    "semicolon separated",
+			mapping: "ci/path A;ci/path B;ci/path C;",
+			want:    []string{"A", "B", "C"},
+		},
+		{
+			name:    "newline separated",
+			mapping: "ci/path A\nci/path B\n",
+			want:    []string{"A", "B"},
+		},
+		{
+			name:    "dedupes repeated vars",
+			mapping: "ci/path A;ci/other A;ci/path B;",
+			want:    []string{"A", "B"},
+		},
+		{
+			name:    "uses aliases when present",
+			mapping: "ci/path KEY1 | ALIAS1;",
+			want:    []string{"ALIAS1"},
+		},
+		{
+			name:    "comma separated keys",
+			mapping: "ci/path KEY1,KEY2;",
+			want:    []string{"KEY1", "KEY2"},
+		},
+		{
+			name:    "skips comments and blanks",
+			mapping: "# a comment\nci/path A;\n\nci/path B;",
+			want:    []string{"A", "B"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RequiredEnvVars(tt.mapping)
+			if len(got) == 0 && len(tt.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("RequiredEnvVars(%q) = %v, want %v", tt.mapping, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateStrictFailsOnMissing(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "secret.yaml")
+	overrides := map[string]string{"PRESENT": "v"} // MISSING is absent
+
+	// Non-strict: omits MISSING, succeeds, writes a file.
+	if err := Generate("ci/path PRESENT,MISSING;", "s", out, overrides); err != nil {
+		t.Fatalf("Generate (non-strict) should succeed, got %v", err)
+	}
+	if _, err := os.Stat(out); err != nil {
+		t.Errorf("non-strict should write the secret file: %v", err)
+	}
+
+	// Strict: fails because MISSING is unset.
+	if err := GenerateStrict("ci/path PRESENT,MISSING;", "s", out, overrides); err == nil {
+		t.Error("GenerateStrict should fail when a mapped var is unset")
+	}
+
+	// Strict with everything present: succeeds.
+	full := map[string]string{"PRESENT": "v", "MISSING": "w"}
+	if err := GenerateStrict("ci/path PRESENT,MISSING;", "s", out, full); err != nil {
+		t.Errorf("GenerateStrict should succeed when all vars set, got %v", err)
+	}
+}


### PR DESCRIPTION
### Which problem does the PR fix?

Using `deploy-camunda` (both single deploys and `matrix run`) is cumbersome around **secrets and environment variables**, the #1 setup pain:

- **No guided first run** — you assemble `.env` + `.camunda-deploy.yaml` + docker creds by hand and only discover what's missing when a deploy fails.
- **Failures surface late** — a missing env var or credential blows up mid-deploy (`ImagePullBackOff` after minutes, or a `kubectl apply` parse error on an unresolved `$PLACEHOLDER`). In `matrix run` you lose an entry partway through fan-out.
- **No visibility** into effective values or which source won.
- **A concrete bug this exposed:** keycloak + Elasticsearch scenarios (e.g. `component-persistence`, `elasticsearch`) fail locally with `missing required environment variables: CONNECTORS_CLIENT_ID, VENOM_CLIENT_ID`. CI is green because `test-integration-runner.yaml` sets those as workflow env defaults (`venom`/`connectors`); local runs never replicated them. The preflight also missed them entirely because it only scanned the top-level scenario file, not the composed identity/persistence layers where the placeholders live.

### What's in this PR?

Tooling-only changes under `scripts/` (no chart files), mirroring `flyctl doctor`, `gh auth login/status`, `git config --show-origin`, and envalid/t3-env:

- **`doctor`** — read-only preflight checklist (config file, kube context reachability, docker creds, vault-mapping vars, scenario `$PLACEHOLDER`s, companion vars) with `--fix` to prompt-and-persist missing vars.
- **`config init`** — interactive first-run wizard scaffolding the config profile, `.env`, docker/test-secret/RDBMS dev creds, ending in the `doctor` checklist.
- **`config env --show-origin`** — effective env table with per-key provenance (flag/config/.env/process/generated), secrets masked.
- **Fail-fast** — the same preflight runs before any namespace/helm action (single deploy + matrix), failing once with the full missing-var list; `--interactive` prompts and persists, `--skip-preflight` is the escape hatch.
- **`matrix run --dry-run`** prints a per-entry preflight checklist; the matrix now inherits the active `config init` deployment profile's infra fields (`ingressBaseDomain`/`kubeContext`/`platform`/`repoRoot`/`envFile`).
- **Layered-values awareness** — the preflight resolves the same layered set the deploy composes (`identity/`, `persistence/`, `features/` …) and scans every layer, so placeholders like `$VENOM_CLIENT_ID` are caught up front.
- **Keycloak client-ID defaults** — `buildScenarioEnv` seeds `VENOM_CLIENT_ID=venom` / `CONNECTORS_CLIENT_ID=connectors` at lowest precedence, mirroring the CI workflow env for local↔CI parity; process env / `.env` override, and OIDC/Entra `ExtraEnv` still overrides with real app GUIDs.
- **Vault mapping externalized** — moved from a hardcoded Go constant into an embedded data file; the mapper now warns on dropped vars and gains `--strict-secrets` so CI refuses to ship an incomplete Secret.

Validation: `go build/vet/test ./...` green across all three touched modules (`deploy-camunda`, `prepare-helm-values`, `vault-secret-mapper`); gofmt clean. New regression tests cover the layered-scan, the keycloak seed (and ExtraEnv override), matrix profile inheritance, provenance, embedded mapping, and the mapper warn/strict paths. End-to-end dry-run preflight for 8.10 keycloak+Elasticsearch scenarios now reports `VENOM_CLIENT_ID`/`CONNECTORS_CLIENT_ID` as satisfied, leaving only the genuinely user-supplied `RDBMS_POSTGRESQL_*`.

### Checklist

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`. _(N/A — no chart templates changed.)_
- [ ] There is no other open pull request for the same update/change.
- [x] Tests for charts are added (if needed). _(Go unit tests added for the tooling.)_
- [x] In-repo documentation are updated (if needed). _(New `scripts/deploy-camunda/README.md` + `SKILLS.md` pointer.)_

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)?
- [ ] Did all checks/tests pass in the PR?
