### PR TITLE
ci: regenerate packaged docs after image overrides

### DIFF
--- a/.github/workflows/chart-build-dev.yaml
+++ b/.github/workflows/chart-build-dev.yaml
@@ -406,6 +406,20 @@ jobs:
           done
           echo "Dev comments removed"
 
+      - name: Install readme-generator-for-helm
+        if: env.SKIP_BUILD == 'false' && env.HAS_IMAGE_OVERRIDES == 'true'
+        run: |
+          # renovate: datasource=npm depName=@bitnami/readme-generator-for-helm
+          npm install -g @bitnami/readme-generator-for-helm@2.7.2
+
+      - name: Regenerate values documentation
+        if: env.SKIP_BUILD == 'false' && env.HAS_IMAGE_OVERRIDES == 'true'
+        run: |
+          make -C ../.. helm.readme-update chartPath="${CHART_DIR}"
+          if [[ -f values.schema.json ]]; then
+            make -C ../.. helm.schema-update chartPath="${CHART_DIR}"
+          fi
+
       - name: Remove badges from README
         if: env.SKIP_BUILD == 'false'
         run: |


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6671.

Image-tag overrides are injected into `values.yaml` while building the immutable dev chart artifact, but the packaged README and values schema are currently left at their source-branch defaults. This makes files inside the same artifact disagree.

Chart 14.3.0 demonstrates the issue: its packaged `values.yaml` contains `orchestration.image.tag: 8.9.5`, while its packaged README and schema report `8.9.0`.

### What's in this PR?

- Installs the repository-pinned Helm README generator only for non-skipped builds with image override inputs.
- Regenerates the chart README after release transformations have finalized `values.yaml` and before packaging.
- Regenerates `values.schema.json` when the chart provides one, while allowing 8.7 to update only its README.
- Leaves builds without image overrides and the immutable promotion/public-release stages unchanged.

Validated with:

- YAML parsing via `yq`.
- `git diff --check`.
- A yamllint comparison against `origin/main` confirming no new lint finding class.
- A disposable 8.9 chart simulation confirming the README and schema both adopt an injected image tag.
- A disposable 8.7 chart simulation confirming the README adopts an injected image tag without requiring a schema.

Live workflow validation:

- [Build Dev run #885](https://github.com/camunda/camunda-platform-helm/actions/runs/29985171164) completed successfully on this PR's head SHA.
- The run built 8.9 with `orchestration-image-tag=8.9.12` and published immutable dev tag `14.7.1-dev-e18907a`.
- Pulling digest `sha256:7aa7abd6035afc62a8ccc576496c0c2a15c196440ac9ffc76fc2f3c627d3d963` from Harbor confirmed `orchestration.image.tag: 8.9.12` in packaged `values.yaml`, `README.md`, and `values.schema.json`.
- The packaged `Chart.yaml` contains `camunda.io/imageOverrides: orchestration: 8.9.12`.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
