### PR TITLE
fix: surface deprecation warnings on the gitops render path

### DIFF
--- a/charts/camunda-platform-8.10/templates/common/configmap-warnings.yaml
+++ b/charts/camunda-platform-8.10/templates/common/configmap-warnings.yaml
@@ -1,0 +1,13 @@
+{{- $warnings := include "camunda.constraints.warnings" . | trim -}}
+{{- if $warnings }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "camundaPlatform.fullname" . }}-warnings
+  labels:
+    {{- include "camundaPlatform.labels" . | nindent 4 }}
+  annotations: {{- toYaml .Values.global.annotations | nindent 4 }}
+data:
+  warnings: |-
+    {{- $warnings | nindent 4 }}
+{{- end }}

--- a/charts/camunda-platform-8.10/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.10/templates/common/constraints.tpl
@@ -104,6 +104,12 @@ Fail with a message if Web Modeler is enabled but management Identity is not ena
   {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}
 
+{{/*
+camunda.constraints.warnings
+Non-fatal deprecation/config warnings. Consumed by NOTES.txt (helm install/upgrade) and by
+configmap-warnings.yaml, which renders the "<release>-warnings" ConfigMap on the GitOps path
+(helm template / Argo CD / Flux). Feed new deprecations here so they reach both channels.
+*/}}
 {{- define "camunda.constraints.warnings" }}
   {{- if .Values.global.testDeprecationFlags.existingSecretsMustBeSet }}
     {{/* TODO: Check if there are more existingSecrets to check */}}
@@ -706,8 +712,9 @@ Usage:
 camundaPlatform.keyDeprecated
 Emit a non-fatal DEPRECATION warning when a deprecated values file key is set.
 Unlike camundaPlatform.keyRemoved/keyRenamed this does NOT fail; it returns a
-warning string, so it must be called from within "camunda.constraints.warnings"
-(included by NOTES.txt) to surface on install/upgrade. Per the Breaking Changes
+warning string, so it must be called from within "camunda.constraints.warnings",
+which surfaces on install/upgrade (NOTES.txt) and on the GitOps render path via the
+"<release>-warnings" ConfigMap (templates/common/configmap-warnings.yaml). Per the Breaking Changes
 & Deprecation Policy (docs/policies/breaking-changes.md): warn when the key is
 set, name the replacement and the removal version.
 Usage:

--- a/charts/camunda-platform-8.10/test/unit/common/configmap_warnings_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/configmap_warnings_test.go
@@ -1,0 +1,92 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package camunda
+
+import (
+	"camunda-platform/test/unit/testhelpers"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type ConfigMapWarningsTemplateTest struct {
+	suite.Suite
+	chartPath string
+	release   string
+	namespace string
+	templates []string
+}
+
+func TestConfigMapWarningsTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../")
+	require.NoError(t, err)
+
+	suite.Run(t, &ConfigMapWarningsTemplateTest{
+		chartPath: chartPath,
+		release:   "camunda-platform-test",
+		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
+		templates: []string{"templates/common/configmap-warnings.yaml"},
+	})
+}
+
+func (s *ConfigMapWarningsTemplateTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestWarningsConfigMapRendersWhenWarningPresent",
+			Values: map[string]string{
+				"orchestration.data.secondaryStorage.type":                      "elasticsearch",
+				"identity.enabled":                                              "true",
+				"global.identity.auth.enabled":                                  "true",
+				"global.security.authentication.method":                         "oidc",
+				"connectors.security.authentication.oidc.secret.existingSecret": "foo",
+				"global.identity.auth.issuerBackendUrl":                         "http://keycloak:80/auth/realms/camunda-platform",
+				"global.testDeprecationFlags.existingSecretsMustBeSet":          "warning",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().True(strings.HasSuffix(configmap.Name, "-warnings"))
+				s.Require().Contains(configmap.Data["warnings"],
+					"the Camunda Helm chart will no longer automatically generate passwords for the Identity component")
+			},
+		},
+		{
+			Name: "TestWarningsConfigMapAbsentWhenNoWarnings",
+			// global.elasticsearch.enabled=false avoids the legacy-option deprecation warning
+			// (the test helper otherwise defaults it to true); the new secondaryStorage key
+			// satisfies the storage-type constraint.
+			Values: map[string]string{
+				"global.elasticsearch.enabled":             "false",
+				"orchestration.data.secondaryStorage.type": "elasticsearch",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				// With no active warnings the helper renders nothing, so --show-only finds no manifest.
+				s.Require().Error(err)
+				s.Require().NotContains(output, "kind: ConfigMap")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}

--- a/charts/camunda-platform-8.7/templates/camunda/configmap-warnings.yaml
+++ b/charts/camunda-platform-8.7/templates/camunda/configmap-warnings.yaml
@@ -1,0 +1,13 @@
+{{- $warnings := include "camunda.constraints.warnings" . | trim -}}
+{{- if $warnings }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "camundaPlatform.fullname" . }}-warnings
+  labels:
+    {{- include "camundaPlatform.labels" . | nindent 4 }}
+  annotations: {{- toYaml .Values.global.annotations | nindent 4 }}
+data:
+  warnings: |-
+    {{- $warnings | nindent 4 }}
+{{- end }}

