### PR TITLE
ci: install release-tools before first use in release-chores workflow

### DIFF
--- a/.github/workflows/chart-release-chores.yaml
+++ b/.github/workflows/chart-release-chores.yaml
@@ -60,6 +60,8 @@ jobs:
             yq
       - name: Add Go bin directory to PATH
         run: echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+      - name: Install release-tools
+        run: make install.release-tools
       - name: Install readme-generator-for-helm
         run: |
           # renovate: datasource=npm depName=@bitnami/readme-generator-for-helm
@@ -114,7 +116,6 @@ jobs:
       - name: Generate version matrix
         run: |
           set -euo pipefail
-          make install.release-tools
           make helm.dependency-update chartPath="${CHANGED_CHARTS}"
           for chartPath in ${CHANGED_CHARTS}; do
             app="${chartPath#charts/camunda-platform-}"


### PR DESCRIPTION
### Which problem does the PR fix?

The `chart-release-chores.yaml` workflow calls `release-tools` in the "Generate release notes" step (via `make release.generate-notes`), but `make install.release-tools` only ran later in the "Generate version matrix" step. On the first release-please run after #6359 moved release-notes generation to the `release-tools` Go binary, the chores check fails with `release-tools: command not found` (e.g. on #6399).

#6385 added the `Add Go bin directory to PATH` step but did not move the install ahead of first use, so the ordering bug remained.

### What's in this PR?

Adds a dedicated `Install release-tools` step right after the PATH is set, before any step that invokes `release-tools`. Removes the now-redundant `make install.release-tools` from the "Generate version matrix" step.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
