### PR TITLE
test: guard test-integration-template.yaml workflow_call contract for 3rd-party callers

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -192,6 +192,27 @@ Each chart version has a `test/ci-test-config.yaml` defining scenarios (e.g., `e
 
 Upgrade flows are two-step: install the previous version's chart from the Helm repo, then `helm upgrade` to the local chart. The `base-upgrade.yaml` layer is included only in Step 2.
 
+## Reusable Workflow Contract (consumed by other repos)
+
+`.github/workflows/test-integration-template.yaml` is a `workflow_call` reusable
+workflow invoked by downstream repositories — `camunda/camunda`,
+`camunda/connectors`, `camunda/camunda-hub` — via `uses: …@main`. Its
+`workflow_call.inputs` are therefore a **public API**. A change here can break a
+caller's next run without any failure showing up in this repo's CI:
+
+- removing or renaming an input a caller passes → caller fails with "unexpected input";
+- adding a `required` input without a `default` (or flipping an optional input to
+  required) → every caller that does not pass it fails at dispatch;
+- changing an input's `type` → callers passing that input can break.
+
+This is guarded by `TestIntegrationTemplateConsumerContract` in
+`scripts/deploy-camunda/matrix/` (run by `make go.test`). It checks the template's
+interface against a fixture of how the known callers invoke it
+(`scripts/deploy-camunda/matrix/testdata/integration_template_consumers.yaml`).
+When you intentionally change a caller's call (or onboard a new caller), refresh
+that fixture — the header documents how. All known callers use `secrets: inherit`,
+so secret-level changes are not contract-breaking and are not modeled.
+
 ## Operational Skills
 
 See `SKILLS.md` for instructions on using:

--- a/scripts/deploy-camunda/matrix/testdata/integration_template_consumers.yaml
+++ b/scripts/deploy-camunda/matrix/testdata/integration_template_consumers.yaml
@@ -1,0 +1,109 @@
+# Consumer-driven contract fixture for .github/workflows/test-integration-template.yaml
+#
+# This records how known 3rd-party repositories call the reusable
+# `test-integration-template.yaml` workflow (`uses: …@main`). It is the input to
+# TestIntegrationTemplateConsumerContract, which fails when a change to the
+# template's `workflow_call` interface would break one of these callers:
+#   - an input a caller passes is removed/renamed
+#   - the template gains a required-without-default input a caller does not pass
+#     (covers new required inputs and optional -> required flips)
+#   - the type of an input a caller passes changes
+#
+# All known callers use `secrets: inherit`, so secret-level changes do not break
+# them; only the inputs interface is contract-relevant here.
+#
+# HOW TO REFRESH (when a caller repo changes how it calls the workflow):
+#   For each workflow below, read the job that `uses:` test-integration-template
+#   and copy its `with:` keys into `inputs`. The expected `type` for each input
+#   comes from the template's own `on.workflow_call.inputs.<name>.type`. Quick
+#   dump of what a caller passes:
+#     gh api repos/<owner>/<repo>/contents/<path> --jq .content | base64 -d \
+#       | yq '.jobs.*.with | keys'
+#
+# Captured 2026-06-25.
+
+consumers:
+  - repo: camunda/camunda
+    workflow: .github/workflows/camunda-helm-integration.yml
+    secrets: inherit
+    inputs:
+      - caller-git-ref
+      - camunda-helm-dir
+      - extra-values
+      - identifier
+      - test-enabled
+      - vault-secret-mapping
+
+  - repo: camunda/camunda
+    workflow: .github/workflows/docker-build-helm-integration.yml
+    secrets: inherit
+    inputs:
+      - always-delete-namespace
+      - camunda-helm-dir
+      - camunda-helm-git-ref
+      - deployment-ttl
+      - e2e-enabled
+      - extra-values
+      - flows
+      - identifier
+      - namespace-prefix
+      - platforms
+      - scenario
+      - shortname
+      - test-enabled
+      - vault-secret-mapping
+
+  - repo: camunda/connectors
+    workflow: .github/workflows/INTEGRATION_TEST.yml
+    secrets: inherit
+    inputs:
+      - always-delete-namespace
+      - camunda-helm-dir
+      - camunda-helm-git-ref
+      - deployment-ttl
+      - e2e-enabled
+      - extra-values
+      - identifier
+      - scenario
+      - shortname
+      - test-enabled
+
+  - repo: camunda/camunda-hub
+    workflow: .github/workflows/stage-helm-tests.yml
+    secrets: inherit
+    inputs:
+      - always-delete-namespace
+      - camunda-helm-dir
+      - camunda-helm-git-ref
+      - e2e-enabled
+      - extra-values
+      - flows
+      - identifier
+      - namespace-prefix
+      - platforms
+      - scenario
+      - shortname
+      - test-enabled
+      - values-digest
+      - vault-secret-mapping
+
+# Expected types for every input any consumer passes, taken from the template's
+# own workflow_call.inputs. A type change here would silently break callers, so
+# the test asserts the template still declares these exact types.
+expectedInputTypes:
+  always-delete-namespace: boolean
+  caller-git-ref: string
+  camunda-helm-dir: string
+  camunda-helm-git-ref: string
+  deployment-ttl: string
+  e2e-enabled: boolean
+  extra-values: string
+  flows: string
+  identifier: string
+  namespace-prefix: string
+  platforms: string
+  scenario: string
+  shortname: string
+  test-enabled: boolean
+  values-digest: string
+  vault-secret-mapping: string

--- a/scripts/deploy-camunda/matrix/workflow_interface_contract_test.go
+++ b/scripts/deploy-camunda/matrix/workflow_interface_contract_test.go
@@ -1,0 +1,286 @@
+// Copyright 2025 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matrix
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// integrationTemplatePath is the reusable workflow whose workflow_call interface
+// is a public contract consumed by other repositories.
+const integrationTemplatePath = ".github/workflows/test-integration-template.yaml"
+
+// consumerContractFixture records how known downstream repos call the template.
+const consumerContractFixture = "testdata/integration_template_consumers.yaml"
+
+// templateInput is the contract-relevant shape of one workflow_call input.
+type templateInput struct {
+	required   bool
+	typ        string
+	hasDefault bool
+}
+
+// consumerContract is the parsed fixture: how each known caller invokes the
+// reusable workflow.
+type consumerContract struct {
+	Consumers []struct {
+		Repo     string   `yaml:"repo"`
+		Workflow string   `yaml:"workflow"`
+		Secrets  string   `yaml:"secrets"`
+		Inputs   []string `yaml:"inputs"`
+	} `yaml:"consumers"`
+	ExpectedInputTypes map[string]string `yaml:"expectedInputTypes"`
+}
+
+// TestIntegrationTemplateConsumerContract guards the workflow_call interface of
+// test-integration-template.yaml against changes that would break 3rd-party
+// callers (camunda/camunda, camunda/connectors, camunda/camunda-hub). A reusable
+// workflow's inputs are a public API: GitHub fails a caller's run if it passes an
+// input the workflow no longer declares, if a required-without-default input is
+// not supplied, or on a type mismatch. None of that surfaces in this repo's own
+// CI — it only fails downstream — so this test brings the breakage forward.
+//
+// The known callers and the inputs they pass are recorded in the fixture
+// (testdata/integration_template_consumers.yaml); refresh it when a caller
+// changes how it invokes the workflow. All known callers use `secrets: inherit`,
+// so secret-level changes are not contract-breaking and are not modeled here.
+func TestIntegrationTemplateConsumerContract(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+
+	inputs := loadTemplateInputs(t, filepath.Join(repoRoot, integrationTemplatePath))
+	contract := loadConsumerContract(t, consumerContractFixture)
+
+	if len(contract.Consumers) == 0 {
+		t.Fatal("consumer contract fixture lists no consumers")
+	}
+
+	for _, msg := range checkConsumerContract(inputs, contract) {
+		t.Error(msg)
+	}
+}
+
+// checkConsumerContract returns one message per contract violation. It is pure
+// (no I/O) so the breaking-change detection can be unit-tested directly.
+func checkConsumerContract(inputs map[string]templateInput, contract consumerContract) []string {
+	var violations []string
+
+	// (A) Every input a caller passes must still be declared by the template.
+	for _, c := range contract.Consumers {
+		for _, in := range c.Inputs {
+			if _, ok := inputs[in]; !ok {
+				violations = append(violations, fmt.Sprintf(
+					"[%s %s] passes input %q which test-integration-template.yaml no longer declares — "+
+						"this breaks the caller's next run with an \"unexpected input\" error. Keep a "+
+						"backward-compatible input (a deprecated no-op is fine) or coordinate the caller change first.",
+					c.Repo, c.Workflow, in))
+			}
+		}
+	}
+
+	// (B) A required-without-default input must be passed by EVERY known caller.
+	// Catches both new required inputs and optional -> required flips: any caller
+	// that does not pass it would fail at dispatch.
+	for _, meta := range sortedInputs(inputs) {
+		if !meta.required || meta.hasDefault {
+			continue
+		}
+		for _, c := range contract.Consumers {
+			if !slices.Contains(c.Inputs, meta.name) {
+				violations = append(violations, fmt.Sprintf(
+					"template input %q is required with no default, but [%s %s] does not pass it — "+
+						"the caller's next run fails. Give the input a default, or keep it optional.",
+					meta.name, c.Repo, c.Workflow))
+			}
+		}
+	}
+
+	// (C) The type of an input callers pass must not change.
+	for name, want := range contract.ExpectedInputTypes {
+		meta, ok := inputs[name]
+		if !ok {
+			continue // already reported by (A)
+		}
+		if meta.typ != want {
+			violations = append(violations, fmt.Sprintf(
+				"template input %q changed type from %q to %q — callers passing it may break. "+
+					"Revert the type, or update every caller and this fixture deliberately.",
+				name, want, meta.typ))
+		}
+	}
+
+	return violations
+}
+
+// inputWithName pairs an input name with its metadata for deterministic ordering.
+type inputWithName struct {
+	name string
+	templateInput
+}
+
+// sortedInputs yields inputs in name order so violation output is stable.
+func sortedInputs(inputs map[string]templateInput) []inputWithName {
+	names := make([]string, 0, len(inputs))
+	for n := range inputs {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	out := make([]inputWithName, 0, len(names))
+	for _, n := range names {
+		out = append(out, inputWithName{name: n, templateInput: inputs[n]})
+	}
+	return out
+}
+
+// loadTemplateInputs parses on.workflow_call.inputs from a workflow file using
+// node navigation, which is robust to YAML resolving the bare `on` key as a
+// boolean (the node's literal Value is still "on" either way).
+func loadTemplateInputs(t *testing.T, path string) map[string]templateInput {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+
+	on := mappingValue(&root, "on")
+	if on == nil {
+		t.Fatalf("%s: no top-level `on:` mapping", path)
+	}
+	workflowCall := mappingValue(on, "workflow_call")
+	if workflowCall == nil {
+		t.Fatalf("%s: `on.workflow_call` is missing — the workflow is no longer reusable", path)
+	}
+	inputsNode := mappingValue(workflowCall, "inputs")
+	if inputsNode == nil || inputsNode.Kind != yaml.MappingNode {
+		t.Fatalf("%s: `on.workflow_call.inputs` is missing or not a mapping", path)
+	}
+
+	out := make(map[string]templateInput)
+	for i := 0; i+1 < len(inputsNode.Content); i += 2 {
+		name := inputsNode.Content[i].Value
+		spec := inputsNode.Content[i+1]
+		ti := templateInput{}
+		if r := mappingValue(spec, "required"); r != nil {
+			ti.required = r.Value == "true"
+		}
+		if ty := mappingValue(spec, "type"); ty != nil {
+			ti.typ = ty.Value
+		}
+		if d := mappingValue(spec, "default"); d != nil {
+			ti.hasDefault = true
+		}
+		out[name] = ti
+	}
+	return out
+}
+
+// mappingValue returns the value node for key in a mapping node, unwrapping a
+// document node. Matching on the literal Value tolerates differing YAML tags.
+func mappingValue(node *yaml.Node, key string) *yaml.Node {
+	if node == nil {
+		return nil
+	}
+	if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
+		node = node.Content[0]
+	}
+	if node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}
+
+func loadConsumerContract(t *testing.T, path string) consumerContract {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var c consumerContract
+	if err := yaml.Unmarshal(data, &c); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return c
+}
+
+// --- unit tests for the pure checker -------------------------------------
+
+func makeContract() consumerContract {
+	c := consumerContract{ExpectedInputTypes: map[string]string{
+		"identifier": "string", "flag": "boolean",
+	}}
+	c.Consumers = append(c.Consumers, struct {
+		Repo     string   `yaml:"repo"`
+		Workflow string   `yaml:"workflow"`
+		Secrets  string   `yaml:"secrets"`
+		Inputs   []string `yaml:"inputs"`
+	}{Repo: "camunda/x", Workflow: ".github/workflows/w.yml", Secrets: "inherit",
+		Inputs: []string{"identifier", "flag"}})
+	return c
+}
+
+func TestCheckConsumerContract_HealthyPasses(t *testing.T) {
+	inputs := map[string]templateInput{
+		"identifier": {required: true, typ: "string", hasDefault: false},
+		"flag":       {required: false, typ: "boolean", hasDefault: true},
+		"extra":      {required: false, typ: "string", hasDefault: true}, // additive optional: safe
+	}
+	if v := checkConsumerContract(inputs, makeContract()); len(v) != 0 {
+		t.Errorf("expected no violations, got %v", v)
+	}
+}
+
+func TestCheckConsumerContract_RemovedInputBreaks(t *testing.T) {
+	inputs := map[string]templateInput{
+		"identifier": {required: true, typ: "string"},
+		// "flag" removed
+	}
+	if v := checkConsumerContract(inputs, makeContract()); len(v) == 0 {
+		t.Error("removing an input a caller passes must be flagged")
+	}
+}
+
+func TestCheckConsumerContract_NewRequiredInputBreaks(t *testing.T) {
+	inputs := map[string]templateInput{
+		"identifier": {required: true, typ: "string"},
+		"flag":       {required: false, typ: "boolean", hasDefault: true},
+		"newReq":     {required: true, typ: "string", hasDefault: false}, // no caller passes it
+	}
+	if v := checkConsumerContract(inputs, makeContract()); len(v) == 0 {
+		t.Error("a required-without-default input no caller passes must be flagged")
+	}
+}
+
+func TestCheckConsumerContract_TypeChangeBreaks(t *testing.T) {
+	inputs := map[string]templateInput{
+		"identifier": {required: true, typ: "string"},
+		"flag":       {required: false, typ: "string", hasDefault: true}, // was boolean
+	}
+	if v := checkConsumerContract(inputs, makeContract()); len(v) == 0 {
+		t.Error("changing the type of a consumed input must be flagged")
+	}
+}


### PR DESCRIPTION
### Which problem does the PR fix?

`.github/workflows/test-integration-template.yaml` is a `workflow_call` reusable workflow that other repositories call via `uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main`:

- `camunda/camunda` — `camunda-helm-integration.yml`, `docker-build-helm-integration.yml`
- `camunda/connectors` — `INTEGRATION_TEST.yml`
- `camunda/camunda-hub` — `stage-helm-tests.yml`

Its `workflow_call.inputs` are effectively a **public API**, but nothing in this repo prevents a change here from breaking those callers. GitHub fails a caller's next run if the workflow removes an input the caller passes, adds a `required` input (without a default) the caller doesn't pass, or changes an input's type — and none of that shows up in this repo's own CI. It only breaks downstream, after merge.

### What's in this PR?

A **consumer-driven contract test** that brings that breakage forward into this repo's `make go.test`:

- **Fixture** (`scripts/deploy-camunda/matrix/testdata/integration_template_consumers.yaml`) — records how each known caller invokes the workflow (the `with:` inputs it passes, the expected input types, and `secrets: inherit`). Header documents how to refresh it.
- **Guard** (`TestIntegrationTemplateConsumerContract`, matrix package) — parses the template's `on.workflow_call.inputs` and asserts, per caller:
  1. every input the caller passes still exists in the template;
  2. every `required`-without-`default` template input is passed by every caller (catches new required inputs and optional→required flips);
  3. the type of each consumed input is unchanged.
  Failure messages name the specific caller and workflow affected.
- **Unit tests** pin each breaking-change class (removed input, new required input, type change) and confirm additive optional inputs stay safe.
- **Docs** — new "Reusable Workflow Contract" section in `.github/AGENTS.md`.

All known callers use `secrets: inherit`, so secret-level changes are not contract-breaking and are not modeled.

### Verification

- `go test ./matrix/` (full suite incl. the new guard) passes; `gofmt`/`vet` clean.
- End-to-end proof: deleting `shortname` from the template makes the test fail with three messages naming `camunda/camunda` (docker-build), `camunda/connectors`, and `camunda/camunda-hub` — the callers that pass it.

### Checklist

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
