### PR TITLE
ci: skip console image-tag injection for 8.10 where no standalone console component exists

### DIFF
--- a/scripts/camunda-core/pkg/valuesinjector/valuesinjector.go
+++ b/scripts/camunda-core/pkg/valuesinjector/valuesinjector.go
@@ -138,9 +138,18 @@ func MergeImageTags89(valuesYAML string, overrides *ValuesYAML89) (string, error
 	return MergeImageTags88(valuesYAML, overrides)
 }
 
-// MergeImageTags810 applies the 8.10 overrides (same structure as 8.8).
+// MergeImageTags810 applies the 8.10 image-tag overrides; no standalone console component.
 func MergeImageTags810(valuesYAML string, overrides *ValuesYAML810) (string, error) {
-	return MergeImageTags88(valuesYAML, overrides)
+	if overrides == nil {
+		return valuesYAML, nil
+	}
+	return applyOverrides(valuesYAML, []override{
+		{"identity", overrides.Identity},
+		{"webModeler", overrides.WebModeler},
+		{"connectors", overrides.Connectors},
+		{"orchestration", overrides.Orchestration},
+		{"optimize", overrides.Optimize},
+	})
 }
 
 // replaceImageTag validates that componentName.image.tag exists, then replaces

--- a/scripts/camunda-core/pkg/valuesinjector/valuesinjector_test.go
+++ b/scripts/camunda-core/pkg/valuesinjector/valuesinjector_test.go
@@ -107,6 +107,42 @@ optimize:
     tag: 8.8.3
 `
 
+// Sample values.yaml content for testing chart 8.10 (no standalone console component).
+const sampleValues810 = `
+global:
+  image:
+    tag: ""
+identity:
+  enabled: false
+  image:
+    registry: ""
+    repository: camunda/identity
+    tag: 8.10.0
+webModeler:
+  enabled: false
+  image:
+    registry: ""
+    tag: 8.10.0
+connectors:
+  enabled: true
+  image:
+    registry: ""
+    repository: camunda/connectors-bundle
+    tag: 8.10.0
+orchestration:
+  enabled: true
+  image:
+    registry: ""
+    repository: camunda/camunda
+    tag: 8.10.0
+optimize:
+  enabled: false
+  image:
+    registry: ""
+    repository: camunda/optimize
+    tag: 8.10.0
+`
+
 func TestMergeImageTags86_SingleComponent(t *testing.T) {
 	overrides := &ValuesYAML86{
 		Console: &ComponentImage{
@@ -352,7 +388,7 @@ func TestMergeImageTags89_UsesChart88Logic(t *testing.T) {
 	}
 }
 
-func TestMergeImageTags810_UsesChart88Logic(t *testing.T) {
+func TestMergeImageTags810_UpdatesOrchestration(t *testing.T) {
 	overrides := &ValuesYAML810{
 		Orchestration: &ComponentImage{
 			Image: ImageTag{Tag: "8.10-test"},
@@ -366,6 +402,29 @@ func TestMergeImageTags810_UsesChart88Logic(t *testing.T) {
 
 	if !strings.Contains(result, "8.10-test") {
 		t.Errorf("expected orchestration tag to be updated")
+	}
+}
+
+func TestMergeImageTags810_IgnoresConsole(t *testing.T) {
+	overrides := &ValuesYAML810{
+		Console: &ComponentImage{
+			Image: ImageTag{Tag: "console-should-be-ignored"},
+		},
+		WebModeler: &ComponentImage{
+			Image: ImageTag{Tag: "wm-810"},
+		},
+	}
+
+	result, err := MergeImageTags810(sampleValues810, overrides)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(result, "wm-810") {
+		t.Errorf("expected webModeler tag to be updated to wm-810, got:\n%s", result)
+	}
+	if strings.Contains(result, "console-should-be-ignored") {
+		t.Errorf("expected console override to be ignored, got:\n%s", result)
 	}
 }
 


### PR DESCRIPTION
### Which problem does the PR fix?

The 8.10 chart release pipeline (`Chart - Release - Pipeline`) fails at the **Inject image-tag overrides into values.yaml** step:

```
release-tools: merge image tags: component 'console' not found in values.yaml
```

Failing run: https://github.com/camunda/camunda-platform-helm/actions/runs/28922477616/job/85802607111

**Root cause:** in 8.10, Camunda Hub consolidated Console + Web Modeler — Console UI now ships inside the hub-restapi (`camunda/hub`) pod, so there is **no standalone `console:` component** in `charts/camunda-platform-8.10/values.yaml` (8.8/8.9 still have one). But the pipeline still passes `CONSOLE_IMAGE_TAG` into `release-tools inject-values`, and `MergeImageTags810` aliased `MergeImageTags88`, whose override list unconditionally includes `console`. When `CONSOLE_IMAGE_TAG` is set it tries to rewrite a nonexistent `console.image.tag` and hard-fails.

### What's in this PR?

- `scripts/camunda-core/pkg/valuesinjector/valuesinjector.go` — `MergeImageTags810` is now standalone and injects only `identity, webModeler, connectors, orchestration, optimize`. A set `CONSOLE_IMAGE_TAG` is silently ignored (no-op) for 8.10. `MergeImageTags86/87/88/89` are untouched — 8.6–8.9 keep injecting `console`.
- `scripts/camunda-core/pkg/valuesinjector/valuesinjector_test.go` — added `TestMergeImageTags810_IgnoresConsole` (console + webModeler overrides → no error, webModeler tag applied, console tag absent); renamed the now-inaccurate `TestMergeImageTags810_UsesChart88Logic` → `TestMergeImageTags810_UpdatesOrchestration`.

The Camunda Hub image tag is already handled correctly for 8.10 via `WEB_MODELER_IMAGE_TAG` → `webModeler.image.tag` (repository `camunda/hub`), so the console tag is genuinely redundant in 8.10 rather than missing.

**Verified locally** (pinned toolchain): `gofmt` clean; `go test ./pkg/valuesinjector/...` passes; and `release-tools inject-values` run with the exact failing-run env (`CONSOLE_IMAGE_TAG` + `WEB_MODELER_IMAGE_TAG` = `8.10.0-alpha3`) now exits 0 and correctly bumps the hub tag.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
