### PR TITLE
test: [ACM 3/4] verify load-responsive scaling on GKE

### DIFF
--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -1027,13 +1027,14 @@ integration:
                 - RDBMS_POSTGRESQL_USERNAME
                 - RDBMS_POSTGRESQL_PASSWORD
         - name: capacity-manager
-          enabled: false
+          enabled: true
           shortname: acm
           auth: basic
           flow: install
           platforms:
             - gke
           exclude: []
+          tier: 2
           infra-type:
             gke: distroci
           identity: basic

--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -1026,6 +1026,34 @@ integration:
               env-vars:
                 - RDBMS_POSTGRESQL_USERNAME
                 - RDBMS_POSTGRESQL_PASSWORD
+        - name: capacity-manager
+          enabled: false
+          shortname: acm
+          auth: basic
+          flow: install
+          platforms:
+            - gke
+          exclude: []
+          infra-type:
+            gke: distroci
+          identity: basic
+          persistence: elasticsearch
+          features:
+            - capacity-manager
+          skip-e2e: true
+          dependencies:
+            - chart: elastic/elasticsearch
+              version: 8.5.1
+              release-name: elasticsearch
+              values-file: test/integration/companion-values/elasticsearch.yaml
+              repo-name: elastic
+              repo-url: https://helm.elastic.co
+          post-deploy:
+            script: verify-capacity-manager.sh
+            description: |
+              Waits for process load to trigger scale-up from one to two brokers, deletes
+              the load generator, then verifies idle traffic triggers topology evacuation
+              before the orchestration StatefulSet contracts.
         - name: qa-elasticsearch-upg
           enabled: false
           shortname: qaelupg

--- a/charts/camunda-platform-8.10/test/ci/registry/hooks/capacity-manager.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/hooks/capacity-manager.yaml
@@ -1,0 +1,5 @@
+script: verify-capacity-manager.sh
+description: |
+  Waits for process load to trigger scale-up from one to two brokers, deletes
+  the load generator, then verifies idle traffic triggers topology evacuation
+  before the orchestration StatefulSet contracts.

--- a/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
@@ -130,6 +130,9 @@ integration:
     - id: alwaysgreen
       shortname: agrn
       enabled: false
+    - id: capacity-manager
+      shortname: acm
+      enabled: false
     - id: qa-elasticsearch-upg-install
       shortname: qaelupg
       enabled: false

--- a/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
@@ -132,7 +132,8 @@ integration:
       enabled: false
     - id: capacity-manager
       shortname: acm
-      enabled: false
+      tier: 2
+      enabled: true
     - id: qa-elasticsearch-upg-install
       shortname: qaelupg
       enabled: false

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/capacity-manager.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/capacity-manager.yaml
@@ -1,0 +1,16 @@
+name: capacity-manager
+auth: basic
+flows:
+  - install
+identity: basic
+persistence: elasticsearch
+features:
+  - capacity-manager
+platforms:
+  - gke
+infra-type:
+  gke: distroci
+skip-e2e: true
+post-deploy: capacity-manager
+dependencies:
+  - elasticsearch

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/capacity-manager.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/capacity-manager.yaml
@@ -11,16 +11,20 @@ capacityManager:
   reconcileInterval: 5s
   operationTimeout: 10m
   prometheusURL: http://integration-zeebe-0.integration-zeebe:9600/orchestration/actuator/prometheus
-  policy:
-    mode: automatic
-    minBrokers: 1
-    maxBrokers: 2
-    targetBrokers: 0
-    pressureQuery: zeebe_log_appender_record_appended_total
-    scaleUpThreshold: 20
-    scaleDownThreshold: 5
-    scaleUpSamples: 3
-    scaleDownSamples: 6
+  extraConfiguration:
+    - file: policy.json
+      content: |
+        {
+          "mode": "automatic",
+          "minBrokers": 1,
+          "maxBrokers": 2,
+          "targetBrokers": 0,
+          "pressureQuery": "zeebe_log_appender_record_appended_total",
+          "scaleUpThreshold": 20,
+          "scaleDownThreshold": 5,
+          "scaleUpSamples": 3,
+          "scaleDownSamples": 6
+        }
 
 orchestration:
   clusterSize: "1"

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/capacity-manager.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/capacity-manager.yaml
@@ -1,5 +1,6 @@
 capacityManager:
   enabled: true
+  replicaOwnership: capacityManager
   image:
     registry: registry.camunda.cloud
     repository: team-distribution/capacity-manager

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/capacity-manager.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/capacity-manager.yaml
@@ -51,7 +51,7 @@ global:
               - name: registry-camunda-cloud
             containers:
               - name: load-generator
