### PR TITLE
chore(deploy-camunda): drain helm output without 64KB line limit

### DIFF
--- a/scripts/camunda-core/pkg/executil/exec.go
+++ b/scripts/camunda-core/pkg/executil/exec.go
@@ -3,6 +3,7 @@ package executil
 import (
 	"bufio"
 	"context"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -28,6 +29,19 @@ func getBufferFromContext(ctx context.Context) bufferCallback {
 		}
 	}
 	return nil
+}
+
+func streamLines(r io.Reader, onLine func(string)) {
+	br := bufio.NewReader(r)
+	for {
+		line, err := br.ReadString('\n')
+		if len(line) > 0 {
+			onLine(strings.TrimRight(line, "\r\n"))
+		}
+		if err != nil {
+			return
+		}
+	}
 }
 
 func RunCommand(ctx context.Context, name string, args []string, env []string, workingDir string) error {
@@ -59,17 +73,15 @@ func RunCommand(ctx context.Context, name string, args []string, env []string, w
 		wg.Add(2)
 		go func() {
 			defer wg.Done()
-			sc := bufio.NewScanner(stdout)
-			for sc.Scan() {
-				bufferCB("info", sc.Text())
-			}
+			streamLines(stdout, func(line string) {
+				bufferCB("info", line)
+			})
 		}()
 		go func() {
 			defer wg.Done()
-			sc := bufio.NewScanner(stderr)
-			for sc.Scan() {
-				bufferCB("warn", sc.Text())
-			}
+			streamLines(stderr, func(line string) {
+				bufferCB("warn", line)
+			})
 		}()
 		wg.Wait()
 		return cmd.Wait()
@@ -89,21 +101,17 @@ func RunCommand(ctx context.Context, name string, args []string, env []string, w
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		sc := bufio.NewScanner(stdout)
-		for sc.Scan() {
-			line := sc.Text()
+		streamLines(stdout, func(line string) {
 			prefix := logging.PrefixFromContext(ctx, name)
 			baseLogger.Info().Msg(prefix + line)
-		}
+		})
 	}()
 	go func() {
 		defer wg.Done()
-		sc := bufio.NewScanner(stderr)
-		for sc.Scan() {
-			line := sc.Text()
+		streamLines(stderr, func(line string) {
 			prefix := logging.PrefixFromContext(ctx, name)
 			baseLogger.Warn().Msg(prefix + line)
-		}
+		})
 	}()
 
 	wg.Wait()
@@ -161,17 +169,15 @@ func RunCommandWithStdin(ctx context.Context, name string, args []string, env []
 		wg.Add(2)
 		go func() {
 			defer wg.Done()
-			sc := bufio.NewScanner(stdout)
-			for sc.Scan() {
-				bufferCB("info", sc.Text())
-			}
+			streamLines(stdout, func(line string) {
+				bufferCB("info", line)
+			})
 		}()
 		go func() {
 			defer wg.Done()
-			sc := bufio.NewScanner(stderr)
-			for sc.Scan() {
-				bufferCB("warn", sc.Text())
-			}
+			streamLines(stderr, func(line string) {
+				bufferCB("warn", line)
+			})
 		}()
 		wg.Wait()
 		return cmd.Wait()
@@ -190,19 +196,17 @@ func RunCommandWithStdin(ctx context.Context, name string, args []string, env []
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		sc := bufio.NewScanner(stdout)
-		for sc.Scan() {
+		streamLines(stdout, func(line string) {
 			prefix := logging.PrefixFromContext(ctx, name)
-			baseLogger.Info().Msg(prefix + sc.Text())
-		}
+			baseLogger.Info().Msg(prefix + line)
+		})
 	}()
 	go func() {
 		defer wg.Done()
-		sc := bufio.NewScanner(stderr)
-		for sc.Scan() {
+		streamLines(stderr, func(line string) {
 			prefix := logging.PrefixFromContext(ctx, name)
-			baseLogger.Warn().Msg(prefix + sc.Text())
-		}
+			baseLogger.Warn().Msg(prefix + line)
+		})
 	}()
 	wg.Wait()
 	return cmd.Wait()
@@ -245,18 +249,16 @@ func RunCommandBuffered(ctx context.Context, name string, args []string, env []s
 
 	go func() {
 		defer wg.Done()
-		sc := bufio.NewScanner(stdout)
-		for sc.Scan() {
-			stdoutLines = append(stdoutLines, sc.Text())
-		}
+		streamLines(stdout, func(line string) {
+			stdoutLines = append(stdoutLines, line)
+		})
 	}()
 
 	go func() {
 		defer wg.Done()
-		sc := bufio.NewScanner(stderr)
-		for sc.Scan() {
-			stderrLines = append(stderrLines, sc.Text())
-		}
+		streamLines(stderr, func(line string) {
+			stderrLines = append(stderrLines, line)
+		})
 	}()
 
 	wg.Wait()
@@ -303,20 +305,17 @@ func RunCommandCaptureStderr(ctx context.Context, name string, args []string, en
 		wg.Add(2)
 		go func() {
 			defer wg.Done()
-			sc := bufio.NewScanner(stdout)
-			for sc.Scan() {
-				bufferCB("info", sc.Text())
-			}
+			streamLines(stdout, func(line string) {
+				bufferCB("info", line)
+			})
 		}()
 		go func() {
 			defer wg.Done()
-			sc := bufio.NewScanner(stderrPipe)
-			for sc.Scan() {
-				line := sc.Text()
+			streamLines(stderrPipe, func(line string) {
 				bufferCB("warn", line)
 				stderrBuf.WriteString(line)
 				stderrBuf.WriteByte('\n')
-			}
+			})
 		}()
 		wg.Wait()
 		return stderrBuf.String(), cmd.Wait()
@@ -335,22 +334,19 @@ func RunCommandCaptureStderr(ctx context.Context, name string, args []string, en
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		sc := bufio.NewScanner(stdout)
-		for sc.Scan() {
+		streamLines(stdout, func(line string) {
 			prefix := logging.PrefixFromContext(ctx, name)
-			baseLogger.Info().Msg(prefix + sc.Text())
-		}
+			baseLogger.Info().Msg(prefix + line)
+		})
 	}()
 	go func() {
 		defer wg.Done()
-		sc := bufio.NewScanner(stderrPipe)
-		for sc.Scan() {
-			line := sc.Text()
+		streamLines(stderrPipe, func(line string) {
 			prefix := logging.PrefixFromContext(ctx, name)
 			baseLogger.Warn().Msg(prefix + line)
 			stderrBuf.WriteString(line)
 			stderrBuf.WriteByte('\n')
-		}
+		})
 	}()
 
 	wg.Wait()

--- a/scripts/camunda-core/pkg/executil/exec_test.go
+++ b/scripts/camunda-core/pkg/executil/exec_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executil
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+const longLineBytes = 200000
+
+var longLineShell = `head -c 200000 /dev/zero | tr "\0" A; echo; head -c 200000 /dev/zero | tr "\0" A 1>&2; echo 1>&2`
+
+func TestRunCommand_longLines(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	err := RunCommand(ctx, "sh", []string{"-c", longLineShell}, nil, "")
+	if err != nil {
+		t.Fatalf("RunCommand returned error: %v", err)
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("RunCommand did not finish before context deadline: %v", ctx.Err())
+	}
+}
+
+func TestRunCommandCapture_longLines(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	out, err := RunCommandCapture(ctx, "sh", []string{"-c", longLineShell}, nil, "")
+	if err != nil {
+		t.Fatalf("RunCommandCapture returned error: %v", err)
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("RunCommandCapture did not finish before context deadline: %v", ctx.Err())
+	}
+
+	line := strings.TrimRight(string(out), "\n")
+	if len(line) != longLineBytes {
+		t.Fatalf("stdout line length = %d, want %d", len(line), longLineBytes)
+	}
+}
+
+func TestRunCommandCaptureStderr_longLines(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	stderr, err := RunCommandCaptureStderr(ctx, "sh", []string{"-c", longLineShell}, nil, "")
+	if err != nil {
+		t.Fatalf("RunCommandCaptureStderr returned error: %v", err)
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("RunCommandCaptureStderr did not finish before context deadline: %v", ctx.Err())
+	}
+
+	lines := strings.Split(strings.TrimRight(stderr, "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("stderr line count = %d, want 1", len(lines))
+	}
+	if len(lines[0]) != longLineBytes {
+		t.Fatalf("stderr line length = %d, want %d", len(lines[0]), longLineBytes)
+	}
+}

--- a/scripts/deploy-camunda/pkg/deployer/template.go
+++ b/scripts/deploy-camunda/pkg/deployer/template.go
@@ -51,8 +51,6 @@ func renderTemplates(ctx context.Context, o types.Options) error {
 	}
 	args = append(args, "--output-dir", outputDir)
 
-	args = append(args, "--debug")
-
 	logging.Logger.Info().
 		Str("outputDir", outputDir).
 		Str("release", o.ReleaseName).


### PR DESCRIPTION
### Which problem does the PR fix?

`deploy-camunda --render-templates` hangs indefinitely under Helm 4 (observed 11+ min, ~0 CPU, all helm goroutines parked on a blocked pipe write).

Root cause: `renderTemplates` hardcodes `--debug` on `helm template`, and Helm 4 logs the entire minified `values.schema.json` on a single line (~137KB for chart 8.7: `level=DEBUG msg="unmarshalled JSON schema" schema="{...}"`). The shared output drainer in `scripts/camunda-core/pkg/executil` uses `bufio.Scanner`, whose default token limit is 64KB. That oversized line trips `bufio.ErrTooLong`, the drain goroutine exits, helm blocks writing to the now-full OS pipe, and `cmd.Wait()` never returns.

This surfaced after the toolchain moved to Helm 4.2.2 — Helm 3 never emitted that debug line, so the hardcoded `--debug` was previously harmless.

### What's in this PR?

- **`pkg/deployer/template.go`** — stop appending `--debug`. With `--output-dir`, helm writes manifests to files regardless; `--debug` only added the schema/values dump that triggers the hang.
- **`camunda-core/pkg/executil/exec.go`** — replace all 14 `bufio.Scanner` drain loops (across `RunCommand`, `RunCommandWithStdin`, `RunCommandBuffered`, `RunCommandCaptureStderr`) with a single shared `streamLines` helper backed by `bufio.Reader.ReadString('\n')`. This has no line-length ceiling, so the pipe is always fully drained and `cmd.Wait()` can never deadlock regardless of output line length. Logging levels, prefixes, buffer callbacks, and stderr accumulation are unchanged.
- **`camunda-core/pkg/executil/exec_test.go`** (new) — regression tests emitting ~200KB single lines on stdout and stderr under a context deadline, so a re-introduced deadlock fails the test instead of hanging CI.

Verified end-to-end: the `--render-templates` invocation that previously hung 11+ min now completes in ~0.8s. `go build`/`go test` pass for both `camunda-core` and `deploy-camunda` modules; `gofmt` clean; license header present.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
