### PR TITLE
ci: scan PR net diff instead of per-commit so merge commits don't trip auto-approve guard

### DIFF
--- a/.github/auto-approve-protected-paths.txt
+++ b/.github/auto-approve-protected-paths.txt
@@ -1,7 +1,7 @@
 # Paths that ALWAYS require a human review — distro-ci never auto-approves a PR
-# whose commits touch any of these. One grep -E (extended regex) pattern per line;
-# blank lines and # comments are ignored. Matched against every file in every commit
-# of the PR, AFTER chart test fixtures (charts/<chart>/test/**) are excluded.
+# whose net diff touches any of these. One grep -E (extended regex) pattern per line;
+# blank lines and # comments are ignored. Matched against every file in the PR net
+# diff (new paths and rename sources), AFTER chart test fixtures (charts/<chart>/test/**) are excluded.
 
 # --- CI-privileged paths (.github) ---
 ^\.github/workflows/

--- a/.github/workflows/repo-auto-approve.yaml
+++ b/.github/workflows/repo-auto-approve.yaml
@@ -44,34 +44,26 @@ jobs:
             allowed=false
           fi
           if [[ "$allowed" == "true" ]]; then
-            if ! shas=$(gh api "repos/${REPO}/pulls/${PR}/commits" --paginate --jq '.[].sha'); then
-              echo "::warning::Could not list PR commits; requiring human review."
+            cf=$(gh api "repos/${REPO}/pulls/${PR}" --jq '.changed_files') || {
+              echo "::warning::Could not read PR metadata; requiring human review."; allowed=false; cf=0; }
+            if [[ "$allowed" == "true" && "$cf" -ge 3000 ]]; then
+              echo "::warning::PR changes ${cf} files (>=3000 API cap); requiring human review."
               allowed=false
-            else
-              n=$(printf '%s\n' "$shas" | sed '/^[[:space:]]*$/d' | wc -l | tr -d ' ')
-              if [[ "$n" -eq 0 || "$n" -ge 250 ]]; then
-                echo "::warning::PR has ${n} commits (empty or >=250 API cap); requiring human review."
+            fi
+            if [[ "$allowed" == "true" ]]; then
+              if ! files=$(gh api "repos/${REPO}/pulls/${PR}/files" --paginate --jq '.[] | .filename, (.previous_filename // empty)'); then
+                echo "::warning::Could not list PR files; requiring human review."
                 allowed=false
               else
-                for sha in $shas; do
-                  commit=$(gh api "repos/${REPO}/commits/${sha}") || {
-                    echo "::warning::Could not fetch ${sha}; requiring human review."; allowed=false; break; }
-                  nf=$(printf '%s' "$commit" | jq '(.files // []) | length')
-                  if [[ "$nf" -ge 300 ]]; then
-                    echo "::warning::commit ${sha} has ${nf} files (>=300 API cap); requiring human review."
-                    allowed=false; break
-                  fi
-                  files=$(printf '%s' "$commit" | jq -r '(.files // [])[] | .filename, (.previous_filename // empty)')
-                  match_rc=0
-                  printf '%s\n' "$files" | grep -vE '^charts/[^/]+/test/' | grep -qE -f <(printf '%s\n' "$pats") || match_rc=$?
-                  if [[ "$match_rc" -eq 0 ]]; then
-                    echo "::notice::commit ${sha} touches a protected path; human review is required."
-                    allowed=false; break
-                  elif [[ "$match_rc" -ge 2 ]]; then
-                    echo "::warning::protected-path check errored (rc=${match_rc}); requiring human review."
-                    allowed=false; break
-                  fi
-                done
+                match_rc=0
+                printf '%s\n' "$files" | grep -vE '^charts/[^/]+/test/' | grep -qE -f <(printf '%s\n' "$pats") || match_rc=$?
+                if [[ "$match_rc" -eq 0 ]]; then
+                  echo "::notice::PR touches a protected path; human review is required."
+                  allowed=false
+                elif [[ "$match_rc" -ge 2 ]]; then
+                  echo "::warning::protected-path check errored (rc=${match_rc}); requiring human review."
+                  allowed=false
+                fi
               fi
             fi
           fi

