### PR TITLE
chore: document that auto-approve ruleset toggles must stay off

### DIFF
--- a/docs/contribution-and-collaboration.md
+++ b/docs/contribution-and-collaboration.md
@@ -154,11 +154,13 @@ The [`Repo - Auto Approve`](https://github.com/camunda/camunda-platform-helm/blo
 
 Guardrails:
 
-- **Approve-only** — the bot never merges; branch protection (required status checks, stale-review dismissal) still gates merge.
+- **Approve-only** — the bot never merges; branch protection (required status checks, merge queue) still gates merge.
 - **Privileged & public-API paths always need a human** — any PR whose commits touch a CI-privileged path (`.github/workflows/`, `.github/actions/`, `CODEOWNERS`, the allowlist) or a chart's public API (`values.yaml`, `values.schema.json`, `constraints.tpl`; chart `test/` fixtures excluded) is never auto-approved. The exact set lives in [`.github/auto-approve-protected-paths.txt`](https://github.com/camunda/camunda-platform-helm/blob/main/.github/auto-approve-protected-paths.txt).
 - **Fail-closed** — if the workflow cannot determine what a PR changed, it does not approve.
 
 Adding or removing allowlist entries requires a normal human-reviewed PR.
+
+**Ruleset constraint:** the `main` ruleset must keep `require_last_push_approval` and `dismiss_stale_reviews_on_push` **off**. Both break the release-please and Renovate bot-merge flows (a bot approval is dismissed or disqualified by the follow-up commit those flows push), and neither adds real protection to this control: the allowlist is a subset of the ruleset's bypass actors, so an allowlisted author can already merge without review regardless.
 
 ### Helm version
 


### PR DESCRIPTION
### Which problem does the PR fix?

The "Trusted-author auto-approval" section cited "stale-review dismissal" as part of the merge gate, implying `dismiss_stale_reviews_on_push` should be on. That toggle plus `require_last_push_approval` break the release-please and Renovate bot-merge flows (#6551, #6556) and were reverted on the `main` ruleset; nothing documented that they must stay off.

### What's in this PR?

Update the "Trusted-author auto-approval" section: drop the stale-review-dismissal wording from the approve-only guardrail, and add a note that both `main` ruleset toggles must stay off, with the reason (they break bot-merge and add no real protection, since the allowlist is a subset of the ruleset's bypass actors).

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
