### PR TITLE
chore: resolve readiness host from deployed routes

### DIFF
--- a/scripts/camunda-core/pkg/kube/kube.go
+++ b/scripts/camunda-core/pkg/kube/kube.go
@@ -136,6 +136,24 @@ func NewClient(kubeconfig, kubeContext string) (*Client, error) {
 	}, nil
 }
 
+// ListNamespacedResources lists arbitrary Kubernetes resources through the
+// dynamic client. Callers provide the exact group, version, and resource name.
+func (c *Client) ListNamespacedResources(
+	ctx context.Context,
+	namespace string,
+	resource schema.GroupVersionResource,
+) (*unstructured.UnstructuredList, error) {
+	if namespace == "" {
+		return nil, errors.New("namespace must not be empty")
+	}
+
+	resources, err := c.dynamicClient.Resource(resource).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list %s in namespace %q: %w", resource.Resource, namespace, err)
+	}
+	return resources, nil
+}
+
 func (c *Client) EnsureNamespace(ctx context.Context, namespace string) error {
 	if namespace == "" {
 		return errors.New("namespace must not be empty")

--- a/scripts/camunda-core/pkg/kube/kube_test.go
+++ b/scripts/camunda-core/pkg/kube/kube_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -73,7 +74,11 @@ func TestListNamespacedResourcesWrapsListError(t *testing.T) {
 		map[schema.GroupVersionResource]string{resource: "IngressList"},
 	)
 	dynamicClient.PrependReactor("list", "ingresses", func(k8stesting.Action) (bool, runtime.Object, error) {
-		return true, nil, errors.New("forbidden")
+		return true, nil, apierrors.NewForbidden(
+			schema.GroupResource{Group: resource.Group, Resource: resource.Resource},
+			"",
+			errors.New("denied"),
+		)
 	})
 
 	client := &Client{dynamicClient: dynamicClient}
@@ -81,7 +86,10 @@ func TestListNamespacedResourcesWrapsListError(t *testing.T) {
 	if err == nil {
 		t.Fatal("ListNamespacedResources() expected a list error")
 	}
-	if !strings.Contains(err.Error(), "ingresses") || !strings.Contains(err.Error(), "test-namespace") || !strings.Contains(err.Error(), "forbidden") {
+	if !apierrors.IsForbidden(err) {
+		t.Fatalf("ListNamespacedResources() error = %q, want Forbidden classification", err)
+	}
+	if !strings.Contains(err.Error(), "ingresses") || !strings.Contains(err.Error(), "test-namespace") || !strings.Contains(err.Error(), "denied") {
 		t.Fatalf("ListNamespacedResources() error = %q, want resource, namespace, and cause", err)
 	}
 }

--- a/scripts/camunda-core/pkg/kube/kube_test.go
+++ b/scripts/camunda-core/pkg/kube/kube_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package kube
 
 import (
@@ -11,6 +25,44 @@ import (
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	k8stesting "k8s.io/client-go/testing"
 )
+
+func TestListNamespacedResources(t *testing.T) {
+	resource := schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "httproutes"}
+	route := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "HTTPRoute",
+		"metadata": map[string]any{
+			"name":      "integration-route",
+			"namespace": "test-namespace",
+		},
+	}}
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{resource: "HTTPRouteList"},
+		route,
+	)
+
+	client := &Client{dynamicClient: dynamicClient}
+	resources, err := client.ListNamespacedResources(context.Background(), "test-namespace", resource)
+	if err != nil {
+		t.Fatalf("ListNamespacedResources() error = %v", err)
+	}
+	if len(resources.Items) != 1 || resources.Items[0].GetName() != "integration-route" {
+		t.Fatalf("ListNamespacedResources() items = %#v", resources.Items)
+	}
+}
+
+func TestListNamespacedResourcesRejectsEmptyNamespace(t *testing.T) {
+	client := &Client{dynamicClient: dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())}
+	_, err := client.ListNamespacedResources(
+		context.Background(),
+		"",
+		schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"},
+	)
+	if err == nil {
+		t.Fatal("ListNamespacedResources() expected an error for an empty namespace")
+	}
+}
 
 func TestCheckConnectivity_InvalidContext(t *testing.T) {
 	err := CheckConnectivity(context.Background(), "nonexistent-context-that-should-not-exist")

--- a/scripts/camunda-core/pkg/kube/kube_test.go
+++ b/scripts/camunda-core/pkg/kube/kube_test.go
@@ -16,6 +16,8 @@ package kube
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -61,6 +63,26 @@ func TestListNamespacedResourcesRejectsEmptyNamespace(t *testing.T) {
 	)
 	if err == nil {
 		t.Fatal("ListNamespacedResources() expected an error for an empty namespace")
+	}
+}
+
+func TestListNamespacedResourcesWrapsListError(t *testing.T) {
+	resource := schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"}
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{resource: "IngressList"},
+	)
+	dynamicClient.PrependReactor("list", "ingresses", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("forbidden")
+	})
+
+	client := &Client{dynamicClient: dynamicClient}
+	_, err := client.ListNamespacedResources(context.Background(), "test-namespace", resource)
+	if err == nil {
+		t.Fatal("ListNamespacedResources() expected a list error")
+	}
+	if !strings.Contains(err.Error(), "ingresses") || !strings.Contains(err.Error(), "test-namespace") || !strings.Contains(err.Error(), "forbidden") {
+		t.Fatalf("ListNamespacedResources() error = %q, want resource, namespace, and cause", err)
 	}
 }
 

--- a/scripts/deploy-camunda/deploy/deploy.go
+++ b/scripts/deploy-camunda/deploy/deploy.go
@@ -516,7 +516,7 @@ func executeDeployment(ctx context.Context, prepared *PreparedScenario, flags *c
 			return result
 		}
 		if ingressHost == "" {
-			result.Error = fmt.Errorf("--wait-ingress-ready is set but no ingress host could be determined: set global.host, --ingress-hostname, --ingress-base-domain, CAMUNDA_HOSTNAME, or TEST_INGRESS_HOST")
+			result.Error = fmt.Errorf("--wait-ingress-ready is set but no ingress host could be determined: set global.ingress.host, global.host, --ingress-hostname, --ingress-base-domain, CAMUNDA_HOSTNAME, or TEST_INGRESS_HOST")
 			return result
 		}
 		timeoutMinutes := flags.Deployment.IngressReadyTimeoutMinutes