--- a/charts/camunda-platform-8.7/templates/camunda/constraints.tpl
+++ b/charts/camunda-platform-8.7/templates/camunda/constraints.tpl
@@ -86,6 +86,12 @@ Fail with a message if zeebeGateway.contextPath and zeebeGateway.ingress.rest.pa
   {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}
 
+{{/*
+camunda.constraints.warnings
+Non-fatal deprecation/config warnings. Consumed by NOTES.txt (helm install/upgrade) and by
+configmap-warnings.yaml, which renders the "<release>-warnings" ConfigMap on the GitOps path
+(helm template / Argo CD / Flux). Feed new deprecations here so they reach both channels.
+*/}}
 {{- define "camunda.constraints.warnings" }}
   {{- if .Values.global.testDeprecationFlags.existingSecretsMustBeSet }}
     {{/* TODO: Check if there are more existingSecrets to check */}}

--- a/charts/camunda-platform-8.7/test/unit/camunda/configmap_warnings_test.go
+++ b/charts/camunda-platform-8.7/test/unit/camunda/configmap_warnings_test.go
@@ -1,0 +1,82 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package camunda
+
+import (
+	"camunda-platform/test/unit/testhelpers"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type ConfigMapWarningsTemplateTest struct {
+	suite.Suite
+	chartPath string
+	release   string
+	namespace string
+	templates []string
+}
+
+func TestConfigMapWarningsTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../")
+	require.NoError(t, err)
+
+	suite.Run(t, &ConfigMapWarningsTemplateTest{
+		chartPath: chartPath,
+		release:   "camunda-platform-test",
+		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
+		templates: []string{"templates/camunda/configmap-warnings.yaml"},
+	})
+}
+
+func (s *ConfigMapWarningsTemplateTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestWarningsConfigMapRendersWhenWarningPresent",
+			Values: map[string]string{
+				"global.testDeprecationFlags.existingSecretsMustBeSet": "warning",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().True(strings.HasSuffix(configmap.Name, "-warnings"))
+				s.Require().Contains(configmap.Data["warnings"],
+					"the Camunda Helm chart will no longer automatically generate passwords for the Identity component")
+			},
+		},
+		{
+			Name: "TestWarningsConfigMapAbsentWhenNoWarnings",
+			Values: map[string]string{
+				"global.testDeprecationFlags.existingSecretsMustBeSet": "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				// With no active warnings the helper renders nothing, so --show-only finds no manifest.
+				s.Require().Error(err)
+				s.Require().NotContains(output, "kind: ConfigMap")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}

--- a/charts/camunda-platform-8.8/templates/common/configmap-warnings.yaml
+++ b/charts/camunda-platform-8.8/templates/common/configmap-warnings.yaml
@@ -1,0 +1,13 @@
+{{- $warnings := include "camunda.constraints.warnings" . | trim -}}
+{{- if $warnings }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "camundaPlatform.fullname" . }}-warnings
+  labels:
+    {{- include "camundaPlatform.labels" . | nindent 4 }}
+  annotations: {{- toYaml .Values.global.annotations | nindent 4 }}
+data:
+  warnings: |-
+    {{- $warnings | nindent 4 }}
+{{- end }}

--- a/charts/camunda-platform-8.8/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.8/templates/common/constraints.tpl
@@ -131,6 +131,12 @@ Fail with a message if Web Modeler is enabled but management Identity is not ena
   {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}
 
+{{/*
+camunda.constraints.warnings
+Non-fatal deprecation/config warnings. Consumed by NOTES.txt (helm install/upgrade) and by
+configmap-warnings.yaml, which renders the "<release>-warnings" ConfigMap on the GitOps path
+(helm template / Argo CD / Flux). Feed new deprecations here so they reach both channels.
+*/}}
 {{- define "camunda.constraints.warnings" }}
   {{- if .Values.global.testDeprecationFlags.existingSecretsMustBeSet }}
     {{/* TODO: Check if there are more existingSecrets to check */}}

