### PR TITLE
test: disable entv enterprise-values scenarios pending upstream image fix

### DIFF
--- a/charts/camunda-platform-8.7/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.7/test/ci/registry-snapshot.yaml
@@ -23,7 +23,7 @@ integration:
           helmVersion: 3.20.2
           skip-e2e: true
         - name: enterprise-values
-          enabled: true
+          enabled: false
           shortname: entv
           auth: keycloak
           flow: install

--- a/charts/camunda-platform-8.7/test/ci/registry/manifest.yaml
+++ b/charts/camunda-platform-8.7/test/ci/registry/manifest.yaml
@@ -11,7 +11,7 @@ integration:
     - id: enterprise-values
       shortname: entv
       tier: 2
-      enabled: true
+      enabled: false
     - id: keycloak-mt
       shortname: kemt
       tier: 2

--- a/charts/camunda-platform-8.9/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry-snapshot.yaml
@@ -43,7 +43,7 @@ integration:
               Cluster gRPC endpoint, creates the server TLS Secret, and creates
               a truststore Secret consumed by Web Modeler restapi.
         - name: enterprise-values
-          enabled: true
+          enabled: false
           shortname: entv
           auth: keycloak
           flow: install

--- a/charts/camunda-platform-8.9/test/ci/registry/manifest.yaml
+++ b/charts/camunda-platform-8.9/test/ci/registry/manifest.yaml
@@ -24,7 +24,7 @@ integration:
     - id: enterprise-values
       shortname: entv
       tier: 2
-      enabled: true
+      enabled: false
     - id: opensearch
       shortname: oske
       tier: 2


### PR DESCRIPTION
### Which problem does the PR fix?

The upstream enterprise images used by the `enterprise-values` (entv) CI
overlay scenarios are currently broken, so these scenarios cannot be
validated. This blocks CI runs that include them.

### What's in this PR?

Temporarily disables the `entv` scenario on chart versions 8.7 and 8.9
(`enabled: true` → `enabled: false` in each version's
`test/ci/registry/manifest.yaml`), and regenerates the corresponding
`registry-snapshot.yaml` files via `make go.update-registry-golden`.

- 8.8 already has `entv` disabled — left untouched.
- 8.10 has no `entv` scenario — no change.

These scenarios should be re-enabled once the upstream enterprise image
issue is resolved.

Verification: the registry golden test
(`cd scripts/deploy-camunda && go test ./matrix/...`) passes with this
change. A broader `make go.test` run failed universally in this local
environment with "requires Helm CLI v4 ... Detected Helm CLI version:
v3.17.3" — a local Helm v3/v4 PATH mismatch unrelated to this diff.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
