### PR TITLE
test(SM-8.9): tune Optimize import for faster e2e nightlies

### DIFF
--- a/charts/camunda-platform-8.9/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry-snapshot.yaml
@@ -328,6 +328,20 @@ integration:
             gke: alwaysgreen
           identity: keycloak
           persistence: elasticsearch
+        - name: shadow-e2e
+          enabled: true
+          shortname: shde2
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          skip-e2e: true
         - name: qa-elasticsearch
           enabled: false
           shortname: qael

--- a/charts/camunda-platform-8.9/test/ci/registry/manifest.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/manifest.yaml
@@ -84,6 +84,10 @@ integration:
     - id: alwaysgreen
       shortname: agrn
       enabled: false
+    - id: shadow-e2e
+      shortname: shde2
+      tier: 2
+      enabled: true
     - id: qa-elasticsearch
       shortname: qael
       enabled: false

--- a/charts/camunda-platform-8.9/test/ci/registry/scenarios/shadow-e2e.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/scenarios/shadow-e2e.yaml
@@ -1,0 +1,11 @@
+name: shadow-e2e
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: elasticsearch
+platforms:
+  - gke
+infra-type:
+  gke: distroci
+skip-e2e: true

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/base.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/base.yaml
@@ -88,6 +88,13 @@ optimize:
   enabled: true
   contextPath: "/optimize"
   partitionCount: "1"
+  env:
+    - name: CAMUNDA_OPTIMIZE_IMPORT_HANDLER_BACKOFF_MAX
+      value: "1"
+    - name: CAMUNDA_OPTIMIZE_IMPORT_CURRENTTIMEBACKOFFMILLISECONDS
+      value: "1000"
+    - name: CAMUNDA_OPTIMIZE_ZEEBE_MAXIMPORTPAGESIZE
+      value: "1000"
   # Right-sized for CI: CPU P99 369m (from 600m default), memory P99 840Mi INCREASE (from 1Gi default).
   resources:
     requests:


### PR DESCRIPTION
### Which problem does the PR fix?

The SM-8.9 cross-component e2e suite's long pole is the Optimize-import-bound
flow (`optimize-user-flows.spec.ts > New Instances Updated Flow`). Under CI
sharding the full-suite wall-clock collapses to the slowest single test, so
this flow gates the whole run.

Optimize's default import scheduling makes newly-run process data invisible to
reports for tens of seconds — `import.handler.backoff.max` is 30s and
`import.currentTimeBackoffMilliseconds` is 5 minutes. That inflates the test
wall-clock and forces long fixed waits in the e2e specs.

### What's in this PR?

**1. Optimize import tuning** (`base.yaml`, Layer 1 — applied to every non-`qa-`
nightly scenario; `base-qa.yaml` only loads for `qa-`-prefixed scenarios, so it
would silently no-op for eske/oske/kemt/kerba):

- `CAMUNDA_OPTIMIZE_IMPORT_HANDLER_BACKOFF_MAX`: 30s → 1s
- `CAMUNDA_OPTIMIZE_IMPORT_CURRENTTIMEBACKOFFMILLISECONDS`: 300000 → 1000
- `CAMUNDA_OPTIMIZE_ZEEBE_MAXIMPORTPAGESIZE`: 200 → 1000

Safe in the low-write QA env. Scope is `test/integration` scenario values only —
no user-facing chart change.

**2. `shadow-e2e` scenario** — mirrors the dedicated full-suite scenario already
present in 8.7 and 8.10. It is `skip-e2e` (no per-scenario e2e), so the
`shadow-e2e-full-suite` job runs the complete SM-8.9 Playwright suite against a
single keycloak + elasticsearch + gke deployment — a representative full-suite
signal and wall-clock for this tuning. Registry snapshot regenerated via
`make go.update-registry-golden`; matrix + scenarios Go tests green.

**Validation (live, `matrix-89-eske-inst-gke`):**
- `New Instances Updated Flow` passed in 4.5m (+35s setup)
- optimize 3 heavy tests + setup green in 5.0m, first attempt, no retries
- `helm template` renders the env into the optimize deployment from `base.yaml` alone
- `go test ./optimize/...` green

Coordinated with the e2e-side change in
camunda/c8-cross-component-e2e-tests#2634 (retry-helper bounding). Merge order:
this Helm PR first (gates the nightly matrix), then #2634.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
