### PR TITLE
ci: push release files to release-please branch with app token

### DIFF
--- a/.github/workflows/chart-promote-rc.yaml
+++ b/.github/workflows/chart-promote-rc.yaml
@@ -138,6 +138,7 @@ jobs:
         with:
           ref: ${{ steps.parse.outputs.sha }}
           fetch-depth: 0
+          token: ${{ steps.generate-github-token.outputs.token }}
 
       - name: Validate commit is on main
         run: |


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6633.

### What's in this PR?

Passes the distro-ci app token to the promote-RC "Checkout at commit SHA" step, so the "Generate release files on the release-please PR" push authenticates as `distro-ci[bot]` instead of the checkout-persisted default `GITHUB_TOKEN`. Since GitHub's 2026-06-11 change ("Bot-created pull requests can run workflows if approved"), `GITHUB_TOKEN` pushes to a PR branch create workflow runs held in approval-required state; pushing with the app token triggers them normally. Mirrors the existing pattern in `chart-release-public.yaml` (post-release rebase push) and `chart-chores.yaml`.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
