### PR TITLE
ci: unblock Camunda snapshot digest updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -445,7 +445,8 @@
       datasourceTemplate: '{{{datasource}}}',
       versioningTemplate: '{{#if versioning}}{{{versioning}}}{{else}}docker{{/if}}',
     },
-    // This regex manager is used to update the image digests in the values-digest.yaml files.
+    // Keep repository, tag, and digest adjacent so a digest-less image block
+    // cannot consume the digest from the next component.
     {
       customType: 'regex',
       fileMatch: [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -357,8 +357,8 @@
       ],
       matchUpdateTypes: ['digest'],
       schedule: ['at any time'],
+      prCreation: 'immediate',
       addLabels: ['camunda-platform', 'priority-high'],
-      minimumReleaseAge: '6 hours',
     },
     {
       matchUpdateTypes: ['minor', 'patch', 'pin', 'digest'],
@@ -460,7 +460,7 @@
             tag: SNAPSHOT
             digest: "sha256:abcdef123456789..."
         */
-        'repository:\\s+(?<depName>\\S+)[\\s\\S]*?tag:\\s+(?<currentValue>[^\\s]+)[\\s\\S]*?digest:\\s+\"?(?<currentDigest>sha256:[a-f0-9]{64})\"?'
+        'repository:\\s+(?<depName>\\S+)\\s*\\n\\s+tag:\\s+(?<currentValue>\\S+)\\s*\\n\\s+digest:\\s+\"?(?<currentDigest>sha256:[a-f0-9]{64})\"?'
       ],
       datasourceTemplate: 'docker',
       versioningTemplate: 'docker',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -359,6 +359,7 @@
       schedule: ['at any time'],
       prCreation: 'immediate',
       addLabels: ['camunda-platform', 'priority-high'],
+      minimumReleaseAge: '6 hours',
     },
     {
       matchUpdateTypes: ['minor', 'patch', 'pin', 'digest'],

--- a/scripts/renovate-config-check/renovate_config_test.go
+++ b/scripts/renovate-config-check/renovate_config_test.go
@@ -44,23 +44,32 @@ func repoRoot(t *testing.T) string {
 
 // RenovateConfig represents the subset of renovate.json5 we need to validate.
 type RenovateConfig struct {
-	PackageRules []PackageRule `json:"packageRules"`
+	PackageRules   []PackageRule   `json:"packageRules"`
+	CustomManagers []CustomManager `json:"customManagers"`
 }
 
 // PackageRule represents a single Renovate package rule.
 type PackageRule struct {
 	Description       string   `json:"description"`
+	GroupName         string   `json:"groupName"`
 	Versioning        string   `json:"versioning"`
 	MatchFileNames    []string `json:"matchFileNames"`
 	MatchManagers     []string `json:"matchManagers"`
 	MatchPackageNames []string `json:"matchPackageNames"`
 	MatchUpdateTypes  []string `json:"matchUpdateTypes"`
+	PRCreation        string   `json:"prCreation"`
+	MinimumReleaseAge string   `json:"minimumReleaseAge"`
 	AddLabels         []string `json:"addLabels"`
 	Schedule          []string `json:"schedule"`
 	Automerge         *bool    `json:"automerge"`
 	PlatformAutomerge *bool    `json:"platformAutomerge"`
 	IgnoreTests       *bool    `json:"ignoreTests"`
 	AutomergeType     string   `json:"automergeType"`
+}
+
+type CustomManager struct {
+	FileMatch    []string `json:"fileMatch"`
+	MatchStrings []string `json:"matchStrings"`
 }
 
 // ChartYAML represents the relevant fields from Chart.yaml.
@@ -260,6 +269,100 @@ func TestGitHubActionsAutomergePolicy(t *testing.T) {
 	} {
 		assert.Contains(t, actionRule.AddLabels, label)
 	}
+}
+
+func TestDigestUpdatesAreCreatedImmediately(t *testing.T) {
+	config := readRenovateConfig(t)
+
+	for _, rule := range config.PackageRules {
+		if rule.GroupName != "camunda-platform-digests" {
+			continue
+		}
+		assert.Contains(t, rule.MatchUpdateTypes, "digest")
+		assert.Equal(t, "immediate", rule.PRCreation,
+			"moving snapshot digests must not be held by the global not-pending policy")
+		assert.Empty(t, rule.MinimumReleaseAge,
+			"a minimum release age can reset indefinitely for moving snapshot tags")
+		return
+	}
+	t.Fatal("camunda-platform-digests package rule not found")
+}
+
+func TestDigestRegexDoesNotCrossImageBlocks(t *testing.T) {
+	root := repoRoot(t)
+	config := readRenovateConfig(t)
+	re := regexp.MustCompile(digestManagerPattern(t, config))
+
+	for _, version := range []string{"8.8", "8.9", "8.10"} {
+		path := filepath.Join(root, "charts", "camunda-platform-"+version, "values-digest.yaml")
+		contents, err := os.ReadFile(path)
+		require.NoError(t, err)
+
+		assert.Equal(t, digestImageBlocks(t, contents), digestRegexMatches(re, string(contents)),
+			"%s digest dependencies must stay within their YAML image block", path)
+	}
+}
+
+func readRenovateConfig(t *testing.T) RenovateConfig {
+	t.Helper()
+	contents, err := os.ReadFile(filepath.Join(repoRoot(t), ".github", "renovate.json5"))
+	require.NoError(t, err)
+	var config RenovateConfig
+	require.NoError(t, json5.Unmarshal(contents, &config))
+	return config
+}
+
+func digestManagerPattern(t *testing.T, config RenovateConfig) string {
+	t.Helper()
+	for _, manager := range config.CustomManagers {
+		if containsFile(manager.FileMatch, "values-digest\\.yaml$") {
+			require.Len(t, manager.MatchStrings, 1)
+			return manager.MatchStrings[0]
+		}
+	}
+	t.Fatal("values-digest custom manager not found")
+	return ""
+}
+
+func digestImageBlocks(t *testing.T, contents []byte) map[string]string {
+	t.Helper()
+	var document yaml.Node
+	require.NoError(t, yaml.Unmarshal(contents, &document))
+	result := map[string]string{}
+	var visit func(*yaml.Node)
+	visit = func(node *yaml.Node) {
+		if node.Kind == yaml.MappingNode {
+			fields := map[string]string{}
+			for i := 0; i+1 < len(node.Content); i += 2 {
+				key, value := node.Content[i], node.Content[i+1]
+				if value.Kind == yaml.ScalarNode {
+					fields[key.Value] = value.Value
+				}
+				visit(value)
+			}
+			if fields["repository"] != "" && fields["tag"] != "" && fields["digest"] != "" {
+				result[fields["repository"]+"@"+fields["tag"]] = fields["digest"]
+			}
+			return
+		}
+		for _, child := range node.Content {
+			visit(child)
+		}
+	}
+	visit(&document)
+	return result
+}
+
+func digestRegexMatches(re *regexp.Regexp, contents string) map[string]string {
+	result := map[string]string{}
+	groups := map[string]int{}
+	for i, name := range re.SubexpNames() {
+		groups[name] = i
+	}
+	for _, match := range re.FindAllStringSubmatch(contents, -1) {
+		result[match[groups["depName"]]+"@"+match[groups["currentValue"]]] = match[groups["currentDigest"]]
+	}
+	return result
 }
 
 // extractChartVersions extracts unique chart version numbers from matchFileNames.

--- a/scripts/renovate-config-check/renovate_config_test.go
+++ b/scripts/renovate-config-check/renovate_config_test.go
@@ -271,7 +271,7 @@ func TestGitHubActionsAutomergePolicy(t *testing.T) {
 	}
 }
 
