### PR TITLE
test(8.10): re-enable authorizations for RDBMS CI scenarios

### DIFF
--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/persistence/rdbms-external.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/persistence/rdbms-external.yaml
@@ -15,11 +15,6 @@ orchestration:
         username: ${RDBMS_POSTGRESQL_USERNAME}
         secret:
           inlineSecret: ${RDBMS_POSTGRESQL_PASSWORD}
-  security:
-    authorizations:
-      enabled: false
-    authentication:
-      unprotectedApi: true
   exporters:
     rdbms:
       enabled: true

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/persistence/rdbms-oracle.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/persistence/rdbms-oracle.yaml
@@ -10,11 +10,6 @@ orchestration:
         username: ${POSTGRESQL_USERNAME}
         secret:
           inlineSecret: ${POSTGRESQL_PASSWORD}
-  security:
-    authorizations:
-      enabled: false
-    authentication:
-      unprotectedApi: true
   exporters:
     rdbms:
       enabled: true

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/persistence/rdbms-self-signed.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/persistence/rdbms-self-signed.yaml
@@ -41,11 +41,6 @@ orchestration:
         username: ${RDBMS_POSTGRESQL_USERNAME}
         secret:
           inlineSecret: ${RDBMS_POSTGRESQL_PASSWORD}
-  security:
-    authorizations:
-      enabled: false
-    authentication:
-      unprotectedApi: true
   exporters:
     rdbms:
       enabled: true

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/persistence/rdbms.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/persistence/rdbms.yaml
@@ -1,4 +1,4 @@
-# RDBMS feature configuration for 8.9 (PostgreSQL)
+# RDBMS feature configuration for 8.10 (PostgreSQL)
 # Layer 4: Feature - RDBMS secondary storage
 
 global:
@@ -15,11 +15,6 @@ orchestration:
         username: ${RDBMS_POSTGRESQL_USERNAME}
         secret:
           inlineSecret: ${RDBMS_POSTGRESQL_PASSWORD}
-  security:
-    authorizations:
-      enabled: false
-    authentication:
-      unprotectedApi: true
   exporters:
     rdbms:
       enabled: true


### PR DESCRIPTION
## Problem

The 8.10 `rdbms` and `rdbss` integration scenarios evict PRs from the merge queue (observed blocking #6494). Their E2E smoke suite can never log into the OC Identity admin console (`/orchestration/admin`): the session dies on a fatal OIDC backchannel token-refresh error, the login helper retries ~442s × 5, and the job runs the full ~30 min until the merge queue cancels it.

## Root cause

The RDBMS persistence values files carry a stale 8.9-era override — `orchestration.security.authorizations.enabled: false` + `authentication.unprotectedApi: true`. This changes the OIDC filter chain so orchestration performs a **backchannel token refresh** against the internal Keycloak service URL, which Keycloak rejects with `invalid_grant: Invalid token issuer` (the CI Keycloak stamps host-relative issuers). Confirmed on live GKE:

- Passing scenarios (`eske`, `osss`, `osot`): `unprotectedApi: false`, **0** issuer errors.
- Failing scenarios (`rdbms`, `rdbss`): `unprotectedApi: true`, **~12** issuer errors.

This is **not** an authorization/role problem: the `demo` user is already Admin via the identity layer — `identity/keycloak.yaml` sets `orchestration.security.initialization.defaultRoles.admin.users: [demo], clients: [venom]` — and a live query confirmed `demo`/`venom` are members of the admin role even in the broken deployment. OpenSearch scenarios pass with **no** mapping rules, proving the identity-layer `defaultRoles` alone is sufficient.

## Change

For all four RDBMS variants (`rdbms`, `rdbms-self-signed`, `rdbms-external`, `rdbms-oracle`): **remove the stale `security.authorizations.enabled: false` + `unprotectedApi: true` override**, so they inherit the chart defaults and the identity-layer auth config — matching the working ES/OpenSearch keycloak scenarios. Also fixes the stale `rdbms.yaml` header (8.9 → 8.10).

No mapping rules or other identity config are added to the persistence layer — identity/authz belongs in `identity/keycloak.yaml`, which already provides it. (An initial commit added redundant mapping-rule env blocks; the follow-up commit removed them once OpenSearch confirmed they're unnecessary.)

## Validation

- `make go.test chartPath=charts/camunda-platform-8.10` — all unit + matrix registry/golden tests pass (no snapshot drift), Helm v4.2.2.
- 8.10 GKE matrix re-run to confirm the `rdbms`/`rdbss` cells go green (in progress).

## Related

- Unblocks #6494 (merge-queue evictions on the `rdbms`/`rdbss` cells).

## Follow-ups (separate)

1. Pin the CI test Keycloak `frontendUrl` (+`hostname-backchannel-dynamic`) to eliminate the latent host-relative-issuer mismatch that this override exposed.
2. Make the E2E `NavigationPage.goTo` retry window fail fast so a login failure can't consume the whole merge-queue budget.
3. The mapping-rule env blocks in `elasticsearch.yaml`/`opensearch-embedded.yaml` are likely redundant (OpenSearch works without them) — candidate for a later consolidation into the identity layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
