### PR TITLE
ci: align release Git tags to release-please merge commits

### DIFF
--- a/.github/workflows/chart-public-files.yaml
+++ b/.github/workflows/chart-public-files.yaml
@@ -8,6 +8,7 @@ on:
     - main
     paths:
     - '.github/workflows/chart-public-files.yaml'
+    - 'charts/camunda-platform*/Chart.yaml'
     - 'charts/camunda-platform*/values*.yaml'
     - 'scripts/templates/version-matrix/*'
     - 'version-matrix/**'
@@ -77,9 +78,7 @@ jobs:
           message: "chore: update camunda-platform public files"
 
   retag-release:
-    # Moves each chart's release Git tag to the release-please merge commit,
-    # closing the window between helm-cr tag creation (Stage 3) and the Chart.yaml
-    # version bump (post-merge). Only runs on chore(release): pushes.
+    # Only runs on chore(release): pushes to main.
     name: Move release tags to release-please merge commit
     runs-on: ubuntu-latest
     permissions:
@@ -87,8 +86,9 @@ jobs:
     steps:
       - name: Check if triggered by a release-please merge
         id: guard
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
-          COMMIT_MSG="${{ github.event.head_commit.message }}"
           if echo "$COMMIT_MSG" | grep -qE '^chore\(release\):'; then
             echo "is_release=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/chart-public-files.yaml
+++ b/.github/workflows/chart-public-files.yaml
@@ -75,3 +75,39 @@ jobs:
       - uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
         with:
           message: "chore: update camunda-platform public files"
+
+  retag-release:
+    # Moves each chart's release Git tag to the release-please merge commit,
+    # closing the window between helm-cr tag creation (Stage 3) and the Chart.yaml
+    # version bump (post-merge). Only runs on chore(release): pushes.
+    name: Move release tags to release-please merge commit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check if triggered by a release-please merge
+        id: guard
+        run: |
+          COMMIT_MSG="${{ github.event.head_commit.message }}"
+          if echo "$COMMIT_MSG" | grep -qE '^chore\(release\):'; then
+            echo "is_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
+            echo "Not a release-please merge commit — skipping retag."
+          fi
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        if: steps.guard.outputs.is_release == 'true'
+
+      - name: Build release-tools
+        if: steps.guard.outputs.is_release == 'true'
+        run: cd scripts/release-tools && go build -o /tmp/release-tools .
+
+      - name: Retag stale release tags
+        if: steps.guard.outputs.is_release == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          /tmp/release-tools retag-release \
+            --repo "${{ github.repository }}" \
+            --sha  "${{ github.sha }}"

