### PR TITLE
ci: emit CAMUNDA_OPTIMIZE_BASE_URL in render-e2e-env.sh

### DIFF
--- a/scripts/render-e2e-env.sh
+++ b/scripts/render-e2e-env.sh
@@ -358,6 +358,7 @@ render_env_file() {
     echo "KEYCLOAK_URL=$keycloak_protocol://$keycloak_host"
     echo "KEYCLOAK_REALM=${keycloak_realm}"
     echo "PLAYWRIGHT_BASE_URL=https://$hostname"
+    echo "CAMUNDA_OPTIMIZE_BASE_URL=https://$hostname/optimize"
     echo "CLUSTER_ENDPOINT=http://integration-zeebe-gateway:26500"
     echo "CLUSTER_VERSION=8"
     echo "MINOR_VERSION=$minor_version_value"


### PR DESCRIPTION
### Which problem does the PR fix?

The Optimize API E2E tests fail in Helm-driven shadow/matrix runs (e.g. [runs/29397353555 · 8.9 shde2 shadow full e2e](https://github.com/camunda/camunda-platform-helm/actions/runs/29397353555/job/87295367330)) with:

```
page.goto: url: expected string, got undefined
  at getOptimizeCookieSm (.../@camunda/e2e-test-suite/dist/utils/apiHelpers.js:581)
```

6 `SM-8.9/optimize-api-tests.spec.js` tests fail. The same suite **passes** in the e2e repo's own nightly (e.g. [c8-cross-component-e2e-tests runs/29464565991](https://github.com/camunda/c8-cross-component-e2e-tests/actions/runs/29464565991)).

### What's in this PR?

Root cause is an env-var name mismatch, not a test or product bug (Optimize deploys healthy — the pod is `1/1 Running`):

- `getOptimizeCookieSm` reads `process.env.CAMUNDA_OPTIMIZE_BASE_URL` and passes it to `page.goto`.
- That var is only *derived* in the suite's `playwright.config.ts`, from `BASE_URL`: `CAMUNDA_OPTIMIZE_BASE_URL = https://${BASE_URL}/optimize`.
- `scripts/render-e2e-env.sh` emits `PLAYWRIGHT_BASE_URL` — **not** `BASE_URL` and not `CAMUNDA_OPTIMIZE_BASE_URL`. So in Helm-driven runs both are unset, the derivation is skipped, and `page.goto(undefined)` throws.
- The e2e repo's nightly sets `BASE_URL` itself, so the derivation works there — hence the same suite is green.

Fix: emit `CAMUNDA_OPTIMIZE_BASE_URL=https://$hostname/optimize` directly from the main runtime env block in `render-e2e-env.sh`, mirroring the suite's own derivation. One line, version-agnostic (fixes 8.8/8.9/8.10 which share `optimize-api-tests`). Not added to the Auth0 short-circuit block (smoke-only, does not run this project) and not gated on `IS_OPTIMIZE` (Optimize tests skip on their own when it isn't deployed).

> Alternative considered: widen the derivation in the e2e repo's `playwright.config.ts` to also accept `PLAYWRIGHT_BASE_URL`. Not done here to keep the fix single-repo and at the choke point; can follow up if we want the suite hardened against consumers that only set `PLAYWRIGHT_BASE_URL`.

Originating nightly run: https://github.com/camunda/camunda-platform-helm/actions/runs/29397353555/job/87295367330

### Checklist

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open pull request for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo documentation are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)?
- [ ] Did all checks/tests pass in the PR?
