### PR TITLE
chore: clarify Chart.yaml changelog is only for user-facing chart changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,6 +228,8 @@ For PRs that touch only non-chart files, use:
 - `build:` — Makefile, tooling, dependency, or other build-system changes
 - `test:` — test files only
 
+**Corollary — the `artifacthub.io/changes` block in `Chart.yaml`:** this is the release-notes changelog. Add an entry ONLY for the same user-facing chart changes that justify a `feat/fix/refactor/docs/revert` title. Do NOT add one for a `test:`/`chore:`/`ci:`/`build:` PR — those are excluded from release notes, and editing `Chart.yaml` to add an entry itself makes an otherwise test-only PR touch a user-facing chart file, defeating the classification. Such PRs should leave `Chart.yaml` untouched.
+
 See [Contribution & Collaboration](docs/contribution-and-collaboration.md) for the full PR checklist.
 
 ### PR body and opening workflow (overrides Claude Code defaults)


### PR DESCRIPTION
### Which problem does the PR fix?

The "PR title type" section of `AGENTS.md` explains which Conventional Commit types are reserved for user-facing chart changes, but doesn't state the corollary for the `artifacthub.io/changes` changelog in `Chart.yaml`. This gap led to a `test:`-only PR being given a manual `Chart.yaml` changelog entry — which injects a non-user-facing note into release notes and makes an otherwise test-only PR touch a user-facing chart file.

### What's in this PR?

A single paragraph added to `AGENTS.md`, right after the non-chart PR-type list: the `artifacthub.io/changes` block gets an entry ONLY for the same user-facing chart changes that justify a `feat/fix/refactor/docs/revert` title; `test:`/`chore:`/`ci:`/`build:` PRs leave `Chart.yaml` untouched.

Docs-only (`AGENTS.md`) — no chart files touched, so no changelog entry here (per the very rule being added).

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