-                image: registry.camunda.cloud/team-distribution/capacity-manager:latest
+                image: registry.camunda.cloud/team-distribution/capacity-manager@sha256:e5d16ee4d35d454a483666b5237dc5c47ae82febdcd1b7c7470bb075935ca696
                 imagePullPolicy: Always
                 command: ["/load-generator"]
                 args:

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/capacity-manager.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/capacity-manager.yaml
@@ -1,0 +1,71 @@
+capacityManager:
+  enabled: true
+  image:
+    registry: registry.camunda.cloud
+    repository: team-distribution/capacity-manager
+    tag: $CAPACITY_MANAGER_IMAGE_TAG
+    pullSecrets:
+      - name: registry-camunda-cloud
+  reconcileInterval: 5s
+  operationTimeout: 10m
+  prometheusURL: http://integration-zeebe-0.integration-zeebe:9600/orchestration/actuator/prometheus
+  policy:
+    mode: automatic
+    minBrokers: 1
+    maxBrokers: 2
+    targetBrokers: 0
+    pressureQuery: zeebe_log_appender_record_appended_total
+    scaleUpThreshold: 20
+    scaleDownThreshold: 5
+    scaleUpSamples: 3
+    scaleDownSamples: 6
+
+orchestration:
+  clusterSize: "1"
+  partitionCount: "2"
+  replicationFactor: "1"
+  affinity: {}
+
+global:
+  extraManifests:
+    - |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: integration-capacity-load
+        labels:
+          app.kubernetes.io/component: capacity-load
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app.kubernetes.io/component: capacity-load
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/component: capacity-load
+          spec:
+            imagePullSecrets:
+              - name: registry-camunda-cloud
+            containers:
+              - name: load-generator
+                image: registry.camunda.cloud/team-distribution/capacity-manager:$CAPACITY_MANAGER_IMAGE_TAG
+                imagePullPolicy: Always
+                command: ["/load-generator"]
+                args:
+                  - --url=http://integration-zeebe-gateway:8080/orchestration/v2
+                  - --username=demo
+                  - --password=demo
+                  - --rate=50
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 32Mi
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  readOnlyRootFilesystem: true
+                  runAsNonRoot: true
+                  runAsUser: 65532

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/capacity-manager.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/capacity-manager.yaml
@@ -3,7 +3,7 @@ capacityManager:
   image:
     registry: registry.camunda.cloud
     repository: team-distribution/capacity-manager
-    tag: $CAPACITY_MANAGER_IMAGE_TAG
+    tag: latest
     pullSecrets:
       - name: registry-camunda-cloud
   reconcileInterval: 5s
@@ -49,7 +49,7 @@ global:
               - name: registry-camunda-cloud
             containers:
               - name: load-generator
-                image: registry.camunda.cloud/team-distribution/capacity-manager:$CAPACITY_MANAGER_IMAGE_TAG
+                image: registry.camunda.cloud/team-distribution/capacity-manager:latest
                 imagePullPolicy: Always
                 command: ["/load-generator"]
                 args:

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/capacity-manager.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/capacity-manager.yaml
@@ -4,6 +4,7 @@ capacityManager:
     registry: registry.camunda.cloud
     repository: team-distribution/capacity-manager
     tag: latest
+    digest: ""
     pullSecrets:
       - name: registry-camunda-cloud
   reconcileInterval: 5s

--- a/charts/camunda-platform-8.10/test/integration/scenarios/pre-setup-scripts/verify-capacity-manager.sh
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/pre-setup-scripts/verify-capacity-manager.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)/scripts/capacity-manager"
+go run ./cmd/verify


### PR DESCRIPTION
> | Order | PR |
> | --- | --- |
> | 1/4 | [#6705 Capacity manager core and image workflow](https://github.com/camunda/camunda-platform-helm/pull/6705) |
> | 2/4 | [#6706 Helm 8.10 integration](https://github.com/camunda/camunda-platform-helm/pull/6706) |
> | **3/4** | **[#6707 GKE load-responsive broker scaling](https://github.com/camunda/camunda-platform-helm/pull/6707) <- you are here** |
> | 4/4 | [#6709 Recommendation-only partition advisor](https://github.com/camunda/camunda-platform-helm/pull/6709) |

### Which problem does the PR fix?

The capacity manager needs an end-to-end proof that real Camunda traffic, rather than an explicit target, causes safe broker scale-up and scale-down.

Tracks #6708.

### What's in this PR?

Adds a disabled GKE matrix scenario with two logical partitions, a 50 process-instances-per-second REST load generator, direct broker metric-rate thresholds, and a post-deploy verifier.

The scenario passed on GKE in 7m03s: load triggered 1-to-2 broker scaling; removing load triggered topology evacuation followed by safe 2-to-1 pod contraction; the removed broker PVC remained retained.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
