### PR TITLE
fix: revert vendor-ee/postgresql to -r2 to restore amd64 image pulls

### DIFF
--- a/charts/camunda-platform-8.7/values-enterprise.yaml
+++ b/charts/camunda-platform-8.7/values-enterprise.yaml
@@ -22,14 +22,14 @@
 global:
   security:
     # This setting is set to true to allow images issued by Camunda to be used instead of those provided by Bitnami
-    allowInsecureImages: true 
+    allowInsecureImages: true
 
 identityPostgresql:
   image:
     registry: registry.camunda.cloud
     repository: vendor-ee/postgresql
     # renovate: datasource=custom.bitnami-postgresql-camunda depName=postgresql versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(-(?<compatibility>debian-\d+)-r(?<build>\d+))?$
-    tag: 15.18.0-debian-12-r14
+    tag: 15.18.0-debian-12-r2
     pullSecrets:
       - name: registry-camunda-cloud
 
@@ -60,7 +60,7 @@ identityKeycloak:
       registry: registry.camunda.cloud
       repository: vendor-ee/postgresql
       # renovate: datasource=custom.bitnami-postgresql-camunda depName=postgresql versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(-(?<compatibility>debian-\d+)-r(?<build>\d+))?$
-      tag: 15.18.0-debian-12-r14
+      tag: 15.18.0-debian-12-r2
       pullSecrets:
         - name: registry-camunda-cloud
 
@@ -84,7 +84,7 @@ postgresql:
     registry: registry.camunda.cloud
     repository: vendor-ee/postgresql
     # renovate: datasource=custom.bitnami-postgresql-camunda depName=postgresql versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(-(?<compatibility>debian-\d+)-r(?<build>\d+))?$
-    tag: 14.23.0-debian-12-r14
+    tag: 14.23.0-debian-12-r2
     pullSecrets:
       - name: registry-camunda-cloud
 

--- a/charts/camunda-platform-8.8/values-enterprise.yaml
+++ b/charts/camunda-platform-8.8/values-enterprise.yaml
@@ -22,14 +22,14 @@
 global:
   security:
     # This setting is set to true to allow images issued by Camunda to be used instead of those provided by Bitnami
-    allowInsecureImages: true 
+    allowInsecureImages: true
 
 identityPostgresql:
   image:
     registry: registry.camunda.cloud
     repository: vendor-ee/postgresql
     # renovate: datasource=custom.bitnami-postgresql-camunda depName=postgresql versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(-(?<compatibility>debian-\d+)-r(?<build>\d+))?$
-    tag: 15.18.0-debian-12-r14
+    tag: 15.18.0-debian-12-r2
     pullSecrets:
       - name: registry-camunda-cloud
 
@@ -67,7 +67,7 @@ identityKeycloak:
       registry: registry.camunda.cloud
       repository: vendor-ee/postgresql
       # renovate: datasource=custom.bitnami-postgresql-camunda depName=postgresql versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(-(?<compatibility>debian-\d+)-r(?<build>\d+))?$
-      tag: 15.18.0-debian-12-r14
+      tag: 15.18.0-debian-12-r2
       pullSecrets:
         - name: registry-camunda-cloud
 
@@ -90,7 +90,7 @@ webModelerPostgresql:
     registry: registry.camunda.cloud
     repository: vendor-ee/postgresql
     # renovate: datasource=custom.bitnami-postgresql-camunda depName=postgresql versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(-(?<compatibility>debian-\d+)-r(?<build>\d+))?$
-    tag: 14.23.0-debian-12-r14
+    tag: 14.23.0-debian-12-r2
     pullSecrets:
       - name: registry-camunda-cloud
 


### PR DESCRIPTION
### Which problem does the PR fix?

`ImagePullBackOff` on GKE (amd64) for `vendor-ee/postgresql` in the 8.7/8.8
integration tests. Triggered by renovate PR #6575, which bumped the postgresql
pins from `-r2` to `-r14`.

### What's in this PR?

Reverts the six `vendor-ee/postgresql` tags in `charts/camunda-platform-8.7`
and `charts/camunda-platform-8.8` `values-enterprise.yaml` from `-r14` back to
`-r2`.

**Root cause.** The `-r14` builds are missing their `linux/amd64` child manifest
at the Broadcom-hosted backend behind `registry.camunda.cloud`. The multi-arch
index (`sha256:d28589…`) references amd64 child `sha256:a02381…`, which now
returns `MANIFEST_UNKNOWN`. arm64 resolves fine — so Apple-silicon `docker pull`
succeeds while amd64 GKE nodes fail with `ImagePullBackOff`.

Verified with `crane`:
- `crane manifest …:15.18.0-debian-12-r14` → index lists amd64=`a02381…`
- `crane manifest …@sha256:a02381…` → `MANIFEST_UNKNOWN`
- `crane config --platform linux/amd64` across builds: **r14 DEAD**, r13–r2 OK
- same defect on `14.23.0-debian-12-r14`

These exact pins passed a real GKE amd64 install on 2026-07-13 (run
`29259120676`) and broke by 2026-07-16 — the amd64 child was GC'd or re-pushed
upstream after publication while the proxy still serves the stale index. This is
a registry data-consistency issue, **not** the concurrent-pull facade stall.

`-r2` verified amd64-OK. A registry-side fix for `-r14` is being raised with
infra separately; renovate will re-propose `-r14` once its amd64 manifest is
repaired.

Note: `values-digest.yaml` regen is release/CI automation (no local command) —
left for CI.

### Checklist

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open pull request for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo documentation are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
