### PR TITLE
feat(8.10): add zero-infra quickstart values profile with embedded H2

### DIFF
--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -601,6 +601,23 @@ integration:
               env-vars:
                 - RDBMS_POSTGRESQL_USERNAME
                 - RDBMS_POSTGRESQL_PASSWORD
+        - name: quickstart-embedded-h2
+          enabled: true
+          shortname: qseh
+          auth: basic
+          flow: install
+          platforms:
+            - gke
+          exclude:
+            - identity
+            - console
+            - orchestration-grpc
+          tier: 2
+          infra-type:
+            gke: distroci
+          identity: basic
+          persistence: rdbms-embedded-h2
+          skip-e2e: true
         - name: component-persistence
           enabled: false
           shortname: cprst

--- a/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
@@ -83,6 +83,10 @@ integration:
       shortname: rdbms
       tier: 2
       enabled: true
+    - id: quickstart-embedded-h2
+      shortname: qseh
+      tier: 2
+      enabled: true
     - id: component-persistence
       shortname: cprst
       tier: 2

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/quickstart-embedded-h2.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/quickstart-embedded-h2.yaml
@@ -1,0 +1,16 @@
+name: quickstart-embedded-h2
+auth: basic
+flows:
+  - install
+identity: basic
+persistence: rdbms-embedded-h2
+exclude:
+  - identity
+  - console
+  - orchestration-grpc
+platforms:
+  - gke
+infra-type:
+  gke: distroci
+skip-e2e: true
+dependencies: []

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/persistence/rdbms-embedded-h2.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/persistence/rdbms-embedded-h2.yaml
@@ -1,0 +1,34 @@
+# Embedded file-based H2 secondary storage for the zero-infra quickstart profile.
+# Layer 3: Backend - embedded H2 (no external infrastructure)
+#
+# Mirrors the orchestration block of charts/camunda-platform-8.10/values-quickstart.yaml;
+# keep the two in sync. The published profile lives at the chart root, outside the
+# extra-values chart-full-setup sandbox, so it cannot be layered in directly.
+
+# Neutralize base.yaml: it enables Elasticsearch, pins secondaryStorage.type to
+# elasticsearch, and enables Optimize (which requires a search backend H2 lacks).
+global:
+  elasticsearch:
+    enabled: false
+
+optimize:
+  enabled: false
+
+orchestration:
+  clusterSize: "1"
+  data:
+    secondaryStorage:
+      type: null
+      rdbms:
+        url: "jdbc:h2:file:/usr/local/camunda/data/camunda-rdbms;DB_CLOSE_DELAY=-1"
+        username: "sa"
+  exporters:
+    rdbms:
+      enabled: true
+  extraConfiguration:
+    - file: cluster-topology.yaml
+      content: |
+        camunda:
+          cluster:
+            partition-count: 1
+            replication-factor: 1