--- a/scripts/camunda-core/pkg/retagger/github.go
+++ b/scripts/camunda-core/pkg/retagger/github.go
@@ -1,0 +1,135 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package retagger
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+const ghAPIBase = "https://api.github.com"
+
+// RealGitHubClient implements GitHubClient against the GitHub REST API using
+// Bearer token auth. The Do field is injectable so tests can exercise all code
+// paths without a real network.
+type RealGitHubClient struct {
+	Token string
+	Do    func(*http.Request) (*http.Response, error)
+}
+
+// NewGitHubClient returns a RealGitHubClient reading the token from GITHUB_TOKEN.
+func NewGitHubClient() *RealGitHubClient {
+	c := &RealGitHubClient{Token: os.Getenv("GITHUB_TOKEN")}
+	c.Do = http.DefaultClient.Do
+	return c
+}
+
+func (c *RealGitHubClient) newRequest(method, url string, body []byte) (*http.Request, error) {
+	var rdr io.Reader
+	if body != nil {
+		rdr = bytes.NewReader(body)
+	}
+	req, err := http.NewRequest(method, url, rdr)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.Token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return req, nil
+}
+
+func (c *RealGitHubClient) doJSON(req *http.Request, out any) (int, error) {
+	resp, err := c.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		io.Copy(io.Discard, resp.Body)
+		return http.StatusNotFound, nil
+	}
+	if resp.StatusCode >= 400 {
+		b, _ := io.ReadAll(resp.Body)
+		return resp.StatusCode, fmt.Errorf("HTTP %d: %s", resp.StatusCode, bytes.TrimSpace(b))
+	}
+	if out != nil {
+		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+			return resp.StatusCode, fmt.Errorf("decode response: %w", err)
+		}
+	} else {
+		io.Copy(io.Discard, resp.Body)
+	}
+	return resp.StatusCode, nil
+}
+
+type ghTagRef struct {
+	Object struct {
+		SHA  string `json:"sha"`
+		Type string `json:"type"`
+	} `json:"object"`
+}
+
+// CommitSHA returns the commit SHA the tag currently points to, or "" if the
+// tag does not exist. Annotated tags (type "tag") are resolved to their
+// underlying commit via a second API call.
+func (c *RealGitHubClient) CommitSHA(repo, tag string) (string, error) {
+	req, err := c.newRequest(http.MethodGet,
+		fmt.Sprintf("%s/repos/%s/git/refs/tags/%s", ghAPIBase, repo, tag), nil)
+	if err != nil {
+		return "", err
+	}
+	var ref ghTagRef
+	code, err := c.doJSON(req, &ref)
+	if err != nil {
+		return "", err
+	}
+	if code == http.StatusNotFound {
+		return "", nil
+	}
+	if ref.Object.Type != "tag" {
+		return ref.Object.SHA, nil
+	}
+	// Annotated tag: resolve tag object → commit SHA.
+	req2, err := c.newRequest(http.MethodGet,
+		fmt.Sprintf("%s/repos/%s/git/tags/%s", ghAPIBase, repo, ref.Object.SHA), nil)
+	if err != nil {
+		return "", err
+	}
+	var obj ghTagRef
+	if _, err := c.doJSON(req2, &obj); err != nil {
+		return "", fmt.Errorf("resolve annotated tag %s: %w", tag, err)
+	}
+	return obj.Object.SHA, nil
+}
+
+// MoveTag force-updates tag to point at sha.
+func (c *RealGitHubClient) MoveTag(repo, tag, sha string) error {
+	body, _ := json.Marshal(map[string]any{"sha": sha, "force": true})
+	req, err := c.newRequest(http.MethodPatch,
+		fmt.Sprintf("%s/repos/%s/git/refs/tags/%s", ghAPIBase, repo, tag), body)
+	if err != nil {
+		return err
+	}
+	_, err = c.doJSON(req, nil)
+	return err
+}

--- a/scripts/camunda-core/pkg/retagger/retagger.go
+++ b/scripts/camunda-core/pkg/retagger/retagger.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package retagger aligns release Git tags to the release-please merge commit
+// that bumps Chart.yaml, fixing the window where helm-cr creates the tag
+// before the version bump is committed.
+package retagger
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"scripts/camunda-core/pkg/chartmeta"
+)
+
+// Chart is a release tag candidate derived from a Chart.yaml.
+type Chart struct {
+	Dir     string // e.g. "charts/camunda-platform-8.7"
+	TagName string // e.g. "camunda-platform-8.7-12.12.1"
+	Version string // chart version, e.g. "12.12.1"
+}
+
+// ListCharts scans chartsRoot for active chart directories and returns one
+// Chart per non-pre-release chart found. Charts are expected at
+// chartsRoot/charts/camunda-platform-8.*/.
+func ListCharts(chartsRoot string) ([]Chart, error) {
+	pattern := filepath.Join(chartsRoot, "charts", "camunda-platform-8.*")
+	dirs, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("glob %s: %w", pattern, err)
+	}
+	var charts []Chart
+	for _, dir := range dirs {
+		chartYAML := filepath.Join(dir, "Chart.yaml")
+		if _, err := os.Stat(chartYAML); err != nil {
+			continue
+		}
+		meta, err := chartmeta.ReadPackageMetadata(chartYAML, "")
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", chartYAML, err)
+		}
+		// Skip alpha/pre-release versions (contain a hyphen, e.g. "15.0.0-alpha1").
+		if strings.Contains(meta.Version, "-") {
+			continue
+		}
+		charts = append(charts, Chart{
+			Dir:     dir,
+			TagName: meta.ReleaseTag,
+			Version: meta.Version,
+		})
+	}
+	return charts, nil
+}
+
+// GitHubClient performs the minimal GitHub tag operations needed for retagging.
+type GitHubClient interface {
+	// CommitSHA returns the commit SHA the named tag currently points to, or ""
+	// if the tag does not exist. Annotated tags are resolved transparently.
+	CommitSHA(repo, tag string) (string, error)
+	// MoveTag force-updates tag to point at sha.
+	MoveTag(repo, tag, sha string) error
+}
+
+// Result is the outcome of processing one chart's release tag.
+type Result struct {
+	TagName string
+	Moved   bool
+	Reason  string
+}
+
+// Run checks and retags all charts under chartsRoot. For each chart's release
+// tag it compares the current tag target to targetSHA and force-moves the tag
+// when they differ.
+func Run(chartsRoot, repo, targetSHA string, client GitHubClient) ([]Result, error) {
+	charts, err := ListCharts(chartsRoot)
+	if err != nil {
+		return nil, err
+	}
+	results := make([]Result, 0, len(charts))
+	for _, ch := range charts {
+		current, err := client.CommitSHA(repo, ch.TagName)
+		if err != nil {
+			return nil, fmt.Errorf("get SHA for %s: %w", ch.TagName, err)
+		}
+		if current == "" {
+			results = append(results, Result{TagName: ch.TagName, Moved: false, Reason: "tag does not exist yet"})
+			continue
+		}
+		if current == targetSHA {
+			results = append(results, Result{TagName: ch.TagName, Moved: false, Reason: "already correct"})
+			continue
+		}
+		if err := client.MoveTag(repo, ch.TagName, targetSHA); err != nil {
+			return nil, fmt.Errorf("move tag %s: %w", ch.TagName, err)
+		}
+		results = append(results, Result{
+			TagName: ch.TagName,
+			Moved:   true,
+			Reason:  fmt.Sprintf("moved from %s to %s", shortSHA(current), shortSHA(targetSHA)),
+		})
+	}
+	return results, nil
+}
+
+func shortSHA(sha string) string {
+	if len(sha) > 7 {
+		return sha[:7]
+	}
+	return sha
+}

