### PR TITLE
test: avoid Keycloak JGROUPS_PING race in hubde migration cutover

### DIFF
--- a/charts/camunda-platform-8.10/test/integration/scenarios/pre-setup-scripts/post-infra-bitnami-migration.sh
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/pre-setup-scripts/post-infra-bitnami-migration.sh
@@ -115,13 +115,17 @@ cd "${migration_dir}"
 source ./env.sh
 bash 1-deploy-targets.sh --yes
 bash 2-backup.sh --yes
+
+# Stop JDBC_PING writes while the realm database is restored.
+echo "Stopping companion Keycloak for realm migration ..."
+kubectl scale deployment/keycloak -n "${NS}" --replicas=0
+kubectl rollout status deployment/keycloak -n "${NS}" --timeout=300s
+
 bash 3-cutover.sh --yes
 
-# The companion Keycloak has been running against an empty realm; restart it so
-# it loads the realm just restored into its database, before the chart upgrade
-# points Camunda at it.
-echo "Restarting companion Keycloak to load the migrated realm ..."
-kubectl rollout restart deployment/keycloak -n "${NS}"
+# Start one fresh pod to load the restored realm before the chart upgrade.
+echo "Starting companion Keycloak with the migrated realm ..."
+kubectl scale deployment/keycloak -n "${NS}" --replicas=1
 kubectl rollout status deployment/keycloak -n "${NS}" --timeout=300s
 
 echo "post-infra migration complete — realm moved to companion Keycloak; chart upgrade to 8.10 is the runner's job."


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6646.

### What's in this PR?

In the `hubde` post-infra Bitnami migration, `3-cutover.sh` restores the realm into
the companion Keycloak's database while that Keycloak is still running, and the script
then did `kubectl rollout restart deployment/keycloak`. With Keycloak's deterministic
JDBC_PING cluster address, the terminating old pod and the new pod collide on
`JGROUPS_PING`, causing `duplicate key value violates unique constraint
"constraint_jgroups_ping"` → intermittent CrashLoopBackOff (a gating failure that
forces a full merge-queue rerun).

This scales `deployment/keycloak` to 0 before the cutover restore (no JDBC_PING writer
during restore), then scales it back to 1 afterwards — a single fresh pod loads the
restored realm against an empty `JGROUPS_PING`, with no pod overlap.

### Checklist

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open pull request for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo documentation are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
