### PR TITLE
test(8.10): increase shadow-e2e companion Elasticsearch capacity

### DIFF
--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -684,7 +684,7 @@ integration:
             - chart: elastic/elasticsearch
               version: 8.5.1
               release-name: elasticsearch
-              values-file: test/integration/companion-values/elasticsearch.yaml
+              values-file: test/integration/companion-values/elasticsearch-shadow.yaml
               repo-name: elastic
               repo-url: https://helm.elastic.co
             - chart: charts/internal-postgresql

--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -671,7 +671,7 @@ integration:
           platforms:
             - gke
           exclude: []
-          tier: 2
+          tier: 1
           infra-type:
             gke: distroci
           identity: keycloak

--- a/charts/camunda-platform-8.10/test/ci/registry/dependencies/elasticsearch-shadow.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/dependencies/elasticsearch-shadow.yaml
@@ -1,0 +1,6 @@
+chart: elastic/elasticsearch
+version: 8.5.1
+release-name: elasticsearch
+values-file: test/integration/companion-values/elasticsearch-shadow.yaml
+repo-name: elastic
+repo-url: https://helm.elastic.co

--- a/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
@@ -93,7 +93,7 @@ integration:
       enabled: true
     - id: shadow-e2e
       shortname: shde2
-      tier: 2
+      tier: 1
       enabled: true
     - id: hub-legacy-upgrade
       shortname: hublu

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/shadow-e2e.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/shadow-e2e.yaml
@@ -11,5 +11,5 @@ infra-type:
 skip-e2e: true
 dependencies:
   - keycloak
-  - elasticsearch
+  - elasticsearch-shadow
   - postgresql

--- a/test/integration/companion-values/elasticsearch-shadow.yaml
+++ b/test/integration/companion-values/elasticsearch-shadow.yaml
@@ -1,0 +1,115 @@
+# CI values for the embedded Elasticsearch companion chart (elastic/elasticsearch).
+# Security/X-Pack disabled, single node, minimal resources for CI/dev environments.
+#
+# Deployed as a separate Helm release by deploy-camunda before the main
+# Camunda chart. Referenced from ci-test-config.yaml dependencies.
+
+clusterName: "elasticsearch"
+
+replicas: 1
+minimumMasterNodes: 1
+
+protocol: http
+
+# Use ES 8.18.0 — the elastic/elasticsearch Helm chart 8.5.1 defaults to its
+# own app version (8.5.1) but Camunda 8.10 requires ES 8.6+ (specifically for
+# the unassignedPrimaryShards field in HealthResponse). The Bitnami subchart
+# this replaces bundled ES 8.18.0.
+imageTag: "8.18.0"
+
+# Disable automatic TLS certificate generation. When createCert=true (default),
+# the chart injects env vars that force xpack.security.enabled=true and
+# xpack.security.{http,transport}.ssl.enabled=true, overriding any esConfig
+# settings. Setting createCert=false prevents cert creation, volume mounts, AND
+# the env var injection — letting our esConfig settings take effect.
+createCert: false
+
+# Keep the credentials secret enabled even though security is disabled.
+# The chart's readiness probe script checks [ -z "${ELASTIC_PASSWORD}" ] and
+# exits 1 if unset. The password is injected from this secret but ignored by
+# ES when xpack.security.enabled=false.
+secret:
+  enabled: true
+
+# Single-node disco + disable HTTP TLS + disable X-Pack security so Camunda
+# can talk to the cluster anonymously over plain HTTP (mirrors the OpenSearch
+# companion chart's "security disabled" stance).
+#
+# NOTE: discovery.type: single-node is NOT set here because the
+# elastic/elasticsearch chart injects cluster.initial_master_nodes via an env
+# var in the StatefulSet template, and ES 8.x rejects having both. With
+# replicas=1 the chart bootstraps correctly without the explicit single-node
+# setting.
+esConfig:
+  elasticsearch.yml: |
+    cluster.name: elasticsearch
+    network.host: 0.0.0.0
+    xpack.security.enabled: false
+    xpack.security.http.ssl.enabled: false
+    # Allow _reindex-from-remote to pull data from the source (bundled Bitnami)
+    # Elasticsearch during the Bitnami→companion migration (upgrade-minor flows).
+    # Harmless for install scenarios, which never issue a remote reindex.
+    reindex.remote.whitelist: "*:9200"
+    xpack.security.transport.ssl.enabled: false
+
+extraEnvs:
+  - name: ES_JAVA_OPTS
+    value: "-Xms1536m -Xmx1536m"
+
+# Single-node clusters cannot allocate index replicas. Camunda components
+# create indices with number_of_replicas=1, which leaves every replica
+# unassigned, drives the cluster to yellow, and causes intermittent "all
+# shards failed" 503s on _search calls.
+#
+# auto_expand_replicas dynamically adjusts replicas based on cluster size:
+# on a 1-node cluster it settles at 0; on a 2-node cluster it scales to 1.
+# It overrides any explicit number_of_replicas setting.
+#
+# Priority MUST be lower than the application's own index templates:
+#   - Zeebe-record templates: priority 20 (define aliases for Optimize)
+#   - Operate/Tasklist/Camunda templates: priority 0
+# Setting priority=1 ensures:
+#   - Zeebe-record templates (p20) win → their aliases are applied correctly
+#   - Our template (p1) wins over operate/tasklist/camunda (p0) → auto_expand
+#     applies to those indices
+# Zeebe-record indices already set number_of_replicas=0 in their templates,
+# so they don't need auto_expand_replicas to be green on a single node.
+#
+# Index patterns are intentionally substring globs (e.g. "*operate*") rather
+# than prefix globs ("operate-*"). CI prepends $GITHUB_WORKFLOW_JOB_ID to
+# every component prefix, and deploy-camunda matrix uses shortened prefixes
+# ("op-*", "opt-*", "orch-*") for index naming.
+lifecycle:
+  postStart:
+    exec:
+      command:
+        - bash
+        - -c
+        - |
+          max=60
+          n=0
+          until curl -fsS --connect-timeout 5 "http://localhost:9200/_cluster/health" >/dev/null 2>&1; do
+            n=$((n + 1))
+            if [ "$n" -ge "$max" ]; then
+              echo "elasticsearch not reachable after $max attempts" >&2
+              exit 1
+            fi
+            sleep 2
+          done
+          curl -fsS --connect-timeout 5 -X PUT "http://localhost:9200/_index_template/camunda-ci-auto-expand-replicas" \
+            -H 'Content-Type: application/json' \
+            -d '{"index_patterns":["*operate*","*orchestration*","*optimize*","*tasklist*","*camunda*","*zeebe*","op-*","opt-*","orch-*"],"priority":1,"template":{"settings":{"index.auto_expand_replicas":"0-1"}}}'
+
+resources:
+  requests:
+    cpu: "1"
+    memory: "2Gi"
+  limits:
+    cpu: "2"
+    memory: "4Gi"
+
+volumeClaimTemplate:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 4Gi


