### PR TITLE
fix: make deprecated app-config keys migratable to extraConfiguration

### DIFF
--- a/charts/camunda-platform-8.10/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/common/_helpers.tpl
@@ -1557,7 +1557,11 @@ migration target (supplied through a spring-imported <component>.extraConfigurat
 override it. Same transitional gating as orchestration.camundaExporterEnabled: the
 deprecated key is the fallback and is removed in chart v16 (8.11). Later extraConfiguration
 entries win; entries with springImport: false are skipped. "path" is the key list to dig in
-each parsed file (keys may themselves contain dots, e.g. "io.camunda.optimize").
+each parsed file (keys may themselves contain dots, e.g. "io.camunda.optimize"). Keys match
+literally on nested map keys: flat dotted keys ("camunda.document.x: y"), relaxed-binding
+camelCase, and keys outside the first YAML document are not matched, so the migration file
+must use the nested YAML form. Non-scalar (map/list) and null nodes are ignored and the
+deprecated default is kept; whole-number floats render as integers.
 Usage:
 {{ include "camundaPlatform.effectiveExtraConfigValue" (dict
   "default" (.Values.optimize.logLevel)
@@ -1580,8 +1584,12 @@ Usage:
           {{- $found = false -}}
         {{- end -}}
       {{- end -}}
-      {{- if $found -}}
-        {{- $value = $node -}}
+      {{- if and $found (not (kindIs "invalid" $node)) (not (kindIs "map" $node)) (not (kindIs "slice" $node)) -}}
+        {{- if and (kindIs "float64" $node) (eq $node (floor $node)) -}}
+          {{- $value = (int64 $node) -}}
+        {{- else -}}
+          {{- $value = $node -}}
+        {{- end -}}
       {{- end -}}
     {{- end -}}
   {{- end -}}
@@ -1594,6 +1602,10 @@ NOTE: reports "true" when a spring-imported <component>.extraConfiguration file 
 given key path (any subkey counts). Used to gate chart-rendered env that would otherwise
 shadow the migration target — e.g. suppress the -documentstore-env-vars envFrom for a
 component that owns document config via camunda.document.* in its extraConfiguration.
+Because any subkey matches, the whole -documentstore-env-vars envFrom is dropped, so a
+component that supplies any camunda.document.* via extraConfiguration owns all of its
+document config (default store id, per-store class/bucket, region). Keys match literally on
+nested map keys (see effectiveExtraConfigValue for the accepted YAML form).
 Usage:
 {{ if eq (include "camundaPlatform.extraConfigHasPath" (dict
   "extraConfiguration" .Values.orchestration.extraConfiguration

--- a/charts/camunda-platform-8.10/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/common/_helpers.tpl
@@ -1550,3 +1550,75 @@ Release highlights.
 - Please refer to the official docs for more details.
 https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/upgrade-hc-890-8100/
 {{- end -}}
+
+{{- /*
+NOTE: resolves the effective value of a deprecated app-config-proxy key, letting its
+migration target (supplied through a spring-imported <component>.extraConfiguration file)
+override it. Same transitional gating as orchestration.camundaExporterEnabled: the
+deprecated key is the fallback and is removed in chart v16 (8.11). Later extraConfiguration
+entries win; entries with springImport: false are skipped. "path" is the key list to dig in
+each parsed file (keys may themselves contain dots, e.g. "io.camunda.optimize").
+Usage:
+{{ include "camundaPlatform.effectiveExtraConfigValue" (dict
+  "default" (.Values.optimize.logLevel)
+  "extraConfiguration" .Values.optimize.extraConfiguration
+  "path" (list "logging" "level" "io.camunda.optimize")
+) }}
+*/ -}}
+{{- define "camundaPlatform.effectiveExtraConfigValue" -}}
+{{- $value := .default -}}
+{{- range .extraConfiguration -}}
+  {{- if not (and (hasKey . "springImport") (eq .springImport false)) -}}
+    {{- $parsed := (.content | default "" | fromYaml) -}}
+    {{- if kindIs "map" $parsed -}}
+      {{- $node := $parsed -}}
+      {{- $found := true -}}
+      {{- range $key := $.path -}}
+        {{- if and $found (kindIs "map" $node) (hasKey $node $key) -}}
+          {{- $node = index $node $key -}}
+        {{- else -}}
+          {{- $found = false -}}
+        {{- end -}}
+      {{- end -}}
+      {{- if $found -}}
+        {{- $value = $node -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- $value -}}
+{{- end -}}
+
+{{- /*
+NOTE: reports "true" when a spring-imported <component>.extraConfiguration file sets the
+given key path (any subkey counts). Used to gate chart-rendered env that would otherwise
+shadow the migration target — e.g. suppress the -documentstore-env-vars envFrom for a
+component that owns document config via camunda.document.* in its extraConfiguration.
+Usage:
+{{ if eq (include "camundaPlatform.extraConfigHasPath" (dict
+  "extraConfiguration" .Values.orchestration.extraConfiguration
+  "path" (list "camunda" "document"))) "true" }}
+*/ -}}
+{{- define "camundaPlatform.extraConfigHasPath" -}}
+{{- $found := "" -}}
+{{- range .extraConfiguration -}}
+  {{- if not (and (hasKey . "springImport") (eq .springImport false)) -}}
+    {{- $parsed := (.content | default "" | fromYaml) -}}
+    {{- if kindIs "map" $parsed -}}
+      {{- $node := $parsed -}}
+      {{- $ok := true -}}
+      {{- range $key := $.path -}}
+        {{- if and $ok (kindIs "map" $node) (hasKey $node $key) -}}
+          {{- $node = index $node $key -}}
+        {{- else -}}
+          {{- $ok = false -}}
+        {{- end -}}
+      {{- end -}}
+      {{- if $ok -}}
+        {{- $found = "true" -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- $found -}}
+{{- end -}}

--- a/charts/camunda-platform-8.10/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.10/templates/common/constraints.tpl
@@ -600,10 +600,10 @@ The following values inside your values.yaml need to be set but were not:
     {{- $wm := mustMergeOverwrite (deepCopy .Values.webModeler) (.Values.camundaHub.webModeler | default dict) }}
     {{- $wmExtra := "webModeler.restapi.extraConfiguration" }}
     {{ include "camundaPlatform.keyDeprecated" (dict
-      "condition" (not (empty .Values.webModeler.restapi.mail.fromAddress))
+      "condition" (not (empty $wm.restapi.mail.fromAddress))
       "oldName" "webModeler.restapi.mail.fromAddress" "migration" $wmExtra) }}
     {{ include "camundaPlatform.keyDeprecated" (dict
-      "condition" (ne (.Values.webModeler.restapi.mail.fromName | toString) "Camunda 8")
+      "condition" (ne ($wm.restapi.mail.fromName | toString) "Camunda 8")
       "oldName" "webModeler.restapi.mail.fromName" "migration" $wmExtra) }}
     {{ include "camundaPlatform.keyDeprecated" (dict
       "condition" (not (empty $wm.restapi.mail.smtpHost))

--- a/charts/camunda-platform-8.10/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.10/templates/common/constraints.tpl
@@ -600,10 +600,10 @@ The following values inside your values.yaml need to be set but were not:
     {{- $wm := mustMergeOverwrite (deepCopy .Values.webModeler) (.Values.camundaHub.webModeler | default dict) }}
     {{- $wmExtra := "webModeler.restapi.extraConfiguration" }}
     {{ include "camundaPlatform.keyDeprecated" (dict
-      "condition" (not (empty $wm.restapi.mail.fromAddress))
+      "condition" (not (empty .Values.webModeler.restapi.mail.fromAddress))
       "oldName" "webModeler.restapi.mail.fromAddress" "migration" $wmExtra) }}
     {{ include "camundaPlatform.keyDeprecated" (dict
-      "condition" (ne ($wm.restapi.mail.fromName | toString) "Camunda 8")
+      "condition" (ne (.Values.webModeler.restapi.mail.fromName | toString) "Camunda 8")
       "oldName" "webModeler.restapi.mail.fromName" "migration" $wmExtra) }}
     {{ include "camundaPlatform.keyDeprecated" (dict
       "condition" (not (empty $wm.restapi.mail.smtpHost))
@@ -629,17 +629,16 @@ The following values inside your values.yaml need to be set but were not:
     {{- $con := mustMergeOverwrite (deepCopy (.Values.console | default dict)) (.Values.camundaHub.console | default dict) }}
     {{ include "camundaPlatform.keyDeprecated" (dict
       "condition" (ne (dig "keycloak" "realm" "camunda-platform" $con) "camunda-platform")
-      "oldName" "console.keycloak.realm" "migration" "console.extraConfiguration") }}
+      "oldName" "console.keycloak.realm" "migration" "console.env") }}
     {{ include "camundaPlatform.keyDeprecated" (dict
       "condition" (ne ($con.nodeEnv | default "prod" | toString) "prod")
       "oldName" "console.nodeEnv" "migration" "console.env") }}
     {{ include "camundaPlatform.keyDeprecated" (dict
       "condition" (not (empty $con.logging))
-      "oldName" "console.logging" "migration" "console.extraConfiguration") }}
+      "oldName" "console.logging" "migration" "console.env") }}
   {{- end }}
 
   {{- $componentExtra := "the consuming component's extraConfiguration" }}
-  {{- $componentEnv := "the consuming component's extraEnvVars" }}
   {{ include "camundaPlatform.keyDeprecated" (dict
     "condition" (ne (.Values.global.config.requestBodySize | toString) "10MB")
     "oldName" "global.config.requestBodySize" "migration" $componentExtra) }}
@@ -648,13 +647,13 @@ The following values inside your values.yaml need to be set but were not:
     "oldName" "global.zeebeClusterName" "migration" $componentExtra) }}
   {{ include "camundaPlatform.keyDeprecated" (dict
     "condition" (ne (.Values.global.documentStore.type.aws.storeId | toString) "AWS")
-    "oldName" "global.documentStore.type.aws.storeId" "migration" $componentEnv) }}
+    "oldName" "global.documentStore.type.aws.storeId" "migration" $componentExtra) }}
   {{ include "camundaPlatform.keyDeprecated" (dict
     "condition" (ne (.Values.global.documentStore.type.gcp.storeId | toString) "GCP")
-    "oldName" "global.documentStore.type.gcp.storeId" "migration" $componentEnv) }}
+    "oldName" "global.documentStore.type.gcp.storeId" "migration" $componentExtra) }}
   {{ include "camundaPlatform.keyDeprecated" (dict
     "condition" (ne (.Values.global.documentStore.type.inmemory.storeId | toString) "INMEMORY")
-    "oldName" "global.documentStore.type.inmemory.storeId" "migration" $componentEnv) }}
+    "oldName" "global.documentStore.type.inmemory.storeId" "migration" $componentExtra) }}
 {{- end }}
 
 {{/*

--- a/charts/camunda-platform-8.10/templates/connectors/deployment.yaml
+++ b/charts/camunda-platform-8.10/templates/connectors/deployment.yaml
@@ -82,15 +82,20 @@ spec:
           {{- if .Values.connectors.env}}
             {{ .Values.connectors.env | toYaml | nindent 12 }}
           {{- end }}
+          {{- $documentStoreEnvFrom := ne (include "camundaPlatform.extraConfigHasPath" (dict "extraConfiguration" .Values.connectors.extraConfiguration "path" (list "camunda" "document"))) "true" }}
+          {{- if or .Values.global.identity.auth.enabled $documentStoreEnvFrom .Values.connectors.envFrom }}
           envFrom:
           {{- if .Values.global.identity.auth.enabled }}
             - configMapRef:
                 name: {{ include "camundaPlatform.fullname" . }}-identity-env-vars
           {{- end }}
+          {{- if $documentStoreEnvFrom }}
             - configMapRef:
                 name: {{ include "camundaPlatform.fullname" . }}-documentstore-env-vars
+          {{- end }}
           {{- if .Values.connectors.envFrom -}}
             {{ .Values.connectors.envFrom | toYaml | nindent 12 }}
+          {{- end }}
           {{- end }}
           {{- if .Values.connectors.command}}
           command: {{ toYaml .Values.connectors.command | nindent 12 }}

--- a/charts/camunda-platform-8.10/templates/identity/deployment.yaml
+++ b/charts/camunda-platform-8.10/templates/identity/deployment.yaml
@@ -155,11 +155,16 @@ spec:
           {{- with .Values.identity.env }}
             {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
+          {{- $documentStoreEnvFrom := ne (include "camundaPlatform.extraConfigHasPath" (dict "extraConfiguration" .Values.identity.extraConfiguration "path" (list "camunda" "document"))) "true" }}
+          {{- if or $documentStoreEnvFrom .Values.identity.envFrom }}
           envFrom:
+          {{- if $documentStoreEnvFrom }}
             - configMapRef:
                 name: {{ include "camundaPlatform.fullname" . }}-documentstore-env-vars
+          {{- end }}
           {{- if .Values.identity.envFrom }}
             {{- .Values.identity.envFrom | toYaml | nindent 12 }}
+          {{- end }}
           {{- end }}
           {{- if .Values.identity.command}}
           command: {{ toYaml .Values.identity.command | nindent 10 }}

--- a/charts/camunda-platform-8.10/templates/optimize/deployment.yaml
+++ b/charts/camunda-platform-8.10/templates/optimize/deployment.yaml
@@ -125,7 +125,7 @@ spec:
             - mountPath: /optimize/config/environment-config.yaml
               subPath: environment-config.yaml
               name: environment-config
-            {{- if .Values.global.identity.auth.enabled }}
+            {{- if or .Values.global.identity.auth.enabled .Values.optimize.extraConfiguration }}
             - mountPath: /optimize/config/application-ccsm.yaml
               subPath: application-ccsm.yaml
               name: environment-config
@@ -334,7 +334,7 @@ spec:
             - mountPath: /optimize/config/environment-config.yaml
               subPath: environment-config.yaml
               name: environment-config
-            {{- if .Values.global.identity.auth.enabled }}
+            {{- if or .Values.global.identity.auth.enabled .Values.optimize.extraConfiguration }}
             - mountPath: /optimize/config/application-ccsm.yaml
               subPath: application-ccsm.yaml
               name: environment-config

--- a/charts/camunda-platform-8.10/templates/optimize/deployment.yaml
+++ b/charts/camunda-platform-8.10/templates/optimize/deployment.yaml
@@ -216,7 +216,7 @@ spec:
             {{- end }}
             {{- end }}
             - name: SPRING_PROFILES_ACTIVE
-              value: {{ .Values.optimize.profiles | default "ccsm" | quote }}
+              value: {{ include "camundaPlatform.effectiveExtraConfigValue" (dict "default" (.Values.optimize.profiles | default "ccsm") "extraConfiguration" .Values.optimize.extraConfiguration "path" (list "spring" "profiles" "active")) | quote }}
             {{- if .Values.global.identity.auth.enabled }}
             {{- include "camundaPlatform.emitEnvVarFromSecretConfig" (dict
                 "envName" "CAMUNDA_IDENTITY_CLIENT_SECRET"
@@ -227,20 +227,20 @@ spec:
             - name: CAMUNDA_OPTIMIZE_MULTITENANCY_ENABLED
               value: "true"
             - name: CAMUNDA_OPTIMIZE_CACHES_CLOUD_TENANT_AUTHORIZATIONS_MAX_SIZE
-              value: {{ .Values.optimize.caches.cloudTenantAuthorizations.maxSize | default "10000" | quote }}
+              value: {{ include "camundaPlatform.effectiveExtraConfigValue" (dict "default" (.Values.optimize.caches.cloudTenantAuthorizations.maxSize | default "10000") "extraConfiguration" .Values.optimize.extraConfiguration "path" (list "camunda" "optimize" "caches" "cloud-tenant-authorizations" "max-size")) | quote }}
             - name: CAMUNDA_OPTIMIZE_CACHES_CLOUD_TENANT_AUTHORIZATIONS_MIN_FETCH_INTERVAL_SECONDS
-              value: {{ .Values.optimize.caches.cloudTenantAuthorizations.minFetchIntervalSeconds | default "600000" | quote }}
+              value: {{ include "camundaPlatform.effectiveExtraConfigValue" (dict "default" (.Values.optimize.caches.cloudTenantAuthorizations.minFetchIntervalSeconds | default "600000") "extraConfiguration" .Values.optimize.extraConfiguration "path" (list "camunda" "optimize" "caches" "cloud-tenant-authorizations" "min-fetch-interval-seconds")) | quote }}
             {{- end }}
             {{- if or .Values.optimize.database.opensearch.aws.enabled .Values.global.opensearch.aws.enabled }}
             - name: CAMUNDA_OPTIMIZE_OPENSEARCH_AWS_ENABLED
               value: "true"
             {{- end }}
             - name: OPTIMIZE_LOG_LEVEL
-              value: {{ .Values.optimize.logLevel | quote }}
+              value: {{ include "camundaPlatform.effectiveExtraConfigValue" (dict "default" .Values.optimize.logLevel "extraConfiguration" .Values.optimize.extraConfiguration "path" (list "logging" "level" "io.camunda.optimize")) | quote }}
             - name: UPGRADE_LOG_LEVEL
-              value: {{ .Values.optimize.upgradeLogLevel | quote }}
+              value: {{ include "camundaPlatform.effectiveExtraConfigValue" (dict "default" .Values.optimize.upgradeLogLevel "extraConfiguration" .Values.optimize.extraConfiguration "path" (list "logging" "level" "io.camunda.optimize.upgrade")) | quote }}
             - name: ES_LOG_LEVEL
-              value: {{ .Values.optimize.esLogLevel | quote }}
+              value: {{ include "camundaPlatform.effectiveExtraConfigValue" (dict "default" .Values.optimize.esLogLevel "extraConfiguration" .Values.optimize.extraConfiguration "path" (list "logging" "level" "org.elasticsearch")) | quote }}
             {{- if and .Values.global.documentStore.type.aws.enabled (not .Values.global.documentStore.type.aws.irsa.enabled) }}
             - name: AWS_ACCESS_KEY_ID
               {{- include "camundaPlatform.emitAwsDocumentStoreSecret" (dict
@@ -263,15 +263,20 @@ spec:
           {{- with .Values.optimize.env }}
             {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
+          {{- $documentStoreEnvFrom := ne (include "camundaPlatform.extraConfigHasPath" (dict "extraConfiguration" .Values.optimize.extraConfiguration "path" (list "camunda" "document"))) "true" }}
+          {{- if or .Values.global.identity.auth.enabled $documentStoreEnvFrom .Values.optimize.envFrom }}
           envFrom:
           {{- if .Values.global.identity.auth.enabled }}
             - configMapRef:
                 name: {{ include "camundaPlatform.fullname" . }}-identity-env-vars
           {{- end }}
+          {{- if $documentStoreEnvFrom }}
             - configMapRef:
                 name: {{ include "camundaPlatform.fullname" . }}-documentstore-env-vars
+          {{- end }}
           {{- if .Values.optimize.envFrom -}}
            {{ .Values.optimize.envFrom | toYaml | nindent 12 }}
+          {{- end }}
           {{- end }}
           {{- if .Values.optimize.command }}
           command: {{ toYaml .Values.optimize.command | nindent 10 }}

--- a/charts/camunda-platform-8.10/templates/optimize/files/_environment-config.yaml
+++ b/charts/camunda-platform-8.10/templates/optimize/files/_environment-config.yaml
@@ -9,8 +9,8 @@ container:
 {{- end }}
 zeebe:
   enabled: true
-  partitionCount: {{ .Values.optimize.partitionCount }}
-  name: {{ include "optimize.indexPrefix" . | quote }}
+  partitionCount: {{ include "camundaPlatform.effectiveExtraConfigValue" (dict "default" .Values.optimize.partitionCount "extraConfiguration" .Values.optimize.extraConfiguration "path" (list "zeebe" "partitionCount")) }}
+  name: {{ include "camundaPlatform.effectiveExtraConfigValue" (dict "default" (include "optimize.indexPrefix" .) "extraConfiguration" .Values.optimize.extraConfiguration "path" (list "zeebe" "name")) | quote }}
 es:
   connection:
     nodes:

--- a/charts/camunda-platform-8.10/templates/orchestration/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/orchestration/_helpers.tpl
@@ -274,8 +274,30 @@ Authentication.
 {{- end -}}
 
 
+{{- /*
+NOTE: resolves the effective camunda-exporter toggle. Starts from the deprecated
+orchestration.exporters.camunda.enabled key and lets its migration target,
+camunda.data.secondary-storage.autoconfigure-camunda-exporter supplied through a
+spring-imported orchestration.extraConfiguration file, override it.
+*/ -}}
+{{- define "orchestration.camundaExporterEnabled" -}}
+{{- $enabled := .Values.orchestration.exporters.camunda.enabled -}}
+{{- range .Values.orchestration.extraConfiguration -}}
+  {{- if not (and (hasKey . "springImport") (eq .springImport false)) -}}
+    {{- $parsed := (.content | default "" | fromYaml) -}}
+    {{- if kindIs "map" $parsed -}}
+      {{- $override := dig "camunda" "data" "secondary-storage" "autoconfigure-camunda-exporter" nil $parsed -}}
+      {{- if not (kindIs "invalid" $override) -}}
+        {{- $enabled = $override -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- $enabled -}}
+{{- end -}}
+
 {{- define "orchestration.hasCamundaExporter" -}}
