### PR TITLE
test: add valuesinjector contract + hub-render tests against real chart values.yaml

### DIFF
--- a/scripts/camunda-core/pkg/valuesinjector/realchart_contract_test.go
+++ b/scripts/camunda-core/pkg/valuesinjector/realchart_contract_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package valuesinjector
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRealChartContract(t *testing.T) {
+	cases := []struct {
+		version    string
+		components []string
+	}{
+		{
+			version: "8.7",
+			components: []string{
+				"console", "zeebe", "zeebeGateway", "operate", "tasklist",
+				"optimize", "identity", "webModeler", "connectors",
+			},
+		},
+		{
+			version: "8.8",
+			components: []string{
+				"identity", "console", "webModeler", "connectors", "orchestration", "optimize",
+			},
+		},
+		{
+			version: "8.9",
+			components: []string{
+				"identity", "console", "webModeler", "connectors", "orchestration", "optimize",
+			},
+		},
+		{
+			version: "8.10",
+			components: []string{
+				"identity", "webModeler", "connectors", "orchestration", "optimize",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.version, func(t *testing.T) {
+			dir := filepath.Join("..", "..", "..", "..", "charts", "camunda-platform-"+tc.version)
+			valuesPath := filepath.Join(dir, "values.yaml")
+			if _, err := os.Stat(valuesPath); err != nil {
+				t.Skipf("chart values.yaml absent at %s", valuesPath)
+			}
+
+			valuesYAML, err := os.ReadFile(valuesPath)
+			if err != nil {
+				t.Fatalf("read values.yaml: %v", err)
+			}
+
+			result, err := mergeRealChartContract(tc.version, string(valuesYAML))
+			if err != nil {
+				t.Fatalf("version %s: injector targets a component missing from values.yaml — "+
+					"update the injector's component list for this version to match the chart: %v",
+					tc.version, err)
+			}
+
+			for _, component := range tc.components {
+				sentinel := contractSentinel(component)
+				if !strings.Contains(result, sentinel) {
+					t.Errorf("version %s: injector did not bump component %q (sentinel %q missing)",
+						tc.version, component, sentinel)
+				}
+			}
+
+			if tc.version == "8.10" {
+				if strings.Contains(result, contractSentinel("console")) {
+					t.Errorf("version 8.10: console must not be injected (no standalone console in values.yaml)")
+				}
+			}
+		})
+	}
+}
+
+func contractSentinel(component string) string {
+	return "CONTRACT-" + component
+}
+
+func contractTag(component string) *ComponentImage {
+	return &ComponentImage{Image: ImageTag{Tag: contractSentinel(component)}}
+}
+
+func buildOverrides86() *ValuesYAML86 {
+	return &ValuesYAML86{
+		Console:      contractTag("console"),
+		Zeebe:        contractTag("zeebe"),
+		ZeebeGateway: contractTag("zeebeGateway"),
+		Operate:      contractTag("operate"),
+		Tasklist:     contractTag("tasklist"),
+		Optimize:     contractTag("optimize"),
+		Identity:     contractTag("identity"),
+		WebModeler:   contractTag("webModeler"),
+		Connectors:   contractTag("connectors"),
+	}
+}
+
+func buildOverrides88() *ValuesYAML88 {
+	return &ValuesYAML88{
+		Identity:      contractTag("identity"),
+		Console:       contractTag("console"),
+		WebModeler:    contractTag("webModeler"),
+		Connectors:    contractTag("connectors"),
+		Orchestration: contractTag("orchestration"),
+		Optimize:      contractTag("optimize"),
+	}
+}
+
+func mergeRealChartContract(version, valuesYAML string) (string, error) {
+	switch version {
+	case "8.7":
+		return MergeImageTags87(valuesYAML, buildOverrides86())
+	case "8.8":
+		return MergeImageTags88(valuesYAML, buildOverrides88())
+	case "8.9":
+		return MergeImageTags89(valuesYAML, buildOverrides88())
+	case "8.10":
+		return MergeImageTags810(valuesYAML, buildOverrides88())
+	default:
+		return "", fmt.Errorf("unsupported chart version for contract test: %s", version)
+	}
+}

--- a/scripts/camunda-core/pkg/valuesinjector/realchart_render_test.go
+++ b/scripts/camunda-core/pkg/valuesinjector/realchart_render_test.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package valuesinjector
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRealChart810RendersHubImage(t *testing.T) {
+	chartDir := filepath.Join("..", "..", "..", "..", "charts", "camunda-platform-8.10")
+
+	if _, err := os.Stat(filepath.Join(chartDir, "values.yaml")); err != nil {
+		t.Skipf("chart values.yaml absent at %s", filepath.Join(chartDir, "values.yaml"))
+	}
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skip("helm not installed")
+	}
+	tgzs, err := filepath.Glob(filepath.Join(chartDir, "charts", "*.tgz"))
+	if err != nil {
+		t.Fatalf("glob chart dependencies: %v", err)
+	}
+	if len(tgzs) == 0 {
+		t.Skip("chart subchart dependencies not vendored (run make helm.dependency-update)")
+	}
+
+	raw, err := os.ReadFile(filepath.Join(chartDir, "values.yaml"))
+	if err != nil {
+		t.Fatalf("read values.yaml: %v", err)
+	}
+
+	const sentinel = "hub-render-sentinel"
+	injected, err := MergeImageTags810(string(raw), &ValuesYAML810{
+		WebModeler: &ComponentImage{Image: ImageTag{Tag: sentinel}},
+	})
+	if err != nil {
+		t.Fatalf("inject webModeler tag: %v", err)
+	}
+
+	tmp := filepath.Join(t.TempDir(), "values.yaml")
+	if err := os.WriteFile(tmp, []byte(injected), 0o644); err != nil {
+		t.Fatalf("write injected values: %v", err)
+	}
+
+	cmd := exec.Command("helm", "template", "hubtest", chartDir,
+		"-f", tmp,
+		"--set", "webModeler.enabled=true",
+		"--set", "identity.enabled=true",
+		"--set", "orchestration.data.secondaryStorage.type=elasticsearch",
+		"--set", "webModeler.restapi.mail.fromAddress=noreply@example.com")
+	stdout, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			t.Fatalf("helm template failed: %v\n%s", err, string(exitErr.Stderr))
+		}
+		t.Fatalf("helm template failed: %v", err)
+	}
+
+	out := string(stdout)
+	if !strings.Contains(out, "camunda/hub:"+sentinel) {
+		t.Errorf("rendered output missing camunda/hub:%s — injected webModeler.image.tag did not flow to the Camunda Hub restapi image", sentinel)
+	}
+	if !strings.Contains(out, "camunda/hub-websockets:"+sentinel) {
+		t.Errorf("rendered output missing camunda/hub-websockets:%s — injected webModeler.image.tag did not flow to the Camunda Hub websockets image", sentinel)
+	}
+}


