### PR TITLE
test: replace weak literal connectors password with secretKeyRef in multitenancy scenario

### DIFF
--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
@@ -33,6 +33,9 @@ connectors:
     - name: username
       value: username
     - name: password
-      value: password
+      valueFrom:
+        secretKeyRef:
+          name: integration-test-credentials
+          key: password
     - name: CAMUNDA_CLIENT_WORKER_DEFAULTS_TENANTIDS
       value: "<default>, Tenant_Main_Connectors, Tenant_Second_Connectors, Tenant_1_Connectors, Tenant_2_Connectors"

--- a/charts/camunda-platform-8.6/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
+++ b/charts/camunda-platform-8.6/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
@@ -45,6 +45,9 @@ connectors:
     - name: username
       value: username
     - name: password
-      value: password
+      valueFrom:
+        secretKeyRef:
+          name: integration-test-credentials
+          key: password
     - name: ZEEBE_CLIENT_DEFAULT_JOB_WORKER_TENANT_IDS
       value: "<default>, Tenant_Main_Connectors, Tenant_Second_Connectors, Tenant_1_Connectors, Tenant_2_Connectors"

--- a/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
+++ b/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
@@ -42,6 +42,9 @@ connectors:
     - name: username
       value: username
     - name: password
-      value: password
+      valueFrom:
+        secretKeyRef:
+          name: integration-test-credentials
+          key: password
     - name: CAMUNDA_CLIENT_ZEEBE_DEFAULTS_TENANTIDS
       value: "<default>, Tenant_Main_Connectors, Tenant_Second_Connectors, Tenant_1_Connectors, Tenant_2_Connectors"

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
@@ -45,6 +45,9 @@ connectors:
     - name: username
       value: username
     - name: password
-      value: password
+      valueFrom:
+        secretKeyRef:
+          name: integration-test-credentials
+          key: password
     - name: ZEEBE_CLIENT_DEFAULT_JOB_WORKER_TENANT_IDS
       value: "<default>, Tenant_Main_Connectors, Tenant_Second_Connectors, Tenant_1_Connectors, Tenant_2_Connectors"

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/features/multitenancy.yaml
@@ -45,6 +45,9 @@ connectors:
     - name: username
       value: username
     - name: password
-      value: password
+      valueFrom:
+        secretKeyRef:
+          name: integration-test-credentials
+          key: password
     - name: CAMUNDA_CLIENT_WORKER_DEFAULTS_TENANTIDS
       value: "<default>, Tenant_Main_Connectors, Tenant_Second_Connectors, Tenant_1_Connectors, Tenant_2_Connectors"


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes the failing `kemt` (keycloak-mt) scenario in the merge queue for #6463.

The GKE CI cluster enforces a `ValidatingAdmissionPolicy` (`deny-weak-password-defaults`) that rejects any Deployment where a password-named env var is set to a known default or a value shorter than 12 characters. The multitenancy scenario values set `connectors.env[].name: password, value: password`, which triggers the policy and causes Helm install to fail immediately with:

```
deployments.apps "integration-connectors" is forbidden: ValidatingAdmissionPolicy
'deny-weak-password-defaults' with binding 'deny-weak-password-defaults' denied request:
container(s) connectors set a password env var to a weak literal value
```

### What's in this PR?

Replace the literal `value: password` with a `secretKeyRef` pointing to the `integration-test-credentials` secret (already provisioned in every integration test namespace via External Secrets). The `password` key in that secret holds a strong, Vault-managed password.

Applied to all five affected chart versions: 8.6, 8.7, 8.8, 8.9, 8.10.

### Checklist

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?