-{{- and (not (eq (include "orchestration.secondaryStorage" .) "none")) .Values.orchestration.exporters.camunda.enabled (not .Values.orchestration.exporters.rdbms.enabled) -}}
+{{- and (not (eq (include "orchestration.secondaryStorage" .) "none")) (eq (include "orchestration.camundaExporterEnabled" .) "true") (not .Values.orchestration.exporters.rdbms.enabled) -}}
 {{- end -}}
 
 {{- define "orchestration.hasNoExporter" -}}

--- a/charts/camunda-platform-8.10/templates/orchestration/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/orchestration/_helpers.tpl
@@ -281,19 +281,11 @@ camunda.data.secondary-storage.autoconfigure-camunda-exporter supplied through a
 spring-imported orchestration.extraConfiguration file, override it.
 */ -}}
 {{- define "orchestration.camundaExporterEnabled" -}}
-{{- $enabled := .Values.orchestration.exporters.camunda.enabled -}}
-{{- range .Values.orchestration.extraConfiguration -}}
-  {{- if not (and (hasKey . "springImport") (eq .springImport false)) -}}
-    {{- $parsed := (.content | default "" | fromYaml) -}}
-    {{- if kindIs "map" $parsed -}}
-      {{- $override := dig "camunda" "data" "secondary-storage" "autoconfigure-camunda-exporter" nil $parsed -}}
-      {{- if not (kindIs "invalid" $override) -}}
-        {{- $enabled = $override -}}
-      {{- end -}}
-    {{- end -}}
-  {{- end -}}
-{{- end -}}
-{{- $enabled -}}
+{{- include "camundaPlatform.effectiveExtraConfigValue" (dict
+  "default" .Values.orchestration.exporters.camunda.enabled
+  "extraConfiguration" .Values.orchestration.extraConfiguration
+  "path" (list "camunda" "data" "secondary-storage" "autoconfigure-camunda-exporter")
+) -}}
 {{- end -}}
 
 {{- define "orchestration.hasCamundaExporter" -}}

