### PR TITLE
fix: hard-fail rendering an image with neither a tag nor a digest

### DIFF
--- a/charts/camunda-platform-8.10/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/common/_helpers.tpl
@@ -140,11 +140,15 @@ Usage: {{ include "camundaPlatform.imageByParams" (dict "base" .Values.global "o
     -}}
   {{- else }}
     {{- /* original tag path */ -}}
+    {{- $imageTag := include "camundaPlatform.imageTagByParams" (dict "base" .base "overlay" .overlay) -}}
+    {{- if not $imageTag -}}
+      {{- fail (printf "camundaPlatform.imageByParams: image %q has neither a tag nor a digest; set image.tag or image.digest" $imageRepository) -}}
+    {{- end -}}
     {{- printf "%s%s%s:%s"
         $imageRegistry
         (empty $imageRegistry | ternary "" "/")
         $imageRepository
-        (include "camundaPlatform.imageTagByParams" (dict "base" .base "overlay" .overlay))
+        $imageTag
     -}}
   {{- end }}
 {{- end -}}

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/deployment_test.go
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/deployment_test.go
@@ -223,6 +223,7 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 				"camundaHub.webModeler.restapi.mail.fromAddress":  "example@example.com",
 				"global.image.pullSecrets[0].name":                "SecretName",
 				"camundaHub.webModeler.image.pullSecrets[0].name": "SecretNameSubChart",
+				"camundaHub.webModeler.image.tag":                 "snapshot",
 				"global.elasticsearch.enabled":                    "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/deployment_test.go
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/deployment_test.go
@@ -234,6 +234,19 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 				s.Require().Equal("SecretNameSubChart", deployment.Spec.Template.Spec.ImagePullSecrets[0].Name)
 			},
 		}, {
+			Name: "TestContainerImageWithoutTagOrDigestFails",
+			Values: map[string]string{
+				"identity.enabled":   "true",
+				"webModeler.enabled": "true",
+				"camundaHub.webModeler.restapi.mail.fromAddress": "example@example.com",
+				"camundaHub.webModeler.image.repository":         "camunda/custom-web-modeler",
+				"global.elasticsearch.enabled":                   "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().Error(err)
+				s.Require().Contains(err.Error(), "neither a tag nor a digest")
+			},
+		}, {
 			Name: "TestContainerOverwriteImageTag",
 			Values: map[string]string{
 				"identity.enabled":   "true",

--- a/charts/camunda-platform-8.8/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.8/templates/common/_helpers.tpl
@@ -104,11 +104,15 @@ Usage: {{ include "camundaPlatform.imageByParams" (dict "base" .Values.global "o
     -}}
   {{- else }}
     {{- /* original tag path */ -}}
+    {{- $imageTag := include "camundaPlatform.imageTagByParams" (dict "base" .base "overlay" .overlay) -}}
+    {{- if not $imageTag -}}
+      {{- fail (printf "camundaPlatform.imageByParams: image %q has neither a tag nor a digest; set image.tag or image.digest" $imageRepository) -}}
+    {{- end -}}
     {{- printf "%s%s%s:%s"
         $imageRegistry
         (empty $imageRegistry | ternary "" "/")
         $imageRepository
-        (include "camundaPlatform.imageTagByParams" (dict "base" .base "overlay" .overlay))
+        $imageTag
     -}}
   {{- end }}
 {{- end -}}

--- a/charts/camunda-platform-8.9/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/common/_helpers.tpl
@@ -140,11 +140,15 @@ Usage: {{ include "camundaPlatform.imageByParams" (dict "base" .Values.global "o
     -}}
   {{- else }}
     {{- /* original tag path */ -}}
+    {{- $imageTag := include "camundaPlatform.imageTagByParams" (dict "base" .base "overlay" .overlay) -}}
+    {{- if not $imageTag -}}
+      {{- fail (printf "camundaPlatform.imageByParams: image %q has neither a tag nor a digest; set image.tag or image.digest" $imageRepository) -}}
+    {{- end -}}
     {{- printf "%s%s%s:%s"
         $imageRegistry
         (empty $imageRegistry | ternary "" "/")
         $imageRepository
-        (include "camundaPlatform.imageTagByParams" (dict "base" .base "overlay" .overlay))
+        $imageTag
     -}}
   {{- end }}
 {{- end -}}


### PR DESCRIPTION
> **Stacked on #6462** (base branch = `fix/nightly-empty-image-tag-digest-strip`). Review/merge #6462 first; this PR will auto-retarget to `main` once it merges. The incremental diff here is only the `fail` guard + one test update.

### Which problem does the PR fix?

Follow-up hardening to #6462. When an image resolves with **neither a tag nor a digest**, the chart rendered an unquoted, trailing-colon reference (`<repository>:`) that Helm rejected with the cryptic `yaml: line NN: mapping values are not allowed in this context` — far from the real cause. This PR makes that a clear, immediate failure.

### What's in this PR?

- `charts/camunda-platform-8.8|8.9|8.10/templates/common/_helpers.tpl` — `camundaPlatform.imageByParams` now calls `fail` with an actionable message (`image %q has neither a tag nor a digest; set image.tag or image.digest`) instead of emitting a version-less image reference. Relies on the `imageTagByParams` `| default ""` coalescing from #6462 so the empty check is reliable (the helper previously yielded the `<no value>` sentinel).
- `charts/camunda-platform-8.10/test/unit/web-modeler/deployment_test.go` — `TestContainerSetImagePullSecretsSubChart` now sets `camundaHub.webModeler.image.tag`. That scenario previously rendered a **tag-less** websockets image: the `webModeler.websockets.image` helper selects `camundaHub.webModeler.image` wholesale via `or` when it is set, and that overlay carries no tag default (unlike `webModeler.image`), so the SM tag default was bypassed. The new guard correctly rejects the tag-less render, so the test now supplies a valid tag.

**Behavior change / scope note.** This turns a previously-tolerated (but broken) tag-less image render into a hard template error. Normal SM deploys are unaffected (they resolve a tag from `webModeler.image.tag` / component defaults). The case this newly rejects is an incomplete image override that sets registry/repository (or a `camundaHub.*` image block) without a tag or digest — which would only ever produce an unpullable image at runtime.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