--- a/docs/contribution-and-collaboration.md
+++ b/docs/contribution-and-collaboration.md
@@ -155,7 +155,7 @@ The [`Repo - Auto Approve`](https://github.com/camunda/camunda-platform-helm/blo
 Guardrails:
 
 - **Approve-only** — the bot never merges; branch protection (required status checks, merge queue) still gates merge.
-- **Privileged & public-API paths always need a human** — any PR whose commits touch a CI-privileged path (`.github/workflows/`, `.github/actions/`, `CODEOWNERS`, the allowlist) or a chart's public API (`values.yaml`, `values.schema.json`, `constraints.tpl`; chart `test/` fixtures excluded) is never auto-approved. The exact set lives in [`.github/auto-approve-protected-paths.txt`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/auto-approve-protected-paths.txt).
+- **Privileged & public-API paths always need a human** — any PR whose net diff (including renamed-from paths) touches a CI-privileged path (`.github/workflows/`, `.github/actions/`, `CODEOWNERS`, the allowlist) or a chart's public API (`values.yaml`, `values.schema.json`, `constraints.tpl`; chart `test/` fixtures excluded) is never auto-approved. The exact set lives in [`.github/auto-approve-protected-paths.txt`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/auto-approve-protected-paths.txt).
 - **Fail-closed** — if the workflow cannot determine what a PR changed, it does not approve.
 
 Adding or removing allowlist entries requires a normal human-reviewed PR.


### PR DESCRIPTION
### Which problem does the PR fix?

Follow-up to #6524. The `Repo - Auto Approve` guard scans the PR **per commit**. For a
`Merge branch 'main' into <branch>` **merge commit**, the commits API returns the diff against
the first parent — i.e. *all of main's divergence* — so the guard falsely reports that the PR
touches a protected path, even when the PR's net diff touches none. This fires on any PR that
merges `main` into its branch.

Example: PR #6525 (net diff = 7 `test/` files only) was flagged as touching a protected path
because its `Merge branch 'main'` commit's first-parent diff included merged-in `values.yaml`,
`constraints.tpl`, `.github/workflows/…` from main.

### What's in this PR?

Scan the PR **net diff** (`pulls/{PR}/files`) instead of per-commit. Since `main` merges are
**squash-only**, the net diff is exactly what lands on `main`, so it's the correct and complete
thing to check — and it excludes changes merged in from `main`.

Preserved from the per-commit version:
- **Rename detection** — `pulls/{PR}/files` exposes `previous_filename`, so renaming a protected
  file out of its path is still caught.
- **Chart `test/` fixture exclusion**, and the **public-API + CI-privileged** protected set.
- **Fail-closed** on API error, on a malformed pattern (`grep` rc ≥ 2), and on the 3000-file
  API cap (via `.changed_files`).

### Trade-off: in-PR touch-then-revert detection

Switching from per-commit to net-diff means the guard **no longer inspects intermediate commits**,
so it will not flag a PR that *touches* a protected path in one commit and *reverts* it in a later
commit within the same branch history. This is a deliberate, safe trade-off:

- **Squash-only merge makes it moot.** `main` merges are squash-only, so the single commit that
  lands on `main` is exactly the net diff. A touch-then-revert nets to zero in that payload — the
  protected path is not actually changed on `main`, so there is nothing to gate.
- **Re-introducing the change re-runs the guard.** Approval is bound to the head SHA; any push that
  brings the protected change back alters the net diff and head SHA, and the guard re-evaluates
  the new SHA and declines to approve it.

### Ruleset toggles: current state and plan

An earlier revision of this description claimed `dismiss_stale_reviews_on_push` and
`require_last_push_approval` were enabled on `main`. **They are not — both are deliberately OFF**
(see #6561): enabling them strands the release-please and Renovate automerge pipelines, whose
flows push follow-up commits *after* their one-shot bot approval (empirically: #6551, #6556).
**Do not cite this PR as a reason to re-enable them** while those pipelines work that way.

Why the guard is still acceptably safe with the toggles off:

- A stale approval on an old SHA does technically still satisfy the 1-approval count after a new
  push — but today the only allowlisted author is on the Distribution team, which holds an
  `always` bypass on the `main` ruleset, so no *additional* access is gained via that path. The
  residual gap only becomes meaningful when that bypass is removed
  (camunda/team-distribution#811).
- The durable closure is making every bot approval **re-issued on every push**, which is exactly
  what the follow-up stack does: #6562 (this guard re-approves Renovate PRs on each `synchronize`,
  replacing the one-shot `renovate-approve[bot]`) and #6563 (guard logic extracted to a
  unit-tested Go tool). A release-please lane is the remaining piece; once both bot pipelines are
  re-approval-based, the toggles can be re-enabled without stranding automation.

Note the previous per-commit approach did not remove this dependency either (it re-scanned on
push but could not itself dismiss a stale approval) — net-diff does not weaken the model; it only
removes the merge-commit false positive.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
