### PR TITLE
ci: add reusable diagnostics-on-demand workflow for E2E readiness failures

### DIFF
--- a/.github/workflows/test-integration-diagnostics-template.yaml
+++ b/.github/workflows/test-integration-diagnostics-template.yaml
@@ -1,0 +1,102 @@
+name: "Test - Integration Diagnostics - Template"
+
+on:
+  workflow_call:
+    inputs:
+      namespace:
+        required: true
+        type: string
+      platform:
+        required: true
+        type: string
+      camunda-helm-git-ref:
+        default: main
+        type: string
+      binary-artifact-name:
+        default: ''
+        type: string
+      teleport-token:
+        default: infra-ci-prod-github-action-qa
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  diagnostics:
+    name: Collect Diagnostics
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        repository: camunda/camunda-platform-helm
+        ref: ${{ inputs.camunda-helm-git-ref }}
+    - name: Download deploy-camunda binary
+      if: inputs.binary-artifact-name != ''
+      continue-on-error: true
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      with:
+        name: ${{ inputs.binary-artifact-name }}
+        path: ${{ runner.temp }}/bin
+    - name: Make deploy-camunda binary executable
+      if: inputs.binary-artifact-name != ''
+      continue-on-error: true
+      shell: bash
+      run: |
+        chmod +x "${{ runner.temp }}/bin/deploy-camunda" || true
+        echo "${{ runner.temp }}/bin" >> "$GITHUB_PATH"
+    - name: Import Vault secrets
+      if: inputs.platform == 'gke'
+      id: test-credentials-secret
+      uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+      with:
+        url: ${{ secrets.VAULT_ADDR }}
+        method: approle
+        roleId: ${{ secrets.VAULT_ROLE_ID }}
+        secretId: ${{ secrets.VAULT_SECRET_ID }}
+        secrets: |
+          secret/data/products/distribution/ci DISTRO_CI_GCP_GKE_CLUSTER_NAME;
+          secret/data/products/distribution/ci DISTRO_CI_GCP_GKE_CLUSTER_LOCATION;
+          secret/data/products/distribution/ci DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER;
+          secret/data/products/distribution/ci DISTRO_CI_GCP_SERVICE_ACCOUNT;
+        exportEnv: false
+    - name: Resolve EKS cluster name
+      if: inputs.platform == 'eks'
+      shell: bash
+      run: echo "INFRA_CLUSTER_NAME=$(yq '.eks.cluster-name' .github/config/infra.yaml)" >> "$GITHUB_ENV"
+    - name: Authenticate to cluster
+      uses: ./.github/actions/cluster-auth
+      env:
+        GH_APP_ID: ${{ secrets.GH_APP_ID_DISTRO_CI_MANAGE_GH_ENVS }}
+        GH_APP_KEY: ${{ secrets.GH_APP_PRIVATE_KEY_DISTRO_CI_MANAGE_GH_ENVS }}
+        GKE_CLUSTER_NAME: ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_GKE_CLUSTER_NAME }}
+        GKE_CLUSTER_LOC: ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_GKE_CLUSTER_LOCATION }}
+        GKE_WIP: ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+        GKE_SA: ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_SERVICE_ACCOUNT }}
+        ROSA_URL: ${{ secrets.DISTRO_CI_OPENSHIFT_CLUSTER_URL }}
+        ROSA_USER: ${{ secrets.DISTRO_CI_OPENSHIFT_CLUSTER_USERNAME }}
+        ROSA_PASS: ${{ secrets.DISTRO_CI_OPENSHIFT_CLUSTER_PASSWORD }}
+        CLUSTER_NAME: ${{ env.INFRA_CLUSTER_NAME }}
+        TELEPORT_TOKEN: ${{ inputs.teleport-token }}
+      with:
+        platform: ${{ inputs.platform }}
+    - name: Print cluster diagnostics
+      env:
+        TEST_NAMESPACE: ${{ inputs.namespace }}
+      run: |
+        mkdir -p diagnostics/e2e-readiness
+        deploy-camunda diagnostics print --namespace "$TEST_NAMESPACE" | tee -a diagnostics/e2e-readiness/cluster-diagnostics.txt || true
+    - name: Get failed Pods info
+      env:
+        TEST_NAMESPACE: ${{ inputs.namespace }}
+      uses: ./.github/actions/failed-pods-info
+    - name: Upload cluster diagnostics
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      with:
+        name: e2e-readiness-cluster-diagnostics-${{ inputs.namespace }}
+        path: diagnostics/**
+        if-no-files-found: ignore
+        retention-days: 14

--- a/.github/workflows/test-integration-diagnostics-template.yaml
+++ b/.github/workflows/test-integration-diagnostics-template.yaml
@@ -88,7 +88,17 @@ jobs:
         TEST_NAMESPACE: ${{ inputs.namespace }}
       run: |
         mkdir -p diagnostics/e2e-readiness
-        deploy-camunda diagnostics print --namespace "$TEST_NAMESPACE" | tee -a diagnostics/e2e-readiness/cluster-diagnostics.txt || true
+        if command -v deploy-camunda >/dev/null 2>&1; then
+          deploy-camunda diagnostics print --namespace "$TEST_NAMESPACE" \
+            | tee -a diagnostics/e2e-readiness/cluster-diagnostics.txt || true
+        else
+          {
+            echo "deploy-camunda unavailable; kubectl fallback"
+            kubectl -n "$TEST_NAMESPACE" get pods -o wide
+            kubectl -n "$TEST_NAMESPACE" get events --sort-by=.lastTimestamp | tail -n 40
+            kubectl -n "$TEST_NAMESPACE" get pvc -o wide
+          } | tee -a diagnostics/e2e-readiness/cluster-diagnostics.txt || true
+        fi
     - name: Get failed Pods info
       env:
         TEST_NAMESPACE: ${{ inputs.namespace }}

--- a/.github/workflows/test-integration-diagnostics-template.yaml
+++ b/.github/workflows/test-integration-diagnostics-template.yaml
@@ -16,7 +16,7 @@ on:
         default: ''
         type: string
       teleport-token:
-        default: infra-ci-prod-github-action-qa
+        default: infra-ci-prod-github-action-distribution
         type: string
 
 permissions:
@@ -93,6 +93,7 @@ jobs:
       with:
         platform: ${{ inputs.platform }}
     - name: Print cluster diagnostics
+      if: always()
       env:
         TEST_NAMESPACE: ${{ inputs.namespace }}
       run: |
@@ -109,10 +110,12 @@ jobs:
           } | tee -a diagnostics/e2e-readiness/cluster-diagnostics.txt || true
         fi
     - name: Get failed Pods info
+      if: always()
       env:
         TEST_NAMESPACE: ${{ inputs.namespace }}
       uses: ./.github/actions/failed-pods-info
     - name: Upload cluster diagnostics
+      if: always()
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: e2e-readiness-cluster-diagnostics-${{ inputs.namespace }}

--- a/.github/workflows/test-integration-diagnostics-template.yaml
+++ b/.github/workflows/test-integration-diagnostics-template.yaml
@@ -30,6 +30,15 @@ jobs:
       contents: read
       id-token: write
     steps:
+    - name: Validate platform
+      shell: bash
+      env:
+        PLATFORM: ${{ inputs.platform }}
+      run: |
+        case "$PLATFORM" in
+          gke|eks|rosa) ;;
+          *) echo "::error::Unsupported platform '$PLATFORM' (expected gke|eks|rosa)"; exit 1 ;;
+        esac
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         repository: camunda/camunda-platform-helm

--- a/.github/workflows/test-integration-diagnostics-template.yaml
+++ b/.github/workflows/test-integration-diagnostics-template.yaml
@@ -30,15 +30,17 @@ jobs:
       contents: read
       id-token: write
     steps:
-    - name: Validate platform
+    - name: Normalize and validate platform
       shell: bash
       env:
-        PLATFORM: ${{ inputs.platform }}
+        PLATFORM_RAW: ${{ inputs.platform }}
       run: |
-        case "$PLATFORM" in
+        platform="$(echo "$PLATFORM_RAW" | tr '[:upper:]' '[:lower:]')"
+        case "$platform" in
           gke|eks|rosa) ;;
-          *) echo "::error::Unsupported platform '$PLATFORM' (expected gke|eks|rosa)"; exit 1 ;;
+          *) echo "::error::Unsupported platform '$PLATFORM_RAW' (expected gke|eks|rosa)"; exit 1 ;;
         esac
+        echo "PLATFORM=$platform" >> "$GITHUB_ENV"
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       with:
         repository: camunda/camunda-platform-helm
@@ -57,8 +59,15 @@ jobs:
       run: |
         chmod +x "${{ runner.temp }}/bin/deploy-camunda" || true
         echo "${{ runner.temp }}/bin" >> "$GITHUB_PATH"
+    - name: Verify requested binary is available
+      if: inputs.binary-artifact-name != ''
+      shell: bash
+      run: |
+        if ! command -v deploy-camunda >/dev/null 2>&1; then
+          echo "::warning::Requested deploy-camunda binary artifact '${{ inputs.binary-artifact-name }}' was not found; falling back to basic kubectl output. Verify the producer's artifact name."
+        fi
     - name: Import Vault secrets
-      if: inputs.platform == 'gke'
+      if: env.PLATFORM == 'gke'
       id: test-credentials-secret
       uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
       with:
@@ -73,7 +82,7 @@ jobs:
           secret/data/products/distribution/ci DISTRO_CI_GCP_SERVICE_ACCOUNT;
         exportEnv: false
     - name: Resolve EKS cluster name
-      if: inputs.platform == 'eks'
+      if: env.PLATFORM == 'eks'
       shell: bash
       run: echo "INFRA_CLUSTER_NAME=$(yq '.eks.cluster-name' .github/config/infra.yaml)" >> "$GITHUB_ENV"
     - name: Authenticate to cluster
@@ -91,7 +100,7 @@ jobs:
         CLUSTER_NAME: ${{ env.INFRA_CLUSTER_NAME }}
         TELEPORT_TOKEN: ${{ inputs.teleport-token }}
       with:
-        platform: ${{ inputs.platform }}
+        platform: ${{ env.PLATFORM }}
     - name: Print cluster diagnostics
       if: always()
       env:
@@ -114,11 +123,15 @@ jobs:
       env:
         TEST_NAMESPACE: ${{ inputs.namespace }}
       uses: ./.github/actions/failed-pods-info
+    - name: Compute artifact suffix
+      if: always()
+      shell: bash
+      run: echo "ARTIFACT_SUFFIX=${{ github.run_id }}-${{ github.run_attempt }}-$RANDOM" >> "$GITHUB_ENV"
     - name: Upload cluster diagnostics
       if: always()
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
-        name: e2e-readiness-cluster-diagnostics-${{ inputs.namespace }}
+        name: e2e-readiness-cluster-diagnostics-${{ inputs.namespace }}-${{ env.ARTIFACT_SUFFIX }}
         path: diagnostics/**
         if-no-files-found: ignore
         retention-days: 14

--- a/.github/workflows/test-integration-diagnostics-template.yaml
+++ b/.github/workflows/test-integration-diagnostics-template.yaml
@@ -45,6 +45,13 @@ jobs:
       with:
         repository: camunda/camunda-platform-helm
         ref: ${{ inputs.camunda-helm-git-ref }}
+    - name: Install tools
+      uses: ./.github/actions/install-tool-versions
+      with:
+        tools: |
+          kubectl
+          oc
+          yq
     - name: Download deploy-camunda binary
       if: inputs.binary-artifact-name != ''
       continue-on-error: true


### PR DESCRIPTION
### Which problem does the PR fix?

The downstream cross-component E2E suite (`camunda/c8-cross-component-e2e-tests`) deploys a
Self-Managed cluster via this repo's `test-integration-template.yaml`, then — in a **separate
job that runs after `helm-deploy` has already returned success** — runs a Keycloak readiness
probe against the ingress. When that probe fails because the cluster is unhealthy at test
time (e.g. Keycloak/Identity returning 5xx), no cluster-side diagnostics are captured: the
helm jobs' own `if: failure()` diagnostics never fire because those jobs passed, and the E2E
job has no cluster credentials.

A reusable workflow cannot react to its caller's later results, so the diagnostics must be
**triggered from the E2E side** but executed here, where per-platform cluster auth already
exists.

### What's in this PR?

Adds `.github/workflows/test-integration-diagnostics-template.yaml`, a `workflow_call`
reusable workflow that **collects** cluster diagnostics for a given namespace and platform —
it never deletes the namespace. The E2E repo will call it from an `if: failure()` job.

It reuses existing machinery only:
- `./.github/actions/cluster-auth` for per-platform auth (GKE via Workload Identity, EKS via
  Teleport, ROSA via oc-login), wired with the same Vault import and secret names as the
  runner `cleanup` job. The EKS Teleport cluster name is read from `.github/config/infra.yaml`
  (`eks.cluster-name`).
- `deploy-camunda diagnostics print` (downloaded via the `deploy-camunda-binary-*` artifact
  when provided) captured to `diagnostics/e2e-readiness/cluster-diagnostics.txt`.
- `./.github/actions/failed-pods-info` for the in-log fast path.
- `actions/upload-artifact` to publish the `diagnostics/**` bundle.

Inputs: `namespace` (required), `platform` (required: gke|eks|rosa), `camunda-helm-git-ref`,
`binary-artifact-name` (optional), `teleport-token`.

No chart files, Go code, or golden files are touched, so `make go.update-golden-only` is not
applicable. Validated locally with `actionlint` (clean).

### Checklist

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open pull request for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo documentation are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?


Fixes https://github.com/camunda/camunda-platform-helm/issues/6698