### PR TITLE
feat(renovate): source vendor-ee Bitnami images from the published datasource

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -98,15 +98,18 @@
     },
   },
   packageRules: [
-    // vendor-ee/postgresql and vendor-ee/elasticsearch in the 8.9 enterprise values
-    // are sourced from the bitnami-*-camunda custom datasources (see customManagers);
-    // disable the docker/helm-values tracking for them so they are not bumped twice.
+    // vendor-ee/postgresql in the 8.9 enterprise values is sourced from the
+    // bitnami-postgresql-camunda custom datasource (see customManagers); disable
+    // the docker/helm-values tracking for it so it is not bumped twice.
     // NOTE (draft): replicate to 8.7/8.8 once their values are annotated too.
+    // vendor-ee/elasticsearch is intentionally NOT wired here: the chart pins a
+    // plain tag (e.g. 8.19.17) while the published feed uses the
+    // '<x.y.z>-debian-12-rN' scheme, so it needs separate handling.
     {
       description: 'Bitnami enterprise images tracked via custom datasource, not docker.',
       matchManagers: ['helm-values'],
       matchFileNames: ['charts/camunda-platform-8.9/values-enterprise.yaml'],
-      matchPackageNames: ['/vendor-ee/(postgresql|elasticsearch)$/'],
+      matchPackageNames: ['/vendor-ee/postgresql$/'],
       enabled: false,
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -64,7 +64,9 @@
       format: 'plain',
     },
     // Bitnami Premium image tags published by camunda-deployment-references, one
-    // self-contained JSON per image whose releases carry {version, newDigest}.
+    // self-contained JSON per image. Only the 'version' field is used here; the
+    // feed also carries 'newDigest', but custom json datasources do not consume or
+    // maintain digest pins (these values pin tags, not digests).
     // Complete upstream tag list (incl. pre-Nov-2025 tags), no registry creds.
     // Opt in per image with a '# renovate: datasource=custom.bitnami-<x>-camunda'
     // annotation in values-enterprise.yaml (see customManagers).
@@ -433,7 +435,9 @@
     },
     // Bitnami Premium image tags sourced from the camunda-deployment-references
     // custom datasources (complete upstream list, credential-free). Opt in per
