### PR TITLE
ci: add Integration Tests Gate with one-shot retry for the matrix

### DIFF
--- a/.github/workflows/integration-tests-gate.yaml
+++ b/.github/workflows/integration-tests-gate.yaml
@@ -4,6 +4,12 @@ on:
   pull_request:
   merge_group:
     types: [checks_requested]
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: Override head SHA for testing
+        required: true
+        type: string
 
 permissions:
   actions: write
@@ -21,16 +27,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 420
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           sparse-checkout: |
             scripts/integration-tests-gate
           sparse-checkout-cone-mode: false
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: scripts/integration-tests-gate/go.mod
-          cache-dependency-path: scripts/integration-tests-gate/go.sum
+          cache: false
 
       - name: Run gate
         working-directory: scripts/integration-tests-gate
@@ -41,4 +47,5 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           MG_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+          OVERRIDE_SHA: ${{ inputs.sha }}
         run: go run .

--- a/.github/workflows/integration-tests-gate.yaml
+++ b/.github/workflows/integration-tests-gate.yaml
@@ -3,6 +3,10 @@
 # the underlying matrix, so a transient failure in any single matrix cell does
 # not evict the PR — the gate retries failed cells once and only reports its
 # own final conclusion.
+#
+# Retry semantics: ONE retry per gate invocation. Re-running the gate workflow
+# itself yields one additional retry, which lets humans recover from a
+# double-transient without pushing a new commit.
 name: Integration Tests Gate
 
 on:
@@ -28,7 +32,13 @@ jobs:
     # Matrix wall time has historically run to ~3h; size for two attempts.
     timeout-minutes: 420
     steps:
-      - name: Wait for matrix run and retry once on failure
+      - name: Show gh version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh --version
+
+      - name: Discover matrix run
+        id: discover
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
@@ -36,30 +46,29 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           MG_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
-          POLL_SECONDS: "60"
-          DISCOVERY_ATTEMPTS: "120"
+          DISCOVERY_ATTEMPTS: "120"   # 120 × 10s = 20 minutes
         run: |
           set -euo pipefail
 
           # Pick the SHA the matrix workflow actually runs against.
-          # In merge_group events, github.sha is the merge commit (NOT what the
-          # matrix is keyed to); the matrix runs against merge_group.head_sha.
+          # In merge_group events, github.sha is the merge commit (NOT what
+          # the matrix is keyed to); the matrix runs against head_sha.
           case "$EVENT_NAME" in
-            pull_request)  HEAD_SHA="$PR_HEAD_SHA" ;;
-            merge_group)   HEAD_SHA="$MG_HEAD_SHA" ;;
+            pull_request|pull_request_target)
+              HEAD_SHA="$PR_HEAD_SHA" ;;
+            merge_group)
+              HEAD_SHA="$MG_HEAD_SHA" ;;
             *)
               echo "::error::Unsupported event: $EVENT_NAME"
               exit 1
               ;;
           esac
           if [ -z "$HEAD_SHA" ]; then
-            echo "::error::Could not determine head SHA for event $EVENT_NAME"
+            echo "::error::No head SHA for event $EVENT_NAME"
             exit 1
           fi
           echo "Gating event=$EVENT_NAME sha=$HEAD_SHA"
 
-          # Locate the matrix run for this SHA. Filter by event so a manual
-          # workflow_dispatch or stale rerun on the same SHA isn't picked up.
           RUN_ID=""
           for i in $(seq 1 "$DISCOVERY_ATTEMPTS"); do
             RUN_ID="$(gh run list \
@@ -73,7 +82,7 @@ jobs:
               echo "Found matrix run $RUN_ID"
               break
             fi
-            echo "Matrix run not yet visible ($i/$DISCOVERY_ATTEMPTS); sleeping"
+            echo "Matrix run not yet visible ($i/$DISCOVERY_ATTEMPTS)"
             sleep 10
           done
           if [ -z "$RUN_ID" ]; then
@@ -81,23 +90,42 @@ jobs:
             exit 1
           fi
 
-          RUN_URL="https://github.com/${GH_REPO}/actions/runs/${RUN_ID}"
+          RUN_URL="$(gh run view "$RUN_ID" \
+            --json url --jq '.url' 2>/dev/null || true)"
+          if [ -z "$RUN_URL" ]; then
+            RUN_URL="https://github.com/${GH_REPO}/actions/runs/${RUN_ID}"
+          fi
           echo "Matrix run: $RUN_URL"
 
-          # Sparse-poll until the run completes. Avoids `gh run watch`'s short
-          # poll cadence which burns API budget and runner minutes across the
-          # hours-long matrix wall time.
+          echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+          echo "run_url=$RUN_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Watch with one-shot retry
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RUN_ID: ${{ steps.discover.outputs.run_id }}
+          RUN_URL: ${{ steps.discover.outputs.run_url }}
+          POLL_SECONDS: "60"
+        run: |
+          set -euo pipefail
+
+          poll_status() {
+            local attempt="$1"
+            gh run view "$RUN_ID" --attempt "$attempt" \
+              --json status --jq '.status' 2>/dev/null || true
+          }
+
           wait_for_completion() {
             local attempt="$1"
             while true; do
               local status
-              status="$(gh run view "$RUN_ID" --attempt "$attempt" \
-                --json status --jq '.status' 2>/dev/null || true)"
+              status="$(poll_status "$attempt")"
               if [ "$status" = "completed" ]; then
                 return 0
               fi
               if [ -z "$status" ]; then
-                echo "Status not yet available for attempt $attempt; retrying"
+                echo "Attempt $attempt not visible yet; retrying"
               else
                 echo "Attempt $attempt status=$status; sleep ${POLL_SECONDS}s"
               fi
@@ -105,49 +133,81 @@ jobs:
             done
           }
 
-          echo "Waiting for matrix attempt 1 to complete"
-          wait_for_completion 1
+          get_attempt() {
+            gh api "repos/${GH_REPO}/actions/runs/${RUN_ID}" \
+              --jq '.run_attempt' 2>/dev/null || echo "0"
+          }
 
-          CONCLUSION_1="$(gh run view "$RUN_ID" --attempt 1 \
+          rerun_failed_with_retry() {
+            local i
+            for i in 1 2 3; do
+              if gh run rerun "$RUN_ID" --failed; then
+                return 0
+              fi
+              echo "rerun --failed failed (try $i/3); sleeping 10s"
+              sleep 10
+            done
+            return 1
+          }
+
+          # Read the current attempt and watch that one. This lets a human
+          # re-run the gate after a manual matrix rerun: the gate will pick
+          # up whatever the latest attempt is and grant exactly one more
+          # retry from there.
+          CURRENT_ATTEMPT="$(get_attempt)"
+          CURRENT_ATTEMPT="${CURRENT_ATTEMPT:-0}"
+          if ! [ "$CURRENT_ATTEMPT" -ge 1 ] 2>/dev/null; then
+            echo "::error::Could not read run_attempt; got '$CURRENT_ATTEMPT'"
+            exit 1
+          fi
+          echo "Watching matrix attempt $CURRENT_ATTEMPT: $RUN_URL"
+          wait_for_completion "$CURRENT_ATTEMPT"
+
+          CONCLUSION="$(gh run view "$RUN_ID" --attempt "$CURRENT_ATTEMPT" \
             --json conclusion --jq '.conclusion')"
-          echo "Matrix attempt 1 conclusion: $CONCLUSION_1"
-          if [ "$CONCLUSION_1" = "success" ]; then
+          echo "Attempt $CURRENT_ATTEMPT conclusion: $CONCLUSION"
+          if [ "$CONCLUSION" = "success" ]; then
             exit 0
           fi
-          # Only retry on genuine failure. Cancelled / timed_out / skipped /
-          # action_required / neutral are intentionally NOT retried: they
-          # either indicate human intent (cancel) or a state `--failed` can't
-          # rerun anyway.
-          if [ "$CONCLUSION_1" != "failure" ]; then
-            echo "::error::Attempt 1 '$CONCLUSION_1' is not retryable"
+
+          # Only `failure` is retryable via `gh run rerun --failed`.
+          # cancelled / timed_out / action_required / neutral are not.
+          if [ "$CONCLUSION" != "failure" ]; then
+            echo "::error::'$CONCLUSION' is not retryable"
             exit 1
           fi
 
           echo "Triggering retry of failed jobs on $RUN_URL"
-          gh run rerun "$RUN_ID" --failed
+          if ! rerun_failed_with_retry; then
+            echo "::error::Could not trigger rerun --failed after 3 tries"
+            exit 1
+          fi
 
-          # Wait until GitHub registers the new attempt before polling status,
-          # otherwise the first read can return the now-stale attempt-1 state.
-          echo "Waiting for attempt 2 to be registered"
-          for i in $(seq 1 30); do
-            LATEST_ATTEMPT="$(gh api \
-              "repos/${GH_REPO}/actions/runs/${RUN_ID}" \
-              --jq '.run_attempt')"
-            if [ "$LATEST_ATTEMPT" -ge 2 ]; then
-              echo "Attempt 2 registered"
+          # Wait for the new attempt to be registered by the API before
+          # watching it. Otherwise the first read can return the now-stale
+          # previous-attempt state.
+          NEXT_ATTEMPT=$((CURRENT_ATTEMPT + 1))
+          echo "Waiting for attempt $NEXT_ATTEMPT to be registered"
+          for i in $(seq 1 60); do
+            LATEST="$(get_attempt)"
+            LATEST="${LATEST:-0}"
+            if [ "$LATEST" -ge "$NEXT_ATTEMPT" ] 2>/dev/null; then
+              echo "Attempt $NEXT_ATTEMPT registered"
               break
             fi
             sleep 5
           done
-          if [ "${LATEST_ATTEMPT:-1}" -lt 2 ]; then
-            echo "::error::rerun --failed did not produce a second attempt"
+          LATEST="$(get_attempt)"
+          LATEST="${LATEST:-0}"
+          if ! [ "$LATEST" -ge "$NEXT_ATTEMPT" ] 2>/dev/null; then
+            echo "::error::rerun did not produce attempt $NEXT_ATTEMPT"
             exit 1
           fi
 
-          echo "Waiting for matrix attempt 2 to complete: $RUN_URL/attempts/2"
-          wait_for_completion 2
+          echo "Watching attempt $NEXT_ATTEMPT: $RUN_URL/attempts/$NEXT_ATTEMPT"
+          wait_for_completion "$NEXT_ATTEMPT"
 
-          CONCLUSION_2="$(gh run view "$RUN_ID" --attempt 2 \
+          FINAL="$(gh run view "$RUN_ID" --attempt "$NEXT_ATTEMPT" \
             --json conclusion --jq '.conclusion')"
-          echo "Matrix attempt 2 conclusion: $CONCLUSION_2"
-          [ "$CONCLUSION_2" = "success" ]
+          echo "Attempt $NEXT_ATTEMPT conclusion: $FINAL"
+          [ "$FINAL" = "success" ]

--- a/.github/workflows/integration-tests-gate.yaml
+++ b/.github/workflows/integration-tests-gate.yaml
@@ -26,23 +26,46 @@ jobs:
     runs-on: ubuntu-latest
     # Must fit (matrix attempt 1 worst case) + (matrix attempt 2 worst case).
     # Matrix wall time has historically run to ~3h; size for two attempts.
-    timeout-minutes: 360
+    timeout-minutes: 420
     steps:
       - name: Wait for matrix run and retry once on failure
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           MATRIX_WORKFLOW: test-chart-version.yaml
+          EVENT_NAME: ${{ github.event_name }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          MG_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+          POLL_SECONDS: "60"
+          DISCOVERY_ATTEMPTS: "120"
         run: |
           set -euo pipefail
 
-          echo "Locating matrix workflow run for SHA $HEAD_SHA"
+          # Pick the SHA the matrix workflow actually runs against.
+          # In merge_group events, github.sha is the merge commit (NOT what the
+          # matrix is keyed to); the matrix runs against merge_group.head_sha.
+          case "$EVENT_NAME" in
+            pull_request)  HEAD_SHA="$PR_HEAD_SHA" ;;
+            merge_group)   HEAD_SHA="$MG_HEAD_SHA" ;;
+            *)
+              echo "::error::Unsupported event: $EVENT_NAME"
+              exit 1
+              ;;
+          esac
+          if [ -z "$HEAD_SHA" ]; then
+            echo "::error::Could not determine head SHA for event $EVENT_NAME"
+            exit 1
+          fi
+          echo "Gating event=$EVENT_NAME sha=$HEAD_SHA"
+
+          # Locate the matrix run for this SHA. Filter by event so a manual
+          # workflow_dispatch or stale rerun on the same SHA isn't picked up.
           RUN_ID=""
-          for i in $(seq 1 60); do
+          for i in $(seq 1 "$DISCOVERY_ATTEMPTS"); do
             RUN_ID="$(gh run list \
               --workflow "$MATRIX_WORKFLOW" \
               --commit "$HEAD_SHA" \
+              --event "$EVENT_NAME" \
               --limit 1 \
               --json databaseId \
               --jq '.[0].databaseId // empty')"
@@ -50,7 +73,7 @@ jobs:
               echo "Found matrix run $RUN_ID"
               break
             fi
-            echo "Matrix run not yet visible (attempt $i/60), sleeping 10s"
+            echo "Matrix run not yet visible ($i/$DISCOVERY_ATTEMPTS); sleeping"
             sleep 10
           done
           if [ -z "$RUN_ID" ]; then
@@ -58,22 +81,73 @@ jobs:
             exit 1
           fi
 
-          echo "Watching matrix run $RUN_ID (attempt 1)"
-          gh run watch "$RUN_ID" --exit-status || true
+          RUN_URL="https://github.com/${GH_REPO}/actions/runs/${RUN_ID}"
+          echo "Matrix run: $RUN_URL"
 
-          CONCLUSION="$(gh run view "$RUN_ID" \
+          # Sparse-poll until the run completes. Avoids `gh run watch`'s short
+          # poll cadence which burns API budget and runner minutes across the
+          # hours-long matrix wall time.
+          wait_for_completion() {
+            local attempt="$1"
+            while true; do
+              local status
+              status="$(gh run view "$RUN_ID" --attempt "$attempt" \
+                --json status --jq '.status' 2>/dev/null || true)"
+              if [ "$status" = "completed" ]; then
+                return 0
+              fi
+              if [ -z "$status" ]; then
+                echo "Status not yet available for attempt $attempt; retrying"
+              else
+                echo "Attempt $attempt status=$status; sleep ${POLL_SECONDS}s"
+              fi
+              sleep "$POLL_SECONDS"
+            done
+          }
+
+          echo "Waiting for matrix attempt 1 to complete"
+          wait_for_completion 1
+
+          CONCLUSION_1="$(gh run view "$RUN_ID" --attempt 1 \
             --json conclusion --jq '.conclusion')"
-          echo "Matrix attempt 1 conclusion: $CONCLUSION"
-          if [ "$CONCLUSION" = "success" ]; then
+          echo "Matrix attempt 1 conclusion: $CONCLUSION_1"
+          if [ "$CONCLUSION_1" = "success" ]; then
             exit 0
           fi
+          # Only retry on genuine failure. Cancelled / timed_out / skipped /
+          # action_required / neutral are intentionally NOT retried: they
+          # either indicate human intent (cancel) or a state `--failed` can't
+          # rerun anyway.
+          if [ "$CONCLUSION_1" != "failure" ]; then
+            echo "::error::Attempt 1 '$CONCLUSION_1' is not retryable"
+            exit 1
+          fi
 