--- a/scripts/camunda-core/pkg/retagger/retagger_test.go
+++ b/scripts/camunda-core/pkg/retagger/retagger_test.go
@@ -1,0 +1,328 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package retagger
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeChart creates a minimal Chart.yaml under root/charts/<dir>/.
+func writeChart(t *testing.T, root, dir, version, appVersion string) {
+	t.Helper()
+	chartDir := filepath.Join(root, "charts", dir)
+	if err := os.MkdirAll(chartDir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", chartDir, err)
+	}
+	content := fmt.Sprintf("version: %q\nappVersion: %q\n", version, appVersion)
+	if err := os.WriteFile(filepath.Join(chartDir, "Chart.yaml"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write Chart.yaml: %v", err)
+	}
+}
+
+func TestListCharts_SkipsPreRelease(t *testing.T) {
+	root := t.TempDir()
+	writeChart(t, root, "camunda-platform-8.7", "12.12.1", "8.7.x")
+	writeChart(t, root, "camunda-platform-8.8", "13.0.0-alpha1", "8.8.x")
+	writeChart(t, root, "camunda-platform-8.10", "13.5.2", "8.10.x")
+
+	charts, err := ListCharts(root)
+	if err != nil {
+		t.Fatalf("ListCharts: %v", err)
+	}
+	if len(charts) != 2 {
+		t.Fatalf("want 2 charts (non-pre-release), got %d: %v", len(charts), charts)
+	}
+	tags := make(map[string]bool)
+	for _, c := range charts {
+		tags[c.TagName] = true
+	}
+	if !tags["camunda-platform-8.7-12.12.1"] {
+		t.Error("missing camunda-platform-8.7-12.12.1")
+	}
+	if !tags["camunda-platform-8.10-13.5.2"] {
+		t.Error("missing camunda-platform-8.10-13.5.2")
+	}
+}
+
+func TestListCharts_StripsDotX(t *testing.T) {
+	root := t.TempDir()
+	writeChart(t, root, "camunda-platform-8.10", "13.5.2", "8.10.x")
+
+	charts, err := ListCharts(root)
+	if err != nil {
+		t.Fatalf("ListCharts: %v", err)
+	}
+	if len(charts) != 1 {
+		t.Fatalf("want 1 chart, got %d", len(charts))
+	}
+	// appVersion "8.10.x" must be stripped to "8.10" in the tag name.
+	want := "camunda-platform-8.10-13.5.2"
+	if charts[0].TagName != want {
+		t.Errorf("TagName = %q, want %q", charts[0].TagName, want)
+	}
+}
+
+func TestListCharts_EmptyRoot(t *testing.T) {
+	root := t.TempDir()
+	charts, err := ListCharts(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(charts) != 0 {
+		t.Errorf("want 0 charts, got %d", len(charts))
+	}
+}
+
+// mockClient implements GitHubClient with configurable responses.
+type mockClient struct {
+	shaFn  func(repo, tag string) (string, error)
+	moveFn func(repo, tag, sha string) error
+	moved  []string // tags that were moved
+}
+
+func (m *mockClient) CommitSHA(repo, tag string) (string, error) {
+	return m.shaFn(repo, tag)
+}
+
+func (m *mockClient) MoveTag(repo, tag, sha string) error {
+	m.moved = append(m.moved, tag)
+	if m.moveFn != nil {
+		return m.moveFn(repo, tag, sha)
+	}
+	return nil
+}
+
+func mustListCharts(t *testing.T) (string, []Chart) {
+	t.Helper()
+	root := t.TempDir()
+	writeChart(t, root, "camunda-platform-8.7", "12.12.1", "8.7.x")
+	charts, err := ListCharts(root)
+	if err != nil {
+		t.Fatalf("ListCharts: %v", err)
+	}
+	return root, charts
+}
+
+func TestRun_AlreadyCorrect(t *testing.T) {
+	root, _ := mustListCharts(t)
+	const target = "abc1234abc1234abc1234abc1234abc1234abc1234"
+	mc := &mockClient{shaFn: func(_, _ string) (string, error) { return target, nil }}
+
+	results, err := Run(root, "owner/repo", target, mc)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("want 1 result, got %d", len(results))
+	}
+	if results[0].Moved {
+		t.Error("expected Moved=false when tag already points to target SHA")
+	}
+	if results[0].Reason != "already correct" {
+		t.Errorf("Reason = %q, want %q", results[0].Reason, "already correct")
+	}
+	if len(mc.moved) != 0 {
+		t.Errorf("MoveTag was called unexpectedly: %v", mc.moved)
+	}
+}
+
+func TestRun_TagMissing(t *testing.T) {
+	root, _ := mustListCharts(t)
+	mc := &mockClient{shaFn: func(_, _ string) (string, error) { return "", nil }}
+
+	results, err := Run(root, "owner/repo", "newsha", mc)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("want 1 result, got %d", len(results))
+	}
+	if results[0].Moved {
+		t.Error("expected Moved=false when tag does not exist")
+	}
+	if !strings.Contains(results[0].Reason, "does not exist") {
+		t.Errorf("Reason = %q, expected to contain 'does not exist'", results[0].Reason)
+	}
+	if len(mc.moved) != 0 {
+		t.Errorf("MoveTag was called unexpectedly: %v", mc.moved)
+	}
+}
+
+func TestRun_MovesStaleTag(t *testing.T) {
+	root, _ := mustListCharts(t)
+	const (
+		staleSHA  = "aaaaaaaabbbbbbbbccccccccddddddddeeeeeeee"
+		targetSHA = "1111111122222222333333334444444455555555"
+	)
+	mc := &mockClient{shaFn: func(_, _ string) (string, error) { return staleSHA, nil }}
+
+	results, err := Run(root, "owner/repo", targetSHA, mc)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("want 1 result, got %d", len(results))
+	}
+	if !results[0].Moved {
+		t.Error("expected Moved=true when tag points to stale SHA")
+	}
+	if len(mc.moved) != 1 || mc.moved[0] != results[0].TagName {
+		t.Errorf("MoveTag called with wrong tags: %v", mc.moved)
+	}
+	// Reason should contain short SHAs.
+	if !strings.Contains(results[0].Reason, "aaaaaaa") {
+		t.Errorf("Reason should contain short stale SHA: %q", results[0].Reason)
+	}
+	if !strings.Contains(results[0].Reason, "1111111") {
+		t.Errorf("Reason should contain short target SHA: %q", results[0].Reason)
+	}
+}
+
+func TestRun_MoveError(t *testing.T) {
+	root, _ := mustListCharts(t)
+	mc := &mockClient{
+		shaFn:  func(_, _ string) (string, error) { return "stalesha", nil },
+		moveFn: func(_, _, _ string) error { return fmt.Errorf("API error") },
+	}
+	_, err := Run(root, "owner/repo", "targetsha", mc)
+	if err == nil {
+		t.Fatal("expected error when MoveTag fails")
+	}
+}
+
+// Tests for RealGitHubClient using httptest.
+
+func newTestClient(handler http.HandlerFunc) (*RealGitHubClient, *httptest.Server) {
+	srv := httptest.NewServer(handler)
+	c := &RealGitHubClient{Token: "test-token"}
+	c.Do = func(req *http.Request) (*http.Response, error) {
+		// Rewrite API base to test server.
+		req.URL.Host = strings.TrimPrefix(srv.URL, "http://")
+		req.URL.Scheme = "http"
+		return http.DefaultClient.Do(req)
+	}
+	return c, srv
+}
+
+func TestGitHubClient_CommitSHA_LightweightTag(t *testing.T) {
+	const (
+		tag    = "camunda-platform-8.7-12.12.1"
+		commit = "abc1234abc1234abc1234abc1234abc1234abc123"
+	)
+	c, srv := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "refs/tags") {
+			http.NotFound(w, r)
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"object": map[string]any{"sha": commit, "type": "commit"},
+		})
+	})
+	defer srv.Close()
+
+	got, err := c.CommitSHA("owner/repo", tag)
+	if err != nil {
+		t.Fatalf("CommitSHA: %v", err)
+	}
+	if got != commit {
+		t.Errorf("CommitSHA = %q, want %q", got, commit)
+	}
+}
+
+func TestGitHubClient_CommitSHA_AnnotatedTag(t *testing.T) {
+	const (
+		tag       = "camunda-platform-8.7-12.12.1"
+		tagObjSHA = "tagobj111tagobj111tagobj111tagobj111tagobj1"
+		commitSHA = "abc1234abc1234abc1234abc1234abc1234abc123"
+	)
+	callCount := 0
+	c, srv := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if strings.Contains(r.URL.Path, "refs/tags") {
+			// First call: return annotated tag object ref.
+			json.NewEncoder(w).Encode(map[string]any{
+				"object": map[string]any{"sha": tagObjSHA, "type": "tag"},
+			})
+			return
+		}
+		// Second call: resolve tag object → commit.
+		json.NewEncoder(w).Encode(map[string]any{
+			"object": map[string]any{"sha": commitSHA, "type": "commit"},
+		})
+	})
+	defer srv.Close()
+
+	got, err := c.CommitSHA("owner/repo", tag)
+	if err != nil {
+		t.Fatalf("CommitSHA: %v", err)
+	}
+	if got != commitSHA {
+		t.Errorf("CommitSHA = %q, want %q", got, commitSHA)
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 API calls for annotated tag, got %d", callCount)
+	}
+}
+
+func TestGitHubClient_CommitSHA_TagNotFound(t *testing.T) {
+	c, srv := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+	defer srv.Close()
+
+	got, err := c.CommitSHA("owner/repo", "no-such-tag")
+	if err != nil {
+		t.Fatalf("CommitSHA: %v", err)
+	}
+	if got != "" {
+		t.Errorf("CommitSHA = %q, want empty string for missing tag", got)
+	}
+}
+
+func TestGitHubClient_MoveTag(t *testing.T) {
+	var capturedBody []byte
+	c, srv := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			http.Error(w, "want PATCH", http.StatusMethodNotAllowed)
+			return
+		}
+		capturedBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	})
+	defer srv.Close()
+
+	const sha = "abc1234abc1234abc1234abc1234abc1234abc123"
+	if err := c.MoveTag("owner/repo", "my-tag", sha); err != nil {
+		t.Fatalf("MoveTag: %v", err)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(capturedBody, &body); err != nil {
+		t.Fatalf("parse body: %v", err)
+	}
+	if body["sha"] != sha {
+		t.Errorf("body sha = %v, want %q", body["sha"], sha)
+	}
+	if body["force"] != true {
+		t.Errorf("body force = %v, want true", body["force"])
+	}
+}

