### PR TITLE
ci(8.9): exclude @tasklistV1/Optimize tests from shadow full-suite and set retries=0

### DIFF
--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -1213,6 +1213,7 @@ jobs:
           ROSA_PASS:        ${{ secrets[inputs.password] }}
           CI_DEPLOYMENT_TTL: ${{ env.CI_DEPLOYMENT_TTL }}
           PLAYWRIGHT_POD_RETRY_MAX_ATTEMPTS: "1"
+          PLAYWRIGHT_E2E_RETRIES: "0"
         with:
           camunda-helm-git-ref: ${{ inputs.camunda-helm-git-ref }}
           camunda-helm-dir: ${{ inputs.camunda-helm-dir }}

--- a/charts/camunda-platform-8.9/test/e2e/playwright.config.ts
+++ b/charts/camunda-platform-8.9/test/e2e/playwright.config.ts
@@ -13,6 +13,14 @@ export default defineConfig({
     {
       name: "full-suite",
       testMatch: ["**/*.spec.{ts,js}"],
+      // cluster-variables requires Vault-managed secrets not available in PR CI.
+      testIgnore: ["**/cluster-variables.spec.{ts,js}"],
+      // @tasklistV1: requires Tasklist v1 mode with RBA enabled, not deployed in
+      // standard CI scenarios. Also excludes all Optimize tests (under
+      // 'Optimize User Flow Tests @tasklistV1') which require long Optimize
+      // warm-up not available on fresh clusters.
+      // Connector Secrets/Custom Tags/Properties: require QA-specific config.
+      grep: /^(?!.*(@tasklistV1|Connector Secrets User Flow|Custom Tags|Custom Properties)).*$/,
     },
   ],
   fullyParallel: true,


### PR DESCRIPTION
### Which problem does the PR fix?

The shadow full-suite job for the 8.9 scenario (`shde2`) was taking ~27.5 minutes and failing due to Optimize tests running against a cluster where `OPTIMIZE_BASE_URL` is undefined inside `@camunda/e2e-test-suite@0.0.723`. Each Optimize test hit a 3-attempt internal retry loop with backoff in `getOptimizeCookieSm`, then Playwright retried the whole test twice more — 9 total attempts per test. With 188 trace files uploaded and `continue-on-error: true`, the job timed out slowly rather than failing fast.

Originating run: https://github.com/camunda/camunda-platform-helm/actions/runs/28088308625/job/83161486554

### What's in this PR?

**`charts/camunda-platform-8.9/test/e2e/playwright.config.ts`**
- Added `grep` filter to the `full-suite` project to exclude `@tasklistV1`-tagged tests (all Optimize tests live under the `Optimize User Flow Tests @tasklistV1` describe block) and tests requiring QA-specific config (Connector Secrets, Custom Tags, Custom Properties). This matches what the 8.10 config already does for the same reason: Optimize requires long warm-up not available on fresh CI clusters.
- Added `testIgnore` for `cluster-variables.spec.{ts,js}` which requires Vault-managed secrets not present in standard CI.

**`.github/workflows/test-integration-runner.yaml`**
- Added `PLAYWRIGHT_E2E_RETRIES: "0"` to the `shadow-e2e-full-suite` job. The shadow job is observational — a single failure is enough signal. Zero retries means genuine failures surface immediately instead of burning through retry cycles.

### Checklist

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).