### PR TITLE
docs: clarify disabling Optimize/legacy exporter requires an actuator disable

### DIFF
--- a/charts/camunda-platform-8.10/README.md
+++ b/charts/camunda-platform-8.10/README.md
@@ -15,6 +15,17 @@
 > [migration from Bitnami guide](https://docs.camunda.io/docs/self-managed/deployment/helm/operational-tasks/migration-from-bitnami/)
 > and its accompanying toolkit for moving each component to externally managed infrastructure.
 
+> [!IMPORTANT]
+> **Disabling Optimize or the legacy Elasticsearch/OpenSearch exporter via Helm values does not stop the running exporter.**
+> Setting `optimize.enabled: false` (or `orchestration.exporters.zeebe.enabled: false`) only removes the legacy exporter from
+> the broker's *static* configuration. The broker reconciles that removal into its *dynamic* cluster configuration, but the
+> reconciliation runs only on partition leaders and relies on cluster gossip to converge across all brokers. If it does not
+> converge, the exporter can remain stuck in an `UNKNOWN` / `CONFIG_NOT_FOUND` state, which halts log compaction and grows the
+> Zeebe PVC. After disabling Optimize or the legacy exporter, explicitly disable the running exporter on each broker via
+> `POST /actuator/exporters/{elasticsearch|opensearch}/disable` and confirm convergence with `GET /actuator/exporters`
+> (every broker should report `DISABLED`). Ensure your Camunda version includes the exporter-state reconciliation fix
+> ([camunda/camunda#52260](https://github.com/camunda/camunda/issues/52260)).
+
 Please also refer to the [documentation](https://docs.camunda.io/docs/self-managed/setup/overview/) on how to use Helm charts.
 
 - [Architecture](#architecture)

--- a/charts/camunda-platform-8.10/README.md
+++ b/charts/camunda-platform-8.10/README.md
@@ -24,7 +24,7 @@
 > Zeebe PVC. After disabling Optimize or the legacy exporter, explicitly disable the running exporter on each broker via
 > `POST /actuator/exporters/{elasticsearch|opensearch}/disable` and confirm convergence with `GET /actuator/exporters`
 > (every broker should report `DISABLED`). Ensure your Camunda version includes the exporter-state reconciliation fix
-> ([camunda/camunda#52260](https://github.com/camunda/camunda/issues/52260)).
+> ([camunda/camunda#52260](https://github.com/camunda/camunda/issues/52260), fixed in 8.10.0-alpha2, so all 8.10.x releases include it).
 
 Please also refer to the [documentation](https://docs.camunda.io/docs/self-managed/setup/overview/) on how to use Helm charts.
 

--- a/charts/camunda-platform-8.8/README.md
+++ b/charts/camunda-platform-8.8/README.md
@@ -1,5 +1,16 @@
 # Camunda 8 Helm Chart
 
+> [!IMPORTANT]
+> **Disabling Optimize or the legacy Elasticsearch/OpenSearch exporter via Helm values does not stop the running exporter.**
+> Setting `optimize.enabled: false` (or `orchestration.exporters.zeebe.enabled: false`) only removes the legacy exporter from
+> the broker's *static* configuration. The broker reconciles that removal into its *dynamic* cluster configuration, but the
+> reconciliation runs only on partition leaders and relies on cluster gossip to converge across all brokers. If it does not
+> converge, the exporter can remain stuck in an `UNKNOWN` / `CONFIG_NOT_FOUND` state, which halts log compaction and grows the
+> Zeebe PVC. After disabling Optimize or the legacy exporter, explicitly disable the running exporter on each broker via
+> `POST /actuator/exporters/{elasticsearch|opensearch}/disable` and confirm convergence with `GET /actuator/exporters`
+> (every broker should report `DISABLED`). Ensure your Camunda version includes the exporter-state reconciliation fix
+> ([camunda/camunda#52260](https://github.com/camunda/camunda/issues/52260), backported to 8.8.25).
+
 Please also refer to the [documentation](https://docs.camunda.io/docs/self-managed/setup/overview/) on how to use Helm charts.
 
 - [Architecture](#architecture)

--- a/charts/camunda-platform-8.9/README.md
+++ b/charts/camunda-platform-8.9/README.md
@@ -1,5 +1,16 @@
 # Camunda 8 Helm Chart
 
+> [!IMPORTANT]
+> **Disabling Optimize or the legacy Elasticsearch/OpenSearch exporter via Helm values does not stop the running exporter.**
+> Setting `optimize.enabled: false` (or `orchestration.exporters.zeebe.enabled: false`) only removes the legacy exporter from
+> the broker's *static* configuration. The broker reconciles that removal into its *dynamic* cluster configuration, but the
+> reconciliation runs only on partition leaders and relies on cluster gossip to converge across all brokers. If it does not
+> converge, the exporter can remain stuck in an `UNKNOWN` / `CONFIG_NOT_FOUND` state, which halts log compaction and grows the
+> Zeebe PVC. After disabling Optimize or the legacy exporter, explicitly disable the running exporter on each broker via
+> `POST /actuator/exporters/{elasticsearch|opensearch}/disable` and confirm convergence with `GET /actuator/exporters`
+> (every broker should report `DISABLED`). Ensure your Camunda version includes the exporter-state reconciliation fix
+> ([camunda/camunda#52260](https://github.com/camunda/camunda/issues/52260)).
+
 Please also refer to the [documentation](https://docs.camunda.io/docs/self-managed/setup/overview/) on how to use Helm charts.
 
 - [Architecture](#architecture)

--- a/charts/camunda-platform-8.9/README.md
+++ b/charts/camunda-platform-8.9/README.md
@@ -9,7 +9,7 @@
 > Zeebe PVC. After disabling Optimize or the legacy exporter, explicitly disable the running exporter on each broker via
 > `POST /actuator/exporters/{elasticsearch|opensearch}/disable` and confirm convergence with `GET /actuator/exporters`
 > (every broker should report `DISABLED`). Ensure your Camunda version includes the exporter-state reconciliation fix
-> ([camunda/camunda#52260](https://github.com/camunda/camunda/issues/52260)).
+> ([camunda/camunda#52260](https://github.com/camunda/camunda/issues/52260), backported to 8.9.3).
 
 Please also refer to the [documentation](https://docs.camunda.io/docs/self-managed/setup/overview/) on how to use Helm charts.
 


### PR DESCRIPTION
### Which problem does the PR fix?

Follow-up to SUPPORT-33221 ("PVC usage grows, is the exporter disfunctional?") and the broker defect [camunda/camunda#52260](https://github.com/camunda/camunda/issues/52260).

A customer did a within-8.8 chart upgrade and disabled Optimize in the same step. The chart correctly removed the legacy Elasticsearch exporter from the broker's **static** config (`hasLegacyElasticsearchExporter` is gated on `optimize.enabled`, so disabling Optimize drops the exporter). However, the broker's **dynamic** cluster-configuration reconciliation (`ExporterStateInitializer`) runs only on partition leaders and relies on gossip to propagate to the remaining brokers. In this cluster one broker never took leadership and gossip did not converge, so the legacy exporter stayed `ENABLED` on that broker while the others moved it to `CONFIG_NOT_FOUND`. The aggregated state was `UNKNOWN`, `exportedPosition` stayed at `-1`, log compaction was blocked, and the Zeebe PVC grew for ~72h. It was resolved manually with `POST /actuator/exporters/elasticsearch/disable`.

This is a broker-side defect (fixed in 8.8.25 via #52260), not a chart defect — the chart does the right thing by removing the static config. The actionable gap on the Helm side is documentation: nothing in `charts/` or `docs/` told operators that disabling Optimize/the legacy exporter via values does not stop the *running* exporter and that an explicit actuator disable is required.

The same coupling exists in 8.8, 8.9, and 8.10 (the `hasLegacyElasticsearchExporter` / `hasLegacyOpenSearchExporter` helpers all include `optimize.enabled`), and #52260 affects all versions since 8.6, so the note is added to all three chart READMEs.

### What's in this PR?

Adds an `[!IMPORTANT]` note to the intro of the 8.8, 8.9, and 8.10 chart READMEs explaining that:

- disabling `optimize.enabled` / `orchestration.exporters.zeebe.enabled` only removes the legacy exporter from static config;
- the dynamic-config reconciliation can fail to converge, leaving the exporter stuck and growing the PVC;
- operators must run `POST /actuator/exporters/{elasticsearch|opensearch}/disable` per broker and verify with `GET /actuator/exporters`;
- the broker reconciliation fix is #52260 (backported to 8.8.25).

Docs-only; no template/values/golden changes. The intro is hand-maintained content, so `make helm.readme-update` (which only regenerates the parameter tables) does not affect it.

### Checklist

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open pull request for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo documentation are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
