### PR TITLE
test: consolidate shadow-e2e Playwright config into a shared base

### DIFF
--- a/.github/workflows/test-chart-version.yaml
+++ b/.github/workflows/test-chart-version.yaml
@@ -136,6 +136,7 @@ jobs:
               - '.github/workflows/test-chart-version.yaml'
               - '.github/config/external-secret/**'
               - 'scripts/**'
+              - 'test/e2e/**'
               - '.tool-versions'
               - 'charts/camunda-platform-8*/**'
               - '!charts/camunda-platform-8*/*.md'

--- a/charts/camunda-platform-8.10/test/e2e/playwright.config.ts
+++ b/charts/camunda-platform-8.10/test/e2e/playwright.config.ts
@@ -50,6 +50,7 @@ export default defineConfig(makeShadowConfig({
   version: "SM-8.10",
   testDir,
   includeSetupProject: true,
+  tasklistV2Header: true,
   extraProjects: [
     {
       // Auth0 scenario: HTTP-level smoke that asserts each Camunda component

--- a/charts/camunda-platform-8.10/test/e2e/playwright.config.ts
+++ b/charts/camunda-platform-8.10/test/e2e/playwright.config.ts
@@ -51,6 +51,9 @@ export default defineConfig(makeShadowConfig({
   testDir,
   includeSetupProject: true,
   tasklistV2Header: true,
+  fullyParallel: true,
+  retries: 2,
+  workers: "100%",
   extraProjects: [
     {
       // Auth0 scenario: HTTP-level smoke that asserts each Camunda component

--- a/charts/camunda-platform-8.10/test/e2e/playwright.config.ts
+++ b/charts/camunda-platform-8.10/test/e2e/playwright.config.ts
@@ -1,7 +1,12 @@
+/// <reference types="node" />
+/// <reference lib="esnext" />
+
 import { defineConfig } from "@playwright/test";
 import * as dotenv from "dotenv";
 import * as fs from "fs";
 import * as path from "path";
+
+import { makeShadowConfig } from "../../../../test/e2e/playwright.base.config";
 
 dotenv.config();
 
@@ -41,46 +46,11 @@ const auth0TestDir = path.resolve(
   "./node_modules/@camunda/e2e-test-suite/dist/tests/auth0",
 );
 
-export default defineConfig({
+export default defineConfig(makeShadowConfig({
+  version: "SM-8.10",
   testDir,
-  projects: [
-    {
-      name: "smoke-tests",
-      testMatch: ["**/smoke-tests.spec.{ts,js}"],
-    },
-    {
-      name: "full-suite-setup",
-      testMatch: ["**/test-setup.spec.{ts,js}"],
-      use: {
-        extraHTTPHeaders: {
-          "X-Test-Tasklist-Version": "v2",
-        },
-      },
-    },
-    {
-      name: "full-suite",
-      dependencies: ["full-suite-setup"],
-      testMatch: ["**/*.spec.{ts,js}"],
-      // cluster-variables requires Vault-managed secrets not available in PR CI.
-      // test-setup is run via the full-suite-setup dependency, not directly.
-      testIgnore: [
-        "**/cluster-variables.spec.{ts,js}",
-        "**/test-setup.spec.{ts,js}",
-      ],
-      // Match the E2E repo's chromium-v2 project behavior:
-      // - @tasklistV1: These tests require Tasklist v1 mode with RBA enabled
-      //   (CAMUNDA_TASKLIST_IDENTITY_RESOURCE_PERMISSIONS_ENABLED=true), which
-      //   is not deployed in standard PR CI scenarios. Also excludes all Optimize
-      //   tests (under 'Optimize User Flow Tests @tasklistV1' describe) which
-      //   require long Optimize warm-up not available on fresh clusters.
-      // - Connector Secrets/Custom Tags/Properties: Require QA-specific config.
-      grep: /^(?!.*(@tasklistV1|Connector Secrets User Flow|Custom Tags|Custom Properties)).*$/,
-      use: {
-        extraHTTPHeaders: {
-          "X-Test-Tasklist-Version": "v2",
-        },
-      },
-    },
+  includeSetupProject: true,
+  extraProjects: [
     {
       // Auth0 scenario: HTTP-level smoke that asserts each Camunda component
       // route redirects to the Auth0 issuer with a well-formed authorize URL.
@@ -90,37 +60,4 @@ export default defineConfig({
       testMatch: ["**/*.spec.{ts,js}"],
     },
   ],
-  fullyParallel: true,
-  retries: 2,
-  timeout: 12 * 60 * 1000, // match E2E repo timeout (12 minutes); test.slow() triples this
-  workers: "100%",
-  //workers: process.env.CI == "true" ? 1 : "50%",
-  use: {
-    baseURL: getBaseURL(),
-    actionTimeout: 10000,
-    // Also applies to flaky tests
-    screenshot: "only-on-failure",
-    video: "retain-on-failure",
-    trace: "on-first-retry",
-  },
-});
-
-function getBaseURL(): string {
-  if (process.env.IS_PROD === "true") {
-    return "https://console.camunda.io";
-  }
-
-  if (typeof process.env.PLAYWRIGHT_BASE_URL === "string") {
-    return process.env.PLAYWRIGHT_BASE_URL;
-  }
-
-  if (process.env.MINOR_VERSION?.includes("SM")) {
-    return "https://gke-" + process.env.BASE_URL + ".ci.distro.ultrawombat.com";
-  }
-
-  if (process.env.MINOR_VERSION?.includes("Run")) {
-    return "http://localhost:8080";
-  }
-
-  return "https://console.cloud.ultrawombat.com";
-}
+}));

--- a/charts/camunda-platform-8.7/test/e2e/playwright.config.ts
+++ b/charts/camunda-platform-8.7/test/e2e/playwright.config.ts
@@ -1,57 +1,11 @@
+/// <reference types="node" />
+/// <reference lib="esnext" />
+
 import { defineConfig } from "@playwright/test";
 import * as dotenv from "dotenv";
 
+import { makeShadowConfig } from "../../../../test/e2e/playwright.base.config";
+
 dotenv.config();
 
-export default defineConfig({
-  testDir: "./node_modules/@camunda/e2e-test-suite/dist/tests/SM-8.7",
-  projects: [
-    {
-      name: "smoke-tests",
-      testMatch: ["**/smoke-tests.spec.{ts,js}"],
-    },
-    {
-      name: "full-suite",
-      testMatch: ["**/*.spec.{ts,js}"],
-      testIgnore: [/test-setup\.spec\.[jt]s$/],
-      // Exclude tests that require QA-specific config:
-      // - Connector Secrets: Requires Vault-managed secrets
-      // - Custom Tags/Custom Properties: Require Console QA cluster config
-      grep: /^(?!.*(Connector Secrets User Flow|Custom Tags|Custom Properties)).*$/,
-    },
-  ],
-  // Match the E2E repo's SM-8.7 settings: short timeout so tests that hit
-  // unresponsive services (e.g. web-modeler-restapi) fail fast instead of
-  // hanging until the job timeout.
-  fullyParallel: false,
-  retries: 1,
-  timeout: 3 * 60 * 1000,
-  workers: process.env.CI === "true" ? 37 : "100%",
-  use: {
-    baseURL: getBaseURL(),
-    actionTimeout: 10000,
-    screenshot: "only-on-failure",
-    video: "retain-on-failure",
-    trace: "on-first-retry",
-  },
-});
-
-function getBaseURL(): string {
-  if (process.env.IS_PROD === "true") {
-    return "https://console.camunda.io";
-  }
-
-  if (typeof process.env.PLAYWRIGHT_BASE_URL === "string") {
-    return process.env.PLAYWRIGHT_BASE_URL;
-  }
-
-  if (process.env.MINOR_VERSION?.includes("SM")) {
-    return "https://gke-" + process.env.BASE_URL + ".ci.distro.ultrawombat.com";
-  }
-
-  if (process.env.MINOR_VERSION?.includes("Run")) {
-    return "http://localhost:8080";
-  }
-
-  return "https://console.cloud.ultrawombat.com";
-}
+export default defineConfig(makeShadowConfig({ version: "SM-8.7" }));

--- a/charts/camunda-platform-8.7/test/e2e/playwright.config.ts
+++ b/charts/camunda-platform-8.7/test/e2e/playwright.config.ts
@@ -8,4 +8,4 @@ import { makeShadowConfig } from "../../../../test/e2e/playwright.base.config";
 
 dotenv.config();
 
-export default defineConfig(makeShadowConfig({ version: "SM-8.7" }));
+export default defineConfig(makeShadowConfig({ version: "SM-8.7", includeSetupProject: false, fullyParallel: false, retries: 1, timeout: 3 * 60 * 1000 }));

--- a/charts/camunda-platform-8.9/test/e2e/playwright.config.ts
+++ b/charts/camunda-platform-8.9/test/e2e/playwright.config.ts
@@ -8,4 +8,4 @@ import { makeShadowConfig } from "../../../../test/e2e/playwright.base.config";
 
 dotenv.config();
 
-export default defineConfig(makeShadowConfig({ version: "SM-8.9" }));
+export default defineConfig(makeShadowConfig({ version: "SM-8.9", includeSetupProject: false, fullyParallel: true, retries: 2, timeout: 10 * 60 * 1000, workers: "100%" }));

--- a/charts/camunda-platform-8.9/test/e2e/playwright.config.ts
+++ b/charts/camunda-platform-8.9/test/e2e/playwright.config.ts
@@ -1,59 +1,11 @@
+/// <reference types="node" />
+/// <reference lib="esnext" />
+
 import { defineConfig } from "@playwright/test";
 import * as dotenv from "dotenv";
 
+import { makeShadowConfig } from "../../../../test/e2e/playwright.base.config";
+
 dotenv.config();
 
-export default defineConfig({
-  testDir: "./node_modules/@camunda/e2e-test-suite/dist/tests/SM-8.9",
-  projects: [
-    {
-      name: "smoke-tests",
-      testMatch: ["**/smoke-tests.spec.{ts,js}"],
-    },
-    {
-      name: "full-suite",
-      testMatch: ["**/*.spec.{ts,js}"],
-      // cluster-variables requires Vault-managed secrets not available in PR CI.
-      testIgnore: ["**/cluster-variables.spec.{ts,js}"],
-      // @tasklistV1: requires Tasklist v1 mode with RBA enabled, not deployed in
-      // standard CI scenarios. Also excludes all Optimize tests (under
-      // 'Optimize User Flow Tests @tasklistV1') which require long Optimize
-      // warm-up not available on fresh clusters.
-      // Connector Secrets/Custom Tags/Properties: require QA-specific config.
-      grep: /^(?!.*(@tasklistV1|Connector Secrets User Flow|Custom Tags|Custom Properties)).*$/,
-    },
-  ],
-  fullyParallel: true,
-  retries: 2,
-  timeout: 10 * 60 * 1000, // no test should take more than 3 minutes (failing fast is important so that we can run our tests on each PR)
-  workers: "100%",
-  //workers: process.env.CI == "true" ? 1 : "50%",
-  use: {
-    baseURL: getBaseURL(),
-    actionTimeout: 10000,
-    // Also applies to flaky tests
-    screenshot: "only-on-failure",
-    video: "retain-on-failure",
-    trace: "on-first-retry",
-  },
-});
-
-function getBaseURL(): string {
-  if (process.env.IS_PROD === "true") {
-    return "https://console.camunda.io";
-  }
-
-  if (typeof process.env.PLAYWRIGHT_BASE_URL === "string") {
-    return process.env.PLAYWRIGHT_BASE_URL;
-  }
-
-  if (process.env.MINOR_VERSION?.includes("SM")) {
-    return "https://gke-" + process.env.BASE_URL + ".ci.distro.ultrawombat.com";
-  }
-
-  if (process.env.MINOR_VERSION?.includes("Run")) {
-    return "http://localhost:8080";
-  }
-
-  return "https://console.cloud.ultrawombat.com";
-}
+export default defineConfig(makeShadowConfig({ version: "SM-8.9" }));

--- a/charts/camunda-platform-8.9/test/e2e/playwright.config.ts
+++ b/charts/camunda-platform-8.9/test/e2e/playwright.config.ts
@@ -8,4 +8,13 @@ import { makeShadowConfig } from "../../../../test/e2e/playwright.base.config";
 
 dotenv.config();
 
-export default defineConfig(makeShadowConfig({ version: "SM-8.9", includeSetupProject: false, fullyParallel: true, retries: 2, timeout: 10 * 60 * 1000, workers: "100%" }));
+export default defineConfig(
+  makeShadowConfig({
+    version: "SM-8.9",
+    includeSetupProject: true,
+    fullyParallel: true,
+    retries: 2,
+    timeout: 10 * 60 * 1000,
+    workers: "100%",
+  }),
+);

--- a/charts/camunda-platform-8.9/test/e2e/playwright.config.ts
+++ b/charts/camunda-platform-8.9/test/e2e/playwright.config.ts
@@ -11,6 +11,11 @@ dotenv.config();
 export default defineConfig(
   makeShadowConfig({
     version: "SM-8.9",
+    includeSetupProject: false,
     extraTestIgnore: ["**/optimize-api-tests.spec.{ts,js}"],
+    fullyParallel: true,
+    retries: 2,
+    timeout: 10 * 60 * 1000,
+    workers: "100%",
   }),
 );

--- a/charts/camunda-platform-8.9/test/e2e/playwright.config.ts
+++ b/charts/camunda-platform-8.9/test/e2e/playwright.config.ts
@@ -1,64 +1,16 @@
+/// <reference types="node" />
+/// <reference lib="esnext" />
+
 import { defineConfig } from "@playwright/test";
 import * as dotenv from "dotenv";
 
+import { makeShadowConfig } from "../../../../test/e2e/playwright.base.config";
+
 dotenv.config();
 
-export default defineConfig({
-  testDir: "./node_modules/@camunda/e2e-test-suite/dist/tests/SM-8.9",
-  projects: [
-    {
-      name: "smoke-tests",
-      testMatch: ["**/smoke-tests.spec.{ts,js}"],
-    },
-    {
-      name: "full-suite",
-      testMatch: ["**/*.spec.{ts,js}"],
-      // cluster-variables requires Vault-managed secrets not available in PR CI.
-      // optimize-api-tests authenticate as the `test` Keycloak client, which is
-      // only created by the base-qa.yaml values layer (scenario `qa: true`).
-      testIgnore: [
-        "**/cluster-variables.spec.{ts,js}",
-        "**/optimize-api-tests.spec.{ts,js}",
-      ],
-      // @tasklistV1: requires Tasklist v1 mode with RBA enabled, not deployed in
-      // standard CI scenarios. Also excludes all Optimize tests (under
-      // 'Optimize User Flow Tests @tasklistV1') which require long Optimize
-      // warm-up not available on fresh clusters.
-      // Connector Secrets/Custom Tags/Properties: require QA-specific config.
-      grep: /^(?!.*(@tasklistV1|Connector Secrets User Flow|Custom Tags|Custom Properties)).*$/,
-    },
-  ],
-  fullyParallel: true,
-  retries: 2,
-  timeout: 10 * 60 * 1000, // no test should take more than 3 minutes (failing fast is important so that we can run our tests on each PR)
-  workers: "100%",
-  //workers: process.env.CI == "true" ? 1 : "50%",
-  use: {
-    baseURL: getBaseURL(),
-    actionTimeout: 10000,
-    // Also applies to flaky tests
-    screenshot: "only-on-failure",
-    video: "retain-on-failure",
-    trace: "on-first-retry",
-  },
-});
-
-function getBaseURL(): string {
-  if (process.env.IS_PROD === "true") {
-    return "https://console.camunda.io";
-  }
-
-  if (typeof process.env.PLAYWRIGHT_BASE_URL === "string") {
-    return process.env.PLAYWRIGHT_BASE_URL;
-  }
-
-  if (process.env.MINOR_VERSION?.includes("SM")) {
-    return "https://gke-" + process.env.BASE_URL + ".ci.distro.ultrawombat.com";
-  }
-
-  if (process.env.MINOR_VERSION?.includes("Run")) {
-    return "http://localhost:8080";
-  }
-
-  return "https://console.cloud.ultrawombat.com";
-}
+export default defineConfig(
+  makeShadowConfig({
+    version: "SM-8.9",
+    extraTestIgnore: ["**/optimize-api-tests.spec.{ts,js}"],
+  }),
+);

--- a/charts/camunda-platform-8.9/test/e2e/playwright.config.ts
+++ b/charts/camunda-platform-8.9/test/e2e/playwright.config.ts
@@ -11,7 +11,7 @@ dotenv.config();
 export default defineConfig(
   makeShadowConfig({
     version: "SM-8.9",
-    includeSetupProject: false,
+    includeSetupProject: true,
     extraTestIgnore: ["**/optimize-api-tests.spec.{ts,js}"],
     fullyParallel: true,
     retries: 2,

--- a/test/e2e/playwright.base.config.ts
+++ b/test/e2e/playwright.base.config.ts
@@ -1,0 +1,128 @@
+declare const process: {
+  env: Record<string, string | undefined>;
+};
+
+type Project = {
+  name: string;
+  testDir?: string;
+  testMatch?: string[];
+  testIgnore?: Array<string | RegExp>;
+  dependencies?: string[];
+  grep?: RegExp;
+  use?: {
+    extraHTTPHeaders?: Record<string, string>;
+  };
+};
+
+type ShadowConfig = {
+  testDir: string;
+  projects: Project[];
+  fullyParallel: boolean;
+  retries: number;
+  timeout: number;
+  workers: number | string;
+  use: {
+    baseURL: string;
+    actionTimeout: number;
+    screenshot: "only-on-failure";
+    video: "retain-on-failure";
+    trace: "on-first-retry";
+  };
+};
+
+type ShadowVersion = "SM-8.7" | "SM-8.9" | "SM-8.10";
+
+export function makeShadowConfig(opts: {
+  version: ShadowVersion;
+  testDir?: string;
+  includeSetupProject?: boolean;
+  extraProjects?: Project[];
+}): ShadowConfig {
+  if (!process.env.CAMUNDA_OPTIMIZE_BASE_URL && process.env.BASE_URL) {
+    process.env.CAMUNDA_OPTIMIZE_BASE_URL = `https://${process.env.BASE_URL}/optimize`;
+  }
+
+  const includeSetupProject = opts.includeSetupProject ?? true;
+
+  return {
+    testDir:
+      opts.testDir ??
+      `./node_modules/@camunda/e2e-test-suite/dist/tests/${opts.version}`,
+    projects: [
+      {
+        name: "smoke-tests",
+        testMatch: ["**/smoke-tests.spec.{ts,js}"],
+      },
+      ...(
+        includeSetupProject
+          ? [
+              {
+                name: "full-suite-setup",
+                testMatch: ["**/test-setup.spec.{ts,js}"],
+                use: {
+                  extraHTTPHeaders: {
+                    "X-Test-Tasklist-Version": "v2",
+                  },
+                },
+              },
+            ]
+          : []
+      ),
+      {
+        name: "full-suite",
+        dependencies: includeSetupProject ? ["full-suite-setup"] : undefined,
+        testMatch: ["**/*.spec.{ts,js}"],
+        testIgnore: [
+          "**/cluster-variables.spec.{ts,js}",
+          "**/test-setup.spec.{ts,js}",
+        ],
+        grep: /^(?!.*(@tasklistV1|Connector Secrets User Flow|Custom Tags|Custom Properties)).*$/,
+        use: {
+          extraHTTPHeaders: {
+            "X-Test-Tasklist-Version": "v2",
+          },
+        },
+      },
+      ...(opts.extraProjects ?? []),
+    ],
+    fullyParallel: false,
+    retries: 1,
+    timeout: 12 * 60 * 1000,
+    workers: workerCount(opts.version),
+    use: {
+      baseURL: getBaseURL(),
+      actionTimeout: 10000,
+      screenshot: "only-on-failure",
+      video: "retain-on-failure",
+      trace: "on-first-retry",
+    },
+  };
+}
+
+function workerCount(version: ShadowVersion): number | string {
+  if (process.env.CI !== "true") {
+    return "100%";
+  }
+
+  return version === "SM-8.7" ? 37 : 25;
+}
+
+function getBaseURL(): string {
+  if (process.env.IS_PROD === "true") {
+    return "https://console.camunda.io";
+  }
+
+  if (typeof process.env.PLAYWRIGHT_BASE_URL === "string") {
+    return process.env.PLAYWRIGHT_BASE_URL;
+  }
+
+  if (process.env.MINOR_VERSION?.includes("SM")) {
+    return "https://gke-" + process.env.BASE_URL + ".ci.distro.ultrawombat.com";
+  }
+
+  if (process.env.MINOR_VERSION?.includes("Run")) {
+    return "http://localhost:8080";
+  }
+
+  return "https://console.cloud.ultrawombat.com";
+}

--- a/test/e2e/playwright.base.config.ts
+++ b/test/e2e/playwright.base.config.ts
@@ -36,6 +36,7 @@ export function makeShadowConfig(opts: {
   version: ShadowVersion;
   testDir?: string;
   includeSetupProject?: boolean;
+  tasklistV2Header?: boolean;
   extraProjects?: Project[];
 }): ShadowConfig {
   if (!process.env.CAMUNDA_OPTIMIZE_BASE_URL && process.env.BASE_URL) {
@@ -43,6 +44,15 @@ export function makeShadowConfig(opts: {
   }
 
   const includeSetupProject = opts.includeSetupProject ?? true;
+  const tasklistV2Use = opts.tasklistV2Header
+    ? {
+        use: {
+          extraHTTPHeaders: {
+            "X-Test-Tasklist-Version": "v2",
+          },
+        },
+      }
+    : {};
 
   return {
     testDir:
@@ -59,11 +69,7 @@ export function makeShadowConfig(opts: {
               {
                 name: "full-suite-setup",
                 testMatch: ["**/test-setup.spec.{ts,js}"],
-                use: {
-                  extraHTTPHeaders: {
-                    "X-Test-Tasklist-Version": "v2",
-                  },
-                },
+                ...tasklistV2Use,
               },
             ]
           : []
@@ -77,11 +83,7 @@ export function makeShadowConfig(opts: {
           "**/test-setup.spec.{ts,js}",
         ],
         grep: /^(?!.*(@tasklistV1|Connector Secrets User Flow|Custom Tags|Custom Properties)).*$/,
-        use: {
-          extraHTTPHeaders: {
-            "X-Test-Tasklist-Version": "v2",
-          },
-        },
+        ...tasklistV2Use,
       },
       ...(opts.extraProjects ?? []),
     ],

--- a/test/e2e/playwright.base.config.ts
+++ b/test/e2e/playwright.base.config.ts
@@ -38,6 +38,10 @@ export function makeShadowConfig(opts: {
   includeSetupProject?: boolean;
   tasklistV2Header?: boolean;
   extraProjects?: Project[];
+  fullyParallel?: boolean;
+  retries?: number;
+  timeout?: number;
+  workers?: number | string;
 }): ShadowConfig {
   if (!process.env.CAMUNDA_OPTIMIZE_BASE_URL && process.env.BASE_URL) {
     process.env.CAMUNDA_OPTIMIZE_BASE_URL = `https://${process.env.BASE_URL}/optimize`;
@@ -87,10 +91,10 @@ export function makeShadowConfig(opts: {
       },
       ...(opts.extraProjects ?? []),
     ],
-    fullyParallel: false,
-    retries: 1,
-    timeout: 12 * 60 * 1000,
-    workers: workerCount(opts.version),
+    fullyParallel: opts.fullyParallel ?? false,
+    retries: opts.retries ?? 1,
+    timeout: opts.timeout ?? 12 * 60 * 1000,
+    workers: opts.workers ?? workerCount(opts.version),
     use: {
       baseURL: getBaseURL(),
       actionTimeout: 10000,

--- a/test/e2e/playwright.base.config.ts
+++ b/test/e2e/playwright.base.config.ts
@@ -44,8 +44,10 @@ export function makeShadowConfig(opts: {
   timeout?: number;
   workers?: number | string;
 }): ShadowConfig {
-  if (!process.env.CAMUNDA_OPTIMIZE_BASE_URL && process.env.BASE_URL) {
-    process.env.CAMUNDA_OPTIMIZE_BASE_URL = `https://${process.env.BASE_URL}/optimize`;
+  const baseURL = getBaseURL();
+
+  if (!process.env.CAMUNDA_OPTIMIZE_BASE_URL) {
+    process.env.CAMUNDA_OPTIMIZE_BASE_URL = `${baseURL.replace(/\/+$/, "")}/optimize`;
   }
 
   const includeSetupProject = opts.includeSetupProject ?? true;
@@ -98,7 +100,7 @@ export function makeShadowConfig(opts: {
     timeout: opts.timeout ?? 12 * 60 * 1000,
     workers: opts.workers ?? workerCount(opts.version),
     use: {
-      baseURL: getBaseURL(),
+      baseURL,
       actionTimeout: 10000,
       screenshot: "only-on-failure",
       video: "retain-on-failure",

--- a/test/e2e/playwright.base.config.ts
+++ b/test/e2e/playwright.base.config.ts
@@ -1,0 +1,130 @@
+declare const process: {
+  env: Record<string, string | undefined>;
+};
+
+type Project = {
+  name: string;
+  testDir?: string;
+  testMatch?: string[];
+  testIgnore?: Array<string | RegExp>;
+  dependencies?: string[];
+  grep?: RegExp;
+  use?: {
+    extraHTTPHeaders?: Record<string, string>;
+  };
+};
+
+type ShadowConfig = {
+  testDir: string;
+  projects: Project[];
+  fullyParallel: boolean;
+  retries: number;
+  timeout: number;
+  workers: number | string;
+  use: {
+    baseURL: string;
+    actionTimeout: number;
+    screenshot: "only-on-failure";
+    video: "retain-on-failure";
+    trace: "on-first-retry";
+  };
+};
+
+type ShadowVersion = "SM-8.7" | "SM-8.9" | "SM-8.10";
+
+export function makeShadowConfig(opts: {
+  version: ShadowVersion;
+  testDir?: string;
+  includeSetupProject?: boolean;
+  extraTestIgnore?: Array<string | RegExp>;
+  extraProjects?: Project[];
+}): ShadowConfig {
+  if (!process.env.CAMUNDA_OPTIMIZE_BASE_URL && process.env.BASE_URL) {
+    process.env.CAMUNDA_OPTIMIZE_BASE_URL = `https://${process.env.BASE_URL}/optimize`;
+  }
+
+  const includeSetupProject = opts.includeSetupProject ?? true;
+
+  return {
+    testDir:
+      opts.testDir ??
+      `./node_modules/@camunda/e2e-test-suite/dist/tests/${opts.version}`,
+    projects: [
+      {
+        name: "smoke-tests",
+        testMatch: ["**/smoke-tests.spec.{ts,js}"],
+      },
+      ...(
+        includeSetupProject
+          ? [
+              {
+                name: "full-suite-setup",
+                testMatch: ["**/test-setup.spec.{ts,js}"],
+                use: {
+                  extraHTTPHeaders: {
+                    "X-Test-Tasklist-Version": "v2",
+                  },
+                },
+              },
+            ]
+          : []
+      ),
+      {
+        name: "full-suite",
+        dependencies: includeSetupProject ? ["full-suite-setup"] : undefined,
+        testMatch: ["**/*.spec.{ts,js}"],
+        testIgnore: [
+          "**/cluster-variables.spec.{ts,js}",
+          "**/test-setup.spec.{ts,js}",
+          ...(opts.extraTestIgnore ?? []),
+        ],
+        grep: /^(?!.*(@tasklistV1|Connector Secrets User Flow|Custom Tags|Custom Properties)).*$/,
+        use: {
+          extraHTTPHeaders: {
+            "X-Test-Tasklist-Version": "v2",
+          },
+        },
+      },
+      ...(opts.extraProjects ?? []),
+    ],
+    fullyParallel: false,
+    retries: 1,
+    timeout: 12 * 60 * 1000,
+    workers: workerCount(opts.version),
+    use: {
+      baseURL: getBaseURL(),
+      actionTimeout: 10000,
+      screenshot: "only-on-failure",
+      video: "retain-on-failure",
+      trace: "on-first-retry",
+    },
+  };
+}
+
+function workerCount(version: ShadowVersion): number | string {
+  if (process.env.CI !== "true") {
+    return "100%";
+  }
+
+  return version === "SM-8.7" ? 37 : 25;
+}
+
+function getBaseURL(): string {
+  if (process.env.IS_PROD === "true") {
+    return "https://console.camunda.io";
+  }
+
+  if (typeof process.env.PLAYWRIGHT_BASE_URL === "string") {
+    return process.env.PLAYWRIGHT_BASE_URL;
+  }
+
+  if (process.env.MINOR_VERSION?.includes("SM")) {
+    return "https://gke-" + process.env.BASE_URL + ".ci.distro.ultrawombat.com";
+  }
+
+  if (process.env.MINOR_VERSION?.includes("Run")) {
+    return "http://localhost:8080";
+  }
+
+  return "https://console.cloud.ultrawombat.com";
+}

--- a/test/e2e/playwright.base.config.ts
+++ b/test/e2e/playwright.base.config.ts
@@ -37,6 +37,7 @@ export function makeShadowConfig(opts: {
   testDir?: string;
   includeSetupProject?: boolean;
   extraTestIgnore?: Array<string | RegExp>;
+  tasklistV2Header?: boolean;
   extraProjects?: Project[];
 }): ShadowConfig {
   if (!process.env.CAMUNDA_OPTIMIZE_BASE_URL && process.env.BASE_URL) {
@@ -44,6 +45,15 @@ export function makeShadowConfig(opts: {
   }
 
   const includeSetupProject = opts.includeSetupProject ?? true;
+  const tasklistV2Use = opts.tasklistV2Header
+    ? {
+        use: {
+          extraHTTPHeaders: {
+            "X-Test-Tasklist-Version": "v2",
+          },
+        },
+      }
+    : {};
 
   return {
     testDir:
@@ -60,11 +70,7 @@ export function makeShadowConfig(opts: {
               {
                 name: "full-suite-setup",
                 testMatch: ["**/test-setup.spec.{ts,js}"],
-                use: {
-                  extraHTTPHeaders: {
-                    "X-Test-Tasklist-Version": "v2",
-                  },
-                },
+                ...tasklistV2Use,
               },
             ]
           : []
@@ -79,11 +85,7 @@ export function makeShadowConfig(opts: {
           ...(opts.extraTestIgnore ?? []),
         ],
         grep: /^(?!.*(@tasklistV1|Connector Secrets User Flow|Custom Tags|Custom Properties)).*$/,
-        use: {
-          extraHTTPHeaders: {
-            "X-Test-Tasklist-Version": "v2",
-          },
-        },
+        ...tasklistV2Use,
       },
       ...(opts.extraProjects ?? []),
     ],

--- a/test/e2e/playwright.base.config.ts
+++ b/test/e2e/playwright.base.config.ts
@@ -39,6 +39,10 @@ export function makeShadowConfig(opts: {
   extraTestIgnore?: Array<string | RegExp>;
   tasklistV2Header?: boolean;
   extraProjects?: Project[];
+  fullyParallel?: boolean;
+  retries?: number;
+  timeout?: number;
+  workers?: number | string;
 }): ShadowConfig {
   if (!process.env.CAMUNDA_OPTIMIZE_BASE_URL && process.env.BASE_URL) {
     process.env.CAMUNDA_OPTIMIZE_BASE_URL = `https://${process.env.BASE_URL}/optimize`;
@@ -89,10 +93,10 @@ export function makeShadowConfig(opts: {
       },
       ...(opts.extraProjects ?? []),
     ],
-    fullyParallel: false,
-    retries: 1,
-    timeout: 12 * 60 * 1000,
-    workers: workerCount(opts.version),
+    fullyParallel: opts.fullyParallel ?? false,
+    retries: opts.retries ?? 1,
+    timeout: opts.timeout ?? 12 * 60 * 1000,
+    workers: opts.workers ?? workerCount(opts.version),
     use: {
       baseURL: getBaseURL(),
       actionTimeout: 10000,

--- a/test/e2e/playwright.base.config.ts
+++ b/test/e2e/playwright.base.config.ts
@@ -43,8 +43,10 @@ export function makeShadowConfig(opts: {
   timeout?: number;
   workers?: number | string;
 }): ShadowConfig {
-  if (!process.env.CAMUNDA_OPTIMIZE_BASE_URL && process.env.BASE_URL) {
-    process.env.CAMUNDA_OPTIMIZE_BASE_URL = `https://${process.env.BASE_URL}/optimize`;
+  const baseURL = getBaseURL();
+
+  if (!process.env.CAMUNDA_OPTIMIZE_BASE_URL) {
+    process.env.CAMUNDA_OPTIMIZE_BASE_URL = `${baseURL.replace(/\/+$/, "")}/optimize`;
   }
 
   const includeSetupProject = opts.includeSetupProject ?? true;
@@ -96,7 +98,7 @@ export function makeShadowConfig(opts: {
     timeout: opts.timeout ?? 12 * 60 * 1000,
     workers: opts.workers ?? workerCount(opts.version),
     use: {
-      baseURL: getBaseURL(),
+      baseURL,
       actionTimeout: 10000,
       screenshot: "only-on-failure",
       video: "retain-on-failure",


### PR DESCRIPTION
### Which problem does the PR fix?

The nightly `shadow-e2e` job runs the full `@camunda/e2e-test-suite` via a **per-chart-version** Playwright config committed in this repo (`charts/camunda-platform-8.{7,9,10}/test/e2e/playwright.config.ts`). These three configs are hand-maintained copies of the canonical `c8-cross-component-e2e-tests/playwright.config.ts` and have **drifted independently**, duplicating `getBaseURL()` three times and diverging in their project lists, grep exclusions and `testIgnore` entries.

The functional gap fixed here is `CAMUNDA_OPTIMIZE_BASE_URL`: 8.7 and 8.9 never derived it, so nothing set it on any path where the env file does not (see below), and Optimize tests failed with `page.goto: url … undefined`.

**Correction to earlier revisions of this description.** Two claims were wrong:

1. The 8.7 `optimize-user-flows › Process Import` failure was attributed to the full-suite grep omitting the `@tasklistV1` exclusion. Those tests are **untagged** in the SM-8.7 suite, so that exclusion cannot match them — `playwright test --list` selects the same 31 tests before and after this PR on 8.7.
2. A later revision then concluded this PR therefore does not help 8.7 at all. The validation run below contradicts that: all three 8.7 `optimize-user-flows` tests executed and passed, and the reported `Process Import` failure did not reproduce.

(The separate 8.10 `Business ID` shadow failure is an unrelated stale image-digest issue — tracked via Renovate PR #6494, not this PR.)

### What's in this PR?

- Adds a single shared base config `test/e2e/playwright.base.config.ts` exporting
  `makeShadowConfig({ version, testDir?, includeSetupProject?, tasklistV2Header?, extraProjects?, fullyParallel?, retries?, timeout?, workers? })`, centralizing:
  - the `CAMUNDA_OPTIMIZE_BASE_URL` derivation,
  - the canonical grep `/^(?!.*(@tasklistV1|Connector Secrets User Flow|Custom Tags|Custom Properties)).*$/`,
  - the `smoke-tests` / `full-suite` project shapes and the optional `full-suite-setup` project,
  - the shared `getBaseURL()` and `use` block.
- Reduces each `charts/camunda-platform-8.{7,9,10}/test/e2e/playwright.config.ts` to a thin shim that calls `makeShadowConfig()`. The 8.10 `empty-test-dir` fallback (including the `REQUIRE_SM_810_TEST_SUITE` guard from #6687) and `auth0-smoke` project remain the only version-specific extras.

`CAMUNDA_OPTIMIZE_BASE_URL` is derived from the **effective** base URL — `getBaseURL()` — not from raw `BASE_URL`. Deriving from `BASE_URL` (as the canonical config does) is wrong in this repo on every path the shadow job takes:

- `scripts/render-e2e-env.sh:361` writes `BASE_URL=https://$hostname` **with** a scheme, so `https://${BASE_URL}/optimize` produced `https://https://host/optimize`;
- the Auth0 branch (`render-e2e-env.sh:299`) writes `PLAYWRIGHT_BASE_URL`/`BASE_URL` but no `CAMUNDA_OPTIMIZE_BASE_URL`;
- when only `PLAYWRIGHT_BASE_URL` is set, a `BASE_URL`-gated fallback never fires even though `getBaseURL()` prefers `PLAYWRIGHT_BASE_URL`;
- on the canonical SM path the effective URL is `https://gke-${BASE_URL}.ci.distro.ultrawombat.com`, not `https://${BASE_URL}`.

**Execution settings are deliberately kept per-version** (`fullyParallel`, `retries`, `timeout`, `workers`), so this PR is behaviour-preserving on that axis rather than unifying it. Consequently the `25`-worker branch in the base's `workerCount()` is currently unreachable — 8.9 and 8.10 both pass `workers: "100%"` and only 8.7 falls through to the default (37 in CI). See the To-Do.

**No test-selection change.** `npx playwright test --list` selects an identical set to `main` on all three versions (31 / 38 / 34). The `full-suite-setup` project is enabled on 8.9 and 8.10 and deliberately **not** on 8.7, which already ignored `test-setup.spec` on `main`. On 8.9 the setup spec moves from a plain `full-suite` test to the `full-suite-setup` dependency project, so it now runs before the rest of the suite.

No chart-template, `values.yaml`, or golden-snapshot changes.

### Validation

Tier-2 `shde2` dispatched on all three versions — run [30990984612](https://github.com/camunda/camunda-platform-helm/actions/runs/30990984612) (against this branch plus the one-line dispatch enabler from #6798, since PR CI pins `tier: 1` and always skips `[shadow] Full e2e`):

| Version | `[shadow] Full e2e` | Result |
|---|---|---|
| 8.10 | [green](https://github.com/camunda/camunda-platform-helm/actions/runs/30990984612/job/92258665606) | 19 passed, 5 skipped |
| 8.7 | [1 failure](https://github.com/camunda/camunda-platform-helm/actions/runs/30990984612/job/92258729893) | 19 passed, 7 skipped, 1 failed — `hto-user-flows › User Task Restrictions Enabled Flow - Candidate Group` (needs RBA, not deployed in `shde2`). All three `optimize-user-flows` tests passed. |
| 8.9 | [6 failures](https://github.com/camunda/camunda-platform-helm/actions/runs/30990984612/job/92258618432) | 19 passed, 7 skipped, 6 failed — 5× `optimize-api-tests`, 1× `play.spec › Update the saved scenario` |

The URL fix does what it claims: `CAMUNDA_OPTIMIZE_BASE_URL` resolved correctly in all three jobs (e.g. `https://cab6a8-gke--intg-8-9-gke-shde2.ci.distro.ultrawombat.com/optimize`) and there are **zero** `url … undefined` occurrences in any log.

The remaining 8.9 `optimize-api-tests` failures have a **different root cause** than the one this PR addresses. They now get past URL resolution and fail on OAuth:

```
Error: Failed to fetch SM access token. Response:
{"error":"unauthorized_client","error_description":"Invalid client or Invalid client credentials"}
```

That is a missing/misconfigured Optimize M2M client in the `shde2` deployment, not a Playwright-config gap — it needs a separate fix. Note `[shadow] Full e2e` is `continue-on-error: true`, so the run's overall conclusion is `success` and CI Gate passed.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`. (not applicable — test-infra TS config only; no templates/goldens touched)
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed). (n/a — this IS test-config; verified via `tsc --noEmit --strict`, a `playwright test --list` diff against `main` on all 3 versions, an env-derivation probe across 5 `BASE_URL`/`PLAYWRIGHT_BASE_URL` combinations, and the tier-2 `shde2` run above)
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

### To-Do

- [ ] Provision/repair the Optimize M2M OAuth client in the `shde2` scenario so the 5 `optimize-api-tests` can authenticate. Separate from this PR — track it as a follow-up.
- [ ] Triage the two remaining unrelated failures: 8.7 `hto-user-flows › User Task Restrictions Enabled Flow - Candidate Group` (RBA not deployed in `shde2` — either exclude it or enable RBA) and 8.9 `play.spec › Update the saved scenario`.
- [ ] Decide what to do about the unreachable `25`-worker default in `workerCount()`. #6520 (`cap full-suite workers at 25`) was closed as superseded by this PR, but because execution settings stayed per-version, that cap is not actually applied anywhere. Either re-apply it to 8.9/8.10 or drop the dead branch.

Fixes https://github.com/camunda/camunda-platform-helm/issues/6702
