### PR TITLE
chore: group deploy-camunda flags + add config init --from-example

### DIFF
--- a/scripts/deploy-camunda/cmd/config_init.go
+++ b/scripts/deploy-camunda/cmd/config_init.go
@@ -16,6 +16,7 @@ import (
 	"scripts/camunda-core/pkg/logging"
 	"scripts/deploy-camunda/config"
 	"scripts/deploy-camunda/deploy"
+	"scripts/deploy-camunda/examples"
 	"scripts/prepare-helm-values/pkg/env"
 
 	"github.com/spf13/cobra"
@@ -29,6 +30,9 @@ import (
 func newInitCommand() *cobra.Command {
 	var nonInteractive bool
 	var envFile string
+	var fromExample string
+	var listExamples bool
+	var force bool
 
 	cmd := &cobra.Command{
 		Use:   "init",
@@ -41,7 +45,11 @@ scaffolds the random test secrets, then runs the doctor preflight so you finish
 with a ✓/✗ checklist instead of guessing what is missing.
 
 Use --non-interactive in CI to ensure a config file exists and print the
-checklist without prompting.`,
+checklist without prompting.
+
+Use --from-example <name> to drop a static starter config into place without
+any prompting — useful when you want a file you can edit and commit. Run with
+--list-examples to see the available templates.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -54,11 +62,29 @@ checklist without prompting.`,
 				return err
 			}
 
+			out := cmd.OutOrStdout()
+
+			if listExamples {
+				names := examples.Names()
+				if len(names) == 0 {
+					fmt.Fprintln(out, "No examples embedded.")
+					return nil
+				}
+				fmt.Fprintln(out, "Available examples:")
+				for _, n := range names {
+					fmt.Fprintf(out, "  %s\n", n)
+				}
+				return nil
+			}
+
 			cfgRes, err := config.ResolvePath(configFile)
 			if err != nil {
 				return err
 			}
-			out := cmd.OutOrStdout()
+
+			if fromExample != "" {
+				return writeExampleConfig(out, cfgRes.Path, fromExample, force)
+			}
 
 			if nonInteractive {
 				if !cfgRes.Found {
@@ -188,7 +214,31 @@ checklist without prompting.`,
 
 	cmd.Flags().BoolVar(&nonInteractive, "non-interactive", false, "Don't prompt; require an existing config and just run doctor")
 	cmd.Flags().StringVar(&envFile, "env-file", ".env", "Path to the .env file to write secrets/credentials into")
+	cmd.Flags().StringVar(&fromExample, "from-example", "", "Non-interactively write the named embedded starter config to the config path (e.g. `getting-started`). See --list-examples.")
+	cmd.Flags().BoolVar(&listExamples, "list-examples", false, "List the embedded example names and exit")
+	cmd.Flags().BoolVar(&force, "force", false, "Overwrite an existing config file when using --from-example")
 	return cmd
+}
+
+// writeExampleConfig drops the named embedded starter at the resolved config
+// path. Refuses to overwrite an existing file unless force is true; the whole
+// point of the flag is safe onboarding, so silent clobbering is off by default.
+func writeExampleConfig(out io.Writer, path, name string, force bool) error {
+	content, err := examples.Load(name)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(path); err == nil && !force {
+		return fmt.Errorf("config already exists at %s; re-run with --force to overwrite", path)
+	} else if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", path, err)
+	}
+	fmt.Fprintf(out, "Wrote starter config to %s (from example %q).\n", path, name)
+	fmt.Fprintln(out, "Next: edit the CHANGE-ME fields, then run `deploy-camunda doctor`.")
+	return nil
 }
 
 // runDoctorAfterInit loads the freshly-written config and prints a preflight

--- a/scripts/deploy-camunda/cmd/config_init.go
+++ b/scripts/deploy-camunda/cmd/config_init.go
@@ -217,6 +217,15 @@ any prompting — useful when you want a file you can edit and commit. Run with
 	cmd.Flags().StringVar(&fromExample, "from-example", "", "Non-interactively write the named embedded starter config to the config path (e.g. `getting-started`). See --list-examples.")
 	cmd.Flags().BoolVar(&listExamples, "list-examples", false, "List the embedded example names and exit")
 	cmd.Flags().BoolVar(&force, "force", false, "Overwrite an existing config file when using --from-example")
+
+	// The three exit paths (list, template-drop, wizard/doctor) are mutually
+	// exclusive by design: combining them would silently prefer one and drop
+	// the other's contract (e.g. --non-interactive's doctor preflight is
+	// skipped if --from-example short-circuits first).
+	cmd.MarkFlagsMutuallyExclusive("from-example", "non-interactive")
+	cmd.MarkFlagsMutuallyExclusive("list-examples", "non-interactive")
+	cmd.MarkFlagsMutuallyExclusive("list-examples", "from-example")
+
 	return cmd
 }
 

--- a/scripts/deploy-camunda/cmd/config_init_test.go
+++ b/scripts/deploy-camunda/cmd/config_init_test.go
@@ -140,3 +140,123 @@ func TestConfigInitNonInteractiveRequiresConfig(t *testing.T) {
 		t.Fatal("expected error when --non-interactive and no config exists")
 	}
 }
+
+func TestConfigInitFromExample(t *testing.T) {
+	t.Setenv("PATH", "")
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, ".camunda-deploy.yaml")
+	prev := configFile
+	configFile = cfgPath
+	t.Cleanup(func() { configFile = prev })
+
+	cmd := newInitCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--from-example", "getting-started"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("--from-example returned error: %v\n%s", err, out.String())
+	}
+
+	raw, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("config file not written: %v", err)
+	}
+	if !strings.Contains(string(raw), "Getting Started") {
+		t.Errorf("written config missing banner from getting-started template; content:\n%s", string(raw))
+	}
+	if !strings.Contains(out.String(), "Wrote starter config") {
+		t.Errorf("expected user-facing 'Wrote starter config' message; got:\n%s", out.String())
+	}
+}
+
+func TestConfigInitFromExampleRefusesToOverwrite(t *testing.T) {
+	t.Setenv("PATH", "")
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, ".camunda-deploy.yaml")
+	if err := os.WriteFile(cfgPath, []byte("existing: true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	prev := configFile
+	configFile = cfgPath
+	t.Cleanup(func() { configFile = prev })
+
+	cmd := newInitCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--from-example", "getting-started"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when writing over existing config without --force")
+	}
+	if !strings.Contains(err.Error(), "--force") {
+		t.Errorf("expected error to mention --force; got: %v", err)
+	}
+	raw, _ := os.ReadFile(cfgPath)
+	if string(raw) != "existing: true\n" {
+		t.Errorf("original config was clobbered without --force; new content:\n%s", string(raw))
+	}
+}
+
+func TestConfigInitFromExampleForceOverwrite(t *testing.T) {
+	t.Setenv("PATH", "")
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, ".camunda-deploy.yaml")
+	if err := os.WriteFile(cfgPath, []byte("existing: true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	prev := configFile
+	configFile = cfgPath
+	t.Cleanup(func() { configFile = prev })
+
+	cmd := newInitCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--from-example", "getting-started", "--force"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("--force overwrite failed: %v", err)
+	}
+	raw, _ := os.ReadFile(cfgPath)
+	if strings.Contains(string(raw), "existing: true") {
+		t.Errorf("--force did not overwrite existing config; content:\n%s", string(raw))
+	}
+}
+
+func TestConfigInitFromExampleUnknownName(t *testing.T) {
+	t.Setenv("PATH", "")
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, ".camunda-deploy.yaml")
+	prev := configFile
+	configFile = cfgPath
+	t.Cleanup(func() { configFile = prev })
+
+	cmd := newInitCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--from-example", "does-not-exist"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for unknown example name")
+	}
+	if !strings.Contains(err.Error(), "does-not-exist") {
+		t.Errorf("error should name the missing example; got: %v", err)
+	}
+}
+
+func TestConfigInitListExamples(t *testing.T) {
+	t.Setenv("PATH", "")
+	cmd := newInitCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--list-examples"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("--list-examples returned error: %v", err)
+	}
+	if !strings.Contains(out.String(), "getting-started") {
+		t.Errorf("--list-examples did not include getting-started; output:\n%s", out.String())
+	}
+}

--- a/scripts/deploy-camunda/cmd/config_init_test.go
+++ b/scripts/deploy-camunda/cmd/config_init_test.go
@@ -246,6 +246,42 @@ func TestConfigInitFromExampleUnknownName(t *testing.T) {
 	}
 }
 
+func TestConfigInitRejectsConflictingModeFlags(t *testing.T) {
+	t.Setenv("PATH", "")
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, ".camunda-deploy.yaml")
+	prev := configFile
+	configFile = cfgPath
+	t.Cleanup(func() { configFile = prev })
+
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"from-example + non-interactive", []string{"--from-example", "getting-started", "--non-interactive"}},
+		{"list-examples + non-interactive", []string{"--list-examples", "--non-interactive"}},
+		{"list-examples + from-example", []string{"--list-examples", "--from-example", "getting-started"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := newInitCommand()
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs(tc.args)
+
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatalf("expected mutual-exclusion error for %v; output:\n%s", tc.args, out.String())
+			}
+			if !strings.Contains(err.Error(), "none of the others can be") {
+				t.Errorf("expected mutual-exclusion error text; got: %v", err)
+			}
+		})
+	}
+}
+
 func TestConfigInitListExamples(t *testing.T) {
 	t.Setenv("PATH", "")
 	cmd := newInitCommand()

--- a/scripts/deploy-camunda/cmd/config_init_test.go
+++ b/scripts/deploy-camunda/cmd/config_init_test.go
@@ -144,7 +144,7 @@ func TestConfigInitNonInteractiveRequiresConfig(t *testing.T) {
 func TestConfigInitFromExample(t *testing.T) {
 	t.Setenv("PATH", "")
 	tmp := t.TempDir()
-	cfgPath := filepath.Join(tmp, ".camunda-deploy.yaml")
+	cfgPath := filepath.Join(tmp, ".deploy-camunda.yaml")
 	prev := configFile
 	configFile = cfgPath
 	t.Cleanup(func() { configFile = prev })
@@ -173,7 +173,7 @@ func TestConfigInitFromExample(t *testing.T) {
 func TestConfigInitFromExampleRefusesToOverwrite(t *testing.T) {
 	t.Setenv("PATH", "")
 	tmp := t.TempDir()
-	cfgPath := filepath.Join(tmp, ".camunda-deploy.yaml")
+	cfgPath := filepath.Join(tmp, ".deploy-camunda.yaml")
 	if err := os.WriteFile(cfgPath, []byte("existing: true\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -202,7 +202,7 @@ func TestConfigInitFromExampleRefusesToOverwrite(t *testing.T) {
 func TestConfigInitFromExampleForceOverwrite(t *testing.T) {
 	t.Setenv("PATH", "")
 	tmp := t.TempDir()
-	cfgPath := filepath.Join(tmp, ".camunda-deploy.yaml")
+	cfgPath := filepath.Join(tmp, ".deploy-camunda.yaml")
 	if err := os.WriteFile(cfgPath, []byte("existing: true\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -227,7 +227,7 @@ func TestConfigInitFromExampleForceOverwrite(t *testing.T) {
 func TestConfigInitFromExampleUnknownName(t *testing.T) {
 	t.Setenv("PATH", "")
 	tmp := t.TempDir()
-	cfgPath := filepath.Join(tmp, ".camunda-deploy.yaml")
+	cfgPath := filepath.Join(tmp, ".deploy-camunda.yaml")
 	prev := configFile
 	configFile = cfgPath
 	t.Cleanup(func() { configFile = prev })
@@ -249,7 +249,7 @@ func TestConfigInitFromExampleUnknownName(t *testing.T) {
 func TestConfigInitRejectsConflictingModeFlags(t *testing.T) {
 	t.Setenv("PATH", "")
 	tmp := t.TempDir()
-	cfgPath := filepath.Join(tmp, ".camunda-deploy.yaml")
+	cfgPath := filepath.Join(tmp, ".deploy-camunda.yaml")
 	prev := configFile
 	configFile = cfgPath
 	t.Cleanup(func() { configFile = prev })

--- a/scripts/deploy-camunda/cmd/flag_groups.go
+++ b/scripts/deploy-camunda/cmd/flag_groups.go
@@ -1,0 +1,215 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// flagGroupAnnotation is the pflag annotation key used to bucket flags into
+// help-output groups. Kept namespaced so we don't collide with third-party
+// annotations Cobra may attach in the future.
+const flagGroupAnnotation = "deploy-camunda:group"
+
+// Group labels rendered as section headings in --help output. Order below
+// controls display order.
+const (
+	grpInfrastructure = "Infrastructure"
+	grpAuth           = "Authentication"
+	grpScenario       = "Scenario"
+	grpRegistry       = "Registry"
+	grpDeployment     = "Deployment behaviour"
+	grpLogging        = "Logging"
+	grpOther          = "Other"
+)
+
+var groupOrder = []string{
+	grpInfrastructure, grpAuth, grpScenario, grpRegistry,
+	grpDeployment, grpLogging, grpOther,
+}
+
+// annotateFlagGroups tags each named flag with the given group. Any local flag
+// on the command that isn't listed in groups is silently bucketed into "Other"
+// so the help output never drops a flag. Unknown flag names in groups are
+// ignored — that lets the caller reference deprecated flags without breaking
+// when they're removed.
+func annotateFlagGroups(cmd *cobra.Command, groups map[string][]string) {
+	for group, names := range groups {
+		for _, n := range names {
+			f := cmd.Flags().Lookup(n)
+			if f == nil {
+				continue
+			}
+			if f.Annotations == nil {
+				f.Annotations = map[string][]string{}
+			}
+			f.Annotations[flagGroupAnnotation] = []string{group}
+		}
+	}
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		if _, ok := f.Annotations[flagGroupAnnotation]; ok {
+			return
+		}
+		if f.Annotations == nil {
+			f.Annotations = map[string][]string{}
+		}
+		f.Annotations[flagGroupAnnotation] = []string{grpOther}
+	})
+	cmd.SetUsageFunc(groupedUsageFunc)
+}
+
+// groupedUsageFunc renders the command usage with flags bucketed into the
+// groups declared via annotateFlagGroups. Falls back to a plain flag dump for
+// commands where no grouping was applied.
+func groupedUsageFunc(cmd *cobra.Command) error {
+	w := cmd.OutOrStderr()
+
+	fmt.Fprintf(w, "Usage:\n  %s", cmd.UseLine())
+	if cmd.HasAvailableSubCommands() {
+		fmt.Fprintf(w, "\n  %s [command]", cmd.CommandPath())
+	}
+	fmt.Fprintln(w)
+
+	if len(cmd.Aliases) > 0 {
+		fmt.Fprintf(w, "\nAliases:\n  %s\n", cmd.NameAndAliases())
+	}
+	if cmd.HasExample() {
+		fmt.Fprintf(w, "\nExamples:\n%s\n", cmd.Example)
+	}
+	if cmd.HasAvailableSubCommands() {
+		fmt.Fprintln(w, "\nAvailable Commands:")
+		maxLen := 0
+		for _, sub := range cmd.Commands() {
+			if !sub.IsAvailableCommand() || sub.IsAdditionalHelpTopicCommand() {
+				continue
+			}
+			if l := len(sub.Name()); l > maxLen {
+				maxLen = l
+			}
+		}
+		for _, sub := range cmd.Commands() {
+			if !sub.IsAvailableCommand() || sub.IsAdditionalHelpTopicCommand() {
+				continue
+			}
+			fmt.Fprintf(w, "  %-*s  %s\n", maxLen, sub.Name(), sub.Short)
+		}
+	}
+
+	printGroupedFlags(w, cmd)
+
+	if cmd.HasAvailableInheritedFlags() {
+		fmt.Fprintln(w, "\nGlobal Flags:")
+		fmt.Fprint(w, cmd.InheritedFlags().FlagUsagesWrapped(120))
+	}
+
+	if cmd.HasAvailableSubCommands() {
+		fmt.Fprintf(w, "\nUse \"%s [command] --help\" for more information about a command.\n", cmd.CommandPath())
+	}
+	return nil
+}
+
+// rootFlagGroups is the flag → group mapping applied to the root
+// `deploy-camunda` command. Unknown or removed flag names are silently
+// tolerated by annotateFlagGroups.
+func rootFlagGroups() map[string][]string {
+	return map[string][]string{
+		grpInfrastructure: {
+			"namespace", "namespace-prefix", "platform", "repo-root",
+			"kube-context", "ingress-subdomain", "ingress-base-domain",
+			"ingress-hostname",
+		},
+		grpAuth: {
+			"auth", "keycloak-host", "keycloak-protocol", "keycloak-realm",
+			"use-vault-backed-secrets",
+		},
+		grpScenario: {
+			"chart-path", "chart", "version", "scenario", "scenario-path",
+			"extra-values", "values-preset", "identity", "persistence",
+			"test-platform", "features", "qa", "image-tags",
+		},
+		grpRegistry: {
+			"docker-username", "docker-password", "ensure-docker-registry",
+			"dockerhub-username", "dockerhub-password", "ensure-docker-hub",
+		},
+		grpDeployment: {
+			"release", "flow", "ttl", "skip-preflight",
+			"skip-dependency-update", "delete-namespace", "render-templates",
+			"render-output-dir", "timeout", "test-e2e", "test-all",
+			"upgrade-flow",
+		},
+		grpLogging: {
+			"log-level",
+		},
+	}
+}
+
+// matrixRunFlagGroups is the flag → group mapping applied to
+// `deploy-camunda matrix run`. Per-platform variants sit alongside their base
+// flag in the same group so users see them together.
+func matrixRunFlagGroups() map[string][]string {
+	return map[string][]string{
+		grpInfrastructure: {
+			"platform", "repo-root", "namespace-prefix",
+			"kube-context", "kube-context-gke", "kube-context-eks",
+			"ingress-base-domain", "ingress-base-domain-gke", "ingress-base-domain-eks",
+			"namespace-override",
+		},
+		grpAuth: {
+			"use-vault-backed-secrets", "use-vault-backed-secrets-gke", "use-vault-backed-secrets-eks",
+			"keycloak-host", "keycloak-protocol",
+		},
+		grpScenario: {
+			"versions", "include-disabled", "scenario-filter",
+			"shortname-filter", "shortname-exact", "flow-filter",
+			"upgrade-from-version", "use-latest", "use-qa",
+			"extra-helm-arg", "extra-helm-set", "extra-values",
+			"chart-ref", "chart-version", "tier",
+		},
+		grpRegistry: {
+			"docker-username", "docker-password", "ensure-docker-registry",
+			"dockerhub-username", "dockerhub-password", "ensure-docker-hub",
+		},
+		grpDeployment: {
+			"dry-run", "coverage", "test-e2e", "test-all",
+			"stop-on-failure", "cleanup", "delete-namespace",
+			"max-parallel", "skip-dependency-update", "timeout",
+		},
+		grpLogging: {
+			"log-level", "log-dir",
+		},
+	}
+}
+
+// printGroupedFlags writes local flags to w, one section per group in
+// groupOrder. Empty groups are skipped so a command that only touches a few
+// groups doesn't get empty headers.
+func printGroupedFlags(w io.Writer, cmd *cobra.Command) {
+	byGroup := map[string][]*pflag.Flag{}
+	cmd.LocalFlags().VisitAll(func(f *pflag.Flag) {
+		if f.Hidden {
+			return
+		}
+		g := grpOther
+		if v, ok := f.Annotations[flagGroupAnnotation]; ok && len(v) > 0 {
+			g = v[0]
+		}
+		byGroup[g] = append(byGroup[g], f)
+	})
+
+	for _, g := range groupOrder {
+		fs := byGroup[g]
+		if len(fs) == 0 {
+			continue
+		}
+		sort.Slice(fs, func(i, j int) bool { return fs[i].Name < fs[j].Name })
+		tmp := pflag.NewFlagSet(g, pflag.ContinueOnError)
+		for _, f := range fs {
+			tmp.AddFlag(f)
+		}
+		fmt.Fprintf(w, "\n%s Flags:\n", g)
+		fmt.Fprint(w, tmp.FlagUsagesWrapped(120))
+	}
+}

--- a/scripts/deploy-camunda/cmd/flag_groups_test.go
+++ b/scripts/deploy-camunda/cmd/flag_groups_test.go
@@ -1,0 +1,163 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestAnnotateFlagGroupsAssignsExplicitGroup(t *testing.T) {
+	cmd := &cobra.Command{Use: "fake"}
+	var placeholder string
+	cmd.Flags().StringVar(&placeholder, "ingress-base-domain", "", "")
+	cmd.Flags().StringVar(&placeholder, "log-level", "", "")
+
+	annotateFlagGroups(cmd, map[string][]string{
+		grpInfrastructure: {"ingress-base-domain"},
+		grpLogging:        {"log-level"},
+	})
+
+	if got := cmd.Flags().Lookup("ingress-base-domain").Annotations[flagGroupAnnotation]; len(got) == 0 || got[0] != grpInfrastructure {
+		t.Errorf("ingress-base-domain group = %v, want %s", got, grpInfrastructure)
+	}
+	if got := cmd.Flags().Lookup("log-level").Annotations[flagGroupAnnotation]; len(got) == 0 || got[0] != grpLogging {
+		t.Errorf("log-level group = %v, want %s", got, grpLogging)
+	}
+}
+
+func TestAnnotateFlagGroupsFallsBackToOther(t *testing.T) {
+	cmd := &cobra.Command{Use: "fake"}
+	var placeholder string
+	cmd.Flags().StringVar(&placeholder, "unspecified-flag", "", "")
+
+	annotateFlagGroups(cmd, map[string][]string{})
+
+	if got := cmd.Flags().Lookup("unspecified-flag").Annotations[flagGroupAnnotation]; len(got) == 0 || got[0] != grpOther {
+		t.Errorf("unlisted flag should default to %q; got %v", grpOther, got)
+	}
+}
+
+func TestAnnotateFlagGroupsIgnoresUnknownFlagNames(t *testing.T) {
+	cmd := &cobra.Command{Use: "fake"}
+	var placeholder string
+	cmd.Flags().StringVar(&placeholder, "real-flag", "", "")
+
+	// Should not panic on the phantom flag name.
+	annotateFlagGroups(cmd, map[string][]string{
+		grpInfrastructure: {"real-flag", "removed-flag"},
+	})
+
+	if got := cmd.Flags().Lookup("real-flag").Annotations[flagGroupAnnotation]; len(got) == 0 || got[0] != grpInfrastructure {
+		t.Errorf("real-flag group = %v, want %s", got, grpInfrastructure)
+	}
+	if f := cmd.Flags().Lookup("removed-flag"); f != nil {
+		t.Errorf("removed-flag should not have been created; got %#v", f)
+	}
+}
+
+func TestGroupedUsageFuncRendersGroupHeaders(t *testing.T) {
+	cmd := &cobra.Command{Use: "fake", Short: "test"}
+	var placeholder string
+	cmd.Flags().StringVar(&placeholder, "kube-context", "", "help1")
+	cmd.Flags().StringVar(&placeholder, "log-level", "", "help2")
+	cmd.Flags().StringVar(&placeholder, "unrelated", "", "help3")
+
+	annotateFlagGroups(cmd, map[string][]string{
+		grpInfrastructure: {"kube-context"},
+		grpLogging:        {"log-level"},
+	})
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	if err := cmd.Usage(); err != nil {
+		t.Fatalf("Usage() error: %v", err)
+	}
+	got := buf.String()
+
+	for _, want := range []string{
+		"Infrastructure Flags:",
+		"--kube-context",
+		"Logging Flags:",
+		"--log-level",
+		"Other Flags:",
+		"--unrelated",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("usage output missing %q\n---\n%s", want, got)
+		}
+	}
+}
+
+func TestGroupedUsageFuncSkipsEmptyGroups(t *testing.T) {
+	cmd := &cobra.Command{Use: "fake", Short: "test"}
+	var placeholder string
+	cmd.Flags().StringVar(&placeholder, "only-flag", "", "")
+
+	annotateFlagGroups(cmd, map[string][]string{
+		grpAuth: {"only-flag"},
+	})
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	_ = cmd.Usage()
+
+	if got := buf.String(); strings.Contains(got, "Registry Flags:") {
+		t.Errorf("empty group header should be suppressed; output:\n%s", got)
+	}
+}
+
+func TestGroupedUsageFuncHidesHiddenFlags(t *testing.T) {
+	cmd := &cobra.Command{Use: "fake", Short: "test"}
+	var placeholder string
+	cmd.Flags().StringVar(&placeholder, "public", "", "")
+	cmd.Flags().StringVar(&placeholder, "hidden-legacy", "", "DEPRECATED")
+	_ = cmd.Flags().MarkHidden("hidden-legacy")
+
+	annotateFlagGroups(cmd, map[string][]string{
+		grpInfrastructure: {"public", "hidden-legacy"},
+	})
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	_ = cmd.Usage()
+
+	if strings.Contains(buf.String(), "hidden-legacy") {
+		t.Errorf("hidden flag rendered in usage output:\n%s", buf.String())
+	}
+}
+
+func TestRootAndMatrixRunFlagGroupsCoverKnownFlags(t *testing.T) {
+	// Guard against typos in the group tables: every flag listed must resolve
+	// to a real flag on the command it targets.
+	rootCmd := NewRootCommand()
+	for _, names := range rootFlagGroups() {
+		for _, n := range names {
+			if rootCmd.Flags().Lookup(n) == nil {
+				t.Errorf("rootFlagGroups references unknown flag %q", n)
+			}
+		}
+	}
+
+	matrixRun := findSub(newMatrixCommand(), "run")
+	if matrixRun == nil {
+		t.Fatal("matrix run subcommand not found")
+	}
+	for _, names := range matrixRunFlagGroups() {
+		for _, n := range names {
+			if matrixRun.Flags().Lookup(n) == nil {
+				t.Errorf("matrixRunFlagGroups references unknown flag %q", n)
+			}
+		}
+	}
+}
+
+func findSub(cmd *cobra.Command, name string) *cobra.Command {
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == name {
+			return sub
+		}
+	}
+	return nil
+}

--- a/scripts/deploy-camunda/cmd/matrix.go
+++ b/scripts/deploy-camunda/cmd/matrix.go
@@ -227,7 +227,7 @@ Prefer a config file over a long flag list — copy the getting-started
 starter and iterate from there:
 
   deploy-camunda config init --from-example getting-started
-  # edit .camunda-deploy.yaml to set kubeContext / ingressBaseDomain
+  # edit .deploy-camunda.yaml to set kubeContext / ingressBaseDomain
   deploy-camunda matrix run --versions 8.10 --shortname-filter keyco
 
 Use --cleanup to delete each entry's namespace after its deployment and

--- a/scripts/deploy-camunda/cmd/matrix.go
+++ b/scripts/deploy-camunda/cmd/matrix.go
@@ -196,12 +196,58 @@ func newMatrixRunCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "run",
 		Short: "Run the CI test matrix against a live cluster",
-		Long: `Run the full CI test matrix, deploying each scenario + flow combination sequentially.
-Each entry gets its own namespace (<prefix>-<version>-<shortname>).
+		Long: `Deploy the CI test matrix — the cartesian product of chart versions,
+scenarios, and flows declared in charts/<v>/test/ci-test-config.yaml — to a
+live cluster. Each entry gets its own namespace (<prefix>-<version>-<shortname>)
+so entries stay isolated and can run in parallel with --max-parallel.
 
-Use --cleanup to automatically delete each entry's namespace after its deployment and tests complete.
+FILTER FIRST. Without --shortname-filter or --versions the runner attempts
+every enabled scenario across every active chart version, which is not what
+you want interactively. Common first-run pattern:
 
-This command calls deploy.Execute() for each matrix entry.`,
+  # Deploy a single 8.10 scenario, scoping by shortname:
+  deploy-camunda matrix run \
+    --repo-root . \
+    --versions 8.10 \
+    --shortname-filter keyco \
+    --ingress-base-domain ci.distro.ultrawombat.com \
+    --platform gke
+
+Docker Hub is required whenever a scenario pulls from docker.io — supply
+credentials via env or flags, and set --ensure-docker-hub so the pull
+secret is created before the deploy:
+
+  DOCKERHUB_USERNAME=... DOCKERHUB_PASSWORD=... \
+  deploy-camunda matrix run \
+    --repo-root . --versions 8.10 --shortname-filter keyco \
+    --ingress-base-domain ci.distro.ultrawombat.com \
+    --ensure-docker-hub
+
+Prefer a config file over a long flag list — copy the getting-started
+starter and iterate from there:
+
+  deploy-camunda config init --from-example getting-started
+  # edit .camunda-deploy.yaml to set kubeContext / ingressBaseDomain
+  deploy-camunda matrix run --versions 8.10 --shortname-filter keyco
+
+Use --cleanup to delete each entry's namespace after its deployment and
+tests complete, or --delete-namespace to start clean before each entry.
+
+Under the hood this invokes deploy.Execute() for each matrix entry.`,
+		Example: `  # Minimal single-scenario run:
+  deploy-camunda matrix run \
+    --repo-root . --versions 8.10 --shortname-filter keyco \
+    --ingress-base-domain ci.distro.ultrawombat.com --platform gke
+
+  # With Docker Hub credentials for docker.io images:
+  DOCKERHUB_USERNAME=... DOCKERHUB_PASSWORD=... \
+  deploy-camunda matrix run \
+    --repo-root . --versions 8.10 --shortname-filter keyco \
+    --ingress-base-domain ci.distro.ultrawombat.com --ensure-docker-hub
+
+  # Config-file driven (recommended for repeat use):
+  deploy-camunda config init --from-example getting-started
+  deploy-camunda matrix run --versions 8.10 --shortname-filter keyco`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return validateChartRefFlags(chartRef, chartRefVersion)
 		},
@@ -580,7 +626,7 @@ This command calls deploy.Execute() for each matrix entry.`,
 	f.StringVar(&kubeContext, "kube-context", "", "Default Kubernetes context for all platforms (overridden by --kube-context-gke/--kube-context-eks)")
 	f.StringVar(&kubeContextGKE, "kube-context-gke", "", "Kubernetes context for GKE entries")
 	f.StringVar(&kubeContextEKS, "kube-context-eks", "", "Kubernetes context for EKS entries")
-	f.StringVar(&ingressBaseDomain, "ingress-base-domain", "", "Fallback base domain for ingress hosts (overridden by --ingress-base-domain-gke/--ingress-base-domain-eks)")
+	f.StringVar(&ingressBaseDomain, "ingress-base-domain", "", "Fallback base DNS zone used to compute each entry's public URL — joined into CAMUNDA_HOSTNAME as <namespace>.<base>. Set to the DNS zone the target cluster's ingress controller serves, e.g. `ci.distro.ultrawombat.com` (Camunda CI) or `apps.mycompany.example`. Overridden per-platform by --ingress-base-domain-gke/--ingress-base-domain-eks.")
 	f.StringVar(&ingressBaseDomainGKE, "ingress-base-domain-gke", "", "Ingress base domain for GKE entries (e.g., ci.distro.ultrawombat.com)")
 	f.StringVar(&ingressBaseDomainEKS, "ingress-base-domain-eks", "", "Ingress base domain for EKS entries (e.g., distribution.aws.camunda.cloud)")
 	f.IntVar(&maxParallel, "max-parallel", 1, "Maximum number of entries to run concurrently (1 = sequential)")
@@ -629,6 +675,8 @@ This command calls deploy.Execute() for each matrix entry.`,
 	_ = cmd.RegisterFlagCompletionFunc("log-level", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completeLogLevels(toComplete)
 	})
+
+	annotateFlagGroups(cmd, matrixRunFlagGroups())
 
 	return cmd
 }

--- a/scripts/deploy-camunda/cmd/root.go
+++ b/scripts/deploy-camunda/cmd/root.go
@@ -252,7 +252,7 @@ func NewRootCommand() *cobra.Command {
 	f.StringSliceVar(&flags.Deployment.ExtraValues, "extra-values", nil, "Additional Helm values files to apply last (comma-separated or repeatable)")
 	f.StringSliceVar(&flags.Chart.ChartRootOverlays, "values-preset", nil, "Chart-root overlay files to apply (comma-separated or repeatable): enterprise, digest, latest, local, bitnami-legacy (resolves to values-{name}.yaml)")
 	f.StringVar(&flags.Ingress.IngressSubdomain, "ingress-subdomain", "", "Ingress subdomain (requires --ingress-base-domain)")
-	f.StringVar(&flags.Ingress.IngressBaseDomain, "ingress-base-domain", "", "Base domain for ingress (ci.distro.ultrawombat.com or distribution.aws.camunda.cloud)")
+	f.StringVar(&flags.Ingress.IngressBaseDomain, "ingress-base-domain", "", "Base DNS zone used to compute the deploy's public URL — deploy-camunda joins <ingress-subdomain>.<base> (or the namespace if no subdomain is set) into CAMUNDA_HOSTNAME, which feeds Keycloak issuers, callback URLs, and every scenario values file. Set to the DNS zone your cluster's ingress controller serves, e.g. `ci.distro.ultrawombat.com` (Camunda CI) or `apps.mycompany.example`. Required for anything that reaches the cluster over HTTPS.")
 	f.StringVar(&flags.Ingress.IngressHostname, "ingress-hostname", "", "Full ingress hostname (overrides --ingress-subdomain)")
 	f.IntVar(&flags.Deployment.Timeout, "timeout", 5, "Timeout in minutes for Helm deployment")
 	f.StringSliceVar(&debugFlagsRaw, "debug", nil, "Enable JVM remote debugging for component (repeatable, e.g., --debug orchestration:5005 --debug connectors:5006)")
@@ -298,6 +298,8 @@ func NewRootCommand() *cobra.Command {
 	registerIngressBaseDomainCompletion(rootCmd)
 	registerSelectionCompletion(rootCmd)
 	registerLayeredValuesCompletion(rootCmd)
+
+	annotateFlagGroups(rootCmd, rootFlagGroups())
 
 	return rootCmd
 }

--- a/scripts/deploy-camunda/examples/embed.go
+++ b/scripts/deploy-camunda/examples/embed.go
@@ -1,0 +1,43 @@
+// Package examples exposes the deploy-camunda starter configs shipped under
+// scripts/deploy-camunda/examples/ as embedded bytes so `deploy-camunda config
+// init --from-example <name>` works without a checked-out repo.
+package examples
+
+import (
+	"embed"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const suffix = ".camunda-deploy.yaml"
+
+//go:embed *.camunda-deploy.yaml
+var files embed.FS
+
+// Load returns the raw bytes of the named example. The name is the base file
+// name with the `.camunda-deploy.yaml` suffix stripped, e.g. "getting-started".
+func Load(name string) ([]byte, error) {
+	b, err := files.ReadFile(name + suffix)
+	if err != nil {
+		return nil, fmt.Errorf("example %q not found; run `deploy-camunda config init --list-examples` to see available templates", name)
+	}
+	return b, nil
+}
+
+// Names returns the available example names (suffix stripped, sorted).
+func Names() []string {
+	entries, err := files.ReadDir(".")
+	if err != nil {
+		return nil
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), suffix) {
+			continue
+		}
+		names = append(names, strings.TrimSuffix(e.Name(), suffix))
+	}
+	sort.Strings(names)
+	return names
+}

--- a/scripts/deploy-camunda/examples/embed.go
+++ b/scripts/deploy-camunda/examples/embed.go
@@ -10,13 +10,13 @@ import (
 	"strings"
 )
 
-const suffix = ".camunda-deploy.yaml"
+const suffix = ".deploy-camunda.yaml"
 
-//go:embed *.camunda-deploy.yaml
+//go:embed *.deploy-camunda.yaml
 var files embed.FS
 
 // Load returns the raw bytes of the named example. The name is the base file
-// name with the `.camunda-deploy.yaml` suffix stripped, e.g. "getting-started".
+// name with the `.deploy-camunda.yaml` suffix stripped, e.g. "getting-started".
 func Load(name string) ([]byte, error) {
 	b, err := files.ReadFile(name + suffix)
 	if err != nil {


### PR DESCRIPTION
> **Stack:** #6564 → #6566 (this) → #6569. Depends on #6564 (config-surface signposting); #6569 (README onboarding guide) depends on this.

---

### Which problem does the PR fix?

External users onboarding onto `deploy-camunda` face two friction points not addressed by #6564:

- `deploy-camunda --help` and `deploy-camunda matrix run --help` dump 50+ ungrouped flags, so first-time users can't find things like `--ingress-base-domain` without tab completion.
- After copying the getting-started starter added in #6564, users still have to know where the file lives (`scripts/deploy-camunda/examples/`) — there's no CLI-native way to drop it into place.

### What's in this PR?

Stacked on #6564. Rebases onto `main` when that PR merges.

1. **Flag grouping via a custom Cobra usage function.** New `scripts/deploy-camunda/cmd/flag_groups.go` bucketing flags into `Infrastructure`, `Authentication`, `Scenario`, `Registry`, `Deployment behaviour`, `Logging`, `Other`. Applied on `deploy-camunda` root and `deploy-camunda matrix run`. Unlisted flags fall into `Other` so nothing disappears from help. Empty groups are suppressed. Hidden (deprecated) flags stay hidden.
2. **Expanded `--ingress-base-domain` help** on root and matrix run — explains what the value feeds (`CAMUNDA_HOSTNAME`, Keycloak issuers, scenario values files) and gives a real example.
3. **`matrix run` Long + Example** — three usage examples (minimal single-scenario, DockerHub-creds variant, config-file-driven variant referencing `--from-example getting-started`).
4. **`deploy-camunda config init --from-example <name>`** (plus `--list-examples` and `--force`) — non-interactive alternative to the wizard for users who want a file they can commit. Backed by a new `scripts/deploy-camunda/examples` Go package that embeds YAML templates via `//go:embed`.

**Behaviour preserved:** All previously interactive `config init` flows behave identically; the new flag is an early-return branch. All existing flags stay parseable at the same names; grouping only changes help rendering.

### Verification

- `go test scripts/deploy-camunda/...` — all packages pass; 6 new tests for the flag grouping helper (assignment, fallback to `Other`, unknown flag names tolerated, header rendering, empty-group suppression, hidden-flag suppression, plus a guard test that every name in the group tables resolves to a real flag on the command).
- `make go.test chartPath=charts/camunda-platform-8.10` — unit + matrix package clean.
- `make go.fmt` — clean.
- Manually inspected `deploy-camunda --help` and `deploy-camunda matrix run --help` output; sections render in the declared order with correct flags in each.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run \`make go.update-golden-only\`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