--- a/scripts/deploy-camunda/deploy/deploy.go
+++ b/scripts/deploy-camunda/deploy/deploy.go
@@ -510,7 +510,11 @@ func executeDeployment(ctx context.Context, prepared *PreparedScenario, flags *c
 	if flags.Deployment.WaitIngressReady {
 		// Probe the host applied to Helm or discovered from the deployed routing
 		// resources before falling back to the precomputed scenario hostname.
-		ingressHost := resolveIngressReadyHost(ctx, flags, scenarioCtx)
+		ingressHost, err := resolveIngressReadyHost(ctx, flags, scenarioCtx)
+		if err != nil {
+			result.Error = fmt.Errorf("failed to resolve ingress readiness host: %w", err)
+			return result
+		}
 		if ingressHost == "" {
 			result.Error = fmt.Errorf("--wait-ingress-ready is set but no ingress host could be determined: set global.host, --ingress-hostname, --ingress-base-domain, CAMUNDA_HOSTNAME, or TEST_INGRESS_HOST")
 			return result

--- a/scripts/deploy-camunda/deploy/deploy.go
+++ b/scripts/deploy-camunda/deploy/deploy.go
@@ -507,27 +507,12 @@ func executeDeployment(ctx context.Context, prepared *PreparedScenario, flags *c
 		}
 	}
 
-	// Gate on the ingress URL becoming publicly DNS-resolvable and HTTP-reachable
-	// before reporting success, so a nightly failure surfaces at the deploy step
-	// instead of downstream in the E2E suite. The host falls back to the same
-	// CAMUNDA_HOSTNAME / TEST_INGRESS_HOST env vars the auth0 flow uses, since CI
-	// passes the hostname that way rather than via --ingress-hostname.
-	ingressHost := scenarioCtx.IngressHost
-	if ingressHost == "" {
-		ingressHost = os.Getenv("CAMUNDA_HOSTNAME")
-	}
-	if ingressHost == "" {
-		ingressHost = os.Getenv("TEST_INGRESS_HOST")
-	}
 	if flags.Deployment.WaitIngressReady {
-		// Prefer the host on the Ingress helm just created: CI configures it with
-		// a hash-based global.host that differs from the <namespace>.<base-domain>
-		// value computed above, and only the deployed host is published to DNS.
-		if live := resolveDeployedIngressHost(ctx, flags.Test.KubeContext, scenarioCtx.Namespace); live != "" {
-			ingressHost = live
-		}
+		// Probe the host applied to Helm or discovered from the deployed routing
+		// resources before falling back to the precomputed scenario hostname.
+		ingressHost := resolveIngressReadyHost(ctx, flags, scenarioCtx)
 		if ingressHost == "" {
-			result.Error = fmt.Errorf("--wait-ingress-ready is set but no ingress host could be determined: set --ingress-hostname, --ingress-base-domain, CAMUNDA_HOSTNAME, or TEST_INGRESS_HOST")
+			result.Error = fmt.Errorf("--wait-ingress-ready is set but no ingress host could be determined: set global.host, --ingress-hostname, --ingress-base-domain, CAMUNDA_HOSTNAME, or TEST_INGRESS_HOST")
 			return result
 		}
 		timeoutMinutes := flags.Deployment.IngressReadyTimeoutMinutes

--- a/scripts/deploy-camunda/deploy/ingress_ready.go
+++ b/scripts/deploy-camunda/deploy/ingress_ready.go
@@ -58,12 +58,15 @@ func resolveIngressReadyHostWith(
 	getenv func(string) string,
 	lookupDeployedHost func(context.Context, string, string, string) string,
 ) string {
+	if host := concreteRoutingHost(flags.Ingress.IngressHostname); host != "" {
+		return host
+	}
+
 	deployedHost := lookupDeployedHost(ctx, flags.Test.KubeContext, scenarioCtx.Namespace, scenarioCtx.Release)
 	return config.FirstNonEmpty(
 		deployedHost,
 		concreteRoutingHost(flags.Deployment.ExtraHelmSets["global.ingress.host"]),
 		concreteRoutingHost(flags.Deployment.ExtraHelmSets["global.host"]),
-		flags.Ingress.IngressHostname,
 		getenv("CAMUNDA_HOSTNAME"),
 		getenv("TEST_INGRESS_HOST"),
 		scenarioCtx.IngressHost,

--- a/scripts/deploy-camunda/deploy/ingress_ready.go
+++ b/scripts/deploy-camunda/deploy/ingress_ready.go
@@ -2,6 +2,7 @@ package deploy
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -38,6 +39,30 @@ type ingressReadyDeps struct {
 
 type kubectlOutputFunc func(ctx context.Context, args ...string) ([]byte, error)
 
+type routingResourceList struct {
+	Items []routingResource `json:"items"`
+}
+
+type routingResource struct {
+	Metadata routingResourceMetadata `json:"metadata"`
+	Spec     routingResourceSpec     `json:"spec"`
+}
+
+type routingResourceMetadata struct {
+	Name   string            `json:"name"`
+	Labels map[string]string `json:"labels"`
+}
+
+type routingResourceSpec struct {
+	Rules []struct {
+		Host string `json:"host"`
+	} `json:"rules"`
+	Hostnames []string `json:"hostnames"`
+	Listeners []struct {
+		Hostname string `json:"hostname"`
+	} `json:"listeners"`
+}
+
 // resolveIngressReadyHost selects the public host that was actually applied
 // to the deployment before falling back to the precomputed scenario host.
 func resolveIngressReadyHost(ctx context.Context, flags *config.RuntimeFlags, scenarioCtx *ScenarioContext) string {
@@ -49,58 +74,59 @@ func resolveIngressReadyHostWith(
 	flags *config.RuntimeFlags,
 	scenarioCtx *ScenarioContext,
 	getenv func(string) string,
-	lookupDeployedHost func(context.Context, string, string) string,
+	lookupDeployedHost func(context.Context, string, string, string) string,
 ) string {
-	if host := concreteRoutingHost(flags.Deployment.ExtraHelmSets["global.host"]); host != "" {
-		return host
-	}
-
-	deployedHost := lookupDeployedHost(ctx, flags.Test.KubeContext, scenarioCtx.Namespace)
+	deployedHost := lookupDeployedHost(ctx, flags.Test.KubeContext, scenarioCtx.Namespace, scenarioCtx.Release)
 	return config.FirstNonEmpty(
 		deployedHost,
-		scenarioCtx.IngressHost,
+		flags.Ingress.IngressHostname,
 		getenv("CAMUNDA_HOSTNAME"),
 		getenv("TEST_INGRESS_HOST"),
+		scenarioCtx.IngressHost,
 	)
 }
 
 // resolveDeployedRoutingHost discovers the first web hostname exposed by the
 // routing resources in a namespace. HTTPRoute is checked before Gateway so an
 // exact route hostname wins over a wildcard listener hostname.
-func resolveDeployedRoutingHost(ctx context.Context, kubeContext, namespace string) string {
+func resolveDeployedRoutingHost(ctx context.Context, kubeContext, namespace, release string) string {
 	lookupCtx, cancel := context.WithTimeout(ctx, routingHostLookupTimeout)
 	defer cancel()
-	return resolveDeployedRoutingHostWith(lookupCtx, kubeContext, namespace, runKubectlOutput)
+	return resolveDeployedRoutingHostWith(lookupCtx, kubeContext, namespace, release, runKubectlOutput)
 }
 
 func resolveDeployedRoutingHostWith(
 	ctx context.Context,
 	kubeContext,
-	namespace string,
+	namespace,
+	release string,
 	kubectlOutput kubectlOutputFunc,
 ) string {
-	queries := []struct {
-		resource string
-		jsonPath string
-	}{
-		{resource: "ingress", jsonPath: "{.items[*].spec.rules[*].host}"},
-		{resource: "httproute", jsonPath: "{.items[*].spec.hostnames[*]}"},
-		{resource: "gateway", jsonPath: "{.items[*].spec.listeners[*].hostname}"},
-	}
+	resources := []string{"ingress", "httproute", "gateway"}
 
-	for _, query := range queries {
+	for _, resource := range resources {
 		args := make([]string, 0, 7)
 		if kubeContext != "" {
 			args = append(args, "--context", kubeContext)
 		}
-		args = append(args, "-n", namespace, "get", query.resource, "--request-timeout=5s", "-o", "jsonpath="+query.jsonPath)
+		args = append(args, "-n", namespace, "get", resource, "--request-timeout=5s", "-o", "json")
 
 		out, err := kubectlOutput(ctx, args...)
 		if err != nil {
 			continue
 		}
-		if host := selectPrimaryRoutingHost(string(out)); host != "" {
-			return host
+
+		var resourceList routingResourceList
+		if err := json.Unmarshal(out, &resourceList); err != nil {
+			continue
+		}
+		for _, item := range resourceList.Items {
+			if !routingResourceOwnedByRelease(item.Metadata, release) {
+				continue
+			}
+			if host := selectPrimaryRoutingHost(strings.Join(routingResourceHosts(item.Spec), " ")); host != "" {
+				return host
+			}
 		}
 	}
 
@@ -109,6 +135,28 @@ func resolveDeployedRoutingHostWith(
 
 func runKubectlOutput(ctx context.Context, args ...string) ([]byte, error) {
 	return exec.CommandContext(ctx, "kubectl", args...).Output()
+}
+
+func routingResourceOwnedByRelease(metadata routingResourceMetadata, release string) bool {
+	if release == "" {
+		return false
+	}
+	if metadata.Labels["app.kubernetes.io/instance"] == release {
+		return true
+	}
+	return metadata.Name == release || strings.HasPrefix(metadata.Name, release+"-")
+}
+
+func routingResourceHosts(spec routingResourceSpec) []string {
+	hosts := make([]string, 0, len(spec.Rules)+len(spec.Hostnames)+len(spec.Listeners))
+	for _, rule := range spec.Rules {
+		hosts = append(hosts, rule.Host)
+	}
+	hosts = append(hosts, spec.Hostnames...)
+	for _, listener := range spec.Listeners {
+		hosts = append(hosts, listener.Hostname)
+	}
+	return hosts
 }
 
 func selectPrimaryRoutingHost(raw string) string {

--- a/scripts/deploy-camunda/deploy/ingress_ready.go
+++ b/scripts/deploy-camunda/deploy/ingress_ready.go
@@ -2,18 +2,20 @@ package deploy
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"os"
-	"os/exec"
 	"strings"
 	"time"
 
+	"scripts/camunda-core/pkg/kube"
 	"scripts/camunda-core/pkg/logging"
 	"scripts/deploy-camunda/config"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // ingressReadyPollInterval is the wait between reachability polls in executeDeployment.
@@ -37,31 +39,11 @@ type ingressReadyDeps struct {
 	sleep    func(ctx context.Context, d time.Duration) error
 }
 
-type kubectlOutputFunc func(ctx context.Context, args ...string) ([]byte, error)
-
-type routingResourceList struct {
-	Items []routingResource `json:"items"`
-}
-
-type routingResource struct {
-	Metadata routingResourceMetadata `json:"metadata"`
-	Spec     routingResourceSpec     `json:"spec"`
-}
-
-type routingResourceMetadata struct {
-	Name   string            `json:"name"`
-	Labels map[string]string `json:"labels"`
-}
-
-type routingResourceSpec struct {
-	Rules []struct {
-		Host string `json:"host"`
-	} `json:"rules"`
-	Hostnames []string `json:"hostnames"`
-	Listeners []struct {
-		Hostname string `json:"hostname"`
-	} `json:"listeners"`
-}
+type routingResourceLister func(
+	ctx context.Context,
+	namespace string,
+	resource schema.GroupVersionResource,
+) (*unstructured.UnstructuredList, error)
 
 // resolveIngressReadyHost selects the public host that was actually applied
 // to the deployment before falling back to the precomputed scenario host.
@@ -79,6 +61,8 @@ func resolveIngressReadyHostWith(
 	deployedHost := lookupDeployedHost(ctx, flags.Test.KubeContext, scenarioCtx.Namespace, scenarioCtx.Release)
 	return config.FirstNonEmpty(
 		deployedHost,
+		concreteRoutingHost(flags.Deployment.ExtraHelmSets["global.ingress.host"]),
+		concreteRoutingHost(flags.Deployment.ExtraHelmSets["global.host"]),
 		flags.Ingress.IngressHostname,
 		getenv("CAMUNDA_HOSTNAME"),
 		getenv("TEST_INGRESS_HOST"),
@@ -92,39 +76,36 @@ func resolveIngressReadyHostWith(
 func resolveDeployedRoutingHost(ctx context.Context, kubeContext, namespace, release string) string {
 	lookupCtx, cancel := context.WithTimeout(ctx, routingHostLookupTimeout)
 	defer cancel()
-	return resolveDeployedRoutingHostWith(lookupCtx, kubeContext, namespace, release, runKubectlOutput)
+
+	client, err := kube.NewClient("", kubeContext)
+	if err != nil {
+		return ""
+	}
+	return resolveDeployedRoutingHostWith(lookupCtx, namespace, release, client.ListNamespacedResources)
 }
 
 func resolveDeployedRoutingHostWith(
 	ctx context.Context,
-	kubeContext,
 	namespace,
 	release string,
-	kubectlOutput kubectlOutputFunc,
+	listResources routingResourceLister,
 ) string {
-	resources := []string{"ingress", "httproute", "gateway"}
+	resources := []schema.GroupVersionResource{
+		{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"},
+		{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "httproutes"},
+		{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gateways"},
+	}
 
 	for _, resource := range resources {
-		args := make([]string, 0, 7)
-		if kubeContext != "" {
-			args = append(args, "--context", kubeContext)
-		}
-		args = append(args, "-n", namespace, "get", resource, "--request-timeout=5s", "-o", "json")
-
-		out, err := kubectlOutput(ctx, args...)
+		resourceList, err := listResources(ctx, namespace, resource)
 		if err != nil {
 			continue
 		}
-
-		var resourceList routingResourceList
-		if err := json.Unmarshal(out, &resourceList); err != nil {
-			continue
-		}
 		for _, item := range resourceList.Items {
-			if !routingResourceOwnedByRelease(item.Metadata, release) {
+			if !routingResourceOwnedByRelease(item, release) {
 				continue
 			}
-			if host := selectPrimaryRoutingHost(strings.Join(routingResourceHosts(item.Spec), " ")); host != "" {
+			if host := selectPrimaryRoutingHost(strings.Join(routingResourceHosts(item), " ")); host != "" {
 				return host
 			}
 		}
@@ -133,28 +114,34 @@ func resolveDeployedRoutingHostWith(
 	return ""
 }
 
-func runKubectlOutput(ctx context.Context, args ...string) ([]byte, error) {
-	return exec.CommandContext(ctx, "kubectl", args...).Output()
-}
-
-func routingResourceOwnedByRelease(metadata routingResourceMetadata, release string) bool {
+func routingResourceOwnedByRelease(resource unstructured.Unstructured, release string) bool {
 	if release == "" {
 		return false
 	}
-	if metadata.Labels["app.kubernetes.io/instance"] == release {
+	if resource.GetLabels()["app.kubernetes.io/instance"] == release {
 		return true
 	}
-	return metadata.Name == release || strings.HasPrefix(metadata.Name, release+"-")
+	name := resource.GetName()
+	return name == release || strings.HasPrefix(name, release+"-")
 }
 
-func routingResourceHosts(spec routingResourceSpec) []string {
-	hosts := make([]string, 0, len(spec.Rules)+len(spec.Hostnames)+len(spec.Listeners))
-	for _, rule := range spec.Rules {
-		hosts = append(hosts, rule.Host)
+func routingResourceHosts(resource unstructured.Unstructured) []string {
+	hosts, _, _ := unstructured.NestedStringSlice(resource.Object, "spec", "hostnames")
+	rules, _, _ := unstructured.NestedSlice(resource.Object, "spec", "rules")
+	for _, rawRule := range rules {
+		if rule, ok := rawRule.(map[string]any); ok {
+			if host, ok := rule["host"].(string); ok {
+				hosts = append(hosts, host)
+			}
+		}
 	}
-	hosts = append(hosts, spec.Hostnames...)
-	for _, listener := range spec.Listeners {
-		hosts = append(hosts, listener.Hostname)
+	listeners, _, _ := unstructured.NestedSlice(resource.Object, "spec", "listeners")
+	for _, rawListener := range listeners {
+		if listener, ok := rawListener.(map[string]any); ok {
+			if host, ok := listener["hostname"].(string); ok {
+				hosts = append(hosts, host)
+			}
+		}
 	}
 	return hosts
 }

--- a/scripts/deploy-camunda/deploy/ingress_ready.go
+++ b/scripts/deploy-camunda/deploy/ingress_ready.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package deploy
 
 import (
@@ -54,10 +68,23 @@ func resolveIngressReadyHost(ctx context.Context, flags *config.RuntimeFlags, sc
 	}
 
 	deployedHost, err := resolveDeployedRoutingHost(ctx, flags.Test.KubeContext, scenarioCtx.Namespace, scenarioCtx.Release)
-	if err != nil {
-		return "", err
+	return resolveIngressReadyHostAfterLookup(flags, scenarioCtx, os.Getenv, deployedHost, err)
+}
+
+func resolveIngressReadyHostAfterLookup(
+	flags *config.RuntimeFlags,
+	scenarioCtx *ScenarioContext,
+	getenv func(string) string,
+	deployedHost string,
+	lookupErr error,
+) (string, error) {
+	if lookupErr != nil {
+		if host := configuredIngressReadyHostFallback(flags, getenv); host != "" {
+			return host, nil
+		}
+		return "", lookupErr
 	}
-	return ingressReadyHostFallback(flags, scenarioCtx, os.Getenv, deployedHost), nil
+	return ingressReadyHostFallback(flags, scenarioCtx, getenv, deployedHost), nil
 }
 
 func resolveIngressReadyHostWith(
@@ -83,11 +110,17 @@ func ingressReadyHostFallback(
 ) string {
 	return config.FirstNonEmpty(
 		deployedHost,
+		configuredIngressReadyHostFallback(flags, getenv),
+		scenarioCtx.IngressHost,
+	)
+}
+
+func configuredIngressReadyHostFallback(flags *config.RuntimeFlags, getenv func(string) string) string {
+	return config.FirstNonEmpty(
 		concreteRoutingHost(flags.Deployment.ExtraHelmSets["global.ingress.host"]),
 		concreteRoutingHost(flags.Deployment.ExtraHelmSets["global.host"]),
 		getenv("CAMUNDA_HOSTNAME"),
 		getenv("TEST_INGRESS_HOST"),
-		scenarioCtx.IngressHost,
 	)
 }
 

--- a/scripts/deploy-camunda/deploy/ingress_ready.go
+++ b/scripts/deploy-camunda/deploy/ingress_ready.go
@@ -14,6 +14,7 @@ import (
 	"scripts/camunda-core/pkg/logging"
 	"scripts/deploy-camunda/config"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -47,8 +48,16 @@ type routingResourceLister func(
 
 // resolveIngressReadyHost selects the public host that was actually applied
 // to the deployment before falling back to the precomputed scenario host.
-func resolveIngressReadyHost(ctx context.Context, flags *config.RuntimeFlags, scenarioCtx *ScenarioContext) string {
-	return resolveIngressReadyHostWith(ctx, flags, scenarioCtx, os.Getenv, resolveDeployedRoutingHost)
+func resolveIngressReadyHost(ctx context.Context, flags *config.RuntimeFlags, scenarioCtx *ScenarioContext) (string, error) {
+	if host := concreteRoutingHost(flags.Ingress.IngressHostname); host != "" {
+		return host, nil
+	}
+
+	deployedHost, err := resolveDeployedRoutingHost(ctx, flags.Test.KubeContext, scenarioCtx.Namespace, scenarioCtx.Release)
+	if err != nil {
+		return "", err
+	}
+	return ingressReadyHostFallback(flags, scenarioCtx, os.Getenv, deployedHost), nil
 }
 
 func resolveIngressReadyHostWith(
@@ -63,6 +72,15 @@ func resolveIngressReadyHostWith(
 	}
 
 	deployedHost := lookupDeployedHost(ctx, flags.Test.KubeContext, scenarioCtx.Namespace, scenarioCtx.Release)
+	return ingressReadyHostFallback(flags, scenarioCtx, getenv, deployedHost)
+}
+
+func ingressReadyHostFallback(
+	flags *config.RuntimeFlags,
+	scenarioCtx *ScenarioContext,
+	getenv func(string) string,
+	deployedHost string,
+) string {
 	return config.FirstNonEmpty(
 		deployedHost,
 		concreteRoutingHost(flags.Deployment.ExtraHelmSets["global.ingress.host"]),
@@ -76,13 +94,13 @@ func resolveIngressReadyHostWith(
 // resolveDeployedRoutingHost discovers the first web hostname exposed by the
 // routing resources in a namespace. HTTPRoute is checked before Gateway so an
 // exact route hostname wins over a wildcard listener hostname.
-func resolveDeployedRoutingHost(ctx context.Context, kubeContext, namespace, release string) string {
+func resolveDeployedRoutingHost(ctx context.Context, kubeContext, namespace, release string) (string, error) {
 	lookupCtx, cancel := context.WithTimeout(ctx, routingHostLookupTimeout)
 	defer cancel()
 
 	client, err := kube.NewClient("", kubeContext)
 	if err != nil {
-		return ""
+		return "", fmt.Errorf("create Kubernetes client for readiness host discovery: %w", err)
 	}
 	return resolveDeployedRoutingHostWith(lookupCtx, namespace, release, client.ListNamespacedResources)
 }
@@ -92,16 +110,20 @@ func resolveDeployedRoutingHostWith(
 	namespace,
 	release string,
 	listResources routingResourceLister,
-) string {
+) (string, error) {
 	resources := []schema.GroupVersionResource{
 		{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"},
 		{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "httproutes"},
 		{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gateways"},
 	}
 
+	var forbiddenErr error
 	for _, resource := range resources {
 		resourceList, err := listResources(ctx, namespace, resource)
 		if err != nil {
+			if apierrors.IsForbidden(err) && forbiddenErr == nil {
+				forbiddenErr = fmt.Errorf("list %s while resolving readiness host in namespace %q: %w", resource.Resource, namespace, err)
+			}
 			continue
 		}
 		for _, item := range resourceList.Items {
@@ -109,12 +131,12 @@ func resolveDeployedRoutingHostWith(
 				continue
 			}
 			if host := selectPrimaryRoutingHost(strings.Join(routingResourceHosts(item), " ")); host != "" {
-				return host
+				return host, nil
 			}
 		}
 	}
 
-	return ""
+	return "", forbiddenErr
 }
 
 func routingResourceOwnedByRelease(resource unstructured.Unstructured, release string) bool {
@@ -125,7 +147,7 @@ func routingResourceOwnedByRelease(resource unstructured.Unstructured, release s
 		return true
 	}
 	name := resource.GetName()
-	return name == release || strings.HasPrefix(name, release+"-")
+	return name == release || name == release+"-camunda-platform"
 }
 
 func routingResourceHosts(resource unstructured.Unstructured) []string {

--- a/scripts/deploy-camunda/deploy/ingress_ready.go
+++ b/scripts/deploy-camunda/deploy/ingress_ready.go
@@ -51,7 +51,7 @@ func resolveIngressReadyHostWith(
 	getenv func(string) string,
 	lookupDeployedHost func(context.Context, string, string) string,
 ) string {
-	if host := config.FirstNonEmpty(flags.Deployment.ExtraHelmSets["global.host"]); host != "" {
+	if host := concreteRoutingHost(flags.Deployment.ExtraHelmSets["global.host"]); host != "" {
 		return host
 	}
 
@@ -113,6 +113,9 @@ func runKubectlOutput(ctx context.Context, args ...string) ([]byte, error) {
 
 func selectPrimaryRoutingHost(raw string) string {
 	for _, host := range strings.Fields(raw) {
+		if concreteRoutingHost(host) == "" {
+			continue
+		}
 		firstLabel := strings.ToLower(strings.SplitN(host, ".", 2)[0])
 		if firstLabel == "grpc" || firstLabel == "zeebe" || firstLabel == "actuator" ||
 			strings.HasPrefix(firstLabel, "grpc-") ||
@@ -123,6 +126,14 @@ func selectPrimaryRoutingHost(raw string) string {
 		return host
 	}
 	return ""
+}
+
+func concreteRoutingHost(raw string) string {
+	host := strings.TrimSpace(raw)
+	if host == "" || strings.Contains(host, "{{") || strings.Contains(host, "}}") || strings.Contains(host, "*") {
+		return ""
+	}
+	return host
 }
 
 // waitIngressReady polls host until it is both publicly DNS-resolvable and

--- a/scripts/deploy-camunda/deploy/ingress_ready.go
+++ b/scripts/deploy-camunda/deploy/ingress_ready.go
@@ -63,10 +63,6 @@ type routingResourceLister func(
 // resolveIngressReadyHost selects the public host that was actually applied
 // to the deployment before falling back to the precomputed scenario host.
 func resolveIngressReadyHost(ctx context.Context, flags *config.RuntimeFlags, scenarioCtx *ScenarioContext) (string, error) {
-	if host := concreteRoutingHost(flags.Ingress.IngressHostname); host != "" {
-		return host, nil
-	}
-
 	deployedHost, err := resolveDeployedRoutingHost(ctx, flags.Test.KubeContext, scenarioCtx.Namespace, scenarioCtx.Release)
 	return resolveIngressReadyHostAfterLookup(flags, scenarioCtx, os.Getenv, deployedHost, err)
 }
@@ -79,6 +75,9 @@ func resolveIngressReadyHostAfterLookup(
 	lookupErr error,
 ) (string, error) {
 	if lookupErr != nil {
+		if !apierrors.IsForbidden(lookupErr) {
+			return "", lookupErr
+		}
 		if host := configuredIngressReadyHostFallback(flags, getenv); host != "" {
 			return host, nil
 		}
@@ -94,10 +93,6 @@ func resolveIngressReadyHostWith(
 	getenv func(string) string,
 	lookupDeployedHost func(context.Context, string, string, string) string,
 ) string {
-	if host := concreteRoutingHost(flags.Ingress.IngressHostname); host != "" {
-		return host
-	}
-
 	deployedHost := lookupDeployedHost(ctx, flags.Test.KubeContext, scenarioCtx.Namespace, scenarioCtx.Release)
 	return ingressReadyHostFallback(flags, scenarioCtx, getenv, deployedHost)
 }
@@ -119,6 +114,7 @@ func configuredIngressReadyHostFallback(flags *config.RuntimeFlags, getenv func(
 	return config.FirstNonEmpty(
 		concreteRoutingHost(flags.Deployment.ExtraHelmSets["global.ingress.host"]),
 		concreteRoutingHost(flags.Deployment.ExtraHelmSets["global.host"]),
+		concreteRoutingHost(flags.Ingress.IngressHostname),
 		getenv("CAMUNDA_HOSTNAME"),
 		getenv("TEST_INGRESS_HOST"),
 	)
@@ -150,12 +146,20 @@ func resolveDeployedRoutingHostWith(
 		{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gateways"},
 	}
 
-	var forbiddenErr error
+	var forbiddenErr, discoveryErr error
 	for _, resource := range resources {
 		resourceList, err := listResources(ctx, namespace, resource)
 		if err != nil {
-			if apierrors.IsForbidden(err) && forbiddenErr == nil {
-				forbiddenErr = fmt.Errorf("list %s while resolving readiness host in namespace %q: %w", resource.Resource, namespace, err)
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			wrappedErr := fmt.Errorf("list %s while resolving readiness host in namespace %q: %w", resource.Resource, namespace, err)
+			if apierrors.IsForbidden(err) {
+				if forbiddenErr == nil {
+					forbiddenErr = wrappedErr
+				}
+			} else if discoveryErr == nil {
+				discoveryErr = wrappedErr
 			}
 			continue
 		}
@@ -169,6 +173,9 @@ func resolveDeployedRoutingHostWith(
 		}
 	}
 
+	if discoveryErr != nil {
+		return "", discoveryErr
+	}
 	return "", forbiddenErr
 }
 
@@ -315,6 +322,7 @@ func waitIngressReadyWithDeps(ctx context.Context, deps ingressReadyDeps, host s
 		}
 	}
 }
+
 // probeIngressOnce runs one DNS + HTTPS attempt bounded by perAttemptCap.
 // It returns (nil, nil) on success; otherwise the DNS and/or HTTP error seen.
 func probeIngressOnce(loopCtx context.Context, deps ingressReadyDeps, host string, perAttemptCap time.Duration, attempt int, start time.Time) (dnsErr, httpErr error) {

--- a/scripts/deploy-camunda/deploy/ingress_ready.go
+++ b/scripts/deploy-camunda/deploy/ingress_ready.go
@@ -6,15 +6,19 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
 
 	"scripts/camunda-core/pkg/logging"
+	"scripts/deploy-camunda/config"
 )
 
 // ingressReadyPollInterval is the wait between reachability polls in executeDeployment.
 const ingressReadyPollInterval = 15 * time.Second
+
+const routingHostLookupTimeout = 10 * time.Second
 
 // hostResolver abstracts DNS resolution so tests can inject a fake without
 // touching the network. net.Resolver satisfies this via LookupHost.
@@ -30,6 +34,95 @@ type ingressReadyDeps struct {
 	resolver hostResolver
 	client   *http.Client
 	sleep    func(ctx context.Context, d time.Duration) error
+}
+
+type kubectlOutputFunc func(ctx context.Context, args ...string) ([]byte, error)
+
+// resolveIngressReadyHost selects the public host that was actually applied
+// to the deployment before falling back to the precomputed scenario host.
+func resolveIngressReadyHost(ctx context.Context, flags *config.RuntimeFlags, scenarioCtx *ScenarioContext) string {
+	return resolveIngressReadyHostWith(ctx, flags, scenarioCtx, os.Getenv, resolveDeployedRoutingHost)
+}
+
+func resolveIngressReadyHostWith(
+	ctx context.Context,
+	flags *config.RuntimeFlags,
+	scenarioCtx *ScenarioContext,
+	getenv func(string) string,
+	lookupDeployedHost func(context.Context, string, string) string,
+) string {
+	if host := config.FirstNonEmpty(flags.Deployment.ExtraHelmSets["global.host"]); host != "" {
+		return host
+	}
+
+	deployedHost := lookupDeployedHost(ctx, flags.Test.KubeContext, scenarioCtx.Namespace)
+	return config.FirstNonEmpty(
+		deployedHost,
+		scenarioCtx.IngressHost,
+		getenv("CAMUNDA_HOSTNAME"),
+		getenv("TEST_INGRESS_HOST"),
+	)
+}
+
+// resolveDeployedRoutingHost discovers the first web hostname exposed by the
+// routing resources in a namespace. HTTPRoute is checked before Gateway so an
+// exact route hostname wins over a wildcard listener hostname.
+func resolveDeployedRoutingHost(ctx context.Context, kubeContext, namespace string) string {
+	lookupCtx, cancel := context.WithTimeout(ctx, routingHostLookupTimeout)
+	defer cancel()
+	return resolveDeployedRoutingHostWith(lookupCtx, kubeContext, namespace, runKubectlOutput)
+}
+
+func resolveDeployedRoutingHostWith(
+	ctx context.Context,
+	kubeContext,
+	namespace string,
+	kubectlOutput kubectlOutputFunc,
+) string {
+	queries := []struct {
+		resource string
+		jsonPath string
+	}{
+		{resource: "ingress", jsonPath: "{.items[*].spec.rules[*].host}"},
+		{resource: "httproute", jsonPath: "{.items[*].spec.hostnames[*]}"},
+		{resource: "gateway", jsonPath: "{.items[*].spec.listeners[*].hostname}"},
+	}
+
+	for _, query := range queries {
+		args := make([]string, 0, 7)
+		if kubeContext != "" {
+			args = append(args, "--context", kubeContext)
+		}
+		args = append(args, "-n", namespace, "get", query.resource, "--request-timeout=5s", "-o", "jsonpath="+query.jsonPath)
+
+		out, err := kubectlOutput(ctx, args...)
+		if err != nil {
+			continue
+		}
+		if host := selectPrimaryRoutingHost(string(out)); host != "" {
+			return host
+		}
+	}
+
+	return ""
+}
+
+func runKubectlOutput(ctx context.Context, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, "kubectl", args...).Output()
+}
+
+func selectPrimaryRoutingHost(raw string) string {
+	for _, host := range strings.Fields(raw) {
+		firstLabel := strings.ToLower(strings.SplitN(host, ".", 2)[0])
+		if firstLabel == "grpc" || firstLabel == "zeebe" || firstLabel == "actuator" ||
+			strings.HasPrefix(firstLabel, "grpc-") ||
+			strings.HasPrefix(firstLabel, "zeebe-") ||
+			strings.HasPrefix(firstLabel, "actuator-") {
+			continue
+		}
+		return host
+	}
+	return ""
 }
 
 // waitIngressReady polls host until it is both publicly DNS-resolvable and
@@ -118,41 +211,6 @@ func waitIngressReadyWithDeps(ctx context.Context, deps ingressReadyDeps, host s
 		}
 	}
 }
-
-// resolveDeployedIngressHost reads the primary web host from the Ingress
-// objects helm just created in namespace, so the readiness gate probes the
-// host actually served (and published to DNS) rather than a computed
-// <namespace>.<base-domain> value that CI overrides via global.host. Returns
-// "" on any error or when no primary host is found, so callers fall back to
-// their computed host.
-func resolveDeployedIngressHost(ctx context.Context, kubeContext, namespace string) string {
-	args := []string{}
-	if kubeContext != "" {
-		args = append(args, "--context", kubeContext)
-	}
-	args = append(args, "-n", namespace, "get", "ingress",
-		"-o", "jsonpath={.items[*].spec.rules[*].host}")
-	out, err := exec.CommandContext(ctx, "kubectl", args...).Output()
-	if err != nil {
-		return ""
-	}
-	return selectPrimaryIngressHost(string(out))
-}
-
-// selectPrimaryIngressHost picks the primary web host from whitespace-separated
-// ingress host tokens, skipping the gRPC/Zeebe/actuator sub-hosts, and returns
-// the first match ("" if none). Kept pure so it is unit-testable without
-// shelling out to kubectl.
-func selectPrimaryIngressHost(raw string) string {
-	for _, h := range strings.Fields(raw) {
-		if strings.Contains(h, "zeebe") || strings.Contains(h, "grpc") || strings.Contains(h, "actuator") {
-			continue
-		}
-		return h
-	}
-	return ""
-}
-
 // probeIngressOnce runs one DNS + HTTPS attempt bounded by perAttemptCap.
 // It returns (nil, nil) on success; otherwise the DNS and/or HTTP error seen.
 func probeIngressOnce(loopCtx context.Context, deps ingressReadyDeps, host string, perAttemptCap time.Duration, attempt int, start time.Time) (dnsErr, httpErr error) {

--- a/scripts/deploy-camunda/deploy/ingress_ready_test.go
+++ b/scripts/deploy-camunda/deploy/ingress_ready_test.go
@@ -58,13 +58,13 @@ func noSleep(ctx context.Context, _ time.Duration) error {
 }
 
 func TestResolveIngressReadyHostWith(t *testing.T) {
-	t.Run("applied global host wins without querying the cluster", func(t *testing.T) {
+	t.Run("rendered routing host wins over raw Helm and computed hosts", func(t *testing.T) {
 		flags := &config.RuntimeFlags{
 			Deployment: config.DeploymentFlags{
-				ExtraHelmSets: map[string]string{"global.host": "applied.example.com"},
+				ExtraHelmSets: map[string]string{"global.host": "stale.example.com"},
 			},
 		}
-		scenarioCtx := &ScenarioContext{Namespace: "test", IngressHost: "computed.example.com"}
+		scenarioCtx := &ScenarioContext{Namespace: "test", Release: "integration", IngressHost: "computed.example.com"}
 		lookupCalled := false
 
 		got := resolveIngressReadyHostWith(
@@ -72,32 +72,38 @@ func TestResolveIngressReadyHostWith(t *testing.T) {
 			flags,
 			scenarioCtx,
 			func(string) string { return "env.example.com" },
-			func(context.Context, string, string) string {
+			func(_ context.Context, _, _, release string) string {
 				lookupCalled = true
-				return "deployed.example.com"
+				if release != "integration" {
+					t.Fatalf("lookup called with release %q", release)
+				}
+				return "rendered.example.com"
 			},
 		)
 
-		if got != "applied.example.com" {
-			t.Fatalf("resolveIngressReadyHostWith() = %q, want applied host", got)
+		if got != "rendered.example.com" {
+			t.Fatalf("resolveIngressReadyHostWith() = %q, want rendered host", got)
 		}
-		if lookupCalled {
-			t.Fatal("cluster lookup should not run when global.host was applied explicitly")
+		if !lookupCalled {
+			t.Fatal("cluster lookup should determine the effective rendered host")
 		}
 	})
 
 	t.Run("deployed routing host wins over computed and environment hosts", func(t *testing.T) {
 		flags := &config.RuntimeFlags{Test: config.TestFlags{KubeContext: "cluster"}}
-		scenarioCtx := &ScenarioContext{Namespace: "test", IngressHost: "computed.example.com"}
+		scenarioCtx := &ScenarioContext{Namespace: "test", Release: "integration", IngressHost: "computed.example.com"}
 
 		got := resolveIngressReadyHostWith(
 			context.Background(),
 			flags,
 			scenarioCtx,
 			func(string) string { return "env.example.com" },
-			func(_ context.Context, kubeContext, namespace string) string {
+			func(_ context.Context, kubeContext, namespace, release string) string {
 				if kubeContext != "cluster" || namespace != "test" {
 					t.Fatalf("lookup called with context=%q namespace=%q", kubeContext, namespace)
+				}
+				if release != "integration" {
+					t.Fatalf("lookup called with release=%q", release)
 				}
 				return "gateway.example.com"
 			},
@@ -114,7 +120,7 @@ func TestResolveIngressReadyHostWith(t *testing.T) {
 				ExtraHelmSets: map[string]string{"global.host": "{{ .Release.Name }}.example.com"},
 			},
 		}
-		scenarioCtx := &ScenarioContext{Namespace: "test", IngressHost: "computed.example.com"}
+		scenarioCtx := &ScenarioContext{Namespace: "test", Release: "integration", IngressHost: "computed.example.com"}
 		lookupCalled := false
 
 		got := resolveIngressReadyHostWith(
@@ -122,7 +128,7 @@ func TestResolveIngressReadyHostWith(t *testing.T) {
 			flags,
 			scenarioCtx,
 			func(string) string { return "env.example.com" },
-			func(context.Context, string, string) string {
+			func(context.Context, string, string, string) string {
 				lookupCalled = true
 				return "rendered.example.com"
 			},
@@ -136,16 +142,33 @@ func TestResolveIngressReadyHostWith(t *testing.T) {
 		}
 	})
 
-	t.Run("computed host remains the fallback when no deployed host is found", func(t *testing.T) {
+	t.Run("environment host wins over computed fallback when no deployed host is found", func(t *testing.T) {
 		flags := &config.RuntimeFlags{}
-		scenarioCtx := &ScenarioContext{Namespace: "test", IngressHost: "computed.example.com"}
+		scenarioCtx := &ScenarioContext{Namespace: "test", Release: "integration", IngressHost: "computed.example.com"}
 
 		got := resolveIngressReadyHostWith(
 			context.Background(),
 			flags,
 			scenarioCtx,
 			func(string) string { return "env.example.com" },
-			func(context.Context, string, string) string { return "" },
+			func(context.Context, string, string, string) string { return "" },
+		)
+
+		if got != "env.example.com" {
+			t.Fatalf("resolveIngressReadyHostWith() = %q, want environment host", got)
+		}
+	})
+
+	t.Run("computed host remains the final fallback", func(t *testing.T) {
+		flags := &config.RuntimeFlags{}
+		scenarioCtx := &ScenarioContext{Namespace: "test", Release: "integration", IngressHost: "computed.example.com"}
+
+		got := resolveIngressReadyHostWith(
+			context.Background(),
+			flags,
+			scenarioCtx,
+			func(string) string { return "" },
+			func(context.Context, string, string, string) string { return "" },
 		)
 
 		if got != "computed.example.com" {
@@ -163,22 +186,32 @@ func TestResolveDeployedRoutingHostWith(t *testing.T) {
 	}{
 		{
 			name:    "classic ingress host wins",
-			outputs: map[string]string{"ingress": "grpc-app.example.com app.example.com"},
+			outputs: map[string]string{"ingress": routingListJSON("integration-http", "integration", `"rules":[{"host":"grpc-app.example.com"},{"host":"app.example.com"}]`)},
 			want:    "app.example.com",
+		},
+		{
+			name: "unrelated routing resources are ignored",
+			outputs: map[string]string{
+				"ingress": routingItemsJSON(
+					routingItemJSON("companion", "companion", `"rules":[{"host":"unrelated.example.com"}]`),
+					routingItemJSON("integration-http", "integration", `"rules":[{"host":"app.example.com"}]`),
+				),
+			},
+			want: "app.example.com",
 		},
 		{
 			name: "HTTPRoute host is used when ingress is empty",
 			outputs: map[string]string{
-				"ingress":   "",
-				"httproute": "grpc-app.example.com route.example.com",
+				"ingress":   `{"items":[]}`,
+				"httproute": routingListJSON("integration-orchestration", "integration", `"hostnames":["grpc-app.example.com","route.example.com"]`),
 			},
 			want: "route.example.com",
 		},
 		{
 			name: "Gateway listener host is used when ingress and HTTPRoute are unavailable",
 			outputs: map[string]string{
-				"ingress": "",
-				"gateway": "grpc-app.example.com gateway.example.com",
+				"ingress": `{"items":[]}`,
+				"gateway": routingListJSON("integration-camunda-platform", "", `"listeners":[{"hostname":"grpc-app.example.com"},{"hostname":"gateway.example.com"}]`),
 			},
 			errors: map[string]error{"httproute": errors.New("resource unavailable")},
 			want:   "gateway.example.com",
@@ -202,12 +235,28 @@ func TestResolveDeployedRoutingHostWith(t *testing.T) {
 				return []byte(tt.outputs[resource]), nil
 			}
 
-			got := resolveDeployedRoutingHostWith(context.Background(), "cluster", "test", kubectlOutput)
+			got := resolveDeployedRoutingHostWith(context.Background(), "cluster", "test", "integration", kubectlOutput)
 			if got != tt.want {
 				t.Fatalf("resolveDeployedRoutingHostWith() = %q, want %q (calls: %v)", got, tt.want, calls)
 			}
 		})
 	}
+}
+
+func routingListJSON(name, release, specFields string) string {
+	return routingItemsJSON(routingItemJSON(name, release, specFields))
+}
+
+func routingItemsJSON(items ...string) string {
+	return fmt.Sprintf(`{"items":[%s]}`, strings.Join(items, ","))
+}
+
+func routingItemJSON(name, release, specFields string) string {
+	labels := "{}"
+	if release != "" {
+		labels = fmt.Sprintf(`{"app.kubernetes.io/instance":%q}`, release)
+	}
+	return fmt.Sprintf(`{"metadata":{"name":%q,"labels":%s},"spec":{%s}}`, name, labels, specFields)
 }
 
 func TestSelectPrimaryRoutingHost(t *testing.T) {

--- a/scripts/deploy-camunda/deploy/ingress_ready_test.go
+++ b/scripts/deploy-camunda/deploy/ingress_ready_test.go
@@ -17,7 +17,6 @@ package deploy
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -26,6 +25,9 @@ import (
 	"time"
 
 	"scripts/deploy-camunda/config"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // fakeResolver returns a canned result for every LookupHost call, tracking how
@@ -159,6 +161,51 @@ func TestResolveIngressReadyHostWith(t *testing.T) {
 		}
 	})
 
+	t.Run("concrete configured host remains a fallback when discovery fails", func(t *testing.T) {
+		flags := &config.RuntimeFlags{
+			Deployment: config.DeploymentFlags{
+				ExtraHelmSets: map[string]string{"global.host": "configured.example.com"},
+			},
+		}
+		scenarioCtx := &ScenarioContext{Namespace: "test", Release: "integration", IngressHost: "computed.example.com"}
+
+		got := resolveIngressReadyHostWith(
+			context.Background(),
+			flags,
+			scenarioCtx,
+			func(string) string { return "env.example.com" },
+			func(context.Context, string, string, string) string { return "" },
+		)
+
+		if got != "configured.example.com" {
+			t.Fatalf("resolveIngressReadyHostWith() = %q, want configured host", got)
+		}
+	})
+
+	t.Run("legacy ingress host takes precedence in configured fallbacks", func(t *testing.T) {
+		flags := &config.RuntimeFlags{
+			Deployment: config.DeploymentFlags{
+				ExtraHelmSets: map[string]string{
+					"global.host":         "current.example.com",
+					"global.ingress.host": "legacy.example.com",
+				},
+			},
+		}
+		scenarioCtx := &ScenarioContext{Namespace: "test", Release: "integration"}
+
+		got := resolveIngressReadyHostWith(
+			context.Background(),
+			flags,
+			scenarioCtx,
+			func(string) string { return "" },
+			func(context.Context, string, string, string) string { return "" },
+		)
+
+		if got != "legacy.example.com" {
+			t.Fatalf("resolveIngressReadyHostWith() = %q, want legacy host", got)
+		}
+	})
+
 	t.Run("computed host remains the final fallback", func(t *testing.T) {
 		flags := &config.RuntimeFlags{}
 		scenarioCtx := &ScenarioContext{Namespace: "test", Release: "integration", IngressHost: "computed.example.com"}
@@ -180,45 +227,57 @@ func TestResolveIngressReadyHostWith(t *testing.T) {
 func TestResolveDeployedRoutingHostWith(t *testing.T) {
 	tests := []struct {
 		name    string
-		outputs map[string]string
+		outputs map[string][]unstructured.Unstructured
 		errors  map[string]error
 		want    string
 	}{
 		{
-			name:    "classic ingress host wins",
-			outputs: map[string]string{"ingress": routingListJSON("integration-http", "integration", `"rules":[{"host":"grpc-app.example.com"},{"host":"app.example.com"}]`)},
-			want:    "app.example.com",
+			name: "classic ingress host wins",
+			outputs: map[string][]unstructured.Unstructured{
+				"ingresses": {routingObject("integration-http", "integration", map[string]any{
+					"rules": []any{
+						map[string]any{"host": "grpc-app.example.com"},
+						map[string]any{"host": "app.example.com"},
+					},
+				})},
+			},
+			want: "app.example.com",
 		},
 		{
 			name: "unrelated routing resources are ignored",
-			outputs: map[string]string{
-				"ingress": routingItemsJSON(
-					routingItemJSON("companion", "companion", `"rules":[{"host":"unrelated.example.com"}]`),
-					routingItemJSON("integration-http", "integration", `"rules":[{"host":"app.example.com"}]`),
-				),
+			outputs: map[string][]unstructured.Unstructured{
+				"ingresses": {
+					routingObject("companion", "companion", map[string]any{"rules": []any{map[string]any{"host": "unrelated.example.com"}}}),
+					routingObject("integration-http", "integration", map[string]any{"rules": []any{map[string]any{"host": "app.example.com"}}}),
+				},
 			},
 			want: "app.example.com",
 		},
 		{
 			name: "HTTPRoute host is used when ingress is empty",
-			outputs: map[string]string{
-				"ingress":   `{"items":[]}`,
-				"httproute": routingListJSON("integration-orchestration", "integration", `"hostnames":["grpc-app.example.com","route.example.com"]`),
+			outputs: map[string][]unstructured.Unstructured{
+				"httproutes": {routingObject("integration-orchestration", "integration", map[string]any{
+					"hostnames": []any{"grpc-app.example.com", "route.example.com"},
+				})},
 			},
 			want: "route.example.com",
 		},
 		{
 			name: "Gateway listener host is used when ingress and HTTPRoute are unavailable",
-			outputs: map[string]string{
-				"ingress": `{"items":[]}`,
-				"gateway": routingListJSON("integration-camunda-platform", "", `"listeners":[{"hostname":"grpc-app.example.com"},{"hostname":"gateway.example.com"}]`),
+			outputs: map[string][]unstructured.Unstructured{
+				"gateways": {routingObject("integration-camunda-platform", "", map[string]any{
+					"listeners": []any{
+						map[string]any{"hostname": "grpc-app.example.com"},
+						map[string]any{"hostname": "gateway.example.com"},
+					},
+				})},
 			},
-			errors: map[string]error{"httproute": errors.New("resource unavailable")},
+			errors: map[string]error{"httproutes": errors.New("resource unavailable")},
 			want:   "gateway.example.com",
 		},
 		{
 			name:   "no routing host returns empty",
-			errors: map[string]error{"ingress": errors.New("not found"), "httproute": errors.New("not found"), "gateway": errors.New("not found")},
+			errors: map[string]error{"ingresses": errors.New("not found"), "httproutes": errors.New("not found"), "gateways": errors.New("not found")},
 			want:   "",
 		},
 	}
@@ -226,16 +285,22 @@ func TestResolveDeployedRoutingHostWith(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var calls []string
-			kubectlOutput := func(_ context.Context, args ...string) ([]byte, error) {
-				resource := resourceAfterGet(args)
-				calls = append(calls, resource)
-				if err := tt.errors[resource]; err != nil {
+			listResources := func(
+				_ context.Context,
+				namespace string,
+				resource schema.GroupVersionResource,
+			) (*unstructured.UnstructuredList, error) {
+				calls = append(calls, resource.Resource)
+				if namespace != "test" {
+					t.Fatalf("namespace = %q, want test", namespace)
+				}
+				if err := tt.errors[resource.Resource]; err != nil {
 					return nil, err
 				}
-				return []byte(tt.outputs[resource]), nil
+				return &unstructured.UnstructuredList{Items: tt.outputs[resource.Resource]}, nil
 			}
 
-			got := resolveDeployedRoutingHostWith(context.Background(), "cluster", "test", "integration", kubectlOutput)
+			got := resolveDeployedRoutingHostWith(context.Background(), "test", "integration", listResources)
 			if got != tt.want {
 				t.Fatalf("resolveDeployedRoutingHostWith() = %q, want %q (calls: %v)", got, tt.want, calls)
 			}
@@ -243,20 +308,15 @@ func TestResolveDeployedRoutingHostWith(t *testing.T) {
 	}
 }
 
-func routingListJSON(name, release, specFields string) string {
-	return routingItemsJSON(routingItemJSON(name, release, specFields))
-}
-
-func routingItemsJSON(items ...string) string {
-	return fmt.Sprintf(`{"items":[%s]}`, strings.Join(items, ","))
-}
-
-func routingItemJSON(name, release, specFields string) string {
-	labels := "{}"
+func routingObject(name, release string, spec map[string]any) unstructured.Unstructured {
+	labels := map[string]any{}
 	if release != "" {
-		labels = fmt.Sprintf(`{"app.kubernetes.io/instance":%q}`, release)
+		labels["app.kubernetes.io/instance"] = release
 	}
-	return fmt.Sprintf(`{"metadata":{"name":%q,"labels":%s},"spec":{%s}}`, name, labels, specFields)
+	return unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{"name": name, "labels": labels},
+		"spec":     spec,
+	}}
 }
 
 func TestSelectPrimaryRoutingHost(t *testing.T) {
@@ -276,15 +336,6 @@ func TestSelectPrimaryRoutingHost(t *testing.T) {
 			t.Errorf("selectPrimaryRoutingHost(%q) = %q, want %q", tt.raw, got, tt.want)
 		}
 	}
-}
-
-func resourceAfterGet(args []string) string {
-	for i, arg := range args {
-		if arg == "get" && i+1 < len(args) {
-			return args[i+1]
-		}
-	}
-	return fmt.Sprintf("missing-get-resource:%v", args)
 }
 
 func TestWaitIngressReadyWithDeps(t *testing.T) {

--- a/scripts/deploy-camunda/deploy/ingress_ready_test.go
+++ b/scripts/deploy-camunda/deploy/ingress_ready_test.go
@@ -26,6 +26,7 @@ import (
 
 	"scripts/deploy-camunda/config"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -256,6 +257,7 @@ func TestResolveDeployedRoutingHostWith(t *testing.T) {
 		outputs map[string][]unstructured.Unstructured
 		errors  map[string]error
 		want    string
+		wantErr bool
 	}{
 		{
 			name: "classic ingress host wins",
@@ -274,6 +276,7 @@ func TestResolveDeployedRoutingHostWith(t *testing.T) {
 			outputs: map[string][]unstructured.Unstructured{
 				"ingresses": {
 					routingObject("companion", "companion", map[string]any{"rules": []any{map[string]any{"host": "unrelated.example.com"}}}),
+					routingObject("integration-companion", "", map[string]any{"rules": []any{map[string]any{"host": "prefix.example.com"}}}),
 					routingObject("integration-http", "integration", map[string]any{"rules": []any{map[string]any{"host": "app.example.com"}}}),
 				},
 			},
@@ -285,6 +288,18 @@ func TestResolveDeployedRoutingHostWith(t *testing.T) {
 				"httproutes": {routingObject("integration-orchestration", "integration", map[string]any{
 					"hostnames": []any{"grpc-app.example.com", "route.example.com"},
 				})},
+			},
+			want: "route.example.com",
+		},
+		{
+			name: "owned route wins despite forbidden lookup for another resource type",
+			outputs: map[string][]unstructured.Unstructured{
+				"httproutes": {routingObject("integration-orchestration", "integration", map[string]any{
+					"hostnames": []any{"route.example.com"},
+				})},
+			},
+			errors: map[string]error{
+				"ingresses": apierrors.NewForbidden(schema.GroupResource{Group: "networking.k8s.io", Resource: "ingresses"}, "", errors.New("denied")),
 			},
 			want: "route.example.com",
 		},
@@ -306,6 +321,13 @@ func TestResolveDeployedRoutingHostWith(t *testing.T) {
 			errors: map[string]error{"ingresses": errors.New("not found"), "httproutes": errors.New("not found"), "gateways": errors.New("not found")},
 			want:   "",
 		},
+		{
+			name: "forbidden discovery without an owned route returns an error",
+			errors: map[string]error{
+				"ingresses": apierrors.NewForbidden(schema.GroupResource{Group: "networking.k8s.io", Resource: "ingresses"}, "", errors.New("denied")),
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -326,7 +348,16 @@ func TestResolveDeployedRoutingHostWith(t *testing.T) {
 				return &unstructured.UnstructuredList{Items: tt.outputs[resource.Resource]}, nil
 			}
 
-			got := resolveDeployedRoutingHostWith(context.Background(), "test", "integration", listResources)
+			got, err := resolveDeployedRoutingHostWith(context.Background(), "test", "integration", listResources)
+			if tt.wantErr {
+				if !apierrors.IsForbidden(err) {
+					t.Fatalf("resolveDeployedRoutingHostWith() error = %v, want Forbidden", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveDeployedRoutingHostWith() unexpected error = %v", err)
+			}
 			if got != tt.want {
 				t.Fatalf("resolveDeployedRoutingHostWith() = %q, want %q (calls: %v)", got, tt.want, calls)
 			}

--- a/scripts/deploy-camunda/deploy/ingress_ready_test.go
+++ b/scripts/deploy-camunda/deploy/ingress_ready_test.go
@@ -60,6 +60,32 @@ func noSleep(ctx context.Context, _ time.Duration) error {
 }
 
 func TestResolveIngressReadyHostWith(t *testing.T) {
+	t.Run("explicit ingress hostname remains the full override", func(t *testing.T) {
+		flags := &config.RuntimeFlags{
+			Ingress: config.IngressFlags{IngressHostname: "override.example.com"},
+		}
+		scenarioCtx := &ScenarioContext{Namespace: "test", Release: "integration", IngressHost: "computed.example.com"}
+		lookupCalled := false
+
+		got := resolveIngressReadyHostWith(
+			context.Background(),
+			flags,
+			scenarioCtx,
+			func(string) string { return "env.example.com" },
+			func(context.Context, string, string, string) string {
+				lookupCalled = true
+				return "rendered.example.com"
+			},
+		)
+
+		if got != "override.example.com" {
+			t.Fatalf("resolveIngressReadyHostWith() = %q, want explicit override", got)
+		}
+		if lookupCalled {
+			t.Fatal("cluster lookup should not run when --ingress-hostname is set")
+		}
+	})
+
 	t.Run("rendered routing host wins over raw Helm and computed hosts", func(t *testing.T) {
 		flags := &config.RuntimeFlags{
 			Deployment: config.DeploymentFlags{

--- a/scripts/deploy-camunda/deploy/ingress_ready_test.go
+++ b/scripts/deploy-camunda/deploy/ingress_ready_test.go
@@ -251,6 +251,70 @@ func TestResolveIngressReadyHostWith(t *testing.T) {
 	})
 }
 
+func TestResolveIngressReadyHostAfterLookup(t *testing.T) {
+	forbiddenErr := apierrors.NewForbidden(
+		schema.GroupResource{Group: "networking.k8s.io", Resource: "ingresses"},
+		"",
+		errors.New("denied"),
+	)
+	tests := []struct {
+		name         string
+		flags        *config.RuntimeFlags
+		getenv       func(string) string
+		computedHost string
+		want         string
+		wantErr      bool
+	}{
+		{
+			name: "configured host survives forbidden discovery",
+			flags: &config.RuntimeFlags{Deployment: config.DeploymentFlags{ExtraHelmSets: map[string]string{
+				"global.host": "configured.example.com",
+			}}},
+			getenv:       func(string) string { return "env.example.com" },
+			computedHost: "computed.example.com",
+			want:         "configured.example.com",
+		},
+		{
+			name:         "environment host survives forbidden discovery",
+			flags:        &config.RuntimeFlags{},
+			getenv:       func(string) string { return "env.example.com" },
+			computedHost: "computed.example.com",
+			want:         "env.example.com",
+		},
+		{
+			name:         "forbidden discovery wins over computed fallback",
+			flags:        &config.RuntimeFlags{},
+			getenv:       func(string) string { return "" },
+			computedHost: "computed.example.com",
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveIngressReadyHostAfterLookup(
+				tt.flags,
+				&ScenarioContext{IngressHost: tt.computedHost},
+				tt.getenv,
+				"",
+				forbiddenErr,
+			)
+			if tt.wantErr {
+				if !apierrors.IsForbidden(err) {
+					t.Fatalf("resolveIngressReadyHostAfterLookup() error = %v, want Forbidden", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveIngressReadyHostAfterLookup() unexpected error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("resolveIngressReadyHostAfterLookup() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestResolveDeployedRoutingHostWith(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/scripts/deploy-camunda/deploy/ingress_ready_test.go
+++ b/scripts/deploy-camunda/deploy/ingress_ready_test.go
@@ -108,6 +108,34 @@ func TestResolveIngressReadyHostWith(t *testing.T) {
 		}
 	})
 
+	t.Run("templated global host defers to the rendered routing host", func(t *testing.T) {
+		flags := &config.RuntimeFlags{
+			Deployment: config.DeploymentFlags{
+				ExtraHelmSets: map[string]string{"global.host": "{{ .Release.Name }}.example.com"},
+			},
+		}
+		scenarioCtx := &ScenarioContext{Namespace: "test", IngressHost: "computed.example.com"}
+		lookupCalled := false
+
+		got := resolveIngressReadyHostWith(
+			context.Background(),
+			flags,
+			scenarioCtx,
+			func(string) string { return "env.example.com" },
+			func(context.Context, string, string) string {
+				lookupCalled = true
+				return "rendered.example.com"
+			},
+		)
+
+		if got != "rendered.example.com" {
+			t.Fatalf("resolveIngressReadyHostWith() = %q, want rendered routing host", got)
+		}
+		if !lookupCalled {
+			t.Fatal("cluster lookup should run when global.host contains a Helm template")
+		}
+	})
+
 	t.Run("computed host remains the fallback when no deployed host is found", func(t *testing.T) {
 		flags := &config.RuntimeFlags{}
 		scenarioCtx := &ScenarioContext{Namespace: "test", IngressHost: "computed.example.com"}
@@ -190,6 +218,8 @@ func TestSelectPrimaryRoutingHost(t *testing.T) {
 		{raw: "grpc-app.example.com app.example.com", want: "app.example.com"},
 		{raw: "zeebe-app.example.com actuator-app.example.com", want: ""},
 		{raw: "app.grpc-company.example", want: "app.grpc-company.example"},
+		{raw: "*.example.com app.example.com", want: "app.example.com"},
+		{raw: "*.example.com", want: ""},
 	}
 
 	for _, tt := range tests {

--- a/scripts/deploy-camunda/deploy/ingress_ready_test.go
+++ b/scripts/deploy-camunda/deploy/ingress_ready_test.go
@@ -1,14 +1,31 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package deploy
 
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
+
+	"scripts/deploy-camunda/config"
 )
 
 // fakeResolver returns a canned result for every LookupHost call, tracking how
@@ -38,6 +55,157 @@ func (alwaysFailResolver) LookupHost(_ context.Context, host string) ([]string, 
 // noSleep replaces the interval wait with a no-op so tests run instantly.
 func noSleep(ctx context.Context, _ time.Duration) error {
 	return ctx.Err()
+}
+
+func TestResolveIngressReadyHostWith(t *testing.T) {
+	t.Run("applied global host wins without querying the cluster", func(t *testing.T) {
+		flags := &config.RuntimeFlags{
+			Deployment: config.DeploymentFlags{
+				ExtraHelmSets: map[string]string{"global.host": "applied.example.com"},
+			},
+		}
+		scenarioCtx := &ScenarioContext{Namespace: "test", IngressHost: "computed.example.com"}
+		lookupCalled := false
+
+		got := resolveIngressReadyHostWith(
+			context.Background(),
+			flags,
+			scenarioCtx,
+			func(string) string { return "env.example.com" },
+			func(context.Context, string, string) string {
+				lookupCalled = true
+				return "deployed.example.com"
+			},
+		)
+
+		if got != "applied.example.com" {
+			t.Fatalf("resolveIngressReadyHostWith() = %q, want applied host", got)
+		}
+		if lookupCalled {
+			t.Fatal("cluster lookup should not run when global.host was applied explicitly")
+		}
+	})
+
+	t.Run("deployed routing host wins over computed and environment hosts", func(t *testing.T) {
+		flags := &config.RuntimeFlags{Test: config.TestFlags{KubeContext: "cluster"}}
+		scenarioCtx := &ScenarioContext{Namespace: "test", IngressHost: "computed.example.com"}
+
+		got := resolveIngressReadyHostWith(
+			context.Background(),
+			flags,
+			scenarioCtx,
+			func(string) string { return "env.example.com" },
+			func(_ context.Context, kubeContext, namespace string) string {
+				if kubeContext != "cluster" || namespace != "test" {
+					t.Fatalf("lookup called with context=%q namespace=%q", kubeContext, namespace)
+				}
+				return "gateway.example.com"
+			},
+		)
+
+		if got != "gateway.example.com" {
+			t.Fatalf("resolveIngressReadyHostWith() = %q, want deployed routing host", got)
+		}
+	})
+
+	t.Run("computed host remains the fallback when no deployed host is found", func(t *testing.T) {
+		flags := &config.RuntimeFlags{}
+		scenarioCtx := &ScenarioContext{Namespace: "test", IngressHost: "computed.example.com"}
+
+		got := resolveIngressReadyHostWith(
+			context.Background(),
+			flags,
+			scenarioCtx,
+			func(string) string { return "env.example.com" },
+			func(context.Context, string, string) string { return "" },
+		)
+
+		if got != "computed.example.com" {
+			t.Fatalf("resolveIngressReadyHostWith() = %q, want computed fallback", got)
+		}
+	})
+}
+
+func TestResolveDeployedRoutingHostWith(t *testing.T) {
+	tests := []struct {
+		name    string
+		outputs map[string]string
+		errors  map[string]error
+		want    string
+	}{
+		{
+			name:    "classic ingress host wins",
+			outputs: map[string]string{"ingress": "grpc-app.example.com app.example.com"},
+			want:    "app.example.com",
+		},
+		{
+			name: "HTTPRoute host is used when ingress is empty",
+			outputs: map[string]string{
+				"ingress":   "",
+				"httproute": "grpc-app.example.com route.example.com",
+			},
+			want: "route.example.com",
+		},
+		{
+			name: "Gateway listener host is used when ingress and HTTPRoute are unavailable",
+			outputs: map[string]string{
+				"ingress": "",
+				"gateway": "grpc-app.example.com gateway.example.com",
+			},
+			errors: map[string]error{"httproute": errors.New("resource unavailable")},
+			want:   "gateway.example.com",
+		},
+		{
+			name:   "no routing host returns empty",
+			errors: map[string]error{"ingress": errors.New("not found"), "httproute": errors.New("not found"), "gateway": errors.New("not found")},
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls []string
+			kubectlOutput := func(_ context.Context, args ...string) ([]byte, error) {
+				resource := resourceAfterGet(args)
+				calls = append(calls, resource)
+				if err := tt.errors[resource]; err != nil {
+					return nil, err
+				}
+				return []byte(tt.outputs[resource]), nil
+			}
+
+			got := resolveDeployedRoutingHostWith(context.Background(), "cluster", "test", kubectlOutput)
+			if got != tt.want {
+				t.Fatalf("resolveDeployedRoutingHostWith() = %q, want %q (calls: %v)", got, tt.want, calls)
+			}
+		})
+	}
+}
+
+func TestSelectPrimaryRoutingHost(t *testing.T) {
+	tests := []struct {
+		raw  string
+		want string
+	}{
+		{raw: "grpc-app.example.com app.example.com", want: "app.example.com"},
+		{raw: "zeebe-app.example.com actuator-app.example.com", want: ""},
+		{raw: "app.grpc-company.example", want: "app.grpc-company.example"},
+	}
+
+	for _, tt := range tests {
+		if got := selectPrimaryRoutingHost(tt.raw); got != tt.want {
+			t.Errorf("selectPrimaryRoutingHost(%q) = %q, want %q", tt.raw, got, tt.want)
+		}
+	}
+}
+
+func resourceAfterGet(args []string) string {
+	for i, arg := range args {
+		if arg == "get" && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return fmt.Sprintf("missing-get-resource:%v", args)
 }
 
 func TestWaitIngressReadyWithDeps(t *testing.T) {
@@ -204,28 +372,4 @@ func containsDNSErr(err error) bool {
 
 func containsHTTPErr(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "http error=") && !strings.Contains(err.Error(), "http error=<nil>")
-}
-
-func TestSelectPrimaryIngressHost(t *testing.T) {
-	cases := []struct {
-		name string
-		raw  string
-		want string
-	}{
-		{"empty", "", ""},
-		{"single web host", "4b5e47-gke-6650-intg-8-10-gke-eske.ci.distro.ultrawombat.com", "4b5e47-gke-6650-intg-8-10-gke-eske.ci.distro.ultrawombat.com"},
-		{
-			"skips grpc sub-host and picks the web host",
-			"grpc-4b5e47-gke-6650-intg-8-10-gke-eske.ci.distro.ultrawombat.com 4b5e47-gke-6650-intg-8-10-gke-eske.ci.distro.ultrawombat.com",
-			"4b5e47-gke-6650-intg-8-10-gke-eske.ci.distro.ultrawombat.com",
-		},
-		{"only grpc/zeebe/actuator yields empty", "grpc-x.example zeebe-x.example actuator-x.example", ""},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := selectPrimaryIngressHost(tc.raw); got != tc.want {
-				t.Fatalf("selectPrimaryIngressHost(%q) = %q, want %q", tc.raw, got, tc.want)
-			}
-		})
-	}
 }

--- a/scripts/deploy-camunda/deploy/ingress_ready_test.go
+++ b/scripts/deploy-camunda/deploy/ingress_ready_test.go
@@ -61,7 +61,7 @@ func noSleep(ctx context.Context, _ time.Duration) error {
 }
 
 func TestResolveIngressReadyHostWith(t *testing.T) {
-	t.Run("explicit ingress hostname remains the full override", func(t *testing.T) {
+	t.Run("deployed routing host wins over explicit ingress hostname", func(t *testing.T) {
 		flags := &config.RuntimeFlags{
 			Ingress: config.IngressFlags{IngressHostname: "override.example.com"},
 		}
@@ -79,11 +79,37 @@ func TestResolveIngressReadyHostWith(t *testing.T) {
 			},
 		)
 
-		if got != "override.example.com" {
-			t.Fatalf("resolveIngressReadyHostWith() = %q, want explicit override", got)
+		if got != "rendered.example.com" {
+			t.Fatalf("resolveIngressReadyHostWith() = %q, want rendered host", got)
 		}
-		if lookupCalled {
-			t.Fatal("cluster lookup should not run when --ingress-hostname is set")
+		if !lookupCalled {
+			t.Fatal("cluster lookup should determine the effective rendered host")
+		}
+	})
+
+	t.Run("explicit ingress hostname remains a fallback", func(t *testing.T) {
+		flags := &config.RuntimeFlags{
+			Ingress: config.IngressFlags{IngressHostname: "override.example.com"},
+		}
+		scenarioCtx := &ScenarioContext{Namespace: "test", Release: "integration", IngressHost: "computed.example.com"}
+		lookupCalled := false
+
+		got := resolveIngressReadyHostWith(
+			context.Background(),
+			flags,
+			scenarioCtx,
+			func(string) string { return "env.example.com" },
+			func(context.Context, string, string, string) string {
+				lookupCalled = true
+				return ""
+			},
+		)
+
+		if got != "override.example.com" {
+			t.Fatalf("resolveIngressReadyHostWith() = %q, want explicit fallback", got)
+		}
+		if !lookupCalled {
+			t.Fatal("cluster lookup should run before using --ingress-hostname as a fallback")
 		}
 	})
 
@@ -188,11 +214,12 @@ func TestResolveIngressReadyHostWith(t *testing.T) {
 		}
 	})
 
-	t.Run("concrete configured host remains a fallback when discovery fails", func(t *testing.T) {
+	t.Run("extra Helm host wins over explicit ingress fallback", func(t *testing.T) {
 		flags := &config.RuntimeFlags{
 			Deployment: config.DeploymentFlags{
 				ExtraHelmSets: map[string]string{"global.host": "configured.example.com"},
 			},
+			Ingress: config.IngressFlags{IngressHostname: "override.example.com"},
 		}
 		scenarioCtx := &ScenarioContext{Namespace: "test", Release: "integration", IngressHost: "computed.example.com"}
 
@@ -258,12 +285,14 @@ func TestResolveIngressReadyHostAfterLookup(t *testing.T) {
 		errors.New("denied"),
 	)
 	tests := []struct {
-		name         string
-		flags        *config.RuntimeFlags
-		getenv       func(string) string
-		computedHost string
-		want         string
-		wantErr      bool
+		name          string
+		flags         *config.RuntimeFlags
+		getenv        func(string) string
+		computedHost  string
+		lookupErr     error
+		want          string
+		wantForbidden bool
+		wantErr       string
 	}{
 		{
 			name: "configured host survives forbidden discovery",
@@ -272,21 +301,42 @@ func TestResolveIngressReadyHostAfterLookup(t *testing.T) {
 			}}},
 			getenv:       func(string) string { return "env.example.com" },
 			computedHost: "computed.example.com",
+			lookupErr:    forbiddenErr,
 			want:         "configured.example.com",
+		},
+		{
+			name:         "explicit ingress host survives forbidden discovery",
+			flags:        &config.RuntimeFlags{Ingress: config.IngressFlags{IngressHostname: "override.example.com"}},
+			getenv:       func(string) string { return "env.example.com" },
+			computedHost: "computed.example.com",
+			lookupErr:    forbiddenErr,
+			want:         "override.example.com",
 		},
 		{
 			name:         "environment host survives forbidden discovery",
 			flags:        &config.RuntimeFlags{},
 			getenv:       func(string) string { return "env.example.com" },
 			computedHost: "computed.example.com",
+			lookupErr:    forbiddenErr,
 			want:         "env.example.com",
 		},
 		{
-			name:         "forbidden discovery wins over computed fallback",
-			flags:        &config.RuntimeFlags{},
-			getenv:       func(string) string { return "" },
+			name:          "forbidden discovery wins over computed fallback",
+			flags:         &config.RuntimeFlags{},
+			getenv:        func(string) string { return "" },
+			computedHost:  "computed.example.com",
+			lookupErr:     forbiddenErr,
+			wantForbidden: true,
+		},
+		{
+			name: "unexpected discovery error does not use configured fallback",
+			flags: &config.RuntimeFlags{Deployment: config.DeploymentFlags{ExtraHelmSets: map[string]string{
+				"global.host": "configured.example.com",
+			}}},
+			getenv:       func(string) string { return "env.example.com" },
 			computedHost: "computed.example.com",
-			wantErr:      true,
+			lookupErr:    errors.New("connection reset"),
+			wantErr:      "connection reset",
 		},
 	}
 
@@ -297,11 +347,17 @@ func TestResolveIngressReadyHostAfterLookup(t *testing.T) {
 				&ScenarioContext{IngressHost: tt.computedHost},
 				tt.getenv,
 				"",
-				forbiddenErr,
+				tt.lookupErr,
 			)
-			if tt.wantErr {
+			if tt.wantForbidden {
 				if !apierrors.IsForbidden(err) {
 					t.Fatalf("resolveIngressReadyHostAfterLookup() error = %v, want Forbidden", err)
+				}
+				return
+			}
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("resolveIngressReadyHostAfterLookup() error = %v, want %q", err, tt.wantErr)
 				}
 				return
 			}
@@ -317,11 +373,12 @@ func TestResolveIngressReadyHostAfterLookup(t *testing.T) {
 
 func TestResolveDeployedRoutingHostWith(t *testing.T) {
 	tests := []struct {
-		name    string
-		outputs map[string][]unstructured.Unstructured
-		errors  map[string]error
-		want    string
-		wantErr bool
+		name          string
+		outputs       map[string][]unstructured.Unstructured
+		errors        map[string]error
+		want          string
+		wantForbidden bool
+		wantErr       string
 	}{
 		{
 			name: "classic ingress host wins",
@@ -381,16 +438,28 @@ func TestResolveDeployedRoutingHostWith(t *testing.T) {
 			want:   "gateway.example.com",
 		},
 		{
-			name:   "no routing host returns empty",
-			errors: map[string]error{"ingresses": errors.New("not found"), "httproutes": errors.New("not found"), "gateways": errors.New("not found")},
-			want:   "",
+			name: "missing routing APIs return empty",
+			errors: map[string]error{
+				"ingresses":  apierrors.NewNotFound(schema.GroupResource{Group: "networking.k8s.io", Resource: "ingresses"}, ""),
+				"httproutes": apierrors.NewNotFound(schema.GroupResource{Group: "gateway.networking.k8s.io", Resource: "httproutes"}, ""),
+				"gateways":   apierrors.NewNotFound(schema.GroupResource{Group: "gateway.networking.k8s.io", Resource: "gateways"}, ""),
+			},
+			want: "",
+		},
+		{
+			name: "unexpected discovery failure takes precedence over forbidden",
+			errors: map[string]error{
+				"ingresses":  apierrors.NewForbidden(schema.GroupResource{Group: "networking.k8s.io", Resource: "ingresses"}, "", errors.New("denied")),
+				"httproutes": errors.New("connection reset"),
+			},
+			wantErr: "connection reset",
 		},
 		{
 			name: "forbidden discovery without an owned route returns an error",
 			errors: map[string]error{
 				"ingresses": apierrors.NewForbidden(schema.GroupResource{Group: "networking.k8s.io", Resource: "ingresses"}, "", errors.New("denied")),
 			},
-			wantErr: true,
+			wantForbidden: true,
 		},
 	}
 
@@ -413,9 +482,15 @@ func TestResolveDeployedRoutingHostWith(t *testing.T) {
 			}
 
 			got, err := resolveDeployedRoutingHostWith(context.Background(), "test", "integration", listResources)
-			if tt.wantErr {
+			if tt.wantForbidden {
 				if !apierrors.IsForbidden(err) {
 					t.Fatalf("resolveDeployedRoutingHostWith() error = %v, want Forbidden", err)
+				}
+				return
+			}
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("resolveDeployedRoutingHostWith() error = %v, want %q", err, tt.wantErr)
 				}
 				return
 			}


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6680.

Gateway API-only integration scenarios can fail `--wait-ingress-ready` because the readiness gate probes a namespace-derived hostname instead of the hostname rendered on the deployment's routing resources.

### What's in this PR?

- Resolve the effective hostname from Ingress, HTTPRoute, or Gateway resources owned by the current Helm release.
- List arbitrary namespaced resources through the shared `camunda-core/pkg/kube` dynamic client.
- Support the exact unlabeled `<release>-camunda-platform` post-deploy routing fixture used by older chart scenarios.
- Preserve explicit CLI overrides and configured, environment, and computed hostname fallbacks when discovery finds no owned route.
- Use concrete configured or environment hosts under restricted RBAC; otherwise surface an actionable discovery error.
- Bound live routing discovery and filter templated, wildcard, gRPC, Zeebe, and actuator-only hosts.
- Add focused tests for Helm override precedence, release ownership, source precedence, and Ingress, HTTPRoute, and Gateway-only routing.

Validated across `camunda-core` and `deploy-camunda` with `go test ./...`, `go vet ./...`, `gofmt`, `addlicense -check`, and `git diff --check`.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