--- a/charts/camunda-platform-8.10/templates/orchestration/files/_application.yaml
+++ b/charts/camunda-platform-8.10/templates/orchestration/files/_application.yaml
@@ -104,7 +104,7 @@ camunda:
           processing: {{ .Values.orchestration.data.disk.freeSpace.processing | quote }}
           replication: {{ .Values.orchestration.data.disk.freeSpace.replication | quote }}
     secondary-storage:
-      autoconfigure-camunda-exporter: {{ .Values.orchestration.exporters.camunda.enabled }}
+      autoconfigure-camunda-exporter: {{ include "orchestration.camundaExporterEnabled" . }}
       type: {{ include "orchestration.secondaryStorage" . | quote -}}
       {{- if .Values.orchestration.history.retention.enabled }}
       retention:

--- a/charts/camunda-platform-8.10/templates/orchestration/statefulset.yaml
+++ b/charts/camunda-platform-8.10/templates/orchestration/statefulset.yaml
@@ -160,11 +160,16 @@ spec:
                 "envName" "VALUES_EXPORTERS_APPINTEGRATIONS_APIKEY"
                 "config" .Values.orchestration.exporters.appIntegrations.apiKey
             ) | nindent 12 }}
+          {{- $documentStoreEnvFrom := ne (include "camundaPlatform.extraConfigHasPath" (dict "extraConfiguration" .Values.orchestration.extraConfiguration "path" (list "camunda" "document"))) "true" }}
+          {{- if or $documentStoreEnvFrom .Values.orchestration.envFrom }}
           envFrom:
