### PR TITLE
test: route EKS integration scenarios via Traefik Gateway API

### DIFF
--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/platform/eks.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/platform/eks.yaml
@@ -1,19 +1,29 @@
-# EKS infrastructure configuration for 8.9
+# EKS infrastructure configuration for 8.10
 # Layer 6: Infrastructure - AWS EKS specific settings
+# Networking uses the chart-native Traefik Gateway API (global.gateway.*, listeners on 8443).
 
 global:
   commonLabels:
     janitor/ttl: 1h
     camunda.cloud/ephemeral: "true"
   ingress:
+    enabled: false
+  gateway:
+    enabled: true
+    createGatewayResource: true
+    className: traefik
     tls:
+      enabled: true
       secretName: aws-camunda-cloud-tls
+      port: 8443
 
 orchestration:
   ingress:
     grpc:
-      tls:
-        secretName: aws-camunda-cloud-tls
+      enabled: false
+  gateway:
+    grpc:
+      enabled: true
 
 prometheusServiceMonitor:
   enabled: false

--- a/charts/camunda-platform-8.8/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry-snapshot.yaml
@@ -274,6 +274,17 @@ integration:
           features:
             - documentstore
           helmVersion: 3.20.2
+          post-deploy:
+            fixtures:
+              - traefik-gateway.yaml
+              - traefik-httproute.yaml
+              - traefik-grpcroute.yaml
+            description: |
+              Applies a per-namespace Traefik Gateway (class traefik, https + grpcs
+              listeners on 8443, TLS from aws-camunda-cloud-tls) plus the HTTPRoute and
+              GRPCRoute that mirror the chart's nginx Ingress routing. 8.8 has no chart
+              Gateway API, so the harness supplies these resources. Runs post-deploy so
+              the component Services and the TLS secret already exist in the namespace.
         - name: noSecondaryStorage
           enabled: true
           shortname: nosec

--- a/charts/camunda-platform-8.8/test/ci/registry/hooks/traefik-gateway.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/hooks/traefik-gateway.yaml
@@ -1,0 +1,10 @@
+fixtures:
+  - traefik-gateway.yaml
+  - traefik-httproute.yaml
+  - traefik-grpcroute.yaml
+description: |
+  Applies a per-namespace Traefik Gateway (class traefik, https + grpcs
+  listeners on 8443, TLS from aws-camunda-cloud-tls) plus the HTTPRoute and
+  GRPCRoute that mirror the chart's nginx Ingress routing. 8.8 has no chart
+  Gateway API, so the harness supplies these resources. Runs post-deploy so
+  the component Services and the TLS secret already exist in the namespace.

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/documentstore.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/documentstore.yaml
@@ -10,4 +10,5 @@ platforms:
   - eks
 infra-type:
   eks: preemptible
+post-deploy: traefik-gateway
 helmVersion: 3.20.2

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/platform/eks.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/platform/eks.yaml
@@ -2,13 +2,15 @@
 # Layer 6: Infrastructure - AWS EKS specific settings
 # Networking uses Traefik Gateway API applied by the traefik-gateway post-deploy hook
 # (8.8 has no chart Gateway API; see test/ci/registry/hooks/traefik-gateway.yaml).
+# Keep external URL generation enabled while suppressing Ingress resources.
 
 global:
   commonLabels:
     janitor/ttl: 1h
     camunda.cloud/ephemeral: "true"
   ingress:
-    enabled: false
+    enabled: true
+    external: true
 
 identityKeycloak:
   commonLabels:

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/platform/eks.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/platform/eks.yaml
@@ -1,13 +1,14 @@
 # EKS infrastructure configuration for 8.8
 # Layer 6: Infrastructure - AWS EKS specific settings
+# Networking uses Traefik Gateway API applied by the traefik-gateway post-deploy hook
+# (8.8 has no chart Gateway API; see test/ci/registry/hooks/traefik-gateway.yaml).
 
 global:
   commonLabels:
     janitor/ttl: 1h
     camunda.cloud/ephemeral: "true"
   ingress:
-    tls:
-      secretName: aws-camunda-cloud-tls
+    enabled: false
 
 identityKeycloak:
   commonLabels:
