### PR TITLE
fix: respect explicit empty global.identity.keycloak.contextPath

### DIFF
--- a/charts/camunda-platform-8.7/templates/identity/_helpers.tpl
+++ b/charts/camunda-platform-8.7/templates/identity/_helpers.tpl
@@ -179,7 +179,7 @@ This is mainly used to access the external Keycloak service in the global Ingres
 [identity] Get Keycloak contextPath based on global value.
 */}}
 {{- define "identity.keycloak.contextPath" -}}
-    {{ .Values.global.identity.keycloak.contextPath | default "/auth/" }}
+    {{- .Values.global.identity.keycloak.contextPath -}}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform-8.8/templates/identity/_helpers.tpl
+++ b/charts/camunda-platform-8.8/templates/identity/_helpers.tpl
@@ -167,7 +167,7 @@ This is mainly used to access the external Keycloak service in the global Ingres
 [identity] Get Keycloak contextPath based on global value.
 */}}
 {{- define "identity.keycloak.contextPath" -}}
-    {{ .Values.global.identity.keycloak.contextPath | default "/auth/" }}
+    {{- .Values.global.identity.keycloak.contextPath -}}
 {{- end -}}
 
 

--- a/charts/camunda-platform-8.9/templates/identity/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/identity/_helpers.tpl
@@ -114,7 +114,7 @@ This is mainly used to access the external Keycloak service in the global Ingres
 [identity] Get Keycloak contextPath based on global value.
 */}}
 {{- define "identity.keycloak.contextPath" -}}
-    {{ .Values.global.identity.keycloak.contextPath | default "/auth/" }}
+    {{- .Values.global.identity.keycloak.contextPath -}}
 {{- end -}}
 
 


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #4567.

Setting `global.identity.keycloak.contextPath` to an empty string had no effect on 8.7/8.8/8.9: the `identity.keycloak.contextPath` helper wrapped the value in `| default "/auth/"`, so Sprig's `default` treated the explicit empty string as unset and substituted `/auth/`. Identity then built `KEYCLOAK_URL` (8.7) and the Keycloak setup `url` (8.8/8.9) with a stale `/auth/` path and could not reach a root-context Keycloak. SUPPORT-27288.

Already fixed on 8.10 via the contextPath helper cleanup in #6146 (#5174); this backports the same change to the remaining supported versions.

### What's in this PR?

Drops `| default "/auth/"` from the `identity.keycloak.contextPath` helper in 8.7, 8.8, and 8.9, matching the form already shipped in 8.10. Each chart's `values.yaml` still defaults `global.identity.keycloak.contextPath` to `/auth`, so a default install renders `/auth` unchanged; an explicit empty string is now honored (root-context Keycloak).

Verified by rendering all three versions: an empty `contextPath` yields a Keycloak URL with no `/auth` suffix, default install unchanged. No golden changes; existing identity unit tests pass.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
