### PR TITLE
build: retry helm repo update in helm.repos-add to survive transient GitHub Pages resets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,20 @@ helm.repos-add:
 			exit 1; \
 		fi; \
 	done
-	@helm repo update
+	@success=false; \
+	for i in 1 2 3; do \
+		if helm repo update; then \
+			success=true; break; \
+		fi; \
+		if [ $$i -lt 3 ]; then \
+			echo "⚠️  helm repo update failed (attempt $$i/3), retrying in 5s..." >&2; \
+			sleep 5; \
+		fi; \
+	done; \
+	if [ "$$success" != "true" ]; then \
+		echo "❌ helm repo update failed after 3 attempts" >&2; \
+		exit 1; \
+	fi
 
 # helm.dependency-update: update and downloads the dependencies for the Helm chart
 .PHONY: helm.dependency-update


### PR DESCRIPTION
### Which problem does the PR fix?

The nightly "Test - Chart Version" job intermittently fails during the "CI Setup - Shared integration test setup" step:

```
"camunda" has been added to your repositories
Hang tight while we grab the latest from your chart repositories...
Error: failed to update the following repositories: [https://helm.camunda.io]
  Get "https://helm.camunda.io/index.yaml": read tcp ...->185.199.111.153:443: read: connection reset by peer
make: *** [Makefile:187: helm.repos-add] Error 1
```

Failing run: https://github.com/camunda/camunda-platform-helm/actions/runs/29981988359

`helm.camunda.io` is served from GitHub Pages, and a `connection reset by peer` while fetching `index.yaml` is a transient network flake. In the `helm.repos-add` Makefile target, `helm repo add --force-update` is already retried 3x with a 5s backoff, but the following `helm repo update` call — which is what actually performs the `index.yaml` fetch, and what flaked in this run — had no retry at all, so a single transient blip failed the whole nightly setup step.

### What's in this PR?

Wraps the `helm repo update` call in `helm.repos-add` in the same 3-attempt / 5s-backoff retry loop already used for `helm repo add`, matching its logging/error conventions (`⚠️`/`❌` prefixes, `>&2`, `exit 1` after exhausting attempts).

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
