### PR TITLE
ci: cap smoke-tests Playwright workers to reduce cluster contention

### DIFF
--- a/scripts/base_playwright_script.sh
+++ b/scripts/base_playwright_script.sh
@@ -1079,6 +1079,13 @@ run_playwright_tests() {
   [[ -n "${PLAYWRIGHT_E2E_VIDEO:-}" ]] && playwright_args+=(--video="$PLAYWRIGHT_E2E_VIDEO")
   [[ -n "${PLAYWRIGHT_E2E_TRACE:-}" ]] && playwright_args+=(--trace="$PLAYWRIGHT_E2E_TRACE")
   [[ -n "${PLAYWRIGHT_E2E_RETRIES:-}" ]] && playwright_args+=(--retries="$PLAYWRIGHT_E2E_RETRIES")
+  # smoke-tests uses a low worker count by default; other projects keep the
+  # config default unless PLAYWRIGHT_E2E_WORKERS is set.
+  if [[ "$project" == "smoke-tests" ]]; then
+    playwright_args+=(--workers="${PLAYWRIGHT_E2E_WORKERS:-2}")
+  elif [[ -n "${PLAYWRIGHT_E2E_WORKERS:-}" ]]; then
+    playwright_args+=(--workers="$PLAYWRIGHT_E2E_WORKERS")
+  fi
   # Namespace-scoped output directory to avoid collisions during parallel matrix runs
   [[ -n "${PLAYWRIGHT_TEST_OUTPUT:-}" ]] && playwright_args+=(--output="$PLAYWRIGHT_TEST_OUTPUT")
 


### PR DESCRIPTION
### Which problem does the PR fix?

Smoke E2E runs share a single SM cluster and each test drives the Keycloak admin
console during per-test user setup. At `workers: "100%"`, all smoke tests hit the
Keycloak/Modeler auth flows concurrently, which can push the short 10s/30s auth
timeouts over on a loaded or partially-degraded cluster (observed in
camunda/camunda run [28852986467](https://github.com/camunda/camunda/actions/runs/28852986467), job 85577547696's sibling job 85574811557:
`switchToCamundaPlatform` and Modeler `/login-callback` timeouts).

### What's in this PR?

Adds a `--workers` flag to the `smoke-tests` invocation only in
`scripts/base_playwright_script.sh` (default `2`, overridable via
`PLAYWRIGHT_E2E_WORKERS`), mirroring the existing `PLAYWRIGHT_E2E_RETRIES`
passthrough. `full-suite` and `auth0-smoke` keep the config's `"100%"`, and no
`charts/*/test/e2e/playwright.config.ts` files change (scoping via the CLI flag
avoids version fan-out). This reduces the auth-contention class of smoke flake;
it is not a fix for spot preemption, which the existing `_run_playwright_with_retry`
harness already handles.

### Checklist

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open pull request for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo documentation are updated (if needed).
