### PR TITLE
fix: document defaultRoles.admin.clients in orchestration values schema [ready]

### DIFF
--- a/charts/camunda-platform-8.10/values.schema.extra.json
+++ b/charts/camunda-platform-8.10/values.schema.extra.json
@@ -758,6 +758,29 @@
                     "description": "can be used to override the automatic mounting of the service account token at the pod level. When unset, the ServiceAccount configuration is used.",
                     "default": null
                 },
+                "security": {
+                    "properties": {
+                        "initialization": {
+                            "properties": {
+                                "defaultRoles": {
+                                    "properties": {
+                                        "admin": {
+                                            "properties": {
+                                                "clients": {
+                                                    "type": "array",
+                                                    "description": "defines the initial clients that will get the admin permission.",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "exporters": {
                     "properties": {
                         "zeebe": {

--- a/charts/camunda-platform-8.10/values.schema.json
+++ b/charts/camunda-platform-8.10/values.schema.json
@@ -4246,6 +4246,13 @@
                                                     "items": {
                                                         "type": "string"
                                                     }
+                                                },
+                                                "clients": {
+                                                    "type": "array",
+                                                    "description": "defines the initial clients that will get the admin permission.",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
                                                 }
                                             }
                                         },

--- a/charts/camunda-platform-8.8/values.schema.extra.json
+++ b/charts/camunda-platform-8.8/values.schema.extra.json
@@ -938,6 +938,25 @@
                                     }
                                 }
                             }
+                        },
+                        "initialization": {
+                            "properties": {
+                                "defaultRoles": {
+                                    "properties": {
+                                        "admin": {
+                                            "properties": {
+                                                "clients": {
+                                                    "type": "array",
+                                                    "description": "defines the initial clients that will get the admin permission.",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/charts/camunda-platform-8.8/values.schema.json
+++ b/charts/camunda-platform-8.8/values.schema.json
@@ -6005,6 +6005,13 @@
                                                     "description": "defines the mapping rule IDs for role assignment",
                                                     "default": [],
                                                     "items": {}
+                                                },
+                                                "clients": {
+                                                    "type": "array",
+                                                    "description": "defines the initial clients that will get the admin permission.",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
                                                 }
                                             }
                                         },

--- a/charts/camunda-platform-8.9/values.schema.extra.json
+++ b/charts/camunda-platform-8.9/values.schema.extra.json
@@ -709,6 +709,29 @@
         },
         "orchestration": {
             "properties": {
+                "security": {
+                    "properties": {
+                        "initialization": {
+                            "properties": {
+                                "defaultRoles": {
+                                    "properties": {
+                                        "admin": {
+                                            "properties": {
+                                                "clients": {
+                                                    "type": "array",
+                                                    "description": "defines the initial clients that will get the admin permission.",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "exporters": {
                     "properties": {
                         "zeebe": {

--- a/charts/camunda-platform-8.9/values.schema.json
+++ b/charts/camunda-platform-8.9/values.schema.json
@@ -5509,6 +5509,13 @@
                                                     "items": {
                                                         "type": "string"
                                                     }
+                                                },
+                                                "clients": {
+                                                    "type": "array",
+                                                    "description": "defines the initial clients that will get the admin permission.",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
                                                 }
                                             }
                                         },


### PR DESCRIPTION
### Which problem does the PR fix?

Relates to #6558. Addresses the self-contained part of it: `orchestration.security.initialization.defaultRoles.admin.clients` is not described by the values schema, so consumers that apply strict validation (`additionalProperties: false`, per #4564) report it as an unknown key even though it is valid configuration.

### What's in this PR?

`defaultRoles.admin` only described `users`, while `defaultRoles.connectors` already documents both `users` and `clients`. The `defaultRoles` map is rendered straight into the orchestration app config (`toYaml` in `templates/orchestration/files/_application.yaml`, `_application-unified.yaml` on 8.8), so assigning the admin role to a client (`admin.clients`) is valid — it was simply undocumented, and the object keeps `additionalProperties: true` so the existing `make helm.schema-validate-values` gate does not surface the gap.

- Add the `clients` property under `orchestration.security.initialization.defaultRoles.admin` in `values.schema.extra.json` for 8.10, 8.9 and 8.8 (schema-only — no change to chart defaults or rendered output).
- Regenerate each `values.schema.json` via `make helm.schema-update` (readme-generator 2.7.2); the sole change per version is the `clients` array added next to the existing `users`.
- 8.7 and older are unaffected: they have no `orchestration.security.initialization.defaultRoles` at all.
- On 8.8 the property is merged into the pre-existing `orchestration.security` object rather than appended as a new one — `values.schema.extra.json` is consumed by `jq`, so two `"security"` keys at the same level silently drop one of the two objects.

Verified with `make helm.schema-validate-values chartPath=charts/camunda-platform-8.{8,9,10}` (all pass) and by re-running `make helm.schema-update`, which is a no-op on the committed schemas.

The broader part of #6558 (`camundaHub.webModeler.*` sub-keys undocumented) is intentionally out of scope here — it is larger and best coordinated with the `camundaHub.webModeler.* → camundaHub.*` hoist tracked in #6539.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
