### PR TITLE
ci: port test-type-vars action logic to go

### DIFF
--- a/.github/actions/generate-chart-matrix/action.yaml
+++ b/.github/actions/generate-chart-matrix/action.yaml
@@ -79,30 +79,8 @@ runs:
     - name: Get chart versions
       id: get-chart-versions
       uses: ./.github/actions/get-chart-versions
-    - name: Restore deploy-camunda binary
-      id: binary-cache
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-      with:
-        path: ~/.local/bin/deploy-camunda
-        key: deploy-camunda-v2-${{ runner.os }}-${{ hashFiles('scripts/deploy-camunda/**/*.go', 'scripts/deploy-camunda/go.sum') }}
-    - name: Setup Go
-      if: steps.binary-cache.outputs.cache-hit != 'true'
-      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
-      with:
-        go-version-file: scripts/deploy-camunda/go.mod
-        cache: true
-        cache-dependency-path: scripts/deploy-camunda/go.sum
-    - name: Build deploy-camunda
-      if: steps.binary-cache.outputs.cache-hit != 'true'
-      shell: bash
-      run: |
-        mkdir -p "$HOME/.local/bin"
-        # CGO_ENABLED=0 produces a static binary so it runs unchanged inside the
-        # ci-runner container used by downstream matrix jobs.
-        (cd scripts/deploy-camunda && CGO_ENABLED=0 go build -o "$HOME/.local/bin/deploy-camunda" .)
-    - name: Export deploy-camunda to PATH
-      shell: bash
-      run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+    - name: Setup deploy-camunda
+      uses: ./.github/actions/setup-deploy-camunda
     - name: Generate matrix
       shell: bash
       id: set-chart-versions

--- a/.github/actions/setup-deploy-camunda/action.yaml
+++ b/.github/actions/setup-deploy-camunda/action.yaml
@@ -1,0 +1,50 @@
+name: Setup deploy-camunda
+description: Restore or build the deploy-camunda binary and add it to PATH.
+
+runs:
+  using: composite
+  steps:
+    - name: Check runner deploy-camunda binary
+      id: runner-binary
+      shell: bash
+      run: echo "present=$([ -n "${RUNNER_TEMP:-}" ] && [ -x "$RUNNER_TEMP/bin/deploy-camunda" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+    - name: Restore deploy-camunda binary
+      if: steps.runner-binary.outputs.present != 'true'
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      with:
+        path: .local-bin/deploy-camunda
+        key: deploy-camunda-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/actions/setup-deploy-camunda/action.yaml', 'scripts/deploy-camunda/**/*.go', 'scripts/deploy-camunda/go.mod', 'scripts/deploy-camunda/go.sum', 'scripts/deploy-camunda/deploy/data/**', 'scripts/deploy-camunda/examples/*.deploy-camunda.yaml', 'scripts/camunda-core/**/*.go', 'scripts/camunda-core/go.mod', 'scripts/camunda-core/go.sum', 'scripts/prepare-helm-values/**/*.go', 'scripts/prepare-helm-values/go.mod', 'scripts/prepare-helm-values/go.sum', 'scripts/vault-secret-mapper/**/*.go', 'scripts/vault-secret-mapper/go.mod', 'scripts/vault-secret-mapper/go.sum') }}
+    - name: Check deploy-camunda binary
+      id: binary-check
+      shell: bash
+      run: echo "present=$([ -x "$GITHUB_WORKSPACE/.local-bin/deploy-camunda" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+    - name: Setup Go
+      if: steps.runner-binary.outputs.present != 'true' && steps.binary-check.outputs.present != 'true'
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+      env:
+        GOROOT: ""
+      with:
+        go-version-file: scripts/deploy-camunda/go.mod
+        cache: true
+        cache-dependency-path: |
+          scripts/deploy-camunda/go.sum
+          scripts/camunda-core/go.sum
+          scripts/prepare-helm-values/go.sum
+          scripts/vault-secret-mapper/go.sum
+    - name: Build deploy-camunda
+      if: steps.runner-binary.outputs.present != 'true' && steps.binary-check.outputs.present != 'true'
+      shell: bash
+      env:
+        GOROOT: ""
+      run: |
+        mkdir -p "$GITHUB_WORKSPACE/.local-bin"
+        # CGO_ENABLED=0 produces a static binary for host and container jobs.
+        (cd scripts/deploy-camunda && CGO_ENABLED=0 go build -o "$GITHUB_WORKSPACE/.local-bin/deploy-camunda" .)
+    - name: Export deploy-camunda to PATH
+      shell: bash
+      run: |
+        if [[ "${{ steps.runner-binary.outputs.present }}" == "true" ]]; then
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+        else
+          echo "$GITHUB_WORKSPACE/.local-bin" >> "$GITHUB_PATH"
+        fi

--- a/.github/actions/test-type-vars/action.yaml
+++ b/.github/actions/test-type-vars/action.yaml
@@ -33,77 +33,18 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Setup deploy-camunda
+      uses: ./.github/actions/setup-deploy-camunda
     - name: Get test type vars
-      shell: bash
       id: vars
+      shell: bash
+      env:
+        DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET: ${{ env.DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET }}
       run: |
