### PR TITLE
chore: harden ingress and OIDC readiness detection before E2E tests

### DIFF
--- a/scripts/base_playwright_script.sh
+++ b/scripts/base_playwright_script.sh
@@ -399,10 +399,10 @@ _wait_for_ingress_ready() {
     while IFS= read -r path; do
       [[ -z "$path" ]] && continue
       local http_code
-      http_code=$(curl -sk -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 10 "${resolve_flag[@]}" "https://${hostname}${path}" 2>/dev/null || echo "000")
+      http_code=$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 10 "${resolve_flag[@]}" "https://${hostname}${path}" 2>/dev/null || echo "000")
       status_summary+=" ${path}=${http_code}"
 
-      # 502, 503, 504, 000 (connection failure) mean the LB is not ready
+      # 502, 503, 504, 000 (connection failure or TLS error) mean not ready
       if [[ "$http_code" == "502" || "$http_code" == "503" || "$http_code" == "504" || "$http_code" == "000" ]]; then
         all_ready=false
       fi
@@ -419,6 +419,29 @@ _wait_for_ingress_ready() {
   done
 
   info "${COLOR_RED}ERROR:${COLOR_RESET} Ingress readiness timed out after ${timeout}s on ${hostname}"
+  return 1
+}
+
+# Args: hostname, [timeout_seconds=300]
+_wait_for_oidc_endpoint() {
+  local hostname="$1"
+  local timeout="${2:-300}"
+  local path="/orchestration/oauth2/authorization/oidc"
+  local elapsed=0
+  info "Waiting for OIDC endpoint to be ready on ${hostname}${path} (timeout ${timeout}s)..."
+  while [[ $elapsed -lt $timeout ]]; do
+    local http_code
+    http_code=$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 10 \
+      --max-redirs 0 "https://${hostname}${path}" 2>/dev/null || echo "000")
+    if [[ "$http_code" != "502" && "$http_code" != "503" && "$http_code" != "504" && "$http_code" != "000" ]]; then
+      info "OIDC endpoint ready (${elapsed}s): ${path}=${http_code}"
+      return 0
+    fi
+    info "  OIDC not ready yet (${elapsed}s/${timeout}s): ${path}=${http_code}"
+    sleep 10
+    elapsed=$((elapsed + 10))
+  done
+  info "${COLOR_RED}ERROR:${COLOR_RESET} OIDC endpoint not ready after ${timeout}s on ${hostname}${path}"
   return 1
 }
 

--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -203,7 +203,11 @@ if [[ "$IS_CI" != "true" ]]; then
   _wait_for_dns_resolution "$hostname" || exit 1
 fi
 
-_wait_for_ingress_ready "$hostname" "$NAMESPACE" 120 "$KUBE_CONTEXT" || exit 1
+_wait_for_ingress_ready "$hostname" "$NAMESPACE" 300 "$KUBE_CONTEXT" || exit 1
+
+if [[ "$IS_AUTH0" == "true" ]]; then
+  _wait_for_oidc_endpoint "$hostname" 300 || exit 1
+fi
 
 if [[ "$IS_CI" != "true" ]] && [[ "$_NEEDS_DNS_FALLBACK" == "true" ]]; then
   _enable_dns_fallback "$hostname" "$_RESOLVED_IP"


### PR DESCRIPTION
### Which problem does the PR fix?

Nightly scenarios `esa0` (8.10, Auth0 OIDC) and `esot` (8.8, Elasticsearch self-signed OS trust) produced intermittent E2E failures because tests started before the cluster was truly ready — cert-manager had not yet provisioned a trusted TLS certificate, or the orchestration service had not yet loaded its OIDC provider configuration.

Observed in nightly runs https://github.com/camunda/camunda-platform-helm/actions/runs/27834165929/job/82379410148 and https://github.com/camunda/camunda-platform-helm/actions/runs/27825932315/job/82352235429.

### What's in this PR?

**`scripts/base_playwright_script.sh`**

1. Remove `-k` (insecure TLS) from `curl` inside `_wait_for_ingress_ready`.  
   Previously `-k` meant curl accepted a not-yet-issued cert and returned an HTTP status code, causing the readiness check to pass before cert-manager had provisioned a trusted certificate. Without `-k`, a certificate error causes curl to exit non-zero → `000`, and the polling loop keeps waiting until the cert is valid.

2. Increase the ingress readiness timeout from 120 s → 300 s to give cert-manager sufficient headroom on fresh namespace deployments (especially `esot`, which provisions a self-signed CA and injects it as a K8s secret before install).

3. Add `_wait_for_oidc_endpoint`: polls `/orchestration/oauth2/authorization/oidc` with `--max-redirs 0` (treats the 302→IdP redirect as "ready" without following it) until the endpoint returns non-5xx, confirming the orchestration service has loaded its OIDC provider metadata.

**`scripts/run-e2e-tests.sh`**

- Wire the increased ingress timeout (120 → 300 s).
- Call `_wait_for_oidc_endpoint` when `--auth0` is active (the `esa0` scenario).

### Checklist

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?