### PR TITLE
ci: add dry-run mode to chart promote-rc and public release workflows

### DIFF
--- a/.github/workflows/chart-promote-rc.yaml
+++ b/.github/workflows/chart-promote-rc.yaml
@@ -12,6 +12,15 @@ on:
           Or rolling tag: {chart-major}-dev-latest (e.g., "13-dev-latest")
         required: true
         type: string
+      dry-run:
+        description: |
+          Dry run: validate the dev package and stage real RC tags to isolated
+          {version}-rc-dryrun / {major}-rc-dryrun-latest Harbor tags, exercise
+          release-notes/matrix generation locally, but skip the release-please
+          PR, branch push, and project-board add. The internal dryrun tags are
+          deletable residue.
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.dev-tag }}
@@ -95,6 +104,7 @@ jobs:
           HARBOR_REPO: "projects/${{ env.HARBOR_PROJECT }}/repositories/camunda-platform"
           HARBOR_REGISTRY_USER: ${{ steps.test-credentials-secret.outputs.HARBOR_REGISTRY_USER }}
           HARBOR_REGISTRY_PASSWORD: ${{ steps.test-credentials-secret.outputs.HARBOR_REGISTRY_PASSWORD }}
+          DRY_RUN: ${{ inputs.dry-run }}
         run: |
           input_tag="${{ inputs.dev-tag }}"
 
@@ -107,6 +117,12 @@ jobs:
               -u "${HARBOR_REGISTRY_USER}:${HARBOR_REGISTRY_PASSWORD}" \
               --retry 3 --retry-delay 5 --retry-all-errors > /tmp/dev-tags.json
             tags_args=(--tags-file /tmp/dev-tags.json)
+          fi
+
+          # With --dry-run, rc_tag/rc_latest_tag carry the isolated
+          # {version}-rc-dryrun / {major}-rc-dryrun-latest names.
+          if [[ "${DRY_RUN}" == "true" ]]; then
+            tags_args+=(--dry-run)
           fi
 
           # Resolve + validate the dev tag; emit resolved_tag/version/chart_major/
@@ -201,10 +217,16 @@ jobs:
         id: release-please
         env:
           GH_TOKEN: ${{ steps.generate-github-token.outputs.token }}
+          DRY_RUN: ${{ inputs.dry-run }}
         run: |
           set -euo pipefail
           chart_path="charts/camunda-platform-${{ steps.package.outputs.chart_dir_id }}"
           head_ref="release-please--branches--main--components--camunda-platform-${{ steps.package.outputs.chart_dir_id }}"
+
+          dry_run_args=()
+          if [[ "${DRY_RUN}" == "true" ]]; then
+            dry_run_args=(--dry-run)
+          fi
 
           # Always pass --release-as with the version from the dev tag. This ensures
           # the release-please PR version matches exactly what the dev build computed.
@@ -220,12 +242,21 @@ jobs:
             --config-file="${{ env.RELEASE_PLEASE_CONFIG_FILE }}" \
             --manifest-file="${{ env.RELEASE_PLEASE_MANIFEST_FILE }}" \
             --release-as="${{ steps.parse.outputs.version }}" \
+            "${dry_run_args[@]}" \
             --debug 2>&1 | tee release-please.log
 
           if grep -qiE 'aborting|untagged, merged release PRs outstanding' release-please.log; then
             echo "::error::release-please aborted (likely due to a merged release PR still labeled as pending)."
             echo "::error::Fix the outstanding release PR labels (e.g., set 'autorelease: published') and re-run this workflow."
             exit 1
+          fi
+
+          echo "head_ref=${head_ref}" | tee -a "$GITHUB_OUTPUT"
+
+          if [[ "${DRY_RUN}" == "true" ]]; then
+            echo "::notice::[dry run] release-please ran with --dry-run; no PR was created or updated."
+            echo "pr_url=" | tee -a "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           # Determine the release-please PR for this component deterministically.
@@ -237,13 +268,13 @@ jobs:
             exit 1
           fi
           echo "pr_url=${pr_url}" | tee -a "$GITHUB_OUTPUT"
-          echo "head_ref=${head_ref}" | tee -a "$GITHUB_OUTPUT"
-          
+
           echo "::notice::Release-please PR: ${pr_url}"
 
       - name: Generate release files on the release-please PR
         env:
           GH_TOKEN: ${{ steps.generate-github-token.outputs.token }}
+          DRY_RUN: ${{ inputs.dry-run }}
         run: |
           set -euo pipefail
 
@@ -251,8 +282,13 @@ jobs:
           app_version="${{ steps.package.outputs.camunda_version }}"
           chart_path="charts/camunda-platform-${{ steps.package.outputs.chart_dir_id }}"
           head_ref="${{ steps.release-please.outputs.head_ref }}"
