### PR TITLE
ci: port workflow-vars action logic to go

### DIFF
--- a/.github/actions/workflow-vars/action.yaml
+++ b/.github/actions/workflow-vars/action.yaml
@@ -39,214 +39,23 @@ outputs:
 runs:
   using: composite
   steps:
-  - name: Configure Git safe directory
-    shell: bash
-    run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+    - name: Configure Git safe directory
+      shell: bash
+      run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
-  - name: Load infra config
-    shell: bash
-    run: |
-      # Load infrastructure values from centralized config.
-      INFRA_CONFIG=".github/config/infra.yaml"
-
-      # Extract first platform when a comma-separated list is passed (e.g. "gke,eks").
-      # Normalize to lowercase so callers can pass "GKE", "gke", "EKS", etc. interchangeably.
-      PLATFORM="${{ inputs.platform }}"
-      PLATFORM="${PLATFORM%%,*}"
-      PLATFORM="${PLATFORM,,}"
-      if [[ -z "$PLATFORM" ]]; then
-        echo "::error::platform input must not be empty"
-        exit 1
-      fi
-      if ! yq -e ".$PLATFORM" "$INFRA_CONFIG" > /dev/null 2>&1; then
-        echo "::error::platform '$PLATFORM' not found in $INFRA_CONFIG"
-        exit 1
-      fi
-
-      # Platform-specific values.
-      INFRA_INGRESS_HOSTNAME_BASE=$(yq ".$PLATFORM.ingress-hostname-base" "$INFRA_CONFIG")
-      INFRA_NAMESPACE_PREFIX=$(yq ".$PLATFORM.namespace-prefix" "$INFRA_CONFIG")
-      echo "INFRA_INGRESS_HOSTNAME_BASE=${INFRA_INGRESS_HOSTNAME_BASE}" | tee -a $GITHUB_ENV
-      echo "INFRA_NAMESPACE_PREFIX=${INFRA_NAMESPACE_PREFIX}" | tee -a $GITHUB_ENV
-
-      # EKS-specific values.
-      INFRA_CLUSTER_NAME=$(yq '.eks.cluster-name' "$INFRA_CONFIG")
-      INFRA_AWS_PROFILE=$(yq '.eks.aws-profile' "$INFRA_CONFIG")
-      echo "INFRA_CLUSTER_NAME=${INFRA_CLUSTER_NAME}" | tee -a $GITHUB_ENV
-      echo "CLUSTER_NAME=${INFRA_CLUSTER_NAME}" | tee -a $GITHUB_ENV
-      echo "AWS_PROFILE=${INFRA_AWS_PROFILE}" | tee -a $GITHUB_ENV
-
-      # PostgreSQL — also set consumer-facing env var.
-      INFRA_PG_HOST=$(yq '.postgresql.jdbc-host' "$INFRA_CONFIG")
-      INFRA_PG_PORT=$(yq '.postgresql.jdbc-port' "$INFRA_CONFIG")
-      echo "POSTGRESQL_JDBC_URL=jdbc:postgresql://${INFRA_PG_HOST}:${INFRA_PG_PORT}" | tee -a $GITHUB_ENV
-
-      # Teleport.
-      INFRA_TELEPORT_PROXY=$(yq '.teleport.proxy' "$INFRA_CONFIG")
-      echo "INFRA_TELEPORT_PROXY=${INFRA_TELEPORT_PROXY}" | tee -a $GITHUB_ENV
-
-  - name: Set workflow vars
-    id: vars
-    shell: bash
-    run: |
-      # Generate workflow vars.
-      is_pr() {
-        echo ${{ github.event.pull_request.number }} | grep -q .
-      }
-
-      if [[ -z "${{ inputs.prefix }}" ]]; then
-        export NAMESPACE_PREFIX="${INFRA_NAMESPACE_PREFIX}"
-      else
-        export NAMESPACE_PREFIX="${{ inputs.prefix }}"
-      fi
-      echo NAMESPACE_PREFIX=$NAMESPACE_PREFIX | tee -a $GITHUB_ENV
-
-      PLATFORM="${{ inputs.platform }}"
-      PLATFORM="${PLATFORM%%,*}"
-      PLATFORM="${PLATFORM,,}"
-      echo PLATFORM=$PLATFORM | tee -a $GITHUB_ENV
-
-      echo "Env vars:"
-      # Namespace.
-      TRIGGER_KEY=$(is_pr && echo "pr" || echo "id")
-      TEST_NAMESPACE="$NAMESPACE_PREFIX-$(echo ${TRIGGER_KEY}-${{ inputs.identifier-base }} | sed 's/\./-/g')"
-    
-      # NOTE: We should use the matrix job id var once it's available.
-      # https://github.com/orgs/community/discussions/40291
-      # NOTE we are using a hash here rather than a random value so that the namespace is deterministic.
-      # We intentionally exclude github.run_attempt so that retried jobs ("re-run failed jobs")
-      # compute the same namespace as the original install job. The install step already handles
-      # stale state via `helm uninstall || true` and the cleanup job removes indices/namespaces.
-      GITHUB_WORKFLOW_JOB_ID=$(echo -n "$TEST_NAMESPACE-${{ github.run_id }}" | sha256sum | head -c 6)
-      # Workflow.
-      echo "GITHUB_WORKFLOW_JOB_ID=$GITHUB_WORKFLOW_JOB_ID" | tee -a $GITHUB_ENV
-      echo "GITHUB_WORKFLOW_RUN_ID=${{ github.run_id }}" | tee -a $GITHUB_ENV
-
-      # K8s caps namespace length at 63. Reserve room for the hash (-XXXXXX, 7 chars) and the flow
-      # suffix (-upgp/-upgm, 5 chars) BEFORE appending them, so on long scenario names the hash and
-      # flow tag survive instead of being silently truncated off — otherwise namespaces stop being
-      # unique per run and concurrent or back-to-back runs collide.
-      RESERVED_SUFFIX_LEN=0
-      if [[ "${{ inputs.deployment-ttl }}" == '' ]]; then
-        RESERVED_SUFFIX_LEN=$((RESERVED_SUFFIX_LEN + 7))
-      fi
-      case "${{ inputs.setup-flow }}" in
-        upgrade-patch|upgrade-minor) RESERVED_SUFFIX_LEN=$((RESERVED_SUFFIX_LEN + 5)) ;;
-      esac
-      TEST_NAMESPACE="$(printf '%s' "$TEST_NAMESPACE" | head -c $((63 - RESERVED_SUFFIX_LEN)) | sed 's/-$//')"
-
-      if [[ "${{ inputs.deployment-ttl }}" == '' ]]; then
-        TEST_NAMESPACE="${TEST_NAMESPACE}-${GITHUB_WORKFLOW_JOB_ID}"
-      fi
-
-      if [[ "${{ inputs.setup-flow }}" == 'upgrade-patch' ]]; then
-        TEST_NAMESPACE="${TEST_NAMESPACE}-upgp"
-      fi
-
-      if [[ "${{ inputs.setup-flow }}" == 'upgrade-minor' ]]; then
-        TEST_NAMESPACE="${TEST_NAMESPACE}-upgm"
-      fi
-
-      if [[ "${{ inputs.setup-flow }}" == 'modular-upgrade-minor' ]]; then
-        : # no-op; this flow depends on the namespace given during installation so we don't adjust it here
-      fi
-
-      TEST_NAMESPACE="$(printf '%s' "$TEST_NAMESPACE" | head -c 63 | sed 's/-$//')"
-      echo "TEST_NAMESPACE=$TEST_NAMESPACE" | tee -a "$GITHUB_ENV"
-      echo "namespace=$TEST_NAMESPACE" >> "$GITHUB_OUTPUT"
-
-      # Get alpha chart dir.
-      TEST_CAMUNDA_HELM_DIR_ALPHA="$(basename $(ls -d1 charts/camunda-platform-8.* | sort -V | tail -n1))"
-      echo "TEST_CAMUNDA_HELM_DIR_ALPHA=${TEST_CAMUNDA_HELM_DIR_ALPHA}" | tee -a $GITHUB_ENV
-
-      echo "Output vars:"
-
-      # Identifier
-      local_identifier=${{ inputs.identifier-base }}
-      if [[ -z "${{ inputs.identifier-base }}" ]]; then
-        local_identifier="no-id-use-ran-$(uuidgen | head -c 6)"
-      fi
-
-      # Deployment identifier.
-      TEST_IDENTIFIER="$(echo ${PLATFORM}-${local_identifier} | sed 's/\./-/g')"
-      if [[ "${{ inputs.setup-flow }}" == 'upgrade-patch' ]]; then
-        TEST_IDENTIFIER="${TEST_IDENTIFIER}-upgp"
-      fi
-      if [[ "${{ inputs.setup-flow }}" == 'upgrade-minor' ]]; then
-        TEST_IDENTIFIER="${TEST_IDENTIFIER}-upgm"
-      fi
-      echo "identifier=${TEST_IDENTIFIER}" | tee -a $GITHUB_OUTPUT
-
-      # Ingress hostname.
-      export INGRESS_HOSTNAME_BASE="${INFRA_INGRESS_HOSTNAME_BASE}"
-
-      TEST_INGRESS_HOST="${TEST_IDENTIFIER}.${INGRESS_HOSTNAME_BASE}"
-      if [[ "${{ inputs.deployment-ttl }}" == "" ]]; then
-        TEST_INGRESS_HOST="${GITHUB_WORKFLOW_JOB_ID}-${TEST_INGRESS_HOST}"
-      fi
-      # The var is needed in some non-shell steps.
-      echo "ingress-host=${TEST_INGRESS_HOST}" | tee -a $GITHUB_OUTPUT
-
-      ## Setting values for the external infra
-      echo "ORCHESTRATION_INDEX_PREFIX=$GITHUB_WORKFLOW_JOB_ID-orchestration" | tee -a $GITHUB_ENV
-      echo "OPTIMIZE_INDEX_PREFIX=$GITHUB_WORKFLOW_JOB_ID-optimize" | tee -a $GITHUB_ENV
-      echo "OPERATE_INDEX_PREFIX=$GITHUB_WORKFLOW_JOB_ID-operate" | tee -a $GITHUB_ENV
-      echo "TASKLIST_INDEX_PREFIX=$GITHUB_WORKFLOW_JOB_ID-tasklist" | tee -a $GITHUB_ENV
-      # For modular-upgrade-minor, the upgrade step must use the same FLOW value
-      # that was used during install (i.e. "install") so that index prefixes match.
-      # The install step creates indices with FLOW=install; if the upgrade step used
-      # FLOW=modular-upgrade-minor, it would look for non-existent indices.
-      if [[ "${{ inputs.setup-flow }}" == 'modular-upgrade-minor' ]]; then
-        echo "FLOW=install" | tee -a $GITHUB_ENV
-      else
-        echo "FLOW=$FLOW" | tee -a $GITHUB_ENV
-      fi
-      keycloakRealm="${GITHUB_WORKFLOW_JOB_ID}-realm"
-      export KEYCLOAK_REALM=$keycloakRealm
-      echo "KEYCLOAK_REALM=$KEYCLOAK_REALM" | tee -a $GITHUB_ENV
-
-  - name: Set workflow vars - Chart version
-    shell: bash
-    run: |
-      # In the upgrade flow, the latest released chart for certain minor Camunda version will installed,
-      # then upgraded from the PR branch to ensure upgradability.
-      if [[ "${{ inputs.setup-flow }}" == 'upgrade-patch' || "${{ inputs.setup-flow }}" == 'upgrade-minor' || "${{ inputs.setup-flow }}" == 'modular-upgrade-minor' ]]; then
-        if [[ -n "${{ inputs.chart-upgrade-version }}" ]]; then
-          TEST_CHART_VERSION="${{ inputs.chart-upgrade-version }}"
-        fi
-        if [[ -z "${{ inputs.chart-upgrade-version }}" ]]; then
-          if [[ "$(git branch --show-current)" != "main" ]]; then
-            # Retry git fetch up to 3 times with exponential backoff.
-            # GitHub occasionally returns transient 500 errors during high load,
-            # which would otherwise fail the entire workflow unnecessarily.
-            for attempt in 1 2 3; do
-              echo "Attempt $attempt of 3: Fetching main branch..."
-              if git fetch origin main:main --no-tags; then
-                break
-              fi
-              if [ $attempt -lt 3 ]; then
-                echo "git fetch failed, retrying in $((attempt * 10)) seconds..."
-                sleep $((attempt * 10))
-              else
-                echo "All git fetch attempts failed"
-                exit 1
-              fi
-            done
-          fi
-          if [[ -n "$(git ls-tree main -- charts/${{ inputs.chart-dir }}/Chart.yaml)" ]]; then
-            TEST_CHART_VERSION="$(git show main:charts/${{ inputs.chart-dir }}/Chart.yaml | yq '.version')"
-          else
-            # Fallback (needed only when we add a new chart directory).
-            TEST_CHART_VERSION="$(cat charts/${{ inputs.chart-dir }}/Chart.yaml | yq '.version')"
-          fi
-        fi
-        echo "TEST_CHART_VERSION=${TEST_CHART_VERSION}" | tee -a $GITHUB_ENV
-      fi
-
-    # Avoid confusion about the chart version since we only change the version during the release process
-    # as the "version" field in "Chart.yaml" file doesn't reflect the changes since the latest release.
-  - name: Set chart version
-    shell: bash
-    run: |
-      chart_version="$(echo ${{ inputs.chart-dir }} | sed 's/camunda-platform/0.0.0-ci-snapshot/g')" \
-        yq -i '.version = env(chart_version)' charts/${{ inputs.chart-dir }}/Chart.yaml
+    - name: Setup deploy-camunda
+      uses: ./.github/actions/setup-deploy-camunda
+    - name: Set workflow vars
+      id: vars
+      shell: bash
+      run: |
+        deploy-camunda ci workflow-vars \
+          --platform "${{ inputs.platform }}" \
+          --setup-flow "${{ inputs.setup-flow }}" \
+          --deployment-ttl "${{ inputs.deployment-ttl }}" \
+          --identifier-base "${{ inputs.identifier-base }}" \
+          --chart-dir "${{ inputs.chart-dir }}" \
+          --chart-upgrade-version "${{ inputs.chart-upgrade-version }}" \
+          --prefix "${{ inputs.prefix }}" \
+          --pr-number "${{ github.event.pull_request.number }}" \
+          --run-id "${{ github.run_id }}"

