### PR TITLE
fix: omit web-modeler restapi datasource password when none is configured

### DIFF
--- a/charts/camunda-platform-8.7/templates/web-modeler/_helpers.tpl
+++ b/charts/camunda-platform-8.7/templates/web-modeler/_helpers.tpl
@@ -211,16 +211,27 @@ Define match labels for Web Modeler websockets to be used in matchLabels selecto
 {{- end -}}
 
 {{/*
+[web-modeler] Whether a rest-api external-database password source is configured: plaintext password, legacy non-empty string existingSecret, or object existingSecret.
+*/}}
+{{- define "webModeler.restapi.externalDatabasePasswordDefined" -}}
+  {{- $existingSecret := .Values.webModeler.restapi.externalDatabase.existingSecret -}}
+  {{- if or .Values.webModeler.restapi.externalDatabase.password (and (typeIs "string" $existingSecret) (ne $existingSecret "")) (typeIs "map[string]interface {}" $existingSecret) -}}
+    {{- true -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 [web-modeler] Get the name of the secret that contains the database password, depending on whether the postgresql dependency chart is enabled.
 */}}
 {{- define "webModeler.restapi.databaseSecretName" -}}
   {{- if .Values.postgresql.enabled }}
     {{- .Values.postgresql.auth.existingSecret | default (include "webModeler.postgresql.fullname" .) }}
   {{- else }}
-    {{- if or (typeIs "string" .Values.webModeler.restapi.externalDatabase.existingSecret) .Values.webModeler.restapi.externalDatabase.password }}
+    {{- $existingSecret := .Values.webModeler.restapi.externalDatabase.existingSecret }}
+    {{- if or .Values.webModeler.restapi.externalDatabase.password (and (typeIs "string" $existingSecret) (ne $existingSecret "")) }}
       {{- include "webModeler.restapi.fullname" . }}
-    {{- else if typeIs "map[string]interface {}" .Values.webModeler.restapi.externalDatabase.existingSecret }}
-      {{- .Values.webModeler.restapi.externalDatabase.existingSecret.name | default (include "webModeler.restapi.fullname" .) }}
+    {{- else if typeIs "map[string]interface {}" $existingSecret }}
+      {{- $existingSecret.name | default (include "webModeler.restapi.fullname" .) }}
     {{- end }}
   {{- end }}
 {{- end -}}

--- a/charts/camunda-platform-8.7/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform-8.7/templates/web-modeler/deployment-restapi.yaml
@@ -41,11 +41,13 @@ spec:
                   key: {{ include "camundaPlatform.licenseSecretKey" . }}
             - name: JAVA_OPTIONS
               value: {{ .Values.webModeler.restapi.javaOpts | default "-XX:MaxRAMPercentage=80.0" | quote }}
+            {{- if or .Values.postgresql.enabled (include "webModeler.restapi.externalDatabasePasswordDefined" .) }}
             - name: SPRING_DATASOURCE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "webModeler.restapi.databaseSecretName" . }}
                   key: {{ include "webModeler.restapi.databaseSecretKey" . }}
+            {{- end }}
             {{- $smtpSecretName := (include "webModeler.restapi.smtpSecretName" .) }}
             {{- if $smtpSecretName }}
             - name: RESTAPI_MAIL_PASSWORD

--- a/charts/camunda-platform-8.7/templates/web-modeler/secret-restapi.yaml
+++ b/charts/camunda-platform-8.7/templates/web-modeler/secret-restapi.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.webModeler.enabled -}}
-{{- $useExternalDatabasePassword := and (not .Values.postgresql.enabled) (or (not .Values.webModeler.restapi.externalDatabase.existingSecret ) (.Values.webModeler.restapi.externalDatabase.password) (typeIs "string" .Values.webModeler.restapi.externalDatabase.existingSecret)) }}
+{{- $existingSecret := .Values.webModeler.restapi.externalDatabase.existingSecret }}
+{{- $useExternalDatabasePassword := and (not .Values.postgresql.enabled) (or .Values.webModeler.restapi.externalDatabase.password (and (typeIs "string" $existingSecret) (ne $existingSecret ""))) }}
 {{- $useSmtpPassword := (and (not (typeIs "map[string]interface {}" .Values.webModeler.restapi.mail.existingSecret)) (or (.Values.webModeler.restapi.mail.smtpPassword) (.Values.webModeler.restapi.mail.existingSecret)) ) }}
 {{- if or $useExternalDatabasePassword $useSmtpPassword }}
 apiVersion: v1


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #3510.

On 8.7, the web-modeler rest-api always injected `SPRING_DATASOURCE_PASSWORD` and always minted a rest-api Secret, even when an external database was configured with neither a `password` nor an `existingSecret`. The gating checks were always-true because `webModeler.restapi.externalDatabase.existingSecret` defaults to an empty string:

- `webModeler.restapi.databaseSecretName` — `typeIs "string" existingSecret` is always true for the `""` default.
- `secret-restapi.yaml` — `not existingSecret` is always true for `""`.

The result was a Secret holding `b64enc ""` and `SPRING_DATASOURCE_PASSWORD` bound to an empty value, which breaks passwordless / AWS IAM authentication to an external Postgres (the datasource password must be absent for the IAM auth plugin to apply). SUPPORT-27288.

8.8+ already handles this correctly via `camundaPlatform.emitEnvVarFromSecretConfig`; this backports the equivalent behavior to 8.7.

### What's in this PR?

Gates the rest-api database password on an actual password source across the three coupled spots, via a new `webModeler.restapi.externalDatabasePasswordDefined` helper:

- `deployment-restapi.yaml` — emits `SPRING_DATASOURCE_PASSWORD` only when the postgresql dependency is enabled or a password source is configured.
- `_helpers.tpl` `databaseSecretName` — treats an empty-string `existingSecret` as "unset" (checks `ne existingSecret ""`).
- `secret-restapi.yaml` — mints the rest-api Secret only for a chart-managed password (plaintext `password` or legacy non-empty string `existingSecret`).

The dual-mode `existingSecret` contract is preserved (object form = external secret ref; non-empty string = legacy literal password). Verified by rendering all five modes on 8.7:

| Mode | `SPRING_DATASOURCE_PASSWORD` | rest-api Secret |
|---|---|---|
| external, no password, no `existingSecret` | omitted | not created |
| plaintext `password` | present (chart Secret) | created |
| string `existingSecret` (legacy literal) | present (chart Secret) | created |
| object `existingSecret` | present (referenced Secret) | not created |
| embedded postgresql | present (postgresql Secret) | not created |

Existing web-modeler unit tests pass; no golden changes.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