-          git fetch origin "${head_ref}"
-          git checkout "${head_ref}"
+
+          # In dry-run no release-please branch exists; generate against the
+          # dev-SHA checkout instead to keep real coverage of the generators.
+          if [[ "${DRY_RUN}" != "true" ]]; then
+            git fetch origin "${head_ref}"
+            git checkout "${head_ref}"
+          fi
 
           make helm.repos-add
           make helm.dependency-update chartPath="${chart_path}"
@@ -269,6 +305,12 @@ jobs:
             --matrix-file "${version_matrix_file}"
           /tmp/release-tools version-matrix --readme "${app_version}" --chart-version "${chart_version}"
           /tmp/release-tools version-matrix --index
+
+          if [[ "${DRY_RUN}" == "true" ]]; then
+            echo "::notice::[dry run] Generated release files locally; skipping commit, push, and project-board add. Changes:"
+            git status --short -- "${chart_path}" version-matrix
+            exit 0
+          fi
 
           git config user.name "distro-ci[bot]"
           git config user.email "122795778+distro-ci[bot]@users.noreply.github.com"
@@ -302,6 +344,9 @@ jobs:
           # idempotently (no-op if already there, else move). Untagging uses the
           # deleteTag endpoint (DELETE .../tags/{tag}) so only the tag is removed,
           # never the shared artifact. Auth is HARBOR_REGISTRY_USER/PASSWORD (env).
+          # In dry-run, rc_tag/rc_latest_tag are the isolated {version}-rc-dryrun /
+          # {major}-rc-dryrun-latest names, so real tags land in a deletable
+          # namespace and the normal rc tags are never touched.
           api="${HARBOR_API}"
           repo="${HARBOR_REPO}"
 
@@ -321,6 +366,8 @@ jobs:
           echo "✅ RC tags added successfully"
 
       - name: Summary
+        env:
+          DRY_RUN: ${{ inputs.dry-run }}
         run: |
           VERSION="${{ steps.parse.outputs.version }}"
           RC_TAG="${{ steps.parse.outputs.rc_tag }}"
@@ -332,8 +379,13 @@ jobs:
 
           COMMIT_URL="https://github.com/${{ github.repository }}/commit/${COMMIT_SHA}"
 
+          if [[ "${DRY_RUN}" == "true" ]]; then
+            echo "## 🧪 DRY RUN 🧪 RC Promotion Rehearsal: ${VERSION}" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "## ✅ RC Promoted: ${VERSION}" >> $GITHUB_STEP_SUMMARY
+          fi
+
           cat >> $GITHUB_STEP_SUMMARY << EOF
-          ## ✅ RC Promoted: ${VERSION}
 
           | | |
           |---|---|
@@ -363,7 +415,17 @@ jobs:
             echo "[${PR_URL}](${PR_URL})" >> $GITHUB_STEP_SUMMARY
           fi
 
