### PR TITLE
build: honor namespace TTL in deploy-camunda instead of hardcoded 60m

### DIFF
--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -686,6 +686,11 @@ jobs:
             EXTRA_VALUES_ARGS=(--extra-values /tmp/extra-values-file.yaml)
           fi
 
+          # Give deploy-camunda the requested namespace TTL; without this it stamps its 60m
+          # default onto cleaner/janitor, so 12h nightly clusters get reaped after an hour.
+          # Empty falls back to deploy-camunda's 60m default.
+          export DEPLOY_CAMUNDA_TTL="${CI_DEPLOYMENT_TTL:-}"
+
           deploy-camunda matrix run \
             --repo-root "${GITHUB_WORKSPACE}" \
             --include-disabled \
@@ -1071,6 +1076,11 @@ jobs:
           if [[ -s /tmp/extra-values-file.yaml ]] && grep -q '[^[:space:]]' /tmp/extra-values-file.yaml; then
             EXTRA_VALUES_ARGS=(--extra-values /tmp/extra-values-file.yaml)
           fi
+
+          # Give deploy-camunda the requested namespace TTL; without this it stamps its 60m
+          # default onto cleaner/janitor, so 12h nightly clusters get reaped after an hour.
+          # Empty falls back to deploy-camunda's 60m default.
+          export DEPLOY_CAMUNDA_TTL="${CI_DEPLOYMENT_TTL:-}"
 
           deploy-camunda matrix run \
             --repo-root "${GITHUB_WORKSPACE}" \

