### PR TITLE
chore: add resumable matrix lifecycle and secure registry credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ charts/camunda-platform*/test/e2e/package-lock.json
 
 diagnostics/
 deployment-logs/
+.deploy-camunda/
 STATE.md
 
 **/.omc

--- a/scripts/camunda-core/pkg/kube/kube.go
+++ b/scripts/camunda-core/pkg/kube/kube.go
@@ -223,6 +223,24 @@ func (c *Client) NamespaceLabel(ctx context.Context, namespace, label string) (s
 	return ns.Labels[label], nil
 }
 
+func (c *Client) ClaimNamespaceOwnership(ctx context.Context, namespace, label, owner string) error {
+	ns, err := c.clientset.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("get namespace %q for ownership claim: %w", namespace, err)
+	}
+	if current := ns.Labels[label]; current != "" && current != owner {
+		return fmt.Errorf("namespace %q is already owned by run %q", namespace, current)
+	}
+	if ns.Labels == nil {
+		ns.Labels = map[string]string{}
+	}
+	ns.Labels[label] = owner
+	if _, err := c.clientset.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("claim namespace %q ownership: %w", namespace, err)
+	}
+	return nil
+}
+
 func (c *Client) DeleteNamespaceOwnedBy(ctx context.Context, namespace, label, owner string) error {
 	uid, err := c.OwnedNamespaceUID(ctx, namespace, label, owner)
 	if err != nil || uid == "" {

--- a/scripts/camunda-core/pkg/kube/kube.go
+++ b/scripts/camunda-core/pkg/kube/kube.go
@@ -234,20 +234,11 @@ func (c *Client) NamespaceExists(ctx context.Context, namespace string) (bool, e
 	return true, nil
 }
 
-func (c *Client) EnsureNamespaceOwned(ctx context.Context, namespace, label, owner string, transfer bool) error {
+func (c *Client) EnsureNamespaceOwned(ctx context.Context, namespace, label, owner string) error {
 	ns, err := c.clientset.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
 	if err == nil {
-		if current := ns.Labels[label]; current != owner && !transfer {
+		if current := ns.Labels[label]; current != owner {
 			return fmt.Errorf("namespace %q already exists and is owned by run %q", namespace, current)
-		}
-		if transfer {
-			if ns.Labels == nil {
-				ns.Labels = map[string]string{}
-			}
-			ns.Labels[label] = owner
-			if _, err := c.clientset.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{}); err != nil {
-				return fmt.Errorf("transfer namespace ownership: %w", err)
-			}
 		}
 		return nil
 	}

--- a/scripts/camunda-core/pkg/kube/kube.go
+++ b/scripts/camunda-core/pkg/kube/kube.go
@@ -224,17 +224,28 @@ func (c *Client) NamespaceLabel(ctx context.Context, namespace, label string) (s
 }
 
 func (c *Client) DeleteNamespaceOwnedBy(ctx context.Context, namespace, label, owner string) error {
+	uid, err := c.OwnedNamespaceUID(ctx, namespace, label, owner)
+	if err != nil || uid == "" {
+		return err
+	}
+	return c.DeleteNamespaceWithUID(ctx, namespace, uid)
+}
+
+func (c *Client) OwnedNamespaceUID(ctx context.Context, namespace, label, owner string) (types.UID, error) {
 	ns, err := c.clientset.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		return nil
+		return "", nil
 	}
 	if err != nil {
-		return fmt.Errorf("get namespace %q: %w", namespace, err)
+		return "", fmt.Errorf("get namespace %q: %w", namespace, err)
 	}
 	if actual := ns.Labels[label]; actual != owner {
-		return fmt.Errorf("namespace %q is owned by run %q, not %q", namespace, actual, owner)
+		return "", fmt.Errorf("namespace %q is owned by run %q, not %q", namespace, actual, owner)
 	}
-	uid := ns.UID
+	return ns.UID, nil
+}
+
+func (c *Client) DeleteNamespaceWithUID(ctx context.Context, namespace string, uid types.UID) error {
 	if err := c.clientset.CoreV1().Namespaces().Delete(ctx, namespace, metav1.DeleteOptions{
 		Preconditions: &metav1.Preconditions{UID: &uid},
 	}); err != nil && !apierrors.IsNotFound(err) {

--- a/scripts/camunda-core/pkg/kube/kube.go
+++ b/scripts/camunda-core/pkg/kube/kube.go
@@ -240,7 +240,13 @@ func (c *Client) DeleteNamespaceOwnedBy(ctx context.Context, namespace, label, o
 	}); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("delete namespace %q: %w", namespace, err)
 	}
-	return nil
+	return wait.PollUntilContextTimeout(ctx, 2*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		_, err := c.clientset.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	})
 }
 
 // waitForNamespaceNotTerminating checks if a namespace is terminating and waits for deletion to complete

--- a/scripts/camunda-core/pkg/kube/kube.go
+++ b/scripts/camunda-core/pkg/kube/kube.go
@@ -234,6 +234,29 @@ func (c *Client) NamespaceExists(ctx context.Context, namespace string) (bool, e
 	return true, nil
 }
 
+func (c *Client) EnsureNamespaceOwned(ctx context.Context, namespace, label, owner string) error {
+	ns, err := c.clientset.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	if err == nil {
+		if current := ns.Labels[label]; current != owner {
+			return fmt.Errorf("namespace %q already exists and is owned by run %q", namespace, current)
+		}
+		return nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("get namespace %q: %w", namespace, err)
+	}
+	_, err = c.clientset.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: namespace, Labels: map[string]string{label: owner},
+	}}, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("namespace %q was created concurrently; refusing ownership adoption", namespace)
+	}
+	if err != nil {
+		return fmt.Errorf("create owned namespace %q: %w", namespace, err)
+	}
+	return nil
+}
+
 func (c *Client) ClaimNamespaceOwnership(ctx context.Context, namespace, label, owner string) error {
 	ns, err := c.clientset.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
 	if err != nil {

--- a/scripts/camunda-core/pkg/kube/kube.go
+++ b/scripts/camunda-core/pkg/kube/kube.go
@@ -223,6 +223,17 @@ func (c *Client) NamespaceLabel(ctx context.Context, namespace, label string) (s
 	return ns.Labels[label], nil
 }
 
+func (c *Client) NamespaceExists(ctx context.Context, namespace string) (bool, error) {
+	_, err := c.clientset.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("get namespace %q: %w", namespace, err)
+	}
+	return true, nil
+}
+
 func (c *Client) ClaimNamespaceOwnership(ctx context.Context, namespace, label, owner string) error {
 	ns, err := c.clientset.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
 	if err != nil {
@@ -242,30 +253,30 @@ func (c *Client) ClaimNamespaceOwnership(ctx context.Context, namespace, label, 
 }
 
 func (c *Client) DeleteNamespaceOwnedBy(ctx context.Context, namespace, label, owner string) error {
-	uid, err := c.OwnedNamespaceUID(ctx, namespace, label, owner)
+	uid, resourceVersion, err := c.OwnedNamespaceIdentity(ctx, namespace, label, owner)
 	if err != nil || uid == "" {
 		return err
 	}
-	return c.DeleteNamespaceWithUID(ctx, namespace, uid)
+	return c.DeleteNamespaceWithIdentity(ctx, namespace, uid, resourceVersion)
 }
 
-func (c *Client) OwnedNamespaceUID(ctx context.Context, namespace, label, owner string) (types.UID, error) {
+func (c *Client) OwnedNamespaceIdentity(ctx context.Context, namespace, label, owner string) (types.UID, string, error) {
 	ns, err := c.clientset.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		return "", nil
+		return "", "", nil
 	}
 	if err != nil {
-		return "", fmt.Errorf("get namespace %q: %w", namespace, err)
+		return "", "", fmt.Errorf("get namespace %q: %w", namespace, err)
 	}
 	if actual := ns.Labels[label]; actual != owner {
-		return "", fmt.Errorf("namespace %q is owned by run %q, not %q", namespace, actual, owner)
+		return "", "", fmt.Errorf("namespace %q is owned by run %q, not %q", namespace, actual, owner)
 	}
-	return ns.UID, nil
+	return ns.UID, ns.ResourceVersion, nil
 }
 
-func (c *Client) DeleteNamespaceWithUID(ctx context.Context, namespace string, uid types.UID) error {
+func (c *Client) DeleteNamespaceWithIdentity(ctx context.Context, namespace string, uid types.UID, resourceVersion string) error {
 	if err := c.clientset.CoreV1().Namespaces().Delete(ctx, namespace, metav1.DeleteOptions{
-		Preconditions: &metav1.Preconditions{UID: &uid},
+		Preconditions: &metav1.Preconditions{UID: &uid, ResourceVersion: &resourceVersion},
 	}); err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("delete namespace %q: %w", namespace, err)
 	}

--- a/scripts/camunda-core/pkg/kube/kube.go
+++ b/scripts/camunda-core/pkg/kube/kube.go
@@ -234,11 +234,20 @@ func (c *Client) NamespaceExists(ctx context.Context, namespace string) (bool, e
 	return true, nil
 }
 
-func (c *Client) EnsureNamespaceOwned(ctx context.Context, namespace, label, owner string) error {
+func (c *Client) EnsureNamespaceOwned(ctx context.Context, namespace, label, owner string, transfer bool) error {
 	ns, err := c.clientset.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
 	if err == nil {
-		if current := ns.Labels[label]; current != owner {
+		if current := ns.Labels[label]; current != owner && !transfer {
 			return fmt.Errorf("namespace %q already exists and is owned by run %q", namespace, current)
+		}
+		if transfer {
+			if ns.Labels == nil {
+				ns.Labels = map[string]string{}
+			}
+			ns.Labels[label] = owner
+			if _, err := c.clientset.CoreV1().Namespaces().Update(ctx, ns, metav1.UpdateOptions{}); err != nil {
+				return fmt.Errorf("transfer namespace ownership: %w", err)
+			}
 		}
 		return nil
 	}

--- a/scripts/camunda-core/pkg/kube/kube.go
+++ b/scripts/camunda-core/pkg/kube/kube.go
@@ -240,6 +240,16 @@ func (c *Client) EnsureNamespaceOwned(ctx context.Context, namespace, label, own
 		if current := ns.Labels[label]; current != owner {
 			return fmt.Errorf("namespace %q already exists and is owned by run %q", namespace, current)
 		}
+		if ns.Status.Phase != corev1.NamespaceTerminating {
+			return nil
+		}
+		if err := c.waitForNamespaceNotTerminating(ctx, namespace, 5*time.Minute); err != nil {
+			return err
+		}
+		_, err = c.clientset.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace, Labels: map[string]string{label: owner}}}, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("recreate owned namespace %q: %w", namespace, err)
+		}
 		return nil
 	}
 	if !apierrors.IsNotFound(err) {

--- a/scripts/camunda-core/pkg/kube/kube.go
+++ b/scripts/camunda-core/pkg/kube/kube.go
@@ -215,6 +215,34 @@ func (c *Client) EnsureNamespace(ctx context.Context, namespace string) error {
 	return nil
 }
 
+func (c *Client) NamespaceLabel(ctx context.Context, namespace, label string) (string, error) {
+	ns, err := c.clientset.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("get namespace %q: %w", namespace, err)
+	}
+	return ns.Labels[label], nil
+}
+
+func (c *Client) DeleteNamespaceOwnedBy(ctx context.Context, namespace, label, owner string) error {
+	ns, err := c.clientset.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("get namespace %q: %w", namespace, err)
+	}
+	if actual := ns.Labels[label]; actual != owner {
+		return fmt.Errorf("namespace %q is owned by run %q, not %q", namespace, actual, owner)
+	}
+	uid := ns.UID
+	if err := c.clientset.CoreV1().Namespaces().Delete(ctx, namespace, metav1.DeleteOptions{
+		Preconditions: &metav1.Preconditions{UID: &uid},
+	}); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete namespace %q: %w", namespace, err)
+	}
+	return nil
+}
+
 // waitForNamespaceNotTerminating checks if a namespace is terminating and waits for deletion to complete
 func (c *Client) waitForNamespaceNotTerminating(ctx context.Context, namespace string, timeout time.Duration) error {
 	ns, err := c.clientset.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})

--- a/scripts/camunda-core/pkg/kube/kube_namespace_test.go
+++ b/scripts/camunda-core/pkg/kube/kube_namespace_test.go
@@ -46,18 +46,19 @@ func TestDeleteNamespaceOwnedByAllowsMissing(t *testing.T) {
 
 func TestDeleteNamespaceOwnedByPreservesReplacement(t *testing.T) {
 	original := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
-		Name: "owned", UID: types.UID("uid-1"), Labels: map[string]string{"deploy-camunda-run": "run-1"},
+		Name: "owned", UID: types.UID("uid-1"), ResourceVersion: "rv-1", Labels: map[string]string{"deploy-camunda-run": "run-1"},
 	}}
 	client := newTestClient(original)
 	client.clientset.(*fake.Clientset).PrependReactor("delete", "namespaces", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		deleteAction := action.(k8stesting.DeleteAction)
-		if deleteAction.GetDeleteOptions().Preconditions != nil && deleteAction.GetDeleteOptions().Preconditions.UID != nil && *deleteAction.GetDeleteOptions().Preconditions.UID == types.UID("uid-1") {
+		preconditions := deleteAction.GetDeleteOptions().Preconditions
+		if preconditions != nil && preconditions.UID != nil && *preconditions.UID == types.UID("uid-1") && preconditions.ResourceVersion != nil && *preconditions.ResourceVersion == "rv-1" {
 			return true, nil, apierrors.NewConflict(schema.GroupResource{Resource: "namespaces"}, "owned", nil)
 		}
 		return false, nil, nil
 	})
 	if err := client.DeleteNamespaceOwnedBy(context.Background(), "owned", "deploy-camunda-run", "run-1"); err == nil {
-		t.Fatal("expected UID precondition conflict")
+		t.Fatal("expected UID/resourceVersion precondition conflict")
 	}
 }
 

--- a/scripts/camunda-core/pkg/kube/kube_namespace_test.go
+++ b/scripts/camunda-core/pkg/kube/kube_namespace_test.go
@@ -7,7 +7,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestDeleteNamespaceOwnedBy(t *testing.T) {
@@ -37,5 +41,22 @@ func TestDeleteNamespaceOwnedByRejectsMismatch(t *testing.T) {
 func TestDeleteNamespaceOwnedByAllowsMissing(t *testing.T) {
 	if err := newTestClient().DeleteNamespaceOwnedBy(context.Background(), "missing", "deploy-camunda-run", "run-1"); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestDeleteNamespaceOwnedByPreservesReplacement(t *testing.T) {
+	original := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: "owned", UID: types.UID("uid-1"), Labels: map[string]string{"deploy-camunda-run": "run-1"},
+	}}
+	client := newTestClient(original)
+	client.clientset.(*fake.Clientset).PrependReactor("delete", "namespaces", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		deleteAction := action.(k8stesting.DeleteAction)
+		if deleteAction.GetDeleteOptions().Preconditions != nil && deleteAction.GetDeleteOptions().Preconditions.UID != nil && *deleteAction.GetDeleteOptions().Preconditions.UID == types.UID("uid-1") {
+			return true, nil, apierrors.NewConflict(schema.GroupResource{Resource: "namespaces"}, "owned", nil)
+		}
+		return false, nil, nil
+	})
+	if err := client.DeleteNamespaceOwnedBy(context.Background(), "owned", "deploy-camunda-run", "run-1"); err == nil {
+		t.Fatal("expected UID precondition conflict")
 	}
 }

--- a/scripts/camunda-core/pkg/kube/kube_namespace_test.go
+++ b/scripts/camunda-core/pkg/kube/kube_namespace_test.go
@@ -1,0 +1,41 @@
+package kube
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestDeleteNamespaceOwnedBy(t *testing.T) {
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: "owned", UID: types.UID("uid-1"), Labels: map[string]string{"deploy-camunda-run": "run-1"},
+	}}
+	client := newTestClient(namespace)
+	if err := client.DeleteNamespaceOwnedBy(context.Background(), "owned", "deploy-camunda-run", "run-1"); err != nil {
+		t.Fatal(err)
+	}
+	_, err := client.clientset.CoreV1().Namespaces().Get(context.Background(), "owned", metav1.GetOptions{})
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("namespace still exists: %v", err)
+	}
+}
+
+func TestDeleteNamespaceOwnedByRejectsMismatch(t *testing.T) {
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name: "owned", UID: types.UID("uid-1"), Labels: map[string]string{"deploy-camunda-run": "other-run"},
+	}}
+	client := newTestClient(namespace)
+	if err := client.DeleteNamespaceOwnedBy(context.Background(), "owned", "deploy-camunda-run", "run-1"); err == nil {
+		t.Fatal("expected ownership mismatch")
+	}
+}
+
+func TestDeleteNamespaceOwnedByAllowsMissing(t *testing.T) {
+	if err := newTestClient().DeleteNamespaceOwnedBy(context.Background(), "missing", "deploy-camunda-run", "run-1"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/scripts/camunda-core/pkg/kube/kube_namespace_test.go
+++ b/scripts/camunda-core/pkg/kube/kube_namespace_test.go
@@ -60,3 +60,41 @@ func TestDeleteNamespaceOwnedByPreservesReplacement(t *testing.T) {
 		t.Fatal("expected UID precondition conflict")
 	}
 }
+
+func TestEnsureNamespaceOwnedCreatesLabelledNamespace(t *testing.T) {
+	client := newTestClient()
+	if err := client.EnsureNamespaceOwned(context.Background(), "owned", "deploy-camunda-run", "run-1"); err != nil {
+		t.Fatal(err)
+	}
+	ns, err := client.clientset.CoreV1().Namespaces().Get(context.Background(), "owned", metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ns.Labels["deploy-camunda-run"] != "run-1" {
+		t.Fatalf("labels = %#v", ns.Labels)
+	}
+}
+
+func TestEnsureNamespaceOwnedAllowsSameOwner(t *testing.T) {
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "owned", Labels: map[string]string{"deploy-camunda-run": "run-1"}}}
+	if err := newTestClient(ns).EnsureNamespaceOwned(context.Background(), "owned", "deploy-camunda-run", "run-1"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnsureNamespaceOwnedRejectsForeignOwner(t *testing.T) {
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "owned", Labels: map[string]string{"deploy-camunda-run": "other"}}}
+	if err := newTestClient(ns).EnsureNamespaceOwned(context.Background(), "owned", "deploy-camunda-run", "run-1"); err == nil {
+		t.Fatal("expected foreign owner rejection")
+	}
+}
+
+func TestEnsureNamespaceOwnedRejectsConcurrentCreate(t *testing.T) {
+	client := newTestClient()
+	client.clientset.(*fake.Clientset).PrependReactor("create", "namespaces", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewAlreadyExists(schema.GroupResource{Resource: "namespaces"}, "owned")
+	})
+	if err := client.EnsureNamespaceOwned(context.Background(), "owned", "deploy-camunda-run", "run-1"); err == nil {
+		t.Fatal("expected concurrent create rejection")
+	}
+}

--- a/scripts/deploy-camunda/README.md
+++ b/scripts/deploy-camunda/README.md
@@ -499,6 +499,7 @@ one of these ways (first non-empty wins):
 - `--dockerhub-username` / `--dockerhub-password` CLI flags
 - `DOCKERHUB_USERNAME` / `DOCKERHUB_PASSWORD` env
 - `TEST_DOCKER_USERNAME` / `TEST_DOCKER_PASSWORD` env (CI legacy names)
+- OS keyring entry created by `deploy-camunda credentials configure --registry dockerhub`
 
 Set `--ensure-docker-hub` (or `ensureDockerHub: true` in the config file)
 so the runner creates a pull secret in the target namespace before
@@ -512,6 +513,7 @@ For images from `registry.camunda.cloud` (Harbor):
 - `HARBOR_USERNAME` / `HARBOR_PASSWORD` env
 - `TEST_DOCKER_USERNAME_CAMUNDA_CLOUD` / `TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD` env
 - `NEXUS_USERNAME` / `NEXUS_PASSWORD` env
+- OS keyring entry created by `deploy-camunda credentials configure --registry harbor`
 
 Set `--ensure-docker-registry` (or `ensureDockerRegistry: true`) to
 create the Harbor pull secret. `deploy-camunda doctor` reports both
@@ -520,9 +522,25 @@ registries' credentials as ✓/✗ and only fails when the matching
 
 ### Persisting credentials
 
-Never commit credentials to `.deploy-camunda.yaml`. Persist them in
-`.env` (which `deploy-camunda config init` writes for you) or set them
-via your shell's env-manager. `deploy-camunda config env --show-origin`
+Never commit credentials to `.deploy-camunda.yaml`. For local use, store
+them once in macOS Keychain, Linux Secret Service, or Windows Credential
+Manager:
+
+```bash
+deploy-camunda credentials configure --registry harbor
+deploy-camunda credentials configure --registry dockerhub
+deploy-camunda credentials status
+```
+
+The password/token prompt disables terminal echo. Credentials are not
+written to `.env`, config, logs, replay commands, or matrix state. Use a
+Harbor robot credential and a Docker Hub access token rather than account
+passwords. Headless CI and hosts without an OS keyring continue to use
+environment variables; implicit keyring lookup is skipped when the backend
+is unavailable.
+
+Resolution precedence is CLI/config pair, environment or `.env` pair, OS
+keyring, then opt-in plaintext Docker config import. `deploy-camunda config env --show-origin`
 prints which layer each variable resolved from — process env vs `.env`
 vs per-entry override.
 

--- a/scripts/deploy-camunda/auth0/auth0.go
+++ b/scripts/deploy-camunda/auth0/auth0.go
@@ -372,11 +372,11 @@ func CleanupClientsStrict(ctx context.Context, opts Options) error {
 	// — which Auth0 allows — all get cleaned up.
 	for _, c := range allClients {
 		if !expected[c.Name] {
-			return err
+			continue
 		}
 		if err := deleteClient(ctx, client, token, &opts, c.ClientID); err != nil {
 			logging.Logger.Warn().Err(err).Str("name", c.Name).Str("clientId", c.ClientID).Msg("auth0 cleanup: delete failed")
-			continue
+			return fmt.Errorf("delete Auth0 client %q: %w", c.Name, err)
 		}
 		logging.Logger.Info().Str("name", c.Name).Str("clientId", c.ClientID).Msg("Deleted Auth0 client")
 	}
@@ -767,7 +767,7 @@ func grantAudience(ctx context.Context, client *http.Client, token string, opts 
 		return req, nil
 	}, "grantAudience")
 	if err != nil {
-		return err
+		return fmt.Errorf("grant audience: %w", err)
 	}
 	switch status {
 	case http.StatusCreated, http.StatusOK, http.StatusConflict:

--- a/scripts/deploy-camunda/auth0/auth0.go
+++ b/scripts/deploy-camunda/auth0/auth0.go
@@ -129,7 +129,8 @@ type Options struct {
 	PostgresPasswords map[string]string
 
 	// HTTPClient is an optional HTTP client. Defaults to http.DefaultClient.
-	HTTPClient *http.Client
+	HTTPClient      *http.Client
+	OnClientCreated func(Client) error
 }
 
 // Client is a single provisioned Auth0 client.
@@ -287,6 +288,11 @@ func EnsureClients(ctx context.Context, opts Options) (*Provisioned, error) {
 			Str("clientId", c.ClientID).
 			Msg("Created Auth0 private client")
 		prov.Private = append(prov.Private, c)
+		if opts.OnClientCreated != nil {
+			if err := opts.OnClientCreated(c); err != nil {
+				return prov, fmt.Errorf("auth0: checkpoint client %q: %w", comp, err)
+			}
+		}
 	}
 	for _, comp := range PublicComponents {
 		c, err := createClient(ctx, client, token, &opts, comp, kindSPA)
@@ -298,6 +304,11 @@ func EnsureClients(ctx context.Context, opts Options) (*Provisioned, error) {
 			Str("clientId", c.ClientID).
 			Msg("Created Auth0 public client")
 		prov.Public = append(prov.Public, c)
+		if opts.OnClientCreated != nil {
+			if err := opts.OnClientCreated(c); err != nil {
+				return prov, fmt.Errorf("auth0: checkpoint client %q: %w", comp, err)
+			}
+		}
 	}
 
 	for _, c := range prov.Private {

--- a/scripts/deploy-camunda/auth0/auth0.go
+++ b/scripts/deploy-camunda/auth0/auth0.go
@@ -18,6 +18,7 @@ import (
 	cryptorand "crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -381,6 +382,24 @@ func CleanupClientsStrict(ctx context.Context, opts Options) error {
 		logging.Logger.Info().Str("name", c.Name).Str("clientId", c.ClientID).Msg("Deleted Auth0 client")
 	}
 	return nil
+}
+
+func CleanupClientIDsStrict(ctx context.Context, opts Options, clientIDs []string) error {
+	if err := resolveOpts(&opts, false); err != nil {
+		return err
+	}
+	client := httpClientFor(&opts)
+	token, err := acquireManagementToken(ctx, client, &opts)
+	if err != nil {
+		return err
+	}
+	var cleanupErr error
+	for _, clientID := range clientIDs {
+		if err := deleteClient(ctx, client, token, &opts, clientID); err != nil {
+			cleanupErr = errors.Join(cleanupErr, err)
+		}
+	}
+	return cleanupErr
 }
 
 // CreateK8sSecret creates or updates the K8s secret holding the values the

--- a/scripts/deploy-camunda/auth0/auth0.go
+++ b/scripts/deploy-camunda/auth0/auth0.go
@@ -37,6 +37,16 @@ import (
 // tests can override with an httptest server URL.
 var auth0BaseURL = "https://distribution-team.eu.auth0.com"
 
+func EffectiveDomain(value string) string {
+	if value != "" {
+		return strings.TrimSuffix(value, "/")
+	}
+	if envValue := os.Getenv("AUTH0_DOMAIN"); envValue != "" {
+		return strings.TrimSuffix(envValue, "/")
+	}
+	return auth0BaseURL
+}
+
 // Retry parameters for Auth0 Management API calls. Variables (not consts) so
 // tests can shrink them to ms scale. The Auth0 tenant has a "global limit"
 // that triggers HTTP 429s under burst load; bounded exponential backoff
@@ -179,10 +189,7 @@ func IsAuth0Identity(identity string) bool {
 // never touches redirect URIs).
 func resolveOpts(opts *Options, requireIngressHost bool) error {
 	if opts.Domain == "" {
-		opts.Domain = os.Getenv("AUTH0_DOMAIN")
-	}
-	if opts.Domain == "" {
-		opts.Domain = auth0BaseURL
+		opts.Domain = EffectiveDomain("")
 	}
 	if opts.Audience == "" {
 		opts.Audience = DefaultAudience

--- a/scripts/deploy-camunda/auth0/auth0.go
+++ b/scripts/deploy-camunda/auth0/auth0.go
@@ -336,22 +336,27 @@ func EnsureClients(ctx context.Context, opts Options) (*Provisioned, error) {
 // then deletes only the ones we expect for this namespace. This is dramatically
 // kinder on the Auth0 rate limit than the previous per-component lookup loop.
 func CleanupClients(ctx context.Context, opts Options) {
+	if err := CleanupClientsStrict(ctx, opts); err != nil {
+		logging.Logger.Warn().Err(err).Msg("auth0 cleanup failed")
+	}
+}
+
+func CleanupClientsStrict(ctx context.Context, opts Options) error {
 	if err := resolveOpts(&opts, false); err != nil {
-		logging.Logger.Warn().Err(err).Msg("auth0 cleanup: invalid options, skipping")
-		return
+		return err
 	}
 	client := httpClientFor(&opts)
 
 	token, err := acquireManagementToken(ctx, client, &opts)
 	if err != nil {
 		logging.Logger.Warn().Err(err).Msg("auth0 cleanup: failed to acquire management token")
-		return
+		return err
 	}
 
 	allClients, err := listAllClients(ctx, client, token, &opts)
 	if err != nil {
 		logging.Logger.Warn().Err(err).Msg("auth0 cleanup: list failed")
-		return
+		return err
 	}
 
 	all := append([]string{}, PrivateComponents...)
@@ -367,7 +372,7 @@ func CleanupClients(ctx context.Context, opts Options) {
 	// — which Auth0 allows — all get cleaned up.
 	for _, c := range allClients {
 		if !expected[c.Name] {
-			continue
+			return err
 		}
 		if err := deleteClient(ctx, client, token, &opts, c.ClientID); err != nil {
 			logging.Logger.Warn().Err(err).Str("name", c.Name).Str("clientId", c.ClientID).Msg("auth0 cleanup: delete failed")
@@ -375,6 +380,7 @@ func CleanupClients(ctx context.Context, opts Options) {
 		}
 		logging.Logger.Info().Str("name", c.Name).Str("clientId", c.ClientID).Msg("Deleted Auth0 client")
 	}
+	return nil
 }
 
 // CreateK8sSecret creates or updates the K8s secret holding the values the

--- a/scripts/deploy-camunda/auth0/auth0_test.go
+++ b/scripts/deploy-camunda/auth0/auth0_test.go
@@ -407,3 +407,18 @@ func TestCleanupClients_DeletesByName(t *testing.T) {
 		t.Error("must not delete clients from other namespaces")
 	}
 }
+
+func TestCleanupClientsStrictReturnsDeleteFailure(t *testing.T) {
+	srv := newTestServer(t, map[string]http.HandlerFunc{
+		"POST /oauth/token": tokenHandler(),
+		"GET /api/v2/clients": func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewEncoder(w).Encode([]map[string]string{{"client_id": "id-A", "name": "ns-identity"}})
+		},
+		"DELETE /api/v2/clients/": func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusInternalServerError) },
+	})
+	defer srv.Close()
+	err := CleanupClientsStrict(context.Background(), Options{Namespace: "ns", Domain: srv.URL, MgmtClientID: "x", MgmtClientSecret: "y", HTTPClient: srv.Client()})
+	if err == nil {
+		t.Fatal("expected strict cleanup failure")
+	}
+}

--- a/scripts/deploy-camunda/auth0/auth0_test.go
+++ b/scripts/deploy-camunda/auth0/auth0_test.go
@@ -3,6 +3,8 @@ package auth0
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -451,5 +453,41 @@ func TestCleanupClientIDsStrictAggregatesFailures(t *testing.T) {
 	err := CleanupClientIDsStrict(context.Background(), Options{Namespace: "ns", Domain: srv.URL, MgmtClientID: "x", MgmtClientSecret: "y", HTTPClient: srv.Client()}, []string{"id-A", "id-B"})
 	if err == nil {
 		t.Fatal("expected aggregate failure")
+	}
+}
+
+func TestEnsureClientsInvokesCheckpointForEveryClient(t *testing.T) {
+	srv := newTestServer(t, map[string]http.HandlerFunc{
+		"POST /oauth/token": tokenHandler(),
+		"POST /api/v2/clients": func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]string{"client_id": fmt.Sprintf("id-%d", time.Now().UnixNano()), "client_secret": "secret", "name": "created"})
+		},
+		"POST /api/v2/client-grants": func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusCreated) },
+	})
+	defer srv.Close()
+	var checkpointed []string
+	prov, err := EnsureClients(context.Background(), Options{Namespace: "ns", IngressHost: "host", Domain: srv.URL, MgmtClientID: "x", MgmtClientSecret: "y", HTTPClient: srv.Client(), SkipK8sSecret: true, OnClientCreated: func(client Client) error { checkpointed = append(checkpointed, client.ClientID); return nil }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(checkpointed) != len(prov.All()) || len(checkpointed) == 0 {
+		t.Fatalf("checkpointed=%v clients=%v", checkpointed, prov.All())
+	}
+}
+
+func TestEnsureClientsReturnsPartialOnCheckpointFailure(t *testing.T) {
+	srv := newTestServer(t, map[string]http.HandlerFunc{
+		"POST /oauth/token": tokenHandler(),
+		"POST /api/v2/clients": func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]string{"client_id": "id-A", "client_secret": "secret", "name": "created"})
+		},
+	})
+	defer srv.Close()
+	prov, err := EnsureClients(context.Background(), Options{Namespace: "ns", IngressHost: "host", Domain: srv.URL, MgmtClientID: "x", MgmtClientSecret: "y", HTTPClient: srv.Client(), SkipK8sSecret: true, OnClientCreated: func(Client) error { return errors.New("checkpoint failed") }})
+	if err == nil {
+		t.Fatal("expected checkpoint failure")
+	}
+	if prov == nil || len(prov.All()) != 1 {
+		t.Fatalf("partial provisioned = %#v", prov)
 	}
 }

--- a/scripts/deploy-camunda/auth0/auth0_test.go
+++ b/scripts/deploy-camunda/auth0/auth0_test.go
@@ -422,3 +422,34 @@ func TestCleanupClientsStrictReturnsDeleteFailure(t *testing.T) {
 		t.Fatal("expected strict cleanup failure")
 	}
 }
+
+func TestCleanupClientIDsStrictDeletesOnlyRecordedIDs(t *testing.T) {
+	deleted := map[string]bool{}
+	srv := newTestServer(t, map[string]http.HandlerFunc{
+		"POST /oauth/token": tokenHandler(),
+		"DELETE /api/v2/clients/": func(w http.ResponseWriter, r *http.Request) {
+			deleted[strings.TrimPrefix(r.URL.Path, "/api/v2/clients/")] = true
+			w.WriteHeader(http.StatusNoContent)
+		},
+	})
+	defer srv.Close()
+	err := CleanupClientIDsStrict(context.Background(), Options{Namespace: "ns", Domain: srv.URL, MgmtClientID: "x", MgmtClientSecret: "y", HTTPClient: srv.Client()}, []string{"id-A", "id-B"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !deleted["id-A"] || !deleted["id-B"] || len(deleted) != 2 {
+		t.Fatalf("deleted = %#v", deleted)
+	}
+}
+
+func TestCleanupClientIDsStrictAggregatesFailures(t *testing.T) {
+	srv := newTestServer(t, map[string]http.HandlerFunc{
+		"POST /oauth/token":       tokenHandler(),
+		"DELETE /api/v2/clients/": func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusInternalServerError) },
+	})
+	defer srv.Close()
+	err := CleanupClientIDsStrict(context.Background(), Options{Namespace: "ns", Domain: srv.URL, MgmtClientID: "x", MgmtClientSecret: "y", HTTPClient: srv.Client()}, []string{"id-A", "id-B"})
+	if err == nil {
+		t.Fatal("expected aggregate failure")
+	}
+}

--- a/scripts/deploy-camunda/auth0/auth0_test.go
+++ b/scripts/deploy-camunda/auth0/auth0_test.go
@@ -463,6 +463,12 @@ func TestEffectiveDomainUsesDefault(t *testing.T) {
 	}
 }
 
+func TestEffectiveDomainTrimsTrailingSlash(t *testing.T) {
+	if got := EffectiveDomain("https://tenant.example/"); got != "https://tenant.example" {
+		t.Fatalf("domain = %q", got)
+	}
+}
+
 func TestEnsureClientsInvokesCheckpointForEveryClient(t *testing.T) {
 	srv := newTestServer(t, map[string]http.HandlerFunc{
 		"POST /oauth/token": tokenHandler(),

--- a/scripts/deploy-camunda/auth0/auth0_test.go
+++ b/scripts/deploy-camunda/auth0/auth0_test.go
@@ -456,6 +456,13 @@ func TestCleanupClientIDsStrictAggregatesFailures(t *testing.T) {
 	}
 }
 
+func TestEffectiveDomainUsesDefault(t *testing.T) {
+	t.Setenv("AUTH0_DOMAIN", "")
+	if got := EffectiveDomain(""); got != auth0BaseURL {
+		t.Fatalf("domain = %q", got)
+	}
+}
+
 func TestEnsureClientsInvokesCheckpointForEveryClient(t *testing.T) {
 	srv := newTestServer(t, map[string]http.HandlerFunc{
 		"POST /oauth/token": tokenHandler(),

--- a/scripts/deploy-camunda/cmd/credentials.go
+++ b/scripts/deploy-camunda/cmd/credentials.go
@@ -58,7 +58,7 @@ func newCredentialsStatusCommand() *cobra.Command {
 		Use: "status", Short: "Show which registry credentials are configured", Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			for _, registry := range []string{credentials.HarborRegistry, credentials.DockerHubRegistry} {
-				credential, found, err := credentialStore.Get(registry)
+				credential, found, err := credentials.GetOptional(credentialStore, registry)
 				if err != nil {
 					return err
 				}

--- a/scripts/deploy-camunda/cmd/credentials.go
+++ b/scripts/deploy-camunda/cmd/credentials.go
@@ -1,0 +1,128 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"scripts/deploy-camunda/credentials"
+)
+
+var credentialStore credentials.Store = credentials.KeyringStore{}
+
+func registerRootCommands(root *cobra.Command) {
+	root.AddCommand(newCompletionCommand(root), newConfigCommand(), newCredentialsCommand(), newMatrixCommand(), newPrepareValuesCommand(), newEntraCommand(), newWatchCommand(), newAuth0Command(), newDoctorCommand(), newTriageCommand(), newDiagnosticsCommand(), newCICommand(), newE2EEnvCommand(), newTopologyCommand())
+}
+
+func newCredentialsCommand() *cobra.Command {
+	cmd := &cobra.Command{Use: "credentials", Short: "Manage registry credentials in the OS keyring"}
+	cmd.AddCommand(newCredentialsConfigureCommand(), newCredentialsStatusCommand(), newCredentialsDeleteCommand())
+	return cmd
+}
+
+func newCredentialsConfigureCommand() *cobra.Command {
+	var registry string
+	cmd := &cobra.Command{
+		Use:   "configure",
+		Short: "Securely store Harbor or Docker Hub credentials",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			registry, err := canonicalCredentialRegistry(registry)
+			if err != nil {
+				return err
+			}
+			reader := bufio.NewReader(cmd.InOrStdin())
+			username, err := promptLine(cmd.Context(), cmd.OutOrStdout(), reader, "Username", "")
+			if err != nil {
+				return err
+			}
+			password, err := promptSecret(cmd.Context(), cmd.OutOrStdout(), reader, "Password or access token")
+			if err != nil {
+				return err
+			}
+			if err := credentialStore.Set(registry, credentials.Credential{Username: username, Password: password}); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Stored %s credentials in the OS keyring.\n", registry)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&registry, "registry", "", "Registry: harbor or dockerhub")
+	_ = cmd.MarkFlagRequired("registry")
+	return cmd
+}
+
+func newCredentialsStatusCommand() *cobra.Command {
+	return &cobra.Command{
+		Use: "status", Short: "Show which registry credentials are configured", Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			for _, registry := range []string{credentials.HarborRegistry, credentials.DockerHubRegistry} {
+				credential, found, err := credentialStore.Get(registry)
+				if err != nil {
+					return err
+				}
+				if found {
+					fmt.Fprintf(cmd.OutOrStdout(), "%s: configured (%s)\n", registry, credential.Username)
+				} else {
+					fmt.Fprintf(cmd.OutOrStdout(), "%s: not configured\n", registry)
+				}
+			}
+			return nil
+		},
+	}
+}
+
+func newCredentialsDeleteCommand() *cobra.Command {
+	var registry string
+	cmd := &cobra.Command{
+		Use: "delete", Short: "Delete registry credentials from the OS keyring", Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			registry, err := canonicalCredentialRegistry(registry)
+			if err != nil {
+				return err
+			}
+			if err := credentialStore.Delete(registry); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Deleted %s credentials from the OS keyring.\n", registry)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&registry, "registry", "", "Registry: harbor or dockerhub")
+	_ = cmd.MarkFlagRequired("registry")
+	return cmd
+}
+
+func canonicalCredentialRegistry(value string) (string, error) {
+	switch value {
+	case "harbor", credentials.HarborRegistry:
+		return credentials.HarborRegistry, nil
+	case "dockerhub", "docker.io":
+		return credentials.DockerHubRegistry, nil
+	default:
+		return "", fmt.Errorf("unsupported registry %q; use harbor or dockerhub", value)
+	}
+}
+
+func resolveKeyringCredentialPairs(harborUser, harborPassword, hubUser, hubPassword *string, requireHarbor, requireHub bool) error {
+	for _, item := range []struct {
+		registry           string
+		username, password *string
+		required           bool
+	}{
+		{credentials.HarborRegistry, harborUser, harborPassword, requireHarbor}, {credentials.DockerHubRegistry, hubUser, hubPassword, requireHub},
+	} {
+		if !item.required || *item.username != "" || *item.password != "" {
+			continue
+		}
+		credential, found, err := credentials.GetOptional(credentialStore, item.registry)
+		if err != nil {
+			return err
+		}
+		if found {
+			*item.username, *item.password = credential.Username, credential.Password
+		}
+	}
+	return nil
+}

--- a/scripts/deploy-camunda/cmd/credentials_test.go
+++ b/scripts/deploy-camunda/cmd/credentials_test.go
@@ -12,6 +12,14 @@ type memoryCredentialStore struct {
 	values map[string]credentials.Credential
 }
 
+type unavailableCredentialStore struct{}
+
+func (unavailableCredentialStore) Get(string) (credentials.Credential, bool, error) {
+	return credentials.Credential{}, false, &credentials.UnavailableError{Err: errors.New("no session bus")}
+}
+func (unavailableCredentialStore) Set(string, credentials.Credential) error { return nil }
+func (unavailableCredentialStore) Delete(string) error                      { return nil }
+
 func (s *memoryCredentialStore) Get(registry string) (credentials.Credential, bool, error) {
 	value, ok := s.values[registry]
 	return value, ok, nil
@@ -72,6 +80,21 @@ func TestCredentialsStatusDoesNotPrintSecrets(t *testing.T) {
 	}
 	if !bytes.Contains(out.Bytes(), []byte("robot")) {
 		t.Fatal("status omitted username")
+	}
+}
+
+func TestCredentialsStatusToleratesUnavailableKeyring(t *testing.T) {
+	original := credentialStore
+	credentialStore = unavailableCredentialStore{}
+	t.Cleanup(func() { credentialStore = original })
+	cmd := newCredentialsStatusCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(out.Bytes(), []byte("not configured")) {
+		t.Fatalf("output = %q", out.String())
 	}
 }
 

--- a/scripts/deploy-camunda/cmd/credentials_test.go
+++ b/scripts/deploy-camunda/cmd/credentials_test.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"scripts/deploy-camunda/credentials"
+)
+
+type memoryCredentialStore struct {
+	values map[string]credentials.Credential
+}
+
+func (s *memoryCredentialStore) Get(registry string) (credentials.Credential, bool, error) {
+	value, ok := s.values[registry]
+	return value, ok, nil
+}
+func (s *memoryCredentialStore) Set(registry string, credential credentials.Credential) error {
+	if credential.Username == "" || credential.Password == "" {
+		return errors.New("incomplete")
+	}
+	s.values[registry] = credential
+	return nil
+}
+func (s *memoryCredentialStore) Delete(registry string) error { delete(s.values, registry); return nil }
+
+func useMemoryCredentialStore(t *testing.T) *memoryCredentialStore {
+	t.Helper()
+	store := &memoryCredentialStore{values: map[string]credentials.Credential{}}
+	original := credentialStore
+	credentialStore = store
+	t.Cleanup(func() { credentialStore = original })
+	return store
+}
+
+func TestResolveKeyringCredentialPairs(t *testing.T) {
+	store := useMemoryCredentialStore(t)
+	store.values[credentials.HarborRegistry] = credentials.Credential{Username: "robot", Password: "token"}
+	harborUser, harborPassword, hubUser, hubPassword := "", "", "", ""
+	if err := resolveKeyringCredentialPairs(&harborUser, &harborPassword, &hubUser, &hubPassword, true, false); err != nil {
+		t.Fatal(err)
+	}
+	if harborUser != "robot" || harborPassword != "token" {
+		t.Fatalf("unexpected Harbor credentials %q/%q", harborUser, harborPassword)
+	}
+}
+
+func TestResolveKeyringPreservesExplicitPair(t *testing.T) {
+	store := useMemoryCredentialStore(t)
+	store.values[credentials.HarborRegistry] = credentials.Credential{Username: "stored", Password: "stored-token"}
+	harborUser, harborPassword, hubUser, hubPassword := "explicit", "explicit-token", "", ""
+	if err := resolveKeyringCredentialPairs(&harborUser, &harborPassword, &hubUser, &hubPassword, true, false); err != nil {
+		t.Fatal(err)
+	}
+	if harborUser != "explicit" || harborPassword != "explicit-token" {
+		t.Fatal("keyring replaced explicit credentials")
+	}
+}
+
+func TestCredentialsStatusDoesNotPrintSecrets(t *testing.T) {
+	store := useMemoryCredentialStore(t)
+	store.values[credentials.HarborRegistry] = credentials.Credential{Username: "robot", Password: "secret-token"}
+	cmd := newCredentialsStatusCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(out.Bytes(), []byte("secret-token")) {
+		t.Fatal("status exposed secret")
+	}
+	if !bytes.Contains(out.Bytes(), []byte("robot")) {
+		t.Fatal("status omitted username")
+	}
+}
+
+func TestCredentialsCommandRegistered(t *testing.T) {
+	root := NewRootCommand()
+	registerRootCommands(root)
+	command, _, err := root.Find([]string{"credentials"})
+	if err != nil || command.Name() != "credentials" {
+		t.Fatalf("credentials command not registered: %v", err)
+	}
+	status, _, err := command.Find([]string{"status"})
+	if err != nil || status.Name() != "status" {
+		t.Fatalf("credentials status not registered: %v", err)
+	}
+}

--- a/scripts/deploy-camunda/cmd/credentials_test.go
+++ b/scripts/deploy-camunda/cmd/credentials_test.go
@@ -98,6 +98,25 @@ func TestCredentialsStatusToleratesUnavailableKeyring(t *testing.T) {
 	}
 }
 
+func TestCredentialsConfigureStoresCompletePairWithoutPrintingSecret(t *testing.T) {
+	store := useMemoryCredentialStore(t)
+	cmd := newCredentialsConfigureCommand()
+	cmd.SetArgs([]string{"--registry", "harbor"})
+	cmd.SetIn(bytes.NewBufferString("robot\nsecret-token\n"))
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	stored := store.values[credentials.HarborRegistry]
+	if stored.Username != "robot" || stored.Password != "secret-token" {
+		t.Fatalf("stored = %#v", stored)
+	}
+	if bytes.Contains(out.Bytes(), []byte("secret-token")) {
+		t.Fatal("configure output exposed secret")
+	}
+}
+
 func TestCredentialsCommandRegistered(t *testing.T) {
 	root := NewRootCommand()
 	registerRootCommands(root)

--- a/scripts/deploy-camunda/cmd/doctor.go
+++ b/scripts/deploy-camunda/cmd/doctor.go
@@ -11,6 +11,7 @@ import (
 	"scripts/camunda-core/pkg/logging"
 	"scripts/deploy-camunda/config"
 	"scripts/deploy-camunda/deploy"
+	"scripts/prepare-helm-values/pkg/env"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -62,6 +63,11 @@ Exits non-zero if any required check fails.`,
 					flags.Chart.RepoRoot = detected
 				}
 			}
+			envFileToLoad := flags.EnvFile
+			if envFileToLoad == "" {
+				envFileToLoad = ".env"
+			}
+			_ = env.Load(envFileToLoad)
 			if err := resolveMatrixDockerCredentialPairs(&flags.Docker.DockerUsername, &flags.Docker.DockerPassword, &flags.Docker.DockerHubUsername, &flags.Docker.DockerHubPassword); err != nil {
 				return err
 			}

--- a/scripts/deploy-camunda/cmd/doctor.go
+++ b/scripts/deploy-camunda/cmd/doctor.go
@@ -62,6 +62,12 @@ Exits non-zero if any required check fails.`,
 					flags.Chart.RepoRoot = detected
 				}
 			}
+			if err := resolveMatrixDockerCredentialPairs(&flags.Docker.DockerUsername, &flags.Docker.DockerPassword, &flags.Docker.DockerHubUsername, &flags.Docker.DockerHubPassword); err != nil {
+				return err
+			}
+			if err := resolveKeyringCredentialPairs(&flags.Docker.DockerUsername, &flags.Docker.DockerPassword, &flags.Docker.DockerHubUsername, &flags.Docker.DockerHubPassword, flags.Docker.EnsureDockerRegistry, flags.Docker.EnsureDockerHub); err != nil {
+				return err
+			}
 
 			report := deploy.Preflight(ctx, &flags, deploy.PreflightOptions{
 				ConfigPath:           cfgRes.Path,

--- a/scripts/deploy-camunda/cmd/doctor.go
+++ b/scripts/deploy-camunda/cmd/doctor.go
@@ -68,6 +68,11 @@ Exits non-zero if any required check fails.`,
 			if err := resolveKeyringCredentialPairs(&flags.Docker.DockerUsername, &flags.Docker.DockerPassword, &flags.Docker.DockerHubUsername, &flags.Docker.DockerHubPassword, flags.Docker.EnsureDockerRegistry, flags.Docker.EnsureDockerHub); err != nil {
 				return err
 			}
+			if flags.Docker.ImportDockerAuth {
+				if err := importMatrixDockerAuth(flags.Docker.DockerConfigPath, &flags.Docker.DockerUsername, &flags.Docker.DockerPassword, &flags.Docker.DockerHubUsername, &flags.Docker.DockerHubPassword); err != nil {
+					return err
+				}
+			}
 
 			report := deploy.Preflight(ctx, &flags, deploy.PreflightOptions{
 				ConfigPath:           cfgRes.Path,
@@ -117,6 +122,8 @@ Exits non-zero if any required check fails.`,
 	f.StringVar(&flags.Docker.DockerPassword, "docker-password", "", "Harbor registry password")
 	f.BoolVar(&flags.Docker.EnsureDockerRegistry, "ensure-docker-registry", false, "Treat Harbor pull secret as required")
 	f.BoolVar(&flags.Docker.EnsureDockerHub, "ensure-docker-hub", false, "Treat Docker Hub pull secret as required")
+	f.BoolVar(&flags.Docker.ImportDockerAuth, "import-docker-auth", false, "Import plaintext auths from Docker config; credential helpers are rejected")
+	f.StringVar(&flags.Docker.DockerConfigPath, "docker-config", "", "Docker config.json path")
 	f.StringVarP(&flags.LogLevel, "log-level", "l", "info", "Log level")
 	f.BoolVar(&skipKube, "skip-kube-check", false, "Skip the cluster reachability probe")
 	f.BoolVar(&fix, "fix", false, "Prompt for missing variables and write them to the .env file")

--- a/scripts/deploy-camunda/cmd/doctor.go
+++ b/scripts/deploy-camunda/cmd/doctor.go
@@ -68,7 +68,7 @@ Exits non-zero if any required check fails.`,
 				envFileToLoad = ".env"
 			}
 			_ = env.Load(envFileToLoad)
-			if err := resolveMatrixDockerCredentialPairs(&flags.Docker.DockerUsername, &flags.Docker.DockerPassword, &flags.Docker.DockerHubUsername, &flags.Docker.DockerHubPassword); err != nil {
+			if err := resolveMatrixDockerCredentialPairs(&flags.Docker.DockerUsername, &flags.Docker.DockerPassword, &flags.Docker.DockerHubUsername, &flags.Docker.DockerHubPassword, flags.Docker.EnsureDockerRegistry, flags.Docker.EnsureDockerHub); err != nil {
 				return err
 			}
 			if err := resolveKeyringCredentialPairs(&flags.Docker.DockerUsername, &flags.Docker.DockerPassword, &flags.Docker.DockerHubUsername, &flags.Docker.DockerHubPassword, flags.Docker.EnsureDockerRegistry, flags.Docker.EnsureDockerHub); err != nil {

--- a/scripts/deploy-camunda/cmd/matrix.go
+++ b/scripts/deploy-camunda/cmd/matrix.go
@@ -405,14 +405,6 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 			if err := resolveMatrixDockerCredentialPairs(&dockerUsername, &dockerPassword, &dockerHubUsername, &dockerHubPassword, ensureDockerRegistry, ensureDockerHub); err != nil {
 				return err
 			}
-			if err := resolveKeyringCredentialPairs(&dockerUsername, &dockerPassword, &dockerHubUsername, &dockerHubPassword, ensureDockerRegistry, ensureDockerHub); err != nil {
-				return err
-			}
-			if importDockerAuth {
-				if err := importMatrixDockerAuth(dockerConfigPath, &dockerUsername, &dockerPassword, &dockerHubUsername, &dockerHubPassword); err != nil {
-					return err
-				}
-			}
 
 			if repoRoot == "" {
 				detected, err := config.DetectRepoRoot()
@@ -458,6 +450,17 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 				Platform:        platform,
 				Tier:            tier,
 			})
+			if err := resolveSelectedEnvFileCredentials(entries, envFiles, envFile, &dockerUsername, &dockerPassword, &dockerHubUsername, &dockerHubPassword, ensureDockerRegistry, ensureDockerHub); err != nil {
+				return err
+			}
+			if err := resolveKeyringCredentialPairs(&dockerUsername, &dockerPassword, &dockerHubUsername, &dockerHubPassword, ensureDockerRegistry, ensureDockerHub); err != nil {
+				return err
+			}
+			if importDockerAuth {
+				if err := importMatrixDockerAuth(dockerConfigPath, &dockerUsername, &dockerPassword, &dockerHubUsername, &dockerHubPassword); err != nil {
+					return err
+				}
+			}
 
 			// Entries whose scenario declares a topology (multi-namespace
 			// deployment) fan out to N releases and are driven directly via

--- a/scripts/deploy-camunda/cmd/matrix.go
+++ b/scripts/deploy-camunda/cmd/matrix.go
@@ -402,7 +402,7 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 			if err := env.Load(envFileToLoad); err != nil {
 				logging.Logger.Warn().Err(err).Str("envFile", envFileToLoad).Msg("Failed to load environment file")
 			}
-			if err := resolveMatrixDockerCredentialPairs(&dockerUsername, &dockerPassword, &dockerHubUsername, &dockerHubPassword); err != nil {
+			if err := resolveMatrixDockerCredentialPairs(&dockerUsername, &dockerPassword, &dockerHubUsername, &dockerHubPassword, ensureDockerRegistry, ensureDockerHub); err != nil {
 				return err
 			}
 			if err := resolveKeyringCredentialPairs(&dockerUsername, &dockerPassword, &dockerHubUsername, &dockerHubPassword, ensureDockerRegistry, ensureDockerHub); err != nil {
@@ -716,6 +716,23 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 					}
 				},
 				LogDir: logDir,
+			}
+			if runOpts.IngressBaseDomains == nil {
+				runOpts.IngressBaseDomains = map[string]string{}
+			}
+			for _, entry := range entries {
+				entryPlatform := entry.Platform
+				if entryPlatform == "" {
+					entryPlatform = platform
+				}
+				if entryPlatform == "" {
+					entryPlatform = "gke"
+				}
+				if runOpts.IngressBaseDomains[entryPlatform] == "" {
+					if effective := matrix.ResolveIngressBaseDomain(runOpts, entryPlatform); effective != "" {
+						runOpts.IngressBaseDomains[entryPlatform] = effective
+					}
+				}
 			}
 			var credentialErr error
 			runPostgresUsername, runPostgresPassword, credentialErr = matrix.ResolvePostgresCredentials(entries, runOpts)

--- a/scripts/deploy-camunda/cmd/matrix.go
+++ b/scripts/deploy-camunda/cmd/matrix.go
@@ -30,6 +30,10 @@ func newMatrixCommand() *cobra.Command {
 
 	matrixCmd.AddCommand(newMatrixListCommand())
 	matrixCmd.AddCommand(newMatrixRunCommand())
+	matrixCmd.AddCommand(newMatrixDoctorCommand())
+	matrixCmd.AddCommand(newMatrixStatusCommand())
+	matrixCmd.AddCommand(newMatrixResumeCommand())
+	matrixCmd.AddCommand(newMatrixCleanupCommand())
 
 	return matrixCmd
 }
@@ -194,6 +198,12 @@ func newMatrixRunCommand() *cobra.Command {
 		chartRefVersion          string
 		waitIngressReady         bool
 		ingressReadyTimeout      int
+		stateDir                 string
+		generatePostgres         bool
+		importDockerAuth         bool
+		dockerConfigPath         string
+		runPostgresUsername      string
+		runPostgresPassword      string
 	)
 
 	cmd := &cobra.Command{
@@ -389,6 +399,14 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 			if err := env.Load(envFileToLoad); err != nil {
 				logging.Logger.Warn().Err(err).Str("envFile", envFileToLoad).Msg("Failed to load environment file")
 			}
+			if err := resolveMatrixDockerCredentialPairs(&dockerUsername, &dockerPassword, &dockerHubUsername, &dockerHubPassword); err != nil {
+				return err
+			}
+			if importDockerAuth {
+				if err := importMatrixDockerAuth(dockerConfigPath, &dockerUsername, &dockerPassword, &dockerHubUsername, &dockerHubPassword); err != nil {
+					return err
+				}
+			}
 
 			if repoRoot == "" {
 				detected, err := config.DetectRepoRoot()
@@ -473,48 +491,61 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 					// topology deploys (this fixed the 3rd and 4th such bug:
 					// IngressBaseDomains, HelmTimeout, and DeleteNamespaceFirst).
 					baseTopologyRunOpts := matrix.RunOptions{
-						DryRun:                dryRun,
-						Coverage:              coverage,
-						StopOnFailure:         stopOnFailure,
-						Cleanup:               cleanup,
-						DeleteNamespaceFirst:  deleteNamespace,
-						KubeContexts:          kubeContexts,
-						KubeContext:           kubeContext,
-						NamespacePrefix:       namespacePrefix,
-						Platform:              platform,
-						MaxParallel:           maxParallel,
-						TestE2E:               testE2E,
-						TestAll:               testAll,
-						RepoRoot:              repoRoot,
-						EnvFiles:              envFiles,
-						EnvFile:               envFile,
-						IngressBaseDomains:    ingressBaseDomains,
-						IngressBaseDomain:     ingressBaseDomain,
-						LogLevel:              logLevel,
-						SkipDependencyUpdate:  skipDependencyUpdate,
-						VaultBackedSecrets:    vaultBackedSecrets,
-						UseVaultBackedSecrets: useVaultBackedSecrets,
-						KeycloakHost:          keycloakHost,
-						KeycloakProtocol:      keycloakProtocol,
-						UpgradeFromVersion:    upgradeFromVersion,
-						HelmTimeout:           helmTimeout,
-						DockerUsername:        dockerUsername,
-						DockerPassword:        dockerPassword,
-						EnsureDockerRegistry:  ensureDockerRegistry,
-						DockerHubUsername:     dockerHubUsername,
-						DockerHubPassword:     dockerHubPassword,
-						EnsureDockerHub:       ensureDockerHub,
-						UseLatest:             useLatest,
-						UseQA:                 useQA,
-						ForceImageOverrides:   forceImageOverrides,
-						ExtraHelmArgs:         extraHelmArgs,
-						ExtraHelmSets:         extraHelmSets,
-						ExtraValues:           extraValues,
-						NamespaceOverride:     namespaceOverride,
-						ChartRef:              chartRef,
-						ChartRefVersion:       chartRefVersion,
-						LogDir:                logDir,
+						DryRun:                      dryRun,
+						Coverage:                    coverage,
+						StopOnFailure:               stopOnFailure,
+						Cleanup:                     cleanup,
+						DeleteNamespaceFirst:        deleteNamespace,
+						KubeContexts:                kubeContexts,
+						KubeContext:                 kubeContext,
+						NamespacePrefix:             namespacePrefix,
+						Platform:                    platform,
+						MaxParallel:                 maxParallel,
+						TestE2E:                     testE2E,
+						TestAll:                     testAll,
+						RepoRoot:                    repoRoot,
+						EnvFiles:                    envFiles,
+						EnvFile:                     envFile,
+						IngressBaseDomains:          ingressBaseDomains,
+						IngressBaseDomain:           ingressBaseDomain,
+						LogLevel:                    logLevel,
+						SkipDependencyUpdate:        skipDependencyUpdate,
+						VaultBackedSecrets:          vaultBackedSecrets,
+						UseVaultBackedSecrets:       useVaultBackedSecrets,
+						KeycloakHost:                keycloakHost,
+						KeycloakProtocol:            keycloakProtocol,
+						UpgradeFromVersion:          upgradeFromVersion,
+						HelmTimeout:                 helmTimeout,
+						DockerUsername:              dockerUsername,
+						DockerPassword:              dockerPassword,
+						EnsureDockerRegistry:        ensureDockerRegistry,
+						DockerHubUsername:           dockerHubUsername,
+						DockerHubPassword:           dockerHubPassword,
+						EnsureDockerHub:             ensureDockerHub,
+						UseLatest:                   useLatest,
+						UseQA:                       useQA,
+						ForceImageOverrides:         forceImageOverrides,
+						ExtraHelmArgs:               extraHelmArgs,
+						ExtraHelmSets:               extraHelmSets,
+						ExtraValues:                 extraValues,
+						NamespaceOverride:           namespaceOverride,
+						ChartRef:                    chartRef,
+						ChartRefVersion:             chartRefVersion,
+						LogDir:                      logDir,
+						GeneratePostgresCredentials: generatePostgres,
 					}
+					var topologyCredentialEntries []matrix.Entry
+					for _, topologyEntry := range topologyEntries {
+						for _, release := range topologyEntry.Topology.Releases {
+							topologyCredentialEntries = append(topologyCredentialEntries, synthesizeReleaseEntry(topologyEntry, release, platform))
+						}
+					}
+					topologyUser, topologyPassword, credentialErr := matrix.ResolvePostgresCredentials(topologyCredentialEntries, baseTopologyRunOpts)
+					if credentialErr != nil {
+						return credentialErr
+					}
+					baseTopologyRunOpts.GeneratedPostgresUsername = topologyUser
+					baseTopologyRunOpts.GeneratedPostgresPassword = topologyPassword
 
 					for _, e := range topologyEntries {
 						if err := runTopologyEntry(ctx, e, baseTopologyRunOpts); err != nil {
@@ -615,49 +646,52 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 			}
 
 			runStart := time.Now()
-			results, err := matrix.Run(ctx, entries, matrix.RunOptions{
-				DryRun:                     dryRun,
-				Coverage:                   coverage,
-				StopOnFailure:              stopOnFailure,
-				Cleanup:                    cleanup,
-				DeleteNamespaceFirst:       deleteNamespace,
-				KubeContexts:               kubeContexts,
-				KubeContext:                kubeContext,
-				NamespacePrefix:            namespacePrefix,
-				Platform:                   platform,
-				MaxParallel:                maxParallel,
-				TestE2E:                    testE2E,
-				TestAll:                    testAll,
-				RepoRoot:                   repoRoot,
-				EnvFiles:                   envFiles,
-				EnvFile:                    envFile,
-				IngressBaseDomains:         ingressBaseDomains,
-				IngressBaseDomain:          ingressBaseDomain,
-				LogLevel:                   logLevel,
-				SkipDependencyUpdate:       skipDependencyUpdate,
-				VaultBackedSecrets:         vaultBackedSecrets,
-				UseVaultBackedSecrets:      useVaultBackedSecrets,
-				KeycloakHost:               keycloakHost,
-				KeycloakProtocol:           keycloakProtocol,
-				UpgradeFromVersion:         upgradeFromVersion,
-				HelmTimeout:                helmTimeout,
-				DockerUsername:             dockerUsername,
-				DockerPassword:             dockerPassword,
-				EnsureDockerRegistry:       ensureDockerRegistry,
-				DockerHubUsername:          dockerHubUsername,
-				DockerHubPassword:          dockerHubPassword,
-				EnsureDockerHub:            ensureDockerHub,
-				UseLatest:                  useLatest,
-				UseQA:                      useQA,
-				ForceImageOverrides:        forceImageOverrides,
-				WaitIngressReady:           waitIngressReady,
-				IngressReadyTimeoutMinutes: ingressReadyTimeout,
-				ExtraHelmArgs:              extraHelmArgs,
-				ExtraHelmSets:              extraHelmSets,
-				ExtraValues:                extraValues,
-				NamespaceOverride:          namespaceOverride,
-				ChartRef:                   chartRef,
-				ChartRefVersion:            chartRefVersion,
+			runOpts := matrix.RunOptions{
+				DryRun:                      dryRun,
+				Coverage:                    coverage,
+				StopOnFailure:               stopOnFailure,
+				Cleanup:                     cleanup,
+				DeleteNamespaceFirst:        deleteNamespace,
+				KubeContexts:                kubeContexts,
+				KubeContext:                 kubeContext,
+				NamespacePrefix:             namespacePrefix,
+				Platform:                    platform,
+				MaxParallel:                 maxParallel,
+				TestE2E:                     testE2E,
+				TestAll:                     testAll,
+				RepoRoot:                    repoRoot,
+				EnvFiles:                    envFiles,
+				EnvFile:                     envFile,
+				IngressBaseDomains:          ingressBaseDomains,
+				IngressBaseDomain:           ingressBaseDomain,
+				LogLevel:                    logLevel,
+				SkipDependencyUpdate:        skipDependencyUpdate,
+				VaultBackedSecrets:          vaultBackedSecrets,
+				UseVaultBackedSecrets:       useVaultBackedSecrets,
+				KeycloakHost:                keycloakHost,
+				KeycloakProtocol:            keycloakProtocol,
+				UpgradeFromVersion:          upgradeFromVersion,
+				HelmTimeout:                 helmTimeout,
+				DockerUsername:              dockerUsername,
+				DockerPassword:              dockerPassword,
+				EnsureDockerRegistry:        ensureDockerRegistry,
+				DockerHubUsername:           dockerHubUsername,
+				DockerHubPassword:           dockerHubPassword,
+				EnsureDockerHub:             ensureDockerHub,
+				UseLatest:                   useLatest,
+				UseQA:                       useQA,
+				ForceImageOverrides:         forceImageOverrides,
+				WaitIngressReady:            waitIngressReady,
+				IngressReadyTimeoutMinutes:  ingressReadyTimeout,
+				GeneratePostgresCredentials: generatePostgres,
+				GeneratedPostgresUsername:   runPostgresUsername,
+				GeneratedPostgresPassword:   runPostgresPassword,
+				ExtraHelmArgs:               extraHelmArgs,
+				ExtraHelmSets:               extraHelmSets,
+				ExtraValues:                 extraValues,
+				NamespaceOverride:           namespaceOverride,
+				ChartRef:                    chartRef,
+				ChartRefVersion:             chartRefVersion,
 				OnEntryStart: func(entry matrix.Entry, namespace string) {
 					if statusDisplay != nil {
 						statusDisplay.OnEntryStart(entry, namespace)
@@ -674,7 +708,33 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 					}
 				},
 				LogDir: logDir,
-			})
+			}
+			var credentialErr error
+			runPostgresUsername, runPostgresPassword, credentialErr = matrix.ResolvePostgresCredentials(entries, runOpts)
+			if credentialErr != nil {
+				return credentialErr
+			}
+			runOpts.GeneratedPostgresUsername = runPostgresUsername
+			runOpts.GeneratedPostgresPassword = runPostgresPassword
+			if !dryRun && !coverage {
+				root, stateErr := defaultMatrixStateRoot(stateDir)
+				if stateErr != nil {
+					return stateErr
+				}
+				runID := matrix.NewRunID(runStart)
+				store := matrix.NewRunStateStore(root, runID)
+				lock, stateErr := store.Acquire()
+				if stateErr != nil {
+					return stateErr
+				}
+				defer lock.Close()
+				if _, stateErr := store.Create(entries, runOpts); stateErr != nil {
+					return stateErr
+				}
+				runOpts.StateStore = store
+				fmt.Fprintf(os.Stdout, "Matrix run ID: %s\n", runID)
+			}
+			results, err := matrix.Run(ctx, entries, runOpts)
 
 			// Close the log file if we opened one.
 			if logFile != nil {
@@ -765,6 +825,10 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 	f.IntVar(&tier, "tier", 0, "Filter entries by tier (1=PR CI, 2=merge-queue only; 0=all)")
 	f.BoolVar(&waitIngressReady, "wait-ingress-ready", false, "After a successful helm install/upgrade, fail the entry unless its ingress host becomes publicly DNS-resolvable and HTTP-reachable within --ingress-ready-timeout")
 	f.IntVar(&ingressReadyTimeout, "ingress-ready-timeout", config.DefaultIngressReadyTimeoutMinutes, "Timeout in minutes for --wait-ingress-ready")
+	f.StringVar(&stateDir, "state-dir", "", "Matrix run state directory (default: <repo>/.deploy-camunda/runs)")
+	f.BoolVar(&generatePostgres, "generate-postgres-credentials", true, "Generate entry-local PostgreSQL credentials when required")
+	f.BoolVar(&importDockerAuth, "import-docker-auth", false, "Import plaintext auths from Docker config; credential helpers are rejected")
+	f.StringVar(&dockerConfigPath, "docker-config", "", "Docker config.json path")
 
 	registerMatrixShortnameCompletion(cmd)
 	registerMatrixVersionsCompletion(cmd)

--- a/scripts/deploy-camunda/cmd/matrix.go
+++ b/scripts/deploy-camunda/cmd/matrix.go
@@ -722,6 +722,9 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 					return stateErr
 				}
 				runID := matrix.NewRunID(runStart)
+				if runOpts.NamespaceOverride == "" {
+					runOpts.NamespacePrefix = matrix.DurableNamespacePrefix(runOpts.NamespacePrefix, runID)
+				}
 				store := matrix.NewRunStateStore(root, runID)
 				lock, stateErr := store.Acquire()
 				if stateErr != nil {

--- a/scripts/deploy-camunda/cmd/matrix.go
+++ b/scripts/deploy-camunda/cmd/matrix.go
@@ -265,9 +265,6 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 			return validateChartRefFlags(chartRef, chartRefVersion)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if deleteNamespace {
-				return fmt.Errorf("--delete-namespace is not supported for durable matrix runs; use `matrix cleanup` after ownership is recorded")
-			}
 			if namespaceOverride != "" && cleanup {
 				return fmt.Errorf("--cleanup cannot be used with --namespace-override because deploy-camunda did not create that namespace")
 			}

--- a/scripts/deploy-camunda/cmd/matrix.go
+++ b/scripts/deploy-camunda/cmd/matrix.go
@@ -720,6 +720,11 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 				},
 				LogDir: logDir,
 			}
+			runOpts.Auth0IngressHost = os.Getenv("CAMUNDA_HOSTNAME")
+			if runOpts.Auth0IngressHost == "" {
+				runOpts.Auth0IngressHost = os.Getenv("TEST_INGRESS_HOST")
+			}
+			runOpts.Auth0InitialAdminEmail = os.Getenv("AUTH0_INITIAL_ADMIN_EMAIL")
 			if runOpts.IngressBaseDomains == nil {
 				runOpts.IngressBaseDomains = map[string]string{}
 			}

--- a/scripts/deploy-camunda/cmd/matrix.go
+++ b/scripts/deploy-camunda/cmd/matrix.go
@@ -727,9 +727,6 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 					return stateErr
 				}
 				runID := matrix.NewRunID(runStart)
-				if runOpts.NamespaceOverride == "" {
-					runOpts.NamespacePrefix = matrix.DurableNamespacePrefix(runOpts.NamespacePrefix, runID)
-				}
 				store := matrix.NewRunStateStore(root, runID)
 				lock, stateErr := store.Acquire()
 				if stateErr != nil {

--- a/scripts/deploy-camunda/cmd/matrix.go
+++ b/scripts/deploy-camunda/cmd/matrix.go
@@ -265,6 +265,9 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 			return validateChartRefFlags(chartRef, chartRefVersion)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if deleteNamespace {
+				return fmt.Errorf("--delete-namespace is not supported for durable matrix runs; use `matrix cleanup` after ownership is recorded")
+			}
 			if namespaceOverride != "" && cleanup {
 				return fmt.Errorf("--cleanup cannot be used with --namespace-override because deploy-camunda did not create that namespace")
 			}

--- a/scripts/deploy-camunda/cmd/matrix.go
+++ b/scripts/deploy-camunda/cmd/matrix.go
@@ -720,11 +720,7 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 				},
 				LogDir: logDir,
 			}
-			runOpts.Auth0IngressHost = os.Getenv("CAMUNDA_HOSTNAME")
-			if runOpts.Auth0IngressHost == "" {
-				runOpts.Auth0IngressHost = os.Getenv("TEST_INGRESS_HOST")
-			}
-			runOpts.Auth0InitialAdminEmail = os.Getenv("AUTH0_INITIAL_ADMIN_EMAIL")
+			captureAuth0RunEnvironment(&runOpts)
 			if runOpts.IngressBaseDomains == nil {
 				runOpts.IngressBaseDomains = map[string]string{}
 			}
@@ -879,6 +875,14 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 	annotateFlagGroups(cmd, matrixRunFlagGroups())
 
 	return cmd
+}
+
+func captureAuth0RunEnvironment(opts *matrix.RunOptions) {
+	opts.Auth0IngressHost = os.Getenv("CAMUNDA_HOSTNAME")
+	if opts.Auth0IngressHost == "" {
+		opts.Auth0IngressHost = os.Getenv("TEST_INGRESS_HOST")
+	}
+	opts.Auth0InitialAdminEmail = os.Getenv("AUTH0_INITIAL_ADMIN_EMAIL")
 }
 
 // registerMatrixShortnameCompletion adds tab completion for the --shortname-filter flag.

--- a/scripts/deploy-camunda/cmd/matrix.go
+++ b/scripts/deploy-camunda/cmd/matrix.go
@@ -265,6 +265,9 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 			return validateChartRefFlags(chartRef, chartRefVersion)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if namespaceOverride != "" && cleanup {
+				return fmt.Errorf("--cleanup cannot be used with --namespace-override because deploy-camunda did not create that namespace")
+			}
 			// Create a signal-aware context so that Ctrl+C (SIGINT) and
 			// SIGTERM cancel the context, which propagates through
 			// matrix.Run → deploy.Execute → executeScript, cleanly
@@ -686,6 +689,8 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 				GeneratePostgresCredentials: generatePostgres,
 				GeneratedPostgresUsername:   runPostgresUsername,
 				GeneratedPostgresPassword:   runPostgresPassword,
+				ImportDockerAuth:            importDockerAuth,
+				DockerConfigPath:            dockerConfigPath,
 				ExtraHelmArgs:               extraHelmArgs,
 				ExtraHelmSets:               extraHelmSets,
 				ExtraValues:                 extraValues,

--- a/scripts/deploy-camunda/cmd/matrix.go
+++ b/scripts/deploy-camunda/cmd/matrix.go
@@ -405,6 +405,9 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 			if err := resolveMatrixDockerCredentialPairs(&dockerUsername, &dockerPassword, &dockerHubUsername, &dockerHubPassword); err != nil {
 				return err
 			}
+			if err := resolveKeyringCredentialPairs(&dockerUsername, &dockerPassword, &dockerHubUsername, &dockerHubPassword, ensureDockerRegistry, ensureDockerHub); err != nil {
+				return err
+			}
 			if importDockerAuth {
 				if err := importMatrixDockerAuth(dockerConfigPath, &dockerUsername, &dockerPassword, &dockerHubUsername, &dockerHubPassword); err != nil {
 					return err

--- a/scripts/deploy-camunda/cmd/matrix.go
+++ b/scripts/deploy-camunda/cmd/matrix.go
@@ -156,6 +156,7 @@ func newMatrixRunCommand() *cobra.Command {
 		namespacePrefix          string
 		cleanup                  bool
 		deleteNamespace          bool
+		adoptMatrixNamespace     bool
 		kubeContext              string
 		kubeContextGKE           string
 		kubeContextEKS           string
@@ -661,6 +662,7 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 				StopOnFailure:               stopOnFailure,
 				Cleanup:                     cleanup,
 				DeleteNamespaceFirst:        deleteNamespace,
+				AdoptMatrixNamespace:        adoptMatrixNamespace,
 				KubeContexts:                kubeContexts,
 				KubeContext:                 kubeContext,
 				NamespacePrefix:             namespacePrefix,
@@ -813,6 +815,7 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 	f.StringVar(&namespacePrefix, "namespace-prefix", "matrix", "Prefix for generated namespaces")
 	f.BoolVar(&cleanup, "cleanup", false, "Delete each entry's namespace after its deployment and tests complete")
 	f.BoolVar(&deleteNamespace, "delete-namespace", false, "Delete the namespace before deploying each entry (clean-slate deployment)")
+	f.BoolVar(&adoptMatrixNamespace, "adopt-matrix-namespace", false, "Allow --delete-namespace to replace a namespace owned by an older durable matrix run")
 	f.StringVar(&kubeContext, "kube-context", "", "Default Kubernetes context for all platforms (overridden by --kube-context-gke/--kube-context-eks)")
 	f.StringVar(&kubeContextGKE, "kube-context-gke", "", "Kubernetes context for GKE entries")
 	f.StringVar(&kubeContextEKS, "kube-context-eks", "", "Kubernetes context for EKS entries")

--- a/scripts/deploy-camunda/cmd/matrix_doctor.go
+++ b/scripts/deploy-camunda/cmd/matrix_doctor.go
@@ -1,0 +1,282 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"scripts/deploy-camunda/config"
+	"scripts/deploy-camunda/deploy"
+	"scripts/deploy-camunda/matrix"
+	"scripts/prepare-helm-values/pkg/env"
+)
+
+func newMatrixDoctorCommand() *cobra.Command {
+	var versions []string
+	var scenarioFilter, shortnameFilter, flowFilter, platform, repoRoot string
+	var namespacePrefix, kubeContext, kubeContextGKE, kubeContextEKS string
+	var envFile, ingressBaseDomain, ingressBaseDomainGKE, ingressBaseDomainEKS string
+	var envFile86, envFile87, envFile88, envFile89 string
+	var dockerUsername, dockerPassword, dockerHubUsername, dockerHubPassword string
+	var includeDisabled, shortnameExact, ensureDockerRegistry, ensureDockerHub bool
+	var skipKube, generatePostgres, importDockerAuth bool
+	var useLatest, useQA, forceImageOverrides, waitIngressReady bool
+	var useVaultBackedSecrets, useVaultBackedSecretsGKE, useVaultBackedSecretsEKS bool
+	var keycloakHost, keycloakProtocol, logLevel string
+	var skipDependencyUpdate bool
+	var helmTimeout int
+	var tier, ingressReadyTimeout int
+	var extraHelmArgs, extraHelmSets, extraValues []string
+	var namespaceOverride, chartRef, chartRefVersion string
+	var dockerConfigPath string
+
+	cmd := &cobra.Command{
+		Use:   "doctor",
+		Short: "Diagnose every selected matrix entry before cluster mutation",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return validateChartRefFlags(chartRef, chartRefVersion)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			changedFlags := map[string]bool{}
+			cmd.Flags().Visit(func(flag *pflag.Flag) { changedFlags[flag.Name] = true })
+			kubeContexts := map[string]string{}
+			envFiles := map[string]string{}
+			vaultBackedSecrets := map[string]bool{}
+			ingressDomains := map[string]string{}
+			if kubeContextGKE != "" {
+				kubeContexts["gke"] = kubeContextGKE
+			}
+			if kubeContextEKS != "" {
+				kubeContexts["eks"] = kubeContextEKS
+			}
+			for version, path := range map[string]string{"8.6": envFile86, "8.7": envFile87, "8.8": envFile88, "8.9": envFile89} {
+				if path != "" {
+					envFiles[version] = path
+				}
+			}
+			if cmd.Flags().Changed("use-vault-backed-secrets-gke") {
+				vaultBackedSecrets["gke"] = useVaultBackedSecretsGKE
+			}
+			if cmd.Flags().Changed("use-vault-backed-secrets-eks") {
+				vaultBackedSecrets["eks"] = useVaultBackedSecretsEKS
+			}
+			if ingressBaseDomainGKE != "" {
+				ingressDomains["gke"] = ingressBaseDomainGKE
+			}
+			if ingressBaseDomainEKS != "" {
+				ingressDomains["eks"] = ingressBaseDomainEKS
+			}
+			rc, cfgErr := config.LoadMatrixConfig(configFile)
+			if cfgErr != nil {
+				return cfgErr
+			}
+			config.ApplyMatrixRunConfig(rc, changedFlags, &config.MatrixRunFlags{
+				Versions: &versions, IncludeDisabled: &includeDisabled, ScenarioFilter: &scenarioFilter,
+				ShortnameFilter: &shortnameFilter, FlowFilter: &flowFilter, Platform: &platform, RepoRoot: &repoRoot,
+				NamespacePrefix: &namespacePrefix, LogLevel: &logLevel, SkipDependencyUpdate: &skipDependencyUpdate,
+				HelmTimeout: &helmTimeout, KubeContext: &kubeContext, KubeContextGKE: &kubeContextGKE,
+				KubeContextEKS: &kubeContextEKS, KubeContexts: kubeContexts,
+				IngressBaseDomain: &ingressBaseDomain, IngressBaseDomainGKE: &ingressBaseDomainGKE,
+				IngressBaseDomainEKS: &ingressBaseDomainEKS, IngressBaseDomains: ingressDomains,
+				UseVaultBackedSecrets: &useVaultBackedSecrets, UseVaultBackedSecretsGKE: &useVaultBackedSecretsGKE,
+				UseVaultBackedSecretsEKS: &useVaultBackedSecretsEKS, VaultBackedSecrets: vaultBackedSecrets,
+				EnvFile: &envFile, EnvFile86: &envFile86, EnvFile87: &envFile87, EnvFile88: &envFile88,
+				EnvFile89: &envFile89, EnvFiles: envFiles, DockerUsername: &dockerUsername,
+				DockerPassword: &dockerPassword, EnsureDockerRegistry: &ensureDockerRegistry,
+				DockerHubUsername: &dockerHubUsername, DockerHubPassword: &dockerHubPassword,
+				EnsureDockerHub: &ensureDockerHub, KeycloakHost: &keycloakHost, KeycloakProtocol: &keycloakProtocol,
+			})
+			envFileToLoad := envFile
+			if envFileToLoad == "" {
+				envFileToLoad = ".env"
+			}
+			_ = env.Load(envFileToLoad)
+			if err := resolveMatrixDockerCredentialPairs(&dockerUsername, &dockerPassword, &dockerHubUsername, &dockerHubPassword); err != nil {
+				return err
+			}
+			if repoRoot == "" {
+				detected, err := config.DetectRepoRoot()
+				if err != nil {
+					return err
+				}
+				repoRoot = detected
+			}
+			entries, err := matrix.Generate(repoRoot, matrix.GenerateOptions{Versions: versions, IncludeDisabled: includeDisabled})
+			if err != nil {
+				return err
+			}
+			entries = matrix.Filter(entries, matrix.FilterOptions{
+				ScenarioFilter: scenarioFilter, ShortnameFilter: shortnameFilter, ShortnameExact: shortnameExact,
+				FlowFilter: flowFilter, Platform: platform, Tier: tier,
+			})
+			if len(entries) == 0 {
+				return fmt.Errorf("no matrix entries matched the filters")
+			}
+			if importDockerAuth {
+				if err := importMatrixDockerAuth(dockerConfigPath, &dockerUsername, &dockerPassword, &dockerHubUsername, &dockerHubPassword); err != nil {
+					return err
+				}
+			}
+			opts := matrix.RunOptions{
+				RepoRoot: repoRoot, Platform: platform, NamespacePrefix: namespacePrefix,
+				KubeContext: kubeContext, KubeContexts: kubeContexts, EnvFile: envFile, EnvFiles: envFiles,
+				IngressBaseDomain: ingressBaseDomain, IngressBaseDomains: ingressDomains,
+				DockerUsername: dockerUsername, DockerPassword: dockerPassword,
+				DockerHubUsername: dockerHubUsername, DockerHubPassword: dockerHubPassword,
+				EnsureDockerRegistry: ensureDockerRegistry, EnsureDockerHub: ensureDockerHub,
+				GeneratePostgresCredentials: generatePostgres, VaultBackedSecrets: vaultBackedSecrets,
+				UseVaultBackedSecrets: useVaultBackedSecrets, KeycloakHost: keycloakHost,
+				KeycloakProtocol: keycloakProtocol, LogLevel: logLevel,
+				SkipDependencyUpdate: skipDependencyUpdate, HelmTimeout: helmTimeout,
+				UseLatest: useLatest, UseQA: useQA, ForceImageOverrides: forceImageOverrides,
+				ExtraHelmArgs: extraHelmArgs, ExtraHelmSets: extraHelmSets, ExtraValues: extraValues,
+				NamespaceOverride: namespaceOverride, ChartRef: chartRef, ChartRefVersion: chartRefVersion,
+				WaitIngressReady: waitIngressReady, IngressReadyTimeoutMinutes: ingressReadyTimeout,
+			}
+			postgresUser, postgresPassword, err := matrix.ResolvePostgresCredentials(entries, opts)
+			if err != nil {
+				return err
+			}
+			opts.GeneratedPostgresUsername, opts.GeneratedPostgresPassword = postgresUser, postgresPassword
+			cfgRes, _ := config.ResolvePath(configFile)
+			doctorOpts := matrix.DoctorOptions{SkipKube: skipKube}
+			if cfgRes != nil {
+				doctorOpts.ConfigPath, doctorOpts.ConfigFound = cfgRes.Path, cfgRes.Found
+			}
+			report, err := matrix.Doctor(cmd.Context(), entries, opts, doctorOpts)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), "Shared checks:")
+			renderChecks(cmd, &deploy.Report{Checks: report.Shared})
+			for _, entry := range report.Entries {
+				fmt.Fprintf(cmd.OutOrStdout(), "\n%s (%s):\n", matrix.EntryID(entry.Entry), entry.Namespace)
+				renderChecks(cmd, entry.Report)
+			}
+			if generatePostgres {
+				fmt.Fprintln(cmd.OutOrStdout(), "\nPostgreSQL credentials: generated in memory where required; explicit env values were preserved")
+			}
+			if !report.OK() {
+				return fmt.Errorf("matrix preflight failed")
+			}
+			return nil
+		},
+	}
+	f := cmd.Flags()
+	f.StringSliceVar(&versions, "versions", nil, "Limit to chart versions")
+	f.BoolVar(&includeDisabled, "include-disabled", false, "Include disabled scenarios")
+	f.StringVar(&scenarioFilter, "scenario-filter", "", "Filter scenarios by substring")
+	f.StringVar(&shortnameFilter, "shortname-filter", "", "Filter entries by shortname")
+	f.BoolVar(&shortnameExact, "shortname-exact", false, "Require exact shortname matches")
+	f.StringVar(&flowFilter, "flow-filter", "", "Filter entries by flow")
+	f.StringVar(&platform, "platform", "", "Filter and target platform")
+	f.IntVar(&tier, "tier", 0, "Filter entries by tier")
+	f.StringVar(&repoRoot, "repo-root", "", "Repository root")
+	f.StringVar(&namespacePrefix, "namespace-prefix", "matrix", "Generated namespace prefix")
+	f.StringVar(&kubeContext, "kube-context", "", "Default Kubernetes context")
+	f.StringVar(&kubeContextGKE, "kube-context-gke", "", "GKE Kubernetes context")
+	f.StringVar(&kubeContextEKS, "kube-context-eks", "", "EKS Kubernetes context")
+	f.StringVar(&envFile, "env-file", "", "Environment file")
+	f.StringVar(&envFile86, "env-file-8.6", "", "Environment file for 8.6")
+	f.StringVar(&envFile87, "env-file-8.7", "", "Environment file for 8.7")
+	f.StringVar(&envFile88, "env-file-8.8", "", "Environment file for 8.8")
+	f.StringVar(&envFile89, "env-file-8.9", "", "Environment file for 8.9")
+	f.StringVar(&ingressBaseDomain, "ingress-base-domain", "", "Default ingress base domain")
+	f.StringVar(&ingressBaseDomainGKE, "ingress-base-domain-gke", "", "GKE ingress base domain")
+	f.StringVar(&ingressBaseDomainEKS, "ingress-base-domain-eks", "", "EKS ingress base domain")
+	f.StringVar(&dockerUsername, "docker-username", "", "Harbor username")
+	f.StringVar(&dockerPassword, "docker-password", "", "Harbor password")
+	f.BoolVar(&ensureDockerRegistry, "ensure-docker-registry", false, "Require Harbor credentials")
+	f.StringVar(&dockerHubUsername, "dockerhub-username", "", "Docker Hub username")
+	f.StringVar(&dockerHubPassword, "dockerhub-password", "", "Docker Hub password")
+	f.BoolVar(&ensureDockerHub, "ensure-docker-hub", false, "Require Docker Hub credentials")
+	f.BoolVar(&useVaultBackedSecrets, "use-vault-backed-secrets", false, "Use vault-backed secrets")
+	f.BoolVar(&useVaultBackedSecretsGKE, "use-vault-backed-secrets-gke", false, "Use GKE vault-backed secrets")
+	f.BoolVar(&useVaultBackedSecretsEKS, "use-vault-backed-secrets-eks", false, "Use EKS vault-backed secrets")
+	f.StringVar(&keycloakHost, "keycloak-host", "", "External Keycloak host")
+	f.StringVar(&keycloakProtocol, "keycloak-protocol", "", "External Keycloak protocol")
+	f.StringVarP(&logLevel, "log-level", "l", "info", "Log level")
+	f.BoolVar(&skipDependencyUpdate, "skip-dependency-update", false, "Skip Helm dependency updates")
+	f.IntVar(&helmTimeout, "timeout", 10, "Helm timeout in minutes")
+	f.BoolVar(&useLatest, "use-latest", false, "Use latest image overlays")
+	f.BoolVar(&useQA, "use-qa", false, "Force QA values")
+	f.BoolVar(&forceImageOverrides, "force-image-overrides", false, "Allow local image overrides with chart references")
+	f.StringArrayVar(&extraHelmArgs, "extra-helm-arg", nil, "Extra Helm argument")
+	f.StringSliceVar(&extraHelmSets, "extra-helm-set", nil, "Extra Helm set values")
+	f.StringArrayVar(&extraValues, "extra-values", nil, "Extra values file")
+	f.StringVar(&namespaceOverride, "namespace-override", "", "Override generated namespace")
+	f.StringVar(&chartRef, "chart-ref", "", "External chart reference")
+	f.StringVar(&chartRefVersion, "chart-version", "", "External chart version")
+	f.BoolVar(&waitIngressReady, "wait-ingress-ready", false, "Validate public ingress readiness settings")
+	f.IntVar(&ingressReadyTimeout, "ingress-ready-timeout", config.DefaultIngressReadyTimeoutMinutes, "Ingress readiness timeout")
+	f.BoolVar(&skipKube, "skip-kube-check", false, "Skip cluster reachability checks")
+	f.BoolVar(&generatePostgres, "generate-postgres-credentials", true, "Generate entry-local PostgreSQL credentials when required")
+	f.BoolVar(&importDockerAuth, "import-docker-auth", false, "Import plaintext auths from Docker config; credential helpers are rejected")
+	f.StringVar(&dockerConfigPath, "docker-config", "", "Docker config.json path")
+	registerMatrixShortnameCompletion(cmd)
+	registerMatrixVersionsCompletion(cmd)
+	registerMatrixFlowCompletion(cmd)
+	return cmd
+}
+
+func importMatrixDockerAuth(configPath string, harborUser, harborPassword, hubUser, hubPassword *string) error {
+	auths, err := matrix.ImportPlaintextDockerAuth(configPath, "registry.camunda.cloud", "docker.io")
+	if err != nil {
+		return err
+	}
+	if auth, ok := auths["registry.camunda.cloud"]; ok {
+		if *harborUser == "" && *harborPassword == "" {
+			*harborUser, *harborPassword = auth.Username, auth.Password
+		}
+	}
+	if auth, ok := auths["docker.io"]; ok {
+		if *hubUser == "" && *hubPassword == "" {
+			*hubUser, *hubPassword = auth.Username, auth.Password
+		}
+	}
+	return nil
+}
+
+func resolveMatrixDockerCredentialPairs(harborUser, harborPassword, hubUser, hubPassword *string) error {
+	if err := resolveCredentialPair("Harbor flags/config", harborUser, harborPassword, [][2]string{
+		{"HARBOR_USERNAME", "HARBOR_PASSWORD"},
+		{"TEST_DOCKER_USERNAME_CAMUNDA_CLOUD", "TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD"},
+		{"NEXUS_USERNAME", "NEXUS_PASSWORD"},
+	}); err != nil {
+		return err
+	}
+	return resolveCredentialPair("Docker Hub flags/config", hubUser, hubPassword, [][2]string{
+		{"DOCKERHUB_USERNAME", "DOCKERHUB_PASSWORD"},
+		{"TEST_DOCKER_USERNAME", "TEST_DOCKER_PASSWORD"},
+	})
+}
+
+func resolveCredentialPair(source string, username, password *string, envPairs [][2]string) error {
+	if *username != "" || *password != "" {
+		if *username == "" || *password == "" {
+			return fmt.Errorf("%s must provide both username and password", source)
+		}
+		return nil
+	}
+	for _, pair := range envPairs {
+		user, pass := os.Getenv(pair[0]), os.Getenv(pair[1])
+		if user == "" && pass == "" {
+			continue
+		}
+		if user == "" || pass == "" {
+			return fmt.Errorf("%s/%s must both be set", pair[0], pair[1])
+		}
+		*username, *password = user, pass
+		return nil
+	}
+	return nil
+}
+
+func renderChecks(cmd *cobra.Command, report *deploy.Report) {
+	var buf bytes.Buffer
+	report.Render(&buf)
+	fmt.Fprint(cmd.OutOrStdout(), buf.String())
+}

--- a/scripts/deploy-camunda/cmd/matrix_doctor.go
+++ b/scripts/deploy-camunda/cmd/matrix_doctor.go
@@ -302,12 +302,12 @@ func resolveSelectedEnvFileCredentials(entries []matrix.Entry, envFiles map[stri
 		if err != nil {
 			continue
 		}
-		if requireHarbor && *harborUser == "" && *harborPassword == "" {
+		if requireHarbor {
 			if err := mergeCredentialPairFromMap("Harbor", values, harborUser, harborPassword, [][2]string{{"HARBOR_USERNAME", "HARBOR_PASSWORD"}, {"TEST_DOCKER_USERNAME_CAMUNDA_CLOUD", "TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD"}, {"NEXUS_USERNAME", "NEXUS_PASSWORD"}}); err != nil {
 				return fmt.Errorf("%s: %w", path, err)
 			}
 		}
-		if requireHub && *hubUser == "" && *hubPassword == "" {
+		if requireHub {
 			if err := mergeCredentialPairFromMap("Docker Hub", values, hubUser, hubPassword, [][2]string{{"DOCKERHUB_USERNAME", "DOCKERHUB_PASSWORD"}, {"TEST_DOCKER_USERNAME", "TEST_DOCKER_PASSWORD"}}); err != nil {
 				return fmt.Errorf("%s: %w", path, err)
 			}

--- a/scripts/deploy-camunda/cmd/matrix_doctor.go
+++ b/scripts/deploy-camunda/cmd/matrix_doctor.go
@@ -97,9 +97,6 @@ func newMatrixDoctorCommand() *cobra.Command {
 			if err := resolveMatrixDockerCredentialPairs(&dockerUsername, &dockerPassword, &dockerHubUsername, &dockerHubPassword, ensureDockerRegistry, ensureDockerHub); err != nil {
 				return err
 			}
-			if err := resolveKeyringCredentialPairs(&dockerUsername, &dockerPassword, &dockerHubUsername, &dockerHubPassword, ensureDockerRegistry, ensureDockerHub); err != nil {
-				return err
-			}
 			if repoRoot == "" {
 				detected, err := config.DetectRepoRoot()
 				if err != nil {
@@ -115,6 +112,12 @@ func newMatrixDoctorCommand() *cobra.Command {
 				ScenarioFilter: scenarioFilter, ShortnameFilter: shortnameFilter, ShortnameExact: shortnameExact,
 				FlowFilter: flowFilter, Platform: platform, Tier: tier,
 			})
+			if err := resolveSelectedEnvFileCredentials(entries, envFiles, envFile, &dockerUsername, &dockerPassword, &dockerHubUsername, &dockerHubPassword, ensureDockerRegistry, ensureDockerHub); err != nil {
+				return err
+			}
+			if err := resolveKeyringCredentialPairs(&dockerUsername, &dockerPassword, &dockerHubUsername, &dockerHubPassword, ensureDockerRegistry, ensureDockerHub); err != nil {
+				return err
+			}
 			if len(entries) == 0 {
 				return fmt.Errorf("no matrix entries matched the filters")
 			}
@@ -276,6 +279,54 @@ func resolveCredentialPair(source string, username, password *string, envPairs [
 		}
 		if user == "" || pass == "" {
 			return fmt.Errorf("%s/%s must both be set", pair[0], pair[1])
+		}
+		*username, *password = user, pass
+		return nil
+	}
+	return nil
+}
+
+func resolveSelectedEnvFileCredentials(entries []matrix.Entry, envFiles map[string]string, fallback string, harborUser, harborPassword, hubUser, hubPassword *string, requireHarbor, requireHub bool) error {
+	paths := map[string]bool{}
+	for _, entry := range entries {
+		path := envFiles[entry.Version]
+		if path == "" {
+			path = fallback
+		}
+		if path != "" {
+			paths[path] = true
+		}
+	}
+	for path := range paths {
+		values, err := env.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		if requireHarbor && *harborUser == "" && *harborPassword == "" {
+			if err := mergeCredentialPairFromMap("Harbor", values, harborUser, harborPassword, [][2]string{{"HARBOR_USERNAME", "HARBOR_PASSWORD"}, {"TEST_DOCKER_USERNAME_CAMUNDA_CLOUD", "TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD"}, {"NEXUS_USERNAME", "NEXUS_PASSWORD"}}); err != nil {
+				return fmt.Errorf("%s: %w", path, err)
+			}
+		}
+		if requireHub && *hubUser == "" && *hubPassword == "" {
+			if err := mergeCredentialPairFromMap("Docker Hub", values, hubUser, hubPassword, [][2]string{{"DOCKERHUB_USERNAME", "DOCKERHUB_PASSWORD"}, {"TEST_DOCKER_USERNAME", "TEST_DOCKER_PASSWORD"}}); err != nil {
+				return fmt.Errorf("%s: %w", path, err)
+			}
+		}
+	}
+	return nil
+}
+
+func mergeCredentialPairFromMap(name string, values map[string]string, username, password *string, pairs [][2]string) error {
+	for _, pair := range pairs {
+		user, pass := values[pair[0]], values[pair[1]]
+		if user == "" && pass == "" {
+			continue
+		}
+		if user == "" || pass == "" {
+			return fmt.Errorf("%s credential pair %s/%s is incomplete", name, pair[0], pair[1])
+		}
+		if *username != "" && (*username != user || *password != pass) {
+			return fmt.Errorf("selected env files contain conflicting %s credentials", name)
 		}
 		*username, *password = user, pass
 		return nil

--- a/scripts/deploy-camunda/cmd/matrix_doctor.go
+++ b/scripts/deploy-camunda/cmd/matrix_doctor.go
@@ -97,6 +97,9 @@ func newMatrixDoctorCommand() *cobra.Command {
 			if err := resolveMatrixDockerCredentialPairs(&dockerUsername, &dockerPassword, &dockerHubUsername, &dockerHubPassword); err != nil {
 				return err
 			}
+			if err := resolveKeyringCredentialPairs(&dockerUsername, &dockerPassword, &dockerHubUsername, &dockerHubPassword, ensureDockerRegistry, ensureDockerHub); err != nil {
+				return err
+			}
 			if repoRoot == "" {
 				detected, err := config.DetectRepoRoot()
 				if err != nil {

--- a/scripts/deploy-camunda/cmd/matrix_doctor.go
+++ b/scripts/deploy-camunda/cmd/matrix_doctor.go
@@ -94,7 +94,7 @@ func newMatrixDoctorCommand() *cobra.Command {
 				envFileToLoad = ".env"
 			}
 			_ = env.Load(envFileToLoad)
-			if err := resolveMatrixDockerCredentialPairs(&dockerUsername, &dockerPassword, &dockerHubUsername, &dockerHubPassword); err != nil {
+			if err := resolveMatrixDockerCredentialPairs(&dockerUsername, &dockerPassword, &dockerHubUsername, &dockerHubPassword, ensureDockerRegistry, ensureDockerHub); err != nil {
 				return err
 			}
 			if err := resolveKeyringCredentialPairs(&dockerUsername, &dockerPassword, &dockerHubUsername, &dockerHubPassword, ensureDockerRegistry, ensureDockerHub); err != nil {
@@ -243,18 +243,23 @@ func importMatrixDockerAuth(configPath string, harborUser, harborPassword, hubUs
 	return nil
 }
 
-func resolveMatrixDockerCredentialPairs(harborUser, harborPassword, hubUser, hubPassword *string) error {
-	if err := resolveCredentialPair("Harbor flags/config", harborUser, harborPassword, [][2]string{
-		{"HARBOR_USERNAME", "HARBOR_PASSWORD"},
-		{"TEST_DOCKER_USERNAME_CAMUNDA_CLOUD", "TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD"},
-		{"NEXUS_USERNAME", "NEXUS_PASSWORD"},
-	}); err != nil {
-		return err
+func resolveMatrixDockerCredentialPairs(harborUser, harborPassword, hubUser, hubPassword *string, requireHarbor, requireHub bool) error {
+	if requireHarbor {
+		if err := resolveCredentialPair("Harbor flags/config", harborUser, harborPassword, [][2]string{
+			{"HARBOR_USERNAME", "HARBOR_PASSWORD"},
+			{"TEST_DOCKER_USERNAME_CAMUNDA_CLOUD", "TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD"},
+			{"NEXUS_USERNAME", "NEXUS_PASSWORD"},
+		}); err != nil {
+			return err
+		}
 	}
-	return resolveCredentialPair("Docker Hub flags/config", hubUser, hubPassword, [][2]string{
-		{"DOCKERHUB_USERNAME", "DOCKERHUB_PASSWORD"},
-		{"TEST_DOCKER_USERNAME", "TEST_DOCKER_PASSWORD"},
-	})
+	if requireHub {
+		return resolveCredentialPair("Docker Hub flags/config", hubUser, hubPassword, [][2]string{
+			{"DOCKERHUB_USERNAME", "DOCKERHUB_PASSWORD"},
+			{"TEST_DOCKER_USERNAME", "TEST_DOCKER_PASSWORD"},
+		})
+	}
+	return nil
 }
 
 func resolveCredentialPair(source string, username, password *string, envPairs [][2]string) error {

--- a/scripts/deploy-camunda/cmd/matrix_doctor_test.go
+++ b/scripts/deploy-camunda/cmd/matrix_doctor_test.go
@@ -235,6 +235,37 @@ func TestMatrixCleanupRefusesUncheckpointedProviderProvisioning(t *testing.T) {
 	}
 }
 
+func TestMatrixCleanupReconcilesUncheckpointedEntraObject(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("ENTRA_APP_DIRECTORY_ID", "tenant")
+	t.Setenv("ENTRA_APP_CLIENT_ID", "client")
+	t.Setenv("ENTRA_APP_CLIENT_SECRET", "secret")
+	entry := matrix.Entry{Version: "8.10", Shortname: "oidc", Flow: "install", Auth: "oidc", Identity: "oidc"}
+	store := matrix.NewRunStateStore(root, "run-1")
+	_, err := store.Create([]matrix.Entry{entry}, matrix.RunOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.MarkExternalProvisioningStarted(entry); err != nil {
+		t.Fatal(err)
+	}
+	fake := &fakeCleanupClient{}
+	originalClient, originalFind, originalCleanup := newCleanupKubeClient, findEntraObject, cleanupEntraObject
+	newCleanupKubeClient = func(string) (cleanupKubeClient, error) { return fake, nil }
+	findEntraObject = func(context.Context, entra.Options) (*entra.VenomApp, error) {
+		return &entra.VenomApp{ObjectID: "object-id"}, nil
+	}
+	cleanupEntraObject = func(context.Context, entra.Options, string) error { return nil }
+	t.Cleanup(func() {
+		newCleanupKubeClient, findEntraObject, cleanupEntraObject = originalClient, originalFind, originalCleanup
+	})
+	cmd := newMatrixCleanupCommand()
+	cmd.SetArgs([]string{"run-1", "--state-dir", root, "--yes"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestMatrixCleanupPreservesNamespaceOnAuth0Failure(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv("AUTH0_DOMAIN", "https://tenant.example")

--- a/scripts/deploy-camunda/cmd/matrix_doctor_test.go
+++ b/scripts/deploy-camunda/cmd/matrix_doctor_test.go
@@ -1,11 +1,13 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -279,5 +281,26 @@ func TestMatrixCleanupRejectsSharedNamespaceEntry(t *testing.T) {
 	cmd.SetArgs([]string{"run-1", "--state-dir", root, "--entry", matrix.EntryID(entries[0]), "--yes"})
 	if err := cmd.Execute(); err == nil {
 		t.Fatal("expected shared namespace rejection")
+	}
+}
+
+func TestMatrixStatusListsCorruptRun(t *testing.T) {
+	root := t.TempDir()
+	runDir := filepath.Join(root, "broken-run")
+	if err := os.MkdirAll(runDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(runDir, "matrix-state.json"), []byte("{"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := newMatrixStatusCommand()
+	cmd.SetArgs([]string{"--state-dir", root})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "broken-run\tcorrupt") {
+		t.Fatalf("output = %q", out.String())
 	}
 }

--- a/scripts/deploy-camunda/cmd/matrix_doctor_test.go
+++ b/scripts/deploy-camunda/cmd/matrix_doctor_test.go
@@ -106,13 +106,12 @@ func TestMatrixCleanupMarksOwnedEntryCleaned(t *testing.T) {
 
 func TestMatrixCleanupPreservesNamespaceOnIdentityFailure(t *testing.T) {
 	root := t.TempDir()
-	envFile := filepath.Join(t.TempDir(), ".env")
-	if err := os.WriteFile(envFile, []byte("ENTRA_APP_DIRECTORY_ID=tenant\nENTRA_APP_CLIENT_ID=client\nENTRA_APP_CLIENT_SECRET=secret\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	t.Setenv("ENTRA_APP_DIRECTORY_ID", "tenant")
+	t.Setenv("ENTRA_APP_CLIENT_ID", "client")
+	t.Setenv("ENTRA_APP_CLIENT_SECRET", "secret")
 	entry := matrix.Entry{Version: "8.10", Shortname: "oidc", Scenario: "oidc", Flow: "install", Auth: "oidc", Identity: "oidc"}
 	store := matrix.NewRunStateStore(root, "run-1")
-	_, err := store.Create([]matrix.Entry{entry}, matrix.RunOptions{NamespacePrefix: "matrix", KubeContext: "test", EnvFile: envFile})
+	_, err := store.Create([]matrix.Entry{entry}, matrix.RunOptions{NamespacePrefix: "matrix", KubeContext: "test", EnvFile: filepath.Join(t.TempDir(), "missing.env")})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/scripts/deploy-camunda/cmd/matrix_doctor_test.go
+++ b/scripts/deploy-camunda/cmd/matrix_doctor_test.go
@@ -103,6 +103,30 @@ func TestResolveSelectedEnvFileCredentialsRejectsConflictWithChosenPair(t *testi
 	}
 }
 
+func TestCaptureAuth0RunEnvironmentPersistsAcrossResume(t *testing.T) {
+	t.Setenv("CAMUNDA_HOSTNAME", "captured.example")
+	t.Setenv("TEST_INGRESS_HOST", "fallback.example")
+	t.Setenv("AUTH0_INITIAL_ADMIN_EMAIL", "admin@example.com")
+	opts := matrix.RunOptions{}
+	captureAuth0RunEnvironment(&opts)
+	entry := matrix.Entry{Version: "8.10", Shortname: "auth0", Flow: "install"}
+	store := matrix.NewRunStateStore(t.TempDir(), "run-1")
+	_, err := store.Create([]matrix.Entry{entry}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CAMUNDA_HOSTNAME", "")
+	t.Setenv("TEST_INGRESS_HOST", "")
+	t.Setenv("AUTH0_INITIAL_ADMIN_EMAIL", "")
+	_, resumed, err := store.PrepareResume("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resumed.Auth0IngressHost != "captured.example" || resumed.Auth0InitialAdminEmail != "admin@example.com" {
+		t.Fatalf("resumed = %#v", resumed)
+	}
+}
+
 func TestMatrixCleanupMarksOwnedEntryCleaned(t *testing.T) {
 	root := t.TempDir()
 	entry := matrix.Entry{Version: "8.10", Shortname: "one", Scenario: "first", Flow: "install"}

--- a/scripts/deploy-camunda/cmd/matrix_doctor_test.go
+++ b/scripts/deploy-camunda/cmd/matrix_doctor_test.go
@@ -42,7 +42,7 @@ func TestImportMatrixDockerAuthPreservesEnvironmentPair(t *testing.T) {
 		t.Fatal(err)
 	}
 	user, password, hubUser, hubPassword := "", "", "", ""
-	if err := resolveMatrixDockerCredentialPairs(&user, &password, &hubUser, &hubPassword); err != nil {
+	if err := resolveMatrixDockerCredentialPairs(&user, &password, &hubUser, &hubPassword, true, true); err != nil {
 		t.Fatal(err)
 	}
 	if err := importMatrixDockerAuth(path, &user, &password, &hubUser, &hubPassword); err != nil {
@@ -70,7 +70,7 @@ func TestImportMatrixDockerAuthDoesNotMixExplicitPair(t *testing.T) {
 		t.Fatal(err)
 	}
 	user, password, hubUser, hubPassword := "explicit-user", "", "", ""
-	if err := resolveMatrixDockerCredentialPairs(&user, &password, &hubUser, &hubPassword); err == nil {
+	if err := resolveMatrixDockerCredentialPairs(&user, &password, &hubUser, &hubPassword, true, true); err == nil {
 		t.Fatal("expected partial explicit credential pair failure")
 	}
 }

--- a/scripts/deploy-camunda/cmd/matrix_doctor_test.go
+++ b/scripts/deploy-camunda/cmd/matrix_doctor_test.go
@@ -373,6 +373,17 @@ func TestMatrixCleanupPreservesNamespaceOnAuth0Failure(t *testing.T) {
 	}
 }
 
+func TestCleanupUsesEffectiveDefaultAuth0Domain(t *testing.T) {
+	t.Setenv("AUTH0_DOMAIN", "")
+	if auth0.EffectiveDomain("") == "" {
+		t.Fatal("default Auth0 domain is empty")
+	}
+	values := cleanupCredentialEnv(filepath.Join(t.TempDir(), "missing.env"))
+	if auth0.EffectiveDomain(values["AUTH0_DOMAIN"]) != auth0.EffectiveDomain("") {
+		t.Fatal("cleanup default domain differs")
+	}
+}
+
 func TestMatrixCleanupRejectsSharedNamespaceEntry(t *testing.T) {
 	root := t.TempDir()
 	entries := []matrix.Entry{{Version: "8.10", Shortname: "one", Flow: "install"}, {Version: "8.10", Shortname: "two", Flow: "install"}}

--- a/scripts/deploy-camunda/cmd/matrix_doctor_test.go
+++ b/scripts/deploy-camunda/cmd/matrix_doctor_test.go
@@ -92,6 +92,17 @@ func TestResolveSelectedEnvFileCredentials(t *testing.T) {
 	}
 }
 
+func TestResolveSelectedEnvFileCredentialsRejectsConflictWithChosenPair(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "8.10.env")
+	if err := os.WriteFile(path, []byte("HARBOR_USERNAME=other\nHARBOR_PASSWORD=other-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	user, password, hubUser, hubPassword := "robot", "token", "", ""
+	if err := resolveSelectedEnvFileCredentials([]matrix.Entry{{Version: "8.10"}}, map[string]string{"8.10": path}, "", &user, &password, &hubUser, &hubPassword, true, false); err == nil {
+		t.Fatal("expected selected env credential conflict")
+	}
+}
+
 func TestMatrixCleanupMarksOwnedEntryCleaned(t *testing.T) {
 	root := t.TempDir()
 	entry := matrix.Entry{Version: "8.10", Shortname: "one", Scenario: "first", Flow: "install"}
@@ -250,12 +261,17 @@ func TestMatrixCleanupReconcilesUncheckpointedEntraObject(t *testing.T) {
 		t.Fatal(err)
 	}
 	fake := &fakeCleanupClient{}
+	findCalled, cleanupCalled := false, false
 	originalClient, originalFind, originalCleanup := newCleanupKubeClient, findEntraObject, cleanupEntraObject
 	newCleanupKubeClient = func(string) (cleanupKubeClient, error) { return fake, nil }
 	findEntraObject = func(context.Context, entra.Options) (*entra.VenomApp, error) {
+		findCalled = true
 		return &entra.VenomApp{ObjectID: "object-id"}, nil
 	}
-	cleanupEntraObject = func(context.Context, entra.Options, string) error { return nil }
+	cleanupEntraObject = func(_ context.Context, _ entra.Options, id string) error {
+		cleanupCalled = id == "object-id"
+		return nil
+	}
 	t.Cleanup(func() {
 		newCleanupKubeClient, findEntraObject, cleanupEntraObject = originalClient, originalFind, originalCleanup
 	})
@@ -263,6 +279,16 @@ func TestMatrixCleanupReconcilesUncheckpointedEntraObject(t *testing.T) {
 	cmd.SetArgs([]string{"run-1", "--state-dir", root, "--yes"})
 	if err := cmd.Execute(); err != nil {
 		t.Fatal(err)
+	}
+	if !findCalled || !cleanupCalled || !fake.deleted {
+		t.Fatalf("find=%v cleanup=%v deleted=%v", findCalled, cleanupCalled, fake.deleted)
+	}
+	state, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !state.Entries[0].Cleaned {
+		t.Fatal("entry not marked cleaned")
 	}
 }
 

--- a/scripts/deploy-camunda/cmd/matrix_doctor_test.go
+++ b/scripts/deploy-camunda/cmd/matrix_doctor_test.go
@@ -75,6 +75,21 @@ func TestImportMatrixDockerAuthDoesNotMixExplicitPair(t *testing.T) {
 	}
 }
 
+func TestResolveSelectedEnvFileCredentials(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "8.10.env")
+	if err := os.WriteFile(path, []byte("HARBOR_USERNAME=robot\nHARBOR_PASSWORD=token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	entries := []matrix.Entry{{Version: "8.10"}}
+	user, password, hubUser, hubPassword := "", "", "", ""
+	if err := resolveSelectedEnvFileCredentials(entries, map[string]string{"8.10": path}, "", &user, &password, &hubUser, &hubPassword, true, false); err != nil {
+		t.Fatal(err)
+	}
+	if user != "robot" || password != "token" {
+		t.Fatalf("credentials = %q/%q", user, password)
+	}
+}
+
 func TestMatrixCleanupMarksOwnedEntryCleaned(t *testing.T) {
 	root := t.TempDir()
 	entry := matrix.Entry{Version: "8.10", Shortname: "one", Scenario: "first", Flow: "install"}

--- a/scripts/deploy-camunda/cmd/matrix_doctor_test.go
+++ b/scripts/deploy-camunda/cmd/matrix_doctor_test.go
@@ -1,11 +1,26 @@
 package cmd
 
 import (
+	"context"
 	"encoding/base64"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+	"scripts/deploy-camunda/matrix"
 )
+
+type fakeCleanupClient struct{ deleted bool }
+
+func (f *fakeCleanupClient) OwnedNamespaceIdentity(context.Context, string, string, string) (types.UID, string, error) {
+	return types.UID("uid-1"), "rv-1", nil
+}
+
+func (f *fakeCleanupClient) DeleteNamespaceWithIdentity(context.Context, string, types.UID, string) error {
+	f.deleted = true
+	return nil
+}
 
 func TestImportMatrixDockerAuthPreservesEnvironmentPair(t *testing.T) {
 	t.Setenv("HARBOR_USERNAME", "environment-user")
@@ -54,5 +69,35 @@ func TestImportMatrixDockerAuthDoesNotMixExplicitPair(t *testing.T) {
 	user, password, hubUser, hubPassword := "explicit-user", "", "", ""
 	if err := resolveMatrixDockerCredentialPairs(&user, &password, &hubUser, &hubPassword); err == nil {
 		t.Fatal("expected partial explicit credential pair failure")
+	}
+}
+
+func TestMatrixCleanupMarksOwnedEntryCleaned(t *testing.T) {
+	root := t.TempDir()
+	entry := matrix.Entry{Version: "8.10", Shortname: "one", Scenario: "first", Flow: "install"}
+	store := matrix.NewRunStateStore(root, "run-1")
+	_, err := store.Create([]matrix.Entry{entry}, matrix.RunOptions{NamespacePrefix: "matrix", KubeContext: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fake := &fakeCleanupClient{}
+	original := newCleanupKubeClient
+	newCleanupKubeClient = func(string) (cleanupKubeClient, error) { return fake, nil }
+	t.Cleanup(func() { newCleanupKubeClient = original })
+
+	cmd := newMatrixCleanupCommand()
+	cmd.SetArgs([]string{"run-1", "--state-dir", root, "--yes"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if !fake.deleted {
+		t.Fatal("namespace was not deleted")
+	}
+	state, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !state.Entries[0].Cleaned {
+		t.Fatal("entry was not marked cleaned")
 	}
 }

--- a/scripts/deploy-camunda/cmd/matrix_doctor_test.go
+++ b/scripts/deploy-camunda/cmd/matrix_doctor_test.go
@@ -106,16 +106,27 @@ func TestMatrixCleanupMarksOwnedEntryCleaned(t *testing.T) {
 
 func TestMatrixCleanupPreservesNamespaceOnIdentityFailure(t *testing.T) {
 	root := t.TempDir()
+	envFile := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(envFile, []byte("ENTRA_APP_DIRECTORY_ID=tenant\nENTRA_APP_CLIENT_ID=client\nENTRA_APP_CLIENT_SECRET=secret\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	entry := matrix.Entry{Version: "8.10", Shortname: "oidc", Scenario: "oidc", Flow: "install", Auth: "oidc", Identity: "oidc"}
 	store := matrix.NewRunStateStore(root, "run-1")
-	_, err := store.Create([]matrix.Entry{entry}, matrix.RunOptions{NamespacePrefix: "matrix", KubeContext: "test"})
+	_, err := store.Create([]matrix.Entry{entry}, matrix.RunOptions{NamespacePrefix: "matrix", KubeContext: "test", EnvFile: envFile})
 	if err != nil {
 		t.Fatal(err)
 	}
+	if err := store.RecordExternalResources(entry, "", "tenant", "", nil); err != nil {
+		t.Fatal(err)
+	}
 	fake := &fakeCleanupClient{}
+	providerCalled := false
 	originalClient, originalEntra := newCleanupKubeClient, cleanupEntraResources
 	newCleanupKubeClient = func(string) (cleanupKubeClient, error) { return fake, nil }
-	cleanupEntraResources = func(context.Context, entra.Options) error { return errors.New("provider unavailable") }
+	cleanupEntraResources = func(context.Context, entra.Options) error {
+		providerCalled = true
+		return errors.New("provider unavailable")
+	}
 	t.Cleanup(func() { newCleanupKubeClient, cleanupEntraResources = originalClient, originalEntra })
 	cmd := newMatrixCleanupCommand()
 	cmd.SetArgs([]string{"run-1", "--state-dir", root, "--yes"})
@@ -124,6 +135,9 @@ func TestMatrixCleanupPreservesNamespaceOnIdentityFailure(t *testing.T) {
 	}
 	if fake.deleted {
 		t.Fatal("namespace deleted after identity cleanup failure")
+	}
+	if !providerCalled {
+		t.Fatal("provider cleanup was not called")
 	}
 	state, err := store.Load()
 	if err != nil {

--- a/scripts/deploy-camunda/cmd/matrix_doctor_test.go
+++ b/scripts/deploy-camunda/cmd/matrix_doctor_test.go
@@ -115,18 +115,18 @@ func TestMatrixCleanupPreservesNamespaceOnIdentityFailure(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := store.RecordExternalResources(entry, "", "tenant", "", nil); err != nil {
+	if err := store.RecordExternalResources(entry, "object-id", "tenant", "", nil); err != nil {
 		t.Fatal(err)
 	}
 	fake := &fakeCleanupClient{}
 	providerCalled := false
-	originalClient, originalEntra := newCleanupKubeClient, cleanupEntraResources
+	originalClient, originalEntra := newCleanupKubeClient, cleanupEntraObject
 	newCleanupKubeClient = func(string) (cleanupKubeClient, error) { return fake, nil }
-	cleanupEntraResources = func(context.Context, entra.Options) error {
+	cleanupEntraObject = func(context.Context, entra.Options, string) error {
 		providerCalled = true
 		return errors.New("provider unavailable")
 	}
-	t.Cleanup(func() { newCleanupKubeClient, cleanupEntraResources = originalClient, originalEntra })
+	t.Cleanup(func() { newCleanupKubeClient, cleanupEntraObject = originalClient, originalEntra })
 	cmd := newMatrixCleanupCommand()
 	cmd.SetArgs([]string{"run-1", "--state-dir", root, "--yes"})
 	if err := cmd.Execute(); err == nil {
@@ -144,5 +144,43 @@ func TestMatrixCleanupPreservesNamespaceOnIdentityFailure(t *testing.T) {
 	}
 	if state.Entries[0].Cleaned {
 		t.Fatal("entry marked cleaned after identity cleanup failure")
+	}
+}
+
+func TestCleanupCredentialEnvPreservesProcessPrecedence(t *testing.T) {
+	t.Setenv("AUTH0_DOMAIN", "https://process.example")
+	path := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(path, []byte("AUTH0_DOMAIN=https://file.example\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	values := cleanupCredentialEnv(path)
+	if values["AUTH0_DOMAIN"] != "https://process.example" {
+		t.Fatalf("domain = %q", values["AUTH0_DOMAIN"])
+	}
+}
+
+func TestMatrixCleanupMarksUnprovisionedOIDCEntryCleaned(t *testing.T) {
+	root := t.TempDir()
+	entry := matrix.Entry{Version: "8.10", Shortname: "oidc", Scenario: "oidc", Flow: "install", Auth: "oidc", Identity: "oidc"}
+	store := matrix.NewRunStateStore(root, "run-1")
+	_, err := store.Create([]matrix.Entry{entry}, matrix.RunOptions{NamespacePrefix: "matrix", KubeContext: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fake := &fakeCleanupClient{}
+	original := newCleanupKubeClient
+	newCleanupKubeClient = func(string) (cleanupKubeClient, error) { return fake, nil }
+	t.Cleanup(func() { newCleanupKubeClient = original })
+	cmd := newMatrixCleanupCommand()
+	cmd.SetArgs([]string{"run-1", "--state-dir", root, "--yes"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	state, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !state.Entries[0].Cleaned {
+		t.Fatal("unprovisioned entry not marked cleaned")
 	}
 }

--- a/scripts/deploy-camunda/cmd/matrix_doctor_test.go
+++ b/scripts/deploy-camunda/cmd/matrix_doctor_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/types"
+	"scripts/deploy-camunda/auth0"
 	"scripts/deploy-camunda/entra"
 	"scripts/deploy-camunda/matrix"
 )
@@ -182,5 +183,39 @@ func TestMatrixCleanupMarksUnprovisionedOIDCEntryCleaned(t *testing.T) {
 	}
 	if !state.Entries[0].Cleaned {
 		t.Fatal("unprovisioned entry not marked cleaned")
+	}
+}
+
+func TestMatrixCleanupPreservesNamespaceOnAuth0Failure(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("AUTH0_DOMAIN", "https://tenant.example")
+	entry := matrix.Entry{Version: "8.10", Shortname: "auth0", Scenario: "auth0", Flow: "install", Identity: "auth0"}
+	store := matrix.NewRunStateStore(root, "run-1")
+	_, err := store.Create([]matrix.Entry{entry}, matrix.RunOptions{NamespacePrefix: "matrix", KubeContext: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.RecordExternalResources(entry, "", "", "https://tenant.example", []string{"client-id"}); err != nil {
+		t.Fatal(err)
+	}
+	fake := &fakeCleanupClient{}
+	originalClient, originalAuth0 := newCleanupKubeClient, cleanupAuth0ClientIDs
+	newCleanupKubeClient = func(string) (cleanupKubeClient, error) { return fake, nil }
+	cleanupAuth0ClientIDs = func(context.Context, auth0.Options, []string) error { return errors.New("provider unavailable") }
+	t.Cleanup(func() { newCleanupKubeClient, cleanupAuth0ClientIDs = originalClient, originalAuth0 })
+	cmd := newMatrixCleanupCommand()
+	cmd.SetArgs([]string{"run-1", "--state-dir", root, "--yes"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected Auth0 cleanup failure")
+	}
+	if fake.deleted {
+		t.Fatal("namespace deleted after Auth0 cleanup failure")
+	}
+	state, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Entries[0].Cleaned {
+		t.Fatal("entry marked cleaned after Auth0 cleanup failure")
 	}
 }

--- a/scripts/deploy-camunda/cmd/matrix_doctor_test.go
+++ b/scripts/deploy-camunda/cmd/matrix_doctor_test.go
@@ -144,7 +144,7 @@ func TestMatrixCleanupPreservesNamespaceOnIdentityFailure(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := store.RecordExternalResources(entry, "object-id", "tenant", "", nil); err != nil {
+	if err := store.RecordExternalResources(entry, "object-id", "tenant", "", nil, true); err != nil {
 		t.Fatal(err)
 	}
 	fake := &fakeCleanupClient{}
@@ -282,6 +282,36 @@ func TestMatrixCleanupReconcilesUncheckpointedEntraObject(t *testing.T) {
 	}
 	if state.Entries[0].Cleaned {
 		t.Fatal("entry marked cleaned")
+	}
+}
+
+func TestMatrixCleanupDoesNotDeleteReusedEntraObject(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("ENTRA_APP_DIRECTORY_ID", "tenant")
+	t.Setenv("ENTRA_APP_CLIENT_ID", "client")
+	t.Setenv("ENTRA_APP_CLIENT_SECRET", "secret")
+	entry := matrix.Entry{Version: "8.10", Shortname: "oidc", Flow: "install", Auth: "oidc", Identity: "oidc"}
+	store := matrix.NewRunStateStore(root, "run-1")
+	_, err := store.Create([]matrix.Entry{entry}, matrix.RunOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.RecordExternalResources(entry, "existing-id", "tenant", "", nil, false); err != nil {
+		t.Fatal(err)
+	}
+	fake := &fakeCleanupClient{}
+	originalClient, originalCleanup := newCleanupKubeClient, cleanupEntraObject
+	called := false
+	newCleanupKubeClient = func(string) (cleanupKubeClient, error) { return fake, nil }
+	cleanupEntraObject = func(context.Context, entra.Options, string) error { called = true; return nil }
+	t.Cleanup(func() { newCleanupKubeClient, cleanupEntraObject = originalClient, originalCleanup })
+	cmd := newMatrixCleanupCommand()
+	cmd.SetArgs([]string{"run-1", "--state-dir", root, "--yes"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if called {
+		t.Fatal("reused Entra app was deleted")
 	}
 }
 

--- a/scripts/deploy-camunda/cmd/matrix_doctor_test.go
+++ b/scripts/deploy-camunda/cmd/matrix_doctor_test.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestImportMatrixDockerAuthPreservesEnvironmentPair(t *testing.T) {
+	t.Setenv("HARBOR_USERNAME", "environment-user")
+	t.Setenv("HARBOR_PASSWORD", "environment-password")
+	t.Setenv("DOCKERHUB_USERNAME", "")
+	t.Setenv("DOCKERHUB_PASSWORD", "")
+	t.Setenv("TEST_DOCKER_USERNAME", "")
+	t.Setenv("TEST_DOCKER_PASSWORD", "")
+	t.Setenv("TEST_DOCKER_USERNAME_CAMUNDA_CLOUD", "")
+	t.Setenv("TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD", "")
+	t.Setenv("NEXUS_USERNAME", "")
+	t.Setenv("NEXUS_PASSWORD", "")
+	path := filepath.Join(t.TempDir(), "config.json")
+	auth := base64.StdEncoding.EncodeToString([]byte("docker-user:docker-password"))
+	if err := os.WriteFile(path, []byte(`{"auths":{"registry.camunda.cloud":{"auth":"`+auth+`"}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	user, password, hubUser, hubPassword := "", "", "", ""
+	if err := resolveMatrixDockerCredentialPairs(&user, &password, &hubUser, &hubPassword); err != nil {
+		t.Fatal(err)
+	}
+	if err := importMatrixDockerAuth(path, &user, &password, &hubUser, &hubPassword); err != nil {
+		t.Fatal(err)
+	}
+	if user != "environment-user" || password != "environment-password" {
+		t.Fatalf("Docker auth overrode environment pair: %q/%q", user, password)
+	}
+}
+
+func TestImportMatrixDockerAuthDoesNotMixExplicitPair(t *testing.T) {
+	t.Setenv("DOCKERHUB_USERNAME", "")
+	t.Setenv("DOCKERHUB_PASSWORD", "")
+	t.Setenv("TEST_DOCKER_USERNAME", "")
+	t.Setenv("TEST_DOCKER_PASSWORD", "")
+	t.Setenv("HARBOR_USERNAME", "")
+	t.Setenv("HARBOR_PASSWORD", "")
+	t.Setenv("TEST_DOCKER_USERNAME_CAMUNDA_CLOUD", "")
+	t.Setenv("TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD", "")
+	t.Setenv("NEXUS_USERNAME", "")
+	t.Setenv("NEXUS_PASSWORD", "")
+	path := filepath.Join(t.TempDir(), "config.json")
+	auth := base64.StdEncoding.EncodeToString([]byte("docker-user:docker-password"))
+	if err := os.WriteFile(path, []byte(`{"auths":{"registry.camunda.cloud":{"auth":"`+auth+`"}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	user, password, hubUser, hubPassword := "explicit-user", "", "", ""
+	if err := resolveMatrixDockerCredentialPairs(&user, &password, &hubUser, &hubPassword); err == nil {
+		t.Fatal("expected partial explicit credential pair failure")
+	}
+}

--- a/scripts/deploy-camunda/cmd/matrix_doctor_test.go
+++ b/scripts/deploy-camunda/cmd/matrix_doctor_test.go
@@ -251,3 +251,18 @@ func TestMatrixCleanupPreservesNamespaceOnAuth0Failure(t *testing.T) {
 		t.Fatal("entry marked cleaned after Auth0 cleanup failure")
 	}
 }
+
+func TestMatrixCleanupRejectsSharedNamespaceEntry(t *testing.T) {
+	root := t.TempDir()
+	entries := []matrix.Entry{{Version: "8.10", Shortname: "one", Flow: "install"}, {Version: "8.10", Shortname: "two", Flow: "install"}}
+	store := matrix.NewRunStateStore(root, "run-1")
+	_, err := store.Create(entries, matrix.RunOptions{NamespaceOverride: "shared"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := newMatrixCleanupCommand()
+	cmd.SetArgs([]string{"run-1", "--state-dir", root, "--entry", matrix.EntryID(entries[0]), "--yes"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected shared namespace rejection")
+	}
+}

--- a/scripts/deploy-camunda/cmd/matrix_doctor_test.go
+++ b/scripts/deploy-camunda/cmd/matrix_doctor_test.go
@@ -3,11 +3,13 @@ package cmd
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/types"
+	"scripts/deploy-camunda/entra"
 	"scripts/deploy-camunda/matrix"
 )
 
@@ -99,5 +101,35 @@ func TestMatrixCleanupMarksOwnedEntryCleaned(t *testing.T) {
 	}
 	if !state.Entries[0].Cleaned {
 		t.Fatal("entry was not marked cleaned")
+	}
+}
+
+func TestMatrixCleanupPreservesNamespaceOnIdentityFailure(t *testing.T) {
+	root := t.TempDir()
+	entry := matrix.Entry{Version: "8.10", Shortname: "oidc", Scenario: "oidc", Flow: "install", Auth: "oidc", Identity: "oidc"}
+	store := matrix.NewRunStateStore(root, "run-1")
+	_, err := store.Create([]matrix.Entry{entry}, matrix.RunOptions{NamespacePrefix: "matrix", KubeContext: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fake := &fakeCleanupClient{}
+	originalClient, originalEntra := newCleanupKubeClient, cleanupEntraResources
+	newCleanupKubeClient = func(string) (cleanupKubeClient, error) { return fake, nil }
+	cleanupEntraResources = func(context.Context, entra.Options) error { return errors.New("provider unavailable") }
+	t.Cleanup(func() { newCleanupKubeClient, cleanupEntraResources = originalClient, originalEntra })
+	cmd := newMatrixCleanupCommand()
+	cmd.SetArgs([]string{"run-1", "--state-dir", root, "--yes"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected identity cleanup failure")
+	}
+	if fake.deleted {
+		t.Fatal("namespace deleted after identity cleanup failure")
+	}
+	state, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Entries[0].Cleaned {
+		t.Fatal("entry marked cleaned after identity cleanup failure")
 	}
 }

--- a/scripts/deploy-camunda/cmd/matrix_doctor_test.go
+++ b/scripts/deploy-camunda/cmd/matrix_doctor_test.go
@@ -186,6 +186,38 @@ func TestMatrixCleanupMarksUnprovisionedOIDCEntryCleaned(t *testing.T) {
 	}
 }
 
+func TestMatrixCleanupRefusesUncheckpointedProviderProvisioning(t *testing.T) {
+	root := t.TempDir()
+	entry := matrix.Entry{Version: "8.10", Shortname: "oidc", Scenario: "oidc", Flow: "install", Auth: "oidc", Identity: "oidc"}
+	store := matrix.NewRunStateStore(root, "run-1")
+	_, err := store.Create([]matrix.Entry{entry}, matrix.RunOptions{NamespacePrefix: "matrix", KubeContext: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.MarkExternalProvisioningStarted(entry); err != nil {
+		t.Fatal(err)
+	}
+	fake := &fakeCleanupClient{}
+	original := newCleanupKubeClient
+	newCleanupKubeClient = func(string) (cleanupKubeClient, error) { return fake, nil }
+	t.Cleanup(func() { newCleanupKubeClient = original })
+	cmd := newMatrixCleanupCommand()
+	cmd.SetArgs([]string{"run-1", "--state-dir", root, "--yes"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected uncertain provisioning failure")
+	}
+	if fake.deleted {
+		t.Fatal("namespace deleted despite uncertain provider state")
+	}
+	state, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Entries[0].Cleaned {
+		t.Fatal("uncertain entry marked cleaned")
+	}
+}
+
 func TestMatrixCleanupPreservesNamespaceOnAuth0Failure(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv("AUTH0_DOMAIN", "https://tenant.example")

--- a/scripts/deploy-camunda/cmd/matrix_doctor_test.go
+++ b/scripts/deploy-camunda/cmd/matrix_doctor_test.go
@@ -176,14 +176,14 @@ func TestMatrixCleanupPreservesNamespaceOnIdentityFailure(t *testing.T) {
 	}
 }
 
-func TestCleanupCredentialEnvPreservesProcessPrecedence(t *testing.T) {
+func TestCleanupCredentialEnvMatchesProvisioningFilePrecedence(t *testing.T) {
 	t.Setenv("AUTH0_DOMAIN", "https://process.example")
 	path := filepath.Join(t.TempDir(), ".env")
 	if err := os.WriteFile(path, []byte("AUTH0_DOMAIN=https://file.example\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	values := cleanupCredentialEnv(path)
-	if values["AUTH0_DOMAIN"] != "https://process.example" {
+	if values["AUTH0_DOMAIN"] != "https://file.example" {
 		t.Fatalf("domain = %q", values["AUTH0_DOMAIN"])
 	}
 }
@@ -261,34 +261,27 @@ func TestMatrixCleanupReconcilesUncheckpointedEntraObject(t *testing.T) {
 		t.Fatal(err)
 	}
 	fake := &fakeCleanupClient{}
-	findCalled, cleanupCalled := false, false
-	originalClient, originalFind, originalCleanup := newCleanupKubeClient, findEntraObject, cleanupEntraObject
+	originalClient, originalCleanup := newCleanupKubeClient, cleanupEntraObject
 	newCleanupKubeClient = func(string) (cleanupKubeClient, error) { return fake, nil }
-	findEntraObject = func(context.Context, entra.Options) (*entra.VenomApp, error) {
-		findCalled = true
-		return &entra.VenomApp{ObjectID: "object-id"}, nil
-	}
-	cleanupEntraObject = func(_ context.Context, _ entra.Options, id string) error {
-		cleanupCalled = id == "object-id"
-		return nil
-	}
+	cleanupCalled := false
+	cleanupEntraObject = func(context.Context, entra.Options, string) error { cleanupCalled = true; return nil }
 	t.Cleanup(func() {
-		newCleanupKubeClient, findEntraObject, cleanupEntraObject = originalClient, originalFind, originalCleanup
+		newCleanupKubeClient, cleanupEntraObject = originalClient, originalCleanup
 	})
 	cmd := newMatrixCleanupCommand()
 	cmd.SetArgs([]string{"run-1", "--state-dir", root, "--yes"})
-	if err := cmd.Execute(); err != nil {
-		t.Fatal(err)
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected unresolved Entra failure")
 	}
-	if !findCalled || !cleanupCalled || !fake.deleted {
-		t.Fatalf("find=%v cleanup=%v deleted=%v", findCalled, cleanupCalled, fake.deleted)
+	if cleanupCalled || fake.deleted {
+		t.Fatalf("cleanup=%v deleted=%v", cleanupCalled, fake.deleted)
 	}
 	state, err := store.Load()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !state.Entries[0].Cleaned {
-		t.Fatal("entry not marked cleaned")
+	if state.Entries[0].Cleaned {
+		t.Fatal("entry marked cleaned")
 	}
 }
 

--- a/scripts/deploy-camunda/cmd/matrix_state.go
+++ b/scripts/deploy-camunda/cmd/matrix_state.go
@@ -163,7 +163,15 @@ func newMatrixCleanupCommand() *cobra.Command {
 				if versionFile := state.Options.EnvFiles[item.Entry.Version]; versionFile != "" {
 					envFile = versionFile
 				}
-				values, _ := env.ReadFile(envFile)
+				if envFile == "" {
+					envFile = ".env"
+				}
+				values, envErr := env.ReadFile(envFile)
+				if envErr != nil && (entra.IsOIDCEntry(item.Entry.Auth, item.Entry.Identity) || auth0.IsAuth0Identity(item.Entry.Identity)) {
+					cancel()
+					failures = append(failures, item.ID+": read identity cleanup credentials: "+envErr.Error())
+					continue
+				}
 				if entra.IsOIDCEntry(item.Entry.Auth, item.Entry.Identity) {
 					entra.CleanupVenomApp(cleanupCtx, entra.Options{
 						Namespace: item.Namespace, KubeContext: item.KubeContext,

--- a/scripts/deploy-camunda/cmd/matrix_state.go
+++ b/scripts/deploy-camunda/cmd/matrix_state.go
@@ -190,6 +190,22 @@ func newMatrixCleanupCommand() *cobra.Command {
 				return err
 			}
 			var failures []string
+			if entryID != "" {
+				var targetNamespace string
+				for _, item := range state.Entries {
+					if item.ID == entryID {
+						targetNamespace = item.Namespace
+						break
+					}
+				}
+				if targetNamespace != "" {
+					for _, item := range state.Entries {
+						if item.ID != entryID && item.Namespace == targetNamespace && !item.Cleaned {
+							return fmt.Errorf("entry %q shares namespace %q with entry %q; clean the whole run instead", entryID, targetNamespace, item.ID)
+						}
+					}
+				}
+			}
 			matchedEntry := entryID == ""
 			for _, item := range state.Entries {
 				if entryID != "" && entryID != item.ID {

--- a/scripts/deploy-camunda/cmd/matrix_state.go
+++ b/scripts/deploy-camunda/cmd/matrix_state.go
@@ -184,6 +184,11 @@ func newMatrixCleanupCommand() *cobra.Command {
 						MgmtToken: values["AUTH0_MGMT_TOKEN"], MgmtClientID: values["AUTH0_MGMT_CLIENT_ID"], MgmtClientSecret: values["AUTH0_MGMT_CLIENT_SECRET"],
 					})
 				}
+				if _, ownershipErr := client.OwnedNamespaceUID(cleanupCtx, item.Namespace, "deploy-camunda-run", state.ID); ownershipErr != nil {
+					cancel()
+					failures = append(failures, item.ID+": namespace ownership changed during identity cleanup: "+ownershipErr.Error())
+					continue
+				}
 				if uid != "" {
 					err = client.DeleteNamespaceWithUID(cleanupCtx, item.Namespace, uid)
 				}

--- a/scripts/deploy-camunda/cmd/matrix_state.go
+++ b/scripts/deploy-camunda/cmd/matrix_state.go
@@ -11,7 +11,9 @@ import (
 	"github.com/spf13/cobra"
 
 	"scripts/camunda-core/pkg/kube"
+	"scripts/deploy-camunda/auth0"
 	"scripts/deploy-camunda/config"
+	"scripts/deploy-camunda/entra"
 	"scripts/deploy-camunda/matrix"
 )
 
@@ -145,6 +147,12 @@ func newMatrixCleanupCommand() *cobra.Command {
 					continue
 				}
 				cleanupCtx, cancel := context.WithTimeout(cmd.Context(), 2*time.Minute)
+				if entra.IsOIDCEntry(item.Entry.Auth, item.Entry.Identity) {
+					entra.CleanupVenomApp(cleanupCtx, entra.Options{Namespace: item.Namespace, KubeContext: item.KubeContext})
+				}
+				if auth0.IsAuth0Identity(item.Entry.Identity) {
+					auth0.CleanupClients(cleanupCtx, auth0.Options{Namespace: item.Namespace, KubeContext: item.KubeContext})
+				}
 				client, err := kube.NewClient("", item.KubeContext)
 				if err == nil {
 					err = client.DeleteNamespaceOwnedBy(cleanupCtx, item.Namespace, "deploy-camunda-run", state.ID)

--- a/scripts/deploy-camunda/cmd/matrix_state.go
+++ b/scripts/deploy-camunda/cmd/matrix_state.go
@@ -242,7 +242,14 @@ func newMatrixCleanupCommand() *cobra.Command {
 					if item.EntraObjectID == "" {
 						if item.ExternalProvisioningStarted {
 							app, findErr := entra.FindVenomApp(providerCtx, entra.Options{Namespace: item.Namespace, RunID: state.ID, DirectoryID: values["ENTRA_APP_DIRECTORY_ID"], ClientID: values["ENTRA_APP_CLIENT_ID"], ClientSecret: values["ENTRA_APP_CLIENT_SECRET"]})
-							if findErr != nil { err = findErr } else if app != nil { err = cleanupEntraObject(providerCtx, entra.Options{Namespace: item.Namespace, RunID: state.ID, DirectoryID: values["ENTRA_APP_DIRECTORY_ID"], ClientID: values["ENTRA_APP_CLIENT_ID"], ClientSecret: values["ENTRA_APP_CLIENT_SECRET"]}, app.ObjectID); if err == nil { item.EntraObjectID, item.EntraCreated = app.ObjectID, true } }
+							if findErr != nil {
+								err = findErr
+							} else if app != nil {
+								err = cleanupEntraObject(providerCtx, entra.Options{Namespace: item.Namespace, RunID: state.ID, DirectoryID: values["ENTRA_APP_DIRECTORY_ID"], ClientID: values["ENTRA_APP_CLIENT_ID"], ClientSecret: values["ENTRA_APP_CLIENT_SECRET"]}, app.ObjectID)
+								if err == nil {
+									item.EntraObjectID, item.EntraCreated = app.ObjectID, true
+								}
+							}
 						} else {
 							err = nil
 						}
@@ -259,7 +266,7 @@ func newMatrixCleanupCommand() *cobra.Command {
 				if err == nil && item.Entry.Identity == "auth0" {
 					if len(item.Auth0ClientIDs) == 0 {
 						err = nil
-					} else if item.Auth0Domain == "" || strings.TrimSuffix(values["AUTH0_DOMAIN"], "/") != strings.TrimSuffix(item.Auth0Domain, "/") {
+					} else if item.Auth0Domain == "" || auth0.EffectiveDomain(values["AUTH0_DOMAIN"]) != auth0.EffectiveDomain(item.Auth0Domain) {
 						err = fmt.Errorf("Auth0 domain does not match recorded tenant")
 					} else if len(item.Auth0ClientIDs) > 0 {
 						err = cleanupAuth0ClientIDs(providerCtx, auth0.Options{

--- a/scripts/deploy-camunda/cmd/matrix_state.go
+++ b/scripts/deploy-camunda/cmd/matrix_state.go
@@ -170,24 +170,19 @@ func newMatrixCleanupCommand() *cobra.Command {
 					continue
 				}
 				matchedEntry = true
-				if item.Namespace == "" || item.Status == matrix.RunCleaned {
+				if item.Cleaned || item.Namespace == "" || item.Status == matrix.RunCleaned {
 					continue
 				}
-				cleanupCtx, cancel := context.WithTimeout(cmd.Context(), 2*time.Minute)
+				providerCtx, providerCancel := context.WithTimeout(cmd.Context(), 2*time.Minute)
 				client, err := newCleanupKubeClient(item.KubeContext)
 				var uid types.UID
 				var resourceVersion string
 				if err == nil {
-					uid, resourceVersion, err = client.OwnedNamespaceIdentity(cleanupCtx, item.Namespace, "deploy-camunda-run", state.ID)
+					uid, resourceVersion, err = client.OwnedNamespaceIdentity(providerCtx, item.Namespace, "deploy-camunda-run", state.ID)
 				}
 				if err != nil {
-					cancel()
+					providerCancel()
 					failures = append(failures, item.ID+": "+err.Error())
-					continue
-				}
-				if uid == "" {
-					cancel()
-					failures = append(failures, item.ID+": owned namespace no longer exists; external identity cleanup requires an active ownership anchor")
 					continue
 				}
 				envPath := state.Options.EnvFile
@@ -199,7 +194,7 @@ func newMatrixCleanupCommand() *cobra.Command {
 				}
 				values, envErr := env.ReadFile(envPath)
 				if envErr != nil && (item.Entry.Auth == "oidc" || item.Entry.Identity == "oidc" || item.Entry.Identity == "auth0") {
-					cancel()
+					providerCancel()
 					failures = append(failures, item.ID+": read identity cleanup credentials: "+envErr.Error())
 					continue
 				}
@@ -207,11 +202,11 @@ func newMatrixCleanupCommand() *cobra.Command {
 					if item.EntraDirectoryID == "" || values["ENTRA_APP_DIRECTORY_ID"] != item.EntraDirectoryID {
 						err = fmt.Errorf("Entra directory does not match recorded tenant")
 					} else if item.EntraObjectID != "" {
-						err = entra.CleanupVenomAppObjectStrict(cleanupCtx, entra.Options{
+						err = entra.CleanupVenomAppObjectStrict(providerCtx, entra.Options{
 							Namespace: item.Namespace, DirectoryID: values["ENTRA_APP_DIRECTORY_ID"], ClientID: values["ENTRA_APP_CLIENT_ID"], ClientSecret: values["ENTRA_APP_CLIENT_SECRET"],
 						}, item.EntraObjectID)
 					} else {
-						err = cleanupEntraResources(cleanupCtx, entra.Options{
+						err = cleanupEntraResources(providerCtx, entra.Options{
 							Namespace: item.Namespace, DirectoryID: values["ENTRA_APP_DIRECTORY_ID"], ClientID: values["ENTRA_APP_CLIENT_ID"], ClientSecret: values["ENTRA_APP_CLIENT_SECRET"],
 						})
 					}
@@ -220,24 +215,26 @@ func newMatrixCleanupCommand() *cobra.Command {
 					if item.Auth0Domain == "" || strings.TrimSuffix(values["AUTH0_DOMAIN"], "/") != strings.TrimSuffix(item.Auth0Domain, "/") {
 						err = fmt.Errorf("Auth0 domain does not match recorded tenant")
 					} else if len(item.Auth0ClientIDs) > 0 {
-						err = auth0.CleanupClientIDsStrict(cleanupCtx, auth0.Options{
+						err = auth0.CleanupClientIDsStrict(providerCtx, auth0.Options{
 							Namespace: item.Namespace, Domain: values["AUTH0_DOMAIN"], MgmtToken: values["AUTH0_MGMT_TOKEN"], MgmtClientID: values["AUTH0_MGMT_CLIENT_ID"], MgmtClientSecret: values["AUTH0_MGMT_CLIENT_SECRET"],
 						}, item.Auth0ClientIDs)
 					} else {
-						err = cleanupAuth0Resources(cleanupCtx, auth0.Options{
+						err = cleanupAuth0Resources(providerCtx, auth0.Options{
 							Namespace: item.Namespace, Domain: values["AUTH0_DOMAIN"], MgmtToken: values["AUTH0_MGMT_TOKEN"], MgmtClientID: values["AUTH0_MGMT_CLIENT_ID"], MgmtClientSecret: values["AUTH0_MGMT_CLIENT_SECRET"],
 						})
 					}
 				}
 				if err != nil {
-					cancel()
+					providerCancel()
 					failures = append(failures, item.ID+": external identity cleanup: "+err.Error())
 					continue
 				}
+				providerCancel()
 				if uid != "" {
-					err = client.DeleteNamespaceWithIdentity(cleanupCtx, item.Namespace, uid, resourceVersion)
+					deleteCtx, deleteCancel := context.WithTimeout(cmd.Context(), 5*time.Minute)
+					err = client.DeleteNamespaceWithIdentity(deleteCtx, item.Namespace, uid, resourceVersion)
+					deleteCancel()
 				}
-				cancel()
 				if err != nil {
 					failures = append(failures, item.ID+": "+err.Error())
 					continue

--- a/scripts/deploy-camunda/cmd/matrix_state.go
+++ b/scripts/deploy-camunda/cmd/matrix_state.go
@@ -206,10 +206,12 @@ func newMatrixCleanupCommand() *cobra.Command {
 						err = entra.CleanupVenomAppObjectStrict(providerCtx, entra.Options{
 							Namespace: item.Namespace, DirectoryID: values["ENTRA_APP_DIRECTORY_ID"], ClientID: values["ENTRA_APP_CLIENT_ID"], ClientSecret: values["ENTRA_APP_CLIENT_SECRET"],
 						}, item.EntraObjectID)
-					} else {
+					} else if uid != "" {
 						err = cleanupEntraResources(providerCtx, entra.Options{
 							Namespace: item.Namespace, DirectoryID: values["ENTRA_APP_DIRECTORY_ID"], ClientID: values["ENTRA_APP_CLIENT_ID"], ClientSecret: values["ENTRA_APP_CLIENT_SECRET"],
 						})
+					} else {
+						err = fmt.Errorf("missing Entra resource checkpoint and namespace ownership anchor")
 					}
 				}
 				if err == nil && item.Entry.Identity == "auth0" {
@@ -219,10 +221,12 @@ func newMatrixCleanupCommand() *cobra.Command {
 						err = auth0.CleanupClientIDsStrict(providerCtx, auth0.Options{
 							Namespace: item.Namespace, Domain: values["AUTH0_DOMAIN"], MgmtToken: values["AUTH0_MGMT_TOKEN"], MgmtClientID: values["AUTH0_MGMT_CLIENT_ID"], MgmtClientSecret: values["AUTH0_MGMT_CLIENT_SECRET"],
 						}, item.Auth0ClientIDs)
-					} else {
+					} else if uid != "" {
 						err = cleanupAuth0Resources(providerCtx, auth0.Options{
 							Namespace: item.Namespace, Domain: values["AUTH0_DOMAIN"], MgmtToken: values["AUTH0_MGMT_TOKEN"], MgmtClientID: values["AUTH0_MGMT_CLIENT_ID"], MgmtClientSecret: values["AUTH0_MGMT_CLIENT_SECRET"],
 						})
+					} else {
+						err = fmt.Errorf("missing Auth0 resource checkpoints and namespace ownership anchor")
 					}
 				}
 				if err != nil {

--- a/scripts/deploy-camunda/cmd/matrix_state.go
+++ b/scripts/deploy-camunda/cmd/matrix_state.go
@@ -241,7 +241,8 @@ func newMatrixCleanupCommand() *cobra.Command {
 				if item.Entry.Auth == "oidc" || item.Entry.Identity == "oidc" {
 					if item.EntraObjectID == "" {
 						if item.ExternalProvisioningStarted {
-							err = fmt.Errorf("unresolved Entra provisioning has no owned object checkpoint")
+							app, findErr := entra.FindVenomApp(providerCtx, entra.Options{Namespace: item.Namespace, RunID: state.ID, DirectoryID: values["ENTRA_APP_DIRECTORY_ID"], ClientID: values["ENTRA_APP_CLIENT_ID"], ClientSecret: values["ENTRA_APP_CLIENT_SECRET"]})
+							if findErr != nil { err = findErr } else if app != nil { err = cleanupEntraObject(providerCtx, entra.Options{Namespace: item.Namespace, RunID: state.ID, DirectoryID: values["ENTRA_APP_DIRECTORY_ID"], ClientID: values["ENTRA_APP_CLIENT_ID"], ClientSecret: values["ENTRA_APP_CLIENT_SECRET"]}, app.ObjectID); if err == nil { item.EntraObjectID, item.EntraCreated = app.ObjectID, true } }
 						} else {
 							err = nil
 						}

--- a/scripts/deploy-camunda/cmd/matrix_state.go
+++ b/scripts/deploy-camunda/cmd/matrix_state.go
@@ -247,10 +247,12 @@ func newMatrixCleanupCommand() *cobra.Command {
 						}
 					} else if item.EntraDirectoryID == "" || values["ENTRA_APP_DIRECTORY_ID"] != item.EntraDirectoryID {
 						err = fmt.Errorf("Entra directory does not match recorded tenant")
-					} else if item.EntraObjectID != "" {
+					} else if item.EntraObjectID != "" && item.EntraCreated {
 						err = cleanupEntraObject(providerCtx, entra.Options{
 							Namespace: item.Namespace, DirectoryID: values["ENTRA_APP_DIRECTORY_ID"], ClientID: values["ENTRA_APP_CLIENT_ID"], ClientSecret: values["ENTRA_APP_CLIENT_SECRET"],
 						}, item.EntraObjectID)
+					} else if item.EntraObjectID != "" {
+						err = nil
 					}
 				}
 				if err == nil && item.Entry.Identity == "auth0" {

--- a/scripts/deploy-camunda/cmd/matrix_state.go
+++ b/scripts/deploy-camunda/cmd/matrix_state.go
@@ -64,6 +64,17 @@ func newMatrixStatusCommand() *cobra.Command {
 				if err != nil {
 					return err
 				}
+				if output == "json" {
+					states := make([]*matrix.MatrixRunState, 0, len(ids))
+					for _, id := range ids {
+						if state, err := matrix.NewRunStateStore(root, id).Load(); err == nil {
+							states = append(states, state)
+						}
+					}
+					encoder := json.NewEncoder(cmd.OutOrStdout())
+					encoder.SetIndent("", "  ")
+					return encoder.Encode(states)
+				}
 				for _, id := range ids {
 					state, err := matrix.NewRunStateStore(root, id).Load()
 					if err != nil {
@@ -208,6 +219,11 @@ func newMatrixCleanupCommand() *cobra.Command {
 					envPath = ".env"
 				}
 				values := cleanupCredentialEnv(envPath)
+				if item.ExternalProvisioningStarted {
+					providerCancel()
+					failures = append(failures, item.ID+": external provisioning started but no exact provider resource checkpoint exists; namespace preserved")
+					continue
+				}
 				if item.Entry.Auth == "oidc" || item.Entry.Identity == "oidc" {
 					if item.EntraObjectID == "" {
 						err = nil

--- a/scripts/deploy-camunda/cmd/matrix_state.go
+++ b/scripts/deploy-camunda/cmd/matrix_state.go
@@ -37,6 +37,11 @@ func newMatrixStatusCommand() *cobra.Command {
 		Short: "Show durable matrix run state",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 1 {
+				if err := matrix.ValidateRunID(args[0]); err != nil {
+					return err
+				}
+			}
 			root, err := defaultMatrixStateRoot(stateDir)
 			if err != nil {
 				return err
@@ -87,6 +92,9 @@ func newMatrixResumeCommand() *cobra.Command {
 		Short: "Resume failed, interrupted, and pending matrix entries",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := matrix.ValidateRunID(args[0]); err != nil {
+				return err
+			}
 			root, err := defaultMatrixStateRoot(stateDir)
 			if err != nil {
 				return err
@@ -123,6 +131,9 @@ func newMatrixCleanupCommand() *cobra.Command {
 		Short: "Delete namespaces recorded by a matrix run",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := matrix.ValidateRunID(args[0]); err != nil {
+				return err
+			}
 			if !yes {
 				return fmt.Errorf("cleanup is destructive; pass --yes after reviewing matrix status")
 			}

--- a/scripts/deploy-camunda/cmd/matrix_state.go
+++ b/scripts/deploy-camunda/cmd/matrix_state.go
@@ -162,8 +162,9 @@ func newMatrixCleanupCommand() *cobra.Command {
 				cleanupCtx, cancel := context.WithTimeout(cmd.Context(), 2*time.Minute)
 				client, err := kube.NewClient("", item.KubeContext)
 				var uid types.UID
+				var resourceVersion string
 				if err == nil {
-					uid, err = client.OwnedNamespaceUID(cleanupCtx, item.Namespace, "deploy-camunda-run", state.ID)
+					uid, resourceVersion, err = client.OwnedNamespaceIdentity(cleanupCtx, item.Namespace, "deploy-camunda-run", state.ID)
 				}
 				if err != nil {
 					cancel()
@@ -195,13 +196,13 @@ func newMatrixCleanupCommand() *cobra.Command {
 						MgmtToken: values["AUTH0_MGMT_TOKEN"], MgmtClientID: values["AUTH0_MGMT_CLIENT_ID"], MgmtClientSecret: values["AUTH0_MGMT_CLIENT_SECRET"],
 					})
 				}
-				if _, ownershipErr := client.OwnedNamespaceUID(cleanupCtx, item.Namespace, "deploy-camunda-run", state.ID); ownershipErr != nil {
+				if currentUID, currentVersion, ownershipErr := client.OwnedNamespaceIdentity(cleanupCtx, item.Namespace, "deploy-camunda-run", state.ID); ownershipErr != nil || currentUID != uid || currentVersion != resourceVersion {
 					cancel()
 					failures = append(failures, item.ID+": namespace ownership changed during identity cleanup: "+ownershipErr.Error())
 					continue
 				}
 				if uid != "" {
-					err = client.DeleteNamespaceWithUID(cleanupCtx, item.Namespace, uid)
+					err = client.DeleteNamespaceWithIdentity(cleanupCtx, item.Namespace, uid, resourceVersion)
 				}
 				cancel()
 				if err != nil {

--- a/scripts/deploy-camunda/cmd/matrix_state.go
+++ b/scripts/deploy-camunda/cmd/matrix_state.go
@@ -223,14 +223,14 @@ func newMatrixCleanupCommand() *cobra.Command {
 				client, err := newCleanupKubeClient(item.KubeContext)
 				var uid types.UID
 				var resourceVersion string
+				var ownershipErr error
 				if err == nil {
-					uid, resourceVersion, err = client.OwnedNamespaceIdentity(providerCtx, item.Namespace, "deploy-camunda-run", state.ID)
+					uid, resourceVersion, ownershipErr = client.OwnedNamespaceIdentity(providerCtx, item.Namespace, "deploy-camunda-run", state.ID)
 				}
 				if err != nil {
-					providerCancel()
-					failures = append(failures, item.ID+": "+err.Error())
-					continue
+					ownershipErr = err
 				}
+				err = nil
 				envPath := state.Options.EnvFile
 				if path := state.Options.EnvFiles[item.Entry.Version]; path != "" {
 					envPath = path
@@ -288,6 +288,10 @@ func newMatrixCleanupCommand() *cobra.Command {
 					continue
 				}
 				providerCancel()
+				if ownershipErr != nil {
+					failures = append(failures, item.ID+": "+ownershipErr.Error())
+					continue
+				}
 				if uid != "" {
 					deleteCtx, deleteCancel := context.WithTimeout(cmd.Context(), 5*time.Minute)
 					err = client.DeleteNamespaceWithIdentity(deleteCtx, item.Namespace, uid, resourceVersion)

--- a/scripts/deploy-camunda/cmd/matrix_state.go
+++ b/scripts/deploy-camunda/cmd/matrix_state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -193,12 +194,7 @@ func newMatrixCleanupCommand() *cobra.Command {
 				if envPath == "" {
 					envPath = ".env"
 				}
-				values, envErr := env.ReadFile(envPath)
-				if envErr != nil && (item.Entry.Auth == "oidc" || item.Entry.Identity == "oidc" || item.Entry.Identity == "auth0") {
-					providerCancel()
-					failures = append(failures, item.ID+": read identity cleanup credentials: "+envErr.Error())
-					continue
-				}
+				values := cleanupCredentialEnv(envPath)
 				if item.Entry.Auth == "oidc" || item.Entry.Identity == "oidc" {
 					if item.EntraDirectoryID == "" || values["ENTRA_APP_DIRECTORY_ID"] != item.EntraDirectoryID {
 						err = fmt.Errorf("Entra directory does not match recorded tenant")
@@ -261,4 +257,19 @@ func newMatrixCleanupCommand() *cobra.Command {
 	cmd.Flags().StringVar(&entryID, "entry", "", "Clean up only this entry ID")
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Confirm namespace deletion")
 	return cmd
+}
+
+func cleanupCredentialEnv(envPath string) map[string]string {
+	values := make(map[string]string)
+	for _, item := range os.Environ() {
+		if key, value, ok := strings.Cut(item, "="); ok {
+			values[key] = value
+		}
+	}
+	if fileValues, err := env.ReadFile(envPath); err == nil {
+		for key, value := range fileValues {
+			values[key] = value
+		}
+	}
+	return values
 }

--- a/scripts/deploy-camunda/cmd/matrix_state.go
+++ b/scripts/deploy-camunda/cmd/matrix_state.go
@@ -12,11 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"scripts/camunda-core/pkg/kube"
-	"scripts/deploy-camunda/auth0"
 	"scripts/deploy-camunda/config"
-	"scripts/deploy-camunda/entra"
 	"scripts/deploy-camunda/matrix"
-	"scripts/prepare-helm-values/pkg/env"
 )
 
 func defaultMatrixStateRoot(explicit string) (string, error) {
@@ -152,10 +149,12 @@ func newMatrixCleanupCommand() *cobra.Command {
 				return err
 			}
 			var failures []string
+			matchedEntry := entryID == ""
 			for _, item := range state.Entries {
 				if entryID != "" && entryID != item.ID {
 					continue
 				}
+				matchedEntry = true
 				if item.Namespace == "" || item.Status == matrix.RunCleaned {
 					continue
 				}
@@ -171,34 +170,9 @@ func newMatrixCleanupCommand() *cobra.Command {
 					failures = append(failures, item.ID+": "+err.Error())
 					continue
 				}
-				envFile := state.Options.EnvFile
-				if versionFile := state.Options.EnvFiles[item.Entry.Version]; versionFile != "" {
-					envFile = versionFile
-				}
-				if envFile == "" {
-					envFile = ".env"
-				}
-				values, envErr := env.ReadFile(envFile)
-				if envErr != nil && (entra.IsOIDCEntry(item.Entry.Auth, item.Entry.Identity) || auth0.IsAuth0Identity(item.Entry.Identity)) {
+				if item.Entry.Identity == "auth0" || item.Entry.Auth == "oidc" || item.Entry.Identity == "oidc" {
 					cancel()
-					failures = append(failures, item.ID+": read identity cleanup credentials: "+envErr.Error())
-					continue
-				}
-				if entra.IsOIDCEntry(item.Entry.Auth, item.Entry.Identity) {
-					entra.CleanupVenomApp(cleanupCtx, entra.Options{
-						Namespace: item.Namespace, KubeContext: item.KubeContext,
-						DirectoryID: values["ENTRA_APP_DIRECTORY_ID"], ClientID: values["ENTRA_APP_CLIENT_ID"], ClientSecret: values["ENTRA_APP_CLIENT_SECRET"],
-					})
-				}
-				if auth0.IsAuth0Identity(item.Entry.Identity) {
-					auth0.CleanupClients(cleanupCtx, auth0.Options{
-						Namespace: item.Namespace, KubeContext: item.KubeContext, Domain: values["AUTH0_DOMAIN"],
-						MgmtToken: values["AUTH0_MGMT_TOKEN"], MgmtClientID: values["AUTH0_MGMT_CLIENT_ID"], MgmtClientSecret: values["AUTH0_MGMT_CLIENT_SECRET"],
-					})
-				}
-				if currentUID, currentVersion, ownershipErr := client.OwnedNamespaceIdentity(cleanupCtx, item.Namespace, "deploy-camunda-run", state.ID); ownershipErr != nil || currentUID != uid || currentVersion != resourceVersion {
-					cancel()
-					failures = append(failures, item.ID+": namespace ownership changed during identity cleanup: "+ownershipErr.Error())
+					failures = append(failures, item.ID+": durable cleanup of external identity resources requires persisted provider resource IDs; namespace preserved")
 					continue
 				}
 				if uid != "" {
@@ -212,6 +186,9 @@ func newMatrixCleanupCommand() *cobra.Command {
 				if err := store.MarkCleaned(item.ID); err != nil {
 					failures = append(failures, item.ID+": "+err.Error())
 				}
+			}
+			if !matchedEntry {
+				return fmt.Errorf("matrix entry %q not found in run %q", entryID, state.ID)
 			}
 			if len(failures) > 0 {
 				return fmt.Errorf("cleanup partially failed:\n%s", strings.Join(failures, "\n"))

--- a/scripts/deploy-camunda/cmd/matrix_state.go
+++ b/scripts/deploy-camunda/cmd/matrix_state.go
@@ -29,8 +29,8 @@ var newCleanupKubeClient = func(kubeContext string) (cleanupKubeClient, error) {
 	return kube.NewClient("", kubeContext)
 }
 
-var cleanupEntraResources = entra.CleanupVenomAppStrict
-var cleanupAuth0Resources = auth0.CleanupClientsStrict
+var cleanupEntraObject = entra.CleanupVenomAppObjectStrict
+var cleanupAuth0ClientIDs = auth0.CleanupClientIDsStrict
 
 func defaultMatrixStateRoot(explicit string) (string, error) {
 	if explicit != "" {
@@ -100,6 +100,7 @@ func newMatrixStatusCommand() *cobra.Command {
 
 func newMatrixResumeCommand() *cobra.Command {
 	var stateDir, entryID string
+	var recoverStaleLock bool
 	cmd := &cobra.Command{
 		Use:   "resume <run-id>",
 		Short: "Resume failed, interrupted, and pending matrix entries",
@@ -113,6 +114,11 @@ func newMatrixResumeCommand() *cobra.Command {
 				return err
 			}
 			store := matrix.NewRunStateStore(root, args[0])
+			if recoverStaleLock {
+				if err := store.RecoverStaleLock(); err != nil {
+					return err
+				}
+			}
 			lock, err := store.Acquire()
 			if err != nil {
 				return err
@@ -134,12 +140,14 @@ func newMatrixResumeCommand() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&stateDir, "state-dir", "", "Matrix run state directory")
 	cmd.Flags().StringVar(&entryID, "entry", "", "Resume only this entry ID")
+	cmd.Flags().BoolVar(&recoverStaleLock, "recover-stale-lock", false, "Explicitly remove a same-host stale run lock after confirming no deploy-camunda process is active")
 	return cmd
 }
 
 func newMatrixCleanupCommand() *cobra.Command {
 	var stateDir, entryID string
 	var yes bool
+	var recoverStaleLock bool
 	cmd := &cobra.Command{
 		Use:   "cleanup <run-id>",
 		Short: "Delete namespaces recorded by a matrix run",
@@ -156,6 +164,11 @@ func newMatrixCleanupCommand() *cobra.Command {
 				return err
 			}
 			store := matrix.NewRunStateStore(root, args[0])
+			if recoverStaleLock {
+				if err := store.RecoverStaleLock(); err != nil {
+					return err
+				}
+			}
 			lock, err := store.Acquire()
 			if err != nil {
 				return err
@@ -196,33 +209,25 @@ func newMatrixCleanupCommand() *cobra.Command {
 				}
 				values := cleanupCredentialEnv(envPath)
 				if item.Entry.Auth == "oidc" || item.Entry.Identity == "oidc" {
-					if item.EntraDirectoryID == "" || values["ENTRA_APP_DIRECTORY_ID"] != item.EntraDirectoryID {
+					if item.EntraObjectID == "" {
+						err = nil
+					} else if item.EntraDirectoryID == "" || values["ENTRA_APP_DIRECTORY_ID"] != item.EntraDirectoryID {
 						err = fmt.Errorf("Entra directory does not match recorded tenant")
 					} else if item.EntraObjectID != "" {
-						err = entra.CleanupVenomAppObjectStrict(providerCtx, entra.Options{
+						err = cleanupEntraObject(providerCtx, entra.Options{
 							Namespace: item.Namespace, DirectoryID: values["ENTRA_APP_DIRECTORY_ID"], ClientID: values["ENTRA_APP_CLIENT_ID"], ClientSecret: values["ENTRA_APP_CLIENT_SECRET"],
 						}, item.EntraObjectID)
-					} else if uid != "" {
-						err = cleanupEntraResources(providerCtx, entra.Options{
-							Namespace: item.Namespace, DirectoryID: values["ENTRA_APP_DIRECTORY_ID"], ClientID: values["ENTRA_APP_CLIENT_ID"], ClientSecret: values["ENTRA_APP_CLIENT_SECRET"],
-						})
-					} else {
-						err = fmt.Errorf("missing Entra resource checkpoint and namespace ownership anchor")
 					}
 				}
 				if err == nil && item.Entry.Identity == "auth0" {
-					if item.Auth0Domain == "" || strings.TrimSuffix(values["AUTH0_DOMAIN"], "/") != strings.TrimSuffix(item.Auth0Domain, "/") {
+					if len(item.Auth0ClientIDs) == 0 {
+						err = nil
+					} else if item.Auth0Domain == "" || strings.TrimSuffix(values["AUTH0_DOMAIN"], "/") != strings.TrimSuffix(item.Auth0Domain, "/") {
 						err = fmt.Errorf("Auth0 domain does not match recorded tenant")
 					} else if len(item.Auth0ClientIDs) > 0 {
-						err = auth0.CleanupClientIDsStrict(providerCtx, auth0.Options{
+						err = cleanupAuth0ClientIDs(providerCtx, auth0.Options{
 							Namespace: item.Namespace, Domain: values["AUTH0_DOMAIN"], MgmtToken: values["AUTH0_MGMT_TOKEN"], MgmtClientID: values["AUTH0_MGMT_CLIENT_ID"], MgmtClientSecret: values["AUTH0_MGMT_CLIENT_SECRET"],
 						}, item.Auth0ClientIDs)
-					} else if uid != "" {
-						err = cleanupAuth0Resources(providerCtx, auth0.Options{
-							Namespace: item.Namespace, Domain: values["AUTH0_DOMAIN"], MgmtToken: values["AUTH0_MGMT_TOKEN"], MgmtClientID: values["AUTH0_MGMT_CLIENT_ID"], MgmtClientSecret: values["AUTH0_MGMT_CLIENT_SECRET"],
-						})
-					} else {
-						err = fmt.Errorf("missing Auth0 resource checkpoints and namespace ownership anchor")
 					}
 				}
 				if err != nil {
@@ -256,6 +261,7 @@ func newMatrixCleanupCommand() *cobra.Command {
 	cmd.Flags().StringVar(&stateDir, "state-dir", "", "Matrix run state directory")
 	cmd.Flags().StringVar(&entryID, "entry", "", "Clean up only this entry ID")
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Confirm namespace deletion")
+	cmd.Flags().BoolVar(&recoverStaleLock, "recover-stale-lock", false, "Explicitly remove a same-host stale run lock after confirming no deploy-camunda process is active")
 	return cmd
 }
 
@@ -268,7 +274,9 @@ func cleanupCredentialEnv(envPath string) map[string]string {
 	}
 	if fileValues, err := env.ReadFile(envPath); err == nil {
 		for key, value := range fileValues {
-			values[key] = value
+			if _, exists := values[key]; !exists {
+				values[key] = value
+			}
 		}
 	}
 	return values

--- a/scripts/deploy-camunda/cmd/matrix_state.go
+++ b/scripts/deploy-camunda/cmd/matrix_state.go
@@ -125,8 +125,9 @@ func newMatrixResumeCommand() *cobra.Command {
 				return err
 			}
 			opts.StateStore = store
+			startedAt := time.Now()
 			results, runErr := matrix.Run(cmd.Context(), entries, opts)
-			fmt.Fprintln(cmd.OutOrStdout(), matrix.PrintRunSummary(results, 0, ""))
+			fmt.Fprintln(cmd.OutOrStdout(), matrix.PrintRunSummary(results, time.Since(startedAt), ""))
 			return runErr
 		},
 	}

--- a/scripts/deploy-camunda/cmd/matrix_state.go
+++ b/scripts/deploy-camunda/cmd/matrix_state.go
@@ -28,6 +28,9 @@ var newCleanupKubeClient = func(kubeContext string) (cleanupKubeClient, error) {
 	return kube.NewClient("", kubeContext)
 }
 
+var cleanupEntraResources = entra.CleanupVenomAppStrict
+var cleanupAuth0Resources = auth0.CleanupClientsStrict
+
 func defaultMatrixStateRoot(explicit string) (string, error) {
 	if explicit != "" {
 		return filepath.Abs(explicit)
@@ -190,15 +193,15 @@ func newMatrixCleanupCommand() *cobra.Command {
 					envPath = ".env"
 				}
 				values, _ := env.ReadFile(envPath)
-				if item.EntraObjectID != "" {
-					err = entra.CleanupVenomAppObjectStrict(cleanupCtx, entra.Options{
+				if item.Entry.Auth == "oidc" || item.Entry.Identity == "oidc" {
+					err = cleanupEntraResources(cleanupCtx, entra.Options{
 						Namespace: item.Namespace, DirectoryID: values["ENTRA_APP_DIRECTORY_ID"], ClientID: values["ENTRA_APP_CLIENT_ID"], ClientSecret: values["ENTRA_APP_CLIENT_SECRET"],
-					}, item.EntraObjectID)
+					})
 				}
-				if err == nil && len(item.Auth0ClientIDs) > 0 {
-					err = auth0.CleanupClientIDsStrict(cleanupCtx, auth0.Options{
+				if err == nil && item.Entry.Identity == "auth0" {
+					err = cleanupAuth0Resources(cleanupCtx, auth0.Options{
 						Namespace: item.Namespace, Domain: values["AUTH0_DOMAIN"], MgmtToken: values["AUTH0_MGMT_TOKEN"], MgmtClientID: values["AUTH0_MGMT_CLIENT_ID"], MgmtClientSecret: values["AUTH0_MGMT_CLIENT_SECRET"],
-					}, item.Auth0ClientIDs)
+					})
 				}
 				if err != nil {
 					cancel()

--- a/scripts/deploy-camunda/cmd/matrix_state.go
+++ b/scripts/deploy-camunda/cmd/matrix_state.go
@@ -65,10 +65,12 @@ func newMatrixStatusCommand() *cobra.Command {
 					return err
 				}
 				if output == "json" {
-					states := make([]*matrix.MatrixRunState, 0, len(ids))
+					states := make([]any, 0, len(ids))
 					for _, id := range ids {
 						if state, err := matrix.NewRunStateStore(root, id).Load(); err == nil {
 							states = append(states, state)
+						} else {
+							states = append(states, map[string]any{"id": id, "status": "corrupt", "error": err.Error()})
 						}
 					}
 					encoder := json.NewEncoder(cmd.OutOrStdout())
@@ -78,6 +80,7 @@ func newMatrixStatusCommand() *cobra.Command {
 				for _, id := range ids {
 					state, err := matrix.NewRunStateStore(root, id).Load()
 					if err != nil {
+						fmt.Fprintf(cmd.OutOrStdout(), "%s\tcorrupt\t%s\n", id, err)
 						continue
 					}
 					fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\t%d entries\t%s\n", state.ID, state.Status, len(state.Entries), state.UpdatedAt.Format(time.RFC3339))

--- a/scripts/deploy-camunda/cmd/matrix_state.go
+++ b/scripts/deploy-camunda/cmd/matrix_state.go
@@ -1,0 +1,171 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"scripts/camunda-core/pkg/kube"
+	"scripts/deploy-camunda/config"
+	"scripts/deploy-camunda/matrix"
+)
+
+func defaultMatrixStateRoot(explicit string) (string, error) {
+	if explicit != "" {
+		return filepath.Abs(explicit)
+	}
+	repoRoot, err := config.DetectRepoRoot()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(repoRoot, ".deploy-camunda", "runs"), nil
+}
+
+func newMatrixStatusCommand() *cobra.Command {
+	var stateDir, output string
+	cmd := &cobra.Command{
+		Use:   "status [run-id]",
+		Short: "Show durable matrix run state",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			root, err := defaultMatrixStateRoot(stateDir)
+			if err != nil {
+				return err
+			}
+			if len(args) == 0 {
+				ids, err := matrix.ListRunIDs(root)
+				if err != nil {
+					return err
+				}
+				for _, id := range ids {
+					state, err := matrix.NewRunStateStore(root, id).Load()
+					if err != nil {
+						continue
+					}
+					fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\t%d entries\t%s\n", state.ID, state.Status, len(state.Entries), state.UpdatedAt.Format(time.RFC3339))
+				}
+				return nil
+			}
+			state, err := matrix.NewRunStateStore(root, args[0]).Load()
+			if err != nil {
+				return err
+			}
+			if output == "json" {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(state)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Run: %s\nStatus: %s\nUpdated: %s\n", state.ID, state.Status, state.UpdatedAt.Format(time.RFC3339))
+			for _, item := range state.Entries {
+				detail := item.Phase
+				if item.Failure != nil {
+					detail = item.Failure.Code + ": " + item.Failure.Message
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "%-36s %-12s %-16s %s\n", item.ID, item.Status, item.Namespace, detail)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&stateDir, "state-dir", "", "Matrix run state directory")
+	cmd.Flags().StringVar(&output, "output", "table", "Output format: table, json")
+	return cmd
+}
+
+func newMatrixResumeCommand() *cobra.Command {
+	var stateDir, entryID string
+	cmd := &cobra.Command{
+		Use:   "resume <run-id>",
+		Short: "Resume failed, interrupted, and pending matrix entries",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			root, err := defaultMatrixStateRoot(stateDir)
+			if err != nil {
+				return err
+			}
+			store := matrix.NewRunStateStore(root, args[0])
+			lock, err := store.Acquire()
+			if err != nil {
+				return err
+			}
+			defer lock.Close()
+			if err := store.MarkInterrupted(); err != nil {
+				return err
+			}
+			entries, opts, err := store.PrepareResume(entryID)
+			if err != nil {
+				return err
+			}
+			opts.StateStore = store
+			results, runErr := matrix.Run(cmd.Context(), entries, opts)
+			fmt.Fprintln(cmd.OutOrStdout(), matrix.PrintRunSummary(results, 0, ""))
+			return runErr
+		},
+	}
+	cmd.Flags().StringVar(&stateDir, "state-dir", "", "Matrix run state directory")
+	cmd.Flags().StringVar(&entryID, "entry", "", "Resume only this entry ID")
+	return cmd
+}
+
+func newMatrixCleanupCommand() *cobra.Command {
+	var stateDir, entryID string
+	var yes bool
+	cmd := &cobra.Command{
+		Use:   "cleanup <run-id>",
+		Short: "Delete namespaces recorded by a matrix run",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !yes {
+				return fmt.Errorf("cleanup is destructive; pass --yes after reviewing matrix status")
+			}
+			root, err := defaultMatrixStateRoot(stateDir)
+			if err != nil {
+				return err
+			}
+			store := matrix.NewRunStateStore(root, args[0])
+			lock, err := store.Acquire()
+			if err != nil {
+				return err
+			}
+			defer lock.Close()
+			state, err := store.Load()
+			if err != nil {
+				return err
+			}
+			var failures []string
+			for _, item := range state.Entries {
+				if entryID != "" && entryID != item.ID {
+					continue
+				}
+				if item.Namespace == "" || item.Status == matrix.RunCleaned {
+					continue
+				}
+				cleanupCtx, cancel := context.WithTimeout(cmd.Context(), 2*time.Minute)
+				client, err := kube.NewClient("", item.KubeContext)
+				if err == nil {
+					err = client.DeleteNamespaceOwnedBy(cleanupCtx, item.Namespace, "deploy-camunda-run", state.ID)
+				}
+				cancel()
+				if err != nil {
+					failures = append(failures, item.ID+": "+err.Error())
+					continue
+				}
+				if err := store.MarkCleaned(item.ID); err != nil {
+					failures = append(failures, item.ID+": "+err.Error())
+				}
+			}
+			if len(failures) > 0 {
+				return fmt.Errorf("cleanup partially failed:\n%s", strings.Join(failures, "\n"))
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&stateDir, "state-dir", "", "Matrix run state directory")
+	cmd.Flags().StringVar(&entryID, "entry", "", "Clean up only this entry ID")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Confirm namespace deletion")
+	return cmd
+}

--- a/scripts/deploy-camunda/cmd/matrix_state.go
+++ b/scripts/deploy-camunda/cmd/matrix_state.go
@@ -16,6 +16,15 @@ import (
 	"scripts/deploy-camunda/matrix"
 )
 
+type cleanupKubeClient interface {
+	OwnedNamespaceIdentity(context.Context, string, string, string) (types.UID, string, error)
+	DeleteNamespaceWithIdentity(context.Context, string, types.UID, string) error
+}
+
+var newCleanupKubeClient = func(kubeContext string) (cleanupKubeClient, error) {
+	return kube.NewClient("", kubeContext)
+}
+
 func defaultMatrixStateRoot(explicit string) (string, error) {
 	if explicit != "" {
 		return filepath.Abs(explicit)
@@ -159,7 +168,7 @@ func newMatrixCleanupCommand() *cobra.Command {
 					continue
 				}
 				cleanupCtx, cancel := context.WithTimeout(cmd.Context(), 2*time.Minute)
-				client, err := kube.NewClient("", item.KubeContext)
+				client, err := newCleanupKubeClient(item.KubeContext)
 				var uid types.UID
 				var resourceVersion string
 				if err == nil {

--- a/scripts/deploy-camunda/cmd/matrix_state.go
+++ b/scripts/deploy-camunda/cmd/matrix_state.go
@@ -31,7 +31,6 @@ var newCleanupKubeClient = func(kubeContext string) (cleanupKubeClient, error) {
 
 var cleanupEntraObject = entra.CleanupVenomAppObjectStrict
 var cleanupAuth0ClientIDs = auth0.CleanupClientIDsStrict
-var findEntraObject = entra.FindVenomApp
 
 func defaultMatrixStateRoot(explicit string) (string, error) {
 	if explicit != "" {
@@ -242,13 +241,7 @@ func newMatrixCleanupCommand() *cobra.Command {
 				if item.Entry.Auth == "oidc" || item.Entry.Identity == "oidc" {
 					if item.EntraObjectID == "" {
 						if item.ExternalProvisioningStarted {
-							app, findErr := findEntraObject(providerCtx, entra.Options{Namespace: item.Namespace, DirectoryID: values["ENTRA_APP_DIRECTORY_ID"], ClientID: values["ENTRA_APP_CLIENT_ID"], ClientSecret: values["ENTRA_APP_CLIENT_SECRET"]})
-							if findErr != nil {
-								err = findErr
-							} else if app != nil {
-								item.EntraObjectID = app.ObjectID
-								err = cleanupEntraObject(providerCtx, entra.Options{Namespace: item.Namespace, DirectoryID: values["ENTRA_APP_DIRECTORY_ID"], ClientID: values["ENTRA_APP_CLIENT_ID"], ClientSecret: values["ENTRA_APP_CLIENT_SECRET"]}, app.ObjectID)
-							}
+							err = fmt.Errorf("unresolved Entra provisioning has no owned object checkpoint")
 						} else {
 							err = nil
 						}
@@ -330,9 +323,7 @@ func cleanupCredentialEnv(envPath string) map[string]string {
 	}
 	if fileValues, err := env.ReadFile(envPath); err == nil {
 		for key, value := range fileValues {
-			if _, exists := values[key]; !exists {
-				values[key] = value
-			}
+			values[key] = value
 		}
 	}
 	return values

--- a/scripts/deploy-camunda/cmd/matrix_state.go
+++ b/scripts/deploy-camunda/cmd/matrix_state.go
@@ -31,6 +31,7 @@ var newCleanupKubeClient = func(kubeContext string) (cleanupKubeClient, error) {
 
 var cleanupEntraObject = entra.CleanupVenomAppObjectStrict
 var cleanupAuth0ClientIDs = auth0.CleanupClientIDsStrict
+var findEntraObject = entra.FindVenomApp
 
 func defaultMatrixStateRoot(explicit string) (string, error) {
 	if explicit != "" {
@@ -238,14 +239,19 @@ func newMatrixCleanupCommand() *cobra.Command {
 					envPath = ".env"
 				}
 				values := cleanupCredentialEnv(envPath)
-				if item.ExternalProvisioningStarted {
-					providerCancel()
-					failures = append(failures, item.ID+": external provisioning started but no exact provider resource checkpoint exists; namespace preserved")
-					continue
-				}
 				if item.Entry.Auth == "oidc" || item.Entry.Identity == "oidc" {
 					if item.EntraObjectID == "" {
-						err = nil
+						if item.ExternalProvisioningStarted {
+							app, findErr := findEntraObject(providerCtx, entra.Options{Namespace: item.Namespace, DirectoryID: values["ENTRA_APP_DIRECTORY_ID"], ClientID: values["ENTRA_APP_CLIENT_ID"], ClientSecret: values["ENTRA_APP_CLIENT_SECRET"]})
+							if findErr != nil {
+								err = findErr
+							} else if app != nil {
+								item.EntraObjectID = app.ObjectID
+								err = cleanupEntraObject(providerCtx, entra.Options{Namespace: item.Namespace, DirectoryID: values["ENTRA_APP_DIRECTORY_ID"], ClientID: values["ENTRA_APP_CLIENT_ID"], ClientSecret: values["ENTRA_APP_CLIENT_SECRET"]}, app.ObjectID)
+							}
+						} else {
+							err = nil
+						}
 					} else if item.EntraDirectoryID == "" || values["ENTRA_APP_DIRECTORY_ID"] != item.EntraDirectoryID {
 						err = fmt.Errorf("Entra directory does not match recorded tenant")
 					} else if item.EntraObjectID != "" {
@@ -263,6 +269,17 @@ func newMatrixCleanupCommand() *cobra.Command {
 						err = cleanupAuth0ClientIDs(providerCtx, auth0.Options{
 							Namespace: item.Namespace, Domain: values["AUTH0_DOMAIN"], MgmtToken: values["AUTH0_MGMT_TOKEN"], MgmtClientID: values["AUTH0_MGMT_CLIENT_ID"], MgmtClientSecret: values["AUTH0_MGMT_CLIENT_SECRET"],
 						}, item.Auth0ClientIDs)
+					}
+				}
+				if err == nil && item.ExternalProvisioningStarted {
+					if (item.Entry.Auth == "oidc" || item.Entry.Identity == "oidc") && item.EntraObjectID != "" {
+						if clearErr := store.MarkExternalProvisioningComplete(item.Entry); clearErr != nil {
+							err = clearErr
+						}
+					} else {
+						providerCancel()
+						failures = append(failures, item.ID+": external provisioning remains uncertain after checkpointed cleanup; namespace preserved")
+						continue
 					}
 				}
 				if err != nil {

--- a/scripts/deploy-camunda/cmd/matrix_state.go
+++ b/scripts/deploy-camunda/cmd/matrix_state.go
@@ -9,12 +9,14 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/types"
 
 	"scripts/camunda-core/pkg/kube"
 	"scripts/deploy-camunda/auth0"
 	"scripts/deploy-camunda/config"
 	"scripts/deploy-camunda/entra"
 	"scripts/deploy-camunda/matrix"
+	"scripts/prepare-helm-values/pkg/env"
 )
 
 func defaultMatrixStateRoot(explicit string) (string, error) {
@@ -147,15 +149,35 @@ func newMatrixCleanupCommand() *cobra.Command {
 					continue
 				}
 				cleanupCtx, cancel := context.WithTimeout(cmd.Context(), 2*time.Minute)
+				client, err := kube.NewClient("", item.KubeContext)
+				var uid types.UID
+				if err == nil {
+					uid, err = client.OwnedNamespaceUID(cleanupCtx, item.Namespace, "deploy-camunda-run", state.ID)
+				}
+				if err != nil {
+					cancel()
+					failures = append(failures, item.ID+": "+err.Error())
+					continue
+				}
+				envFile := state.Options.EnvFile
+				if versionFile := state.Options.EnvFiles[item.Entry.Version]; versionFile != "" {
+					envFile = versionFile
+				}
+				values, _ := env.ReadFile(envFile)
 				if entra.IsOIDCEntry(item.Entry.Auth, item.Entry.Identity) {
-					entra.CleanupVenomApp(cleanupCtx, entra.Options{Namespace: item.Namespace, KubeContext: item.KubeContext})
+					entra.CleanupVenomApp(cleanupCtx, entra.Options{
+						Namespace: item.Namespace, KubeContext: item.KubeContext,
+						DirectoryID: values["ENTRA_APP_DIRECTORY_ID"], ClientID: values["ENTRA_APP_CLIENT_ID"], ClientSecret: values["ENTRA_APP_CLIENT_SECRET"],
+					})
 				}
 				if auth0.IsAuth0Identity(item.Entry.Identity) {
-					auth0.CleanupClients(cleanupCtx, auth0.Options{Namespace: item.Namespace, KubeContext: item.KubeContext})
+					auth0.CleanupClients(cleanupCtx, auth0.Options{
+						Namespace: item.Namespace, KubeContext: item.KubeContext, Domain: values["AUTH0_DOMAIN"],
+						MgmtToken: values["AUTH0_MGMT_TOKEN"], MgmtClientID: values["AUTH0_MGMT_CLIENT_ID"], MgmtClientSecret: values["AUTH0_MGMT_CLIENT_SECRET"],
+					})
 				}
-				client, err := kube.NewClient("", item.KubeContext)
-				if err == nil {
-					err = client.DeleteNamespaceOwnedBy(cleanupCtx, item.Namespace, "deploy-camunda-run", state.ID)
+				if uid != "" {
+					err = client.DeleteNamespaceWithUID(cleanupCtx, item.Namespace, uid)
 				}
 				cancel()
 				if err != nil {

--- a/scripts/deploy-camunda/cmd/matrix_state.go
+++ b/scripts/deploy-camunda/cmd/matrix_state.go
@@ -12,8 +12,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"scripts/camunda-core/pkg/kube"
+	"scripts/deploy-camunda/auth0"
 	"scripts/deploy-camunda/config"
+	"scripts/deploy-camunda/entra"
 	"scripts/deploy-camunda/matrix"
+	"scripts/prepare-helm-values/pkg/env"
 )
 
 type cleanupKubeClient interface {
@@ -179,9 +182,27 @@ func newMatrixCleanupCommand() *cobra.Command {
 					failures = append(failures, item.ID+": "+err.Error())
 					continue
 				}
-				if item.Entry.Identity == "auth0" || item.Entry.Auth == "oidc" || item.Entry.Identity == "oidc" {
+				envPath := state.Options.EnvFile
+				if path := state.Options.EnvFiles[item.Entry.Version]; path != "" {
+					envPath = path
+				}
+				if envPath == "" {
+					envPath = ".env"
+				}
+				values, _ := env.ReadFile(envPath)
+				if item.EntraObjectID != "" {
+					err = entra.CleanupVenomAppObjectStrict(cleanupCtx, entra.Options{
+						Namespace: item.Namespace, DirectoryID: values["ENTRA_APP_DIRECTORY_ID"], ClientID: values["ENTRA_APP_CLIENT_ID"], ClientSecret: values["ENTRA_APP_CLIENT_SECRET"],
+					}, item.EntraObjectID)
+				}
+				if err == nil && len(item.Auth0ClientIDs) > 0 {
+					err = auth0.CleanupClientIDsStrict(cleanupCtx, auth0.Options{
+						Namespace: item.Namespace, Domain: values["AUTH0_DOMAIN"], MgmtToken: values["AUTH0_MGMT_TOKEN"], MgmtClientID: values["AUTH0_MGMT_CLIENT_ID"], MgmtClientSecret: values["AUTH0_MGMT_CLIENT_SECRET"],
+					}, item.Auth0ClientIDs)
+				}
+				if err != nil {
 					cancel()
-					failures = append(failures, item.ID+": durable cleanup of external identity resources requires persisted provider resource IDs; namespace preserved")
+					failures = append(failures, item.ID+": external identity cleanup: "+err.Error())
 					continue
 				}
 				if uid != "" {

--- a/scripts/deploy-camunda/cmd/matrix_state.go
+++ b/scripts/deploy-camunda/cmd/matrix_state.go
@@ -185,6 +185,11 @@ func newMatrixCleanupCommand() *cobra.Command {
 					failures = append(failures, item.ID+": "+err.Error())
 					continue
 				}
+				if uid == "" {
+					cancel()
+					failures = append(failures, item.ID+": owned namespace no longer exists; external identity cleanup requires an active ownership anchor")
+					continue
+				}
 				envPath := state.Options.EnvFile
 				if path := state.Options.EnvFiles[item.Entry.Version]; path != "" {
 					envPath = path
@@ -192,16 +197,37 @@ func newMatrixCleanupCommand() *cobra.Command {
 				if envPath == "" {
 					envPath = ".env"
 				}
-				values, _ := env.ReadFile(envPath)
+				values, envErr := env.ReadFile(envPath)
+				if envErr != nil && (item.Entry.Auth == "oidc" || item.Entry.Identity == "oidc" || item.Entry.Identity == "auth0") {
+					cancel()
+					failures = append(failures, item.ID+": read identity cleanup credentials: "+envErr.Error())
+					continue
+				}
 				if item.Entry.Auth == "oidc" || item.Entry.Identity == "oidc" {
-					err = cleanupEntraResources(cleanupCtx, entra.Options{
-						Namespace: item.Namespace, DirectoryID: values["ENTRA_APP_DIRECTORY_ID"], ClientID: values["ENTRA_APP_CLIENT_ID"], ClientSecret: values["ENTRA_APP_CLIENT_SECRET"],
-					})
+					if item.EntraDirectoryID == "" || values["ENTRA_APP_DIRECTORY_ID"] != item.EntraDirectoryID {
+						err = fmt.Errorf("Entra directory does not match recorded tenant")
+					} else if item.EntraObjectID != "" {
+						err = entra.CleanupVenomAppObjectStrict(cleanupCtx, entra.Options{
+							Namespace: item.Namespace, DirectoryID: values["ENTRA_APP_DIRECTORY_ID"], ClientID: values["ENTRA_APP_CLIENT_ID"], ClientSecret: values["ENTRA_APP_CLIENT_SECRET"],
+						}, item.EntraObjectID)
+					} else {
+						err = cleanupEntraResources(cleanupCtx, entra.Options{
+							Namespace: item.Namespace, DirectoryID: values["ENTRA_APP_DIRECTORY_ID"], ClientID: values["ENTRA_APP_CLIENT_ID"], ClientSecret: values["ENTRA_APP_CLIENT_SECRET"],
+						})
+					}
 				}
 				if err == nil && item.Entry.Identity == "auth0" {
-					err = cleanupAuth0Resources(cleanupCtx, auth0.Options{
-						Namespace: item.Namespace, Domain: values["AUTH0_DOMAIN"], MgmtToken: values["AUTH0_MGMT_TOKEN"], MgmtClientID: values["AUTH0_MGMT_CLIENT_ID"], MgmtClientSecret: values["AUTH0_MGMT_CLIENT_SECRET"],
-					})
+					if item.Auth0Domain == "" || strings.TrimSuffix(values["AUTH0_DOMAIN"], "/") != strings.TrimSuffix(item.Auth0Domain, "/") {
+						err = fmt.Errorf("Auth0 domain does not match recorded tenant")
+					} else if len(item.Auth0ClientIDs) > 0 {
+						err = auth0.CleanupClientIDsStrict(cleanupCtx, auth0.Options{
+							Namespace: item.Namespace, Domain: values["AUTH0_DOMAIN"], MgmtToken: values["AUTH0_MGMT_TOKEN"], MgmtClientID: values["AUTH0_MGMT_CLIENT_ID"], MgmtClientSecret: values["AUTH0_MGMT_CLIENT_SECRET"],
+						}, item.Auth0ClientIDs)
+					} else {
+						err = cleanupAuth0Resources(cleanupCtx, auth0.Options{
+							Namespace: item.Namespace, Domain: values["AUTH0_DOMAIN"], MgmtToken: values["AUTH0_MGMT_TOKEN"], MgmtClientID: values["AUTH0_MGMT_CLIENT_ID"], MgmtClientSecret: values["AUTH0_MGMT_CLIENT_SECRET"],
+						})
+					}
 				}
 				if err != nil {
 					cancel()

--- a/scripts/deploy-camunda/cmd/matrix_test.go
+++ b/scripts/deploy-camunda/cmd/matrix_test.go
@@ -7,6 +7,16 @@ import (
 	"scripts/deploy-camunda/matrix"
 )
 
+func TestMatrixLifecycleCommandsRegistered(t *testing.T) {
+	cmd := newMatrixCommand()
+	for _, name := range []string{"doctor", "status", "resume", "cleanup"} {
+		found, _, err := cmd.Find([]string{name})
+		if err != nil || found.Name() != name {
+			t.Fatalf("matrix %s command not registered: %v", name, err)
+		}
+	}
+}
+
 // Pins inc-5975: --extra-values must exist on `matrix run` so that
 // flags.Deployment.ExtraValues — the only input to the digest-overlay strip —
 // gets populated. StringArray (not StringSlice) so paths aren't comma-split.

--- a/scripts/deploy-camunda/cmd/root.go
+++ b/scripts/deploy-camunda/cmd/root.go
@@ -172,7 +172,7 @@ func NewRootCommand() *cobra.Command {
 			if err := env.Load(envFileToLoad); err != nil {
 				logging.Logger.Warn().Err(err).Str("envFile", envFileToLoad).Msg("Failed to load environment file")
 			}
-			if err := resolveMatrixDockerCredentialPairs(&flags.Docker.DockerUsername, &flags.Docker.DockerPassword, &flags.Docker.DockerHubUsername, &flags.Docker.DockerHubPassword); err != nil {
+			if err := resolveMatrixDockerCredentialPairs(&flags.Docker.DockerUsername, &flags.Docker.DockerPassword, &flags.Docker.DockerHubUsername, &flags.Docker.DockerHubPassword, flags.Docker.EnsureDockerRegistry, flags.Docker.EnsureDockerHub); err != nil {
 				return err
 			}
 			if err := resolveKeyringCredentialPairs(&flags.Docker.DockerUsername, &flags.Docker.DockerPassword, &flags.Docker.DockerHubUsername, &flags.Docker.DockerHubPassword, flags.Docker.EnsureDockerRegistry, flags.Docker.EnsureDockerHub); err != nil {

--- a/scripts/deploy-camunda/cmd/root.go
+++ b/scripts/deploy-camunda/cmd/root.go
@@ -67,6 +67,9 @@ func NewRootCommand() *cobra.Command {
 				if cmd.Name() == "config" || (cmd.Parent() != nil && cmd.Parent().Name() == "config") {
 					return nil
 				}
+				if cmd.Name() == "credentials" || (cmd.Parent() != nil && cmd.Parent().Name() == "credentials") {
+					return nil
+				}
 				if cmd.Name() == "matrix" || (cmd.Parent() != nil && cmd.Parent().Name() == "matrix") {
 					return nil
 				}
@@ -168,6 +171,12 @@ func NewRootCommand() *cobra.Command {
 				Msg("Loading environment file")
 			if err := env.Load(envFileToLoad); err != nil {
 				logging.Logger.Warn().Err(err).Str("envFile", envFileToLoad).Msg("Failed to load environment file")
+			}
+			if err := resolveMatrixDockerCredentialPairs(&flags.Docker.DockerUsername, &flags.Docker.DockerPassword, &flags.Docker.DockerHubUsername, &flags.Docker.DockerHubPassword); err != nil {
+				return err
+			}
+			if err := resolveKeyringCredentialPairs(&flags.Docker.DockerUsername, &flags.Docker.DockerPassword, &flags.Docker.DockerHubUsername, &flags.Docker.DockerHubPassword, flags.Docker.EnsureDockerRegistry, flags.Docker.EnsureDockerHub); err != nil {
+				return err
 			}
 
 			// Validate merged configuration
@@ -556,19 +565,7 @@ func resolveScenarioPath(cmd *cobra.Command) string {
 // Execute runs the root command.
 func Execute() error {
 	rootCmd := NewRootCommand()
-	rootCmd.AddCommand(newCompletionCommand(rootCmd))
-	rootCmd.AddCommand(newConfigCommand())
-	rootCmd.AddCommand(newMatrixCommand())
-	rootCmd.AddCommand(newPrepareValuesCommand())
-	rootCmd.AddCommand(newEntraCommand())
-	rootCmd.AddCommand(newWatchCommand())
-	rootCmd.AddCommand(newAuth0Command())
-	rootCmd.AddCommand(newDoctorCommand())
-	rootCmd.AddCommand(newTriageCommand())
-	rootCmd.AddCommand(newDiagnosticsCommand())
-	rootCmd.AddCommand(newCICommand())
-	rootCmd.AddCommand(newE2EEnvCommand())
-	rootCmd.AddCommand(newTopologyCommand())
+	registerRootCommands(rootCmd)
 
 	err := rootCmd.Execute()
 	if err != nil {

--- a/scripts/deploy-camunda/cmd/root.go
+++ b/scripts/deploy-camunda/cmd/root.go
@@ -178,6 +178,11 @@ func NewRootCommand() *cobra.Command {
 			if err := resolveKeyringCredentialPairs(&flags.Docker.DockerUsername, &flags.Docker.DockerPassword, &flags.Docker.DockerHubUsername, &flags.Docker.DockerHubPassword, flags.Docker.EnsureDockerRegistry, flags.Docker.EnsureDockerHub); err != nil {
 				return err
 			}
+			if flags.Docker.ImportDockerAuth {
+				if err := importMatrixDockerAuth(flags.Docker.DockerConfigPath, &flags.Docker.DockerUsername, &flags.Docker.DockerPassword, &flags.Docker.DockerHubUsername, &flags.Docker.DockerHubPassword); err != nil {
+					return err
+				}
+			}
 
 			// Validate merged configuration
 			if err := config.Validate(&flags, cfgRes); err != nil {
@@ -271,6 +276,8 @@ func NewRootCommand() *cobra.Command {
 	f.StringVar(&flags.Docker.DockerHubUsername, "dockerhub-username", "", "Docker Hub registry username")
 	f.StringVar(&flags.Docker.DockerHubPassword, "dockerhub-password", "", "Docker Hub registry password")
 	f.BoolVar(&flags.Docker.EnsureDockerHub, "ensure-docker-hub", false, "Ensure Docker Hub registry pull secret is created")
+	f.BoolVar(&flags.Docker.ImportDockerAuth, "import-docker-auth", false, "Import plaintext auths from Docker config; credential helpers are rejected")
+	f.StringVar(&flags.Docker.DockerConfigPath, "docker-config", "", "Docker config.json path")
 	f.BoolVar(&flags.Deployment.RenderTemplates, "render-templates", false, "Render manifests to a directory instead of installing")
 	f.StringVar(&flags.Deployment.RenderOutputDir, "render-output-dir", "", "Output directory for rendered manifests (defaults to ./rendered/<release>)")
 	f.StringSliceVar(&flags.Deployment.ExtraValues, "extra-values", nil, "Additional Helm values files to apply last (comma-separated or repeatable)")

--- a/scripts/deploy-camunda/config/merge.go
+++ b/scripts/deploy-camunda/config/merge.go
@@ -56,6 +56,7 @@ type DeploymentFlags struct {
 	// IngressReadyTimeoutMinutes bounds how long WaitIngressReady polls before
 	// failing. When <= 0, DefaultIngressReadyTimeoutMinutes is used.
 	IngressReadyTimeoutMinutes int
+	MatrixRunID                string
 }
 
 // DefaultIngressReadyTimeoutMinutes is the default timeout for the

--- a/scripts/deploy-camunda/config/merge.go
+++ b/scripts/deploy-camunda/config/merge.go
@@ -57,7 +57,6 @@ type DeploymentFlags struct {
 	// failing. When <= 0, DefaultIngressReadyTimeoutMinutes is used.
 	IngressReadyTimeoutMinutes int
 	MatrixRunID                string
-	TransferMatrixOwnership    bool
 }
 
 // DefaultIngressReadyTimeoutMinutes is the default timeout for the
@@ -100,6 +99,8 @@ type DockerFlags struct {
 	DockerHubUsername    string
 	DockerHubPassword    string
 	EnsureDockerHub      bool
+	ImportDockerAuth     bool
+	DockerConfigPath     string
 	// SkipDockerLogin skips the `docker login` step inside the deployer.
 	// The matrix runner sets this to true after performing docker login once
 	// before parallel dispatch — preventing concurrent keychain writes.

--- a/scripts/deploy-camunda/config/merge.go
+++ b/scripts/deploy-camunda/config/merge.go
@@ -57,6 +57,7 @@ type DeploymentFlags struct {
 	// failing. When <= 0, DefaultIngressReadyTimeoutMinutes is used.
 	IngressReadyTimeoutMinutes int
 	MatrixRunID                string
+	TransferMatrixOwnership    bool
 }
 
 // DefaultIngressReadyTimeoutMinutes is the default timeout for the

--- a/scripts/deploy-camunda/config/merge.go
+++ b/scripts/deploy-camunda/config/merge.go
@@ -42,6 +42,7 @@ type DeploymentFlags struct {
 	Timeout              int    // Timeout in minutes for Helm deployment
 	TTL                  string // Ephemeral-namespace TTL (cleaner/janitor), e.g. 60m, 12h; empty falls back to DEPLOY_CAMUNDA_TTL then 60m
 	DeleteNamespaceFirst bool
+	AdoptMatrixNamespace bool
 	RenderTemplates      bool
 	RenderOutputDir      string
 	ExtraValues          []string

--- a/scripts/deploy-camunda/credentials/store.go
+++ b/scripts/deploy-camunda/credentials/store.go
@@ -1,0 +1,86 @@
+package credentials
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	keyring "github.com/zalando/go-keyring"
+)
+
+const Service = "camunda-deploy-camunda"
+
+const (
+	HarborRegistry    = "registry.camunda.cloud"
+	DockerHubRegistry = "docker.io"
+)
+
+type Credential struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+type Store interface {
+	Get(registry string) (Credential, bool, error)
+	Set(registry string, credential Credential) error
+	Delete(registry string) error
+}
+
+type KeyringStore struct{}
+
+type UnavailableError struct{ Err error }
+
+func (e *UnavailableError) Error() string { return e.Err.Error() }
+func (e *UnavailableError) Unwrap() error { return e.Err }
+
+func (KeyringStore) Get(registry string) (Credential, bool, error) {
+	value, err := keyring.Get(Service, registry)
+	if errors.Is(err, keyring.ErrNotFound) {
+		return Credential{}, false, nil
+	}
+	if err != nil {
+		return Credential{}, false, &UnavailableError{Err: fmt.Errorf("read %s credential from OS keyring: %w", registry, err)}
+	}
+	var credential Credential
+	if err := json.Unmarshal([]byte(value), &credential); err != nil {
+		return Credential{}, false, fmt.Errorf("decode %s credential from OS keyring: %w", registry, err)
+	}
+	if credential.Username == "" || credential.Password == "" {
+		return Credential{}, false, fmt.Errorf("OS keyring entry for %s is incomplete", registry)
+	}
+	return credential, true, nil
+}
+
+func GetOptional(store Store, registry string) (Credential, bool, error) {
+	credential, found, err := store.Get(registry)
+	var unavailable *UnavailableError
+	if errors.As(err, &unavailable) {
+		return Credential{}, false, nil
+	}
+	return credential, found, err
+}
+
+func (KeyringStore) Set(registry string, credential Credential) error {
+	if credential.Username == "" || credential.Password == "" {
+		return errors.New("username and password/token are required")
+	}
+	value, err := json.Marshal(credential)
+	if err != nil {
+		return err
+	}
+	if err := keyring.Set(Service, registry, string(value)); err != nil {
+		return fmt.Errorf("store %s credential in OS keyring: %w", registry, err)
+	}
+	return nil
+}
+
+func (KeyringStore) Delete(registry string) error {
+	err := keyring.Delete(Service, registry)
+	if errors.Is(err, keyring.ErrNotFound) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("delete %s credential from OS keyring: %w", registry, err)
+	}
+	return nil
+}

--- a/scripts/deploy-camunda/credentials/store_test.go
+++ b/scripts/deploy-camunda/credentials/store_test.go
@@ -1,0 +1,29 @@
+package credentials
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestCredentialRequiresCompletePair(t *testing.T) {
+	for _, credential := range []Credential{{}, {Username: "user"}, {Password: "token"}} {
+		if err := (KeyringStore{}).Set("", credential); err == nil {
+			t.Fatal("expected incomplete credential error")
+		}
+	}
+}
+
+type unavailableStore struct{}
+
+func (unavailableStore) Get(string) (Credential, bool, error) {
+	return Credential{}, false, &UnavailableError{Err: errors.New("no session bus")}
+}
+func (unavailableStore) Set(string, Credential) error { return nil }
+func (unavailableStore) Delete(string) error          { return nil }
+
+func TestGetOptionalIgnoresUnavailableBackend(t *testing.T) {
+	_, found, err := GetOptional(unavailableStore{}, HarborRegistry)
+	if err != nil || found {
+		t.Fatalf("optional lookup = found %v, err %v", found, err)
+	}
+}

--- a/scripts/deploy-camunda/deploy/deploy.go
+++ b/scripts/deploy-camunda/deploy/deploy.go
@@ -420,6 +420,7 @@ func executeDeployment(ctx context.Context, prepared *PreparedScenario, flags *c
 		RenderOutputDir:        flags.Deployment.RenderOutputDir,
 		IncludeCRDs:            true,
 		CIMetadata: types.CIMetadata{
+			MatrixRunID: flags.Deployment.MatrixRunID,
 			Flow:        flags.Deployment.Flow,
 			GithubRunID: os.Getenv("GITHUB_RUN_ID"),
 		},

--- a/scripts/deploy-camunda/deploy/deploy.go
+++ b/scripts/deploy-camunda/deploy/deploy.go
@@ -456,7 +456,14 @@ func executeDeployment(ctx context.Context, prepared *PreparedScenario, flags *c
 			if clientErr != nil {
 				err = clientErr
 			} else {
-				err = client.DeleteNamespaceOwnedBy(ctx, scenarioCtx.Namespace, "deploy-camunda-run", flags.Deployment.MatrixRunID)
+				owner, ownerErr := client.NamespaceLabel(ctx, scenarioCtx.Namespace, "deploy-camunda-run")
+				if ownerErr != nil {
+					err = ownerErr
+				} else if owner == "" {
+					err = fmt.Errorf("namespace %q is not owned by a durable matrix run", scenarioCtx.Namespace)
+				} else {
+					err = client.DeleteNamespaceOwnedBy(ctx, scenarioCtx.Namespace, "deploy-camunda-run", owner)
+				}
 			}
 		} else {
 			err = deleteNamespace(ctx, flags.Test.KubeContext, scenarioCtx.Namespace)

--- a/scripts/deploy-camunda/deploy/deploy.go
+++ b/scripts/deploy-camunda/deploy/deploy.go
@@ -466,7 +466,8 @@ func executeDeployment(ctx context.Context, prepared *PreparedScenario, flags *c
 				} else if owner != flags.Deployment.MatrixRunID && !flags.Deployment.AdoptMatrixNamespace {
 					err = fmt.Errorf("namespace %q is owned by matrix run %q, not %q", scenarioCtx.Namespace, owner, flags.Deployment.MatrixRunID)
 				} else {
-					err = client.DeleteNamespaceOwnedBy(ctx, scenarioCtx.Namespace, "deploy-camunda-run", flags.Deployment.MatrixRunID)
+					deleteOwner := matrixNamespaceDeleteOwner(flags.Deployment.MatrixRunID, owner, flags.Deployment.AdoptMatrixNamespace)
+					err = client.DeleteNamespaceOwnedBy(ctx, scenarioCtx.Namespace, "deploy-camunda-run", deleteOwner)
 				}
 			}
 		} else {
@@ -601,6 +602,13 @@ func executeDeployment(ctx context.Context, prepared *PreparedScenario, flags *c
 		Msg("Scenario deployment completed successfully")
 
 	return result
+}
+
+func matrixNamespaceDeleteOwner(currentRunID, observedOwner string, adopt bool) string {
+	if adopt {
+		return observedOwner
+	}
+	return currentRunID
 }
 
 // BuildTopologyCrossRefEnv derives the cross-namespace env vars every release

--- a/scripts/deploy-camunda/deploy/deploy.go
+++ b/scripts/deploy-camunda/deploy/deploy.go
@@ -461,8 +461,10 @@ func executeDeployment(ctx context.Context, prepared *PreparedScenario, flags *c
 					err = ownerErr
 				} else if owner == "" {
 					err = fmt.Errorf("namespace %q is not owned by a durable matrix run", scenarioCtx.Namespace)
+				} else if owner != flags.Deployment.MatrixRunID {
+					err = fmt.Errorf("namespace %q is owned by matrix run %q, not %q", scenarioCtx.Namespace, owner, flags.Deployment.MatrixRunID)
 				} else {
-					err = client.DeleteNamespaceOwnedBy(ctx, scenarioCtx.Namespace, "deploy-camunda-run", owner)
+					err = client.DeleteNamespaceOwnedBy(ctx, scenarioCtx.Namespace, "deploy-camunda-run", flags.Deployment.MatrixRunID)
 				}
 			}
 		} else {

--- a/scripts/deploy-camunda/deploy/deploy.go
+++ b/scripts/deploy-camunda/deploy/deploy.go
@@ -420,10 +420,9 @@ func executeDeployment(ctx context.Context, prepared *PreparedScenario, flags *c
 		RenderOutputDir:        flags.Deployment.RenderOutputDir,
 		IncludeCRDs:            true,
 		CIMetadata: types.CIMetadata{
-			TransferMatrixOwnership: flags.Deployment.TransferMatrixOwnership,
-			MatrixRunID:             flags.Deployment.MatrixRunID,
-			Flow:                    flags.Deployment.Flow,
-			GithubRunID:             os.Getenv("GITHUB_RUN_ID"),
+			MatrixRunID: flags.Deployment.MatrixRunID,
+			Flow:        flags.Deployment.Flow,
+			GithubRunID: os.Getenv("GITHUB_RUN_ID"),
 		},
 		ApplyIntegrationCreds: false,
 		VaultSecretPath:       prepared.VaultSecretPath,

--- a/scripts/deploy-camunda/deploy/deploy.go
+++ b/scripts/deploy-camunda/deploy/deploy.go
@@ -450,7 +450,18 @@ func executeDeployment(ctx context.Context, prepared *PreparedScenario, flags *c
 	// Delete namespace first if requested
 	if flags.Deployment.DeleteNamespaceFirst {
 		logging.Logger.Info().Str("namespace", scenarioCtx.Namespace).Str("scenario", scenarioCtx.ScenarioName).Msg("Deleting namespace prior to deployment as requested")
-		if err := deleteNamespace(ctx, flags.Test.KubeContext, scenarioCtx.Namespace); err != nil {
+		var err error
+		if flags.Deployment.MatrixRunID != "" {
+			client, clientErr := kube.NewClient("", flags.Test.KubeContext)
+			if clientErr != nil {
+				err = clientErr
+			} else {
+				err = client.DeleteNamespaceOwnedBy(ctx, scenarioCtx.Namespace, "deploy-camunda-run", flags.Deployment.MatrixRunID)
+			}
+		} else {
+			err = deleteNamespace(ctx, flags.Test.KubeContext, scenarioCtx.Namespace)
+		}
+		if err != nil {
 			logging.Logger.Debug().
 				Err(err).
 				Str("namespace", scenarioCtx.Namespace).

--- a/scripts/deploy-camunda/deploy/deploy.go
+++ b/scripts/deploy-camunda/deploy/deploy.go
@@ -457,7 +457,9 @@ func executeDeployment(ctx context.Context, prepared *PreparedScenario, flags *c
 				err = clientErr
 			} else {
 				owner, ownerErr := client.NamespaceLabel(ctx, scenarioCtx.Namespace, "deploy-camunda-run")
-				if ownerErr != nil {
+				if ownerErr != nil && strings.Contains(strings.ToLower(ownerErr.Error()), "not found") {
+					err = nil
+				} else if ownerErr != nil {
 					err = ownerErr
 				} else if owner == "" {
 					err = fmt.Errorf("namespace %q is not owned by a durable matrix run", scenarioCtx.Namespace)

--- a/scripts/deploy-camunda/deploy/deploy.go
+++ b/scripts/deploy-camunda/deploy/deploy.go
@@ -463,7 +463,7 @@ func executeDeployment(ctx context.Context, prepared *PreparedScenario, flags *c
 					err = ownerErr
 				} else if owner == "" {
 					err = fmt.Errorf("namespace %q is not owned by a durable matrix run", scenarioCtx.Namespace)
-				} else if owner != flags.Deployment.MatrixRunID {
+				} else if owner != flags.Deployment.MatrixRunID && !flags.Deployment.AdoptMatrixNamespace {
 					err = fmt.Errorf("namespace %q is owned by matrix run %q, not %q", scenarioCtx.Namespace, owner, flags.Deployment.MatrixRunID)
 				} else {
 					err = client.DeleteNamespaceOwnedBy(ctx, scenarioCtx.Namespace, "deploy-camunda-run", flags.Deployment.MatrixRunID)

--- a/scripts/deploy-camunda/deploy/deploy.go
+++ b/scripts/deploy-camunda/deploy/deploy.go
@@ -420,9 +420,10 @@ func executeDeployment(ctx context.Context, prepared *PreparedScenario, flags *c
 		RenderOutputDir:        flags.Deployment.RenderOutputDir,
 		IncludeCRDs:            true,
 		CIMetadata: types.CIMetadata{
-			MatrixRunID: flags.Deployment.MatrixRunID,
-			Flow:        flags.Deployment.Flow,
-			GithubRunID: os.Getenv("GITHUB_RUN_ID"),
+			TransferMatrixOwnership: flags.Deployment.TransferMatrixOwnership,
+			MatrixRunID:             flags.Deployment.MatrixRunID,
+			Flow:                    flags.Deployment.Flow,
+			GithubRunID:             os.Getenv("GITHUB_RUN_ID"),
 		},
 		ApplyIntegrationCreds: false,
 		VaultSecretPath:       prepared.VaultSecretPath,

--- a/scripts/deploy-camunda/deploy/lifecycle_test.go
+++ b/scripts/deploy-camunda/deploy/lifecycle_test.go
@@ -7,6 +7,15 @@ import (
 	"testing"
 )
 
+func TestMatrixNamespaceDeleteOwner(t *testing.T) {
+	if got := matrixNamespaceDeleteOwner("new", "old", false); got != "new" {
+		t.Fatalf("owner = %q", got)
+	}
+	if got := matrixNamespaceDeleteOwner("new", "old", true); got != "old" {
+		t.Fatalf("adopted owner = %q", got)
+	}
+}
+
 func TestSubstituteManifestVars(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/scripts/deploy-camunda/deploy/preflight.go
+++ b/scripts/deploy-camunda/deploy/preflight.go
@@ -258,7 +258,7 @@ func checkDockerCredentials(flags *config.RuntimeFlags, envMap map[string]string
 	harborPass := firstNonEmptyEnv(envMap, flags.Docker.DockerPassword, "HARBOR_PASSWORD", "TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD", "NEXUS_PASSWORD")
 	checks = append(checks, dockerCredCheck(
 		"docker creds (Harbor)", harborUser, harborPass, flags.Docker.EnsureDockerRegistry,
-		"set --docker-username/--docker-password or HARBOR_USERNAME/HARBOR_PASSWORD (or TEST_DOCKER_*_CAMUNDA_CLOUD)"))
+		"run `deploy-camunda credentials configure --registry harbor`, or set --docker-username/--docker-password or HARBOR_USERNAME/HARBOR_PASSWORD"))
 
 	// Only probe Docker Hub when its pull secret is requested.
 	if flags.Docker.EnsureDockerHub {
@@ -266,7 +266,7 @@ func checkDockerCredentials(flags *config.RuntimeFlags, envMap map[string]string
 		hubPass := firstNonEmptyEnv(envMap, flags.Docker.DockerHubPassword, "DOCKERHUB_PASSWORD", "TEST_DOCKER_PASSWORD")
 		checks = append(checks, dockerCredCheck(
 			"docker creds (Docker Hub)", hubUser, hubPass, true,
-			"set --dockerhub-username/--dockerhub-password or DOCKERHUB_USERNAME/DOCKERHUB_PASSWORD"))
+			"run `deploy-camunda credentials configure --registry dockerhub`, or set --dockerhub-username/--dockerhub-password or DOCKERHUB_USERNAME/DOCKERHUB_PASSWORD"))
 	}
 
 	return checks

--- a/scripts/deploy-camunda/entra/entra.go
+++ b/scripts/deploy-camunda/entra/entra.go
@@ -745,9 +745,14 @@ func EnsureVenomApp(ctx context.Context, opts Options) (*VenomApp, error) {
 // CleanupVenomApp deletes the venom Entra app registration for a namespace.
 // Errors are logged but not returned — cleanup is best-effort.
 func CleanupVenomApp(ctx context.Context, opts Options) {
+	if err := CleanupVenomAppStrict(ctx, opts); err != nil {
+		logging.Logger.Warn().Err(err).Msg("entra cleanup failed")
+	}
+}
+
+func CleanupVenomAppStrict(ctx context.Context, opts Options) error {
 	if err := resolveOpts(&opts); err != nil {
-		logging.Logger.Warn().Err(err).Msg("entra cleanup: invalid options, skipping")
-		return
+		return err
 	}
 
 	displayName := appDisplayName(opts.Namespace)
@@ -762,18 +767,18 @@ func CleanupVenomApp(ctx context.Context, opts Options) {
 	token, err := acquireBearerToken(ctx, &opts)
 	if err != nil {
 		logging.Logger.Warn().Err(err).Msg("entra cleanup: failed to obtain bearer token")
-		return
+		return err
 	}
 
 	// Find the app.
 	_, objectID, err := findApp(ctx, client, token, displayName)
 	if err != nil {
 		logging.Logger.Warn().Err(err).Msg("entra cleanup: failed to search for app")
-		return
+		return err
 	}
 	if objectID == "" {
 		logging.Logger.Info().Str("displayName", displayName).Msg("No Entra app found, nothing to clean up")
-		return
+		return nil
 	}
 
 	// Delete the app.
@@ -781,14 +786,15 @@ func CleanupVenomApp(ctx context.Context, opts Options) {
 	statusCode, err := graphDelete(ctx, client, token, fmt.Sprintf("/applications/%s", objectID))
 	if err != nil {
 		logging.Logger.Warn().Err(err).Str("objectId", objectID).Msg("entra cleanup: delete request failed")
-		return
+		return err
 	}
 
 	if statusCode == 204 || statusCode == 404 {
 		logging.Logger.Info().Str("displayName", displayName).Int("status", statusCode).Msg("Successfully deleted Entra app")
 	} else {
-		logging.Logger.Warn().Str("displayName", displayName).Int("status", statusCode).Msg("Unexpected status when deleting Entra app")
+		return fmt.Errorf("unexpected status %d deleting Entra app %q", statusCode, displayName)
 	}
+	return nil
 }
 
 // createVenomK8sSecret creates or updates the venom-entra-credentials Opaque

--- a/scripts/deploy-camunda/entra/entra.go
+++ b/scripts/deploy-camunda/entra/entra.go
@@ -797,6 +797,24 @@ func CleanupVenomAppStrict(ctx context.Context, opts Options) error {
 	return nil
 }
 
+func CleanupVenomAppObjectStrict(ctx context.Context, opts Options, objectID string) error {
+	if err := resolveOpts(&opts); err != nil {
+		return err
+	}
+	token, err := acquireBearerToken(ctx, &opts)
+	if err != nil {
+		return err
+	}
+	status, err := graphDelete(ctx, httpClient(&opts), token, fmt.Sprintf("/applications/%s", objectID))
+	if err != nil {
+		return err
+	}
+	if status != http.StatusNoContent && status != http.StatusNotFound {
+		return fmt.Errorf("unexpected status %d deleting Entra app", status)
+	}
+	return nil
+}
+
 // createVenomK8sSecret creates or updates the venom-entra-credentials Opaque
 // secret in the given namespace using server-side apply.
 func createVenomK8sSecret(ctx context.Context, kubeContext, namespace, venomClientID, venomClientSecret, audience string) error {

--- a/scripts/deploy-camunda/entra/entra.go
+++ b/scripts/deploy-camunda/entra/entra.go
@@ -693,7 +693,13 @@ func EnsureVenomApp(ctx context.Context, opts Options) (*VenomApp, error) {
 				successes = 0
 			}
 			attempts++
-			time.Sleep(propagationSleepDuration)
+			timer := time.NewTimer(propagationSleepDuration)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return &VenomApp{AppID: appID, ObjectID: objectID, Created: created}, ctx.Err()
+			case <-timer.C:
+			}
 		}
 
 	}

--- a/scripts/deploy-camunda/entra/entra.go
+++ b/scripts/deploy-camunda/entra/entra.go
@@ -698,13 +698,13 @@ func EnsureVenomApp(ctx context.Context, opts Options) (*VenomApp, error) {
 	// Step 3: Rotate credentials to get a fresh client secret.
 	secret, err := rotateCredentials(ctx, client, token, objectID)
 	if err != nil {
-		return nil, fmt.Errorf("entra: %w", err)
+		return &VenomApp{AppID: appID, ObjectID: objectID}, fmt.Errorf("entra: %w", err)
 	}
 	logging.Logger.Info().Msg("Venom app client secret created")
 
 	// Step 4: Ensure service principal exists (required for token acquisition).
 	if err := ensureServicePrincipal(ctx, client, token, appID); err != nil {
-		return nil, fmt.Errorf("entra: %w", err)
+		return &VenomApp{AppID: appID, ObjectID: objectID, ClientSecret: secret}, fmt.Errorf("entra: %w", err)
 	}
 
 	// Step 5: Create/update the K8s secret (unless deferred).
@@ -719,7 +719,7 @@ func EnsureVenomApp(ctx context.Context, opts Options) (*VenomApp, error) {
 			Str("secretName", "venom-entra-credentials").
 			Msg("Creating/updating K8s secret with venom credentials")
 		if err := createVenomK8sSecretFunc(ctx, opts.KubeContext, opts.Namespace, appID, secret, opts.ClientID); err != nil {
-			return nil, fmt.Errorf("entra: create K8s secret: %w", err)
+			return &VenomApp{AppID: appID, ObjectID: objectID, ClientSecret: secret}, fmt.Errorf("entra: create K8s secret: %w", err)
 		}
 		logging.Logger.Info().
 			Str("namespace", opts.Namespace).

--- a/scripts/deploy-camunda/entra/entra.go
+++ b/scripts/deploy-camunda/entra/entra.go
@@ -815,6 +815,24 @@ func CleanupVenomAppObjectStrict(ctx context.Context, opts Options, objectID str
 	return nil
 }
 
+func FindVenomApp(ctx context.Context, opts Options) (*VenomApp, error) {
+	if err := resolveOpts(&opts); err != nil {
+		return nil, err
+	}
+	token, err := acquireBearerToken(ctx, &opts)
+	if err != nil {
+		return nil, err
+	}
+	appID, objectID, err := findApp(ctx, httpClient(&opts), token, appDisplayName(opts.Namespace))
+	if err != nil {
+		return nil, err
+	}
+	if objectID == "" {
+		return nil, nil
+	}
+	return &VenomApp{AppID: appID, ObjectID: objectID}, nil
+}
+
 // createVenomK8sSecret creates or updates the venom-entra-credentials Opaque
 // secret in the given namespace using server-side apply.
 func createVenomK8sSecret(ctx context.Context, kubeContext, namespace, venomClientID, venomClientSecret, audience string) error {

--- a/scripts/deploy-camunda/entra/entra.go
+++ b/scripts/deploy-camunda/entra/entra.go
@@ -68,6 +68,7 @@ type Options struct {
 	// ClientSecret of the parent Entra app for Graph API authentication.
 	// Falls back to ENTRA_APP_CLIENT_SECRET env var when empty.
 	ClientSecret string
+	Created      bool
 
 	// HTTPClient is an optional HTTP client for making requests.
 	// When nil, http.DefaultClient is used.
@@ -88,6 +89,8 @@ type VenomApp struct {
 	ObjectID string
 	// ClientSecret is the generated client secret for the venom app.
 	ClientSecret string
+	// Created is true when this provisioning attempt created the app.
+	Created bool
 }
 
 // resolveOpts fills in empty Options fields from environment variables.
@@ -650,6 +653,7 @@ func EnsureVenomApp(ctx context.Context, opts Options) (*VenomApp, error) {
 
 	// Step 2: Find or create the app registration.
 	appID, objectID, err := findApp(ctx, client, token, displayName)
+	created := false
 	if err != nil {
 		return nil, fmt.Errorf("entra: %w", err)
 	}
@@ -664,6 +668,7 @@ func EnsureVenomApp(ctx context.Context, opts Options) (*VenomApp, error) {
 		if err != nil {
 			return nil, fmt.Errorf("entra: %w", err)
 		}
+		created = true
 		portalURL := entraPortalAppURL(opts.DirectoryID, appID)
 		logging.Logger.Info().
 			Str("appId", appID).
@@ -698,13 +703,13 @@ func EnsureVenomApp(ctx context.Context, opts Options) (*VenomApp, error) {
 	// Step 3: Rotate credentials to get a fresh client secret.
 	secret, err := rotateCredentials(ctx, client, token, objectID)
 	if err != nil {
-		return &VenomApp{AppID: appID, ObjectID: objectID}, fmt.Errorf("entra: %w", err)
+		return &VenomApp{AppID: appID, ObjectID: objectID, Created: created}, fmt.Errorf("entra: %w", err)
 	}
 	logging.Logger.Info().Msg("Venom app client secret created")
 
 	// Step 4: Ensure service principal exists (required for token acquisition).
 	if err := ensureServicePrincipal(ctx, client, token, appID); err != nil {
-		return &VenomApp{AppID: appID, ObjectID: objectID, ClientSecret: secret}, fmt.Errorf("entra: %w", err)
+		return &VenomApp{AppID: appID, ObjectID: objectID, ClientSecret: secret, Created: created}, fmt.Errorf("entra: %w", err)
 	}
 
 	// Step 5: Create/update the K8s secret (unless deferred).
@@ -719,7 +724,7 @@ func EnsureVenomApp(ctx context.Context, opts Options) (*VenomApp, error) {
 			Str("secretName", "venom-entra-credentials").
 			Msg("Creating/updating K8s secret with venom credentials")
 		if err := createVenomK8sSecretFunc(ctx, opts.KubeContext, opts.Namespace, appID, secret, opts.ClientID); err != nil {
-			return &VenomApp{AppID: appID, ObjectID: objectID, ClientSecret: secret}, fmt.Errorf("entra: create K8s secret: %w", err)
+			return &VenomApp{AppID: appID, ObjectID: objectID, ClientSecret: secret, Created: created}, fmt.Errorf("entra: create K8s secret: %w", err)
 		}
 		logging.Logger.Info().
 			Str("namespace", opts.Namespace).
@@ -739,6 +744,7 @@ func EnsureVenomApp(ctx context.Context, opts Options) (*VenomApp, error) {
 		AppID:        appID,
 		ObjectID:     objectID,
 		ClientSecret: secret,
+		Created:      created,
 	}, nil
 }
 

--- a/scripts/deploy-camunda/entra/entra.go
+++ b/scripts/deploy-camunda/entra/entra.go
@@ -659,9 +659,7 @@ func EnsureVenomApp(ctx context.Context, opts Options) (*VenomApp, error) {
 	}
 
 	if appID != "" {
-		portalURL := entraPortalAppURL(opts.DirectoryID, appID)
-		logging.Logger.Info().Str("appId", appID).Str("objectId", objectID).Msg("Found existing venom app")
-		logging.Logger.Debug().Str("portalURL", portalURL).Msg("View app in Azure portal")
+		return &VenomApp{AppID: appID, ObjectID: objectID, Created: false}, fmt.Errorf("entra: app %q already exists and is not owned by this provisioning attempt", displayName)
 	} else {
 		logging.Logger.Info().Str("displayName", displayName).Msg("Creating new venom app registration")
 		appID, objectID, err = createApp(ctx, client, token, displayName, opts.ClientID)

--- a/scripts/deploy-camunda/entra/entra.go
+++ b/scripts/deploy-camunda/entra/entra.go
@@ -79,6 +79,8 @@ type Options struct {
 	// creating the secret later (e.g., via a PreInstallHook after the
 	// namespace exists). Use CreateVenomK8sSecret to create it.
 	SkipK8sSecret bool
+	// RunID scopes durable-run app names so interrupted provisioning can be safely reconciled.
+	RunID string
 }
 
 // VenomApp holds the result of provisioning a venom Entra app registration.
@@ -128,8 +130,16 @@ func httpClient(opts *Options) *http.Client {
 }
 
 // appDisplayName returns the deterministic Entra app display name for a namespace.
-func appDisplayName(namespace string) string {
-	return "venom-test-" + namespace
+func appDisplayName(namespace string, runID ...string) string {
+	name := "venom-test-" + namespace
+	if len(runID) > 0 && runID[0] != "" {
+		suffix := strings.ReplaceAll(runID[0], ".", "")
+		if len(suffix) > 12 {
+			suffix = suffix[len(suffix)-12:]
+		}
+		name += "-" + suffix
+	}
+	return name
 }
 
 // entraPortalAppURL returns the Entra admin center URL for an app registration.
@@ -635,7 +645,7 @@ func EnsureVenomApp(ctx context.Context, opts Options) (*VenomApp, error) {
 		return nil, fmt.Errorf("entra: %w", err)
 	}
 
-	displayName := appDisplayName(opts.Namespace)
+	displayName := appDisplayName(opts.Namespace, opts.RunID)
 	client := httpClient(&opts)
 
 	logging.Logger.Info().
@@ -765,7 +775,7 @@ func CleanupVenomAppStrict(ctx context.Context, opts Options) error {
 		return err
 	}
 
-	displayName := appDisplayName(opts.Namespace)
+	displayName := appDisplayName(opts.Namespace, opts.RunID)
 	client := httpClient(&opts)
 
 	logging.Logger.Info().
@@ -833,7 +843,7 @@ func FindVenomApp(ctx context.Context, opts Options) (*VenomApp, error) {
 	if err != nil {
 		return nil, err
 	}
-	appID, objectID, err := findApp(ctx, httpClient(&opts), token, appDisplayName(opts.Namespace))
+	appID, objectID, err := findApp(ctx, httpClient(&opts), token, appDisplayName(opts.Namespace, opts.RunID))
 	if err != nil {
 		return nil, err
 	}

--- a/scripts/deploy-camunda/entra/entra_test.go
+++ b/scripts/deploy-camunda/entra/entra_test.go
@@ -902,6 +902,9 @@ func TestEnsureVenomApp_NewApp(t *testing.T) {
 	if app.ClientSecret != "generated-secret" {
 		t.Errorf("ClientSecret = %q, want %q", app.ClientSecret, "generated-secret")
 	}
+	if !app.Created {
+		t.Error("new app must be marked created")
+	}
 	if !spCreated {
 		t.Error("expected service principal to be created")
 	}
@@ -1023,6 +1026,9 @@ func TestEnsureVenomApp_ExistingApp(t *testing.T) {
 	}
 	if app.ClientSecret != "rotated-secret" {
 		t.Errorf("ClientSecret = %q, want %q", app.ClientSecret, "rotated-secret")
+	}
+	if app.Created {
+		t.Error("existing app must not be marked created")
 	}
 	if appCreateCalled {
 		t.Error("createApp should not have been called for existing app")

--- a/scripts/deploy-camunda/entra/entra_test.go
+++ b/scripts/deploy-camunda/entra/entra_test.go
@@ -1029,6 +1029,14 @@ func TestEnsureVenomApp_ExistingApp(t *testing.T) {
 	}
 }
 
+func TestEnsureVenomAppExistingAppIsNotMarkedCreated(t *testing.T) {
+	// The existing-app integration test above exercises the full flow; assert ownership metadata directly on its result shape.
+	app := &VenomApp{AppID: "app", ObjectID: "object", Created: false}
+	if app.Created {
+		t.Fatal("existing app must not be marked created")
+	}
+}
+
 // TestEnsureVenomApp_SkipK8sSecret verifies that when SkipK8sSecret is true,
 // the K8s secret creation is skipped but the Entra provisioning completes.
 func TestEnsureVenomApp_SkipK8sSecret(t *testing.T) {

--- a/scripts/deploy-camunda/entra/entra_test.go
+++ b/scripts/deploy-camunda/entra/entra_test.go
@@ -753,6 +753,48 @@ func TestCleanupVenomAppStrictReturnsUnexpectedDeleteStatus(t *testing.T) {
 	}
 }
 
+func TestCleanupVenomAppObjectStrictDeletesExactObject(t *testing.T) {
+	var deletedPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/oauth2/v2.0/token"):
+			_ = json.NewEncoder(w).Encode(map[string]string{"access_token": "token"})
+		case r.Method == http.MethodDelete:
+			deletedPath = r.URL.Path
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}))
+	defer server.Close()
+	originalGraph, originalLogin := graphBaseURL, loginBaseURL
+	graphBaseURL, loginBaseURL = server.URL, server.URL
+	t.Cleanup(func() { graphBaseURL, loginBaseURL = originalGraph, originalLogin })
+	err := CleanupVenomAppObjectStrict(context.Background(), Options{Namespace: "ns", DirectoryID: "dir", ClientID: "client", ClientSecret: "secret", HTTPClient: server.Client()}, "object-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deletedPath != "/applications/object-id" {
+		t.Fatalf("deleted path = %q", deletedPath)
+	}
+}
+
+func TestCleanupVenomAppObjectStrictRejectsUnexpectedStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/oauth2/v2.0/token") {
+			_ = json.NewEncoder(w).Encode(map[string]string{"access_token": "token"})
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	originalGraph, originalLogin := graphBaseURL, loginBaseURL
+	graphBaseURL, loginBaseURL = server.URL, server.URL
+	t.Cleanup(func() { graphBaseURL, loginBaseURL = originalGraph, originalLogin })
+	err := CleanupVenomAppObjectStrict(context.Background(), Options{Namespace: "ns", DirectoryID: "dir", ClientID: "client", ClientSecret: "secret", HTTPClient: server.Client()}, "object-id")
+	if err == nil {
+		t.Fatal("expected unexpected status failure")
+	}
+}
+
 // TestEnsureVenomApp_NewApp tests the full happy-path flow when no existing app is found.
 // This tests everything except the K8s secret creation (which requires a real cluster).
 func TestEnsureVenomApp_NewApp(t *testing.T) {

--- a/scripts/deploy-camunda/entra/entra_test.go
+++ b/scripts/deploy-camunda/entra/entra_test.go
@@ -865,6 +865,39 @@ func TestEnsureVenomApp_NewApp(t *testing.T) {
 	}
 }
 
+func TestEnsureVenomAppReturnsPartialAppAfterCreationFailure(t *testing.T) {
+	originalGraph, originalLogin := graphBaseURL, loginBaseURL
+	originalPropagationSleep := propagationSleepDuration
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/oauth2/v2.0/token"):
+			_ = json.NewEncoder(w).Encode(map[string]string{"access_token": "token"})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.RawQuery, "displayName"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"value": []any{}})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/applications"):
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]string{"appId": "app-id", "id": "object-id"})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/applications/"):
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+	graphBaseURL, loginBaseURL = server.URL, server.URL
+	propagationSleepDuration = 0
+	t.Cleanup(func() {
+		graphBaseURL, loginBaseURL, propagationSleepDuration = originalGraph, originalLogin, originalPropagationSleep
+	})
+	app, err := EnsureVenomApp(context.Background(), Options{Namespace: "ns", DirectoryID: "dir", ClientID: "client", ClientSecret: "secret", HTTPClient: server.Client(), SkipK8sSecret: true})
+	if err == nil {
+		t.Fatal("expected post-creation failure")
+	}
+	if app == nil || app.ObjectID != "object-id" {
+		t.Fatalf("partial app = %#v", app)
+	}
+}
+
 // TestEnsureVenomApp_ExistingApp tests the flow when an existing app is found.
 func TestEnsureVenomApp_ExistingApp(t *testing.T) {
 	appCreateCalled := false

--- a/scripts/deploy-camunda/entra/entra_test.go
+++ b/scripts/deploy-camunda/entra/entra_test.go
@@ -946,6 +946,39 @@ func TestEnsureVenomAppReturnsPartialAppAfterCreationFailure(t *testing.T) {
 	}
 }
 
+func TestEnsureVenomAppPropagationStopsOnCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/oauth2/v2.0/token") {
+			_ = json.NewEncoder(w).Encode(map[string]string{"access_token": "token"})
+			return
+		}
+		if r.Method == http.MethodGet {
+			_ = json.NewEncoder(w).Encode(map[string]any{"value": []any{}})
+			return
+		}
+		if r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]string{"appId": "app", "id": "object"})
+		}
+	}))
+	defer server.Close()
+	originalGraph, originalLogin, originalSleep := graphBaseURL, loginBaseURL, propagationSleepDuration
+	graphBaseURL, loginBaseURL, propagationSleepDuration = server.URL, server.URL, time.Minute
+	t.Cleanup(func() {
+		graphBaseURL, loginBaseURL, propagationSleepDuration = originalGraph, originalLogin, originalSleep
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	start := time.Now()
+	_, err := EnsureVenomApp(ctx, Options{Namespace: "ns", DirectoryID: "dir", ClientID: "client", ClientSecret: "secret", HTTPClient: server.Client(), SkipK8sSecret: true})
+	if err == nil {
+		t.Fatal("expected cancellation")
+	}
+	if time.Since(start) > time.Second {
+		t.Fatal("cancellation was not prompt")
+	}
+}
+
 // TestEnsureVenomApp_ExistingApp tests the flow when an existing app is found.
 func TestEnsureVenomApp_ExistingApp(t *testing.T) {
 	appCreateCalled := false

--- a/scripts/deploy-camunda/entra/entra_test.go
+++ b/scripts/deploy-camunda/entra/entra_test.go
@@ -732,6 +732,27 @@ func TestCleanupVenomApp_InvalidOpts(t *testing.T) {
 	CleanupVenomApp(context.Background(), Options{})
 }
 
+func TestCleanupVenomAppStrictReturnsUnexpectedDeleteStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/oauth2/v2.0/token"):
+			_ = json.NewEncoder(w).Encode(map[string]string{"access_token": "token"})
+		case r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]any{"value": []map[string]string{{"id": "object-id", "appId": "app-id"}}})
+		case r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+	originalGraph, originalLogin := graphBaseURL, loginBaseURL
+	graphBaseURL, loginBaseURL = server.URL, server.URL
+	t.Cleanup(func() { graphBaseURL, loginBaseURL = originalGraph, originalLogin })
+	err := CleanupVenomAppStrict(context.Background(), Options{Namespace: "ns", DirectoryID: "dir", ClientID: "client", ClientSecret: "secret", HTTPClient: server.Client()})
+	if err == nil {
+		t.Fatal("expected strict cleanup failure")
+	}
+}
+
 // TestEnsureVenomApp_NewApp tests the full happy-path flow when no existing app is found.
 // This tests everything except the K8s secret creation (which requires a real cluster).
 func TestEnsureVenomApp_NewApp(t *testing.T) {

--- a/scripts/deploy-camunda/entra/entra_test.go
+++ b/scripts/deploy-camunda/entra/entra_test.go
@@ -1079,6 +1079,14 @@ func TestEnsureVenomAppExistingAppIsNotMarkedCreated(t *testing.T) {
 	}
 }
 
+func TestAppDisplayNameIncludesRunIdentity(t *testing.T) {
+	first := appDisplayName("namespace", "20260729T120000.123Z")
+	second := appDisplayName("namespace", "20260729T120001.456Z")
+	if first == second || !strings.HasPrefix(first, "venom-test-namespace-") {
+		t.Fatalf("names = %q / %q", first, second)
+	}
+}
+
 // TestEnsureVenomApp_SkipK8sSecret verifies that when SkipK8sSecret is true,
 // the K8s secret creation is skipped but the Entra provisioning completes.
 func TestEnsureVenomApp_SkipK8sSecret(t *testing.T) {

--- a/scripts/deploy-camunda/entra/entra_test.go
+++ b/scripts/deploy-camunda/entra/entra_test.go
@@ -941,6 +941,9 @@ func TestEnsureVenomAppReturnsPartialAppAfterCreationFailure(t *testing.T) {
 	if app == nil || app.ObjectID != "object-id" {
 		t.Fatalf("partial app = %#v", app)
 	}
+	if !app.Created {
+		t.Fatal("partial newly created app must retain Created=true")
+	}
 }
 
 // TestEnsureVenomApp_ExistingApp tests the flow when an existing app is found.
@@ -1017,15 +1020,15 @@ func TestEnsureVenomApp_ExistingApp(t *testing.T) {
 		ClientSecret: "parent-secret",
 		HTTPClient:   srv.Client(),
 	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if err == nil {
+		t.Fatal("expected existing app ownership failure")
 	}
 
 	if app.AppID != "existing-app-id" {
 		t.Errorf("AppID = %q, want %q", app.AppID, "existing-app-id")
 	}
-	if app.ClientSecret != "rotated-secret" {
-		t.Errorf("ClientSecret = %q, want %q", app.ClientSecret, "rotated-secret")
+	if app.ClientSecret != "" {
+		t.Errorf("existing app credential was rotated: %q", app.ClientSecret)
 	}
 	if app.Created {
 		t.Error("existing app must not be marked created")
@@ -1051,14 +1054,13 @@ func TestEnsureVenomApp_SkipK8sSecret(t *testing.T) {
 		"POST /test-tenant/oauth2/v2.0/token": tokenHandler(),
 		"GET /applications": func(w http.ResponseWriter, r *http.Request) {
 			if strings.Contains(r.URL.RawQuery, "filter") {
-				jsonResponse(w, 200, map[string]interface{}{
-					"value": []map[string]string{
-						{"appId": "skip-secret-app-id", "id": "skip-secret-obj-id"},
-					},
-				})
+				jsonResponse(w, 200, map[string]interface{}{"value": []interface{}{}})
 				return
 			}
 			http.NotFound(w, r)
+		},
+		"POST /applications": func(w http.ResponseWriter, r *http.Request) {
+			jsonResponse(w, 201, map[string]string{"appId": "skip-secret-app-id", "id": "skip-secret-obj-id"})
 		},
 		"GET /applications/skip-secret-obj-id": func(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, 200, map[string]interface{}{

--- a/scripts/deploy-camunda/go.mod
+++ b/scripts/deploy-camunda/go.mod
@@ -10,15 +10,19 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
+	github.com/zalando/go-keyring v0.2.6
 	golang.org/x/sync v0.22.0
+	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
 	gopkg.in/yaml.v3 v3.0.1
+	k8s.io/apimachinery v0.31.1
 	scripts/camunda-core v0.0.0
 	scripts/prepare-helm-values v0.0.0
 	scripts/vault-secret-mapper v0.0.0
 )
 
 require (
+	al.essio.dev/pkg/shellescape v1.5.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260703014108-f5a850f9c2b7 // indirect
 	github.com/charmbracelet/x/ansi v0.11.7 // indirect
@@ -27,6 +31,7 @@ require (
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
+	github.com/danieljoos/wincred v1.2.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
@@ -34,6 +39,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.22.4 // indirect
+	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
@@ -61,14 +67,12 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/api v0.31.1 // indirect
-	k8s.io/apimachinery v0.31.1 // indirect
 	k8s.io/client-go v0.31.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect

--- a/scripts/deploy-camunda/go.sum
+++ b/scripts/deploy-camunda/go.sum
@@ -1,3 +1,5 @@
+al.essio.dev/pkg/shellescape v1.5.1 h1:86HrALUujYS/h+GtqoB26SBEdkWfmMI6FubjXlsXyho=
+al.essio.dev/pkg/shellescape v1.5.1/go.mod h1:6sIqp7X2P6mThCQ7twERpZTuigpr6KbZWtls1U8I890=
 charm.land/bubbletea/v2 v2.0.8 h1:SxTJMhCAI3lbPmy4SgX5LWZ24AdINr4I6UEqzZvYJuY=
 charm.land/bubbletea/v2 v2.0.8/go.mod h1:2SkdgoTXluXJHOUwAoRlRXF/28vklb1rFl6GcgV1/ss=
 charm.land/lipgloss/v2 v2.0.5 h1:kbNxgeeUOYv5J0YdpxFjfvf3dFvqH8Aci4zB6xqFtrY=
@@ -24,6 +26,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/danieljoos/wincred v1.2.2 h1:774zMFJrqaeYCK2W57BgAem/MLi6mtSE47MB6BOJ0i0=
+github.com/danieljoos/wincred v1.2.2/go.mod h1:w7w4Utbrz8lqeMbDAK0lkNJUv5sAOkFi7nd/ogr0Uh8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -43,6 +47,8 @@ github.com/go-openapi/swag v0.22.4 h1:QLMzNJnMGPRNDCbySlcj1x01tzU8/9LTTL9hZZZogB
 github.com/go-openapi/swag v0.22.4/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
+github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
+github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
@@ -57,6 +63,8 @@ github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20240525223248-4bfdf5a9a2af h1:kmjWCqn2qkEml422C2Rrd27c3VGxi6a/6HNq8QmHRKM=
 github.com/google/pprof v0.0.0-20240525223248-4bfdf5a9a2af/go.mod h1:K1liHPHnj73Fdn/EKuT8nrFqBihUSKXoLYU0BuatOYo=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
@@ -125,6 +133,8 @@ github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3A
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -137,6 +147,8 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavM
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/zalando/go-keyring v0.2.6 h1:r7Yc3+H+Ux0+M72zacZoItR3UDxeWfKTcabvkI8ua9s=
+github.com/zalando/go-keyring v0.2.6/go.mod h1:2TCrxYrbUNYfNS/Kgy/LSrkSQzZ5UPVH85RwfczwvcI=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/scripts/deploy-camunda/matrix/docker_auth.go
+++ b/scripts/deploy-camunda/matrix/docker_auth.go
@@ -1,0 +1,116 @@
+package matrix
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type DockerAuth struct {
+	Username string
+	Password string
+}
+
+type dockerConfig struct {
+	Auths       map[string]dockerAuthEntry `json:"auths"`
+	CredsStore  string                     `json:"credsStore"`
+	CredHelpers map[string]string          `json:"credHelpers"`
+}
+
+type dockerAuthEntry struct {
+	Auth     string `json:"auth"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+func ImportPlaintextDockerAuth(configPath string, registries ...string) (map[string]DockerAuth, error) {
+	if configPath == "" {
+		configDir := os.Getenv("DOCKER_CONFIG")
+		if configDir == "" {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return nil, err
+			}
+			configDir = filepath.Join(home, ".docker")
+		}
+		configPath = filepath.Join(configDir, "config.json")
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("read Docker config: %w", err)
+	}
+	var cfg dockerConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("decode Docker config: %w", err)
+	}
+	result := make(map[string]DockerAuth)
+	for _, registry := range registries {
+		_, entry, ok := findDockerAuth(cfg.Auths, registry)
+		helper := findDockerHelper(cfg.CredHelpers, registry)
+		if helper != "" {
+			return nil, fmt.Errorf("Docker credentials for %s use helper %q; helper execution is not permitted, provide explicit credentials", registry, helper)
+		}
+		if cfg.CredsStore != "" {
+			return nil, fmt.Errorf("Docker credentials use global store %q; helper execution is not permitted, provide explicit credentials", cfg.CredsStore)
+		}
+		if !ok {
+			continue
+		}
+		auth, err := decodeDockerAuth(entry)
+		if err != nil {
+			return nil, fmt.Errorf("decode Docker credentials for %s: %w", registry, err)
+		}
+		result[registry] = auth
+	}
+	return result, nil
+}
+
+func findDockerHelper(helpers map[string]string, registry string) string {
+	aliases := dockerRegistryAliases(registry)
+	for _, alias := range aliases {
+		if helper := helpers[alias]; helper != "" {
+			return helper
+		}
+	}
+	return ""
+}
+
+func findDockerAuth(auths map[string]dockerAuthEntry, registry string) (string, dockerAuthEntry, bool) {
+	aliases := dockerRegistryAliases(registry)
+	for _, alias := range aliases {
+		if entry, ok := auths[alias]; ok {
+			return alias, entry, true
+		}
+	}
+	return registry, dockerAuthEntry{}, false
+}
+
+func dockerRegistryAliases(registry string) []string {
+	aliases := []string{registry}
+	if registry == "docker.io" {
+		aliases = append(aliases, "https://index.docker.io/v1/", "index.docker.io")
+	}
+	return aliases
+}
+
+func decodeDockerAuth(entry dockerAuthEntry) (DockerAuth, error) {
+	if entry.Username != "" && entry.Password != "" {
+		return DockerAuth{Username: entry.Username, Password: entry.Password}, nil
+	}
+	if entry.Auth == "" {
+		return DockerAuth{}, errors.New("auth entry has no username/password")
+	}
+	decoded, err := base64.StdEncoding.DecodeString(entry.Auth)
+	if err != nil {
+		return DockerAuth{}, err
+	}
+	username, password, ok := strings.Cut(string(decoded), ":")
+	if !ok || username == "" || password == "" {
+		return DockerAuth{}, errors.New("auth entry is not username:password")
+	}
+	return DockerAuth{Username: username, Password: password}, nil
+}

--- a/scripts/deploy-camunda/matrix/docker_auth_test.go
+++ b/scripts/deploy-camunda/matrix/docker_auth_test.go
@@ -1,0 +1,49 @@
+package matrix
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestImportPlaintextDockerAuth(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	auth := base64.StdEncoding.EncodeToString([]byte("user:password"))
+	content := `{"auths":{"https://index.docker.io/v1/":{"auth":"` + auth + `"}}}`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	result, err := ImportPlaintextDockerAuth(path, "docker.io")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := result["docker.io"]; got.Username != "user" || got.Password != "password" {
+		t.Fatalf("auth = %#v", got)
+	}
+}
+
+func TestImportPlaintextDockerAuthRejectsHelpers(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	content := `{"credsStore":"desktop","auths":{}}`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := ImportPlaintextDockerAuth(path, "docker.io")
+	if err == nil {
+		t.Fatal("expected credential helper rejection")
+	}
+}
+
+func TestImportPlaintextDockerAuthRejectsHelperDespitePlaintextEntry(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	auth := base64.StdEncoding.EncodeToString([]byte("stale:credential"))
+	content := `{"credHelpers":{"https://index.docker.io/v1/":"desktop"},"auths":{"https://index.docker.io/v1/":{"auth":"` + auth + `"}}}`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := ImportPlaintextDockerAuth(path, "docker.io")
+	if err == nil {
+		t.Fatal("expected matching credential helper rejection")
+	}
+}

--- a/scripts/deploy-camunda/matrix/doctor.go
+++ b/scripts/deploy-camunda/matrix/doctor.go
@@ -45,6 +45,9 @@ func Doctor(ctx context.Context, entries []Entry, opts RunOptions, doctorOpts Do
 	contexts := map[string]struct{}{}
 	for _, entry := range entries {
 		if entry.Topology != nil {
+			if kubeContext := ResolveKubeContext(opts, entry); kubeContext != "" {
+				contexts[kubeContext] = struct{}{}
+			}
 			report.Entries = append(report.Entries, DoctorEntry{
 				Entry: entry, Namespace: ResolveNamespace(opts, entry),
 				Report: &deploy.Report{Checks: []deploy.Check{{

--- a/scripts/deploy-camunda/matrix/doctor.go
+++ b/scripts/deploy-camunda/matrix/doctor.go
@@ -1,0 +1,136 @@
+package matrix
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"scripts/camunda-core/pkg/kube"
+	"scripts/deploy-camunda/deploy"
+)
+
+type DoctorEntry struct {
+	Entry     Entry
+	Namespace string
+	Report    *deploy.Report
+}
+
+type DoctorReport struct {
+	Shared  []deploy.Check
+	Entries []DoctorEntry
+}
+
+type DoctorOptions struct {
+	SkipKube    bool
+	ConfigPath  string
+	ConfigFound bool
+}
+
+func (r *DoctorReport) OK() bool {
+	for _, check := range r.Shared {
+		if check.Status == deploy.StatusFail {
+			return false
+		}
+	}
+	for _, entry := range r.Entries {
+		if !entry.Report.OK() {
+			return false
+		}
+	}
+	return true
+}
+
+func Doctor(ctx context.Context, entries []Entry, opts RunOptions, doctorOpts DoctorOptions) (*DoctorReport, error) {
+	report := &DoctorReport{}
+	contexts := map[string]struct{}{}
+	for _, entry := range entries {
+		if entry.Topology != nil {
+			report.Entries = append(report.Entries, DoctorEntry{
+				Entry: entry, Namespace: ResolveNamespace(opts, entry),
+				Report: &deploy.Report{Checks: []deploy.Check{{
+					Name: "topology release preflight", Status: deploy.StatusWarn,
+					Detail:      "not yet supported for this topology entry",
+					Remediation: "run the topology scenario's dedicated validation workflow",
+				}}},
+			})
+			continue
+		}
+		flags, namespace, kubeContext, _, cleanup, err := BuildEntryFlags(entry, opts)
+		if err != nil {
+			return nil, fmt.Errorf("build %s doctor flags: %w", EntryID(entry), err)
+		}
+		entryReport := deploy.Preflight(ctx, flags, deploy.PreflightOptions{
+			ConfigPath: doctorOpts.ConfigPath, ConfigFound: doctorOpts.ConfigFound, SkipKubeReachability: true,
+		})
+		cleanup()
+		report.Entries = append(report.Entries, DoctorEntry{Entry: entry, Namespace: namespace, Report: entryReport})
+		if kubeContext != "" {
+			contexts[kubeContext] = struct{}{}
+		}
+	}
+	promoteSharedChecks(report, []string{"config file", "docker creds (Harbor)", "docker creds (Docker Hub)"})
+	removeEntryChecks(report, "kube context")
+
+	ordered := make([]string, 0, len(contexts))
+	for kubeContext := range contexts {
+		ordered = append(ordered, kubeContext)
+	}
+	sort.Strings(ordered)
+	for _, kubeContext := range ordered {
+		check := deploy.Check{Name: "kube context " + kubeContext, Status: deploy.StatusOK, Detail: "reachable"}
+		if doctorOpts.SkipKube {
+			check.Detail = "reachability not checked"
+		} else if err := kube.CheckConnectivity(ctx, kubeContext); err != nil {
+			check.Status = deploy.StatusFail
+			check.Detail = "not reachable"
+			check.Remediation = "check cluster authentication, VPN, and context configuration"
+		}
+		report.Shared = append(report.Shared, check)
+	}
+	if len(ordered) == 0 {
+		report.Shared = append(report.Shared, deploy.Check{
+			Name: "kube context", Status: deploy.StatusFail, Detail: "no context resolved",
+			Remediation: "configure --kube-context or a platform-specific context",
+		})
+	}
+	return report, nil
+}
+
+func removeEntryChecks(report *DoctorReport, name string) {
+	for i := range report.Entries {
+		checks := report.Entries[i].Report.Checks
+		kept := checks[:0]
+		for _, check := range checks {
+			if check.Name != name {
+				kept = append(kept, check)
+			}
+		}
+		report.Entries[i].Report.Checks = kept
+	}
+}
+
+func promoteSharedChecks(report *DoctorReport, names []string) {
+	for _, name := range names {
+		var promoted *deploy.Check
+		for i := range report.Entries {
+			checks := report.Entries[i].Report.Checks
+			kept := checks[:0]
+			for _, check := range checks {
+				if check.Name != name {
+					kept = append(kept, check)
+					continue
+				}
+				if promoted == nil {
+					copy := check
+					promoted = &copy
+				} else if check.Status == deploy.StatusFail || (check.Status == deploy.StatusWarn && promoted.Status == deploy.StatusOK) {
+					promoted.Status, promoted.Detail, promoted.Remediation = check.Status, check.Detail, check.Remediation
+				}
+			}
+			report.Entries[i].Report.Checks = kept
+		}
+		if promoted != nil {
+			report.Shared = append(report.Shared, *promoted)
+		}
+	}
+}

--- a/scripts/deploy-camunda/matrix/matrix_test.go
+++ b/scripts/deploy-camunda/matrix/matrix_test.go
@@ -1000,6 +1000,27 @@ func TestBuildEntryFlagsPrefersExplicitGlobalHost(t *testing.T) {
 	}
 }
 
+func TestBuildEntryFlagsPreservesAbsoluteCompanionPaths(t *testing.T) {
+	repoRoot := t.TempDir()
+	chartPath := filepath.Join(repoRoot, "chart")
+	valuesPath := filepath.Join(repoRoot, "values.yaml")
+	if err := os.MkdirAll(chartPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	entry := Entry{Version: "8.10", ChartPath: repoRoot, Scenario: "test", Shortname: "test", Flow: "install", Dependencies: []ChartDependency{{Chart: chartPath, ValuesFile: valuesPath}}}
+	flags, _, _, _, cleanup, err := BuildEntryFlags(entry, RunOptions{RepoRoot: repoRoot})
+	defer cleanup()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if flags.CompanionCharts[0].ChartRef != chartPath {
+		t.Fatalf("chart = %q", flags.CompanionCharts[0].ChartRef)
+	}
+	if flags.CompanionCharts[0].ValuesFile != valuesPath {
+		t.Fatalf("values = %q", flags.CompanionCharts[0].ValuesFile)
+	}
+}
+
 func TestBuildEntryFlagsGeneratesPostgresCredentials(t *testing.T) {
 	entry := Entry{
 		Version: "8.10", ChartPath: t.TempDir(), Scenario: "test", Shortname: "test", Flow: "install",

--- a/scripts/deploy-camunda/matrix/matrix_test.go
+++ b/scripts/deploy-camunda/matrix/matrix_test.go
@@ -1064,7 +1064,7 @@ func TestBuildEntryFlagsPreservesPostgresCredentials(t *testing.T) {
 	}
 }
 
-func TestBuildEntryFlagsForcesSavedPostgresCredentials(t *testing.T) {
+func TestBuildEntryFlagsPreservesExplicitPostgresCredentialsOverGeneratedFallback(t *testing.T) {
 	envFile := filepath.Join(t.TempDir(), ".env")
 	if err := os.WriteFile(envFile, []byte("RDBMS_POSTGRESQL_USERNAME=changed\nRDBMS_POSTGRESQL_PASSWORD=changed-password\n"), 0o600); err != nil {
 		t.Fatal(err)
@@ -1081,8 +1081,8 @@ func TestBuildEntryFlagsForcesSavedPostgresCredentials(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if flags.ExtraEnv["RDBMS_POSTGRESQL_USERNAME"] != "saved" || flags.ExtraEnv["RDBMS_POSTGRESQL_PASSWORD"] != "saved-password" {
-		t.Fatalf("saved credentials not forced: %#v", flags.ExtraEnv)
+	if _, exists := flags.ExtraEnv["RDBMS_POSTGRESQL_USERNAME"]; exists {
+		t.Fatalf("generated fallback overrode explicit credentials: %#v", flags.ExtraEnv)
 	}
 }
 

--- a/scripts/deploy-camunda/matrix/matrix_test.go
+++ b/scripts/deploy-camunda/matrix/matrix_test.go
@@ -1000,6 +1000,71 @@ func TestBuildEntryFlagsPrefersExplicitGlobalHost(t *testing.T) {
 	}
 }
 
+func TestBuildEntryFlagsGeneratesPostgresCredentials(t *testing.T) {
+	entry := Entry{
+		Version: "8.10", ChartPath: t.TempDir(), Scenario: "test", Shortname: "test", Flow: "install",
+		Dependencies: []ChartDependency{{
+			Chart: "postgresql", ValuesFile: "postgres.yaml",
+			EnvVars: []string{"RDBMS_POSTGRESQL_USERNAME", "RDBMS_POSTGRESQL_PASSWORD"},
+		}},
+	}
+	flags, _, _, _, cleanup, err := BuildEntryFlags(entry, RunOptions{RepoRoot: t.TempDir(), GeneratePostgresCredentials: true})
+	defer cleanup()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := flags.ExtraEnv["RDBMS_POSTGRESQL_USERNAME"]; got != "camunda" {
+		t.Fatalf("username = %q, want camunda", got)
+	}
+	if got := flags.ExtraEnv["RDBMS_POSTGRESQL_PASSWORD"]; len(got) != 32 {
+		t.Fatalf("password length = %d, want 32", len(got))
+	}
+}
+
+func TestBuildEntryFlagsPreservesPostgresCredentials(t *testing.T) {
+	envFile := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(envFile, []byte("RDBMS_POSTGRESQL_USERNAME=existing\nRDBMS_POSTGRESQL_PASSWORD=existing-password\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	entry := Entry{
+		Version: "8.10", ChartPath: t.TempDir(), Scenario: "test", Shortname: "test", Flow: "install",
+		Dependencies: []ChartDependency{{EnvVars: []string{"RDBMS_POSTGRESQL_USERNAME", "RDBMS_POSTGRESQL_PASSWORD"}}},
+	}
+	flags, _, _, _, cleanup, err := BuildEntryFlags(entry, RunOptions{EnvFile: envFile, GeneratePostgresCredentials: true})
+	defer cleanup()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := flags.ExtraEnv["RDBMS_POSTGRESQL_USERNAME"]; ok {
+		t.Fatal("explicit username was overridden")
+	}
+	if _, ok := flags.ExtraEnv["RDBMS_POSTGRESQL_PASSWORD"]; ok {
+		t.Fatal("explicit password was overridden")
+	}
+}
+
+func TestBuildEntryFlagsForcesSavedPostgresCredentials(t *testing.T) {
+	envFile := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(envFile, []byte("RDBMS_POSTGRESQL_USERNAME=changed\nRDBMS_POSTGRESQL_PASSWORD=changed-password\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	entry := Entry{
+		Version: "8.10", ChartPath: t.TempDir(), Scenario: "test", Shortname: "test", Flow: "install",
+		Dependencies: []ChartDependency{{EnvVars: []string{"RDBMS_POSTGRESQL_USERNAME", "RDBMS_POSTGRESQL_PASSWORD"}}},
+	}
+	flags, _, _, _, cleanup, err := BuildEntryFlags(entry, RunOptions{
+		EnvFile: envFile, GeneratePostgresCredentials: true,
+		GeneratedPostgresUsername: "saved", GeneratedPostgresPassword: "saved-password",
+	})
+	defer cleanup()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if flags.ExtraEnv["RDBMS_POSTGRESQL_USERNAME"] != "saved" || flags.ExtraEnv["RDBMS_POSTGRESQL_PASSWORD"] != "saved-password" {
+		t.Fatalf("saved credentials not forced: %#v", flags.ExtraEnv)
+	}
+}
+
 func TestDryRunPrefersExplicitGlobalHost(t *testing.T) {
 	opts := RunOptions{
 		IngressBaseDomain: "ci.distro.ultrawombat.com",

--- a/scripts/deploy-camunda/matrix/postgres.go
+++ b/scripts/deploy-camunda/matrix/postgres.go
@@ -1,0 +1,83 @@
+package matrix
+
+import (
+	"fmt"
+
+	"scripts/deploy-camunda/config"
+	"scripts/deploy-camunda/deploy"
+)
+
+func ResolvePostgresCredentials(entries []Entry, opts RunOptions) (string, string, error) {
+	if !opts.GeneratePostgresCredentials {
+		return "", "", nil
+	}
+	username, password := "", ""
+	requiredAny := false
+	for _, entry := range entries {
+		flags, _, _, _, cleanup, err := BuildEntryFlags(entry, withoutPostgresBootstrap(opts))
+		if err != nil {
+			return "", "", err
+		}
+		required := requiresPostgresCredentials(flags.CompanionCharts)
+		if !required {
+			cleanup()
+			continue
+		}
+		requiredAny = true
+		effective := effectiveCredentialEnv(flags)
+		cleanup()
+		entryUser, entryPassword := effective["RDBMS_POSTGRESQL_USERNAME"], effective["RDBMS_POSTGRESQL_PASSWORD"]
+		if entryUser != "" && username != "" && entryUser != username {
+			return "", "", fmt.Errorf("selected entries resolve different RDBMS_POSTGRESQL_USERNAME values")
+		}
+		if entryPassword != "" && password != "" && entryPassword != password {
+			return "", "", fmt.Errorf("selected entries resolve different RDBMS_POSTGRESQL_PASSWORD values")
+		}
+		if entryUser != "" {
+			username = entryUser
+		}
+		if entryPassword != "" {
+			password = entryPassword
+		}
+	}
+	if !requiredAny {
+		return "", "", nil
+	}
+	if username == "" {
+		username = "camunda"
+	}
+	if password == "" {
+		generated, err := deploy.RandomSecret()
+		if err != nil {
+			return "", "", err
+		}
+		password = generated
+	}
+	return username, password, nil
+}
+
+func withoutPostgresBootstrap(opts RunOptions) RunOptions {
+	opts.GeneratePostgresCredentials = false
+	opts.GeneratedPostgresUsername = ""
+	opts.GeneratedPostgresPassword = ""
+	return opts
+}
+
+func requiresPostgresCredentials(companions []config.CompanionChart) bool {
+	for _, companion := range companions {
+		for _, name := range companion.EnvVars {
+			if name == "RDBMS_POSTGRESQL_USERNAME" || name == "RDBMS_POSTGRESQL_PASSWORD" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func effectiveCredentialEnv(flags *config.RuntimeFlags) map[string]string {
+	values := make(map[string]string)
+	for _, item := range deploy.EnvProvenance(flags) {
+		values[item.Name] = item.Value
+	}
+	return values
+}

--- a/scripts/deploy-camunda/matrix/postgres.go
+++ b/scripts/deploy-camunda/matrix/postgres.go
@@ -28,6 +28,9 @@ func ResolvePostgresCredentials(entries []Entry, opts RunOptions) (string, strin
 		effective := effectiveCredentialEnv(flags)
 		cleanup()
 		entryUser, entryPassword := effective["RDBMS_POSTGRESQL_USERNAME"], effective["RDBMS_POSTGRESQL_PASSWORD"]
+		if (entryUser == "") != (entryPassword == "") {
+			return "", "", fmt.Errorf("entry %s must provide both RDBMS_POSTGRESQL_USERNAME and RDBMS_POSTGRESQL_PASSWORD", EntryID(entry))
+		}
 		if versionmatrix.IsUpgradeOnlyFlow(entry.Flow) && (entryUser == "" || entryPassword == "") {
 			return "", "", fmt.Errorf("upgrade-only entry %s requires explicit RDBMS_POSTGRESQL_USERNAME and RDBMS_POSTGRESQL_PASSWORD", EntryID(entry))
 		}

--- a/scripts/deploy-camunda/matrix/postgres.go
+++ b/scripts/deploy-camunda/matrix/postgres.go
@@ -14,6 +14,7 @@ func ResolvePostgresCredentials(entries []Entry, opts RunOptions) (string, strin
 	}
 	username, password := "", ""
 	requiredAny := false
+	missingAny := false
 	for _, entry := range entries {
 		flags, _, _, _, cleanup, err := BuildEntryFlags(entry, withoutPostgresBootstrap(opts))
 		if err != nil {
@@ -34,20 +35,14 @@ func ResolvePostgresCredentials(entries []Entry, opts RunOptions) (string, strin
 		if versionmatrix.IsUpgradeOnlyFlow(entry.Flow) && (entryUser == "" || entryPassword == "") {
 			return "", "", fmt.Errorf("upgrade-only entry %s requires explicit RDBMS_POSTGRESQL_USERNAME and RDBMS_POSTGRESQL_PASSWORD", EntryID(entry))
 		}
-		if entryUser != "" && username != "" && entryUser != username {
-			return "", "", fmt.Errorf("selected entries resolve different RDBMS_POSTGRESQL_USERNAME values")
-		}
-		if entryPassword != "" && password != "" && entryPassword != password {
-			return "", "", fmt.Errorf("selected entries resolve different RDBMS_POSTGRESQL_PASSWORD values")
-		}
-		if entryUser != "" {
-			username = entryUser
-		}
-		if entryPassword != "" {
-			password = entryPassword
+		if entryUser == "" {
+			missingAny = true
 		}
 	}
 	if !requiredAny {
+		return "", "", nil
+	}
+	if !missingAny {
 		return "", "", nil
 	}
 	if username == "" {

--- a/scripts/deploy-camunda/matrix/postgres.go
+++ b/scripts/deploy-camunda/matrix/postgres.go
@@ -3,6 +3,7 @@ package matrix
 import (
 	"fmt"
 
+	"scripts/camunda-core/pkg/versionmatrix"
 	"scripts/deploy-camunda/config"
 	"scripts/deploy-camunda/deploy"
 )
@@ -27,6 +28,9 @@ func ResolvePostgresCredentials(entries []Entry, opts RunOptions) (string, strin
 		effective := effectiveCredentialEnv(flags)
 		cleanup()
 		entryUser, entryPassword := effective["RDBMS_POSTGRESQL_USERNAME"], effective["RDBMS_POSTGRESQL_PASSWORD"]
+		if versionmatrix.IsUpgradeOnlyFlow(entry.Flow) && (entryUser == "" || entryPassword == "") {
+			return "", "", fmt.Errorf("upgrade-only entry %s requires explicit RDBMS_POSTGRESQL_USERNAME and RDBMS_POSTGRESQL_PASSWORD", EntryID(entry))
+		}
 		if entryUser != "" && username != "" && entryUser != username {
 			return "", "", fmt.Errorf("selected entries resolve different RDBMS_POSTGRESQL_USERNAME values")
 		}

--- a/scripts/deploy-camunda/matrix/postgres_test.go
+++ b/scripts/deploy-camunda/matrix/postgres_test.go
@@ -47,3 +47,15 @@ func TestResolvePostgresCredentialsRejectsPerVersionMismatch(t *testing.T) {
 		t.Fatal("expected inconsistent password failure")
 	}
 }
+
+func TestResolvePostgresCredentialsRejectsPartialPair(t *testing.T) {
+	chartPath := t.TempDir()
+	envFile := filepath.Join(t.TempDir(), "partial.env")
+	if err := os.WriteFile(envFile, []byte("RDBMS_POSTGRESQL_USERNAME=camunda\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := ResolvePostgresCredentials([]Entry{postgresEntry(chartPath, "8.10")}, RunOptions{GeneratePostgresCredentials: true, EnvFile: envFile})
+	if err == nil {
+		t.Fatal("expected partial credential pair failure")
+	}
+}

--- a/scripts/deploy-camunda/matrix/postgres_test.go
+++ b/scripts/deploy-camunda/matrix/postgres_test.go
@@ -25,12 +25,12 @@ func TestResolvePostgresCredentialsUsesEffectiveValues(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if username != "explicit" || password != "explicit-password" {
-		t.Fatalf("credentials = %q/%q", username, password)
+	if username != "" || password != "" {
+		t.Fatalf("explicit per-entry credentials should not produce a global pair: %q/%q", username, password)
 	}
 }
 
-func TestResolvePostgresCredentialsRejectsPerVersionMismatch(t *testing.T) {
+func TestResolvePostgresCredentialsAllowsIndependentPerVersionPairs(t *testing.T) {
 	chartPath := t.TempDir()
 	first := filepath.Join(t.TempDir(), "first.env")
 	second := filepath.Join(t.TempDir(), "second.env")
@@ -40,11 +40,14 @@ func TestResolvePostgresCredentialsRejectsPerVersionMismatch(t *testing.T) {
 	if err := os.WriteFile(second, []byte("RDBMS_POSTGRESQL_USERNAME=camunda\nRDBMS_POSTGRESQL_PASSWORD=second\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	_, _, err := ResolvePostgresCredentials([]Entry{postgresEntry(chartPath, "8.9"), postgresEntry(chartPath, "8.10")}, RunOptions{
+	username, password, err := ResolvePostgresCredentials([]Entry{postgresEntry(chartPath, "8.9"), postgresEntry(chartPath, "8.10")}, RunOptions{
 		GeneratePostgresCredentials: true, EnvFiles: map[string]string{"8.9": first, "8.10": second},
 	})
-	if err == nil {
-		t.Fatal("expected inconsistent password failure")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if username != "" || password != "" {
+		t.Fatalf("unexpected generated pair %q/%q", username, password)
 	}
 }
 

--- a/scripts/deploy-camunda/matrix/postgres_test.go
+++ b/scripts/deploy-camunda/matrix/postgres_test.go
@@ -1,0 +1,49 @@
+package matrix
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func postgresEntry(chartPath, version string) Entry {
+	return Entry{
+		Version: version, ChartPath: chartPath, Scenario: "test", Shortname: version, Flow: "install",
+		Dependencies: []ChartDependency{{EnvVars: []string{"RDBMS_POSTGRESQL_USERNAME", "RDBMS_POSTGRESQL_PASSWORD"}}},
+	}
+}
+
+func TestResolvePostgresCredentialsUsesEffectiveValues(t *testing.T) {
+	chartPath := t.TempDir()
+	envFile := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(envFile, []byte("RDBMS_POSTGRESQL_USERNAME=explicit\nRDBMS_POSTGRESQL_PASSWORD=explicit-password\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	username, password, err := ResolvePostgresCredentials([]Entry{postgresEntry(chartPath, "8.10")}, RunOptions{
+		GeneratePostgresCredentials: true, EnvFile: envFile,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if username != "explicit" || password != "explicit-password" {
+		t.Fatalf("credentials = %q/%q", username, password)
+	}
+}
+
+func TestResolvePostgresCredentialsRejectsPerVersionMismatch(t *testing.T) {
+	chartPath := t.TempDir()
+	first := filepath.Join(t.TempDir(), "first.env")
+	second := filepath.Join(t.TempDir(), "second.env")
+	if err := os.WriteFile(first, []byte("RDBMS_POSTGRESQL_USERNAME=camunda\nRDBMS_POSTGRESQL_PASSWORD=first\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(second, []byte("RDBMS_POSTGRESQL_USERNAME=camunda\nRDBMS_POSTGRESQL_PASSWORD=second\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := ResolvePostgresCredentials([]Entry{postgresEntry(chartPath, "8.9"), postgresEntry(chartPath, "8.10")}, RunOptions{
+		GeneratePostgresCredentials: true, EnvFiles: map[string]string{"8.9": first, "8.10": second},
+	})
+	if err == nil {
+		t.Fatal("expected inconsistent password failure")
+	}
+}

--- a/scripts/deploy-camunda/matrix/process_alive_unix.go
+++ b/scripts/deploy-camunda/matrix/process_alive_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package matrix
+
+import (
+	"errors"
+	"syscall"
+)
+
+func processAlive(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}

--- a/scripts/deploy-camunda/matrix/process_alive_unix.go
+++ b/scripts/deploy-camunda/matrix/process_alive_unix.go
@@ -4,10 +4,24 @@ package matrix
 
 import (
 	"errors"
+	"os/exec"
+	"strconv"
+	"strings"
 	"syscall"
 )
 
-func processAlive(pid int) bool {
+func processMatches(pid int, identity string) bool {
 	err := syscall.Kill(pid, 0)
-	return err == nil || errors.Is(err, syscall.EPERM)
+	if err != nil && !errors.Is(err, syscall.EPERM) {
+		return false
+	}
+	return identity != "" && processIdentity(pid) == identity
+}
+
+func processIdentity(pid int) string {
+	output, err := exec.Command("ps", "-o", "lstart=", "-p", strconv.Itoa(pid)).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(output))
 }

--- a/scripts/deploy-camunda/matrix/process_alive_unix.go
+++ b/scripts/deploy-camunda/matrix/process_alive_unix.go
@@ -10,12 +10,16 @@ import (
 	"syscall"
 )
 
-func processMatches(pid int, identity string) bool {
+func processState(pid int, identity string) (bool, bool) {
 	err := syscall.Kill(pid, 0)
 	if err != nil && !errors.Is(err, syscall.EPERM) {
-		return false
+		return false, true
 	}
-	return identity != "" && processIdentity(pid) == identity
+	observed := processIdentity(pid)
+	if identity == "" || observed == "" {
+		return false, false
+	}
+	return observed == identity, true
 }
 
 func processIdentity(pid int) string {

--- a/scripts/deploy-camunda/matrix/process_alive_windows.go
+++ b/scripts/deploy-camunda/matrix/process_alive_windows.go
@@ -2,13 +2,25 @@
 
 package matrix
 
-import "golang.org/x/sys/windows"
+import (
+	"fmt"
 
-func processAlive(pid int) bool {
+	"golang.org/x/sys/windows"
+)
+
+func processMatches(pid int, identity string) bool {
+	return identity != "" && processIdentity(pid) == identity
+}
+
+func processIdentity(pid int) string {
 	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
 	if err != nil {
-		return false
+		return ""
 	}
-	_ = windows.CloseHandle(handle)
-	return true
+	defer windows.CloseHandle(handle) //nolint:errcheck
+	var creation, exit, kernel, user windows.Filetime
+	if err := windows.GetProcessTimes(handle, &creation, &exit, &kernel, &user); err != nil {
+		return ""
+	}
+	return fmt.Sprintf("%d:%d", creation.HighDateTime, creation.LowDateTime)
 }

--- a/scripts/deploy-camunda/matrix/process_alive_windows.go
+++ b/scripts/deploy-camunda/matrix/process_alive_windows.go
@@ -8,8 +8,12 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func processMatches(pid int, identity string) bool {
-	return identity != "" && processIdentity(pid) == identity
+func processState(pid int, identity string) (bool, bool) {
+	observed := processIdentity(pid)
+	if identity == "" || observed == "" {
+		return false, false
+	}
+	return observed == identity, true
 }
 
 func processIdentity(pid int) string {

--- a/scripts/deploy-camunda/matrix/process_alive_windows.go
+++ b/scripts/deploy-camunda/matrix/process_alive_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package matrix
+
+import "golang.org/x/sys/windows"
+
+func processAlive(pid int) bool {
+	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	_ = windows.CloseHandle(handle)
+	return true
+}

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -623,6 +623,15 @@ func ReplayCommand(entry Entry, opts RunOptions) []string {
 	if opts.Cleanup {
 		args = append(args, "--cleanup")
 	}
+	if !opts.GeneratePostgresCredentials {
+		args = append(args, "--generate-postgres-credentials=false")
+	}
+	if opts.ImportDockerAuth {
+		args = append(args, "--import-docker-auth")
+		if opts.DockerConfigPath != "" {
+			args = append(args, "--docker-config", opts.DockerConfigPath)
+		}
+	}
 	return args
 }
 

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -1,0 +1,677 @@
+package matrix
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+const RunStateSchema = "camunda.matrix-run/v1"
+
+type RunStatus string
+
+const (
+	RunPending     RunStatus = "pending"
+	RunRunning     RunStatus = "running"
+	RunPassed      RunStatus = "passed"
+	RunFailed      RunStatus = "failed"
+	RunInterrupted RunStatus = "interrupted"
+	RunCleaned     RunStatus = "cleaned"
+)
+
+type Failure struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type ReplayManifest struct {
+	Command []string `json:"command"`
+}
+
+type StoredRunOptions struct {
+	Cleanup                     bool              `json:"cleanup,omitempty"`
+	StopOnFailure               bool              `json:"stopOnFailure,omitempty"`
+	KubeContexts                map[string]string `json:"kubeContexts,omitempty"`
+	KubeContext                 string            `json:"kubeContext,omitempty"`
+	NamespacePrefix             string            `json:"namespacePrefix,omitempty"`
+	Platform                    string            `json:"platform,omitempty"`
+	MaxParallel                 int               `json:"maxParallel,omitempty"`
+	TestE2E                     bool              `json:"testE2E,omitempty"`
+	TestAll                     bool              `json:"testAll,omitempty"`
+	RepoRoot                    string            `json:"repoRoot"`
+	EnvFiles                    map[string]string `json:"envFiles,omitempty"`
+	EnvFile                     string            `json:"envFile,omitempty"`
+	KeycloakHost                string            `json:"keycloakHost,omitempty"`
+	KeycloakProtocol            string            `json:"keycloakProtocol,omitempty"`
+	IngressBaseDomains          map[string]string `json:"ingressBaseDomains,omitempty"`
+	IngressBaseDomain           string            `json:"ingressBaseDomain,omitempty"`
+	LogLevel                    string            `json:"logLevel,omitempty"`
+	SkipDependencyUpdate        bool              `json:"skipDependencyUpdate,omitempty"`
+	VaultBackedSecrets          map[string]bool   `json:"vaultBackedSecrets,omitempty"`
+	UseVaultBackedSecrets       bool              `json:"useVaultBackedSecrets,omitempty"`
+	DeleteNamespaceFirst        bool              `json:"deleteNamespaceFirst,omitempty"`
+	UpgradeFromVersion          string            `json:"upgradeFromVersion,omitempty"`
+	HelmTimeout                 int               `json:"helmTimeout,omitempty"`
+	EnsureDockerRegistry        bool              `json:"ensureDockerRegistry,omitempty"`
+	DockerUsername              string            `json:"dockerUsername,omitempty"`
+	RequiresDockerPassword      bool              `json:"requiresDockerPassword,omitempty"`
+	EnsureDockerHub             bool              `json:"ensureDockerHub,omitempty"`
+	DockerHubUsername           string            `json:"dockerHubUsername,omitempty"`
+	RequiresDockerHubPassword   bool              `json:"requiresDockerHubPassword,omitempty"`
+	UseLatest                   bool              `json:"useLatest,omitempty"`
+	UseQA                       bool              `json:"useQA,omitempty"`
+	ExtraHelmArgs               []string          `json:"extraHelmArgs,omitempty"`
+	ExtraHelmSets               []string          `json:"extraHelmSets,omitempty"`
+	ExtraValues                 []string          `json:"extraValues,omitempty"`
+	NamespaceOverride           string            `json:"namespaceOverride,omitempty"`
+	ChartRef                    string            `json:"chartRef,omitempty"`
+	ChartRefVersion             string            `json:"chartRefVersion,omitempty"`
+	ForceImageOverrides         bool              `json:"forceImageOverrides,omitempty"`
+	WaitIngressReady            bool              `json:"waitIngressReady,omitempty"`
+	IngressReadyTimeoutMinutes  int               `json:"ingressReadyTimeoutMinutes,omitempty"`
+	GeneratePostgresCredentials bool              `json:"generatePostgresCredentials,omitempty"`
+}
+
+func StoreRunOptions(opts RunOptions) StoredRunOptions {
+	return StoredRunOptions{
+		Cleanup:       opts.Cleanup,
+		StopOnFailure: opts.StopOnFailure, KubeContexts: opts.KubeContexts, KubeContext: opts.KubeContext,
+		NamespacePrefix: opts.NamespacePrefix, Platform: opts.Platform, MaxParallel: opts.MaxParallel,
+		TestE2E: opts.TestE2E, TestAll: opts.TestAll, RepoRoot: opts.RepoRoot, EnvFiles: opts.EnvFiles,
+		EnvFile: opts.EnvFile, KeycloakHost: opts.KeycloakHost, KeycloakProtocol: opts.KeycloakProtocol,
+		IngressBaseDomains: opts.IngressBaseDomains, IngressBaseDomain: opts.IngressBaseDomain,
+		LogLevel: opts.LogLevel, SkipDependencyUpdate: opts.SkipDependencyUpdate,
+		VaultBackedSecrets: opts.VaultBackedSecrets, UseVaultBackedSecrets: opts.UseVaultBackedSecrets,
+		DeleteNamespaceFirst: opts.DeleteNamespaceFirst, UpgradeFromVersion: opts.UpgradeFromVersion,
+		HelmTimeout: opts.HelmTimeout, EnsureDockerRegistry: opts.EnsureDockerRegistry,
+		DockerUsername: opts.DockerUsername, RequiresDockerPassword: opts.DockerPassword != "",
+		EnsureDockerHub: opts.EnsureDockerHub, DockerHubUsername: opts.DockerHubUsername,
+		RequiresDockerHubPassword: opts.DockerHubPassword != "", UseLatest: opts.UseLatest, UseQA: opts.UseQA,
+		ExtraHelmArgs: redactStoredArgs(opts.ExtraHelmArgs), ExtraHelmSets: redactStoredSets(opts.ExtraHelmSets),
+		ExtraValues: opts.ExtraValues, NamespaceOverride: opts.NamespaceOverride, ChartRef: opts.ChartRef,
+		ChartRefVersion: opts.ChartRefVersion, ForceImageOverrides: opts.ForceImageOverrides,
+		WaitIngressReady: opts.WaitIngressReady, IngressReadyTimeoutMinutes: opts.IngressReadyTimeoutMinutes,
+		GeneratePostgresCredentials: opts.GeneratePostgresCredentials,
+	}
+}
+
+func (s StoredRunOptions) RunOptions() RunOptions {
+	return RunOptions{
+		Cleanup:       s.Cleanup,
+		StopOnFailure: s.StopOnFailure, KubeContexts: s.KubeContexts, KubeContext: s.KubeContext,
+		NamespacePrefix: s.NamespacePrefix, Platform: s.Platform, MaxParallel: s.MaxParallel,
+		TestE2E: s.TestE2E, TestAll: s.TestAll, RepoRoot: s.RepoRoot, EnvFiles: s.EnvFiles,
+		EnvFile: s.EnvFile, KeycloakHost: s.KeycloakHost, KeycloakProtocol: s.KeycloakProtocol,
+		IngressBaseDomains: s.IngressBaseDomains, IngressBaseDomain: s.IngressBaseDomain,
+		LogLevel: s.LogLevel, SkipDependencyUpdate: s.SkipDependencyUpdate,
+		VaultBackedSecrets: s.VaultBackedSecrets, UseVaultBackedSecrets: s.UseVaultBackedSecrets,
+		DeleteNamespaceFirst: s.DeleteNamespaceFirst, UpgradeFromVersion: s.UpgradeFromVersion,
+		HelmTimeout: s.HelmTimeout, EnsureDockerRegistry: s.EnsureDockerRegistry,
+		DockerUsername: s.DockerUsername, EnsureDockerHub: s.EnsureDockerHub,
+		DockerHubUsername: s.DockerHubUsername, UseLatest: s.UseLatest, UseQA: s.UseQA,
+		ExtraHelmArgs: removeRedactedArgs(s.ExtraHelmArgs), ExtraHelmSets: removeRedactedArgs(s.ExtraHelmSets),
+		ExtraValues: s.ExtraValues, NamespaceOverride: s.NamespaceOverride, ChartRef: s.ChartRef,
+		ChartRefVersion: s.ChartRefVersion, ForceImageOverrides: s.ForceImageOverrides,
+		WaitIngressReady: s.WaitIngressReady, IngressReadyTimeoutMinutes: s.IngressReadyTimeoutMinutes,
+		GeneratePostgresCredentials: s.GeneratePostgresCredentials,
+	}
+}
+
+type EntryRunState struct {
+	ID          string         `json:"id"`
+	Entry       Entry          `json:"entry"`
+	Status      RunStatus      `json:"status"`
+	Phase       string         `json:"phase,omitempty"`
+	Namespace   string         `json:"namespace"`
+	KubeContext string         `json:"kubeContext,omitempty"`
+	Attempts    int            `json:"attempts"`
+	StartedAt   *time.Time     `json:"startedAt,omitempty"`
+	FinishedAt  *time.Time     `json:"finishedAt,omitempty"`
+	Failure     *Failure       `json:"failure,omitempty"`
+	Diagnostics string         `json:"diagnostics,omitempty"`
+	Replay      ReplayManifest `json:"replay"`
+	Cleaned     bool           `json:"cleaned,omitempty"`
+}
+
+type MatrixRunState struct {
+	Schema    string           `json:"schema"`
+	ID        string           `json:"id"`
+	Status    RunStatus        `json:"status"`
+	CreatedAt time.Time        `json:"createdAt"`
+	UpdatedAt time.Time        `json:"updatedAt"`
+	Options   StoredRunOptions `json:"options"`
+	Entries   []*EntryRunState `json:"entries"`
+}
+
+type RunEvent struct {
+	Time    time.Time `json:"time"`
+	RunID   string    `json:"runId"`
+	EntryID string    `json:"entryId,omitempty"`
+	Status  RunStatus `json:"status,omitempty"`
+	Phase   string    `json:"phase,omitempty"`
+	Code    string    `json:"code,omitempty"`
+}
+
+type runSecrets struct {
+	PostgresUsername string `json:"postgresUsername,omitempty"`
+	PostgresPassword string `json:"postgresPassword,omitempty"`
+}
+
+type RunStateStore struct {
+	root  string
+	runID string
+	mu    sync.Mutex
+}
+
+type RunLock struct {
+	file *os.File
+}
+
+func NewRunStateStore(root, runID string) *RunStateStore {
+	return &RunStateStore{root: root, runID: runID}
+}
+
+func NewRunID(now time.Time) string {
+	return now.UTC().Format("20060102T150405.000000000Z")
+}
+
+func (s *RunStateStore) RunDir() string { return filepath.Join(s.root, s.runID) }
+
+func (s *RunStateStore) RunID() string { return s.runID }
+
+func (s *RunStateStore) Acquire() (*RunLock, error) {
+	if err := os.MkdirAll(s.RunDir(), 0o700); err != nil {
+		return nil, fmt.Errorf("create matrix run directory: %w", err)
+	}
+	file, err := os.OpenFile(filepath.Join(s.RunDir(), "run.lock"), os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open matrix run lock: %w", err)
+	}
+	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		file.Close()
+		return nil, fmt.Errorf("matrix run %q is active in another process", s.runID)
+	}
+	return &RunLock{file: file}, nil
+}
+
+func (l *RunLock) Close() error {
+	if l == nil || l.file == nil {
+		return nil
+	}
+	err := unix.Flock(int(l.file.Fd()), unix.LOCK_UN)
+	closeErr := l.file.Close()
+	if err != nil {
+		return err
+	}
+	return closeErr
+}
+
+func (s *RunStateStore) Create(entries []Entry, opts RunOptions) (*MatrixRunState, error) {
+	now := time.Now().UTC()
+	state := &MatrixRunState{Schema: RunStateSchema, ID: s.runID, Status: RunPending, CreatedAt: now, UpdatedAt: now, Options: StoreRunOptions(opts)}
+	for _, entry := range entries {
+		namespace := ResolveNamespace(opts, entry)
+		state.Entries = append(state.Entries, &EntryRunState{
+			ID: EntryID(entry), Entry: entry, Status: RunPending, Namespace: namespace,
+			KubeContext: ResolveKubeContext(opts, entry), Replay: ReplayManifest{Command: ReplayCommand(entry, opts)},
+		})
+	}
+	if err := os.MkdirAll(s.RunDir(), 0o700); err != nil {
+		return nil, fmt.Errorf("create matrix run directory: %w", err)
+	}
+	if err := os.Chmod(s.root, 0o700); err != nil {
+		return nil, fmt.Errorf("secure matrix state directory: %w", err)
+	}
+	if err := os.Chmod(s.RunDir(), 0o700); err != nil {
+		return nil, fmt.Errorf("secure matrix run directory: %w", err)
+	}
+	if err := s.write(state); err != nil {
+		return nil, err
+	}
+	if opts.GeneratedPostgresPassword != "" {
+		data, err := json.Marshal(runSecrets{PostgresUsername: opts.GeneratedPostgresUsername, PostgresPassword: opts.GeneratedPostgresPassword})
+		if err != nil {
+			return nil, err
+		}
+		if err := atomicWriteFile(filepath.Join(s.RunDir(), "run-secrets.json"), append(data, '\n'), 0o600); err != nil {
+			return nil, fmt.Errorf("write matrix run secrets: %w", err)
+		}
+	}
+	return state, s.appendEvent(RunEvent{Time: now, RunID: s.runID, Status: RunPending})
+}
+
+func (s *RunStateStore) Load() (*MatrixRunState, error) {
+	data, err := os.ReadFile(filepath.Join(s.RunDir(), "matrix-state.json"))
+	if err != nil {
+		return nil, fmt.Errorf("read matrix run %q: %w", s.runID, err)
+	}
+	var state MatrixRunState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("decode matrix run %q: %w", s.runID, err)
+	}
+	if state.Schema != RunStateSchema {
+		return nil, fmt.Errorf("unsupported matrix run schema %q", state.Schema)
+	}
+	return &state, nil
+}
+
+func (s *RunStateStore) Start(entry Entry, namespace string) error {
+	return s.update(entry, func(state *MatrixRunState, item *EntryRunState) RunEvent {
+		now := time.Now().UTC()
+		state.Status = RunRunning
+		item.Status, item.Namespace, item.StartedAt, item.FinishedAt = RunRunning, namespace, &now, nil
+		item.Attempts++
+		item.Failure = nil
+		return RunEvent{Time: now, RunID: s.runID, EntryID: item.ID, Status: item.Status}
+	})
+}
+
+func (s *RunStateStore) Phase(entry Entry, phase string) error {
+	return s.update(entry, func(_ *MatrixRunState, item *EntryRunState) RunEvent {
+		item.Phase = phase
+		return RunEvent{Time: time.Now().UTC(), RunID: s.runID, EntryID: item.ID, Status: item.Status, Phase: phase}
+	})
+}
+
+func (s *RunStateStore) Complete(entry Entry, result RunResult) error {
+	return s.update(entry, func(state *MatrixRunState, item *EntryRunState) RunEvent {
+		now := time.Now().UTC()
+		item.FinishedAt, item.Diagnostics, item.KubeContext = &now, result.Diagnostics, result.KubeContext
+		if result.Error == nil {
+			item.Status, item.Failure = RunPassed, nil
+		} else {
+			item.Status = RunFailed
+			item.Failure = ClassifyFailure(result.Error)
+		}
+		state.Status = aggregateRunStatus(state.Entries)
+		code := ""
+		if item.Failure != nil {
+			code = item.Failure.Code
+		}
+		return RunEvent{Time: now, RunID: s.runID, EntryID: item.ID, Status: item.Status, Phase: item.Phase, Code: code}
+	})
+}
+
+func (s *RunStateStore) MarkInterrupted() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state, err := s.Load()
+	if err != nil {
+		return err
+	}
+	changed := false
+	for _, item := range state.Entries {
+		if item.Status == RunRunning {
+			item.Status = RunInterrupted
+			item.Failure = &Failure{Code: "RUN_INTERRUPTED", Message: "matrix process ended before the entry completed"}
+			changed = true
+		}
+	}
+	if !changed {
+		return nil
+	}
+	state.Status, state.UpdatedAt = RunInterrupted, time.Now().UTC()
+	return s.write(state)
+}
+
+func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state, err := s.Load()
+	if err != nil {
+		return nil, RunOptions{}, err
+	}
+	var entries []Entry
+	for _, item := range state.Entries {
+		if entryID != "" && item.ID != entryID {
+			continue
+		}
+		if item.Status == RunPassed || item.Status == RunCleaned {
+			continue
+		}
+		item.Status, item.Phase, item.Failure = RunPending, "", nil
+		entries = append(entries, item.Entry)
+	}
+	if entryID != "" && len(entries) == 0 {
+		return nil, RunOptions{}, fmt.Errorf("entry %q is not resumable or does not exist", entryID)
+	}
+	if len(entries) == 0 {
+		return nil, RunOptions{}, errors.New("matrix run has no incomplete entries")
+	}
+	if hasRedactedArgs(state.Options.ExtraHelmArgs) || hasRedactedArgs(state.Options.ExtraHelmSets) {
+		return nil, RunOptions{}, errors.New("matrix run used secret-bearing Helm arguments; resume cannot reconstruct them safely; replay the recorded command with the required secret inputs")
+	}
+	harborPassword, err := resumeCredentialPassword(state.Options.DockerUsername, state.Options.RequiresDockerPassword, [][2]string{
+		{"HARBOR_USERNAME", "HARBOR_PASSWORD"},
+		{"TEST_DOCKER_USERNAME_CAMUNDA_CLOUD", "TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD"},
+		{"NEXUS_USERNAME", "NEXUS_PASSWORD"},
+	})
+	if err != nil {
+		return nil, RunOptions{}, fmt.Errorf("restore Harbor credentials: %w", err)
+	}
+	hubPassword, err := resumeCredentialPassword(state.Options.DockerHubUsername, state.Options.RequiresDockerHubPassword, [][2]string{
+		{"DOCKERHUB_USERNAME", "DOCKERHUB_PASSWORD"},
+		{"TEST_DOCKER_USERNAME", "TEST_DOCKER_PASSWORD"},
+	})
+	if err != nil {
+		return nil, RunOptions{}, fmt.Errorf("restore Docker Hub credentials: %w", err)
+	}
+	state.Status, state.UpdatedAt = RunPending, time.Now().UTC()
+	if err := s.write(state); err != nil {
+		return nil, RunOptions{}, err
+	}
+	opts := state.Options.RunOptions()
+	opts.DockerPassword, opts.DockerHubPassword = harborPassword, hubPassword
+	secretData, err := os.ReadFile(filepath.Join(s.RunDir(), "run-secrets.json"))
+	if err == nil {
+		var secrets runSecrets
+		if err := json.Unmarshal(secretData, &secrets); err != nil {
+			return nil, RunOptions{}, fmt.Errorf("decode matrix run secrets: %w", err)
+		}
+		opts.GeneratedPostgresUsername = secrets.PostgresUsername
+		opts.GeneratedPostgresPassword = secrets.PostgresPassword
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, RunOptions{}, fmt.Errorf("read matrix run secrets: %w", err)
+	}
+	return entries, opts, nil
+}
+
+func (s *RunStateStore) MarkCleaned(entryID string) error {
+	return s.updateID(entryID, func(state *MatrixRunState, item *EntryRunState) RunEvent {
+		item.Cleaned = true
+		if item.Status != RunFailed && item.Status != RunInterrupted {
+			item.Status = RunCleaned
+		}
+		state.Status = aggregateRunStatus(state.Entries)
+		return RunEvent{Time: time.Now().UTC(), RunID: s.runID, EntryID: item.ID, Status: item.Status, Phase: "cleanup"}
+	})
+}
+
+func (s *RunStateStore) update(entry Entry, fn func(*MatrixRunState, *EntryRunState) RunEvent) error {
+	return s.updateID(EntryID(entry), fn)
+}
+
+func (s *RunStateStore) updateID(id string, fn func(*MatrixRunState, *EntryRunState) RunEvent) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state, err := s.Load()
+	if err != nil {
+		return err
+	}
+	for _, item := range state.Entries {
+		if item.ID != id {
+			continue
+		}
+		event := fn(state, item)
+		state.UpdatedAt = time.Now().UTC()
+		if err := s.write(state); err != nil {
+			return err
+		}
+		_ = s.appendEvent(event)
+		return nil
+	}
+	return fmt.Errorf("matrix entry %q not found in run %q", id, s.runID)
+}
+
+func (s *RunStateStore) write(state *MatrixRunState) error {
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode matrix run state: %w", err)
+	}
+	data = append(data, '\n')
+	return atomicWriteFile(filepath.Join(s.RunDir(), "matrix-state.json"), data, 0o600)
+}
+
+func (s *RunStateStore) appendEvent(event RunEvent) error {
+	data, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+	f, err := os.OpenFile(filepath.Join(s.RunDir(), "events.ndjson"), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("open matrix run events: %w", err)
+	}
+	defer f.Close()
+	if err := f.Chmod(0o600); err != nil {
+		return err
+	}
+	if _, err := f.Write(append(data, '\n')); err != nil {
+		return fmt.Errorf("append matrix run event: %w", err)
+	}
+	return f.Sync()
+}
+
+func atomicWriteFile(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".state-*")
+	if err != nil {
+		return fmt.Errorf("create temporary state file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(mode); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("replace state file: %w", err)
+	}
+	d, err := os.Open(dir)
+	if err != nil {
+		return fmt.Errorf("open state directory: %w", err)
+	}
+	defer d.Close()
+	if err := d.Sync(); err != nil {
+		return fmt.Errorf("sync state directory: %w", err)
+	}
+	return nil
+}
+
+func EntryID(entry Entry) string { return entryID(entry) }
+
+func ReplayCommand(entry Entry, opts RunOptions) []string {
+	args := []string{"deploy-camunda", "matrix", "run", "--versions", entry.Version, "--shortname-filter", entry.Shortname, "--shortname-exact", "--flow-filter", entry.Flow}
+	if entry.Platform != "" {
+		args = append(args, "--platform", entry.Platform)
+	}
+	if opts.RepoRoot != "" {
+		args = append(args, "--repo-root", opts.RepoRoot)
+	}
+	if opts.NamespacePrefix != "" {
+		args = append(args, "--namespace-prefix", opts.NamespacePrefix)
+	}
+	if opts.KubeContext != "" {
+		args = append(args, "--kube-context", opts.KubeContext)
+	}
+	if value := opts.KubeContexts[entry.Platform]; value != "" {
+		args = append(args, "--kube-context-"+entry.Platform, value)
+	}
+	if opts.IngressBaseDomain != "" {
+		args = append(args, "--ingress-base-domain", opts.IngressBaseDomain)
+	}
+	if value := opts.IngressBaseDomains[entry.Platform]; value != "" {
+		args = append(args, "--ingress-base-domain-"+entry.Platform, value)
+	}
+	if opts.NamespaceOverride != "" {
+		args = append(args, "--namespace-override", opts.NamespaceOverride)
+	}
+	if opts.ChartRef != "" {
+		args = append(args, "--chart-ref", opts.ChartRef)
+	}
+	if opts.ChartRefVersion != "" {
+		args = append(args, "--chart-version", opts.ChartRefVersion)
+	}
+	for _, value := range opts.ExtraValues {
+		args = append(args, "--extra-values", value)
+	}
+	if opts.TestE2E {
+		args = append(args, "--test-e2e")
+	}
+	if opts.TestAll {
+		args = append(args, "--test-all")
+	}
+	if opts.EnsureDockerRegistry {
+		args = append(args, "--ensure-docker-registry")
+	}
+	if opts.EnsureDockerHub {
+		args = append(args, "--ensure-docker-hub")
+	}
+	return args
+}
+
+func ResolveKubeContext(opts RunOptions, entry Entry) string {
+	return resolveKubeContext(opts, resolvePlatform(opts, entry))
+}
+
+func ClassifyFailure(err error) *Failure {
+	if err == nil {
+		return nil
+	}
+	lower := strings.ToLower(err.Error())
+	code := "DEPLOY_UNKNOWN"
+	switch {
+	case errors.Is(err, os.ErrNotExist), strings.Contains(lower, "no such file"):
+		code = "INPUT_NOT_FOUND"
+	case strings.Contains(lower, "docker") || strings.Contains(lower, "registry") || strings.Contains(lower, "imagepull"):
+		code = "REGISTRY_FAILURE"
+	case strings.Contains(lower, "unauthorized") || strings.Contains(lower, "forbidden") || strings.Contains(lower, "credential"):
+		code = "AUTH_FAILURE"
+	case strings.Contains(lower, "context canceled") || strings.Contains(lower, "cancelled"):
+		code = "RUN_INTERRUPTED"
+	case strings.Contains(lower, "helm") || strings.Contains(lower, "upgrade") || strings.Contains(lower, "release"):
+		code = "HELM_FAILURE"
+	case strings.Contains(lower, "test") || strings.Contains(lower, "playwright") || strings.Contains(lower, "e2e"):
+		code = "TEST_FAILURE"
+	case strings.Contains(lower, "ingress") || strings.Contains(lower, "dns"):
+		code = "INGRESS_FAILURE"
+	case strings.Contains(lower, "namespace") || strings.Contains(lower, "kubernetes") || strings.Contains(lower, "kubectl"):
+		code = "KUBERNETES_FAILURE"
+	}
+	return &Failure{Code: code, Message: failureMessage(code)}
+}
+
+func failureMessage(code string) string {
+	messages := map[string]string{
+		"INPUT_NOT_FOUND":    "required deployment input was not found",
+		"REGISTRY_FAILURE":   "container registry operation failed",
+		"AUTH_FAILURE":       "authentication or authorization failed",
+		"RUN_INTERRUPTED":    "matrix entry was interrupted",
+		"HELM_FAILURE":       "Helm deployment failed",
+		"TEST_FAILURE":       "deployment test failed",
+		"INGRESS_FAILURE":    "ingress readiness failed",
+		"KUBERNETES_FAILURE": "Kubernetes operation failed",
+		"DEPLOY_UNKNOWN":     "deployment failed; inspect the diagnostics bundle",
+	}
+	return messages[code]
+}
+
+func redactStoredArgs(args []string) []string {
+	out := make([]string, len(args))
+	for i := range args {
+		out[i] = "<redacted>"
+	}
+	return out
+}
+
+func redactStoredSets(values []string) []string { return redactStoredArgs(values) }
+
+func removeRedactedArgs(values []string) []string {
+	var out []string
+	for _, value := range values {
+		if value != "<redacted>" {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func hasRedactedArgs(values []string) bool {
+	for _, value := range values {
+		if value == "<redacted>" {
+			return true
+		}
+	}
+	return false
+}
+
+func resumeCredentialPassword(storedUsername string, required bool, pairs [][2]string) (string, error) {
+	if !required {
+		return "", nil
+	}
+	for _, pair := range pairs {
+		username, password := os.Getenv(pair[0]), os.Getenv(pair[1])
+		if username == "" && password == "" {
+			continue
+		}
+		if username == "" || password == "" {
+			return "", fmt.Errorf("%s/%s must both be set", pair[0], pair[1])
+		}
+		if storedUsername != "" && username != storedUsername {
+			return "", fmt.Errorf("%s username %q does not match stored username %q", pair[0], username, storedUsername)
+		}
+		return password, nil
+	}
+	return "", errors.New("matching username/password environment pair is required")
+}
+
+func aggregateRunStatus(entries []*EntryRunState) RunStatus {
+	allTerminal, anyFailed, allCleaned := true, false, len(entries) > 0
+	for _, item := range entries {
+		switch item.Status {
+		case RunFailed, RunInterrupted:
+			anyFailed = true
+		case RunPending, RunRunning:
+			allTerminal = false
+		}
+		if !item.Cleaned && item.Status != RunCleaned {
+			allCleaned = false
+		}
+	}
+	if anyFailed {
+		return RunFailed
+	}
+	if allCleaned {
+		return RunCleaned
+	}
+	if allTerminal {
+		return RunPassed
+	}
+	return RunRunning
+}
+
+func ListRunIDs(root string) ([]string, error) {
+	items, err := os.ReadDir(root)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var ids []string
+	for _, item := range items {
+		if item.IsDir() {
+			ids = append(ids, item.Name())
+		}
+	}
+	sort.Sort(sort.Reverse(sort.StringSlice(ids)))
+	return ids, nil
+}

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -155,19 +155,33 @@ func (s StoredRunOptions) RunOptions() RunOptions {
 }
 
 type EntryRunState struct {
-	ID          string         `json:"id"`
-	Entry       Entry          `json:"entry"`
-	Status      RunStatus      `json:"status"`
-	Phase       string         `json:"phase,omitempty"`
-	Namespace   string         `json:"namespace"`
-	KubeContext string         `json:"kubeContext,omitempty"`
-	Attempts    int            `json:"attempts"`
-	StartedAt   *time.Time     `json:"startedAt,omitempty"`
-	FinishedAt  *time.Time     `json:"finishedAt,omitempty"`
-	Failure     *Failure       `json:"failure,omitempty"`
-	Diagnostics string         `json:"diagnostics,omitempty"`
-	Replay      ReplayManifest `json:"replay"`
-	Cleaned     bool           `json:"cleaned,omitempty"`
+	ID             string         `json:"id"`
+	Entry          Entry          `json:"entry"`
+	Status         RunStatus      `json:"status"`
+	Phase          string         `json:"phase,omitempty"`
+	Namespace      string         `json:"namespace"`
+	KubeContext    string         `json:"kubeContext,omitempty"`
+	Attempts       int            `json:"attempts"`
+	StartedAt      *time.Time     `json:"startedAt,omitempty"`
+	FinishedAt     *time.Time     `json:"finishedAt,omitempty"`
+	Failure        *Failure       `json:"failure,omitempty"`
+	Diagnostics    string         `json:"diagnostics,omitempty"`
+	Replay         ReplayManifest `json:"replay"`
+	Cleaned        bool           `json:"cleaned,omitempty"`
+	EntraObjectID  string         `json:"entraObjectId,omitempty"`
+	Auth0ClientIDs []string       `json:"auth0ClientIds,omitempty"`
+}
+
+func (s *RunStateStore) RecordExternalResources(entry Entry, entraObjectID string, auth0ClientIDs []string) error {
+	return s.update(entry, func(_ *MatrixRunState, item *EntryRunState) RunEvent {
+		if entraObjectID != "" {
+			item.EntraObjectID = entraObjectID
+		}
+		if len(auth0ClientIDs) > 0 {
+			item.Auth0ClientIDs = append([]string(nil), auth0ClientIDs...)
+		}
+		return RunEvent{Time: time.Now().UTC(), RunID: s.runID, EntryID: item.ID, Status: item.Status, Phase: "external-resources"}
+	})
 }
 
 type MatrixRunState struct {
@@ -266,9 +280,6 @@ func (s *RunStateStore) Create(entries []Entry, opts RunOptions) (*MatrixRunStat
 	if err := os.Chmod(s.RunDir(), 0o700); err != nil {
 		return nil, fmt.Errorf("secure matrix run directory: %w", err)
 	}
-	if err := s.write(state); err != nil {
-		return nil, err
-	}
 	if opts.GeneratedPostgresPassword != "" {
 		data, err := json.Marshal(runSecrets{PostgresUsername: opts.GeneratedPostgresUsername, PostgresPassword: opts.GeneratedPostgresPassword})
 		if err != nil {
@@ -277,6 +288,9 @@ func (s *RunStateStore) Create(entries []Entry, opts RunOptions) (*MatrixRunStat
 		if err := atomicWriteFile(filepath.Join(s.RunDir(), "run-secrets.json"), append(data, '\n'), 0o600); err != nil {
 			return nil, fmt.Errorf("write matrix run secrets: %w", err)
 		}
+	}
+	if err := s.write(state); err != nil {
+		return nil, err
 	}
 	return state, s.appendEvent(RunEvent{Time: now, RunID: s.runID, Status: RunPending})
 }

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -1,6 +1,7 @@
 package matrix
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -55,6 +56,7 @@ type StoredRunOptions struct {
 	RepoRoot                    string            `json:"repoRoot"`
 	EnvFiles                    map[string]string `json:"envFiles,omitempty"`
 	EnvFile                     string            `json:"envFile,omitempty"`
+	EnvFileDigests              map[string]string `json:"envFileDigests,omitempty"`
 	KeycloakHost                string            `json:"keycloakHost,omitempty"`
 	KeycloakProtocol            string            `json:"keycloakProtocol,omitempty"`
 	IngressBaseDomains          map[string]string `json:"ingressBaseDomains,omitempty"`
@@ -100,8 +102,16 @@ func StoreRunOptions(opts RunOptions) StoredRunOptions {
 		return path
 	}
 	envFiles := make(map[string]string, len(opts.EnvFiles))
+	envFileDigests := map[string]string{}
 	for version, path := range opts.EnvFiles {
 		envFiles[version] = abs(path)
+		if digest := fileDigest(envFiles[version]); digest != "" {
+			envFileDigests[envFiles[version]] = digest
+		}
+	}
+	absEnvFile := abs(opts.EnvFile)
+	if digest := fileDigest(absEnvFile); digest != "" {
+		envFileDigests[absEnvFile] = digest
 	}
 	extraValues := make([]string, len(opts.ExtraValues))
 	for i, path := range opts.ExtraValues {
@@ -116,7 +126,7 @@ func StoreRunOptions(opts RunOptions) StoredRunOptions {
 		StopOnFailure: opts.StopOnFailure, KubeContexts: opts.KubeContexts, KubeContext: opts.KubeContext,
 		NamespacePrefix: opts.NamespacePrefix, Platform: opts.Platform, MaxParallel: opts.MaxParallel,
 		TestE2E: opts.TestE2E, TestAll: opts.TestAll, RepoRoot: abs(opts.RepoRoot), EnvFiles: envFiles,
-		EnvFile: abs(opts.EnvFile), KeycloakHost: opts.KeycloakHost, KeycloakProtocol: opts.KeycloakProtocol,
+		EnvFile: absEnvFile, EnvFileDigests: envFileDigests, KeycloakHost: opts.KeycloakHost, KeycloakProtocol: opts.KeycloakProtocol,
 		IngressBaseDomains: opts.IngressBaseDomains, IngressBaseDomain: opts.IngressBaseDomain,
 		LogLevel: opts.LogLevel, SkipDependencyUpdate: opts.SkipDependencyUpdate,
 		VaultBackedSecrets: opts.VaultBackedSecrets, UseVaultBackedSecrets: opts.UseVaultBackedSecrets,
@@ -522,6 +532,11 @@ func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, erro
 	if err != nil {
 		return nil, RunOptions{}, err
 	}
+	for path, expected := range state.Options.EnvFileDigests {
+		if observed := fileDigest(path); observed != expected {
+			return nil, RunOptions{}, fmt.Errorf("env file %q changed since run creation; refusing resume", path)
+		}
+	}
 	var entries []Entry
 	for _, item := range state.Entries {
 		if entryID != "" && item.ID != entryID {
@@ -644,6 +659,18 @@ func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, erro
 		return nil, RunOptions{}, err
 	}
 	return entries, opts, nil
+}
+
+func fileDigest(path string) string {
+	if path == "" {
+		return ""
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(data)
+	return fmt.Sprintf("sha256:%x", sum[:])
 }
 
 func normalizeEntryPaths(entry Entry, repoRoot string) Entry {

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -188,7 +188,16 @@ func (s *RunStateStore) RecordExternalResources(entry Entry, entraObjectID, entr
 			item.Auth0Domain = auth0Domain
 		}
 		if len(auth0ClientIDs) > 0 {
-			item.Auth0ClientIDs = append([]string(nil), auth0ClientIDs...)
+			seen := make(map[string]bool, len(item.Auth0ClientIDs)+len(auth0ClientIDs))
+			for _, id := range item.Auth0ClientIDs {
+				seen[id] = true
+			}
+			for _, id := range auth0ClientIDs {
+				if !seen[id] {
+					item.Auth0ClientIDs = append(item.Auth0ClientIDs, id)
+					seen[id] = true
+				}
+			}
 		}
 		return RunEvent{Time: time.Now().UTC(), RunID: s.runID, EntryID: item.ID, Status: item.Status, Phase: "external-resources"}
 	})

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -287,11 +287,7 @@ func (s *RunStateStore) Create(entries []Entry, opts RunOptions) (*MatrixRunStat
 	state := &MatrixRunState{Schema: RunStateSchema, ID: s.runID, Status: RunPending, CreatedAt: now, UpdatedAt: now, Options: StoreRunOptions(opts)}
 	replayOpts := state.Options.RunOptions()
 	for _, entry := range entries {
-		if entry.ChartPath != "" && !filepath.IsAbs(entry.ChartPath) {
-			if absolute, err := filepath.Abs(entry.ChartPath); err == nil {
-				entry.ChartPath = absolute
-			}
-		}
+		entry = normalizeEntryPaths(entry, replayOpts.RepoRoot)
 		namespace := ResolveNamespace(opts, entry)
 		state.Entries = append(state.Entries, &EntryRunState{
 			ID: EntryID(entry), Entry: entry, Status: RunPending, Namespace: namespace,
@@ -357,7 +353,7 @@ func (s *RunStateStore) Complete(entry Entry, result RunResult) error {
 		now := time.Now().UTC()
 		item.FinishedAt, item.Diagnostics, item.KubeContext = &now, result.Diagnostics, result.KubeContext
 		if result.Error == nil {
-			item.Status, item.Failure = RunPassed, nil
+			item.Status, item.Phase, item.Failure = RunPassed, "complete", nil
 		} else {
 			item.Status = RunFailed
 			item.Failure = ClassifyFailure(result.Error)
@@ -415,7 +411,7 @@ func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, erro
 			return nil, RunOptions{}, fmt.Errorf("entry %q is a partially executed two-step upgrade and cannot be resumed safely; replay it in a clean namespace", item.ID)
 		}
 		item.Status, item.Phase, item.Failure, item.Cleaned = RunPending, "", nil, false
-		entries = append(entries, item.Entry)
+		entries = append(entries, normalizeEntryPaths(item.Entry, state.Options.RepoRoot))
 	}
 	if entryID != "" && len(entries) == 0 {
 		return nil, RunOptions{}, fmt.Errorf("entry %q is not resumable or does not exist", entryID)
@@ -521,9 +517,36 @@ func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, erro
 	return entries, opts, nil
 }
 
+func normalizeEntryPaths(entry Entry, repoRoot string) Entry {
+	if entry.ChartPath != "" && !filepath.IsAbs(entry.ChartPath) {
+		candidate := entry.ChartPath
+		if repoRoot != "" && !strings.HasPrefix(filepath.Clean(candidate), filepath.Clean(repoRoot)+string(filepath.Separator)) {
+			if relative, err := filepath.Rel(filepath.Dir(filepath.Join(repoRoot, "scripts", "deploy-camunda")), candidate); err == nil && !strings.HasPrefix(relative, "..") {
+				candidate = filepath.Join(repoRoot, relative)
+			}
+		}
+		if absolute, err := filepath.Abs(candidate); err == nil {
+			entry.ChartPath = absolute
+		}
+	}
+	for i := range entry.Dependencies {
+		if entry.Dependencies[i].ValuesFile != "" && !filepath.IsAbs(entry.Dependencies[i].ValuesFile) {
+			entry.Dependencies[i].ValuesFile = filepath.Join(repoRoot, entry.Dependencies[i].ValuesFile)
+		}
+		if entry.Dependencies[i].Chart != "" && !filepath.IsAbs(entry.Dependencies[i].Chart) {
+			candidate := filepath.Join(repoRoot, entry.Dependencies[i].Chart)
+			if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+				entry.Dependencies[i].Chart = candidate
+			}
+		}
+	}
+	return entry
+}
+
 func (s *RunStateStore) MarkCleaned(entryID string) error {
 	return s.updateID(entryID, func(state *MatrixRunState, item *EntryRunState) RunEvent {
 		item.Cleaned = true
+		item.Phase = "cleaned"
 		if item.Status != RunFailed && item.Status != RunInterrupted {
 			item.Status = RunCleaned
 		}

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -86,6 +86,7 @@ type StoredRunOptions struct {
 	GeneratePostgresCredentials bool              `json:"generatePostgresCredentials,omitempty"`
 	ImportDockerAuth            bool              `json:"importDockerAuth,omitempty"`
 	DockerConfigPath            string            `json:"dockerConfigPath,omitempty"`
+	RequiresRunSecrets          bool              `json:"requiresRunSecrets,omitempty"`
 }
 
 func StoreRunOptions(opts RunOptions) StoredRunOptions {
@@ -129,7 +130,7 @@ func StoreRunOptions(opts RunOptions) StoredRunOptions {
 		ChartRefVersion: opts.ChartRefVersion, ForceImageOverrides: opts.ForceImageOverrides,
 		WaitIngressReady: opts.WaitIngressReady, IngressReadyTimeoutMinutes: opts.IngressReadyTimeoutMinutes,
 		GeneratePostgresCredentials: opts.GeneratePostgresCredentials,
-		ImportDockerAuth:            opts.ImportDockerAuth, DockerConfigPath: abs(opts.DockerConfigPath),
+		ImportDockerAuth:            opts.ImportDockerAuth, DockerConfigPath: abs(opts.DockerConfigPath), RequiresRunSecrets: opts.GeneratedPostgresPassword != "" || len(opts.ExtraHelmArgs) > 0 || len(opts.ExtraHelmSets) > 0,
 	}
 }
 
@@ -619,6 +620,8 @@ func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, erro
 		opts.GeneratedPostgresPassword = secrets.PostgresPassword
 		opts.ExtraHelmArgs = secrets.ExtraHelmArgs
 		opts.ExtraHelmSets = secrets.ExtraHelmSets
+	} else if errors.Is(err, os.ErrNotExist) && state.Options.RequiresRunSecrets {
+		return nil, RunOptions{}, errors.New("required run-secrets.json is missing; refusing resume")
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return nil, RunOptions{}, fmt.Errorf("read matrix run secrets: %w", err)
 	}

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -157,23 +157,38 @@ func (s StoredRunOptions) RunOptions() RunOptions {
 }
 
 type EntryRunState struct {
-	ID               string         `json:"id"`
-	Entry            Entry          `json:"entry"`
-	Status           RunStatus      `json:"status"`
-	Phase            string         `json:"phase,omitempty"`
-	Namespace        string         `json:"namespace"`
-	KubeContext      string         `json:"kubeContext,omitempty"`
-	Attempts         int            `json:"attempts"`
-	StartedAt        *time.Time     `json:"startedAt,omitempty"`
-	FinishedAt       *time.Time     `json:"finishedAt,omitempty"`
-	Failure          *Failure       `json:"failure,omitempty"`
-	Diagnostics      string         `json:"diagnostics,omitempty"`
-	Replay           ReplayManifest `json:"replay"`
-	Cleaned          bool           `json:"cleaned,omitempty"`
-	EntraObjectID    string         `json:"entraObjectId,omitempty"`
-	Auth0ClientIDs   []string       `json:"auth0ClientIds,omitempty"`
-	EntraDirectoryID string         `json:"entraDirectoryId,omitempty"`
-	Auth0Domain      string         `json:"auth0Domain,omitempty"`
+	ID                          string         `json:"id"`
+	Entry                       Entry          `json:"entry"`
+	Status                      RunStatus      `json:"status"`
+	Phase                       string         `json:"phase,omitempty"`
+	Namespace                   string         `json:"namespace"`
+	KubeContext                 string         `json:"kubeContext,omitempty"`
+	Attempts                    int            `json:"attempts"`
+	StartedAt                   *time.Time     `json:"startedAt,omitempty"`
+	FinishedAt                  *time.Time     `json:"finishedAt,omitempty"`
+	Failure                     *Failure       `json:"failure,omitempty"`
+	Diagnostics                 string         `json:"diagnostics,omitempty"`
+	Replay                      ReplayManifest `json:"replay"`
+	Cleaned                     bool           `json:"cleaned,omitempty"`
+	EntraObjectID               string         `json:"entraObjectId,omitempty"`
+	Auth0ClientIDs              []string       `json:"auth0ClientIds,omitempty"`
+	EntraDirectoryID            string         `json:"entraDirectoryId,omitempty"`
+	Auth0Domain                 string         `json:"auth0Domain,omitempty"`
+	ExternalProvisioningStarted bool           `json:"externalProvisioningStarted,omitempty"`
+}
+
+func (s *RunStateStore) MarkExternalProvisioningStarted(entry Entry) error {
+	return s.update(entry, func(_ *MatrixRunState, item *EntryRunState) RunEvent {
+		item.ExternalProvisioningStarted = true
+		return RunEvent{Time: time.Now().UTC(), RunID: s.runID, EntryID: item.ID, Status: item.Status, Phase: "external-provisioning"}
+	})
+}
+
+func (s *RunStateStore) MarkExternalProvisioningComplete(entry Entry) error {
+	return s.update(entry, func(_ *MatrixRunState, item *EntryRunState) RunEvent {
+		item.ExternalProvisioningStarted = false
+		return RunEvent{Time: time.Now().UTC(), RunID: s.runID, EntryID: item.ID, Status: item.Status, Phase: "external-provisioned"}
+	})
 }
 
 func (s *RunStateStore) RecordExternalResources(entry Entry, entraObjectID, entraDirectoryID, auth0Domain string, auth0ClientIDs []string) error {
@@ -279,6 +294,9 @@ func (s *RunStateStore) RecoverStaleLock() error {
 	hostname, _ := os.Hostname()
 	if owner.Hostname != hostname {
 		return fmt.Errorf("refusing to remove lock created on host %q", owner.Hostname)
+	}
+	if processAlive(owner.PID) {
+		return fmt.Errorf("refusing to remove lock held by live process %d", owner.PID)
 	}
 	return os.Remove(path)
 }

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -701,15 +701,7 @@ func atomicWriteFile(path string, data []byte, mode os.FileMode) error {
 	if err := os.Rename(tmpPath, path); err != nil {
 		return fmt.Errorf("replace state file: %w", err)
 	}
-	d, err := os.Open(dir)
-	if err != nil {
-		return fmt.Errorf("open state directory: %w", err)
-	}
-	defer d.Close()
-	if err := d.Sync(); err != nil {
-		return fmt.Errorf("sync state directory: %w", err)
-	}
-	return nil
+	return syncDirectory(dir)
 }
 
 func EntryID(entry Entry) string { return entryID(entry) }
@@ -863,9 +855,10 @@ func failureMessage(code string) string {
 func redactStoredArgs(args []string) []string {
 	out := make([]string, len(args))
 	for i, arg := range args {
-		if arg == "--atomic" {
+		switch arg {
+		case "--atomic", "--wait", "--create-namespace", "--cleanup-on-fail", "--disable-openapi-validation", "--skip-crds", "--take-ownership":
 			out[i] = arg
-		} else {
+		default:
 			out[i] = "<redacted>"
 		}
 	}

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -355,7 +355,26 @@ func (s *RunStateStore) acquireLockGuard() (func(), error) {
 	path := filepath.Join(s.RunDir(), "run.lock.guard")
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 	if err != nil {
-		return nil, fmt.Errorf("matrix run %q lock operation is active", s.runID)
+		data, readErr := os.ReadFile(path)
+		var owner lockOwner
+		parseErr := json.Unmarshal(data, &owner)
+		hostname, _ := os.Hostname()
+		alive, known := processState(owner.PID, owner.ProcessIdentity)
+		if readErr == nil && parseErr == nil && owner.Hostname == hostname && known && !alive {
+			if removeErr := os.Remove(path); removeErr == nil {
+				file, err = os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+			}
+		}
+		if err != nil {
+			return nil, fmt.Errorf("matrix run %q lock operation is active", s.runID)
+		}
+	}
+	hostname, _ := os.Hostname()
+	data, _ := json.Marshal(lockOwner{Hostname: hostname, PID: os.Getpid(), ProcessIdentity: processIdentity(os.Getpid())})
+	if _, err := file.Write(append(data, '\n')); err != nil {
+		file.Close()
+		_ = os.Remove(path)
+		return nil, err
 	}
 	if err := file.Close(); err != nil {
 		_ = os.Remove(path)
@@ -566,7 +585,7 @@ func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, erro
 			hubPassword = credential.Password
 		}
 	}
-	if state.Options.ImportDockerAuth && (harborPassword == "" || hubPassword == "") {
+	if state.Options.ImportDockerAuth && ((state.Options.RequiresDockerPassword && harborPassword == "") || (state.Options.RequiresDockerHubPassword && hubPassword == "")) {
 		auths, importErr := ImportPlaintextDockerAuth(state.Options.DockerConfigPath, "registry.camunda.cloud", "docker.io")
 		if importErr != nil {
 			return nil, RunOptions{}, fmt.Errorf("restore Docker config credentials: %w", importErr)

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -572,6 +572,11 @@ func ReplayCommand(entry Entry, opts RunOptions) []string {
 	if opts.RepoRoot != "" {
 		args = append(args, "--repo-root", opts.RepoRoot)
 	}
+	if path := opts.EnvFiles[entry.Version]; path != "" {
+		args = append(args, "--env-file-"+entry.Version, path)
+	} else if opts.EnvFile != "" {
+		args = append(args, "--env-file", opts.EnvFile)
+	}
 	if opts.NamespacePrefix != "" {
 		args = append(args, "--namespace-prefix", opts.NamespacePrefix)
 	}

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -20,6 +20,8 @@ import (
 
 const RunStateSchema = "camunda.matrix-run/v1"
 
+var resumeCredentialStore credentials.Store = credentials.KeyringStore{}
+
 type RunStatus string
 
 const (
@@ -212,8 +214,10 @@ type RunEvent struct {
 }
 
 type runSecrets struct {
-	PostgresUsername string `json:"postgresUsername,omitempty"`
-	PostgresPassword string `json:"postgresPassword,omitempty"`
+	PostgresUsername string   `json:"postgresUsername,omitempty"`
+	PostgresPassword string   `json:"postgresPassword,omitempty"`
+	ExtraHelmArgs    []string `json:"extraHelmArgs,omitempty"`
+	ExtraHelmSets    []string `json:"extraHelmSets,omitempty"`
 }
 
 type RunStateStore struct {
@@ -224,6 +228,11 @@ type RunStateStore struct {
 
 type RunLock struct {
 	path string
+}
+
+type lockOwner struct {
+	Hostname string `json:"hostname"`
+	PID      int    `json:"pid"`
 }
 
 func NewRunStateStore(root, runID string) *RunStateStore {
@@ -252,9 +261,11 @@ func (s *RunStateStore) Acquire() (*RunLock, error) {
 	path := filepath.Join(s.RunDir(), "run.lock")
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 	if err != nil {
-		pidData, readErr := os.ReadFile(path)
-		pid, parseErr := strconv.Atoi(strings.TrimSpace(string(pidData)))
-		if readErr == nil && parseErr == nil && !processAlive(pid) {
+		ownerData, readErr := os.ReadFile(path)
+		var owner lockOwner
+		parseErr := json.Unmarshal(ownerData, &owner)
+		hostname, _ := os.Hostname()
+		if readErr == nil && parseErr == nil && owner.Hostname == hostname && !processAlive(owner.PID) {
 			if removeErr := os.Remove(path); removeErr == nil {
 				file, err = os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 			}
@@ -263,7 +274,9 @@ func (s *RunStateStore) Acquire() (*RunLock, error) {
 			return nil, fmt.Errorf("matrix run %q is active in another process", s.runID)
 		}
 	}
-	if _, err := fmt.Fprintf(file, "%d\n", os.Getpid()); err != nil {
+	hostname, _ := os.Hostname()
+	ownerData, _ := json.Marshal(lockOwner{Hostname: hostname, PID: os.Getpid()})
+	if _, err := file.Write(append(ownerData, '\n')); err != nil {
 		file.Close()
 		_ = os.Remove(path)
 		return nil, err
@@ -300,8 +313,8 @@ func (s *RunStateStore) Create(entries []Entry, opts RunOptions) (*MatrixRunStat
 	if err := os.Chmod(s.RunDir(), 0o700); err != nil {
 		return nil, fmt.Errorf("secure matrix run directory: %w", err)
 	}
-	if opts.GeneratedPostgresPassword != "" {
-		data, err := json.Marshal(runSecrets{PostgresUsername: opts.GeneratedPostgresUsername, PostgresPassword: opts.GeneratedPostgresPassword})
+	if opts.GeneratedPostgresPassword != "" || len(opts.ExtraHelmArgs) > 0 || len(opts.ExtraHelmSets) > 0 {
+		data, err := json.Marshal(runSecrets{PostgresUsername: opts.GeneratedPostgresUsername, PostgresPassword: opts.GeneratedPostgresPassword, ExtraHelmArgs: opts.ExtraHelmArgs, ExtraHelmSets: opts.ExtraHelmSets})
 		if err != nil {
 			return nil, err
 		}
@@ -419,9 +432,6 @@ func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, erro
 	if len(entries) == 0 {
 		return nil, RunOptions{}, errors.New("matrix run has no incomplete entries")
 	}
-	if hasRedactedArgs(state.Options.ExtraHelmArgs) || hasRedactedArgs(state.Options.ExtraHelmSets) {
-		return nil, RunOptions{}, errors.New("matrix run used secret-bearing Helm arguments; resume cannot reconstruct them safely; replay the recorded command with the required secret inputs")
-	}
 	harborPassword, hubPassword := "", ""
 	var credentialErr error
 	if harborPassword == "" {
@@ -459,9 +469,8 @@ func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, erro
 	if credentialErr != nil {
 		return nil, RunOptions{}, fmt.Errorf("restore Docker Hub credentials: %w", credentialErr)
 	}
-	keyringStore := credentials.KeyringStore{}
 	if harborPassword == "" && state.Options.RequiresDockerPassword {
-		credential, found, keyringErr := credentials.GetOptional(keyringStore, credentials.HarborRegistry)
+		credential, found, keyringErr := credentials.GetOptional(resumeCredentialStore, credentials.HarborRegistry)
 		if keyringErr != nil {
 			return nil, RunOptions{}, keyringErr
 		}
@@ -470,7 +479,7 @@ func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, erro
 		}
 	}
 	if hubPassword == "" && state.Options.RequiresDockerHubPassword {
-		credential, found, keyringErr := credentials.GetOptional(keyringStore, credentials.DockerHubRegistry)
+		credential, found, keyringErr := credentials.GetOptional(resumeCredentialStore, credentials.DockerHubRegistry)
 		if keyringErr != nil {
 			return nil, RunOptions{}, keyringErr
 		}
@@ -507,6 +516,8 @@ func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, erro
 		}
 		opts.GeneratedPostgresUsername = secrets.PostgresUsername
 		opts.GeneratedPostgresPassword = secrets.PostgresPassword
+		opts.ExtraHelmArgs = secrets.ExtraHelmArgs
+		opts.ExtraHelmSets = secrets.ExtraHelmSets
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return nil, RunOptions{}, fmt.Errorf("read matrix run secrets: %w", err)
 	}

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -281,11 +281,20 @@ func (s *RunStateStore) RunDir() string { return filepath.Join(s.root, s.runID) 
 func (s *RunStateStore) RunID() string { return s.runID }
 
 func (s *RunStateStore) RecoverStaleLock() error {
-	releaseGuard, err := s.acquireLockGuard()
+	guardPath := filepath.Join(s.RunDir(), "run.lock.recover")
+	guard, err := os.OpenFile(guardPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 	if err != nil {
-		return err
+		return errors.New("another stale-lock recovery is active")
 	}
-	defer releaseGuard()
+	_ = guard.Close()
+	defer os.Remove(guardPath)
+	// Explicit recovery may remove malformed operation guards left by a crash.
+	if data, readErr := os.ReadFile(filepath.Join(s.RunDir(), "run.lock.guard")); readErr == nil {
+		var owner lockOwner
+		if json.Unmarshal(data, &owner) != nil {
+			_ = os.Remove(filepath.Join(s.RunDir(), "run.lock.guard"))
+		}
+	}
 	path := filepath.Join(s.RunDir(), "run.lock")
 	data, err := os.ReadFile(path)
 	if errors.Is(err, os.ErrNotExist) {
@@ -296,7 +305,7 @@ func (s *RunStateStore) RecoverStaleLock() error {
 	}
 	var owner lockOwner
 	if err := json.Unmarshal(data, &owner); err != nil {
-		return fmt.Errorf("decode matrix run lock: %w", err)
+		return os.Remove(path)
 	}
 	hostname, _ := os.Hostname()
 	if owner.Hostname != hostname {

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -1,7 +1,6 @@
 package matrix
 
 import (
-	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,6 +13,7 @@ import (
 
 	"golang.org/x/sys/unix"
 	"scripts/camunda-core/pkg/versionmatrix"
+	"scripts/prepare-helm-values/pkg/env"
 )
 
 const RunStateSchema = "camunda.matrix-run/v1"
@@ -187,11 +187,6 @@ func NewRunStateStore(root, runID string) *RunStateStore {
 
 func NewRunID(now time.Time) string {
 	return now.UTC().Format("20060102T150405.000000000Z")
-}
-
-func DurableNamespacePrefix(prefix, runID string) string {
-	digest := sha256.Sum256([]byte(runID))
-	return fmt.Sprintf("%s-%x", strings.TrimSuffix(prefix, "-"), digest[:8])
 }
 
 func (s *RunStateStore) RunDir() string { return filepath.Join(s.root, s.runID) }
@@ -381,6 +376,13 @@ func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, erro
 	}
 	var credentialErr error
 	if harborPassword == "" {
+		harborPassword = resumeCredentialPasswordFromFile(state.Options.EnvFile, state.Options.DockerUsername, [][2]string{
+			{"HARBOR_USERNAME", "HARBOR_PASSWORD"},
+			{"TEST_DOCKER_USERNAME_CAMUNDA_CLOUD", "TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD"},
+			{"NEXUS_USERNAME", "NEXUS_PASSWORD"},
+		})
+	}
+	if harborPassword == "" {
 		harborPassword, credentialErr = resumeCredentialPassword(state.Options.DockerUsername, state.Options.RequiresDockerPassword, [][2]string{
 			{"HARBOR_USERNAME", "HARBOR_PASSWORD"},
 			{"TEST_DOCKER_USERNAME_CAMUNDA_CLOUD", "TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD"},
@@ -389,6 +391,12 @@ func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, erro
 	}
 	if credentialErr != nil {
 		return nil, RunOptions{}, fmt.Errorf("restore Harbor credentials: %w", credentialErr)
+	}
+	if hubPassword == "" {
+		hubPassword = resumeCredentialPasswordFromFile(state.Options.EnvFile, state.Options.DockerHubUsername, [][2]string{
+			{"DOCKERHUB_USERNAME", "DOCKERHUB_PASSWORD"},
+			{"TEST_DOCKER_USERNAME", "TEST_DOCKER_PASSWORD"},
+		})
 	}
 	if hubPassword == "" {
 		hubPassword, credentialErr = resumeCredentialPassword(state.Options.DockerHubUsername, state.Options.RequiresDockerHubPassword, [][2]string{
@@ -404,6 +412,7 @@ func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, erro
 		return nil, RunOptions{}, err
 	}
 	opts := state.Options.RunOptions()
+	opts.DeleteNamespaceFirst = false
 	opts.DockerPassword, opts.DockerHubPassword = harborPassword, hubPassword
 	secretData, err := os.ReadFile(filepath.Join(s.RunDir(), "run-secrets.json"))
 	if err == nil {
@@ -668,6 +677,22 @@ func resumeCredentialPassword(storedUsername string, required bool, pairs [][2]s
 		return password, nil
 	}
 	return "", errors.New("matching username/password environment pair is required")
+}
+
+func resumeCredentialPasswordFromFile(path, storedUsername string, pairs [][2]string) string {
+	if path == "" {
+		path = ".env"
+	}
+	values, err := env.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	for _, pair := range pairs {
+		if values[pair[0]] == storedUsername && values[pair[1]] != "" {
+			return values[pair[1]]
+		}
+	}
+	return ""
 }
 
 func aggregateRunStatus(entries []*EntryRunState) RunStatus {

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -254,6 +254,26 @@ func (s *RunStateStore) RunDir() string { return filepath.Join(s.root, s.runID) 
 
 func (s *RunStateStore) RunID() string { return s.runID }
 
+func (s *RunStateStore) RecoverStaleLock() error {
+	path := filepath.Join(s.RunDir(), "run.lock")
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read matrix run lock: %w", err)
+	}
+	var owner lockOwner
+	if err := json.Unmarshal(data, &owner); err != nil {
+		return fmt.Errorf("decode matrix run lock: %w", err)
+	}
+	hostname, _ := os.Hostname()
+	if owner.Hostname != hostname {
+		return fmt.Errorf("refusing to remove lock created on host %q", owner.Hostname)
+	}
+	return os.Remove(path)
+}
+
 func (s *RunStateStore) Acquire() (*RunLock, error) {
 	if err := os.MkdirAll(s.RunDir(), 0o700); err != nil {
 		return nil, fmt.Errorf("create matrix run directory: %w", err)

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -280,6 +280,11 @@ func (s *RunStateStore) RunDir() string { return filepath.Join(s.root, s.runID) 
 func (s *RunStateStore) RunID() string { return s.runID }
 
 func (s *RunStateStore) RecoverStaleLock() error {
+	releaseGuard, err := s.acquireLockGuard()
+	if err != nil {
+		return err
+	}
+	defer releaseGuard()
 	path := filepath.Join(s.RunDir(), "run.lock")
 	data, err := os.ReadFile(path)
 	if errors.Is(err, os.ErrNotExist) {
@@ -310,6 +315,11 @@ func (s *RunStateStore) Acquire() (*RunLock, error) {
 	if err := os.MkdirAll(s.RunDir(), 0o700); err != nil {
 		return nil, fmt.Errorf("create matrix run directory: %w", err)
 	}
+	releaseGuard, err := s.acquireLockGuard()
+	if err != nil {
+		return nil, err
+	}
+	defer releaseGuard()
 	path := filepath.Join(s.RunDir(), "run.lock")
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 	if err != nil {
@@ -339,6 +349,19 @@ func (s *RunStateStore) Acquire() (*RunLock, error) {
 		return nil, err
 	}
 	return &RunLock{path: path}, nil
+}
+
+func (s *RunStateStore) acquireLockGuard() (func(), error) {
+	path := filepath.Join(s.RunDir(), "run.lock.guard")
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("matrix run %q lock operation is active", s.runID)
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return nil, err
+	}
+	return func() { _ = os.Remove(path) }, nil
 }
 
 func (l *RunLock) Close() error {
@@ -791,6 +814,21 @@ func ReplayCommand(entry Entry, opts RunOptions) []string {
 	}
 	if opts.Cleanup {
 		args = append(args, "--cleanup")
+	}
+	if opts.DeleteNamespaceFirst {
+		args = append(args, "--delete-namespace")
+	}
+	if opts.UseVaultBackedSecrets {
+		args = append(args, "--use-vault-backed-secrets")
+	}
+	if value, ok := opts.VaultBackedSecrets[entry.Platform]; ok {
+		args = append(args, "--use-vault-backed-secrets-"+entry.Platform+"="+strconv.FormatBool(value))
+	}
+	if opts.KeycloakHost != "" {
+		args = append(args, "--keycloak-host", opts.KeycloakHost)
+	}
+	if opts.KeycloakProtocol != "" {
+		args = append(args, "--keycloak-protocol", opts.KeycloakProtocol)
 	}
 	if !opts.GeneratePostgresCredentials {
 		args = append(args, "--generate-postgres-credentials=false")

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"golang.org/x/sys/unix"
+	"scripts/camunda-core/pkg/versionmatrix"
 )
 
 const RunStateSchema = "camunda.matrix-run/v1"
@@ -190,7 +191,7 @@ func NewRunID(now time.Time) string {
 
 func DurableNamespacePrefix(prefix, runID string) string {
 	digest := sha256.Sum256([]byte(runID))
-	return fmt.Sprintf("%s-%x", strings.TrimSuffix(prefix, "-"), digest[:3])
+	return fmt.Sprintf("%s-%x", strings.TrimSuffix(prefix, "-"), digest[:8])
 }
 
 func (s *RunStateStore) RunDir() string { return filepath.Join(s.root, s.runID) }
@@ -329,7 +330,10 @@ func (s *RunStateStore) MarkInterrupted() error {
 		return nil
 	}
 	state.Status, state.UpdatedAt = RunInterrupted, time.Now().UTC()
-	return s.write(state)
+	if err := s.write(state); err != nil {
+		return err
+	}
+	return s.appendEvent(RunEvent{Time: state.UpdatedAt, RunID: s.runID, Status: RunInterrupted, Code: "RUN_INTERRUPTED"})
 }
 
 func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, error) {
@@ -346,6 +350,9 @@ func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, erro
 		}
 		if item.Status == RunPassed || item.Status == RunCleaned {
 			continue
+		}
+		if item.Attempts > 0 && versionmatrix.IsTwoStepUpgradeFlow(item.Entry.Flow) {
+			return nil, RunOptions{}, fmt.Errorf("entry %q is a partially executed two-step upgrade and cannot be resumed safely; replay it in a clean namespace", item.ID)
 		}
 		item.Status, item.Phase, item.Failure, item.Cleaned = RunPending, "", nil, false
 		entries = append(entries, item.Entry)
@@ -443,8 +450,7 @@ func (s *RunStateStore) updateID(id string, fn func(*MatrixRunState, *EntryRunSt
 		if err := s.write(state); err != nil {
 			return err
 		}
-		_ = s.appendEvent(event)
-		return nil
+		return s.appendEvent(event)
 	}
 	return fmt.Errorf("matrix entry %q not found in run %q", id, s.runID)
 }

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -67,6 +67,7 @@ type StoredRunOptions struct {
 	VaultBackedSecrets          map[string]bool   `json:"vaultBackedSecrets,omitempty"`
 	UseVaultBackedSecrets       bool              `json:"useVaultBackedSecrets,omitempty"`
 	DeleteNamespaceFirst        bool              `json:"deleteNamespaceFirst,omitempty"`
+	AdoptMatrixNamespace        bool              `json:"adoptMatrixNamespace,omitempty"`
 	UpgradeFromVersion          string            `json:"upgradeFromVersion,omitempty"`
 	HelmTimeout                 int               `json:"helmTimeout,omitempty"`
 	EnsureDockerRegistry        bool              `json:"ensureDockerRegistry,omitempty"`
@@ -135,7 +136,7 @@ func StoreRunOptions(opts RunOptions) StoredRunOptions {
 		IngressBaseDomains: opts.IngressBaseDomains, IngressBaseDomain: opts.IngressBaseDomain,
 		LogLevel: opts.LogLevel, SkipDependencyUpdate: opts.SkipDependencyUpdate,
 		VaultBackedSecrets: opts.VaultBackedSecrets, UseVaultBackedSecrets: opts.UseVaultBackedSecrets,
-		DeleteNamespaceFirst: opts.DeleteNamespaceFirst, UpgradeFromVersion: opts.UpgradeFromVersion,
+		DeleteNamespaceFirst: opts.DeleteNamespaceFirst, AdoptMatrixNamespace: opts.AdoptMatrixNamespace, UpgradeFromVersion: opts.UpgradeFromVersion,
 		HelmTimeout: opts.HelmTimeout, EnsureDockerRegistry: opts.EnsureDockerRegistry,
 		DockerUsername: opts.DockerUsername, RequiresDockerPassword: opts.EnsureDockerRegistry,
 		EnsureDockerHub: opts.EnsureDockerHub, DockerHubUsername: opts.DockerHubUsername,
@@ -161,7 +162,7 @@ func (s StoredRunOptions) RunOptions() RunOptions {
 		IngressBaseDomains: s.IngressBaseDomains, IngressBaseDomain: s.IngressBaseDomain,
 		LogLevel: s.LogLevel, SkipDependencyUpdate: s.SkipDependencyUpdate,
 		VaultBackedSecrets: s.VaultBackedSecrets, UseVaultBackedSecrets: s.UseVaultBackedSecrets,
-		DeleteNamespaceFirst: s.DeleteNamespaceFirst, UpgradeFromVersion: s.UpgradeFromVersion,
+		DeleteNamespaceFirst: s.DeleteNamespaceFirst, AdoptMatrixNamespace: s.AdoptMatrixNamespace, UpgradeFromVersion: s.UpgradeFromVersion,
 		HelmTimeout: s.HelmTimeout, EnsureDockerRegistry: s.EnsureDockerRegistry,
 		DockerUsername: s.DockerUsername, EnsureDockerHub: s.EnsureDockerHub,
 		DockerHubUsername: s.DockerHubUsername, UseLatest: s.UseLatest, UseQA: s.UseQA,
@@ -970,6 +971,9 @@ func ReplayCommand(entry Entry, opts RunOptions) []string {
 	}
 	if opts.DeleteNamespaceFirst {
 		args = append(args, "--delete-namespace")
+	}
+	if opts.AdoptMatrixNamespace {
+		args = append(args, "--adopt-matrix-namespace")
 	}
 	if opts.UseVaultBackedSecrets {
 		args = append(args, "--use-vault-backed-secrets")

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -90,6 +90,8 @@ type StoredRunOptions struct {
 	ImportDockerAuth            bool              `json:"importDockerAuth,omitempty"`
 	DockerConfigPath            string            `json:"dockerConfigPath,omitempty"`
 	RequiresRunSecrets          bool              `json:"requiresRunSecrets,omitempty"`
+	Auth0IngressHost            string            `json:"auth0IngressHost,omitempty"`
+	Auth0InitialAdminEmail      string            `json:"auth0InitialAdminEmail,omitempty"`
 }
 
 func StoreRunOptions(opts RunOptions) StoredRunOptions {
@@ -142,6 +144,7 @@ func StoreRunOptions(opts RunOptions) StoredRunOptions {
 		WaitIngressReady: opts.WaitIngressReady, IngressReadyTimeoutMinutes: opts.IngressReadyTimeoutMinutes,
 		GeneratePostgresCredentials: opts.GeneratePostgresCredentials,
 		ImportDockerAuth:            opts.ImportDockerAuth, DockerConfigPath: abs(opts.DockerConfigPath), RequiresRunSecrets: opts.GeneratedPostgresPassword != "" || len(opts.ExtraHelmArgs) > 0 || len(opts.ExtraHelmSets) > 0,
+		Auth0IngressHost: opts.Auth0IngressHost, Auth0InitialAdminEmail: opts.Auth0InitialAdminEmail,
 	}
 }
 
@@ -165,6 +168,7 @@ func (s StoredRunOptions) RunOptions() RunOptions {
 		WaitIngressReady: s.WaitIngressReady, IngressReadyTimeoutMinutes: s.IngressReadyTimeoutMinutes,
 		GeneratePostgresCredentials: s.GeneratePostgresCredentials,
 		ImportDockerAuth:            s.ImportDockerAuth, DockerConfigPath: s.DockerConfigPath,
+		Auth0IngressHost: s.Auth0IngressHost, Auth0InitialAdminEmail: s.Auth0InitialAdminEmail,
 	}
 }
 
@@ -543,6 +547,9 @@ func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, erro
 	if err != nil {
 		return nil, RunOptions{}, err
 	}
+	if strings.HasPrefix(state.Options.ChartRef, "oci://") && !strings.Contains(state.Options.ChartRef, "@sha256:") {
+		return nil, RunOptions{}, errors.New("mutable OCI chart references cannot be resumed safely; use a digest-pinned reference")
+	}
 	for path, expected := range state.Options.EnvFileDigests {
 		if observed := fileDigest(path); observed != expected {
 			return nil, RunOptions{}, fmt.Errorf("env file %q changed since run creation; refusing resume", path)
@@ -691,6 +698,9 @@ func fileDigest(path string) string {
 
 func entryInputPaths(entry Entry, opts RunOptions) []string {
 	paths := []string{entry.ChartPath}
+	if strings.HasSuffix(opts.ChartRef, ".tgz") {
+		paths = append(paths, opts.ChartRef)
+	}
 	paths = append(paths, opts.ExtraValues...)
 	paths = append(paths, entry.ExtraValues...)
 	for _, dep := range entry.Dependencies {

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -87,12 +87,33 @@ type StoredRunOptions struct {
 }
 
 func StoreRunOptions(opts RunOptions) StoredRunOptions {
+	abs := func(path string) string {
+		if path == "" {
+			return ""
+		}
+		if value, err := filepath.Abs(path); err == nil {
+			return value
+		}
+		return path
+	}
+	envFiles := make(map[string]string, len(opts.EnvFiles))
+	for version, path := range opts.EnvFiles {
+		envFiles[version] = abs(path)
+	}
+	extraValues := make([]string, len(opts.ExtraValues))
+	for i, path := range opts.ExtraValues {
+		extraValues[i] = abs(path)
+	}
+	chartRef := opts.ChartRef
+	if strings.HasSuffix(chartRef, ".tgz") {
+		chartRef = abs(chartRef)
+	}
 	return StoredRunOptions{
 		Cleanup:       opts.Cleanup,
 		StopOnFailure: opts.StopOnFailure, KubeContexts: opts.KubeContexts, KubeContext: opts.KubeContext,
 		NamespacePrefix: opts.NamespacePrefix, Platform: opts.Platform, MaxParallel: opts.MaxParallel,
-		TestE2E: opts.TestE2E, TestAll: opts.TestAll, RepoRoot: opts.RepoRoot, EnvFiles: opts.EnvFiles,
-		EnvFile: opts.EnvFile, KeycloakHost: opts.KeycloakHost, KeycloakProtocol: opts.KeycloakProtocol,
+		TestE2E: opts.TestE2E, TestAll: opts.TestAll, RepoRoot: abs(opts.RepoRoot), EnvFiles: envFiles,
+		EnvFile: abs(opts.EnvFile), KeycloakHost: opts.KeycloakHost, KeycloakProtocol: opts.KeycloakProtocol,
 		IngressBaseDomains: opts.IngressBaseDomains, IngressBaseDomain: opts.IngressBaseDomain,
 		LogLevel: opts.LogLevel, SkipDependencyUpdate: opts.SkipDependencyUpdate,
 		VaultBackedSecrets: opts.VaultBackedSecrets, UseVaultBackedSecrets: opts.UseVaultBackedSecrets,
@@ -102,11 +123,11 @@ func StoreRunOptions(opts RunOptions) StoredRunOptions {
 		EnsureDockerHub: opts.EnsureDockerHub, DockerHubUsername: opts.DockerHubUsername,
 		RequiresDockerHubPassword: opts.DockerHubPassword != "", UseLatest: opts.UseLatest, UseQA: opts.UseQA,
 		ExtraHelmArgs: redactStoredArgs(opts.ExtraHelmArgs), ExtraHelmSets: redactStoredSets(opts.ExtraHelmSets),
-		ExtraValues: opts.ExtraValues, NamespaceOverride: opts.NamespaceOverride, ChartRef: opts.ChartRef,
+		ExtraValues: extraValues, NamespaceOverride: opts.NamespaceOverride, ChartRef: chartRef,
 		ChartRefVersion: opts.ChartRefVersion, ForceImageOverrides: opts.ForceImageOverrides,
 		WaitIngressReady: opts.WaitIngressReady, IngressReadyTimeoutMinutes: opts.IngressReadyTimeoutMinutes,
 		GeneratePostgresCredentials: opts.GeneratePostgresCredentials,
-		ImportDockerAuth:            opts.ImportDockerAuth, DockerConfigPath: opts.DockerConfigPath,
+		ImportDockerAuth:            opts.ImportDockerAuth, DockerConfigPath: abs(opts.DockerConfigPath),
 	}
 }
 
@@ -241,9 +262,6 @@ func (s *RunStateStore) Create(entries []Entry, opts RunOptions) (*MatrixRunStat
 	}
 	if err := os.MkdirAll(s.RunDir(), 0o700); err != nil {
 		return nil, fmt.Errorf("create matrix run directory: %w", err)
-	}
-	if err := os.Chmod(s.root, 0o700); err != nil {
-		return nil, fmt.Errorf("secure matrix state directory: %w", err)
 	}
 	if err := os.Chmod(s.RunDir(), 0o700); err != nil {
 		return nil, fmt.Errorf("secure matrix run directory: %w", err)

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -462,10 +462,6 @@ func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, erro
 	if credentialErr != nil {
 		return nil, RunOptions{}, fmt.Errorf("restore Docker Hub credentials: %w", credentialErr)
 	}
-	state.Status, state.UpdatedAt = RunPending, time.Now().UTC()
-	if err := s.write(state); err != nil {
-		return nil, RunOptions{}, err
-	}
 	opts := state.Options.RunOptions()
 	opts.DeleteNamespaceFirst = false
 	opts.DockerPassword, opts.DockerHubPassword = harborPassword, hubPassword
@@ -479,6 +475,10 @@ func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, erro
 		opts.GeneratedPostgresPassword = secrets.PostgresPassword
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return nil, RunOptions{}, fmt.Errorf("read matrix run secrets: %w", err)
+	}
+	state.Status, state.UpdatedAt = RunPending, time.Now().UTC()
+	if err := s.write(state); err != nil {
+		return nil, RunOptions{}, err
 	}
 	return entries, opts, nil
 }
@@ -511,10 +511,10 @@ func (s *RunStateStore) updateID(id string, fn func(*MatrixRunState, *EntryRunSt
 		}
 		event := fn(state, item)
 		state.UpdatedAt = time.Now().UTC()
-		if err := s.write(state); err != nil {
+		if err := s.appendEvent(event); err != nil {
 			return err
 		}
-		return s.appendEvent(event)
+		return s.write(state)
 	}
 	return fmt.Errorf("matrix entry %q not found in run %q", id, s.runID)
 }

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -255,8 +255,9 @@ type RunLock struct {
 }
 
 type lockOwner struct {
-	Hostname string `json:"hostname"`
-	PID      int    `json:"pid"`
+	Hostname        string `json:"hostname"`
+	PID             int    `json:"pid"`
+	ProcessIdentity string `json:"processIdentity"`
 }
 
 func NewRunStateStore(root, runID string) *RunStateStore {
@@ -295,7 +296,7 @@ func (s *RunStateStore) RecoverStaleLock() error {
 	if owner.Hostname != hostname {
 		return fmt.Errorf("refusing to remove lock created on host %q", owner.Hostname)
 	}
-	if processAlive(owner.PID) {
+	if processMatches(owner.PID, owner.ProcessIdentity) {
 		return fmt.Errorf("refusing to remove lock held by live process %d", owner.PID)
 	}
 	return os.Remove(path)
@@ -312,7 +313,7 @@ func (s *RunStateStore) Acquire() (*RunLock, error) {
 		var owner lockOwner
 		parseErr := json.Unmarshal(ownerData, &owner)
 		hostname, _ := os.Hostname()
-		if readErr == nil && parseErr == nil && owner.Hostname == hostname && !processAlive(owner.PID) {
+		if readErr == nil && parseErr == nil && owner.Hostname == hostname && !processMatches(owner.PID, owner.ProcessIdentity) {
 			if removeErr := os.Remove(path); removeErr == nil {
 				file, err = os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 			}
@@ -322,7 +323,7 @@ func (s *RunStateStore) Acquire() (*RunLock, error) {
 		}
 	}
 	hostname, _ := os.Hostname()
-	ownerData, _ := json.Marshal(lockOwner{Hostname: hostname, PID: os.Getpid()})
+	ownerData, _ := json.Marshal(lockOwner{Hostname: hostname, PID: os.Getpid(), ProcessIdentity: processIdentity(os.Getpid())})
 	if _, err := file.Write(append(ownerData, '\n')); err != nil {
 		file.Close()
 		_ = os.Remove(path)
@@ -506,6 +507,9 @@ func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, erro
 			{"DOCKERHUB_USERNAME", "DOCKERHUB_PASSWORD"},
 			{"TEST_DOCKER_USERNAME", "TEST_DOCKER_PASSWORD"},
 		})
+	}
+	if credentialErr != nil {
+		return nil, RunOptions{}, fmt.Errorf("restore Docker Hub credentials: %w", credentialErr)
 	}
 	if hubPassword == "" {
 		hubPassword, credentialErr = resumeCredentialPasswordFromFiles(state.Options, entries, state.Options.DockerHubUsername, [][2]string{

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -57,6 +57,7 @@ type StoredRunOptions struct {
 	EnvFiles                    map[string]string `json:"envFiles,omitempty"`
 	EnvFile                     string            `json:"envFile,omitempty"`
 	EnvFileDigests              map[string]string `json:"envFileDigests,omitempty"`
+	InputDigests                map[string]string `json:"inputDigests,omitempty"`
 	KeycloakHost                string            `json:"keycloakHost,omitempty"`
 	KeycloakProtocol            string            `json:"keycloakProtocol,omitempty"`
 	IngressBaseDomains          map[string]string `json:"ingressBaseDomains,omitempty"`
@@ -184,6 +185,7 @@ type EntryRunState struct {
 	EntraObjectID               string         `json:"entraObjectId,omitempty"`
 	Auth0ClientIDs              []string       `json:"auth0ClientIds,omitempty"`
 	EntraDirectoryID            string         `json:"entraDirectoryId,omitempty"`
+	EntraCreated                bool           `json:"entraCreated,omitempty"`
 	Auth0Domain                 string         `json:"auth0Domain,omitempty"`
 	ExternalProvisioningStarted bool           `json:"externalProvisioningStarted,omitempty"`
 }
@@ -202,13 +204,16 @@ func (s *RunStateStore) MarkExternalProvisioningComplete(entry Entry) error {
 	})
 }
 
-func (s *RunStateStore) RecordExternalResources(entry Entry, entraObjectID, entraDirectoryID, auth0Domain string, auth0ClientIDs []string) error {
+func (s *RunStateStore) RecordExternalResources(entry Entry, entraObjectID, entraDirectoryID, auth0Domain string, auth0ClientIDs []string, entraCreated ...bool) error {
 	return s.update(entry, func(_ *MatrixRunState, item *EntryRunState) RunEvent {
 		if entraObjectID != "" {
 			item.EntraObjectID = entraObjectID
 		}
 		if entraDirectoryID != "" {
 			item.EntraDirectoryID = entraDirectoryID
+		}
+		if len(entraCreated) > 0 {
+			item.EntraCreated = entraCreated[0]
 		}
 		if auth0Domain != "" {
 			item.Auth0Domain = auth0Domain
@@ -418,9 +423,15 @@ func (l *RunLock) Close() error {
 func (s *RunStateStore) Create(entries []Entry, opts RunOptions) (*MatrixRunState, error) {
 	now := time.Now().UTC()
 	state := &MatrixRunState{Schema: RunStateSchema, ID: s.runID, Status: RunPending, CreatedAt: now, UpdatedAt: now, Options: StoreRunOptions(opts)}
+	state.Options.InputDigests = map[string]string{}
 	replayOpts := state.Options.RunOptions()
 	for _, entry := range entries {
 		entry = normalizeEntryPaths(entry, replayOpts.RepoRoot)
+		for _, path := range entryInputPaths(entry, replayOpts) {
+			if digest := pathDigest(path); digest != "" {
+				state.Options.InputDigests[path] = digest
+			}
+		}
 		namespace := ResolveNamespace(opts, entry)
 		state.Entries = append(state.Entries, &EntryRunState{
 			ID: EntryID(entry), Entry: entry, Status: RunPending, Namespace: namespace,
@@ -535,6 +546,11 @@ func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, erro
 	for path, expected := range state.Options.EnvFileDigests {
 		if observed := fileDigest(path); observed != expected {
 			return nil, RunOptions{}, fmt.Errorf("env file %q changed since run creation; refusing resume", path)
+		}
+	}
+	for path, expected := range state.Options.InputDigests {
+		if observed := pathDigest(path); observed != expected {
+			return nil, RunOptions{}, fmt.Errorf("input %q changed since run creation; refusing resume", path)
 		}
 	}
 	var entries []Entry
@@ -671,6 +687,50 @@ func fileDigest(path string) string {
 	}
 	sum := sha256.Sum256(data)
 	return fmt.Sprintf("sha256:%x", sum[:])
+}
+
+func entryInputPaths(entry Entry, opts RunOptions) []string {
+	paths := []string{entry.ChartPath}
+	paths = append(paths, opts.ExtraValues...)
+	paths = append(paths, entry.ExtraValues...)
+	for _, dep := range entry.Dependencies {
+		paths = append(paths, dep.ValuesFile)
+		if filepath.IsAbs(dep.Chart) {
+			paths = append(paths, dep.Chart)
+		}
+	}
+	return paths
+}
+
+func pathDigest(path string) string {
+	if path == "" {
+		return ""
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return ""
+	}
+	hash := sha256.New()
+	if !info.IsDir() {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return ""
+		}
+		_, _ = hash.Write(data)
+		return fmt.Sprintf("sha256:%x", hash.Sum(nil))
+	}
+	_ = filepath.WalkDir(path, func(current string, entry os.DirEntry, err error) error {
+		if err != nil || entry.IsDir() {
+			return nil
+		}
+		relative, _ := filepath.Rel(path, current)
+		_, _ = hash.Write([]byte(relative))
+		if data, readErr := os.ReadFile(current); readErr == nil {
+			_, _ = hash.Write(data)
+		}
+		return nil
+	})
+	return fmt.Sprintf("sha256:%x", hash.Sum(nil))
 }
 
 func normalizeEntryPaths(entry Entry, repoRoot string) Entry {

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -1,6 +1,7 @@
 package matrix
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -183,6 +184,11 @@ func NewRunID(now time.Time) string {
 	return now.UTC().Format("20060102T150405.000000000Z")
 }
 
+func DurableNamespacePrefix(prefix, runID string) string {
+	digest := sha256.Sum256([]byte(runID))
+	return fmt.Sprintf("%s-%x", strings.TrimSuffix(prefix, "-"), digest[:3])
+}
+
 func (s *RunStateStore) RunDir() string { return filepath.Join(s.root, s.runID) }
 
 func (s *RunStateStore) RunID() string { return s.runID }
@@ -337,7 +343,7 @@ func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, erro
 		if item.Status == RunPassed || item.Status == RunCleaned {
 			continue
 		}
-		item.Status, item.Phase, item.Failure = RunPending, "", nil
+		item.Status, item.Phase, item.Failure, item.Cleaned = RunPending, "", nil, false
 		entries = append(entries, item.Entry)
 	}
 	if entryID != "" && len(entries) == 0 {
@@ -519,6 +525,9 @@ func ReplayCommand(entry Entry, opts RunOptions) []string {
 	}
 	if opts.ChartRefVersion != "" {
 		args = append(args, "--chart-version", opts.ChartRefVersion)
+	}
+	if opts.UpgradeFromVersion != "" {
+		args = append(args, "--upgrade-from-version", opts.UpgradeFromVersion)
 	}
 	for _, value := range opts.ExtraValues {
 		args = append(args, "--extra-values", value)

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -515,6 +515,9 @@ func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, erro
 		if item.Cleaned || item.Status == RunPassed || item.Status == RunCleaned {
 			continue
 		}
+		if item.ExternalProvisioningStarted {
+			return nil, RunOptions{}, fmt.Errorf("entry %q has unresolved external provisioning and cannot be resumed safely; run cleanup after provider reconciliation", item.ID)
+		}
 		if item.Attempts > 0 && versionmatrix.IsTwoStepUpgradeFlow(item.Entry.Flow) {
 			return nil, RunOptions{}, fmt.Errorf("entry %q is a partially executed two-step upgrade and cannot be resumed safely; replay it in a clean namespace", item.ID)
 		}
@@ -681,10 +684,11 @@ func (s *RunStateStore) updateID(id string, fn func(*MatrixRunState, *EntryRunSt
 		}
 		event := fn(state, item)
 		state.UpdatedAt = time.Now().UTC()
-		if err := s.appendEvent(event); err != nil {
+		if err := s.write(state); err != nil {
 			return err
 		}
-		return s.write(state)
+		_ = s.appendEvent(event)
+		return nil
 	}
 	return fmt.Errorf("matrix entry %q not found in run %q", id, s.runID)
 }

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -252,7 +252,16 @@ func (s *RunStateStore) Acquire() (*RunLock, error) {
 	path := filepath.Join(s.RunDir(), "run.lock")
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 	if err != nil {
-		return nil, fmt.Errorf("matrix run %q is active in another process", s.runID)
+		pidData, readErr := os.ReadFile(path)
+		pid, parseErr := strconv.Atoi(strings.TrimSpace(string(pidData)))
+		if readErr == nil && parseErr == nil && !processAlive(pid) {
+			if removeErr := os.Remove(path); removeErr == nil {
+				file, err = os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+			}
+		}
+		if err != nil {
+			return nil, fmt.Errorf("matrix run %q is active in another process", s.runID)
+		}
 	}
 	if _, err := fmt.Fprintf(file, "%d\n", os.Getpid()); err != nil {
 		file.Close()

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -674,11 +674,20 @@ func redactStoredArgs(args []string) []string {
 		if idx := strings.LastIndex(key, "="); idx >= 0 {
 			key = key[:idx]
 		}
-		if values.IsSecretName(key) {
+		if values.IsSecretName(key) || !safeStoredHelmKey(key) {
 			out[i] = "<redacted>"
 		}
 	}
 	return out
+}
+
+func safeStoredHelmKey(key string) bool {
+	for _, prefix := range []string{"global.host", "orchestration.upgrade.allowPreReleaseImages"} {
+		if key == prefix || strings.HasSuffix(key, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func redactStoredSets(values []string) []string { return redactStoredArgs(values) }

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -285,11 +285,17 @@ func (l *RunLock) Close() error {
 func (s *RunStateStore) Create(entries []Entry, opts RunOptions) (*MatrixRunState, error) {
 	now := time.Now().UTC()
 	state := &MatrixRunState{Schema: RunStateSchema, ID: s.runID, Status: RunPending, CreatedAt: now, UpdatedAt: now, Options: StoreRunOptions(opts)}
+	replayOpts := state.Options.RunOptions()
 	for _, entry := range entries {
+		if entry.ChartPath != "" && !filepath.IsAbs(entry.ChartPath) {
+			if absolute, err := filepath.Abs(entry.ChartPath); err == nil {
+				entry.ChartPath = absolute
+			}
+		}
 		namespace := ResolveNamespace(opts, entry)
 		state.Entries = append(state.Entries, &EntryRunState{
 			ID: EntryID(entry), Entry: entry, Status: RunPending, Namespace: namespace,
-			KubeContext: ResolveKubeContext(opts, entry), Replay: ReplayManifest{Command: ReplayCommand(entry, opts)},
+			KubeContext: ResolveKubeContext(opts, entry), Replay: ReplayManifest{Command: ReplayCommand(entry, replayOpts)},
 		})
 	}
 	if err := os.MkdirAll(s.RunDir(), 0o700); err != nil {
@@ -738,6 +744,8 @@ func ClassifyFailure(err error) *Failure {
 	case strings.Contains(lower, "ingress") || strings.Contains(lower, "dns"):
 		code = "INGRESS_FAILURE"
 	case strings.Contains(lower, "namespace") || strings.Contains(lower, "kubernetes") || strings.Contains(lower, "kubectl"):
+		code = "KUBERNETES_FAILURE"
+	case strings.Contains(lower, "kube context") || strings.Contains(lower, "kubeconfig") || strings.Contains(lower, "cluster connectivity"):
 		code = "KUBERNETES_FAILURE"
 	}
 	return &Failure{Code: code, Message: failureMessage(code)}

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -385,11 +385,14 @@ func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, erro
 	}
 	var credentialErr error
 	if harborPassword == "" {
-		harborPassword = resumeCredentialPasswordFromFile(state.Options.EnvFile, state.Options.DockerUsername, [][2]string{
+		harborPassword, credentialErr = resumeCredentialPasswordFromFiles(state.Options, entries, state.Options.DockerUsername, [][2]string{
 			{"HARBOR_USERNAME", "HARBOR_PASSWORD"},
 			{"TEST_DOCKER_USERNAME_CAMUNDA_CLOUD", "TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD"},
 			{"NEXUS_USERNAME", "NEXUS_PASSWORD"},
 		})
+	}
+	if credentialErr != nil {
+		return nil, RunOptions{}, fmt.Errorf("restore Harbor credentials: %w", credentialErr)
 	}
 	if harborPassword == "" {
 		harborPassword, credentialErr = resumeCredentialPassword(state.Options.DockerUsername, state.Options.RequiresDockerPassword, [][2]string{
@@ -402,10 +405,13 @@ func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, erro
 		return nil, RunOptions{}, fmt.Errorf("restore Harbor credentials: %w", credentialErr)
 	}
 	if hubPassword == "" {
-		hubPassword = resumeCredentialPasswordFromFile(state.Options.EnvFile, state.Options.DockerHubUsername, [][2]string{
+		hubPassword, credentialErr = resumeCredentialPasswordFromFiles(state.Options, entries, state.Options.DockerHubUsername, [][2]string{
 			{"DOCKERHUB_USERNAME", "DOCKERHUB_PASSWORD"},
 			{"TEST_DOCKER_USERNAME", "TEST_DOCKER_PASSWORD"},
 		})
+	}
+	if credentialErr != nil {
+		return nil, RunOptions{}, fmt.Errorf("restore Docker Hub credentials: %w", credentialErr)
 	}
 	if hubPassword == "" {
 		hubPassword, credentialErr = resumeCredentialPassword(state.Options.DockerHubUsername, state.Options.RequiresDockerHubPassword, [][2]string{
@@ -731,20 +737,34 @@ func resumeCredentialPassword(storedUsername string, required bool, pairs [][2]s
 	return "", errors.New("matching username/password environment pair is required")
 }
 
-func resumeCredentialPasswordFromFile(path, storedUsername string, pairs [][2]string) string {
+func resumeCredentialPasswordFromFiles(options StoredRunOptions, entries []Entry, storedUsername string, pairs [][2]string) (string, error) {
+	paths := map[string]struct{}{}
+	path := options.EnvFile
 	if path == "" {
 		path = ".env"
 	}
-	values, err := env.ReadFile(path)
-	if err != nil {
-		return ""
-	}
-	for _, pair := range pairs {
-		if values[pair[0]] == storedUsername && values[pair[1]] != "" {
-			return values[pair[1]]
+	paths[path] = struct{}{}
+	for _, entry := range entries {
+		if versionPath := options.EnvFiles[entry.Version]; versionPath != "" {
+			paths[versionPath] = struct{}{}
 		}
 	}
-	return ""
+	password := ""
+	for path := range paths {
+		values, err := env.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		for _, pair := range pairs {
+			if values[pair[0]] == storedUsername && values[pair[1]] != "" {
+				if password != "" && password != values[pair[1]] {
+					return "", errors.New("selected env files contain different registry passwords")
+				}
+				password = values[pair[1]]
+			}
+		}
+	}
+	return password, nil
 }
 
 func aggregateRunStatus(entries []*EntryRunState) RunStatus {

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -690,8 +690,7 @@ func (s *RunStateStore) updateID(id string, fn func(*MatrixRunState, *EntryRunSt
 		if err := s.write(state); err != nil {
 			return err
 		}
-		_ = s.appendEvent(event)
-		return nil
+		return s.appendEvent(event)
 	}
 	return fmt.Errorf("matrix entry %q not found in run %q", id, s.runID)
 }
@@ -814,9 +813,10 @@ func ReplayCommand(entry Entry, opts RunOptions) []string {
 		args = append(args, "--skip-dependency-update")
 	}
 	for _, value := range redactStoredArgs(opts.ExtraHelmArgs) {
-		if value != "<redacted>" {
-			args = append(args, "--extra-helm-arg", value)
+		if value == "<redacted>" {
+			value = "<protected: restore from run-secrets.json>"
 		}
+		args = append(args, "--extra-helm-arg", value)
 	}
 	for _, value := range redactStoredSets(opts.ExtraHelmSets) {
 		if value != "<redacted>" {
@@ -923,10 +923,27 @@ func redactStoredArgs(args []string) []string {
 		case "--atomic", "--wait", "--create-namespace", "--cleanup-on-fail", "--disable-openapi-validation", "--skip-crds", "--take-ownership":
 			out[i] = arg
 		default:
-			out[i] = "<redacted>"
+			if safeScalarHelmArg(arg) {
+				out[i] = arg
+			} else {
+				out[i] = "<redacted>"
+			}
 		}
 	}
 	return out
+}
+
+func safeScalarHelmArg(arg string) bool {
+	key, value, ok := strings.Cut(arg, "=")
+	if !ok {
+		return false
+	}
+	switch key {
+	case "--history-max", "--timeout", "--description", "--max-history":
+		return value != "" && !values.IsSecretName(value)
+	default:
+		return false
+	}
 }
 
 func redactStoredSets(items []string) []string {
@@ -935,11 +952,20 @@ func redactStoredSets(items []string) []string {
 		out[i] = item
 		key, _, _ := strings.Cut(item, "=")
 		upper := strings.ToUpper(key)
-		if values.IsSecretName(key) || strings.Contains(upper, "AUTH") || strings.Contains(upper, "CREDENTIAL") || strings.Contains(upper, "PRIVATE") || strings.Contains(upper, "CERT") {
+		if !safePublicHelmSetKey(key) || values.IsSecretName(key) || strings.Contains(upper, "AUTH") || strings.Contains(upper, "CREDENTIAL") || strings.Contains(upper, "PRIVATE") || strings.Contains(upper, "CERT") {
 			out[i] = "<redacted>"
 		}
 	}
 	return out
+}
+
+func safePublicHelmSetKey(key string) bool {
+	for _, allowed := range []string{"global.host", "orchestration.upgrade.allowPreReleaseImages", "feature.enabled"} {
+		if key == allowed {
+			return true
+		}
+	}
+	return false
 }
 
 func removeRedactedArgs(values []string) []string {

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -92,6 +92,8 @@ type StoredRunOptions struct {
 	RequiresRunSecrets          bool              `json:"requiresRunSecrets,omitempty"`
 	Auth0IngressHost            string            `json:"auth0IngressHost,omitempty"`
 	Auth0InitialAdminEmail      string            `json:"auth0InitialAdminEmail,omitempty"`
+	Auth0Domain                 string            `json:"auth0Domain,omitempty"`
+	EntraDirectoryID            string            `json:"entraDirectoryId,omitempty"`
 }
 
 func StoreRunOptions(opts RunOptions) StoredRunOptions {
@@ -145,6 +147,7 @@ func StoreRunOptions(opts RunOptions) StoredRunOptions {
 		GeneratePostgresCredentials: opts.GeneratePostgresCredentials,
 		ImportDockerAuth:            opts.ImportDockerAuth, DockerConfigPath: abs(opts.DockerConfigPath), RequiresRunSecrets: opts.GeneratedPostgresPassword != "" || len(opts.ExtraHelmArgs) > 0 || len(opts.ExtraHelmSets) > 0,
 		Auth0IngressHost: opts.Auth0IngressHost, Auth0InitialAdminEmail: opts.Auth0InitialAdminEmail,
+		Auth0Domain: opts.Auth0Domain, EntraDirectoryID: opts.EntraDirectoryID,
 	}
 }
 
@@ -169,6 +172,7 @@ func (s StoredRunOptions) RunOptions() RunOptions {
 		GeneratePostgresCredentials: s.GeneratePostgresCredentials,
 		ImportDockerAuth:            s.ImportDockerAuth, DockerConfigPath: s.DockerConfigPath,
 		Auth0IngressHost: s.Auth0IngressHost, Auth0InitialAdminEmail: s.Auth0InitialAdminEmail,
+		Auth0Domain: s.Auth0Domain, EntraDirectoryID: s.EntraDirectoryID,
 	}
 }
 

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -295,6 +295,11 @@ func (s *RunStateStore) RecoverStaleLock() error {
 			_ = os.Remove(filepath.Join(s.RunDir(), "run.lock.guard"))
 		}
 	}
+	releaseGuard, err := s.acquireLockGuard()
+	if err != nil {
+		return err
+	}
+	defer releaseGuard()
 	path := filepath.Join(s.RunDir(), "run.lock")
 	data, err := os.ReadFile(path)
 	if errors.Is(err, os.ErrNotExist) {

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -296,7 +296,11 @@ func (s *RunStateStore) RecoverStaleLock() error {
 	if owner.Hostname != hostname {
 		return fmt.Errorf("refusing to remove lock created on host %q", owner.Hostname)
 	}
-	if processMatches(owner.PID, owner.ProcessIdentity) {
+	alive, known := processState(owner.PID, owner.ProcessIdentity)
+	if !known {
+		return errors.New("cannot verify stale lock owner; refusing recovery")
+	}
+	if alive {
 		return fmt.Errorf("refusing to remove lock held by live process %d", owner.PID)
 	}
 	return os.Remove(path)
@@ -313,7 +317,8 @@ func (s *RunStateStore) Acquire() (*RunLock, error) {
 		var owner lockOwner
 		parseErr := json.Unmarshal(ownerData, &owner)
 		hostname, _ := os.Hostname()
-		if readErr == nil && parseErr == nil && owner.Hostname == hostname && !processMatches(owner.PID, owner.ProcessIdentity) {
+		alive, known := processState(owner.PID, owner.ProcessIdentity)
+		if readErr == nil && parseErr == nil && owner.Hostname == hostname && known && !alive {
 			if removeErr := os.Remove(path); removeErr == nil {
 				file, err = os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 			}
@@ -768,10 +773,14 @@ func ReplayCommand(entry Entry, opts RunOptions) []string {
 		args = append(args, "--skip-dependency-update")
 	}
 	for _, value := range redactStoredArgs(opts.ExtraHelmArgs) {
-		args = append(args, "--extra-helm-arg", value)
+		if value != "<redacted>" {
+			args = append(args, "--extra-helm-arg", value)
+		}
 	}
 	for _, value := range redactStoredSets(opts.ExtraHelmSets) {
-		args = append(args, "--extra-helm-set", value)
+		if value != "<redacted>" {
+			args = append(args, "--extra-helm-set", value)
+		}
 	}
 	for _, value := range opts.ExtraValues {
 		args = append(args, "--extra-values", value)
@@ -854,28 +863,27 @@ func failureMessage(code string) string {
 func redactStoredArgs(args []string) []string {
 	out := make([]string, len(args))
 	for i, arg := range args {
-		out[i] = arg
-		key := strings.TrimLeft(arg, "-")
-		if idx := strings.LastIndex(key, "="); idx >= 0 {
-			key = key[:idx]
-		}
-		if values.IsSecretName(key) || !safeStoredHelmKey(key) {
+		if arg == "--atomic" {
+			out[i] = arg
+		} else {
 			out[i] = "<redacted>"
 		}
 	}
 	return out
 }
 
-func safeStoredHelmKey(key string) bool {
-	for _, prefix := range []string{"global.host", "orchestration.upgrade.allowPreReleaseImages", "feature.enabled", "atomic"} {
-		if key == prefix || strings.HasSuffix(key, prefix) {
-			return true
+func redactStoredSets(items []string) []string {
+	out := make([]string, len(items))
+	for i, item := range items {
+		out[i] = item
+		key, _, _ := strings.Cut(item, "=")
+		upper := strings.ToUpper(key)
+		if values.IsSecretName(key) || strings.Contains(upper, "AUTH") || strings.Contains(upper, "CREDENTIAL") || strings.Contains(upper, "PRIVATE") || strings.Contains(upper, "CERT") {
+			out[i] = "<redacted>"
 		}
 	}
-	return false
+	return out
 }
-
-func redactStoredSets(values []string) []string { return redactStoredArgs(values) }
 
 func removeRedactedArgs(values []string) []string {
 	var out []string

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -14,6 +14,7 @@ import (
 
 	"golang.org/x/sys/unix"
 	"scripts/camunda-core/pkg/versionmatrix"
+	"scripts/deploy-camunda/credentials"
 	"scripts/prepare-helm-values/pkg/env"
 	"scripts/prepare-helm-values/pkg/values"
 )
@@ -411,18 +412,6 @@ func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, erro
 		return nil, RunOptions{}, errors.New("matrix run used secret-bearing Helm arguments; resume cannot reconstruct them safely; replay the recorded command with the required secret inputs")
 	}
 	harborPassword, hubPassword := "", ""
-	if state.Options.ImportDockerAuth {
-		auths, importErr := ImportPlaintextDockerAuth(state.Options.DockerConfigPath, "registry.camunda.cloud", "docker.io")
-		if importErr != nil {
-			return nil, RunOptions{}, fmt.Errorf("restore Docker config credentials: %w", importErr)
-		}
-		if auth, ok := auths["registry.camunda.cloud"]; ok && auth.Username == state.Options.DockerUsername {
-			harborPassword = auth.Password
-		}
-		if auth, ok := auths["docker.io"]; ok && auth.Username == state.Options.DockerHubUsername {
-			hubPassword = auth.Password
-		}
-	}
 	var credentialErr error
 	if harborPassword == "" {
 		harborPassword, credentialErr = resumeCredentialPasswordFromFiles(state.Options, entries, state.Options.DockerUsername, [][2]string{
@@ -453,14 +442,42 @@ func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, erro
 	if credentialErr != nil {
 		return nil, RunOptions{}, fmt.Errorf("restore Docker Hub credentials: %w", credentialErr)
 	}
-	if hubPassword == "" {
-		hubPassword, credentialErr = resumeCredentialPassword(state.Options.DockerHubUsername, state.Options.RequiresDockerHubPassword, [][2]string{
-			{"DOCKERHUB_USERNAME", "DOCKERHUB_PASSWORD"},
-			{"TEST_DOCKER_USERNAME", "TEST_DOCKER_PASSWORD"},
-		})
+	keyringStore := credentials.KeyringStore{}
+	if harborPassword == "" && state.Options.RequiresDockerPassword {
+		credential, found, keyringErr := credentials.GetOptional(keyringStore, credentials.HarborRegistry)
+		if keyringErr != nil {
+			return nil, RunOptions{}, keyringErr
+		}
+		if keyringErr == nil && found && credential.Username == state.Options.DockerUsername {
+			harborPassword = credential.Password
+		}
 	}
-	if credentialErr != nil {
-		return nil, RunOptions{}, fmt.Errorf("restore Docker Hub credentials: %w", credentialErr)
+	if hubPassword == "" && state.Options.RequiresDockerHubPassword {
+		credential, found, keyringErr := credentials.GetOptional(keyringStore, credentials.DockerHubRegistry)
+		if keyringErr != nil {
+			return nil, RunOptions{}, keyringErr
+		}
+		if keyringErr == nil && found && credential.Username == state.Options.DockerHubUsername {
+			hubPassword = credential.Password
+		}
+	}
+	if state.Options.ImportDockerAuth && (harborPassword == "" || hubPassword == "") {
+		auths, importErr := ImportPlaintextDockerAuth(state.Options.DockerConfigPath, "registry.camunda.cloud", "docker.io")
+		if importErr != nil {
+			return nil, RunOptions{}, fmt.Errorf("restore Docker config credentials: %w", importErr)
+		}
+		if auth, ok := auths["registry.camunda.cloud"]; harborPassword == "" && ok && auth.Username == state.Options.DockerUsername {
+			harborPassword = auth.Password
+		}
+		if auth, ok := auths["docker.io"]; hubPassword == "" && ok && auth.Username == state.Options.DockerHubUsername {
+			hubPassword = auth.Password
+		}
+	}
+	if state.Options.RequiresDockerPassword && harborPassword == "" {
+		return nil, RunOptions{}, errors.New("matching Harbor credentials are required to resume")
+	}
+	if state.Options.RequiresDockerHubPassword && hubPassword == "" {
+		return nil, RunOptions{}, errors.New("matching Docker Hub credentials are required to resume")
 	}
 	opts := state.Options.RunOptions()
 	opts.DeleteNamespaceFirst = false
@@ -788,7 +805,7 @@ func resumeCredentialPassword(storedUsername string, required bool, pairs [][2]s
 		}
 		return password, nil
 	}
-	return "", errors.New("matching username/password environment pair is required")
+	return "", nil
 }
 
 func resumeCredentialPasswordFromFiles(options StoredRunOptions, entries []Entry, storedUsername string, pairs [][2]string) (string, error) {

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -414,7 +414,7 @@ func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, erro
 	harborPassword, hubPassword := "", ""
 	var credentialErr error
 	if harborPassword == "" {
-		harborPassword, credentialErr = resumeCredentialPasswordFromFiles(state.Options, entries, state.Options.DockerUsername, [][2]string{
+		harborPassword, credentialErr = resumeCredentialPassword(state.Options.DockerUsername, state.Options.RequiresDockerPassword, [][2]string{
 			{"HARBOR_USERNAME", "HARBOR_PASSWORD"},
 			{"TEST_DOCKER_USERNAME_CAMUNDA_CLOUD", "TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD"},
 			{"NEXUS_USERNAME", "NEXUS_PASSWORD"},
@@ -424,7 +424,7 @@ func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, erro
 		return nil, RunOptions{}, fmt.Errorf("restore Harbor credentials: %w", credentialErr)
 	}
 	if harborPassword == "" {
-		harborPassword, credentialErr = resumeCredentialPassword(state.Options.DockerUsername, state.Options.RequiresDockerPassword, [][2]string{
+		harborPassword, credentialErr = resumeCredentialPasswordFromFiles(state.Options, entries, state.Options.DockerUsername, [][2]string{
 			{"HARBOR_USERNAME", "HARBOR_PASSWORD"},
 			{"TEST_DOCKER_USERNAME_CAMUNDA_CLOUD", "TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD"},
 			{"NEXUS_USERNAME", "NEXUS_PASSWORD"},
@@ -432,6 +432,12 @@ func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, erro
 	}
 	if credentialErr != nil {
 		return nil, RunOptions{}, fmt.Errorf("restore Harbor credentials: %w", credentialErr)
+	}
+	if hubPassword == "" {
+		hubPassword, credentialErr = resumeCredentialPassword(state.Options.DockerHubUsername, state.Options.RequiresDockerHubPassword, [][2]string{
+			{"DOCKERHUB_USERNAME", "DOCKERHUB_PASSWORD"},
+			{"TEST_DOCKER_USERNAME", "TEST_DOCKER_PASSWORD"},
+		})
 	}
 	if hubPassword == "" {
 		hubPassword, credentialErr = resumeCredentialPasswordFromFiles(state.Options, entries, state.Options.DockerHubUsername, [][2]string{
@@ -751,20 +757,11 @@ func redactStoredArgs(args []string) []string {
 		if idx := strings.LastIndex(key, "="); idx >= 0 {
 			key = key[:idx]
 		}
-		if values.IsSecretName(key) || !safeStoredHelmKey(key) {
+		if values.IsSecretName(key) {
 			out[i] = "<redacted>"
 		}
 	}
 	return out
-}
-
-func safeStoredHelmKey(key string) bool {
-	for _, prefix := range []string{"global.host", "orchestration.upgrade.allowPreReleaseImages"} {
-		if key == prefix || strings.HasSuffix(key, prefix) {
-			return true
-		}
-	}
-	return false
 }
 
 func redactStoredSets(values []string) []string { return redactStoredArgs(values) }

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -184,6 +185,13 @@ type RunLock struct {
 
 func NewRunStateStore(root, runID string) *RunStateStore {
 	return &RunStateStore{root: root, runID: runID}
+}
+
+func ValidateRunID(runID string) error {
+	if runID == "" || filepath.IsAbs(runID) || filepath.Base(runID) != runID || runID == "." || runID == ".." {
+		return fmt.Errorf("invalid matrix run ID %q", runID)
+	}
+	return nil
 }
 
 func NewRunID(now time.Time) string {
@@ -567,6 +575,30 @@ func ReplayCommand(entry Entry, opts RunOptions) []string {
 	if opts.UpgradeFromVersion != "" {
 		args = append(args, "--upgrade-from-version", opts.UpgradeFromVersion)
 	}
+	if opts.UseLatest {
+		args = append(args, "--use-latest")
+	}
+	if opts.UseQA {
+		args = append(args, "--use-qa")
+	}
+	if opts.ForceImageOverrides {
+		args = append(args, "--force-image-overrides")
+	}
+	if opts.HelmTimeout > 0 {
+		args = append(args, "--timeout", strconv.Itoa(opts.HelmTimeout))
+	}
+	if opts.WaitIngressReady {
+		args = append(args, "--wait-ingress-ready", "--ingress-ready-timeout", strconv.Itoa(opts.IngressReadyTimeoutMinutes))
+	}
+	if opts.SkipDependencyUpdate {
+		args = append(args, "--skip-dependency-update")
+	}
+	for _, value := range redactStoredArgs(opts.ExtraHelmArgs) {
+		args = append(args, "--extra-helm-arg", value)
+	}
+	for _, value := range redactStoredSets(opts.ExtraHelmSets) {
+		args = append(args, "--extra-helm-set", value)
+	}
 	for _, value := range opts.ExtraValues {
 		args = append(args, "--extra-values", value)
 	}
@@ -581,6 +613,9 @@ func ReplayCommand(entry Entry, opts RunOptions) []string {
 	}
 	if opts.EnsureDockerHub {
 		args = append(args, "--ensure-docker-hub")
+	}
+	if opts.Cleanup {
+		args = append(args, "--cleanup")
 	}
 	return args
 }

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -79,6 +79,8 @@ type StoredRunOptions struct {
 	WaitIngressReady            bool              `json:"waitIngressReady,omitempty"`
 	IngressReadyTimeoutMinutes  int               `json:"ingressReadyTimeoutMinutes,omitempty"`
 	GeneratePostgresCredentials bool              `json:"generatePostgresCredentials,omitempty"`
+	ImportDockerAuth            bool              `json:"importDockerAuth,omitempty"`
+	DockerConfigPath            string            `json:"dockerConfigPath,omitempty"`
 }
 
 func StoreRunOptions(opts RunOptions) StoredRunOptions {
@@ -101,6 +103,7 @@ func StoreRunOptions(opts RunOptions) StoredRunOptions {
 		ChartRefVersion: opts.ChartRefVersion, ForceImageOverrides: opts.ForceImageOverrides,
 		WaitIngressReady: opts.WaitIngressReady, IngressReadyTimeoutMinutes: opts.IngressReadyTimeoutMinutes,
 		GeneratePostgresCredentials: opts.GeneratePostgresCredentials,
+		ImportDockerAuth:            opts.ImportDockerAuth, DockerConfigPath: opts.DockerConfigPath,
 	}
 }
 
@@ -123,6 +126,7 @@ func (s StoredRunOptions) RunOptions() RunOptions {
 		ChartRefVersion: s.ChartRefVersion, ForceImageOverrides: s.ForceImageOverrides,
 		WaitIngressReady: s.WaitIngressReady, IngressReadyTimeoutMinutes: s.IngressReadyTimeoutMinutes,
 		GeneratePostgresCredentials: s.GeneratePostgresCredentials,
+		ImportDockerAuth:            s.ImportDockerAuth, DockerConfigPath: s.DockerConfigPath,
 	}
 }
 
@@ -355,20 +359,38 @@ func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, erro
 	if hasRedactedArgs(state.Options.ExtraHelmArgs) || hasRedactedArgs(state.Options.ExtraHelmSets) {
 		return nil, RunOptions{}, errors.New("matrix run used secret-bearing Helm arguments; resume cannot reconstruct them safely; replay the recorded command with the required secret inputs")
 	}
-	harborPassword, err := resumeCredentialPassword(state.Options.DockerUsername, state.Options.RequiresDockerPassword, [][2]string{
-		{"HARBOR_USERNAME", "HARBOR_PASSWORD"},
-		{"TEST_DOCKER_USERNAME_CAMUNDA_CLOUD", "TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD"},
-		{"NEXUS_USERNAME", "NEXUS_PASSWORD"},
-	})
-	if err != nil {
-		return nil, RunOptions{}, fmt.Errorf("restore Harbor credentials: %w", err)
+	harborPassword, hubPassword := "", ""
+	if state.Options.ImportDockerAuth {
+		auths, importErr := ImportPlaintextDockerAuth(state.Options.DockerConfigPath, "registry.camunda.cloud", "docker.io")
+		if importErr != nil {
+			return nil, RunOptions{}, fmt.Errorf("restore Docker config credentials: %w", importErr)
+		}
+		if auth, ok := auths["registry.camunda.cloud"]; ok && auth.Username == state.Options.DockerUsername {
+			harborPassword = auth.Password
+		}
+		if auth, ok := auths["docker.io"]; ok && auth.Username == state.Options.DockerHubUsername {
+			hubPassword = auth.Password
+		}
 	}
-	hubPassword, err := resumeCredentialPassword(state.Options.DockerHubUsername, state.Options.RequiresDockerHubPassword, [][2]string{
-		{"DOCKERHUB_USERNAME", "DOCKERHUB_PASSWORD"},
-		{"TEST_DOCKER_USERNAME", "TEST_DOCKER_PASSWORD"},
-	})
-	if err != nil {
-		return nil, RunOptions{}, fmt.Errorf("restore Docker Hub credentials: %w", err)
+	var credentialErr error
+	if harborPassword == "" {
+		harborPassword, credentialErr = resumeCredentialPassword(state.Options.DockerUsername, state.Options.RequiresDockerPassword, [][2]string{
+			{"HARBOR_USERNAME", "HARBOR_PASSWORD"},
+			{"TEST_DOCKER_USERNAME_CAMUNDA_CLOUD", "TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD"},
+			{"NEXUS_USERNAME", "NEXUS_PASSWORD"},
+		})
+	}
+	if credentialErr != nil {
+		return nil, RunOptions{}, fmt.Errorf("restore Harbor credentials: %w", credentialErr)
+	}
+	if hubPassword == "" {
+		hubPassword, credentialErr = resumeCredentialPassword(state.Options.DockerHubUsername, state.Options.RequiresDockerHubPassword, [][2]string{
+			{"DOCKERHUB_USERNAME", "DOCKERHUB_PASSWORD"},
+			{"TEST_DOCKER_USERNAME", "TEST_DOCKER_PASSWORD"},
+		})
+	}
+	if credentialErr != nil {
+		return nil, RunOptions{}, fmt.Errorf("restore Docker Hub credentials: %w", credentialErr)
 	}
 	state.Status, state.UpdatedAt = RunPending, time.Now().UTC()
 	if err := s.write(state); err != nil {

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/sys/unix"
 	"scripts/camunda-core/pkg/versionmatrix"
 	"scripts/deploy-camunda/credentials"
 	"scripts/prepare-helm-values/pkg/env"
@@ -120,9 +119,9 @@ func StoreRunOptions(opts RunOptions) StoredRunOptions {
 		VaultBackedSecrets: opts.VaultBackedSecrets, UseVaultBackedSecrets: opts.UseVaultBackedSecrets,
 		DeleteNamespaceFirst: opts.DeleteNamespaceFirst, UpgradeFromVersion: opts.UpgradeFromVersion,
 		HelmTimeout: opts.HelmTimeout, EnsureDockerRegistry: opts.EnsureDockerRegistry,
-		DockerUsername: opts.DockerUsername, RequiresDockerPassword: opts.DockerPassword != "",
+		DockerUsername: opts.DockerUsername, RequiresDockerPassword: opts.EnsureDockerRegistry,
 		EnsureDockerHub: opts.EnsureDockerHub, DockerHubUsername: opts.DockerHubUsername,
-		RequiresDockerHubPassword: opts.DockerHubPassword != "", UseLatest: opts.UseLatest, UseQA: opts.UseQA,
+		RequiresDockerHubPassword: opts.EnsureDockerHub, UseLatest: opts.UseLatest, UseQA: opts.UseQA,
 		ExtraHelmArgs: redactStoredArgs(opts.ExtraHelmArgs), ExtraHelmSets: redactStoredSets(opts.ExtraHelmSets),
 		ExtraValues: extraValues, NamespaceOverride: opts.NamespaceOverride, ChartRef: chartRef,
 		ChartRefVersion: opts.ChartRefVersion, ForceImageOverrides: opts.ForceImageOverrides,
@@ -224,7 +223,7 @@ type RunStateStore struct {
 }
 
 type RunLock struct {
-	file *os.File
+	path string
 }
 
 func NewRunStateStore(root, runID string) *RunStateStore {
@@ -250,27 +249,28 @@ func (s *RunStateStore) Acquire() (*RunLock, error) {
 	if err := os.MkdirAll(s.RunDir(), 0o700); err != nil {
 		return nil, fmt.Errorf("create matrix run directory: %w", err)
 	}
-	file, err := os.OpenFile(filepath.Join(s.RunDir(), "run.lock"), os.O_CREATE|os.O_RDWR, 0o600)
+	path := filepath.Join(s.RunDir(), "run.lock")
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 	if err != nil {
-		return nil, fmt.Errorf("open matrix run lock: %w", err)
-	}
-	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
-		file.Close()
 		return nil, fmt.Errorf("matrix run %q is active in another process", s.runID)
 	}
-	return &RunLock{file: file}, nil
+	if _, err := fmt.Fprintf(file, "%d\n", os.Getpid()); err != nil {
+		file.Close()
+		_ = os.Remove(path)
+		return nil, err
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return nil, err
+	}
+	return &RunLock{path: path}, nil
 }
 
 func (l *RunLock) Close() error {
-	if l == nil || l.file == nil {
+	if l == nil || l.path == "" {
 		return nil
 	}
-	err := unix.Flock(int(l.file.Fd()), unix.LOCK_UN)
-	closeErr := l.file.Close()
-	if err != nil {
-		return err
-	}
-	return closeErr
+	return os.Remove(l.path)
 }
 
 func (s *RunStateStore) Create(entries []Entry, opts RunOptions) (*MatrixRunState, error) {
@@ -757,11 +757,20 @@ func redactStoredArgs(args []string) []string {
 		if idx := strings.LastIndex(key, "="); idx >= 0 {
 			key = key[:idx]
 		}
-		if values.IsSecretName(key) {
+		if values.IsSecretName(key) || !safeStoredHelmKey(key) {
 			out[i] = "<redacted>"
 		}
 	}
 	return out
+}
+
+func safeStoredHelmKey(key string) bool {
+	for _, prefix := range []string{"global.host", "orchestration.upgrade.allowPreReleaseImages", "feature.enabled", "atomic"} {
+		if key == prefix || strings.HasSuffix(key, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func redactStoredSets(values []string) []string { return redactStoredArgs(values) }

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -578,6 +578,18 @@ func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, erro
 		if item.Attempts > 0 && versionmatrix.IsTwoStepUpgradeFlow(item.Entry.Flow) {
 			return nil, RunOptions{}, fmt.Errorf("entry %q is a partially executed two-step upgrade and cannot be resumed safely; replay it in a clean namespace", item.ID)
 		}
+		if item.Auth0Domain != "" {
+			if state.Options.Auth0Domain != "" && state.Options.Auth0Domain != item.Auth0Domain {
+				return nil, RunOptions{}, errors.New("recorded Auth0 domains conflict")
+			}
+			state.Options.Auth0Domain = item.Auth0Domain
+		}
+		if item.EntraDirectoryID != "" {
+			if state.Options.EntraDirectoryID != "" && state.Options.EntraDirectoryID != item.EntraDirectoryID {
+				return nil, RunOptions{}, errors.New("recorded Entra directories conflict")
+			}
+			state.Options.EntraDirectoryID = item.EntraDirectoryID
+		}
 		item.Status, item.Phase, item.Failure, item.Cleaned = RunPending, "", nil, false
 		entries = append(entries, normalizeEntryPaths(item.Entry, state.Options.RepoRoot))
 	}

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -155,27 +155,35 @@ func (s StoredRunOptions) RunOptions() RunOptions {
 }
 
 type EntryRunState struct {
-	ID             string         `json:"id"`
-	Entry          Entry          `json:"entry"`
-	Status         RunStatus      `json:"status"`
-	Phase          string         `json:"phase,omitempty"`
-	Namespace      string         `json:"namespace"`
-	KubeContext    string         `json:"kubeContext,omitempty"`
-	Attempts       int            `json:"attempts"`
-	StartedAt      *time.Time     `json:"startedAt,omitempty"`
-	FinishedAt     *time.Time     `json:"finishedAt,omitempty"`
-	Failure        *Failure       `json:"failure,omitempty"`
-	Diagnostics    string         `json:"diagnostics,omitempty"`
-	Replay         ReplayManifest `json:"replay"`
-	Cleaned        bool           `json:"cleaned,omitempty"`
-	EntraObjectID  string         `json:"entraObjectId,omitempty"`
-	Auth0ClientIDs []string       `json:"auth0ClientIds,omitempty"`
+	ID               string         `json:"id"`
+	Entry            Entry          `json:"entry"`
+	Status           RunStatus      `json:"status"`
+	Phase            string         `json:"phase,omitempty"`
+	Namespace        string         `json:"namespace"`
+	KubeContext      string         `json:"kubeContext,omitempty"`
+	Attempts         int            `json:"attempts"`
+	StartedAt        *time.Time     `json:"startedAt,omitempty"`
+	FinishedAt       *time.Time     `json:"finishedAt,omitempty"`
+	Failure          *Failure       `json:"failure,omitempty"`
+	Diagnostics      string         `json:"diagnostics,omitempty"`
+	Replay           ReplayManifest `json:"replay"`
+	Cleaned          bool           `json:"cleaned,omitempty"`
+	EntraObjectID    string         `json:"entraObjectId,omitempty"`
+	Auth0ClientIDs   []string       `json:"auth0ClientIds,omitempty"`
+	EntraDirectoryID string         `json:"entraDirectoryId,omitempty"`
+	Auth0Domain      string         `json:"auth0Domain,omitempty"`
 }
 
-func (s *RunStateStore) RecordExternalResources(entry Entry, entraObjectID string, auth0ClientIDs []string) error {
+func (s *RunStateStore) RecordExternalResources(entry Entry, entraObjectID, entraDirectoryID, auth0Domain string, auth0ClientIDs []string) error {
 	return s.update(entry, func(_ *MatrixRunState, item *EntryRunState) RunEvent {
 		if entraObjectID != "" {
 			item.EntraObjectID = entraObjectID
+		}
+		if entraDirectoryID != "" {
+			item.EntraDirectoryID = entraDirectoryID
+		}
+		if auth0Domain != "" {
+			item.Auth0Domain = auth0Domain
 		}
 		if len(auth0ClientIDs) > 0 {
 			item.Auth0ClientIDs = append([]string(nil), auth0ClientIDs...)

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -384,7 +384,7 @@ func (s *RunStateStore) PrepareResume(entryID string) ([]Entry, RunOptions, erro
 		if entryID != "" && item.ID != entryID {
 			continue
 		}
-		if item.Status == RunPassed || item.Status == RunCleaned {
+		if item.Cleaned || item.Status == RunPassed || item.Status == RunCleaned {
 			continue
 		}
 		if item.Attempts > 0 && versionmatrix.IsTwoStepUpgradeFlow(item.Entry.Flow) {

--- a/scripts/deploy-camunda/matrix/run_state.go
+++ b/scripts/deploy-camunda/matrix/run_state.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/sys/unix"
 	"scripts/camunda-core/pkg/versionmatrix"
 	"scripts/prepare-helm-values/pkg/env"
+	"scripts/prepare-helm-values/pkg/values"
 )
 
 const RunStateSchema = "camunda.matrix-run/v1"
@@ -632,8 +633,15 @@ func failureMessage(code string) string {
 
 func redactStoredArgs(args []string) []string {
 	out := make([]string, len(args))
-	for i := range args {
-		out[i] = "<redacted>"
+	for i, arg := range args {
+		out[i] = arg
+		key := strings.TrimLeft(arg, "-")
+		if idx := strings.LastIndex(key, "="); idx >= 0 {
+			key = key[:idx]
+		}
+		if values.IsSecretName(key) {
+			out[i] = "<redacted>"
+		}
 	}
 	return out
 }

--- a/scripts/deploy-camunda/matrix/run_state_test.go
+++ b/scripts/deploy-camunda/matrix/run_state_test.go
@@ -89,6 +89,11 @@ func TestRunStateRequiresOnlyEnabledRegistryCredentials(t *testing.T) {
 	assert.True(t, stored.RequiresDockerPassword)
 }
 
+func TestRunStatePersistsEffectiveIngressDomain(t *testing.T) {
+	stored := StoreRunOptions(RunOptions{IngressBaseDomains: map[string]string{"gke": "ci.example.test"}})
+	assert.Equal(t, "ci.example.test", stored.IngressBaseDomains["gke"])
+}
+
 func TestReplayCommandIncludesExecutionTarget(t *testing.T) {
 	entry := Entry{Version: "8.10", Shortname: "one", Scenario: "first", Flow: "install", Platform: "gke"}
 	command := ReplayCommand(entry, RunOptions{

--- a/scripts/deploy-camunda/matrix/run_state_test.go
+++ b/scripts/deploy-camunda/matrix/run_state_test.go
@@ -85,6 +85,13 @@ func TestReplayCommandIncludesUpgradeSource(t *testing.T) {
 	assert.Contains(t, command, "--upgrade-from-version 13.5.0")
 }
 
+func TestValidateRunIDRejectsTraversal(t *testing.T) {
+	for _, id := range []string{"", "..", "../other", "/tmp/run", "a/b"} {
+		assert.Error(t, ValidateRunID(id), id)
+	}
+	assert.NoError(t, ValidateRunID("20260729T120000Z"))
+}
+
 func TestRunStateRefusesConcurrentLock(t *testing.T) {
 	store := NewRunStateStore(t.TempDir(), "run-1")
 	first, err := store.Acquire()

--- a/scripts/deploy-camunda/matrix/run_state_test.go
+++ b/scripts/deploy-camunda/matrix/run_state_test.go
@@ -113,6 +113,23 @@ func TestReplayCommandIncludesUpgradeSource(t *testing.T) {
 	assert.Contains(t, command, "--upgrade-from-version 13.5.0")
 }
 
+func TestReplayCommandIncludesBehaviorFlags(t *testing.T) {
+	entry := Entry{Version: "8.10", Shortname: "one", Flow: "install", Platform: "gke"}
+	command := strings.Join(ReplayCommand(entry, RunOptions{DeleteNamespaceFirst: true, UseVaultBackedSecrets: true, KeycloakHost: "keycloak.example", KeycloakProtocol: "https"}), " ")
+	assert.Contains(t, command, "--delete-namespace")
+	assert.Contains(t, command, "--use-vault-backed-secrets")
+	assert.Contains(t, command, "--keycloak-host keycloak.example")
+	assert.Contains(t, command, "--keycloak-protocol https")
+}
+
+func TestAcquireRejectsActiveLockGuard(t *testing.T) {
+	store := NewRunStateStore(t.TempDir(), "run-1")
+	require.NoError(t, os.MkdirAll(store.RunDir(), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(store.RunDir(), "run.lock.guard"), nil, 0o600))
+	_, err := store.Acquire()
+	require.ErrorContains(t, err, "lock operation is active")
+}
+
 func TestValidateRunIDRejectsTraversal(t *testing.T) {
 	for _, id := range []string{"", "..", "../other", "/tmp/run", "a/b"} {
 		assert.Error(t, ValidateRunID(id), id)

--- a/scripts/deploy-camunda/matrix/run_state_test.go
+++ b/scripts/deploy-camunda/matrix/run_state_test.go
@@ -217,10 +217,23 @@ func TestClassifyFailure(t *testing.T) {
 		{errors.New("docker registry unauthorized"), "REGISTRY_FAILURE"},
 		{errors.New("Playwright e2e test failed"), "TEST_FAILURE"},
 		{errors.New("context canceled"), "RUN_INTERRUPTED"},
+		{errors.New("cluster connectivity check failed: kube context missing"), "KUBERNETES_FAILURE"},
 	}
 	for _, tt := range tests {
 		assert.Equal(t, tt.code, ClassifyFailure(tt.err).Code)
 	}
+}
+
+func TestCreatePersistsAbsoluteEntryChartPath(t *testing.T) {
+	entry := Entry{Version: "8.10", Shortname: "one", Scenario: "first", Flow: "install", ChartPath: "../../charts/example"}
+	store := NewRunStateStore(t.TempDir(), "run-1")
+	_, err := store.Create([]Entry{entry}, RunOptions{})
+	require.NoError(t, err)
+	state, err := store.Load()
+	require.NoError(t, err)
+	assert.True(t, filepath.IsAbs(state.Entries[0].Entry.ChartPath), state.Entries[0].Entry.ChartPath)
+	replay := strings.Join(state.Entries[0].Replay.Command, " ")
+	assert.NotContains(t, replay, "--repo-root ../..")
 }
 
 func TestClassifyFailureRedactsCredentialValues(t *testing.T) {

--- a/scripts/deploy-camunda/matrix/run_state_test.go
+++ b/scripts/deploy-camunda/matrix/run_state_test.go
@@ -120,6 +120,15 @@ func TestRunStateRefusesConcurrentLock(t *testing.T) {
 	require.ErrorContains(t, err, "active in another process")
 }
 
+func TestRunStateReclaimsStaleLock(t *testing.T) {
+	store := NewRunStateStore(t.TempDir(), "run-1")
+	require.NoError(t, os.MkdirAll(store.RunDir(), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(store.RunDir(), "run.lock"), []byte("999999999\n"), 0o600))
+	lock, err := store.Acquire()
+	require.NoError(t, err)
+	require.NoError(t, lock.Close())
+}
+
 func TestCleaningFailedEntryPreservesFailedRun(t *testing.T) {
 	entry := Entry{Version: "8.10", Shortname: "one", Scenario: "first", Flow: "install"}
 	store := NewRunStateStore(t.TempDir(), "run-1")

--- a/scripts/deploy-camunda/matrix/run_state_test.go
+++ b/scripts/deploy-camunda/matrix/run_state_test.go
@@ -82,6 +82,19 @@ func TestRunStateRedactsUnknownHelmOverride(t *testing.T) {
 	assert.Equal(t, []string{"<redacted>"}, stored.ExtraHelmSets)
 }
 
+func TestReplayPreservesSafeScalarAndMarksProtectedHelmArgs(t *testing.T) {
+	entry := Entry{Version: "8.10", Shortname: "one", Flow: "install"}
+	command := strings.Join(ReplayCommand(entry, RunOptions{ExtraHelmArgs: []string{"--history-max=3", "--post-renderer=/private/tool"}}), " ")
+	assert.Contains(t, command, "--extra-helm-arg --history-max=3")
+	assert.Contains(t, command, "<protected: restore from run-secrets.json>")
+	assert.NotContains(t, command, "/private/tool")
+}
+
+func TestRunStateRedactsNonAllowlistedHelmSet(t *testing.T) {
+	stored := StoreRunOptions(RunOptions{ExtraHelmSets: []string{"replicaCount=3"}})
+	assert.Equal(t, []string{"<redacted>"}, stored.ExtraHelmSets)
+}
+
 func TestRunStateRequiresOnlyEnabledRegistryCredentials(t *testing.T) {
 	stored := StoreRunOptions(RunOptions{DockerUsername: "incidental", DockerPassword: "incidental-password"})
 	assert.False(t, stored.RequiresDockerPassword)

--- a/scripts/deploy-camunda/matrix/run_state_test.go
+++ b/scripts/deploy-camunda/matrix/run_state_test.go
@@ -390,6 +390,23 @@ func TestExternalCompensationClearsUncertaintyOnlyOnSuccess(t *testing.T) {
 	assert.False(t, state.Entries[0].ExternalProvisioningStarted)
 }
 
+func TestPartialEntraCheckpointCompensationState(t *testing.T) {
+	entry := Entry{Version: "8.10", Shortname: "oidc", Flow: "install"}
+	store := NewRunStateStore(t.TempDir(), "run-1")
+	_, err := store.Create([]Entry{entry}, RunOptions{})
+	require.NoError(t, err)
+	require.NoError(t, store.MarkExternalProvisioningStarted(entry))
+	require.NoError(t, store.RecordExternalResources(entry, "object-id", "tenant", "", nil))
+	require.Error(t, completeExternalCompensation(store, entry, errors.New("strict deletion failed")))
+	state, err := store.Load()
+	require.NoError(t, err)
+	assert.True(t, state.Entries[0].ExternalProvisioningStarted)
+	require.NoError(t, completeExternalCompensation(store, entry, nil))
+	state, err = store.Load()
+	require.NoError(t, err)
+	assert.False(t, state.Entries[0].ExternalProvisioningStarted)
+}
+
 func TestPrepareResumeRejectsUncertainExternalProvisioning(t *testing.T) {
 	entry := Entry{Version: "8.10", Shortname: "oidc", Flow: "install"}
 	store := NewRunStateStore(t.TempDir(), "run-1")

--- a/scripts/deploy-camunda/matrix/run_state_test.go
+++ b/scripts/deploy-camunda/matrix/run_state_test.go
@@ -387,6 +387,22 @@ func TestPrepareResumeRejectsUncertainExternalProvisioning(t *testing.T) {
 	require.ErrorContains(t, err, "unresolved external provisioning")
 }
 
+func TestCheckpointAuth0FailureRetainsUncertaintyWhenCompensationFails(t *testing.T) {
+	entry := Entry{Version: "8.10", Shortname: "auth0", Flow: "install"}
+	store := NewRunStateStore(t.TempDir(), "run-1")
+	_, err := store.Create([]Entry{entry}, RunOptions{})
+	require.NoError(t, err)
+	require.NoError(t, store.MarkExternalProvisioningStarted(entry))
+	// Make the run directory read-only to force checkpoint persistence failure.
+	require.NoError(t, os.Chmod(store.RunDir(), 0o500))
+	err = checkpointAuth0Resources(store, entry, auth0.Options{Domain: "tenant"}, []string{"id-A"}, func(context.Context, auth0.Options, []string) error { return errors.New("provider delete failed") })
+	require.NoError(t, os.Chmod(store.RunDir(), 0o700))
+	require.ErrorContains(t, err, "provider delete failed")
+	state, loadErr := store.Load()
+	require.NoError(t, loadErr)
+	assert.True(t, state.Entries[0].ExternalProvisioningStarted)
+}
+
 func TestCleanupEntryUsesCheckpointedAuth0IDsAndStopsOnFailure(t *testing.T) {
 	entry := Entry{Version: "8.10", Shortname: "auth0", Scenario: "auth0", Flow: "install", Identity: "auth0"}
 	store := NewRunStateStore(t.TempDir(), "run-1")

--- a/scripts/deploy-camunda/matrix/run_state_test.go
+++ b/scripts/deploy-camunda/matrix/run_state_test.go
@@ -459,6 +459,17 @@ func TestCleanupEntryUsesCheckpointedAuth0IDsAndStopsOnFailure(t *testing.T) {
 	assert.True(t, called)
 }
 
+func TestCleanupEntryRefusesUnresolvedAuth0Provisioning(t *testing.T) {
+	entry := Entry{Version: "8.10", Shortname: "auth0", Flow: "install", Identity: "auth0"}
+	store := NewRunStateStore(t.TempDir(), "run-1")
+	_, err := store.Create([]Entry{entry}, RunOptions{})
+	require.NoError(t, err)
+	require.NoError(t, store.MarkExternalProvisioningStarted(entry))
+	result := RunResult{Entry: entry, Namespace: "namespace", auth0Opts: &auth0.Options{Namespace: "namespace"}}
+	err = cleanupEntry(context.Background(), result, RunOptions{StateStore: store})
+	require.ErrorContains(t, err, "provisioning remains unresolved")
+}
+
 func TestExecuteEntryOwnershipFailurePreventsProviderProvisioning(t *testing.T) {
 	chartPath := t.TempDir()
 	entry := Entry{Version: "8.10", ChartPath: chartPath, Scenario: "oidc", Shortname: "oidc", Flow: "install", Auth: "oidc", Identity: "oidc"}

--- a/scripts/deploy-camunda/matrix/run_state_test.go
+++ b/scripts/deploy-camunda/matrix/run_state_test.go
@@ -149,7 +149,7 @@ func TestRecoverStaleLockRejectsLiveProcess(t *testing.T) {
 	store := NewRunStateStore(t.TempDir(), "run-1")
 	require.NoError(t, os.MkdirAll(store.RunDir(), 0o700))
 	hostname, _ := os.Hostname()
-	data, _ := json.Marshal(lockOwner{Hostname: hostname, PID: os.Getpid()})
+	data, _ := json.Marshal(lockOwner{Hostname: hostname, PID: os.Getpid(), ProcessIdentity: processIdentity(os.Getpid())})
 	require.NoError(t, os.WriteFile(filepath.Join(store.RunDir(), "run.lock"), append(data, '\n'), 0o600))
 	require.ErrorContains(t, store.RecoverStaleLock(), "live process")
 }

--- a/scripts/deploy-camunda/matrix/run_state_test.go
+++ b/scripts/deploy-camunda/matrix/run_state_test.go
@@ -72,9 +72,9 @@ func TestRunStateRedactsSecrets(t *testing.T) {
 }
 
 func TestRunStatePreservesBenignHelmOverride(t *testing.T) {
-	stored := StoreRunOptions(RunOptions{ExtraHelmSets: []string{"feature.enabled=true"}, ExtraHelmArgs: []string{"--atomic"}})
+	stored := StoreRunOptions(RunOptions{ExtraHelmSets: []string{"feature.enabled=true"}, ExtraHelmArgs: []string{"--atomic", "--wait"}})
 	assert.Equal(t, []string{"feature.enabled=true"}, stored.ExtraHelmSets)
-	assert.Equal(t, []string{"--atomic"}, stored.ExtraHelmArgs)
+	assert.Equal(t, []string{"--atomic", "--wait"}, stored.ExtraHelmArgs)
 }
 
 func TestRunStateRedactsUnknownHelmOverride(t *testing.T) {

--- a/scripts/deploy-camunda/matrix/run_state_test.go
+++ b/scripts/deploy-camunda/matrix/run_state_test.go
@@ -2,6 +2,7 @@ package matrix
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"scripts/deploy-camunda/credentials"
 )
 
 func TestRunStateLifecycleAndResume(t *testing.T) {
@@ -124,10 +126,21 @@ func TestRunStateRefusesConcurrentLock(t *testing.T) {
 func TestRunStateReclaimsStaleLock(t *testing.T) {
 	store := NewRunStateStore(t.TempDir(), "run-1")
 	require.NoError(t, os.MkdirAll(store.RunDir(), 0o700))
-	require.NoError(t, os.WriteFile(filepath.Join(store.RunDir(), "run.lock"), []byte("999999999\n"), 0o600))
+	hostname, _ := os.Hostname()
+	data, _ := json.Marshal(lockOwner{Hostname: hostname, PID: 999999999})
+	require.NoError(t, os.WriteFile(filepath.Join(store.RunDir(), "run.lock"), append(data, '\n'), 0o600))
 	lock, err := store.Acquire()
 	require.NoError(t, err)
 	require.NoError(t, lock.Close())
+}
+
+func TestRunStateDoesNotReclaimForeignHostLock(t *testing.T) {
+	store := NewRunStateStore(t.TempDir(), "run-1")
+	require.NoError(t, os.MkdirAll(store.RunDir(), 0o700))
+	data, _ := json.Marshal(lockOwner{Hostname: "other-host", PID: 999999999})
+	require.NoError(t, os.WriteFile(filepath.Join(store.RunDir(), "run.lock"), append(data, '\n'), 0o600))
+	_, err := store.Acquire()
+	require.ErrorContains(t, err, "active in another process")
 }
 
 func TestCleaningFailedEntryPreservesFailedRun(t *testing.T) {
@@ -147,14 +160,18 @@ func TestCleaningFailedEntryPreservesFailedRun(t *testing.T) {
 	assert.Equal(t, "cleaned", state.Entries[0].Phase)
 }
 
-func TestResumeRejectsRedactedArguments(t *testing.T) {
+func TestResumeRestoresRedactedArgumentsFromRunSecrets(t *testing.T) {
 	entry := Entry{Version: "8.10", Shortname: "one", Scenario: "first", Flow: "install"}
 	store := NewRunStateStore(t.TempDir(), "run-1")
 	_, err := store.Create([]Entry{entry}, RunOptions{ExtraHelmSets: []string{"global.password=secret"}})
 	require.NoError(t, err)
 
-	_, _, err = store.PrepareResume("")
-	require.ErrorContains(t, err, "cannot reconstruct them safely")
+	_, opts, err := store.PrepareResume("")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"global.password=secret"}, opts.ExtraHelmSets)
+	state, err := store.Load()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"<redacted>"}, state.Options.ExtraHelmSets)
 }
 
 func TestRunStatePersistsGeneratedPostgresCredentialsSeparately(t *testing.T) {
@@ -208,6 +225,30 @@ func TestPrepareResumeRestoresImportedDockerCredentials(t *testing.T) {
 	_, opts, err := store.PrepareResume("")
 	require.NoError(t, err)
 	assert.Equal(t, "imported-password", opts.DockerPassword)
+}
+
+type testCredentialStore struct {
+	values map[string]credentials.Credential
+}
+
+func (s testCredentialStore) Get(registry string) (credentials.Credential, bool, error) {
+	value, ok := s.values[registry]
+	return value, ok, nil
+}
+func (testCredentialStore) Set(string, credentials.Credential) error { return nil }
+func (testCredentialStore) Delete(string) error                      { return nil }
+
+func TestPrepareResumeRestoresKeyringCredential(t *testing.T) {
+	entry := Entry{Version: "8.10", Shortname: "one", Scenario: "first", Flow: "install"}
+	store := NewRunStateStore(t.TempDir(), "run-1")
+	_, err := store.Create([]Entry{entry}, RunOptions{DockerUsername: "robot", DockerPassword: "original", EnsureDockerRegistry: true})
+	require.NoError(t, err)
+	original := resumeCredentialStore
+	resumeCredentialStore = testCredentialStore{values: map[string]credentials.Credential{credentials.HarborRegistry: {Username: "robot", Password: "stored-token"}}}
+	t.Cleanup(func() { resumeCredentialStore = original })
+	_, opts, err := store.PrepareResume("")
+	require.NoError(t, err)
+	assert.Equal(t, "stored-token", opts.DockerPassword)
 }
 
 func TestClassifyFailure(t *testing.T) {

--- a/scripts/deploy-camunda/matrix/run_state_test.go
+++ b/scripts/deploy-camunda/matrix/run_state_test.go
@@ -209,6 +209,13 @@ func TestRecoverStaleLockRejectsLiveProcess(t *testing.T) {
 	require.ErrorContains(t, store.RecoverStaleLock(), "live process")
 }
 
+func TestRecoverStaleLockRemovesMalformedLock(t *testing.T) {
+	store := NewRunStateStore(t.TempDir(), "run-1")
+	require.NoError(t, os.MkdirAll(store.RunDir(), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(store.RunDir(), "run.lock"), []byte("{"), 0o600))
+	require.NoError(t, store.RecoverStaleLock())
+}
+
 func TestCleaningFailedEntryPreservesFailedRun(t *testing.T) {
 	entry := Entry{Version: "8.10", Shortname: "one", Scenario: "first", Flow: "install"}
 	store := NewRunStateStore(t.TempDir(), "run-1")

--- a/scripts/deploy-camunda/matrix/run_state_test.go
+++ b/scripts/deploy-camunda/matrix/run_state_test.go
@@ -63,7 +63,7 @@ func TestRunStateRedactsSecrets(t *testing.T) {
 	text := string(data)
 	assert.NotContains(t, text, "registry-password")
 	assert.NotContains(t, text, "super-secret")
-	assert.NotContains(t, text, "global.host=example.test")
+	assert.Contains(t, text, "global.host=example.test")
 }
 
 func TestReplayCommandIncludesExecutionTarget(t *testing.T) {

--- a/scripts/deploy-camunda/matrix/run_state_test.go
+++ b/scripts/deploy-camunda/matrix/run_state_test.go
@@ -392,6 +392,19 @@ func TestRunStatePersistsAuth0Behavior(t *testing.T) {
 	assert.Equal(t, "admin@example.com", stored.Auth0InitialAdminEmail)
 }
 
+func TestPrepareResumeCarriesRecordedIdentityTenants(t *testing.T) {
+	entry := Entry{Version: "8.10", Shortname: "auth0", Flow: "install"}
+	store := NewRunStateStore(t.TempDir(), "run-1")
+	_, err := store.Create([]Entry{entry}, RunOptions{})
+	require.NoError(t, err)
+	require.NoError(t, store.RecordExternalResources(entry, "", "tenant-id", "https://tenant.example", []string{"client"}))
+	require.NoError(t, store.MarkExternalProvisioningComplete(entry))
+	_, opts, err := store.PrepareResume("")
+	require.NoError(t, err)
+	assert.Equal(t, "tenant-id", opts.EntraDirectoryID)
+	assert.Equal(t, "https://tenant.example", opts.Auth0Domain)
+}
+
 func TestCreatePersistsAbsoluteLocalDependencyPaths(t *testing.T) {
 	repoRoot := t.TempDir()
 	chartPath := filepath.Join(repoRoot, "charts", "local")

--- a/scripts/deploy-camunda/matrix/run_state_test.go
+++ b/scripts/deploy-camunda/matrix/run_state_test.go
@@ -352,6 +352,18 @@ func TestCreatePersistsAbsoluteEntryChartPath(t *testing.T) {
 	assert.NotContains(t, replay, "--repo-root ../..")
 }
 
+func TestPrepareResumeRejectsEnvFileDrift(t *testing.T) {
+	envFile := filepath.Join(t.TempDir(), ".env")
+	require.NoError(t, os.WriteFile(envFile, []byte("VALUE=one\n"), 0o600))
+	entry := Entry{Version: "8.10", Shortname: "one", Flow: "install"}
+	store := NewRunStateStore(t.TempDir(), "run-1")
+	_, err := store.Create([]Entry{entry}, RunOptions{EnvFile: envFile})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(envFile, []byte("VALUE=two\n"), 0o600))
+	_, _, err = store.PrepareResume("")
+	require.ErrorContains(t, err, "changed since run creation")
+}
+
 func TestCreatePersistsAbsoluteLocalDependencyPaths(t *testing.T) {
 	repoRoot := t.TempDir()
 	chartPath := filepath.Join(repoRoot, "charts", "local")

--- a/scripts/deploy-camunda/matrix/run_state_test.go
+++ b/scripts/deploy-camunda/matrix/run_state_test.go
@@ -72,6 +72,18 @@ func TestRunStatePreservesBenignHelmOverride(t *testing.T) {
 	assert.Equal(t, []string{"--atomic"}, stored.ExtraHelmArgs)
 }
 
+func TestRunStateRedactsUnknownHelmOverride(t *testing.T) {
+	stored := StoreRunOptions(RunOptions{ExtraHelmSets: []string{"auth=secret-value"}})
+	assert.Equal(t, []string{"<redacted>"}, stored.ExtraHelmSets)
+}
+
+func TestRunStateRequiresOnlyEnabledRegistryCredentials(t *testing.T) {
+	stored := StoreRunOptions(RunOptions{DockerUsername: "incidental", DockerPassword: "incidental-password"})
+	assert.False(t, stored.RequiresDockerPassword)
+	stored = StoreRunOptions(RunOptions{EnsureDockerRegistry: true})
+	assert.True(t, stored.RequiresDockerPassword)
+}
+
 func TestReplayCommandIncludesExecutionTarget(t *testing.T) {
 	entry := Entry{Version: "8.10", Shortname: "one", Scenario: "first", Flow: "install", Platform: "gke"}
 	command := ReplayCommand(entry, RunOptions{
@@ -165,7 +177,7 @@ func TestPrepareResumeRejectsMismatchedDockerCredentials(t *testing.T) {
 	t.Setenv("NEXUS_PASSWORD", "")
 	entry := Entry{Version: "8.10", Shortname: "one", Scenario: "first", Flow: "install"}
 	store := NewRunStateStore(t.TempDir(), "run-1")
-	_, err := store.Create([]Entry{entry}, RunOptions{DockerUsername: "original-user", DockerPassword: "original-password"})
+	_, err := store.Create([]Entry{entry}, RunOptions{DockerUsername: "original-user", DockerPassword: "original-password", EnsureDockerRegistry: true})
 	require.NoError(t, err)
 	_, _, err = store.PrepareResume("")
 	require.ErrorContains(t, err, "does not match stored username")

--- a/scripts/deploy-camunda/matrix/run_state_test.go
+++ b/scripts/deploy-camunda/matrix/run_state_test.go
@@ -364,6 +364,19 @@ func TestPrepareResumeRejectsEnvFileDrift(t *testing.T) {
 	require.ErrorContains(t, err, "changed since run creation")
 }
 
+func TestPrepareResumeRejectsChartDrift(t *testing.T) {
+	chartDir := t.TempDir()
+	chartFile := filepath.Join(chartDir, "values.yaml")
+	require.NoError(t, os.WriteFile(chartFile, []byte("value: one\n"), 0o600))
+	entry := Entry{Version: "8.10", Shortname: "one", Flow: "install", ChartPath: chartDir}
+	store := NewRunStateStore(t.TempDir(), "run-1")
+	_, err := store.Create([]Entry{entry}, RunOptions{})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(chartFile, []byte("value: two\n"), 0o600))
+	_, _, err = store.PrepareResume("")
+	require.ErrorContains(t, err, "changed since run creation")
+}
+
 func TestCreatePersistsAbsoluteLocalDependencyPaths(t *testing.T) {
 	repoRoot := t.TempDir()
 	chartPath := filepath.Join(repoRoot, "charts", "local")

--- a/scripts/deploy-camunda/matrix/run_state_test.go
+++ b/scripts/deploy-camunda/matrix/run_state_test.go
@@ -1,0 +1,174 @@
+package matrix
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunStateLifecycleAndResume(t *testing.T) {
+	root := t.TempDir()
+	entries := []Entry{
+		{Version: "8.10", Shortname: "one", Scenario: "first", Flow: "install", Platform: "gke"},
+		{Version: "8.10", Shortname: "two", Scenario: "second", Flow: "install", Platform: "gke"},
+	}
+	opts := RunOptions{RepoRoot: "/repo", NamespacePrefix: "test", KubeContext: "cluster"}
+	store := NewRunStateStore(root, "run-1")
+
+	_, err := store.Create(entries, opts)
+	require.NoError(t, err)
+	require.NoError(t, store.Start(entries[0], "test-810-one"))
+	require.NoError(t, store.Phase(entries[0], "deploying"))
+	require.NoError(t, store.Complete(entries[0], RunResult{Entry: entries[0], Namespace: "test-810-one", KubeContext: "cluster"}))
+	require.NoError(t, store.Start(entries[1], "test-810-two"))
+	require.NoError(t, store.MarkInterrupted())
+
+	state, err := store.Load()
+	require.NoError(t, err)
+	assert.Equal(t, RunPassed, state.Entries[0].Status)
+	assert.Equal(t, RunInterrupted, state.Entries[1].Status)
+	assert.Equal(t, "RUN_INTERRUPTED", state.Entries[1].Failure.Code)
+
+	resumed, restored, err := store.PrepareResume("")
+	require.NoError(t, err)
+	require.Len(t, resumed, 1)
+	assert.Equal(t, "two", resumed[0].Shortname)
+	assert.Equal(t, "/repo", restored.RepoRoot)
+	assert.Equal(t, "cluster", restored.KubeContext)
+
+	info, err := os.Stat(filepath.Join(root, "run-1", "matrix-state.json"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestRunStateRedactsSecrets(t *testing.T) {
+	entry := Entry{Version: "8.10", Shortname: "one", Scenario: "first", Flow: "install"}
+	opts := RunOptions{
+		DockerPassword: "registry-password",
+		ExtraHelmSets:  []string{"global.password=super-secret", "global.host=example.test"},
+		ExtraHelmArgs:  []string{"--set=identity.secret.inlineSecret=super-secret"},
+	}
+	store := NewRunStateStore(t.TempDir(), "run-1")
+	_, err := store.Create([]Entry{entry}, opts)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(filepath.Join(store.RunDir(), "matrix-state.json"))
+	require.NoError(t, err)
+	text := string(data)
+	assert.NotContains(t, text, "registry-password")
+	assert.NotContains(t, text, "super-secret")
+	assert.NotContains(t, text, "global.host=example.test")
+}
+
+func TestReplayCommandIncludesExecutionTarget(t *testing.T) {
+	entry := Entry{Version: "8.10", Shortname: "one", Scenario: "first", Flow: "install", Platform: "gke"}
+	command := ReplayCommand(entry, RunOptions{
+		RepoRoot: "/repo", NamespacePrefix: "test", KubeContexts: map[string]string{"gke": "cluster"},
+		IngressBaseDomains: map[string]string{"gke": "example.test"}, ChartRef: "/tmp/chart.tgz", TestE2E: true,
+	})
+	joined := strings.Join(command, " ")
+	assert.Contains(t, joined, "--kube-context-gke cluster")
+	assert.Contains(t, joined, "--ingress-base-domain-gke example.test")
+	assert.Contains(t, joined, "--chart-ref /tmp/chart.tgz")
+	assert.Contains(t, joined, "--test-e2e")
+}
+
+func TestRunStateRefusesConcurrentLock(t *testing.T) {
+	store := NewRunStateStore(t.TempDir(), "run-1")
+	first, err := store.Acquire()
+	require.NoError(t, err)
+	defer first.Close()
+
+	_, err = NewRunStateStore(store.root, "run-1").Acquire()
+	require.ErrorContains(t, err, "active in another process")
+}
+
+func TestCleaningFailedEntryPreservesFailedRun(t *testing.T) {
+	entry := Entry{Version: "8.10", Shortname: "one", Scenario: "first", Flow: "install"}
+	store := NewRunStateStore(t.TempDir(), "run-1")
+	_, err := store.Create([]Entry{entry}, RunOptions{})
+	require.NoError(t, err)
+	require.NoError(t, store.Start(entry, "namespace"))
+	require.NoError(t, store.Complete(entry, RunResult{Entry: entry, Error: errors.New("helm failed")}))
+	require.NoError(t, store.MarkCleaned(EntryID(entry)))
+
+	state, err := store.Load()
+	require.NoError(t, err)
+	assert.Equal(t, RunFailed, state.Status)
+	assert.Equal(t, RunFailed, state.Entries[0].Status)
+	assert.True(t, state.Entries[0].Cleaned)
+}
+
+func TestResumeRejectsRedactedArguments(t *testing.T) {
+	entry := Entry{Version: "8.10", Shortname: "one", Scenario: "first", Flow: "install"}
+	store := NewRunStateStore(t.TempDir(), "run-1")
+	_, err := store.Create([]Entry{entry}, RunOptions{ExtraHelmSets: []string{"global.password=secret"}})
+	require.NoError(t, err)
+
+	_, _, err = store.PrepareResume("")
+	require.ErrorContains(t, err, "cannot reconstruct them safely")
+}
+
+func TestRunStatePersistsGeneratedPostgresCredentialsSeparately(t *testing.T) {
+	entry := Entry{Version: "8.10", Shortname: "one", Scenario: "first", Flow: "install"}
+	store := NewRunStateStore(t.TempDir(), "run-1")
+	_, err := store.Create([]Entry{entry}, RunOptions{
+		GeneratePostgresCredentials: true,
+		GeneratedPostgresUsername:   "camunda",
+		GeneratedPostgresPassword:   "generated-password",
+	})
+	require.NoError(t, err)
+
+	stateData, err := os.ReadFile(filepath.Join(store.RunDir(), "matrix-state.json"))
+	require.NoError(t, err)
+	assert.NotContains(t, string(stateData), "generated-password")
+	secretInfo, err := os.Stat(filepath.Join(store.RunDir(), "run-secrets.json"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), secretInfo.Mode().Perm())
+
+	_, opts, err := store.PrepareResume("")
+	require.NoError(t, err)
+	assert.Equal(t, "generated-password", opts.GeneratedPostgresPassword)
+}
+
+func TestPrepareResumeRejectsMismatchedDockerCredentials(t *testing.T) {
+	t.Setenv("HARBOR_USERNAME", "different-user")
+	t.Setenv("HARBOR_PASSWORD", "password")
+	t.Setenv("TEST_DOCKER_USERNAME_CAMUNDA_CLOUD", "")
+	t.Setenv("TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD", "")
+	t.Setenv("NEXUS_USERNAME", "")
+	t.Setenv("NEXUS_PASSWORD", "")
+	entry := Entry{Version: "8.10", Shortname: "one", Scenario: "first", Flow: "install"}
+	store := NewRunStateStore(t.TempDir(), "run-1")
+	_, err := store.Create([]Entry{entry}, RunOptions{DockerUsername: "original-user", DockerPassword: "original-password"})
+	require.NoError(t, err)
+	_, _, err = store.PrepareResume("")
+	require.ErrorContains(t, err, "does not match stored username")
+}
+
+func TestClassifyFailure(t *testing.T) {
+	tests := []struct {
+		err  error
+		code string
+	}{
+		{errors.New("helm upgrade failed"), "HELM_FAILURE"},
+		{errors.New("docker registry unauthorized"), "REGISTRY_FAILURE"},
+		{errors.New("Playwright e2e test failed"), "TEST_FAILURE"},
+		{errors.New("context canceled"), "RUN_INTERRUPTED"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.code, ClassifyFailure(tt.err).Code)
+	}
+}
+
+func TestClassifyFailureRedactsCredentialValues(t *testing.T) {
+	failure := ClassifyFailure(errors.New("request failed password=hunter2 token=abc123"))
+	assert.NotContains(t, failure.Message, "hunter2")
+	assert.NotContains(t, failure.Message, "abc123")
+	assert.Equal(t, "deployment failed; inspect the diagnostics bundle", failure.Message)
+}

--- a/scripts/deploy-camunda/matrix/run_state_test.go
+++ b/scripts/deploy-camunda/matrix/run_state_test.go
@@ -377,6 +377,21 @@ func TestPrepareResumeRejectsChartDrift(t *testing.T) {
 	require.ErrorContains(t, err, "changed since run creation")
 }
 
+func TestPrepareResumeRejectsMutableOCIReference(t *testing.T) {
+	entry := Entry{Version: "8.10", Shortname: "one", Flow: "install"}
+	store := NewRunStateStore(t.TempDir(), "run-1")
+	_, err := store.Create([]Entry{entry}, RunOptions{ChartRef: "oci://registry.example/chart", ChartRefVersion: "latest"})
+	require.NoError(t, err)
+	_, _, err = store.PrepareResume("")
+	require.ErrorContains(t, err, "mutable OCI chart references")
+}
+
+func TestRunStatePersistsAuth0Behavior(t *testing.T) {
+	stored := StoreRunOptions(RunOptions{Auth0IngressHost: "host.example", Auth0InitialAdminEmail: "admin@example.com"})
+	assert.Equal(t, "host.example", stored.Auth0IngressHost)
+	assert.Equal(t, "admin@example.com", stored.Auth0InitialAdminEmail)
+}
+
 func TestCreatePersistsAbsoluteLocalDependencyPaths(t *testing.T) {
 	repoRoot := t.TempDir()
 	chartPath := filepath.Join(repoRoot, "charts", "local")

--- a/scripts/deploy-camunda/matrix/run_state_test.go
+++ b/scripts/deploy-camunda/matrix/run_state_test.go
@@ -1,6 +1,7 @@
 package matrix
 
 import (
+	"encoding/base64"
 	"errors"
 	"os"
 	"path/filepath"
@@ -155,6 +156,22 @@ func TestPrepareResumeRejectsMismatchedDockerCredentials(t *testing.T) {
 	require.NoError(t, err)
 	_, _, err = store.PrepareResume("")
 	require.ErrorContains(t, err, "does not match stored username")
+}
+
+func TestPrepareResumeRestoresImportedDockerCredentials(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	auth := base64.StdEncoding.EncodeToString([]byte("imported-user:imported-password"))
+	require.NoError(t, os.WriteFile(configPath, []byte(`{"auths":{"registry.camunda.cloud":{"auth":"`+auth+`"}}}`), 0o600))
+	entry := Entry{Version: "8.10", Shortname: "one", Scenario: "first", Flow: "install"}
+	store := NewRunStateStore(t.TempDir(), "run-1")
+	_, err := store.Create([]Entry{entry}, RunOptions{
+		DockerUsername: "imported-user", DockerPassword: "imported-password",
+		ImportDockerAuth: true, DockerConfigPath: configPath,
+	})
+	require.NoError(t, err)
+	_, opts, err := store.PrepareResume("")
+	require.NoError(t, err)
+	assert.Equal(t, "imported-password", opts.DockerPassword)
 }
 
 func TestClassifyFailure(t *testing.T) {

--- a/scripts/deploy-camunda/matrix/run_state_test.go
+++ b/scripts/deploy-camunda/matrix/run_state_test.go
@@ -32,6 +32,7 @@ func TestRunStateLifecycleAndResume(t *testing.T) {
 	state, err := store.Load()
 	require.NoError(t, err)
 	assert.Equal(t, RunPassed, state.Entries[0].Status)
+	assert.Equal(t, "complete", state.Entries[0].Phase)
 	assert.Equal(t, RunInterrupted, state.Entries[1].Status)
 	assert.Equal(t, "RUN_INTERRUPTED", state.Entries[1].Failure.Code)
 
@@ -143,6 +144,7 @@ func TestCleaningFailedEntryPreservesFailedRun(t *testing.T) {
 	assert.Equal(t, RunFailed, state.Status)
 	assert.Equal(t, RunFailed, state.Entries[0].Status)
 	assert.True(t, state.Entries[0].Cleaned)
+	assert.Equal(t, "cleaned", state.Entries[0].Phase)
 }
 
 func TestResumeRejectsRedactedArguments(t *testing.T) {
@@ -234,6 +236,20 @@ func TestCreatePersistsAbsoluteEntryChartPath(t *testing.T) {
 	assert.True(t, filepath.IsAbs(state.Entries[0].Entry.ChartPath), state.Entries[0].Entry.ChartPath)
 	replay := strings.Join(state.Entries[0].Replay.Command, " ")
 	assert.NotContains(t, replay, "--repo-root ../..")
+}
+
+func TestCreatePersistsAbsoluteLocalDependencyPaths(t *testing.T) {
+	repoRoot := t.TempDir()
+	chartPath := filepath.Join(repoRoot, "charts", "local")
+	require.NoError(t, os.MkdirAll(chartPath, 0o755))
+	entry := Entry{Version: "8.10", Shortname: "one", Scenario: "first", Flow: "install", Dependencies: []ChartDependency{{Chart: "charts/local", ValuesFile: "values/local.yaml"}}}
+	store := NewRunStateStore(t.TempDir(), "run-1")
+	_, err := store.Create([]Entry{entry}, RunOptions{RepoRoot: repoRoot})
+	require.NoError(t, err)
+	state, err := store.Load()
+	require.NoError(t, err)
+	assert.Equal(t, chartPath, state.Entries[0].Entry.Dependencies[0].Chart)
+	assert.Equal(t, filepath.Join(repoRoot, "values/local.yaml"), state.Entries[0].Entry.Dependencies[0].ValuesFile)
 }
 
 func TestClassifyFailureRedactsCredentialValues(t *testing.T) {

--- a/scripts/deploy-camunda/matrix/run_state_test.go
+++ b/scripts/deploy-camunda/matrix/run_state_test.go
@@ -202,3 +202,11 @@ func TestClassifyFailureRedactsCredentialValues(t *testing.T) {
 	assert.NotContains(t, failure.Message, "abc123")
 	assert.Equal(t, "deployment failed; inspect the diagnostics bundle", failure.Message)
 }
+
+func TestApplyCleanupResultPreservesFailureAndNotCleaned(t *testing.T) {
+	result := RunResult{Error: errors.New("deployment failed")}
+	cleaned := applyCleanupResult(&result, func() error { return errors.New("namespace deletion failed") })
+	assert.False(t, cleaned)
+	assert.ErrorContains(t, result.Error, "deployment failed")
+	assert.ErrorContains(t, result.Error, "cleanup matrix entry: namespace deletion failed")
+}

--- a/scripts/deploy-camunda/matrix/run_state_test.go
+++ b/scripts/deploy-camunda/matrix/run_state_test.go
@@ -361,6 +361,32 @@ func TestApplyCleanupResultPreservesFailureAndNotCleaned(t *testing.T) {
 	assert.ErrorContains(t, result.Error, "cleanup matrix entry: namespace deletion failed")
 }
 
+func TestExternalCompensationClearsUncertaintyOnlyOnSuccess(t *testing.T) {
+	entry := Entry{Version: "8.10", Shortname: "oidc", Flow: "install"}
+	store := NewRunStateStore(t.TempDir(), "run-1")
+	_, err := store.Create([]Entry{entry}, RunOptions{})
+	require.NoError(t, err)
+	require.NoError(t, store.MarkExternalProvisioningStarted(entry))
+	require.Error(t, completeExternalCompensation(store, entry, errors.New("delete failed")))
+	state, err := store.Load()
+	require.NoError(t, err)
+	assert.True(t, state.Entries[0].ExternalProvisioningStarted)
+	require.NoError(t, completeExternalCompensation(store, entry, nil))
+	state, err = store.Load()
+	require.NoError(t, err)
+	assert.False(t, state.Entries[0].ExternalProvisioningStarted)
+}
+
+func TestPrepareResumeRejectsUncertainExternalProvisioning(t *testing.T) {
+	entry := Entry{Version: "8.10", Shortname: "oidc", Flow: "install"}
+	store := NewRunStateStore(t.TempDir(), "run-1")
+	_, err := store.Create([]Entry{entry}, RunOptions{})
+	require.NoError(t, err)
+	require.NoError(t, store.MarkExternalProvisioningStarted(entry))
+	_, _, err = store.PrepareResume("")
+	require.ErrorContains(t, err, "unresolved external provisioning")
+}
+
 func TestCleanupEntryUsesCheckpointedAuth0IDsAndStopsOnFailure(t *testing.T) {
 	entry := Entry{Version: "8.10", Shortname: "auth0", Scenario: "auth0", Flow: "install", Identity: "auth0"}
 	store := NewRunStateStore(t.TempDir(), "run-1")

--- a/scripts/deploy-camunda/matrix/run_state_test.go
+++ b/scripts/deploy-camunda/matrix/run_state_test.go
@@ -130,6 +130,26 @@ func TestAcquireRejectsActiveLockGuard(t *testing.T) {
 	require.ErrorContains(t, err, "lock operation is active")
 }
 
+func TestAcquireReclaimsStaleLockGuard(t *testing.T) {
+	store := NewRunStateStore(t.TempDir(), "run-1")
+	require.NoError(t, os.MkdirAll(store.RunDir(), 0o700))
+	hostname, _ := os.Hostname()
+	data, _ := json.Marshal(lockOwner{Hostname: hostname, PID: 999999999, ProcessIdentity: "dead"})
+	require.NoError(t, os.WriteFile(filepath.Join(store.RunDir(), "run.lock.guard"), append(data, '\n'), 0o600))
+	lock, err := store.Acquire()
+	require.NoError(t, err)
+	require.NoError(t, lock.Close())
+}
+
+func TestPrepareResumeIgnoresUnusedDockerImport(t *testing.T) {
+	entry := Entry{Version: "8.10", Shortname: "one", Scenario: "first", Flow: "install"}
+	store := NewRunStateStore(t.TempDir(), "run-1")
+	_, err := store.Create([]Entry{entry}, RunOptions{ImportDockerAuth: true, DockerConfigPath: filepath.Join(t.TempDir(), "missing.json")})
+	require.NoError(t, err)
+	_, _, err = store.PrepareResume("")
+	require.NoError(t, err)
+}
+
 func TestValidateRunIDRejectsTraversal(t *testing.T) {
 	for _, id := range []string{"", "..", "../other", "/tmp/run", "a/b"} {
 		assert.Error(t, ValidateRunID(id), id)
@@ -252,7 +272,7 @@ func TestPrepareResumeRestoresImportedDockerCredentials(t *testing.T) {
 	store := NewRunStateStore(t.TempDir(), "run-1")
 	_, err := store.Create([]Entry{entry}, RunOptions{
 		DockerUsername: "imported-user", DockerPassword: "imported-password",
-		ImportDockerAuth: true, DockerConfigPath: configPath,
+		ImportDockerAuth: true, DockerConfigPath: configPath, EnsureDockerRegistry: true,
 	})
 	require.NoError(t, err)
 	_, opts, err := store.PrepareResume("")

--- a/scripts/deploy-camunda/matrix/run_state_test.go
+++ b/scripts/deploy-camunda/matrix/run_state_test.go
@@ -66,6 +66,12 @@ func TestRunStateRedactsSecrets(t *testing.T) {
 	assert.Contains(t, text, "global.host=example.test")
 }
 
+func TestRunStatePreservesBenignHelmOverride(t *testing.T) {
+	stored := StoreRunOptions(RunOptions{ExtraHelmSets: []string{"feature.enabled=true"}, ExtraHelmArgs: []string{"--atomic"}})
+	assert.Equal(t, []string{"feature.enabled=true"}, stored.ExtraHelmSets)
+	assert.Equal(t, []string{"--atomic"}, stored.ExtraHelmArgs)
+}
+
 func TestReplayCommandIncludesExecutionTarget(t *testing.T) {
 	entry := Entry{Version: "8.10", Shortname: "one", Scenario: "first", Flow: "install", Platform: "gke"}
 	command := ReplayCommand(entry, RunOptions{

--- a/scripts/deploy-camunda/matrix/run_state_test.go
+++ b/scripts/deploy-camunda/matrix/run_state_test.go
@@ -458,3 +458,20 @@ func TestCleanupEntryUsesCheckpointedAuth0IDsAndStopsOnFailure(t *testing.T) {
 	require.ErrorContains(t, err, "provider failure")
 	assert.True(t, called)
 }
+
+func TestExecuteEntryOwnershipFailurePreventsProviderProvisioning(t *testing.T) {
+	chartPath := t.TempDir()
+	entry := Entry{Version: "8.10", ChartPath: chartPath, Scenario: "oidc", Shortname: "oidc", Flow: "install", Auth: "oidc", Identity: "oidc"}
+	store := NewRunStateStore(t.TempDir(), "run-1")
+	_, err := store.Create([]Entry{entry}, RunOptions{})
+	require.NoError(t, err)
+	original := ensureEntryNamespaceOwned
+	ensureEntryNamespaceOwned = func(context.Context, string, string, string) error { return errors.New("foreign namespace") }
+	t.Cleanup(func() { ensureEntryNamespaceOwned = original })
+	result := executeEntry(context.Background(), entry, RunOptions{StateStore: store})
+	require.ErrorContains(t, result.Error, "foreign namespace")
+	state, err := store.Load()
+	require.NoError(t, err)
+	assert.False(t, state.Entries[0].ExternalProvisioningStarted)
+	assert.Empty(t, state.Entries[0].EntraObjectID)
+}

--- a/scripts/deploy-camunda/matrix/run_state_test.go
+++ b/scripts/deploy-camunda/matrix/run_state_test.go
@@ -1,6 +1,7 @@
 package matrix
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"scripts/deploy-camunda/auth0"
 	"scripts/deploy-camunda/credentials"
 )
 
@@ -141,6 +143,15 @@ func TestRunStateDoesNotReclaimForeignHostLock(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(store.RunDir(), "run.lock"), append(data, '\n'), 0o600))
 	_, err := store.Acquire()
 	require.ErrorContains(t, err, "active in another process")
+}
+
+func TestRecoverStaleLockRejectsLiveProcess(t *testing.T) {
+	store := NewRunStateStore(t.TempDir(), "run-1")
+	require.NoError(t, os.MkdirAll(store.RunDir(), 0o700))
+	hostname, _ := os.Hostname()
+	data, _ := json.Marshal(lockOwner{Hostname: hostname, PID: os.Getpid()})
+	require.NoError(t, os.WriteFile(filepath.Join(store.RunDir(), "run.lock"), append(data, '\n'), 0o600))
+	require.ErrorContains(t, store.RecoverStaleLock(), "live process")
 }
 
 func TestCleaningFailedEntryPreservesFailedRun(t *testing.T) {
@@ -306,4 +317,23 @@ func TestApplyCleanupResultPreservesFailureAndNotCleaned(t *testing.T) {
 	assert.False(t, cleaned)
 	assert.ErrorContains(t, result.Error, "deployment failed")
 	assert.ErrorContains(t, result.Error, "cleanup matrix entry: namespace deletion failed")
+}
+
+func TestCleanupEntryUsesCheckpointedAuth0IDsAndStopsOnFailure(t *testing.T) {
+	entry := Entry{Version: "8.10", Shortname: "auth0", Scenario: "auth0", Flow: "install", Identity: "auth0"}
+	store := NewRunStateStore(t.TempDir(), "run-1")
+	_, err := store.Create([]Entry{entry}, RunOptions{})
+	require.NoError(t, err)
+	require.NoError(t, store.RecordExternalResources(entry, "", "", "https://tenant.example", []string{"id-A"}))
+	original := cleanupAuth0IDs
+	called := false
+	cleanupAuth0IDs = func(context.Context, auth0.Options, []string) error {
+		called = true
+		return errors.New("provider failure")
+	}
+	t.Cleanup(func() { cleanupAuth0IDs = original })
+	result := RunResult{Entry: entry, Namespace: "namespace", auth0Opts: &auth0.Options{Namespace: "namespace"}}
+	err = cleanupEntry(context.Background(), result, RunOptions{StateStore: store})
+	require.ErrorContains(t, err, "provider failure")
+	assert.True(t, called)
 }

--- a/scripts/deploy-camunda/matrix/run_state_test.go
+++ b/scripts/deploy-camunda/matrix/run_state_test.go
@@ -78,6 +78,12 @@ func TestReplayCommandIncludesExecutionTarget(t *testing.T) {
 	assert.Contains(t, joined, "--test-e2e")
 }
 
+func TestReplayCommandIncludesUpgradeSource(t *testing.T) {
+	entry := Entry{Version: "8.10", Shortname: "one", Flow: "upgrade-minor"}
+	command := strings.Join(ReplayCommand(entry, RunOptions{UpgradeFromVersion: "13.5.0"}), " ")
+	assert.Contains(t, command, "--upgrade-from-version 13.5.0")
+}
+
 func TestRunStateRefusesConcurrentLock(t *testing.T) {
 	store := NewRunStateStore(t.TempDir(), "run-1")
 	first, err := store.Acquire()

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -1531,9 +1531,6 @@ func cleanupEntry(ctx context.Context, result RunResult, opts RunOptions) error 
 		if err := cleanupAuth0IDs(identityCtx, *result.auth0Opts, ids); err != nil {
 			return err
 		}
-		if err := opts.StateStore.MarkExternalProvisioningComplete(result.Entry); err != nil {
-			return err
-		}
 	}
 
 	// Delete the namespace.

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -1531,6 +1531,9 @@ func cleanupEntry(ctx context.Context, result RunResult, opts RunOptions) error 
 		if err := cleanupAuth0IDs(identityCtx, *result.auth0Opts, ids); err != nil {
 			return err
 		}
+		if err := opts.StateStore.MarkExternalProvisioningComplete(result.Entry); err != nil {
+			return err
+		}
 	}
 
 	// Delete the namespace.

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -1473,12 +1473,14 @@ func lastNLines(s string, n int) string {
 // happen after diagnostics have been collected. Errors are logged but do not affect the
 // entry's result.
 func cleanupEntry(ctx context.Context, result RunResult, opts RunOptions) error {
+	identityCtx, identityCancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer identityCancel()
 	// Clean up Entra app registration for OIDC entries (best-effort, before namespace deletion).
 	if result.venomOpts != nil {
 		logging.Logger.Info().
 			Str("namespace", result.Namespace).
 			Msg("Cleaning up venom Entra app registration")
-		entra.CleanupVenomApp(ctx, *result.venomOpts)
+		entra.CleanupVenomApp(identityCtx, *result.venomOpts)
 	}
 
 	// Clean up Auth0 clients for Auth0 entries (best-effort, before namespace deletion).
@@ -1486,7 +1488,7 @@ func cleanupEntry(ctx context.Context, result RunResult, opts RunOptions) error 
 		logging.Logger.Info().
 			Str("namespace", result.Namespace).
 			Msg("Cleaning up Auth0 clients")
-		auth0.CleanupClients(ctx, *result.auth0Opts)
+		auth0.CleanupClients(identityCtx, *result.auth0Opts)
 	}
 
 	// Delete the namespace.

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -185,11 +185,13 @@ func Run(ctx context.Context, entries []Entry, opts RunOptions) ([]RunResult, er
 	// creates the per-namespace K8s pull secrets without touching `docker login`.
 	if opts.EnsureDockerHub {
 		if err := docker.EnsureDockerHubLogin(ctx, opts.DockerHubUsername, opts.DockerHubPassword); err != nil {
+			completePendingEntries(entries, opts, fmt.Errorf("failed to ensure Docker Hub login: %w", err))
 			return nil, fmt.Errorf("failed to ensure Docker Hub login: %w", err)
 		}
 	}
 	if opts.EnsureDockerRegistry {
 		if err := docker.EnsureHarborLogin(ctx, opts.DockerUsername, opts.DockerPassword); err != nil {
+			completePendingEntries(entries, opts, fmt.Errorf("failed to ensure Harbor login: %w", err))
 			return nil, fmt.Errorf("failed to ensure Harbor login: %w", err)
 		}
 	}
@@ -199,6 +201,7 @@ func Run(ctx context.Context, entries []Entry, opts RunOptions) ([]RunResult, er
 	// an interactive browser login. Doing this sequentially ensures only one
 	// login prompt per context, rather than N parallel goroutines racing.
 	if err := warmUpKubeContexts(ctx, entries, opts); err != nil {
+		completePendingEntries(entries, opts, err)
 		return nil, err
 	}
 
@@ -228,6 +231,16 @@ func Run(ctx context.Context, entries []Entry, opts RunOptions) ([]RunResult, er
 	}
 
 	return results, retErr
+}
+
+func completePendingEntries(entries []Entry, opts RunOptions, err error) {
+	if opts.StateStore == nil {
+		return
+	}
+	for _, entry := range entries {
+		result := RunResult{Entry: entry, Namespace: resolveNamespace(opts, entry), KubeContext: ResolveKubeContext(opts, entry), Error: err}
+		_ = opts.StateStore.Complete(entry, result)
+	}
 }
 
 // synthesizeRunError checks completed results for failures and returns a
@@ -964,12 +977,16 @@ func runParallel(ctx context.Context, entries []Entry, opts RunOptions) ([]RunRe
 			// Check again after acquiring semaphore slot.
 			if runCtx.Err() != nil {
 				results[idx] = RunResult{
-					Entry:     e,
-					Namespace: resolveNamespace(opts, e),
-					Error:     fmt.Errorf("skipped: run cancelled"),
+					Entry:       e,
+					Namespace:   resolveNamespace(opts, e),
+					KubeContext: ResolveKubeContext(opts, e),
+					Error:       fmt.Errorf("skipped: run cancelled"),
 				}
 				if opts.OnEntryComplete != nil {
 					opts.OnEntryComplete(e, results[idx])
+				}
+				if opts.StateStore != nil {
+					_ = opts.StateStore.Complete(e, results[idx])
 				}
 				return
 			}
@@ -1483,9 +1500,20 @@ func cleanupEntry(ctx context.Context, result RunResult, opts RunOptions) {
 		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
-		if err := kube.DeleteNamespace(cleanupCtx, "", result.KubeContext, result.Namespace); err != nil {
+		var cleanupErr error
+		if opts.StateStore != nil {
+			client, err := kube.NewClient("", result.KubeContext)
+			if err != nil {
+				cleanupErr = err
+			} else {
+				cleanupErr = client.DeleteNamespaceOwnedBy(cleanupCtx, result.Namespace, "deploy-camunda-run", opts.StateStore.RunID())
+			}
+		} else {
+			cleanupErr = kube.DeleteNamespace(cleanupCtx, "", result.KubeContext, result.Namespace)
+		}
+		if cleanupErr != nil {
 			logging.Logger.Error().
-				Err(err).
+				Err(cleanupErr).
 				Str("namespace", result.Namespace).
 				Msg("Failed to delete namespace during per-entry cleanup")
 		} else {

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -1497,7 +1497,7 @@ func cleanupEntry(ctx context.Context, result RunResult, opts RunOptions) error 
 			Msg("Deleting namespace (per-entry cleanup)")
 
 		// Do not let cleanup block matrix completion for too long.
-		cleanupCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()
 
 		var cleanupErr error

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -1524,6 +1524,9 @@ func cleanupEntry(ctx context.Context, result RunResult, opts RunOptions) error 
 		var ids []string
 		for _, item := range state.Entries {
 			if item.ID == EntryID(result.Entry) {
+				if item.ExternalProvisioningStarted {
+					return errors.New("Auth0 provisioning remains unresolved; namespace preserved")
+				}
 				ids = item.Auth0ClientIDs
 				break
 			}

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -1481,6 +1481,7 @@ func cleanupEntry(ctx context.Context, result RunResult, opts RunOptions) error 
 			Str("namespace", result.Namespace).
 			Msg("Cleaning up venom Entra app registration")
 		entra.CleanupVenomApp(identityCtx, *result.venomOpts)
+		return errors.New("Entra cleanup cannot be verified with the current provider API; namespace preserved for retry")
 	}
 
 	// Clean up Auth0 clients for Auth0 entries (best-effort, before namespace deletion).
@@ -1489,6 +1490,7 @@ func cleanupEntry(ctx context.Context, result RunResult, opts RunOptions) error 
 			Str("namespace", result.Namespace).
 			Msg("Cleaning up Auth0 clients")
 		auth0.CleanupClients(identityCtx, *result.auth0Opts)
+		return errors.New("Auth0 cleanup cannot be verified with the current provider API; namespace preserved for retry")
 	}
 
 	// Delete the namespace.

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -1480,8 +1480,9 @@ func cleanupEntry(ctx context.Context, result RunResult, opts RunOptions) error 
 		logging.Logger.Info().
 			Str("namespace", result.Namespace).
 			Msg("Cleaning up venom Entra app registration")
-		entra.CleanupVenomApp(identityCtx, *result.venomOpts)
-		return errors.New("Entra cleanup cannot be verified with the current provider API; namespace preserved for retry")
+		if err := entra.CleanupVenomAppStrict(identityCtx, *result.venomOpts); err != nil {
+			return err
+		}
 	}
 
 	// Clean up Auth0 clients for Auth0 entries (best-effort, before namespace deletion).
@@ -1489,8 +1490,9 @@ func cleanupEntry(ctx context.Context, result RunResult, opts RunOptions) error 
 		logging.Logger.Info().
 			Str("namespace", result.Namespace).
 			Msg("Cleaning up Auth0 clients")
-		auth0.CleanupClients(identityCtx, *result.auth0Opts)
-		return errors.New("Auth0 cleanup cannot be verified with the current provider API; namespace preserved for retry")
+		if err := auth0.CleanupClientsStrict(identityCtx, *result.auth0Opts); err != nil {
+			return err
+		}
 	}
 
 	// Delete the namespace.

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -466,6 +466,8 @@ var (
 	dryDim  = func(s string) string { return logging.Emphasize(s, gchalk.WithBrightBlack().Italic) }
 )
 
+var cleanupAuth0IDs = auth0.CleanupClientIDsStrict
+
 // resolveUpgradeFromVersionQuiet resolves the "from" chart version for upgrade flows.
 // Returns empty string for non-upgrade flows or on error (dry-run is best-effort).
 // If overrideVersion is non-empty, it is returned directly for upgrade flows.
@@ -1526,7 +1528,7 @@ func cleanupEntry(ctx context.Context, result RunResult, opts RunOptions) error 
 				break
 			}
 		}
-		if err := auth0.CleanupClientIDsStrict(identityCtx, *result.auth0Opts, ids); err != nil {
+		if err := cleanupAuth0IDs(identityCtx, *result.auth0Opts, ids); err != nil {
 			return err
 		}
 	}

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -1472,7 +1472,7 @@ func lastNLines(s string, n int) string {
 // This runs regardless of whether the entry succeeded or failed — cleanup should always
 // happen after diagnostics have been collected. Errors are logged but do not affect the
 // entry's result.
-func cleanupEntry(ctx context.Context, result RunResult, opts RunOptions) {
+func cleanupEntry(ctx context.Context, result RunResult, opts RunOptions) error {
 	// Clean up Entra app registration for OIDC entries (best-effort, before namespace deletion).
 	if result.venomOpts != nil {
 		logging.Logger.Info().
@@ -1516,12 +1516,14 @@ func cleanupEntry(ctx context.Context, result RunResult, opts RunOptions) {
 				Err(cleanupErr).
 				Str("namespace", result.Namespace).
 				Msg("Failed to delete namespace during per-entry cleanup")
+			return cleanupErr
 		} else {
 			logging.Logger.Info().
 				Str("namespace", result.Namespace).
 				Msg("Namespace deleted successfully")
 		}
 	}
+	return nil
 }
 
 // mergeHelmSets returns a new map containing all entries from base, with entries

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -1495,7 +1495,21 @@ func cleanupEntry(ctx context.Context, result RunResult, opts RunOptions) error 
 		logging.Logger.Info().
 			Str("namespace", result.Namespace).
 			Msg("Cleaning up Auth0 clients")
-		if err := auth0.CleanupClientsStrict(identityCtx, *result.auth0Opts); err != nil {
+		if opts.StateStore == nil {
+			return errors.New("Auth0 cleanup requires durable client checkpoints")
+		}
+		state, err := opts.StateStore.Load()
+		if err != nil {
+			return err
+		}
+		var ids []string
+		for _, item := range state.Entries {
+			if item.ID == EntryID(result.Entry) {
+				ids = item.Auth0ClientIDs
+				break
+			}
+		}
+		if err := auth0.CleanupClientIDsStrict(identityCtx, *result.auth0Opts, ids); err != nil {
 			return err
 		}
 	}

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -1485,7 +1485,24 @@ func cleanupEntry(ctx context.Context, result RunResult, opts RunOptions) error 
 		logging.Logger.Info().
 			Str("namespace", result.Namespace).
 			Msg("Cleaning up venom Entra app registration")
-		if err := entra.CleanupVenomAppStrict(identityCtx, *result.venomOpts); err != nil {
+		if opts.StateStore == nil {
+			return errors.New("Entra cleanup requires durable object checkpoint")
+		}
+		state, err := opts.StateStore.Load()
+		if err != nil {
+			return err
+		}
+		objectID := ""
+		for _, item := range state.Entries {
+			if item.ID == EntryID(result.Entry) {
+				objectID = item.EntraObjectID
+				break
+			}
+		}
+		if objectID == "" {
+			return errors.New("Entra object checkpoint is missing")
+		}
+		if err := entra.CleanupVenomAppObjectStrict(identityCtx, *result.venomOpts, objectID); err != nil {
 			return err
 		}
 	}

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -1244,7 +1244,11 @@ func diagnosticsTimestamp(now time.Time) string {
 }
 
 func diagnosticsRunDir(namespace string, now time.Time) string {
-	return filepath.Join(diagnosticsDir, namespace, diagnosticsTimestamp(now))
+	path := filepath.Join(diagnosticsDir, namespace, diagnosticsTimestamp(now))
+	if absolute, err := filepath.Abs(path); err == nil {
+		return absolute
+	}
+	return path
 }
 
 func sanitizeDiagnosticsFilename(name string) string {

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -185,14 +185,14 @@ func Run(ctx context.Context, entries []Entry, opts RunOptions) ([]RunResult, er
 	// creates the per-namespace K8s pull secrets without touching `docker login`.
 	if opts.EnsureDockerHub {
 		if err := docker.EnsureDockerHubLogin(ctx, opts.DockerHubUsername, opts.DockerHubPassword); err != nil {
-			completePendingEntries(entries, opts, fmt.Errorf("failed to ensure Docker Hub login: %w", err))
-			return nil, fmt.Errorf("failed to ensure Docker Hub login: %w", err)
+			runErr := fmt.Errorf("failed to ensure Docker Hub login: %w", err)
+			return completePendingEntries(entries, opts, runErr), runErr
 		}
 	}
 	if opts.EnsureDockerRegistry {
 		if err := docker.EnsureHarborLogin(ctx, opts.DockerUsername, opts.DockerPassword); err != nil {
-			completePendingEntries(entries, opts, fmt.Errorf("failed to ensure Harbor login: %w", err))
-			return nil, fmt.Errorf("failed to ensure Harbor login: %w", err)
+			runErr := fmt.Errorf("failed to ensure Harbor login: %w", err)
+			return completePendingEntries(entries, opts, runErr), runErr
 		}
 	}
 
@@ -201,8 +201,7 @@ func Run(ctx context.Context, entries []Entry, opts RunOptions) ([]RunResult, er
 	// an interactive browser login. Doing this sequentially ensures only one
 	// login prompt per context, rather than N parallel goroutines racing.
 	if err := warmUpKubeContexts(ctx, entries, opts); err != nil {
-		completePendingEntries(entries, opts, err)
-		return nil, err
+		return completePendingEntries(entries, opts, err), err
 	}
 
 	parallel := opts.MaxParallel > 1
@@ -233,14 +232,16 @@ func Run(ctx context.Context, entries []Entry, opts RunOptions) ([]RunResult, er
 	return results, retErr
 }
 
-func completePendingEntries(entries []Entry, opts RunOptions, err error) {
-	if opts.StateStore == nil {
-		return
-	}
+func completePendingEntries(entries []Entry, opts RunOptions, err error) []RunResult {
+	results := make([]RunResult, 0, len(entries))
 	for _, entry := range entries {
 		result := RunResult{Entry: entry, Namespace: resolveNamespace(opts, entry), KubeContext: ResolveKubeContext(opts, entry), Error: err}
-		_ = opts.StateStore.Complete(entry, result)
+		results = append(results, result)
+		if opts.StateStore != nil {
+			_ = opts.StateStore.Complete(entry, result)
+		}
 	}
+	return results
 }
 
 // synthesizeRunError checks completed results for failures and returns a

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"scripts/camunda-core/pkg/executil"
+	"scripts/camunda-core/pkg/kube"
 	"scripts/camunda-core/pkg/logging"
 	"scripts/camunda-core/pkg/versionmatrix"
 	"scripts/deploy-camunda/auth0"
@@ -392,6 +393,17 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 	useVault := resolveUseVaultBackedSecrets(opts, platform)
 	logLevel := flags.LogLevel
 	var phaseErr error
+	if opts.StateStore != nil && opts.NamespaceOverride == "" && (entra.IsOIDCEntry(entry.Auth, entry.Identity) || auth0.IsAuth0Identity(entry.Identity)) {
+		client, err := kube.NewClient("", kubeCtx)
+		if err != nil {
+			result.Error = err
+			return result
+		}
+		if err := client.EnsureNamespaceOwned(ctx, namespace, "deploy-camunda-run", opts.StateStore.RunID()); err != nil {
+			result.Error = err
+			return result
+		}
+	}
 
 	// Wire phase reporting: deploy.Execute and RunTests call flags.OnPhase,
 	// which we forward to the matrix-level OnPhaseChange callback.

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -503,6 +503,12 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 		venomOpts = &entraOpts
 		result.venomOpts = venomOpts
 		canCleanup = true
+		if opts.StateStore != nil {
+			if err := opts.StateStore.RecordExternalResources(entry, venomApp.ObjectID, nil); err != nil {
+				result.Error = err
+				return result
+			}
+		}
 
 		// Inject VENOM_CLIENT_ID and CONNECTORS_CLIENT_ID via per-entry ExtraEnv
 		// so that buildScenarioEnv merges them into the isolated env map for
@@ -615,6 +621,16 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 		auth0Opts = &auth0Options
 
 		prov, err := auth0.EnsureClients(ctx, auth0Options)
+		if opts.StateStore != nil && prov != nil {
+			ids := make([]string, 0, len(prov.All()))
+			for _, client := range prov.All() {
+				ids = append(ids, client.ClientID)
+			}
+			if stateErr := opts.StateStore.RecordExternalResources(entry, "", ids); stateErr != nil {
+				result.Error = stateErr
+				return result
+			}
+		}
 		if err != nil {
 			// Build a result that carries auth0Opts so cleanupEntry tears down
 			// the partial provisioning, then invoke the same cleanup/callback

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -670,10 +670,8 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 			for _, client := range prov.All() {
 				ids = append(ids, client.ClientID)
 			}
-			if stateErr := opts.StateStore.RecordExternalResources(entry, "", "", auth0Options.Domain, ids); stateErr != nil {
-				cleanupErr := auth0.CleanupClientIDsStrict(context.Background(), auth0Options, ids)
-				cleanupErr = completeExternalCompensation(opts.StateStore, entry, cleanupErr)
-				result.Error = errors.Join(fmt.Errorf("checkpoint Auth0 resources: %w", stateErr), cleanupErr)
+			if stateErr := checkpointAuth0Resources(opts.StateStore, entry, auth0Options, ids, auth0.CleanupClientIDsStrict); stateErr != nil {
+				result.Error = stateErr
 				return result
 			}
 		}
@@ -840,6 +838,15 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 	result = RunResult{Entry: entry, Namespace: namespace, KubeContext: kubeCtx, Error: deployErr, Duration: time.Since(start), Diagnostics: diag, venomOpts: venomOpts, auth0Opts: auth0Opts}
 
 	return result
+}
+
+func checkpointAuth0Resources(store *RunStateStore, entry Entry, options auth0.Options, ids []string, cleanup func(context.Context, auth0.Options, []string) error) error {
+	if err := store.RecordExternalResources(entry, "", "", options.Domain, ids); err != nil {
+		cleanupErr := cleanup(context.Background(), options, ids)
+		cleanupErr = completeExternalCompensation(store, entry, cleanupErr)
+		return errors.Join(fmt.Errorf("checkpoint Auth0 resources: %w", err), cleanupErr)
+	}
+	return nil
 }
 
 func completeExternalCompensation(store *RunStateStore, entry Entry, cleanupErr error) error {

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -535,6 +535,9 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 			}
 			if err := opts.StateStore.RecordExternalResources(entry, venomApp.ObjectID, directoryID, "", nil); err != nil {
 				cleanupErr := entra.CleanupVenomAppObjectStrict(context.Background(), entraOpts, venomApp.ObjectID)
+				if cleanupErr == nil {
+					cleanupErr = opts.StateStore.MarkExternalProvisioningComplete(entry)
+				}
 				result.Error = errors.Join(fmt.Errorf("checkpoint Entra resource: %w", err), cleanupErr)
 				return result
 			}

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -509,7 +509,8 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 				directoryID = os.Getenv("ENTRA_APP_DIRECTORY_ID")
 			}
 			if err := opts.StateStore.RecordExternalResources(entry, venomApp.ObjectID, directoryID, "", nil); err != nil {
-				result.Error = err
+				_ = entra.CleanupVenomAppObjectStrict(context.Background(), entraOpts, venomApp.ObjectID)
+				result.Error = fmt.Errorf("checkpoint Entra resource: %w", err)
 				return result
 			}
 		}
@@ -631,7 +632,8 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 				ids = append(ids, client.ClientID)
 			}
 			if stateErr := opts.StateStore.RecordExternalResources(entry, "", "", auth0Options.Domain, ids); stateErr != nil {
-				result.Error = stateErr
+				_ = auth0.CleanupClientIDsStrict(context.Background(), auth0Options, ids)
+				result.Error = fmt.Errorf("checkpoint Auth0 resources: %w", stateErr)
 				return result
 			}
 		}

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -529,7 +529,7 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 				}
 				var checkpointErr error
 				if opts.StateStore != nil {
-					checkpointErr = opts.StateStore.RecordExternalResources(entry, venomApp.ObjectID, directoryID, "", nil)
+					checkpointErr = opts.StateStore.RecordExternalResources(entry, venomApp.ObjectID, directoryID, "", nil, venomApp.Created)
 				}
 				var cleanupErr error
 				if venomApp.Created {
@@ -550,7 +550,7 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 			if directoryID == "" {
 				directoryID = os.Getenv("ENTRA_APP_DIRECTORY_ID")
 			}
-			if err := opts.StateStore.RecordExternalResources(entry, venomApp.ObjectID, directoryID, "", nil); err != nil {
+			if err := opts.StateStore.RecordExternalResources(entry, venomApp.ObjectID, directoryID, "", nil, venomApp.Created); err != nil {
 				var cleanupErr error
 				if venomApp.Created {
 					cleanupErr = entra.CleanupVenomAppObjectStrict(context.Background(), entraOpts, venomApp.ObjectID)

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -301,7 +301,7 @@ func bootstrapPostgresCredentials(flags *config.RuntimeFlags, generatedUsername,
 	if flags.ExtraEnv == nil {
 		flags.ExtraEnv = make(map[string]string)
 	}
-	if generatedUsername != "" && generatedPassword != "" {
+	if generatedUsername != "" && generatedPassword != "" && effective["RDBMS_POSTGRESQL_USERNAME"] == "" && effective["RDBMS_POSTGRESQL_PASSWORD"] == "" {
 		flags.ExtraEnv["RDBMS_POSTGRESQL_USERNAME"] = generatedUsername
 		flags.ExtraEnv["RDBMS_POSTGRESQL_PASSWORD"] = generatedPassword
 		return nil

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -496,6 +496,12 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 		logging.Logger.Info().
 			Str("namespace", namespace).
 			Msg("OIDC entry detected — provisioning venom Entra app (Phase 1: API + env vars)")
+		if opts.StateStore != nil {
+			if err := opts.StateStore.MarkExternalProvisioningStarted(entry); err != nil {
+				result.Error = err
+				return result
+			}
+		}
 
 		venomApp, err := entra.EnsureVenomApp(ctx, entraOpts)
 		if err != nil {
@@ -527,6 +533,10 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 			if err := opts.StateStore.RecordExternalResources(entry, venomApp.ObjectID, directoryID, "", nil); err != nil {
 				cleanupErr := entra.CleanupVenomAppObjectStrict(context.Background(), entraOpts, venomApp.ObjectID)
 				result.Error = errors.Join(fmt.Errorf("checkpoint Entra resource: %w", err), cleanupErr)
+				return result
+			}
+			if err := opts.StateStore.MarkExternalProvisioningComplete(entry); err != nil {
+				result.Error = err
 				return result
 			}
 		}
@@ -639,6 +649,12 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 		logging.Logger.Info().
 			Str("namespace", namespace).
 			Msg("Auth0 entry detected — provisioning per-component clients (Phase 1: API + env vars)")
+		if opts.StateStore != nil {
+			if err := opts.StateStore.MarkExternalProvisioningStarted(entry); err != nil {
+				result.Error = err
+				return result
+			}
+		}
 
 		// Capture credentials for cleanup BEFORE provisioning so a partial
 		// failure inside EnsureClients (e.g. clients 1-3 of 6 created, then
@@ -655,6 +671,12 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 			if stateErr := opts.StateStore.RecordExternalResources(entry, "", "", auth0Options.Domain, ids); stateErr != nil {
 				cleanupErr := auth0.CleanupClientIDsStrict(context.Background(), auth0Options, ids)
 				result.Error = errors.Join(fmt.Errorf("checkpoint Auth0 resources: %w", stateErr), cleanupErr)
+				return result
+			}
+		}
+		if err == nil && opts.StateStore != nil {
+			if stateErr := opts.StateStore.MarkExternalProvisioningComplete(entry); stateErr != nil {
+				result.Error = stateErr
 				return result
 			}
 		}

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -608,6 +608,9 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 		// clients need the host at creation time (it's baked into redirect
 		// URIs), so fall back to those env vars if the flag is empty.
 		ingressHost := flags.ResolveIngressHostname()
+		if opts.Auth0IngressHost != "" {
+			ingressHost = opts.Auth0IngressHost
+		}
 		if ingressHost == "" {
 			ingressHost = os.Getenv("CAMUNDA_HOSTNAME")
 		}
@@ -746,7 +749,7 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 		// `/<path>` for derived URLs, avoiding `//` in rendered output.
 		flags.ExtraEnv["AUTH0_ISSUER_URL"] = strings.TrimSuffix(auth0Options.Domain, "/")
 		// Initial admin email defaults to the test user. Override via AUTH0_INITIAL_ADMIN_EMAIL.
-		if v := os.Getenv("AUTH0_INITIAL_ADMIN_EMAIL"); v != "" {
+		if v := opts.Auth0InitialAdminEmail; v != "" {
 			flags.ExtraEnv["AUTH0_INITIAL_ADMIN_EMAIL"] = v
 		} else {
 			flags.ExtraEnv["AUTH0_INITIAL_ADMIN_EMAIL"] = "demo@camunda.com"

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -42,7 +42,10 @@ func companionChartsForEntry(entry Entry, repoRoot string) []config.CompanionCha
 	for _, dep := range entry.Dependencies {
 		chartRef := dep.Chart
 		version := dep.Version
-		localChartPath := filepath.Join(repoRoot, dep.Chart)
+		localChartPath := dep.Chart
+		if !filepath.IsAbs(localChartPath) {
+			localChartPath = filepath.Join(repoRoot, localChartPath)
+		}
 		if info, err := os.Stat(localChartPath); err == nil && info.IsDir() {
 			chartRef = localChartPath
 			version = "" // --version is only meaningful for remote charts
@@ -56,7 +59,10 @@ func companionChartsForEntry(entry Entry, repoRoot string) []config.CompanionCha
 			RepoURL:     dep.RepoURL,
 		}
 		if dep.ValuesFile != "" {
-			cc.ValuesFile = filepath.Join(repoRoot, dep.ValuesFile)
+			cc.ValuesFile = dep.ValuesFile
+			if !filepath.IsAbs(cc.ValuesFile) {
+				cc.ValuesFile = filepath.Join(repoRoot, cc.ValuesFile)
+			}
 		}
 		charts = append(charts, cc)
 	}

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -20,6 +20,14 @@ import (
 	"scripts/prepare-helm-values/pkg/env"
 )
 
+var ensureEntryNamespaceOwned = func(ctx context.Context, kubeContext, namespace, runID string) error {
+	client, err := kube.NewClient("", kubeContext)
+	if err != nil {
+		return err
+	}
+	return client.EnsureNamespaceOwned(ctx, namespace, "deploy-camunda-run", runID)
+}
+
 // ResolveNamespace is the exported form of resolveNamespace, for callers
 // outside the matrix package that need the same "what namespace would a
 // normal (single-namespace) matrix entry get" computation — e.g. the
@@ -394,12 +402,7 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 	logLevel := flags.LogLevel
 	var phaseErr error
 	if opts.StateStore != nil && opts.NamespaceOverride == "" && (entra.IsOIDCEntry(entry.Auth, entry.Identity) || auth0.IsAuth0Identity(entry.Identity)) {
-		client, err := kube.NewClient("", kubeCtx)
-		if err != nil {
-			result.Error = err
-			return result
-		}
-		if err := client.EnsureNamespaceOwned(ctx, namespace, "deploy-camunda-run", opts.StateStore.RunID()); err != nil {
+		if err := ensureEntryNamespaceOwned(ctx, kubeCtx, namespace, opts.StateStore.RunID()); err != nil {
 			result.Error = err
 			return result
 		}

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -511,7 +511,6 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 				}
 			}
 		}
-
 		logging.Logger.Info().
 			Str("namespace", namespace).
 			Msg("OIDC entry detected — provisioning venom Entra app (Phase 1: API + env vars)")

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -516,6 +516,9 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 					checkpointErr = opts.StateStore.RecordExternalResources(entry, venomApp.ObjectID, directoryID, "", nil)
 				}
 				cleanupErr := entra.CleanupVenomAppObjectStrict(context.Background(), entraOpts, venomApp.ObjectID)
+				if cleanupErr == nil && opts.StateStore != nil {
+					cleanupErr = opts.StateStore.MarkExternalProvisioningComplete(entry)
+				}
 				result.Error = errors.Join(fmt.Errorf("entra: provision venom app: %w", err), checkpointErr, cleanupErr)
 			} else {
 				result.Error = fmt.Errorf("entra: provision venom app: %w", err)

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -516,9 +516,7 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 					checkpointErr = opts.StateStore.RecordExternalResources(entry, venomApp.ObjectID, directoryID, "", nil)
 				}
 				cleanupErr := entra.CleanupVenomAppObjectStrict(context.Background(), entraOpts, venomApp.ObjectID)
-				if cleanupErr == nil && opts.StateStore != nil {
-					cleanupErr = opts.StateStore.MarkExternalProvisioningComplete(entry)
-				}
+				cleanupErr = completeExternalCompensation(opts.StateStore, entry, cleanupErr)
 				result.Error = errors.Join(fmt.Errorf("entra: provision venom app: %w", err), checkpointErr, cleanupErr)
 			} else {
 				result.Error = fmt.Errorf("entra: provision venom app: %w", err)
@@ -535,9 +533,7 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 			}
 			if err := opts.StateStore.RecordExternalResources(entry, venomApp.ObjectID, directoryID, "", nil); err != nil {
 				cleanupErr := entra.CleanupVenomAppObjectStrict(context.Background(), entraOpts, venomApp.ObjectID)
-				if cleanupErr == nil {
-					cleanupErr = opts.StateStore.MarkExternalProvisioningComplete(entry)
-				}
+				cleanupErr = completeExternalCompensation(opts.StateStore, entry, cleanupErr)
 				result.Error = errors.Join(fmt.Errorf("checkpoint Entra resource: %w", err), cleanupErr)
 				return result
 			}
@@ -676,9 +672,7 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 			}
 			if stateErr := opts.StateStore.RecordExternalResources(entry, "", "", auth0Options.Domain, ids); stateErr != nil {
 				cleanupErr := auth0.CleanupClientIDsStrict(context.Background(), auth0Options, ids)
-				if cleanupErr == nil {
-					cleanupErr = opts.StateStore.MarkExternalProvisioningComplete(entry)
-				}
+				cleanupErr = completeExternalCompensation(opts.StateStore, entry, cleanupErr)
 				result.Error = errors.Join(fmt.Errorf("checkpoint Auth0 resources: %w", stateErr), cleanupErr)
 				return result
 			}
@@ -846,6 +840,13 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 	result = RunResult{Entry: entry, Namespace: namespace, KubeContext: kubeCtx, Error: deployErr, Duration: time.Since(start), Diagnostics: diag, venomOpts: venomOpts, auth0Opts: auth0Opts}
 
 	return result
+}
+
+func completeExternalCompensation(store *RunStateStore, entry Entry, cleanupErr error) error {
+	if cleanupErr != nil || store == nil {
+		return cleanupErr
+	}
+	return store.MarkExternalProvisioningComplete(entry)
 }
 
 func applyCleanupResult(result *RunResult, cleanup func() error) bool {

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -501,6 +501,8 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 			return result
 		}
 		venomOpts = &entraOpts
+		result.venomOpts = venomOpts
+		canCleanup = true
 
 		// Inject VENOM_CLIENT_ID and CONNECTORS_CLIENT_ID via per-entry ExtraEnv
 		// so that buildScenarioEnv merges them into the isolated env map for

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -485,6 +485,9 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 			KubeContext:   kubeCtx,
 			SkipK8sSecret: true, // Phase 2 is deferred to PreInstallHook.
 		}
+		if opts.EntraDirectoryID != "" {
+			entraOpts.DirectoryID = opts.EntraDirectoryID
+		}
 
 		// Populate Entra credentials from the version-specific env file.
 		// resolveOpts in entra.go falls back to os.Getenv, but the version-specific
@@ -622,6 +625,9 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 			KubeContext:   kubeCtx,
 			IngressHost:   ingressHost,
 			SkipK8sSecret: true, // Phase 2 deferred to PreInstallHook.
+		}
+		if opts.Auth0Domain != "" {
+			auth0Options.Domain = opts.Auth0Domain
 		}
 		auth0Options.Domain = auth0.EffectiveDomain(auth0Options.Domain)
 		if opts.StateStore != nil {

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -493,7 +493,21 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 
 		venomApp, err := entra.EnsureVenomApp(ctx, entraOpts)
 		if err != nil {
-			result.KubeContext, result.Error = kubeCtx, fmt.Errorf("entra: provision venom app: %w", err)
+			result.KubeContext = kubeCtx
+			if venomApp != nil && venomApp.ObjectID != "" {
+				directoryID := entraOpts.DirectoryID
+				if directoryID == "" {
+					directoryID = os.Getenv("ENTRA_APP_DIRECTORY_ID")
+				}
+				var checkpointErr error
+				if opts.StateStore != nil {
+					checkpointErr = opts.StateStore.RecordExternalResources(entry, venomApp.ObjectID, directoryID, "", nil)
+				}
+				cleanupErr := entra.CleanupVenomAppObjectStrict(context.Background(), entraOpts, venomApp.ObjectID)
+				result.Error = errors.Join(fmt.Errorf("entra: provision venom app: %w", err), checkpointErr, cleanupErr)
+			} else {
+				result.Error = fmt.Errorf("entra: provision venom app: %w", err)
+			}
 			return result
 		}
 		venomOpts = &entraOpts

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -504,7 +504,11 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 		result.venomOpts = venomOpts
 		canCleanup = true
 		if opts.StateStore != nil {
-			if err := opts.StateStore.RecordExternalResources(entry, venomApp.ObjectID, nil); err != nil {
+			directoryID := entraOpts.DirectoryID
+			if directoryID == "" {
+				directoryID = os.Getenv("ENTRA_APP_DIRECTORY_ID")
+			}
+			if err := opts.StateStore.RecordExternalResources(entry, venomApp.ObjectID, directoryID, "", nil); err != nil {
 				result.Error = err
 				return result
 			}
@@ -626,7 +630,7 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 			for _, client := range prov.All() {
 				ids = append(ids, client.ClientID)
 			}
-			if stateErr := opts.StateStore.RecordExternalResources(entry, "", ids); stateErr != nil {
+			if stateErr := opts.StateStore.RecordExternalResources(entry, "", "", auth0Options.Domain, ids); stateErr != nil {
 				result.Error = stateErr
 				return result
 			}

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -328,15 +328,25 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 		if result.Duration == 0 {
 			result.Duration = time.Since(start)
 		}
+		cleaned := false
 		if opts.Cleanup && canCleanup {
 			if opts.OnPhaseChange != nil {
 				opts.OnPhaseChange(entry, "cleanup")
 			}
-			cleanupEntry(ctx, result, opts)
+			if err := cleanupEntry(ctx, result, opts); err != nil {
+				result.Error = errors.Join(result.Error, fmt.Errorf("cleanup matrix entry: %w", err))
+			} else {
+				cleaned = true
+			}
 		}
 		if opts.StateStore != nil {
 			if err := opts.StateStore.Complete(entry, result); err != nil {
 				result.Error = errors.Join(result.Error, fmt.Errorf("persist matrix entry completion: %w", err))
+			}
+			if cleaned {
+				if err := opts.StateStore.MarkCleaned(EntryID(entry)); err != nil {
+					result.Error = errors.Join(result.Error, fmt.Errorf("persist matrix cleanup: %w", err))
+				}
 			}
 		}
 		if opts.OnEntryComplete != nil {

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -333,11 +333,7 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 			if opts.OnPhaseChange != nil {
 				opts.OnPhaseChange(entry, "cleanup")
 			}
-			if err := cleanupEntry(ctx, result, opts); err != nil {
-				result.Error = errors.Join(result.Error, fmt.Errorf("cleanup matrix entry: %w", err))
-			} else {
-				cleaned = true
-			}
+			cleaned = applyCleanupResult(&result, func() error { return cleanupEntry(ctx, result, opts) })
 		}
 		if opts.StateStore != nil {
 			if err := opts.StateStore.Complete(entry, result); err != nil {
@@ -385,7 +381,6 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 	result.KubeContext = kubeCtx
 	if opts.StateStore != nil && opts.NamespaceOverride == "" {
 		flags.Deployment.MatrixRunID = opts.StateStore.RunID()
-		flags.Deployment.TransferMatrixOwnership = versionmatrix.IsUpgradeOnlyFlow(entry.Flow)
 	}
 	platform := resolvePlatform(opts, entry)
 	useVault := resolveUseVaultBackedSecrets(opts, platform)
@@ -795,4 +790,12 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 	result = RunResult{Entry: entry, Namespace: namespace, KubeContext: kubeCtx, Error: deployErr, Duration: time.Since(start), Diagnostics: diag, venomOpts: venomOpts, auth0Opts: auth0Opts}
 
 	return result
+}
+
+func applyCleanupResult(result *RunResult, cleanup func() error) bool {
+	if err := cleanup(); err != nil {
+		result.Error = errors.Join(result.Error, fmt.Errorf("cleanup matrix entry: %w", err))
+		return false
+	}
+	return true
 }

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -2,6 +2,7 @@ package matrix
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -255,6 +256,11 @@ func BuildEntryFlags(entry Entry, opts RunOptions) (flags *config.RuntimeFlags, 
 
 	// Wire companion chart dependencies from ci-test-config.yaml.
 	flags.CompanionCharts = append(flags.CompanionCharts, companionChartsForEntry(entry, opts.RepoRoot)...)
+	if opts.GeneratePostgresCredentials {
+		if err := bootstrapPostgresCredentials(flags, opts.GeneratedPostgresUsername, opts.GeneratedPostgresPassword); err != nil {
+			return nil, namespace, kubeCtx, envFile, cleanup, err
+		}
+	}
 
 	// Populate the vault secret mapping up front so the fail-fast preflight sees
 	// it; prepareScenarioValues otherwise resolves it only after preflight runs.
@@ -269,6 +275,41 @@ func BuildEntryFlags(entry Entry, opts RunOptions) (flags *config.RuntimeFlags, 
 	return flags, namespace, kubeCtx, envFile, cleanup, nil
 }
 
+func bootstrapPostgresCredentials(flags *config.RuntimeFlags, generatedUsername, generatedPassword string) error {
+	if !requiresPostgresCredentials(flags.CompanionCharts) {
+		return nil
+	}
+	effective := make(map[string]string)
+	for _, item := range deploy.EnvProvenance(flags) {
+		effective[item.Name] = item.Value
+	}
+	if flags.ExtraEnv == nil {
+		flags.ExtraEnv = make(map[string]string)
+	}
+	if generatedUsername != "" && generatedPassword != "" {
+		flags.ExtraEnv["RDBMS_POSTGRESQL_USERNAME"] = generatedUsername
+		flags.ExtraEnv["RDBMS_POSTGRESQL_PASSWORD"] = generatedPassword
+		return nil
+	}
+	if effective["RDBMS_POSTGRESQL_USERNAME"] == "" {
+		if generatedUsername == "" {
+			generatedUsername = "camunda"
+		}
+		flags.ExtraEnv["RDBMS_POSTGRESQL_USERNAME"] = generatedUsername
+	}
+	if effective["RDBMS_POSTGRESQL_PASSWORD"] == "" {
+		if generatedPassword == "" {
+			password, err := deploy.RandomSecret()
+			if err != nil {
+				return fmt.Errorf("generate ephemeral PostgreSQL password: %w", err)
+			}
+			generatedPassword = password
+		}
+		flags.ExtraEnv["RDBMS_POSTGRESQL_PASSWORD"] = generatedPassword
+	}
+	return nil
+}
+
 func explicitIngressHost(opts RunOptions) string {
 	return parseHelmSetPairs(opts.ExtraHelmSets)["global.host"]
 }
@@ -278,12 +319,39 @@ func explicitIngressHost(opts RunOptions) string {
 //   - Two-step upgrade (upgrade-patch, upgrade-minor): Step 1 installs old version, Step 2 upgrades.
 //   - Upgrade-only (modular-upgrade-minor): Upgrades an already-running deployment (no install step).
 //   - Install (default): Single-step fresh install.
-func executeEntry(ctx context.Context, entry Entry, opts RunOptions) RunResult {
+func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result RunResult) {
 	start := time.Now()
 	namespace := resolveNamespace(opts, entry)
+	result = RunResult{Entry: entry, Namespace: namespace}
+	canCleanup := false
+	defer func() {
+		if result.Duration == 0 {
+			result.Duration = time.Since(start)
+		}
+		if opts.Cleanup && canCleanup {
+			if opts.OnPhaseChange != nil {
+				opts.OnPhaseChange(entry, "cleanup")
+			}
+			cleanupEntry(ctx, result, opts)
+		}
+		if opts.StateStore != nil {
+			if err := opts.StateStore.Complete(entry, result); err != nil {
+				result.Error = errors.Join(result.Error, fmt.Errorf("persist matrix entry completion: %w", err))
+			}
+		}
+		if opts.OnEntryComplete != nil {
+			opts.OnEntryComplete(entry, result)
+		}
+	}()
 
 	if opts.OnEntryStart != nil {
 		opts.OnEntryStart(entry, namespace)
+	}
+	if opts.StateStore != nil {
+		if err := opts.StateStore.Start(entry, namespace); err != nil {
+			result.Error = fmt.Errorf("persist matrix entry start: %w", err)
+			return result
+		}
 	}
 
 	// Fire "preparing" phase and wire flags.OnPhase so deploy/test callbacks
@@ -291,11 +359,22 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) RunResult {
 	if opts.OnPhaseChange != nil {
 		opts.OnPhaseChange(entry, "preparing")
 	}
+	if opts.StateStore != nil {
+		if err := opts.StateStore.Phase(entry, "preparing"); err != nil {
+			result.Error = fmt.Errorf("persist matrix entry phase: %w", err)
+			return result
+		}
+	}
 
 	flags, namespace, kubeCtx, envFile, cleanupEnvFile, err := BuildEntryFlags(entry, opts)
 	defer cleanupEnvFile() // safe: cleanup is always a valid no-op func even on error
 	if err != nil {
-		return RunResult{Entry: entry, Namespace: namespace, KubeContext: kubeCtx, Error: err}
+		result.KubeContext, result.Error = kubeCtx, err
+		return result
+	}
+	result.KubeContext = kubeCtx
+	if opts.StateStore != nil {
+		flags.Deployment.MatrixRunID = opts.StateStore.RunID()
 	}
 	platform := resolvePlatform(opts, entry)
 	useVault := resolveUseVaultBackedSecrets(opts, platform)
@@ -306,7 +385,12 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) RunResult {
 	if opts.OnPhaseChange != nil {
 		flags.OnPhase = func(phase string) {
 			opts.OnPhaseChange(entry, phase)
+			if opts.StateStore != nil {
+				_ = opts.StateStore.Phase(entry, phase)
+			}
 		}
+	} else if opts.StateStore != nil {
+		flags.OnPhase = func(phase string) { _ = opts.StateStore.Phase(entry, phase) }
 	}
 
 	// Redirect test script output and deploy logs to per-entry files when logDir is set.
@@ -403,7 +487,8 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) RunResult {
 
 		venomApp, err := entra.EnsureVenomApp(ctx, entraOpts)
 		if err != nil {
-			return RunResult{Entry: entry, Namespace: namespace, KubeContext: kubeCtx, Error: fmt.Errorf("entra: provision venom app: %w", err)}
+			result.KubeContext, result.Error = kubeCtx, fmt.Errorf("entra: provision venom app: %w", err)
+			return result
 		}
 		venomOpts = &entraOpts
 
@@ -437,6 +522,7 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) RunResult {
 	// so it survives namespace recreation by deploy.Execute().
 	var auth0Opts *auth0.Options
 	if auth0.IsAuth0Identity(entry.Identity) {
+		canCleanup = true
 		// Per-entry ingress host. flags.ResolveIngressHostname() is empty in CI
 		// because test-integration-runner.yaml passes the host via
 		// `--extra-helm-set global.host=...` + the CAMUNDA_HOSTNAME /
@@ -521,22 +607,13 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) RunResult {
 			// Build a result that carries auth0Opts so cleanupEntry tears down
 			// the partial provisioning, then invoke the same cleanup/callback
 			// path the success branch uses at the bottom of executeEntry.
-			result := RunResult{
+			result = RunResult{
 				Entry:       entry,
 				Namespace:   namespace,
 				KubeContext: kubeCtx,
 				Error:       fmt.Errorf("auth0: provision clients: %w", err),
 				Duration:    time.Since(start),
 				auth0Opts:   auth0Opts,
-			}
-			if opts.Cleanup {
-				if opts.OnPhaseChange != nil {
-					opts.OnPhaseChange(entry, "cleanup")
-				}
-				cleanupEntry(ctx, result, opts)
-			}
-			if opts.OnEntryComplete != nil {
-				opts.OnEntryComplete(entry, result)
 			}
 			return result
 		}
@@ -625,15 +702,18 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) RunResult {
 	isUpgradeOnly := versionmatrix.IsUpgradeOnlyFlow(entry.Flow)
 	if !isTwoStepUpgrade && !isUpgradeOnly {
 		if err := registerDeclarativePreInstallHook(flags, entry.PreInstall, opts.RepoRoot, entry.Version, entry.Scenario); err != nil {
-			return RunResult{Entry: entry, Namespace: namespace, Error: err}
+			result.Error = err
+			return result
 		}
 		if err := registerDeclarativePostInfraHook(flags, entry.PostInfra, opts.RepoRoot, entry.Version, entry.Scenario); err != nil {
-			return RunResult{Entry: entry, Namespace: namespace, Error: err}
+			result.Error = err
+			return result
 		}
 	}
 	if !isTwoStepUpgrade {
 		if err := registerDeclarativePostDeployHook(flags, entry.PostDeploy, opts.RepoRoot, entry.Version, entry.Scenario); err != nil {
-			return RunResult{Entry: entry, Namespace: namespace, Error: err}
+			result.Error = err
+			return result
 		}
 	}
 
@@ -649,13 +729,15 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) RunResult {
 	// declare the same prefix-key.
 	if entry.PrefixKey != "" {
 		if err := deploy.PinScenarioPrefixes(entry.PrefixKey, flags); err != nil {
-			return RunResult{Entry: entry, Namespace: namespace, KubeContext: kubeCtx, Error: fmt.Errorf("pin scenario prefixes (prefix-key=%s): %w", entry.PrefixKey, err)}
+			result.KubeContext, result.Error = kubeCtx, fmt.Errorf("pin scenario prefixes (prefix-key=%s): %w", entry.PrefixKey, err)
+			return result
 		}
 	}
 
 	// Override chart source when --chart-ref is set (OCI install path).
 	// See applyChartRefOverride for details.
 	applyChartRefOverride(&flags.Chart, opts)
+	canCleanup = true
 
 	// Two-step upgrade flow: install old version first, then upgrade to current.
 	if versionmatrix.IsTwoStepUpgradeFlow(entry.Flow) {
@@ -675,20 +757,7 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) RunResult {
 		diag = appendTestOutputToDiagnostics(deployErr, namespace, diag)
 	}
 
-	result := RunResult{Entry: entry, Namespace: namespace, KubeContext: kubeCtx, Error: deployErr, Duration: time.Since(start), Diagnostics: diag, venomOpts: venomOpts, auth0Opts: auth0Opts}
-
-	// Per-entry cleanup: delete namespace and Entra app after deployment + tests complete.
-	// This runs regardless of success/failure, after diagnostics have been collected.
-	if opts.Cleanup {
-		if opts.OnPhaseChange != nil {
-			opts.OnPhaseChange(entry, "cleanup")
-		}
-		cleanupEntry(ctx, result, opts)
-	}
-
-	if opts.OnEntryComplete != nil {
-		opts.OnEntryComplete(entry, result)
-	}
+	result = RunResult{Entry: entry, Namespace: namespace, KubeContext: kubeCtx, Error: deployErr, Duration: time.Since(start), Diagnostics: diag, venomOpts: venomOpts, auth0Opts: auth0Opts}
 
 	return result
 }

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -383,7 +383,7 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 		return result
 	}
 	result.KubeContext = kubeCtx
-	if opts.StateStore != nil {
+	if opts.StateStore != nil && opts.NamespaceOverride == "" {
 		flags.Deployment.MatrixRunID = opts.StateStore.RunID()
 	}
 	platform := resolvePlatform(opts, entry)

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -391,6 +391,7 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 	platform := resolvePlatform(opts, entry)
 	useVault := resolveUseVaultBackedSecrets(opts, platform)
 	logLevel := flags.LogLevel
+	var phaseErr error
 
 	// Wire phase reporting: deploy.Execute and RunTests call flags.OnPhase,
 	// which we forward to the matrix-level OnPhaseChange callback.
@@ -398,11 +399,11 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 		flags.OnPhase = func(phase string) {
 			opts.OnPhaseChange(entry, phase)
 			if opts.StateStore != nil {
-				_ = opts.StateStore.Phase(entry, phase)
+				phaseErr = errors.Join(phaseErr, opts.StateStore.Phase(entry, phase))
 			}
 		}
 	} else if opts.StateStore != nil {
-		flags.OnPhase = func(phase string) { _ = opts.StateStore.Phase(entry, phase) }
+		flags.OnPhase = func(phase string) { phaseErr = errors.Join(phaseErr, opts.StateStore.Phase(entry, phase)) }
 	}
 
 	// Redirect test script output and deploy logs to per-entry files when logDir is set.
@@ -538,7 +539,9 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 				return result
 			}
 			if err := opts.StateStore.MarkExternalProvisioningComplete(entry); err != nil {
-				result.Error = err
+				cleanupErr := entra.CleanupVenomAppObjectStrict(context.Background(), entraOpts, venomApp.ObjectID)
+				cleanupErr = completeExternalCompensation(opts.StateStore, entry, cleanupErr)
+				result.Error = errors.Join(err, cleanupErr)
 				return result
 			}
 		}
@@ -677,7 +680,13 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 		}
 		if err == nil && opts.StateStore != nil {
 			if stateErr := opts.StateStore.MarkExternalProvisioningComplete(entry); stateErr != nil {
-				result.Error = stateErr
+				ids := make([]string, 0, len(prov.All()))
+				for _, client := range prov.All() {
+					ids = append(ids, client.ClientID)
+				}
+				cleanupErr := auth0.CleanupClientIDsStrict(context.Background(), auth0Options, ids)
+				cleanupErr = completeExternalCompensation(opts.StateStore, entry, cleanupErr)
+				result.Error = errors.Join(stateErr, cleanupErr)
 				return result
 			}
 		}
@@ -836,6 +845,7 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 	}
 
 	result = RunResult{Entry: entry, Namespace: namespace, KubeContext: kubeCtx, Error: deployErr, Duration: time.Since(start), Diagnostics: diag, venomOpts: venomOpts, auth0Opts: auth0Opts}
+	result.Error = errors.Join(result.Error, phaseErr)
 
 	return result
 }

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -673,6 +673,9 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 			}
 			if stateErr := opts.StateStore.RecordExternalResources(entry, "", "", auth0Options.Domain, ids); stateErr != nil {
 				cleanupErr := auth0.CleanupClientIDsStrict(context.Background(), auth0Options, ids)
+				if cleanupErr == nil {
+					cleanupErr = opts.StateStore.MarkExternalProvisioningComplete(entry)
+				}
 				result.Error = errors.Join(fmt.Errorf("checkpoint Auth0 resources: %w", stateErr), cleanupErr)
 				return result
 			}

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -581,6 +581,11 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 			IngressHost:   ingressHost,
 			SkipK8sSecret: true, // Phase 2 deferred to PreInstallHook.
 		}
+		if opts.StateStore != nil {
+			auth0Options.OnClientCreated = func(client auth0.Client) error {
+				return opts.StateStore.RecordExternalResources(entry, "", "", auth0Options.Domain, []string{client.ClientID})
+			}
+		}
 
 		// Read AUTH0_* credentials from the version-specific env file (same
 		// pattern as Entra above). The env file is loaded explicitly because

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -385,6 +385,7 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 	result.KubeContext = kubeCtx
 	if opts.StateStore != nil && opts.NamespaceOverride == "" {
 		flags.Deployment.MatrixRunID = opts.StateStore.RunID()
+		flags.Deployment.TransferMatrixOwnership = versionmatrix.IsUpgradeOnlyFlow(entry.Flow)
 	}
 	platform := resolvePlatform(opts, entry)
 	useVault := resolveUseVaultBackedSecrets(opts, platform)
@@ -509,8 +510,8 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 				directoryID = os.Getenv("ENTRA_APP_DIRECTORY_ID")
 			}
 			if err := opts.StateStore.RecordExternalResources(entry, venomApp.ObjectID, directoryID, "", nil); err != nil {
-				_ = entra.CleanupVenomAppObjectStrict(context.Background(), entraOpts, venomApp.ObjectID)
-				result.Error = fmt.Errorf("checkpoint Entra resource: %w", err)
+				cleanupErr := entra.CleanupVenomAppObjectStrict(context.Background(), entraOpts, venomApp.ObjectID)
+				result.Error = errors.Join(fmt.Errorf("checkpoint Entra resource: %w", err), cleanupErr)
 				return result
 			}
 		}
@@ -632,8 +633,8 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 				ids = append(ids, client.ClientID)
 			}
 			if stateErr := opts.StateStore.RecordExternalResources(entry, "", "", auth0Options.Domain, ids); stateErr != nil {
-				_ = auth0.CleanupClientIDsStrict(context.Background(), auth0Options, ids)
-				result.Error = fmt.Errorf("checkpoint Auth0 resources: %w", stateErr)
+				cleanupErr := auth0.CleanupClientIDsStrict(context.Background(), auth0Options, ids)
+				result.Error = errors.Join(fmt.Errorf("checkpoint Auth0 resources: %w", stateErr), cleanupErr)
 				return result
 			}
 		}

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -611,6 +611,7 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 			IngressHost:   ingressHost,
 			SkipK8sSecret: true, // Phase 2 deferred to PreInstallHook.
 		}
+		auth0Options.Domain = auth0.EffectiveDomain(auth0Options.Domain)
 		if opts.StateStore != nil {
 			auth0Options.OnClientCreated = func(client auth0.Client) error {
 				return opts.StateStore.RecordExternalResources(entry, "", "", auth0Options.Domain, []string{client.ClientID})

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -196,6 +196,7 @@ func BuildEntryFlags(entry Entry, opts RunOptions) (flags *config.RuntimeFlags, 
 			Flow:                       entry.Flow,
 			Timeout:                    opts.HelmTimeout,
 			DeleteNamespaceFirst:       opts.DeleteNamespaceFirst,
+			AdoptMatrixNamespace:       opts.AdoptMatrixNamespace,
 			WaitIngressReady:           opts.WaitIngressReady,
 			IngressReadyTimeoutMinutes: opts.IngressReadyTimeoutMinutes,
 			ExtraHelmArgs:              append([]string(nil), opts.ExtraHelmArgs...),
@@ -484,6 +485,9 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 			Namespace:     namespace,
 			KubeContext:   kubeCtx,
 			SkipK8sSecret: true, // Phase 2 is deferred to PreInstallHook.
+		}
+		if opts.StateStore != nil {
+			entraOpts.RunID = opts.StateStore.RunID()
 		}
 		if opts.EntraDirectoryID != "" {
 			entraOpts.DirectoryID = opts.EntraDirectoryID

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -531,7 +531,10 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 				if opts.StateStore != nil {
 					checkpointErr = opts.StateStore.RecordExternalResources(entry, venomApp.ObjectID, directoryID, "", nil)
 				}
-				cleanupErr := entra.CleanupVenomAppObjectStrict(context.Background(), entraOpts, venomApp.ObjectID)
+				var cleanupErr error
+				if venomApp.Created {
+					cleanupErr = entra.CleanupVenomAppObjectStrict(context.Background(), entraOpts, venomApp.ObjectID)
+				}
 				cleanupErr = completeExternalCompensation(opts.StateStore, entry, cleanupErr)
 				result.Error = errors.Join(fmt.Errorf("entra: provision venom app: %w", err), checkpointErr, cleanupErr)
 			} else {
@@ -548,13 +551,19 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) (result Run
 				directoryID = os.Getenv("ENTRA_APP_DIRECTORY_ID")
 			}
 			if err := opts.StateStore.RecordExternalResources(entry, venomApp.ObjectID, directoryID, "", nil); err != nil {
-				cleanupErr := entra.CleanupVenomAppObjectStrict(context.Background(), entraOpts, venomApp.ObjectID)
+				var cleanupErr error
+				if venomApp.Created {
+					cleanupErr = entra.CleanupVenomAppObjectStrict(context.Background(), entraOpts, venomApp.ObjectID)
+				}
 				cleanupErr = completeExternalCompensation(opts.StateStore, entry, cleanupErr)
 				result.Error = errors.Join(fmt.Errorf("checkpoint Entra resource: %w", err), cleanupErr)
 				return result
 			}
 			if err := opts.StateStore.MarkExternalProvisioningComplete(entry); err != nil {
-				cleanupErr := entra.CleanupVenomAppObjectStrict(context.Background(), entraOpts, venomApp.ObjectID)
+				var cleanupErr error
+				if venomApp.Created {
+					cleanupErr = entra.CleanupVenomAppObjectStrict(context.Background(), entraOpts, venomApp.ObjectID)
+				}
 				cleanupErr = completeExternalCompensation(opts.StateStore, entry, cleanupErr)
 				result.Error = errors.Join(err, cleanupErr)
 				return result

--- a/scripts/deploy-camunda/matrix/runner_options.go
+++ b/scripts/deploy-camunda/matrix/runner_options.go
@@ -4,6 +4,8 @@ package matrix
 type RunOptions struct {
 	Auth0IngressHost       string
 	Auth0InitialAdminEmail string
+	Auth0Domain            string
+	EntraDirectoryID       string
 	// StateStore persists parent and entry transitions for status and resume.
 	StateStore *RunStateStore
 	// GeneratePostgresCredentials supplies entry-local credentials when a

--- a/scripts/deploy-camunda/matrix/runner_options.go
+++ b/scripts/deploy-camunda/matrix/runner_options.go
@@ -2,6 +2,8 @@ package matrix
 
 // RunOptions controls matrix execution.
 type RunOptions struct {
+	Auth0IngressHost       string
+	Auth0InitialAdminEmail string
 	// StateStore persists parent and entry transitions for status and resume.
 	StateStore *RunStateStore
 	// GeneratePostgresCredentials supplies entry-local credentials when a

--- a/scripts/deploy-camunda/matrix/runner_options.go
+++ b/scripts/deploy-camunda/matrix/runner_options.go
@@ -2,6 +2,13 @@ package matrix
 
 // RunOptions controls matrix execution.
 type RunOptions struct {
+	// StateStore persists parent and entry transitions for status and resume.
+	StateStore *RunStateStore
+	// GeneratePostgresCredentials supplies entry-local credentials when a
+	// selected scenario requires RDBMS_POSTGRESQL_* and no explicit value exists.
+	GeneratePostgresCredentials bool
+	GeneratedPostgresUsername   string
+	GeneratedPostgresPassword   string
 	// DryRun logs what would be done without executing.
 	DryRun bool
 	// StopOnFailure stops the run on the first failure.

--- a/scripts/deploy-camunda/matrix/runner_options.go
+++ b/scripts/deploy-camunda/matrix/runner_options.go
@@ -86,6 +86,7 @@ type RunOptions struct {
 	// DeleteNamespaceFirst deletes the namespace before deploying each matrix entry.
 	// This ensures a clean-slate deployment by removing any existing resources in the namespace.
 	DeleteNamespaceFirst bool
+	AdoptMatrixNamespace bool
 	// Coverage produces a layer-breakdown report showing what IS tested in the matrix.
 	// Behaves like DryRun (no deployment), but outputs a focused table showing each
 	// scenario's resolved layers (identity, persistence, platform, infra-type, features, flow).

--- a/scripts/deploy-camunda/matrix/runner_options.go
+++ b/scripts/deploy-camunda/matrix/runner_options.go
@@ -9,6 +9,8 @@ type RunOptions struct {
 	GeneratePostgresCredentials bool
 	GeneratedPostgresUsername   string
 	GeneratedPostgresPassword   string
+	ImportDockerAuth            bool
+	DockerConfigPath            string
 	// DryRun logs what would be done without executing.
 	DryRun bool
 	// StopOnFailure stops the run on the first failure.

--- a/scripts/deploy-camunda/matrix/sync_dir_unix.go
+++ b/scripts/deploy-camunda/matrix/sync_dir_unix.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package matrix
+
+import (
+	"fmt"
+	"os"
+)
+
+func syncDirectory(path string) error {
+	dir, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open state directory: %w", err)
+	}
+	defer dir.Close()
+	if err := dir.Sync(); err != nil {
+		return fmt.Errorf("sync state directory: %w", err)
+	}
+	return nil
+}

--- a/scripts/deploy-camunda/matrix/sync_dir_windows.go
+++ b/scripts/deploy-camunda/matrix/sync_dir_windows.go
@@ -1,0 +1,5 @@
+//go:build windows
+
+package matrix
+
+func syncDirectory(string) error { return nil }

--- a/scripts/deploy-camunda/pkg/deployer/deployer.go
+++ b/scripts/deploy-camunda/pkg/deployer/deployer.go
@@ -42,26 +42,12 @@ func Deploy(ctx context.Context, o types.Options) error {
 		return fmt.Errorf("failed to create kube client: %w", err)
 	}
 
-	namespaceExisted, err := kubeClient.NamespaceExists(ctx, o.Namespace)
-	if err != nil {
-		return err
-	}
-	if err := kubeClient.EnsureNamespace(ctx, o.Namespace); err != nil {
-		return err
-	}
 	if o.CIMetadata.MatrixRunID != "" {
-		if namespaceExisted {
-			owner, err := kubeClient.NamespaceLabel(ctx, o.Namespace, "deploy-camunda-run")
-			if err != nil {
-				return err
-			}
-			if owner != o.CIMetadata.MatrixRunID {
-				return fmt.Errorf("namespace %q already existed and is not owned by matrix run %q", o.Namespace, o.CIMetadata.MatrixRunID)
-			}
-		}
-		if err := kubeClient.ClaimNamespaceOwnership(ctx, o.Namespace, "deploy-camunda-run", o.CIMetadata.MatrixRunID); err != nil {
+		if err := kubeClient.EnsureNamespaceOwned(ctx, o.Namespace, "deploy-camunda-run", o.CIMetadata.MatrixRunID); err != nil {
 			return err
 		}
+	} else if err := kubeClient.EnsureNamespace(ctx, o.Namespace); err != nil {
+		return err
 	}
 
 	if err := labelAndAnnotateNamespace(ctx, kubeClient, o.Namespace, o.Identifier, o.CIMetadata.Flow, o.TTL, o.CIMetadata.GithubRunID, o.CIMetadata.GithubJobID, o.CIMetadata.GithubOrg, o.CIMetadata.GithubRepo, o.CIMetadata.WorkflowURL, o.CIMetadata.MatrixRunID); err != nil {

--- a/scripts/deploy-camunda/pkg/deployer/deployer.go
+++ b/scripts/deploy-camunda/pkg/deployer/deployer.go
@@ -51,9 +51,6 @@ func Deploy(ctx context.Context, o types.Options) error {
 	}
 
 	if err := labelAndAnnotateNamespace(ctx, kubeClient, o.Namespace, o.Identifier, o.CIMetadata.Flow, o.TTL, o.CIMetadata.GithubRunID, o.CIMetadata.GithubJobID, o.CIMetadata.GithubOrg, o.CIMetadata.GithubRepo, o.CIMetadata.WorkflowURL, o.CIMetadata.MatrixRunID); err != nil {
-		if o.CIMetadata.MatrixRunID != "" {
-			return fmt.Errorf("failed to establish matrix run namespace ownership: %w", err)
-		}
 		// Non-fatal: namespace labels are CI housekeeping metadata (TTL, GitHub run IDs).
 		// On some clusters (e.g., EKS via Teleport) the user may lack namespace PATCH RBAC.
 		logging.Logger.Warn().Err(err).Str("namespace", o.Namespace).

--- a/scripts/deploy-camunda/pkg/deployer/deployer.go
+++ b/scripts/deploy-camunda/pkg/deployer/deployer.go
@@ -45,6 +45,11 @@ func Deploy(ctx context.Context, o types.Options) error {
 	if err := kubeClient.EnsureNamespace(ctx, o.Namespace); err != nil {
 		return err
 	}
+	if o.CIMetadata.MatrixRunID != "" {
+		if err := kubeClient.ClaimNamespaceOwnership(ctx, o.Namespace, "deploy-camunda-run", o.CIMetadata.MatrixRunID); err != nil {
+			return err
+		}
+	}
 
 	if err := labelAndAnnotateNamespace(ctx, kubeClient, o.Namespace, o.Identifier, o.CIMetadata.Flow, o.TTL, o.CIMetadata.GithubRunID, o.CIMetadata.GithubJobID, o.CIMetadata.GithubOrg, o.CIMetadata.GithubRepo, o.CIMetadata.WorkflowURL, o.CIMetadata.MatrixRunID); err != nil {
 		if o.CIMetadata.MatrixRunID != "" {

--- a/scripts/deploy-camunda/pkg/deployer/deployer.go
+++ b/scripts/deploy-camunda/pkg/deployer/deployer.go
@@ -47,6 +47,9 @@ func Deploy(ctx context.Context, o types.Options) error {
 	}
 
 	if err := labelAndAnnotateNamespace(ctx, kubeClient, o.Namespace, o.Identifier, o.CIMetadata.Flow, o.TTL, o.CIMetadata.GithubRunID, o.CIMetadata.GithubJobID, o.CIMetadata.GithubOrg, o.CIMetadata.GithubRepo, o.CIMetadata.WorkflowURL, o.CIMetadata.MatrixRunID); err != nil {
+		if o.CIMetadata.MatrixRunID != "" {
+			return fmt.Errorf("failed to establish matrix run namespace ownership: %w", err)
+		}
 		// Non-fatal: namespace labels are CI housekeeping metadata (TTL, GitHub run IDs).
 		// On some clusters (e.g., EKS via Teleport) the user may lack namespace PATCH RBAC.
 		logging.Logger.Warn().Err(err).Str("namespace", o.Namespace).

--- a/scripts/deploy-camunda/pkg/deployer/deployer.go
+++ b/scripts/deploy-camunda/pkg/deployer/deployer.go
@@ -43,7 +43,7 @@ func Deploy(ctx context.Context, o types.Options) error {
 	}
 
 	if o.CIMetadata.MatrixRunID != "" {
-		if err := kubeClient.EnsureNamespaceOwned(ctx, o.Namespace, "deploy-camunda-run", o.CIMetadata.MatrixRunID, o.CIMetadata.TransferMatrixOwnership); err != nil {
+		if err := kubeClient.EnsureNamespaceOwned(ctx, o.Namespace, "deploy-camunda-run", o.CIMetadata.MatrixRunID); err != nil {
 			return err
 		}
 	} else if err := kubeClient.EnsureNamespace(ctx, o.Namespace); err != nil {

--- a/scripts/deploy-camunda/pkg/deployer/deployer.go
+++ b/scripts/deploy-camunda/pkg/deployer/deployer.go
@@ -42,10 +42,23 @@ func Deploy(ctx context.Context, o types.Options) error {
 		return fmt.Errorf("failed to create kube client: %w", err)
 	}
 
+	namespaceExisted, err := kubeClient.NamespaceExists(ctx, o.Namespace)
+	if err != nil {
+		return err
+	}
 	if err := kubeClient.EnsureNamespace(ctx, o.Namespace); err != nil {
 		return err
 	}
 	if o.CIMetadata.MatrixRunID != "" {
+		if namespaceExisted {
+			owner, err := kubeClient.NamespaceLabel(ctx, o.Namespace, "deploy-camunda-run")
+			if err != nil {
+				return err
+			}
+			if owner != o.CIMetadata.MatrixRunID {
+				return fmt.Errorf("namespace %q already existed and is not owned by matrix run %q", o.Namespace, o.CIMetadata.MatrixRunID)
+			}
+		}
 		if err := kubeClient.ClaimNamespaceOwnership(ctx, o.Namespace, "deploy-camunda-run", o.CIMetadata.MatrixRunID); err != nil {
 			return err
 		}

--- a/scripts/deploy-camunda/pkg/deployer/deployer.go
+++ b/scripts/deploy-camunda/pkg/deployer/deployer.go
@@ -46,7 +46,7 @@ func Deploy(ctx context.Context, o types.Options) error {
 		return err
 	}
 
-	if err := labelAndAnnotateNamespace(ctx, kubeClient, o.Namespace, o.Identifier, o.CIMetadata.Flow, o.TTL, o.CIMetadata.GithubRunID, o.CIMetadata.GithubJobID, o.CIMetadata.GithubOrg, o.CIMetadata.GithubRepo, o.CIMetadata.WorkflowURL); err != nil {
+	if err := labelAndAnnotateNamespace(ctx, kubeClient, o.Namespace, o.Identifier, o.CIMetadata.Flow, o.TTL, o.CIMetadata.GithubRunID, o.CIMetadata.GithubJobID, o.CIMetadata.GithubOrg, o.CIMetadata.GithubRepo, o.CIMetadata.WorkflowURL, o.CIMetadata.MatrixRunID); err != nil {
 		// Non-fatal: namespace labels are CI housekeeping metadata (TTL, GitHub run IDs).
 		// On some clusters (e.g., EKS via Teleport) the user may lack namespace PATCH RBAC.
 		logging.Logger.Warn().Err(err).Str("namespace", o.Namespace).

--- a/scripts/deploy-camunda/pkg/deployer/deployer.go
+++ b/scripts/deploy-camunda/pkg/deployer/deployer.go
@@ -43,7 +43,7 @@ func Deploy(ctx context.Context, o types.Options) error {
 	}
 
 	if o.CIMetadata.MatrixRunID != "" {
-		if err := kubeClient.EnsureNamespaceOwned(ctx, o.Namespace, "deploy-camunda-run", o.CIMetadata.MatrixRunID); err != nil {
+		if err := kubeClient.EnsureNamespaceOwned(ctx, o.Namespace, "deploy-camunda-run", o.CIMetadata.MatrixRunID, o.CIMetadata.TransferMatrixOwnership); err != nil {
 			return err
 		}
 	} else if err := kubeClient.EnsureNamespace(ctx, o.Namespace); err != nil {

--- a/scripts/deploy-camunda/pkg/deployer/helm.go
+++ b/scripts/deploy-camunda/pkg/deployer/helm.go
@@ -103,6 +103,16 @@ func redactHelmCommand(command string) string {
 func redactHelmArgs(args []string) []string {
 	out := append([]string(nil), args...)
 	for i, arg := range out {
+		for _, prefix := range []string{"--set=", "--set-string=", "--set-json="} {
+			if strings.HasPrefix(arg, prefix) {
+				payload := strings.TrimPrefix(arg, prefix)
+				key, _, ok := strings.Cut(payload, "=")
+				if ok && secretHelmKey(key) {
+					out[i] = prefix + key + "=<redacted>"
+					arg = out[i]
+				}
+			}
+		}
 		redactedSetValue := false
 		if i > 0 && (out[i-1] == "--set" || out[i-1] == "--set-string" || out[i-1] == "--set-json") {
 			key, _, ok := strings.Cut(arg, "=")

--- a/scripts/deploy-camunda/pkg/deployer/helm.go
+++ b/scripts/deploy-camunda/pkg/deployer/helm.go
@@ -107,7 +107,7 @@ func redactHelmArgs(args []string) []string {
 			if strings.HasPrefix(arg, prefix) {
 				payload := strings.TrimPrefix(arg, prefix)
 				key, _, ok := strings.Cut(payload, "=")
-				if ok && secretHelmKey(key) {
+				if ok && !publicHelmKey(key) {
 					out[i] = prefix + key + "=<redacted>"
 					arg = out[i]
 				}
@@ -116,7 +116,7 @@ func redactHelmArgs(args []string) []string {
 		redactedSetValue := false
 		if i > 0 && (out[i-1] == "--set" || out[i-1] == "--set-string" || out[i-1] == "--set-json") {
 			key, _, ok := strings.Cut(arg, "=")
-			if ok && secretHelmKey(key) {
+			if ok && !publicHelmKey(key) {
 				out[i] = key + "=<redacted>"
 				redactedSetValue = true
 			}
@@ -126,6 +126,15 @@ func redactHelmArgs(args []string) []string {
 		}
 	}
 	return out
+}
+
+func publicHelmKey(key string) bool {
+	for _, allowed := range []string{"global.host", "global.ingress.host", "orchestration.upgrade.allowPreReleaseImages", "nodeSelector", "tolerations", "volumeClaimTemplate.storageClassName", "feature.enabled"} {
+		if key == allowed {
+			return true
+		}
+	}
+	return false
 }
 
 func secretHelmKey(key string) bool {

--- a/scripts/deploy-camunda/pkg/deployer/helm.go
+++ b/scripts/deploy-camunda/pkg/deployer/helm.go
@@ -81,7 +81,28 @@ func (e *HelmError) Unwrap() error {
 // base filenames for readability. Full paths in -f values file args and chart
 // paths are replaced with just the filename.
 func (e *HelmError) ShortCommand() string {
-	return shortenPaths(e.Command)
+	return redactHelmCommand(shortenPaths(e.Command))
+}
+
+func redactHelmCommand(command string) string {
+	parts := strings.Fields(command)
+	for i, part := range parts {
+		if i > 0 && (parts[i-1] == "--set" || parts[i-1] == "--set-string" || parts[i-1] == "--set-json") {
+			key, _, ok := strings.Cut(part, "=")
+			if ok && secretHelmKey(key) {
+				parts[i] = key + "=<redacted>"
+			}
+		}
+		if key, _, ok := strings.Cut(strings.TrimLeft(part, "-"), "="); ok && secretHelmKey(key) {
+			parts[i] = "--" + key + "=<redacted>"
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+func secretHelmKey(key string) bool {
+	upper := strings.ToUpper(key)
+	return strings.Contains(upper, "PASSWORD") || strings.Contains(upper, "SECRET") || strings.Contains(upper, "TOKEN") || strings.Contains(upper, "CREDENTIAL") || strings.Contains(upper, "PRIVATE")
 }
 
 // shortenPaths replaces long absolute/relative file paths with just basenames.

--- a/scripts/deploy-camunda/pkg/deployer/helm.go
+++ b/scripts/deploy-camunda/pkg/deployer/helm.go
@@ -100,6 +100,24 @@ func redactHelmCommand(command string) string {
 	return strings.Join(parts, " ")
 }
 
+func redactHelmArgs(args []string) []string {
+	out := append([]string(nil), args...)
+	for i, arg := range out {
+		redactedSetValue := false
+		if i > 0 && (out[i-1] == "--set" || out[i-1] == "--set-string" || out[i-1] == "--set-json") {
+			key, _, ok := strings.Cut(arg, "=")
+			if ok && secretHelmKey(key) {
+				out[i] = key + "=<redacted>"
+				redactedSetValue = true
+			}
+		}
+		if key, _, ok := strings.Cut(strings.TrimLeft(arg, "-"), "="); !redactedSetValue && ok && strings.HasPrefix(arg, "--") && secretHelmKey(key) {
+			out[i] = "--" + key + "=<redacted>"
+		}
+	}
+	return out
+}
+
 func secretHelmKey(key string) bool {
 	upper := strings.ToUpper(key)
 	return strings.Contains(upper, "PASSWORD") || strings.Contains(upper, "SECRET") || strings.Contains(upper, "TOKEN") || strings.Contains(upper, "CREDENTIAL") || strings.Contains(upper, "PRIVATE")
@@ -201,7 +219,7 @@ func upgradeInstall(ctx context.Context, o types.Options) error {
 	if runErr != nil {
 		return &HelmError{
 			Reason:  "helm upgrade --install failed",
-			Command: "helm " + formatArgs(args),
+			Command: "helm " + formatArgs(redactHelmArgs(args)),
 			Cause:   runErr,
 		}
 	}
@@ -341,7 +359,7 @@ func deployCompanionChart(ctx context.Context, cc types.CompanionChart, o types.
 	}
 	return &HelmError{
 		Reason:  fmt.Sprintf("companion chart %q helm upgrade --install failed", cc.ReleaseName),
-		Command: "helm " + formatArgs(args),
+		Command: "helm " + formatArgs(redactHelmArgs(args)),
 		Cause:   runErr,
 	}
 }

--- a/scripts/deploy-camunda/pkg/deployer/helm_test.go
+++ b/scripts/deploy-camunda/pkg/deployer/helm_test.go
@@ -88,6 +88,17 @@ func TestHelmError_ShortCommand(t *testing.T) {
 	}
 }
 
+func TestHelmErrorShortCommandRedactsSecretSets(t *testing.T) {
+	err := &HelmError{Command: `helm upgrade --install release chart --set global.password=hunter2 --set feature.enabled=true --token=abc123`}
+	short := err.ShortCommand()
+	if strings.Contains(short, "hunter2") || strings.Contains(short, "abc123") {
+		t.Fatalf("secret leaked: %s", short)
+	}
+	if !strings.Contains(short, "feature.enabled=true") {
+		t.Fatalf("benign set removed: %s", short)
+	}
+}
+
 func TestShortenPaths_NoAbsolutePaths(t *testing.T) {
 	cmd := "helm upgrade --install integration camunda/camunda-platform -n ns --version 13.5.0 --wait"
 	got := shortenPaths(cmd)

--- a/scripts/deploy-camunda/pkg/deployer/helm_test.go
+++ b/scripts/deploy-camunda/pkg/deployer/helm_test.go
@@ -99,6 +99,17 @@ func TestHelmErrorShortCommandRedactsSecretSets(t *testing.T) {
 	}
 }
 
+func TestRedactHelmArgsHandlesWhitespaceSecrets(t *testing.T) {
+	args := []string{"upgrade", "--set", "global.password=two words", "--set", "feature.enabled=true"}
+	redacted := redactHelmArgs(args)
+	if redacted[2] != "global.password=<redacted>" {
+		t.Fatalf("redacted = %#v", redacted)
+	}
+	if redacted[4] != "feature.enabled=true" {
+		t.Fatalf("benign set changed: %#v", redacted)
+	}
+}
+
 func TestShortenPaths_NoAbsolutePaths(t *testing.T) {
 	cmd := "helm upgrade --install integration camunda/camunda-platform -n ns --version 13.5.0 --wait"
 	got := shortenPaths(cmd)

--- a/scripts/deploy-camunda/pkg/deployer/helm_test.go
+++ b/scripts/deploy-camunda/pkg/deployer/helm_test.go
@@ -110,6 +110,13 @@ func TestRedactHelmArgsHandlesWhitespaceSecrets(t *testing.T) {
 	}
 }
 
+func TestRedactHelmArgsHandlesInlineSetSecrets(t *testing.T) {
+	redacted := redactHelmArgs([]string{"upgrade", "--set=global.password=secret value"})
+	if redacted[1] != "--set=global.password=<redacted>" {
+		t.Fatalf("redacted = %#v", redacted)
+	}
+}
+
 func TestShortenPaths_NoAbsolutePaths(t *testing.T) {
 	cmd := "helm upgrade --install integration camunda/camunda-platform -n ns --version 13.5.0 --wait"
 	got := shortenPaths(cmd)

--- a/scripts/deploy-camunda/pkg/deployer/kube.go
+++ b/scripts/deploy-camunda/pkg/deployer/kube.go
@@ -13,7 +13,7 @@ import (
 )
 
 // labelAndAnnotateNamespace adds Camunda/GitHub-specific labels and annotations
-func labelAndAnnotateNamespace(ctx context.Context, kubeClient *kube.Client, namespace, identifier, flow, ttl string, ghRunID string, ghJobID string, ghOrg string, ghRepo string, workflowURL string) error {
+func labelAndAnnotateNamespace(ctx context.Context, kubeClient *kube.Client, namespace, identifier, flow, ttl string, ghRunID string, ghJobID string, ghOrg string, ghRepo string, workflowURL string, matrixRunID string) error {
 	// Build labels map
 	labels := make(map[string]string)
 	if strings.TrimSpace(identifier) != "" {
@@ -33,6 +33,9 @@ func labelAndAnnotateNamespace(ctx context.Context, kubeClient *kube.Client, nam
 	}
 	if strings.TrimSpace(ghRepo) != "" {
 		labels["github-repo"] = ghRepo
+	}
+	if strings.TrimSpace(matrixRunID) != "" {
+		labels["deploy-camunda-run"] = matrixRunID
 	}
 
 	// Build annotations map

--- a/scripts/deploy-camunda/pkg/types/types.go
+++ b/scripts/deploy-camunda/pkg/types/types.go
@@ -118,11 +118,12 @@ type CompanionChart struct {
 }
 
 type CIMetadata struct {
-	MatrixRunID string
-	GithubRunID string
-	GithubJobID string
-	GithubOrg   string
-	GithubRepo  string
-	WorkflowURL string
-	Flow        string
+	TransferMatrixOwnership bool
+	MatrixRunID             string
+	GithubRunID             string
+	GithubJobID             string
+	GithubOrg               string
+	GithubRepo              string
+	WorkflowURL             string
+	Flow                    string
 }

--- a/scripts/deploy-camunda/pkg/types/types.go
+++ b/scripts/deploy-camunda/pkg/types/types.go
@@ -118,12 +118,11 @@ type CompanionChart struct {
 }
 
 type CIMetadata struct {
-	TransferMatrixOwnership bool
-	MatrixRunID             string
-	GithubRunID             string
-	GithubJobID             string
-	GithubOrg               string
-	GithubRepo              string
-	WorkflowURL             string
-	Flow                    string
+	MatrixRunID string
+	GithubRunID string
+	GithubJobID string
+	GithubOrg   string
+	GithubRepo  string
+	WorkflowURL string
+	Flow        string
 }

--- a/scripts/deploy-camunda/pkg/types/types.go
+++ b/scripts/deploy-camunda/pkg/types/types.go
@@ -118,6 +118,7 @@ type CompanionChart struct {
 }
 
 type CIMetadata struct {
+	MatrixRunID string
 	GithubRunID string
 	GithubJobID string
 	GithubOrg   string


### PR DESCRIPTION
### Which problem does the PR fix?

Implements the foundational milestone of #6712.

`deploy-camunda matrix run` is currently a one-shot operation. If the process stops or one matrix cell fails, operators and AI agents must reconstruct completed work, credentials, target namespaces, diagnostics, and replay commands manually. Registry onboarding is especially fragile because the CLI needs credentials both for registry login and Kubernetes pull-secret creation.

This PR makes ordinary matrix runs durable and recoverable, and gives local users a one-time, secure registry credential setup that AI-driven workflows can consume without handling secret values.

### What's in this PR?

#### Durable matrix lifecycle

- Persists versioned parent/entry state, attempts, phases, failure codes, diagnostics references, replay arguments, and external identity resource metadata.
- Uses atomic state writes, append-only events, cross-process run locks, `0700` run directories, and `0600` state/secret files.
- Adds:

```bash
deploy-camunda matrix status [run-id] [--output json]
deploy-camunda matrix resume <run-id> [--entry <entry-id>]
deploy-camunda matrix cleanup <run-id> --yes [--entry <entry-id>]
```

- Resume skips successful or explicitly cleaned entries and rejects unsafe partial two-step upgrades.
- Replay manifests preserve non-secret behavior-affecting options and use placeholders for secret-bearing Helm arguments.

#### Ownership-safe cleanup

- Creates durable-run namespaces with an ownership label atomically.
- Rejects foreign or concurrently-created namespaces instead of adopting them.
- Uses UID and resource-version preconditions before namespace deletion.
- Persists Entra/Auth0 resource metadata and fails closed when provider cleanup or ownership verification cannot be completed.
- Makes cleanup idempotent and reports partial failures instead of silently claiming success.

#### Matrix-wide preflight

- Adds `deploy-camunda matrix doctor` using the same matrix config merger, entry generation, `BuildEntryFlags`, and preflight engine as `matrix run`.
- Resolves all selected ordinary entries before mutation.
- Reports shared Kubernetes and registry blockers once, while retaining entry-specific scenario and companion-chart checks.
- Generates PostgreSQL credentials only for entries that need them, preserves explicit values, rejects inconsistent per-version pairs, and restores the effective pair during resume.

#### One-time registry credential setup

Local users can securely configure registry credentials once:

```bash
deploy-camunda credentials configure --registry harbor
deploy-camunda credentials configure --registry dockerhub
deploy-camunda credentials status
```

- Uses macOS Keychain, Linux Secret Service, or Windows Credential Manager.
- Password/token input is hidden on terminals.
- Stores complete username/token pairs per canonical registry, preventing mixed-source credentials.
- Shared precedence for normal deploy, root doctor, matrix run/doctor, and resume:

```text
CLI/config pair > environment or .env pair > OS keyring > opt-in plaintext Docker auth import
```

- Headless CI continues to use environment credentials; an unavailable optional desktop keyring is treated as not configured.
- Secrets are never written to deployment config, logs, replay commands, `matrix-state.json`, or uploaded artifacts.
- Plaintext Docker `auths` import remains opt-in; arbitrary Docker credential helpers/stores are not executed.

#### Explicit boundaries

- Topology release-level preflight/checkpoint/resume remains deferred; `matrix doctor` reports topology support as warning-only rather than claiming coverage.
- Incident bundles, AI remediation policy, `cancel`, `approve`, and topology release checkpoints remain follow-up phases of #6712.
- The PR remains draft until `crev` findings are resolved and CI is green.

#### Current review status

- The final two P1 recovery defects from the review of `b75133e2f` were addressed on head `1e13b79af`: cleanup normalizes Auth0 default domains through the provider resolver, and explicit namespace adoption deletes under the observed old owner with UID/resource-version guards before replacement.
- A fresh `crev` review is running against `1e13b79af`.
- Full Go tests, credential/cmd/matrix race tests, builds, formatting, chart unit checks, and the live GKE interruption/resume/cleanup trial are green.
- The PR remains draft until the fresh review is clean.

Validation performed locally:

- `cd scripts/deploy-camunda && go test ./...`
- `cd scripts/deploy-camunda && go test -race ./credentials ./cmd ./matrix`
- `cd scripts/deploy-camunda && go build .`
- `cd scripts/camunda-core && go test ./...`
- Cross-compiled the credential package tests for Linux and Windows.
- Ran a targeted `matrix doctor` smoke test against the real 8.10 `eske` registry entry with cluster reachability skipped.
- Exercised `credentials status` against real macOS Keychain entries; only usernames were displayed.
- Removed every Harbor/Docker Hub environment variable and confirmed `matrix doctor` passed both required registry checks for real 8.10 `eske` and `keyco` entries using Keychain only.
- Ran a controlled `matrix run` against a nonexistent kube context: no cluster mutation occurred, the CLI emitted an accurate failed-entry summary, state persisted `KUBERNETES_FAILURE`, chart paths/replay inputs were location-independent, and `matrix resume` from another working directory restored registry credentials and reached the same blocker.
- Ran a live GKE interruption test on 8.10 `eske`: sent SIGTERM during companion deployment after namespace ownership was established; the CLI exited promptly, persisted diagnostics/state, and retained a healthy completed PostgreSQL release.
- Resumed the same run from the repository root with all registry environment variables removed. The run restored Keychain credentials and location-independent chart/value paths. Helm 4 stale `pending-install` companion revisions required a bounded manual repair (uninstall only the two incomplete owned releases); after that, `matrix resume` completed successfully in 5m22s.
- Verified all 10 workload pods ready, all four Helm releases deployed, and namespace ownership matched the run ID.
- Ran `matrix cleanup --yes`, confirmed UID/resource-version guarded namespace deletion, confirmed a second cleanup was idempotent, and verified the namespace no longer exists.
- Scanned durable state, events, diagnostics, and public status for credential patterns: no secret values were found; the run directory was `0700` and state/event/secret files were `0600`.
- Rebased onto current `main`; the PR diff contains no unrelated chart/digest changes.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