-          cat >> $GITHUB_STEP_SUMMARY << EOF
+          if [[ "${DRY_RUN}" == "true" ]]; then
+            cat >> $GITHUB_STEP_SUMMARY << EOF
+
+          ### Dry Run Notes
+
+          - No release-please PR was created or updated.
+          - Harbor tags \`${RC_TAG}\` and \`${{ steps.parse.outputs.rc_latest_tag }}\` are real but isolated dry-run residue — deletable at any time.
+          - To rehearse the next stage: run **Chart - Release - Pipeline - 3 - Public** with \`${RC_TAG}\` and dry-run enabled.
+          EOF
+          else
+            cat >> $GITHUB_STEP_SUMMARY << EOF
 
           ### Next Steps
 
@@ -371,11 +433,12 @@ jobs:
           2. Review release-please PR
           3. Run **Chart - Release - Pipeline - 3 - Public** with \`${RC_TAG}\`
           EOF
+          fi
 
   notify-on-failure:
     name: Notify on Failure
     needs: [promote-rc]
-    if: failure()
+    if: ${{ failure() && !inputs.dry-run }}
     runs-on: ubuntu-latest
     steps:
       - name: Import Vault secrets

--- a/.github/workflows/chart-release-public.yaml
+++ b/.github/workflows/chart-release-public.yaml
@@ -12,6 +12,15 @@ on:
           Or rolling tag: {chart-major}-rc-latest (e.g., "13-rc-latest")
         required: true
         type: string
+      dry-run:
+        description: |
+          Dry run: pull and validate the RC package from Harbor, extract
+          metadata, then LOG (not execute) the GitHub release, index push,
+          cosign signing, and post-release PR automation. Accepts dry-run RC
+          tags ({version}-rc-dryrun / {major}-rc-dryrun-latest) in addition to
+          the plain rc forms. Nothing public is written.
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.rc-tag }}
@@ -85,13 +94,14 @@ jobs:
           HARBOR_REPO: "projects/${{ env.HARBOR_PROJECT }}/repositories/camunda-platform"
           HARBOR_REGISTRY_USER: ${{ steps.vault-harbor.outputs.HARBOR_REGISTRY_USER }}
           HARBOR_REGISTRY_PASSWORD: ${{ steps.vault-harbor.outputs.HARBOR_REGISTRY_PASSWORD }}
+          DRY_RUN: ${{ inputs.dry-run }}
         run: |
           input_tag="${{ inputs.rc-tag }}"
 
           # Fetch the artifact's tag list. All of an artifact's tags (rc/dev/
           # rolling) live on the one artifact, so a single GET resolves both the
           # concrete RC tag and (for traceability) the source dev tag.
-          if [[ "$input_tag" =~ ^[0-9]+-rc-latest$ ]]; then
+          if [[ "$input_tag" =~ ^[0-9]+-rc(-dryrun)?-latest$ ]]; then
             echo "::notice::Rolling tag detected: ${input_tag}, resolving to actual RC tag..."
             # Rolling resolution needs the tag list — fatal on failure.
             curl -sf "${HARBOR_API}/${HARBOR_REPO}/artifacts/${input_tag}/tags" \
@@ -105,9 +115,16 @@ jobs:
               --retry 3 --retry-delay 5 --retry-all-errors > /tmp/rc-tags.json 2>/dev/null || echo "[]" > /tmp/rc-tags.json
           fi
 
+          # With --dry-run, -rc-dryrun tags (staged by a dry-run RC promotion)
+          # are accepted in addition to the plain rc forms.
+          dry_run_args=()
+          if [[ "${DRY_RUN}" == "true" ]]; then
+            dry_run_args=(--dry-run)
+          fi
+
           # Resolve + validate the RC tag; emit resolved_tag/version and
           # (best-effort) dev_tag/commit_sha to $GITHUB_OUTPUT.
-          /tmp/release-tools resolve-tag --kind rc --input-tag "$input_tag" --tags-file /tmp/rc-tags.json
+          /tmp/release-tools resolve-tag --kind rc --input-tag "$input_tag" --tags-file /tmp/rc-tags.json "${dry_run_args[@]}"
 
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -158,9 +175,11 @@ jobs:
             exit 1
           fi
 
-          # drop -rc from filename
+          # drop -rc (or -rc-dryrun) from filename
           filename=$(ls .cr-release-packages/camunda-platform-*-rc*.tgz)
-          mv "$filename" "${filename/-rc/}"
+          target="${filename/-rc-dryrun/}"
+          target="${target/-rc/}"
+          mv "$filename" "$target"
 
           echo "Downloaded package:"
           ls -la .cr-release-packages/
@@ -183,6 +202,7 @@ jobs:
             --chart-versions "$(git rev-parse --show-toplevel)/charts/chart-versions.yaml"
 
       - name: Check if release already exists
+        if: ${{ !inputs.dry-run }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -194,6 +214,7 @@ jobs:
           fi
 
       - name: Run Chart Releaser - Tagging/Uploading
+        if: ${{ !inputs.dry-run }}
         env:
           CR_TOKEN: ${{ steps.generate-github-token.outputs.token }}
         run: |
@@ -205,6 +226,7 @@ jobs:
             --release-name-template "${{ steps.metadata.outputs.release_tag }}"
 
       - name: Run Chart Releaser - Indexing
+        if: ${{ !inputs.dry-run }}
         env:
           CR_TOKEN: ${{ steps.generate-github-token.outputs.token }}
         run: |
@@ -214,7 +236,10 @@ jobs:
             --git-repo "$(basename ${{ github.repository }})" \
             --release-name-template "${{ steps.metadata.outputs.release_tag }}"
 
+      # Cosign keyless signing is gated too: it writes a permanent entry to the
+      # public Rekor transparency log, so it is a public side effect.
       - name: Sign Helm chart with Cosign
+        if: ${{ !inputs.dry-run }}
         working-directory: .cr-release-packages
         run: |
           cosign sign-blob -y "${{ steps.metadata.outputs.package_file }}" \
@@ -222,6 +247,7 @@ jobs:
 
       - name: Get Cosign Rekor log index
         id: rekor
+        if: ${{ !inputs.dry-run }}
         working-directory: .cr-release-packages
         run: |
           # New cosign bundle format uses .verificationMaterial.tlogEntries[0].logIndex
@@ -229,6 +255,7 @@ jobs:
           echo "log_index=${rekor_log_index}" | tee -a $GITHUB_OUTPUT
 
       - name: Create Cosign verify script
+        if: ${{ !inputs.dry-run }}
         working-directory: .cr-release-packages
         run: |
           cat << EOF > "${{ steps.metadata.outputs.cosign_verify }}"
@@ -244,11 +271,13 @@ jobs:
           EOF
 
       - name: Verify signed Helm chart
+        if: ${{ !inputs.dry-run }}
         working-directory: .cr-release-packages
         run: |
           bash "${{ steps.metadata.outputs.cosign_verify }}"
 
       - name: Upload Cosign bundle to release
+        if: ${{ !inputs.dry-run }}
         working-directory: .cr-release-packages
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -258,6 +287,7 @@ jobs:
             --repo "${GITHUB_REPOSITORY}"
 
       - name: Upload Cosign verify script to release
+        if: ${{ !inputs.dry-run }}
         working-directory: .cr-release-packages
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -266,7 +296,18 @@ jobs:
             "${{ steps.metadata.outputs.cosign_verify }}" \
             --repo "${GITHUB_REPOSITORY}"
 
+      - name: Dry run - log skipped public publishes
+        if: ${{ inputs.dry-run }}
+        run: |
+          echo "::notice::[dry run] Public publishes were skipped. Plan:"
+          echo "::notice::[dry run] - GitHub release '${{ steps.metadata.outputs.release_tag }}' with chart package '${{ steps.metadata.outputs.package_file }}' (make-release-latest: ${{ steps.metadata.outputs.is_latest_stable }})"
+          echo "::notice::[dry run] - Push '${{ steps.metadata.outputs.package_file }}' entry to the gh-pages index.yaml (helm repo)"
+          echo "::notice::[dry run] - Cosign keyless signing of the package (public Rekor transparency log entry)"
+          echo "::notice::[dry run] - Upload cosign bundle + verify script to the GitHub release"
+          echo "::notice::[dry run] - Post-release: version-label PRs/issues, mark release-please PR published, approve + auto-merge it"
+
       - name: Add release info to workflow summary
+        if: ${{ !inputs.dry-run }}
         run: |
           VERSION="${{ steps.metadata.outputs.version }}"
           APP_VERSION="${{ steps.metadata.outputs.app_version }}"
@@ -332,9 +373,27 @@ jobs:
           \`\`\`
           EOF
 
+      - name: Add dry-run info to workflow summary
+        if: ${{ inputs.dry-run }}
+        run: |
+          cat >> $GITHUB_STEP_SUMMARY << EOF
+          ## 🧪 DRY RUN 🧪 Helm Chart ${{ steps.metadata.outputs.version }} Release Rehearsal
+
+          | | |
+          |---|---|
+          | **RC Tag** | \`${{ steps.parse.outputs.resolved_tag }}\` |
+          | **Would release** | \`${{ steps.metadata.outputs.release_tag }}\` |
+          | **Camunda** | \`${{ steps.metadata.outputs.app_version }}\` |
+          | **Latest stable** | ${{ steps.metadata.outputs.is_latest_stable }} |
+
+          Validated: Harbor pull, package metadata extraction.
+          Skipped (logged above): GitHub release, index.yaml push, cosign signing + uploads, post-release PR automation.
+          EOF
+
   post-release:
     name: Post-Release
     needs: release
+    if: ${{ !inputs.dry-run }}
     runs-on: ubuntu-latest
     outputs:
       pr-number: ${{ steps.mark-published.outputs.pr_number }}
@@ -564,7 +623,7 @@ jobs:
   notify-on-failure:
     name: Notify on Failure
     needs: [release, post-release]
-    if: failure()
+    if: ${{ failure() && !inputs.dry-run }}
     runs-on: ubuntu-latest
     steps:
       - name: Import Vault secrets

--- a/scripts/camunda-core/pkg/harbortag/harbortag.go
+++ b/scripts/camunda-core/pkg/harbortag/harbortag.go
@@ -19,10 +19,12 @@
 //
 // Tag forms:
 //
-//	dev:          {version}-dev-{sha}        e.g. 13.4.0-dev-abc1234, 14.0.0-alpha2-dev-abc1234
-//	dev rolling:  {major}-dev-latest         e.g. 13-dev-latest
-//	rc:           {version}-rc               e.g. 13.4.0-rc, 14.0.0-alpha2-rc
-//	rc rolling:   {major}-rc-latest          e.g. 13-rc-latest
+//	dev:               {version}-dev-{sha}        e.g. 13.4.0-dev-abc1234, 14.0.0-alpha2-dev-abc1234
+//	dev rolling:       {major}-dev-latest         e.g. 13-dev-latest
+//	rc:                {version}-rc               e.g. 13.4.0-rc, 14.0.0-alpha2-rc
+//	rc rolling:        {major}-rc-latest          e.g. 13-rc-latest
+//	rc dryrun:         {version}-rc-dryrun        e.g. 13.4.0-rc-dryrun
+//	rc dryrun rolling: {major}-rc-dryrun-latest   e.g. 13-rc-dryrun-latest
 package harbortag
 
 import (
@@ -34,16 +36,19 @@ import (
 type Kind string
 
 const (
-	Dev Kind = "dev"
-	RC  Kind = "rc"
+	Dev      Kind = "dev"
+	RC       Kind = "rc"
+	RCDryRun Kind = "rc-dryrun"
 )
 
 var (
-	devRollingRe = regexp.MustCompile(`^[0-9]+-dev-latest$`)
-	rcRollingRe  = regexp.MustCompile(`^[0-9]+-rc-latest$`)
+	devRollingRe      = regexp.MustCompile(`^[0-9]+-dev-latest$`)
+	rcRollingRe       = regexp.MustCompile(`^[0-9]+-rc-latest$`)
+	rcDryRunRollingRe = regexp.MustCompile(`^[0-9]+-rc-dryrun-latest$`)
 	// Concrete tag patterns.
-	devTagRe = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?-dev-[a-f0-9]+$`)
-	rcTagRe  = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?-rc$`)
+	devTagRe      = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?-dev-[a-f0-9]+$`)
+	rcTagRe       = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?-rc$`)
+	rcDryRunTagRe = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?-rc-dryrun$`)
 )
 
 // IsRolling reports whether inputTag is a rolling tag ({major}-{kind}-latest)
