### PR TITLE
ci: prevent harbor retry misreading 401 in image tag as auth error

### DIFF
--- a/scripts/harbor-retry.sh
+++ b/scripts/harbor-retry.sh
@@ -111,7 +111,7 @@ harbor_helm_pull() {
     fi
 
     # Auth error -> retry with re-auth; anything else -> return failure immediately
-    if grep -qiE '401|unauthorized|unauthenticated' "${pull_stderr}"; then
+    if grep -qiE 'unauthorized|unauthenticated|status code 401' "${pull_stderr}"; then
       echo "::warning::helm pull auth error on attempt ${attempt}/${max_retries}"
       cat "${pull_stderr}" >&2
       if [[ ${attempt} -lt ${max_retries} ]]; then


### PR DESCRIPTION
### Which problem does the PR fix?

Build Dev fails the "Check if artifact already exists" step for any commit whose short SHA contains `401`. `harbor_helm_pull` matched a bare `401` against the 404 message, treating `camunda-platform:13.11.2-dev-040152b: not found` (SHA `040152b`) as an auth error → 3 retries → `Harbor auth failure`.

### What's in this PR?

Match auth tokens that can't occur in a hex SHA or tag: `grep -qiE 'unauthorized|unauthenticated|status code 401'`.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