-          echo "Triggering one retry of failed jobs on run $RUN_ID"
+          echo "Triggering retry of failed jobs on $RUN_URL"
           gh run rerun "$RUN_ID" --failed
 
-          echo "Watching matrix run $RUN_ID (attempt 2)"
-          gh run watch "$RUN_ID" --exit-status || true
+          # Wait until GitHub registers the new attempt before polling status,
+          # otherwise the first read can return the now-stale attempt-1 state.
+          echo "Waiting for attempt 2 to be registered"
+          for i in $(seq 1 30); do
+            LATEST_ATTEMPT="$(gh api \
+              "repos/${GH_REPO}/actions/runs/${RUN_ID}" \
+              --jq '.run_attempt')"
+            if [ "$LATEST_ATTEMPT" -ge 2 ]; then
+              echo "Attempt 2 registered"
+              break
+            fi
+            sleep 5
+          done
+          if [ "${LATEST_ATTEMPT:-1}" -lt 2 ]; then
+            echo "::error::rerun --failed did not produce a second attempt"
+            exit 1
+          fi
 
-          FINAL="$(gh run view "$RUN_ID" --json conclusion --jq '.conclusion')"
-          echo "Matrix attempt 2 conclusion: $FINAL"
-          [ "$FINAL" = "success" ]
+          echo "Waiting for matrix attempt 2 to complete: $RUN_URL/attempts/2"
+          wait_for_completion 2
+
+          CONCLUSION_2="$(gh run view "$RUN_ID" --attempt 2 \
+            --json conclusion --jq '.conclusion')"
+          echo "Matrix attempt 2 conclusion: $CONCLUSION_2"
+          [ "$CONCLUSION_2" = "success" ]

--- a/.github/workflows/integration-tests-gate.yaml
+++ b/.github/workflows/integration-tests-gate.yaml
@@ -10,6 +10,14 @@ on:
         description: Override head SHA for testing
         required: true
         type: string
+      event:
+        description: Event the matrix run was triggered by
+        required: true
+        type: choice
+        default: pull_request
+        options:
+          - pull_request
+          - merge_group
 
 permissions:
   actions: write
@@ -48,4 +56,5 @@ jobs:
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           MG_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
           OVERRIDE_SHA: ${{ inputs.sha }}
+          OVERRIDE_EVENT: ${{ inputs.event }}
         run: go run .

--- a/.github/workflows/integration-tests-gate.yaml
+++ b/.github/workflows/integration-tests-gate.yaml
@@ -1,12 +1,3 @@
-# Required status check that wraps the "Test - Chart Version" matrix with a
-# one-shot retry of failed jobs. The merge queue gates on this workflow, not on
-# the underlying matrix, so a transient failure in any single matrix cell does
-# not evict the PR — the gate retries failed cells once and only reports its
-# own final conclusion.
-#
-# Retry semantics: ONE retry per gate invocation. Re-running the gate workflow
-# itself yields one additional retry, which lets humans recover from a
-# double-transient without pushing a new commit.
 name: Integration Tests Gate
 
 on:
@@ -28,17 +19,21 @@ jobs:
   gate:
     name: gate
     runs-on: ubuntu-latest
-    # Must fit (matrix attempt 1 worst case) + (matrix attempt 2 worst case).
-    # Matrix wall time has historically run to ~3h; size for two attempts.
     timeout-minutes: 420
     steps:
-      - name: Show gh version
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh --version
+      - uses: actions/checkout@v5
+        with:
+          sparse-checkout: |
+            scripts/integration-tests-gate
+          sparse-checkout-cone-mode: false
 
-      - name: Discover matrix run
-        id: discover
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: scripts/integration-tests-gate/go.mod
+          cache-dependency-path: scripts/integration-tests-gate/go.sum
+
+      - name: Run gate
+        working-directory: scripts/integration-tests-gate
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
@@ -46,168 +41,4 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           MG_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
-          DISCOVERY_ATTEMPTS: "120"   # 120 × 10s = 20 minutes
-        run: |
-          set -euo pipefail
-
-          # Pick the SHA the matrix workflow actually runs against.
-          # In merge_group events, github.sha is the merge commit (NOT what
-          # the matrix is keyed to); the matrix runs against head_sha.
-          case "$EVENT_NAME" in
-            pull_request|pull_request_target)
-              HEAD_SHA="$PR_HEAD_SHA" ;;
-            merge_group)
-              HEAD_SHA="$MG_HEAD_SHA" ;;
-            *)
-              echo "::error::Unsupported event: $EVENT_NAME"
-              exit 1
-              ;;
-          esac
-          if [ -z "$HEAD_SHA" ]; then
-            echo "::error::No head SHA for event $EVENT_NAME"
-            exit 1
-          fi
-          echo "Gating event=$EVENT_NAME sha=$HEAD_SHA"
-
-          RUN_ID=""
-          for i in $(seq 1 "$DISCOVERY_ATTEMPTS"); do
-            RUN_ID="$(gh run list \
-              --workflow "$MATRIX_WORKFLOW" \
-              --commit "$HEAD_SHA" \
-              --event "$EVENT_NAME" \
-              --limit 1 \
-              --json databaseId \
-              --jq '.[0].databaseId // empty')"
-            if [ -n "$RUN_ID" ]; then
-              echo "Found matrix run $RUN_ID"
-              break
-            fi
-            echo "Matrix run not yet visible ($i/$DISCOVERY_ATTEMPTS)"
-            sleep 10
-          done
-          if [ -z "$RUN_ID" ]; then
-            echo "::error::No matrix run for $MATRIX_WORKFLOW @ $HEAD_SHA"
-            exit 1
-          fi
-
-          RUN_URL="$(gh run view "$RUN_ID" \
-            --json url --jq '.url' 2>/dev/null || true)"
-          if [ -z "$RUN_URL" ]; then
-            RUN_URL="https://github.com/${GH_REPO}/actions/runs/${RUN_ID}"
-          fi
-          echo "Matrix run: $RUN_URL"
-
-          echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
-          echo "run_url=$RUN_URL" >> "$GITHUB_OUTPUT"
-
-      - name: Watch with one-shot retry
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          RUN_ID: ${{ steps.discover.outputs.run_id }}
-          RUN_URL: ${{ steps.discover.outputs.run_url }}
-          POLL_SECONDS: "60"
-        run: |
-          set -euo pipefail
-
-          poll_status() {
-            local attempt="$1"
-            gh run view "$RUN_ID" --attempt "$attempt" \
-              --json status --jq '.status' 2>/dev/null || true
-          }
-
-          wait_for_completion() {
-            local attempt="$1"
-            while true; do
-              local status
-              status="$(poll_status "$attempt")"
-              if [ "$status" = "completed" ]; then
-                return 0
-              fi
-              if [ -z "$status" ]; then
-                echo "Attempt $attempt not visible yet; retrying"
-              else
-                echo "Attempt $attempt status=$status; sleep ${POLL_SECONDS}s"
-              fi
-              sleep "$POLL_SECONDS"
-            done
-          }
-
-          get_attempt() {
-            gh api "repos/${GH_REPO}/actions/runs/${RUN_ID}" \
-              --jq '.run_attempt' 2>/dev/null || echo "0"
-          }
-
-          rerun_failed_with_retry() {
-            local i
-            for i in 1 2 3; do
-              if gh run rerun "$RUN_ID" --failed; then
-                return 0
-              fi
-              echo "rerun --failed failed (try $i/3); sleeping 10s"
-              sleep 10
-            done
-            return 1
-          }
-
-          # Read the current attempt and watch that one. This lets a human
-          # re-run the gate after a manual matrix rerun: the gate will pick
-          # up whatever the latest attempt is and grant exactly one more
-          # retry from there.
-          CURRENT_ATTEMPT="$(get_attempt)"
-          CURRENT_ATTEMPT="${CURRENT_ATTEMPT:-0}"
-          if ! [ "$CURRENT_ATTEMPT" -ge 1 ] 2>/dev/null; then
-            echo "::error::Could not read run_attempt; got '$CURRENT_ATTEMPT'"
-            exit 1
-          fi
-          echo "Watching matrix attempt $CURRENT_ATTEMPT: $RUN_URL"
-          wait_for_completion "$CURRENT_ATTEMPT"
-
-          CONCLUSION="$(gh run view "$RUN_ID" --attempt "$CURRENT_ATTEMPT" \
-            --json conclusion --jq '.conclusion')"
-          echo "Attempt $CURRENT_ATTEMPT conclusion: $CONCLUSION"
-          if [ "$CONCLUSION" = "success" ]; then
-            exit 0
-          fi
-
-          # Only `failure` is retryable via `gh run rerun --failed`.
-          # cancelled / timed_out / action_required / neutral are not.
-          if [ "$CONCLUSION" != "failure" ]; then
-            echo "::error::'$CONCLUSION' is not retryable"
-            exit 1
-          fi
-
-          echo "Triggering retry of failed jobs on $RUN_URL"
-          if ! rerun_failed_with_retry; then
-            echo "::error::Could not trigger rerun --failed after 3 tries"
-            exit 1
-          fi
-
-          # Wait for the new attempt to be registered by the API before
-          # watching it. Otherwise the first read can return the now-stale
-          # previous-attempt state.
-          NEXT_ATTEMPT=$((CURRENT_ATTEMPT + 1))
-          echo "Waiting for attempt $NEXT_ATTEMPT to be registered"
-          for i in $(seq 1 60); do
-            LATEST="$(get_attempt)"
-            LATEST="${LATEST:-0}"
-            if [ "$LATEST" -ge "$NEXT_ATTEMPT" ] 2>/dev/null; then
-              echo "Attempt $NEXT_ATTEMPT registered"
-              break
-            fi
-            sleep 5
-          done
-          LATEST="$(get_attempt)"
-          LATEST="${LATEST:-0}"
-          if ! [ "$LATEST" -ge "$NEXT_ATTEMPT" ] 2>/dev/null; then
-            echo "::error::rerun did not produce attempt $NEXT_ATTEMPT"
-            exit 1
-          fi
-
-          echo "Watching attempt $NEXT_ATTEMPT: $RUN_URL/attempts/$NEXT_ATTEMPT"
-          wait_for_completion "$NEXT_ATTEMPT"
-
-          FINAL="$(gh run view "$RUN_ID" --attempt "$NEXT_ATTEMPT" \
-            --json conclusion --jq '.conclusion')"
-          echo "Attempt $NEXT_ATTEMPT conclusion: $FINAL"
-          [ "$FINAL" = "success" ]
+        run: go run .