-        matrix_file="charts/${{ inputs.chart-dir }}/test/ci-test-config.yaml"
-
-        # Chart path.
-        # For upgrade-minor, the install step deploys the previous chart version,
-        # but the upgrade step must use the current (target) chart so helm upgrade
-        # actually moves to the new version.
-        if [[ "${{ inputs.flow }}" == "upgrade-minor" && -n "${{ inputs.camunda-version-previous }}" && "${{ inputs.upgrade-step }}" != "true" ]]; then
-          chart_path="charts/camunda-platform-${{ inputs.camunda-version-previous }}"
-        else
-          chart_path="charts/${{ inputs.chart-dir }}"
-        fi
-
-        echo "CHART_PATH=${chart_path}" | tee -a $GITHUB_ENV
-
-        # Relative path needed for the chart-full-setup Taskfile (test/integration/scenarios/chart-full-setup)
-        chart_path_relative="../../../../${chart_path}"
-
-        #
-        # Unit Tests.
-
-        # Unit test enabled or not. Assume it's enabled by default.
-        unit_enabled="$(yq '.unit.enabled' --indent=0 --output-format json ${matrix_file})"
-        echo "unit-enabled=${unit_enabled}" | tee -a $GITHUB_OUTPUT
-
-        # Unit test matrix.
-        unit_matrix="$(yq '.unit.matrix' --indent=0 --output-format json ${matrix_file})"
-        echo "unit-matrix=${unit_matrix}" | tee -a $GITHUB_OUTPUT
-
-        #
-        # Integration Tests.
-        integration_vars="$(yq '.integration' --indent=0 --output-format json ${matrix_file})"
-        charts_base_dir="$(echo ${integration_vars} | jq -r '.vars.chartsBaseDir')"
-
-        # Scenarios config.
-
-        # Tasks dir.
-        tasks_base_dir="$(echo ${integration_vars} | jq -r '.vars.tasksBaseDir')"
-        integration_scenarios_tasks_dir="${chart_path}/test/${tasks_base_dir}"
-        echo "CI_TASKS_BASE_DIR=${integration_scenarios_tasks_dir}" | tee -a $GITHUB_ENV
-
-        # Values dir.
-        values_base_dir="$(echo ${integration_vars} | jq -r '.vars.valuesBaseDir')"
-
-        integration_scenarios_values_dir="${chart_path_relative}/test/${values_base_dir}"
-        echo "TEST_VALUES_BASE_DIR=${integration_scenarios_values_dir}" | tee -a $GITHUB_ENV
-
-        # Charts dir.
-        echo "TEST_CHART_DIR=${charts_base_dir}/${chart_path}" | tee -a $GITHUB_ENV
-        echo "ABSOLUTE_TEST_CHART_DIR=${GITHUB_WORKSPACE}/${chart_path}" | tee -a $GITHUB_ENV
-
-        # Configuring TEST_HELM_EXTRA_ARGS
-        if [[ "${{ inputs.values-enterprise }}" == "true" ]]; then
-          helm_extra_args="--values ${chart_path_relative}/values-enterprise.yaml"
-          echo "TEST_HELM_EXTRA_ARGS=${helm_extra_args}" | tee -a $GITHUB_ENV
-        fi
-
-        # The values-digest file is used only in:
-        #  - The install step in the install flow.
-        #  - The upgrade step in the upgrade flow.
-        # It's not used in the install step in the upgrade flow.
-        if [[ "${{ inputs.values-digest }}" == "true" ]] && [[ -f "${chart_path}/values-digest.yaml" ]]; then
-          test_helm_digest_values="${chart_path_relative}/values-digest.yaml"
-          echo "TEST_HELM_DIGEST_VALUES=${test_helm_digest_values}" | tee -a $GITHUB_ENV
-        fi
-
-        # DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET is used in the E2E tests
-        if [[ -z "${{ env.DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET }}" ]]; then
-          echo "DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET=dummyValueNotUsed"
-        fi
-        echo "DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET=${{ env.DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET }}" | tee -a $GITHUB_ENV
+        deploy-camunda ci test-type-vars \
+          --chart-dir "${{ inputs.chart-dir }}" \
+          --flow "${{ inputs.flow }}" \
+          --camunda-version-previous "${{ inputs.camunda-version-previous }}" \
+          --upgrade-step "${{ inputs.upgrade-step }}" \
+          --values-enterprise "${{ inputs.values-enterprise }}" \
+          --values-digest "${{ inputs.values-digest }}"

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -323,33 +323,15 @@ jobs:
           echo "${matrix}" | jq
           echo "matrix=$(echo ${matrix} | jq -c)" > "$GITHUB_OUTPUT"
 
-      - name: Restore deploy-camunda binary
-        id: binary-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-        with:
-          path: ~/.local/bin/deploy-camunda
-          key: deploy-camunda-v2-${{ runner.os }}-${{ hashFiles('scripts/deploy-camunda/**/*.go', 'scripts/deploy-camunda/go.sum') }}
-      - name: Setup Go
-        if: steps.binary-cache.outputs.cache-hit != 'true'
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
-        with:
-          go-version-file: scripts/deploy-camunda/go.mod
-          cache: true
-          cache-dependency-path: scripts/deploy-camunda/go.sum
-      - name: Build deploy-camunda
-        if: steps.binary-cache.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          mkdir -p "$HOME/.local/bin"
-          # CGO_ENABLED=0 produces a static binary so it runs unchanged inside the
-          # ci-runner container used by downstream matrix jobs.
-          (cd scripts/deploy-camunda && CGO_ENABLED=0 go build -o "$HOME/.local/bin/deploy-camunda" .)
+      - name: Setup deploy-camunda
+        uses: ./.github/actions/setup-deploy-camunda
       - name: Upload deploy-camunda binary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: deploy-camunda-binary-${{ inputs.identifier }}
-          path: ~/.local/bin/deploy-camunda
+          name: deploy-camunda-binary-${{ inputs.identifier }}-${{ inputs.shortname }}-${{ inputs.flows }}
+          path: .local-bin/deploy-camunda
           if-no-files-found: error
+          overwrite: true
           retention-days: 1
 
   # The runner job is used to run the install/upgrade flows on the plaform (gke, rosa, etc.). This level of abstraction is needed so