+          {{- if $documentStoreEnvFrom }}
             - configMapRef:
                 name: {{ include "camundaPlatform.fullname" . }}-documentstore-env-vars
+          {{- end }}
           {{- if .Values.orchestration.envFrom }}
             {{- .Values.orchestration.envFrom | toYaml | nindent 12 }}
+          {{- end }}
           {{- end }}
           ports:
             - containerPort: {{ .Values.orchestration.service.httpPort }}

--- a/charts/camunda-platform-8.10/templates/web-modeler/configmap-restapi.yaml
+++ b/charts/camunda-platform-8.10/templates/web-modeler/configmap-restapi.yaml
@@ -48,7 +48,9 @@ data:
         {{- end }}
 
         mail:
-          from-address: {{ required "The value 'webModeler.restapi.mail.fromAddress' is required" (or .Values.camundaHub.webModeler.restapi.mail.fromAddress .Values.webModeler.restapi.mail.fromAddress) | quote }}
+          {{- with (or .Values.camundaHub.webModeler.restapi.mail.fromAddress .Values.webModeler.restapi.mail.fromAddress) }}
+          from-address: {{ . | quote }}
+          {{- end }}
           from-name: {{ (or .Values.camundaHub.webModeler.restapi.mail.fromName .Values.webModeler.restapi.mail.fromName) | quote }}
 
         oauth2:

