### PR TITLE
test: add registry-camunda-cloud pull secret to camunda component integration values

### DIFF
--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/base.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/base.yaml
@@ -111,6 +111,10 @@ optimize:
     timeoutSeconds: 5
 
 connectors:
+  image:
+    pullSecrets:
+      - name: index-docker-io
+      - name: registry-camunda-cloud
   contextPath: "/connectors"
   # Right-sized for CI: CPU P99 389m (from 1000m default), memory P99 531Mi (from 1Gi default).
   resources:

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/base.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/base.yaml
@@ -25,6 +25,10 @@ global:
 # Context paths for all components
 identity:
   enabled: true
+  image:
+    pullSecrets:
+      - name: index-docker-io
+      - name: registry-camunda-cloud
   contextPath: "/identity"
   # Right-sized for CI: "camunda-platform" container P99 mem 849Mi (from 400Mi default).
   resources:
@@ -82,6 +86,10 @@ identity:
 
 optimize:
   enabled: true
+  image:
+    pullSecrets:
+      - name: index-docker-io
+      - name: registry-camunda-cloud
   contextPath: "/optimize"
   partitionCount: "1"
   # Right-sized for CI: CPU P99 369m (from 600m default), memory P99 840Mi INCREASE (from 1Gi default).
@@ -220,6 +228,10 @@ webModeler:
       - name: registry-camunda-cloud
 
 orchestration:
+  image:
+    pullSecrets:
+      - name: index-docker-io
+      - name: registry-camunda-cloud
   data:
     secondaryStorage:
       type: elasticsearch

--- a/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values/base.yaml
+++ b/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values/base.yaml
@@ -28,6 +28,10 @@ global:
 
 # Context paths for all components
 identity:
+  image:
+    pullSecrets:
+      - name: index-docker-io
+      - name: registry-camunda-cloud
   contextPath: "/identity"
   # Right-sized for CI: "camunda-platform" container P99 mem 849Mi (from 400Mi default).
   resources:
@@ -97,6 +101,10 @@ identityPostgresql:
       userPasswordKey: "identity-keycloak-postgresql-user-password"
 
 operate:
+  image:
+    pullSecrets:
+      - name: index-docker-io
+      - name: registry-camunda-cloud
   contextPath: "/operate"
   # Right-sized for CI: CPU P99 446m (from 600m default), memory P99 499Mi INCREASE (from 400Mi default).
   resources:
@@ -125,6 +133,10 @@ operate:
     timeoutSeconds: 1
 
 optimize:
+  image:
+    pullSecrets:
+      - name: index-docker-io
+      - name: registry-camunda-cloud
   contextPath: "/optimize"
   partitionCount: "1"
   # Right-sized for CI: CPU P99 369m (from 600m default), memory P99 840Mi INCREASE (from 1Gi default).
@@ -154,6 +166,10 @@ optimize:
     timeoutSeconds: 5
 
 tasklist:
+  image:
+    pullSecrets:
+      - name: index-docker-io
+      - name: registry-camunda-cloud
   contextPath: "/tasklist"
   # Right-sized for CI: CPU P99 253m (from 400m default), memory P99 425Mi (from 1Gi default).
   resources:
@@ -319,6 +335,10 @@ postgresql:
 
 # Zeebe (Broker)
 zeebe:
+  image:
+    pullSecrets:
+      - name: index-docker-io
+      - name: registry-camunda-cloud
   clusterSize: "1"
   partitionCount: "1"
   replicationFactor: "1"
@@ -351,6 +371,10 @@ zeebe:
     timeoutSeconds: 5
 
 zeebeGateway:
+  image:
+    pullSecrets:
+      - name: index-docker-io
+      - name: registry-camunda-cloud
   contextPath: "/zeebe"
   # Single gateway replica for CI (chart default is 2). CI does not test gateway
   # HA/failover, so the second replica only adds a JVM contending for CPU on shared

--- a/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values/base.yaml
+++ b/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values/base.yaml
@@ -182,6 +182,10 @@ tasklist:
     timeoutSeconds: 1
 
 connectors:
+  image:
+    pullSecrets:
+      - name: index-docker-io
+      - name: registry-camunda-cloud
   contextPath: "/connectors"
   # Right-sized for CI: CPU P99 389m (from 1000m default), memory P99 531Mi (from 1Gi default).
   resources:

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/base.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/base.yaml
@@ -26,6 +26,10 @@ global:
 # Identity base setup
 identity:
   enabled: true
+  image:
+    pullSecrets:
+      - name: index-docker-io
+      - name: registry-camunda-cloud
   contextPath: "/identity"
   # Right-sized for CI: "camunda-platform" container P99 mem 849Mi (from 400Mi default).
   resources:
