### PR TITLE
ci: push generated release files as distro-ci to keep release PR approval valid

### DIFF
--- a/.github/workflows/chart-promote-rc.yaml
+++ b/.github/workflows/chart-promote-rc.yaml
@@ -138,6 +138,7 @@ jobs:
         with:
           ref: ${{ steps.parse.outputs.sha }}
           fetch-depth: 0
+          token: ${{ steps.generate-github-token.outputs.token }}
 
       - name: Validate commit is on main
         run: |


### PR DESCRIPTION
### Which problem does the PR fix?

Release-please PRs are blocked: "require approval from someone other than github-actions[bot] because they were the last pusher." Since #6485, the release-files push in `chart-promote-rc.yaml` uses the checkout's default `GITHUB_TOKEN`, so the pusher is `github-actions[bot]` — the same identity that approves the PR. With `require_last_push_approval: true` the approval is disqualified.

### What's in this PR?

Give the "Checkout at commit SHA" step the distro-ci app token so the push is attributed to `distro-ci[bot]`, restoring the pusher/approver split from before #6485.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
