### PR TITLE
chore: document local tier-2 scenario verification loop

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -191,6 +191,10 @@ For detailed documentation on how scenario resolution works, see `docs/integrati
 
 Each chart version has a `test/ci-test-config.yaml` defining scenarios (e.g., `elasticsearch`, `opensearch`). Each scenario specifies identity, persistence, platforms, and allowed flows. The matrix is filtered by `.github/config/permitted-flows.yaml` which denies specific flows per version (e.g., 8.9 denies `upgrade-patch` but allows `upgrade-minor`).
 
+**Tier split:** `pull_request` runs **tier-1 only** — `test-chart-version.yaml` passes `tier: 1` on PR events. The **full matrix** (tier-2 plus untiered scenarios) runs on `merge_group` (merge queue). A PR that adds or changes a tier-2 scenario gets no CI signal until merge is clicked; validate tier-2 changes locally before merge. See [SKILLS.md → Verifying tier-2 scenarios before merge](../SKILLS.md#verifying-tier-2-scenarios-before-merge).
+
+Scenarios and tiers for 8.7–8.10 live in the composable registry `test/ci/registry/manifest.yaml`; only 8.6 uses `test/ci-test-config.yaml`. Use `deploy-camunda matrix list --tier 2 --versions <v>` to re-derive the current set regardless of source.
+
 Upgrade flows are two-step: install the previous version's chart from the Helm repo, then `helm upgrade` to the local chart. The `base-upgrade.yaml` layer is included only in Step 2.
 
 ## Operational Skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,7 +280,7 @@ Before deploying, confirm these requirements — they are the most common source
    (e.g., `gke_camunda-distribution_europe-west1-b_distro-ci`).
 3. **Helm dependencies are up to date** — `make helm.dependency-update chartPath=charts/camunda-platform-<version>`.
 4. **Ingress hostname** — for non-matrix deploys, set `CAMUNDA_HOSTNAME` or use `--ingress-hostname`.
-   The matrix runner computes this automatically from the namespace prefix and base domain.
+   Matrix runs require `--ingress-base-domain-gke ci.distro.ultrawombat.com` (host computed per-namespace from that base domain; without it, values substitution fails on `CAMUNDA_HOSTNAME`).
 
 ### Use `deploy-camunda watch` for live diagnosis
 
@@ -291,11 +291,14 @@ on a short cadence and surfaces diagnoses in real time — far better than manua
 ```bash
 # Terminal 1: deploy
 deploy-camunda matrix run --repo-root . --versions 8.10 --shortname-filter keyco \
-  --platform gke --delete-namespace --timeout 10 --yes
+  --platform gke --ingress-base-domain-gke ci.distro.ultrawombat.com \
+  --delete-namespace --timeout 10 --yes
 
 # Terminal 2: watch (start immediately after deploy begins)
 deploy-camunda watch --namespace matrix-810-keyco-inst-gke --release integration --interval 30
 ```
+
+To validate tier-2 scenarios a PR adds or changes before merge, see [SKILLS.md → Verifying tier-2 scenarios before merge](SKILLS.md#verifying-tier-2-scenarios-before-merge).
 
 The watcher exits automatically when all pods reach Running/Ready. If a pod enters
 CrashLoopBackOff or ImagePullBackOff, the watcher diagnoses the root cause and prints it

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -726,11 +726,10 @@ PR CI runs **tier-1 only** (~5 deploys, the `eske` baseline). The full matrix (~
 
 ### Tier Reference
 
-Authoritative source: `charts/camunda-platform-<v>/test/ci-test-config.yaml` (`tier:`, `enabled:`). The table below is a snapshot — re-derive with:
+Authoritative source depends on chart version: 8.7–8.10 define `tier:` and `enabled:` in the composable registry `charts/camunda-platform-<v>/test/ci/registry/manifest.yaml`; only 8.6 uses the legacy `charts/camunda-platform-8.6/test/ci-test-config.yaml`. The table below is a snapshot — re-derive with the source-agnostic CLI:
 
 ```bash
-awk '/shortname:/{s=$2} /enabled:/{e=$2} /tier:/{t=$2; print s, e, "tier", t}' \
-  charts/camunda-platform-<v>/test/ci-test-config.yaml | grep "true tier 2"
+deploy-camunda matrix list --tier 2 --versions <v>
 ```
 
 **Tier 1:** `eske` on every version. 8.9 covers both `install` and `upgrade-minor`.
@@ -793,16 +792,55 @@ asdf reshim golang   # if using asdf
 # PR-CI baseline
 deploy-camunda matrix list --tier 1 --versions 8.10
 
-# Full merge-queue set
+# Tier-2 merge-queue set
+deploy-camunda matrix list --tier 2 --versions 8.10
+
+# Full merge-queue set (tier-2 plus untiered)
 deploy-camunda matrix list --versions 8.10
 
 # Run one scenario
 deploy-camunda matrix run \
-  --versions 8.10 --shortname-filter eske \
-  --flow-filter install --platform gke
+  --versions 8.10 --shortname-filter eske --shortname-exact \
+  --flow-filter install --platform gke \
+  --ingress-base-domain-gke ci.distro.ultrawombat.com
 
 # CI-parity overrides: --extra-helm-arg, --extra-helm-set, --namespace-override
 ```
