### PR TITLE
ci: rewire merge-queue shepherds to self-minting action tokens

### DIFF
--- a/.github/workflows/chart-release-public.yaml
+++ b/.github/workflows/chart-release-public.yaml
@@ -523,28 +523,45 @@ jobs:
             secret/data/products/distribution/ci SLACK_DISTRO_BOT_WEBHOOK;
           exportEnv: false
 
-      - name: Generate GitHub token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
-        id: generate-github-token
-        with:
-          app_id: ${{ steps.secrets.outputs.GH_APP_ID_DISTRO_CI }}
-          private_key: ${{ steps.secrets.outputs.GH_APP_PRIVATE_KEY_DISTRO_CI }}
-
       - name: Shepherd release-please PR through merge queue
         id: merge-queue
         continue-on-error: true
         uses: camunda/infra-global-github-actions/ensure-pr-passes-merge-queue@305de9730455a10c1df97262d42ced69855f2b16 # main
         with:
           pr-number: ${{ needs.post-release.outputs.pr-number }}
-          app-token: ${{ steps.generate-github-token.outputs.token }}
+          app-id: ${{ steps.secrets.outputs.GH_APP_ID_DISTRO_CI }}
+          private-key: ${{ steps.secrets.outputs.GH_APP_PRIVATE_KEY_DISTRO_CI }}
           repository-owner: ${{ github.repository_owner }}
           repository-name: ${{ github.event.repository.name }}
           merge-method: squash
-          timeout-minutes: "90"
+          timeout-minutes: "120"
           max-evictions: "3"
 
+      - name: Notice if monitor ended with PR still queued
+        if: >-
+          ${{ steps.merge-queue.outputs.result == 'timeout' &&
+              steps.merge-queue.outputs.queue-state != 'NOT_IN_QUEUE' &&
+              steps.merge-queue.outputs.queue-state != 'UNKNOWN' }}
+        continue-on-error: true
+        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
+        with:
+          webhook: ${{ steps.secrets.outputs.SLACK_DISTRO_BOT_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: |
+                    :hourglass_flowing_sand: *Helm Chart ${{ needs.release.outputs.version }}* was published; its release-please PR was still in the merge queue (state: `${{ steps.merge-queue.outputs.queue-state }}`, position: `${{ steps.merge-queue.outputs.queue-position }}`) when the 120-minute monitor window ended. It should merge on its own — verify it landed so `main` syncs with the released artifact.
+                    <${{ github.server_url }}/${{ github.repository }}/pull/${{ needs.post-release.outputs.pr-number }}|View PR> · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow>
+
       - name: Alert if release-please PR did not merge
-        if: ${{ steps.merge-queue.outputs.result != 'merged' }}
+        if: >-
+          ${{ steps.merge-queue.outputs.result != 'merged' &&
+              (steps.merge-queue.outputs.result != 'timeout' ||
+               steps.merge-queue.outputs.queue-state == 'NOT_IN_QUEUE' ||
+               steps.merge-queue.outputs.queue-state == 'UNKNOWN') }}
         continue-on-error: true
         uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
         with:
@@ -557,7 +574,7 @@ jobs:
                   type: mrkdwn
                   text: |
                     <!subteam^S05K9BK6RTK> :rotating_light:
-                    *Helm Chart ${{ needs.release.outputs.version }}* was published, but its release-please PR is *not merged* (merge-queue result: `${{ steps.merge-queue.outputs.result || 'unknown' }}`).
+                    *Helm Chart ${{ needs.release.outputs.version }}* was published, but its release-please PR did *not* merge (result: `${{ steps.merge-queue.outputs.result || 'unknown' }}`, last queue state: `${{ steps.merge-queue.outputs.queue-state || 'unknown' }}`).
                     Please merge it so `main` syncs with the released artifact.
                     <${{ github.server_url }}/${{ github.repository }}/pull/${{ needs.post-release.outputs.pr-number }}|View PR> · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow>
 

--- a/.github/workflows/renovate-merge-shepherd.yaml
+++ b/.github/workflows/renovate-merge-shepherd.yaml
@@ -72,18 +72,12 @@ jobs:
             secret/data/products/distribution/ci GH_APP_PRIVATE_KEY_DISTRO_CI;
           exportEnv: false
 
-      - name: Generate GitHub token
-        id: generate-github-token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2
-        with:
-          app_id: ${{ steps.secrets.outputs.GH_APP_ID_DISTRO_CI }}
-          private_key: ${{ steps.secrets.outputs.GH_APP_PRIVATE_KEY_DISTRO_CI }}
-
       - name: Shepherd PR through merge queue
         uses: camunda/infra-global-github-actions/ensure-pr-passes-merge-queue@305de9730455a10c1df97262d42ced69855f2b16 # main
         with:
           pr-number: ${{ matrix.pr }}
-          app-token: ${{ steps.generate-github-token.outputs.token }}
+          app-id: ${{ steps.secrets.outputs.GH_APP_ID_DISTRO_CI }}
+          private-key: ${{ steps.secrets.outputs.GH_APP_PRIVATE_KEY_DISTRO_CI }}
           repository-owner: ${{ github.repository_owner }}
           repository-name: ${{ github.event.repository.name }}
           merge-method: squash


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6634.

camunda/infra-global-github-actions#754 is merged; the action pin points at the merged SHA (`f74bcfa`).

### What's in this PR?

- Both shepherd jobs pass `app-id`/`private-key` (Vault outputs) to `ensure-pr-passes-merge-queue`, which now mints and refreshes installation tokens itself — the `tibdex/github-app-token` steps are removed, which also removes the failing token-revoke post-step that turned the job red.
- Release shepherd timeout raised 90 → 120 minutes (14.7.0 needed 81 minutes of queue time); Renovate shepherd stays at 90 (its job ceiling is 95).
- The single "not merged" alert becomes two-tier: a calm notice without a subteam ping when the monitor window ends with the PR still progressing in the queue, and the rotating-light `@distribution-release-manager` page for everything else (`closed`, `evicted`, `api_failure`, or timeout while not queued), now including the last observed queue state.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?


