### PR TITLE
docs: remove stale Console/Web Modeler references after Camunda Hub consolidation

### DIFF
--- a/charts/camunda-platform-8.10/Chart.yaml
+++ b/charts/camunda-platform-8.10/Chart.yaml
@@ -51,6 +51,8 @@ annotations:
       url: https://github.com/camunda/camunda-platform-helm
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
+    - kind: changed
+      description: "docs: remove stale Console/Web Modeler references after Camunda Hub consolidation"
     - kind: added
       description: "Deprecate app-config proxy keys in favor of extraConfiguration"
     - kind: added

--- a/charts/camunda-platform-8.10/Chart.yaml
+++ b/charts/camunda-platform-8.10/Chart.yaml
@@ -51,8 +51,6 @@ annotations:
       url: https://github.com/camunda/camunda-platform-helm
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - kind: changed
-      description: "docs: remove stale Console/Web Modeler references after Camunda Hub consolidation"
     - kind: added
       description: "Deprecate app-config proxy keys in favor of extraConfiguration"
     - kind: added

--- a/charts/camunda-platform-8.10/README.md
+++ b/charts/camunda-platform-8.10/README.md
@@ -49,7 +49,6 @@ Please also refer to the [documentation](https://docs.camunda.io/docs/self-manag
   - [Identity Parameters](#identity-parameters)
   - [Identity - PostgreSQL Parameters](#identity---postgresql-parameters)
   - [Identity - Keycloak Parameters](#identity---keycloak-parameters)
-  - [Console Parameters](#console-parameters)
   - [WebModeler Parameters](#webmodeler-parameters)
   - [WebModeler - RestAPI Parameters](#webmodeler---restapi-parameters)
   - [WebModeler - WebSockets Parameters](#webmodeler---websockets-parameters)

--- a/charts/camunda-platform-8.10/templates/NOTES.txt
+++ b/charts/camunda-platform-8.10/templates/NOTES.txt
@@ -46,10 +46,10 @@
   - Docker Image used for Identity: {{ .Values.identity.image.repository }}:{{ .Values.identity.image.tag }}
     {{- end }}
   {{- end }}
-- Web Modeler:
+- Camunda Hub:
   - Enabled: {{ eq (include "camundaHub.webModelerEnabled" .) "true" }}
   {{- if eq (include "camundaHub.webModelerEnabled" .) "true" }}
-  - Docker images used for Web Modeler:
+  - Docker images used for Camunda Hub:
     - {{ include "webModeler.restapi.image" . }}
     - {{ include "webModeler.websockets.image" . }}
   {{- end }}
@@ -79,7 +79,7 @@ Optimize:
 > kubectl port-forward svc/{{ .Release.Name }}-optimize 8083:80
 {{- end }}
 {{ if eq (include "camundaHub.webModelerEnabled" .) "true" -}}
-Web Modeler:
+Camunda Hub:
 > kubectl port-forward svc/{{ include "webModeler.restapi.fullname" . }} 8070:80
 > kubectl port-forward svc/{{ include "webModeler.websockets.fullname" . }} 8085:80
 {{- end }}
@@ -115,8 +115,8 @@ Default user and password: "{{ .Values.identity.firstUser.username -}}/{{ .Value
   - Identity: {{ include "camundaPlatform.identityExternalURL" . }}
   {{- end }}
   {{ if eq (include "camundaHub.webModelerEnabled" .) "true" -}}
-  - WebModeler: {{ include "camundaPlatform.webModelerExternalURL" . }}
-  - WebModeler WebSockets: {{ include "camundaPlatform.webModelerWebSocketsExternalURL" . }}
+  - Camunda Hub: {{ include "camundaPlatform.webModelerExternalURL" . }}
+  - Camunda Hub WebSockets: {{ include "camundaPlatform.webModelerWebSocketsExternalURL" . }}
   {{- end }}
 {{- end }}
 {{- end }}
@@ -132,7 +132,7 @@ Default user and password: "{{ .Values.identity.firstUser.username -}}/{{ .Value
 
 {{ if .Values.global.createReleaseInfo -}}
 
-## Console configuration
+## Release information
 
 {{ include "camundaPlatform.releaseInfo" . }}
 

--- a/charts/camunda-platform-8.10/templates/camunda-hub/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/camunda-hub/_helpers.tpl
@@ -8,8 +8,7 @@ The camundaHub component consolidates Console and WebModeler into a single
 logical unit. The backward-compatibility shim helpers that bridge the legacy
 console.* / webModeler.* keys to the new camundaHub.* key live in
 templates/common/_helpers.tpl (see "camundaHub.consoleEnabled",
-"camundaHub.webModelerEnabled", "camundaHub.consoleValues",
-"camundaHub.webModelerValues").
+"camundaHub.webModelerEnabled").
 
 This file is reserved for any camundaHub-specific helpers that do NOT belong
 in the common shim layer. For now, no additional helpers are needed because:

--- a/charts/camunda-platform-8.10/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/common/_helpers.tpl
@@ -114,7 +114,7 @@ app.kubernetes.io/component: {{ .componentName }}
 {{/*
 Get image tag according the values of "base" or "overlay" values.
 If the "overlay" values exist, they will override the "base" values, otherwise the "base" values will be used.
-Usage: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.console) }}
+Usage: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" .Values.connectors) }}
 */}}
 {{- define "camundaPlatform.imageTagByParams" -}}
     {{- .overlay.image.tag | default .base.image.tag | default "" -}}
@@ -123,7 +123,7 @@ Usage: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global
 {{/*
 Get image according the values of "base" or "overlay" values.
 If the "overlay" values exist, they will override the "base" values, otherwise the "base" values will be used.
-Usage: {{ include "camundaPlatform.imageByParams" (dict "base" .Values.global "overlay" .Values.console) }}
+Usage: {{ include "camundaPlatform.imageByParams" (dict "base" .Values.global "overlay" .Values.connectors) }}
 */}}
 {{- define "camundaPlatform.imageByParams" -}}
   {{- $imageRegistry    := .overlay.image.registry | default .base.image.registry -}}
@@ -308,7 +308,7 @@ NOTE: This is for Management Identity config, all new types will be supported vi
 {{- end -}}
 
 {{/*
-Get the externally-reachable Keycloak URL for display in Console and NOTES.txt.
+Get the externally-reachable Keycloak URL for display in Camunda Hub and NOTES.txt.
 When the chart proxies Keycloak through its combined Ingress (internal: true), use
 the chart host + contextPath. Otherwise return the configured external Keycloak URL.
 */}}
@@ -1324,12 +1324,7 @@ Emits env vars pointing at the mounted CA bundle so both native and
 Node.js TLS stacks can resolve trust:
   - SSL_CERT_FILE: honoured by the OpenSearch client (post-8.6.7) and many
     native HTTP/TLS libraries that resolve trust through the OS.
-  - NODE_EXTRA_CA_CERTS: honoured by Node.js (Web Modeler websockets,
-    Console, etc.)
-
-Note: Console gates its own NODE_EXTRA_CA_CERTS behind
-`ne (include "camundaPlatform.hasCaBundle" .) "true"` to avoid
-duplication when this helper is also included.
+  - NODE_EXTRA_CA_CERTS: honoured by Node.js (web-modeler websockets, etc.)
 
 Usage (inside an env: list):
   {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
@@ -1520,7 +1515,7 @@ Usage (inside an env: list, after computing the trustStore branch):
 caBundleJavaToolOptionsEnv
 Emits a JAVA_TOOL_OPTIONS env var pre-populated with caBundleJavaOpts.
 Use on components that do NOT already render their own JAVA_TOOL_OPTIONS
-(connectors, identity, console, web-modeler websockets) so the chart-built
+(connectors, identity, web-modeler websockets) so the chart-built
 truststore takes effect with no per-component branching.
 
 Components that already render JAVA_TOOL_OPTIONS conditionally


### PR DESCRIPTION
### Which problem does the PR fix?

Follow-up to the Camunda Hub consolidation in 8.10. `camundaHub.*` replaced the
separate Console and Web Modeler components, but stale/misleading references to
the old components remained in template comments, a placeholder docstring, the
`NOTES.txt` install output, and the README TOC.

Stacked on top of #6525 (Part A — zero-touch upgrade scenario tests). Base is
`camunda-hub-zero-touch-upgrade`; retarget to `main` once #6525 merges.

### What's in this PR?

Comment/annotation/TOC-only cleanup — **no rendered Kubernetes resource changes**.
The 8.9 → 8.10 upgrade stays zero-touch: the backward-compat shim, legacy
`webModeler.*`/`console.*` keys, resource names, the `web-modeler` OIDC
`client_id`, and the `CAMUNDA_MODELER_FEATURE_CONSOLE_ENABLED` env var are all
preserved.

- `templates/common/_helpers.tpl`: fix stale docstrings — `imageTagByParams`/`imageByParams` usage examples (`.Values.console` → `.Values.connectors`), Keycloak external-URL comment, and the `NODE_EXTRA_CA_CERTS` / `JAVA_TOOL_OPTIONS` component lists (drop Console + its dead gating note).
- `templates/camunda-hub/_helpers.tpl`: remove references to the nonexistent `camundaHub.consoleValues` / `camundaHub.webModelerValues` helpers (only `camundaHub.consoleEnabled` / `camundaHub.webModelerEnabled` exist). Placeholder file kept intentionally.
- `templates/NOTES.txt`: relabel `## Console configuration` → `## Release information` (the block renders release info + warnings + highlights, not console config).
- `README.md`: remove the orphaned `[Console Parameters]` TOC entry (no such `@section` in `values.yaml`).
- `Chart.yaml`: changelog entry.

**Verification:** `make helm.dependency-update`, `make helm.readme-update`, `make helm.lint`, `make go.test` all pass; `make go.update-golden-only` produces **zero golden/test-file changes**, confirming no rendered-output delta.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
