### PR TITLE
ci: fetch full history in init job so merge_group change-detection resolves base commit

### DIFF
--- a/.github/workflows/test-chart-version.yaml
+++ b/.github/workflows/test-chart-version.yaml
@@ -114,6 +114,8 @@ jobs:
       pr-head-sha: ${{ steps.resolve-pr-sha.outputs.pr-head-sha }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
 
       # Detect whether any chart/CI-relevant files changed. On non-PR events
       # (merge_group, workflow_dispatch) we always consider changes present.


### PR DESCRIPTION
### Which problem does the PR fix?

In `merge_group` (merge queue) runs, the `Test - Chart Version` workflow was silently producing an **empty test matrix** and skipping the entire suite while still reporting green.

Root cause: the `init` job's `actions/checkout` used the default shallow `fetch-depth: 1`. `generate-chart-matrix` uses `tj-actions/changed-files` to diff against the merge-queue base commit (the prior tip of `main`), which is absent from a shallow clone. That produced these annotations —

```
Initial commit detected no previous commit found.
Previous commit <base-sha> is not valid. Using parent commit.
Unable to locate the commit sha: <base-sha>
```

— an empty `all_modified_files` list, and therefore an empty matrix (`{"include":[]}`) from `scripts/generate-chart-matrix.sh`. Every downstream matrix job was skipped, and the `ci-result-cache` annotate step had nothing to reuse. Because it depends on shallow-clone git state, the failure is intermittent across queue entries.

Observed on run: https://github.com/camunda/camunda-platform-helm/actions/runs/29505911044/job/87653475363

### What's in this PR?

Adds `with: fetch-depth: 0` to the `init` job's checkout step so `tj-actions/changed-files` has the full history it needs to resolve the `merge_group` `base_sha`. The impacted-version matrix then populates correctly and the result cache can mark already-passed scenarios as `cached`.

Single-line, version-agnostic change; no scripts, Go tooling, or composite actions touched.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
