### PR TITLE
ci: add distro-ci auto-approve for allowlisted PR authors

### DIFF
--- a/.github/auto-approve-allowlist.txt
+++ b/.github/auto-approve-allowlist.txt
@@ -1,0 +1,6 @@
+# GitHub usernames whose PRs distro-ci auto-approves.
+# One login per line. Lines starting with # are ignored.
+# Everyone NOT listed here requires a human review.
+# Example:
+# alice-camunda
+eamonnmoloney

--- a/.github/auto-approve-protected-paths.txt
+++ b/.github/auto-approve-protected-paths.txt
@@ -1,0 +1,16 @@
+# Paths that ALWAYS require a human review — distro-ci never auto-approves a PR
+# whose commits touch any of these. One grep -E (extended regex) pattern per line;
+# blank lines and # comments are ignored. Matched against every file in every commit
+# of the PR, AFTER chart test fixtures (charts/<chart>/test/**) are excluded.
+
+# --- CI-privileged paths (.github) ---
+^\.github/workflows/
+^\.github/actions/
+^\.github/CODEOWNERS$
+^\.github/auto-approve-allowlist\.txt$
+^\.github/auto-approve-protected-paths\.txt$
+
+# --- Chart public API (the user-facing contract) ---
+^charts/.+/values\.yaml$
+^charts/.+/values\.schema(\.extra)?\.json$
+^charts/.+/constraints\.tpl$

--- a/.github/escalation-policy.md
+++ b/.github/escalation-policy.md
@@ -10,6 +10,8 @@ closer attention is warranted.
 > for every pull request**, regardless of the AI assessment outcome. The AI
 > score and labels are advisory only — humans retain full review responsibility
 > and sign-off authority.