@@ -26,8 +27,7 @@ webModelerPostgresql:
 orchestration:
   ingress:
     grpc:
-      tls:
-        secretName: aws-camunda-cloud-tls
+      enabled: false
 
 elasticsearch:
   commonLabels:

--- a/charts/camunda-platform-8.8/test/integration/scenarios/common/resources/traefik-gateway.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/common/resources/traefik-gateway.yaml
@@ -1,6 +1,6 @@
 # Per-namespace Traefik Gateway for the EKS documentstore scenario (8.8 has no
-# chart Gateway API). Hostnames use $NAMESPACE + the EKS base domain because
-# $CAMUNDA_HOSTNAME is not passed to lifecycle fixtures.
+# chart Gateway API). Hostnames use $CAMUNDA_HOSTNAME (global.host) so the
+# external URLs the apps generate resolve through this Gateway.
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
@@ -12,7 +12,7 @@ spec:
     - name: https
       port: 8443
       protocol: HTTPS
-      hostname: $NAMESPACE.distribution.aws.camunda.cloud
+      hostname: $CAMUNDA_HOSTNAME
       allowedRoutes:
         kinds:
           - kind: HTTPRoute
@@ -26,7 +26,7 @@ spec:
     - name: grpcs
       port: 8443
       protocol: HTTPS
-      hostname: grpc-$NAMESPACE.distribution.aws.camunda.cloud
+      hostname: grpc-$CAMUNDA_HOSTNAME
       allowedRoutes:
         kinds:
           - kind: GRPCRoute

--- a/charts/camunda-platform-8.8/test/integration/scenarios/common/resources/traefik-gateway.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/common/resources/traefik-gateway.yaml
@@ -1,0 +1,39 @@
+# Per-namespace Traefik Gateway for the EKS documentstore scenario (8.8 has no
+# chart Gateway API). Hostnames use $NAMESPACE + the EKS base domain because
+# $CAMUNDA_HOSTNAME is not passed to lifecycle fixtures.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: $RELEASE_NAME-camunda-platform
+  namespace: $NAMESPACE
+spec:
+  gatewayClassName: traefik
+  listeners:
+    - name: https
+      port: 8443
+      protocol: HTTPS
+      hostname: $NAMESPACE.distribution.aws.camunda.cloud
+      allowedRoutes:
+        kinds:
+          - kind: HTTPRoute
+        namespaces:
+          from: Same
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: aws-camunda-cloud-tls
+    - name: grpcs
+      port: 8443
+      protocol: HTTPS
+      hostname: grpc-$NAMESPACE.distribution.aws.camunda.cloud
+      allowedRoutes:
+        kinds:
+          - kind: GRPCRoute
+        namespaces:
+          from: Same
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: aws-camunda-cloud-tls

--- a/charts/camunda-platform-8.8/test/integration/scenarios/common/resources/traefik-grpcroute.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/common/resources/traefik-grpcroute.yaml
@@ -11,7 +11,7 @@ spec:
     - name: $RELEASE_NAME-camunda-platform
       sectionName: grpcs
   hostnames:
-    - grpc-$NAMESPACE.distribution.aws.camunda.cloud
+    - grpc-$CAMUNDA_HOSTNAME
   rules:
     - backendRefs:
         - name: $RELEASE_NAME-zeebe-gateway

--- a/charts/camunda-platform-8.8/test/integration/scenarios/common/resources/traefik-grpcroute.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/common/resources/traefik-grpcroute.yaml
@@ -1,0 +1,18 @@
+# gRPC routing for the EKS documentstore scenario (Zeebe gateway), mirroring the
+# 8.8 nginx gRPC Ingress. DNS for this host needs the external-dns
+# gateway-grpcroute source on camunda-ci-eks (tracked in camunda/infra-core).
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: $RELEASE_NAME-camunda-platform-grpc
+  namespace: $NAMESPACE
+spec:
+  parentRefs:
+    - name: $RELEASE_NAME-camunda-platform
+      sectionName: grpcs
+  hostnames:
+    - grpc-$NAMESPACE.distribution.aws.camunda.cloud
+  rules:
+    - backendRefs:
+        - name: $RELEASE_NAME-zeebe-gateway
+          port: 26500