--- a/scripts/release-tools/main.go
+++ b/scripts/release-tools/main.go
@@ -54,6 +54,8 @@ func main() {
 		err = runInjectValues(os.Args[2:])
 	case "version-matrix":
 		err = runVersionMatrix(os.Args[2:])
+	case "retag-release":
+		err = runRetagRelease(os.Args[2:])
 	case "-h", "--help", "help":
 		usage()
 		return
@@ -84,5 +86,6 @@ Subcommands:
   release-notes   Generate RELEASE-NOTES.md + Chart.yaml release annotations (--main / --footer)
   inject-values   Override component image tags in a chart's values.yaml from *_IMAGE_TAG env
   version-matrix  Render version-matrix/camunda-<app>/README.md (--readme <app>) or version-matrix/README.md (--index)
+  retag-release   Move each chart's release Git tag to the release-please merge commit (--repo --sha)
 `)
 }

--- a/scripts/release-tools/retag_release.go
+++ b/scripts/release-tools/retag_release.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"scripts/camunda-core/pkg/retagger"
+)
+
+// runRetagRelease moves each chart's release Git tag to targetSHA when the
+// existing tag points to a different commit — closing the window between
+// helm-cr tag creation and the release-please Chart.yaml version bump.
+//
+//	retag-release --repo <owner/name> --sha <commit-sha> [--charts-root <path>]
+func runRetagRelease(args []string) error {
+	fs := flag.NewFlagSet("retag-release", flag.ContinueOnError)
+	var (
+		repo       string
+		sha        string
+		chartsRoot string
+	)
+	fs.StringVar(&repo, "repo", "", "GitHub repo slug (owner/name)")
+	fs.StringVar(&sha, "sha", "", "target commit SHA (the release-please merge commit)")
+	fs.StringVar(&chartsRoot, "charts-root", ".", "repo root containing charts/")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if repo == "" || sha == "" {
+		return fmt.Errorf("--repo and --sha are required")
+	}
+
+	client := retagger.NewGitHubClient()
+	results, err := retagger.Run(chartsRoot, repo, sha, client)
+	if err != nil {
+		return err
+	}
+	return writeRetagSummary(results, sha)
+}
+
+func writeRetagSummary(results []retagger.Result, targetSHA string) error {
+	var moved, skipped []string
+	for _, r := range results {
+		if r.Moved {
+			moved = append(moved, r.TagName)
+		} else {
+			skipped = append(skipped, fmt.Sprintf("%s (%s)", r.TagName, r.Reason))
+		}
+	}
+
+	var sb strings.Builder
+	sb.WriteString("## 🏷️ Release Tag Sync\n")
+	if len(moved) > 0 {
+		shortSHA := targetSHA
+		if len(shortSHA) > 7 {
+			shortSHA = shortSHA[:7]
+		}
+		fmt.Fprintf(&sb, "### ✅ Moved to `%s`\n", shortSHA)
+		for _, t := range moved {
+			fmt.Fprintf(&sb, "- `%s`\n", t)
+		}
+	}
+	if len(skipped) > 0 {
+		sb.WriteString("### ⏭️ Skipped\n")
+		for _, t := range skipped {
+			fmt.Fprintf(&sb, "- %s\n", t)
+		}
+	}
+	summary := sb.String()
+
+	// Always print to stdout for local visibility.
+	fmt.Print(summary)
+
+	summaryPath := os.Getenv("GITHUB_STEP_SUMMARY")
+	if summaryPath == "" {
+		return nil
+	}
+	f, err := os.OpenFile(summaryPath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o644)
+	if err != nil {
+		return fmt.Errorf("open GITHUB_STEP_SUMMARY: %w", err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(summary); err != nil {
+		return fmt.Errorf("write GITHUB_STEP_SUMMARY: %w", err)
+	}
+	return nil
+}

--- a/scripts/release-tools/retag_release_test.go
+++ b/scripts/release-tools/retag_release_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"scripts/camunda-core/pkg/retagger"
+)
+
+func TestRunRetagRelease_MissingFlags(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"no flags", []string{}},
+		{"missing sha", []string{"--repo", "owner/repo"}},
+		{"missing repo", []string{"--sha", "abc1234"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := runRetagRelease(tc.args); err == nil {
+				t.Fatal("expected error for missing required flags")
+			}
+		})
+	}
+}
+
+func TestWriteRetagSummary_WritesStepSummary(t *testing.T) {
+	dir := t.TempDir()
+	summaryPath := filepath.Join(dir, "summary.md")
+	t.Setenv("GITHUB_STEP_SUMMARY", summaryPath)
+
+	results := []retagger.Result{
+		{TagName: "camunda-platform-8.7-12.12.1", Moved: true, Reason: "moved from aaa to bbb"},
+		{TagName: "camunda-platform-8.10-13.5.2", Moved: false, Reason: "already correct"},
+	}
+	if err := writeRetagSummary(results, "abc1234abc1234abc1234abc1234abc1234abc123"); err != nil {
+		t.Fatalf("writeRetagSummary: %v", err)
+	}
+
+	content, err := os.ReadFile(summaryPath)
+	if err != nil {
+		t.Fatalf("read summary: %v", err)
+	}
+	got := string(content)
+	if !strings.Contains(got, "camunda-platform-8.7-12.12.1") {
+		t.Error("summary missing moved tag")
+	}
+	if !strings.Contains(got, "camunda-platform-8.10-13.5.2") {
+		t.Error("summary missing skipped tag")
+	}
+	if !strings.Contains(got, "abc1234") {
+		t.Error("summary missing short SHA")
+	}
+}
+
+func TestWriteRetagSummary_NoSummaryPath(t *testing.T) {
+	t.Setenv("GITHUB_STEP_SUMMARY", "")
+	// Should not fail when GITHUB_STEP_SUMMARY is unset.
+	if err := writeRetagSummary(nil, "sha"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
### Which problem does the PR fix?

When a user runs:

```
git clone https://github.com/camunda/camunda-platform-helm.git
git checkout camunda-platform-8.7-12.12.1
cat charts/camunda-platform-8.7/Chart.yaml | yq .version
# → 12.12.0   ← wrong!
```

The release Git tag points to the **Stage-1 build-trigger commit**, not the **release-please merge commit** that bumps `Chart.yaml` to the released version. The released `.tgz` artifact is correct (`version: 12.12.1`); only the Git tag is misaligned.

Verified locally:

```
$ git show camunda-platform-8.7-12.12.1:charts/camunda-platform-8.7/Chart.yaml | grep ^version
version: 12.12.0   ← tag points to wrong commit

$ tar -xzf camunda-platform-12.12.1.tgz --to-stdout camunda-platform/Chart.yaml | grep ^version
version: 12.12.1   ← released artifact is correct
```

### What's in this PR?

**Root cause:** `chart-release-public.yaml` creates the Git tag at Stage 3 (public release), before the release-please PR is merged. The release-please PR merge is what bumps `Chart.yaml` — but by then the tag already points at the Stage-1 commit.

**Options considered:**

- **Option A — Move the tag after the release-please merge** ✅ (this PR): `chart-public-files.yaml` fires on every push to `main` that touches `Chart.yaml`. A new `retag-release` job reads each chart's version, reconstructs the release tag name, and force-moves it to the merge commit via the GitHub API. Guard on `chore(release):` prefix prevents spurious retags on normal updates.
- **Option B — Create the tag only post-merge, skip helm-cr tagging**: More invasive changes to the release pipeline; tag doesn't exist until the release-please PR merges.
- **Option C — Documentation only**: No code change, perpetuates user confusion.

**What changed:**

1. **`charts/camunda-platform*/Chart.yaml` added to `on.push.paths`** — ensures the workflow fires on release-please merges (which bump `Chart.yaml`, not `values*.yaml`).
2. **`retag-release` job in `chart-public-files.yaml`** — builds `release-tools` and calls the new `retag-release` subcommand. `COMMIT_MSG` passed via `env:` to avoid shell injection.
3. **`scripts/camunda-core/pkg/retagger/`** — Go package implementing chart discovery, tag comparison, and GitHub API calls. `GitHubClient` interface is injectable; tests use `httptest` with no mocks framework. Covers: pre-release skip, `.x` stripping, already-correct / missing / stale tag branches, annotated tag two-step resolution, PATCH request body.
4. **`retag-release` subcommand in `release-tools`** — stdlib-flag dispatcher, writes `GITHUB_STEP_SUMMARY`.

**Backfill script (`scripts/fix-stale-release-tags.sh`) is intentionally not committed** — it exists locally for one-off maintainer use and doesn't belong in the permanent codebase. To fix currently stale tags:

```bash
# Find correct commit and move the tag
CORRECT=$(git log --oneline main -- charts/camunda-platform-8.7/Chart.yaml \
  | while read sha _; do
      v=$(git show "$sha:charts/camunda-platform-8.7/Chart.yaml" | yq '.version')
      [[ "$v" == "12.12.1" ]] && echo "$sha" && break
    done)
gh api --method PATCH repos/camunda/camunda-platform-helm/git/refs/tags/camunda-platform-8.7-12.12.1 \
  -f sha="$CORRECT" -F force=true
```

### Checklist

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?