### PR TITLE
test(8.10): run bitnami→companion migration hook for MT and document-store modular upgrades

### DIFF
--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -1224,6 +1224,16 @@ integration:
               values-file: test/integration/companion-values/elasticsearch-qa.yaml
               repo-name: elastic
               repo-url: https://helm.elastic.co
+          post-infra:
+            script: post-infra-bitnami-migration.sh
+            description: |
+              After the companion PostgreSQL/Keycloak/Elasticsearch are deployed but before
+              the chart upgrade to 8.10, migrate the bundled (Bitnami) Keycloak realm and the
+              Elasticsearch authorization indices off the bundled backends onto the companion
+              services. Uses the camunda-deployment-references migration scripts in external
+              mode with SKIP_HELM_UPGRADE=true (data-only; the matrix runner performs the
+              chart upgrade). This keeps users/realm alive across the upgrade that removes the
+              bundled Bitnami subcharts.
         - name: qa-elasticsearch-rba
           enabled: false
           shortname: qaelrba
@@ -1422,6 +1432,16 @@ integration:
               values-file: test/integration/companion-values/elasticsearch-qa.yaml
               repo-name: elastic
               repo-url: https://helm.elastic.co
+          post-infra:
+            script: post-infra-bitnami-migration.sh
+            description: |
+              After the companion PostgreSQL/Keycloak/Elasticsearch are deployed but before
+              the chart upgrade to 8.10, migrate the bundled (Bitnami) Keycloak realm and the
+              Elasticsearch authorization indices off the bundled backends onto the companion
+              services. Uses the camunda-deployment-references migration scripts in external
+              mode with SKIP_HELM_UPGRADE=true (data-only; the matrix runner performs the
+              chart upgrade). This keeps users/realm alive across the upgrade that removes the
+              bundled Bitnami subcharts.
         - name: qa-document-store-upg
           enabled: false
           shortname: qadocupg
@@ -1455,6 +1475,16 @@ integration:
               values-file: test/integration/companion-values/elasticsearch.yaml
               repo-name: elastic
               repo-url: https://helm.elastic.co
+          post-infra:
+            script: post-infra-bitnami-migration.sh
+            description: |
+              After the companion PostgreSQL/Keycloak/Elasticsearch are deployed but before
+              the chart upgrade to 8.10, migrate the bundled (Bitnami) Keycloak realm and the
+              Elasticsearch authorization indices off the bundled backends onto the companion
+              services. Uses the camunda-deployment-references migration scripts in external
+              mode with SKIP_HELM_UPGRADE=true (data-only; the matrix runner performs the
+              chart upgrade). This keeps users/realm alive across the upgrade that removes the
+              bundled Bitnami subcharts.
         - name: qa-license
           enabled: false
           shortname: lic

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/qa-document-store-upg-modular-eks.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/qa-document-store-upg-modular-eks.yaml
@@ -13,6 +13,7 @@ infra-type:
   eks: preemptible
 qa: true
 image-tags: true
+post-infra: post-infra-bitnami-migration
 dependencies:
   - postgresql
   - keycloak

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/qa-document-store-upg-modular-gke.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/qa-document-store-upg-modular-gke.yaml
@@ -13,6 +13,7 @@ infra-type:
   gke: qa-workloads
 qa: true
 image-tags: true
+post-infra: post-infra-bitnami-migration
 dependencies:
   - postgresql-qa
   - keycloak-qa

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/qa-elasticsearch-mt-upg-modular.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/qa-elasticsearch-mt-upg-modular.yaml
@@ -13,6 +13,7 @@ infra-type:
   gke: qa-workloads
 qa: true
 image-tags: true
+post-infra: post-infra-bitnami-migration
 dependencies:
   - postgresql-qa
   - keycloak-qa


### PR DESCRIPTION
### Which problem does the PR fix?

The `SM Nightly 8.10 Upgrade Minor MT` run fails: after the 8.9→8.10 modular
upgrade, demo/bart/lisa hit **"You don't have access to this component"** in
Operate, and `/v2/authentication/me` returns empty `roles` and `tenants`.

Originating nightly run:
https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/27930811972

Root cause: the `post-infra-bitnami-migration` hook — which migrates the bundled
(Bitnami) Keycloak realm and the Elasticsearch authorization indices onto the
companion services *before* the chart upgrade removes the bundled subcharts —
was wired only to `qa-elasticsearch-upg-modular` when it was introduced in #6343.
The MT and document-store modular-upgrade scenarios were left without it, so the
companion Elasticsearch is never seeded with the 8.9 authorization data. After
the upgrade the orchestration reads an effectively empty authorization store.

This is why the plain ES modular upgrade is green while MT / document-store are red.

### What's in this PR?

Adds `post-infra: post-infra-bitnami-migration` to the Elasticsearch-backed
modular-upgrade scenarios that were missing it:

- `qa-elasticsearch-mt-upg-modular.yaml`
- `qa-document-store-upg-modular-gke.yaml`
- `qa-document-store-upg-modular-eks.yaml`

Registry snapshot regenerated via `make go.update-registry-golden`.

OpenSearch modular upgrade is intentionally out of scope here: the hook is
Elasticsearch-specific, and that scenario shows a separate `/identity` login
failure that needs its own fix.

**Verification (live GKE repro):** installed 8.9-MT (bundled), ran the
`modular-upgrade-minor` flow, and inspected the companion Elasticsearch. Without
the hook the companion ES had **0 authorizations / 0 tenants** and the `admin`
role kept only the newly-seeded mapping rules (demo and the 8.9 members were
absent) — reproducing the nightly failure. The plain ES modular scenario, which
already carries the hook, is green.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
