### PR TITLE
ci: centralize deploy-camunda setup

### DIFF
--- a/.github/actions/generate-chart-matrix/action.yaml
+++ b/.github/actions/generate-chart-matrix/action.yaml
@@ -79,30 +79,8 @@ runs:
     - name: Get chart versions
       id: get-chart-versions
       uses: ./.github/actions/get-chart-versions
-    - name: Restore deploy-camunda binary
-      id: binary-cache
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-      with:
-        path: ~/.local/bin/deploy-camunda
-        key: deploy-camunda-v2-${{ runner.os }}-${{ hashFiles('scripts/deploy-camunda/**/*.go', 'scripts/deploy-camunda/go.sum') }}
-    - name: Setup Go
-      if: steps.binary-cache.outputs.cache-hit != 'true'
-      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
-      with:
-        go-version-file: scripts/deploy-camunda/go.mod
-        cache: true
-        cache-dependency-path: scripts/deploy-camunda/go.sum
-    - name: Build deploy-camunda
-      if: steps.binary-cache.outputs.cache-hit != 'true'
-      shell: bash
-      run: |
-        mkdir -p "$HOME/.local/bin"
-        # CGO_ENABLED=0 produces a static binary so it runs unchanged inside the
-        # ci-runner container used by downstream matrix jobs.
-        (cd scripts/deploy-camunda && CGO_ENABLED=0 go build -o "$HOME/.local/bin/deploy-camunda" .)
-    - name: Export deploy-camunda to PATH
-      shell: bash
-      run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+    - name: Setup deploy-camunda
+      uses: ./.github/actions/setup-deploy-camunda
     - name: Generate matrix
       shell: bash
       id: set-chart-versions

--- a/.github/actions/setup-deploy-camunda/action.yaml
+++ b/.github/actions/setup-deploy-camunda/action.yaml
@@ -1,0 +1,50 @@
+name: Setup deploy-camunda
+description: Restore or build the deploy-camunda binary and add it to PATH.
+
+runs:
+  using: composite
+  steps:
+    - name: Check runner deploy-camunda binary
+      id: runner-binary
+      shell: bash
+      run: echo "present=$([ -n "${RUNNER_TEMP:-}" ] && [ -x "$RUNNER_TEMP/bin/deploy-camunda" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+    - name: Restore deploy-camunda binary
+      if: steps.runner-binary.outputs.present != 'true'
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+      with:
+        path: .local-bin/deploy-camunda
+        key: deploy-camunda-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/actions/setup-deploy-camunda/action.yaml', 'scripts/deploy-camunda/**/*.go', 'scripts/deploy-camunda/go.mod', 'scripts/deploy-camunda/go.sum', 'scripts/deploy-camunda/deploy/data/**', 'scripts/deploy-camunda/examples/*.deploy-camunda.yaml', 'scripts/camunda-core/**/*.go', 'scripts/camunda-core/go.mod', 'scripts/camunda-core/go.sum', 'scripts/prepare-helm-values/**/*.go', 'scripts/prepare-helm-values/go.mod', 'scripts/prepare-helm-values/go.sum', 'scripts/vault-secret-mapper/**/*.go', 'scripts/vault-secret-mapper/go.mod', 'scripts/vault-secret-mapper/go.sum') }}
+    - name: Check deploy-camunda binary
+      id: binary-check
+      shell: bash
+      run: echo "present=$([ -x "$GITHUB_WORKSPACE/.local-bin/deploy-camunda" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+    - name: Setup Go
+      if: steps.runner-binary.outputs.present != 'true' && steps.binary-check.outputs.present != 'true'
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+      env:
+        GOROOT: ""
+      with:
+        go-version-file: scripts/deploy-camunda/go.mod
+        cache: true
+        cache-dependency-path: |
+          scripts/deploy-camunda/go.sum
+          scripts/camunda-core/go.sum
+          scripts/prepare-helm-values/go.sum
+          scripts/vault-secret-mapper/go.sum
+    - name: Build deploy-camunda
+      if: steps.runner-binary.outputs.present != 'true' && steps.binary-check.outputs.present != 'true'
+      shell: bash
+      env:
+        GOROOT: ""
+      run: |
+        mkdir -p "$GITHUB_WORKSPACE/.local-bin"
+        # CGO_ENABLED=0 produces a static binary for host and container jobs.
+        (cd scripts/deploy-camunda && CGO_ENABLED=0 go build -o "$GITHUB_WORKSPACE/.local-bin/deploy-camunda" .)
+    - name: Export deploy-camunda to PATH
+      shell: bash
+      run: |
+        if [[ "${{ steps.runner-binary.outputs.present }}" == "true" ]]; then
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+        else
+          echo "$GITHUB_WORKSPACE/.local-bin" >> "$GITHUB_PATH"
+        fi

