### PR TITLE
test: increase companion Elasticsearch capacity for QA e2e scenario

### DIFF
--- a/test/integration/companion-values/elasticsearch-qa.yaml
+++ b/test/integration/companion-values/elasticsearch-qa.yaml
@@ -31,7 +31,7 @@ esConfig:
 
 extraEnvs:
   - name: ES_JAVA_OPTS
-    value: "-Xms512m -Xmx512m"
+    value: "-Xms1536m -Xmx1536m"
 
 lifecycle:
   postStart:
@@ -56,11 +56,11 @@ lifecycle:
 
 resources:
   requests:
-    cpu: "500m"
-    memory: "1Gi"
-  limits:
     cpu: "1"
     memory: "2Gi"
+  limits:
+    cpu: "2"
+    memory: "4Gi"
 
 volumeClaimTemplate:
   accessModes: ["ReadWriteOnce"]


### PR DESCRIPTION
### Which problem does the PR fix?

Complements #6520. That PR fixed nightly full-suite Playwright flakiness (`assertBusinessIdVisible`-style assertions exhausting their 60s retry budget) by capping `workers: "100%"` → `workers: 25`. That addresses the symptom by reducing load; this PR addresses the underlying capacity gap.

The QA/nightly companion Elasticsearch node (`test/integration/companion-values/elasticsearch-qa.yaml`) runs with a 512MB heap and a 1 CPU limit on a single node — a minimal dev footprint. Under concurrent Playwright workers driving both exporter bulk writes and Operate/Tasklist UI queries simultaneously, this is undersized and can fall behind on indexing well before the 60s assertion timeout, independent of worker count.

Tuning explored and ruled out: the Zeebe exporter's `bulk.delay` (default 5s) already gives ~6-10x headroom under the 60s timeout in steady state, so hitting that timeout implies a growing backlog under load, not a flush-scheduling issue — shrinking `bulk.delay` wouldn't add capacity.

### What's in this PR?

Bumps the QA-only companion Elasticsearch sizing:
- requests: `500m/1Gi` → `1/2Gi`
- limits: `1/2Gi` → `2/4Gi`
- `ES_JAVA_OPTS` heap: `-Xms512m -Xmx512m` → `-Xms1536m -Xmx1536m` (~50% of the new memory limit, per ES guidance)

`replicas: 1` is left unchanged — the file has an existing `auto_expand_replicas: "0-1"` lifecycle hook specifically to avoid yellow-cluster issues with a single node; going multi-node would need that logic revisited and is out of scope here.

Only the QA/nightly variant is touched; the default/PR-CI companion values (`elasticsearch.yaml`) are left as-is since that scenario hasn't shown the same symptom.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`. (not applicable — no templates/goldens touched, values-only change to a companion Helm release file)
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed). (not applicable — sizing-only change, no new behavior to unit test)
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

### To-Do

- [ ] Deploy the QA scenario to GKE and confirm the ES pod picks up the new resources/heap.
- [ ] Re-run the full-suite Playwright project (workers:25 per #6520) against that deployment and confirm `assertBusinessIdVisible`-style assertions stop exhausting the 60s retry budget.
- [ ] If flakiness persists after this bump, that signals `workers: 25` is doing real work and shouldn't be loosened.