--- a/charts/camunda-platform-8.8/test/unit/common/configmap_warnings_test.go
+++ b/charts/camunda-platform-8.8/test/unit/common/configmap_warnings_test.go
@@ -1,0 +1,92 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package camunda
+
+import (
+	"camunda-platform/test/unit/testhelpers"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type ConfigMapWarningsTemplateTest struct {
+	suite.Suite
+	chartPath string
+	release   string
+	namespace string
+	templates []string
+}
+
+func TestConfigMapWarningsTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../")
+	require.NoError(t, err)
+
+	suite.Run(t, &ConfigMapWarningsTemplateTest{
+		chartPath: chartPath,
+		release:   "camunda-platform-test",
+		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
+		templates: []string{"templates/common/configmap-warnings.yaml"},
+	})
+}
+
+func (s *ConfigMapWarningsTemplateTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestWarningsConfigMapRendersWhenWarningPresent",
+			Values: map[string]string{
+				"identity.enabled":                                              "true",
+				"global.identity.auth.enabled":                                  "true",
+				"global.security.authentication.method":                         "oidc",
+				"connectors.security.authentication.oidc.secret.existingSecret": "foo",
+				"global.identity.auth.issuerBackendUrl":                         "http://keycloak:80/auth/realms/camunda-platform",
+				"global.testDeprecationFlags.existingSecretsMustBeSet":          "warning",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().True(strings.HasSuffix(configmap.Name, "-warnings"))
+				s.Require().Contains(configmap.Data["warnings"],
+					"the Camunda Helm chart will no longer automatically generate passwords for the Identity component")
+			},
+		},
+		{
+			Name: "TestWarningsConfigMapAbsentWhenNoWarnings",
+			// The chart default documentStore.type.aws/gcp ship legacy secret keys that
+			// trigger a deprecation warning; neutralize them for a warning-free render.
+			Values: map[string]string{
+				"global.documentStore.type.aws.existingSecret":     "",
+				"global.documentStore.type.aws.accessKeyIdKey":     "",
+				"global.documentStore.type.aws.secretAccessKeyKey": "",
+				"global.documentStore.type.gcp.existingSecret":     "",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				// With no active warnings the helper renders nothing, so --show-only finds no manifest.
+				s.Require().Error(err)
+				s.Require().NotContains(output, "kind: ConfigMap")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}

--- a/charts/camunda-platform-8.9/templates/common/configmap-warnings.yaml
+++ b/charts/camunda-platform-8.9/templates/common/configmap-warnings.yaml
@@ -1,0 +1,13 @@
+{{- $warnings := include "camunda.constraints.warnings" . | trim -}}
+{{- if $warnings }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "camundaPlatform.fullname" . }}-warnings
+  labels:
+    {{- include "camundaPlatform.labels" . | nindent 4 }}
+  annotations: {{- toYaml .Values.global.annotations | nindent 4 }}
+data:
+  warnings: |-
+    {{- $warnings | nindent 4 }}
+{{- end }}

--- a/charts/camunda-platform-8.9/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.9/templates/common/constraints.tpl
@@ -120,6 +120,12 @@ Fail with a message if Web Modeler is enabled but management Identity is not ena
   {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}
 
+{{/*
+camunda.constraints.warnings
+Non-fatal deprecation/config warnings. Consumed by NOTES.txt (helm install/upgrade) and by
+configmap-warnings.yaml, which renders the "<release>-warnings" ConfigMap on the GitOps path
+(helm template / Argo CD / Flux). Feed new deprecations here so they reach both channels.
+*/}}
 {{- define "camunda.constraints.warnings" }}
   {{- if .Values.global.testDeprecationFlags.existingSecretsMustBeSet }}
     {{/* TODO: Check if there are more existingSecrets to check */}}

