### PR TITLE
ci: resolve requested reviewers to Slack mentions in PR activity notifications

### DIFF
--- a/scripts/notify-pr-activity/main.go
+++ b/scripts/notify-pr-activity/main.go
@@ -50,6 +50,14 @@ func mustEnv(key string) string {
 	return v
 }
 
+// userMapPath returns the slack-user-map.json path, overridable via SLACK_USER_MAP_PATH.
+func userMapPath() string {
+	if p := os.Getenv("SLACK_USER_MAP_PATH"); p != "" {
+		return p
+	}
+	return "slack-user-map.json"
+}
+
 func shortRepo(name string) string {
 	return strings.TrimPrefix(name, "camunda-platform-")
 }
@@ -70,8 +78,33 @@ func formatDuration(from, to time.Time) string {
 	}
 }
 
-// parseReviewers decodes a JSON array of GitHub user objects and returns "@login, ..." string.
-func parseReviewers(raw string) string {
+// loadUserMap reads a GitHub-login -> Slack-user-ID JSON map. A missing or
+// unreadable file yields an empty map, so reviewers fall back to "@login".
+func loadUserMap(path string) map[string]string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ℹ️  no user map at %s: %v (falling back to @login)\n", path, err)
+		return map[string]string{}
+	}
+	var m map[string]string
+	if err := json.Unmarshal(data, &m); err != nil {
+		fmt.Fprintf(os.Stderr, "⚠️  invalid user map %s: %v (falling back to @login)\n", path, err)
+		return map[string]string{}
+	}
+	return m
+}
+
+// slackMention resolves a GitHub login to a Slack "<@UID>" mention, or "@login" when unmapped.
+func slackMention(login string, userMap map[string]string) string {
+	if uid, ok := userMap[login]; ok && uid != "" {
+		return "<@" + uid + ">"
+	}
+	return "@" + login
+}
+
+// parseReviewers decodes a JSON array of GitHub user objects and returns a
+// comma-separated list of Slack mentions (or "@login" fallbacks).
+func parseReviewers(raw string, userMap map[string]string) string {
 	var users []struct {
 		Login string `json:"login"`
 	}
@@ -80,7 +113,7 @@ func parseReviewers(raw string) string {
 	}
 	names := make([]string, 0, len(users))
 	for _, u := range users {
-		names = append(names, "@"+u.Login)
+		names = append(names, slackMention(u.Login, userMap))
 	}
 	return strings.Join(names, ", ")
 }
@@ -113,7 +146,8 @@ func buildMessage() string {
 
 	switch action {
 	case "opened", "ready_for_review":
-		reviewers := parseReviewers(os.Getenv("PR_REVIEWERS_JSON"))
+		userMap := loadUserMap(userMapPath())
+		reviewers := parseReviewers(os.Getenv("PR_REVIEWERS_JSON"), userMap)
 		if reviewers != "" {
 			return fmt.Sprintf("↗ [%s] %s — review: %s", repo, link, reviewers)
 		}

--- a/scripts/notify-pr-activity/main_test.go
+++ b/scripts/notify-pr-activity/main_test.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"os"
 	"testing"
 	"time"
 )
@@ -115,12 +114,46 @@ func TestFormatDuration(t *testing.T) {
 	}
 }
 
-// TestParseReviewers checks the reviewer JSON parsing helper.
+// TestParseReviewers checks reviewer resolution with and without a Slack user map.
 func TestParseReviewers(t *testing.T) {
-	os.Setenv("PR_REVIEWERS_JSON", `[{"login":"alice"},{"login":"bob"}]`)
-	got := parseReviewers(`[{"login":"alice"},{"login":"bob"}]`)
-	want := "@alice, @bob"
-	if got != want {
-		t.Errorf("got %q, want %q", got, want)
+	userMap := map[string]string{"alice": "U123"}
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"mapped and fallback", `[{"login":"alice"},{"login":"bob"}]`, "<@U123>, @bob"},
+		{"all fallback", `[{"login":"bob"}]`, "@bob"},
+		{"empty", `[]`, ""},
+	}
+	for _, c := range cases {
+		if got := parseReviewers(c.raw, userMap); got != c.want {
+			t.Errorf("%s: got %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+// TestSlackMention checks mapped resolution and the @login fallback.
+func TestSlackMention(t *testing.T) {
+	userMap := map[string]string{"alice": "U123", "empty": ""}
+	cases := []struct {
+		login string
+		want  string
+	}{
+		{"alice", "<@U123>"},
+		{"bob", "@bob"},
+		{"empty", "@empty"},
+	}
+	for _, c := range cases {
+		if got := slackMention(c.login, userMap); got != c.want {
+			t.Errorf("login=%s: got %q, want %q", c.login, got, c.want)
+		}
+	}
+}
+
+// TestLoadUserMap_Missing returns an empty map for an absent file.
+func TestLoadUserMap_Missing(t *testing.T) {
+	if m := loadUserMap("does-not-exist.json"); len(m) != 0 {
+		t.Errorf("expected empty map for missing file, got %v", m)
 	}
 }

--- a/scripts/notify-pr-activity/slack-user-map.json
+++ b/scripts/notify-pr-activity/slack-user-map.json
@@ -1,0 +1,6 @@
+{
+    "eamonnmoloney": "U08J0CGB7L5",
+    "hisImminence": "UP42EDQSW",
+    "bkenez": "U082FTSHCNM",
+    "Ian-wang-liyang": "U0B0CR35TMZ"
+}


### PR DESCRIPTION
### Which problem does the PR fix?

Closes camunda/camunda-platform-helm#5835.

PR-opened Slack notifications in #team-distribution-github show requested
reviewers as plain `@login` text, so reviewers are not actually pinged. (The
Renovate-skip half of #5835 already shipped in #5839.)

### What's in this PR?

- Adds `scripts/notify-pr-activity/slack-user-map.json`, a GitHub-login →
  Slack-user-ID map seeded from `camunda/team-distribution`'s map.
- `main.go`: `loadUserMap` reads the map (missing/invalid file → empty map, so
  all reviewers fall back to `@login`); `slackMention` resolves a login to
  `<@UID>` or `@login`; `parseReviewers` now emits Slack mentions. Path is
  overridable via `SLACK_USER_MAP_PATH` (default: co-located file).
- Unit tests for `slackMention`, map-based `parseReviewers`, and the
  missing-map fallback.

The map is co-located under the workflow's existing `sparse-checkout`, so
`workflow_call` from other repos keeps working — the reusable workflow always
checks out this repo's script and map.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
