### PR TITLE
ci: add failure-triage tooling and durable CI diagnostics

### DIFF
--- a/.github/actions/failed-pods-info/action.yaml
+++ b/.github/actions/failed-pods-info/action.yaml
@@ -8,32 +8,14 @@ runs:
     shell: bash
     # Structured diagnostics are also uploaded as the `diagnostics-*` artifact by the
     # deploy-camunda matrix runner. This step prints an in-log fast path for the common
-    # failure shapes (crash, image pull, scheduling, and volume-mount/init hangs).
+    # failure shapes. The dump logic lives in Go (`deploy-camunda diagnostics print`,
+    # unit-tested) per AGENTS.md; this is a thin wrapper with a kubectl fallback for
+    # jobs where the CLI is not yet on PATH.
     run: |
-      echo "::group::Pods"
-      kubectl -n $TEST_NAMESPACE get po -o wide || true
-      echo "::endgroup::"
-
-      echo "::group::Events (sorted by lastTimestamp)"
-      kubectl -n $TEST_NAMESPACE get events --sort-by=.lastTimestamp | tail -n 40 || true
-      echo "::endgroup::"
-
-      echo "::group::PersistentVolumeClaims"
-      kubectl -n $TEST_NAMESPACE get pvc -o wide || true
-      kubectl -n $TEST_NAMESPACE describe pvc || true
-      echo "::endgroup::"
-
-      # Match any pod that is not fully ready or not in a terminal-success state. This
-      # catches 0/N (not ready) plus Init:/Pending/CrashLoopBackOff/ImagePullBackOff/
-      # ErrImagePull/PodInitializing/ContainerCreating states that the old `0/` filter missed.
-      kubectl -n $TEST_NAMESPACE get po --no-headers 2>/dev/null \
-        | grep -vE "Completed|Running" \
-        | grep -E "0/|Init:|Pending|CrashLoopBackOff|ImagePullBackOff|ErrImagePull|PodInitializing|ContainerCreating|Error" \
-        | awk '{print $1}' | sort -u | while read pod_name; do
-        [ -z "${pod_name}" ] && continue
-        echo -e "\n###Failed Pod: ${pod_name}###\n";
-        kubectl -n $TEST_NAMESPACE describe po ${pod_name} || true;
-        # Logs are empty for pods still initializing; --previous surfaces a prior crash.
-        kubectl -n $TEST_NAMESPACE logs ${pod_name} --all-containers || true;
-        kubectl -n $TEST_NAMESPACE logs ${pod_name} --all-containers --previous 2>/dev/null || true;
-      done
+      if command -v deploy-camunda >/dev/null 2>&1; then
+        deploy-camunda diagnostics print --namespace "$TEST_NAMESPACE" || true
+      else
+        kubectl -n "$TEST_NAMESPACE" get po -o wide || true
+        kubectl -n "$TEST_NAMESPACE" get events --sort-by=.lastTimestamp | tail -n 40 || true
+        kubectl -n "$TEST_NAMESPACE" get pvc -o wide || true
+      fi

--- a/.github/actions/failed-pods-info/action.yaml
+++ b/.github/actions/failed-pods-info/action.yaml
@@ -6,11 +6,34 @@ runs:
   steps:
   - name: Get failed Pods info
     shell: bash
-    # TODO: Better way to collect logs and store them as artifacts in GitHub Actions.
+    # Structured diagnostics are also uploaded as the `diagnostics-*` artifact by the
+    # deploy-camunda matrix runner. This step prints an in-log fast path for the common
+    # failure shapes (crash, image pull, scheduling, and volume-mount/init hangs).
     run: |
-      kubectl -n $TEST_NAMESPACE get po
-      kubectl -n $TEST_NAMESPACE get po | grep -v "Completed" | awk '/0\//{print $1}' | while read pod_name; do
+      echo "::group::Pods"
+      kubectl -n $TEST_NAMESPACE get po -o wide || true
+      echo "::endgroup::"
+
+      echo "::group::Events (sorted by lastTimestamp)"
+      kubectl -n $TEST_NAMESPACE get events --sort-by=.lastTimestamp | tail -n 40 || true
+      echo "::endgroup::"
+
+      echo "::group::PersistentVolumeClaims"
+      kubectl -n $TEST_NAMESPACE get pvc -o wide || true
+      kubectl -n $TEST_NAMESPACE describe pvc || true
+      echo "::endgroup::"
+
+      # Match any pod that is not fully ready or not in a terminal-success state. This
+      # catches 0/N (not ready) plus Init:/Pending/CrashLoopBackOff/ImagePullBackOff/
+      # ErrImagePull/PodInitializing/ContainerCreating states that the old `0/` filter missed.
+      kubectl -n $TEST_NAMESPACE get po --no-headers 2>/dev/null \
+        | grep -vE "Completed|Running" \
+        | grep -E "0/|Init:|Pending|CrashLoopBackOff|ImagePullBackOff|ErrImagePull|PodInitializing|ContainerCreating|Error" \
+        | awk '{print $1}' | sort -u | while read pod_name; do
+        [ -z "${pod_name}" ] && continue
         echo -e "\n###Failed Pod: ${pod_name}###\n";
         kubectl -n $TEST_NAMESPACE describe po ${pod_name} || true;
+        # Logs are empty for pods still initializing; --previous surfaces a prior crash.
         kubectl -n $TEST_NAMESPACE logs ${pod_name} --all-containers || true;
+        kubectl -n $TEST_NAMESPACE logs ${pod_name} --all-containers --previous 2>/dev/null || true;
       done

--- a/.github/actions/generate-chart-matrix/action.yaml
+++ b/.github/actions/generate-chart-matrix/action.yaml
@@ -68,8 +68,9 @@ runs:
       env:
         GITHUB_CONTEXT: ${{ toJson(inputs) }}
       run: |
-        echo "Action Inputs:"
+        echo "::group::Action Inputs"
         echo "${GITHUB_CONTEXT}"
+        echo "::endgroup::"
     - name: Get changed dirs
       id: changed-files
       uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -1509,6 +1509,19 @@ jobs:
       deployments: write
       packages: read
     steps:
+      # Put deploy-camunda on PATH before failed-pods-info so its Go
+      # `diagnostics print` path runs here too, rather than the reduced kubectl
+      # fallback. download-artifact needs no workspace checkout.
+      - name: Download deploy-camunda binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ${{ inputs.binary-artifact-name }}
+          path: ${{ runner.temp }}/bin
+      - name: Add deploy-camunda to PATH
+        run: |
+          chmod +x "${RUNNER_TEMP}/bin/deploy-camunda"
+          echo "${RUNNER_TEMP}/bin" >> "$GITHUB_PATH"
+
       - name: CI Cleanup - 🚨 Get failed Pods info 🚨
         if: failure()
         uses: ./.github/actions/failed-pods-info
@@ -1522,16 +1535,6 @@ jobs:
 
       - name: CI Setup - Configure Git safe directory
         run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
-
-      - name: Download deploy-camunda binary
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: ${{ inputs.binary-artifact-name }}
-          path: ${{ runner.temp }}/bin
-      - name: Add deploy-camunda to PATH
-        run: |
-          chmod +x "${RUNNER_TEMP}/bin/deploy-camunda"
-          echo "${RUNNER_TEMP}/bin" >> "$GITHUB_PATH"
 
       - name: CI Setup - ℹ️ Set workflow vars for both install and upgrade ℹ️
         id: vars

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -322,10 +322,13 @@ jobs:
           if [[ -n "${INITIAL_CLAIM_VALUE}" ]]; then
             echo "::add-mask::${INITIAL_CLAIM_VALUE}"
           fi
-          echo "Workflow Inputs:"
+          # Collapse the multi-KB input dump into a log group so it does not bury
+          # the meaningful lines; expand it in the UI when needed.
+          echo "::group::Workflow Inputs"
           echo "${GITHUB_CONTEXT}" | jq '."extra-values" = "<Check below>"'
           echo "Workflow Inputs - Extra Values:"
           echo "${GITHUB_CONTEXT}" | jq -r '."extra-values"'
+          echo "::endgroup::"
 
       - name: CI Setup - Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -748,6 +751,15 @@ jobs:
         if: failure()
         uses: ./.github/actions/failed-pods-info
 
