### PR TITLE
chore: filter target-only features from upgrade-minor step 1

### DIFF
--- a/scripts/deploy-camunda/matrix/runner_upgrade.go
+++ b/scripts/deploy-camunda/matrix/runner_upgrade.go
@@ -8,6 +8,7 @@ import (
 	"scripts/camunda-core/pkg/helm"
 	"scripts/camunda-core/pkg/kube"
 	"scripts/camunda-core/pkg/logging"
+	"scripts/camunda-core/pkg/scenarios"
 	"scripts/camunda-core/pkg/versionmatrix"
 	"scripts/deploy-camunda/config"
 	"scripts/deploy-camunda/deploy"
@@ -30,6 +31,23 @@ var bitnamiPGPasswordMapping = map[string][]string{
 
 func shouldExtractBitnamiPGPasswords(targetVersion string) bool {
 	return compareVersions(targetVersion, "8.10") < 0
+}
+
+// filterKnownFeatures splits want into features present in available and those
+// that are not, preserving the original order of want in both results.
+func filterKnownFeatures(want, available []string) (kept, dropped []string) {
+	known := make(map[string]struct{}, len(available))
+	for _, a := range available {
+		known[a] = struct{}{}
+	}
+	for _, f := range want {
+		if _, ok := known[f]; ok {
+			kept = append(kept, f)
+		} else {
+			dropped = append(dropped, f)
+		}
+	}
+	return kept, dropped
 }
 
 // extractBitnamiPGPasswords reads the "integration-test-credentials" Kubernetes Secret from the
@@ -208,6 +226,26 @@ func executeTwoStepUpgrade(ctx context.Context, entry Entry, flags *config.Runti
 			Str("previousVersion", prevVersion).
 			Str("scenarioDir", prevScenarioDir).
 			Msg("Step 1: using previous app version's values files (matching CI behavior)")
+
+		// Features new to the target version have no values file in the previous
+		// version's scenario dir; drop them from Step 1 (Step 2 applies the full
+		// set against the current chart). Reassigns the slice header on the copy,
+		// so the parent flags' Features are unaffected.
+		if len(step1Flags.Selection.Features) > 0 {
+			prevFeatures, err := scenarios.ListFeatures(prevScenarioDir)
+			if err != nil {
+				return fmt.Errorf("step 1: list features for %s: %w", prevVersion, err)
+			}
+			kept, dropped := filterKnownFeatures(step1Flags.Selection.Features, prevFeatures)
+			step1Flags.Selection.Features = kept
+			if len(dropped) > 0 {
+				logging.Logger.Info().
+					Str("previousVersion", prevVersion).
+					Strs("dropped", dropped).
+					Strs("kept", kept).
+					Msg("Step 1: dropped features absent from previous version (applied in Step 2)")
+			}
+		}
 	}
 
 	// --- Pre-install lifecycle hook (Step 1 of two-step upgrade) ---

--- a/scripts/deploy-camunda/matrix/upgrade_prev_version_test.go
+++ b/scripts/deploy-camunda/matrix/upgrade_prev_version_test.go
@@ -1,0 +1,174 @@
+// Licensed to Camunda Services GmbH under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Camunda licenses this file to you under the Apache License,
+// Version 2.0; you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matrix
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"scripts/camunda-core/pkg/scenarios"
+	"scripts/camunda-core/pkg/versionmatrix"
+)
+
+// TestUpgradeMinorPrevVersionDimensions asserts that every upgrade-minor
+// scenario's identity, persistence, and platform are each backed by a values
+// file in the PREVIOUS app version's scenario dir. Step 1 of an upgrade-minor
+// deploy installs the previous version using its own values files, so a
+// dimension absent there fails validation at deploy time (nightly CI), not at
+// PR time. This test moves that failure to PR time with an actionable message.
+//
+// Features are intentionally NOT checked: the runner drops target-only features
+// from Step 1 (filterKnownFeatures in runner_upgrade.go), so a feature that
+// exists only in the target version is valid — it is applied in Step 2.
+func TestUpgradeMinorPrevVersionDimensions(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+	chartsDir := filepath.Join(repoRoot, "charts")
+	entries, err := os.ReadDir(chartsDir)
+	if err != nil {
+		t.Fatalf("read charts dir: %v", err)
+	}
+
+	const prefix = "camunda-platform-"
+	checked := false
+	for _, e := range entries {
+		if !e.IsDir() || !strings.HasPrefix(e.Name(), prefix) {
+			continue
+		}
+		version := e.Name()[len(prefix):]
+		chartDir := filepath.Join(chartsDir, e.Name())
+		if !HasRegistry(chartDir) {
+			continue
+		}
+		prevVersion, err := versionmatrix.PreviousAppVersion(version)
+		if err != nil {
+			continue
+		}
+		prevScenarioDir := filepath.Join(chartsDir, prefix+prevVersion, "test/integration/scenarios/chart-full-setup")
+		if _, statErr := os.Stat(prevScenarioDir); statErr != nil {
+			continue
+		}
+
+		cfg, err := LoadRegistry(chartDir)
+		if err != nil {
+			t.Fatalf("LoadRegistry(%s): %v", version, err)
+		}
+
+		ids := mustListPrev(t, prevScenarioDir, scenarios.ListIdentities)
+		pers := mustListPrev(t, prevScenarioDir, scenarios.ListPersistence)
+		plats := mustListPrev(t, prevScenarioDir, scenarios.ListPlatforms)
+
+		for _, s := range cfg.Integration.Case.PR.Scenarios {
+			// Flow is comma-joined at the registry level (e.g. "install,upgrade-minor");
+			// match the exact upgrade-minor token, excluding modular-upgrade-minor,
+			// which routes to the upgrade-only path with no prev-version install.
+			if !slices.Contains(strings.Split(s.Flow, ","), "upgrade-minor") {
+				continue
+			}
+			checked = true
+			t.Run(version+"/"+s.Name, func(t *testing.T) {
+				if s.Identity != "" && !slices.Contains(ids, s.Identity) {
+					t.Errorf("upgrade-minor scenario %q: identity %q has no values file in previous version %s (available: %v). "+
+						"Step 1 install of the previous version would fail validation. "+
+						"Backport the identity to %s or restrict the scenario to flows: [install].",
+						s.Name, s.Identity, prevVersion, ids, prevVersion)
+				}
+				if s.Persistence != "" && !slices.Contains(pers, s.Persistence) {
+					t.Errorf("upgrade-minor scenario %q: persistence %q has no values file in previous version %s (available: %v). "+
+						"Step 1 install of the previous version would fail validation. "+
+						"Backport the persistence layer to %s or restrict the scenario to flows: [install].",
+						s.Name, s.Persistence, prevVersion, pers, prevVersion)
+				}
+				for _, p := range s.Platforms {
+					if !slices.Contains(plats, p) {
+						t.Errorf("upgrade-minor scenario %q: platform %q has no values file in previous version %s (available: %v). "+
+							"Step 1 install of the previous version would fail validation.",
+							s.Name, p, prevVersion, plats)
+					}
+				}
+			})
+		}
+	}
+	if !checked {
+		t.Skip("no upgrade-minor scenarios found in any registry")
+	}
+}
+
+// TestUpgradeMinorFeatureFilter_ReproAndFix drives scenarios.BuildDeploymentConfig
+// — the exact function whose validation aborted the nightly upgrade-minor run —
+// against the 8.9 (previous) scenario dir. It asserts the original failure
+// reproduces with the unfiltered feature and disappears after filterKnownFeatures.
+func TestUpgradeMinorFeatureFilter_ReproAndFix(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+	prevDir := filepath.Join(repoRoot, "charts", "camunda-platform-8.9", "test/integration/scenarios/chart-full-setup")
+	if _, err := os.Stat(prevDir); err != nil {
+		t.Skipf("previous version scenario dir absent: %v", err)
+	}
+
+	// Reproduce: component-persistence's target-only feature fails against 8.9.
+	_, err := scenarios.BuildDeploymentConfig(prevDir, "component-persistence", scenarios.BuilderOverrides{
+		Features: []string{"persistence"},
+	})
+	if err == nil {
+		t.Fatal("expected validation error for unfiltered [persistence] against 8.9, got nil")
+	}
+	if !strings.Contains(err.Error(), `invalid --features value "persistence"`) {
+		t.Fatalf("expected invalid-features error, got: %v", err)
+	}
+
+	// Fix: after the runner's filter, the feature is gone and the build succeeds.
+	prevFeatures, ferr := scenarios.ListFeatures(prevDir)
+	if ferr != nil {
+		t.Fatalf("list features: %v", ferr)
+	}
+	kept, dropped := filterKnownFeatures([]string{"persistence"}, prevFeatures)
+	if !slices.Equal(dropped, []string{"persistence"}) {
+		t.Fatalf("expected persistence dropped, got kept=%v dropped=%v", kept, dropped)
+	}
+	if _, err := scenarios.BuildDeploymentConfig(prevDir, "component-persistence", scenarios.BuilderOverrides{
+		Features: kept,
+	}); err != nil {
+		t.Fatalf("build after filter should succeed, got: %v", err)
+	}
+}
+
+func TestFilterKnownFeatures(t *testing.T) {
+	want := []string{"postgresql-companion", "documentstore", "persistence"}
+	available := []string{"rba", "documentstore", "multitenancy"}
+
+	kept, dropped := filterKnownFeatures(want, available)
+
+	if !slices.Equal(kept, []string{"documentstore"}) {
+		t.Errorf("kept = %v, want [documentstore]", kept)
+	}
+	if !slices.Equal(dropped, []string{"postgresql-companion", "persistence"}) {
+		t.Errorf("dropped = %v, want [postgresql-companion persistence]", dropped)
+	}
+	if !slices.Equal(want, []string{"postgresql-companion", "documentstore", "persistence"}) {
+		t.Errorf("want slice mutated: %v", want)
+	}
+}
+
+func mustListPrev(t *testing.T, dir string, fn func(string) ([]string, error)) []string {
+	t.Helper()
+	got, err := fn(dir)
+	if err != nil {
+		t.Fatalf("list values in %s: %v", dir, err)
+	}
+	return got
+}

--- a/scripts/deploy-camunda/matrix/upgrade_prev_version_test.go
+++ b/scripts/deploy-camunda/matrix/upgrade_prev_version_test.go
@@ -1,9 +1,8 @@
-// Licensed to Camunda Services GmbH under one or more contributor
-// license agreements. See the NOTICE file distributed with
-// this work for additional information regarding copyright
-// ownership. Camunda licenses this file to you under the Apache License,
-// Version 2.0; you may not use this file except in compliance with
-// the License. You may obtain a copy of the License at
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //


### PR DESCRIPTION
### Which problem does the PR fix?

Nightly `upgrade-minor` matrix entries abort during scenario prep with
`invalid --features value "..."` (e.g. `persistence`, `postgresql-companion`,
`hub-*`). Step 1 of a two-step `upgrade-minor` installs the **previous** app
version using that version's own values files, but the scenario's features were
passed through unchanged. A feature that only exists in the **target** version
has no values file in the previous version's scenario dir, so validation
(`scenarios.BuildDeploymentConfig` → `ValidateAgainstValues`) rejects it before
any helm install.

### What's in this PR?

- **Runtime fix** (`runner_upgrade.go`): filter step-1 features down to those
  the previous version's scenario dir defines. Step 2 applies the full set
  against the current chart. Mirrors the real upgrade path (install old without
  the new feature, then enable it on upgrade). No-op for existing scenarios —
  their features already exist in both versions (verified: 8.9's
  documentstore/multitenancy/rba all exist in 8.8).
- **PR-time guard** (`TestUpgradeMinorPrevVersionDimensions`): identity,
  persistence, and platform cannot be filtered (a deploy needs a backend +
  identity), so they still hard-fail if new-in-target. This test walks every
  version's registry and fails at PR time with an actionable message
  (backport the dimension, or restrict the scenario to `flows: [install]`)
  instead of surfacing in nightly CI.
- **Repro-and-fix test** (`TestUpgradeMinorFeatureFilter_ReproAndFix`): drives
  the exact `BuildDeploymentConfig` path that aborted nightly — asserts the
  error reproduces unfiltered and disappears after the filter.
- **Unit test** (`TestFilterKnownFeatures`): order preservation + no mutation
  of the caller's slice.

Scope: `scripts/deploy-camunda/matrix/` only — no chart files, hence `chore:`.

Verification: hermetic tests pass; a live GKE `upgrade-minor` run confirmed the
deploy now clears validation and reaches real helm installs (step 1 installs
the previous version with features filtered). Remaining live-deploy failures on
that cluster were unrelated (a `deny-weak-password-defaults` admission policy on
the 8.10 install + a step-1 connectors OAuth timeout), not this change.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
