### PR TITLE
fix: exclude operate and tasklist profiles when noSecondaryStorage is enabled

### DIFF
--- a/charts/camunda-platform-8.8/templates/orchestration/_helpers.tpl
+++ b/charts/camunda-platform-8.8/templates/orchestration/_helpers.tpl
@@ -255,7 +255,14 @@ Authentication.
 {{- define "orchestration.enabledProfiles" -}}
     {{- $enabledProfiles := list -}}
     {{- range $key, $value := .Values.orchestration.profiles }}
-        {{- if eq $value true }}
+        {{- $isNoStorageProfile := and
+            (or
+                (eq $key "operate")
+                (eq $key "tasklist")
+            )
+            $.Values.global.noSecondaryStorage
+        }}
+        {{- if and (not $isNoStorageProfile) (eq $value true) }}
             {{- $enabledProfiles = append $enabledProfiles $key }}
         {{- end }}
     {{- end }}

--- a/charts/camunda-platform-8.8/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry-snapshot.yaml
@@ -274,6 +274,22 @@ integration:
           features:
             - documentstore
           helmVersion: 3.20.2
+        - name: noSecondaryStorage
+          enabled: true
+          shortname: nosec
+          auth: keycloak
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            gke: distroci
+          identity: keycloak
+          persistence: no-elasticsearch
+          features:
+            - no-secondary-storage
+          skip-e2e: true
         - name: component-persistence
           enabled: true
           shortname: cprst

--- a/charts/camunda-platform-8.8/test/ci/registry/manifest.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/manifest.yaml
@@ -82,6 +82,10 @@ integration:
       shortname: docstr
       tier: 2
       enabled: true
+    - id: no-secondary-storage
+      shortname: nosec
+      tier: 2
+      enabled: true
     - id: component-persistence
       shortname: cprst
       tier: 2

--- a/charts/camunda-platform-8.8/test/ci/registry/scenarios/no-secondary-storage.yaml
+++ b/charts/camunda-platform-8.8/test/ci/registry/scenarios/no-secondary-storage.yaml
@@ -1,0 +1,13 @@
+name: noSecondaryStorage
+auth: keycloak
+flows:
+  - install
+identity: keycloak
+persistence: no-elasticsearch
+features:
+  - no-secondary-storage
+platforms:
+  - gke
+infra-type:
+  gke: distroci
+skip-e2e: true

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/no-secondary-storage.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/features/no-secondary-storage.yaml
@@ -1,0 +1,10 @@
+# No-secondary-storage feature configuration for 8.8
+# Layer 4: Feature - No secondary storage (no Elasticsearch/OpenSearch backend)
+#
+# Composed with persistence/no-elasticsearch.yaml. Optimize requires a
+# secondary-storage backend, so it is disabled here.
+optimize:
+  enabled: false
+
+identity:
+  clients: null

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/persistence/no-elasticsearch.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/persistence/no-elasticsearch.yaml
@@ -1,0 +1,11 @@
+# Elasticsearch backend configuration for 8.8
+# Layer 3: Backend - Elasticsearch (internal)
+
+global:
+  elasticsearch:
+    enabled: false
+
+  noSecondaryStorage: true
+
+elasticsearch:
+  enabled: false

--- a/charts/camunda-platform-8.8/test/unit/common/no_secondary_storage_test.go
+++ b/charts/camunda-platform-8.8/test/unit/common/no_secondary_storage_test.go
@@ -71,6 +71,8 @@ func (s *NoSecondaryStorageTemplateTest) TestNoSecondaryStorageGlobalValue() {
 				require.Contains(t, output, "agenticai:\n          enabled: false")
 				// Optimize should not be rendered
 				require.NotContains(t, output, "templates/optimize")
+				// Operate and Tasklist profiles should be excluded (no secondary storage to serve them)
+				require.Contains(t, output, `active: "broker,identity,consolidated-auth"`)
 			},
 		},
 	}


### PR DESCRIPTION
### Which problem does the PR fix?

Closes camunda/camunda-platform-helm#5217.

### What's in this PR?

Backports the `orchestration.enabledProfiles` fix from #5234 (8.9) to 8.8: excludes `operate` and `tasklist` from the active Spring profiles when `global.noSecondaryStorage: true`, since neither component can run without secondary storage. Also backports the `noSecondaryStorage` CI scenario (`nosec`, tier 2) from 8.9's registry, and adds a profile-string assertion to the existing unit test.

Verified live on GKE: `helm install` with `global.noSecondaryStorage: true` now reaches `STATUS: deployed` with all pods Ready, and the rendered configmap shows `active: "broker,identity,consolidated-auth"` (no more `operate,tasklist`).

### Checklist

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open pull request for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo documentation are updated (if needed).