--- a/charts/camunda-platform-8.9/test/unit/common/configmap_warnings_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/configmap_warnings_test.go
@@ -1,0 +1,93 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package camunda
+
+import (
+	"camunda-platform/test/unit/testhelpers"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type ConfigMapWarningsTemplateTest struct {
+	suite.Suite
+	chartPath string
+	release   string
+	namespace string
+	templates []string
+}
+
+func TestConfigMapWarningsTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../")
+	require.NoError(t, err)
+
+	suite.Run(t, &ConfigMapWarningsTemplateTest{
+		chartPath: chartPath,
+		release:   "camunda-platform-test",
+		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
+		templates: []string{"templates/common/configmap-warnings.yaml"},
+	})
+}
+
+func (s *ConfigMapWarningsTemplateTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestWarningsConfigMapRendersWhenWarningPresent",
+			Values: map[string]string{
+				"orchestration.data.secondaryStorage.type":                      "elasticsearch",
+				"identity.enabled":                                              "true",
+				"global.identity.auth.enabled":                                  "true",
+				"global.security.authentication.method":                         "oidc",
+				"connectors.security.authentication.oidc.secret.existingSecret": "foo",
+				"global.identity.auth.issuerBackendUrl":                         "http://keycloak:80/auth/realms/camunda-platform",
+				"global.testDeprecationFlags.existingSecretsMustBeSet":          "warning",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().True(strings.HasSuffix(configmap.Name, "-warnings"))
+				s.Require().Contains(configmap.Data["warnings"],
+					"the Camunda Helm chart will no longer automatically generate passwords for the Identity component")
+			},
+		},
+		{
+			Name: "TestWarningsConfigMapAbsentWhenNoWarnings",
+			// Both ES flags off avoid the legacy-option deprecation warning (the test helper
+			// otherwise defaults them to true); the new secondaryStorage key satisfies the
+			// storage-type constraint.
+			Values: map[string]string{
+				"elasticsearch.enabled":                    "false",
+				"global.elasticsearch.enabled":             "false",
+				"orchestration.data.secondaryStorage.type": "elasticsearch",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				// With no active warnings the helper renders nothing, so --show-only finds no manifest.
+				s.Require().Error(err)
+				s.Require().NotContains(output, "kind: ConfigMap")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}

--- a/docs/policies/breaking-changes.md
+++ b/docs/policies/breaking-changes.md
@@ -94,7 +94,7 @@ Major chart releases follow Camunda's release cycle.
 
 1. **Deprecate (keep compatibility):**
    - Add a `values.yaml` comment: `DEPRECATED since vX.Y.Z; remove in vNextMajor; use instead: ...`.
-   - On install/upgrade, warn if the deprecated key is set (old key, replacement, removal version).
+   - Warn if the deprecated key is set (old key, replacement, removal version). Warnings are collected by the `camunda.constraints.warnings` helper, which surfaces them on both the CLI path (`NOTES.txt` on install/upgrade) and the GitOps render path (the `<release>-warnings` ConfigMap rendered by `configmap-warnings.yaml`, visible to `helm template` / Argo CD / Flux). Feed new deprecation warnings through that helper rather than wiring them directly into `NOTES.txt`.
    - If both old and new are set: new wins + warning.
 
 2. **Document:**


### PR DESCRIPTION
### Which problem does the PR fix?

Non-fatal deprecation/config warnings (collected by the `camunda.constraints.warnings` helper) were rendered only through `NOTES.txt`, which Helm surfaces exclusively during a CLI `helm install`/`helm upgrade`. GitOps tooling (Argo CD, Flux, any `helm template` pipeline) applies rendered manifests and discards `NOTES.txt`, so GitOps-driven users never saw these warnings — including deprecation notices meant to give a migration window before a value is removed. Hard constraints (`fail`) already render on every path; only the soft-warning channel had this gap.

Closes #6514.

### What's in this PR?

Adds a chart-level `<release>-warnings` ConfigMap (modeled on `configmap-release.yaml`) that renders `camunda.constraints.warnings` into its `data.warnings` field. As a rendered manifest it is applied on the GitOps path and visible in-cluster regardless of deployment method.

- Rendered only when the helper produces output, so clean installs get no extra object.
- Non-fatal by construction — it carries the same soft warnings `NOTES.txt` already shows; no soft warning becomes a hard `fail`. `helm template` already executes `NOTES.txt`, so the pre-existing `existingSecretsMustBeSet=error` fail is unchanged.
- Applied across 8.7–8.10 (8.7 under `templates/camunda/`, 8.8/8.9/8.10 under `templates/common/`). `NOTES.txt` is unchanged and stays the CLI surface.
- Documents the GitOps-visible channel in `docs/policies/breaking-changes.md` and the `camunda.constraints.warnings` helper comments so future deprecations use it by default.
- Adds per-version unit tests: warning present → ConfigMap with the text; clean values → no ConfigMap.

On versions whose defaults already emit warnings (8.7 `existingSecretsMustBeSet: "warning"`, 8.8 `documentStore` legacy secret keys, 8.10 legacy `global.elasticsearch.enabled`), the `-warnings` ConfigMap now appears in-cluster for those default deployments — surfacing warnings `NOTES.txt` already prints today.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
