### PR TITLE
fix: decouple requestBodySize from Zeebe maxMessageSize

### DIFF
--- a/charts/camunda-platform-8.10/README.md
+++ b/charts/camunda-platform-8.10/README.md
@@ -42,6 +42,7 @@ Please also refer to the [documentation](https://docs.camunda.io/docs/self-manag
   - [Web Modeler](#web-modeler)
   - [Elasticsearch](#elasticsearch)
   - [Keycloak](#keycloak)
+  - [Zeebe Message Size](#zeebe-message-size)
 - [Development](#development)
 - [Releasing the Charts](#releasing-the-charts)
 - [Parameters](#parameters)
@@ -232,6 +233,14 @@ it, copy the theme into your own Keycloak deployment — for example via an init
 mounts the Identity image's theme directory into your Keycloak themes path. The exact themes
 path depends on the Keycloak image you run.
 
+### Zeebe Message Size
+
+Zeebe now always uses its engine default maximum message size (4MB) and is no longer tied to
+`global.config.requestBodySize`, which governs only HTTP upload and form-post size (e.g. for
+process deployments through REST endpoints). To raise the maximum message size Zeebe accepts,
+configure it directly via the component's `extraConfiguration`, the supported mechanism per
+[ADR 91](../../docs/adr/0091-adopt-component-extraconfiguration-as-the-standard-application-configuration-mechanism.md).
+
 ## Development
 
 For development purposes, you might want to deploy and test the charts without creating a new helm chart release.
@@ -291,7 +300,7 @@ Please see the corresponding [release guide](../../docs/release.md) to find out 
 | `global.compatibility`                                  | Compatibility adaptations in the chart.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |                                     |
 | `global.compatibility.openshift.adaptSecurityContext`   | Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: force (perform the adaptation always), disabled (do not perform adaptation)                                                                                                                                                                                                                                   | `disabled`                          |
 | `global.config`                                         | Config used in various places.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |                                     |
-| `global.config.requestBodySize`                         | defines the maximum request body size for file uploads, HTTP form posts, and Zeebe messages.                                                                                                                                                                                                                                                                                                                                                                                                                                               | `10MB`                              |
+| `global.config.requestBodySize`                         | defines the maximum request body size for file uploads and HTTP form posts.                                                                                                                                                                                                                                                                                                                                                                                                                                                                | `10MB`                              |
 | `global.multitenancy`                                   |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |                                     |
 | `global.multitenancy.enabled`                           | if true, then enable multitenancy in all applicable components.                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | `false`                             |
 | `global.security`                                       |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |                                     |

--- a/charts/camunda-platform-8.10/templates/orchestration/files/_application.yaml
+++ b/charts/camunda-platform-8.10/templates/orchestration/files/_application.yaml
@@ -68,9 +68,6 @@ camunda:
     size: {{ .Values.orchestration.clusterSize | quote }}
     replication-factor: {{ .Values.orchestration.replicationFactor | quote }}
     partition-count: {{ .Values.orchestration.partitionCount | quote }}
-    # Keep the unified Camunda and legacy Zeebe network limits aligned while supported versions bind both namespaces.
-    network:
-      max-message-size: {{ .Values.global.config.requestBodySize | quote }}
     # zeebe.broker.cluster
     {{- if le (int .Values.global.multiregion.regions) 1 }}
     initial-contact-points:
@@ -88,7 +85,6 @@ camunda:
     grpc:
       address: 0.0.0.0
       port: {{ .Values.orchestration.service.grpcPort }}
-      max-message-size: {{ .Values.global.config.requestBodySize | quote }}
 
   # Database configuration - Separated syntax.
   database:
@@ -310,8 +306,6 @@ zeebe:
       advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
       {{- end }}
       host: 0.0.0.0
-      # Legacy Zeebe namespace retained while supported versions still bind it; keep it aligned with camunda.cluster.network.
-      maxMessageSize: {{ .Values.global.config.requestBodySize | quote }}
       commandApi:
         port: {{ .Values.orchestration.service.commandPort }}
       internalApi:

--- a/charts/camunda-platform-8.10/test/unit/orchestration/configmap_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/configmap_test.go
@@ -135,8 +135,51 @@ func (s *ConfigmapLegacyTemplateTest) TestRequestBodySizeConfiguresUploadLimits(
 				applicationYaml := configmap.Data["application.yaml"]
 
 				require.Contains(t, applicationYaml, "max-http-form-post-size: \"50MB\"")
-				require.Contains(t, applicationYaml, "max-message-size: \"50MB\"")
-				require.Contains(t, applicationYaml, "maxMessageSize: \"50MB\"")
+				require.Contains(t, applicationYaml, "max-file-size: \"50MB\"")
+				require.Contains(t, applicationYaml, "max-request-size: \"50MB\"")
+				require.NotContains(t, applicationYaml, "max-message-size: \"50MB\"")
+				require.NotContains(t, applicationYaml, "maxMessageSize: \"50MB\"")
+				require.Equal(t, 0, strings.Count(applicationYaml, "max-message-size:"))
+				require.Equal(t, 0, strings.Count(applicationYaml, "maxMessageSize:"))
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
+func (s *ConfigmapLegacyTemplateTest) TestZeebeMaxMessageSizeUsesEngineDefault() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name:   "TestZeebeMaxMessageSizeUsesEngineDefaultWithDefaultValues",
+			Values: map[string]string{},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(t, output, &configmap)
+				applicationYaml := configmap.Data["application.yaml"]
+
+				// the chart must never render a Zeebe message-size key, keeping the engine's 4MB default
+				require.Equal(t, 0, strings.Count(applicationYaml, "max-message-size:"))
+				require.Equal(t, 0, strings.Count(applicationYaml, "maxMessageSize:"))
+			},
+		},
+		{
+			Name: "TestZeebeMaxMessageSizeUsesEngineDefaultWithRequestBodySizeOverride",
+			Values: map[string]string{
+				"global.config.requestBodySize": "50MB",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(t, output, &configmap)
+				applicationYaml := configmap.Data["application.yaml"]
+
+				// requestBodySize must not leak into a Zeebe message-size key
+				require.Equal(t, 0, strings.Count(applicationYaml, "max-message-size:"))
+				require.Equal(t, 0, strings.Count(applicationYaml, "maxMessageSize:"))
 			},
 		},
 	}

--- a/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap-authorizations.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap-authorizations.golden.yaml
@@ -74,9 +74,6 @@ data:
         size: "3"
         replication-factor: "3"
         partition-count: "3"
-        # Keep the unified Camunda and legacy Zeebe network limits aligned while supported versions bind both namespaces.
-        network:
-          max-message-size: "10MB"
         # zeebe.broker.cluster
         initial-contact-points:
           - camunda-platform-test-zeebe-0.${K8S_SERVICE_NAME}:26502
@@ -87,7 +84,6 @@ data:
         grpc:
           address: 0.0.0.0
           port: 26500
-          max-message-size: "10MB"
     
       # Database configuration - Separated syntax.
       database:
@@ -186,8 +182,6 @@ data:
         network:
           advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
           host: 0.0.0.0
-          # Legacy Zeebe namespace retained while supported versions still bind it; keep it aligned with camunda.cluster.network.
-          maxMessageSize: "10MB"
           commandApi:
             port: 26501
           internalApi:

--- a/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap-log4j2.golden.yaml
@@ -74,9 +74,6 @@ data:
         size: "3"
         replication-factor: "3"
         partition-count: "3"
-        # Keep the unified Camunda and legacy Zeebe network limits aligned while supported versions bind both namespaces.
-        network:
-          max-message-size: "10MB"
         # zeebe.broker.cluster
         initial-contact-points:
           - camunda-platform-test-zeebe-0.${K8S_SERVICE_NAME}:26502
@@ -87,7 +84,6 @@ data:
         grpc:
           address: 0.0.0.0
           port: 26500
-          max-message-size: "10MB"
     
       # Database configuration - Separated syntax.
       database:
@@ -186,8 +182,6 @@ data:
         network:
           advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
           host: 0.0.0.0
-          # Legacy Zeebe namespace retained while supported versions still bind it; keep it aligned with camunda.cluster.network.
-          maxMessageSize: "10MB"
           commandApi:
             port: 26501
           internalApi:

--- a/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap-retention.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap-retention.golden.yaml
@@ -74,9 +74,6 @@ data:
         size: "3"
         replication-factor: "3"
         partition-count: "3"
-        # Keep the unified Camunda and legacy Zeebe network limits aligned while supported versions bind both namespaces.
-        network:
-          max-message-size: "10MB"
         # zeebe.broker.cluster
         initial-contact-points:
           - camunda-platform-test-zeebe-0.${K8S_SERVICE_NAME}:26502
@@ -87,7 +84,6 @@ data:
         grpc:
           address: 0.0.0.0
           port: 26500
-          max-message-size: "10MB"
     
       # Database configuration - Separated syntax.
       database:
@@ -197,8 +193,6 @@ data:
         network:
           advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
           host: 0.0.0.0
-          # Legacy Zeebe namespace retained while supported versions still bind it; keep it aligned with camunda.cluster.network.
-          maxMessageSize: "10MB"
           commandApi:
             port: 26501
           internalApi:

--- a/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/golden/configmap.golden.yaml
@@ -74,9 +74,6 @@ data:
         size: "3"
         replication-factor: "3"
         partition-count: "3"
-        # Keep the unified Camunda and legacy Zeebe network limits aligned while supported versions bind both namespaces.
-        network:
-          max-message-size: "10MB"
         # zeebe.broker.cluster
         initial-contact-points:
           - camunda-platform-test-zeebe-0.${K8S_SERVICE_NAME}:26502
@@ -87,7 +84,6 @@ data:
         grpc:
           address: 0.0.0.0
           port: 26500
-          max-message-size: "10MB"
     
       # Database configuration - Separated syntax.
       database:
@@ -186,8 +182,6 @@ data:
         network:
           advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
           host: 0.0.0.0
-          # Legacy Zeebe namespace retained while supported versions still bind it; keep it aligned with camunda.cluster.network.
-          maxMessageSize: "10MB"
           commandApi:
             port: 26501
           internalApi:

--- a/charts/camunda-platform-8.10/values.schema.json
+++ b/charts/camunda-platform-8.10/values.schema.json
@@ -50,7 +50,7 @@
                     "properties": {
                         "requestBodySize": {
                             "type": "string",
-                            "description": "defines the maximum request body size for file uploads, HTTP form posts, and Zeebe messages.",
+                            "description": "defines the maximum request body size for file uploads and HTTP form posts.",
                             "default": "10MB"
                         }
                     }

--- a/charts/camunda-platform-8.10/values.yaml
+++ b/charts/camunda-platform-8.10/values.yaml
@@ -65,7 +65,7 @@ global:
 
   ## @extra global.config Config used in various places.
   config:
-    ## @param global.config.requestBodySize defines the maximum request body size for file uploads, HTTP form posts, and Zeebe messages.
+    ## @param global.config.requestBodySize defines the maximum request body size for file uploads and HTTP form posts.
     requestBodySize: 10MB
 
   ## Multitenancy configuration.

--- a/charts/camunda-platform-8.7/README.md
+++ b/charts/camunda-platform-8.7/README.md
@@ -16,6 +16,7 @@ Please also refer to the [documentation](https://docs.camunda.io/docs/self-manag
   - [Web Modeler](#web-modeler)
   - [Elasticsearch](#elasticsearch)
   - [Keycloak](#keycloak)
+  - [Zeebe Message Size](#zeebe-message-size)
 - [Identity auth existing secrets](#identity-auth-existing-secrets)
 - [Development](#development)
 - [Releasing the Charts](#releasing-the-charts)
@@ -301,6 +302,14 @@ identity:
       mountPath: /opt/bitnami/keycloak/themes/identity
 ```
 
+### Zeebe Message Size
+
+Zeebe now always uses its engine default maximum message size (4MB) and is no longer tied to
+`global.config.requestBodySize`, which governs only HTTP upload and form-post size (e.g. for
+process deployments through REST endpoints). To raise the maximum message size Zeebe accepts,
+configure it directly via the component's `extraConfiguration`, the supported mechanism per
+[ADR 91](../../docs/adr/0091-adopt-component-extraconfiguration-as-the-standard-application-configuration-mechanism.md).
+
 ## Identity auth existing secrets
 
 To configure client secrets for the components, you can use `global.identity.auth.<component>.existingSecret`. It will accept the actual client secret as a value:
@@ -407,7 +416,7 @@ Please see the corresponding [release guide](../../docs/release.md) to find out 
 | `global.compatibility`                                  | Compatibility adaptations for Kubernetes platforms                                                                                                                                                                                                                                                       |                                                                    |
 | `global.compatibility.openshift.adaptSecurityContext`   | Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: force (perform the adaptation always), disabled (do not perform adaptation) | `disabled`                                                         |
 | `global.config`                                         | Config used in various places.                                                                                                                                                                                                                                                                           |                                                                    |
-| `global.config.requestBodySize`                         | defines the maximum request body size for file uploads, HTTP form posts, and Zeebe messages.                                                                                                                                                                                                             | `10MB`                                                             |
+| `global.config.requestBodySize`                         | defines the maximum request body size for file uploads and HTTP form posts.                                                                                                                                                                                                                              | `10MB`                                                             |
 | `global.multitenancy`                                   |                                                                                                                                                                                                                                                                                                          |                                                                    |
 | `global.multitenancy.enabled`                           | if true, then enable multitenancy in all applicable components.                                                                                                                                                                                                                                          | `false`                                                            |
 | `global.createReleaseInfo`                              | Create config that will be used in Camunda Console.                                                                                                                                                                                                                                                      | `true`                                                             |

--- a/charts/camunda-platform-8.7/templates/zeebe-gateway/configmap.yaml
+++ b/charts/camunda-platform-8.7/templates/zeebe-gateway/configmap.yaml
@@ -86,7 +86,6 @@ data:
         network:
           host: 0.0.0.0
           port: {{ .Values.zeebeGateway.service.grpcPort | quote }}
-          maxMessageSize: {{ .Values.global.config.requestBodySize | quote }}
         {{- if .Values.global.multitenancy.enabled }}
         multitenancy:
           enabled: true

--- a/charts/camunda-platform-8.7/templates/zeebe/configmap.yaml
+++ b/charts/camunda-platform-8.7/templates/zeebe/configmap.yaml
@@ -63,8 +63,6 @@ data:
               mode: none
         network:
           host: 0.0.0.0
-          # Bounds inbound messages on the broker command API, including requests from the standalone gateway.
-          maxMessageSize: {{ .Values.global.config.requestBodySize | quote }}
           commandApi:
             port: {{ .Values.zeebe.service.commandPort }}
           internalApi:

--- a/charts/camunda-platform-8.7/test/unit/zeebe-gateway/configmap_test.go
+++ b/charts/camunda-platform-8.7/test/unit/zeebe-gateway/configmap_test.go
@@ -124,7 +124,45 @@ func (s *ConfigmapTemplateTest) TestRequestBodySizeConfiguresGatewayLimits() {
 				applicationYaml := configmap.Data["application.yaml"]
 
 				require.Contains(t, applicationYaml, "max-http-form-post-size: \"50MB\"")
-				require.Contains(t, applicationYaml, "maxMessageSize: \"50MB\"")
+				require.NotContains(t, applicationYaml, "maxMessageSize: \"50MB\"")
+				require.Equal(t, 0, strings.Count(applicationYaml, "maxMessageSize:"))
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
+func (s *ConfigmapTemplateTest) TestZeebeMaxMessageSizeUsesEngineDefault() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name:   "TestZeebeMaxMessageSizeUsesEngineDefaultWithDefaultValues",
+			Values: map[string]string{},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(t, output, &configmap)
+				applicationYaml := configmap.Data["application.yaml"]
+
+				// the chart must never render a Zeebe message-size key, keeping the engine's 4MB default
+				require.Equal(t, 0, strings.Count(applicationYaml, "maxMessageSize:"))
+			},
+		},
+		{
+			Name: "TestZeebeMaxMessageSizeUsesEngineDefaultWithRequestBodySizeOverride",
+			Values: map[string]string{
+				"global.config.requestBodySize": "50MB",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(t, output, &configmap)
+				applicationYaml := configmap.Data["application.yaml"]
+
+				// requestBodySize must not leak into a Zeebe message-size key
+				require.Equal(t, 0, strings.Count(applicationYaml, "maxMessageSize:"))
 			},
 		},
 	}

--- a/charts/camunda-platform-8.7/test/unit/zeebe-gateway/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform-8.7/test/unit/zeebe-gateway/golden/configmap-log4j2.golden.yaml
@@ -59,4 +59,3 @@ data:
         network:
           host: 0.0.0.0
           port: "26500"
-          maxMessageSize: "10MB"

--- a/charts/camunda-platform-8.7/test/unit/zeebe-gateway/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.7/test/unit/zeebe-gateway/golden/configmap.golden.yaml
@@ -57,4 +57,3 @@ data:
         network:
           host: 0.0.0.0
           port: "26500"
-          maxMessageSize: "10MB"

--- a/charts/camunda-platform-8.7/test/unit/zeebe/configmap_test.go
+++ b/charts/camunda-platform-8.7/test/unit/zeebe/configmap_test.go
@@ -100,8 +100,45 @@ func (s *configmapTemplateTest) TestRequestBodySizeConfiguresBrokerMessageSize()
 				helm.UnmarshalK8SYaml(t, output, &configmap)
 				applicationYaml := configmap.Data["application.yaml"]
 
-				require.Contains(t, applicationYaml, "maxMessageSize: \"50MB\"")
-				require.Equal(t, 1, strings.Count(applicationYaml, "maxMessageSize:"))
+				require.NotContains(t, applicationYaml, "maxMessageSize: \"50MB\"")
+				require.Equal(t, 0, strings.Count(applicationYaml, "maxMessageSize:"))
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
+func (s *configmapTemplateTest) TestZeebeMaxMessageSizeUsesEngineDefault() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name:   "TestZeebeMaxMessageSizeUsesEngineDefaultWithDefaultValues",
+			Values: map[string]string{},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(t, output, &configmap)
+				applicationYaml := configmap.Data["application.yaml"]
+
+				// the chart must never render a Zeebe message-size key, keeping the engine's 4MB default
+				require.Equal(t, 0, strings.Count(applicationYaml, "maxMessageSize:"))
+			},
+		},
+		{
+			Name: "TestZeebeMaxMessageSizeUsesEngineDefaultWithRequestBodySizeOverride",
+			Values: map[string]string{
+				"global.config.requestBodySize": "50MB",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(t, output, &configmap)
+				applicationYaml := configmap.Data["application.yaml"]
+
+				// requestBodySize must not leak into a Zeebe message-size key
+				require.Equal(t, 0, strings.Count(applicationYaml, "maxMessageSize:"))
 			},
 		},
 	}

--- a/charts/camunda-platform-8.7/test/unit/zeebe/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform-8.7/test/unit/zeebe/golden/configmap-log4j2.golden.yaml
@@ -33,8 +33,6 @@ data:
               mode: none
         network:
           host: 0.0.0.0
-          # Bounds inbound messages on the broker command API, including requests from the standalone gateway.
-          maxMessageSize: "10MB"
           commandApi:
             port: 26501
           internalApi:

--- a/charts/camunda-platform-8.7/test/unit/zeebe/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.7/test/unit/zeebe/golden/configmap.golden.yaml
@@ -33,8 +33,6 @@ data:
               mode: none
         network:
           host: 0.0.0.0
-          # Bounds inbound messages on the broker command API, including requests from the standalone gateway.
-          maxMessageSize: "10MB"
           commandApi:
             port: 26501
           internalApi:

--- a/charts/camunda-platform-8.7/values.yaml
+++ b/charts/camunda-platform-8.7/values.yaml
@@ -76,7 +76,7 @@ global:
 
   ## @extra global.config Config used in various places.
   config:
-    ## @param global.config.requestBodySize defines the maximum request body size for file uploads, HTTP form posts, and Zeebe messages.
+    ## @param global.config.requestBodySize defines the maximum request body size for file uploads and HTTP form posts.
     requestBodySize: 10MB
 
   ## Multitenancy configuration.

--- a/charts/camunda-platform-8.8/README.md
+++ b/charts/camunda-platform-8.8/README.md
@@ -27,6 +27,7 @@ Please also refer to the [documentation](https://docs.camunda.io/docs/self-manag
   - [Web Modeler](#web-modeler)
   - [Elasticsearch](#elasticsearch)
   - [Keycloak](#keycloak)
+  - [Zeebe Message Size](#zeebe-message-size)
 - [Development](#development)
 - [Releasing the Charts](#releasing-the-charts)
 - [Parameters](#parameters)
@@ -277,6 +278,14 @@ identity:
         mountPath: /opt/bitnami/keycloak/themes/identity
 ```
 
+### Zeebe Message Size
+
+Zeebe now always uses its engine default maximum message size (4MB) and is no longer tied to
+`global.config.requestBodySize`, which governs only HTTP upload and form-post size (e.g. for
+process deployments through REST endpoints). To raise the maximum message size Zeebe accepts,
+configure it directly via the component's `extraConfiguration`, the supported mechanism per
+[ADR 91](../../docs/adr/0091-adopt-component-extraconfiguration-as-the-standard-application-configuration-mechanism.md).
+
 ## Development
 
 For development purposes, you might want to deploy and test the charts without creating a new helm chart release.
@@ -363,7 +372,7 @@ Please see the corresponding [release guide](../../docs/release.md) to find out 
 | `global.compatibility.openshift.adaptSecurityContext`   | Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: force (perform the adaptation always), disabled (do not perform adaptation) | `disabled`                          |
 | `global.compatibility.orchestration.enabled`            | if true, enables compatibility layer for Camunda Orchestration Cluster between Camunda 8.7 chart (12.x.x) and Camunda 8.8 chart (13.x.x).                                                                                                                                                                | `true`                              |
 | `global.config`                                         | Config used in various places.                                                                                                                                                                                                                                                                           |                                     |
-| `global.config.requestBodySize`                         | defines the maximum request body size for file uploads, HTTP form posts, and Zeebe messages.                                                                                                                                                                                                             | `10MB`                              |
+| `global.config.requestBodySize`                         | defines the maximum request body size for file uploads and HTTP form posts.                                                                                                                                                                                                                              | `10MB`                              |
 | `global.multitenancy`                                   |                                                                                                                                                                                                                                                                                                          |                                     |
 | `global.multitenancy.enabled`                           | if true, then enable multitenancy in all applicable components.                                                                                                                                                                                                                                          | `false`                             |
 | `global.security`                                       |                                                                                                                                                                                                                                                                                                          |                                     |

--- a/charts/camunda-platform-8.8/templates/orchestration/files/_application-unified.yaml
+++ b/charts/camunda-platform-8.8/templates/orchestration/files/_application-unified.yaml
@@ -50,15 +50,11 @@ camunda:
     size: {{ .Values.orchestration.clusterSize | quote }}
     replication-factor: {{ .Values.orchestration.replicationFactor | quote }}
     partition-count: {{ .Values.orchestration.partitionCount | quote }}
-    # Keep the unified Camunda and legacy Zeebe network limits aligned while supported versions bind both namespaces.
-    network:
-      max-message-size: {{ .Values.global.config.requestBodySize | quote }}
 
   api:
     grpc:
       address: 0.0.0.0
       port: {{ .Values.orchestration.service.grpcPort }}
-      max-message-size: {{ .Values.global.config.requestBodySize | quote }}
 
   # Database configuration - Separated syntax.
   database:
@@ -260,8 +256,6 @@ zeebe:
       advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
       {{- end }}
       host: 0.0.0.0
-      # Legacy Zeebe namespace retained while supported versions still bind it; keep it aligned with camunda.cluster.network.
-      maxMessageSize: {{ .Values.global.config.requestBodySize | quote }}
       commandApi:
         port: {{ .Values.orchestration.service.commandPort }}
       internalApi:

--- a/charts/camunda-platform-8.8/test/unit/orchestration/configmap_test.go
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/configmap_test.go
@@ -135,8 +135,51 @@ func (s *ConfigmapLegacyTemplateTest) TestRequestBodySizeConfiguresUploadLimits(
 				applicationYaml := configmap.Data["application.yaml"]
 
 				require.Contains(t, applicationYaml, "max-http-form-post-size: \"50MB\"")
-				require.Contains(t, applicationYaml, "max-message-size: \"50MB\"")
-				require.Contains(t, applicationYaml, "maxMessageSize: \"50MB\"")
+				require.Contains(t, applicationYaml, "max-file-size: \"50MB\"")
+				require.Contains(t, applicationYaml, "max-request-size: \"50MB\"")
+				require.NotContains(t, applicationYaml, "max-message-size: \"50MB\"")
+				require.NotContains(t, applicationYaml, "maxMessageSize: \"50MB\"")
+				require.Equal(t, 0, strings.Count(applicationYaml, "max-message-size:"))
+				require.Equal(t, 0, strings.Count(applicationYaml, "maxMessageSize:"))
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
+func (s *ConfigmapLegacyTemplateTest) TestZeebeMaxMessageSizeUsesEngineDefault() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name:   "TestZeebeMaxMessageSizeUsesEngineDefaultWithDefaultValues",
+			Values: map[string]string{},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(t, output, &configmap)
+				applicationYaml := configmap.Data["application.yaml"]
+
+				// the chart must never render a Zeebe message-size key, keeping the engine's 4MB default
+				require.Equal(t, 0, strings.Count(applicationYaml, "max-message-size:"))
+				require.Equal(t, 0, strings.Count(applicationYaml, "maxMessageSize:"))
+			},
+		},
+		{
+			Name: "TestZeebeMaxMessageSizeUsesEngineDefaultWithRequestBodySizeOverride",
+			Values: map[string]string{
+				"global.config.requestBodySize": "50MB",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(t, output, &configmap)
+				applicationYaml := configmap.Data["application.yaml"]
+
+				// requestBodySize must not leak into a Zeebe message-size key
+				require.Equal(t, 0, strings.Count(applicationYaml, "max-message-size:"))
+				require.Equal(t, 0, strings.Count(applicationYaml, "maxMessageSize:"))
 			},
 		},
 	}

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-authorizations.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-authorizations.golden.yaml
@@ -65,15 +65,11 @@ data:
         size: "3"
         replication-factor: "3"
         partition-count: "3"
-        # Keep the unified Camunda and legacy Zeebe network limits aligned while supported versions bind both namespaces.
-        network:
-          max-message-size: "10MB"
     
       api:
         grpc:
           address: 0.0.0.0
           port: 26500
-          max-message-size: "10MB"
     
       # Database configuration - Separated syntax.
       database:
@@ -172,8 +168,6 @@ data:
         network:
           advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
           host: 0.0.0.0
-          # Legacy Zeebe namespace retained while supported versions still bind it; keep it aligned with camunda.cluster.network.
-          maxMessageSize: "10MB"
           commandApi:
             port: 26501
           internalApi:

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-log4j2.golden.yaml
@@ -65,15 +65,11 @@ data:
         size: "3"
         replication-factor: "3"
         partition-count: "3"
-        # Keep the unified Camunda and legacy Zeebe network limits aligned while supported versions bind both namespaces.
-        network:
-          max-message-size: "10MB"
     
       api:
         grpc:
           address: 0.0.0.0
           port: 26500
-          max-message-size: "10MB"
     
       # Database configuration - Separated syntax.
       database:
@@ -172,8 +168,6 @@ data:
         network:
           advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
           host: 0.0.0.0
-          # Legacy Zeebe namespace retained while supported versions still bind it; keep it aligned with camunda.cluster.network.
-          maxMessageSize: "10MB"
           commandApi:
             port: 26501
           internalApi:

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-retention.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-retention.golden.yaml
@@ -65,15 +65,11 @@ data:
         size: "3"
         replication-factor: "3"
         partition-count: "3"
-        # Keep the unified Camunda and legacy Zeebe network limits aligned while supported versions bind both namespaces.
-        network:
-          max-message-size: "10MB"
     
       api:
         grpc:
           address: 0.0.0.0
           port: 26500
-          max-message-size: "10MB"
     
       # Database configuration - Separated syntax.
       database:
@@ -184,8 +180,6 @@ data:
         network:
           advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
           host: 0.0.0.0
-          # Legacy Zeebe namespace retained while supported versions still bind it; keep it aligned with camunda.cluster.network.
-          maxMessageSize: "10MB"
           commandApi:
             port: 26501
           internalApi:

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-unified.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/configmap-unified.golden.yaml
@@ -65,15 +65,11 @@ data:
         size: "3"
         replication-factor: "3"
         partition-count: "3"
-        # Keep the unified Camunda and legacy Zeebe network limits aligned while supported versions bind both namespaces.
-        network:
-          max-message-size: "10MB"
     
       api:
         grpc:
           address: 0.0.0.0
           port: 26500
-          max-message-size: "10MB"
     
       # Database configuration - Separated syntax.
       database:
@@ -172,8 +168,6 @@ data:
         network:
           advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
           host: 0.0.0.0
-          # Legacy Zeebe namespace retained while supported versions still bind it; keep it aligned with camunda.cluster.network.
-          maxMessageSize: "10MB"
           commandApi:
             port: 26501
           internalApi:

--- a/charts/camunda-platform-8.8/values.schema.json
+++ b/charts/camunda-platform-8.8/values.schema.json
@@ -98,7 +98,7 @@
                     "properties": {
                         "requestBodySize": {
                             "type": "string",
-                            "description": "defines the maximum request body size for file uploads, HTTP form posts, and Zeebe messages.",
+                            "description": "defines the maximum request body size for file uploads and HTTP form posts.",
                             "default": "10MB"
                         }
                     }

--- a/charts/camunda-platform-8.8/values.yaml
+++ b/charts/camunda-platform-8.8/values.yaml
@@ -89,7 +89,7 @@ global:
 
   ## @extra global.config Config used in various places.
   config:
-    ## @param global.config.requestBodySize defines the maximum request body size for file uploads, HTTP form posts, and Zeebe messages.
+    ## @param global.config.requestBodySize defines the maximum request body size for file uploads and HTTP form posts.
     requestBodySize: 10MB
 
   ## Multitenancy configuration.

--- a/charts/camunda-platform-8.9/README.md
+++ b/charts/camunda-platform-8.9/README.md
@@ -27,6 +27,7 @@ Please also refer to the [documentation](https://docs.camunda.io/docs/self-manag
   - [Web Modeler](#web-modeler)
   - [Elasticsearch](#elasticsearch)
   - [Keycloak](#keycloak)
+  - [Zeebe Message Size](#zeebe-message-size)
 - [Development](#development)
 - [Releasing the Charts](#releasing-the-charts)
 - [Parameters](#parameters)
@@ -264,6 +265,14 @@ identity:
         mountPath: /opt/bitnami/keycloak/themes/identity
 ```
 
+### Zeebe Message Size
+
+Zeebe now always uses its engine default maximum message size (4MB) and is no longer tied to
+`global.config.requestBodySize`, which governs only HTTP upload and form-post size (e.g. for
+process deployments through REST endpoints). To raise the maximum message size Zeebe accepts,
+configure it directly via the component's `extraConfiguration`, the supported mechanism per
+[ADR 91](../../docs/adr/0091-adopt-component-extraconfiguration-as-the-standard-application-configuration-mechanism.md).
+
 ## Development
 
 For development purposes, you might want to deploy and test the charts without creating a new helm chart release.
@@ -342,7 +351,7 @@ Please see the corresponding [release guide](../../docs/release.md) to find out 
 | `global.compatibility`                                  | Compatibility adaptations in the chart.                                                                                                                                                                                                                                                                  |                                     |
 | `global.compatibility.openshift.adaptSecurityContext`   | Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: force (perform the adaptation always), disabled (do not perform adaptation) | `disabled`                          |
 | `global.config`                                         | Config used in various places.                                                                                                                                                                                                                                                                           |                                     |
-| `global.config.requestBodySize`                         | defines the maximum request body size for file uploads, HTTP form posts, and Zeebe messages.                                                                                                                                                                                                             | `10MB`                              |
+| `global.config.requestBodySize`                         | defines the maximum request body size for file uploads and HTTP form posts.                                                                                                                                                                                                                              | `10MB`                              |
 | `global.multitenancy`                                   |                                                                                                                                                                                                                                                                                                          |                                     |
 | `global.multitenancy.enabled`                           | if true, then enable multitenancy in all applicable components.                                                                                                                                                                                                                                          | `false`                             |
 | `global.security`                                       |                                                                                                                                                                                                                                                                                                          |                                     |

--- a/charts/camunda-platform-8.9/templates/orchestration/files/_application.yaml
+++ b/charts/camunda-platform-8.9/templates/orchestration/files/_application.yaml
@@ -68,9 +68,6 @@ camunda:
     size: {{ .Values.orchestration.clusterSize | quote }}
     replication-factor: {{ .Values.orchestration.replicationFactor | quote }}
     partition-count: {{ .Values.orchestration.partitionCount | quote }}
-    # Keep the unified Camunda and legacy Zeebe network limits aligned while supported versions bind both namespaces.
-    network:
-      max-message-size: {{ .Values.global.config.requestBodySize | quote }}
     # zeebe.broker.cluster
     {{- if le (int .Values.global.multiregion.regions) 1 }}
     initial-contact-points:
@@ -88,7 +85,6 @@ camunda:
     grpc:
       address: 0.0.0.0
       port: {{ .Values.orchestration.service.grpcPort }}
-      max-message-size: {{ .Values.global.config.requestBodySize | quote }}
 
   # Database configuration - Separated syntax.
   database:
@@ -310,8 +306,6 @@ zeebe:
       advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
       {{- end }}
       host: 0.0.0.0
-      # Legacy Zeebe namespace retained while supported versions still bind it; keep it aligned with camunda.cluster.network.
-      maxMessageSize: {{ .Values.global.config.requestBodySize | quote }}
       commandApi:
         port: {{ .Values.orchestration.service.commandPort }}
       internalApi:

--- a/charts/camunda-platform-8.9/test/unit/orchestration/configmap_test.go
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/configmap_test.go
@@ -135,8 +135,51 @@ func (s *ConfigmapLegacyTemplateTest) TestRequestBodySizeConfiguresUploadLimits(
 				applicationYaml := configmap.Data["application.yaml"]
 
 				require.Contains(t, applicationYaml, "max-http-form-post-size: \"50MB\"")
-				require.Contains(t, applicationYaml, "max-message-size: \"50MB\"")
-				require.Contains(t, applicationYaml, "maxMessageSize: \"50MB\"")
+				require.Contains(t, applicationYaml, "max-file-size: \"50MB\"")
+				require.Contains(t, applicationYaml, "max-request-size: \"50MB\"")
+				require.NotContains(t, applicationYaml, "max-message-size: \"50MB\"")
+				require.NotContains(t, applicationYaml, "maxMessageSize: \"50MB\"")
+				require.Equal(t, 0, strings.Count(applicationYaml, "max-message-size:"))
+				require.Equal(t, 0, strings.Count(applicationYaml, "maxMessageSize:"))
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
+func (s *ConfigmapLegacyTemplateTest) TestZeebeMaxMessageSizeUsesEngineDefault() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name:   "TestZeebeMaxMessageSizeUsesEngineDefaultWithDefaultValues",
+			Values: map[string]string{},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(t, output, &configmap)
+				applicationYaml := configmap.Data["application.yaml"]
+
+				// the chart must never render a Zeebe message-size key, keeping the engine's 4MB default
+				require.Equal(t, 0, strings.Count(applicationYaml, "max-message-size:"))
+				require.Equal(t, 0, strings.Count(applicationYaml, "maxMessageSize:"))
+			},
+		},
+		{
+			Name: "TestZeebeMaxMessageSizeUsesEngineDefaultWithRequestBodySizeOverride",
+			Values: map[string]string{
+				"global.config.requestBodySize": "50MB",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(t, output, &configmap)
+				applicationYaml := configmap.Data["application.yaml"]
+
+				// requestBodySize must not leak into a Zeebe message-size key
+				require.Equal(t, 0, strings.Count(applicationYaml, "max-message-size:"))
+				require.Equal(t, 0, strings.Count(applicationYaml, "maxMessageSize:"))
 			},
 		},
 	}

--- a/charts/camunda-platform-8.9/test/unit/orchestration/golden/configmap-authorizations.golden.yaml
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/golden/configmap-authorizations.golden.yaml
@@ -74,9 +74,6 @@ data:
         size: "3"
         replication-factor: "3"
         partition-count: "3"
-        # Keep the unified Camunda and legacy Zeebe network limits aligned while supported versions bind both namespaces.
-        network:
-          max-message-size: "10MB"
         # zeebe.broker.cluster
         initial-contact-points:
           - camunda-platform-test-zeebe-0.${K8S_SERVICE_NAME}:26502
@@ -87,7 +84,6 @@ data:
         grpc:
           address: 0.0.0.0
           port: 26500
-          max-message-size: "10MB"
     
       # Database configuration - Separated syntax.
       database:
@@ -186,8 +182,6 @@ data:
         network:
           advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
           host: 0.0.0.0
-          # Legacy Zeebe namespace retained while supported versions still bind it; keep it aligned with camunda.cluster.network.
-          maxMessageSize: "10MB"
           commandApi:
             port: 26501
           internalApi:

--- a/charts/camunda-platform-8.9/test/unit/orchestration/golden/configmap-log4j2.golden.yaml
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/golden/configmap-log4j2.golden.yaml
@@ -74,9 +74,6 @@ data:
         size: "3"
         replication-factor: "3"
         partition-count: "3"
-        # Keep the unified Camunda and legacy Zeebe network limits aligned while supported versions bind both namespaces.
-        network:
-          max-message-size: "10MB"
         # zeebe.broker.cluster
         initial-contact-points:
           - camunda-platform-test-zeebe-0.${K8S_SERVICE_NAME}:26502
@@ -87,7 +84,6 @@ data:
         grpc:
           address: 0.0.0.0
           port: 26500
-          max-message-size: "10MB"
     
       # Database configuration - Separated syntax.
       database:
@@ -186,8 +182,6 @@ data:
         network:
           advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
           host: 0.0.0.0
-          # Legacy Zeebe namespace retained while supported versions still bind it; keep it aligned with camunda.cluster.network.
-          maxMessageSize: "10MB"
           commandApi:
             port: 26501
           internalApi:

--- a/charts/camunda-platform-8.9/test/unit/orchestration/golden/configmap-retention.golden.yaml
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/golden/configmap-retention.golden.yaml
@@ -74,9 +74,6 @@ data:
         size: "3"
         replication-factor: "3"
         partition-count: "3"
-        # Keep the unified Camunda and legacy Zeebe network limits aligned while supported versions bind both namespaces.
-        network:
-          max-message-size: "10MB"
         # zeebe.broker.cluster
         initial-contact-points:
           - camunda-platform-test-zeebe-0.${K8S_SERVICE_NAME}:26502
@@ -87,7 +84,6 @@ data:
         grpc:
           address: 0.0.0.0
           port: 26500
-          max-message-size: "10MB"
     
       # Database configuration - Separated syntax.
       database:
@@ -197,8 +193,6 @@ data:
         network:
           advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
           host: 0.0.0.0
-          # Legacy Zeebe namespace retained while supported versions still bind it; keep it aligned with camunda.cluster.network.
-          maxMessageSize: "10MB"
           commandApi:
             port: 26501
           internalApi:

--- a/charts/camunda-platform-8.9/test/unit/orchestration/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/golden/configmap.golden.yaml
@@ -74,9 +74,6 @@ data:
         size: "3"
         replication-factor: "3"
         partition-count: "3"
-        # Keep the unified Camunda and legacy Zeebe network limits aligned while supported versions bind both namespaces.
-        network:
-          max-message-size: "10MB"
         # zeebe.broker.cluster
         initial-contact-points:
           - camunda-platform-test-zeebe-0.${K8S_SERVICE_NAME}:26502
@@ -87,7 +84,6 @@ data:
         grpc:
           address: 0.0.0.0
           port: 26500
-          max-message-size: "10MB"
     
       # Database configuration - Separated syntax.
       database:
@@ -186,8 +182,6 @@ data:
         network:
           advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
           host: 0.0.0.0
-          # Legacy Zeebe namespace retained while supported versions still bind it; keep it aligned with camunda.cluster.network.
-          maxMessageSize: "10MB"
           commandApi:
             port: 26501
           internalApi:

--- a/charts/camunda-platform-8.9/values.schema.json
+++ b/charts/camunda-platform-8.9/values.schema.json
@@ -50,7 +50,7 @@
                     "properties": {
                         "requestBodySize": {
                             "type": "string",
-                            "description": "defines the maximum request body size for file uploads, HTTP form posts, and Zeebe messages.",
+                            "description": "defines the maximum request body size for file uploads and HTTP form posts.",
                             "default": "10MB"
                         }
                     }

--- a/charts/camunda-platform-8.9/values.yaml
+++ b/charts/camunda-platform-8.9/values.yaml
@@ -65,7 +65,7 @@ global:
 
   ## @extra global.config Config used in various places.
   config:
-    ## @param global.config.requestBodySize defines the maximum request body size for file uploads, HTTP form posts, and Zeebe messages.
+    ## @param global.config.requestBodySize defines the maximum request body size for file uploads and HTTP form posts.
     requestBodySize: 10MB
 
   ## Multitenancy configuration.


### PR DESCRIPTION
### Which problem does the PR fix?

Follow-up to #6279 (SUPPORT-32927). #6279 wired `global.config.requestBodySize` (default 10MB) into Zeebe's transport limits (`camunda.cluster.network.max-message-size`, `camunda.api.grpc.max-message-size`, legacy `zeebe.broker.network.maxMessageSize`), raising Zeebe's effective max message size from the 4MB engine default and diverging it from the application/SaaS defaults without load validation (raised by @ChrisKujawa).

`requestBodySize=10MB` was introduced in #3248 (Mar 2025) specifically as the **document-upload** limit for the document-handling API — an HTTP/multipart concern that #3200 explicitly said should stay **separate** from the Zeebe message limit. SUPPORT-32927's actual failure was an HTTP `413` / `MaxUploadSizeExceededException` on the document-upload path, not a Zeebe `maxMessageSize` rejection.

### What's in this PR?

Decouples the two limits across charts **8.7–8.10**:

- `requestBodySize` continues to govern the HTTP upload path (Spring multipart + Tomcat `max-http-form-post-size`). Default stays **10MB** — the SUPPORT-32927 fix is preserved.
- The three Zeebe `maxMessageSize` overrides are removed, so the broker/gateway fall back to the **4MB engine default** (matches product/SaaS).
- Tests assert multipart/form-post follow `requestBodySize` and that no `maxMessageSize`/`max-message-size` key is rendered (strict absence).
- README documents the supported override: to raise Zeebe's message size, use component `extraConfiguration` (per ADR 91), since a dedicated Tier-1 key is not permitted on active charts.

### Breaking change (GA lines 8.7/8.8/8.9) — impact assessment

#6279's 10MB Zeebe coupling shipped GA in **12.11.0 / 13.10.1 / 14.4.0 on 2026-06-04/05** (~6 weeks before this PR). On upgrade, an operator who did not set an explicit override sees Zeebe's effective message-size limit return from 10MB to the 4MB engine default. 8.10 is alpha, so no policy exception is needed there.

**Customer impact is assessed as very low:**

- **Baseline was always 4MB.** The chart never set Zeebe `maxMessageSize`; it inherited the 4MB engine default. Operators who genuinely need larger Zeebe messages set it explicitly via env / `extraConfiguration` — and those users are **unaffected** by this change, because they configure it directly, not through `requestBodySize`.
- **The only impacted population is vanishingly small:** someone who, within the ~6-week window, upgraded to a #6279 release, discovered the undocumented accidental 10MB Zeebe headroom, and built a process depending on 4–10MB Zeebe messages/variables — without pinning an override. Having previously run on 4MB, their existing processes were already designed for ≤4MB.
- **The one supporting data point agrees:** SUPPORT-32927 set `requestBodySize=20MB`, which incidentally raised their Zeebe limit too, but their actual need was document uploads (~4MB file), not Zeebe messages. After this change their document uploads still succeed (10MB+) and Zeebe returns to 4MB — which is sufficient for them.

**Migration:** if you rely on Zeebe messages/variables >4MB, set the limit via the component's `extraConfiguration` (broker, gateway, and internal namespaces) — see the "Zeebe Message Size" note in each chart README.

**Rolling-upgrade note:** during the StatefulSet rollout, restarted pods use the 4MB default while not-yet-restarted pods still use 10MB; payloads in the 4–10MB range may be handled non-deterministically. Operators with active >4MB traffic should drain large-payload work or pin an explicit override for the duration of the rollout.

### Validation

- `make go.test` + `make helm.lint` — pass on 8.7, 8.8, 8.9, 8.10.
- **GKE (chart 8.8, ES+Keycloak):** rendered config shows multipart/form-post at 10MB, Zeebe `maxMessageSize` absent → 4MB default. Multipart sweep on `POST /orchestration/v2/documents`: 4–9MB → `401` (passed the 10MB gate), 10–12MB → `413`. `5MB → 401` confirms the customer's ~4MB upload is not blocked.

### Breaking-change checklist status (per docs/policies/breaking-changes.md)

- [x] Migration documented (README `extraConfiguration` note + rolling-upgrade guidance above)
- [x] Customer-impact assessment documented (above)
- [x] `breaking change` label
- [x] EM/PM justification & sign-off — signed off by @eamonnmoloney (2026-07-17)
- [ ] InfraEx / #oc-reliability-testing acknowledgement (heads-up to follow)
- [ ] Release notes + upgrade guide entry (camunda-docs)

### Related

- Docs PR (to follow): reword `requestBodySize` guidance (counterpart to #6279 docs #8975).
- Connectors component wires none of these; SUPPORT-32927 customer used `JDK_JAVA_OPTIONS` — separate follow-up.
- Raising the Zeebe transport default remains gated on an engine-team A/B benchmark — out of scope.
