### PR TITLE
test: emit BASE_URL in render-e2e-env for SM auth in e2e suite

### DIFF
--- a/scripts/render-e2e-env.sh
+++ b/scripts/render-e2e-env.sh
@@ -297,6 +297,7 @@ render_env_file() {
 
     {
       echo "PLAYWRIGHT_BASE_URL=https://$hostname"
+      echo "BASE_URL=https://$hostname"
       echo "CI=${is_ci}"
       echo "CLUSTER_NAME=integration"
       echo "IS_AUTH0=true"
@@ -358,6 +359,7 @@ render_env_file() {
     echo "KEYCLOAK_URL=$keycloak_protocol://$keycloak_host"
     echo "KEYCLOAK_REALM=${keycloak_realm}"
     echo "PLAYWRIGHT_BASE_URL=https://$hostname"
+    echo "BASE_URL=https://$hostname"
     echo "CAMUNDA_OPTIMIZE_BASE_URL=https://$hostname/optimize"
     echo "CLUSTER_ENDPOINT=http://integration-zeebe-gateway:26500"
     echo "CLUSTER_VERSION=8"


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6647.

### What's in this PR?

`scripts/render-e2e-env.sh` emitted `PLAYWRIGHT_BASE_URL` and
`CAMUNDA_OPTIMIZE_BASE_URL` but never `BASE_URL`. The e2e suite's `authSmAPI()`
requires `BASE_URL` (bare cluster origin) to build the Keycloak token URL, so the 8.9
`shadow-e2e` Optimize API tests failed deterministically with
`Missing BASE_URL (required for SM auth)`.

This emits `BASE_URL=https://$hostname` (bare origin, no path — distinct from
`CAMUNDA_OPTIMIZE_BASE_URL`) alongside `PLAYWRIGHT_BASE_URL` in both env-render blocks.

### Checklist

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open pull request for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo documentation are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