--- a/charts/camunda-platform-8.10/test/unit/orchestration/configmap_unified_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/configmap_unified_test.go
@@ -494,6 +494,34 @@ func (s *ConfigmapTemplateTest) TestDifferentValuesInputsUnifiedRDBMS() {
 	testhelpers.RunTestCases(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
 
+func (s *ConfigmapTemplateTest) TestQuickstartProfileRendersEmbeddedH2() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name:        "TestQuickstartProfileResolvesRdbmsWithEmbeddedH2",
+			ValuesFiles: []string{filepath.Join(s.chartPath, "values-quickstart.yaml")},
+			Expected: map[string]string{
+				"configmapApplication.camunda.data.secondary-storage.type":           "rdbms",
+				"configmapApplication.camunda.data.secondary-storage.rdbms.url":      "jdbc:h2:file:/usr/local/camunda/data/camunda-rdbms;DB_CLOSE_DELAY=-1",
+				"configmapApplication.camunda.data.secondary-storage.rdbms.username": "sa",
+				"configmapApplication.camunda.cluster.size":                          "1",
+			},
+		},
+		{
+			Name:        "TestQuickstartProfileSetsSingleBrokerTopologyViaExtraConfiguration",
+			ValuesFiles: []string{filepath.Join(s.chartPath, "values-quickstart.yaml")},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.Contains(t, output, "optional:file:/usr/local/camunda/config/cluster-topology.yaml")
+				require.Contains(t, output, "cluster-topology.yaml: |")
+				require.Contains(t, output, "partition-count: 1")
+				require.Contains(t, output, "replication-factor: 1")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
 func (s *ConfigmapTemplateTest) TestHasLegacyElasticsearchExporter() {
 	testCases := []testhelpers.TestCase{
 		{

--- a/charts/camunda-platform-8.10/values-quickstart.yaml
+++ b/charts/camunda-platform-8.10/values-quickstart.yaml
@@ -8,6 +8,10 @@
 # NON-PRODUCTION: single broker + single partition only; data is local to the
 # broker PVC. For production, choose a real secondary-storage backend
 # (Elasticsearch / OpenSearch / external RDBMS) and a multi-broker topology.
+#
+# CI coverage mirrors this orchestration block in
+# test/integration/scenarios/chart-full-setup/values/persistence/rdbms-embedded-h2.yaml;
+# keep the two in sync.
 orchestration:
   clusterSize: "1"
   exporters:

--- a/charts/camunda-platform-8.10/values-quickstart.yaml
+++ b/charts/camunda-platform-8.10/values-quickstart.yaml
@@ -1,0 +1,30 @@
+# Zero-infrastructure developer / evaluation profile.
+#
+#   helm install camunda camunda/camunda-platform --devel --version '15.x' \
+#     -f https://helm.camunda.io/camunda-platform/values/camunda-8.10/values-quickstart.yaml
+#
+# Runs the Orchestration Cluster + Connectors on an embedded, file-based H2
+# database with Basic auth (demo/demo) and NO external infrastructure.
+# NON-PRODUCTION: single broker + single partition only; data is local to the
+# broker PVC. For production, choose a real secondary-storage backend
+# (Elasticsearch / OpenSearch / external RDBMS) and a multi-broker topology.
+orchestration:
+  clusterSize: "1"
+  exporters:
+    rdbms:
+      enabled: true
+  data:
+    secondaryStorage:
+      rdbms:
+        url: "jdbc:h2:file:/usr/local/camunda/data/camunda-rdbms;DB_CLOSE_DELAY=-1"
+        username: "sa"
+  # partition-count / replication-factor set via extraConfiguration (imported over
+  # the base application.yaml through spring.config.import) instead of the deprecated
+  # orchestration.partitionCount / orchestration.replicationFactor keys.
+  extraConfiguration:
+    - file: cluster-topology.yaml
+      content: |
+        camunda:
+          cluster:
+            partition-count: 1
+            replication-factor: 1


### PR DESCRIPTION
### Which problem does the PR fix?

A plain `helm install camunda camunda/camunda-platform` (no `--set`, no pre-provisioned infrastructure) **fails at template-render time** on the 8.10 chart: `orchestration.enabled` is `true` by default but no secondary-storage backend is configured, so the guard in `templates/common/constraints.tpl` aborts the install. Since the bundled Bitnami subcharts were removed in 8.10, there is no zero-config path to a running cluster for developers/evaluators.

### What's in this PR?

Adds an **opt-in, non-production** quickstart values profile so developers/evaluators get a running cluster with no external infrastructure — **without changing any chart defaults**.

- `charts/camunda-platform-8.10/values-quickstart.yaml` — runs the Orchestration Cluster + Connectors on an embedded, file-based **H2** database with Basic auth (`demo`/`demo`), single broker/partition. RDBMS exporter on, embedded-H2 `jdbcUrl` + user `sa`, and single-broker topology via `orchestration.extraConfiguration` (avoids the deprecated `partitionCount`/`replicationFactor` keys → no deprecation warnings). Published automatically by `chart-public-files.yaml`:
  ```bash
  helm install camunda camunda/camunda-platform --devel --version '15.x' \
    -f https://helm.camunda.io/camunda-platform/values/camunda-8.10/values-quickstart.yaml
  ```
- CI scenario `quickstart-embedded-h2` (tier 2, shortname `qseh`) — deploys the profile with **no companion charts** and `skip-e2e: true`, so the install/readiness gate exercises the embedded-H2 path in the matrix (would catch a broker CrashLoop). Mirrored into a persistence layer because the runner can't layer a chart-root values file.
- Render tests for the profile; regenerated registry snapshot. No chart defaults / templates / goldens changed.

### ⚠️ ADR-0094 — deliberate, maintainer-accepted exception

ADR-0094 ("Remove bundled Bitnami subcharts") establishes that from 8.10 **the customer owns the database** and explicitly rejected an embedded/bundled database *as a supported install path* (directing quick-dev users to external-infra examples, #5989). This profile is a knowing, scoped exception: an **opt-in, clearly-labelled non-production** dev/eval path shipping embedded H2 (which runs inside the Camunda app image — no unmaintained third-party image, so ADR-0094's supply-chain driver does not apply). Merged as a maintainer decision; **an ADR amendment recording this exception should follow.** cc ADR-0094 decision-maker (Balázs).

### Validation

- `helm template … -f values-quickstart.yaml` renders (rdbms + H2 + single broker); default `helm template` still correctly errors on the storage guard (defaults unchanged); `make helm.lint` clean; `make go.test` EXIT 0.
- **Live GKE (`distro-ci`), `helm install … -f values-quickstart.yaml`:** `camunda-zeebe-0` + `camunda-connectors` both **1/1 Ready** (0 restarts); `curl -u demo:demo /v2/topology` → healthy, **`partitionsCount=1, replicationFactor=1`** (confirms the `extraConfiguration` override holds at runtime).

### Checklist

- [x] `make go.update-golden-only` (no golden changes — defaults untouched)
- [x] No other open PR for the same change
- [x] Tests added (render tests + CI scenario)
- [ ] In-repo docs updated (docs live in `camunda-docs` — see To-Do)
- [ ] CLA
- [ ] Checks pass in the PR

### To-Do

- [x] Validate the profile end-to-end on GKE (both pods Ready, topology 1/1/1).
- [x] Add CI coverage (tier-2 `quickstart-embedded-h2` scenario).
- [ ] Author an ADR amendment/superseding note for the ADR-0094 exception (maintainer).
- [ ] Reconcile `camunda-docs` quick-install to point at `-f values-quickstart.yaml` (drops the `--set` list + the `CAMUNDA_PERSISTENT_SESSIONS_ENABLED` workaround).
- [ ] (Minor) Make the CI persistence layer set `partitionCount`/`replicationFactor` to `"3"` so only `extraConfiguration` drives topology — exact profile fidelity + no deprecation warning in that scenario.


Fixes https://github.com/camunda/camunda-platform-helm/issues/6697