--- a/.github/workflows/test-integration-template.yaml
+++ b/.github/workflows/test-integration-template.yaml
@@ -323,33 +323,15 @@ jobs:
           echo "${matrix}" | jq
           echo "matrix=$(echo ${matrix} | jq -c)" > "$GITHUB_OUTPUT"
 
-      - name: Restore deploy-camunda binary
-        id: binary-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-        with:
-          path: ~/.local/bin/deploy-camunda
-          key: deploy-camunda-v2-${{ runner.os }}-${{ hashFiles('scripts/deploy-camunda/**/*.go', 'scripts/deploy-camunda/go.sum') }}
-      - name: Setup Go
-        if: steps.binary-cache.outputs.cache-hit != 'true'
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
-        with:
-          go-version-file: scripts/deploy-camunda/go.mod
-          cache: true
-          cache-dependency-path: scripts/deploy-camunda/go.sum
-      - name: Build deploy-camunda
-        if: steps.binary-cache.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          mkdir -p "$HOME/.local/bin"
-          # CGO_ENABLED=0 produces a static binary so it runs unchanged inside the
-          # ci-runner container used by downstream matrix jobs.
-          (cd scripts/deploy-camunda && CGO_ENABLED=0 go build -o "$HOME/.local/bin/deploy-camunda" .)
+      - name: Setup deploy-camunda
+        uses: ./.github/actions/setup-deploy-camunda
       - name: Upload deploy-camunda binary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: deploy-camunda-binary-${{ inputs.identifier }}
-          path: ~/.local/bin/deploy-camunda
+          name: deploy-camunda-binary-${{ inputs.identifier }}-${{ inputs.shortname }}-${{ inputs.flows }}
+          path: .local-bin/deploy-camunda
           if-no-files-found: error
+          overwrite: true
           retention-days: 1
 
   # The runner job is used to run the install/upgrade flows on the plaform (gke, rosa, etc.). This level of abstraction is needed so
@@ -374,7 +356,7 @@ jobs:
       auth: ${{ inputs.auth }}
       exclude: ${{ inputs.exclude }}
       identifier: ${{ inputs.identifier }}-${{ inputs.shortname }}
-      binary-artifact-name: deploy-camunda-binary-${{ inputs.identifier }}
+      binary-artifact-name: deploy-camunda-binary-${{ inputs.identifier }}-${{ inputs.shortname }}-${{ inputs.flows }}
       camunda-helm-repo: ${{ inputs.camunda-helm-repo }}
       camunda-helm-dir: ${{ inputs.camunda-helm-dir }}
       camunda-helm-git-ref: ${{ inputs.camunda-helm-git-ref }}


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6611.

Foundational cleanup for the bash→Go CI migration tracked in #4705 and the
stack beginning at #6598.

### What's in this PR?

- Adds `.github/actions/setup-deploy-camunda` as the single owner of binary
  restore, presence validation, static build, and PATH export.
- Replaces both direct build/cache blocks currently on `main`:
  `generate-chart-matrix` and `test-integration-template`.
- Removes the manual cache-generation suffix. The key hashes the setup action
  itself, runner OS/architecture, Go/module inputs, local replace-module
  sources, and both sets of `//go:embed` runtime YAML.
- Keeps the binary under the workspace so host and container jobs share the
  same cache/artifact path.
- Reuses the exact parent-job binary when it is already available at
  `$RUNNER_TEMP/bin/deploy-camunda`, avoiding redundant container builds.
- Clears an inherited container `GOROOT` for genuine cache-miss builds so
  `actions/setup-go` uses its selected toolchain root consistently.
- Makes integration binary artifact names unique by identifier, shortname, and
  flow, with overwrite enabled for reruns.
- Leaves artifact-download blocks in `test-integration-runner` unchanged;
  those consume the exact parent-job binary rather than build from source.

Validation:

- `actionlint` on `test-integration-template.yaml` (excluding existing
  `SC2086` findings)
- YAML parsing for both composite actions
- Exact `CGO_ENABLED=0` static build and binary smoke test
- Runner-artifact detection and empty-`GOROOT` build simulation
- `go test ./cmd ./matrix` in `scripts/deploy-camunda`
- All current non-chart-contract `camunda-core/pkg/...` tests

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?