### PR TITLE
ci: temporarily disable auto-approve workflow

### DIFF
--- a/.github/auto-approve-allowlist.txt
+++ b/.github/auto-approve-allowlist.txt
@@ -3,4 +3,3 @@
 # Everyone NOT listed here requires a human review.
 # Example:
 # alice-camunda
-eamonnmoloney

--- a/.github/workflows/repo-auto-approve.yaml
+++ b/.github/workflows/repo-auto-approve.yaml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   auto-approve:
     name: Auto approve allowlisted authors
-    if: ${{ github.event.pull_request.draft == false }}
+    if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/repo-auto-approve.yaml
+++ b/.github/workflows/repo-auto-approve.yaml
@@ -1,8 +1,7 @@
 name: Repo - Auto Approve
 
 on:
-  pull_request_target:
-    types: [opened, reopened, synchronize, ready_for_review]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}


### PR DESCRIPTION
### Which problem does the PR fix?

Temporary pause of PR auto-approval while the approval trust model is reviewed. Independent of #6562 (which reworks the same workflow) — this acts on the current `main` version.

### What's in this PR?

Three independent, easily-reversible layers so the workflow cannot run and cannot auto-approve anyone:

- **No auto-trigger** — `.github/workflows/repo-auto-approve.yaml`: the `on:` trigger is switched from `pull_request_target` to `workflow_dispatch:` only, so the workflow no longer fires on pull requests.
- **Job hard-gated** — the `auto-approve` job's condition is set to `if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.draft == false }}`. Since `workflow_dispatch` is now the only trigger, `github.event_name` is never `pull_request_target`, so even a manual "Run workflow" dispatch produces a **skipped job** — the approval/dismiss steps can never execute. (A literal `if: ${{ false }}` was avoided because actionlint rejects constant conditions.)
- **Empty allowlist** — `.github/auto-approve-allowlist.txt`: the sole allowlisted username (`eamonnmoloney`) is removed, so no author would be auto-approved even if the job ran.

`actionlint` passes with zero findings.

This is a **temporary pause**. To re-enable: restore the `pull_request_target` trigger (types `opened, reopened, synchronize, ready_for_review`) and re-add the allowlist entry. The job condition already permits `pull_request_target` and restores the original draft check, so no further change to the `if:` is needed.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?