### PR TITLE
ci(sec-scorecard): add 20m timeout and disable unconfigured repo_token

### DIFF
--- a/.github/workflows/sec-scorecard.yaml
+++ b/.github/workflows/sec-scorecard.yaml
@@ -17,6 +17,7 @@ jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
@@ -41,7 +42,7 @@ jobs:
           # - you want to enable the Branch-Protection check on a *public* repository, or
           # - you are installing Scorecard on a *private* repository
           # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action#authentication-with-pat.
-          repo_token: ${{ secrets.SCORECARD_TOKEN }}
+          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
 
           # Public repositories:
           #   - Publish results to OpenSSF REST API for easy access by consumers


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6323.

### What's in this PR?

Hardens the non-blocking `Security - Scorecard` workflow (`.github/workflows/sec-scorecard.yaml`).

1. **`timeout-minutes: 20` on the `analysis` job.** The job had no timeout, so a transient GitHub GraphQL `503` mid-analysis ([run 26908556266](https://github.com/camunda/camunda-platform-helm/actions/runs/26908556266/job/79380050363)) made the action retry against the degraded endpoint for **1h5m** before failing. The timeout now fails fast on upstream outages.

2. **Commented out the `repo_token` line.** It referenced `secrets.SCORECARD_TOKEN`, which is **not configured** anywhere in the repo or org (single reference, no README badge, no docs). Every run logged `The 'repo_token' variable is empty. Using the 'INPUT_INTERNAL_DEFAULT_TOKEN' variable instead.` and fell back to `GITHUB_TOKEN`. Commenting it out restores the upstream scorecard-action starter default, silences the per-run auth notice and the IDE `Context access might be invalid: SCORECARD_TOKEN` diagnostic, and keeps the adjacent "Uncomment the line below…" comment accurate. Reversible by one uncomment if an admin later adds the PAT to enable full Branch-Protection scoring.

**Deliberately not done (out of scope for #6323):**
- **No 503 retry wrapper.** Retry is optional per the issue, a re-run clears the transient 503, and the job is non-blocking. Retrying a `uses:` step would require a third-party retry action (`Wandalen/wretry`); this repo uses zero third-party retry deps (only bash loops / `curl --retry` / `scripts/harbor-retry.sh`). The 20m timeout already removes the 1h hang.

**Follow-ups (separate issues/PRs):**
- An org/admin can add the `SCORECARD_TOKEN` PAT and uncomment the line to enable the OSSF Branch-Protection check.
- ~36 jobs across ~20 workflow files lack `timeout-minutes`. Worth a separate hardening pass; highest-risk (Harbor + GitHub API callers): `chart-release-public.yaml` (release/post-release), `chart-build-dev.yaml` (build), `chart-release-artifact-verify.yaml` (verify), `chart-promote-rc.yaml` (promote-rc).

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