-    // image with '# renovate: datasource=custom.bitnami-<x>-camunda depName=<x> versioning=docker'.
+    // image with '# renovate: datasource=custom.bitnami-<x>-camunda depName=<x>
+    // versioning=regex:...'. Bitnami '<x.y.z>-debian-12-rN' tags require regex
+    // versioning; docker versioning does not order across the '-rN' build suffix.
     {
       customType: 'regex',
       fileMatch: [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -63,8 +63,52 @@
       defaultRegistryUrlTemplate: 'https://camunda.github.io/camunda-tf-rosa/rosa_versions.txt',
       format: 'plain',
     },
+    // Bitnami Premium image tags published by camunda-deployment-references, one
+    // self-contained JSON per image whose releases carry {version, newDigest}.
+    // Complete upstream tag list (incl. pre-Nov-2025 tags), no registry creds.
+    // Opt in per image with a '# renovate: datasource=custom.bitnami-<x>-camunda'
+    // annotation in values-enterprise.yaml (see customManagers).
+    'bitnami-postgresql-camunda': {
+      defaultRegistryUrlTemplate: 'https://camunda.github.io/camunda-deployment-references/bitnami_postgresql.json',
+      format: 'json',
+    },
+    'bitnami-os-shell-camunda': {
+      defaultRegistryUrlTemplate: 'https://camunda.github.io/camunda-deployment-references/bitnami_os-shell.json',
+      format: 'json',
+    },
+    'bitnami-postgres-exporter-camunda': {
+      defaultRegistryUrlTemplate: 'https://camunda.github.io/camunda-deployment-references/bitnami_postgres-exporter.json',
+      format: 'json',
+    },
+    'bitnami-elasticsearch-camunda': {
+      defaultRegistryUrlTemplate: 'https://camunda.github.io/camunda-deployment-references/bitnami_elasticsearch.json',
+      format: 'json',
+    },
+    'bitnami-elasticsearch-exporter-camunda': {
+      defaultRegistryUrlTemplate: 'https://camunda.github.io/camunda-deployment-references/bitnami_elasticsearch-exporter.json',
+      format: 'json',
+    },
+    'bitnami-keycloak-config-cli-camunda': {
+      defaultRegistryUrlTemplate: 'https://camunda.github.io/camunda-deployment-references/bitnami_keycloak-config-cli.json',
+      format: 'json',
+    },
+    'bitnami-keycloak-camunda': {
+      defaultRegistryUrlTemplate: 'https://camunda.github.io/camunda-deployment-references/bitnami_keycloak.json',
+      format: 'json',
+    },
   },
   packageRules: [
+    // vendor-ee/postgresql and vendor-ee/elasticsearch in the 8.9 enterprise values
+    // are sourced from the bitnami-*-camunda custom datasources (see customManagers);
+    // disable the docker/helm-values tracking for them so they are not bumped twice.
+    // NOTE (draft): replicate to 8.7/8.8 once their values are annotated too.
+    {
+      description: 'Bitnami enterprise images tracked via custom datasource, not docker.',
+      matchManagers: ['helm-values'],
+      matchFileNames: ['charts/camunda-platform-8.9/values-enterprise.yaml'],
+      matchPackageNames: ['/vendor-ee/(postgresql|elasticsearch)$/'],
+      enabled: false,
+    },
     {
       description: 'Major updates require manual review to prevent breaking changes.',
       matchUpdateTypes: ['major'],
@@ -380,6 +424,20 @@
         '# renovate: datasource=docker depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s*?(tag|imageTag): (?<currentValue>\\S+)',
       ],
       versioningTemplate: '{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}',
+    },
+    // Bitnami Premium image tags sourced from the camunda-deployment-references
+    // custom datasources (complete upstream list, credential-free). Opt in per
+    // image with '# renovate: datasource=custom.bitnami-<x>-camunda depName=<x> versioning=docker'.
+    {
+      customType: 'regex',
+      fileMatch: [
+        'values-enterprise\\.yaml$',
+      ],
+      matchStrings: [
+        '# renovate: datasource=(?<datasource>custom\\.bitnami-[^\\s]+?) depName=(?<depName>[^\\s]+?)(?: versioning=(?<versioning>[^\\s]+?))?\\s*?tag: (?<currentValue>\\S+)',
+      ],
+      datasourceTemplate: '{{{datasource}}}',
+      versioningTemplate: '{{#if versioning}}{{{versioning}}}{{else}}docker{{/if}}',
     },
     // This regex manager is used to update the image digests in the values-digest.yaml files.
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -98,17 +98,20 @@
     },
   },
   packageRules: [
-    // vendor-ee/postgresql in the 8.9 enterprise values is sourced from the
-    // bitnami-postgresql-camunda custom datasource (see customManagers); disable
-    // the docker/helm-values tracking for it so it is not bumped twice.
-    // NOTE (draft): replicate to 8.7/8.8 once their values are annotated too.
+    // vendor-ee/postgresql in the 8.7/8.8/8.9 enterprise values is sourced from
+    // the bitnami-postgresql-camunda custom datasource (see customManagers);
+    // disable the docker/helm-values tracking for it so it is not bumped twice.
     // vendor-ee/elasticsearch is intentionally NOT wired here: the chart pins a
-    // plain tag (e.g. 8.19.17) while the published feed uses the
+    // plain tag (e.g. 8.19.16) while the published feed uses the
     // '<x.y.z>-debian-12-rN' scheme, so it needs separate handling.
     {
       description: 'Bitnami enterprise images tracked via custom datasource, not docker.',
       matchManagers: ['helm-values'],
-      matchFileNames: ['charts/camunda-platform-8.9/values-enterprise.yaml'],
+      matchFileNames: [
+        'charts/camunda-platform-8.7/values-enterprise.yaml',
+        'charts/camunda-platform-8.8/values-enterprise.yaml',
+        'charts/camunda-platform-8.9/values-enterprise.yaml',
+      ],
       matchPackageNames: ['/vendor-ee/postgresql$/'],
       enabled: false,
     },

--- a/charts/camunda-platform-8.7/values-enterprise.yaml
+++ b/charts/camunda-platform-8.7/values-enterprise.yaml
@@ -28,6 +28,7 @@ identityPostgresql:
   image:
     registry: registry.camunda.cloud
     repository: vendor-ee/postgresql
+    # renovate: datasource=custom.bitnami-postgresql-camunda depName=postgresql versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(-(?<compatibility>debian-\d+)-r(?<build>\d+))?$
     tag: 15.18.0-debian-12-r2
     pullSecrets:
       - name: registry-camunda-cloud
@@ -58,6 +59,7 @@ identityKeycloak:
     image:
       registry: registry.camunda.cloud
       repository: vendor-ee/postgresql
+      # renovate: datasource=custom.bitnami-postgresql-camunda depName=postgresql versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(-(?<compatibility>debian-\d+)-r(?<build>\d+))?$
       tag: 15.18.0-debian-12-r2
       pullSecrets:
         - name: registry-camunda-cloud
@@ -81,6 +83,7 @@ postgresql:
   image:
     registry: registry.camunda.cloud
     repository: vendor-ee/postgresql
+    # renovate: datasource=custom.bitnami-postgresql-camunda depName=postgresql versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(-(?<compatibility>debian-\d+)-r(?<build>\d+))?$
     tag: 14.23.0-debian-12-r2
     pullSecrets:
       - name: registry-camunda-cloud

--- a/charts/camunda-platform-8.8/values-enterprise.yaml
+++ b/charts/camunda-platform-8.8/values-enterprise.yaml
@@ -28,6 +28,7 @@ identityPostgresql:
   image:
     registry: registry.camunda.cloud
     repository: vendor-ee/postgresql
+    # renovate: datasource=custom.bitnami-postgresql-camunda depName=postgresql versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(-(?<compatibility>debian-\d+)-r(?<build>\d+))?$
     tag: 15.18.0-debian-12-r2
     pullSecrets:
       - name: registry-camunda-cloud
@@ -65,6 +66,7 @@ identityKeycloak:
     image:
       registry: registry.camunda.cloud
       repository: vendor-ee/postgresql
+      # renovate: datasource=custom.bitnami-postgresql-camunda depName=postgresql versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(-(?<compatibility>debian-\d+)-r(?<build>\d+))?$
       tag: 15.18.0-debian-12-r2
       pullSecrets:
         - name: registry-camunda-cloud
@@ -87,6 +89,7 @@ webModelerPostgresql:
   image:
     registry: registry.camunda.cloud
     repository: vendor-ee/postgresql
+    # renovate: datasource=custom.bitnami-postgresql-camunda depName=postgresql versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(-(?<compatibility>debian-\d+)-r(?<build>\d+))?$
     tag: 14.23.0-debian-12-r2
     pullSecrets:
       - name: registry-camunda-cloud

--- a/charts/camunda-platform-8.9/values-enterprise.yaml
+++ b/charts/camunda-platform-8.9/values-enterprise.yaml
@@ -28,6 +28,7 @@ identityPostgresql:
   image:
     registry: registry.camunda.cloud
     repository: vendor-ee/postgresql
+    # renovate: datasource=custom.bitnami-postgresql-camunda depName=postgresql versioning=docker
     tag: 18.4.0-debian-12-r2
     pullSecrets:
       - name: registry-camunda-cloud
@@ -65,6 +66,7 @@ identityKeycloak:
     image:
       registry: registry.camunda.cloud
       repository: vendor-ee/postgresql
+      # renovate: datasource=custom.bitnami-postgresql-camunda depName=postgresql versioning=docker
       tag: 18.4.0-debian-12-r2
       pullSecrets:
         - name: registry-camunda-cloud
@@ -87,6 +89,7 @@ webModelerPostgresql:
   image:
     registry: registry.camunda.cloud
     repository: vendor-ee/postgresql
+    # renovate: datasource=custom.bitnami-postgresql-camunda depName=postgresql versioning=docker
     tag: 18.4.0-debian-12-r2
     pullSecrets:
       - name: registry-camunda-cloud
@@ -109,6 +112,7 @@ elasticsearch:
   image:
     registry: registry.camunda.cloud
     repository: vendor-ee/elasticsearch
+    # renovate: datasource=custom.bitnami-elasticsearch-camunda depName=elasticsearch versioning=docker
     tag: 8.19.16
     pullSecrets:
       - name: registry-camunda-cloud

--- a/charts/camunda-platform-8.9/values-enterprise.yaml
+++ b/charts/camunda-platform-8.9/values-enterprise.yaml
@@ -28,7 +28,7 @@ identityPostgresql:
   image:
     registry: registry.camunda.cloud
     repository: vendor-ee/postgresql
-    # renovate: datasource=custom.bitnami-postgresql-camunda depName=postgresql versioning=docker
+    # renovate: datasource=custom.bitnami-postgresql-camunda depName=postgresql versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(-(?<compatibility>debian-\d+)-r(?<build>\d+))?$
     tag: 18.4.0-debian-12-r2
     pullSecrets:
       - name: registry-camunda-cloud
@@ -66,7 +66,7 @@ identityKeycloak:
     image:
       registry: registry.camunda.cloud
       repository: vendor-ee/postgresql
-      # renovate: datasource=custom.bitnami-postgresql-camunda depName=postgresql versioning=docker
+      # renovate: datasource=custom.bitnami-postgresql-camunda depName=postgresql versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(-(?<compatibility>debian-\d+)-r(?<build>\d+))?$
       tag: 18.4.0-debian-12-r2
       pullSecrets:
         - name: registry-camunda-cloud
@@ -89,7 +89,7 @@ webModelerPostgresql:
   image:
     registry: registry.camunda.cloud
     repository: vendor-ee/postgresql
-    # renovate: datasource=custom.bitnami-postgresql-camunda depName=postgresql versioning=docker
+    # renovate: datasource=custom.bitnami-postgresql-camunda depName=postgresql versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(-(?<compatibility>debian-\d+)-r(?<build>\d+))?$
     tag: 18.4.0-debian-12-r2
     pullSecrets:
       - name: registry-camunda-cloud
@@ -112,7 +112,6 @@ elasticsearch:
   image:
     registry: registry.camunda.cloud
     repository: vendor-ee/elasticsearch
-    # renovate: datasource=custom.bitnami-elasticsearch-camunda depName=elasticsearch versioning=docker
     tag: 8.19.16
     pullSecrets:
       - name: registry-camunda-cloud


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6444 — source the Bitnami Premium (`vendor-ee/*`) image tags for Renovate from the published per-image feeds. Part of the infraex tracking issue camunda/team-infrastructure-experience#1038.

> [!NOTE]
> The published `bitnami_<image>.json` feeds are live (camunda/camunda-deployment-references#2765 is merged), so Renovate can resolve the custom datasources. All supported enterprise charts (8.7 / 8.8 / 8.9) are wired. The final gate is the **post-merge Renovate scan** (see _Post-merge validation_) — that check is inherently post-merge, as it runs against `main`.

## What

Make Renovate track the **Bitnami Premium (`vendor-ee/*`) images** from the per-image JSON feeds published by `camunda-deployment-references`, instead of the `docker` datasource against `registry.camunda.cloud`.

- Adds 7 `customDatasources` (`bitnami-*-camunda`, `format: json`), one per image.
- Adds a `customManager` that opts an image in via a `# renovate: datasource=custom.bitnami-<x>-camunda depName=<x> versioning=<v>` annotation in `values-enterprise.yaml`.
- Wires **`vendor-ee/postgresql` (×3 instances each) in 8.7, 8.8 and 8.9** and disables its `helm-values` tracking so it is not bumped twice.

The annotation pins the Bitnami tag versioning explicitly:

```
# renovate: datasource=custom.bitnami-postgresql-camunda depName=postgresql versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(-(?<compatibility>debian-\d+)-r(?<build>\d+))?$
```

`versioning=docker` is **not** used: it does not order across the `-debian-12-rN` build suffix, so the regex versioning is required to bump `…-r2 → …-r9` etc.

## Why

The published feed is the **complete upstream tag list** (including tags from before the November 2025 vendor migration, which `skopeo` and the Harbor proxy can no longer list) and needs **no registry credentials**.

## Note: digest pinning is not supported on this datasource

Custom (`format: json`) datasources track **versions only** — they cannot maintain an `@sha256` digest pin (no `getDigest`). These helm values pin a **tag, not a digest**, so this is fine. Any image that pins `…@sha256:…` (as `camunda/keycloak`'s `bases.yml` did) must stay on the `docker` datasource — see camunda/keycloak#591.

## Post-merge validation

After this merges, **run a Renovate scan** on `camunda-platform-helm` (Mend dashboard → _Check this box to trigger a request for Renovate to run_, or wait for the next scheduled run) and confirm:

- the `vendor-ee/postgresql` update branches resolve from `custom.bitnami-postgresql-camunda`;
- there are **no** `Package lookup failures` / `Could not determine new digest` repository problems.

This is the same end-to-end check that validated the `camunda/keycloak` wiring — its Mend log came back clean after camunda/keycloak#591.

## Scope / follow-up

Wired across **all renovate-tracked enterprise charts: 8.7, 8.8, 8.9** (three `vendor-ee/postgresql` instances each). **8.5 / 8.6 are intentionally excluded** — they are out of support and already renovate-disabled. **8.10** has no `values-enterprise.yaml` yet; annotate it when one is added.

- `vendor-ee/elasticsearch` is intentionally **not** wired: the chart pins a plain tag (e.g. `8.19.16`) while the feed uses the `<x.y.z>-debian-12-rN` scheme, so it needs separate handling.
- `os-shell`, the exporters and `keycloak-config-cli` use chart-default tags (no explicit tag to track).
- `keycloak-ee/keycloak` is the Camunda-built image and intentionally left on its current source.

Refs camunda/team-infrastructure-experience#1038.
