### PR TITLE
ci: automerge github action updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -122,6 +122,7 @@
     {
       description: 'Major updates require manual review to prevent breaking changes.',
       matchUpdateTypes: ['major'],
+      matchManagers: ['!github-actions'],
       automerge: false,
       platformAutomerge: false,
       dependencyDashboardApproval: false,
@@ -130,6 +131,7 @@
     {
       description: 'Schedule major updates for Friday nights.',
       matchUpdateTypes: ['major'],
+      matchManagers: ['!github-actions'],
       excludePackageNames: ['/.*camunda.*/'],
       schedule: ['* 0-6,18-23 * * 5'],
     },
@@ -159,9 +161,19 @@
       schedule: ['every weekend'],
     },
     {
-      addLabels: ['deps/github-actions'],
+      description: 'Automerge GitHub Actions updates after status checks pass.',
+      addLabels: [
+        'deps/github-actions',
+        'automerge',
+        'automation/renovatebot',
+        'kind/chore',
+      ],
       matchManagers: ['github-actions'],
       schedule: ['every weekend'],
+      platformAutomerge: true,
+      automerge: true,
+      automergeType: 'pr',
+      ignoreTests: false,
     },
     // Limit tools and libs versions to the actual Distro CI Kubernetes cluster.
     {

--- a/scripts/renovate-config-check/renovate_config_test.go
+++ b/scripts/renovate-config-check/renovate_config_test.go
@@ -49,9 +49,18 @@ type RenovateConfig struct {
 
 // PackageRule represents a single Renovate package rule.
 type PackageRule struct {
-	Description    string   `json:"description"`
-	Versioning     string   `json:"versioning"`
-	MatchFileNames []string `json:"matchFileNames"`
+	Description       string   `json:"description"`
+	Versioning        string   `json:"versioning"`
+	MatchFileNames    []string `json:"matchFileNames"`
+	MatchManagers     []string `json:"matchManagers"`
+	MatchPackageNames []string `json:"matchPackageNames"`
+	MatchUpdateTypes  []string `json:"matchUpdateTypes"`
+	AddLabels         []string `json:"addLabels"`
+	Schedule          []string `json:"schedule"`
+	Automerge         *bool    `json:"automerge"`
+	PlatformAutomerge *bool    `json:"platformAutomerge"`
+	IgnoreTests       *bool    `json:"ignoreTests"`
+	AutomergeType     string   `json:"automergeType"`
 }
 
 // ChartYAML represents the relevant fields from Chart.yaml.
@@ -197,6 +206,62 @@ func TestGAChartsHavePatchUpdatesEnabled(t *testing.T) {
 	}
 }
 
+func TestGitHubActionsAutomergePolicy(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+	configBytes, err := os.ReadFile(filepath.Join(root, ".github", "renovate.json5"))
+	require.NoError(t, err, "failed to read renovate.json5")
+
+	var config RenovateConfig
+	err = json5.Unmarshal(configBytes, &config)
+	require.NoError(t, err, "failed to parse renovate.json5 as JSON5")
+
+	var actionRules []PackageRule
+	var manualMajorRule *PackageRule
+	var scheduledMajorRule *PackageRule
+	for i := range config.PackageRules {
+		rule := &config.PackageRules[i]
+		if containsString(rule.MatchManagers, "github-actions") {
+			actionRules = append(actionRules, *rule)
+		}
+		switch rule.Description {
+		case "Major updates require manual review to prevent breaking changes.":
+			manualMajorRule = rule
+		case "Schedule major updates for Friday nights.":
+			scheduledMajorRule = rule
+		}
+	}
+
+	require.NotNil(t, manualMajorRule)
+	assert.Equal(t, []string{"!github-actions"}, manualMajorRule.MatchManagers)
+	require.NotNil(t, scheduledMajorRule)
+	assert.Equal(t, []string{"!github-actions"}, scheduledMajorRule.MatchManagers)
+
+	require.Len(t, actionRules, 1, "GitHub Actions policy must be defined by one manager-wide rule")
+	actionRule := actionRules[0]
+	assert.Empty(t, actionRule.MatchPackageNames)
+	assert.Empty(t, actionRule.MatchUpdateTypes)
+	assert.Contains(t, actionRule.Schedule, "every weekend")
+
+	require.NotNil(t, actionRule.Automerge)
+	assert.True(t, *actionRule.Automerge)
+	require.NotNil(t, actionRule.PlatformAutomerge)
+	assert.True(t, *actionRule.PlatformAutomerge)
+	require.NotNil(t, actionRule.IgnoreTests)
+	assert.False(t, *actionRule.IgnoreTests)
+	assert.Equal(t, "pr", actionRule.AutomergeType)
+
+	for _, label := range []string{
+		"deps/github-actions",
+		"automerge",
+		"automation/renovatebot",
+		"kind/chore",
+	} {
+		assert.Contains(t, actionRule.AddLabels, label)
+	}
+}
+
 // extractChartVersions extracts unique chart version numbers from matchFileNames.
 func extractChartVersions(fileNames []string) []string {
 	seen := make(map[string]bool)
@@ -254,6 +319,15 @@ func findGACharts(t *testing.T, root string) []string {
 func containsFile(fileNames []string, suffix string) bool {
 	for _, f := range fileNames {
 		if strings.HasSuffix(f, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsString(values []string, expected string) bool {
+	for _, value := range values {
+		if value == expected {
 			return true
 		}
 	}


### PR DESCRIPTION
### Which problem does the PR fix?

Renovate classifies GitHub Action release-channel changes such as `v6` to `v7` as major updates. The repository's generic major-update rules consequently disable automerge and request human review even though GitHub Action updates should use the existing required-check and bot-approval path.

This focused PR supersedes #6493 for the GitHub Actions automerge policy. It excludes that PR's unrelated digest grouping and KIND changes.

### What's in this PR?

- Excludes the `github-actions` manager from generic major manual-review and Friday scheduling rules.
- Enables PR automerge for all GitHub Action updates while continuing to wait for required status checks.
- Adds a regression test that keeps the policy manager-wide and verifies its labels, schedule, and automerge settings.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
