### PR TITLE
ci: defer CI Gate verdict to integration-tests gate on merge queue

### DIFF
--- a/.github/workflows/test-chart-version.yaml
+++ b/.github/workflows/test-chart-version.yaml
@@ -317,6 +317,10 @@ jobs:
     steps:
       - name: Check job results
         run: |
+          if [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            echo "merge_group: verdict owned by the 'gate' check; not failing here."
+            exit 0
+          fi
           results=(
             "${{ needs.init.result }}"
             "${{ needs.unit-testing.result }}"


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6643.

### What's in this PR?

On `merge_group`, the `CI Gate` aggregator job now exits 0 and defers the CI verdict
to the `gate` check (`integration-tests-gate`), which reruns transient failures and
reports the authoritative terminal result. This stops the merge queue (ALLGREEN) from
evicting a PR on a transient `CI Gate` failure before the `gate` rerun recovers it.

`gate` still reports genuine failures, so broken runs are still blocked. On
`pull_request`, `CI Gate` behaviour is unchanged (fast-fail + PR visibility). As a
side effect the `gate` rerun becomes a genuine retry: with `CI Gate` out of the
eviction path the merge group stays alive instead of dying mid-rerun.

### Checklist

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open pull request for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo documentation are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