@@ -374,7 +356,7 @@ jobs:
       auth: ${{ inputs.auth }}
       exclude: ${{ inputs.exclude }}
       identifier: ${{ inputs.identifier }}-${{ inputs.shortname }}
-      binary-artifact-name: deploy-camunda-binary-${{ inputs.identifier }}
+      binary-artifact-name: deploy-camunda-binary-${{ inputs.identifier }}-${{ inputs.shortname }}-${{ inputs.flows }}
       camunda-helm-repo: ${{ inputs.camunda-helm-repo }}
       camunda-helm-dir: ${{ inputs.camunda-helm-dir }}
       camunda-helm-git-ref: ${{ inputs.camunda-helm-git-ref }}

--- a/.github/workflows/test-release-tooling.yaml
+++ b/.github/workflows/test-release-tooling.yaml
@@ -3,7 +3,8 @@
 name: "Test - Release Tooling"
 
 # Gates the Go that the release and chart-validate pipelines depend on
-# (scripts/camunda-core + scripts/release-tools + scripts/validate-values-schema).
+# (scripts/camunda-core + scripts/release-tools + scripts/validate-values-schema
+# + scripts/deploy-camunda).
 # Deliberately UNFILTERED: the tooling's behavior is
 # coupled to inputs that live outside scripts/ (charts/**/values*.yaml,
 # charts/chart-versions.yaml, the committed version-matrix, the release-please
@@ -51,6 +52,12 @@ jobs:
         run: |
           go vet ./pkg/...
           go test ./pkg/...
+
+      - name: deploy-camunda — vet + test
+        working-directory: scripts/deploy-camunda
+        run: |
+          go vet ./...
+          go test ./...
 
       - name: release-tools — vet + test
         working-directory: scripts/release-tools

--- a/scripts/camunda-core/pkg/ciworkflow/testtypevars.go
+++ b/scripts/camunda-core/pkg/ciworkflow/testtypevars.go
@@ -1,0 +1,181 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ciworkflow ports GitHub Actions CI variable-computation logic from
+// bash to testable Go. It replaces the shell body of the composite action at
+// .github/actions/test-type-vars.
+package ciworkflow
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"scripts/camunda-core/pkg/ghactions"
+
+	"gopkg.in/yaml.v3"
+)
+
+// UnitMatrixEntry is one entry of the unit-test matrix declared under `unit:`
+// in a chart's ci-test-config.yaml. The JSON tags reproduce the compact output
+// previously produced by `yq --indent=0 --output-format json`.
+type UnitMatrixEntry struct {
+	Name     string `json:"name" yaml:"name"`
+	Packages string `json:"packages" yaml:"packages"`
+}
+
+// ciTestConfig is the minimal view of ci-test-config.yaml consumed here. The
+// integration block was migrated to the composable scenario registry, so only
+// the `unit:` block remains as the source of truth for these vars.
+type ciTestConfig struct {
+	Unit struct {
+		Enabled bool              `yaml:"enabled"`
+		Matrix  []UnitMatrixEntry `yaml:"matrix"`
+	} `yaml:"unit"`
+}
+
+// TestTypeVarsInput carries the composite-action inputs plus the ambient env
+// values the computation depends on.
+type TestTypeVarsInput struct {
+	// ChartDir is the chart directory name, e.g. "camunda-platform-8.10".
+	ChartDir string
+	// Flow is the setup flow, e.g. "install", "upgrade-patch", "upgrade-minor".
+	Flow string
+	// CamundaVersionPrevious is the previous Camunda minor, e.g. "8.9".
+	CamundaVersionPrevious string
+	// UpgradeStep is true when called from the upgrade phase of an upgrade flow.
+	UpgradeStep bool
+	// ValuesEnterprise enables the enterprise values file.
+	ValuesEnterprise bool
+	// ValuesDigest enables the digest values file when it exists.
+	ValuesDigest bool
+	// GitHubWorkspace is $GITHUB_WORKSPACE, used for AbsoluteTestChartDir.
+	GitHubWorkspace string
+	// KeycloakClientsSecret is the passthrough DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET.
+	KeycloakClientsSecret string
+	// RepoRoot is the directory the chart paths are resolved against. Empty
+	// means "." (the CI working directory / repo root).
+	RepoRoot string
+}
+
+// TestTypeVars is the computed result. It is returned as a struct (so callers
+// can consume it directly and env-var passing can be removed later) and can be
+// emitted to $GITHUB_ENV / $GITHUB_OUTPUT via Emit.
+type TestTypeVars struct {
+	ChartPath             string
+	AbsoluteTestChartDir  string
+	TestHelmExtraArgs     string
+	TestHelmDigestValues  string
+	KeycloakClientsSecret string
+	UnitEnabled           bool
+	UnitMatrix            []UnitMatrixEntry
+}
+
+// Compute reproduces the test-type-vars shell logic.
+func Compute(in TestTypeVarsInput) (TestTypeVars, error) {
+	repoRoot := in.RepoRoot
+	if repoRoot == "" {
+		repoRoot = "."
+	}
+
+	// Chart path. For upgrade-minor, the install step deploys the previous
+	// chart version, but the upgrade step must use the current (target) chart.
+	var chartPath string
+	if in.Flow == "upgrade-minor" && in.CamundaVersionPrevious != "" && !in.UpgradeStep {
+		chartPath = "charts/camunda-platform-" + in.CamundaVersionPrevious
+	} else {
+		chartPath = "charts/" + in.ChartDir
+	}
+
+	// Relative path used by the chart-full-setup Taskfile
+	// (test/integration/scenarios/chart-full-setup).
+	chartPathRelative := "../../../../" + chartPath
+
+	matrixFile := filepath.Join(repoRoot, "charts", in.ChartDir, "test", "ci-test-config.yaml")
+	raw, err := os.ReadFile(matrixFile)
+	if err != nil {
+		return TestTypeVars{}, fmt.Errorf("read %s: %w", matrixFile, err)
+	}
+	var cfg ciTestConfig
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		return TestTypeVars{}, fmt.Errorf("parse %s: %w", matrixFile, err)
+	}
+
+	out := TestTypeVars{
+		ChartPath:             chartPath,
+		AbsoluteTestChartDir:  in.GitHubWorkspace + "/" + chartPath,
+		KeycloakClientsSecret: in.KeycloakClientsSecret,
+		UnitEnabled:           cfg.Unit.Enabled,
+		UnitMatrix:            cfg.Unit.Matrix,
+	}
+
+	if in.ValuesEnterprise {
+		out.TestHelmExtraArgs = "--values " + chartPathRelative + "/values-enterprise.yaml"
+	}
+
+	// The digest values file is used only when enabled and the file exists for
+	// the resolved chart path.
+	if in.ValuesDigest {
+		if _, err := os.Stat(filepath.Join(repoRoot, chartPath, "values-digest.yaml")); err == nil {
+			out.TestHelmDigestValues = chartPathRelative + "/values-digest.yaml"
+		}
+	}
+
+	return out, nil
+}
+
+// UnitMatrixJSON returns the unit matrix as compact JSON, matching the previous
+// `yq --indent=0 --output-format json` output consumed as a GHA job matrix.
+func (v TestTypeVars) UnitMatrixJSON() (string, error) {
+	b, err := json.Marshal(v.UnitMatrix)
+	if err != nil {
+		return "", fmt.Errorf("marshal unit matrix: %w", err)
+	}
+	return string(b), nil
+}
+
+// Emit writes the environment variables to env and the step outputs to out.
+// TestHelmExtraArgs and TestHelmDigestValues are only written when non-empty,
+// matching the original conditional shell behavior.
+func (v TestTypeVars) Emit(env, out *ghactions.Writer) error {
+	if err := env.Set("CHART_PATH", v.ChartPath); err != nil {
+		return err
+	}
+	if err := env.Set("ABSOLUTE_TEST_CHART_DIR", v.AbsoluteTestChartDir); err != nil {
+		return err
+	}
+	if v.TestHelmExtraArgs != "" {
+		if err := env.Set("TEST_HELM_EXTRA_ARGS", v.TestHelmExtraArgs); err != nil {
+			return err
+		}
+	}
+	if v.TestHelmDigestValues != "" {
+		if err := env.Set("TEST_HELM_DIGEST_VALUES", v.TestHelmDigestValues); err != nil {
+			return err
+		}
+	}
+	if err := env.Set("DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET", v.KeycloakClientsSecret); err != nil {
+		return err
+	}
+
+	if err := out.Set("unit-enabled", fmt.Sprintf("%t", v.UnitEnabled)); err != nil {
+		return err
+	}
+	matrixJSON, err := v.UnitMatrixJSON()
+	if err != nil {
+		return err
+	}
+	return out.Set("unit-matrix", matrixJSON)
+}

