### PR TITLE
fix(8.10): back Optimize /tmp with emptyDir to fix persistence double-mount

### DIFF
--- a/charts/camunda-platform-8.10/templates/optimize/deployment.yaml
+++ b/charts/camunda-platform-8.10/templates/optimize/deployment.yaml
@@ -359,15 +359,7 @@ spec:
         {{- end }}
       volumes:
         - name: tmp
-          {{- if and .Values.optimize.persistence.enabled .Values.optimize.persistence.existingClaim }}
-          persistentVolumeClaim:
-            claimName: {{ .Values.optimize.persistence.existingClaim }}
-          {{- else if .Values.optimize.persistence.enabled }}
-          persistentVolumeClaim:
-            claimName: {{ include "camundaPlatform.fullname" . }}-optimize-data
-          {{- else }}
           emptyDir: {}
-          {{- end }}
         - name: camunda
           {{- if and .Values.optimize.persistence.enabled .Values.optimize.persistence.existingClaim }}
           persistentVolumeClaim:

--- a/charts/camunda-platform-8.10/templates/optimize/deployment.yaml
+++ b/charts/camunda-platform-8.10/templates/optimize/deployment.yaml
@@ -366,15 +366,7 @@ spec:
         {{- end }}
       volumes:
         - name: tmp
-          {{- if and .Values.optimize.persistence.enabled .Values.optimize.persistence.existingClaim }}
-          persistentVolumeClaim:
-            claimName: {{ .Values.optimize.persistence.existingClaim }}
-          {{- else if .Values.optimize.persistence.enabled }}
-          persistentVolumeClaim:
-            claimName: {{ include "camundaPlatform.fullname" . }}-optimize-data
-          {{- else }}
           emptyDir: {}
-          {{- end }}
         - name: camunda
           {{- if and .Values.optimize.persistence.enabled .Values.optimize.persistence.existingClaim }}
           persistentVolumeClaim:

--- a/charts/camunda-platform-8.10/templates/optimize/persistentvolumeclaim.yaml
+++ b/charts/camunda-platform-8.10/templates/optimize/persistentvolumeclaim.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "camundaPlatform.fullname" . }}-optimize-data
-  labels: {{- include "camundaPlatform.labels" . | nindent 4 }}
+  labels: {{- include "optimize.labels" . | nindent 4 }}
   {{- with .Values.optimize.persistence.annotations }}
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/persistence.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/persistence.yaml
@@ -3,12 +3,16 @@
 # =============================================================================
 # Layer 4: Optional feature - exercises persistent volume configuration on
 # Camunda components so the chart's PVC/StatefulSet templates are covered by
-# nightly CI. Currently scoped to Web Modeler restapi persistence
-# (SUPPORT-30069). Optimize persistence (SUPPORT-30042) and orchestration
-# extraVolumeClaimTemplates (SUPPORT-30094) are tracked in their own PRs and
-# will be re-enabled here when the corresponding template fixes land.
+# nightly CI. Orchestration extraVolumeClaimTemplates (SUPPORT-30094) remains
+# deferred until the corresponding template fixes land.
 # Used with: TEST_VALUES_FEATURES containing "persistence"
 # =============================================================================
+
+optimize:
+  enabled: true
+  persistence:
+    enabled: true
+    size: 1Gi
 
 webModeler:
   persistence:

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/persistence.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/persistence.yaml
@@ -3,13 +3,17 @@
 # =============================================================================
 # Layer 4: Optional feature - exercises persistent volume configuration on
 # Camunda components so the chart's PVC/StatefulSet templates are covered by
-# nightly CI. Optimize persistence (SUPPORT-30042) is still deferred here; it
-# double-mounts one claim as both tmp and camunda and is tracked in #6521.
-# The set of components below must stay aligned with the 8.9 fixture, because
-# upgrade-minor installs 8.9 first and StatefulSet volumeClaimTemplates cannot
-# be added or removed by an upgrade.
+# nightly CI. The set of components below must stay aligned with the 8.9
+# fixture, because upgrade-minor installs 8.9 first and StatefulSet
+# volumeClaimTemplates cannot be added or removed by an upgrade.
 # Used with: TEST_VALUES_FEATURES containing "persistence"
 # =============================================================================
+
+optimize:
+  enabled: true
+  persistence:
+    enabled: true
+    size: 1Gi
 
 webModeler:
   persistence:

--- a/charts/camunda-platform-8.10/test/unit/optimize/persistence_test.go
+++ b/charts/camunda-platform-8.10/test/unit/optimize/persistence_test.go
@@ -113,9 +113,8 @@ func (s *PersistenceTemplateTest) TestPersistenceConfiguration() {
 
 				// then
 				s.Require().NotNil(tmpVolume, "tmp volume should exist")
-				s.Require().NotNil(tmpVolume.PersistentVolumeClaim, "tmp should use PVC when persistence is enabled")
-				s.Require().Nil(tmpVolume.EmptyDir, "tmp should not use emptyDir when persistence is enabled")
-				s.Require().Equal("camunda-platform-test-optimize-data", tmpVolume.PersistentVolumeClaim.ClaimName)
+				s.Require().NotNil(tmpVolume.EmptyDir, "tmp should use emptyDir when persistence is enabled")
+				s.Require().Nil(tmpVolume.PersistentVolumeClaim, "tmp should not use PVC when persistence is enabled")
 
 				s.Require().NotNil(camundaVolume, "camunda volume should exist")
 				s.Require().NotNil(camundaVolume.PersistentVolumeClaim, "camunda should use PVC when persistence is enabled")
@@ -148,8 +147,8 @@ func (s *PersistenceTemplateTest) TestPersistenceConfiguration() {
 
 				// then
 				s.Require().NotNil(tmpVolume, "tmp volume should exist")
-				s.Require().NotNil(tmpVolume.PersistentVolumeClaim, "tmp should use PVC when persistence is enabled")
-				s.Require().Equal("my-existing-pvc", tmpVolume.PersistentVolumeClaim.ClaimName)
+				s.Require().NotNil(tmpVolume.EmptyDir, "tmp should use emptyDir when persistence is enabled")
+				s.Require().Nil(tmpVolume.PersistentVolumeClaim, "tmp should not use PVC when persistence is enabled")
 
 				s.Require().NotNil(camundaVolume, "camunda volume should exist")
 				s.Require().NotNil(camundaVolume.PersistentVolumeClaim, "camunda should use PVC when persistence is enabled")

--- a/charts/camunda-platform-8.10/test/unit/optimize/persistence_test.go
+++ b/charts/camunda-platform-8.10/test/unit/optimize/persistence_test.go
@@ -220,6 +220,10 @@ func TestPVCManifestCreated(t *testing.T) {
 			require.Equal(t, "camunda-platform-test-optimize-data", pvc.Name)
 			require.Equal(t, "5Gi", pvc.Spec.Resources.Requests.Storage().String())
 			require.Equal(t, corev1.ReadWriteOnce, pvc.Spec.AccessModes[0])
+			require.Equal(t, "optimize", pvc.Labels["app.kubernetes.io/component"])
+			require.NotEmpty(t, pvc.Labels["app.kubernetes.io/version"])
+			require.Equal(t, "camunda-platform", pvc.Labels["app.kubernetes.io/part-of"])
+			require.Equal(t, "camunda-platform-test", pvc.Labels["app.kubernetes.io/instance"])
 		},
 	}
 


### PR DESCRIPTION
## Summary

Fixes the Optimize persistence **double-mount deadlock** on 8.10 (identical to the 8.9 fix in #6027) and re-enables Optimize coverage in the `component-persistence` (`cprst`) nightly scenario.

## Why

When `optimize.persistence.enabled=true`, `templates/optimize/deployment.yaml` bound a single RWO PVC (`<release>-optimize-data`) to **two** pod volumes — `tmp` (`/tmp`) and `camunda` (`/camunda`). Referencing one PVC from two `volumes` entries is unsupported: on GKE the PD CSI driver issues only one `NodePublishVolume` (both collapse to the same PV-name-keyed target path), so the pod hangs forever pre-init (`PodReadyToStartContainers=False`, `Initialized=False: [migration]`, no image pull, no `FailedMount` event). Optimize never becomes Ready, so `helm upgrade --install --wait --timeout 1200s` rides the full 20 min and fails with `context deadline exceeded`.

Root cause was diagnosed and the fix verified live on GKE via the 8.9 counterpart (this PR mirrors it). 8.10 was previously dormant because #6406 scoped 8.10's `cprst` `persistence.yaml` to web-modeler only, explicitly deferring Optimize until this template fix landed.

## What changed

- `templates/optimize/deployment.yaml`: the `tmp` volume is now unconditionally `emptyDir: {}` (scratch `/tmp` no longer sits on the PVC). The `camunda` volume keeps its existing persistence branching, so the PVC is referenced by exactly one volume.
- `test/unit/optimize/persistence_test.go`: assert `tmp` is `emptyDir` and only `camunda` uses `<release>-optimize-data`.
- `test/integration/scenarios/chart-full-setup/values/features/persistence.yaml`: re-enable `optimize.persistence` in `cprst` (parity with 8.9). Orchestration `extraVolumeClaimTemplates` (SUPPORT-30094) remains deferred.
- `test/ci/registry/manifest.yaml`: flip the `component-persistence` (`cprst`) scenario to `enabled: true` so the default/nightly matrix actually emits it (previously `enabled: false`, which meant it was only reachable via `--include-disabled`).
- `test/ci/registry-snapshot.yaml`: regenerated via `make go.update-registry-golden` to match the manifest change.

## Test plan

- [x] `make go.test chartPath=charts/camunda-platform-8.10`
- [x] `make helm.lint chartPath=charts/camunda-platform-8.10`
- [x] `make go.update-golden-only chartPath=charts/camunda-platform-8.10` (no manual golden edits)
- [ ] nightly `cprst` (install) green on 8.10

## Related

- 8.9 counterpart: #6027 (Optimize `/tmp` fix rides on that PR's branch)
- Sibling PR: Connectors + Identity `/tmp`->emptyDir (8.9 & 8.10)
- Nightly run that surfaced this class of issue: https://github.com/camunda/camunda-platform-helm/actions/runs/28842074055
- SUPPORT-30042

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Fixes https://github.com/camunda/camunda-platform-helm/issues/6703