### PR TITLE
ci: [TOPOLOGY 1/6] validate split-host multi-namespace smoke tests

### DIFF
--- a/.github/actions/playwright-e2e-tests/action.yaml
+++ b/.github/actions/playwright-e2e-tests/action.yaml
@@ -232,6 +232,7 @@ runs:
         TEST_EXCLUDE: ${{ inputs.exclude }}
         TEST_AUTH_TYPE: ${{ inputs.auth }}
         MANAGEMENT_NAMESPACE: ${{ inputs.management-namespace }}
+        REQUIRE_SM_810_TEST_SUITE: ${{ inputs.management-namespace != '' }}
       run: |
         cd "$GITHUB_WORKSPACE/scripts"
         # Unset KEYCLOAK_REALM to avoid conflicts with the integration tests

--- a/charts/camunda-platform-8.10/test/e2e/playwright.config.ts
+++ b/charts/camunda-platform-8.10/test/e2e/playwright.config.ts
@@ -8,9 +8,13 @@ dotenv.config();
 // TODO: Remove the fallback once QA publishes the SM-8.10 e2e test suite
 //  in the @camunda/e2e-test-suite npm package.
 const smTestDir = "./node_modules/@camunda/e2e-test-suite/dist/tests/SM-8.10";
-const testDir = fs.existsSync(path.resolve(__dirname, smTestDir))
-  ? smTestDir
-  : "./empty-test-dir";
+const hasSmSmokeSuite = fs.existsSync(
+  path.resolve(__dirname, smTestDir, "smoke-tests.spec.js"),
+);
+if (process.env.REQUIRE_SM_810_TEST_SUITE === "true" && !hasSmSmokeSuite) {
+  throw new Error("The required SM-8.10 smoke test suite is not installed");
+}
+const testDir = hasSmSmokeSuite ? smTestDir : "./empty-test-dir";
 
 // When SM-8.10 is missing, create a fallback directory with a single skipped
 // test so Playwright exits with code 0 instead of failing on "No tests found".
@@ -25,7 +29,7 @@ if (!fs.existsSync(skipFile)) {
   fs.writeFileSync(
     skipFile,
     `const { test } = require("@playwright/test");\n` +
-      `test.skip("SM-8.10 e2e suite not yet published", () => {});\n`
+      `test.skip("SM-8.10 e2e suite not yet published", () => {});\n`,
   );
 }
 
