### PR TITLE
chore: broaden Renovate automerge rule to all file paths

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -307,12 +307,6 @@
       prCreation: 'immediate',
     },
     {
-      matchFileNames: [
-        '.tool-versions',
-        '.github/workflows/*',
-        '.github/actions/*',
-        'charts/**',
-      ],
       matchUpdateTypes: ['minor', 'patch', 'pin', 'digest'],
       addLabels: [
         'automerge',


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6446

### What's in this PR?

Removes `matchFileNames` from the automerge `packageRule`. Updates outside the previous allowlist (e.g. `helm-values-mcp/package.json`) were getting `automerge: Disabled by config` and required manual approval. The `matchUpdateTypes` gate and the existing `automerge: false` rule for majors are unchanged.

### Checklist

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?