@@ -54,6 +59,8 @@ func IsRolling(inputTag string, kind Kind) bool {
 		return devRollingRe.MatchString(inputTag)
 	case RC:
 		return rcRollingRe.MatchString(inputTag)
+	case RCDryRun:
+		return rcDryRunRollingRe.MatchString(inputTag)
 	}
 	return false
 }
@@ -72,20 +79,25 @@ func ResolveConcrete(tags []string, kind Kind) (string, error) {
 }
 
 func concreteRe(kind Kind) *regexp.Regexp {
-	if kind == RC {
+	switch kind {
+	case RC:
 		return rcTagRe
+	case RCDryRun:
+		return rcDryRunTagRe
 	}
 	return devTagRe
 }
 
 // DevTag is the parsed form of a concrete dev tag.
 type DevTag struct {
-	ResolvedTag string // {version}-dev-{sha}
-	Version     string // {version}
-	SHA         string // {sha} (may be short; the workflow expands it via the GitHub API)
-	ChartMajor  string // major of {version}
-	RCTag       string // {version}-rc
-	RCLatestTag string // {major}-rc-latest
+	ResolvedTag       string // {version}-dev-{sha}
+	Version           string // {version}
+	SHA               string // {sha} (may be short; the workflow expands it via the GitHub API)
+	ChartMajor        string // major of {version}
+	RCTag             string // {version}-rc
+	RCLatestTag       string // {major}-rc-latest
+	RCDryRunTag       string // {version}-rc-dryrun
+	RCDryRunLatestTag string // {major}-rc-dryrun-latest
 }
 
 // ParseDevTag validates a concrete dev tag and extracts its parts.
@@ -99,12 +111,14 @@ func ParseDevTag(tag string) (DevTag, error) {
 	}
 	major := majorOf(version)
 	return DevTag{
-		ResolvedTag: tag,
-		Version:     version,
-		SHA:         sha,
-		ChartMajor:  major,
-		RCTag:       version + "-rc",
-		RCLatestTag: major + "-rc-latest",
+		ResolvedTag:       tag,
+		Version:           version,
+		SHA:               sha,
+		ChartMajor:        major,
+		RCTag:             version + "-rc",
+		RCLatestTag:       major + "-rc-latest",
+		RCDryRunTag:       version + "-rc-dryrun",
+		RCDryRunLatestTag: major + "-rc-dryrun-latest",
 	}, nil
 }
 
