### PR TITLE
build: deploy companion charts in parallel

### DIFF
--- a/scripts/camunda-deployer/go.mod
+++ b/scripts/camunda-deployer/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/sync v0.21.0
 	gopkg.in/yaml.v3 v3.0.1
 	scripts/camunda-core v0.0.0
 )

--- a/scripts/camunda-deployer/go.sum
+++ b/scripts/camunda-deployer/go.sum
@@ -117,6 +117,8 @@ golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
+golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/scripts/camunda-deployer/pkg/deployer/deployer.go
+++ b/scripts/camunda-deployer/pkg/deployer/deployer.go
@@ -114,11 +114,8 @@ func Deploy(ctx context.Context, o types.Options) error {
 		}
 	}
 
-	// Deploy companion charts (e.g., OpenSearch) as separate Helm releases in
-	// the same namespace, concurrently — they are independent of each other and
-	// each is deployed with --wait. deployCompanionCharts blocks until all are
-	// ready, which keeps them ordered before the post-infra hooks and the main
-	// Camunda chart below.
+	// Deploy companion charts before the post-infra hooks and main chart.
+	// deployCompanionCharts blocks until all companions are ready.
 	if err := deployCompanionCharts(ctx, o); err != nil {
 		return err
 	}

--- a/scripts/camunda-deployer/pkg/deployer/deployer.go
+++ b/scripts/camunda-deployer/pkg/deployer/deployer.go
@@ -114,19 +114,13 @@ func Deploy(ctx context.Context, o types.Options) error {
 		}
 	}
 