--- a/charts/camunda-platform-8.8/test/integration/scenarios/common/resources/traefik-httproute.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/common/resources/traefik-httproute.yaml
@@ -21,6 +21,20 @@ spec:
           port: 80
     - matches:
         - path:
+            type: Exact
+            value: /identity
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            hostname: $NAMESPACE.distribution.aws.camunda.cloud
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: /identity/
+      backendRefs:
+        - name: $RELEASE_NAME-identity
+          port: 80
+    - matches:
+        - path:
             type: PathPrefix
             value: /identity
       backendRefs:

--- a/charts/camunda-platform-8.8/test/integration/scenarios/common/resources/traefik-httproute.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/common/resources/traefik-httproute.yaml
@@ -1,0 +1,70 @@
+# HTTP routing for the EKS documentstore scenario, mirroring the 8.8 nginx
+# Ingress path -> Service map (see templates/*/ingress-*.yaml).
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: $RELEASE_NAME-camunda-platform
+  namespace: $NAMESPACE
+spec:
+  parentRefs:
+    - name: $RELEASE_NAME-camunda-platform
+      sectionName: https
+  hostnames:
+    - $NAMESPACE.distribution.aws.camunda.cloud
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /auth/
+      backendRefs:
+        - name: $RELEASE_NAME-keycloak
+          port: 80
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /identity
+      backendRefs:
+        - name: $RELEASE_NAME-identity
+          port: 80
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /modeler-ws
+      backendRefs:
+        - name: $RELEASE_NAME-web-modeler-websockets
+          port: 80
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /modeler
+      backendRefs:
+        - name: $RELEASE_NAME-web-modeler-webapp
+          port: 80
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /orchestration
+      backendRefs:
+        - name: $RELEASE_NAME-zeebe-gateway
+          port: 8080
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /optimize
+      backendRefs:
+        - name: $RELEASE_NAME-optimize
+          port: 80
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /connectors
+      backendRefs:
+        - name: $RELEASE_NAME-connectors
+          port: 8080
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: $RELEASE_NAME-console
+          port: 80

--- a/charts/camunda-platform-8.8/test/integration/scenarios/common/resources/traefik-httproute.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/common/resources/traefik-httproute.yaml
@@ -10,7 +10,7 @@ spec:
     - name: $RELEASE_NAME-camunda-platform
       sectionName: https
   hostnames:
-    - $NAMESPACE.distribution.aws.camunda.cloud
+    - $CAMUNDA_HOSTNAME
   rules:
     - matches:
         - path:
@@ -26,7 +26,7 @@ spec:
       filters:
         - type: URLRewrite
           urlRewrite:
-            hostname: $NAMESPACE.distribution.aws.camunda.cloud
+            hostname: $CAMUNDA_HOSTNAME
             path:
               type: ReplaceFullPath
               replaceFullPath: /identity/

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/platform/eks.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/platform/eks.yaml
@@ -1,13 +1,22 @@
 # EKS infrastructure configuration for 8.9
 # Layer 6: Infrastructure - AWS EKS specific settings
+# Networking uses the chart-native Traefik Gateway API (global.gateway.*, listeners on 8443).
 
 global:
+  host: "$CAMUNDA_HOSTNAME"
   commonLabels:
     janitor/ttl: 1h
     camunda.cloud/ephemeral: "true"
   ingress:
+    enabled: false
+  gateway:
+    enabled: true
+    createGatewayResource: true
+    className: traefik
     tls:
+      enabled: true
       secretName: aws-camunda-cloud-tls
+      port: 8443
 
 identityKeycloak:
   commonLabels:
@@ -26,8 +35,10 @@ webModelerPostgresql:
 orchestration:
   ingress:
     grpc:
-      tls:
-        secretName: aws-camunda-cloud-tls
+      enabled: false
+  gateway:
+    grpc:
+      enabled: true
 
 elasticsearch:
   commonLabels:

--- a/scripts/base_playwright_script.sh
+++ b/scripts/base_playwright_script.sh
@@ -107,7 +107,8 @@ get_ingress_hostname() {
   if [[ -z "$hostname" ]]; then
     # might be using the Gateway api
     log "No matching Ingress found, trying Gateway API..."
-    hostname=$($kubectl_cmd -n "$namespace" get gateway -o json | jq -r '.items[].spec.listeners[].hostname')
+    hostname=$($kubectl_cmd -n "$namespace" get httproute -o json | jq -r '
+      [.items[].spec.hostnames[]?] | unique | if length == 1 then .[0] else empty end')
   fi
 
   if [[ -z "$hostname" || "$hostname" == "null" ]]; then

--- a/scripts/camunda-core/pkg/kube/kube.go
+++ b/scripts/camunda-core/pkg/kube/kube.go
@@ -24,8 +24,10 @@ import (
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 	corev1apply "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -90,6 +92,7 @@ type Client struct {
 	clientset       kubernetes.Interface
 	dynamicClient   dynamic.Interface
 	discoveryClient discovery.DiscoveryInterface
+	restMapper      meta.RESTMapper
 	kubeconfig      string
 	kubeContext     string
 }
@@ -127,6 +130,7 @@ func NewClient(kubeconfig, kubeContext string) (*Client, error) {
 		clientset:       clientset,
 		dynamicClient:   dynamicClient,
 		discoveryClient: discoveryClient,
+		restMapper:      restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(discoveryClient)),
 		kubeconfig:      kubeconfig,
 		kubeContext:     kubeContext,
 	}, nil
@@ -830,9 +834,10 @@ func applySingleManifestObject(ctx context.Context, client *Client, namespace st
 		unstructuredObj.SetNamespace(namespace)
 	}
 
-	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
-	gvr.Group = gvk.Group
-	gvr.Version = gvk.Version
+	gvr, err := client.resourceForGVK(gvk)
+	if err != nil {
+		return fmt.Errorf("failed to resolve resource for %s (document %d): %w", gvk.String(), docNum, err)
+	}
 
 	logging.Logger.Debug().
 		Str("kind", gvk.Kind).
@@ -919,6 +924,14 @@ func applySingleManifestObject(ctx context.Context, client *Client, namespace st
 
 	// This should not be reached, but handle it just in case
 	return fmt.Errorf("failed to apply %s %q in namespace %q (document %d): %w", gvk.Kind, unstructuredObj.GetName(), namespace, docNum, lastErr)
+}
+
+func (c *Client) resourceForGVK(gvk schema.GroupVersionKind) (schema.GroupVersionResource, error) {
+	mapping, err := c.restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return schema.GroupVersionResource{}, err
+	}
+	return mapping.Resource, nil
 }
 
 // isWebhookNotReadyError checks if the error is due to a webhook not being ready.

--- a/scripts/camunda-core/pkg/kube/kube_test.go
+++ b/scripts/camunda-core/pkg/kube/kube_test.go
@@ -3,11 +3,51 @@ package kube
 import (
 	"context"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestCheckConnectivity_InvalidContext(t *testing.T) {
 	err := CheckConnectivity(context.Background(), "nonexistent-context-that-should-not-exist")
 	if err == nil {
 		t.Fatal("expected error for non-existent kube context, got nil")
+	}
+}
+
+func TestApplyManifestGatewayUsesDiscoveredResource(t *testing.T) {
+	groupVersion := schema.GroupVersion{Group: "gateway.networking.k8s.io", Version: "v1"}
+	mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{groupVersion})
+	mapper.AddSpecific(
+		groupVersion.WithKind("Gateway"),
+		groupVersion.WithResource("gateways"),
+		groupVersion.WithResource("gateway"),
+		meta.RESTScopeNamespace,
+	)
+
+	dynamicClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	var appliedResource string
+	dynamicClient.PrependReactor("patch", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		appliedResource = action.GetResource().Resource
+		return true, &unstructured.Unstructured{}, nil
+	})
+
+	client := &Client{dynamicClient: dynamicClient, restMapper: mapper}
+	err := applySingleManifestObject(context.Background(), client, "test-namespace", map[string]any{
+		"apiVersion": groupVersion.String(),
+		"kind":       "Gateway",
+		"metadata": map[string]any{
+			"name": "test-gateway",
+		},
+	}, 1)
+	if err != nil {
+		t.Fatalf("applySingleManifestObject() error = %v", err)
+	}
+	if appliedResource != "gateways" {
+		t.Fatalf("applied resource = %q, want %q", appliedResource, "gateways")
 	}
 }