--- a/charts/camunda-platform-8.10/templates/web-modeler/configmap-restapi.yaml
+++ b/charts/camunda-platform-8.10/templates/web-modeler/configmap-restapi.yaml
@@ -48,8 +48,12 @@ data:
         {{- end }}
 
         mail:
-          {{- with (or .Values.camundaHub.webModeler.restapi.mail.fromAddress .Values.webModeler.restapi.mail.fromAddress) }}
-          from-address: {{ . | quote }}
+          {{- $fromAddress := or .Values.camundaHub.webModeler.restapi.mail.fromAddress .Values.webModeler.restapi.mail.fromAddress }}
+          {{- $restapiExtraConfig := or .Values.camundaHub.webModeler.restapi.extraConfiguration .Values.webModeler.restapi.extraConfiguration }}
+          {{- if $fromAddress }}
+          from-address: {{ $fromAddress | quote }}
+          {{- else if ne (include "camundaPlatform.extraConfigHasPath" (dict "extraConfiguration" $restapiExtraConfig "path" (list "camunda" "modeler" "mail" "from-address"))) "true" }}
+          from-address: {{ required "The value 'webModeler.restapi.mail.fromAddress' is required (or supply camunda.modeler.mail.from-address via webModeler.restapi.extraConfiguration)" "" | quote }}
           {{- end }}
           from-name: {{ (or .Values.camundaHub.webModeler.restapi.mail.fromName .Values.webModeler.restapi.mail.fromName) | quote }}
 

--- a/charts/camunda-platform-8.10/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform-8.10/templates/web-modeler/deployment-restapi.yaml
@@ -109,11 +109,16 @@ spec:
           {{- with (or .Values.camundaHub.webModeler.restapi.env .Values.webModeler.restapi.env) }}
             {{- tpl (toYaml .) $ | nindent 12 }}
             {{- end }}
+          {{- $documentStoreEnvFrom := ne (include "camundaPlatform.extraConfigHasPath" (dict "extraConfiguration" (or .Values.camundaHub.webModeler.restapi.extraConfiguration .Values.webModeler.restapi.extraConfiguration) "path" (list "camunda" "document"))) "true" }}
+          {{- if or $documentStoreEnvFrom (or .Values.camundaHub.webModeler.restapi.envFrom .Values.webModeler.restapi.envFrom) }}
           envFrom:
+          {{- if $documentStoreEnvFrom }}
             - configMapRef:
                 name: {{ include "camundaPlatform.fullname" . }}-documentstore-env-vars
+          {{- end }}
           {{- if (or .Values.camundaHub.webModeler.restapi.envFrom .Values.webModeler.restapi.envFrom) }}
             {{- (or .Values.camundaHub.webModeler.restapi.envFrom .Values.webModeler.restapi.envFrom) | toYaml | nindent 12 }}
+          {{- end }}
           {{- end }}
           {{- if (or .Values.camundaHub.webModeler.restapi.command .Values.webModeler.restapi.command) }}
           command: {{ toYaml (or .Values.camundaHub.webModeler.restapi.command .Values.webModeler.restapi.command) | nindent 10 }}

--- a/charts/camunda-platform-8.10/test/unit/optimize/configmap_test.go
+++ b/charts/camunda-platform-8.10/test/unit/optimize/configmap_test.go
@@ -396,3 +396,37 @@ func (s *ConfigMapTemplateTest) TestExtraConfigurationSpringImport() {
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
+
+func (s *ConfigMapTemplateTest) TestOptimizeNativeConfigHonorsExtraConfiguration() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name:        "TestPartitionCountAndIndexNameResolvedFromExtraConfiguration",
+			ValuesFiles: []string{filepath.Join(s.chartPath, "test/unit/optimize/testdata/values-optimize-gating-extraconfig.yaml")},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				envConfig := configmap.Data["environment-config.yaml"]
+				s.Require().Contains(envConfig, "partitionCount: 7",
+					"partitionCount should be resolved from extraConfiguration")
+				s.Require().Contains(envConfig, "name: \"gated-index\"",
+					"index name should be resolved from extraConfiguration")
+			},
+		},
+		{
+			Name:        "TestDeprecatedPartitionCountUsedWithoutExtraConfiguration",
+			ValuesFiles: []string{filepath.Join(s.chartPath, "test/unit/optimize/testdata/values-optimize-gating-deprecated.yaml")},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				s.Require().Contains(configmap.Data["environment-config.yaml"], "partitionCount: 9",
+					"deprecated optimize.partitionCount should still apply without extraConfiguration")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}

--- a/charts/camunda-platform-8.10/test/unit/optimize/configmap_test.go
+++ b/charts/camunda-platform-8.10/test/unit/optimize/configmap_test.go
@@ -426,6 +426,21 @@ func (s *ConfigMapTemplateTest) TestOptimizeNativeConfigHonorsExtraConfiguration
 					"deprecated optimize.partitionCount should still apply without extraConfiguration")
 			},
 		},
+		{
+			Name:        "TestLargeNumberRendersAsIntegerNotScientificNotation",
+			ValuesFiles: []string{filepath.Join(s.chartPath, "test/unit/optimize/testdata/values-optimize-gating-nonscalar.yaml")},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+				envConfig := configmap.Data["environment-config.yaml"]
+				s.Require().Contains(envConfig, "partitionCount: 10000000",
+					"a whole-number float must render as an integer")
+				s.Require().NotContains(envConfig, "1e+07",
+					"a large number must not render in scientific notation")
+			},
+		},
 	}
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)

--- a/charts/camunda-platform-8.10/test/unit/optimize/deployment_test.go
+++ b/charts/camunda-platform-8.10/test/unit/optimize/deployment_test.go
@@ -1513,3 +1513,50 @@ func (s *DeploymentTemplateTest) TestOptimizeEnvHonorsExtraConfiguration() {
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
+
+func (s *DeploymentTemplateTest) TestOptimizeEnvGuardsNonScalarExtraConfiguration() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name:        "TestNonScalarAndNullNodesFallBackToDeprecatedDefault",
+			ValuesFiles: []string{filepath.Join(s.chartPath, "test/unit/optimize/testdata/values-optimize-gating-nonscalar.yaml")},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env, corev1.EnvVar{Name: "SPRING_PROFILES_ACTIVE", Value: "myprofile"},
+					"a list node must not render as Go slice syntax; fall back to the deprecated default")
+				s.Require().Contains(env, corev1.EnvVar{Name: "OPTIMIZE_LOG_LEVEL", Value: "mylevel"},
+					"a null leaf must not render as an empty string; fall back to the deprecated default")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
+func (s *DeploymentTemplateTest) TestOptimizeMountsSpringImportWithoutAuth() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name:        "TestApplicationCcsmMountedWhenExtraConfigurationSetAndAuthDisabled",
+			ValuesFiles: []string{filepath.Join(s.chartPath, "test/unit/optimize/testdata/values-optimize-gating-extraconfig.yaml")},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				mounted := false
+				for _, vm := range deployment.Spec.Template.Spec.Containers[0].VolumeMounts {
+					if vm.MountPath == "/optimize/config/application-ccsm.yaml" {
+						mounted = true
+					}
+				}
+				s.Require().True(mounted,
+					"application-ccsm.yaml carries spring.config.import and must be mounted whenever extraConfiguration is set, even with auth disabled, otherwise the migration file is never imported")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}