### PR DESCRIPTION
### Which problem does the PR fix?

Follow-up to #6526 (QA/nightly companion Elasticsearch capacity fix). The `shadow-e2e` CI scenario (8.10 only — this scenario doesn't exist in 8.8, and in 8.7/8.9 it uses a completely different mechanism, a bundled Bitnami subchart, not this companion values file) has the same underlying Elasticsearch under-provisioning: `test/integration/companion-values/elasticsearch.yaml` runs with a 512MB heap and a 1 CPU limit on a single node.

Unlike the QA fix, this file is shared by ~28 other PR-CI scenarios (auth0, oidc, gateway-keycloak, keycloak-mt, etc.), so bumping it directly would raise resource requests for every PR-triggered CI check that uses Elasticsearch persistence, not just shadow-e2e. Instead, this PR adds a shadow-e2e-specific companion values file, mirroring the existing `elasticsearch.yaml` / `elasticsearch-qa.yaml` split.

### What's in this PR?

- Added `test/integration/companion-values/elasticsearch-shadow.yaml`, a copy of `elasticsearch.yaml` with the same sizing bump applied in #6526:
  - `ES_JAVA_OPTS`: `-Xms512m -Xmx512m` → `-Xms1536m -Xmx1536m`
  - requests: `500m/1Gi` → `1/2Gi`
  - limits: `1/2Gi` → `2/4Gi`
- Added `charts/camunda-platform-8.10/test/ci/registry/dependencies/elasticsearch-shadow.yaml` registering the new companion values file as a dependency.
- Updated `charts/camunda-platform-8.10/test/ci/registry/scenarios/shadow-e2e.yaml` to depend on `elasticsearch-shadow` instead of `elasticsearch`.
- Regenerated `charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml` via `make go.update-registry-golden`.

No other scenario's dependencies changed — the shared `elasticsearch.yaml` and the ~28 scenarios depending on it are untouched.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`. (ran `make go.update-registry-golden` — the relevant golden for this change; no chart template goldens touched)
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed). (not applicable — CI scenario/test-infra sizing change, no new chart behavior)
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

### To-Do

- [ ] Deploy the `shadow-e2e` scenario (`deploy-camunda matrix run --shortname-filter shde2`) and confirm the ES pod picks up the new resources/heap.
- [ ] If 8.7/8.9 shadow-e2e turns out to show the same flakiness symptom, that needs a separate fix — it uses a bundled Bitnami subchart, a different mechanism than this companion values file.
