### PR TITLE
chore: update Chart.yaml maintainers for team changes

### DIFF
--- a/charts/camunda-platform-8.10/Chart.yaml
+++ b/charts/camunda-platform-8.10/Chart.yaml
@@ -31,14 +31,14 @@ dependencies:
     repository: "file://../common-2"
     version: 2.x.x
 maintainers:
-  - name: aabouzaid
-    email: ahmed.abouzaid@camunda.com
-  - name: drodriguez-305
-    email: daniel.rodriguez@camunda.com
-  - name: hamza-m-masood
-    email: hamza.masood@camunda.com
-  - name: jessesimpson36
-    email: jesse.simpson@camunda.com
+  - name: eamonnmoloney
+    email: eamonn.moloney@camunda.com
+  - name: Ian-wang-liyang
+    email: ian.wang@camunda.com
+  - name: hisImminence
+    email: immanuel.monma@camunda.com
+  - name: bkenez
+    email: balazs.kenez@camunda.com
 annotations:
   artifacthub.io/prerelease: "true"
   camunda.io/helmCLIVersion: "4.1.4"

--- a/charts/camunda-platform-8.7/Chart.yaml
+++ b/charts/camunda-platform-8.7/Chart.yaml
@@ -53,14 +53,14 @@ dependencies:
     repository: "file://../common-2"
     version: 2.x.x
 maintainers:
-  - name: aabouzaid
-    email: ahmed.abouzaid@camunda.com
-  - name: drodriguez-305
-    email: daniel.rodriguez@camunda.com
-  - name: hamza-m-masood
-    email: hamza.masood@camunda.com
-  - name: jessesimpson36
-    email: jesse.simpson@camunda.com
+  - name: eamonnmoloney
+    email: eamonn.moloney@camunda.com
+  - name: Ian-wang-liyang
+    email: ian.wang@camunda.com
+  - name: hisImminence
+    email: immanuel.monma@camunda.com
+  - name: bkenez
+    email: balazs.kenez@camunda.com
 annotations:
   camunda.io/helmCLIVersion: "3.20.2"
   artifacthub.io/links: |

--- a/charts/camunda-platform-8.8/Chart.yaml
+++ b/charts/camunda-platform-8.8/Chart.yaml
@@ -53,14 +53,14 @@ dependencies:
     repository: "file://../common-2"
     version: 2.x.x
 maintainers:
-  - name: aabouzaid
-    email: ahmed.abouzaid@camunda.com
-  - name: drodriguez-305
-    email: daniel.rodriguez@camunda.com
-  - name: hamza-m-masood
-    email: hamza.masood@camunda.com
-  - name: jessesimpson36
-    email: jesse.simpson@camunda.com
+  - name: eamonnmoloney
+    email: eamonn.moloney@camunda.com
+  - name: Ian-wang-liyang
+    email: ian.wang@camunda.com
+  - name: hisImminence
+    email: immanuel.monma@camunda.com
+  - name: bkenez
+    email: balazs.kenez@camunda.com
 annotations:
   camunda.io/helmCLIVersion: "3.20.2"
   artifacthub.io/links: |

--- a/charts/camunda-platform-8.9/Chart.yaml
+++ b/charts/camunda-platform-8.9/Chart.yaml
@@ -53,14 +53,14 @@ dependencies:
     repository: "file://../common-2"
     version: 2.x.x
 maintainers:
-  - name: aabouzaid
-    email: ahmed.abouzaid@camunda.com
-  - name: drodriguez-305
-    email: daniel.rodriguez@camunda.com
-  - name: hamza-m-masood
-    email: hamza.masood@camunda.com
-  - name: jessesimpson36
-    email: jesse.simpson@camunda.com
+  - name: eamonnmoloney
+    email: eamonn.moloney@camunda.com
+  - name: Ian-wang-liyang
+    email: ian.wang@camunda.com
+  - name: hisImminence
+    email: immanuel.monma@camunda.com
+  - name: bkenez
+    email: balazs.kenez@camunda.com
 annotations:
   # Comma-separated list of supported Helm CLI versions; first entry is the minimum.
   # 8.9 is the last chart minor that supports Helm v3 — listed alongside v4.


### PR DESCRIPTION
### Which problem does the PR fix?

Team membership update: two members left the distribution team, others are being added.

### What's in this PR?

Updates the `maintainers:` block in `Chart.yaml` for charts 8.7–8.10:

- **Removed:** `aabouzaid`, `hamza-m-masood`, `drodriguez-305`, `jessesimpson36`
- **Added:** `eamonnmoloney`, `Ian-wang-liyang`, `hisImminence`, `bkenez`

### Checklist

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?