--- a/charts/camunda-platform-8.10/test/unit/optimize/deployment_test.go
+++ b/charts/camunda-platform-8.10/test/unit/optimize/deployment_test.go
@@ -1464,3 +1464,52 @@ func (s *DeploymentTemplateTest) TestDatabaseOverrides() {
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
+
+func (s *DeploymentTemplateTest) TestOptimizeEnvHonorsExtraConfiguration() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name:        "TestEnvResolvedFromExtraConfiguration",
+			ValuesFiles: []string{filepath.Join(s.chartPath, "test/unit/optimize/testdata/values-optimize-gating-extraconfig.yaml")},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env, corev1.EnvVar{Name: "SPRING_PROFILES_ACTIVE", Value: "ccsm,gated"})
+				s.Require().Contains(env, corev1.EnvVar{Name: "OPTIMIZE_LOG_LEVEL", Value: "debug"})
+				s.Require().Contains(env, corev1.EnvVar{Name: "UPGRADE_LOG_LEVEL", Value: "trace"})
+				s.Require().Contains(env, corev1.EnvVar{Name: "ES_LOG_LEVEL", Value: "error"})
+				s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_OPTIMIZE_CACHES_CLOUD_TENANT_AUTHORIZATIONS_MAX_SIZE", Value: "22222"})
+				s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_OPTIMIZE_CACHES_CLOUD_TENANT_AUTHORIZATIONS_MIN_FETCH_INTERVAL_SECONDS", Value: "33333"})
+			},
+		},
+		{
+			Name:        "TestDeprecatedKeyUsedWithoutExtraConfiguration",
+			ValuesFiles: []string{filepath.Join(s.chartPath, "test/unit/optimize/testdata/values-optimize-gating-deprecated.yaml")},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env, corev1.EnvVar{Name: "SPRING_PROFILES_ACTIVE", Value: "ccsm,legacy"})
+				s.Require().Contains(env, corev1.EnvVar{Name: "OPTIMIZE_LOG_LEVEL", Value: "warn"})
+			},
+		},
+		{
+			Name:        "TestSpringImportFalseEntryDoesNotOverride",
+			ValuesFiles: []string{filepath.Join(s.chartPath, "test/unit/optimize/testdata/values-optimize-gating-noimport.yaml")},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env, corev1.EnvVar{Name: "OPTIMIZE_LOG_LEVEL", Value: "warn"})
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}

--- a/charts/camunda-platform-8.10/test/unit/optimize/testdata/values-optimize-gating-deprecated.yaml
+++ b/charts/camunda-platform-8.10/test/unit/optimize/testdata/values-optimize-gating-deprecated.yaml
@@ -1,0 +1,8 @@
+# Deprecated keys set, no extraConfiguration: values must still apply (backward compat).
+identity:
+  enabled: true
+optimize:
+  enabled: true
+  logLevel: warn
+  profiles: ccsm,legacy
+  partitionCount: "9"

--- a/charts/camunda-platform-8.10/test/unit/optimize/testdata/values-optimize-gating-extraconfig.yaml
+++ b/charts/camunda-platform-8.10/test/unit/optimize/testdata/values-optimize-gating-extraconfig.yaml
@@ -1,0 +1,31 @@
+# Deprecated optimize keys NOT set (defaults); migration targets supplied via
+# optimize.extraConfiguration. Exercises the effectiveExtraConfigValue gating so
+# extraConfiguration wins over the chart-rendered env / native config.
+identity:
+  enabled: true
+optimize:
+  enabled: true
+  multitenancy:
+    enabled: true
+  extraConfiguration:
+    - file: application-migrated.yaml
+      content: |
+        spring:
+          profiles:
+            active: ccsm,gated
+        logging:
+          level:
+            io.camunda.optimize: debug
+            io.camunda.optimize.upgrade: trace
+            org.elasticsearch: error
+        camunda:
+          optimize:
+            caches:
+              cloud-tenant-authorizations:
+                max-size: 22222
+                min-fetch-interval-seconds: 33333
+    - file: environment-migrated.yaml
+      content: |
+        zeebe:
+          partitionCount: 7
+          name: gated-index

--- a/charts/camunda-platform-8.10/test/unit/optimize/testdata/values-optimize-gating-noimport.yaml
+++ b/charts/camunda-platform-8.10/test/unit/optimize/testdata/values-optimize-gating-noimport.yaml
@@ -1,0 +1,13 @@
+# extraConfiguration entry with springImport: false must NOT override the deprecated key.
+identity:
+  enabled: true
+optimize:
+  enabled: true
+  logLevel: warn
+  extraConfiguration:
+    - file: log4j2.xml
+      springImport: false
+      content: |
+        logging:
+          level:
+            io.camunda.optimize: debug

--- a/charts/camunda-platform-8.10/test/unit/optimize/testdata/values-optimize-gating-nonscalar.yaml
+++ b/charts/camunda-platform-8.10/test/unit/optimize/testdata/values-optimize-gating-nonscalar.yaml
@@ -1,0 +1,26 @@
+# extraConfiguration supplies non-scalar / null / large-number values at the migration
+# paths. The effectiveExtraConfigValue helper must not emit Go slice syntax, scientific
+# notation, or an empty string; non-scalar and null nodes fall back to the deprecated
+# default, whole-number floats render as integers.
+identity:
+  enabled: true
+optimize:
+  enabled: true
+  profiles: myprofile
+  logLevel: mylevel
+  partitionCount: "3"
+  extraConfiguration:
+    - file: application-migrated.yaml
+      content: |
+        spring:
+          profiles:
+            active:
+              - ccsm
+              - gated
+        logging:
+          level:
+            io.camunda.optimize:
+    - file: environment-migrated.yaml
+      content: |
+        zeebe:
+          partitionCount: 10000000