--- a/scripts/camunda-core/pkg/ciworkflow/chartversion.go
+++ b/scripts/camunda-core/pkg/ciworkflow/chartversion.go
@@ -1,0 +1,190 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ciworkflow
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// GitOps abstracts the git operations chart-version resolution needs, so the
+// resolution logic is unit-testable without a repository.
+type GitOps interface {
+	// CurrentBranch returns the checked-out branch name.
+	CurrentBranch() (string, error)
+	// FetchMain fetches origin main into the local main ref.
+	FetchMain() error
+	// MainChartYaml returns the content of charts/<chartDir>/Chart.yaml on
+	// main, and whether the file exists there.
+	MainChartYaml(chartDir string) (content []byte, exists bool, err error)
+}
+
+// ExecGit is the GitOps implementation backed by the git CLI, run in Dir.
+type ExecGit struct {
+	Dir string
+}
+
+func (g ExecGit) run(args ...string) ([]byte, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = g.Dir
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok && len(ee.Stderr) > 0 {
+			return nil, fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(ee.Stderr)))
+		}
+		return nil, fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+	}
+	return out, nil
+}
+
+func (g ExecGit) CurrentBranch() (string, error) {
+	out, err := g.run("branch", "--show-current")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func (g ExecGit) FetchMain() error {
+	_, err := g.run("fetch", "origin", "main:main", "--no-tags")
+	return err
+}
+
+func (g ExecGit) MainChartYaml(chartDir string) ([]byte, bool, error) {
+	path := fmt.Sprintf("charts/%s/Chart.yaml", chartDir)
+	lsOut, err := g.run("ls-tree", "main", "--", path)
+	if err != nil {
+		return nil, false, err
+	}
+	if strings.TrimSpace(string(lsOut)) == "" {
+		return nil, false, nil
+	}
+	content, err := g.run("show", "main:"+path)
+	if err != nil {
+		return nil, false, err
+	}
+	return content, true, nil
+}
+
+// ResolveChartVersionInput selects the chart version that upgrade flows
+// install before upgrading to the PR branch.
+type ResolveChartVersionInput struct {
+	SetupFlow           string
+	ChartDir            string
+	ChartUpgradeVersion string
+	// RepoRoot is the directory chart paths are resolved against. Empty means ".".
+	RepoRoot string
+	// Sleep replaces time.Sleep between fetch retries; nil means time.Sleep.
+	Sleep func(time.Duration)
+}
+
+// ResolveChartVersion reproduces the "Set workflow vars - Chart version" shell
+// step. It returns the resolved version and true for upgrade flows, and
+// ("", false, nil) for flows that do not resolve a version.
+func ResolveChartVersion(in ResolveChartVersionInput, git GitOps) (string, bool, error) {
+	switch in.SetupFlow {
+	case "upgrade-patch", "upgrade-minor", "modular-upgrade-minor":
+	default:
+		return "", false, nil
+	}
+	if in.ChartUpgradeVersion != "" {
+		return in.ChartUpgradeVersion, true, nil
+	}
+
+	branch, err := git.CurrentBranch()
+	if err != nil {
+		return "", false, err
+	}
+	if branch != "main" {
+		if err := fetchMainWithRetry(git, in.Sleep); err != nil {
+			return "", false, err
+		}
+	}
+
+	content, exists, err := git.MainChartYaml(in.ChartDir)
+	if err != nil {
+		return "", false, err
+	}
+	if !exists {
+		// Fallback needed only when a new chart directory is added.
+		repoRoot := in.RepoRoot
+		if repoRoot == "" {
+			repoRoot = "."
+		}
+		content, err = os.ReadFile(filepath.Join(repoRoot, "charts", in.ChartDir, "Chart.yaml"))
+		if err != nil {
+			return "", false, err
+		}
+	}
+	var chart struct {
+		Version string `yaml:"version"`
+	}
+	if err := yaml.Unmarshal(content, &chart); err != nil {
+		return "", false, fmt.Errorf("parse Chart.yaml for %s: %w", in.ChartDir, err)
+	}
+	return chart.Version, true, nil
+}
+
+// fetchMainWithRetry retries transient fetch failures (GitHub occasionally
+// returns 500s under load) up to 3 times with 10s/20s backoff.
+func fetchMainWithRetry(git GitOps, sleep func(time.Duration)) error {
+	if sleep == nil {
+		sleep = time.Sleep
+	}
+	var err error
+	for attempt := 1; attempt <= 3; attempt++ {
+		if err = git.FetchMain(); err == nil {
+			return nil
+		}
+		if attempt < 3 {
+			sleep(time.Duration(attempt) * 10 * time.Second)
+		}
+	}
+	return fmt.Errorf("all git fetch attempts failed: %w", err)
+}
+
+var chartVersionLine = regexp.MustCompile(`(?m)^version:.*$`)
+
+// StampChartVersion sets the top-level version field of
+// charts/<chartDir>/Chart.yaml to the CI snapshot version derived from the
+// chart directory name (camunda-platform-8.10 → 0.0.0-ci-snapshot-8.10),
+// touching only the version line so the rest of the file stays byte-identical.
+func StampChartVersion(repoRoot, chartDir string) error {
+	if repoRoot == "" {
+		repoRoot = "."
+	}
+	version := strings.ReplaceAll(chartDir, "camunda-platform", "0.0.0-ci-snapshot")
+	path := filepath.Join(repoRoot, "charts", chartDir, "Chart.yaml")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	matches := chartVersionLine.FindAll(raw, -1)
+	if len(matches) != 1 {
+		return fmt.Errorf("%s: expected exactly one top-level version line, found %d", path, len(matches))
+	}
+	updated := chartVersionLine.ReplaceAll(raw, []byte("version: "+version))
+	if err := os.WriteFile(path, updated, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}

--- a/scripts/camunda-core/pkg/ciworkflow/chartversion_test.go
+++ b/scripts/camunda-core/pkg/ciworkflow/chartversion_test.go
@@ -1,0 +1,209 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ciworkflow
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+type fakeGit struct {
+	branch        string
+	fetchErrs     []error
+	fetchCalls    int
+	mainContent   []byte
+	mainExists    bool
+	mainErr       error
+	mainCalledFor string
+}
+
+func (f *fakeGit) CurrentBranch() (string, error) { return f.branch, nil }
+
+func (f *fakeGit) FetchMain() error {
+	f.fetchCalls++
+	if len(f.fetchErrs) == 0 {
+		return nil
+	}
+	err := f.fetchErrs[0]
+	f.fetchErrs = f.fetchErrs[1:]
+	return err
+}
+
+func (f *fakeGit) MainChartYaml(chartDir string) ([]byte, bool, error) {
+	f.mainCalledFor = chartDir
+	return f.mainContent, f.mainExists, f.mainErr
+}
+
+func TestResolveChartVersionNonUpgradeFlow(t *testing.T) {
+	version, ok, err := ResolveChartVersion(ResolveChartVersionInput{SetupFlow: "install"}, &fakeGit{})
+	if err != nil || ok || version != "" {
+		t.Fatalf("install flow: got (%q, %t, %v), want no resolution", version, ok, err)
+	}
+}
+
+func TestResolveChartVersionExplicitOverride(t *testing.T) {
+	git := &fakeGit{}
+	version, ok, err := ResolveChartVersion(ResolveChartVersionInput{
+		SetupFlow: "upgrade-patch", ChartUpgradeVersion: "13.1.0",
+	}, git)
+	if err != nil || !ok || version != "13.1.0" {
+		t.Fatalf("got (%q, %t, %v)", version, ok, err)
+	}
+	if git.fetchCalls != 0 {
+		t.Errorf("explicit version must not fetch, got %d calls", git.fetchCalls)
+	}
+}
+
+func TestResolveChartVersionFromMain(t *testing.T) {
+	git := &fakeGit{branch: "feature", mainContent: []byte("name: camunda-platform\nversion: 13.0.2\n"), mainExists: true}
+	version, ok, err := ResolveChartVersion(ResolveChartVersionInput{
+		SetupFlow: "upgrade-minor", ChartDir: "camunda-platform-8.10",
+		Sleep: func(time.Duration) {},
+	}, git)
+	if err != nil || !ok || version != "13.0.2" {
+		t.Fatalf("got (%q, %t, %v)", version, ok, err)
+	}
+	if git.fetchCalls != 1 {
+		t.Errorf("fetchCalls = %d, want 1", git.fetchCalls)
+	}
+	if git.mainCalledFor != "camunda-platform-8.10" {
+		t.Errorf("mainCalledFor = %q", git.mainCalledFor)
+	}
+}
+
+func TestResolveChartVersionOnMainSkipsFetch(t *testing.T) {
+	git := &fakeGit{branch: "main", mainContent: []byte("version: 12.9.0\n"), mainExists: true}
+	version, ok, err := ResolveChartVersion(ResolveChartVersionInput{
+		SetupFlow: "modular-upgrade-minor", ChartDir: "camunda-platform-8.9",
+	}, git)
+	if err != nil || !ok || version != "12.9.0" {
+		t.Fatalf("got (%q, %t, %v)", version, ok, err)
+	}
+	if git.fetchCalls != 0 {
+		t.Errorf("on main, fetch must be skipped; got %d calls", git.fetchCalls)
+	}
+}
+
+func TestResolveChartVersionFetchRetriesWithBackoff(t *testing.T) {
+	git := &fakeGit{
+		branch:      "feature",
+		fetchErrs:   []error{errors.New("500"), errors.New("500")},
+		mainContent: []byte("version: 13.0.0\n"),
+		mainExists:  true,
+	}
+	var sleeps []time.Duration
+	version, ok, err := ResolveChartVersion(ResolveChartVersionInput{
+		SetupFlow: "upgrade-patch", ChartDir: "camunda-platform-8.10",
+		Sleep: func(d time.Duration) { sleeps = append(sleeps, d) },
+	}, git)
+	if err != nil || !ok || version != "13.0.0" {
+		t.Fatalf("got (%q, %t, %v)", version, ok, err)
+	}
+	if git.fetchCalls != 3 {
+		t.Errorf("fetchCalls = %d, want 3", git.fetchCalls)
+	}
+	if len(sleeps) != 2 || sleeps[0] != 10*time.Second || sleeps[1] != 20*time.Second {
+		t.Errorf("sleeps = %v, want [10s 20s]", sleeps)
+	}
+}
+
+func TestResolveChartVersionFetchExhausted(t *testing.T) {
+	git := &fakeGit{branch: "feature", fetchErrs: []error{errors.New("a"), errors.New("b"), errors.New("c")}}
+	_, _, err := ResolveChartVersion(ResolveChartVersionInput{
+		SetupFlow: "upgrade-patch", ChartDir: "camunda-platform-8.10",
+		Sleep: func(time.Duration) {},
+	}, git)
+	if err == nil || !strings.Contains(err.Error(), "all git fetch attempts failed") {
+		t.Fatalf("err = %v", err)
+	}
+	if git.fetchCalls != 3 {
+		t.Errorf("fetchCalls = %d, want 3", git.fetchCalls)
+	}
+}
+
+func TestResolveChartVersionLocalFallback(t *testing.T) {
+	repoRoot := t.TempDir()
+	dir := filepath.Join(repoRoot, "charts", "camunda-platform-8.11")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "Chart.yaml"), []byte("version: 14.0.0-alpha1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git := &fakeGit{branch: "main", mainExists: false}
+	version, ok, err := ResolveChartVersion(ResolveChartVersionInput{
+		SetupFlow: "upgrade-minor", ChartDir: "camunda-platform-8.11", RepoRoot: repoRoot,
+	}, git)
+	if err != nil || !ok || version != "14.0.0-alpha1" {
+		t.Fatalf("got (%q, %t, %v)", version, ok, err)
+	}
+}
+
+const stampFixture = `apiVersion: v2
+name: camunda-platform
+# The chart version comment stays.
+version: 13.0.0
+dependencies:
+  - name: elasticsearch
+    version: 21.3.1
+    repository: oci://registry-1.docker.io/bitnamicharts
+annotations:
+  artifacthub.io/changes: |
+    - kind: fixed
+      description: "something with version: 1.2.3 in it is fine, not column zero"
+`
+
+func TestStampChartVersion(t *testing.T) {
+	repoRoot := t.TempDir()
+	dir := filepath.Join(repoRoot, "charts", "camunda-platform-8.10")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "Chart.yaml")
+	if err := os.WriteFile(path, []byte(stampFixture), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := StampChartVersion(repoRoot, "camunda-platform-8.10"); err != nil {
+		t.Fatalf("StampChartVersion: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := strings.Replace(stampFixture, "version: 13.0.0", "version: 0.0.0-ci-snapshot-8.10", 1)
+	if string(got) != want {
+		t.Errorf("stamped file differs:\n%s", got)
+	}
+}
+
+func TestStampChartVersionRejectsAmbiguousFile(t *testing.T) {
+	repoRoot := t.TempDir()
+	dir := filepath.Join(repoRoot, "charts", "camunda-platform-8.10")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "Chart.yaml"), []byte("version: 1\nname: x\nversion: 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := StampChartVersion(repoRoot, "camunda-platform-8.10"); err == nil {
+		t.Fatal("expected error on two top-level version lines")
+	}
+}

--- a/scripts/camunda-core/pkg/ciworkflow/workflowvars.go
+++ b/scripts/camunda-core/pkg/ciworkflow/workflowvars.go
@@ -1,0 +1,346 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ciworkflow
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"scripts/camunda-core/pkg/ghactions"
+
+	"gopkg.in/yaml.v3"
+)
+
+// InfraPlatform is one platform section of .github/config/infra.yaml.
+type InfraPlatform struct {
+	IngressHostnameBase string `yaml:"ingress-hostname-base"`
+	NamespacePrefix     string `yaml:"namespace-prefix"`
+	ClusterName         string `yaml:"cluster-name"`
+	AWSProfile          string `yaml:"aws-profile"`
+}
+
+// InfraConfig is the parsed .github/config/infra.yaml.
+type InfraConfig struct {
+	Platforms  map[string]InfraPlatform
+	PostgreSQL struct {
+		JDBCHost string `yaml:"jdbc-host"`
+		JDBCPort string `yaml:"jdbc-port"`
+	}
+	TeleportProxy string
+}
+
+// LoadInfraConfig parses .github/config/infra.yaml. Non-platform sections
+// (postgresql, teleport) are extracted; every other top-level map is a
+// platform entry.
+func LoadInfraConfig(path string) (InfraConfig, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return InfraConfig{}, fmt.Errorf("read %s: %w", path, err)
+	}
+	var sections map[string]yaml.Node
+	if err := yaml.Unmarshal(raw, &sections); err != nil {
+		return InfraConfig{}, fmt.Errorf("parse %s: %w", path, err)
+	}
+	cfg := InfraConfig{Platforms: map[string]InfraPlatform{}}
+	for name, node := range sections {
+		var sectionErr error
+		switch name {
+		case "postgresql":
+			sectionErr = node.Decode(&cfg.PostgreSQL)
+		case "teleport":
+			var tp struct {
+				Proxy string `yaml:"proxy"`
+			}
+			sectionErr = node.Decode(&tp)
+			cfg.TeleportProxy = tp.Proxy
+		default:
+			var p InfraPlatform
+			sectionErr = node.Decode(&p)
+			cfg.Platforms[name] = p
+		}
+		if sectionErr != nil {
+			return InfraConfig{}, fmt.Errorf("parse %s section %q: %w", path, name, sectionErr)
+		}
+	}
+	return cfg, nil
+}
+
+// WorkflowVarsInput carries the workflow-vars composite-action inputs plus the
+// ambient GitHub context values the computation depends on.
+type WorkflowVarsInput struct {
+	// Platform is the deployment platform input; may be a comma-separated
+	// list and any case — only the first entry, lowercased, is used.
+	Platform string
+	// SetupFlow is install, upgrade-patch, upgrade-minor, or modular-upgrade-minor.
+	SetupFlow string
+	// DeploymentTTL is the deployment lifespan input; empty selects the
+	// per-run hashed namespace/ingress variant.
+	DeploymentTTL string
+	// IdentifierBase is the fixed identifier part (PR number or a name).
+	IdentifierBase string
+	// Prefix overrides the platform namespace prefix when non-empty.
+	Prefix string
+	// PRNumber is github.event.pull_request.number; empty on non-PR events.
+	PRNumber string
+	// RunID is github.run_id.
+	RunID string
+	// Flow is the ambient $FLOW environment value re-emitted to GITHUB_ENV.
+	Flow string
+	// RandomID replaces an empty IdentifierBase ("no-id-use-ran-<RandomID>").
+	RandomID string
+	// RepoRoot is the directory chart paths are resolved against. Empty means ".".
+	RepoRoot string
+}
+
+// WorkflowVars is the computed result, consumable directly as a struct and
+// emittable to $GITHUB_ENV / $GITHUB_OUTPUT via Emit.
+type WorkflowVars struct {
+	IngressHostnameBase  string
+	NamespacePrefixInfra string
+	ClusterName          string
+	AWSProfile           string
+	PostgresJDBCURL      string
+	TeleportProxy        string
+	NamespacePrefix      string
+	Platform             string
+	JobID                string
+	RunID                string
+	Namespace            string
+	AlphaChartDir        string
+	Identifier           string
+	IngressHost          string
+	Flow                 string
+	KeycloakRealm        string
+}
+
+// ComputeWorkflowVars reproduces the "Load infra config" and "Set workflow
+// vars" shell steps of the workflow-vars composite action.
+func ComputeWorkflowVars(in WorkflowVarsInput, infra InfraConfig) (WorkflowVars, error) {
+	platform, err := normalizePlatform(in.Platform, infra)
+	if err != nil {
+		return WorkflowVars{}, err
+	}
+	if in.RunID == "" {
+		return WorkflowVars{}, fmt.Errorf("run ID must not be empty")
+	}
+	eks, ok := infra.Platforms["eks"]
+	if !ok {
+		return WorkflowVars{}, fmt.Errorf("platform %q not found in infra config", "eks")
+	}
+	p := infra.Platforms[platform]
+
+	out := WorkflowVars{
+		IngressHostnameBase:  p.IngressHostnameBase,
+		NamespacePrefixInfra: p.NamespacePrefix,
+		ClusterName:          eks.ClusterName,
+		AWSProfile:           eks.AWSProfile,
+		PostgresJDBCURL:      fmt.Sprintf("jdbc:postgresql://%s:%s", infra.PostgreSQL.JDBCHost, infra.PostgreSQL.JDBCPort),
+		TeleportProxy:        infra.TeleportProxy,
+		Platform:             platform,
+		RunID:                in.RunID,
+	}
+
+	out.NamespacePrefix = in.Prefix
+	if out.NamespacePrefix == "" {
+		out.NamespacePrefix = p.NamespacePrefix
+	}
+
+	triggerKey := "id"
+	if in.PRNumber != "" {
+		triggerKey = "pr"
+	}
+	namespace := out.NamespacePrefix + "-" + dotsToDashes(triggerKey+"-"+in.IdentifierBase)
+
+	// Deterministic per-run hash; the pre-truncation namespace feeds it. The
+	// run attempt is deliberately not part of the hash so "re-run failed
+	// jobs" computes the same namespace as the original install job.
+	sum := sha256.Sum256([]byte(namespace + "-" + in.RunID))
+	out.JobID = hex.EncodeToString(sum[:])[:6]
+
+	// K8s caps namespace length at 63. Reserve room for the hash (-XXXXXX)
+	// and the flow suffix (-upgp/-upgm) before appending them so they survive
+	// truncation on long scenario names.
+	reserved := 0
+	if in.DeploymentTTL == "" {
+		reserved += 7
+	}
+	switch in.SetupFlow {
+	case "upgrade-patch", "upgrade-minor":
+		reserved += 5
+	}
+	namespace = trimOneTrailingDash(truncateBytes(namespace, 63-reserved))
+	if in.DeploymentTTL == "" {
+		namespace += "-" + out.JobID
+	}
+	switch in.SetupFlow {
+	case "upgrade-patch":
+		namespace += "-upgp"
+	case "upgrade-minor":
+		namespace += "-upgm"
+	case "modular-upgrade-minor":
+		// The namespace must match the one used during installation, so no
+		// flow suffix is appended.
+	}
+	out.Namespace = trimOneTrailingDash(truncateBytes(namespace, 63))
+
+	out.AlphaChartDir, err = alphaChartDir(in.RepoRoot)
+	if err != nil {
+		return WorkflowVars{}, err
+	}
+
+	localIdentifier := in.IdentifierBase
+	if localIdentifier == "" {
+		localIdentifier = "no-id-use-ran-" + in.RandomID
+	}
+	identifier := dotsToDashes(platform + "-" + localIdentifier)
+	switch in.SetupFlow {
+	case "upgrade-patch":
+		identifier += "-upgp"
+	case "upgrade-minor":
+		identifier += "-upgm"
+	}
+	out.Identifier = identifier
+
+	out.IngressHost = identifier + "." + p.IngressHostnameBase
+	if in.DeploymentTTL == "" {
+		out.IngressHost = out.JobID + "-" + out.IngressHost
+	}
+
+	// For modular-upgrade-minor the upgrade step must reuse the FLOW value
+	// from installation ("install") so index prefixes keep matching.
+	out.Flow = in.Flow
+	if in.SetupFlow == "modular-upgrade-minor" {
+		out.Flow = "install"
+	}
+	out.KeycloakRealm = out.JobID + "-realm"
+
+	return out, nil
+}
+
+func normalizePlatform(input string, infra InfraConfig) (string, error) {
+	platform, _, _ := strings.Cut(input, ",")
+	platform = strings.ToLower(platform)
+	if platform == "" {
+		return "", fmt.Errorf("platform input must not be empty")
+	}
+	if _, ok := infra.Platforms[platform]; !ok {
+		return "", fmt.Errorf("platform %q not found in infra config", platform)
+	}
+	return platform, nil
+}
+
+func dotsToDashes(s string) string { return strings.ReplaceAll(s, ".", "-") }
+
+func truncateBytes(s string, n int) string {
+	if n < 0 {
+		n = 0
+	}
+	if len(s) > n {
+		return s[:n]
+	}
+	return s
+}
+
+func trimOneTrailingDash(s string) string { return strings.TrimSuffix(s, "-") }
+
+// alphaChartDir returns the basename of the highest-versioned
+// charts/camunda-platform-8.* directory (version sort, like `sort -V`).
+func alphaChartDir(repoRoot string) (string, error) {
+	if repoRoot == "" {
+		repoRoot = "."
+	}
+	matches, err := filepath.Glob(filepath.Join(repoRoot, "charts", "camunda-platform-8.*"))
+	if err != nil {
+		return "", err
+	}
+	var dirs []string
+	for _, m := range matches {
+		if fi, err := os.Stat(m); err == nil && fi.IsDir() {
+			dirs = append(dirs, filepath.Base(m))
+		}
+	}
+	if len(dirs) == 0 {
+		return "", fmt.Errorf("no charts/camunda-platform-8.* directories under %s", repoRoot)
+	}
+	sort.Slice(dirs, func(i, j int) bool {
+		return versionLess(strings.TrimPrefix(dirs[i], "camunda-platform-"), strings.TrimPrefix(dirs[j], "camunda-platform-"))
+	})
+	return dirs[len(dirs)-1], nil
+}
+
+func versionLess(a, b string) bool {
+	as, bs := strings.Split(a, "."), strings.Split(b, ".")
+	for i := 0; i < len(as) && i < len(bs); i++ {
+		ai, aerr := strconv.Atoi(as[i])
+		bi, berr := strconv.Atoi(bs[i])
+		if aerr == nil && berr == nil {
+			if ai != bi {
+				return ai < bi
+			}
+			continue
+		}
+		if as[i] != bs[i] {
+			return as[i] < bs[i]
+		}
+	}
+	return len(as) < len(bs)
+}
+
+// Emit writes the environment variables and step outputs in the same order as
+// the original shell steps.
+func (v WorkflowVars) Emit(env, out *ghactions.Writer) error {
+	envPairs := [][2]string{
+		{"INFRA_INGRESS_HOSTNAME_BASE", v.IngressHostnameBase},
+		{"INFRA_NAMESPACE_PREFIX", v.NamespacePrefixInfra},
+		{"INFRA_CLUSTER_NAME", v.ClusterName},
+		{"CLUSTER_NAME", v.ClusterName},
+		{"AWS_PROFILE", v.AWSProfile},
+		{"POSTGRESQL_JDBC_URL", v.PostgresJDBCURL},
+		{"INFRA_TELEPORT_PROXY", v.TeleportProxy},
+		{"NAMESPACE_PREFIX", v.NamespacePrefix},
+		{"PLATFORM", v.Platform},
+		{"GITHUB_WORKFLOW_JOB_ID", v.JobID},
+		{"GITHUB_WORKFLOW_RUN_ID", v.RunID},
+		{"TEST_NAMESPACE", v.Namespace},
+		{"TEST_CAMUNDA_HELM_DIR_ALPHA", v.AlphaChartDir},
+		{"ORCHESTRATION_INDEX_PREFIX", v.JobID + "-orchestration"},
+		{"OPTIMIZE_INDEX_PREFIX", v.JobID + "-optimize"},
+		{"OPERATE_INDEX_PREFIX", v.JobID + "-operate"},
+		{"TASKLIST_INDEX_PREFIX", v.JobID + "-tasklist"},
+		{"FLOW", v.Flow},
+		{"KEYCLOAK_REALM", v.KeycloakRealm},
+	}
+	for _, kv := range envPairs {
+		if err := env.Set(kv[0], kv[1]); err != nil {
+			return err
+		}
+	}
+	for _, kv := range [][2]string{
+		{"namespace", v.Namespace},
+		{"identifier", v.Identifier},
+		{"ingress-host", v.IngressHost},
+	} {
+		if err := out.Set(kv[0], kv[1]); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/scripts/camunda-core/pkg/ciworkflow/workflowvars_test.go
+++ b/scripts/camunda-core/pkg/ciworkflow/workflowvars_test.go
@@ -1,0 +1,273 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ciworkflow
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"scripts/camunda-core/pkg/ghactions"
+)
+
+// infraFixture is a frozen copy of .github/config/infra.yaml so expected
+// values below never drift with live infrastructure changes.
+const infraFixture = `gke:
+  ingress-hostname-base: ci.distro.ultrawombat.com
+  namespace-prefix: camunda
+
+eks:
+  ingress-hostname-base: distribution.aws.camunda.cloud
+  namespace-prefix: distribution
+  cluster-name: camunda-ci-eks
+  aws-profile: distribution
+
+rosa:
+  ingress-hostname-base: ci.distro.ultrawombat.com
+  namespace-prefix: camunda
+
+postgresql:
+  jdbc-host: postgresql-cluster-rw.distribution-postgresql.svc.cluster.local
+  jdbc-port: "5432"
+
+teleport:
+  proxy: camunda.teleport.sh:443
+`
+
+func loadTestInfra(t *testing.T) InfraConfig {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "infra.yaml")
+	if err := os.WriteFile(path, []byte(infraFixture), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	infra, err := LoadInfraConfig(path)
+	if err != nil {
+		t.Fatalf("load infra: %v", err)
+	}
+	return infra
+}
+
+func chartsRepoRoot(t *testing.T, dirs ...string) string {
+	t.Helper()
+	repoRoot := t.TempDir()
+	for _, d := range dirs {
+		if err := os.MkdirAll(filepath.Join(repoRoot, "charts", d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return repoRoot
+}
+
+// Expected values were captured from the original composite-action shell
+// steps (bash 5, yq v4.53.3) running on identical inputs with infraFixture
+// and a charts dir containing camunda-platform-8.9 and -8.10.
+func TestComputeWorkflowVarsBashParity(t *testing.T) {
+	infra := loadTestInfra(t)
+	repoRoot := chartsRepoRoot(t, "camunda-platform-8.9", "camunda-platform-8.10")
+
+	for _, tc := range []struct {
+		name string
+		in   WorkflowVarsInput
+		want WorkflowVars
+	}{
+		{
+			name: "gke-install-pr",
+			in:   WorkflowVarsInput{Platform: "gke", SetupFlow: "install", DeploymentTTL: "1h", IdentifierBase: "6598", PRNumber: "1234", RunID: "16400000001", Flow: "install"},
+			want: WorkflowVars{NamespacePrefix: "camunda", Platform: "gke", JobID: "b73169", Namespace: "camunda-pr-6598", Identifier: "gke-6598", IngressHost: "gke-6598.ci.distro.ultrawombat.com", Flow: "install"},
+		},
+		{
+			name: "gke-install-nottl",
+			in:   WorkflowVarsInput{Platform: "gke", SetupFlow: "install", IdentifierBase: "6598", RunID: "16400000002", Flow: "install"},
+			want: WorkflowVars{NamespacePrefix: "camunda", Platform: "gke", JobID: "20203d", Namespace: "camunda-id-6598-20203d", Identifier: "gke-6598", IngressHost: "20203d-gke-6598.ci.distro.ultrawombat.com", Flow: "install"},
+		},
+		{
+			name: "eks-install-pr",
+			in:   WorkflowVarsInput{Platform: "EKS", SetupFlow: "install", DeploymentTTL: "1h", IdentifierBase: "6598", PRNumber: "1234", RunID: "16400000003", Flow: "install"},
+			want: WorkflowVars{NamespacePrefix: "distribution", Platform: "eks", JobID: "b87450", Namespace: "distribution-pr-6598", Identifier: "eks-6598", IngressHost: "eks-6598.distribution.aws.camunda.cloud", Flow: "install"},
+		},
+		{
+			name: "gke-upgpatch-nottl",
+			in:   WorkflowVarsInput{Platform: "gke", SetupFlow: "upgrade-patch", IdentifierBase: "6598", RunID: "16400000004", Flow: "upgrade-patch"},
+			want: WorkflowVars{NamespacePrefix: "camunda", Platform: "gke", JobID: "71bf01", Namespace: "camunda-id-6598-71bf01-upgp", Identifier: "gke-6598-upgp", IngressHost: "71bf01-gke-6598-upgp.ci.distro.ultrawombat.com", Flow: "upgrade-patch"},
+		},
+		{
+			name: "gke-upgminor-nottl",
+			in:   WorkflowVarsInput{Platform: "gke", SetupFlow: "upgrade-minor", IdentifierBase: "6598", RunID: "16400000005", Flow: "upgrade-minor"},
+			want: WorkflowVars{NamespacePrefix: "camunda", Platform: "gke", JobID: "7a6e94", Namespace: "camunda-id-6598-7a6e94-upgm", Identifier: "gke-6598-upgm", IngressHost: "7a6e94-gke-6598-upgm.ci.distro.ultrawombat.com", Flow: "upgrade-minor"},
+		},
+		{
+			name: "gke-modupgminor-nottl",
+			in:   WorkflowVarsInput{Platform: "gke", SetupFlow: "modular-upgrade-minor", IdentifierBase: "6598", RunID: "16400000006", Flow: "modular-upgrade-minor"},
+			want: WorkflowVars{NamespacePrefix: "camunda", Platform: "gke", JobID: "668ceb", Namespace: "camunda-id-6598-668ceb", Identifier: "gke-6598", IngressHost: "668ceb-gke-6598.ci.distro.ultrawombat.com", Flow: "install"},
+		},
+		{
+			name: "rosa-install-id",
+			in:   WorkflowVarsInput{Platform: "rosa,gke", SetupFlow: "install", DeploymentTTL: "1h", IdentifierBase: "nightly-8.10", PRNumber: "987", RunID: "16400000007", Flow: "install"},
+			want: WorkflowVars{NamespacePrefix: "camunda", Platform: "rosa", JobID: "312fef", Namespace: "camunda-pr-nightly-8-10", Identifier: "rosa-nightly-8-10", IngressHost: "rosa-nightly-8-10.ci.distro.ultrawombat.com", Flow: "install"},
+		},
+		{
+			name: "gke-longid-nottl",
+			in:   WorkflowVarsInput{Platform: "gke", SetupFlow: "upgrade-minor", IdentifierBase: "integration-oidc-multitenancy-documentstore-very-long-name-x", RunID: "16400000008", Flow: "upgrade-minor"},
+			want: WorkflowVars{NamespacePrefix: "camunda", Platform: "gke", JobID: "97b460", Namespace: "camunda-id-integration-oidc-multitenancy-documentst-97b460-upgm", Identifier: "gke-integration-oidc-multitenancy-documentstore-very-long-name-x-upgm", IngressHost: "97b460-gke-integration-oidc-multitenancy-documentstore-very-long-name-x-upgm.ci.distro.ultrawombat.com", Flow: "upgrade-minor"},
+		},
+		{
+			name: "gke-prefix-override",
+			in:   WorkflowVarsInput{Platform: "gke", SetupFlow: "install", IdentifierBase: "6598", Prefix: "distribution", RunID: "16400000009", Flow: "install"},
+			want: WorkflowVars{NamespacePrefix: "distribution", Platform: "gke", JobID: "7820f5", Namespace: "distribution-id-6598-7820f5", Identifier: "gke-6598", IngressHost: "7820f5-gke-6598.ci.distro.ultrawombat.com", Flow: "install"},
+		},
+		{
+			name: "gke-dots-id",
+			in:   WorkflowVarsInput{Platform: "gke", SetupFlow: "install", IdentifierBase: "venom.8.10.test", RunID: "16400000010", Flow: "install"},
+			want: WorkflowVars{NamespacePrefix: "camunda", Platform: "gke", JobID: "c36c12", Namespace: "camunda-id-venom-8-10-test-c36c12", Identifier: "gke-venom-8-10-test", IngressHost: "c36c12-gke-venom-8-10-test.ci.distro.ultrawombat.com", Flow: "install"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			in := tc.in
+			in.RepoRoot = repoRoot
+			got, err := ComputeWorkflowVars(in, infra)
+			if err != nil {
+				t.Fatalf("ComputeWorkflowVars: %v", err)
+			}
+			for _, f := range []struct{ name, got, want string }{
+				{"NamespacePrefix", got.NamespacePrefix, tc.want.NamespacePrefix},
+				{"Platform", got.Platform, tc.want.Platform},
+				{"JobID", got.JobID, tc.want.JobID},
+				{"Namespace", got.Namespace, tc.want.Namespace},
+				{"Identifier", got.Identifier, tc.want.Identifier},
+				{"IngressHost", got.IngressHost, tc.want.IngressHost},
+				{"Flow", got.Flow, tc.want.Flow},
+			} {
+				if f.got != f.want {
+					t.Errorf("%s = %q, want %q", f.name, f.got, f.want)
+				}
+			}
+		})
+	}
+}
+
+// TestEmitWorkflowContract pins the full set of variable names and values the
+// action contract exposes to workflows, byte-compared against the bash-captured
+// output for the gke-install-pr case.
+func TestEmitWorkflowContract(t *testing.T) {
+	infra := loadTestInfra(t)
+	repoRoot := chartsRepoRoot(t, "camunda-platform-8.9", "camunda-platform-8.10")
+	vars, err := ComputeWorkflowVars(WorkflowVarsInput{
+		Platform: "gke", SetupFlow: "install", DeploymentTTL: "1h",
+		IdentifierBase: "6598", PRNumber: "1234", RunID: "16400000001",
+		Flow: "install", RepoRoot: repoRoot,
+	}, infra)
+	if err != nil {
+		t.Fatalf("ComputeWorkflowVars: %v", err)
+	}
+
+	envFile := filepath.Join(t.TempDir(), "env")
+	outFile := filepath.Join(t.TempDir(), "out")
+	if err := vars.Emit(&ghactions.Writer{Path: envFile}, &ghactions.Writer{Path: outFile}); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+
+	wantEnv := `INFRA_INGRESS_HOSTNAME_BASE=ci.distro.ultrawombat.com
+INFRA_NAMESPACE_PREFIX=camunda
+INFRA_CLUSTER_NAME=camunda-ci-eks
+CLUSTER_NAME=camunda-ci-eks
+AWS_PROFILE=distribution
+POSTGRESQL_JDBC_URL=jdbc:postgresql://postgresql-cluster-rw.distribution-postgresql.svc.cluster.local:5432
+INFRA_TELEPORT_PROXY=camunda.teleport.sh:443
+NAMESPACE_PREFIX=camunda
+PLATFORM=gke
+GITHUB_WORKFLOW_JOB_ID=b73169
+GITHUB_WORKFLOW_RUN_ID=16400000001
+TEST_NAMESPACE=camunda-pr-6598
+TEST_CAMUNDA_HELM_DIR_ALPHA=camunda-platform-8.10
+ORCHESTRATION_INDEX_PREFIX=b73169-orchestration
+OPTIMIZE_INDEX_PREFIX=b73169-optimize
+OPERATE_INDEX_PREFIX=b73169-operate
+TASKLIST_INDEX_PREFIX=b73169-tasklist
+FLOW=install
+KEYCLOAK_REALM=b73169-realm
+`
+	wantOut := `namespace=camunda-pr-6598
+identifier=gke-6598
+ingress-host=gke-6598.ci.distro.ultrawombat.com
+`
+	assertFileContent(t, envFile, wantEnv)
+	assertFileContent(t, outFile, wantOut)
+}
+
+func assertFileContent(t *testing.T, path, want string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if string(got) != want {
+		t.Errorf("%s content differs\n--- want\n%s\n--- got\n%s", filepath.Base(path), want, got)
+	}
+}
+
+func TestComputeWorkflowVarsEmptyIdentifierUsesRandomID(t *testing.T) {
+	infra := loadTestInfra(t)
+	vars, err := ComputeWorkflowVars(WorkflowVarsInput{
+		Platform: "gke", SetupFlow: "install", DeploymentTTL: "1h",
+		RunID: "1", Flow: "install", RandomID: "abc123",
+		RepoRoot: chartsRepoRoot(t, "camunda-platform-8.10"),
+	}, infra)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vars.Identifier != "gke-no-id-use-ran-abc123" {
+		t.Errorf("identifier = %q", vars.Identifier)
+	}
+}
+
+func TestComputeWorkflowVarsPlatformValidation(t *testing.T) {
+	infra := loadTestInfra(t)
+	for _, tc := range []struct {
+		platform string
+		wantErr  string
+	}{
+		{"", "must not be empty"},
+		{"aks", "not found"},
+	} {
+		_, err := ComputeWorkflowVars(WorkflowVarsInput{Platform: tc.platform}, infra)
+		if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+			t.Errorf("platform %q: err = %v, want containing %q", tc.platform, err, tc.wantErr)
+		}
+	}
+}
+
+func TestComputeWorkflowVarsRequiredInputs(t *testing.T) {
+	infra := loadTestInfra(t)
+	if _, err := ComputeWorkflowVars(WorkflowVarsInput{Platform: "gke"}, infra); err == nil || !strings.Contains(err.Error(), "run ID must not be empty") {
+		t.Fatalf("empty run ID: err = %v", err)
+	}
+
+	delete(infra.Platforms, "eks")
+	if _, err := ComputeWorkflowVars(WorkflowVarsInput{Platform: "gke", RunID: "1"}, infra); err == nil || !strings.Contains(err.Error(), `platform "eks" not found`) {
+		t.Fatalf("missing EKS config: err = %v", err)
+	}
+}
+
+func TestAlphaChartDirVersionSort(t *testing.T) {
+	repoRoot := chartsRepoRoot(t, "camunda-platform-8.2", "camunda-platform-8.9", "camunda-platform-8.10", "camunda-platform-8.11")
+	got, err := alphaChartDir(repoRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "camunda-platform-8.11" {
+		t.Errorf("alphaChartDir = %q, want camunda-platform-8.11", got)
+	}
+}

--- a/scripts/deploy-camunda/cmd/ci.go
+++ b/scripts/deploy-camunda/cmd/ci.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"os"
 
 	"scripts/camunda-core/pkg/ciworkflow"
@@ -18,8 +20,112 @@ func newCICommand() *cobra.Command {
 	}
 
 	ciCmd.AddCommand(newCITestTypeVarsCommand())
+	ciCmd.AddCommand(newCIWorkflowVarsCommand())
 
 	return ciCmd
+}
+
+// newCIWorkflowVarsCommand creates the "ci workflow-vars" subcommand. It
+// replaces the shell bodies of the composite action
+// .github/actions/workflow-vars: infra-config loading, namespace/identifier/
+// ingress derivation, upgrade-flow chart-version resolution, and the CI
+// snapshot version stamp on Chart.yaml.
+func newCIWorkflowVarsCommand() *cobra.Command {
+	var (
+		platform            string
+		setupFlow           string
+		deploymentTTL       string
+		identifierBase      string
+		chartDir            string
+		chartUpgradeVersion string
+		prefix              string
+		prNumber            string
+		runID               string
+		infraConfig         string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "workflow-vars",
+		Short: "Compute the common CI workflow variables for a test deployment",
+		Long: `Compute the common CI workflow variables (namespace, identifier, ingress
+host, index prefixes, upgrade chart version) and write them to
+$GITHUB_ENV / $GITHUB_OUTPUT, then stamp the chart's CI snapshot version.
+
+Environment variables:
+  FLOW   Ambient flow value re-emitted to $GITHUB_ENV (rewritten to "install"
+         for the modular-upgrade-minor flow)`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			infra, err := ciworkflow.LoadInfraConfig(infraConfig)
+			if err != nil {
+				return err
+			}
+
+			randomID, err := randomHex(3)
+			if err != nil {
+				return err
+			}
+			in := ciworkflow.WorkflowVarsInput{
+				Platform:       platform,
+				SetupFlow:      setupFlow,
+				DeploymentTTL:  deploymentTTL,
+				IdentifierBase: identifierBase,
+				Prefix:         prefix,
+				PRNumber:       prNumber,
+				RunID:          runID,
+				Flow:           os.Getenv("FLOW"),
+				RandomID:       randomID,
+			}
+			vars, err := ciworkflow.ComputeWorkflowVars(in, infra)
+			if err != nil {
+				return err
+			}
+
+			env, out := ghactions.NewGitHubEnv(), ghactions.NewGitHubOutput()
+			if err := vars.Emit(env, out); err != nil {
+				return err
+			}
+
+			version, resolved, err := ciworkflow.ResolveChartVersion(ciworkflow.ResolveChartVersionInput{
+				SetupFlow:           setupFlow,
+				ChartDir:            chartDir,
+				ChartUpgradeVersion: chartUpgradeVersion,
+			}, ciworkflow.ExecGit{})
+			if err != nil {
+				return err
+			}
+			if resolved {
+				if err := env.Set("TEST_CHART_VERSION", version); err != nil {
+					return err
+				}
+			}
+
+			return ciworkflow.StampChartVersion("", chartDir)
+		},
+	}
+
+	cmd.Flags().StringVar(&platform, "platform", "", "deployment platform, e.g. gke (first entry of a comma-separated list is used)")
+	cmd.Flags().StringVar(&setupFlow, "setup-flow", "install", "setup flow: install, upgrade-patch, upgrade-minor, modular-upgrade-minor")
+	cmd.Flags().StringVar(&deploymentTTL, "deployment-ttl", "", "deployment lifespan; empty selects the per-run hashed namespace")
+	cmd.Flags().StringVar(&identifierBase, "identifier-base", "", "fixed identifier part (PR number or name)")
+	cmd.Flags().StringVar(&chartDir, "chart-dir", "", "chart directory name, e.g. camunda-platform-8.10")
+	cmd.Flags().StringVar(&chartUpgradeVersion, "chart-upgrade-version", "", "explicit chart version for upgrade flows")
+	cmd.Flags().StringVar(&prefix, "prefix", "", "namespace prefix override")
+	cmd.Flags().StringVar(&prNumber, "pr-number", "", "github.event.pull_request.number; empty on non-PR events")
+	cmd.Flags().StringVar(&runID, "run-id", "", "github.run_id")
+	cmd.Flags().StringVar(&infraConfig, "infra-config", ".github/config/infra.yaml", "path to the infra config file")
+	_ = cmd.MarkFlagRequired("platform")
+	_ = cmd.MarkFlagRequired("chart-dir")
+	_ = cmd.MarkFlagRequired("run-id")
+
+	return cmd
+}
+
+func randomHex(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
 }
 
 // newCITestTypeVarsCommand creates the "ci test-type-vars" subcommand. It

--- a/scripts/deploy-camunda/cmd/ci_test.go
+++ b/scripts/deploy-camunda/cmd/ci_test.go
@@ -7,6 +7,85 @@ import (
 	"testing"
 )
 
+func TestCIWorkflowVarsWiring(t *testing.T) {
+	repo := t.TempDir()
+	chartDir := "camunda-platform-8.10"
+	writeFile(t, filepath.Join(repo, ".github", "config", "infra.yaml"), `gke:
+  ingress-hostname-base: ci.example.com
+  namespace-prefix: camunda
+eks:
+  ingress-hostname-base: ci.aws.example.com
+  namespace-prefix: distribution
+  cluster-name: camunda-ci-eks
+  aws-profile: distribution
+postgresql:
+  jdbc-host: postgresql.example.com
+  jdbc-port: "5432"
+teleport:
+  proxy: teleport.example.com:443
+`)
+	writeFile(t, filepath.Join(repo, "charts", "camunda-platform-8.9", "Chart.yaml"), "version: 14.0.0\n")
+	chartPath := filepath.Join(repo, "charts", chartDir, "Chart.yaml")
+	writeFile(t, chartPath, "apiVersion: v2\nname: camunda-platform\nversion: 15.0.0\n")
+
+	envFile := filepath.Join(t.TempDir(), "github_env")
+	outFile := filepath.Join(t.TempDir(), "github_output")
+	t.Setenv("GITHUB_ENV", envFile)
+	t.Setenv("GITHUB_OUTPUT", outFile)
+	t.Setenv("FLOW", "install")
+	t.Chdir(repo)
+
+	root := NewRootCommand()
+	root.AddCommand(newCICommand())
+	root.SetArgs([]string{
+		"ci", "workflow-vars",
+		"--platform", "GKE",
+		"--setup-flow", "install",
+		"--deployment-ttl", "1h",
+		"--identifier-base", "6598",
+		"--chart-dir", chartDir,
+		"--pr-number", "1234",
+		"--run-id", "16400000001",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	env := readFile(t, envFile)
+	for _, want := range []string{
+		"INFRA_INGRESS_HOSTNAME_BASE=ci.example.com\n",
+		"INFRA_CLUSTER_NAME=camunda-ci-eks\n",
+		"POSTGRESQL_JDBC_URL=jdbc:postgresql://postgresql.example.com:5432\n",
+		"PLATFORM=gke\n",
+		"GITHUB_WORKFLOW_JOB_ID=b73169\n",
+		"GITHUB_WORKFLOW_RUN_ID=16400000001\n",
+		"TEST_NAMESPACE=camunda-pr-6598\n",
+		"TEST_CAMUNDA_HELM_DIR_ALPHA=camunda-platform-8.10\n",
+		"FLOW=install\n",
+		"KEYCLOAK_REALM=b73169-realm\n",
+	} {
+		if !strings.Contains(env, want) {
+			t.Errorf("GITHUB_ENV missing %q; got:\n%s", want, env)
+		}
+	}
+
+	out := readFile(t, outFile)
+	for _, want := range []string{
+		"namespace=camunda-pr-6598\n",
+		"identifier=gke-6598\n",
+		"ingress-host=gke-6598.ci.example.com\n",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("GITHUB_OUTPUT missing %q; got:\n%s", want, out)
+		}
+	}
+
+	chart := readFile(t, chartPath)
+	if !strings.Contains(chart, "version: 0.0.0-ci-snapshot-8.10\n") {
+		t.Errorf("Chart.yaml version was not stamped:\n%s", chart)
+	}
+}
+
 // Pins the flag→struct wiring of "ci test-type-vars": string flags compared
 // against "true" (composite-action argument shape), the env passthroughs, and
 // the root PersistentPreRunE skip (ci needs no chart/namespace config). The
@@ -71,6 +150,16 @@ func TestCITestTypeVarsRequiresChartDir(t *testing.T) {
 	cmd.SilenceErrors = true
 	if err := cmd.Execute(); err == nil {
 		t.Fatal("expected error when --chart-dir is missing")
+	}
+}
+
+func TestCIWorkflowVarsRequiresRunID(t *testing.T) {
+	cmd := newCIWorkflowVarsCommand()
+	cmd.SetArgs([]string{"--platform", "gke", "--chart-dir", "camunda-platform-8.10"})
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), `required flag(s) "run-id" not set`) {
+		t.Fatalf("error = %v, want missing run-id error", err)
 	}
 }
 


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #5784.

Part of the bash-to-Go CI migration tracked in #4705.

### What's in this PR?

Ports the shell logic of the `workflow-vars` composite action to typed, testable Go as `deploy-camunda ci workflow-vars`, following the pattern established by #6598.

- `ciworkflow.LoadInfraConfig` parses `.github/config/infra.yaml` into typed platform, PostgreSQL, and Teleport values instead of using separate `yq` reads.
- `ciworkflow.ComputeWorkflowVars` returns namespace, platform, identifier, ingress, index-prefix, flow, and Keycloak realm values as a struct. The deterministic namespace hash still excludes `github.run_attempt`, preserving failed-job rerun behavior.
- `ciworkflow.ResolveChartVersion` puts upgrade-flow Git operations behind a mockable interface and retains the three-attempt fetch retry with 10s/20s backoff.
- `ciworkflow.StampChartVersion` updates only the top-level chart version line, leaving unrelated `Chart.yaml` content byte-identical.
- `deploy-camunda ci workflow-vars` writes the existing environment/output contract through `ghactions.Writer`; `--run-id` is required so manual invocations cannot silently produce a collision-prone hash.
- Bash-parity tests cover platforms, flows, TTL on/off, PR versus non-PR triggers, namespace-prefix overrides, dotted identifiers, modular upgrades, and 63-character truncation. Command-level coverage pins flags, environment/output files, and chart stamping.
- `.github/actions/workflow-vars/action.yaml` becomes a thin wrapper around the shared cached binary. Its inputs and outputs are unchanged.

Intentional behavior improvement: the previous `yq -i` command reformatted the complete `Chart.yaml`; the Go implementation changes only its top-level `version:` line.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
