### PR TITLE
test(e2e): cap full-suite workers at 25 to prevent Operate indexing overload

### DIFF
--- a/charts/camunda-platform-8.10/test/e2e/playwright.config.ts
+++ b/charts/camunda-platform-8.10/test/e2e/playwright.config.ts
@@ -86,7 +86,7 @@ export default defineConfig({
   fullyParallel: true,
   retries: 2,
   timeout: 12 * 60 * 1000, // match E2E repo timeout (12 minutes); test.slow() triples this
-  workers: "100%",
+  workers: 25,
   //workers: process.env.CI == "true" ? 1 : "50%",
   use: {
     baseURL: getBaseURL(),

--- a/charts/camunda-platform-8.8/test/e2e/playwright.config.ts
+++ b/charts/camunda-platform-8.8/test/e2e/playwright.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   fullyParallel: true,
   retries: 2,
   timeout: 10 * 60 * 1000, // no test should take more than 3 minutes (failing fast is important so that we can run our tests on each PR)
-  workers: "100%",
+  workers: 25,
   //workers: process.env.CI == "true" ? 1 : "50%",
   use: {
     baseURL: getBaseURL(),

--- a/charts/camunda-platform-8.9/test/e2e/playwright.config.ts
+++ b/charts/camunda-platform-8.9/test/e2e/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
   fullyParallel: true,
   retries: 2,
   timeout: 10 * 60 * 1000, // no test should take more than 3 minutes (failing fast is important so that we can run our tests on each PR)
-  workers: "100%",
+  workers: 25,
   //workers: process.env.CI == "true" ? 1 : "50%",
   use: {
     baseURL: getBaseURL(),


### PR DESCRIPTION
## Summary

- Changes `workers: "100%"` to `workers: 25` for the full-suite project in the 8.8, 8.9, and 8.10 Playwright configs (8.7 already uses a fixed count of 37)

## Why

`workers: "100%"` causes Playwright to spawn one worker per CPU core, which on a typical CI runner means 30–60 concurrent tests. Each test creates process instances that must be indexed by Operate/Elasticsearch. At that concurrency level the indexing queue backs up and assertions like `getByTestId('instance-header').getByText('Business ID')` (with a 60 s retry window) exhaust all retries before the instance appears.

The `@camunda/e2e-test-suite` nightly CI uses a fixed cap of 25 workers for SM versions and runs `fullyParallel: false` — which is why the nightly suite passes and the helm full-suite fails.

## Test plan

- [ ] Full-suite run on 8.8, 8.9, 8.10 completes without the `assertBusinessIdVisible` timeout
- [ ] Smoke-suite run unaffected (already fast, single spec file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)