### PR DESCRIPTION
### Which problem does the PR fix?

The release pipeline broke when 8.10 dropped the standalone `console:` component (fixed in #6544), but the `valuesinjector` unit tests never caught it: they only exercised **hand-written inline YAML fixtures**, never the real `charts/camunda-platform-<version>/values.yaml`. Drift between the injector's per-version component list and the actual chart values went undetected until the release job failed.

Follow-up to #6544 (merged). Adds the regression coverage that would have caught it in CI.

### What's in this PR?

Two new test files under `scripts/camunda-core/pkg/valuesinjector/` (test-only, no production/CI changes):

**1. `realchart_contract_test.go` — `TestRealChartContract` (8.7–8.10).** A structural contract test. For each version it reads the real `values.yaml`, runs that version's `MergeImageTags*` with a fully-populated override set (unique `CONTRACT-<component>` sentinel tags), and asserts:
- **no error** — every component the injector targets exists (with `image.tag`) in that version's `values.yaml` → catches the console class of bug (component removed from `values.yaml` but still injected);
- **each expected component's sentinel is present** → catches the reverse (a component silently no longer injected, e.g. `webModeler` dropped from 8.10, which carries the `camunda/hub` image tag);
- **for 8.10, the `console` sentinel is absent** → documents/guards the intentional skip.

Stdlib `testing` only; mirrors chartmeta's `TestImageSetRealChartContract` structural pattern (values-only, no render).

**2. `realchart_render_test.go` — `TestRealChart810RendersHubImage` (8.10, render-level).** Injects a sentinel tag into the 8.10 `webModeler` component via `MergeImageTags810`, then **shells out to the `helm` binary** (`os/exec`) to `helm template` the real chart and asserts the tag lands on **both `camunda/hub` and `camunda/hub-websockets`** — proving `webModeler` *is* Camunda Hub at the image level and that the injector's output flows to the real Hub images. This is a **new mechanism for this package**: it requires the `helm` binary and the chart's vendored subchart `.tgz` deps; it `t.Skip`s cleanly when either is absent (keeps local `go test` green without them).

Both tests run in the existing **Test - Release Tooling** CI job (`go test ./pkg/...` in `scripts/camunda-core`), which installs `helm` and runs `helm dependency-update` for 8.7–8.10 before the tests — so the render test executes for real there rather than skipping.

Verified both have teeth: reverting the fix (aliasing `MergeImageTags810` → `MergeImageTags88`) fails the contract test with `component 'console' not found`; dropping `webModeler` from the injector fails the render test on both hub images.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open pull request for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo documentation are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?