--- a/scripts/camunda-core/pkg/ciworkflow/testtypevars_test.go
+++ b/scripts/camunda-core/pkg/ciworkflow/testtypevars_test.go
@@ -1,0 +1,269 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ciworkflow
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"scripts/camunda-core/pkg/ghactions"
+)
+
+const sampleConfig = `unit:
+  enabled: true
+  matrix:
+    - name: Management
+      packages: identity common
+    - name: Orchestration
+      packages: orchestration connectors optimize
+    - name: Design
+      packages: web-modeler
+`
+
+// writeConfig creates repoRoot/charts/<chartDir>/test/ci-test-config.yaml and,
+// when digest is true, an empty values-digest.yaml next to the chart.
+func writeConfig(t *testing.T, chartDir, body string, digest bool) string {
+	t.Helper()
+	root := t.TempDir()
+	chartTestDir := filepath.Join(root, "charts", chartDir, "test")
+	if err := os.MkdirAll(chartTestDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(chartTestDir, "ci-test-config.yaml"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if digest {
+		if err := os.WriteFile(filepath.Join(root, "charts", chartDir, "values-digest.yaml"), []byte("{}\n"), 0o644); err != nil {
+			t.Fatalf("write digest: %v", err)
+		}
+	}
+	return root
+}
+
+func TestComputeChartPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		in          TestTypeVarsInput
+		wantPath    string
+		wantAbsPath string
+	}{
+		{
+			name:        "install flow uses current chart",
+			in:          TestTypeVarsInput{ChartDir: "camunda-platform-8.10", Flow: "install", GitHubWorkspace: "/ws"},
+			wantPath:    "charts/camunda-platform-8.10",
+			wantAbsPath: "/ws/charts/camunda-platform-8.10",
+		},
+		{
+			name:        "upgrade-minor install step uses previous chart",
+			in:          TestTypeVarsInput{ChartDir: "camunda-platform-8.10", Flow: "upgrade-minor", CamundaVersionPrevious: "8.9", UpgradeStep: false, GitHubWorkspace: "/ws"},
+			wantPath:    "charts/camunda-platform-8.9",
+			wantAbsPath: "/ws/charts/camunda-platform-8.9",
+		},
+		{
+			name:        "upgrade-minor upgrade step uses current chart",
+			in:          TestTypeVarsInput{ChartDir: "camunda-platform-8.10", Flow: "upgrade-minor", CamundaVersionPrevious: "8.9", UpgradeStep: true, GitHubWorkspace: "/ws"},
+			wantPath:    "charts/camunda-platform-8.10",
+			wantAbsPath: "/ws/charts/camunda-platform-8.10",
+		},
+		{
+			name:        "upgrade-minor without previous falls back to current chart",
+			in:          TestTypeVarsInput{ChartDir: "camunda-platform-8.10", Flow: "upgrade-minor", CamundaVersionPrevious: "", GitHubWorkspace: "/ws"},
+			wantPath:    "charts/camunda-platform-8.10",
+			wantAbsPath: "/ws/charts/camunda-platform-8.10",
+		},
+		{
+			name:        "upgrade-patch uses current chart",
+			in:          TestTypeVarsInput{ChartDir: "camunda-platform-8.10", Flow: "upgrade-patch", CamundaVersionPrevious: "8.9", GitHubWorkspace: "/ws"},
+			wantPath:    "charts/camunda-platform-8.10",
+			wantAbsPath: "/ws/charts/camunda-platform-8.10",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.in.RepoRoot = writeConfig(t, tc.in.ChartDir, sampleConfig, false)
+			got, err := Compute(tc.in)
+			if err != nil {
+				t.Fatalf("Compute: %v", err)
+			}
+			if got.ChartPath != tc.wantPath {
+				t.Errorf("ChartPath = %q, want %q", got.ChartPath, tc.wantPath)
+			}
+			if got.AbsoluteTestChartDir != tc.wantAbsPath {
+				t.Errorf("AbsoluteTestChartDir = %q, want %q", got.AbsoluteTestChartDir, tc.wantAbsPath)
+			}
+		})
+	}
+}
+
+func TestComputeEnterpriseArgs(t *testing.T) {
+	root := writeConfig(t, "camunda-platform-8.10", sampleConfig, false)
+
+	off, err := Compute(TestTypeVarsInput{ChartDir: "camunda-platform-8.10", Flow: "install", RepoRoot: root})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	if off.TestHelmExtraArgs != "" {
+		t.Errorf("TestHelmExtraArgs = %q, want empty when disabled", off.TestHelmExtraArgs)
+	}
+
+	on, err := Compute(TestTypeVarsInput{ChartDir: "camunda-platform-8.10", Flow: "install", ValuesEnterprise: true, RepoRoot: root})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	want := "--values ../../../../charts/camunda-platform-8.10/values-enterprise.yaml"
+	if on.TestHelmExtraArgs != want {
+		t.Errorf("TestHelmExtraArgs = %q, want %q", on.TestHelmExtraArgs, want)
+	}
+}
+
+func TestComputeDigestGate(t *testing.T) {
+	// File present + enabled -> set.
+	rootWith := writeConfig(t, "camunda-platform-8.10", sampleConfig, true)
+	withFile, err := Compute(TestTypeVarsInput{ChartDir: "camunda-platform-8.10", Flow: "install", ValuesDigest: true, RepoRoot: rootWith})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	want := "../../../../charts/camunda-platform-8.10/values-digest.yaml"
+	if withFile.TestHelmDigestValues != want {
+		t.Errorf("TestHelmDigestValues = %q, want %q", withFile.TestHelmDigestValues, want)
+	}
+
+	// Enabled but file absent -> empty.
+	rootWithout := writeConfig(t, "camunda-platform-8.10", sampleConfig, false)
+	noFile, err := Compute(TestTypeVarsInput{ChartDir: "camunda-platform-8.10", Flow: "install", ValuesDigest: true, RepoRoot: rootWithout})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	if noFile.TestHelmDigestValues != "" {
+		t.Errorf("TestHelmDigestValues = %q, want empty when file missing", noFile.TestHelmDigestValues)
+	}
+
+	// File present but disabled -> empty.
+	disabled, err := Compute(TestTypeVarsInput{ChartDir: "camunda-platform-8.10", Flow: "install", ValuesDigest: false, RepoRoot: rootWith})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	if disabled.TestHelmDigestValues != "" {
+		t.Errorf("TestHelmDigestValues = %q, want empty when disabled", disabled.TestHelmDigestValues)
+	}
+}
+
+func TestComputeUnitBlock(t *testing.T) {
+	root := writeConfig(t, "camunda-platform-8.10", sampleConfig, false)
+	got, err := Compute(TestTypeVarsInput{ChartDir: "camunda-platform-8.10", Flow: "install", RepoRoot: root})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	if !got.UnitEnabled {
+		t.Errorf("UnitEnabled = false, want true")
+	}
+	if len(got.UnitMatrix) != 3 {
+		t.Fatalf("UnitMatrix len = %d, want 3", len(got.UnitMatrix))
+	}
+	gotJSON, err := got.UnitMatrixJSON()
+	if err != nil {
+		t.Fatalf("UnitMatrixJSON: %v", err)
+	}
+	// Must match the compact form previously produced by
+	// `yq --indent=0 --output-format json`.
+	wantJSON := `[{"name":"Management","packages":"identity common"},` +
+		`{"name":"Orchestration","packages":"orchestration connectors optimize"},` +
+		`{"name":"Design","packages":"web-modeler"}]`
+	if gotJSON != wantJSON {
+		t.Errorf("UnitMatrixJSON =\n  %s\nwant\n  %s", gotJSON, wantJSON)
+	}
+}
+
+func TestComputeMissingConfig(t *testing.T) {
+	root := t.TempDir()
+	_, err := Compute(TestTypeVarsInput{ChartDir: "camunda-platform-8.10", Flow: "install", RepoRoot: root})
+	if err == nil {
+		t.Fatalf("Compute: want error for missing config, got nil")
+	}
+}
+
+func TestEmit(t *testing.T) {
+	root := writeConfig(t, "camunda-platform-8.10", sampleConfig, true)
+	v, err := Compute(TestTypeVarsInput{
+		ChartDir:              "camunda-platform-8.10",
+		Flow:                  "install",
+		ValuesEnterprise:      true,
+		ValuesDigest:          true,
+		GitHubWorkspace:       "/ws",
+		KeycloakClientsSecret: "s3cr3t",
+		RepoRoot:              root,
+	})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+
+	envFile := filepath.Join(t.TempDir(), "env")
+	outFile := filepath.Join(t.TempDir(), "out")
+	if err := v.Emit(&ghactions.Writer{Path: envFile}, &ghactions.Writer{Path: outFile}); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	env := readFile(t, envFile)
+	out := readFile(t, outFile)
+
+	wantEnv := []string{
+		"CHART_PATH=charts/camunda-platform-8.10",
+		"ABSOLUTE_TEST_CHART_DIR=/ws/charts/camunda-platform-8.10",
+		"TEST_HELM_EXTRA_ARGS=--values ../../../../charts/camunda-platform-8.10/values-enterprise.yaml",
+		"TEST_HELM_DIGEST_VALUES=../../../../charts/camunda-platform-8.10/values-digest.yaml",
+		"DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET=s3cr3t",
+	}
+	for _, line := range wantEnv {
+		if !strings.Contains(env, line+"\n") {
+			t.Errorf("env missing line %q\n--- env ---\n%s", line, env)
+		}
+	}
+	if !strings.Contains(out, "unit-enabled=true\n") {
+		t.Errorf("out missing unit-enabled\n--- out ---\n%s", out)
+	}
+	if !strings.Contains(out, `unit-matrix=[{"name":"Management"`) {
+		t.Errorf("out missing unit-matrix\n--- out ---\n%s", out)
+	}
+}
+
+func TestEmitOmitsEmptyConditionalVars(t *testing.T) {
+	root := writeConfig(t, "camunda-platform-8.10", sampleConfig, false)
+	v, err := Compute(TestTypeVarsInput{ChartDir: "camunda-platform-8.10", Flow: "install", RepoRoot: root})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	envFile := filepath.Join(t.TempDir(), "env")
+	if err := v.Emit(&ghactions.Writer{Path: envFile}, &ghactions.Writer{Path: filepath.Join(t.TempDir(), "out")}); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	env := readFile(t, envFile)
+	if strings.Contains(env, "TEST_HELM_EXTRA_ARGS=") {
+		t.Errorf("env should not contain TEST_HELM_EXTRA_ARGS when disabled\n%s", env)
+	}
+	if strings.Contains(env, "TEST_HELM_DIGEST_VALUES=") {
+		t.Errorf("env should not contain TEST_HELM_DIGEST_VALUES when disabled\n%s", env)
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}

--- a/scripts/camunda-core/pkg/ghactions/writer.go
+++ b/scripts/camunda-core/pkg/ghactions/writer.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ghactions provides small helpers for GitHub Actions step logic that
+// is being ported from bash to Go. Writer appends key/value pairs to the files
+// named by $GITHUB_ENV and $GITHUB_OUTPUT.
+package ghactions
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Writer appends key/value pairs to the file named by a GitHub Actions
+// environment variable ($GITHUB_ENV or $GITHUB_OUTPUT). When that env var is
+// unset it falls back to stdout so the values stay visible on local runs —
+// unless $GITHUB_ACTIONS is "true", where a missing target file means the
+// step is misconfigured and Set returns an error instead of echoing values
+// (potentially secrets) into the job log. Multiline values use the heredoc
+// form GitHub requires.
+type Writer struct {
+	// Path is the target file. Empty means stdout.
+	Path string
+}
+
+// NewGitHubEnv targets $GITHUB_ENV, the job-scoped environment file.
+func NewGitHubEnv() *Writer { return &Writer{Path: os.Getenv("GITHUB_ENV")} }
+
+// NewGitHubOutput targets $GITHUB_OUTPUT, the step outputs file.
+func NewGitHubOutput() *Writer { return &Writer{Path: os.Getenv("GITHUB_OUTPUT")} }
+
+// Set appends a single key/value pair.
+func (w *Writer) Set(key, value string) error {
+	var line string
+	if strings.Contains(value, "\n") {
+		// GitHub Actions requires a heredoc delimiter that does not occur in
+		// the value; a random per-call delimiter guarantees that for arbitrary
+		// content.
+		delim, err := randomDelimiter()
+		if err != nil {
+			return err
+		}
+		line = fmt.Sprintf("%s<<%s\n%s\n%s\n", key, delim, value, delim)
+	} else {
+		line = fmt.Sprintf("%s=%s\n", key, value)
+	}
+	if w.Path == "" {
+		if os.Getenv("GITHUB_ACTIONS") == "true" {
+			return fmt.Errorf("set %s: no target file configured while running in GitHub Actions", key)
+		}
+		_, err := fmt.Fprint(os.Stdout, line)
+		return err
+	}
+	f, err := os.OpenFile(w.Path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o644)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", w.Path, err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(line); err != nil {
+		return fmt.Errorf("write %s: %w", w.Path, err)
+	}
+	return nil
+}
+
+// randomDelimiter returns a delimiter that is not feasibly present in any value.
+func randomDelimiter() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate delimiter: %w", err)
+	}
+	return "ghadelimiter_" + hex.EncodeToString(b), nil
+}