@@ -59,7 +63,10 @@ export default defineConfig({
       testMatch: ["**/*.spec.{ts,js}"],
       // cluster-variables requires Vault-managed secrets not available in PR CI.
       // test-setup is run via the full-suite-setup dependency, not directly.
-      testIgnore: ["**/cluster-variables.spec.{ts,js}", "**/test-setup.spec.{ts,js}"],
+      testIgnore: [
+        "**/cluster-variables.spec.{ts,js}",
+        "**/test-setup.spec.{ts,js}",
+      ],
       // Match the E2E repo's chromium-v2 project behavior:
       // - @tasklistV1: These tests require Tasklist v1 mode with RBA enabled
       //   (CAMUNDA_TASKLIST_IDENTITY_RESOURCE_PERMISSIONS_ENABLED=true), which

--- a/scripts/deploy-camunda/cmd/e2e_env.go
+++ b/scripts/deploy-camunda/cmd/e2e_env.go
@@ -83,10 +83,17 @@ func newE2EEnvMergeCommand() *cobra.Command {
 
 			tokenURL := "https://" + mgmtHost + "/auth/realms/camunda-platform/protocol/openid-connect/token"
 			overrides := map[string]string{
-				"MANAGEMENT_BASE_URL": "https://" + mgmtHost,
-				"KEYCLOAK_URL":        "https://" + mgmtHost,
-				"OAUTH_URL":           tokenURL,
-				"AUTH_URL":            tokenURL,
+				"MANAGEMENT_BASE_URL":              "https://" + mgmtHost,
+				"MANAGEMENT_IDENTITY_CONTEXT_PATH": "https://" + mgmtHost + "/identity",
+				"MODELER_CONTEXT_PATH":             "https://" + mgmtHost + "/modeler",
+				"CONSOLE_CONTEXT_PATH":             "https://" + mgmtHost + "/modeler",
+				"CONSOLE_BASE_URL":                 "https://" + mgmtHost,
+				"IDENTITY_BASE_URL":                "https://" + mgmtHost + "/identity/",
+				"KEYCLOAK_BASE_URL":                "https://" + mgmtHost + "/auth",
+				"KEYCLOAK_URL":                     "https://" + mgmtHost,
+				"WEBMODELER_BASE_URL":              "https://" + mgmtHost + "/modeler",
+				"OAUTH_URL":                        tokenURL,
+				"AUTH_URL":                         tokenURL,
 				"DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD": firstUserPw,
 				"DISTRO_QA_E2E_TESTS_KEYCLOAK_PASSWORD":           kcAdminPw,
 				"DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET":     clientSecret,
@@ -150,27 +157,25 @@ func resolveSecretKey(kubeContext, namespace, key string) (string, error) {
 }
 
 // selectIngressHost filters raw whitespace-separated ingress/gateway host
-// tokens (as emitted by a kubectl jsonpath query), dropping any host that
-// looks like the Zeebe gRPC gateway, de-duplicates repeats (a namespace's
-// Ingress can list the same host across multiple rules, e.g. in a
-// shared-host multi-namespace topology), and joins what remains with a
-// comma, preserving first-seen order. Returns "" if no host survives the
-// filter.
+// tokens (as emitted by a kubectl jsonpath query), dropping hosts that look
+// like the Zeebe gRPC gateway, and returning the first remaining host.
+// Returns "" if no host survives the filter.
 func selectIngressHost(raw string) string {
 	tokens := strings.Fields(raw)
-	kept := make([]string, 0, len(tokens))
-	seen := make(map[string]bool, len(tokens))
+	host := ""
 	for _, t := range tokens {
 		if strings.Contains(t, "zeebe") || strings.Contains(t, "grpc") {
 			continue
 		}
-		if seen[t] {
+		if host == "" {
+			host = t
 			continue
 		}
-		seen[t] = true
-		kept = append(kept, t)
+		if t != host {
+			return ""
+		}
 	}
-	return strings.Join(kept, ",")
+	return host
 }
 
 // resolveIngressHost discovers the live ingress hostname for a namespace by

--- a/scripts/deploy-camunda/cmd/e2e_env.go
+++ b/scripts/deploy-camunda/cmd/e2e_env.go
@@ -160,7 +160,7 @@ func resolveSecretKey(kubeContext, namespace, key string) (string, error) {
 // tokens (as emitted by a kubectl jsonpath query), dropping hosts that look
 // like the Zeebe gRPC gateway, and returning the first remaining host.
 // Returns "" if no host survives the filter.
-func selectIngressHost(raw string) string {
+func selectIngressHost(raw string) (string, error) {
 	tokens := strings.Fields(raw)
 	host := ""
 	for _, t := range tokens {
@@ -172,10 +172,10 @@ func selectIngressHost(raw string) string {
 			continue
 		}
 		if t != host {
-			return ""
+			return "", fmt.Errorf("multiple distinct HTTP hosts found: %q and %q", host, t)
 		}
 	}
-	return host
+	return host, nil
 }
 
 // resolveIngressHost discovers the live ingress hostname for a namespace by
@@ -194,7 +194,11 @@ func resolveIngressHost(kubeContext, namespace string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolve ingress host for namespace %q: %w", namespace, err)
 	}
-	if host := selectIngressHost(string(out)); host != "" {
+	host, err := selectIngressHost(string(out))
+	if err != nil {
+		return "", fmt.Errorf("resolve ingress host for namespace %q: %w", namespace, err)
+	}
+	if host != "" {
 		return host, nil
 	}
 
@@ -205,7 +209,11 @@ func resolveIngressHost(kubeContext, namespace string) (string, error) {
 	gatewayArgs = append(gatewayArgs, "-n", namespace, "get", "gateway",
 		"-o", "jsonpath={.items[*].spec.listeners[*].hostname}")
 	if gwOut, err := exec.Command("kubectl", gatewayArgs...).Output(); err == nil {
-		if host := selectIngressHost(string(gwOut)); host != "" {
+		host, selectErr := selectIngressHost(string(gwOut))
+		if selectErr != nil {
+			return "", fmt.Errorf("resolve gateway host for namespace %q: %w", namespace, selectErr)
+		}
+		if host != "" {
 			return host, nil
 		}
 	}

--- a/scripts/deploy-camunda/cmd/e2e_env_test.go
+++ b/scripts/deploy-camunda/cmd/e2e_env_test.go
@@ -142,7 +142,10 @@ func TestE2EEnvMergeFailsOnMissingRenderScript(t *testing.T) {
 func TestSelectIngressHostFiltersZeebeAndGrpcHosts(t *testing.T) {
 	raw := "matrix-810-mns-mgmt.ci.distro.ultrawombat.com zeebe-matrix-810-mns-mgmt.ci.distro.ultrawombat.com grpc-matrix-810-mns-mgmt.ci.distro.ultrawombat.com"
 
-	got := selectIngressHost(raw)
+	got, err := selectIngressHost(raw)
+	if err != nil {
+		t.Fatalf("selectIngressHost() unexpected error: %v", err)
+	}
 	want := "matrix-810-mns-mgmt.ci.distro.ultrawombat.com"
 
 	if got != want {
@@ -153,7 +156,10 @@ func TestSelectIngressHostFiltersZeebeAndGrpcHosts(t *testing.T) {
 func TestSelectIngressHostPassesThroughSingleHost(t *testing.T) {
 	raw := "matrix-810-mns-mgmt.ci.distro.ultrawombat.com"
 
-	got := selectIngressHost(raw)
+	got, err := selectIngressHost(raw)
+	if err != nil {
+		t.Fatalf("selectIngressHost() unexpected error: %v", err)
+	}
 	want := "matrix-810-mns-mgmt.ci.distro.ultrawombat.com"
 
 	if got != want {
@@ -162,7 +168,11 @@ func TestSelectIngressHostPassesThroughSingleHost(t *testing.T) {
 }
 
 func TestSelectIngressHostEmptyInputReturnsEmpty(t *testing.T) {
-	if got := selectIngressHost(""); got != "" {
+	got, err := selectIngressHost("")
+	if err != nil {
+		t.Fatalf("selectIngressHost() unexpected error: %v", err)
+	}
+	if got != "" {
 		t.Fatalf("selectIngressHost() = %q, want empty string", got)
 	}
 }
@@ -175,7 +185,10 @@ func TestSelectIngressHostEmptyInputReturnsEmpty(t *testing.T) {
 func TestSelectIngressHostDedupesRepeatedHost(t *testing.T) {
 	raw := "matrix-810-mns-mgmt.ci.distro.ultrawombat.com matrix-810-mns-mgmt.ci.distro.ultrawombat.com matrix-810-mns-mgmt.ci.distro.ultrawombat.com"
 
-	got := selectIngressHost(raw)
+	got, err := selectIngressHost(raw)
+	if err != nil {
+		t.Fatalf("selectIngressHost() unexpected error: %v", err)
+	}
 	want := "matrix-810-mns-mgmt.ci.distro.ultrawombat.com"
 
 	if got != want {
@@ -186,11 +199,12 @@ func TestSelectIngressHostDedupesRepeatedHost(t *testing.T) {
 func TestSelectIngressHostRejectsMultipleDistinctHosts(t *testing.T) {
 	raw := "b.example.com a.example.com b.example.com zeebe-a.example.com a.example.com"
 
-	got := selectIngressHost(raw)
-	want := ""
-
-	if got != want {
-		t.Fatalf("selectIngressHost() = %q, want %q", got, want)
+	got, err := selectIngressHost(raw)
+	if err == nil {
+		t.Fatalf("selectIngressHost() = %q, want ambiguity error", got)
+	}
+	if !strings.Contains(err.Error(), "multiple distinct HTTP hosts") {
+		t.Fatalf("selectIngressHost() error = %q, want ambiguity error", err)
 	}
 }
 

--- a/scripts/deploy-camunda/cmd/e2e_env_test.go
+++ b/scripts/deploy-camunda/cmd/e2e_env_test.go
@@ -75,6 +75,36 @@ func TestMergeEnvOverridesAppendsMissingKeysSorted(t *testing.T) {
 	}
 }
 
+func TestMergeEnvOverridesRoutesManagementApplicationsToManagementHost(t *testing.T) {
+	content := strings.Join([]string{
+		"PLAYWRIGHT_BASE_URL=https://orcha.example.com",
+		"CONSOLE_BASE_URL=https://orcha.example.com",
+		"IDENTITY_BASE_URL=https://orcha.example.com/identity/",
+		"KEYCLOAK_BASE_URL=https://orcha.example.com/auth",
+		"WEBMODELER_BASE_URL=https://orcha.example.com/modeler",
+		"",
+	}, "\n")
+	overrides := map[string]string{
+		"CONSOLE_BASE_URL":                 "https://mgmt.example.com",
+		"CONSOLE_CONTEXT_PATH":             "https://mgmt.example.com/modeler",
+		"IDENTITY_BASE_URL":                "https://mgmt.example.com/identity/",
+		"KEYCLOAK_BASE_URL":                "https://mgmt.example.com/auth",
+		"MANAGEMENT_IDENTITY_CONTEXT_PATH": "https://mgmt.example.com/identity",
+		"MODELER_CONTEXT_PATH":             "https://mgmt.example.com/modeler",
+		"WEBMODELER_BASE_URL":              "https://mgmt.example.com/modeler",
+	}
+
+	got := mergeEnvOverrides(content, overrides)
+	if !strings.Contains(got, "PLAYWRIGHT_BASE_URL=https://orcha.example.com\n") {
+		t.Fatalf("mergeEnvOverrides() changed orchestration base URL: %q", got)
+	}
+	for key, value := range overrides {
+		if !strings.Contains(got, key+"="+value+"\n") {
+			t.Errorf("mergeEnvOverrides() missing %s management URL: %q", key, got)
+		}
+	}
+}
+
 func TestMergeEnvOverridesPreservesNoTrailingNewline(t *testing.T) {
 	content := "PLAYWRIGHT_BASE_URL=https://orcha.example.com"
 	overrides := map[string]string{
@@ -153,14 +183,11 @@ func TestSelectIngressHostDedupesRepeatedHost(t *testing.T) {
 	}
 }
 
-// TestSelectIngressHostDedupesWhilePreservingOrderAndFilter combines the
-// repeated-host and zeebe/grpc-filter behaviors: distinct hosts survive in
-// first-seen order, duplicates collapse, and zeebe/grpc hosts are dropped.
-func TestSelectIngressHostDedupesWhilePreservingOrderAndFilter(t *testing.T) {
+func TestSelectIngressHostRejectsMultipleDistinctHosts(t *testing.T) {
 	raw := "b.example.com a.example.com b.example.com zeebe-a.example.com a.example.com"
 
 	got := selectIngressHost(raw)
-	want := "b.example.com,a.example.com"
+	want := ""
 
 	if got != want {
 		t.Fatalf("selectIngressHost() = %q, want %q", got, want)


### PR DESCRIPTION
> | # | PR | Phase | Purpose |
> | --- | --- | --- | --- |
> | **1/6** | **[helm#6687](https://github.com/camunda/camunda-platform-helm/pull/6687)** | **Test foundation** | **Route split-host E2E traffic and require the real SM-8.10 suite. ← you are here** |
> | 2/6 | [helm#6711](https://github.com/camunda/camunda-platform-helm/pull/6711) | Architecture decision | Record release roles and management-owned topology inventory. |
> | 3/6 | [helm#6688](https://github.com/camunda/camunda-platform-helm/pull/6688) | Topology contract | Add combined, management, and orchestration release roles. |
> | 4/6 | [e2e#2884](https://github.com/camunda/c8-cross-component-e2e-tests/pull/2884) | Multi-cluster E2E | Select the target Modeler cluster for stateful smoke flows. |
> | 5/6 | [docs#9479](https://github.com/camunda/camunda-docs/pull/9479) | Baseline guidance | Replace stale 8.9 examples with the supported split deployment. |
> | 6/6 | [docs#9480](https://github.com/camunda/camunda-docs/pull/9480) | Topology guidance | Explain Identity, Hub, GitOps, compatibility, and lifecycle behavior. |

Merge test foundation and the approved ADR before the Helm topology contract, then E2E, baseline docs, and topology docs.

### Which problem does the PR fix?

The 8.10 multi-namespace topology used orchestration-host URLs for Management Identity and Camunda Hub in the Playwright fixtures. Its blocking smoke job could also pass with a skipped fallback when the published SM-8.10 suite was absent.

### What's in this PR?

- Route Management Identity, Camunda Hub/Modeler, Console, and Keycloak test URLs to the management ingress while keeping Orchestration, Tasklist, Operate, Optimize, and Connectors on the orchestration ingress.
- Fail the topology smoke job if the published `SM-8.10/smoke-tests.spec.js` suite is missing.
- Reject ambiguous management namespaces that expose multiple distinct non-gRPC ingress hosts.
- Add focused Go coverage for merged URLs and ingress-host selection.

Validated on GKE with separate management and orchestration hosts. All 10 deployed pods were ready with zero restarts. The published SM-8.10 suite completed with three executable tests passing in 3.5 minutes (`Basic Login`, `Basic Navigation`, and `Most Common Flow User Flow With All Apps`); its connector test is currently skipped upstream. Both test namespaces were removed afterward.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?


Fixes https://github.com/camunda/camunda-platform-helm/issues/4915