### PR TITLE
ci: build deploy-camunda binary on the nightly integration path

### DIFF
--- a/.github/actions/generate-chart-matrix/action.yaml
+++ b/.github/actions/generate-chart-matrix/action.yaml
@@ -102,13 +102,6 @@ runs:
     - name: Export deploy-camunda to PATH
       shell: bash
       run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-    - name: Upload deploy-camunda binary
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-      with:
-        name: deploy-camunda-binary
-        path: ~/.local/bin/deploy-camunda
-        if-no-files-found: error
-        retention-days: 1
     - name: Generate matrix
       shell: bash
       id: set-chart-versions

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -27,6 +27,11 @@ on:
         description: The unique identifier of used in the deployment hostname.
         required: true
         type: string
+      binary-artifact-name:
+        description: Name of the uploaded deploy-camunda binary artifact to download. Callers that build the binary per-leg must override this with a per-run-unique name to avoid artifact-name collisions across parallel reusable-workflow legs.
+        required: false
+        default: deploy-camunda-binary
+        type: string
       camunda-helm-repo:
         description: The Helm repo which is used during the upgrade flow.
         required: false
@@ -335,7 +340,7 @@ jobs:
       - name: Download deploy-camunda binary
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: deploy-camunda-binary
+          name: ${{ inputs.binary-artifact-name }}
           path: ${{ runner.temp }}/bin
       - name: Add deploy-camunda to PATH
         run: |
@@ -798,7 +803,7 @@ jobs:
       - name: Download deploy-camunda binary
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: deploy-camunda-binary
+          name: ${{ inputs.binary-artifact-name }}
           path: ${{ runner.temp }}/bin
       - name: Add deploy-camunda to PATH
         run: |
@@ -1475,7 +1480,7 @@ jobs:
       - name: Download deploy-camunda binary
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: deploy-camunda-binary
+          name: ${{ inputs.binary-artifact-name }}
           path: ${{ runner.temp }}/bin
       - name: Add deploy-camunda to PATH
         run: |

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -323,6 +323,35 @@ jobs:
           echo "${matrix}" | jq
           echo "matrix=$(echo ${matrix} | jq -c)" > "$GITHUB_OUTPUT"
 
+      - name: Restore deploy-camunda binary
+        id: binary-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.local/bin/deploy-camunda
+          key: deploy-camunda-v2-${{ runner.os }}-${{ hashFiles('scripts/deploy-camunda/**/*.go', 'scripts/deploy-camunda/go.sum') }}
+      - name: Setup Go
+        if: steps.binary-cache.outputs.cache-hit != 'true'
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: scripts/deploy-camunda/go.mod
+          cache: true
+          cache-dependency-path: scripts/deploy-camunda/go.sum
+      - name: Build deploy-camunda
+        if: steps.binary-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          # CGO_ENABLED=0 produces a static binary so it runs unchanged inside the
+          # ci-runner container used by downstream matrix jobs.
+          (cd scripts/deploy-camunda && CGO_ENABLED=0 go build -o "$HOME/.local/bin/deploy-camunda" .)
+      - name: Upload deploy-camunda binary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: deploy-camunda-binary-${{ inputs.identifier }}
+          path: ~/.local/bin/deploy-camunda
+          if-no-files-found: error
+          retention-days: 1
+
   # The runner job is used to run the install/upgrade flows on the plaform (gke, rosa, etc.). This level of abstraction is needed so
   # we can shard the tests across multiple jobs (this is done via the matrix). If the tests where another job in this workflow, we
   # would need to wait for all the install/upgrade flows to complete before we can run the tests.
@@ -345,6 +374,7 @@ jobs:
       auth: ${{ inputs.auth }}
       exclude: ${{ inputs.exclude }}
       identifier: ${{ inputs.identifier }}-${{ inputs.shortname }}
+      binary-artifact-name: deploy-camunda-binary-${{ inputs.identifier }}
       camunda-helm-repo: ${{ inputs.camunda-helm-repo }}
       camunda-helm-dir: ${{ inputs.camunda-helm-dir }}
       camunda-helm-git-ref: ${{ inputs.camunda-helm-git-ref }}


### PR DESCRIPTION
### Which problem does the PR fix?

Every SM nightly that enters the Helm integration suite through
`test-integration-template.yaml` (e.g. **SM Nightly 8.10 Upgrade Minor**)
fails immediately at the **Download deploy-camunda binary** step:

```
Unable to download artifact(s): Artifact not found for name: deploy-camunda-binary
```

All downstream steps (Helm install, Playwright e2e, upgrade) are then
skipped. This is a CI plumbing gap, not a chart or test regression.

Example failing run:
https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/28075385080/job/83118495302

### What's in this PR?

`test-integration-runner.yaml` downloads a pre-built `deploy-camunda-binary`
artifact in its `install` / `upgrade` / `cleanup` jobs. That artifact is
only produced on the **PR / merge-queue** entrypoint — `test-chart-version.yaml`'s
`init` job, via the `generate-chart-matrix` composite action. The **nightly**
path enters `test-integration-template.yaml` directly (from the E2E repo's
reusable flow), whose `init` job never builds or uploads the binary, so the
download has no producer.

This PR:

- **Builds + uploads the binary in `test-integration-template.yaml`'s `init`
  job** (cache-restore → conditional Go build → upload), so both entry paths
  have a producer. The cache key matches the existing one, so the PR path
  restores from cache rather than rebuilding.
- **Suffixes the artifact name with the per-leg `identifier`**
  (`deploy-camunda-binary-${{ inputs.identifier }}`). The upgrade-minor
  nightlies invoke the reusable flow twice in a single run (8.9 install +
  8.10 upgrade); a static artifact name would collide under
  `upload-artifact@v4+` immutability. `identifier` is already required to be
  unique per deployment (it keys the namespace/hostname), so it is a safe
  uniqueness key.
- **Adds a `binary-artifact-name` input to `test-integration-runner.yaml`**
  (default `deploy-camunda-binary`) used by the three download steps. The
  template passes the suffixed name; the PR-CI path keeps the default and is
  unchanged.

### Checklist

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open pull request for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo documentation are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