--- a/scripts/camunda-core/pkg/ghactions/writer_test.go
+++ b/scripts/camunda-core/pkg/ghactions/writer_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ghactions
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSetSingleLine(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "env")
+	w := &Writer{Path: path}
+	if err := w.Set("CHART_PATH", "charts/camunda-platform-8.10"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	got := readAll(t, path)
+	if got != "CHART_PATH=charts/camunda-platform-8.10\n" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestSetMultilineUsesRandomDelimiter(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "env")
+	w := &Writer{Path: path}
+	// A value that contains the delimiter previously hardcoded would corrupt
+	// the file; the random delimiter must not appear inside the value.
+	value := "line1\n__EOF__\nline3"
+	if err := w.Set("KEY", value); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	got := readAll(t, path)
+	if !strings.HasPrefix(got, "KEY<<ghadelimiter_") {
+		t.Fatalf("expected random heredoc delimiter, got %q", got)
+	}
+	delim := strings.TrimSuffix(strings.TrimPrefix(strings.SplitN(got, "\n", 2)[0], "KEY<<"), "")
+	if strings.Contains(value, delim) {
+		t.Errorf("delimiter %q must not occur in value", delim)
+	}
+	// The value must round-trip verbatim between the two delimiter lines.
+	if !strings.Contains(got, "\n"+value+"\n"+delim+"\n") {
+		t.Errorf("value not framed by delimiter\n%q", got)
+	}
+}
+
+func TestSetNoPathFailsInGitHubActions(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "true")
+	w := &Writer{}
+	if err := w.Set("SECRET", "value"); err == nil {
+		t.Fatal("expected error when no target file is configured in GitHub Actions")
+	}
+}
+
+func TestSetNoPathFallsBackToStdoutLocally(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "")
+	w := &Writer{}
+	if err := w.Set("KEY", "value"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+}
+
+func TestRandomDelimiterUnique(t *testing.T) {
+	a, err := randomDelimiter()
+	if err != nil {
+		t.Fatalf("randomDelimiter: %v", err)
+	}
+	b, err := randomDelimiter()
+	if err != nil {
+		t.Fatalf("randomDelimiter: %v", err)
+	}
+	if a == b {
+		t.Errorf("expected distinct delimiters, got %q twice", a)
+	}
+}
+
+func readAll(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}