+      - name: Upload deployment diagnostics bundle
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: diagnostics-${{ inputs.identifier }}-${{ inputs.flow }}-${{ inputs.shortname }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: diagnostics/
+          retention-days: 14
+          if-no-files-found: ignore
+
   upgrade:
     if: always() && github.event.action != 'closed' && (needs.install.result == 'success' || needs.install.result == 'skipped') && inputs.flow != 'install'
     name: upgrade for ${{ inputs.flow }} on ${{ inputs.distro-platform }} - ${{ inputs.shortname }}
@@ -784,10 +796,13 @@ jobs:
           if [[ -n "${INITIAL_CLAIM_VALUE}" ]]; then
             echo "::add-mask::${INITIAL_CLAIM_VALUE}"
           fi
-          echo "Workflow Inputs:"
+          # Collapse the multi-KB input dump into a log group so it does not bury
+          # the meaningful lines; expand it in the UI when needed.
+          echo "::group::Workflow Inputs"
           echo "${GITHUB_CONTEXT}" | jq '."extra-values" = "<Check below>"'
           echo "Workflow Inputs - Extra Values:"
           echo "${GITHUB_CONTEXT}" | jq -r '."extra-values"'
+          echo "::endgroup::"
 
       - name: CI Setup - Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -1084,6 +1099,15 @@ jobs:
       - name: 🚨 Get failed Pods info 🚨
         if: failure()
         uses: ./.github/actions/failed-pods-info
+
+      - name: Upload deployment diagnostics bundle
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: diagnostics-${{ inputs.identifier }}-${{ inputs.flow }}-${{ inputs.shortname }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: diagnostics/
+          retention-days: 14
+          if-no-files-found: ignore
 
   playwright-e2e-tests-after-install:
     name: Playwright e2e after install - ${{ inputs.flow }} on ${{ inputs.distro-platform }} - ${{ inputs.shortname }} (${{ matrix.shardIndex }} of ${{ matrix.shardTotal }})

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -751,11 +751,20 @@ jobs:
         if: failure()
         uses: ./.github/actions/failed-pods-info
 
+      - name: Compute diagnostics artifact name
+        if: failure()
+        id: diag-artifact
+        shell: bash
+        run: |
+          raw="diagnostics-${{ inputs.identifier }}-${{ inputs.flow }}-${{ inputs.shortname }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}"
+          # Artifact names reject spaces/colons/slashes etc.; normalize to a safe set.
+          echo "name=${raw//[^a-zA-Z0-9._-]/-}" >> "$GITHUB_OUTPUT"
+
       - name: Upload deployment diagnostics bundle
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: diagnostics-${{ inputs.identifier }}-${{ inputs.flow }}-${{ inputs.shortname }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          name: ${{ steps.diag-artifact.outputs.name }}
           path: diagnostics/
           retention-days: 14
           if-no-files-found: ignore
@@ -1100,11 +1109,20 @@ jobs:
         if: failure()
         uses: ./.github/actions/failed-pods-info
 
+      - name: Compute diagnostics artifact name
+        if: failure()
+        id: diag-artifact
+        shell: bash
+        run: |
+          raw="diagnostics-${{ inputs.identifier }}-${{ inputs.flow }}-${{ inputs.shortname }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}"
+          # Artifact names reject spaces/colons/slashes etc.; normalize to a safe set.
+          echo "name=${raw//[^a-zA-Z0-9._-]/-}" >> "$GITHUB_OUTPUT"
+
       - name: Upload deployment diagnostics bundle
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: diagnostics-${{ inputs.identifier }}-${{ inputs.flow }}-${{ inputs.shortname }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+          name: ${{ steps.diag-artifact.outputs.name }}
           path: diagnostics/
           retention-days: 14
           if-no-files-found: ignore

--- a/docs/skills/reproducing-ci-e2e-failures.md
+++ b/docs/skills/reproducing-ci-e2e-failures.md
@@ -16,6 +16,31 @@ Designed for application developers: you do not need deep Kubernetes knowledge �
 
 Repo slug used throughout: `camunda/camunda-platform-helm`.
 
+## Fast path — `deploy-camunda triage`
+
+For a failed run, `deploy-camunda triage` collapses "Step 1 → Step 4" below into one
+command: it resolves the failing job, pulls its log via the jobs API (not
+`gh run view --log-failed`, which is empty for merge-queue runs), strips the env-var
+noise, and prints the matrix cell, the failing helm command, the error/signals, the
+diagnostics-bundle path, and a ready-to-run local-repro command.
+
+```bash
+# Pass the failing job's URL (click into the job on GitHub) — always works,
+# including merge-queue and nested reusable-workflow runs:
+deploy-camunda triage "https://github.com/camunda/camunda-platform-helm/actions/runs/<run-id>/job/<job-id>"
+```
+
+For **deploy** failures, also pull the structured diagnostics bundle the matrix runner
+uploads (pod state, events, PVC state, per-pod logs) — more precise than the raw log:
+
+```bash
+gh run download <run-id> --repo camunda/camunda-platform-helm --name 'diagnostics-*'
+# read summary.json + logs/<pod>.log
+```
+
+The manual steps below remain the reference for E2E (Playwright) failures and for
+cases the fast path doesn't cover.
+
 ## Prerequisites
 
 Two cold-start requirements for anyone new to this workflow:

--- a/scripts/camunda-core/pkg/kube/diagnostics.go
+++ b/scripts/camunda-core/pkg/kube/diagnostics.go
@@ -99,6 +99,25 @@ func GetPodLogs(ctx context.Context, kubeContext, namespace, pod string, tailLin
 	return runKubectl(ctx, args)
 }
 
+// GetPodLogsPrevious returns the last tailLines of logs from the previous
+// (crashed) container instance. Empty when the pod never restarted.
+func GetPodLogsPrevious(ctx context.Context, kubeContext, namespace, pod string, tailLines int) (string, error) {
+	args := append(kubectlBaseArgs(kubeContext),
+		"logs", pod, "-n", namespace,
+		"--tail", fmt.Sprintf("%d", tailLines),
+		"--all-containers", "--previous",
+	)
+	return runKubectl(ctx, args)
+}
+
+// DescribePod returns the output of `kubectl describe pod <pod> -n <namespace>`.
+// The Events section is the key evidence for scheduling, mount, and image-pull
+// failures on a pod that never became ready.
+func DescribePod(ctx context.Context, kubeContext, namespace, pod string) (string, error) {
+	args := append(kubectlBaseArgs(kubeContext), "describe", "pod", pod, "-n", namespace)
+	return runKubectl(ctx, args)
+}
+
 // GetNonReadyPods returns the names of pods that are not fully ready.
 // It uses a field-selector to find non-Running pods and also parses output to
 // catch Running-but-not-Ready pods (e.g., readiness probe failing).

--- a/scripts/camunda-core/pkg/kube/diagnostics.go
+++ b/scripts/camunda-core/pkg/kube/diagnostics.go
@@ -73,6 +73,22 @@ func GetEvents(ctx context.Context, kubeContext, namespace string) (string, erro
 	return runKubectl(ctx, args)
 }
 
+// GetPVCs returns the output of `kubectl get pvc -n <namespace> -o wide`.
+// PVC state (bound/pending, capacity, storage class) is the key evidence for
+// volume-mount and provisioning failures.
+func GetPVCs(ctx context.Context, kubeContext, namespace string) (string, error) {
+	args := append(kubectlBaseArgs(kubeContext), "get", "pvc", "-n", namespace, "-o", "wide")
+	return runKubectl(ctx, args)
+}
+
+// DescribePVCs returns the output of `kubectl describe pvc -n <namespace>`, which
+// includes the events explaining why a claim is stuck (e.g., waiting for a consumer,
+// provisioning errors, multi-attach conflicts).
+func DescribePVCs(ctx context.Context, kubeContext, namespace string) (string, error) {
+	args := append(kubectlBaseArgs(kubeContext), "describe", "pvc", "-n", namespace)
+	return runKubectl(ctx, args)
+}
+
 // GetPodLogs returns the last tailLines of logs from all containers in a pod.
 func GetPodLogs(ctx context.Context, kubeContext, namespace, pod string, tailLines int) (string, error) {
 	args := append(kubectlBaseArgs(kubeContext),

--- a/scripts/deploy-camunda/cmd/diagnostics.go
+++ b/scripts/deploy-camunda/cmd/diagnostics.go
@@ -1,0 +1,174 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"sort"
+	"strings"
+	"syscall"
+
+	"scripts/camunda-core/pkg/kube"
+	"scripts/camunda-core/pkg/logging"
+
+	"github.com/spf13/cobra"
+)
+
+// diagnosticsEventsTail bounds the events dump so the in-log output stays readable.
+const diagnosticsEventsTail = 40
+
+// podDiagnosticsSource is the set of namespace-inspection calls the print command
+// needs. It is a struct of funcs (defaulting to the kube package) so tests can
+// inject fakes without a cluster or a fake kubectl on PATH.
+type podDiagnosticsSource struct {
+	GetPods            func(ctx context.Context, kubeContext, namespace string) (string, error)
+	GetEvents          func(ctx context.Context, kubeContext, namespace string) (string, error)
+	GetPVCs            func(ctx context.Context, kubeContext, namespace string) (string, error)
+	DescribePVCs       func(ctx context.Context, kubeContext, namespace string) (string, error)
+	GetNonReadyPods    func(ctx context.Context, kubeContext, namespace string) ([]string, error)
+	DescribePod        func(ctx context.Context, kubeContext, namespace, pod string) (string, error)
+	GetPodLogs         func(ctx context.Context, kubeContext, namespace, pod string, tail int) (string, error)
+	GetPodLogsPrevious func(ctx context.Context, kubeContext, namespace, pod string, tail int) (string, error)
+}
+
+func defaultPodDiagnosticsSource() podDiagnosticsSource {
+	return podDiagnosticsSource{
+		GetPods:            kube.GetPods,
+		GetEvents:          kube.GetEvents,
+		GetPVCs:            kube.GetPVCs,
+		DescribePVCs:       kube.DescribePVCs,
+		GetNonReadyPods:    kube.GetNonReadyPods,
+		DescribePod:        kube.DescribePod,
+		GetPodLogs:         kube.GetPodLogs,
+		GetPodLogsPrevious: kube.GetPodLogsPrevious,
+	}
+}
+
+// newDiagnosticsCommand creates the `diagnostics` parent command.
+func newDiagnosticsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "diagnostics",
+		Short: "Namespace diagnostics helpers",
+	}
+	cmd.AddCommand(newDiagnosticsPrintCommand())
+	return cmd
+}
+
+// newDiagnosticsPrintCommand creates `diagnostics print`: the in-log fast path
+// for the failed-pods-info CI action. It prints pods, events, PVC state, and —
+// for every non-ready pod — describe + current/previous logs. Non-ready is
+// determined by the Ready condition (via kube.GetNonReadyPods), so a `0/N Running`
+// pod (the common deploy-timeout shape) is captured, not just crashed ones.
+func newDiagnosticsPrintCommand() *cobra.Command {
+	var namespace, kubeContext string
+	var tail int
+
+	cmd := &cobra.Command{
+		Use:   "print",
+		Short: "Print namespace diagnostics (pods, events, PVCs, non-ready pod describe+logs) to stdout",
+		Long: `Print a best-effort namespace diagnostics dump for CI logs.
+
+Backs the failed-pods-info GitHub action. Structured diagnostics are also
+uploaded as the diagnostics-* artifact by the matrix runner; this command is the
+human-readable in-log fast path for the common failure shapes (crash, image
+pull, scheduling, and volume-mount/init hangs).
+
+All calls are best-effort: errors are printed inline and never abort the dump.`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+			defer stop()
+
+			if err := logging.Setup(logging.Options{
+				LevelString:  flags.LogLevel,
+				ColorEnabled: logging.IsTerminal(os.Stdout.Fd()),
+			}); err != nil {
+				return err
+			}
+			if namespace == "" {
+				return fmt.Errorf("--namespace is required")
+			}
+
+			printNamespaceDiagnostics(ctx, os.Stdout, defaultPodDiagnosticsSource(), kubeContext, namespace, tail)
+			return nil
+		},
+	}
+
+	f := cmd.Flags()
+	f.StringVarP(&namespace, "namespace", "n", "", "Namespace to inspect (required)")
+	f.StringVar(&kubeContext, "kube-context", "", "Kubernetes context")
+	f.IntVar(&tail, "tail", 500, "Log tail lines per non-ready pod")
+	f.StringVarP(&flags.LogLevel, "log-level", "l", "info", "Log level")
+
+	return cmd
+}
+
+// printNamespaceDiagnostics writes the diagnostics dump to w. It is pure
+// orchestration over src so it can be unit-tested with a fake source.
+func printNamespaceDiagnostics(ctx context.Context, w io.Writer, src podDiagnosticsSource, kubeContext, namespace string, tail int) {
+	section := func(title string) { fmt.Fprintf(w, "\n===== %s =====\n", title) }
+	emit := func(title string, out string, err error) {
+		section(title)
+		if err != nil {
+			fmt.Fprintf(w, "(error: %v)\n", err)
+			return
+		}
+		if out == "" {
+			fmt.Fprintln(w, "(none)")
+			return
+		}
+		fmt.Fprintln(w, out)
+	}
+
+	pods, podsErr := src.GetPods(ctx, kubeContext, namespace)
+	emit("Pods", pods, podsErr)
+
+	events, eventsErr := src.GetEvents(ctx, kubeContext, namespace)
+	emit(fmt.Sprintf("Events (last %d)", diagnosticsEventsTail), lastLines(events, diagnosticsEventsTail), eventsErr)
+
+	pvcs, pvcsErr := src.GetPVCs(ctx, kubeContext, namespace)
+	emit("PersistentVolumeClaims", pvcs, pvcsErr)
+
+	pvcDesc, pvcDescErr := src.DescribePVCs(ctx, kubeContext, namespace)
+	emit("PVC describe", pvcDesc, pvcDescErr)
+
+	nonReady, err := src.GetNonReadyPods(ctx, kubeContext, namespace)
+	if err != nil {
+		section("Non-ready pods")
+		fmt.Fprintf(w, "(error: %v)\n", err)
+		return
+	}
+	sort.Strings(nonReady)
+	if len(nonReady) == 0 {
+		section("Non-ready pods")
+		fmt.Fprintln(w, "(none)")
+		return
+	}
+	for _, pod := range nonReady {
+		desc, descErr := src.DescribePod(ctx, kubeContext, namespace, pod)
+		emit("Non-ready pod: "+pod+" — describe", desc, descErr)
+
+		podLogs, logsErr := src.GetPodLogs(ctx, kubeContext, namespace, pod, tail)
+		emit("Non-ready pod: "+pod+" — logs", podLogs, logsErr)
+
+		// --previous surfaces the prior crash; empty/erroring when the pod never restarted.
+		if prev, err := src.GetPodLogsPrevious(ctx, kubeContext, namespace, pod, tail); err == nil && prev != "" {
+			emit("Non-ready pod: "+pod+" — previous logs", prev, nil)
+		}
+	}
+}
+
+// lastLines returns the last n lines of s. Short inputs are returned unchanged.
+func lastLines(s string, n int) string {
+	if s == "" {
+		return ""
+	}
+	lines := strings.Split(s, "\n")
+	if len(lines) <= n {
+		return s
+	}
+	return strings.Join(lines[len(lines)-n:], "\n")
+}

--- a/scripts/deploy-camunda/cmd/diagnostics_test.go
+++ b/scripts/deploy-camunda/cmd/diagnostics_test.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestPrintNamespaceDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	var describedPods []string
+	src := podDiagnosticsSource{
+		GetPods: func(_ context.Context, _, _ string) (string, error) {
+			return "pod-a 0/1 Running\npod-b 1/1 Running", nil
+		},
+		GetEvents:    func(_ context.Context, _, _ string) (string, error) { return "e1\ne2\ne3", nil },
+		GetPVCs:      func(_ context.Context, _, _ string) (string, error) { return "pvc-a Pending", nil },
+		DescribePVCs: func(_ context.Context, _, _ string) (string, error) { return "Name: pvc-a\nStatus: Pending", nil },
+		// The key behaviour: a 0/1 Running pod (not crashed) must be treated as
+		// non-ready and described — the regression the old grep filter caused.
+		GetNonReadyPods: func(_ context.Context, _, _ string) ([]string, error) { return []string{"pod-a"}, nil },
+		DescribePod: func(_ context.Context, _, _, pod string) (string, error) {
+			describedPods = append(describedPods, pod)
+			return "Name: " + pod + "\nEvents: FailedMount", nil
+		},
+		GetPodLogs:         func(_ context.Context, _, _, pod string, _ int) (string, error) { return pod + " current log", nil },
+		GetPodLogsPrevious: func(_ context.Context, _, _, _ string, _ int) (string, error) { return "", nil },
+	}
+
+	var buf bytes.Buffer
+	printNamespaceDiagnostics(context.Background(), &buf, src, "", "ns", 500)
+	out := buf.String()
+
+	for _, want := range []string{"Pods", "Events", "PersistentVolumeClaims", "PVC describe", "Non-ready pod: pod-a", "FailedMount", "pod-a current log"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+	if len(describedPods) != 1 || describedPods[0] != "pod-a" {
+		t.Errorf("expected pod-a described exactly once, got %v", describedPods)
+	}
+	// pod-b is ready; it must not be described.
+	if strings.Contains(out, "Non-ready pod: pod-b") {
+		t.Errorf("ready pod-b should not be described:\n%s", out)
+	}
+}
+
+func TestPrintNamespaceDiagnosticsErrorsAreInline(t *testing.T) {
+	t.Parallel()
+	boom := func(_ context.Context, _, _ string) (string, error) { return "", fmt.Errorf("boom") }
+	src := podDiagnosticsSource{
+		GetPods:         boom,
+		GetEvents:       boom,
+		GetPVCs:         boom,
+		DescribePVCs:    boom,
+		GetNonReadyPods: func(_ context.Context, _, _ string) ([]string, error) { return nil, fmt.Errorf("list failed") },
+	}
+	var buf bytes.Buffer
+	// Must not panic and must surface the errors rather than aborting.
+	printNamespaceDiagnostics(context.Background(), &buf, src, "", "ns", 10)
+	out := buf.String()
+	if !strings.Contains(out, "(error: boom)") || !strings.Contains(out, "(error: list failed)") {
+		t.Errorf("expected inline errors, got:\n%s", out)
+	}
+}
+
+func TestLastLines(t *testing.T) {
+	t.Parallel()
+	if got := lastLines("a\nb\nc\nd", 2); got != "c\nd" {
+		t.Errorf("lastLines tail = %q", got)
+	}
+	if got := lastLines("a\nb", 5); got != "a\nb" {
+		t.Errorf("short input should be unchanged, got %q", got)
+	}
+	if got := lastLines("", 3); got != "" {
+		t.Errorf("empty input should stay empty, got %q", got)
+	}
+}

--- a/scripts/deploy-camunda/cmd/root.go
+++ b/scripts/deploy-camunda/cmd/root.go
@@ -90,6 +90,10 @@ func NewRootCommand() *cobra.Command {
 				if cmd.Name() == "triage" {
 					return nil
 				}
+				// diagnostics is a read-only namespace dump; no chart config needed.
+				if cmd.Name() == "diagnostics" || (cmd.Parent() != nil && cmd.Parent().Name() == "diagnostics") {
+					return nil
+				}
 				if cmd.Name() == "completion" ||
 					cmd.Name() == cobra.ShellCompRequestCmd ||
 					cmd.Name() == cobra.ShellCompNoDescRequestCmd {
@@ -543,6 +547,7 @@ func Execute() error {
 	rootCmd.AddCommand(newAuth0Command())
 	rootCmd.AddCommand(newDoctorCommand())
 	rootCmd.AddCommand(newTriageCommand())
+	rootCmd.AddCommand(newDiagnosticsCommand())
 
 	err := rootCmd.Execute()
 	if err != nil {

--- a/scripts/deploy-camunda/cmd/root.go
+++ b/scripts/deploy-camunda/cmd/root.go
@@ -85,6 +85,11 @@ func NewRootCommand() *cobra.Command {
 				if cmd.Name() == "doctor" {
 					return nil
 				}
+				// triage is a read-only post-mortem over a GitHub Actions run;
+				// it needs no chart/namespace config, so skip the deploy pre-run.
+				if cmd.Name() == "triage" {
+					return nil
+				}
 				if cmd.Name() == "completion" ||
 					cmd.Name() == cobra.ShellCompRequestCmd ||
 					cmd.Name() == cobra.ShellCompNoDescRequestCmd {
@@ -537,6 +542,7 @@ func Execute() error {
 	rootCmd.AddCommand(newWatchCommand())
 	rootCmd.AddCommand(newAuth0Command())
 	rootCmd.AddCommand(newDoctorCommand())
+	rootCmd.AddCommand(newTriageCommand())
 
 	err := rootCmd.Execute()
 	if err != nil {

--- a/scripts/deploy-camunda/cmd/triage.go
+++ b/scripts/deploy-camunda/cmd/triage.go
@@ -312,7 +312,7 @@ func selectFailedJob(jobs []ghJob) *ghJob {
 
 func firstFailedStep(job ghJob) string {
 	for _, s := range job.Steps {
-		if s.Conclusion == "failure" {
+		if failedConclusions[s.Conclusion] {
 			return s.Name
 		}
 	}

--- a/scripts/deploy-camunda/cmd/triage.go
+++ b/scripts/deploy-camunda/cmd/triage.go
@@ -72,7 +72,16 @@ type ghJob struct {
 }
 
 type ghJobsResponse struct {
-	Jobs []ghJob `json:"jobs"`
+	TotalCount int     `json:"total_count"`
+	Jobs       []ghJob `json:"jobs"`
+}
+
+// failedConclusions are the job conclusions triage treats as a failure to
+// diagnose. "cancelled" is excluded — cancelled matrix legs are usually victims
+// of another leg's failure, not the root cause.
+var failedConclusions = map[string]bool{
+	"failure":   true,
+	"timed_out": true,
 }
 
 var (
@@ -85,8 +94,10 @@ var (
 	// quotedHelmCmdRe matches a quoted command="helm ..." field, which the matrix
 	// runner emits with the exact failing invocation.
 	quotedHelmCmdRe = regexp.MustCompile(`command="(helm [^"]*)"`)
-	// ansiRe matches ANSI SGR color escapes present in raw gh job logs.
-	ansiRe = regexp.MustCompile("\x1b\\[[0-9;]*m|\\[[0-9]{1,2}m")
+	// ansiRe matches ANSI SGR color escapes present in raw gh job logs. Raw logs
+	// carry the ESC byte, so anchoring on \x1b is sufficient — matching a bare
+	// "[Nm" would corrupt real content like "[20m]" timeouts or "[1m" fragments.
+	ansiRe = regexp.MustCompile("\x1b\\[[0-9;]*m")
 )
 
 // newTriageCommand creates the `triage` subcommand: from a failed integration
@@ -244,6 +255,11 @@ func fetchFailingJobLog(ctx context.Context, ref runRef) (string, *ghJob, error)
 		if err := json.Unmarshal(out, &resp); err != nil {
 			return "", nil, fmt.Errorf("parse jobs response: %w", err)
 		}
+		if resp.TotalCount > len(resp.Jobs) {
+			fmt.Fprintf(os.Stderr,
+				"warning: only the first %d of %d jobs were inspected; if the failure isn't found, pass the failing job's URL or --job <id>\n",
+				len(resp.Jobs), resp.TotalCount)
+		}
 		job := selectFailedJob(resp.Jobs)
 		if job == nil {
 			return "", nil, fmt.Errorf(
@@ -281,7 +297,7 @@ func fetchFailingJobLog(ctx context.Context, ref runRef) (string, *ghJob, error)
 func selectFailedJob(jobs []ghJob) *ghJob {
 	var firstFailed *ghJob
 	for i := range jobs {
-		if jobs[i].Conclusion != "failure" {
+		if !failedConclusions[jobs[i].Conclusion] {
 			continue
 		}
 		if firstFailed == nil {

--- a/scripts/deploy-camunda/cmd/triage.go
+++ b/scripts/deploy-camunda/cmd/triage.go
@@ -1,0 +1,563 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/signal"
+	"regexp"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"scripts/camunda-core/pkg/executil"
+	"scripts/camunda-core/pkg/logging"
+
+	"github.com/spf13/cobra"
+)
+
+const defaultTriageRepo = "camunda/camunda-platform-helm"
+
+// ghAPI shells out to the GitHub CLI's `gh api` and returns stdout. It is a
+// package var so tests can inject canned responses without a network call.
+var ghAPI = func(ctx context.Context, args []string) ([]byte, error) {
+	return executil.RunCommandCapture(ctx, "gh", append([]string{"api"}, args...), nil, "")
+}
+
+// runRef identifies a GitHub Actions run (and optionally a specific job) to triage.
+type runRef struct {
+	Owner string
+	Repo  string
+	RunID string
+	JobID string // optional; when set, that job is triaged directly
+}
+
+// matrixCell is the decoded integration matrix coordinate parsed from a job name
+// like "8.9 - cprst - install - pr - gke".
+type matrixCell struct {
+	Version   string
+	Shortname string
+	Flow      string
+	Case      string
+	Platform  string
+}
+
+func (c matrixCell) empty() bool {
+	return c.Version == "" && c.Shortname == "" && c.Flow == ""
+}
+
+// failureRecord is the denoised, structured summary extracted from a failing job log.
+type failureRecord struct {
+	JobName        string
+	Conclusion     string
+	Cell           matrixCell
+	FailingStep    string
+	HelmCommand    string
+	Reason         string
+	DiagnosticsDir string
+	Signals        []string
+}
+
+// ghJob is the subset of the GitHub Actions job object we consume.
+type ghJob struct {
+	ID         int64  `json:"id"`
+	Name       string `json:"name"`
+	Status     string `json:"status"`
+	Conclusion string `json:"conclusion"`
+	Steps      []struct {
+		Name       string `json:"name"`
+		Conclusion string `json:"conclusion"`
+	} `json:"steps"`
+}
+
+type ghJobsResponse struct {
+	Jobs []ghJob `json:"jobs"`
+}
+
+var (
+	// runURLRe matches .../actions/runs/<runID>[/job/<jobID>] in a GitHub URL.
+	runURLRe = regexp.MustCompile(`/actions/runs/(\d+)(?:/job/(\d+))?`)
+	// repoURLRe matches github.com/<owner>/<repo> in a URL.
+	repoURLRe = regexp.MustCompile(`github\.com/([^/]+)/([^/]+)`)
+	// diagnosticsRe matches the "Diagnostics: diagnostics/<ns>/<ts>" hint.
+	diagnosticsRe = regexp.MustCompile(`Diagnostics:\s*(\S+)`)
+	// quotedHelmCmdRe matches a quoted command="helm ..." field, which the matrix
+	// runner emits with the exact failing invocation.
+	quotedHelmCmdRe = regexp.MustCompile(`command="(helm [^"]*)"`)
+	// ansiRe matches ANSI SGR color escapes present in raw gh job logs.
+	ansiRe = regexp.MustCompile("\x1b\\[[0-9;]*m|\\[[0-9]{1,2}m")
+)
+
+// newTriageCommand creates the `triage` subcommand: from a failed integration
+// run URL/ID, pull the failing job log, strip the env-var noise, and print the
+// structured failure record (matrix cell, helm command, error, diagnostics path)
+// plus a local-repro command — the post-mortem entry point that replaces manual
+// `gh api` + grep.
+func newTriageCommand() *cobra.Command {
+	var repoFlag string
+	var jobFlag string
+	var showLog bool
+
+	cmd := &cobra.Command{
+		Use:   "triage <run-url|run-id>",
+		Short: "Triage a failed integration run: extract the failure record from its job log",
+		Long: `Turn a failed GitHub Actions run into a structured failure summary.
+
+Accepts a run URL (https://github.com/<owner>/<repo>/actions/runs/<id>[/job/<jobid>])
+or a bare run ID. Resolves the failing job(s), pulls the job log via the reliable
+` + "`gh api .../actions/jobs/<id>/logs`" + ` path (not --log-failed, which is empty
+for merge-queue runs), strips the env-var noise, and prints:
+
+  - the decoded matrix cell (version / shortname / flow / platform),
+  - the failing step and the helm command that failed,
+  - the error/reason and notable log signals,
+  - the Diagnostics bundle path (download with: gh run download <run-id> --name 'diagnostics-*'),
+  - a ready-to-run local reproduction command.
+
+Requires the GitHub CLI (gh) to be installed and authenticated.`,
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+			defer stop()
+
+			if err := logging.Setup(logging.Options{
+				LevelString:  flags.LogLevel,
+				ColorEnabled: logging.IsTerminal(os.Stdout.Fd()),
+			}); err != nil {
+				return err
+			}
+
+			ref, err := parseRunRef(args[0], repoFlag)
+			if err != nil {
+				return err
+			}
+			if jobFlag != "" {
+				ref.JobID = jobFlag
+			}
+
+			log, job, err := fetchFailingJobLog(ctx, ref)
+			if err != nil {
+				return err
+			}
+
+			rec := extractFailureRecord(log)
+			if job != nil {
+				if rec.JobName == "" {
+					rec.JobName = job.Name
+				}
+				rec.Conclusion = job.Conclusion
+				if rec.Cell.empty() {
+					rec.Cell = parseMatrixCell(job.Name)
+				}
+				if rec.FailingStep == "" {
+					rec.FailingStep = firstFailedStep(*job)
+				}
+			}
+
+			fmt.Fprint(os.Stdout, renderTriageReport(ref, rec))
+			if showLog {
+				fmt.Fprintf(os.Stdout, "\n----- denoised log -----\n%s\n", stripLogNoise(log))
+			}
+			return nil
+		},
+	}
+
+	f := cmd.Flags()
+	f.StringVar(&repoFlag, "repo", "", "owner/repo (default: derived from the URL, else "+defaultTriageRepo+")")
+	f.StringVar(&jobFlag, "job", "", "Triage a specific job ID instead of auto-selecting the failed job")
+	f.BoolVar(&showLog, "show-log", false, "Also print the denoised job log after the summary")
+	f.StringVarP(&flags.LogLevel, "log-level", "l", "info", "Log level")
+
+	return cmd
+}
+
+// parseRunRef resolves a run URL or bare run ID into a runRef. repoOverride, when
+// non-empty ("owner/repo"), wins over any repo derived from the URL.
+func parseRunRef(input, repoOverride string) (runRef, error) {
+	ref := runRef{Owner: "", Repo: ""}
+
+	if m := runURLRe.FindStringSubmatch(input); m != nil {
+		ref.RunID = m[1]
+		if len(m) > 2 {
+			ref.JobID = m[2]
+		}
+		if rm := repoURLRe.FindStringSubmatch(input); rm != nil {
+			ref.Owner = rm[1]
+			ref.Repo = strings.TrimSuffix(rm[2], ".git")
+		}
+	} else if isAllDigits(strings.TrimSpace(input)) {
+		ref.RunID = strings.TrimSpace(input)
+	} else {
+		return runRef{}, fmt.Errorf("could not parse a run URL or run ID from %q", input)
+	}
+
+	if repoOverride != "" {
+		owner, repo, ok := splitOwnerRepo(repoOverride)
+		if !ok {
+			return runRef{}, fmt.Errorf("--repo must be owner/repo, got %q", repoOverride)
+		}
+		ref.Owner, ref.Repo = owner, repo
+	}
+	if ref.Owner == "" || ref.Repo == "" {
+		owner, repo, _ := splitOwnerRepo(defaultTriageRepo)
+		ref.Owner, ref.Repo = owner, repo
+	}
+	if ref.RunID == "" {
+		return runRef{}, fmt.Errorf("no run ID found in %q", input)
+	}
+	return ref, nil
+}
+
+func splitOwnerRepo(s string) (string, string, bool) {
+	parts := strings.SplitN(strings.TrimSpace(s), "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], strings.TrimSuffix(parts[1], ".git"), true
+}
+
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	_, err := strconv.ParseInt(s, 10, 64)
+	return err == nil
+}
+
+// fetchFailingJobLog resolves the failing job for the ref (unless a job is already
+// pinned) and returns its raw log plus the job metadata (nil if a job was pinned
+// by ID and the jobs list was not fetched).
+func fetchFailingJobLog(ctx context.Context, ref runRef) (string, *ghJob, error) {
+	var chosen *ghJob
+
+	if ref.JobID == "" {
+		out, err := ghAPI(ctx, []string{
+			fmt.Sprintf("/repos/%s/%s/actions/runs/%s/jobs?per_page=100", ref.Owner, ref.Repo, ref.RunID),
+		})
+		if err != nil {
+			return "", nil, fmt.Errorf("list jobs for run %s: %w (is `gh` installed and authenticated?)", ref.RunID, err)
+		}
+		var resp ghJobsResponse
+		if err := json.Unmarshal(out, &resp); err != nil {
+			return "", nil, fmt.Errorf("parse jobs response: %w", err)
+		}
+		job := selectFailedJob(resp.Jobs)
+		if job == nil {
+			return "", nil, fmt.Errorf(
+				"no failed job found directly in run %s — integration failures often live in a nested reusable workflow that this run's job list does not include.\n"+
+					"Open the failing job on GitHub and pass its URL (…/actions/runs/<id>/job/<jobid>), or `deploy-camunda triage --job <jobid> <run-id>`.",
+				ref.RunID)
+		}
+		chosen = job
+		ref.JobID = strconv.FormatInt(job.ID, 10)
+	} else {
+		// A job was pinned by ID/URL — fetch its metadata so the report still
+		// carries the job name and matrix cell. Best-effort: log parsing works
+		// even if this fails.
+		if out, err := ghAPI(ctx, []string{
+			fmt.Sprintf("/repos/%s/%s/actions/jobs/%s", ref.Owner, ref.Repo, ref.JobID),
+		}); err == nil {
+			var job ghJob
+			if json.Unmarshal(out, &job) == nil && job.ID != 0 {
+				chosen = &job
+			}
+		}
+	}
+
+	logOut, err := ghAPI(ctx, []string{
+		fmt.Sprintf("/repos/%s/%s/actions/jobs/%s/logs", ref.Owner, ref.Repo, ref.JobID),
+	})
+	if err != nil {
+		return "", chosen, fmt.Errorf("fetch log for job %s: %w", ref.JobID, err)
+	}
+	return string(logOut), chosen, nil
+}
+
+// selectFailedJob returns the first job whose conclusion is "failure", preferring
+// one whose name looks like an integration matrix cell.
+func selectFailedJob(jobs []ghJob) *ghJob {
+	var firstFailed *ghJob
+	for i := range jobs {
+		if jobs[i].Conclusion != "failure" {
+			continue
+		}
+		if firstFailed == nil {
+			firstFailed = &jobs[i]
+		}
+		if !parseMatrixCell(jobs[i].Name).empty() {
+			return &jobs[i]
+		}
+	}
+	return firstFailed
+}
+
+func firstFailedStep(job ghJob) string {
+	for _, s := range job.Steps {
+		if s.Conclusion == "failure" {
+			return s.Name
+		}
+	}
+	return ""
+}
+
+// parseMatrixCell decodes an integration job name like
+// "8.9 - cprst - install - pr - gke" into its coordinates. Job names carry extra
+// prose (e.g. "install for install on gke - cprst"); only the leading
+// " - "-delimited cell is parsed, and a non-version leading token yields empty.
+func parseMatrixCell(name string) matrixCell {
+	parts := strings.Split(name, " - ")
+	for i := range parts {
+		parts[i] = strings.TrimSpace(parts[i])
+	}
+	if len(parts) < 3 {
+		return matrixCell{}
+	}
+	// The leading token must look like a chart version (e.g. 8.9, 8.10).
+	if !regexp.MustCompile(`^\d+\.\d+$`).MatchString(parts[0]) {
+		return matrixCell{}
+	}
+	cell := matrixCell{Version: parts[0]}
+	if len(parts) > 1 {
+		cell.Shortname = parts[1]
+	}
+	if len(parts) > 2 {
+		cell.Flow = parts[2]
+	}
+	if len(parts) > 3 {
+		cell.Case = firstToken(parts[3])
+	}
+	if len(parts) > 4 {
+		// Integration job names append prose after the cell (e.g.
+		// "gke / gke - ITs / ..."); keep only the leading platform token.
+		cell.Platform = firstToken(parts[4])
+	}
+	return cell
+}
+
+// firstToken returns the first whitespace-delimited word of s.
+func firstToken(s string) string {
+	fields := strings.Fields(s)
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
+}
+
+// extractFailureRecord pulls the structured failure fields out of a raw job log.
+// The log is ANSI-stripped up front so extraction and matching see clean text.
+func extractFailureRecord(rawLog string) failureRecord {
+	log := stripANSI(rawLog)
+	rec := failureRecord{}
+
+	rec.HelmCommand = extractHelmCommand(log)
+	if m := diagnosticsRe.FindStringSubmatch(log); m != nil {
+		rec.DiagnosticsDir = m[1]
+	}
+	rec.Reason = extractReason(log)
+	rec.Signals = collectSignals(log)
+	return rec
+}
+
+// extractHelmCommand returns the real helm invocation from the (ANSI-stripped) log.
+// It prefers the quoted command="helm ..." field the matrix runner emits, then a
+// line that names a release/namespace, over the error-message line
+// ("helm upgrade --install failed: exit status 1"), which carries no such args.
+func extractHelmCommand(log string) string {
+	if m := quotedHelmCmdRe.FindStringSubmatch(log); m != nil {
+		return strings.TrimSpace(m[1])
+	}
+	var fallback string
+	for _, line := range strings.Split(log, "\n") {
+		idx := strings.Index(line, "helm upgrade")
+		if idx < 0 {
+			idx = strings.Index(line, "helm install")
+		}
+		if idx < 0 {
+			continue
+		}
+		// Skip prose/comment mentions: a shell comment or narrative sentence that
+		// merely refers to "helm upgrade" is not a command (e.g. script echoes
+		// like "# ...so helm upgrade").
+		if before := strings.TrimSpace(stripTimestamp(line[:idx])); strings.Contains(before, "#") {
+			continue
+		}
+		cmd := strings.TrimSpace(stripTimestamp(line[idx:]))
+		// Cut a trailing quoted-field tail if the invocation was embedded in a
+		// larger structured log line (e.g. ... version=8.9).
+		if q := strings.Index(cmd, `" `); q >= 0 {
+			cmd = cmd[:q]
+		}
+		// A real invocation carries flags/args; a bare "helm upgrade" with nothing
+		// after it is prose, not a command.
+		if !looksLikeHelmInvocation(cmd) {
+			continue
+		}
+		if strings.Contains(cmd, " -n ") || strings.Contains(cmd, "--namespace") || strings.Contains(cmd, "camunda-platform-") {
+			return cmd
+		}
+		if fallback == "" {
+			fallback = cmd
+		}
+	}
+	return fallback
+}
+
+// looksLikeHelmInvocation reports whether cmd is a real helm command line rather
+// than a prose mention — it must carry a flag or a release/chart argument.
+func looksLikeHelmInvocation(cmd string) bool {
+	rest := strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(cmd, "helm upgrade"), "helm install"))
+	if rest == "" {
+		return false
+	}
+	return strings.Contains(cmd, " -") || strings.Contains(cmd, "camunda-platform-") || strings.Contains(cmd, "integration")
+}
+
+// reasonPatterns are ordered most-specific-first; the first match wins.
+var reasonPatterns = []string{
+	"Matrix entry failed",
+	"context deadline exceeded",
+	"UPGRADE FAILED",
+	"INSTALLATION FAILED",
+	"Error: 1 of",
+	"Error:",
+}
+
+func extractReason(log string) string {
+	lines := strings.Split(stripANSI(log), "\n")
+	// Priority order over the whole log: a more-specific reason (e.g. "Matrix
+	// entry failed") wins even if a generic one appears earlier in the log.
+	for _, p := range reasonPatterns {
+		for _, line := range lines {
+			if strings.Contains(line, p) {
+				return strings.TrimSpace(stripTimestamp(line))
+			}
+		}
+	}
+	return ""
+}
+
+// signalPatterns are notable failure fingerprints worth surfacing verbatim.
+var signalPatterns = []string{
+	"Multi-Attach",
+	"context deadline exceeded",
+	"PodInitializing",
+	"CrashLoopBackOff",
+	"ImagePullBackOff",
+	"ErrImagePull",
+	"FailedMount",
+	"FailedScheduling",
+	"OOMKilled",
+	"Unschedulable",
+	"exceeded its progress deadline",
+	"waiting to start",
+}
+
+func collectSignals(log string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, p := range signalPatterns {
+		if strings.Contains(log, p) && !seen[p] {
+			seen[p] = true
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// tsPrefixRe matches a leading ISO-8601 timestamp GitHub prepends to every log line.
+var tsPrefixRe = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s*`)
+
+func stripTimestamp(line string) string {
+	return tsPrefixRe.ReplaceAllString(line, "")
+}
+
+// stripANSI removes ANSI SGR color escapes from log text.
+func stripANSI(s string) string {
+	return ansiRe.ReplaceAllString(s, "")
+}
+
+// envDumpRe matches a step's echoed env entry: leading whitespace then
+// "UPPER_SNAKE: value". These dominate integration logs and carry no signal.
+var envDumpRe = regexp.MustCompile(`^\s*[A-Z][A-Z0-9_]{2,}:\s`)
+
+// stripLogNoise removes the timestamp prefix and the per-step env-var dumps that
+// bury the signal in integration logs, so a human (or a follow-up grep) reads only
+// the meaningful lines.
+func stripLogNoise(log string) string {
+	var b strings.Builder
+	for _, line := range strings.Split(log, "\n") {
+		clean := stripTimestamp(stripANSI(line))
+		if envDumpRe.MatchString(clean) {
+			continue
+		}
+		b.WriteString(clean)
+		b.WriteByte('\n')
+	}
+	return strings.TrimRight(b.String(), "\n") + "\n"
+}
+
+// renderTriageReport formats the failure record for the terminal.
+func renderTriageReport(ref runRef, rec failureRecord) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Triage: %s/%s run %s\n", ref.Owner, ref.Repo, ref.RunID)
+	fmt.Fprintf(&b, "  https://github.com/%s/%s/actions/runs/%s\n\n", ref.Owner, ref.Repo, ref.RunID)
+
+	if rec.JobName != "" {
+		fmt.Fprintf(&b, "Job:          %s", rec.JobName)
+		if rec.Conclusion != "" {
+			fmt.Fprintf(&b, "  (%s)", rec.Conclusion)
+		}
+		b.WriteByte('\n')
+	}
+	if !rec.Cell.empty() {
+		fmt.Fprintf(&b, "Matrix cell:  version=%s shortname=%s flow=%s", rec.Cell.Version, rec.Cell.Shortname, rec.Cell.Flow)
+		if rec.Cell.Platform != "" {
+			fmt.Fprintf(&b, " platform=%s", rec.Cell.Platform)
+		}
+		b.WriteByte('\n')
+	}
+	if rec.FailingStep != "" {
+		fmt.Fprintf(&b, "Failing step: %s\n", rec.FailingStep)
+	}
+	if rec.Reason != "" {
+		fmt.Fprintf(&b, "Reason:       %s\n", rec.Reason)
+	}
+	if len(rec.Signals) > 0 {
+		fmt.Fprintf(&b, "Signals:      %s\n", strings.Join(rec.Signals, ", "))
+	}
+	if rec.HelmCommand != "" {
+		fmt.Fprintf(&b, "Helm command: %s\n", rec.HelmCommand)
+	}
+	if rec.DiagnosticsDir != "" {
+		fmt.Fprintf(&b, "Diagnostics:  %s\n", rec.DiagnosticsDir)
+		fmt.Fprintf(&b, "  download:   gh run download %s --repo %s/%s --name 'diagnostics-*'\n", ref.RunID, ref.Owner, ref.Repo)
+	}
+
+	if repro := reproCommand(rec.Cell); repro != "" {
+		fmt.Fprintf(&b, "\nReproduce locally:\n  %s\n", repro)
+	}
+	return b.String()
+}
+
+// reproCommand builds the deploy-camunda matrix run invocation that reproduces the
+// failing cell locally. Returns "" when the cell could not be decoded.
+func reproCommand(c matrixCell) string {
+	if c.empty() {
+		return ""
+	}
+	flow := c.Flow
+	if flow == "" {
+		flow = "install"
+	}
+	platform := c.Platform
+	if platform == "" || platform == "pr" {
+		platform = "gke"
+	}
+	return fmt.Sprintf(
+		"deploy-camunda matrix run --repo-root . --versions %s --shortname-filter %s --shortname-exact --flow-filter %s --platform %s --delete-namespace --timeout 20 --yes",
+		c.Version, c.Shortname, flow, platform,
+	)
+}

--- a/scripts/deploy-camunda/cmd/triage_test.go
+++ b/scripts/deploy-camunda/cmd/triage_test.go
@@ -232,6 +232,25 @@ func TestSelectFailedJob(t *testing.T) {
 	}
 }
 
+func TestFirstFailedStep(t *testing.T) {
+	t.Parallel()
+	job := ghJob{Steps: []struct {
+		Name       string `json:"name"`
+		Conclusion string `json:"conclusion"`
+	}{
+		{Name: "Setup", Conclusion: "success"},
+		{Name: "Install Camunda chart", Conclusion: "timed_out"},
+		{Name: "Later", Conclusion: "failure"},
+	}}
+	// timed_out must count as failed (matches selectFailedJob's failedConclusions).
+	if got := firstFailedStep(job); got != "Install Camunda chart" {
+		t.Errorf("firstFailedStep = %q, want the timed_out step", got)
+	}
+	if got := firstFailedStep(ghJob{}); got != "" {
+		t.Errorf("no steps should yield empty, got %q", got)
+	}
+}
+
 func TestFetchFailingJobLog(t *testing.T) {
 	ref := runRef{Owner: "camunda", Repo: "camunda-platform-helm", RunID: "42"}
 

--- a/scripts/deploy-camunda/cmd/triage_test.go
+++ b/scripts/deploy-camunda/cmd/triage_test.go
@@ -1,0 +1,266 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseRunRef(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		input     string
+		repo      string
+		wantOwner string
+		wantRepo  string
+		wantRun   string
+		wantJob   string
+		wantErr   bool
+	}{
+		{
+			name:      "full job url",
+			input:     "https://github.com/camunda/camunda-platform-helm/actions/runs/28577691601/job/84730355206",
+			wantOwner: "camunda",
+			wantRepo:  "camunda-platform-helm",
+			wantRun:   "28577691601",
+			wantJob:   "84730355206",
+		},
+		{
+			name:      "run url without job",
+			input:     "https://github.com/camunda/camunda-platform-helm/actions/runs/28577691601",
+			wantOwner: "camunda",
+			wantRepo:  "camunda-platform-helm",
+			wantRun:   "28577691601",
+		},
+		{
+			name:      "bare run id falls back to default repo",
+			input:     "28577691601",
+			wantOwner: "camunda",
+			wantRepo:  "camunda-platform-helm",
+			wantRun:   "28577691601",
+		},
+		{
+			name:      "repo override wins over url",
+			input:     "https://github.com/someone/fork/actions/runs/42",
+			repo:      "camunda/camunda-platform-helm",
+			wantOwner: "camunda",
+			wantRepo:  "camunda-platform-helm",
+			wantRun:   "42",
+		},
+		{
+			name:    "garbage input errors",
+			input:   "not-a-run",
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ref, err := parseRunRef(tc.input, tc.repo)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got ref %+v", ref)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if ref.Owner != tc.wantOwner || ref.Repo != tc.wantRepo || ref.RunID != tc.wantRun || ref.JobID != tc.wantJob {
+				t.Errorf("got %+v, want owner=%s repo=%s run=%s job=%s",
+					ref, tc.wantOwner, tc.wantRepo, tc.wantRun, tc.wantJob)
+			}
+		})
+	}
+}
+
+func TestParseMatrixCell(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want matrixCell
+	}{
+		{
+			name: "full cell",
+			in:   "8.9 - cprst - install - pr - gke",
+			want: matrixCell{Version: "8.9", Shortname: "cprst", Flow: "install", Case: "pr", Platform: "gke"},
+		},
+		{
+			name: "8.10 double-digit minor",
+			in:   "8.10 - keyco - upgrade-minor - pr - gke",
+			want: matrixCell{Version: "8.10", Shortname: "keyco", Flow: "upgrade-minor", Case: "pr", Platform: "gke"},
+		},
+		{
+			name: "real job name with trailing prose keeps only the platform token",
+			in:   "8.9 - cprst - install - pr - gke / gke - ITs / cprst - install - gke / install for install on gke - cprst",
+			want: matrixCell{Version: "8.9", Shortname: "cprst", Flow: "install", Case: "pr", Platform: "gke"},
+		},
+		{
+			name: "non-version leading token is not a cell",
+			in:   "install for install on gke - cprst",
+			want: matrixCell{},
+		},
+		{
+			name: "too few parts",
+			in:   "CI Gate",
+			want: matrixCell{},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseMatrixCell(tc.in)
+			if got != tc.want {
+				t.Errorf("parseMatrixCell(%q) = %+v, want %+v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// sampleLog mirrors the shape of a real failing cprst install job log: GitHub
+// timestamp prefixes, an env-var dump block, the helm command, the matrix-failed
+// reason, the diagnostics path, and a PodInitializing signal.
+const sampleLog = "2026-07-02T08:55:05.7514311Z   POSTGRESQL_JDBC_URL: jdbc:postgresql://host:5432\n" +
+	"2026-07-02T08:55:05.7527586Z   DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET: ***\n" +
+	"2026-07-02T09:15:24.7142716Z \x1b[90m09:15:24\x1b[0m WARN \x1b[1m[cmd:helm] Error: context deadline exceeded\x1b[0m\n" +
+	"2026-07-02T09:15:34.8612245Z \x1b[90m09:15:34\x1b[0m ERROR \x1b[1mMatrix entry failed\x1b[0m error=\"helm upgrade --install failed: exit status 1\" command=\"helm upgrade --install integration camunda-platform-8.9 -n camunda-id--intg-8-9-gke-cprst-aa43b0 --create-namespace --wait=legacy --timeout 1200s -f values-digest.yaml\" flow=install scenario=component-persistence version=8.9\n" +
+	"2026-07-02T09:15:34.8629904Z     Diagnostics: diagnostics/camunda-id--intg-8-9-gke-cprst-aa43b0/20260702T091524Z\n" +
+	"2026-07-02T09:15:37.6651835Z Error from server (BadRequest): container \"migration\" in pod \"integration-optimize-58bb88d6-q8q2p\" is waiting to start: PodInitializing\n"
+
+func TestExtractFailureRecord(t *testing.T) {
+	t.Parallel()
+	rec := extractFailureRecord(sampleLog)
+
+	if !strings.HasPrefix(rec.HelmCommand, "helm upgrade --install integration camunda-platform-8.9") {
+		t.Errorf("HelmCommand not extracted cleanly: %q", rec.HelmCommand)
+	}
+	if strings.Contains(rec.HelmCommand, "failed: exit status") {
+		t.Errorf("HelmCommand should be the real invocation, not the error message: %q", rec.HelmCommand)
+	}
+	if strings.Contains(rec.HelmCommand, "2026-07-02T") || strings.Contains(rec.HelmCommand, "\x1b[") {
+		t.Errorf("HelmCommand should have timestamp and ANSI stripped: %q", rec.HelmCommand)
+	}
+	if strings.Contains(rec.Reason, "\x1b[") {
+		t.Errorf("Reason should have ANSI stripped: %q", rec.Reason)
+	}
+	if rec.DiagnosticsDir != "diagnostics/camunda-id--intg-8-9-gke-cprst-aa43b0/20260702T091524Z" {
+		t.Errorf("DiagnosticsDir = %q", rec.DiagnosticsDir)
+	}
+	if !strings.Contains(rec.Reason, "Matrix entry failed") {
+		t.Errorf("Reason = %q, want it to mention 'Matrix entry failed'", rec.Reason)
+	}
+	wantSignals := map[string]bool{"context deadline exceeded": true, "PodInitializing": true, "waiting to start": true}
+	for _, s := range rec.Signals {
+		delete(wantSignals, s)
+	}
+	if len(wantSignals) != 0 {
+		t.Errorf("missing signals %v in %v", wantSignals, rec.Signals)
+	}
+}
+
+func TestStripLogNoise(t *testing.T) {
+	t.Parallel()
+	out := stripLogNoise(sampleLog)
+
+	if strings.Contains(out, "POSTGRESQL_JDBC_URL:") || strings.Contains(out, "DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET:") {
+		t.Errorf("env-var dump lines should be removed:\n%s", out)
+	}
+	if strings.Contains(out, "2026-07-02T09:15:34") {
+		t.Errorf("timestamp prefixes should be stripped:\n%s", out)
+	}
+	if !strings.Contains(out, "Matrix entry failed") {
+		t.Errorf("meaningful lines should be preserved:\n%s", out)
+	}
+	if !strings.Contains(out, "Diagnostics: diagnostics/") {
+		t.Errorf("diagnostics line should be preserved:\n%s", out)
+	}
+}
+
+func TestSelectFailedJob(t *testing.T) {
+	t.Parallel()
+	jobs := []ghJob{
+		{ID: 1, Name: "CI Gate", Conclusion: "success"},
+		{ID: 2, Name: "Generate chart matrix", Conclusion: "failure"},
+		{ID: 3, Name: "8.9 - cprst - install - pr - gke", Conclusion: "failure"},
+	}
+	got := selectFailedJob(jobs)
+	if got == nil || got.ID != 3 {
+		t.Fatalf("expected the matrix-cell job (id 3) to be selected, got %+v", got)
+	}
+
+	// When no failed job looks like a matrix cell, fall back to the first failure.
+	got = selectFailedJob([]ghJob{
+		{ID: 1, Name: "CI Gate", Conclusion: "success"},
+		{ID: 2, Name: "Generate chart matrix", Conclusion: "failure"},
+	})
+	if got == nil || got.ID != 2 {
+		t.Fatalf("expected first failed job (id 2), got %+v", got)
+	}
+
+	// All green -> nil.
+	if got := selectFailedJob([]ghJob{{ID: 1, Conclusion: "success"}}); got != nil {
+		t.Fatalf("expected nil for all-green jobs, got %+v", got)
+	}
+}
+
+func TestReproCommand(t *testing.T) {
+	t.Parallel()
+	cmd := reproCommand(matrixCell{Version: "8.9", Shortname: "cprst", Flow: "install", Case: "pr", Platform: "gke"})
+	for _, want := range []string{"--versions 8.9", "--shortname-filter cprst", "--shortname-exact", "--flow-filter install", "--platform gke"} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("repro command missing %q: %s", want, cmd)
+		}
+	}
+	if reproCommand(matrixCell{}) != "" {
+		t.Error("empty cell should yield no repro command")
+	}
+	// A 'pr' platform token should be normalized to gke.
+	if got := reproCommand(matrixCell{Version: "8.10", Shortname: "keyco", Flow: "install", Platform: "pr"}); !strings.Contains(got, "--platform gke") {
+		t.Errorf("pr platform should normalize to gke: %s", got)
+	}
+}
+
+func TestExtractHelmCommand(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		log  string
+		want string
+	}{
+		{
+			name: "quoted command field wins",
+			log:  `x ERROR failed command="helm upgrade --install integration -n ns" version=8.9`,
+			want: "helm upgrade --install integration -n ns",
+		},
+		{
+			name: "shell comment mention is not a command",
+			log:  "2026-07-06T10:11:23Z \x1b[36;1m# but the upgrade step must use the current chart so helm upgrade\x1b[0m",
+			want: "",
+		},
+		{
+			name: "bare mention with no args is not a command",
+			log:  "we then run helm upgrade to roll the release",
+			want: "",
+		},
+		{
+			name: "real invocation on its own line is the fallback",
+			log:  "2026-07-06T10:11:23Z helm upgrade --install integration camunda-platform-8.10 -n test",
+			want: "helm upgrade --install integration camunda-platform-8.10 -n test",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractHelmCommand(stripANSI(tc.log))
+			if got != tc.want {
+				t.Errorf("extractHelmCommand() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExtractFailureRecordEmptyLog(t *testing.T) {
+	t.Parallel()
+	rec := extractFailureRecord("nothing interesting here\n")
+	if rec.HelmCommand != "" || rec.DiagnosticsDir != "" || rec.Reason != "" || len(rec.Signals) != 0 {
+		t.Errorf("expected empty record for a boring log, got %+v", rec)
+	}
+}

--- a/scripts/deploy-camunda/cmd/triage_test.go
+++ b/scripts/deploy-camunda/cmd/triage_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"context"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -157,6 +159,22 @@ func TestExtractFailureRecord(t *testing.T) {
 	}
 }
 
+func TestStripANSILeavesNonANSIIntact(t *testing.T) {
+	t.Parallel()
+	// Real ANSI (with ESC) must be stripped; bare "[Nm" text must NOT be touched.
+	cases := map[string]string{
+		"\x1b[90m09:15:24\x1b[0m WARN":            "09:15:24 WARN",
+		"waiting: [1m PodInitializing":            "waiting: [1m PodInitializing",
+		"context deadline exceeded after [20m] x": "context deadline exceeded after [20m] x",
+		"##[error]something failed":               "##[error]something failed",
+	}
+	for in, want := range cases {
+		if got := stripANSI(in); got != want {
+			t.Errorf("stripANSI(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
 func TestStripLogNoise(t *testing.T) {
 	t.Parallel()
 	out := stripLogNoise(sampleLog)
@@ -200,6 +218,109 @@ func TestSelectFailedJob(t *testing.T) {
 	if got := selectFailedJob([]ghJob{{ID: 1, Conclusion: "success"}}); got != nil {
 		t.Fatalf("expected nil for all-green jobs, got %+v", got)
 	}
+
+	// timed_out is treated as a failure; cancelled is not.
+	got = selectFailedJob([]ghJob{
+		{ID: 1, Name: "CI Gate", Conclusion: "cancelled"},
+		{ID: 2, Name: "8.10 - keyco - install - pr - gke", Conclusion: "timed_out"},
+	})
+	if got == nil || got.ID != 2 {
+		t.Fatalf("expected the timed_out matrix job (id 2), got %+v", got)
+	}
+	if got := selectFailedJob([]ghJob{{ID: 1, Conclusion: "cancelled"}}); got != nil {
+		t.Fatalf("cancelled-only jobs should not be selected, got %+v", got)
+	}
+}
+
+func TestFetchFailingJobLog(t *testing.T) {
+	ref := runRef{Owner: "camunda", Repo: "camunda-platform-helm", RunID: "42"}
+
+	t.Run("selects failed job then fetches its log", func(t *testing.T) {
+		orig := ghAPI
+		defer func() { ghAPI = orig }()
+		var logJobID string
+		ghAPI = func(_ context.Context, args []string) ([]byte, error) {
+			arg := args[len(args)-1]
+			if strings.Contains(arg, "/runs/42/jobs") {
+				return []byte(`{"total_count":2,"jobs":[
+					{"id":1,"name":"CI Gate","conclusion":"success"},
+					{"id":2,"name":"8.9 - cprst - install - pr - gke","conclusion":"failure"}]}`), nil
+			}
+			if strings.Contains(arg, "/jobs/2/logs") {
+				logJobID = "2"
+				return []byte("some log body\n"), nil
+			}
+			return nil, fmt.Errorf("unexpected api call: %s", arg)
+		}
+		log, job, err := fetchFailingJobLog(context.Background(), ref)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if logJobID != "2" || !strings.Contains(log, "some log body") {
+			t.Errorf("expected log for job 2, got job=%q log=%q", logJobID, log)
+		}
+		if job == nil || job.ID != 2 {
+			t.Errorf("expected selected job 2, got %+v", job)
+		}
+	})
+
+	t.Run("all-green run returns the guidance error", func(t *testing.T) {
+		orig := ghAPI
+		defer func() { ghAPI = orig }()
+		ghAPI = func(_ context.Context, _ []string) ([]byte, error) {
+			return []byte(`{"total_count":1,"jobs":[{"id":1,"name":"CI Gate","conclusion":"success"}]}`), nil
+		}
+		_, _, err := fetchFailingJobLog(context.Background(), ref)
+		if err == nil || !strings.Contains(err.Error(), "no failed job found") {
+			t.Fatalf("expected no-failed-job error, got %v", err)
+		}
+	})
+
+	t.Run("malformed jobs response errors", func(t *testing.T) {
+		orig := ghAPI
+		defer func() { ghAPI = orig }()
+		ghAPI = func(_ context.Context, _ []string) ([]byte, error) {
+			return []byte("not json"), nil
+		}
+		_, _, err := fetchFailingJobLog(context.Background(), ref)
+		if err == nil || !strings.Contains(err.Error(), "parse jobs response") {
+			t.Fatalf("expected parse error, got %v", err)
+		}
+	})
+
+	t.Run("pinned job id bypasses the jobs list", func(t *testing.T) {
+		orig := ghAPI
+		defer func() { ghAPI = orig }()
+		pinned := ref
+		pinned.JobID = "999"
+		var calls []string
+		ghAPI = func(_ context.Context, args []string) ([]byte, error) {
+			arg := args[len(args)-1]
+			calls = append(calls, arg)
+			if strings.Contains(arg, "/jobs/999/logs") {
+				return []byte("pinned log\n"), nil
+			}
+			if strings.Contains(arg, "/jobs/999") {
+				return []byte(`{"id":999,"name":"8.9 - cprst - install - pr - gke","conclusion":"failure"}`), nil
+			}
+			return nil, fmt.Errorf("unexpected api call: %s", arg)
+		}
+		log, job, err := fetchFailingJobLog(context.Background(), pinned)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(log, "pinned log") {
+			t.Errorf("expected pinned log, got %q", log)
+		}
+		if job == nil || job.ID != 999 {
+			t.Errorf("expected pinned job metadata, got %+v", job)
+		}
+		for _, c := range calls {
+			if strings.Contains(c, "/runs/42/jobs") {
+				t.Errorf("pinned path must not list run jobs, but called %s", c)
+			}
+		}
+	})
 }
 
 func TestReproCommand(t *testing.T) {

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -1189,6 +1189,8 @@ type diagnosticsSummary struct {
 	PodLogTailLines   int                 `json:"podLogTailLines"`
 	Pods              string              `json:"pods,omitempty"`
 	Events            string              `json:"events,omitempty"`
+	PVCs              string              `json:"pvcs,omitempty"`
+	PVCDescribe       string              `json:"pvcDescribe,omitempty"`
 	PodLogs           []diagnosticsPodLog `json:"podLogs,omitempty"`
 	TestOutputLast200 string              `json:"testOutputLast200,omitempty"`
 	Errors            []string            `json:"errors,omitempty"`
@@ -1288,6 +1290,19 @@ func collectDiagnostics(namespace, kubeContext string) string {
 		summary.Events = strings.Join(lines, "\n")
 	} else if err != nil {
 		summary.Errors = append(summary.Errors, fmt.Sprintf("get events: %v", err))
+	}
+
+	// PVCs: state + describe. Key evidence for volume-mount and provisioning hangs
+	// (pending claims, WaitForFirstConsumer, multi-attach conflicts).
+	if pvcs, err := kube.GetPVCs(ctx, kubeContext, namespace); err == nil && pvcs != "" {
+		summary.PVCs = pvcs
+	} else if err != nil {
+		summary.Errors = append(summary.Errors, fmt.Sprintf("get pvc: %v", err))
+	}
+	if pvcDesc, err := kube.DescribePVCs(ctx, kubeContext, namespace); err == nil && pvcDesc != "" {
+		summary.PVCDescribe = pvcDesc
+	} else if err != nil {
+		summary.Errors = append(summary.Errors, fmt.Sprintf("describe pvc: %v", err))
 	}
 
 	// Logs from all pods: one file per pod under logs/.

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -1292,19 +1292,6 @@ func collectDiagnostics(namespace, kubeContext string) string {
 		summary.Errors = append(summary.Errors, fmt.Sprintf("get events: %v", err))
 	}
 
-	// PVCs: state + describe. Key evidence for volume-mount and provisioning hangs
-	// (pending claims, WaitForFirstConsumer, multi-attach conflicts).
-	if pvcs, err := kube.GetPVCs(ctx, kubeContext, namespace); err == nil && pvcs != "" {
-		summary.PVCs = pvcs
-	} else if err != nil {
-		summary.Errors = append(summary.Errors, fmt.Sprintf("get pvc: %v", err))
-	}
-	if pvcDesc, err := kube.DescribePVCs(ctx, kubeContext, namespace); err == nil && pvcDesc != "" {
-		summary.PVCDescribe = pvcDesc
-	} else if err != nil {
-		summary.Errors = append(summary.Errors, fmt.Sprintf("describe pvc: %v", err))
-	}
-
 	// Logs from all pods: one file per pod under logs/.
 	if podNames, err := kube.GetPodNames(ctx, kubeContext, namespace); err == nil {
 		sort.Strings(podNames)
@@ -1334,6 +1321,21 @@ func collectDiagnostics(namespace, kubeContext string) string {
 		}
 	} else {
 		summary.Errors = append(summary.Errors, fmt.Sprintf("list pod names: %v", err))
+	}
+
+	// PVCs: state + describe. Key evidence for volume-mount and provisioning hangs
+	// (pending claims, WaitForFirstConsumer, multi-attach conflicts). Collected
+	// after per-pod logs so that, under the shared collection deadline, the
+	// higher-value pod logs are not starved by the slower `describe pvc`.
+	if pvcs, err := kube.GetPVCs(ctx, kubeContext, namespace); err == nil && pvcs != "" {
+		summary.PVCs = pvcs
+	} else if err != nil {
+		summary.Errors = append(summary.Errors, fmt.Sprintf("get pvc: %v", err))
+	}
+	if pvcDesc, err := kube.DescribePVCs(ctx, kubeContext, namespace); err == nil && pvcDesc != "" {
+		summary.PVCDescribe = pvcDesc
+	} else if err != nil {
+		summary.Errors = append(summary.Errors, fmt.Sprintf("describe pvc: %v", err))
 	}
 
 	if err := writeDiagnosticsSummary(runDir, summary); err != nil {


### PR DESCRIPTION
### Which problem does the PR fix?

Post-mortem triage of a failed integration/nightly run was slow and imprecise. In practice:

- `gh run view --log-failed` returns **empty** for merge-queue runs, so the documented first step silently fails.
- Integration logs are buried in per-step `env:`/`toJson(inputs)` dumps, forcing heavy `grep` to find the few meaningful lines.
- The structured diagnostics bundle `deploy-camunda` already collects on failure (pod state, events, per-pod logs) was **never uploaded**, so it died with the runner — root cause had to be *inferred* from whatever `failed-pods-info` happened to echo.
- `failed-pods-info` captured neither PVC state nor events, exactly the evidence a volume-mount / scheduling hang needs.
- There was no single entry point from a failed-run URL to a structured summary.

No linked issue.

### What's in this PR?

Five changes that make failure triage fast and evidence-based:

- **Durable diagnostics artifact** (`test-integration-runner.yaml`): the `diagnostics/<ns>/<ts>/` bundle is uploaded as `diagnostics-*` on failure (install + upgrade jobs, `if-no-files-found: ignore`), so every triage starts from `summary.json` + pod events + PVC state + per-pod logs via `gh run download`.
- **Thicker in-log evidence** (`failed-pods-info/action.yaml`): also dumps `get events`, `get/describe pvc`, `--previous` logs, and broadens the pod match beyond `0/` to `Init:/Pending/CrashLoopBackOff/ImagePullBackOff/PodInitializing`. The Go collector (`kube/diagnostics.go`, `matrix/runner.go`) gains `GetPVCs`/`DescribePVCs`, wired into the bundle.
- **`deploy-camunda triage <run-url|run-id>`** (new `cmd/triage.go`): resolves the failing job, pulls its log via the reliable jobs API (not `--log-failed`), strips env-var + ANSI noise, and prints the decoded matrix cell, failing step, helm command, error, notable signals, the diagnostics path (+ download hint), and a ready-to-run local-repro command. Unit-tested (`cmd/triage_test.go`) and validated live against two real failures (a GKE matrix cell and a KIND install).
- **Less log noise**: the `toJson(inputs)` dumps are collapsed into `::group::` so failing-step logs are readable without `grep`.
- **Docs**: `docs/skills/reproducing-ci-e2e-failures.md` documents the `triage` fast path and the diagnostics-artifact download, and notes the merge-queue `--log-failed` gotcha.

Notes for reviewers:

- Non-chart change (`.github/`, `scripts/`, `docs/`), hence `ci:` — no `charts/<version>/` files touched.
- Bare-run-ID auto-select can't reach failures nested in reusable workflows (they're absent from the top-level job list); the command detects this and directs you to pass the **job URL**, which always works.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