@@ -121,6 +135,22 @@ func ParseRcTag(tag string) (RcTag, error) {
 		return RcTag{}, fmt.Errorf("invalid rc tag format %q: expected {version}-rc (e.g. 13.4.0-rc or 14.0.0-alpha2-rc)", tag)
 	}
 	version := tag[:len(tag)-len("-rc")]
+	return RcTag{ResolvedTag: tag, Version: version, ChartMajor: majorOf(version)}, nil
+}
+
+// IsRcDryRunTag reports whether tag is a concrete dry-run rc tag
+// ({version}-rc-dryrun).
+func IsRcDryRunTag(tag string) bool {
+	return rcDryRunTagRe.MatchString(tag)
+}
+
+// ParseRcDryRunTag validates a concrete dry-run rc tag ({version}-rc-dryrun,
+// staged by a dry-run RC promotion) and extracts its parts.
+func ParseRcDryRunTag(tag string) (RcTag, error) {
+	if !rcDryRunTagRe.MatchString(tag) {
+		return RcTag{}, fmt.Errorf("invalid dry-run rc tag format %q: expected {version}-rc-dryrun (e.g. 13.4.0-rc-dryrun)", tag)
+	}
+	version := tag[:len(tag)-len("-rc-dryrun")]
 	return RcTag{ResolvedTag: tag, Version: version, ChartMajor: majorOf(version)}, nil
 }
 