@@ -89,6 +93,10 @@ identityPostgresql:
 
 optimize:
   enabled: true
+  image:
+    pullSecrets:
+      - name: index-docker-io
+      - name: registry-camunda-cloud
   contextPath: "/optimize"
   partitionCount: "1"
   # Right-sized for CI: CPU P99 369m (from 600m default), memory P99 840Mi INCREASE (from 1Gi default).
@@ -253,6 +261,10 @@ webModelerPostgresql:
       synchronous_commit = off
 
 orchestration:
+  image:
+    pullSecrets:
+      - name: index-docker-io
+      - name: registry-camunda-cloud
   contextPath: "/orchestration"
   clusterSize: "1"
   partitionCount: "1"

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/base.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/base.yaml
@@ -118,6 +118,10 @@ optimize:
     timeoutSeconds: 5
 
 connectors:
+  image:
+    pullSecrets:
+      - name: index-docker-io
+      - name: registry-camunda-cloud
   contextPath: "/connectors"
   # Right-sized for CI: CPU P99 389m (from 1000m default), memory P99 531Mi (from 1Gi default).
   resources:

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/base.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/base.yaml
@@ -122,6 +122,10 @@ optimize:
     timeoutSeconds: 5
 
 connectors:
+  image:
+    pullSecrets:
+      - name: index-docker-io
+      - name: registry-camunda-cloud
   contextPath: "/connectors"
   # Right-sized for CI: CPU P99 389m (from 1000m default), memory P99 531Mi (from 1Gi default).
   resources:

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/base.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/base.yaml
@@ -29,6 +29,10 @@ global:
 # Context paths for all components
 identity:
   enabled: true
+  image:
+    pullSecrets:
+      - name: index-docker-io
+      - name: registry-camunda-cloud
   contextPath: "/identity"
   # Right-sized for CI: "camunda-platform" container P99 mem 849Mi (from 400Mi default).
   resources:
@@ -86,6 +90,10 @@ identity:
 
 optimize:
   enabled: true
+  image:
+    pullSecrets:
+      - name: index-docker-io
+      - name: registry-camunda-cloud
   contextPath: "/optimize"
   partitionCount: "1"
   env:
@@ -245,6 +253,10 @@ webModelerPostgresql:
       synchronous_commit = off
 
 orchestration:
+  image:
+    pullSecrets:
+      - name: index-docker-io
+      - name: registry-camunda-cloud
   data:
     secondaryStorage:
       type: elasticsearch


### PR DESCRIPTION
### Which problem does the PR fix?

Camunda-image pods in `chart-full-setup` integration/nightly deploys fail with **ImagePullBackOff** whenever a component image is overridden to a `registry.camunda.cloud` build (e.g. `registry.camunda.cloud/team-connectors/connectors-bundle:8.8.14-stable-8.8-run<id>`). The kubelet reports `pull access denied … no basic auth credentials`.

Root cause: `camundaPlatform.subChartImagePullSecrets` (`templates/common/_helpers.tpl`) is an **`else if`, not a merge** — a component-level `image.pullSecrets` *fully replaces* `global.image.pullSecrets`. The global camunda default is only `index-docker-io`, so any component whose image is overridden to the Camunda registry but lacks an explicit `registry-camunda-cloud` entry authenticates anonymously and fails to pull. First observed on connectors (namespace `camunda-id-connectors-int-…`): in the same pod set, `web-modeler-restapi` got both secrets (inline in base.yaml) while connectors got only the global one. The same gap exists for every other camunda component that has no inline `image.pullSecrets`.

### What's in this PR?

Mirror the `webModeler`/`console` pattern for the remaining camunda components in each version's `chart-full-setup/values/base.yaml`, adding both `index-docker-io` and `registry-camunda-cloud` to `image.pullSecrets`:

- **8.8 – 8.10**: `connectors`, `identity`, `optimize`, `orchestration`
- **8.7** (pre-unified split): `connectors`, `identity`, `operate`, `optimize`, `tasklist`, `zeebe`, `zeebeGateway`

(`index-docker-io` is repeated because component-level pull secrets replace rather than merge with global, so the Docker-Hub default pull must stay covered. A global fix is not viable uniformly — 8.9/8.10 have no `global.image.pullSecrets` key at all.)

Values-file-only change — no chart templates touched, so no golden snapshots are affected.

Verified: `helm lint` passes for all four versions, and `helm template … -f base.yaml` now renders **every** camunda workload (`identity`, `optimize`, `connectors`, `console`, `web-modeler-*`, `orchestration`/`zeebe`, plus 8.7 `operate`/`tasklist`/`zeebe-gateway`) with both `index-docker-io` and `registry-camunda-cloud`.

### Checklist

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)?