--- a/scripts/deploy-camunda/matrix/lifecycle_hook.go
+++ b/scripts/deploy-camunda/matrix/lifecycle_hook.go
@@ -24,6 +24,7 @@ var lifecycleVarPassthrough = []string{
 	"RDBMS_POSTGRESQL_PASSWORD",
 	"GITHUB_WORKFLOW_JOB_ID",
 	"POSTGRESQL_JDBC_URL",
+	"CAMUNDA_HOSTNAME",
 }
 
 // resolveLifecycleEnv builds the env map used to resolve lifecycle hook

--- a/test/scripts/base_playwright_script.bats
+++ b/test/scripts/base_playwright_script.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+
+setup() {
+  if ROOT="$(git -C "$here" rev-parse --show-toplevel 2>/dev/null)"; then
+    :
+  else
+    ROOT="$(cd "$here/../.." && pwd)"
+  fi
+  export ROOT
+  export VERBOSE=false
+  export TEST_INGRESS_HOST=""
+
+  source "$ROOT/scripts/base_playwright_script.sh"
+}
+
+kubectl() {
+  case "$*" in
+    *"get ingress"*)
+      printf '%s\n' '{"items":[]}'
+      ;;
+    *"get httproute"*)
+      printf '%s\n' '{"items":[{"spec":{"hostnames":["camunda.example.com"]}}]}'
+      ;;
+    *"get gateway"*)
+      printf '%s\n' '{"items":[{"spec":{"listeners":[{"hostname":"camunda.example.com"},{"hostname":"grpc-camunda.example.com"}]}}]}'
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+@test "Gateway API hostname discovery uses the HTTPRoute host" {
+  run get_ingress_hostname test-namespace
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"camunda.example.com" ]]
+  [[ "$output" != *"grpc-camunda.example.com"* ]]
+  [ "${lines[${#lines[@]} - 1]}" = "camunda.example.com" ]
+}


### PR DESCRIPTION
closes #6499 

### Which problem does the PR fix?

Infra is decommissioning ingress-nginx on `camunda-ci-eks` in favour of Traefik's Gateway API (camunda/team-infrastructure#986). Our EKS integration-test scenarios still create nginx `Ingress` resources, which stop being served once ingress-nginx is removed.

### What's in this PR?

> Prerequisite #6535 (configurable Gateway listener ports, closing #6168) has merged; this PR is rebased on `main`.

Routes the EKS `documentstore` scenario (8.8/8.9/8.10) via the Traefik Gateway API instead of nginx Ingress. Scenario configuration remains EKS-only; GKE routing is untouched. The 8.8 lifecycle path also fixes generic fixture resource resolution discovered by the merge queue.

- **8.9 / 8.10** — chart-native Gateway on `8443`: `global.gateway` enabled with `createGatewayResource: true`, `className: traefik`, `tls.port: 8443`, `aws-camunda-cloud-tls`; disables the nginx HTTP + gRPC Ingress. The chart renders the Gateway + HTTPRoute/GRPCRoute/ReferenceGrant.
- **8.8** (no chart Gateway API) — a `post-deploy: traefik-gateway` hook applies a hand-written Gateway + HTTPRoute + GRPCRoute (`common/resources/traefik-*.yaml`) mirroring the nginx Ingress path→Service map.

**Infra prerequisites:** camunda/infra-core#13485 merged on 2026-07-17, adding the external-dns `gateway-grpcroute` source and Gateway API RBAC for the Distribution CI identity on `camunda-ci-eks`.

**Rejected alternatives:** pure harness fixtures for all versions (most YAML, per-version drift — kept only for 8.8); attach to a shared infra Gateway (infra uses per-service Gateways); className swap nginx→traefik (Traefik is Gateway-API-only on the cluster); move documentstore to GKE (loses AWS-S3-on-EKS coverage).

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