--- a/scripts/deploy-camunda/cmd/ci.go
+++ b/scripts/deploy-camunda/cmd/ci.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"os"
+
+	"scripts/camunda-core/pkg/ciworkflow"
+	"scripts/camunda-core/pkg/ghactions"
+
+	"github.com/spf13/cobra"
+)
+
+// newCICommand creates the "ci" parent command grouping subcommands that
+// replace bash step logic inside GitHub Actions workflows.
+func newCICommand() *cobra.Command {
+	ciCmd := &cobra.Command{
+		Use:   "ci",
+		Short: "Compute CI workflow variables inside GitHub Actions",
+	}
+
+	ciCmd.AddCommand(newCITestTypeVarsCommand())
+
+	return ciCmd
+}
+
+// newCITestTypeVarsCommand creates the "ci test-type-vars" subcommand. It
+// replaces the shell body of the composite action
+// .github/actions/test-type-vars: computed vars are appended to the files
+// named by $GITHUB_ENV and $GITHUB_OUTPUT (stdout on local runs).
+//
+// Boolean-like inputs are string flags compared against "true" because the
+// composite action forwards its inputs verbatim as separate arguments
+// (--upgrade-step "true"), a shape cobra bool flags do not accept.
+func newCITestTypeVarsCommand() *cobra.Command {
+	var (
+		chartDir         string
+		flow             string
+		prev             string
+		upgradeStep      string
+		valuesEnterprise string
+		valuesDigest     string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "test-type-vars",
+		Short: "Compute the CI test-type variables for a chart version",
+		Long: `Compute the CI test-type variables for a chart version and write them
+to $GITHUB_ENV / $GITHUB_OUTPUT.
+
+Environment variables:
+  GITHUB_WORKSPACE                              Absolute repo checkout path
+  DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET   Passed through to $GITHUB_ENV`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			in := ciworkflow.TestTypeVarsInput{
+				ChartDir:               chartDir,
+				Flow:                   flow,
+				CamundaVersionPrevious: prev,
+				UpgradeStep:            upgradeStep == "true",
+				ValuesEnterprise:       valuesEnterprise == "true",
+				ValuesDigest:           valuesDigest == "true",
+				GitHubWorkspace:        os.Getenv("GITHUB_WORKSPACE"),
+				KeycloakClientsSecret:  os.Getenv("DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET"),
+			}
+
+			vars, err := ciworkflow.Compute(in)
+			if err != nil {
+				return err
+			}
+			return vars.Emit(ghactions.NewGitHubEnv(), ghactions.NewGitHubOutput())
+		},
+	}
+
+	cmd.Flags().StringVar(&chartDir, "chart-dir", "", "chart directory name, e.g. camunda-platform-8.10")
+	cmd.Flags().StringVar(&flow, "flow", "install", "setup flow: install, upgrade-patch, upgrade-minor")
+	cmd.Flags().StringVar(&prev, "camunda-version-previous", "", "previous Camunda minor, e.g. 8.9")
+	cmd.Flags().StringVar(&upgradeStep, "upgrade-step", "false", `"true" during the upgrade phase of an upgrade flow`)
+	cmd.Flags().StringVar(&valuesEnterprise, "values-enterprise", "false", `"true" to enable enterprise values`)
+	cmd.Flags().StringVar(&valuesDigest, "values-digest", "false", `"true" to enable digest values when present`)
+	_ = cmd.MarkFlagRequired("chart-dir")
+
+	return cmd
+}