+
+GKE matrix runs require `--ingress-base-domain-gke` — the host is computed per-namespace from that base domain; without it, `${CAMUNDA_HOSTNAME}` substitution in `base.yaml` fails with `missing required environment variables: CAMUNDA_HOSTNAME`.
+
+### Verifying tier-2 scenarios before merge
+
+**When:** your PR adds or changes a tier-2 scenario (or a diff exercises one). PR CI runs tier-1 only; the merge queue runs tier-2. Validate locally before merge to avoid a slow, expensive red merge queue.
+
+**The loop:**
+
+1. `deploy-camunda matrix list --tier 2 --versions <v>` — confirm your scenarios, tier, and `enabled` status.
+2. `deploy-camunda matrix run … --dry-run` — offline gate: layers resolve, exactly the expected entries, no template errors.
+3. Real run (comma-separated `--shortname-filter` runs several in one invocation; per-entry PASS/FAIL summary at the end):
+
+```bash
+deploy-camunda matrix run \
+  --versions 8.10 --shortname-filter <sn1>,<sn2> --shortname-exact \
+  --flow-filter upgrade-minor --platform gke \
+  --ingress-base-domain-gke ci.distro.ultrawombat.com \
+  --delete-namespace --timeout 25 --yes
+```
+
+4. Fix failures, then re-run just the failing shortname. Upgrade flows re-install the prior minor each run (~10–15 min/scenario).
+
+**Credentials:** export (or place in `.env`) before running:
+
+- `TEST_DOCKER_USERNAME_CAMUNDA_CLOUD` / `TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD` — Harbor pull secret.
+- For `postgresql-companion` scenarios: `RDBMS_POSTGRESQL_USERNAME` / `RDBMS_POSTGRESQL_PASSWORD`.
+
+Obtain values from your team's secret store. `deploy-camunda doctor` and `matrix run --dry-run` validate presence per entry.
+
+**Local-run gotchas:**
+
+- **`--ingress-base-domain-gke` required** on GKE — else `CAMUNDA_HOSTNAME` substitution fails.
+- **`post-infra` migration hooks and asdf:** hooks like `post-infra-bitnami-migration` clone `camunda-deployment-references` and run under *its* `.tool-versions`; an uninstalled pinned tool (e.g. `jq 1.7.1`) makes the asdf shim exit 126. Fix: `asdf install <tool> <version>` for the versions that clone pins. This is a local-env issue, not a chart bug.
+- A tier-2 failure that is clearly local-environment (exit 126, missing creds) is **not** a merge-queue signal — fix the environment and re-run.
 
 #### Flow Semantics
 
@@ -839,7 +877,7 @@ crev <pr-url> --single --dry-run
 - Treating PR CI green as sufficient when the diff exercises a non-baseline variant; the merge queue will reject the PR.
 - Hand-editing golden files instead of running `make go.update-golden-only`.
 - Adding speculative tier-2 entries not exercised by the diff (consumes local capacity without coverage gain).
-- Reading the tier list above without re-checking `ci-test-config.yaml`; the YAML is authoritative.
+- Reading the tier list above without re-checking via `deploy-camunda matrix list --tier 2` (or the version-appropriate YAML/registry source).
 - Using the merge queue as a discovery mechanism for predictable variant breakage.
 - Running the matrix on PRs that change no rendering output (workflow, Dockerfile, compose, docs, Go-tooling).
 


### PR DESCRIPTION
### Which problem does the PR fix?

CI runs tier-1 integration scenarios on `pull_request` and tier-2 only in the merge queue (`merge_group`). A PR that adds or changes a tier-2 scenario therefore gets no CI signal until merge is clicked — and a red merge queue is a slow, expensive feedback loop. The repo's own agent-facing docs also didn't explain this split and, worse, the documented local `deploy-camunda matrix run` invocation was incomplete (missing `--ingress-base-domain-gke`), so following it verbatim fails with `missing required environment variables: CAMUNDA_HOSTNAME`.

### What's in this PR?

Documentation only — teaches the local tier-2 verification loop so an agent or human can run and verify the exact tier-2 scenarios a PR touches, locally against GKE, before merge.

- **SKILLS.md**
  - Correct the tier source-of-truth: 8.10 defines `tier:`/`enabled:` in the composable registry `test/ci/registry/manifest.yaml` (older versions: `test/ci-test-config.yaml`); recommend `deploy-camunda matrix list --tier 2 --versions <v>` as the source-agnostic authoritative re-derivation.
  - Fix the `matrix run` example: add `--ingress-base-domain-gke ci.distro.ultrawombat.com` and `--shortname-exact`.
  - New **"Verifying tier-2 scenarios before merge"** subsection: when, the loop (list → dry-run → real run), required credentials (generic env-var names), and local-run gotchas (ingress base domain; asdf/`.tool-versions` exit-126 in `post-infra` migration hooks that clone `camunda-deployment-references`).
- **.github/AGENTS.md** — explain the tier-1 (`pull_request`) vs tier-2 (`merge_group`) split and the registry source; cross-link SKILLS.md.
- **AGENTS.md** — document `--ingress-base-domain-gke` in the GKE pre-flight + example; pointer to the SKILLS.md loop.

No chart, scenario, registry, or CI-workflow changes. Guidance verified against a live local run of the 8.10 tier-2 `hub-console-only` and `hub-double-enable` scenarios.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?