### PR TITLE
ci: split camunda-platform-digests group and allow GH Actions major automerge

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -122,10 +122,20 @@
     {
       description: 'Major updates require manual review to prevent breaking changes.',
       matchUpdateTypes: ['major'],
+      matchManagers: ['!github-actions'],
       automerge: false,
       platformAutomerge: false,
       dependencyDashboardApproval: false,
       addLabels: ['requires-manual-review'],
+    },
+    {
+      description: 'GitHub Actions use v1/v2/v3 versioning — major = node bump, not semver API break.',
+      matchManagers: ['github-actions'],
+      matchUpdateTypes: ['major'],
+      automerge: true,
+      platformAutomerge: true,
+      automergeType: 'pr',
+      addLabels: ['automerge', 'automation/renovatebot', 'kind/chore'],
     },
     {
       description: 'Schedule major updates for Friday nights.',
@@ -341,6 +351,24 @@
       matchFileNames: [
         'charts/camunda-platform-8.8/values-digest.yaml',
         'charts/camunda-platform-8.9/values-digest.yaml',
+      ],
+      matchUpdateTypes: ['digest'],
+      schedule: ['at any time'],
+      addLabels: ['camunda-platform', 'priority-high'],
+      prCreation: 'immediate',
+    },
+    {
+      enabled: true,
+      groupName: 'camunda-platform-digests-alpha',
+      matchPackageNames: [
+        '/.*camunda.*/',
+      ],
+      matchDatasources: [
+        'helm',
+        'docker',
+        'regex',
+      ],
+      matchFileNames: [
         'charts/camunda-platform-8.10/values-digest.yaml',
       ],
       matchUpdateTypes: ['digest'],

--- a/.github/workflows/test-local-template.yaml
+++ b/.github/workflows/test-local-template.yaml
@@ -45,6 +45,8 @@ jobs:
           secrets: |
             secret/data/products/distribution/ci DOCKERHUB_USERNAME | TEST_DOCKER_USERNAME;
             secret/data/products/distribution/ci DOCKERHUB_PASSWORD | TEST_DOCKER_PASSWORD;
+            secret/data/products/distribution/ci HARBOR_REGISTRY_USER | TEST_DOCKER_USERNAME_CAMUNDA_CLOUD;
+            secret/data/products/distribution/ci HARBOR_REGISTRY_PASSWORD | TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD;
           exportEnv: false
       - name: Install common software tooling
         uses: camunda/infra-global-github-actions/common-tooling@8f6fae58d4594d3a700982c6642d9de28a950fcc # main
@@ -88,6 +90,8 @@ jobs:
           TEST_CREATE_DOCKER_LOGIN_SECRET: "TRUE"
           TEST_DOCKER_USERNAME: ${{ steps.test-credentials-secret.outputs.TEST_DOCKER_USERNAME }}
           TEST_DOCKER_PASSWORD: ${{ steps.test-credentials-secret.outputs.TEST_DOCKER_PASSWORD }}
+          TEST_DOCKER_USERNAME_CAMUNDA_CLOUD: ${{ steps.test-credentials-secret.outputs.TEST_DOCKER_USERNAME_CAMUNDA_CLOUD }}
+          TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD: ${{ steps.test-credentials-secret.outputs.TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD }}
         run: |
           kubectl create namespace ${{ env.TEST_NAMESPACE }}
           # Docker Hub pull secret (replaces legacy `task docker-login --taskfile lib/init-seed-taskfile.yaml`).
@@ -97,6 +101,14 @@ jobs:
               --docker-server "https://index.docker.io/v1/" \
               --docker-username "${TEST_DOCKER_USERNAME}" \
               --docker-password "${TEST_DOCKER_PASSWORD}" \
+              --dry-run=client -o yaml | kubectl apply -f -
+          fi
+          if [[ -n "${TEST_DOCKER_USERNAME_CAMUNDA_CLOUD:-}" && -n "${TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD:-}" ]]; then
+            kubectl create secret docker-registry registry-camunda-cloud \
+              --namespace ${{ env.TEST_NAMESPACE }} \
+              --docker-server "registry.camunda.cloud" \
+              --docker-username "${TEST_DOCKER_USERNAME_CAMUNDA_CLOUD}" \
+              --docker-password "${TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD}" \
               --dry-run=client -o yaml | kubectl apply -f -
           fi
       - name: Install ECK operator + Elasticsearch (8.10+)


### PR DESCRIPTION
### Which problem does the PR fix?

Three stuck Renovate deps PRs caused by automerge policy gaps:

1. **PR #6101 (55 days)** — `camunda-platform-digests` group bundles 8.8/8.9/8.10 together; 8.10 alpha CI instability (stale SNAPSHOT digest GC'd from Docker Hub) blocked 8.8/8.9 stable digest updates indefinitely
2. **PRs #6472/#6473** — `actions/checkout v7` and `actions/cache v6` wrongly gated behind `requires-manual-review`; GH Actions use `v1/v2/v3` versioning which is always "major" by semver but rarely breaking
3. **KIND 8.10** — `registry-camunda-cloud` pull secret never created in KIND test namespace; defensive fix for alpha images that may be private-only

### What's in this PR?

- **renovate.json5**: Split `camunda-platform-digests` into `camunda-platform-digests` (8.8/8.9) and `camunda-platform-digests-alpha` (8.10); 8.10 alpha CI failures no longer block stable digest updates
- **renovate.json5**: Exclude `github-actions` manager from the `requires-manual-review` major rule; add explicit rule allowing GH Actions major automerge on the existing `every weekend` schedule
- **test-local-template.yaml**: Fetch `HARBOR_REGISTRY_USER`/`HARBOR_REGISTRY_PASSWORD` from Vault and create `registry-camunda-cloud` pull secret in KIND namespace (mirrors what GKE integration tests already do)

PR #6101 was separately closed to trigger Renovate recreation with the current `camunda/camunda:8.10-SNAPSHOT` digest.

### Checklist

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?