### PR TITLE
fix: allow Web Modeler and Console with external management Identity

### DIFF
--- a/charts/camunda-platform-8.10/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.10/templates/common/constraints.tpl
@@ -96,10 +96,10 @@ Fail with a message if adaptSecurityContext has any value other than "force" or 
 {{/*
 Fail with a message if Web Modeler is enabled but management Identity is not enabled.
 */}}
-{{- if and (eq (include "camundaHub.webModelerEnabled" .) "true") (not .Values.identity.enabled) }}
+{{- if and (eq (include "camundaHub.webModelerEnabled" .) "true") (not $identityEnabled) }}
   {{- $errorMessage := printf "[camunda][error] %s %s"
-      "Web Modeler is enabled but management Identity is not enabled."
-      "Please ensure that if Web Modeler is enabled, management Identity must also be enabled."
+      "Web Modeler is enabled but management Identity is not configured."
+      "Enable local management Identity with \"identity.enabled: true\", or point to an external management Identity via \"global.identity.service.url\"."
   -}}
   {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}

--- a/charts/camunda-platform-8.10/test/unit/common/constraints_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/constraints_test.go
@@ -602,3 +602,35 @@ func (s *ConstraintTemplateTest) TestDeprecatedKeyHelperRendersWithoutCrash() {
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
+
+func (s *ConstraintTemplateTest) TestManagementIdentityExternalServiceUrl() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "WebModelerWithExternalManagementIdentityRenders",
+			Values: map[string]string{
+				"orchestration.enabled":               "false",
+				"webModeler.enabled":                  "true",
+				"webModeler.restapi.mail.fromAddress": "test@example.com",
+				"identity.enabled":                    "false",
+				"global.identity.service.url":         "http://identity.other-ns.svc:8080",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+			},
+		},
+		{
+			Name: "WebModelerWithoutManagementIdentityFails",
+			Values: map[string]string{
+				"orchestration.enabled":               "false",
+				"webModeler.enabled":                  "true",
+				"webModeler.restapi.mail.fromAddress": "test@example.com",
+				"identity.enabled":                    "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().ErrorContains(err, "Web Modeler is enabled but management Identity is not configured")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}

--- a/charts/camunda-platform-8.8/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.8/templates/common/constraints.tpl
@@ -112,10 +112,10 @@ Fail with a message if Identity is disabled and identityKeycloak is enabled.
 {{/*
 Fail with a message if Console is enabled but management Identity is not enabled.
 */}}
-{{- if and .Values.console.enabled (not .Values.identity.enabled) }}
+{{- if and .Values.console.enabled (not $identityEnabled) }}
   {{- $errorMessage := printf "[camunda][error] %s %s"
-      "Console is enabled but management Identity is not enabled."
-      "Please ensure that if Console is enabled, management Identity must also be enabled."
+      "Console is enabled but management Identity is not configured."
+      "Enable local management Identity with \"identity.enabled: true\", or point to an external management Identity via \"global.identity.service.url\"."
   -}}
   {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}
@@ -123,10 +123,10 @@ Fail with a message if Console is enabled but management Identity is not enabled
 {{/*
 Fail with a message if Web Modeler is enabled but management Identity is not enabled.
 */}}
-{{- if and .Values.webModeler.enabled (not .Values.identity.enabled) }}
+{{- if and .Values.webModeler.enabled (not $identityEnabled) }}
   {{- $errorMessage := printf "[camunda][error] %s %s"
-      "Web Modeler is enabled but management Identity is not enabled."
-      "Please ensure that if Web Modeler is enabled, management Identity must also be enabled."
+      "Web Modeler is enabled but management Identity is not configured."
+      "Enable local management Identity with \"identity.enabled: true\", or point to an external management Identity via \"global.identity.service.url\"."
   -}}
   {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}

--- a/charts/camunda-platform-8.8/test/unit/common/constraints_test.go
+++ b/charts/camunda-platform-8.8/test/unit/common/constraints_test.go
@@ -165,3 +165,58 @@ func (s *ConstraintTemplateTest) TestCaBundleConsoleCertKeyFilenameWarningRender
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
+
+func (s *ConstraintTemplateTest) TestManagementIdentityExternalServiceUrl() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "WebModelerWithExternalManagementIdentityRenders",
+			Values: map[string]string{
+				"orchestration.enabled":               "false",
+				"webModeler.enabled":                  "true",
+				"webModeler.restapi.mail.fromAddress": "test@example.com",
+				"identity.enabled":                    "false",
+				"global.identity.service.url":         "http://identity.other-ns.svc:8080",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+			},
+		},
+		{
+			Name: "WebModelerWithoutManagementIdentityFails",
+			Values: map[string]string{
+				"orchestration.enabled":               "false",
+				"webModeler.enabled":                  "true",
+				"webModeler.restapi.mail.fromAddress": "test@example.com",
+				"identity.enabled":                    "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().ErrorContains(err, "Web Modeler is enabled but management Identity is not configured")
+			},
+		},
+		{
+			Name: "ConsoleWithExternalManagementIdentityRenders",
+			Values: map[string]string{
+				"orchestration.enabled":       "false",
+				"console.enabled":             "true",
+				"identity.enabled":            "false",
+				"global.identity.service.url": "http://identity.other-ns.svc:8080",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+			},
+		},
+		{
+			Name: "ConsoleWithoutManagementIdentityFails",
+			Values: map[string]string{
+				"orchestration.enabled": "false",
+				"console.enabled":       "true",
+				"identity.enabled":      "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().ErrorContains(err, "Console is enabled but management Identity is not configured")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}

--- a/charts/camunda-platform-8.8/test/unit/common/identitykeycloak_constraints_test.go
+++ b/charts/camunda-platform-8.8/test/unit/common/identitykeycloak_constraints_test.go
@@ -38,15 +38,13 @@ func TestConstraintsTemplate(t *testing.T) {
 func (s *ConstraintsTemplateTest) TestDifferentValuesInputs() {
 	testCases := []testhelpers.TestCase{
 		{
-			Skip: true,
 			Name: "TestIdentityKeycloakConstraintFailure",
 			Values: map[string]string{
 				"identity.enabled":         "false",
 				"identityKeycloak.enabled": "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
-
-				require.Error(t, err, "[camunda][error] Identity is disabled but identityKeycloak is enabled")
+				require.ErrorContains(t, err, "Identity is disabled but identityKeycloak is enabled")
 			},
 		}, {
 			Name: "TestIdentityKeycloakConstraintSuccess",
@@ -61,7 +59,7 @@ func (s *ConstraintsTemplateTest) TestDifferentValuesInputs() {
 				var deployment appsv1.Deployment
 				helm.UnmarshalK8SYaml(t, output, &deployment)
 
-				require.NoError(t, err, "[camunda][error] Identity is disabled but identityKeycloak is enabled")
+				require.NoError(t, err)
 			},
 		},
 	}

--- a/charts/camunda-platform-8.9/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.9/templates/common/constraints.tpl
@@ -101,10 +101,10 @@ Fail with a message if Identity is disabled and identityKeycloak is enabled.
 {{/*
 Fail with a message if Console is enabled but management Identity is not enabled.
 */}}
-{{- if and .Values.console.enabled (not .Values.identity.enabled) }}
+{{- if and .Values.console.enabled (not $identityEnabled) }}
   {{- $errorMessage := printf "[camunda][error] %s %s"
-      "Console is enabled but management Identity is not enabled."
-      "Please ensure that if Console is enabled, management Identity must also be enabled."
+      "Console is enabled but management Identity is not configured."
+      "Enable local management Identity with \"identity.enabled: true\", or point to an external management Identity via \"global.identity.service.url\"."
   -}}
   {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}
@@ -112,10 +112,10 @@ Fail with a message if Console is enabled but management Identity is not enabled
 {{/*
 Fail with a message if Web Modeler is enabled but management Identity is not enabled.
 */}}
-{{- if and .Values.webModeler.enabled (not .Values.identity.enabled) }}
+{{- if and .Values.webModeler.enabled (not $identityEnabled) }}
   {{- $errorMessage := printf "[camunda][error] %s %s"
-      "Web Modeler is enabled but management Identity is not enabled."
-      "Please ensure that if Web Modeler is enabled, management Identity must also be enabled."
+      "Web Modeler is enabled but management Identity is not configured."
+      "Enable local management Identity with \"identity.enabled: true\", or point to an external management Identity via \"global.identity.service.url\"."
   -}}
   {{ printf "\n%s" $errorMessage | trimSuffix "\n"| fail }}
 {{- end }}

--- a/charts/camunda-platform-8.9/test/unit/common/constraints_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/constraints_test.go
@@ -370,3 +370,58 @@ func (s *ConstraintTemplateTest) TestCaBundleConsoleCertKeyFilenameWarningRender
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
+
+func (s *ConstraintTemplateTest) TestManagementIdentityExternalServiceUrl() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "WebModelerWithExternalManagementIdentityRenders",
+			Values: map[string]string{
+				"orchestration.enabled":               "false",
+				"webModeler.enabled":                  "true",
+				"webModeler.restapi.mail.fromAddress": "test@example.com",
+				"identity.enabled":                    "false",
+				"global.identity.service.url":         "http://identity.other-ns.svc:8080",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+			},
+		},
+		{
+			Name: "WebModelerWithoutManagementIdentityFails",
+			Values: map[string]string{
+				"orchestration.enabled":               "false",
+				"webModeler.enabled":                  "true",
+				"webModeler.restapi.mail.fromAddress": "test@example.com",
+				"identity.enabled":                    "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().ErrorContains(err, "Web Modeler is enabled but management Identity is not configured")
+			},
+		},
+		{
+			Name: "ConsoleWithExternalManagementIdentityRenders",
+			Values: map[string]string{
+				"orchestration.enabled":       "false",
+				"console.enabled":             "true",
+				"identity.enabled":            "false",
+				"global.identity.service.url": "http://identity.other-ns.svc:8080",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+			},
+		},
+		{
+			Name: "ConsoleWithoutManagementIdentityFails",
+			Values: map[string]string{
+				"orchestration.enabled": "false",
+				"console.enabled":       "true",
+				"identity.enabled":      "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().ErrorContains(err, "Console is enabled but management Identity is not configured")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}

--- a/charts/camunda-platform-8.9/test/unit/common/identitykeycloak_constraints_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/identitykeycloak_constraints_test.go
@@ -38,15 +38,13 @@ func TestConstraintsTemplate(t *testing.T) {
 func (s *ConstraintsTemplateTest) TestDifferentValuesInputs() {
 	testCases := []testhelpers.TestCase{
 		{
-			Skip: true,
 			Name: "TestIdentityKeycloakConstraintFailure",
 			Values: map[string]string{
 				"identity.enabled":         "false",
 				"identityKeycloak.enabled": "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
-
-				require.Error(t, err, "[camunda][error] Identity is disabled but identityKeycloak is enabled")
+				require.ErrorContains(t, err, "Identity is disabled but identityKeycloak is enabled")
 			},
 		}, {
 			Name: "TestIdentityKeycloakConstraintSuccess",
@@ -61,7 +59,7 @@ func (s *ConstraintsTemplateTest) TestDifferentValuesInputs() {
 				var deployment appsv1.Deployment
 				helm.UnmarshalK8SYaml(t, output, &deployment)
 
-				require.NoError(t, err, "[camunda][error] Identity is disabled but identityKeycloak is enabled")
+				require.NoError(t, err)
 			},
 		}, {
 			Name: "TestKeycloakAuthLegacySecretRendersSuccessfully",


### PR DESCRIPTION
### Which problem does the PR fix?

Closes camunda/camunda-platform-helm#4916.

The Web Modeler and Console render-time constraints hard-failed whenever
`identity.enabled=false`, ignoring an external management Identity supplied via
`global.identity.service.url`. This blocked the documented multi-namespace
topology (management Identity in a separate namespace), the same class of stale
coupling removed for Optimize in #4866.

### What's in this PR?

- Gate the Web Modeler (8.8/8.9/8.10) and Console (8.8/8.9) constraints on the
  existing `$identityEnabled` helper (`identity.enabled` OR
  `global.identity.service.url`) instead of bare `identity.enabled`, and clarify
  the error to name both remediation paths. Pure loosening — no config that
  rendered before changes behaviour.
- `identityKeycloak` coupling is left unchanged: bundled Keycloak is the IdP for a
  local Identity, so pairing it with an external Identity is not a valid topology.
- Add positive (external Identity renders) and negative (neither configured fails)
  unit tests for both components.
- Un-skip `TestIdentityKeycloakConstraintFailure` and replace the misused
  `require.Error(t, err, msg)` (3rd arg is a log label, not an assertion) with
  `require.ErrorContains`, so the message is actually verified.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