--- a/scripts/deploy-camunda/cmd/ci_test.go
+++ b/scripts/deploy-camunda/cmd/ci_test.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Pins the flag→struct wiring of "ci test-type-vars": string flags compared
+// against "true" (composite-action argument shape), the env passthroughs, and
+// the root PersistentPreRunE skip (ci needs no chart/namespace config). The
+// computation itself is covered in camunda-core/pkg/ciworkflow.
+func TestCITestTypeVarsWiring(t *testing.T) {
+	repo := t.TempDir()
+	chartDir := "camunda-platform-8.10"
+	writeFile(t, filepath.Join(repo, "charts", chartDir, "test", "ci-test-config.yaml"),
+		"unit:\n  enabled: true\n  matrix:\n    - name: core\n      packages: test/unit/camunda\n")
+	writeFile(t, filepath.Join(repo, "charts", chartDir, "values-digest.yaml"), "{}\n")
+
+	envFile := filepath.Join(t.TempDir(), "github_env")
+	outFile := filepath.Join(t.TempDir(), "github_output")
+	t.Setenv("GITHUB_ENV", envFile)
+	t.Setenv("GITHUB_OUTPUT", outFile)
+	t.Setenv("GITHUB_WORKSPACE", "/workspace")
+	t.Setenv("DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET", "s3cret")
+	t.Chdir(repo)
+
+	root := NewRootCommand()
+	root.AddCommand(newCICommand())
+	root.SetArgs([]string{
+		"ci", "test-type-vars",
+		"--chart-dir", chartDir,
+		"--flow", "install",
+		"--upgrade-step", "false",
+		"--values-enterprise", "true",
+		"--values-digest", "true",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	env := readFile(t, envFile)
+	for _, want := range []string{
+		"CHART_PATH=charts/camunda-platform-8.10\n",
+		"ABSOLUTE_TEST_CHART_DIR=/workspace/charts/camunda-platform-8.10\n",
+		"TEST_HELM_EXTRA_ARGS=--values ../../../../charts/camunda-platform-8.10/values-enterprise.yaml\n",
+		"TEST_HELM_DIGEST_VALUES=../../../../charts/camunda-platform-8.10/values-digest.yaml\n",
+		"DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET=s3cret\n",
+	} {
+		if !strings.Contains(env, want) {
+			t.Errorf("GITHUB_ENV missing %q; got:\n%s", want, env)
+		}
+	}
+
+	out := readFile(t, outFile)
+	for _, want := range []string{
+		"unit-enabled=true\n",
+		`unit-matrix=[{"name":"core","packages":"test/unit/camunda"}]` + "\n",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("GITHUB_OUTPUT missing %q; got:\n%s", want, out)
+		}
+	}
+}
+
+func TestCITestTypeVarsRequiresChartDir(t *testing.T) {
+	cmd := newCITestTypeVarsCommand()
+	cmd.SetArgs([]string{"--flow", "install"})
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error when --chart-dir is missing")
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}

--- a/scripts/deploy-camunda/cmd/root.go
+++ b/scripts/deploy-camunda/cmd/root.go
@@ -94,6 +94,11 @@ func NewRootCommand() *cobra.Command {
 				if cmd.Name() == "diagnostics" || (cmd.Parent() != nil && cmd.Parent().Name() == "diagnostics") {
 					return nil
 				}
+				// ci subcommands compute GitHub Actions step variables; no
+				// chart/namespace config needed.
+				if cmd.Name() == "ci" || (cmd.Parent() != nil && cmd.Parent().Name() == "ci") {
+					return nil
+				}
 				if cmd.Name() == "completion" ||
 					cmd.Name() == cobra.ShellCompRequestCmd ||
 					cmd.Name() == cobra.ShellCompNoDescRequestCmd {
@@ -551,6 +556,7 @@ func Execute() error {
 	rootCmd.AddCommand(newDoctorCommand())
 	rootCmd.AddCommand(newTriageCommand())
 	rootCmd.AddCommand(newDiagnosticsCommand())
+	rootCmd.AddCommand(newCICommand())
 
 	err := rootCmd.Execute()
 	if err != nil {


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #5783.

Part of the bash→Go CI migration tracked in #4705. Stacked on #6612 (base:
`6611-centralize-deploy-camunda-setup`) so this PR only contains the first Go
behavior port.

### What's in this PR?

Ports the shell body of the `test-type-vars` composite action to testable Go,
as a `deploy-camunda` subcommand shared by the follow-up CI-logic ports.

- `scripts/camunda-core/pkg/ciworkflow` — `TestTypeVars` struct + `Compute`
  (reads the `unit:` block of `ci-test-config.yaml`, resolves the chart path
  incl. the upgrade-minor swap, gates enterprise/digest values) + `Emit` to
  `$GITHUB_ENV`/`$GITHUB_OUTPUT`. Returned as a struct so the env-var passing
  can be removed by a later refactor (per the issue's acceptance criteria).
- `scripts/camunda-core/pkg/ghactions` — small `$GITHUB_ENV`/`$GITHUB_OUTPUT`
  writer, reusable by the follow-up ports. In GitHub Actions
  (`GITHUB_ACTIONS=true`) a missing target file is an error instead of a
  stdout fallback, so values (incl. secrets) can't leak into job logs.
- `deploy-camunda ci test-type-vars` — thin CLI wiring (`cmd/ci.go`), exempt
  from the deploy config pre-run; wiring test runs through the root command.
- Table-driven unit tests: chart-path branches, enterprise args, digest
  file-exists gate, unit-matrix JSON (byte-equal to the previous
  `yq --output-format json` output), and `Emit` output.
- `.github/actions/test-type-vars/action.yaml` calls the shared setup action
  introduced by #6612; the input/output contract
  (`unitTestEnabled`/`unitTestMatrix` + env vars) is unchanged.
- `test-release-tooling.yaml`: the new-module compile gate is replaced by a
  `deploy-camunda` vet+test step (the module previously had no CI test gate).

**Dropped 3 dead outputs.** `CI_TASKS_BASE_DIR`, `TEST_CHART_DIR`, and
`TEST_VALUES_BASE_DIR` were computed from `.integration.vars.*`, which #6318
removed when it migrated the integration block to the composable scenario
registry. Since then the bash emitted `.../test/null` paths for these. Verified
no live consumer remains: `CI_TASKS_BASE_DIR` (comment only),
`TEST_CHART_DIR` (only `ABSOLUTE_TEST_CHART_DIR` is used),
`TEST_VALUES_BASE_DIR` (only the dormant `pre-install-upgrade.sh`, wired to no
flow). This is the only behavior change.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?