--- a/scripts/camunda-core/pkg/harbortag/harbortag_test.go
+++ b/scripts/camunda-core/pkg/harbortag/harbortag_test.go
@@ -30,6 +30,10 @@ func TestIsRolling(t *testing.T) {
 		{"13-rc-latest", RC, true},
 		{"13.4.0-rc", RC, false},
 		{"13-dev-latest", RC, false},
+		{"13-rc-dryrun-latest", RCDryRun, true},
+		{"13-rc-dryrun-latest", RC, false},
+		{"13-rc-latest", RCDryRun, false},
+		{"13.4.0-rc-dryrun", RCDryRun, false},
 	}
 	for _, tt := range tests {
 		if got := IsRolling(tt.tag, tt.kind); got != tt.want {
@@ -50,6 +54,15 @@ func TestResolveConcrete(t *testing.T) {
 	if _, err := ResolveConcrete([]string{"13-dev-latest"}, Dev); err == nil {
 		t.Error("expected error when no concrete dev tag present")
 	}
+
+	dryRunTags := []string{"13-rc-dryrun-latest", "13.4.0-rc", "13.4.0-rc-dryrun"}
+	got, err = ResolveConcrete(dryRunTags, RCDryRun)
+	if err != nil {
+		t.Fatalf("ResolveConcrete rc-dryrun: %v", err)
+	}
+	if got != "13.4.0-rc-dryrun" {
+		t.Errorf("ResolveConcrete rc-dryrun = %q, want 13.4.0-rc-dryrun", got)
+	}
 }
 
 func TestParseDevTag(t *testing.T) {
@@ -59,11 +72,19 @@ func TestParseDevTag(t *testing.T) {
 	}{
 		{
 			"13.4.0-dev-abc1234",
-			DevTag{ResolvedTag: "13.4.0-dev-abc1234", Version: "13.4.0", SHA: "abc1234", ChartMajor: "13", RCTag: "13.4.0-rc", RCLatestTag: "13-rc-latest"},
+			DevTag{
+				ResolvedTag: "13.4.0-dev-abc1234", Version: "13.4.0", SHA: "abc1234", ChartMajor: "13",
+				RCTag: "13.4.0-rc", RCLatestTag: "13-rc-latest",
+				RCDryRunTag: "13.4.0-rc-dryrun", RCDryRunLatestTag: "13-rc-dryrun-latest",
+			},
 		},
 		{
 			"14.0.0-alpha2-dev-deadbeef",
-			DevTag{ResolvedTag: "14.0.0-alpha2-dev-deadbeef", Version: "14.0.0-alpha2", SHA: "deadbeef", ChartMajor: "14", RCTag: "14.0.0-alpha2-rc", RCLatestTag: "14-rc-latest"},
+			DevTag{
+				ResolvedTag: "14.0.0-alpha2-dev-deadbeef", Version: "14.0.0-alpha2", SHA: "deadbeef", ChartMajor: "14",
+				RCTag: "14.0.0-alpha2-rc", RCLatestTag: "14-rc-latest",
+				RCDryRunTag: "14.0.0-alpha2-rc-dryrun", RCDryRunLatestTag: "14-rc-dryrun-latest",
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -93,6 +114,42 @@ func TestParseRcTag(t *testing.T) {
 	}
 	if _, err := ParseRcTag("13.4.0-dev-abc1234"); err == nil {
 		t.Error("expected error for dev tag passed to ParseRcTag")
+	}
+	if _, err := ParseRcTag("13.4.0-rc-dryrun"); err == nil {
+		t.Error("expected error for dry-run rc tag passed to ParseRcTag")
+	}
+}
+
+func TestParseRcDryRunTag(t *testing.T) {
+	got, err := ParseRcDryRunTag("14.0.0-alpha2-rc-dryrun")
+	if err != nil {
+		t.Fatalf("ParseRcDryRunTag: %v", err)
+	}
+	want := RcTag{ResolvedTag: "14.0.0-alpha2-rc-dryrun", Version: "14.0.0-alpha2", ChartMajor: "14"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ParseRcDryRunTag=%+v want %+v", got, want)
+	}
+	for _, bad := range []string{"13.4.0-rc", "13-rc-dryrun-latest", "13.4.0-dev-abc1234"} {
+		if _, err := ParseRcDryRunTag(bad); err == nil {
+			t.Errorf("ParseRcDryRunTag(%q) expected error", bad)
+		}
+	}
+}
+
+func TestIsRcDryRunTag(t *testing.T) {
+	tests := []struct {
+		tag  string
+		want bool
+	}{
+		{"13.4.0-rc-dryrun", true},
+		{"14.0.0-alpha2-rc-dryrun", true},
+		{"13.4.0-rc", false},
+		{"13-rc-dryrun-latest", false},
+	}
+	for _, tt := range tests {
+		if got := IsRcDryRunTag(tt.tag); got != tt.want {
+			t.Errorf("IsRcDryRunTag(%q)=%v want %v", tt.tag, got, tt.want)
+		}
 	}
 }
 

--- a/scripts/release-tools/resolve_tag.go
+++ b/scripts/release-tools/resolve_tag.go
@@ -31,28 +31,34 @@ import (
 // tags (dev/rc/rolling) all live on the one underlying artifact, a single tag
 // list resolves both the concrete tag and (for rc) the source dev tag.
 //
-//	resolve-tag --kind dev|rc --input-tag <tag> [--tags-file <harbor-tags.json|->]
+//	resolve-tag --kind dev|rc --input-tag <tag> [--tags-file <harbor-tags.json|->] [--dry-run]
 //
 // dev: emits resolved_tag, version, chart_major, rc_tag, rc_latest_tag to
 //
 //	$GITHUB_OUTPUT and prints the (short) commit SHA to stdout. The caller
 //	captures stdout to expand the short SHA to a full 40-char SHA (via the
-//	GitHub API) and emits the final `sha` output itself.
+//	GitHub API) and emits the final `sha` output itself. With --dry-run,
+//	rc_tag/rc_latest_tag carry the isolated dry-run names
+//	({version}-rc-dryrun / {major}-rc-dryrun-latest).
 //
 // rc:  emits resolved_tag, version, and (when --tags-file is given) dev_tag +
 //
 //	commit_sha for traceability — empty when no dev tag is present. commit_sha
 //	is the short SHA as-is (no expansion; the commit is not checked out).
+//	With --dry-run, dry-run rc tags ({version}-rc-dryrun and rolling
+//	{major}-rc-dryrun-latest) are accepted in addition to the plain rc forms.
 func runResolveTag(args []string) error {
 	fs := flag.NewFlagSet("resolve-tag", flag.ContinueOnError)
 	var (
 		kindStr  string
 		input    string
 		tagsFile string
+		dryRun   bool
 	)
 	fs.StringVar(&kindStr, "kind", "", "tag family: dev or rc")
 	fs.StringVar(&input, "input-tag", "", "the input tag (concrete or rolling {major}-{kind}-latest)")
 	fs.StringVar(&tagsFile, "tags-file", "", "Harbor artifact tags JSON (path or - for stdin); required to resolve a rolling tag")
+	fs.BoolVar(&dryRun, "dry-run", false, "dry-run tag naming: emit -rc-dryrun names for dev; also accept -rc-dryrun tags for rc")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -64,6 +70,14 @@ func runResolveTag(args []string) error {
 		return fmt.Errorf("--input-tag is required")
 	}
 
+	// In dry-run, an rc input in the isolated dry-run namespace resolves and
+	// parses against the -rc-dryrun tag forms.
+	resolveKind := kind
+	if dryRun && kind == harbortag.RC &&
+		(harbortag.IsRolling(input, harbortag.RCDryRun) || harbortag.IsRcDryRunTag(input)) {
+		resolveKind = harbortag.RCDryRun
+	}
+
 	concrete := input
 	var tags []string
 	if tagsFile != "" {
@@ -73,12 +87,12 @@ func runResolveTag(args []string) error {
 			return err
 		}
 	}
-	if harbortag.IsRolling(input, kind) {
+	if harbortag.IsRolling(input, resolveKind) {
 		if len(tags) == 0 {
 			return fmt.Errorf("rolling tag %q requires --tags-file with the artifact's tags", input)
 		}
 		var err error
-		concrete, err = harbortag.ResolveConcrete(tags, kind)
+		concrete, err = harbortag.ResolveConcrete(tags, resolveKind)
 		if err != nil {
 			return fmt.Errorf("resolve rolling tag %q: %w", input, err)
 		}
@@ -91,12 +105,16 @@ func runResolveTag(args []string) error {
 		if err != nil {
 			return err
 		}
+		rcTag, rcLatestTag := d.RCTag, d.RCLatestTag
+		if dryRun {
+			rcTag, rcLatestTag = d.RCDryRunTag, d.RCDryRunLatestTag
+		}
 		// `sha` is intentionally NOT emitted here: the workflow expands the
 		// short SHA to a full 40-char SHA via the GitHub API and emits `sha`
 		// itself. We print the short SHA to stdout so it can capture it.
 		for _, kv := range [][2]string{
 			{"resolved_tag", d.ResolvedTag}, {"version", d.Version},
-			{"chart_major", d.ChartMajor}, {"rc_tag", d.RCTag}, {"rc_latest_tag", d.RCLatestTag},
+			{"chart_major", d.ChartMajor}, {"rc_tag", rcTag}, {"rc_latest_tag", rcLatestTag},
 		} {
 			if err := out.set(kv[0], kv[1]); err != nil {
 				return err
@@ -104,7 +122,13 @@ func runResolveTag(args []string) error {
 		}
 		fmt.Println(d.SHA)
 	case harbortag.RC:
-		r, err := harbortag.ParseRcTag(concrete)
+		var r harbortag.RcTag
+		var err error
+		if resolveKind == harbortag.RCDryRun {
+			r, err = harbortag.ParseRcDryRunTag(concrete)
+		} else {
+			r, err = harbortag.ParseRcTag(concrete)
+		}
 		if err != nil {
 			return err
 		}

--- a/scripts/release-tools/resolve_tag_test.go
+++ b/scripts/release-tools/resolve_tag_test.go
@@ -143,6 +143,57 @@ func TestResolveTagRcNoDevTag(t *testing.T) {
 	}
 }
 
+func TestResolveTagDevDryRun(t *testing.T) {
+	out, stdout, err := runResolveTagCapture(t, []string{"--kind", "dev", "--input-tag", "13.4.0-dev-abc1234", "--dry-run"})
+	if err != nil {
+		t.Fatalf("runResolveTag: %v", err)
+	}
+	if out["rc_tag"] != "13.4.0-rc-dryrun" || out["rc_latest_tag"] != "13-rc-dryrun-latest" {
+		t.Errorf("dry-run rc tags = %q/%q want 13.4.0-rc-dryrun/13-rc-dryrun-latest", out["rc_tag"], out["rc_latest_tag"])
+	}
+	if out["resolved_tag"] != "13.4.0-dev-abc1234" || out["version"] != "13.4.0" || stdout != "abc1234" {
+		t.Errorf("unexpected dev dry-run output: %v stdout=%q", out, stdout)
+	}
+}
+
+func TestResolveTagRcDryRun(t *testing.T) {
+	// Concrete dry-run tag.
+	out, _, err := runResolveTagCapture(t, []string{"--kind", "rc", "--input-tag", "13.4.0-rc-dryrun", "--dry-run"})
+	if err != nil {
+		t.Fatalf("runResolveTag concrete dryrun: %v", err)
+	}
+	if out["resolved_tag"] != "13.4.0-rc-dryrun" || out["version"] != "13.4.0" {
+		t.Errorf("unexpected rc dry-run output: %v", out)
+	}
+
+	// Rolling dry-run tag resolves against -rc-dryrun concretes only.
+	tags := writeTags(t, "13-rc-dryrun-latest", "13.4.0-rc", "13.4.0-rc-dryrun", "13.4.0-dev-abc1234")
+	out, _, err = runResolveTagCapture(t, []string{"--kind", "rc", "--input-tag", "13-rc-dryrun-latest", "--tags-file", tags, "--dry-run"})
+	if err != nil {
+		t.Fatalf("runResolveTag rolling dryrun: %v", err)
+	}
+	if out["resolved_tag"] != "13.4.0-rc-dryrun" || out["dev_tag"] != "13.4.0-dev-abc1234" {
+		t.Errorf("unexpected rolling rc dry-run output: %v", out)
+	}
+
+	// Plain rc tags stay valid in dry-run.
+	out, _, err = runResolveTagCapture(t, []string{"--kind", "rc", "--input-tag", "13.4.0-rc", "--dry-run"})
+	if err != nil {
+		t.Fatalf("runResolveTag plain rc in dryrun: %v", err)
+	}
+	if out["resolved_tag"] != "13.4.0-rc" || out["version"] != "13.4.0" {
+		t.Errorf("unexpected plain rc output in dry-run: %v", out)
+	}
+
+	// Without --dry-run, dryrun tags are rejected.
+	if _, _, err := runResolveTagCapture(t, []string{"--kind", "rc", "--input-tag", "13.4.0-rc-dryrun"}); err == nil {
+		t.Error("expected error for dryrun tag without --dry-run")
+	}
+	if _, _, err := runResolveTagCapture(t, []string{"--kind", "rc", "--input-tag", "13-rc-dryrun-latest", "--tags-file", tags}); err == nil {
+		t.Error("expected error for rolling dryrun tag without --dry-run")
+	}
+}
+
 func TestResolveTagErrors(t *testing.T) {
 	// rolling without tags-file
 	if _, _, err := runResolveTagCapture(t, []string{"--kind", "dev", "--input-tag", "13-dev-latest"}); err == nil {


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6614.

### What's in this PR?

- `dry-run` boolean input on `chart-promote-rc.yaml`: release-please runs with `--dry-run` (no PR created), release files are generated locally without commit/push/board-add, and RC tags are staged to the isolated `{version}-rc-dryrun` / `{major}-rc-dryrun-latest` Harbor tags.
- `dry-run` boolean input on `chart-release-public.yaml`: the RC package is pulled and validated as usual; the GitHub release, index.yaml push, cosign signing/uploads, and the post-release job are skipped and their plan logged. Dry-run RC tags are accepted as input so a stage-2 → stage-3 dry-run chain works.
- `release-tools resolve-tag --dry-run`: emits the dryrun RC tag names for dev tags and accepts dryrun rc tags.
- Failure Slack notifications are suppressed for dry-run runs.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] There is no other open [pull request](../pulls) for the same update/change.

**After opening the PR:**

- [ ] Did all checks/tests pass in the PR?
