### PR TITLE
ci: pass HARBOR_REGISTRY_* env vars to upgrade step for OCI chart auth

### DIFF
--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -967,6 +967,9 @@ jobs:
           HELM_CHART_VERSION: ${{ inputs.helmChartVersion }}
           TEST_DOCKER_USERNAME_CAMUNDA_CLOUD: ${{ steps.setup.outputs.TEST_DOCKER_USERNAME_CAMUNDA_CLOUD }}
           TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD: ${{ steps.setup.outputs.TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD }}
+          HARBOR_REGISTRY_HOST: registry.camunda.cloud
+          HARBOR_REGISTRY_USER: ${{ steps.setup.outputs.TEST_DOCKER_USERNAME_CAMUNDA_CLOUD }}
+          HARBOR_REGISTRY_PASSWORD: ${{ steps.setup.outputs.TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD }}
           NEXUS_USERNAME: ${{ steps.setup.outputs.NEXUS_USERNAME }}
           NEXUS_PASSWORD: ${{ steps.setup.outputs.NEXUS_PASSWORD }}
           TEST_DOCKER_USERNAME: ${{ steps.setup.outputs.TEST_DOCKER_USERNAME }}


### PR DESCRIPTION
## Summary

- The `Helm - Upgrade` step was missing `HARBOR_REGISTRY_HOST`, `HARBOR_REGISTRY_USER`, and `HARBOR_REGISTRY_PASSWORD` env vars
- The preceding `Helm - OCI Registry Login (Upgrade)` step exports these only within its own shell — they do not persist to the next step
- Older `deploy-camunda` binaries (e.g. the 8.7 binary used in `modular-upgrade-minor` flows) lack the internal re-auth logic present in newer binaries and depend on these vars being available in the environment
- Without them, the binary fails with `401 unauthorized` when attempting to pull an OCI-packaged chart version (e.g. `13.12.1-rc`)

## Root cause

In `modular-upgrade-minor` flows, the upgrade step uses the **8.7 `deploy-camunda` binary** (produced during the prior install step). This binary does not have the Harbor re-auth feature introduced in newer versions, which reconstructs credentials from `TEST_DOCKER_USERNAME_CAMUNDA_CLOUD`. Passing `HARBOR_REGISTRY_*` vars directly mirrors what the login step does and makes auth available to any binary version.

## Test plan

- [ ] Trigger `SM On-Demand 8.8 Upgrade Minor` workflow with `helmChartVersion: 13.12.1-rc` against this branch and confirm the `Helm - Upgrade` step passes
- [ ] Confirm install-only flows (e.g. RBA 8.8+) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)