-	// Deploy companion charts (e.g., OpenSearch) as separate Helm releases
-	// in the same namespace. Each chart is deployed with --wait to ensure
-	// it is ready before the main Camunda chart deployment begins.
-	for i, cc := range o.CompanionCharts {
-		logging.Logger.Info().
-			Str("chart", cc.ChartRef).
-			Str("version", cc.Version).
-			Str("release", cc.ReleaseName).
-			Str("namespace", o.Namespace).
-			Msg("Deploying companion chart")
-		if err := deployCompanionChart(ctx, cc, o); err != nil {
-			return fmt.Errorf("companion chart [%d] %q failed: %w", i, cc.ReleaseName, err)
-		}
+	// Deploy companion charts (e.g., OpenSearch) as separate Helm releases in
+	// the same namespace, concurrently — they are independent of each other and
+	// each is deployed with --wait. deployCompanionCharts blocks until all are
+	// ready, which keeps them ordered before the post-infra hooks and the main
+	// Camunda chart below.
+	if err := deployCompanionCharts(ctx, o); err != nil {
+		return err
 	}
 
 	// Run post-infra hooks after the companion charts (external infrastructure)

--- a/scripts/camunda-deployer/pkg/deployer/helm.go
+++ b/scripts/camunda-deployer/pkg/deployer/helm.go
@@ -212,19 +212,13 @@ func formatArgs(args []string) string {
 	return strings.Join(parts, " ")
 }
 
-// companionRepoMu serializes helm repo add/update across concurrent companion
-// deployments — those commands rewrite the shared repositories.yaml, so
-// concurrent writers would race. No current scenario pairs two remote-repo
-// companions, so contention is effectively zero; this guards future ones.
+// companionRepoMu serializes helm repo add/update — those commands rewrite the
+// shared repositories.yaml and must not run concurrently.
 var companionRepoMu sync.Mutex
 
-// deployCompanionCharts deploys all configured companion charts concurrently as
-// separate Helm releases in the same namespace. Companions are independent of
-// each other (only the main chart depends on them), so they install in
-// parallel. The call blocks until every companion is ready; on the first
-// failure the shared context is cancelled, terminating in-flight siblings, and
-// the first error is returned. A single companion behaves identically to a
-// serial deploy.
+// deployCompanionCharts deploys all configured companion charts concurrently,
+// blocking until every companion is ready or the first failure cancels the rest.
+// Returns the first error encountered; nil means all companions are up.
 func deployCompanionCharts(ctx context.Context, o types.Options) error {
 	g, gCtx := errgroup.WithContext(ctx)
 	for i, cc := range o.CompanionCharts {

--- a/scripts/camunda-deployer/pkg/deployer/helm.go
+++ b/scripts/camunda-deployer/pkg/deployer/helm.go
@@ -8,7 +8,10 @@ import (
 	"scripts/camunda-core/pkg/logging"
 	"scripts/camunda-deployer/pkg/types"
 	"strings"
+	"sync"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 )
 
 // Package-level function variables for helm operations. These default to the
@@ -209,17 +212,57 @@ func formatArgs(args []string) string {
 	return strings.Join(parts, " ")
 }
 
+// companionRepoMu serializes helm repo add/update across concurrent companion
+// deployments — those commands rewrite the shared repositories.yaml, so
+// concurrent writers would race. No current scenario pairs two remote-repo
+// companions, so contention is effectively zero; this guards future ones.
+var companionRepoMu sync.Mutex
+
+// deployCompanionCharts deploys all configured companion charts concurrently as
+// separate Helm releases in the same namespace. Companions are independent of
+// each other (only the main chart depends on them), so they install in
+// parallel. The call blocks until every companion is ready; on the first
+// failure the shared context is cancelled, terminating in-flight siblings, and
+// the first error is returned. A single companion behaves identically to a
+// serial deploy.
+func deployCompanionCharts(ctx context.Context, o types.Options) error {
+	g, gCtx := errgroup.WithContext(ctx)
+	for i, cc := range o.CompanionCharts {
+		g.Go(func() error {
+			logging.Logger.Info().
+				Str("chart", cc.ChartRef).
+				Str("version", cc.Version).
+				Str("release", cc.ReleaseName).
+				Str("namespace", o.Namespace).
+				Msg("Deploying companion chart")
+			if err := deployCompanionChart(gCtx, cc, o); err != nil {
+				return fmt.Errorf("companion chart [%d] %q failed: %w", i, cc.ReleaseName, err)
+			}
+			return nil
+		})
+	}
+	return g.Wait()
+}
+
 // deployCompanionChart deploys a single companion chart as its own Helm release
 // in the same namespace as the main Camunda chart. It uses helm upgrade --install
 // with --wait to ensure the chart is fully ready before returning.
 func deployCompanionChart(ctx context.Context, cc types.CompanionChart, o types.Options) error {
 	// Ensure the Helm repo is registered when a repo-style chart ref is used.
 	if cc.RepoName != "" && cc.RepoURL != "" {
-		if err := helmRepoAdd(ctx, cc.RepoName, cc.RepoURL); err != nil {
-			return fmt.Errorf("companion chart %q: repo add failed: %w", cc.ReleaseName, err)
-		}
-		if err := helmRepoUpdate(ctx); err != nil {
-			return fmt.Errorf("companion chart %q: repo update failed: %w", cc.ReleaseName, err)
+		companionRepoMu.Lock()
+		err := func() error {
+			if err := helmRepoAdd(ctx, cc.RepoName, cc.RepoURL); err != nil {
+				return fmt.Errorf("companion chart %q: repo add failed: %w", cc.ReleaseName, err)
+			}
+			if err := helmRepoUpdate(ctx); err != nil {
+				return fmt.Errorf("companion chart %q: repo update failed: %w", cc.ReleaseName, err)
+			}
+			return nil
+		}()
+		companionRepoMu.Unlock()
+		if err != nil {
+			return err
 		}
 	}
 

--- a/scripts/camunda-deployer/pkg/deployer/helm.go
+++ b/scripts/camunda-deployer/pkg/deployer/helm.go
@@ -244,8 +244,9 @@ func deployCompanionCharts(ctx context.Context, o types.Options) error {
 func deployCompanionChart(ctx context.Context, cc types.CompanionChart, o types.Options) error {
 	// Ensure the Helm repo is registered when a repo-style chart ref is used.
 	if cc.RepoName != "" && cc.RepoURL != "" {
-		companionRepoMu.Lock()
 		err := func() error {
+			companionRepoMu.Lock()
+			defer companionRepoMu.Unlock()
 			if err := helmRepoAdd(ctx, cc.RepoName, cc.RepoURL); err != nil {
 				return fmt.Errorf("companion chart %q: repo add failed: %w", cc.ReleaseName, err)
 			}
@@ -254,7 +255,6 @@ func deployCompanionChart(ctx context.Context, cc types.CompanionChart, o types.
 			}
 			return nil
 		}()
-		companionRepoMu.Unlock()
 		if err != nil {
 			return err
 		}

--- a/scripts/camunda-deployer/pkg/deployer/helm_test.go
+++ b/scripts/camunda-deployer/pkg/deployer/helm_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"scripts/camunda-deployer/pkg/types"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -503,5 +504,150 @@ func TestUpgradeInstall_NoRetryOnNonTransient(t *testing.T) {
 	}
 	if attempts != 1 {
 		t.Errorf("expected exactly 1 helm invocation for non-transient error, got %d", attempts)
+	}
+}
+
+func TestDeployCompanionCharts_DeploysInParallel(t *testing.T) {
+	restore := stubHelm(
+		func(ctx context.Context, args []string, workDir string) error { return nil },
+		func(ctx context.Context, name, url string) error { return nil },
+		func(ctx context.Context) error { return nil },
+	)
+	defer restore()
+
+	var inFlight, maxInFlight, total int32
+	helmRunCapturing = func(ctx context.Context, args []string, workDir string) (string, error) {
+		atomic.AddInt32(&total, 1)
+		cur := atomic.AddInt32(&inFlight, 1)
+		for {
+			prev := atomic.LoadInt32(&maxInFlight)
+			if cur <= prev || atomic.CompareAndSwapInt32(&maxInFlight, prev, cur) {
+				break
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+		atomic.AddInt32(&inFlight, -1)
+		return "", nil
+	}
+
+	err := deployCompanionCharts(context.Background(), types.Options{
+		Namespace: "ns",
+		CompanionCharts: []types.CompanionChart{
+			{ChartRef: "/charts/a", ReleaseName: "a"},
+			{ChartRef: "/charts/b", ReleaseName: "b"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if total != 2 {
+		t.Errorf("expected both companions to deploy, got %d invocations", total)
+	}
+	if maxInFlight < 2 {
+		t.Errorf("expected companions to overlap (maxInFlight>=2), got %d — deploys ran serially", maxInFlight)
+	}
+}
+
+func TestDeployCompanionCharts_ErrorCancelsSiblings(t *testing.T) {
+	restore := stubHelm(
+		func(ctx context.Context, args []string, workDir string) error { return nil },
+		func(ctx context.Context, name, url string) error { return nil },
+		func(ctx context.Context) error { return nil },
+	)
+	defer restore()
+
+	var siblingCancelled atomic.Bool
+	helmRunCapturing = func(ctx context.Context, args []string, workDir string) (string, error) {
+		if containsArg(args, "fails") {
+			return "", fmt.Errorf("boom")
+		}
+		// Slow sibling: block until the failing companion cancels the group ctx.
+		select {
+		case <-ctx.Done():
+			siblingCancelled.Store(true)
+			return "", ctx.Err()
+		case <-time.After(2 * time.Second):
+			return "", nil
+		}
+	}
+
+	err := deployCompanionCharts(context.Background(), types.Options{
+		Namespace: "ns",
+		CompanionCharts: []types.CompanionChart{
+			{ChartRef: "/charts/fails", ReleaseName: "fails"},
+			{ChartRef: "/charts/slow", ReleaseName: "slow"},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error from failing companion, got nil")
+	}
+	if !strings.Contains(err.Error(), "companion chart") {
+		t.Errorf("error = %q, want it to mention the failing companion chart", err.Error())
+	}
+	if !siblingCancelled.Load() {
+		t.Error("expected the in-flight sibling to observe context cancellation")
+	}
+}
+
+func TestDeployCompanionCharts_SingleCompanionSucceeds(t *testing.T) {
+	restore := stubHelm(
+		func(ctx context.Context, args []string, workDir string) error { return nil },
+		func(ctx context.Context, name, url string) error { return nil },
+		func(ctx context.Context) error { return nil },
+	)
+	defer restore()
+
+	var calls int32
+	helmRunCapturing = func(ctx context.Context, args []string, workDir string) (string, error) {
+		atomic.AddInt32(&calls, 1)
+		return "", nil
+	}
+
+	err := deployCompanionCharts(context.Background(), types.Options{
+		Namespace: "ns",
+		CompanionCharts: []types.CompanionChart{
+			{ChartRef: "/charts/only", ReleaseName: "only"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected exactly 1 companion deploy, got %d", calls)
+	}
+}
+
+func TestDeployCompanionCharts_RepoRegistrationSerialized(t *testing.T) {
+	var inFlight, maxRepoInFlight int32
+	repoOp := func() {
+		cur := atomic.AddInt32(&inFlight, 1)
+		for {
+			prev := atomic.LoadInt32(&maxRepoInFlight)
+			if cur <= prev || atomic.CompareAndSwapInt32(&maxRepoInFlight, prev, cur) {
+				break
+			}
+		}
+		time.Sleep(30 * time.Millisecond)
+		atomic.AddInt32(&inFlight, -1)
+	}
+	restore := stubHelm(
+		func(ctx context.Context, args []string, workDir string) error { return nil },
+		func(ctx context.Context, name, url string) error { repoOp(); return nil },
+		func(ctx context.Context) error { return nil },
+	)
+	defer restore()
+
+	err := deployCompanionCharts(context.Background(), types.Options{
+		Namespace: "ns",
+		CompanionCharts: []types.CompanionChart{
+			{ChartRef: "x/a", ReleaseName: "a", RepoName: "x", RepoURL: "https://x"},
+			{ChartRef: "y/b", ReleaseName: "b", RepoName: "y", RepoURL: "https://y"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if maxRepoInFlight != 1 {
+		t.Errorf("repo registration must be serialized (maxRepoInFlight=1), got %d", maxRepoInFlight)
 	}
 }

--- a/scripts/deploy-camunda/go.mod
+++ b/scripts/deploy-camunda/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
+	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	golang.org/x/time v0.3.0 // indirect

--- a/scripts/deploy-camunda/go.sum
+++ b/scripts/deploy-camunda/go.sum
@@ -156,8 +156,8 @@ golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
-golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
+golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes #6252.

CI scenarios with multiple companion charts (e.g. 8.10 `eske` = Elasticsearch + Keycloak) deployed companions **serially**, each with `--wait`, so total pre-deploy time was the **sum** of all companion install times (~6 min) before the main Camunda chart even started.

### What's in this PR?

Companions are independent of each other (only the main chart depends on them), so they now install **concurrently** via `errgroup`:

- New `deployCompanionCharts` helper fans out one goroutine per companion. `g.Wait()` is a barrier that keeps all companions ordered **before** the post-infra hooks and the main chart — preserving the maintainer-required lifecycle (post-infra runs after companions are ready, e.g. Bitnami 8.9→8.10 migration scripts). Loop position in `deployer.go` is unchanged, so the ordering constraint holds.
- On the first companion failure, the shared context is cancelled, terminating in-flight siblings (verified: `helm.RunCaptureStderr` → `executil.RunCommandCaptureStderr` uses `exec.CommandContext`).
- `helm repo add/update` rewrite the shared `repositories.yaml`; a mutex guards them so concurrent companions never race on that file. No current scenario pairs two remote-repo companions (8.10 `eske`: Keycloak is a local chart, only Elasticsearch is remote), so contention is effectively zero today — the guard protects future ones.

Expected impact: pre-deploy time drops from sum → max (~2 min saved per multi-companion scenario, across the 8.10 `identity: keycloak` matrix).

Tests added in `helm_test.go`: parallel overlap, error-cancels-siblings, single-companion preserved, repo-registration serialized (all pass under `-race`).

Files changed are Go tooling under `scripts/` only (no user-facing chart files), hence `build:` per the CI PR-title rule.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
