### PR TITLE
feat: adopt rebaseWhen=conflicted Renovate strategy

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,8 @@
     'config:recommended',
     'helpers:pinGitHubActionDigests',
     ':semanticCommitTypeAll(deps)',
+    // Rebase Renovate PRs only on real conflicts, not on every base-branch push (issue #1053).
+    'github>camunda/infra-renovate-config:rebase.json5',
   ],
   semanticCommitScope: '',
   labels: [
@@ -12,7 +14,6 @@
   prHourlyLimit: 6,
   prConcurrentLimit: 20,
   recreateWhen: 'always',
-  rebaseWhen: 'behind-base-branch',
   commitBodyTable: true,
   separateMajorMinor: true,
   separateMinorPatch: true,

--- a/.github/workflows/renovate-pr-maintainer.yml
+++ b/.github/workflows/renovate-pr-maintainer.yml
@@ -12,6 +12,10 @@
 name: Renovate PR maintainer
 
 on:
+  # TEMP(#1053): push trigger to smoke-test this workflow before merge; reverted after.
+  push:
+    branches:
+    - 1053-renovate-rebase-when-conflicted
   schedule:
   # Runs hourly; actions are taken selectively per PR state, not on every run.
   - cron: "23 * * * *"
@@ -46,7 +50,7 @@ jobs:
     - name: Maintain Renovate PRs
       uses: camunda/infra-global-github-actions/renovate-pr-maintainer@be5b0496892a83e6b3c5cedb818b771e8ed68121 # main
       with:
-        dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || false }}
+        dry-run: true  # TEMP(#1053): dry-run for push-triggered smoke test; reverted after.
         github-token: ${{ secrets.GITHUB_TOKEN }}
         # PR is considered stale when its head branch is behind base by >= 20 commits
         # (~a few days' worth of base-branch commits; PRs older than 24h rebase regardless).

--- a/.github/workflows/renovate-pr-maintainer.yml
+++ b/.github/workflows/renovate-pr-maintainer.yml
@@ -12,10 +12,6 @@
 name: Renovate PR maintainer
 
 on:
-  # TEMP(#1053): push trigger to smoke-test this workflow before merge; reverted after.
-  push:
-    branches:
-    - 1053-renovate-rebase-when-conflicted
   schedule:
   # Runs hourly; actions are taken selectively per PR state, not on every run.
   - cron: "23 * * * *"
@@ -50,7 +46,7 @@ jobs:
     - name: Maintain Renovate PRs
       uses: camunda/infra-global-github-actions/renovate-pr-maintainer@be5b0496892a83e6b3c5cedb818b771e8ed68121 # main
       with:
-        dry-run: true  # TEMP(#1053): dry-run for push-triggered smoke test; reverted after.
+        dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || false }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
         # PR is considered stale when its head branch is behind base by >= 20 commits
         # (~a few days' worth of base-branch commits; PRs older than 24h rebase regardless).

--- a/.github/workflows/renovate-pr-maintainer.yml
+++ b/.github/workflows/renovate-pr-maintainer.yml
@@ -1,0 +1,96 @@
+# type: Automation
+# owner: @camunda/distribution-team
+
+---
+# Renovate PR maintainer
+#
+# Companion to the `rebaseWhen: conflicted` policy (issue #1053). Renovate no
+# longer rebases every open PR on each base-branch push; instead this workflow
+# selectively rebases only PRs that have genuinely fallen behind, and reruns
+# their flaky required checks. Runs hourly but acts per-PR based on the strategy
+# thresholds below.
+name: Renovate PR maintainer
+
+on:
+  schedule:
+  # Runs hourly; actions are taken selectively per PR state, not on every run.
+  - cron: "23 * * * *"
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Run without modifying any PR (check to enable dry run)
+        required: false
+        type: boolean
+        default: false
+
+permissions: {}
+
+jobs:
+  maintain:
+    concurrency:
+      group: renovate-pr-maintainer
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: write
+      checks: read
+      contents: read
+      pull-requests: write
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+    # Inspects in-scope Renovate PRs and acts per PR: rebase stale PRs (via the
+    # Renovate `rebase` label) or re-run their failed required jobs.
+    - name: Maintain Renovate PRs
+      uses: camunda/infra-global-github-actions/renovate-pr-maintainer@be5b0496892a83e6b3c5cedb818b771e8ed68121 # main
+      with:
+        dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || false }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        # PR is considered stale when its head branch is behind base by >= 100 commits.
+        behind-threshold: 100
+        # PR is considered stale when its head commit is older than 24 hours.
+        stale-hours: 24
+        # Re-run failing required checks up to twice to absorb flaky CI jobs.
+        rerun-budget: 2
+
+  # Failure alerting — intentionally commented out until reviewed and the Slack
+  # webhook secret is confirmed for this repo. Uncomment to enable (issue #1053).
+  #
+  # notify:
+  #   name: Send Slack notification
+  #   runs-on: ubuntu-latest
+  #   needs: [maintain]
+  #   if: ${{ always() && needs.maintain.result != 'success' && github.event_name == 'schedule' }}
+  #   timeout-minutes: 5
+  #   permissions: {}
+  #   steps:
+  #   - name: Import Vault secrets
+  #     id: secrets
+  #     uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+  #     with:
+  #       url: ${{ secrets.VAULT_ADDR }}
+  #       method: approle
+  #       roleId: ${{ secrets.VAULT_ROLE_ID }}
+  #       secretId: ${{ secrets.VAULT_SECRET_ID }}
+  #       exportEnv: false
+  #       secrets: |
+  #         secret/data/products/distribution/ci SLACK_DISTRO_BOT_WEBHOOK_GH;
+  #   - name: Send failure Slack notification
+  #     uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+  #     with:
+  #       webhook: ${{ steps.secrets.outputs.SLACK_DISTRO_BOT_WEBHOOK_GH }}
+  #       webhook-type: incoming-webhook
+  #       payload: |
+  #         {
+  #           "blocks": [
+  #             {
+  #               "type": "section",
+  #               "text": {
+  #                 "type": "mrkdwn",
+  #                 "text": ":alarm: *Renovate PR maintainer* automation failed on `main`!\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>"
+  #               }
+  #             }
+  #           ]
+  #         }

