### PR TITLE
fix: omit empty zeebe.broker.exporters map for no-exporter scenarios

### DIFF
--- a/charts/camunda-platform-8.10/templates/orchestration/files/_application.yaml
+++ b/charts/camunda-platform-8.10/templates/orchestration/files/_application.yaml
@@ -326,10 +326,9 @@ zeebe:
       (eq (include "orchestration.hasLegacyOpenSearchExporter" .) "true")
       (eq (include "orchestration.hasCamundaExporter" .) "true")
       (eq (include "orchestration.hasAppIntegrations" .) "true")
-      (eq (include "orchestration.hasNoExporter" .) "true")
     }}
     # zeebe.broker.exporters
-    exporters: {{- if eq (include "orchestration.hasNoExporter" .) "true" }}{{ printf " %s" "{}" }}{{ end }}
+    exporters:
     {{- end }}
     {{- if eq (include "orchestration.hasLegacyElasticsearchExporter" .) "true" }}
       elasticsearch:

--- a/charts/camunda-platform-8.9/templates/orchestration/files/_application.yaml
+++ b/charts/camunda-platform-8.9/templates/orchestration/files/_application.yaml
@@ -326,10 +326,9 @@ zeebe:
       (eq (include "orchestration.hasLegacyOpenSearchExporter" .) "true")
       (eq (include "orchestration.hasCamundaExporter" .) "true")
       (eq (include "orchestration.hasAppIntegrations" .) "true")
-      (eq (include "orchestration.hasNoExporter" .) "true")
     }}
     # zeebe.broker.exporters
-    exporters: {{- if eq (include "orchestration.hasNoExporter" .) "true" }}{{ printf " %s" "{}" }}{{ end }}
+    exporters:
     {{- end }}
     {{- if eq (include "orchestration.hasLegacyElasticsearchExporter" .) "true" }}
       elasticsearch:


### PR DESCRIPTION
### Which problem does the PR fix?

The `noSecondaryStorage` (no-secondary-storage) nightly scenario crashes the Orchestration (zeebe) pod on newer `camunda/camunda` images built with Spring Boot 4.1:

```
Failed to bind properties under 'zeebe.broker.exporters' to Map<String, ExporterCfg>
Caused by: ConverterNotFoundException: from [java.lang.String] to [Map<...>]
```

Surfaced by the camunda-platform-digests bump (#6494), which advances the image from a Spring Boot 4.0.5 build to a 4.1.0 build. Failing run: https://github.com/camunda/camunda-platform-helm/actions/runs/28808991327/job/85432103156

### What's in this PR?

The chart rendered `zeebe.broker.exporters: {}` (an explicit empty flow-map) when no exporter is configured. Spring Boot 4.1 flattens an empty `{}` to an empty String, which then fails to bind to `Map<String, ExporterCfg>` (Spring Boot 4.0.5 tolerated it). Scenarios with a real exporter (ES/OS/camunda/appIntegrations) render nested keys and are unaffected.

Fix: omit the `exporters:` key entirely when there are no exporters, so the field binds to its default empty map instead of an unparseable `{}`. Applied to camunda-platform-8.10 and 8.9 (identical latent bug). No golden changes; `helm.lint` and `go.test` pass for both versions.

Gates the #6494 digest bump: with this merged, the no-secondary-storage scenario passes on the Spring Boot 4.1 image.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
