### PR TITLE
build: honor namespace TTL in deploy-camunda instead of hardcoded 60m

### DIFF
--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -683,6 +683,11 @@ jobs:
             EXTRA_VALUES_ARGS=(--extra-values /tmp/extra-values-file.yaml)
           fi
 
+          # Give deploy-camunda the requested namespace TTL; without this it stamps
+          # its 60m default onto cleaner/janitor, so 12h nightly clusters get reaped
+          # after an hour. Empty falls back to deploy-camunda's 60m default.
+          export DEPLOY_CAMUNDA_TTL="${CI_DEPLOYMENT_TTL:-}"
+
           deploy-camunda matrix run \
             --repo-root "${GITHUB_WORKSPACE}" \
             --include-disabled \
@@ -1047,6 +1052,11 @@ jobs:
           if [[ -s /tmp/extra-values-file.yaml ]] && grep -q '[^[:space:]]' /tmp/extra-values-file.yaml; then
             EXTRA_VALUES_ARGS=(--extra-values /tmp/extra-values-file.yaml)
           fi
+
+          # Give deploy-camunda the requested namespace TTL; without this it stamps
+          # its 60m default onto cleaner/janitor, so 12h nightly clusters get reaped
+          # after an hour. Empty falls back to deploy-camunda's 60m default.
+          export DEPLOY_CAMUNDA_TTL="${CI_DEPLOYMENT_TTL:-}"
 
           deploy-camunda matrix run \
             --repo-root "${GITHUB_WORKSPACE}" \

--- a/scripts/deploy-camunda/cmd/root.go
+++ b/scripts/deploy-camunda/cmd/root.go
@@ -206,6 +206,7 @@ func NewRootCommand() *cobra.Command {
 	f.StringVarP(&flags.Chart.ChartVersion, "version", "v", "", "Chart version (only valid with --chart; not allowed with --chart-path)")
 	f.StringVarP(&flags.Deployment.Namespace, "namespace", "n", "", "Kubernetes namespace")
 	f.StringVar(&flags.Deployment.NamespacePrefix, "namespace-prefix", "", "Prefix to prepend to namespace (e.g., 'distribution' for EKS results in 'distribution-<namespace>')")
+	f.StringVar(&flags.Deployment.TTL, "ttl", "", "Ephemeral-namespace TTL for the cleaner/janitor (e.g. 60m, 12h). Empty falls back to the DEPLOY_CAMUNDA_TTL env var, then 60m.")
 	f.StringVarP(&flags.Deployment.Release, "release", "r", "", "Helm release name")
 	f.StringVarP(&flags.Deployment.Scenario, "scenario", "s", "", "The name of the scenario to deploy (comma-separated for parallel deployment)")
 	f.StringVar(&flags.Deployment.ScenarioPath, "scenario-path", "", "Path to scenario files")

--- a/scripts/deploy-camunda/config/merge.go
+++ b/scripts/deploy-camunda/config/merge.go
@@ -39,7 +39,8 @@ type DeploymentFlags struct {
 	ScenarioPath         string
 	Platform             string
 	Flow                 string
-	Timeout              int // Timeout in minutes for Helm deployment
+	TTL                  string // Ephemeral-namespace TTL (cleaner/janitor), e.g. 60m, 12h; empty falls back to DEPLOY_CAMUNDA_TTL then 60m
+	Timeout              int    // Timeout in minutes for Helm deployment
 	DeleteNamespaceFirst bool
 	RenderTemplates      bool
 	RenderOutputDir      string

--- a/scripts/deploy-camunda/deploy/deploy.go
+++ b/scripts/deploy-camunda/deploy/deploy.go
@@ -338,6 +338,15 @@ func executeDeployment(ctx context.Context, prepared *PreparedScenario, flags *c
 			Msg("🔧 [executeDeployment] using specified kubeContext")
 	}
 
+	// TTL precedence: --ttl flag, then DEPLOY_CAMUNDA_TTL env, else 60m default.
+	deployTTL := flags.Deployment.TTL
+	if deployTTL == "" {
+		deployTTL = os.Getenv("DEPLOY_CAMUNDA_TTL")
+	}
+	if deployTTL == "" {
+		deployTTL = "60m"
+	}
+
 	// Build deployment options
 	deployOpts := types.Options{
 		ChartPath:              flags.Chart.ChartPath,
@@ -364,7 +373,7 @@ func executeDeployment(ctx context.Context, prepared *PreparedScenario, flags *c
 		NamespacePrefix:        flags.Deployment.NamespacePrefix,
 		RepoRoot:               flags.Chart.RepoRoot,
 		Identifier:             identifier,
-		TTL:                    "60m",
+		TTL:                    deployTTL,
 		LoadKeycloakRealm:      true,
 		KeycloakRealmName:      prepared.RealmName,
 		RenderTemplates:        flags.Deployment.RenderTemplates,


### PR DESCRIPTION
### Which problem does the PR fix?

Nightly Self-Managed CI clusters are reaped ~1 hour after creation even though the workflow
requests a 12h TTL — so by the time triage/on-call (or a fix agent) looks, the environment is gone.

Root cause (GKE audit-log confirmed, namespace `qa-id-qaos-f36f-8-10-qaos`):

- `04:11:57Z` namespace created
- `04:12:03Z` `cleaner/ttl=12h` set (the workflow's requested TTL)
- `04:12:43Z` `cleaner/ttl` / `janitor/ttl` **overwritten to `60m`**
- `05:12:00Z` namespace **deleted** by `system:serviceaccount:k8s-cleaner:k8s-cleaner`

The overwrite comes from `deploy-camunda`, which hardcoded `TTL: "60m"` when applying the namespace
(`scripts/deploy-camunda/deploy/deploy.go` → `scripts/camunda-deployer/pkg/deployer/kube.go` sets
`cleaner/ttl` + `janitor/ttl`). `"60m"` was the only occurrence of that value in the codebase, and
the patch body matches `kube.go`'s annotation set exactly.

### What's in this PR?

Make the namespace TTL configurable instead of hardcoded, so deploys keep the lifetime the caller
asked for:

- `deploy.go` resolves the TTL as **`--ttl` flag → `DEPLOY_CAMUNDA_TTL` env → `60m` default**
  (unchanged behavior for ad-hoc/local deploys).
- New `--ttl` flag on the deploy command (`cmd/root.go`, `config/merge.go`).
- `deploy-camunda matrix run` builds its own config and does not register `--ttl`, so the integration
  runner (`.github/workflows/test-integration-runner.yaml`) exports `DEPLOY_CAMUNDA_TTL` from the
  existing `CI_DEPLOYMENT_TTL` (= the `deployment-ttl` input) right before each `matrix run`. Nightly
  clusters (`12h`) now keep their full lifetime; PR runs keep whatever TTL they already pass (empty →
  `60m`, unchanged).

Verified locally: `gofmt` clean, `go build` passes, `--ttl` appears in `deploy --help`.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