--- a/.github/workflows/renovate-pr-maintainer.yml
+++ b/.github/workflows/renovate-pr-maintainer.yml
@@ -48,8 +48,9 @@ jobs:
       with:
         dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || false }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        # PR is considered stale when its head branch is behind base by >= 100 commits.
-        behind-threshold: 100
+        # PR is considered stale when its head branch is behind base by >= 5 commits
+        # (~one day's worth of commits on the base branch; PRs older than 24h rebase regardless).
+        behind-threshold: 5
         # PR is considered stale when its head commit is older than 24 hours.
         stale-hours: 24
         # Re-run failing required checks up to twice to absorb flaky CI jobs.

--- a/.github/workflows/renovate-pr-maintainer.yml
+++ b/.github/workflows/renovate-pr-maintainer.yml
@@ -48,9 +48,9 @@ jobs:
       with:
         dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || false }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        # PR is considered stale when its head branch is behind base by >= 5 commits
-        # (~one day's worth of commits on the base branch; PRs older than 24h rebase regardless).
-        behind-threshold: 5
+        # PR is considered stale when its head branch is behind base by >= 20 commits
+        # (~a few days' worth of base-branch commits; PRs older than 24h rebase regardless).
+        behind-threshold: 20
         # PR is considered stale when its head commit is older than 24 hours.
         stale-hours: 24
         # Re-run failing required checks up to twice to absorb flaky CI jobs.

--- a/.github/workflows/renovate-pr-maintainer.yml
+++ b/.github/workflows/renovate-pr-maintainer.yml
@@ -12,10 +12,6 @@
 name: Renovate PR maintainer
 
 on:
-  # TEMP(#1053): push trigger to smoke-test this workflow before merge; reverted after.
-  push:
-    branches:
-    - 1053-renovate-rebase-when-conflicted
   schedule:
   # Runs hourly; actions are taken selectively per PR state, not on every run.
   - cron: "23 * * * *"
@@ -50,7 +46,7 @@ jobs:
     - name: Maintain Renovate PRs
       uses: camunda/infra-global-github-actions/renovate-pr-maintainer@e5e6668cef06b3ab76e94a8eb0045b9b16b33bd1 # main
       with:
-        dry-run: true  # TEMP(#1053): dry-run for push-triggered smoke test; reverted after.
+        dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || false }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
         # PR is considered stale when its head branch is behind base by >= 20 commits
         # (~a few days' worth of base-branch commits; PRs older than 24h rebase regardless).

--- a/.github/workflows/renovate-pr-maintainer.yml
+++ b/.github/workflows/renovate-pr-maintainer.yml
@@ -12,6 +12,10 @@
 name: Renovate PR maintainer
 
 on:
+  # TEMP(#1053): push trigger to smoke-test this workflow before merge; reverted after.
+  push:
+    branches:
+    - 1053-renovate-rebase-when-conflicted
   schedule:
   # Runs hourly; actions are taken selectively per PR state, not on every run.
   - cron: "23 * * * *"
@@ -44,9 +48,9 @@ jobs:
     # Inspects in-scope Renovate PRs and acts per PR: rebase stale PRs (via the
     # Renovate `rebase` label) or re-run their failed required jobs.
     - name: Maintain Renovate PRs
-      uses: camunda/infra-global-github-actions/renovate-pr-maintainer@be5b0496892a83e6b3c5cedb818b771e8ed68121 # main
+      uses: camunda/infra-global-github-actions/renovate-pr-maintainer@e5e6668cef06b3ab76e94a8eb0045b9b16b33bd1 # main
       with:
-        dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || false }}
+        dry-run: true  # TEMP(#1053): dry-run for push-triggered smoke test; reverted after.
         github-token: ${{ secrets.GITHUB_TOKEN }}
         # PR is considered stale when its head branch is behind base by >= 20 commits
         # (~a few days' worth of base-branch commits; PRs older than 24h rebase regardless).


### PR DESCRIPTION
### Which problem does the PR fix?

Renovate currently rebases **every** open dependency PR whenever `main` moves, which re-triggers the full CI suite hundreds of times a day. This is a top driver of Renovate CI volume in this repo.

Related: camunda/team-infrastructure#1053

### What's in this PR?

Switches this repo to an optimized rebase strategy so dependency PRs only rebase when they actually need to — saving CI runs and queue time without changing what gets updated.

- **Renovate preset:** adopt the shared `infra-renovate-config:rebase` preset → `rebaseWhen: conflicted` (rebase only on a real merge conflict, not on every base-branch push). Replaces the previous `behind-base-branch` setting. Opt back in per-PR with the `keep-updated` label; force a one-off rebase with the `rebase` label.
- **Caller workflow** (`renovate-pr-maintainer.yml`): hourly companion that keeps PRs unstuck under the new strategy — rebases a PR only once it's genuinely stale (**≥100 commits behind** base or head **>24h** old) and reruns flaky required checks (budget: 2).
- Failure alerting is included but **commented out** until reviewed; nothing notifies yet.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?