### PR TITLE
fix: normalize orchestration internal REST URL when contextPath is root

### DIFF
--- a/charts/camunda-platform-8.10/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/common/_helpers.tpl
@@ -669,7 +669,7 @@ Zeebe templates.
       printf "%s://%s%s"
         (ternary "https" "http" (eq (include "camundaPlatform.orchestrationEnvIsTrue" (dict "context" . "name" "SERVER_SSL_ENABLED")) "true"))
         (include "orchestration.serviceNameHTTP" .)
-        (.Values.orchestration.contextPath | default "")
+        (.Values.orchestration.contextPath | default "" | trimSuffix "/")
     -}}
   {{- end -}}
 {{- end -}}

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/configmap_restapi_test.go
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/configmap_restapi_test.go
@@ -542,6 +542,52 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldConfigureClusterFromSa
 	}
 }
 
+func (s *configmapRestAPITemplateTest) TestContainerShouldConfigureClusterRestUrlWithoutTrailingSlashWhenContextPathIsRoot() {
+	// given
+	values := map[string]string{
+		"identity.enabled":                              "true",
+		"global.zeebeClusterName":                       "test-zeebe",
+		"global.ingress.enabled":                        "true",
+		"global.ingress.tls.enabled":                    "true",
+		"global.host":                                   "example.com",
+		"orchestration.contextPath":                     "/",
+		"orchestration.service.grpcPort":                "26600",
+		"orchestration.service.httpPort":                "8090",
+		"orchestration.security.authorizations.enabled": "false",
+		"global.elasticsearch.enabled":                  "true",
+	}
+	maps.Insert(values, maps.All(requiredValues))
+	options := &helm.Options{
+		SetValues:      values,
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var configmap corev1.ConfigMap
+	var configmapApplication WebModelerRestAPIApplicationYAML
+	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	if err != nil {
+		s.Fail("Failed to unmarshal yaml. error=", err)
+	}
+
+	// then
+	s.Require().Equal(2, len(configmapApplication.Camunda.Modeler.Clusters))
+	defaultCluster := configmapApplication.Camunda.Modeler.Clusters[1]
+	s.Require().Equal("default-cluster", defaultCluster.Id)
+	var orchestrationComp ComponentYAML
+	for _, c := range defaultCluster.Components {
+		if c.Type == "orchestration" {
+			orchestrationComp = c
+			break
+		}
+	}
+	s.Require().Equal("grpc://camunda-platform-test-zeebe-gateway:26600", orchestrationComp.Urls.Grpc)
+	s.Require().Equal("http://camunda-platform-test-zeebe-gateway:8090", orchestrationComp.Urls.Rest)
+}
+
 func (s *configmapRestAPITemplateTest) TestContainerShouldUseSecureGrpcUrlWhenOrchestrationGrpcTlsIsEnabled() {
 	values := map[string]string{
 		"identity.enabled":                              "true",

--- a/charts/camunda-platform-8.8/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.8/templates/common/_helpers.tpl
@@ -596,7 +596,7 @@ Zeebe templates.
       printf "%s://%s%s"
         (ternary "https" "http" (eq (include "camundaPlatform.orchestrationEnvIsTrue" (dict "context" . "name" "SERVER_SSL_ENABLED")) "true"))
         (include "orchestration.serviceNameHTTP" .)
-        (.Values.orchestration.contextPath | default "")
+        (.Values.orchestration.contextPath | default "" | trimSuffix "/")
     -}}
   {{- end -}}
 {{- end -}}

--- a/charts/camunda-platform-8.8/test/unit/web-modeler/configmap_restapi_test.go
+++ b/charts/camunda-platform-8.8/test/unit/web-modeler/configmap_restapi_test.go
@@ -385,6 +385,43 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldConfigureClusterFromSa
 	}
 }
 