--- a/scripts/deploy-camunda/cmd/root.go
+++ b/scripts/deploy-camunda/cmd/root.go
@@ -233,6 +233,7 @@ func NewRootCommand() *cobra.Command {
 	f.StringVar(&flags.Index.OperateIndexPrefix, "operate-index-prefix", "", "Operate Elasticsearch index prefix (auto-generated if not specified)")
 	f.StringVar(&flags.Chart.RepoRoot, "repo-root", "", "Repository root path")
 	f.StringVar(&flags.Deployment.Flow, "flow", "install", "Flow type")
+	f.StringVar(&flags.Deployment.TTL, "ttl", "", "Ephemeral namespace TTL for cleaner/janitor; precedence: --ttl, DEPLOY_CAMUNDA_TTL env, 60m default")
 	f.StringVar(&flags.EnvFile, "env-file", "", "Path to .env file (defaults to .env in current dir)")
 	f.BoolVar(&flags.Interactive, "interactive", true, "Enable interactive prompts for missing variables")
 	f.BoolVar(&flags.SkipPreflight, "skip-preflight", false, "Skip the fail-fast secrets/env preflight run before deploying")

--- a/scripts/deploy-camunda/config/merge.go
+++ b/scripts/deploy-camunda/config/merge.go
@@ -39,7 +39,8 @@ type DeploymentFlags struct {
 	ScenarioPath         string
 	Platform             string
 	Flow                 string
-	Timeout              int // Timeout in minutes for Helm deployment
+	Timeout              int    // Timeout in minutes for Helm deployment
+	TTL                  string // Ephemeral-namespace TTL (cleaner/janitor), e.g. 60m, 12h; empty falls back to DEPLOY_CAMUNDA_TTL then 60m
 	DeleteNamespaceFirst bool
 	RenderTemplates      bool
 	RenderOutputDir      string

--- a/scripts/deploy-camunda/deploy/deploy.go
+++ b/scripts/deploy-camunda/deploy/deploy.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -364,7 +365,7 @@ func executeDeployment(ctx context.Context, prepared *PreparedScenario, flags *c
 		NamespacePrefix:        flags.Deployment.NamespacePrefix,
 		RepoRoot:               flags.Chart.RepoRoot,
 		Identifier:             identifier,
-		TTL:                    "60m",
+		TTL:                    resolveDeployTTL(flags.Deployment.TTL, os.Getenv("DEPLOY_CAMUNDA_TTL")),
 		LoadKeycloakRealm:      true,
 		KeycloakRealmName:      prepared.RealmName,
 		RenderTemplates:        flags.Deployment.RenderTemplates,
@@ -484,6 +485,16 @@ func executeDeployment(ctx context.Context, prepared *PreparedScenario, flags *c
 		Msg("Scenario deployment completed successfully")
 
 	return result
+}
+
+func resolveDeployTTL(flagTTL, envTTL string) string {
+	if strings.TrimSpace(flagTTL) != "" {
+		return flagTTL
+	}
+	if strings.TrimSpace(envTTL) != "" {
+		return envTTL
+	}
+	return "60m"
 }
 
 // deleteNamespace deletes a Kubernetes namespace.

--- a/scripts/deploy-camunda/deploy/ttl_test.go
+++ b/scripts/deploy-camunda/deploy/ttl_test.go
@@ -1,0 +1,48 @@
+// Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+// one or more contributor license agreements. See the NOTICE file distributed
+// with this work for additional information regarding copyright ownership.
+// Licensed under the Camunda License 1.0. You may not use this file
+// except in compliance with the Camunda License 1.0.
+
+package deploy
+
+import "testing"
+
+func TestResolveDeployTTL(t *testing.T) {
+	tests := []struct {
+		name    string
+		flagTTL string
+		envTTL  string
+		want    string
+	}{
+		{
+			name:    "flag wins over env",
+			flagTTL: "12h",
+			envTTL:  "60m",
+			want:    "12h",
+		},
+		{
+			name:   "env used when flag empty",
+			envTTL: "12h",
+			want:   "12h",
+		},
+		{
+			name: "default used when flag and env empty",
+			want: "60m",
+		},
+		{
+			name:    "whitespace flag and env treated as empty",
+			flagTTL: "  ",
+			envTTL:  "\t",
+			want:    "60m",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveDeployTTL(tt.flagTTL, tt.envTTL); got != tt.want {
+				t.Fatalf("resolveDeployTTL(%q, %q) = %q, want %q", tt.flagTTL, tt.envTTL, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Which problem does the PR fix?

Nightly Self-Managed CI clusters on GKE are configured to live **12h**, but they are reaped after
~1h — so by the time triage/on-call (or a fix-validation agent) looks, the environment is gone.

Root cause (GKE audit-log confirmed, namespace `qa-id-qaos-f36f-8-10-qaos`):

- `04:11:57Z` namespace created
- `04:12:03Z` `cleaner/ttl=12h` set (the workflow's requested TTL)
- `04:12:43Z` `cleaner/ttl` / `janitor/ttl` **overwritten to `60m`**
- `05:12:00Z` namespace **deleted** by `system:serviceaccount:k8s-cleaner:k8s-cleaner`

`deploy-camunda` hardcoded `TTL: "60m"` when annotating the namespace
(`deploy/deploy.go` → `camunda-deployer/pkg/deployer/kube.go` sets `cleaner/ttl` + `janitor/ttl`).
That single value clobbered the `12h` the caller requested. It was the only writer of `60m` in the
codebase. The `12h` request flows correctly end-to-end (E2E nightly workflows pass
`deployment_ttl: 12h` → helm reusable workflow → `CI_DEPLOYMENT_TTL`); only the overwrite was at fault.

### What's in this PR?

Make the namespace TTL configurable instead of hardcoded, so deploys keep the lifetime the caller
asked for:

- `deploy.go` resolves the TTL as **`--ttl` flag → `DEPLOY_CAMUNDA_TTL` env → `60m` default**
  (unchanged behavior for ad-hoc/local deploys), via a small pure `resolveDeployTTL` helper.
- New `--ttl` flag on the deploy command (`cmd/root.go`, `config/merge.go`).
- `deploy-camunda matrix run` builds its own config and does not register `--ttl`, so the
  integration runner (`.github/workflows/test-integration-runner.yaml`) exports `DEPLOY_CAMUNDA_TTL`
  from the existing `CI_DEPLOYMENT_TTL` (= the `deployment-ttl` input) right before each `matrix run`.
- All three matrix deploy paths — install, two-step upgrade, upgrade-only — funnel through
  `deploy.Execute → executeDeployment`, so this single change covers every nightly scenario type.
- Added a table-driven unit test for the flag→env→default precedence.

### Verification

- `gofmt -l .`, `go vet`, `go build ./...` — clean
- `go test ./deploy/ -run TestResolveDeployTTL -v` — all 4 subtests pass
- `deploy-camunda --help | grep ttl` — `--ttl` flag present with precedence help text

Still to validate on a live run: trigger an ad-hoc nightly matrix run with `deployment-ttl: 12h` and
confirm `cleaner/ttl`/`janitor/ttl` read `12h` and the namespace survives >1h.

### Context

- Originating nightly run: https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/28767167433
- Re-implements #6512 (closed) with test coverage and a verified root-cause analysis.

### Checklist

- [ ] In the repo's root dir, run `make go.update-golden-only`. — N/A, no chart templates changed
- [x] There is no other open pull request for the same update/change.
- [x] Tests for charts are added (if needed).
- [ ] In-repo documentation are updated (if needed). — N/A