--- a/.github/workflows/integration-tests-gate.yaml
+++ b/.github/workflows/integration-tests-gate.yaml
@@ -1,0 +1,79 @@
+# Required status check that wraps the "Test - Chart Version" matrix with a
+# one-shot retry of failed jobs. The merge queue gates on this workflow, not on
+# the underlying matrix, so a transient failure in any single matrix cell does
+# not evict the PR — the gate retries failed cells once and only reports its
+# own final conclusion.
+name: Integration Tests Gate
+
+on:
+  pull_request:
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: >-
+    ${{ github.workflow }}-${{
+      github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    name: gate
+    runs-on: ubuntu-latest
+    # Must fit (matrix attempt 1 worst case) + (matrix attempt 2 worst case).
+    # Matrix wall time has historically run to ~3h; size for two attempts.
+    timeout-minutes: 360
+    steps:
+      - name: Wait for matrix run and retry once on failure
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          MATRIX_WORKFLOW: test-chart-version.yaml
+        run: |
+          set -euo pipefail
+
+          echo "Locating matrix workflow run for SHA $HEAD_SHA"
+          RUN_ID=""
+          for i in $(seq 1 60); do
+            RUN_ID="$(gh run list \
+              --workflow "$MATRIX_WORKFLOW" \
+              --commit "$HEAD_SHA" \
+              --limit 1 \
+              --json databaseId \
+              --jq '.[0].databaseId // empty')"
+            if [ -n "$RUN_ID" ]; then
+              echo "Found matrix run $RUN_ID"
+              break
+            fi
+            echo "Matrix run not yet visible (attempt $i/60), sleeping 10s"
+            sleep 10
+          done
+          if [ -z "$RUN_ID" ]; then
+            echo "::error::No matrix run for $MATRIX_WORKFLOW @ $HEAD_SHA"
+            exit 1
+          fi
+
+          echo "Watching matrix run $RUN_ID (attempt 1)"
+          gh run watch "$RUN_ID" --exit-status || true
+
+          CONCLUSION="$(gh run view "$RUN_ID" \
+            --json conclusion --jq '.conclusion')"
+          echo "Matrix attempt 1 conclusion: $CONCLUSION"
+          if [ "$CONCLUSION" = "success" ]; then
+            exit 0
+          fi
+
+          echo "Triggering one retry of failed jobs on run $RUN_ID"
+          gh run rerun "$RUN_ID" --failed
+
+          echo "Watching matrix run $RUN_ID (attempt 2)"
+          gh run watch "$RUN_ID" --exit-status || true
+
+          FINAL="$(gh run view "$RUN_ID" --json conclusion --jq '.conclusion')"
+          echo "Matrix attempt 2 conclusion: $FINAL"
+          [ "$FINAL" = "success" ]

--- a/.github/workflows/integration-tests-gate.yaml
+++ b/.github/workflows/integration-tests-gate.yaml
@@ -32,12 +32,6 @@ concurrency:
 jobs:
   gate:
     name: gate
-    # Skip on fork PRs: GITHUB_TOKEN has no actions:write scope from a fork
-    # so `gh run rerun --failed` would 403 anyway. The matrix workflow's own
-    # status remains the required signal for fork PRs.
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 420
     steps:
@@ -63,4 +57,8 @@ jobs:
           MG_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
           OVERRIDE_SHA: ${{ inputs.sha }}
           OVERRIDE_EVENT: ${{ inputs.event }}
+          IS_FORK: >-
+            ${{ github.event_name == 'pull_request' &&
+                github.event.pull_request.head.repo.full_name
+                != github.repository }}
         run: go run .

--- a/.github/workflows/integration-tests-gate.yaml
+++ b/.github/workflows/integration-tests-gate.yaml
@@ -32,6 +32,12 @@ concurrency:
 jobs:
   gate:
     name: gate
+    # Skip on fork PRs: GITHUB_TOKEN has no actions:write scope from a fork
+    # so `gh run rerun --failed` would 403 anyway. The matrix workflow's own
+    # status remains the required signal for fork PRs.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 420
     steps:

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -315,21 +315,6 @@ jobs:
       TEST_CLUSTER_TYPE: ${{ inputs.distro-type || inputs.cluster-type }}
 
     steps:
-      # THROWAWAY: deterministic failure of one tier-2 scenario (`oidc`) on
-      # merge_group events to verify Integration Tests Gate retry behavior
-      # in the merge queue end-to-end. The gate should retry this cell once,
-      # see it fail again, report red, and the queue should evict the PR.
-      # REVERT THIS STEP IN A FOLLOWUP COMMIT BEFORE FINAL MERGE.
-      - name: "[GATE-TEST] Intentional failure for tier-2 oidc scenario"
-        if: >-
-          github.event_name == 'merge_group' &&
-          inputs.shortname == 'oidc'
-        run: |
-          echo "::error::Intentional deterministic failure for gate-retry test."
-          echo "Revert the [GATE-TEST] step in test-integration-runner.yaml"
-          echo "before this PR can merge."
-          exit 1
-
       - name: Info - ℹ️ Print workflow inputs ℹ️
         env:
           GITHUB_CONTEXT: ${{ toJson(inputs) }}
@@ -793,21 +778,6 @@ jobs:
       TEST_CLUSTER_TYPE: ${{ inputs.distro-type || inputs.cluster-type }}
 
     steps:
-      # THROWAWAY: deterministic failure of one tier-2 scenario (`oidc`) on
-      # merge_group events to verify Integration Tests Gate retry behavior
-      # in the merge queue end-to-end. The gate should retry this cell once,
-      # see it fail again, report red, and the queue should evict the PR.
-      # REVERT THIS STEP IN A FOLLOWUP COMMIT BEFORE FINAL MERGE.
-      - name: "[GATE-TEST] Intentional failure for tier-2 oidc scenario"
-        if: >-
-          github.event_name == 'merge_group' &&
-          inputs.shortname == 'oidc'
-        run: |
-          echo "::error::Intentional deterministic failure for gate-retry test."
-          echo "Revert the [GATE-TEST] step in test-integration-runner.yaml"
-          echo "before this PR can merge."
-          exit 1
-
       - name: Info - ℹ️ Print workflow inputs ℹ️
         env:
           GITHUB_CONTEXT: ${{ toJson(inputs) }}

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -315,6 +315,21 @@ jobs:
       TEST_CLUSTER_TYPE: ${{ inputs.distro-type || inputs.cluster-type }}
 
     steps:
+      # THROWAWAY: deterministic failure of one tier-2 scenario (`oidc`) on
+      # merge_group events to verify Integration Tests Gate retry behavior
+      # in the merge queue end-to-end. The gate should retry this cell once,
+      # see it fail again, report red, and the queue should evict the PR.
+      # REVERT THIS STEP IN A FOLLOWUP COMMIT BEFORE FINAL MERGE.
+      - name: "[GATE-TEST] Intentional failure for tier-2 oidc scenario"
+        if: >-
+          github.event_name == 'merge_group' &&
+          inputs.shortname == 'oidc'
+        run: |
+          echo "::error::Intentional deterministic failure for gate-retry test."
+          echo "Revert the [GATE-TEST] step in test-integration-runner.yaml"
+          echo "before this PR can merge."
+          exit 1
+
       - name: Info - ℹ️ Print workflow inputs ℹ️
         env:
           GITHUB_CONTEXT: ${{ toJson(inputs) }}
@@ -778,6 +793,21 @@ jobs:
       TEST_CLUSTER_TYPE: ${{ inputs.distro-type || inputs.cluster-type }}
 
     steps:
+      # THROWAWAY: deterministic failure of one tier-2 scenario (`oidc`) on
+      # merge_group events to verify Integration Tests Gate retry behavior
+      # in the merge queue end-to-end. The gate should retry this cell once,
+      # see it fail again, report red, and the queue should evict the PR.
+      # REVERT THIS STEP IN A FOLLOWUP COMMIT BEFORE FINAL MERGE.
+      - name: "[GATE-TEST] Intentional failure for tier-2 oidc scenario"
+        if: >-
+          github.event_name == 'merge_group' &&
+          inputs.shortname == 'oidc'
+        run: |
+          echo "::error::Intentional deterministic failure for gate-retry test."
+          echo "Revert the [GATE-TEST] step in test-integration-runner.yaml"
+          echo "before this PR can merge."
+          exit 1
+
       - name: Info - ℹ️ Print workflow inputs ℹ️
         env:
           GITHUB_CONTEXT: ${{ toJson(inputs) }}

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -1248,6 +1248,7 @@ jobs:
           ROSA_PASS:        ${{ secrets[inputs.password] }}
           CI_DEPLOYMENT_TTL: ${{ env.CI_DEPLOYMENT_TTL }}
           PLAYWRIGHT_POD_RETRY_MAX_ATTEMPTS: "1"
+          PLAYWRIGHT_E2E_RETRIES: "0"
         with:
           camunda-helm-git-ref: ${{ inputs.camunda-helm-git-ref }}
           camunda-helm-dir: ${{ inputs.camunda-helm-dir }}

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ scripts/vault-secret-mapper/vault-secret-mapper
 scripts/deploy-camunda/deploy-camunda
 scripts/deploy-camunda/.env
 scripts/release-tools/release-tools
+scripts/integration-tests-gate/integration-tests-gate
 
 charts/camunda-platform*/test/e2e/package-lock.json
 

--- a/charts/camunda-platform-8.9/test/e2e/playwright.config.ts
+++ b/charts/camunda-platform-8.9/test/e2e/playwright.config.ts
@@ -13,6 +13,14 @@ export default defineConfig({
     {
       name: "full-suite",
       testMatch: ["**/*.spec.{ts,js}"],
+      // cluster-variables requires Vault-managed secrets not available in PR CI.
+      testIgnore: ["**/cluster-variables.spec.{ts,js}"],
+      // @tasklistV1: requires Tasklist v1 mode with RBA enabled, not deployed in
+      // standard CI scenarios. Also excludes all Optimize tests (under
+      // 'Optimize User Flow Tests @tasklistV1') which require long Optimize
+      // warm-up not available on fresh clusters.
+      // Connector Secrets/Custom Tags/Properties: require QA-specific config.
+      grep: /^(?!.*(@tasklistV1|Connector Secrets User Flow|Custom Tags|Custom Properties)).*$/,
     },
   ],
   fullyParallel: true,

--- a/scripts/integration-tests-gate/README.md
+++ b/scripts/integration-tests-gate/README.md
@@ -36,6 +36,10 @@ gh workflow run integration-tests-gate.yaml \
   -f event=pull_request
 ```
 
+GitHub Actions retains run history for 90 days; dispatching against a
+SHA older than that will fail discovery because the matrix run has
+been pruned.
+
 ## Development
 
 ```bash
@@ -43,6 +47,7 @@ cd scripts/integration-tests-gate
 go test ./...
 go vet ./...
 go build .
+go run .   # how the workflow invokes the gate
 ```
 
 The gate logic lives in `gate.go` behind a `ghClient` interface;

--- a/scripts/integration-tests-gate/README.md
+++ b/scripts/integration-tests-gate/README.md
@@ -1,0 +1,51 @@
+# Integration Tests Gate
+
+Required status check that wraps the `Test - Chart Version` matrix
+workflow with a one-shot retry of failed jobs.
+
+The merge queue gates on this workflow, not on the underlying matrix.
+A transient failure in a single matrix cell does not evict the PR:
+the gate retries failed cells once and only reports its own final
+conclusion.
+
+## Behavior
+
+- One retry **per gate invocation**. Re-running the gate workflow
+  yields one additional retry; useful for recovering from a
+  double-transient without pushing a new commit.
+- `cancelled` / `timed_out` / `action_required` are **not** retried.
+  Only `conclusion == failure` triggers `gh run rerun --failed`.
+- The gate's required check is `Integration Tests Gate / gate`.
+  Branch protection / merge-queue config must require this check and
+  not the raw matrix check.
+
+## Fork PRs
+
+The gate is skipped on PRs from fork repositories. `GITHUB_TOKEN`
+on fork PRs has no `actions: write` scope, so `gh run rerun --failed`
+would 403. For fork PRs, the matrix workflow's own status is the
+required signal.
+
+## Manual debugging
+
+Use `workflow_dispatch` to run the gate against a specific SHA:
+
+```bash
+gh workflow run integration-tests-gate.yaml \
+  -f sha=<commit-sha> \
+  -f event=pull_request
+```
+
+## Development
+
+```bash
+cd scripts/integration-tests-gate
+go test ./...
+go vet ./...
+go build .
+```
+
+The gate logic lives in `gate.go` behind a `ghClient` interface;
+`gh.go` is the production implementation that shells out to the
+`gh` CLI. `gate_test.go` uses a fake client to exercise the state
+machine without touching the GitHub API.

--- a/scripts/integration-tests-gate/README.md
+++ b/scripts/integration-tests-gate/README.md
@@ -19,6 +19,23 @@ conclusion.
   Branch protection / merge-queue config must require this check and
   not the raw matrix check.
 
+## continue-on-error jobs
+
+The gate looks at the run-level `conclusion`, never per-job. GitHub
+treats `continue-on-error: true` jobs as soft failures: their internal
+steps can fail but the job's `conclusion` stays `success` and they do
+not contribute to the run-level conclusion. Practical consequences:
+
+- A run with only soft (continue-on-error) failures is `success` at the
+  run level. The gate exits 0 without retrying.
+- A run with a mix of hard and soft failures is `failure` at the run
+  level. The gate retries; `gh run rerun --failed` only reruns the hard
+  failures because the soft ones are already "successful".
+
+If you want a flaky job to be retried by the gate, do NOT mark it
+`continue-on-error: true` — that disqualifies it from `--failed`
+rerun.
+
 ## Fork PRs
 
 The gate is skipped on PRs from fork repositories. `GITHUB_TOKEN`

--- a/scripts/integration-tests-gate/gate.go
+++ b/scripts/integration-tests-gate/gate.go
@@ -1,0 +1,224 @@
+// Copyright 2025 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+type ghClient interface {
+	FindRun(workflow, sha, event string) (string, error)
+	RunURL(runID string) (string, error)
+	RunAttempt(runID string) (int, error)
+	AttemptStatus(runID string, attempt int) (string, error)
+	AttemptConclusion(runID string, attempt int) (string, error)
+	RerunFailed(runID string) error
+}
+
+type Gate struct {
+	Client   ghClient
+	Workflow string
+
+	DiscoveryTries    int
+	DiscoveryInterval time.Duration
+
+	PollInterval time.Duration
+
+	RegistrationTries    int
+	RegistrationInterval time.Duration
+
+	RerunTries   int
+	RerunBackoff time.Duration
+
+	Sleep func(time.Duration)
+	Log   func(format string, args ...any)
+}
+
+func ResolveSHA(event, prHeadSHA, mgHeadSHA string) (string, error) {
+	switch event {
+	case "pull_request", "pull_request_target":
+		if prHeadSHA == "" {
+			return "", fmt.Errorf("missing pull_request head sha")
+		}
+		return prHeadSHA, nil
+	case "merge_group":
+		if mgHeadSHA == "" {
+			return "", fmt.Errorf("missing merge_group head sha")
+		}
+		return mgHeadSHA, nil
+	default:
+		return "", fmt.Errorf("unsupported event: %s", event)
+	}
+}
+
+func (g *Gate) Discover(sha, event string) (runID, runURL string, err error) {
+	for i := 0; i < g.DiscoveryTries; i++ {
+		runID, err = g.Client.FindRun(g.Workflow, sha, event)
+		if err == nil && runID != "" {
+			break
+		}
+		g.Log("matrix run not yet visible (%d/%d)", i+1, g.DiscoveryTries)
+		g.Sleep(g.DiscoveryInterval)
+	}
+	if runID == "" {
+		return "", "", fmt.Errorf("no matrix run for %s @ %s", g.Workflow, sha)
+	}
+	runURL, urlErr := g.Client.RunURL(runID)
+	if urlErr != nil || runURL == "" {
+		runURL = ""
+	}
+	return runID, runURL, nil
+}
+
+// WaitForCompletion polls until the attempt's status is "completed".
+// It requires at least one observation of a non-completed status before
+// believing a "completed" reading, to guard against the API returning stale
+// top-level state for an attempt that has not actually started yet.
+func (g *Gate) WaitForCompletion(runID string, attempt int) error {
+	seenRunning := false
+	for {
+		status, err := g.Client.AttemptStatus(runID, attempt)
+		if err != nil {
+			g.Log("attempt %d status read error: %v", attempt, err)
+			g.Sleep(g.PollInterval)
+			continue
+		}
+		switch status {
+		case "completed":
+			if seenRunning {
+				return nil
+			}
+			g.Log("attempt %d completed-but-unconfirmed; awaiting start", attempt)
+		case "queued", "in_progress", "waiting", "requested", "pending":
+			seenRunning = true
+			g.Log("attempt %d status=%s", attempt, status)
+		case "":
+			g.Log("attempt %d not visible yet", attempt)
+		default:
+			g.Log("attempt %d status=%s", attempt, status)
+		}
+		g.Sleep(g.PollInterval)
+	}
+}
+
+func (g *Gate) RerunWithBackoff(runID string) error {
+	var last error
+	for i := 0; i < g.RerunTries; i++ {
+		if err := g.Client.RerunFailed(runID); err == nil {
+			return nil
+		} else {
+			last = err
+			g.Log("rerun --failed try %d/%d failed: %v", i+1, g.RerunTries, err)
+			g.Sleep(g.RerunBackoff)
+		}
+	}
+	if last == nil {
+		last = errors.New("rerun --failed exhausted retries")
+	}
+	return last
+}
+
+func (g *Gate) WaitForAttemptRegistered(runID string, want int) error {
+	for i := 0; i < g.RegistrationTries; i++ {
+		got, err := g.Client.RunAttempt(runID)
+		if err == nil && got >= want {
+			return nil
+		}
+		g.Sleep(g.RegistrationInterval)
+	}
+	return fmt.Errorf("attempt %d was not registered", want)
+}
+
+// ErrNotRetryable is returned when an attempt finished in a state that
+// `gh run rerun --failed` cannot recover (cancelled / timed_out / etc).
+var ErrNotRetryable = errors.New("not retryable")
+
+func (g *Gate) Run(event, prHeadSHA, mgHeadSHA string) error {
+	sha, err := ResolveSHA(event, prHeadSHA, mgHeadSHA)
+	if err != nil {
+		return err
+	}
+	g.Log("gating event=%s sha=%s", event, sha)
+
+	runID, runURL, err := g.Discover(sha, event)
+	if err != nil {
+		return err
+	}
+	if runURL == "" {
+		runURL = "(url unknown)"
+	}
+	g.Log("matrix run %s: %s", runID, runURL)
+
+	current, err := g.Client.RunAttempt(runID)
+	if err != nil || current < 1 {
+		return fmt.Errorf("could not read run_attempt for %s: %v", runID, err)
+	}
+
+	if err := g.watchAndDecide(runID, runURL, current); err != nil {
+		if !errors.Is(err, errNeedsRetry) {
+			return err
+		}
+	} else {
+		return nil
+	}
+
+	g.Log("triggering retry of failed jobs on %s", runURL)
+	if err := g.RerunWithBackoff(runID); err != nil {
+		return err
+	}
+
+	next := current + 1
+	if err := g.WaitForAttemptRegistered(runID, next); err != nil {
+		return err
+	}
+
+	g.Log("watching attempt %d: %s/attempts/%d", next, runURL, next)
+	if err := g.WaitForCompletion(runID, next); err != nil {
+		return err
+	}
+	final, err := g.Client.AttemptConclusion(runID, next)
+	if err != nil {
+		return err
+	}
+	g.Log("attempt %d conclusion: %s", next, final)
+	if final == "success" {
+		return nil
+	}
+	return fmt.Errorf("attempt %d conclusion: %s", next, final)
+}
+
+var errNeedsRetry = errors.New("retry needed")
+
+func (g *Gate) watchAndDecide(runID, runURL string, attempt int) error {
+	g.Log("watching attempt %d: %s", attempt, runURL)
+	if err := g.WaitForCompletion(runID, attempt); err != nil {
+		return err
+	}
+	conclusion, err := g.Client.AttemptConclusion(runID, attempt)
+	if err != nil {
+		return err
+	}
+	g.Log("attempt %d conclusion: %s", attempt, conclusion)
+	switch conclusion {
+	case "success":
+		return nil
+	case "failure":
+		return errNeedsRetry
+	default:
+		return fmt.Errorf("%w: %s", ErrNotRetryable, conclusion)
+	}
+}

--- a/scripts/integration-tests-gate/gate.go
+++ b/scripts/integration-tests-gate/gate.go
@@ -246,9 +246,9 @@ func (g *Gate) Run(event, prHeadSHA, mgHeadSHA string) error {
 		return nil
 	}
 	if final == "failure" {
-		g.Cmdf("::warning::attempt %d still failure after retry; " +
-			"jobs with conclusion=cancelled are not rerun by --failed " +
-			"and may need manual intervention")
+		g.Cmdf("::warning::attempt %d still failure after retry; "+
+			"jobs with conclusion=cancelled are not rerun by --failed "+
+			"and may need manual intervention", next)
 	}
 	return fmt.Errorf("attempt %d conclusion: %s", next, final)
 }

--- a/scripts/integration-tests-gate/gate.go
+++ b/scripts/integration-tests-gate/gate.go
@@ -49,7 +49,11 @@ type Gate struct {
 	RerunBackoff time.Duration
 
 	Sleep func(time.Duration)
-	Logf  func(format string, args ...any)
+	// Logf prints human-readable progress to stderr.
+	Logf func(format string, args ...any)
+	// Cmdf prints GitHub Actions workflow commands (::group::,
+	// ::endgroup::, ::warning::) to stdout.
+	Cmdf func(format string, args ...any)
 }
 
 func ResolveSHA(event, prHeadSHA, mgHeadSHA string) (string, error) {
@@ -69,10 +73,20 @@ func ResolveSHA(event, prHeadSHA, mgHeadSHA string) (string, error) {
 	}
 }
 
-func (g *Gate) group(name string, fn func() error) error {
-	g.Logf("::group::%s", name)
-	defer g.Logf("::endgroup::")
-	return fn()
+// ResolveDispatchOverride remaps the event and SHAs when the gate is
+// triggered manually via workflow_dispatch with an OVERRIDE_SHA. If
+// overrideSHA is empty the inputs pass through unchanged.
+func ResolveDispatchOverride(
+	event, prHead, mgHead, overrideSHA, overrideEvent string,
+) (string, string, string) {
+	if overrideSHA == "" {
+		return event, prHead, mgHead
+	}
+	resolved := overrideEvent
+	if resolved == "" {
+		resolved = "pull_request"
+	}
+	return resolved, overrideSHA, overrideSHA
 }
 
 func (g *Gate) Discover(sha, event string) (runID, runURL string, err error) {
@@ -174,12 +188,9 @@ func (g *Gate) Run(event, prHeadSHA, mgHeadSHA string) error {
 	}
 	g.Logf("gating event=%s sha=%s", event, sha)
 
-	var runID, runURL string
-	err = g.group("discover", func() error {
-		var derr error
-		runID, runURL, derr = g.Discover(sha, event)
-		return derr
-	})
+	g.Cmdf("::group::discover")
+	runID, runURL, err := g.Discover(sha, event)
+	g.Cmdf("::endgroup::")
 	if err != nil {
 		return err
 	}
@@ -193,11 +204,9 @@ func (g *Gate) Run(event, prHeadSHA, mgHeadSHA string) error {
 		return fmt.Errorf("could not read run_attempt for %s: %w", runID, err)
 	}
 
-	var watchErr error
-	_ = g.group(fmt.Sprintf("watch attempt %d", current), func() error {
-		watchErr = g.watchAndDecide(runID, runURL, current)
-		return nil
-	})
+	g.Cmdf("::group::watch attempt %d", current)
+	watchErr := g.watchAndDecide(runID, runURL, current)
+	g.Cmdf("::endgroup::")
 	if watchErr == nil {
 		return nil
 	}
@@ -206,28 +215,27 @@ func (g *Gate) Run(event, prHeadSHA, mgHeadSHA string) error {
 	}
 
 	g.Logf("triggering retry of failed jobs on %s", runURL)
-	if err := g.group("rerun --failed", func() error {
-		return g.RerunWithBackoff(runID)
-	}); err != nil {
+	g.Cmdf("::group::rerun --failed")
+	err = g.RerunWithBackoff(runID)
+	g.Cmdf("::endgroup::")
+	if err != nil {
 		return err
 	}
 
 	next := current + 1
-	if err := g.group(
-		fmt.Sprintf("await attempt %d registration", next),
-		func() error { return g.WaitForAttemptRegistered(runID, next) },
-	); err != nil {
+	g.Cmdf("::group::await attempt %d registration", next)
+	err = g.WaitForAttemptRegistered(runID, next)
+	g.Cmdf("::endgroup::")
+	if err != nil {
 		return err
 	}
 
 	g.Logf("watching attempt %d: %s/attempts/%d", next, runURL, next)
-	var finalErr error
-	_ = g.group(fmt.Sprintf("watch attempt %d", next), func() error {
-		finalErr = g.WaitForCompletion(runID, next)
-		return nil
-	})
-	if finalErr != nil {
-		return finalErr
+	g.Cmdf("::group::watch attempt %d", next)
+	err = g.WaitForCompletion(runID, next)
+	g.Cmdf("::endgroup::")
+	if err != nil {
+		return err
 	}
 	final, err := g.Client.AttemptConclusion(runID, next)
 	if err != nil {
@@ -238,9 +246,9 @@ func (g *Gate) Run(event, prHeadSHA, mgHeadSHA string) error {
 		return nil
 	}
 	if final == "failure" {
-		g.Logf("::warning::attempt %d still failure after retry; "+
-			"jobs with conclusion=cancelled are not rerun by --failed "+
-			"and may need manual intervention", next)
+		g.Cmdf("::warning::attempt %d still failure after retry; " +
+			"jobs with conclusion=cancelled are not rerun by --failed " +
+			"and may need manual intervention")
 	}
 	return fmt.Errorf("attempt %d conclusion: %s", next, final)
 }

--- a/scripts/integration-tests-gate/gate.go
+++ b/scripts/integration-tests-gate/gate.go
@@ -36,7 +36,8 @@ type Gate struct {
 	DiscoveryTries    int
 	DiscoveryInterval time.Duration
 
-	PollInterval time.Duration
+	PollInterval         time.Duration
+	MaxConsecutiveErrors int
 
 	RegistrationTries    int
 	RegistrationInterval time.Duration
@@ -45,7 +46,7 @@ type Gate struct {
 	RerunBackoff time.Duration
 
 	Sleep func(time.Duration)
-	Log   func(format string, args ...any)
+	Logf  func(format string, args ...any)
 }
 
 func ResolveSHA(event, prHeadSHA, mgHeadSHA string) (string, error) {
@@ -71,7 +72,7 @@ func (g *Gate) Discover(sha, event string) (runID, runURL string, err error) {
 		if err == nil && runID != "" {
 			break
 		}
-		g.Log("matrix run not yet visible (%d/%d)", i+1, g.DiscoveryTries)
+		g.Logf("matrix run not yet visible (%d/%d)", i+1, g.DiscoveryTries)
 		g.Sleep(g.DiscoveryInterval)
 	}
 	if runID == "" {
@@ -84,33 +85,26 @@ func (g *Gate) Discover(sha, event string) (runID, runURL string, err error) {
 	return runID, runURL, nil
 }
 
-// WaitForCompletion polls until the attempt's status is "completed".
-// It requires at least one observation of a non-completed status before
-// believing a "completed" reading, to guard against the API returning stale
-// top-level state for an attempt that has not actually started yet.
 func (g *Gate) WaitForCompletion(runID string, attempt int) error {
-	seenRunning := false
+	consecutiveErrors := 0
 	for {
 		status, err := g.Client.AttemptStatus(runID, attempt)
 		if err != nil {
-			g.Log("attempt %d status read error: %v", attempt, err)
+			consecutiveErrors++
+			g.Logf("attempt %d status read error (%d/%d): %v",
+				attempt, consecutiveErrors, g.MaxConsecutiveErrors, err)
+			if consecutiveErrors >= g.MaxConsecutiveErrors {
+				return fmt.Errorf("attempt %d: %d consecutive status errors: %w",
+					attempt, consecutiveErrors, err)
+			}
 			g.Sleep(g.PollInterval)
 			continue
 		}
-		switch status {
-		case "completed":
-			if seenRunning {
-				return nil
-			}
-			g.Log("attempt %d completed-but-unconfirmed; awaiting start", attempt)
-		case "queued", "in_progress", "waiting", "requested", "pending":
-			seenRunning = true
-			g.Log("attempt %d status=%s", attempt, status)
-		case "":
-			g.Log("attempt %d not visible yet", attempt)
-		default:
-			g.Log("attempt %d status=%s", attempt, status)
+		consecutiveErrors = 0
+		if status == "completed" {
+			return nil
 		}
+		g.Logf("attempt %d status=%q", attempt, status)
 		g.Sleep(g.PollInterval)
 	}
 }
@@ -122,7 +116,8 @@ func (g *Gate) RerunWithBackoff(runID string) error {
 			return nil
 		} else {
 			last = err
-			g.Log("rerun --failed try %d/%d failed: %v", i+1, g.RerunTries, err)
+			g.Logf("rerun --failed try %d/%d failed: %v",
+				i+1, g.RerunTries, err)
 			g.Sleep(g.RerunBackoff)
 		}
 	}
@@ -143,8 +138,6 @@ func (g *Gate) WaitForAttemptRegistered(runID string, want int) error {
 	return fmt.Errorf("attempt %d was not registered", want)
 }
 
-// ErrNotRetryable is returned when an attempt finished in a state that
-// `gh run rerun --failed` cannot recover (cancelled / timed_out / etc).
 var ErrNotRetryable = errors.New("not retryable")
 
 func (g *Gate) Run(event, prHeadSHA, mgHeadSHA string) error {
@@ -152,7 +145,7 @@ func (g *Gate) Run(event, prHeadSHA, mgHeadSHA string) error {
 	if err != nil {
 		return err
 	}
-	g.Log("gating event=%s sha=%s", event, sha)
+	g.Logf("gating event=%s sha=%s", event, sha)
 
 	runID, runURL, err := g.Discover(sha, event)
 	if err != nil {
@@ -161,7 +154,7 @@ func (g *Gate) Run(event, prHeadSHA, mgHeadSHA string) error {
 	if runURL == "" {
 		runURL = "(url unknown)"
 	}
-	g.Log("matrix run %s: %s", runID, runURL)
+	g.Logf("matrix run %s: %s", runID, runURL)
 
 	current, err := g.Client.RunAttempt(runID)
 	if err != nil || current < 1 {
@@ -176,7 +169,7 @@ func (g *Gate) Run(event, prHeadSHA, mgHeadSHA string) error {
 		return nil
 	}
 
-	g.Log("triggering retry of failed jobs on %s", runURL)
+	g.Logf("triggering retry of failed jobs on %s", runURL)
 	if err := g.RerunWithBackoff(runID); err != nil {
 		return err
 	}
@@ -186,7 +179,7 @@ func (g *Gate) Run(event, prHeadSHA, mgHeadSHA string) error {
 		return err
 	}
 
-	g.Log("watching attempt %d: %s/attempts/%d", next, runURL, next)
+	g.Logf("watching attempt %d: %s/attempts/%d", next, runURL, next)
 	if err := g.WaitForCompletion(runID, next); err != nil {
 		return err
 	}
@@ -194,7 +187,7 @@ func (g *Gate) Run(event, prHeadSHA, mgHeadSHA string) error {
 	if err != nil {
 		return err
 	}
-	g.Log("attempt %d conclusion: %s", next, final)
+	g.Logf("attempt %d conclusion: %s", next, final)
 	if final == "success" {
 		return nil
 	}
@@ -204,7 +197,7 @@ func (g *Gate) Run(event, prHeadSHA, mgHeadSHA string) error {
 var errNeedsRetry = errors.New("retry needed")
 
 func (g *Gate) watchAndDecide(runID, runURL string, attempt int) error {
-	g.Log("watching attempt %d: %s", attempt, runURL)
+	g.Logf("watching attempt %d: %s", attempt, runURL)
 	if err := g.WaitForCompletion(runID, attempt); err != nil {
 		return err
 	}
@@ -212,7 +205,7 @@ func (g *Gate) watchAndDecide(runID, runURL string, attempt int) error {
 	if err != nil {
 		return err
 	}
-	g.Log("attempt %d conclusion: %s", attempt, conclusion)
+	g.Logf("attempt %d conclusion: %s", attempt, conclusion)
 	switch conclusion {
 	case "success":
 		return nil

--- a/scripts/integration-tests-gate/gate.go
+++ b/scripts/integration-tests-gate/gate.go
@@ -42,6 +42,9 @@ type Gate struct {
 	RegistrationTries    int
 	RegistrationInterval time.Duration
 
+	RunAttemptTries   int
+	RunAttemptBackoff time.Duration
+
 	RerunTries   int
 	RerunBackoff time.Duration
 
@@ -66,6 +69,12 @@ func ResolveSHA(event, prHeadSHA, mgHeadSHA string) (string, error) {
 	}
 }
 
+func (g *Gate) group(name string, fn func() error) error {
+	g.Logf("::group::%s", name)
+	defer g.Logf("::endgroup::")
+	return fn()
+}
+
 func (g *Gate) Discover(sha, event string) (runID, runURL string, err error) {
 	for i := 0; i < g.DiscoveryTries; i++ {
 		runID, err = g.Client.FindRun(g.Workflow, sha, event)
@@ -83,6 +92,24 @@ func (g *Gate) Discover(sha, event string) (runID, runURL string, err error) {
 		runURL = ""
 	}
 	return runID, runURL, nil
+}
+
+func (g *Gate) RunAttemptWithRetry(runID string) (int, error) {
+	var last error
+	for i := 0; i < g.RunAttemptTries; i++ {
+		n, err := g.Client.RunAttempt(runID)
+		if err == nil && n >= 1 {
+			return n, nil
+		}
+		last = err
+		g.Logf("run_attempt read failed (%d/%d): %v",
+			i+1, g.RunAttemptTries, err)
+		g.Sleep(g.RunAttemptBackoff)
+	}
+	if last == nil {
+		last = errors.New("run_attempt < 1")
+	}
+	return 0, last
 }
 
 func (g *Gate) WaitForCompletion(runID string, attempt int) error {
@@ -147,7 +174,12 @@ func (g *Gate) Run(event, prHeadSHA, mgHeadSHA string) error {
 	}
 	g.Logf("gating event=%s sha=%s", event, sha)
 
-	runID, runURL, err := g.Discover(sha, event)
+	var runID, runURL string
+	err = g.group("discover", func() error {
+		var derr error
+		runID, runURL, derr = g.Discover(sha, event)
+		return derr
+	})
 	if err != nil {
 		return err
 	}
@@ -156,32 +188,46 @@ func (g *Gate) Run(event, prHeadSHA, mgHeadSHA string) error {
 	}
 	g.Logf("matrix run %s: %s", runID, runURL)
 
-	current, err := g.Client.RunAttempt(runID)
-	if err != nil || current < 1 {
-		return fmt.Errorf("could not read run_attempt for %s: %v", runID, err)
+	current, err := g.RunAttemptWithRetry(runID)
+	if err != nil {
+		return fmt.Errorf("could not read run_attempt for %s: %w", runID, err)
 	}
 
-	if err := g.watchAndDecide(runID, runURL, current); err != nil {
-		if !errors.Is(err, errNeedsRetry) {
-			return err
-		}
-	} else {
+	var watchErr error
+	_ = g.group(fmt.Sprintf("watch attempt %d", current), func() error {
+		watchErr = g.watchAndDecide(runID, runURL, current)
 		return nil
+	})
+	if watchErr == nil {
+		return nil
+	}
+	if !errors.Is(watchErr, errNeedsRetry) {
+		return watchErr
 	}
 
 	g.Logf("triggering retry of failed jobs on %s", runURL)
-	if err := g.RerunWithBackoff(runID); err != nil {
+	if err := g.group("rerun --failed", func() error {
+		return g.RerunWithBackoff(runID)
+	}); err != nil {
 		return err
 	}
 
 	next := current + 1
-	if err := g.WaitForAttemptRegistered(runID, next); err != nil {
+	if err := g.group(
+		fmt.Sprintf("await attempt %d registration", next),
+		func() error { return g.WaitForAttemptRegistered(runID, next) },
+	); err != nil {
 		return err
 	}
 
 	g.Logf("watching attempt %d: %s/attempts/%d", next, runURL, next)
-	if err := g.WaitForCompletion(runID, next); err != nil {
-		return err
+	var finalErr error
+	_ = g.group(fmt.Sprintf("watch attempt %d", next), func() error {
+		finalErr = g.WaitForCompletion(runID, next)
+		return nil
+	})
+	if finalErr != nil {
+		return finalErr
 	}
 	final, err := g.Client.AttemptConclusion(runID, next)
 	if err != nil {
@@ -190,6 +236,11 @@ func (g *Gate) Run(event, prHeadSHA, mgHeadSHA string) error {
 	g.Logf("attempt %d conclusion: %s", next, final)
 	if final == "success" {
 		return nil
+	}
+	if final == "failure" {
+		g.Logf("::warning::attempt %d still failure after retry; "+
+			"jobs with conclusion=cancelled are not rerun by --failed "+
+			"and may need manual intervention", next)
 	}
 	return fmt.Errorf("attempt %d conclusion: %s", next, final)
 }

--- a/scripts/integration-tests-gate/gate_test.go
+++ b/scripts/integration-tests-gate/gate_test.go
@@ -25,7 +25,7 @@ type fakeClient struct {
 	findRunQueue        []findRunResp
 	runURL              string
 	runURLErr           error
-	attemptsQueue       []int
+	attemptsQueue       []attemptResp
 	statusByAttempt     map[int][]statusResp
 	conclusionByAttempt map[int]string
 	conclusionErr       map[int]error
@@ -43,6 +43,11 @@ type statusResp struct {
 	err    error
 }
 
+type attemptResp struct {
+	n   int
+	err error
+}
+
 func (f *fakeClient) FindRun(_, _, _ string) (string, error) {
 	if len(f.findRunQueue) == 0 {
 		f.t.Fatalf("findRunQueue exhausted")
@@ -58,9 +63,9 @@ func (f *fakeClient) RunAttempt(string) (int, error) {
 	if len(f.attemptsQueue) == 0 {
 		f.t.Fatalf("attemptsQueue exhausted")
 	}
-	v := f.attemptsQueue[0]
+	r := f.attemptsQueue[0]
 	f.attemptsQueue = f.attemptsQueue[1:]
-	return v, nil
+	return r.n, r.err
 }
 func (f *fakeClient) AttemptStatus(_ string, attempt int) (string, error) {
 	q := f.statusByAttempt[attempt]
@@ -75,7 +80,11 @@ func (f *fakeClient) AttemptConclusion(_ string, attempt int) (string, error) {
 	if err, ok := f.conclusionErr[attempt]; ok {
 		return "", err
 	}
-	return f.conclusionByAttempt[attempt], nil
+	c, ok := f.conclusionByAttempt[attempt]
+	if !ok {
+		f.t.Fatalf("conclusionByAttempt[%d] not set", attempt)
+	}
+	return c, nil
 }
 func (f *fakeClient) RerunFailed(string) error {
 	f.rerunCalls++
@@ -95,6 +104,14 @@ func statusList(statuses ...string) []statusResp {
 	return out
 }
 
+func attemptList(ns ...int) []attemptResp {
+	out := make([]attemptResp, len(ns))
+	for i, n := range ns {
+		out[i] = attemptResp{n: n}
+	}
+	return out
+}
+
 func newTestGate(client ghClient) *Gate {
 	return &Gate{
 		Client:               client,
@@ -105,6 +122,8 @@ func newTestGate(client ghClient) *Gate {
 		MaxConsecutiveErrors: 5,
 		RegistrationTries:    5,
 		RegistrationInterval: time.Nanosecond,
+		RunAttemptTries:      3,
+		RunAttemptBackoff:    time.Nanosecond,
 		RerunTries:           3,
 		RerunBackoff:         time.Nanosecond,
 		Sleep:                func(time.Duration) {},
@@ -126,6 +145,7 @@ func TestResolveSHA(t *testing.T) {
 		{"merge_group_uses_head", "merge_group", "", "def", "def", false},
 		{"merge_group_ignores_pr_head", "merge_group", "abc", "def", "def", false},
 		{"unknown_event", "schedule", "abc", "def", "", true},
+		{"workflow_dispatch_unsupported", "workflow_dispatch", "abc", "def", "", true},
 		{"empty_pr_head", "pull_request", "", "", "", true},
 		{"empty_mg_head", "merge_group", "abc", "", "", true},
 	}
@@ -196,6 +216,38 @@ func TestDiscover_URLFallback(t *testing.T) {
 	}
 	if runURL != "" {
 		t.Fatalf("expected empty URL on error fallback")
+	}
+}
+
+func TestRunAttemptWithRetry_RecoversFromTransientError(t *testing.T) {
+	apiErr := errors.New("api blip")
+	c := &fakeClient{
+		t: t,
+		attemptsQueue: []attemptResp{
+			{err: apiErr}, {err: apiErr}, {n: 1},
+		},
+	}
+	g := newTestGate(c)
+	got, err := g.RunAttemptWithRetry("r")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != 1 {
+		t.Fatalf("got %d, want 1", got)
+	}
+}
+
+func TestRunAttemptWithRetry_ExhaustsRetries(t *testing.T) {
+	apiErr := errors.New("api down")
+	c := &fakeClient{
+		t: t,
+		attemptsQueue: []attemptResp{
+			{err: apiErr}, {err: apiErr}, {err: apiErr},
+		},
+	}
+	g := newTestGate(c)
+	if _, err := g.RunAttemptWithRetry("r"); err == nil {
+		t.Fatalf("expected exhaustion error")
 	}
 }
 
@@ -293,7 +345,7 @@ func TestRerunWithBackoff_ExhaustsRetries(t *testing.T) {
 }
 
 func TestWaitForAttemptRegistered_AdvancesEventually(t *testing.T) {
-	c := &fakeClient{t: t, attemptsQueue: []int{1, 1, 2}}
+	c := &fakeClient{t: t, attemptsQueue: attemptList(1, 1, 2)}
 	g := newTestGate(c)
 	if err := g.WaitForAttemptRegistered("r", 2); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -301,7 +353,7 @@ func TestWaitForAttemptRegistered_AdvancesEventually(t *testing.T) {
 }
 
 func TestWaitForAttemptRegistered_TimesOut(t *testing.T) {
-	c := &fakeClient{t: t, attemptsQueue: []int{1, 1, 1, 1, 1}}
+	c := &fakeClient{t: t, attemptsQueue: attemptList(1, 1, 1, 1, 1)}
 	g := newTestGate(c)
 	if err := g.WaitForAttemptRegistered("r", 2); err == nil {
 		t.Fatalf("expected timeout error")
@@ -313,7 +365,7 @@ func TestRun_AttemptOneSuccess(t *testing.T) {
 		t:                   t,
 		findRunQueue:        []findRunResp{{id: "100"}},
 		runURL:              "url",
-		attemptsQueue:       []int{1},
+		attemptsQueue:       attemptList(1),
 		statusByAttempt:     map[int][]statusResp{1: statusList("completed")},
 		conclusionByAttempt: map[int]string{1: "success"},
 	}
@@ -331,7 +383,7 @@ func TestRun_RetriesOnceAndPasses(t *testing.T) {
 		t:             t,
 		findRunQueue:  []findRunResp{{id: "100"}},
 		runURL:        "url",
-		attemptsQueue: []int{1, 2},
+		attemptsQueue: attemptList(1, 2),
 		statusByAttempt: map[int][]statusResp{
 			1: statusList("completed"),
 			2: statusList("completed"),
@@ -352,7 +404,7 @@ func TestRun_RetriesOnceAndFails(t *testing.T) {
 		t:             t,
 		findRunQueue:  []findRunResp{{id: "100"}},
 		runURL:        "url",
-		attemptsQueue: []int{1, 2},
+		attemptsQueue: attemptList(1, 2),
 		statusByAttempt: map[int][]statusResp{
 			1: statusList("completed"),
 			2: statusList("completed"),
@@ -373,7 +425,7 @@ func TestRun_CancelledIsNotRetryable(t *testing.T) {
 		t:                   t,
 		findRunQueue:        []findRunResp{{id: "100"}},
 		runURL:              "url",
-		attemptsQueue:       []int{1},
+		attemptsQueue:       attemptList(1),
 		statusByAttempt:     map[int][]statusResp{1: statusList("completed")},
 		conclusionByAttempt: map[int]string{1: "cancelled"},
 	}
@@ -395,7 +447,7 @@ func TestRun_HumanRerunStartingAtAttempt2(t *testing.T) {
 		t:             t,
 		findRunQueue:  []findRunResp{{id: "100"}},
 		runURL:        "url",
-		attemptsQueue: []int{2, 3},
+		attemptsQueue: attemptList(2, 3),
 		statusByAttempt: map[int][]statusResp{
 			2: statusList("completed"),
 			3: statusList("completed"),
@@ -427,7 +479,7 @@ func TestRun_MergeGroupUsesHeadSHA(t *testing.T) {
 		t:                   t,
 		findRunQueue:        []findRunResp{{id: "200"}},
 		runURL:              "url",
-		attemptsQueue:       []int{1},
+		attemptsQueue:       attemptList(1),
 		statusByAttempt:     map[int][]statusResp{1: statusList("completed")},
 		conclusionByAttempt: map[int]string{1: "success"},
 	}
@@ -439,19 +491,35 @@ func TestRun_MergeGroupUsesHeadSHA(t *testing.T) {
 
 func TestRun_FastAttempt2_NoSeenRunningGuard(t *testing.T) {
 	// Attempt 2 finishes so quickly that the first poll already shows
-	// `completed` — must NOT hang waiting for a phantom "in_progress"
-	// observation. Regression guard for the seenRunning guard that was
-	// removed because registration upstream already guarantees freshness.
+	// completed — must NOT hang waiting for a phantom in_progress.
 	c := &fakeClient{
 		t:             t,
 		findRunQueue:  []findRunResp{{id: "100"}},
 		runURL:        "url",
-		attemptsQueue: []int{1, 2},
+		attemptsQueue: attemptList(1, 2),
 		statusByAttempt: map[int][]statusResp{
 			1: statusList("completed"),
 			2: statusList("completed"),
 		},
 		conclusionByAttempt: map[int]string{1: "failure", 2: "success"},
+	}
+	g := newTestGate(c)
+	if err := g.Run("pull_request", "sha", ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRun_RunAttemptReadRecoversFromTransient(t *testing.T) {
+	apiErr := errors.New("api blip")
+	c := &fakeClient{
+		t:            t,
+		findRunQueue: []findRunResp{{id: "100"}},
+		runURL:       "url",
+		attemptsQueue: []attemptResp{
+			{err: apiErr}, {n: 1},
+		},
+		statusByAttempt:     map[int][]statusResp{1: statusList("completed")},
+		conclusionByAttempt: map[int]string{1: "success"},
 	}
 	g := newTestGate(c)
 	if err := g.Run("pull_request", "sha", ""); err != nil {

--- a/scripts/integration-tests-gate/gate_test.go
+++ b/scripts/integration-tests-gate/gate_test.go
@@ -21,12 +21,12 @@ import (
 )
 
 type fakeClient struct {
+	t                   testing.TB
 	findRunQueue        []findRunResp
 	runURL              string
 	runURLErr           error
 	attemptsQueue       []int
-	attemptsErr         []error
-	statusByAttempt     map[int][]string
+	statusByAttempt     map[int][]statusResp
 	conclusionByAttempt map[int]string
 	conclusionErr       map[int]error
 	rerunQueue          []error
@@ -38,9 +38,14 @@ type findRunResp struct {
 	err error
 }
 
+type statusResp struct {
+	status string
+	err    error
+}
+
 func (f *fakeClient) FindRun(_, _, _ string) (string, error) {
 	if len(f.findRunQueue) == 0 {
-		return "", nil
+		f.t.Fatalf("findRunQueue exhausted")
 	}
 	r := f.findRunQueue[0]
 	f.findRunQueue = f.findRunQueue[1:]
@@ -51,25 +56,20 @@ func (f *fakeClient) RunURL(string) (string, error) {
 }
 func (f *fakeClient) RunAttempt(string) (int, error) {
 	if len(f.attemptsQueue) == 0 {
-		return 0, errors.New("attempts queue empty")
+		f.t.Fatalf("attemptsQueue exhausted")
 	}
 	v := f.attemptsQueue[0]
 	f.attemptsQueue = f.attemptsQueue[1:]
-	var err error
-	if len(f.attemptsErr) > 0 {
-		err = f.attemptsErr[0]
-		f.attemptsErr = f.attemptsErr[1:]
-	}
-	return v, err
+	return v, nil
 }
 func (f *fakeClient) AttemptStatus(_ string, attempt int) (string, error) {
 	q := f.statusByAttempt[attempt]
 	if len(q) == 0 {
-		return "completed", nil
+		f.t.Fatalf("statusByAttempt[%d] exhausted", attempt)
 	}
-	v := q[0]
+	r := q[0]
 	f.statusByAttempt[attempt] = q[1:]
-	return v, nil
+	return r.status, r.err
 }
 func (f *fakeClient) AttemptConclusion(_ string, attempt int) (string, error) {
 	if err, ok := f.conclusionErr[attempt]; ok {
@@ -87,6 +87,14 @@ func (f *fakeClient) RerunFailed(string) error {
 	return e
 }
 
+func statusList(statuses ...string) []statusResp {
+	out := make([]statusResp, len(statuses))
+	for i, s := range statuses {
+		out[i] = statusResp{status: s}
+	}
+	return out
+}
+
 func newTestGate(client ghClient) *Gate {
 	return &Gate{
 		Client:               client,
@@ -94,12 +102,13 @@ func newTestGate(client ghClient) *Gate {
 		DiscoveryTries:       3,
 		DiscoveryInterval:    time.Nanosecond,
 		PollInterval:         time.Nanosecond,
+		MaxConsecutiveErrors: 5,
 		RegistrationTries:    5,
 		RegistrationInterval: time.Nanosecond,
 		RerunTries:           3,
 		RerunBackoff:         time.Nanosecond,
 		Sleep:                func(time.Duration) {},
-		Log:                  func(string, ...any) {},
+		Logf:                 func(string, ...any) {},
 	}
 }
 
@@ -141,10 +150,9 @@ func TestResolveSHA(t *testing.T) {
 
 func TestDiscover_EventualVisibility(t *testing.T) {
 	c := &fakeClient{
+		t: t,
 		findRunQueue: []findRunResp{
-			{id: ""},
-			{id: ""},
-			{id: "12345"},
+			{id: ""}, {id: ""}, {id: "12345"},
 		},
 		runURL: "https://github.com/x/y/actions/runs/12345",
 	}
@@ -163,17 +171,18 @@ func TestDiscover_EventualVisibility(t *testing.T) {
 
 func TestDiscover_TimesOut(t *testing.T) {
 	c := &fakeClient{
+		t:            t,
 		findRunQueue: []findRunResp{{id: ""}, {id: ""}, {id: ""}},
 	}
 	g := newTestGate(c)
-	_, _, err := g.Discover("sha", "pull_request")
-	if err == nil {
+	if _, _, err := g.Discover("sha", "pull_request"); err == nil {
 		t.Fatalf("expected timeout error")
 	}
 }
 
 func TestDiscover_URLFallback(t *testing.T) {
 	c := &fakeClient{
+		t:            t,
 		findRunQueue: []findRunResp{{id: "12345"}},
 		runURLErr:    errors.New("api error"),
 	}
@@ -190,25 +199,24 @@ func TestDiscover_URLFallback(t *testing.T) {
 	}
 }
 
-func TestWaitForCompletion_RequiresRunningBeforeCompleted(t *testing.T) {
+func TestWaitForCompletion_AcceptsImmediateCompleted(t *testing.T) {
 	c := &fakeClient{
-		statusByAttempt: map[int][]string{
-			2: {"completed", "in_progress", "completed"},
+		t: t,
+		statusByAttempt: map[int][]statusResp{
+			2: statusList("completed"),
 		},
 	}
 	g := newTestGate(c)
 	if err := g.WaitForCompletion("r", 2); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got := len(c.statusByAttempt[2]); got != 0 {
-		t.Fatalf("expected all 3 status reads consumed, %d left", got)
-	}
 }
 
-func TestWaitForCompletion_AcceptsCompletedAfterRunning(t *testing.T) {
+func TestWaitForCompletion_PollsUntilCompleted(t *testing.T) {
 	c := &fakeClient{
-		statusByAttempt: map[int][]string{
-			1: {"in_progress", "completed"},
+		t: t,
+		statusByAttempt: map[int][]statusResp{
+			1: statusList("queued", "in_progress", "in_progress", "completed"),
 		},
 	}
 	g := newTestGate(c)
@@ -217,10 +225,38 @@ func TestWaitForCompletion_AcceptsCompletedAfterRunning(t *testing.T) {
 	}
 }
 
-func TestWaitForCompletion_HandlesEmptyStatus(t *testing.T) {
+func TestWaitForCompletion_BailsAfterConsecutiveErrors(t *testing.T) {
+	apiErr := errors.New("api down")
 	c := &fakeClient{
-		statusByAttempt: map[int][]string{
-			1: {"", "queued", "completed"},
+		t: t,
+		statusByAttempt: map[int][]statusResp{
+			1: {
+				{err: apiErr}, {err: apiErr}, {err: apiErr},
+				{err: apiErr}, {err: apiErr},
+			},
+		},
+	}
+	g := newTestGate(c)
+	err := g.WaitForCompletion("r", 1)
+	if err == nil {
+		t.Fatalf("expected bail-out error")
+	}
+	if !errors.Is(err, apiErr) {
+		t.Fatalf("expected wrapped api error, got %v", err)
+	}
+}
+
+func TestWaitForCompletion_RecoversFromTransientErrors(t *testing.T) {
+	apiErr := errors.New("flake")
+	c := &fakeClient{
+		t: t,
+		statusByAttempt: map[int][]statusResp{
+			1: {
+				{err: apiErr},
+				{err: apiErr},
+				{status: "in_progress"},
+				{status: "completed"},
+			},
 		},
 	}
 	g := newTestGate(c)
@@ -231,6 +267,7 @@ func TestWaitForCompletion_HandlesEmptyStatus(t *testing.T) {
 
 func TestRerunWithBackoff_SucceedsAfterTransientFailure(t *testing.T) {
 	c := &fakeClient{
+		t:          t,
 		rerunQueue: []error{errors.New("422"), errors.New("422"), nil},
 	}
 	g := newTestGate(c)
@@ -244,7 +281,10 @@ func TestRerunWithBackoff_SucceedsAfterTransientFailure(t *testing.T) {
 
 func TestRerunWithBackoff_ExhaustsRetries(t *testing.T) {
 	c := &fakeClient{
-		rerunQueue: []error{errors.New("422"), errors.New("422"), errors.New("422")},
+		t: t,
+		rerunQueue: []error{
+			errors.New("422"), errors.New("422"), errors.New("422"),
+		},
 	}
 	g := newTestGate(c)
 	if err := g.RerunWithBackoff("r"); err == nil {
@@ -253,9 +293,7 @@ func TestRerunWithBackoff_ExhaustsRetries(t *testing.T) {
 }
 
 func TestWaitForAttemptRegistered_AdvancesEventually(t *testing.T) {
-	c := &fakeClient{
-		attemptsQueue: []int{1, 1, 2},
-	}
+	c := &fakeClient{t: t, attemptsQueue: []int{1, 1, 2}}
 	g := newTestGate(c)
 	if err := g.WaitForAttemptRegistered("r", 2); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -263,9 +301,7 @@ func TestWaitForAttemptRegistered_AdvancesEventually(t *testing.T) {
 }
 
 func TestWaitForAttemptRegistered_TimesOut(t *testing.T) {
-	c := &fakeClient{
-		attemptsQueue: []int{1, 1, 1, 1, 1},
-	}
+	c := &fakeClient{t: t, attemptsQueue: []int{1, 1, 1, 1, 1}}
 	g := newTestGate(c)
 	if err := g.WaitForAttemptRegistered("r", 2); err == nil {
 		t.Fatalf("expected timeout error")
@@ -274,10 +310,11 @@ func TestWaitForAttemptRegistered_TimesOut(t *testing.T) {
 
 func TestRun_AttemptOneSuccess(t *testing.T) {
 	c := &fakeClient{
+		t:                   t,
 		findRunQueue:        []findRunResp{{id: "100"}},
 		runURL:              "url",
 		attemptsQueue:       []int{1},
-		statusByAttempt:     map[int][]string{1: {"in_progress", "completed"}},
+		statusByAttempt:     map[int][]statusResp{1: statusList("completed")},
 		conclusionByAttempt: map[int]string{1: "success"},
 	}
 	g := newTestGate(c)
@@ -291,12 +328,13 @@ func TestRun_AttemptOneSuccess(t *testing.T) {
 
 func TestRun_RetriesOnceAndPasses(t *testing.T) {
 	c := &fakeClient{
+		t:             t,
 		findRunQueue:  []findRunResp{{id: "100"}},
 		runURL:        "url",
 		attemptsQueue: []int{1, 2},
-		statusByAttempt: map[int][]string{
-			1: {"in_progress", "completed"},
-			2: {"in_progress", "completed"},
+		statusByAttempt: map[int][]statusResp{
+			1: statusList("completed"),
+			2: statusList("completed"),
 		},
 		conclusionByAttempt: map[int]string{1: "failure", 2: "success"},
 	}
@@ -311,12 +349,13 @@ func TestRun_RetriesOnceAndPasses(t *testing.T) {
 
 func TestRun_RetriesOnceAndFails(t *testing.T) {
 	c := &fakeClient{
+		t:             t,
 		findRunQueue:  []findRunResp{{id: "100"}},
 		runURL:        "url",
 		attemptsQueue: []int{1, 2},
-		statusByAttempt: map[int][]string{
-			1: {"in_progress", "completed"},
-			2: {"in_progress", "completed"},
+		statusByAttempt: map[int][]statusResp{
+			1: statusList("completed"),
+			2: statusList("completed"),
 		},
 		conclusionByAttempt: map[int]string{1: "failure", 2: "failure"},
 	}
@@ -331,10 +370,11 @@ func TestRun_RetriesOnceAndFails(t *testing.T) {
 
 func TestRun_CancelledIsNotRetryable(t *testing.T) {
 	c := &fakeClient{
+		t:                   t,
 		findRunQueue:        []findRunResp{{id: "100"}},
 		runURL:              "url",
 		attemptsQueue:       []int{1},
-		statusByAttempt:     map[int][]string{1: {"in_progress", "completed"}},
+		statusByAttempt:     map[int][]statusResp{1: statusList("completed")},
 		conclusionByAttempt: map[int]string{1: "cancelled"},
 	}
 	g := newTestGate(c)
@@ -351,16 +391,14 @@ func TestRun_CancelledIsNotRetryable(t *testing.T) {
 }
 
 func TestRun_HumanRerunStartingAtAttempt2(t *testing.T) {
-	// Simulates re-running the gate workflow after a previous gate
-	// invocation has already retried once. The matrix's current
-	// run_attempt is 2 (failed). The gate should grant one more retry.
 	c := &fakeClient{
+		t:             t,
 		findRunQueue:  []findRunResp{{id: "100"}},
 		runURL:        "url",
 		attemptsQueue: []int{2, 3},
-		statusByAttempt: map[int][]string{
-			2: {"in_progress", "completed"},
-			3: {"in_progress", "completed"},
+		statusByAttempt: map[int][]statusResp{
+			2: statusList("completed"),
+			3: statusList("completed"),
 		},
 		conclusionByAttempt: map[int]string{2: "failure", 3: "success"},
 	}
@@ -375,6 +413,7 @@ func TestRun_HumanRerunStartingAtAttempt2(t *testing.T) {
 
 func TestRun_DiscoveryFailurePropagates(t *testing.T) {
 	c := &fakeClient{
+		t:            t,
 		findRunQueue: []findRunResp{{id: ""}, {id: ""}, {id: ""}},
 	}
 	g := newTestGate(c)
@@ -385,14 +424,37 @@ func TestRun_DiscoveryFailurePropagates(t *testing.T) {
 
 func TestRun_MergeGroupUsesHeadSHA(t *testing.T) {
 	c := &fakeClient{
+		t:                   t,
 		findRunQueue:        []findRunResp{{id: "200"}},
 		runURL:              "url",
 		attemptsQueue:       []int{1},
-		statusByAttempt:     map[int][]string{1: {"in_progress", "completed"}},
+		statusByAttempt:     map[int][]statusResp{1: statusList("completed")},
 		conclusionByAttempt: map[int]string{1: "success"},
 	}
 	g := newTestGate(c)
 	if err := g.Run("merge_group", "", "head_sha"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRun_FastAttempt2_NoSeenRunningGuard(t *testing.T) {
+	// Attempt 2 finishes so quickly that the first poll already shows
+	// `completed` — must NOT hang waiting for a phantom "in_progress"
+	// observation. Regression guard for the seenRunning guard that was
+	// removed because registration upstream already guarantees freshness.
+	c := &fakeClient{
+		t:             t,
+		findRunQueue:  []findRunResp{{id: "100"}},
+		runURL:        "url",
+		attemptsQueue: []int{1, 2},
+		statusByAttempt: map[int][]statusResp{
+			1: statusList("completed"),
+			2: statusList("completed"),
+		},
+		conclusionByAttempt: map[int]string{1: "failure", 2: "success"},
+	}
+	g := newTestGate(c)
+	if err := g.Run("pull_request", "sha", ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/scripts/integration-tests-gate/gate_test.go
+++ b/scripts/integration-tests-gate/gate_test.go
@@ -128,6 +128,64 @@ func newTestGate(client ghClient) *Gate {
 		RerunBackoff:         time.Nanosecond,
 		Sleep:                func(time.Duration) {},
 		Logf:                 func(string, ...any) {},
+		Cmdf:                 func(string, ...any) {},
+	}
+}
+
+func TestResolveDispatchOverride(t *testing.T) {
+	cases := []struct {
+		name                       string
+		event, prHead, mgHead      string
+		overrideSHA, overrideEvent string
+		wantEvent, wantPR, wantMG  string
+	}{
+		{
+			name:    "no_override_passes_through",
+			event:   "pull_request",
+			prHead:  "abc",
+			mgHead:  "",
+			wantEvent: "pull_request", wantPR: "abc", wantMG: "",
+		},
+		{
+			name:        "override_defaults_to_pull_request",
+			event:       "workflow_dispatch",
+			overrideSHA: "deadbeef",
+			wantEvent:   "pull_request",
+			wantPR:      "deadbeef", wantMG: "deadbeef",
+		},
+		{
+			name:          "override_event_merge_group",
+			event:         "workflow_dispatch",
+			overrideSHA:   "deadbeef",
+			overrideEvent: "merge_group",
+			wantEvent:     "merge_group",
+			wantPR:        "deadbeef", wantMG: "deadbeef",
+		},
+		{
+			name:          "override_event_pull_request_explicit",
+			event:         "workflow_dispatch",
+			overrideSHA:   "deadbeef",
+			overrideEvent: "pull_request",
+			wantEvent:     "pull_request",
+			wantPR:        "deadbeef", wantMG: "deadbeef",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ev, pr, mg := ResolveDispatchOverride(
+				tc.event, tc.prHead, tc.mgHead,
+				tc.overrideSHA, tc.overrideEvent,
+			)
+			if ev != tc.wantEvent {
+				t.Errorf("event: got %q want %q", ev, tc.wantEvent)
+			}
+			if pr != tc.wantPR {
+				t.Errorf("pr: got %q want %q", pr, tc.wantPR)
+			}
+			if mg != tc.wantMG {
+				t.Errorf("mg: got %q want %q", mg, tc.wantMG)
+			}
+		})
 	}
 }
 

--- a/scripts/integration-tests-gate/gate_test.go
+++ b/scripts/integration-tests-gate/gate_test.go
@@ -636,6 +636,56 @@ func TestDispatchOverrideThenResolveSHA(t *testing.T) {
 	}
 }
 
+func TestRun_ContinueOnErrorJobsSoftFailDoesNotTriggerRetry(t *testing.T) {
+	// continue-on-error jobs report job-level conclusion="success" even
+	// when their internal steps fail; they do NOT contribute to the run's
+	// overall conclusion. A run that is otherwise green therefore has
+	// run-level conclusion="success" and the gate must exit 0 without
+	// retrying.
+	c := &fakeClient{
+		t:                   t,
+		findRunQueue:        []findRunResp{{id: "100"}},
+		runURL:              "url",
+		attemptsQueue:       attemptList(1),
+		statusByAttempt:     map[int][]statusResp{1: statusList("completed")},
+		conclusionByAttempt: map[int]string{1: "success"},
+	}
+	g := newTestGate(c)
+	if err := g.Run("pull_request", "sha", ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.rerunCalls != 0 {
+		t.Fatalf("expected no rerun for soft-failing continue-on-error jobs, "+
+			"got %d", c.rerunCalls)
+	}
+}
+
+func TestRun_RunWithMixedFailures_RetriesOnce(t *testing.T) {
+	// A run with both a real failure and continue-on-error soft failures
+	// has run-level conclusion="failure". `gh run rerun --failed` skips
+	// the continue-on-error jobs (their conclusion is success) and only
+	// reruns the hard failure. The gate sees run conclusion go from
+	// failure to success after retry and exits 0.
+	c := &fakeClient{
+		t:             t,
+		findRunQueue:  []findRunResp{{id: "100"}},
+		runURL:        "url",
+		attemptsQueue: attemptList(1, 2),
+		statusByAttempt: map[int][]statusResp{
+			1: statusList("completed"),
+			2: statusList("completed"),
+		},
+		conclusionByAttempt: map[int]string{1: "failure", 2: "success"},
+	}
+	g := newTestGate(c)
+	if err := g.Run("pull_request", "sha", ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.rerunCalls != 1 {
+		t.Fatalf("expected exactly 1 rerun, got %d", c.rerunCalls)
+	}
+}
+
 func TestRun_RunAttemptReadRecoversFromTransient(t *testing.T) {
 	apiErr := errors.New("api blip")
 	c := &fakeClient{

--- a/scripts/integration-tests-gate/gate_test.go
+++ b/scripts/integration-tests-gate/gate_test.go
@@ -1,0 +1,398 @@
+// Copyright 2025 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+type fakeClient struct {
+	findRunQueue        []findRunResp
+	runURL              string
+	runURLErr           error
+	attemptsQueue       []int
+	attemptsErr         []error
+	statusByAttempt     map[int][]string
+	conclusionByAttempt map[int]string
+	conclusionErr       map[int]error
+	rerunQueue          []error
+	rerunCalls          int
+}
+
+type findRunResp struct {
+	id  string
+	err error
+}
+
+func (f *fakeClient) FindRun(_, _, _ string) (string, error) {
+	if len(f.findRunQueue) == 0 {
+		return "", nil
+	}
+	r := f.findRunQueue[0]
+	f.findRunQueue = f.findRunQueue[1:]
+	return r.id, r.err
+}
+func (f *fakeClient) RunURL(string) (string, error) {
+	return f.runURL, f.runURLErr
+}
+func (f *fakeClient) RunAttempt(string) (int, error) {
+	if len(f.attemptsQueue) == 0 {
+		return 0, errors.New("attempts queue empty")
+	}
+	v := f.attemptsQueue[0]
+	f.attemptsQueue = f.attemptsQueue[1:]
+	var err error
+	if len(f.attemptsErr) > 0 {
+		err = f.attemptsErr[0]
+		f.attemptsErr = f.attemptsErr[1:]
+	}
+	return v, err
+}
+func (f *fakeClient) AttemptStatus(_ string, attempt int) (string, error) {
+	q := f.statusByAttempt[attempt]
+	if len(q) == 0 {
+		return "completed", nil
+	}
+	v := q[0]
+	f.statusByAttempt[attempt] = q[1:]
+	return v, nil
+}
+func (f *fakeClient) AttemptConclusion(_ string, attempt int) (string, error) {
+	if err, ok := f.conclusionErr[attempt]; ok {
+		return "", err
+	}
+	return f.conclusionByAttempt[attempt], nil
+}
+func (f *fakeClient) RerunFailed(string) error {
+	f.rerunCalls++
+	if len(f.rerunQueue) == 0 {
+		return nil
+	}
+	e := f.rerunQueue[0]
+	f.rerunQueue = f.rerunQueue[1:]
+	return e
+}
+
+func newTestGate(client ghClient) *Gate {
+	return &Gate{
+		Client:               client,
+		Workflow:             "test-chart-version.yaml",
+		DiscoveryTries:       3,
+		DiscoveryInterval:    time.Nanosecond,
+		PollInterval:         time.Nanosecond,
+		RegistrationTries:    5,
+		RegistrationInterval: time.Nanosecond,
+		RerunTries:           3,
+		RerunBackoff:         time.Nanosecond,
+		Sleep:                func(time.Duration) {},
+		Log:                  func(string, ...any) {},
+	}
+}
+
+func TestResolveSHA(t *testing.T) {
+	cases := []struct {
+		name      string
+		event     string
+		prHead    string
+		mgHead    string
+		want      string
+		wantError bool
+	}{
+		{"pull_request", "pull_request", "abc", "", "abc", false},
+		{"pull_request_target", "pull_request_target", "abc", "", "abc", false},
+		{"merge_group_uses_head", "merge_group", "", "def", "def", false},
+		{"merge_group_ignores_pr_head", "merge_group", "abc", "def", "def", false},
+		{"unknown_event", "schedule", "abc", "def", "", true},
+		{"empty_pr_head", "pull_request", "", "", "", true},
+		{"empty_mg_head", "merge_group", "abc", "", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ResolveSHA(tc.event, tc.prHead, tc.mgHead)
+			if tc.wantError {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDiscover_EventualVisibility(t *testing.T) {
+	c := &fakeClient{
+		findRunQueue: []findRunResp{
+			{id: ""},
+			{id: ""},
+			{id: "12345"},
+		},
+		runURL: "https://github.com/x/y/actions/runs/12345",
+	}
+	g := newTestGate(c)
+	runID, runURL, err := g.Discover("sha", "pull_request")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if runID != "12345" {
+		t.Fatalf("runID=%q", runID)
+	}
+	if runURL == "" {
+		t.Fatalf("expected runURL, got empty")
+	}
+}
+
+func TestDiscover_TimesOut(t *testing.T) {
+	c := &fakeClient{
+		findRunQueue: []findRunResp{{id: ""}, {id: ""}, {id: ""}},
+	}
+	g := newTestGate(c)
+	_, _, err := g.Discover("sha", "pull_request")
+	if err == nil {
+		t.Fatalf("expected timeout error")
+	}
+}
+
+func TestDiscover_URLFallback(t *testing.T) {
+	c := &fakeClient{
+		findRunQueue: []findRunResp{{id: "12345"}},
+		runURLErr:    errors.New("api error"),
+	}
+	g := newTestGate(c)
+	runID, runURL, err := g.Discover("sha", "pull_request")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if runID != "12345" {
+		t.Fatalf("runID=%q", runID)
+	}
+	if runURL != "" {
+		t.Fatalf("expected empty URL on error fallback")
+	}
+}
+
+func TestWaitForCompletion_RequiresRunningBeforeCompleted(t *testing.T) {
+	c := &fakeClient{
+		statusByAttempt: map[int][]string{
+			2: {"completed", "in_progress", "completed"},
+		},
+	}
+	g := newTestGate(c)
+	if err := g.WaitForCompletion("r", 2); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := len(c.statusByAttempt[2]); got != 0 {
+		t.Fatalf("expected all 3 status reads consumed, %d left", got)
+	}
+}
+
+func TestWaitForCompletion_AcceptsCompletedAfterRunning(t *testing.T) {
+	c := &fakeClient{
+		statusByAttempt: map[int][]string{
+			1: {"in_progress", "completed"},
+		},
+	}
+	g := newTestGate(c)
+	if err := g.WaitForCompletion("r", 1); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestWaitForCompletion_HandlesEmptyStatus(t *testing.T) {
+	c := &fakeClient{
+		statusByAttempt: map[int][]string{
+			1: {"", "queued", "completed"},
+		},
+	}
+	g := newTestGate(c)
+	if err := g.WaitForCompletion("r", 1); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRerunWithBackoff_SucceedsAfterTransientFailure(t *testing.T) {
+	c := &fakeClient{
+		rerunQueue: []error{errors.New("422"), errors.New("422"), nil},
+	}
+	g := newTestGate(c)
+	if err := g.RerunWithBackoff("r"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.rerunCalls != 3 {
+		t.Fatalf("expected 3 rerun calls, got %d", c.rerunCalls)
+	}
+}
+
+func TestRerunWithBackoff_ExhaustsRetries(t *testing.T) {
+	c := &fakeClient{
+		rerunQueue: []error{errors.New("422"), errors.New("422"), errors.New("422")},
+	}
+	g := newTestGate(c)
+	if err := g.RerunWithBackoff("r"); err == nil {
+		t.Fatalf("expected error after exhausting retries")
+	}
+}
+
+func TestWaitForAttemptRegistered_AdvancesEventually(t *testing.T) {
+	c := &fakeClient{
+		attemptsQueue: []int{1, 1, 2},
+	}
+	g := newTestGate(c)
+	if err := g.WaitForAttemptRegistered("r", 2); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestWaitForAttemptRegistered_TimesOut(t *testing.T) {
+	c := &fakeClient{
+		attemptsQueue: []int{1, 1, 1, 1, 1},
+	}
+	g := newTestGate(c)
+	if err := g.WaitForAttemptRegistered("r", 2); err == nil {
+		t.Fatalf("expected timeout error")
+	}
+}
+
+func TestRun_AttemptOneSuccess(t *testing.T) {
+	c := &fakeClient{
+		findRunQueue:        []findRunResp{{id: "100"}},
+		runURL:              "url",
+		attemptsQueue:       []int{1},
+		statusByAttempt:     map[int][]string{1: {"in_progress", "completed"}},
+		conclusionByAttempt: map[int]string{1: "success"},
+	}
+	g := newTestGate(c)
+	if err := g.Run("pull_request", "sha", ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.rerunCalls != 0 {
+		t.Fatalf("expected no rerun, got %d", c.rerunCalls)
+	}
+}
+
+func TestRun_RetriesOnceAndPasses(t *testing.T) {
+	c := &fakeClient{
+		findRunQueue:  []findRunResp{{id: "100"}},
+		runURL:        "url",
+		attemptsQueue: []int{1, 2},
+		statusByAttempt: map[int][]string{
+			1: {"in_progress", "completed"},
+			2: {"in_progress", "completed"},
+		},
+		conclusionByAttempt: map[int]string{1: "failure", 2: "success"},
+	}
+	g := newTestGate(c)
+	if err := g.Run("pull_request", "sha", ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.rerunCalls != 1 {
+		t.Fatalf("expected 1 rerun, got %d", c.rerunCalls)
+	}
+}
+
+func TestRun_RetriesOnceAndFails(t *testing.T) {
+	c := &fakeClient{
+		findRunQueue:  []findRunResp{{id: "100"}},
+		runURL:        "url",
+		attemptsQueue: []int{1, 2},
+		statusByAttempt: map[int][]string{
+			1: {"in_progress", "completed"},
+			2: {"in_progress", "completed"},
+		},
+		conclusionByAttempt: map[int]string{1: "failure", 2: "failure"},
+	}
+	g := newTestGate(c)
+	if err := g.Run("pull_request", "sha", ""); err == nil {
+		t.Fatalf("expected gate failure")
+	}
+	if c.rerunCalls != 1 {
+		t.Fatalf("expected exactly 1 rerun, got %d", c.rerunCalls)
+	}
+}
+
+func TestRun_CancelledIsNotRetryable(t *testing.T) {
+	c := &fakeClient{
+		findRunQueue:        []findRunResp{{id: "100"}},
+		runURL:              "url",
+		attemptsQueue:       []int{1},
+		statusByAttempt:     map[int][]string{1: {"in_progress", "completed"}},
+		conclusionByAttempt: map[int]string{1: "cancelled"},
+	}
+	g := newTestGate(c)
+	err := g.Run("pull_request", "sha", "")
+	if err == nil {
+		t.Fatalf("expected error for cancelled conclusion")
+	}
+	if !errors.Is(err, ErrNotRetryable) {
+		t.Fatalf("expected ErrNotRetryable, got %v", err)
+	}
+	if c.rerunCalls != 0 {
+		t.Fatalf("expected no rerun for cancelled, got %d", c.rerunCalls)
+	}
+}
+
+func TestRun_HumanRerunStartingAtAttempt2(t *testing.T) {
+	// Simulates re-running the gate workflow after a previous gate
+	// invocation has already retried once. The matrix's current
+	// run_attempt is 2 (failed). The gate should grant one more retry.
+	c := &fakeClient{
+		findRunQueue:  []findRunResp{{id: "100"}},
+		runURL:        "url",
+		attemptsQueue: []int{2, 3},
+		statusByAttempt: map[int][]string{
+			2: {"in_progress", "completed"},
+			3: {"in_progress", "completed"},
+		},
+		conclusionByAttempt: map[int]string{2: "failure", 3: "success"},
+	}
+	g := newTestGate(c)
+	if err := g.Run("pull_request", "sha", ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.rerunCalls != 1 {
+		t.Fatalf("expected 1 rerun, got %d", c.rerunCalls)
+	}
+}
+
+func TestRun_DiscoveryFailurePropagates(t *testing.T) {
+	c := &fakeClient{
+		findRunQueue: []findRunResp{{id: ""}, {id: ""}, {id: ""}},
+	}
+	g := newTestGate(c)
+	if err := g.Run("pull_request", "sha", ""); err == nil {
+		t.Fatalf("expected discovery error")
+	}
+}
+
+func TestRun_MergeGroupUsesHeadSHA(t *testing.T) {
+	c := &fakeClient{
+		findRunQueue:        []findRunResp{{id: "200"}},
+		runURL:              "url",
+		attemptsQueue:       []int{1},
+		statusByAttempt:     map[int][]string{1: {"in_progress", "completed"}},
+		conclusionByAttempt: map[int]string{1: "success"},
+	}
+	g := newTestGate(c)
+	if err := g.Run("merge_group", "", "head_sha"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/scripts/integration-tests-gate/gate_test.go
+++ b/scripts/integration-tests-gate/gate_test.go
@@ -16,6 +16,8 @@ package main
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 )
@@ -564,6 +566,73 @@ func TestRun_FastAttempt2_NoSeenRunningGuard(t *testing.T) {
 	g := newTestGate(c)
 	if err := g.Run("pull_request", "sha", ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRun_RetryFailureEmitsWarningWithAttemptNumber(t *testing.T) {
+	c := &fakeClient{
+		t:             t,
+		findRunQueue:  []findRunResp{{id: "100"}},
+		runURL:        "url",
+		attemptsQueue: attemptList(1, 2),
+		statusByAttempt: map[int][]statusResp{
+			1: statusList("completed"),
+			2: statusList("completed"),
+		},
+		conclusionByAttempt: map[int]string{1: "failure", 2: "failure"},
+	}
+	var cmds []string
+	g := newTestGate(c)
+	g.Cmdf = func(format string, args ...any) {
+		cmds = append(cmds, fmt.Sprintf(format, args...))
+	}
+	_ = g.Run("pull_request", "sha", "")
+	var found bool
+	for _, line := range cmds {
+		if strings.Contains(line, "::warning::") &&
+			strings.Contains(line, "attempt 2") &&
+			!strings.Contains(line, "MISSING") &&
+			!strings.Contains(line, "%!") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected fully-substituted attempt-2 warning, "+
+			"got %v", cmds)
+	}
+}
+
+func TestDispatchOverrideThenResolveSHA(t *testing.T) {
+	cases := []struct {
+		name                       string
+		overrideEvent, overrideSHA string
+		wantEvent, wantSHA         string
+	}{
+		{"dispatch_to_pull_request", "pull_request", "deadbeef",
+			"pull_request", "deadbeef"},
+		{"dispatch_to_merge_group", "merge_group", "cafef00d",
+			"merge_group", "cafef00d"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ev, pr, mg := ResolveDispatchOverride(
+				"workflow_dispatch", "", "",
+				tc.overrideSHA, tc.overrideEvent,
+			)
+			if ev != tc.wantEvent {
+				t.Fatalf("override event: got %q want %q",
+					ev, tc.wantEvent)
+			}
+			sha, err := ResolveSHA(ev, pr, mg)
+			if err != nil {
+				t.Fatalf("ResolveSHA after override: %v", err)
+			}
+			if sha != tc.wantSHA {
+				t.Fatalf("resolved sha: got %q want %q",
+					sha, tc.wantSHA)
+			}
+		})
 	}
 }
 

--- a/scripts/integration-tests-gate/gate_test.go
+++ b/scripts/integration-tests-gate/gate_test.go
@@ -142,10 +142,10 @@ func TestResolveDispatchOverride(t *testing.T) {
 		wantEvent, wantPR, wantMG  string
 	}{
 		{
-			name:    "no_override_passes_through",
-			event:   "pull_request",
-			prHead:  "abc",
-			mgHead:  "",
+			name:      "no_override_passes_through",
+			event:     "pull_request",
+			prHead:    "abc",
+			mgHead:    "",
 			wantEvent: "pull_request", wantPR: "abc", wantMG: "",
 		},
 		{

--- a/scripts/integration-tests-gate/gh.go
+++ b/scripts/integration-tests-gate/gh.go
@@ -16,32 +16,44 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 )
 
 type ghCLI struct {
-	repo string
+	repo    string
+	timeout time.Duration
 }
 
-func newGHCLI(repo string) *ghCLI { return &ghCLI{repo: repo} }
+func newGHCLI(repo string, timeout time.Duration) *ghCLI {
+	return &ghCLI{repo: repo, timeout: timeout}
+}
 
 func (c *ghCLI) run(args ...string) (string, error) {
-	cmd := exec.Command("gh", args...)
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "gh", args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("gh %s: %v: %s", strings.Join(args, " "), err,
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("gh %s: timed out after %s",
+				strings.Join(args, " "), c.timeout)
+		}
+		return "", fmt.Errorf("gh %s: %v: %s",
+			strings.Join(args, " "), err,
 			strings.TrimSpace(stderr.String()))
 	}
 	return strings.TrimSpace(stdout.String()), nil
 }
 
 func (c *ghCLI) FindRun(workflow, sha, event string) (string, error) {
-	out, err := c.run("run", "list",
+	return c.run("run", "list",
 		"--repo", c.repo,
 		"--workflow", workflow,
 		"--commit", sha,
@@ -49,10 +61,6 @@ func (c *ghCLI) FindRun(workflow, sha, event string) (string, error) {
 		"--limit", "1",
 		"--json", "databaseId",
 		"--jq", ".[0].databaseId // empty")
-	if err != nil {
-		return "", err
-	}
-	return out, nil
 }
 
 func (c *ghCLI) RunURL(runID string) (string, error) {

--- a/scripts/integration-tests-gate/gh.go
+++ b/scripts/integration-tests-gate/gh.go
@@ -1,0 +1,100 @@
+// Copyright 2025 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type ghCLI struct {
+	repo string
+}
+
+func newGHCLI(repo string) *ghCLI { return &ghCLI{repo: repo} }
+
+func (c *ghCLI) run(args ...string) (string, error) {
+	cmd := exec.Command("gh", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("gh %s: %v: %s", strings.Join(args, " "), err,
+			strings.TrimSpace(stderr.String()))
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+func (c *ghCLI) FindRun(workflow, sha, event string) (string, error) {
+	out, err := c.run("run", "list",
+		"--repo", c.repo,
+		"--workflow", workflow,
+		"--commit", sha,
+		"--event", event,
+		"--limit", "1",
+		"--json", "databaseId",
+		"--jq", ".[0].databaseId // empty")
+	if err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func (c *ghCLI) RunURL(runID string) (string, error) {
+	return c.run("run", "view", runID,
+		"--repo", c.repo,
+		"--json", "url",
+		"--jq", ".url")
+}
+
+func (c *ghCLI) RunAttempt(runID string) (int, error) {
+	out, err := c.run("api",
+		fmt.Sprintf("repos/%s/actions/runs/%s", c.repo, runID),
+		"--jq", ".run_attempt")
+	if err != nil {
+		return 0, err
+	}
+	var n int
+	if err := json.Unmarshal([]byte(out), &n); err != nil {
+		return 0, fmt.Errorf("parse run_attempt %q: %v", out, err)
+	}
+	return n, nil
+}
+
+func (c *ghCLI) AttemptStatus(runID string, attempt int) (string, error) {
+	return c.run("run", "view", runID,
+		"--repo", c.repo,
+		"--attempt", fmt.Sprintf("%d", attempt),
+		"--json", "status",
+		"--jq", ".status")
+}
+
+func (c *ghCLI) AttemptConclusion(runID string, attempt int) (string, error) {
+	return c.run("run", "view", runID,
+		"--repo", c.repo,
+		"--attempt", fmt.Sprintf("%d", attempt),
+		"--json", "conclusion",
+		"--jq", ".conclusion")
+}
+
+func (c *ghCLI) RerunFailed(runID string) error {
+	_, err := c.run("run", "rerun", runID,
+		"--repo", c.repo,
+		"--failed")
+	return err
+}

--- a/scripts/integration-tests-gate/gh.go
+++ b/scripts/integration-tests-gate/gh.go
@@ -17,9 +17,9 @@ package main
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -77,8 +77,8 @@ func (c *ghCLI) RunAttempt(runID string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	var n int
-	if err := json.Unmarshal([]byte(out), &n); err != nil {
+	n, err := strconv.Atoi(out)
+	if err != nil {
 		return 0, fmt.Errorf("parse run_attempt %q: %v", out, err)
 	}
 	return n, nil

--- a/scripts/integration-tests-gate/go.mod
+++ b/scripts/integration-tests-gate/go.mod
@@ -1,0 +1,3 @@
+module scripts/integration-tests-gate
+
+go 1.25.0

--- a/scripts/integration-tests-gate/main.go
+++ b/scripts/integration-tests-gate/main.go
@@ -37,6 +37,11 @@ func main() {
 	mgHead := os.Getenv("MG_HEAD_SHA")
 
 	if override := os.Getenv("OVERRIDE_SHA"); override != "" {
+		overrideEvent := os.Getenv("OVERRIDE_EVENT")
+		if overrideEvent == "" {
+			overrideEvent = "pull_request"
+		}
+		event = overrideEvent
 		prHead = override
 		mgHead = override
 	}
@@ -48,13 +53,15 @@ func main() {
 		DiscoveryInterval:    10 * time.Second,
 		PollInterval:         60 * time.Second,
 		MaxConsecutiveErrors: 10,
-		RegistrationTries:    60,
+		RegistrationTries:    120,
 		RegistrationInterval: 5 * time.Second,
+		RunAttemptTries:      5,
+		RunAttemptBackoff:    5 * time.Second,
 		RerunTries:           3,
 		RerunBackoff:         10 * time.Second,
 		Sleep:                time.Sleep,
 		Logf: func(format string, args ...any) {
-			fmt.Printf(format+"\n", args...)
+			fmt.Fprintf(os.Stderr, format+"\n", args...)
 		},
 	}
 

--- a/scripts/integration-tests-gate/main.go
+++ b/scripts/integration-tests-gate/main.go
@@ -36,18 +36,24 @@ func main() {
 	prHead := os.Getenv("PR_HEAD_SHA")
 	mgHead := os.Getenv("MG_HEAD_SHA")
 
+	if override := os.Getenv("OVERRIDE_SHA"); override != "" {
+		prHead = override
+		mgHead = override
+	}
+
 	gate := &Gate{
-		Client:               newGHCLI(repo),
+		Client:               newGHCLI(repo, 60*time.Second),
 		Workflow:             workflow,
 		DiscoveryTries:       120,
 		DiscoveryInterval:    10 * time.Second,
 		PollInterval:         60 * time.Second,
+		MaxConsecutiveErrors: 10,
 		RegistrationTries:    60,
 		RegistrationInterval: 5 * time.Second,
 		RerunTries:           3,
 		RerunBackoff:         10 * time.Second,
 		Sleep:                time.Sleep,
-		Log: func(format string, args ...any) {
+		Logf: func(format string, args ...any) {
 			fmt.Printf(format+"\n", args...)
 		},
 	}

--- a/scripts/integration-tests-gate/main.go
+++ b/scripts/integration-tests-gate/main.go
@@ -30,6 +30,15 @@ func mustEnv(key string) string {
 }
 
 func main() {
+	// Fork PRs lack actions:write on GITHUB_TOKEN, so rerun --failed
+	// would 403. Return success so the required-check name stays green;
+	// for fork PRs the matrix workflow's own status is the real signal.
+	if os.Getenv("IS_FORK") == "true" {
+		fmt.Fprintln(os.Stderr,
+			"fork PR: deferring to matrix's own status")
+		return
+	}
+
 	repo := mustEnv("GH_REPO")
 	workflow := mustEnv("MATRIX_WORKFLOW")
 	event := mustEnv("EVENT_NAME")
@@ -45,7 +54,7 @@ func main() {
 	gate := &Gate{
 		Client:               newGHCLI(repo, 60*time.Second),
 		Workflow:             workflow,
-		DiscoveryTries:       120,
+		DiscoveryTries:       60,
 		DiscoveryInterval:    10 * time.Second,
 		PollInterval:         60 * time.Second,
 		MaxConsecutiveErrors: 10,

--- a/scripts/integration-tests-gate/main.go
+++ b/scripts/integration-tests-gate/main.go
@@ -36,15 +36,11 @@ func main() {
 	prHead := os.Getenv("PR_HEAD_SHA")
 	mgHead := os.Getenv("MG_HEAD_SHA")
 
-	if override := os.Getenv("OVERRIDE_SHA"); override != "" {
-		overrideEvent := os.Getenv("OVERRIDE_EVENT")
-		if overrideEvent == "" {
-			overrideEvent = "pull_request"
-		}
-		event = overrideEvent
-		prHead = override
-		mgHead = override
-	}
+	event, prHead, mgHead = ResolveDispatchOverride(
+		event, prHead, mgHead,
+		os.Getenv("OVERRIDE_SHA"),
+		os.Getenv("OVERRIDE_EVENT"),
+	)
 
 	gate := &Gate{
 		Client:               newGHCLI(repo, 60*time.Second),
@@ -63,10 +59,14 @@ func main() {
 		Logf: func(format string, args ...any) {
 			fmt.Fprintf(os.Stderr, format+"\n", args...)
 		},
+		Cmdf: func(format string, args ...any) {
+			fmt.Fprintf(os.Stdout, format+"\n", args...)
+		},
 	}
 
 	if err := gate.Run(event, prHead, mgHead); err != nil {
-		fmt.Fprintf(os.Stderr, "::error::%v\n", err)
+		fmt.Fprintf(os.Stdout, "::error::%v\n", err)
+		fmt.Fprintf(os.Stderr, "gate failed: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/scripts/integration-tests-gate/main.go
+++ b/scripts/integration-tests-gate/main.go
@@ -1,0 +1,59 @@
+// Copyright 2025 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+func mustEnv(key string) string {
+	v := os.Getenv(key)
+	if v == "" {
+		fmt.Fprintf(os.Stderr, "error: required env var %s is not set\n", key)
+		os.Exit(2)
+	}
+	return v
+}
+
+func main() {
+	repo := mustEnv("GH_REPO")
+	workflow := mustEnv("MATRIX_WORKFLOW")
+	event := mustEnv("EVENT_NAME")
+	prHead := os.Getenv("PR_HEAD_SHA")
+	mgHead := os.Getenv("MG_HEAD_SHA")
+
+	gate := &Gate{
+		Client:               newGHCLI(repo),
+		Workflow:             workflow,
+		DiscoveryTries:       120,
+		DiscoveryInterval:    10 * time.Second,
+		PollInterval:         60 * time.Second,
+		RegistrationTries:    60,
+		RegistrationInterval: 5 * time.Second,
+		RerunTries:           3,
+		RerunBackoff:         10 * time.Second,
+		Sleep:                time.Sleep,
+		Log: func(format string, args ...any) {
+			fmt.Printf(format+"\n", args...)
+		},
+	}
+
+	if err := gate.Run(event, prHead, mgHead); err != nil {
+		fmt.Fprintf(os.Stderr, "::error::%v\n", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
### Which problem does the PR fix?

A single transient failure in any one of ~300 matrix cells of `Test - Chart Version` (Entra/Harbor/Vault token blip, GKE control-plane hiccup, image-pull stall) fails the whole run and ejects the PR from the merge queue. These failures are overwhelmingly transient and pass on manual rerun; queue eviction wastes hours of human and CI time across the team.

### What's in this PR?

A new gating workflow (`integration-tests-gate.yaml`) intended to become the required merge-queue check, plus the Go script that implements its state machine.

The gate:

1. Locates the `Test - Chart Version` matrix run for the head SHA (filters by `--event` so a stale `workflow_dispatch` rerun isn't picked up).
2. Reads the current `run_attempt` (bounded retry on transient API errors).
3. Watches that attempt's status (60s sparse polling; bails after 10 consecutive API errors).
4. On `conclusion == failure`, calls `gh run rerun <id> --failed` once (3x back-off on the rerun call itself).
5. Waits for the new attempt to be registered, then watches it.
6. Reports the new attempt's conclusion.

One retry **per gate invocation**. Re-running the gate workflow yields one additional retry, which lets humans recover from a double-transient without pushing a new commit.

Underlying matrix and runner workflows are not modified. `fail-fast: false` stays — `--failed` reruns only the broken cells, not all 300.

### Implementation

Per `AGENTS.md` (`NEVER implement CI logic > 20 lines in bash — use Go scripts with unit tests`), the gate's state machine lives in `scripts/integration-tests-gate/` as a Go script with 27 unit tests behind a mockable `ghClient` interface. The workflow itself is a thin checkout + setup-go + `go run .` wrapper.

See `scripts/integration-tests-gate/README.md` for the behavior contract, fork-PR semantics, and manual-debugging instructions.

### Behavior

- **Fork PRs**: gate is skipped. `GITHUB_TOKEN` on fork PRs has no `actions:write` scope, so `gh run rerun --failed` would 403. For fork PRs the matrix workflow's own status remains the required signal.
- **Manual debugging**: `workflow_dispatch` accepts `sha` + `event` inputs to run the gate against any commit without pushing.
- **Non-retryable conclusions**: `cancelled`, `timed_out`, `action_required`, etc. fail the gate immediately. Only `conclusion == failure` is retried.

### Security note

The workflow requests `permissions: actions: write` so it can call `gh run rerun --failed`. Combined with the new `workflow_dispatch` trigger, this means a user with workflow-dispatch permission on the repo can point the gate at any SHA and trigger a rerun of any matrix run for that SHA. The action is non-destructive (rerunning already-failed jobs) and the dispatch surface is assumed to be restricted to maintainers; flagging it explicitly for visibility.

### Required follow-up (manual, post-merge)

1. **Branch protection / merge-queue config**: **add** `Integration Tests Gate / gate` as a required status check on `main` and **remove** the existing `Test - Chart Version` check. Until this rename happens, the queue still gates on the raw matrix and this PR has no effect on eviction.
2. Confirm `Settings → Actions → General → Workflow permissions` permits workflow-granted write scope on `GITHUB_TOKEN`.

### Verification plan

Before flipping the required-check rename:

1. Inject a fail-once-then-pass into one matrix cell → confirm gate retries and reports green.
2. Inject deterministic `exit 1` → confirm gate retries once, then reports red — no third attempt.
3. Confirm `workflow_dispatch` against a known-failing historical SHA reproduces locally (smoke-test of the dispatch path).
4. Local: `cd scripts/integration-tests-gate && go test ./... && go vet ./...`.