--- a/charts/camunda-platform-8.10/test/unit/orchestration/configmap_unified_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/configmap_unified_test.go
@@ -741,6 +741,14 @@ func (s *ConfigmapTemplateTest) TestCamundaExporterHonorsAutoconfigureFromExtraC
 				require.Contains(t, output, "camundaexporter:")
 			},
 		},
+		{
+			Name:        "TestScalarIntermediateDoesNotAbortRender",
+			ValuesFiles: []string{filepath.Join(s.chartPath, "test/unit/orchestration/testdata/values-camunda-exporter-scalar-intermediate.yaml")},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.Contains(t, output, "autoconfigure-camunda-exporter: true")
+			},
+		},
 	}
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)

--- a/charts/camunda-platform-8.10/test/unit/orchestration/configmap_unified_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/configmap_unified_test.go
@@ -720,3 +720,28 @@ func (s *ConfigmapTemplateTest) TestMultiRegionInitialContactPoints() {
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
+
+func (s *ConfigmapTemplateTest) TestCamundaExporterHonorsAutoconfigureFromExtraConfiguration() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name:        "TestDisabledViaExtraConfigurationSuppressesBlock",
+			ValuesFiles: []string{filepath.Join(s.chartPath, "test/unit/orchestration/testdata/values-camunda-exporter-disable-via-extraconfig.yaml")},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.Contains(t, output, "autoconfigure-camunda-exporter: false")
+				require.NotContains(t, output, "camundaexporter:")
+			},
+		},
+		{
+			Name:        "TestNonImportedOverrideIgnoredSoDefaultKeepsBlock",
+			ValuesFiles: []string{filepath.Join(s.chartPath, "test/unit/orchestration/testdata/values-camunda-exporter-disable-via-extraconfig-noimport.yaml")},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.Contains(t, output, "autoconfigure-camunda-exporter: true")
+				require.Contains(t, output, "camundaexporter:")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}

--- a/charts/camunda-platform-8.10/test/unit/orchestration/statefulset_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/statefulset_test.go
@@ -1143,3 +1143,43 @@ func (s *StatefulSetTest) TestJKSDoesNotFireForSecondaryStorageOnlyTLS() {
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
+
+func (s *StatefulSetTest) TestDocumentStoreEnvFromGatedByExtraConfiguration() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name:        "TestEnvFromSuppressedWhenCamundaDocumentInExtraConfiguration",
+			ValuesFiles: []string{filepath.Join(s.chartPath, "test/unit/orchestration/testdata/values-documentstore-via-extraconfig.yaml")},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				var statefulSet appsv1.StatefulSet
+				helm.UnmarshalK8SYaml(s.T(), output, &statefulSet)
+
+				for _, ef := range statefulSet.Spec.Template.Spec.Containers[0].EnvFrom {
+					if ef.ConfigMapRef != nil {
+						s.Require().NotContains(ef.ConfigMapRef.Name, "documentstore-env-vars",
+							"documentstore envFrom must be suppressed when camunda.document is set via extraConfiguration")
+					}
+				}
+				// When the only envFrom entry is suppressed, the whole envFrom key must be
+				// omitted rather than rendered as `envFrom:`/`envFrom: null` (invalid under
+				// a strict schema). Unmarshalling can't tell null from omitted, so assert on
+				// the raw manifest that the key is absent for this orchestration-only render.
+				s.Require().NotContains(output, "envFrom:",
+					"envFrom key must be omitted when it would be empty, not rendered as null")
+			},
+		},
+		{
+			Name: "TestEnvFromPresentWithoutCamundaDocument",
+			Values: map[string]string{
+				"orchestration.enabled": "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.Contains(t, output, "-documentstore-env-vars",
+					"documentstore envFrom must remain when camunda.document is not set via extraConfiguration")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}

--- a/charts/camunda-platform-8.10/test/unit/orchestration/testdata/values-camunda-exporter-disable-via-extraconfig-noimport.yaml
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/testdata/values-camunda-exporter-disable-via-extraconfig-noimport.yaml
@@ -1,0 +1,12 @@
+orchestration:
+  data:
+    secondaryStorage:
+      type: elasticsearch
+  extraConfiguration:
+    - file: camunda-exporter.yaml
+      springImport: false
+      content: |
+        camunda:
+          data:
+            secondary-storage:
+              autoconfigure-camunda-exporter: false

--- a/charts/camunda-platform-8.10/test/unit/orchestration/testdata/values-camunda-exporter-disable-via-extraconfig.yaml
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/testdata/values-camunda-exporter-disable-via-extraconfig.yaml
@@ -1,0 +1,11 @@
+orchestration:
+  data:
+    secondaryStorage:
+      type: elasticsearch
+  extraConfiguration:
+    - file: camunda-exporter.yaml
+      content: |
+        camunda:
+          data:
+            secondary-storage:
+              autoconfigure-camunda-exporter: false

--- a/charts/camunda-platform-8.10/test/unit/orchestration/testdata/values-camunda-exporter-scalar-intermediate.yaml
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/testdata/values-camunda-exporter-scalar-intermediate.yaml
@@ -1,0 +1,13 @@
+# A scalar where the exporter helper expects a map on its lookup path
+# (camunda.data.secondary-storage). The helper must tolerate this and fall back to the
+# default instead of aborting the whole render (sprig dig panics on a scalar intermediate).
+orchestration:
+  data:
+    secondaryStorage:
+      type: elasticsearch
+  extraConfiguration:
+    - file: camunda-exporter.yaml
+      content: |
+        camunda:
+          data:
+            secondary-storage: elasticsearch