+>
+> **Trusted-author auto-approval:** This advisory-AI requirement is separate from the team-sanctioned [trusted-author auto-approval](https://github.com/camunda/camunda-platform-helm/blob/main/docs/contribution-and-collaboration.md#trusted-author-auto-approval) control, under which `distro-ci[bot]` may satisfy the review requirement for PRs from allowlisted authors that do not touch CI-privileged paths.
 
 ## How It Works
 

--- a/.github/escalation-policy.md
+++ b/.github/escalation-policy.md
@@ -11,7 +11,7 @@ closer attention is warranted.
 > score and labels are advisory only — humans retain full review responsibility
 > and sign-off authority.
 >
-> **Trusted-author auto-approval:** This advisory-AI requirement is separate from the team-sanctioned [trusted-author auto-approval](https://github.com/camunda/camunda-platform-helm/blob/main/docs/contribution-and-collaboration.md#trusted-author-auto-approval) control, under which `distro-ci[bot]` may satisfy the review requirement for PRs from allowlisted authors that do not touch CI-privileged paths.
+> **Trusted-author auto-approval:** This advisory-AI requirement is separate from the team-sanctioned [trusted-author auto-approval](https://github.com/camunda/camunda-platform-helm/blob/main/docs/contribution-and-collaboration.md#trusted-author-auto-approval) control, under which `distro-ci[bot]` may satisfy the review requirement for PRs from allowlisted authors that do not touch CI-privileged paths or a chart's public API (values, schema, constraints).
 
 ## How It Works
 

--- a/.github/workflows/repo-auto-approve.yaml
+++ b/.github/workflows/repo-auto-approve.yaml
@@ -20,6 +20,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Check author against allowlist
         id: check
@@ -35,13 +37,14 @@ jobs:
           if [[ -f "$list" ]] && grep -vE '^\s*(#|$)' "$list" | grep -qxF "$AUTHOR"; then
             allowed=true
           fi
-          if [[ "$allowed" == "true" ]] && gh api "repos/${REPO}/pulls/${PR}/files" --paginate --jq '.[].filename' \
-              | grep -xF -f <(printf '%s\n' \
-                '.github/auto-approve-allowlist.txt' \
-                '.github/workflows/repo-auto-approve.yaml' \
-                '.github/CODEOWNERS') > /dev/null; then
-            allowed=false
-            echo "::notice::PR modifies auto-approval protected paths; human review is required."
+          if [[ "$allowed" == "true" ]]; then
+            if ! changed=$(gh api "repos/${REPO}/pulls/${PR}/files" --paginate --jq '.[].filename'); then
+              echo "::warning::Could not list PR files; requiring human review."
+              allowed=false
+            elif printf '%s\n' "$changed" | grep -qE '^\.github/(workflows/|actions/|CODEOWNERS$|auto-approve-allowlist\.txt$)'; then
+              echo "::notice::PR modifies auto-approval or CI-privileged paths; human review is required."
+              allowed=false
+            fi
           fi
           echo "allowed=$allowed" >> "$GITHUB_OUTPUT"
           echo "::notice::author=$AUTHOR allowlisted=$allowed"
@@ -73,10 +76,11 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
           SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          approved=$(gh api "repos/${{ github.repository }}/pulls/${PR}/reviews" \
+          approved=$(gh api "repos/${REPO}/pulls/${PR}/reviews" \
             --jq "[.[] | select(.user.login==\"distro-ci[bot]\" and .commit_id==\"${SHA}\" and .state==\"APPROVED\")] | length")
           if [[ "$approved" -gt 0 ]]; then
             echo "::notice::Already approved by distro-ci for ${SHA}; skipping."

--- a/.github/workflows/repo-auto-approve.yaml
+++ b/.github/workflows/repo-auto-approve.yaml
@@ -33,10 +33,15 @@ jobs:
         run: |
           set -euo pipefail
           list=".github/auto-approve-allowlist.txt"
-          protected='^\.github/(workflows/|actions/|CODEOWNERS$|auto-approve-allowlist\.txt$)'
+          protected_file=".github/auto-approve-protected-paths.txt"
           allowed=false
           if [[ -f "$list" ]] && grep -vE '^\s*(#|$)' "$list" | grep -qxF "$AUTHOR"; then
             allowed=true
+          fi
+          pats=$(grep -vE '^\s*(#|$)' "$protected_file" 2>/dev/null || true)
+          if [[ "$allowed" == "true" && -z "$pats" ]]; then
+            echo "::warning::protected-paths list missing/empty; requiring human review."
+            allowed=false
           fi
           if [[ "$allowed" == "true" ]]; then
             if ! shas=$(gh api "repos/${REPO}/pulls/${PR}/commits" --paginate --jq '.[].sha'); then
@@ -48,8 +53,9 @@ jobs:
                   echo "::warning::Could not list files for ${sha}; requiring human review."
                   allowed=false; break
                 fi
-                if printf '%s\n' "$files" | grep -qE "$protected"; then
-                  echo "::notice::commit ${sha} touches a CI-privileged path; human review is required."
+                if printf '%s\n' "$files" | grep -vE '^charts/[^/]+/test/' \
+                     | grep -qE -f <(printf '%s\n' "$pats"); then
+                  echo "::notice::commit ${sha} touches a protected path; human review is required."
                   allowed=false; break
                 fi
               done

--- a/.github/workflows/repo-auto-approve.yaml
+++ b/.github/workflows/repo-auto-approve.yaml
@@ -54,17 +54,21 @@ jobs:
                 allowed=false
               else
                 for sha in $shas; do
-                  nf=$(gh api "repos/${REPO}/commits/${sha}" --jq '(.files // []) | length') || {
+                  commit=$(gh api "repos/${REPO}/commits/${sha}") || {
                     echo "::warning::Could not fetch ${sha}; requiring human review."; allowed=false; break; }
+                  nf=$(printf '%s' "$commit" | jq '(.files // []) | length')
                   if [[ "$nf" -ge 300 ]]; then
                     echo "::warning::commit ${sha} has ${nf} files (>=300 API cap); requiring human review."
                     allowed=false; break
                   fi
-                  files=$(gh api "repos/${REPO}/commits/${sha}" --jq '(.files // [])[] | .filename, (.previous_filename // empty)') || {
-                    echo "::warning::Could not list files for ${sha}; requiring human review."; allowed=false; break; }
-                  if printf '%s\n' "$files" | grep -vE '^charts/[^/]+/test/' \
-                       | grep -qE -f <(printf '%s\n' "$pats"); then
+                  files=$(printf '%s' "$commit" | jq -r '(.files // [])[] | .filename, (.previous_filename // empty)')
+                  match_rc=0
+                  printf '%s\n' "$files" | grep -vE '^charts/[^/]+/test/' | grep -qE -f <(printf '%s\n' "$pats") || match_rc=$?
+                  if [[ "$match_rc" -eq 0 ]]; then
                     echo "::notice::commit ${sha} touches a protected path; human review is required."
+                    allowed=false; break
+                  elif [[ "$match_rc" -ge 2 ]]; then
+                    echo "::warning::protected-path check errored (rc=${match_rc}); requiring human review."
                     allowed=false; break
                   fi
                 done

--- a/.github/workflows/repo-auto-approve.yaml
+++ b/.github/workflows/repo-auto-approve.yaml
@@ -48,17 +48,27 @@ jobs:
               echo "::warning::Could not list PR commits; requiring human review."
               allowed=false
             else
-              for sha in $shas; do
-                if ! files=$(gh api "repos/${REPO}/commits/${sha}" --jq '.files[].filename'); then
-                  echo "::warning::Could not list files for ${sha}; requiring human review."
-                  allowed=false; break
-                fi
-                if printf '%s\n' "$files" | grep -vE '^charts/[^/]+/test/' \
-                     | grep -qE -f <(printf '%s\n' "$pats"); then
-                  echo "::notice::commit ${sha} touches a protected path; human review is required."
-                  allowed=false; break
-                fi
-              done
+              n=$(printf '%s\n' "$shas" | sed '/^[[:space:]]*$/d' | wc -l | tr -d ' ')
+              if [[ "$n" -eq 0 || "$n" -ge 250 ]]; then
+                echo "::warning::PR has ${n} commits (empty or >=250 API cap); requiring human review."
+                allowed=false
+              else
+                for sha in $shas; do
+                  nf=$(gh api "repos/${REPO}/commits/${sha}" --jq '(.files // []) | length') || {
+                    echo "::warning::Could not fetch ${sha}; requiring human review."; allowed=false; break; }
+                  if [[ "$nf" -ge 300 ]]; then
+                    echo "::warning::commit ${sha} has ${nf} files (>=300 API cap); requiring human review."
+                    allowed=false; break
+                  fi
+                  files=$(gh api "repos/${REPO}/commits/${sha}" --jq '(.files // [])[] | .filename, (.previous_filename // empty)') || {
+                    echo "::warning::Could not list files for ${sha}; requiring human review."; allowed=false; break; }
+                  if printf '%s\n' "$files" | grep -vE '^charts/[^/]+/test/' \
+                       | grep -qE -f <(printf '%s\n' "$pats"); then
+                    echo "::notice::commit ${sha} touches a protected path; human review is required."
+                    allowed=false; break
+                  fi
+                done
+              fi
             fi
           fi
           echo "allowed=$allowed" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/repo-auto-approve.yaml
+++ b/.github/workflows/repo-auto-approve.yaml
@@ -10,7 +10,7 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   auto-approve:

--- a/.github/workflows/repo-auto-approve.yaml
+++ b/.github/workflows/repo-auto-approve.yaml
@@ -6,7 +6,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -33,17 +33,26 @@ jobs:
         run: |
           set -euo pipefail
           list=".github/auto-approve-allowlist.txt"
+          protected='^\.github/(workflows/|actions/|CODEOWNERS$|auto-approve-allowlist\.txt$)'
           allowed=false
           if [[ -f "$list" ]] && grep -vE '^\s*(#|$)' "$list" | grep -qxF "$AUTHOR"; then
             allowed=true
           fi
           if [[ "$allowed" == "true" ]]; then
-            if ! changed=$(gh api "repos/${REPO}/pulls/${PR}/files" --paginate --jq '.[].filename'); then
-              echo "::warning::Could not list PR files; requiring human review."
+            if ! shas=$(gh api "repos/${REPO}/pulls/${PR}/commits" --paginate --jq '.[].sha'); then
+              echo "::warning::Could not list PR commits; requiring human review."
               allowed=false
-            elif printf '%s\n' "$changed" | grep -qE '^\.github/(workflows/|actions/|CODEOWNERS$|auto-approve-allowlist\.txt$)'; then
-              echo "::notice::PR modifies auto-approval or CI-privileged paths; human review is required."
-              allowed=false
+            else
+              for sha in $shas; do
+                if ! files=$(gh api "repos/${REPO}/commits/${sha}" --jq '.files[].filename'); then
+                  echo "::warning::Could not list files for ${sha}; requiring human review."
+                  allowed=false; break
+                fi
+                if printf '%s\n' "$files" | grep -qE "$protected"; then
+                  echo "::notice::commit ${sha} touches a CI-privileged path; human review is required."
+                  allowed=false; break
+                fi
+              done
             fi
           fi
           echo "allowed=$allowed" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/repo-auto-approve.yaml
+++ b/.github/workflows/repo-auto-approve.yaml
@@ -1,0 +1,85 @@
+name: Repo - Auto Approve
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  auto-approve:
+    name: Auto approve allowlisted authors
+    if: ${{ github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Check author against allowlist
+        id: check
+        env:
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          list=".github/auto-approve-allowlist.txt"
+          allowed=false
+          if [[ -f "$list" ]] && grep -vE '^\s*(#|$)' "$list" | grep -qxF "$AUTHOR"; then
+            allowed=true
+          fi
+          if [[ "$allowed" == "true" ]] && gh api "repos/${REPO}/pulls/${PR}/files" --paginate --jq '.[].filename' \
+              | grep -xF -f <(printf '%s\n' \
+                '.github/auto-approve-allowlist.txt' \
+                '.github/workflows/repo-auto-approve.yaml' \
+                '.github/CODEOWNERS') > /dev/null; then
+            allowed=false
+            echo "::notice::PR modifies auto-approval protected paths; human review is required."
+          fi
+          echo "allowed=$allowed" >> "$GITHUB_OUTPUT"
+          echo "::notice::author=$AUTHOR allowlisted=$allowed"
+
+      - name: Import Vault secrets
+        if: ${{ steps.check.outputs.allowed == 'true' }}
+        id: vault-secrets
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/distribution/ci GH_APP_ID_DISTRO_CI;
+            secret/data/products/distribution/ci GH_APP_PRIVATE_KEY_DISTRO_CI;
+
+      - name: Generate distro-ci token
+        if: ${{ steps.check.outputs.allowed == 'true' }}
+        id: app-token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
+        with:
+          app_id: ${{ steps.vault-secrets.outputs.GH_APP_ID_DISTRO_CI }}
+          private_key: ${{ steps.vault-secrets.outputs.GH_APP_PRIVATE_KEY_DISTRO_CI }}
+
+      - name: Approve PR
+        if: ${{ steps.check.outputs.allowed == 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR: ${{ github.event.pull_request.number }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          approved=$(gh api "repos/${{ github.repository }}/pulls/${PR}/reviews" \
+            --jq "[.[] | select(.user.login==\"distro-ci[bot]\" and .commit_id==\"${SHA}\" and .state==\"APPROVED\")] | length")
+          if [[ "$approved" -gt 0 ]]; then
+            echo "::notice::Already approved by distro-ci for ${SHA}; skipping."
+            exit 0
+          fi
+          gh pr review "$PR" --approve --body "Auto-approved: author is on .github/auto-approve-allowlist.txt."

--- a/docs/contribution-and-collaboration.md
+++ b/docs/contribution-and-collaboration.md
@@ -134,7 +134,7 @@ Every pull request (PR) related to Helm chart changes must adhere to the followi
 - **Unit tests:** Changes should include or update corresponding unit tests where applicable.
 - **Documentation updates:** User or technical documentation must reflect configuration or behavior changes.
 - **Passing CI:** All CI checks must pass successfully before merge.
-- **Code review:** At least one formal human review must be completed and approved. **Exception:** PRs authored by a maintainer listed in [`.github/auto-approve-allowlist.txt`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/auto-approve-allowlist.txt) may be approved by `distro-ci[bot]` under the team-sanctioned [trusted-author auto-approval](#trusted-author-auto-approval) control. This exception never applies to PRs that modify CI-privileged paths (`.github/workflows/`, `.github/actions/`, `CODEOWNERS`, or the allowlist itself) — those always require a human review.
+- **Code review:** At least one formal human review must be completed and approved. **Exception:** PRs authored by a maintainer listed in [`.github/auto-approve-allowlist.txt`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/auto-approve-allowlist.txt) may be approved by `distro-ci[bot]` under the team-sanctioned [trusted-author auto-approval](#trusted-author-auto-approval) control. This exception never applies to PRs that modify CI-privileged paths (`.github/workflows/`, `.github/actions/`, `CODEOWNERS`, the allowlist, or a chart's public API — values.yaml, values.schema.json, constraints.tpl) — those always require a human review.
 - **Atomic changes:** Aim for small, focused PRs that address a single issue or configuration change to simplify review and reduce merge complexity.
 
 ### Automated AI review and escalation
@@ -155,7 +155,7 @@ The [`Repo - Auto Approve`](https://github.com/camunda/camunda-platform-helm/blo
 Guardrails:
 
 - **Approve-only** — the bot never merges; branch protection (required status checks, stale-review dismissal) still gates merge.
-- **CI-privileged paths always need a human** — any PR touching `.github/workflows/`, `.github/actions/`, `CODEOWNERS`, or the allowlist is never auto-approved, so the allowlist itself can only change with human review.
+- **Privileged & public-API paths always need a human** — any PR whose commits touch a CI-privileged path (`.github/workflows/`, `.github/actions/`, `CODEOWNERS`, the allowlist) or a chart's public API (`values.yaml`, `values.schema.json`, `constraints.tpl`; chart `test/` fixtures excluded) is never auto-approved. The exact set lives in [`.github/auto-approve-protected-paths.txt`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/auto-approve-protected-paths.txt).
 - **Fail-closed** — if the workflow cannot determine what a PR changed, it does not approve.
 
 Adding or removing allowlist entries requires a normal human-reviewed PR.

--- a/docs/contribution-and-collaboration.md
+++ b/docs/contribution-and-collaboration.md
@@ -134,7 +134,7 @@ Every pull request (PR) related to Helm chart changes must adhere to the followi
 - **Unit tests:** Changes should include or update corresponding unit tests where applicable.
 - **Documentation updates:** User or technical documentation must reflect configuration or behavior changes.
 - **Passing CI:** All CI checks must pass successfully before merge.
-- **Code review:** At least one formal human review must be completed and approved.
+- **Code review:** At least one formal human review must be completed and approved. **Exception:** PRs authored by a maintainer listed in [`.github/auto-approve-allowlist.txt`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/auto-approve-allowlist.txt) may be approved by `distro-ci[bot]` under the team-sanctioned [trusted-author auto-approval](#trusted-author-auto-approval) control. This exception never applies to PRs that modify CI-privileged paths (`.github/workflows/`, `.github/actions/`, `CODEOWNERS`, or the allowlist itself) — those always require a human review.
 - **Atomic changes:** Aim for small, focused PRs that address a single issue or configuration change to simplify review and reduce merge complexity.
 
 ### Automated AI review and escalation
@@ -147,6 +147,18 @@ PRs are automatically reviewed by [`crev`](https://github.com/camunda/crev), an 
 The escalation decision is governed by the [escalation policy](https://github.com/camunda/camunda-platform-helm/blob/main/.github/escalation-policy.md). PRs that touch security surfaces, span multiple chart versions, or violate hard rules always require human review. Routine additive changes by familiar authors may be approved with AI review alone.
 
 Contributors should treat the `human-review-required` label as a signal that the Distro team must approve before merge.
+
+### Trusted-author auto-approval
+
+The [`Repo - Auto Approve`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/workflows/repo-auto-approve.yaml) workflow lets `distro-ci[bot]` post an approving review on PRs whose author is listed in `.github/auto-approve-allowlist.txt`. This is a Distro-team-sanctioned control that satisfies the human-review requirement above for those authors, on the basis that the allowlist is a small, high-trust set curated by the team.
+
+Guardrails:
+
+- **Approve-only** — the bot never merges; branch protection (required status checks, stale-review dismissal) still gates merge.
+- **CI-privileged paths always need a human** — any PR touching `.github/workflows/`, `.github/actions/`, `CODEOWNERS`, or the allowlist is never auto-approved, so the allowlist itself can only change with human review.
+- **Fail-closed** — if the workflow cannot determine what a PR changed, it does not approve.
+
+Adding or removing allowlist entries requires a normal human-reviewed PR.
 
 ### Helm version
 


### PR DESCRIPTION
### Which problem does the PR fix?

Reviewing every PR by hand is toil for a trusted set of contributors, while we still want a human gate for everyone else. There is currently no way for the distro-ci bot to approve PRs for specific authors only.

### What's in this PR?

Adds an opt-in auto-approval workflow so the existing **distro-ci** GitHub App approves PRs **only** when the author is on an explicit allowlist. Everyone not listed still requires a human review.

- `.github/auto-approve-allowlist.txt` — committed allowlist, one GitHub login per line (`#` comments ignored). Seeded with `eamonnmoloney`.
- `.github/auto-approve-protected-paths.txt` — committed, human-editable list (one `grep -E` pattern per line, commented) of paths that **always** require a human review. Add a line to protect more.
- `.github/workflows/repo-auto-approve.yaml` — `pull_request_target` workflow that:
  - reads the trusted (base-branch) allowlist and matches the PR author;
  - if allowlisted, mints a distro-ci token via the established Vault → `tibdex/github-app-token` pattern (pinned SHAs, `secret/data/products/distribution/ci`) and posts an approving review;
  - **approve-only** — merge stays gated by branch protection;
  - skips re-approving the same commit SHA (no noise on `synchronize`);
  - **never auto-approves a PR whose commits touch a protected path** — CI-privileged paths (`.github/workflows/`, `.github/actions/`, `CODEOWNERS`, the two list files) **or a chart's public API** (`values.yaml`, `values.schema(.extra).json`, `constraints.tpl`; chart `test/` fixtures excluded).

### Security considerations

Security-reviewed for bad-actor and social-engineering vectors, including an adversarial (regex + "how would I hack this") pass.

**Built into the workflow:**
- Uses `pull_request_target` but **never checks out or executes PR head code** — it only reads base-branch lists and calls the GitHub API, so a fork PR cannot exfiltrate the token/secrets (the primary `pull_request_target` risk).
- The allowlist and protected-paths list are read from the **trusted base ref**, not the PR head, and the protected list **includes itself** — a PR can't weaken the rules.
- Author/PR/repo values are passed via `env:`, never interpolated into shell (no script injection); no PR title/body/branch is used in `run:`.
- **Per-commit scan** of every commit in the PR (not just the net diff) — closes the add-then-revert race; `cancel-in-progress: false`.
- **Rename-aware** — matches both `filename` and `previous_filename`, so renaming a protected file out of its path (e.g. `CODEOWNERS` → `CODEOWNERS.disabled`) is still caught.
- **Fails closed** everywhere: on any API error, on an empty commit list, and on GitHub's API caps (a commit with ≥300 files, or a PR with ≥250 commits) — anything it can't fully enumerate requires a human.
- Least privilege (`contents: read`, `pull-requests: read` — the approval uses the App token, not `GITHUB_TOKEN`), Vault `exportEnv: false`, `persist-credentials: false` on checkout, third-party actions pinned to full SHAs.

**Required on the `main` branch ruleset ("Protect main branch - require PR & checks") — auto-approval is only safe with these:**
- **Enable `dismiss_stale_reviews_on_push`** (currently off) — otherwise a bot approval of an old commit persists after a new push. **This is the key setting.**
- **Enable `require_last_push_approval`** (currently off) — the most recent push must be approved by someone other than the pusher.
- **Keep required status checks** (`license/cla`, `CI Gate`, `gate`) — ensures auto-approved ≠ merges without CI.
- **Keep Code Owner review OFF.** A GitHub App approval does not satisfy code-owner review, so enabling it would force a human on every PR and **neutralize this feature**. Safety instead rests on required checks + a short, high-trust allowlist + the fail-closed guard above.
- **Audit ruleset bypass actors** (apps + team with mode "always") — they merge to `main` with zero review; confirm the set is intentional and that distro-ci is not among them (it only needs to approve, never bypass).

**Residual risk (inherent to any auto-approval):** if an allowlisted user's account is compromised, the attacker gets auto-approval on non-protected paths (merge still gated by the checks above). Mitigate by keeping the allowlist short/high-trust and requiring 2FA for those accounts. `required_approving_review_count` is 1 (the bot fills it for allowlisted authors); raise to 2 if you want bot + 1 human.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