+func (s *configmapRestAPITemplateTest) TestContainerShouldConfigureClusterRestUrlWithoutTrailingSlashWhenContextPathIsRoot() {
+	// given
+	values := map[string]string{
+		"identity.enabled":                              "true",
+		"webModelerPostgresql.enabled":                  "false",
+		"global.zeebeClusterName":                       "test-zeebe",
+		"global.ingress.enabled":                        "true",
+		"global.ingress.tls.enabled":                    "true",
+		"global.ingress.host":                           "example.com",
+		"orchestration.contextPath":                     "/",
+		"orchestration.service.grpcPort":                "26600",
+		"orchestration.service.httpPort":                "8090",
+		"orchestration.security.authorizations.enabled": "false",
+	}
+	maps.Insert(values, maps.All(requiredValues))
+	options := &helm.Options{
+		SetValues:      values,
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var configmap corev1.ConfigMap
+	var configmapApplication WebModelerRestAPIApplicationYAML
+	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	if err != nil {
+		s.Fail("Failed to unmarshal yaml. error=", err)
+	}
+
+	// then
+	s.Require().Equal(1, len(configmapApplication.Camunda.Modeler.Clusters))
+	s.Require().Equal("grpc://camunda-platform-test-zeebe-gateway:26600", configmapApplication.Camunda.Modeler.Clusters[0].Url.Grpc)
+	s.Require().Equal("http://camunda-platform-test-zeebe-gateway:8090", configmapApplication.Camunda.Modeler.Clusters[0].Url.Rest)
+}
+
 func (s *configmapRestAPITemplateTest) TestContainerShouldUseSecureGrpcUrlWhenOrchestrationGrpcTlsIsEnabled() {
 	values := map[string]string{
 		"identity.enabled":                              "true",

--- a/charts/camunda-platform-8.9/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/common/_helpers.tpl
@@ -656,7 +656,7 @@ Zeebe templates.
       printf "%s://%s%s"
         (ternary "https" "http" (eq (include "camundaPlatform.orchestrationEnvIsTrue" (dict "context" . "name" "SERVER_SSL_ENABLED")) "true"))
         (include "orchestration.serviceNameHTTP" .)
-        (.Values.orchestration.contextPath | default "")
+        (.Values.orchestration.contextPath | default "" | trimSuffix "/")
     -}}
   {{- end -}}
 {{- end -}}

--- a/charts/camunda-platform-8.9/test/unit/web-modeler/configmap_restapi_test.go
+++ b/charts/camunda-platform-8.9/test/unit/web-modeler/configmap_restapi_test.go
@@ -531,6 +531,45 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldConfigureClusterFromSa
 	}
 }
 
+func (s *configmapRestAPITemplateTest) TestContainerShouldConfigureClusterRestUrlWithoutTrailingSlashWhenContextPathIsRoot() {
+	// given
+	values := map[string]string{
+		"identity.enabled":                              "true",
+		"webModelerPostgresql.enabled":                  "false",
+		"global.zeebeClusterName":                       "test-zeebe",
+		"global.ingress.enabled":                        "true",
+		"global.ingress.tls.enabled":                    "true",
+		"global.ingress.host":                           "example.com",
+		"orchestration.contextPath":                     "/",
+		"orchestration.service.grpcPort":                "26600",
+		"orchestration.service.httpPort":                "8090",
+		"orchestration.security.authorizations.enabled": "false",
+		"global.elasticsearch.enabled":                  "true",
+		"elasticsearch.enabled":                         "true",
+	}
+	maps.Insert(values, maps.All(requiredValues))
+	options := &helm.Options{
+		SetValues:      values,
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var configmap corev1.ConfigMap
+	var configmapApplication WebModelerRestAPIApplicationYAML
+	helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+
+	err := yaml.Unmarshal([]byte(configmap.Data["application.yaml"]), &configmapApplication)
+	if err != nil {
+		s.Fail("Failed to unmarshal yaml. error=", err)
+	}
+
+	// then
+	s.Require().Equal(1, len(configmapApplication.Camunda.Modeler.Clusters))
+	s.Require().Equal("grpc://camunda-platform-test-zeebe-gateway:26600", configmapApplication.Camunda.Modeler.Clusters[0].Url.Grpc)
+	s.Require().Equal("http://camunda-platform-test-zeebe-gateway:8090", configmapApplication.Camunda.Modeler.Clusters[0].Url.Rest)
+}
+
 func (s *configmapRestAPITemplateTest) TestContainerShouldUseSecureGrpcUrlWhenOrchestrationGrpcTlsIsEnabled() {
 	values := map[string]string{
 		"identity.enabled":                              "true",


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6227.

### What's in this PR?

Setting `orchestration.contextPath: "/"` made `camundaPlatform.orchestrationHTTPInternalURL` render the internal orchestration REST base URL with a trailing slash (`http://<svc>:8080/`), so Web Modeler Play/Deploy requested `http://<svc>:8080//v2/deployment`. The same helper feeds the connectors `rest-address` and orchestration `restAddress`.

The helper now trims a trailing slash from `orchestration.contextPath` in charts 8.8, 8.9, and 8.10, so a root context path yields `http://<svc>:8080` while non-root context paths render unchanged. Adds a unit test per chart version asserting the cluster REST URL has no trailing slash when the context path is root.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
