### PR TITLE
fix: repair failing scheduled workflows for docs links, lychee, and values-latest

### DIFF
--- a/.github/workflows/global-links.yaml
+++ b/.github/workflows/global-links.yaml
@@ -66,6 +66,7 @@ jobs:
         continue-on-error: ${{ github.event_name == 'pull_request' }}
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
+          lycheeVersion: v0.24.2
           fail: true
           args: >-
             -c ./lychee-links.toml

--- a/charts/camunda-platform-8.7/RELEASE-NOTES.md
+++ b/charts/camunda-platform-8.7/RELEASE-NOTES.md
@@ -37,7 +37,7 @@ Non-Camunda images:
 - docker.io/bitnamilegacy/postgresql:14.18.0-debian-12-r0
 - docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
 
-Enterprise images ([Camunda Enterprise](https://docs.camunda.io/docs/self-managed/setup/guides/install-bitnami-enterprise-images/)):
+Enterprise images ([Camunda Enterprise](https://docs.camunda.io/docs/8.7/self-managed/setup/guides/install-bitnami-enterprise-images/)):
 
 - registry.camunda.cloud/keycloak-ee/keycloak:26.6.1
 - registry.camunda.cloud/vendor-ee/elasticsearch:8.19.17

--- a/charts/camunda-platform-8.8/RELEASE-NOTES.md
+++ b/charts/camunda-platform-8.8/RELEASE-NOTES.md
@@ -45,7 +45,7 @@ Non-Camunda images:
 - docker.io/bitnamilegacy/postgresql:14.18.0-debian-12-r0
 - docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
 
-Enterprise images ([Camunda Enterprise](https://docs.camunda.io/docs/self-managed/setup/guides/install-bitnami-enterprise-images/)):
+Enterprise images ([Camunda Enterprise](https://docs.camunda.io/docs/8.8/self-managed/deployment/helm/configure/registry-and-images/install-bitnami-enterprise-images/)):
 
 - registry.camunda.cloud/keycloak-ee/keycloak:26.6.1
 - registry.camunda.cloud/vendor-ee/elasticsearch:8.19.17

--- a/charts/camunda-platform-8.9/RELEASE-NOTES.md
+++ b/charts/camunda-platform-8.9/RELEASE-NOTES.md
@@ -41,7 +41,7 @@ Non-Camunda images:
 - docker.io/bitnamilegacy/postgresql:14.18.0-debian-12-r0
 - docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
 
-Enterprise images ([Camunda Enterprise](https://docs.camunda.io/docs/self-managed/setup/guides/install-bitnami-enterprise-images/)):
+Enterprise images ([Camunda Enterprise](https://docs.camunda.io/docs/8.9/self-managed/deployment/helm/configure/registry-and-images/install-bitnami-enterprise-images/)):
 
 - registry.camunda.cloud/keycloak-ee/keycloak:26.6.1
 - registry.camunda.cloud/vendor-ee/elasticsearch:8.19.17

--- a/charts/camunda-platform-8.9/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/common/_helpers.tpl
@@ -1472,5 +1472,5 @@ Release highlights.
 - Some values have been renamed or moved in the new chart structure.
 - When upgraded from 8.8 to 8.9, manual adjustments may be required for some cases like custom configurations.
 - Please refer to the official docs for more details.
-https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/upgrade-hc-880-890/
+https://docs.camunda.io/docs/8.9/self-managed/upgrade/helm/880-to-890/
 {{- end -}}

--- a/charts/camunda-platform-8.9/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.9/templates/common/constraints.tpl
@@ -62,7 +62,7 @@ Fail with a message if the auth type is set to non-Keycloak and its requirements
 */}}
 {{- if has (include "camundaPlatform.authIssuerType" .) (list "MICROSOFT" "GENERIC") }}
   {{/*
-  TODO: Once refactor the auth issuers, we need to add more constraints here to validate the new auth types. 
+  TODO: Once refactor the auth issuers, we need to add more constraints here to validate the new auth types.
         More details: https://github.com/camunda/camunda-platform-helm/issues/4419
   */}}
 {{- end }}
@@ -195,7 +195,7 @@ Fail with a message if Web Modeler is enabled but management Identity is not ena
       `
 [camunda][warning]
 DEPRECATION NOTICE: Starting from appVersion 8.7, the Camunda Helm chart will no longer automatically generate passwords for the Identity component.
-Users must provide passwords as Kubernetes secrets. 
+Users must provide passwords as Kubernetes secrets.
 In appVersion 8.6, this warning will appear if all necessary existingSecrets are not set.
 
 The following values inside your values.yaml need to be set but were not:
@@ -212,7 +212,7 @@ The following values inside your values.yaml need to be set but were not:
       `
 [camunda][error]
 DEPRECATION NOTICE: Starting from appVersion 8.7, the Camunda Helm chart will no longer automatically generate passwords for the Identity component.
-Users must provide passwords as Kubernetes secrets. 
+Users must provide passwords as Kubernetes secrets.
 
 The following values inside your values.yaml need to be set but were not:
       `
@@ -250,7 +250,7 @@ The following values inside your values.yaml need to be set but were not:
         "DEPRECATION: The following Bitnami-based subcharts are deprecated and will be removed in Camunda 8.10:"
         (join ", " $bitnamiSubchartsEnabled | printf "[%s].")
         "Please migrate to externally managed services before upgrading to 8.10."
-        "For more details: https://docs.camunda.io/self-managed/deployment/helm/operational-tasks/migration-from-bitnami/"
+        "For more details: https://docs.camunda.io/docs/8.9/self-managed/deployment/helm/operational-tasks/migration-from-bitnami/"
     -}}
     {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
   {{- end }}

--- a/lychee-links.toml
+++ b/lychee-links.toml
@@ -25,7 +25,7 @@ exclude = [
   "^https?://signup\\.camunda\\.com",
 ]
 
-exclude_mail = true
+include_mail = false
 exclude_loopback = true
 
 # Folders not worth scanning (build outputs, vendored content, generated sites).

--- a/scripts/camunda-core/pkg/versionmatrix/readme.go
+++ b/scripts/camunda-core/pkg/versionmatrix/readme.go
@@ -148,7 +148,15 @@ func SortAppVersionsDescending(versions []string) []string {
 	return sorted
 }
 
-const enterpriseDocsURL = "https://docs.camunda.io/docs/self-managed/setup/guides/install-bitnami-enterprise-images/"
+// enterpriseDocsURL returns the version-pinned Bitnami enterprise-images guide
+// URL. The docs path for this guide differs between 8.7 and later minors.
+func enterpriseDocsURL(appVersion string) string {
+	path := "self-managed/deployment/helm/configure/registry-and-images/install-bitnami-enterprise-images"
+	if appVersion == "8.7" {
+		path = "self-managed/setup/guides/install-bitnami-enterprise-images"
+	}
+	return fmt.Sprintf("https://docs.camunda.io/docs/%s/%s/", appVersion, path)
+}
 
 // ReleaseSection renders one chart version's block of a version-matrix README.
 // appVersion is the Camunda minor (e.g.
@@ -183,7 +191,7 @@ func ReleaseSection(appVersion string, entry ChartEntry, helmCLIVersions []strin
 		fmt.Fprintf(&b, "\nNon-Camunda images:\n\n%s\n", imageList(nonCamunda))
 	}
 	if len(entry.ChartEnterpriseImages) > 0 {
-		fmt.Fprintf(&b, "\nEnterprise images ([Camunda Enterprise](%s)):\n\n%s\n", enterpriseDocsURL, imageList(entry.ChartEnterpriseImages))
+		fmt.Fprintf(&b, "\nEnterprise images ([Camunda Enterprise](%s)):\n\n%s\n", enterpriseDocsURL(appVersion), imageList(entry.ChartEnterpriseImages))
 	}
 	return b.String()
 }

--- a/scripts/camunda-core/pkg/versionmatrix/readme_test.go
+++ b/scripts/camunda-core/pkg/versionmatrix/readme_test.go
@@ -50,7 +50,7 @@ Non-Camunda images:
 
 - docker.io/bitnamilegacy/elasticsearch:8.17.4
 
-Enterprise images ([Camunda Enterprise](https://docs.camunda.io/docs/self-managed/setup/guides/install-bitnami-enterprise-images/)):
+Enterprise images ([Camunda Enterprise](https://docs.camunda.io/docs/8.7/self-managed/setup/guides/install-bitnami-enterprise-images/)):
 
 - registry.camunda.cloud/keycloak-ee/keycloak:26.4.0
 `
@@ -278,6 +278,19 @@ func TestRenderIndex(t *testing.T) {
 	// No blank line between consecutive chart entries.
 	if !containsStr(got, "alpha2)\n### [Helm chart 15.0.0-alpha1]") {
 		t.Errorf("RenderIndex: expected no blank line between chart entries")
+	}
+}
+
+func TestEnterpriseDocsURL(t *testing.T) {
+	cases := map[string]string{
+		"8.7": "https://docs.camunda.io/docs/8.7/self-managed/setup/guides/install-bitnami-enterprise-images/",
+		"8.8": "https://docs.camunda.io/docs/8.8/self-managed/deployment/helm/configure/registry-and-images/install-bitnami-enterprise-images/",
+		"8.9": "https://docs.camunda.io/docs/8.9/self-managed/deployment/helm/configure/registry-and-images/install-bitnami-enterprise-images/",
+	}
+	for appVersion, want := range cases {
+		if got := enterpriseDocsURL(appVersion); got != want {
+			t.Errorf("enterpriseDocsURL(%q) = %q, want %q", appVersion, got, want)
+		}
 	}
 }
 

--- a/scripts/check-values-latest.sh
+++ b/scripts/check-values-latest.sh
@@ -189,12 +189,9 @@ main() {
             charts+=("camunda-platform-${version}")
         done
     else
-        # Validate only Renovate-managed versions (alpha + supportStandard).
-        # supportExtended/endOfLife charts have Renovate updates disabled
-        # (see renovate.json5), so their values-latest.yaml is not kept current.
         while IFS= read -r version; do
             charts+=("camunda-platform-${version}")
-        done < <(yq '.camundaVersions.alpha[], .camundaVersions.supportStandard[]' "${REPO_ROOT}/charts/chart-versions.yaml")
+        done < <(yq eval -r '.camundaVersions.alpha[], .camundaVersions.supportStandard[]' "${REPO_ROOT}/charts/chart-versions.yaml")
     fi
     
     # Validate each chart

--- a/scripts/check-values-latest.sh
+++ b/scripts/check-values-latest.sh
@@ -189,10 +189,12 @@ main() {
             charts+=("camunda-platform-${version}")
         done
     else
-        # Find all chart directories
-        while IFS= read -r chart_dir; do
-            charts+=("$(basename "$chart_dir")")
-        done < <(find "${REPO_ROOT}/charts" -maxdepth 1 -type d -name "camunda-platform-8.*" | sort)
+        # Validate only Renovate-managed versions (alpha + supportStandard).
+        # supportExtended/endOfLife charts have Renovate updates disabled
+        # (see renovate.json5), so their values-latest.yaml is not kept current.
+        while IFS= read -r version; do
+            charts+=("camunda-platform-${version}")
+        done < <(yq '.camundaVersions.alpha[], .camundaVersions.supportStandard[]' "${REPO_ROOT}/charts/chart-versions.yaml")
     fi
     
     # Validate each chart


### PR DESCRIPTION
### Which problem does the PR fix?

Three scheduled (nightly) workflows on `main` were failing independently:

- **Chart - Validate All Documentation Links** (lychee) — failed to load its config; newer lychee dropped the `exclude_mail` field.
- **Chart - Validate Docs Links** — 404s after the Camunda docs site restructured Self-Managed paths (migration-from-bitnami, upgrade-hc-880-890, and the Bitnami enterprise-images guide in RELEASE-NOTES).
- **Check values-latest.yaml** — flagged `console 8.6.105` as outdated for an out-of-support chart that Renovate is configured not to bump.

### What's in this PR?

One commit per fix:

1. **`ci:` lychee** — `exclude_mail = true` → `include_mail = false` (renamed/inverted in lychee ≥0.15; default already skips mail), and pin `lycheeVersion: v0.24.2` so the action's bundled binary can't drift silently again. Verified: real lychee v0.24.2 loads the config clean (exit 0).

2. **`fix:` docs links** — correct the 404'd docs URLs. The enterprise-images guide URL was a flat, unversioned `const` in the version-matrix generator (regression from the Go consolidation in #6359) — it lost the per-version pinning every other `ReleaseSection` link has. Replaced with a version-aware `enterpriseDocsURL(appVersion)` helper (8.7 uses the legacy guide path; 8.8+ the current one) and updated the committed RELEASE-NOTES footers to match. New `TestEnterpriseDocsURL` locks the per-version contract. All final URLs verified live (200); replicating the CI scanner over 8.7–8.9 chart dirs yields 0/39 invalid.

3. **`ci:` values-latest scope** — default the check to `alpha + supportStandard` from `chart-versions.yaml` (the Renovate-managed set) instead of globbing every `8.*` dir. supportExtended/EOL charts have Renovate disabled (`renovate.json5`), so demanding they be latest failed on every upstream patch. Explicit `chart-version` argument still overrides. Verified: local run passes, validates only 8.7–8.10, skips 8.6.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
