### PR TITLE
ci: use --force-with-lease in release-chores commit step

### DIFF
--- a/.github/workflows/chart-release-chores.yaml
+++ b/.github/workflows/chart-release-chores.yaml
@@ -152,6 +152,7 @@ jobs:
           author_name: "distro-ci[bot]"
           author_email: "122795778+distro-ci[bot]@users.noreply.github.com"
           message: "chore(release): update chart files + version matrix"
+          push_options: '--force-with-lease'
 
   report-status:
     name: "Report release-chores status"


### PR DESCRIPTION
### Which problem does the PR fix?

The `Generate release files` job in `chart-release-chores.yaml` intermittently fails with:

```
GH006: Protected branch update failed for refs/heads/release-please--branches--main--components--<version>
[remote rejected] (protected branch hook declined)
```

**Root cause — two push types, one race:**

There are two types of pushes to the release-please tracking branch:

1. **Release-please push** — when a `fix:`/`feat:` is merged to `main`, release-please pushes to the tracking branch updating `Chart.yaml`, `.release-please-manifest.json`, and `CHANGELOG.md`.
2. **Chores push** — the chores workflow responds to push #1 by generating extra files (release notes, version matrix, golden snapshots, README) and pushing those on top.

The chores push itself triggers another `pull_request: synchronize` event (the PR still has manifest changes vs `main`), which starts a new chores run. This creates the following loop:

```
fix merged to main
  → release-please pushes commit A to tracking branch
    → chores run #1 triggered (action_required — waits for Vault approval)
      → hours later, approved and runs
        → chores pushes commit B ("chore(release): update chart files")
          → commit B triggers pull_request synchronize
            → chores run #2 starts immediately
```

Run #1 and run #2 now overlap. Both check out the branch at the same HEAD (by branch name, not SHA). Both run ~4 minutes of release tooling. The first to push wins; the second gets GH006 because the repo's `*` wildcard legacy branch protection rule enforces **Require Linear History**, which rejects non-fast-forward pushes.

The concurrency group (`cancel-in-progress: true`) does not help here — it only cancels runs that are queued or in-progress. Run #1 was sitting in `action_required` (waiting for Vault approval) and was never cancelled when run #2 started.

A manual retry fixes it because the retry checks out the current branch HEAD (post run #1's push) and pushes a fast-forward commit.

### What's in this PR?

Adds `push_options: '--force-with-lease'` to the `EndBug/add-and-commit` step.

`--force-with-lease` pushes successfully when the remote branch has not moved since checkout (the normal case). If the branch moved (i.e. two runs raced and the other won), it fails fast with a clear error instead of GH006. The result is the same — a retry is needed — but the failure is explicit and the root cause is obvious.

### Checklist

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?