-func TestDigestUpdatesAreCreatedImmediately(t *testing.T) {
+func TestDigestUpdatePolicy(t *testing.T) {
 	config := readRenovateConfig(t)
 
 	for _, rule := range config.PackageRules {
@@ -281,8 +281,8 @@ func TestDigestUpdatesAreCreatedImmediately(t *testing.T) {
 		assert.Contains(t, rule.MatchUpdateTypes, "digest")
 		assert.Equal(t, "immediate", rule.PRCreation,
 			"moving snapshot digests must not be held by the global not-pending policy")
-		assert.Empty(t, rule.MinimumReleaseAge,
-			"a minimum release age can reset indefinitely for moving snapshot tags")
+		assert.Equal(t, "6 hours", rule.MinimumReleaseAge,
+			"digest updates need time to detect retracted image hashes")
 		return
 	}
 	t.Fatal("camunda-platform-digests package rule not found")

--- a/scripts/renovate-config-check/renovate_config_test.go
+++ b/scripts/renovate-config-check/renovate_config_test.go
@@ -303,6 +303,28 @@ func TestDigestRegexDoesNotCrossImageBlocks(t *testing.T) {
 	}
 }
 
+func TestDigestRegexSkipsDigestlessBlockWithoutConsumingNextDigest(t *testing.T) {
+	config := readRenovateConfig(t)
+	re := regexp.MustCompile(digestManagerPattern(t, config))
+	contents := `
+webModeler:
+  restapi:
+    image:
+      repository: camunda/hub
+      tag: SNAPSHOT
+
+orchestration:
+  image:
+    repository: camunda/camunda
+    tag: 8.10-SNAPSHOT
+    digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+`
+
+	assert.Equal(t, map[string]string{
+		"camunda/camunda@8.10-SNAPSHOT": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}, digestRegexMatches(re, contents))
+}
+
 func readRenovateConfig(t *testing.T) RenovateConfig {
 	t.Helper()
 	contents, err := os.ReadFile(filepath.Join(repoRoot(t), ".github", "renovate.json5"))


### PR DESCRIPTION
### Which problem does the PR fix?

Renovate has not recreated the `camunda-platform-digests` PR even though moving Camunda snapshot tags have newer image digests. This leaves CI pinned to stale snapshots and currently blocks authenticated Hub-ping validation in #6655.

Two configuration issues caused this:

- The values-digest regex could cross YAML image blocks because it used `[\s\S]*?` between `repository`, `tag`, and `digest`. That expression matches arbitrary lines, including later component blocks. A digest-less Hub block could therefore consume the Orchestration digest, misattribute it to Hub, and omit `camunda/camunda` from the update.
- The digest group inherited `prCreation: not-pending`, which could prevent PR creation for moving snapshot tags.

### What's in this PR?

- Restricts the digest regex to adjacent `repository`, `tag`, and `digest` fields in one image block.
- Sets the Camunda digest group to `prCreation: immediate` while retaining the six-hour minimum release age that protects against retracted image hashes.
- Adds regression tests that:
  - Compare regex extraction with parsed YAML image blocks for the 8.8, 8.9, and 8.10 digest files.
  - Reproduce a digest-less Hub block followed by a pinned Orchestration block and assert that only `camunda/camunda@8.10-SNAPSHOT` is extracted.
  - Require immediate digest PR creation and the six-hour safety window.

Validation:

- `go test ./... -v` in `scripts/renovate-config-check`
- `docker run --rm -v "$PWD:/usr/src/app" -w /usr/src/app renovate/renovate renovate-config-validator`

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?


Fixes https://github.com/camunda/camunda-platform-helm/issues/6704