### PR TITLE
ci: dispatch values-migrator release-train on chart release when values change

### DIFF
--- a/.github/workflows/notify-values-migrator.yaml
+++ b/.github/workflows/notify-values-migrator.yaml
@@ -46,13 +46,16 @@ jobs:
 
       - name: Gate on values change
         id: diff
+        env:
+          PREV: ${{ steps.rel.outputs.prev }}
+          SHA: ${{ steps.rel.outputs.sha }}
         run: |
           set -euo pipefail
-          if [ -z "${{ steps.rel.outputs.prev }}" ]; then
+          if [ -z "$PREV" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if git diff --quiet "${{ steps.rel.outputs.prev }}" "${{ steps.rel.outputs.sha }}" \
+          if git diff --quiet "$PREV" "$SHA" \
                -- 'charts/camunda-platform-*/values.yaml' 'charts/camunda-platform-*/values.schema.json'; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/notify-values-migrator.yaml
+++ b/.github/workflows/notify-values-migrator.yaml
@@ -1,0 +1,94 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow
+---
+name: "Chart - Notify Values Migrator"
+
+# Fires the camunda/helm-values-migrator rolling release-train (release-train.yml,
+# repository_dispatch) whenever a chart release is published here AND its
+# values.yaml / values.schema.json changed since the previous release on the
+# same chart line. Pins the migrator's regen to this exact release commit
+# instead of upstream main. Does not touch the migrator's semver channel.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+env:
+  VAULT_DISTRO_CI_PATH: secret/data/products/distribution/ci
+
+jobs:
+  dispatch:
+    # Only stable chart releases (skip non-chart tags/releases and prereleases).
+    if: startsWith(github.event.release.tag_name, 'camunda-platform-') && github.event.release.prerelease == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release commit + previous tag on this chart line
+        id: rel
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          SHA="$(git rev-list -n1 "$TAG")"
+          # Tag shape: camunda-platform-{appVersion}-{chartVersion}, e.g.
+          # camunda-platform-8.8-13.4.0 -> prefix camunda-platform-8.8
+          PREFIX="$(echo "$TAG" | sed -E 's/^(camunda-platform-[0-9]+\.[0-9]+)-.*/\1/')"
+          PREV="$(git tag -l "${PREFIX}-*" --sort=-v:refname | grep -v "^${TAG}$" | head -1 || true)"
+          echo "sha=$SHA"     >> "$GITHUB_OUTPUT"
+          echo "prefix=$PREFIX" >> "$GITHUB_OUTPUT"
+          echo "prev=$PREV"   >> "$GITHUB_OUTPUT"
+
+      - name: Gate on values change
+        id: diff
+        run: |
+          set -euo pipefail
+          if [ -z "${{ steps.rel.outputs.prev }}" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git diff --quiet "${{ steps.rel.outputs.prev }}" "${{ steps.rel.outputs.sha }}" \
+               -- 'charts/camunda-platform-*/values.yaml' 'charts/camunda-platform-*/values.schema.json'; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true"  >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Import distro-ci App creds from Vault
+        if: steps.diff.outputs.changed == 'true'
+        id: vault
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            ${{ env.VAULT_DISTRO_CI_PATH }} GH_APP_ID_DISTRO_CI;
+            ${{ env.VAULT_DISTRO_CI_PATH }} GH_APP_PRIVATE_KEY_DISTRO_CI;
+
+      - name: Generate cross-repo token
+        if: steps.diff.outputs.changed == 'true'
+        id: token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
+        with:
+          app_id: ${{ steps.vault.outputs.GH_APP_ID_DISTRO_CI }}
+          private_key: ${{ steps.vault.outputs.GH_APP_PRIVATE_KEY_DISTRO_CI }}
+
+      - name: Dispatch release-train with the release commit
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          SHA: ${{ steps.rel.outputs.sha }}
+          CHART_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          gh api repos/camunda/helm-values-migrator/dispatches \
+            -f event_type=release-train \
+            -f "client_payload[sha]=${SHA}" \
+            -f "client_payload[chart_tag]=${CHART_TAG}"

--- a/.github/workflows/notify-values-migrator.yaml
+++ b/.github/workflows/notify-values-migrator.yaml
@@ -12,6 +12,10 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
@@ -23,6 +27,9 @@ jobs:
     # Only stable chart releases (skip non-chart tags/releases and prereleases).
     if: startsWith(github.event.release.tag_name, 'camunda-platform-') && github.event.release.prerelease == false
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/notify-values-migrator.yaml
+++ b/.github/workflows/notify-values-migrator.yaml
@@ -39,7 +39,13 @@ jobs:
           # Tag shape: camunda-platform-{appVersion}-{chartVersion}, e.g.
           # camunda-platform-8.8-13.4.0 -> prefix camunda-platform-8.8
           PREFIX="$(echo "$TAG" | sed -E 's/^(camunda-platform-[0-9]+\.[0-9]+)-.*/\1/')"
-          PREV="$(git tag -l "${PREFIX}-*" --sort=-v:refname | grep -v "^${TAG}$" | head -1 || true)"
+          # Restrict to strictly-stable X.Y.Z tags: git's default version-sort
+          # ranks a "-alpha3"-style suffix above the plain release (opposite
+          # of semver precedence), so an unfiltered list can pick a prerelease
+          # as "previous" and corrupt the diff baseline.
+          PREV="$(git tag -l "${PREFIX}-*" --sort=-v:refname \
+            | grep -E "^${PREFIX}-[0-9]+\.[0-9]+\.[0-9]+$" \
+            | grep -vF "$TAG" | head -1 || true)"
           echo "sha=$SHA"     >> "$GITHUB_OUTPUT"
           echo "prefix=$PREFIX" >> "$GITHUB_OUTPUT"
           echo "prev=$PREV"   >> "$GITHUB_OUTPUT"
@@ -55,6 +61,10 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          # Glob intentionally spans every chart line, not just the released
+          # one: broader than strictly necessary, but the safe direction (an
+          # extra idempotent regen on an unrelated line's change, never a
+          # missed one on this line).
           if git diff --quiet "$PREV" "$SHA" \
                -- 'charts/camunda-platform-*/values.yaml' 'charts/camunda-platform-*/values.schema.json'; then
             echo "changed=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### Which problem does the PR fix?

None — no existing issue. This wires camunda/helm-values-migrator's rolling
release-train to fire automatically off chart releases here, instead of only
regenerating against a moving upstream `main`.

### What's in this PR?

New workflow `.github/workflows/notify-values-migrator.yaml`, triggered on
`release: published`:

- Gates on the tag starting with `camunda-platform-` (skips non-chart
  releases) and `prerelease == false` (skips alpha/rc chart releases).
- Resolves the release commit and the previous release tag on the same chart
  line (`camunda-platform-{major}.{minor}-*`), then diffs
  `values.yaml`/`values.schema.json` across the two — no diff, no dispatch.
- On a diff, mints a token via the distro-ci GitHub App (Vault approle, same
  pattern as `chart-release-public.yaml`) and sends a `repository_dispatch`
  (`event_type: release-train`) to `camunda/helm-values-migrator` with
  `client_payload.sha` = this release's commit and `client_payload.chart_tag`
  for traceability.
- Companion change on the migrator side (already merged/pending in
  camunda/helm-values-migrator) makes `release-train.yml` honor
  `client_payload.sha`, falling back to `main` for manual runs.

Untrusted `github.event.release.tag_name` is passed through `env:` (not
interpolated into the `run:` shell string) in both steps that use it, to avoid
a script-injection sink.

**Depends on:** the chart GitHub Release must be created by the distro-ci App
token (as `chart-release-public.yaml` already does via `helm-cr upload`), not
the default `GITHUB_TOKEN` — `GITHUB_TOKEN`-authored releases do not trigger
downstream `on: release` workflows. If that ever changes, this workflow will
silently stop firing.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