--- a/charts/camunda-platform-8.10/test/unit/orchestration/testdata/values-documentstore-via-extraconfig.yaml
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/testdata/values-documentstore-via-extraconfig.yaml
@@ -1,0 +1,13 @@
+# camunda.document.* supplied via orchestration.extraConfiguration: the shadowing
+# -documentstore-env-vars envFrom must be suppressed so the extraConfiguration wins.
+orchestration:
+  enabled: true
+  extraConfiguration:
+    - file: document-store.yaml
+      content: |
+        camunda:
+          document:
+            default-store-id: s3main
+            aws:
+              s3main:
+                bucket-name: my-bucket

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/configmap_restapi_test.go
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/configmap_restapi_test.go
@@ -1109,3 +1109,48 @@ func (s *configmapRestAPITemplateTest) TestExtraConfigurationSpringImport() {
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
+
+func (s *configmapRestAPITemplateTest) TestMailFromAddressOptionalForExtraConfigurationMigration() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestFromAddressOmittedWhenUnset",
+			Values: map[string]string{
+				"identity.enabled":             "true",
+				"webModeler.enabled":           "true",
+				"global.elasticsearch.enabled": "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				applicationYaml := configmap.Data["application.yaml"]
+				s.Require().NotContains(applicationYaml, "from-address:",
+					"from-address must be omitted, not required, when unset")
+				s.Require().Contains(applicationYaml, "from-name:",
+					"from-name still renders from its default")
+			},
+		},
+		{
+			Name: "TestFromAddressMigratedViaExtraConfiguration",
+			Values: map[string]string{
+				"identity.enabled":                                 "true",
+				"webModeler.enabled":                               "true",
+				"global.elasticsearch.enabled":                     "true",
+				"webModeler.restapi.extraConfiguration[0].file":    "mail.yaml",
+				"webModeler.restapi.extraConfiguration[0].content": "some: config",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				applicationYaml := configmap.Data["application.yaml"]
+				s.Require().NotContains(applicationYaml, "from-address:",
+					"from-address must be omitted so extraConfiguration can supply it")
+				s.Require().Contains(applicationYaml, "optional:file:/home/runner/config/mail.yaml",
+					"extraConfiguration file must be imported")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/configmap_restapi_test.go
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/configmap_restapi_test.go
@@ -1113,31 +1113,21 @@ func (s *configmapRestAPITemplateTest) TestExtraConfigurationSpringImport() {
 func (s *configmapRestAPITemplateTest) TestMailFromAddressOptionalForExtraConfigurationMigration() {
 	testCases := []testhelpers.TestCase{
 		{
-			Name: "TestFromAddressOmittedWhenUnset",
+			Name: "TestFromAddressRequiredWhenUnsetAndNotMigrated",
 			Values: map[string]string{
 				"identity.enabled":             "true",
 				"webModeler.enabled":           "true",
 				"global.elasticsearch.enabled": "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				var configmap corev1.ConfigMap
-				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-				applicationYaml := configmap.Data["application.yaml"]
-				s.Require().NotContains(applicationYaml, "from-address:",
-					"from-address must be omitted, not required, when unset")
-				s.Require().Contains(applicationYaml, "from-name:",
-					"from-name still renders from its default")
+				s.Require().ErrorContains(err, "webModeler.restapi.mail.fromAddress' is required",
+					"a fresh install with no from-address anywhere must fail fast, not render an incomplete config")
 			},
 		},
 		{
 			Name: "TestFromAddressMigratedViaExtraConfiguration",
-			Values: map[string]string{
-				"identity.enabled":                                 "true",
-				"webModeler.enabled":                               "true",
-				"global.elasticsearch.enabled":                     "true",
-				"webModeler.restapi.extraConfiguration[0].file":    "mail.yaml",
-				"webModeler.restapi.extraConfiguration[0].content": "some: config",
+			ValuesFiles: []string{
+				filepath.Join(s.chartPath, "test/unit/web-modeler/testdata/values-mail-from-address-migrated.yaml"),
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				require.NoError(t, err)
@@ -1145,9 +1135,26 @@ func (s *configmapRestAPITemplateTest) TestMailFromAddressOptionalForExtraConfig
 				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
 				applicationYaml := configmap.Data["application.yaml"]
 				s.Require().NotContains(applicationYaml, "from-address:",
-					"from-address must be omitted so extraConfiguration can supply it")
+					"from-address must be omitted so the imported extraConfiguration file supplies it")
 				s.Require().Contains(applicationYaml, "optional:file:/home/runner/config/mail.yaml",
 					"extraConfiguration file must be imported")
+			},
+		},
+		{
+			Name: "TestDeprecatedFromAddressStillRenders",
+			Values: map[string]string{
+				"identity.enabled":                    "true",
+				"webModeler.enabled":                  "true",
+				"global.elasticsearch.enabled":        "true",
+				"webModeler.restapi.mail.fromAddress": "deprecated@example.com",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				applicationYaml := configmap.Data["application.yaml"]
+				s.Require().Contains(applicationYaml, "from-address: \"deprecated@example.com\"",
+					"the deprecated key must still render its value when set")
 			},
 		},
 	}

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/testdata/values-mail-from-address-migrated.yaml
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/testdata/values-mail-from-address-migrated.yaml
@@ -1,0 +1,18 @@
+# from-address migrated to restapi.extraConfiguration (camunda.modeler.mail.from-address);
+# the deprecated webModeler.restapi.mail.fromAddress is left unset. The chart-rendered
+# from-address must be omitted (so the imported file wins) and helm install must not fail.
+identity:
+  enabled: true
+global:
+  elasticsearch:
+    enabled: true
+webModeler:
+  enabled: true
+  restapi:
+    extraConfiguration:
+      - file: mail.yaml
+        content: |
+          camunda:
+            modeler:
+              mail:
+                from-address: migrated@example.com


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6507.

Several deprecated `camunda-platform` 8.10 keys tell users to move configuration to
`extraConfiguration` (or `console.env`), but the value is either rendered as a container
env var, consumed at Helm template time, or read by a component's native loader. Following
the deprecation guidance is then a silent no-op (the env/toggle wins) or aborts rendering.

### What's in this PR?

Adds transitional gating so a value supplied via a component's `extraConfiguration` wins
over the deprecated key, mirroring the existing `orchestration.camundaExporterEnabled`
read-back pattern. Two shared helpers in `common/_helpers.tpl`:

- `camundaPlatform.effectiveExtraConfigValue` — resolves a deprecated key's effective value
  from a spring-imported `extraConfiguration` file (`fromYaml` + `dig` the migration path).
- `camundaPlatform.extraConfigHasPath` — reports whether a path is present, used to gate a
  shadowing `envFrom`.

Beyond the two keys named in the issue, this covers every similarly-affected key found
while auditing the 8.10 deprecations:

- **Orchestration** — `exporters.camunda.enabled` template toggle and web-modeler
  `restapi.mail.*` (the two from the issue).
- **Optimize** — `profiles`, `logLevel`, `upgradeLogLevel`, `esLogLevel`,
  `caches.cloudTenantAuthorizations.{maxSize,minFetchIntervalSeconds}` (rendered as env),
  plus `partitionCount` and the index prefix (native `environment-config.yaml`).
- **Document store** — the `-documentstore-env-vars` `envFrom` is suppressed per Spring
  component when `camunda.document.*` is supplied via that component's `extraConfiguration`.
- **Console** — deprecation-warning targets corrected to `console.env` (the app is Node.js
  and reads these from the environment, not a config file).

Backward compatible: with no `extraConfiguration` the deprecated key still applies; entries
with `springImport: false` are ignored. Unit tests added for the optimize env/native gating
and the document-store `envFrom` gating (with testdata).

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
