### PR TITLE
ci: capture namespace diagnostics when the e2e job fails

### DIFF
--- a/.github/actions/playwright-e2e-tests/action.yaml
+++ b/.github/actions/playwright-e2e-tests/action.yaml
@@ -78,9 +78,12 @@ inputs:
     required: false
     default: ""
   binary-artifact-name:
-    description: Name of the uploaded deploy-camunda binary artifact to download (only used when management-namespace is set).
+    description: >
+      Name of the uploaded deploy-camunda binary artifact to download. When set, the
+      binary is placed on PATH for multi-namespace credential merging and for the
+      on-failure namespace diagnostics capture. Empty skips the download.
     required: false
-    default: deploy-camunda-binary
+    default: ""
 runs:
   using: composite
   steps:
@@ -164,14 +167,14 @@ runs:
           zbctl
           jq
 
-    - name: Download deploy-camunda binary (multi-namespace topology)
-      if: inputs.management-namespace != ''
+    - name: Download deploy-camunda binary
+      if: inputs.binary-artifact-name != ''
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
         name: ${{ inputs.binary-artifact-name }}
         path: ${{ runner.temp }}/bin
-    - name: Add deploy-camunda to PATH (multi-namespace topology)
-      if: inputs.management-namespace != ''
+    - name: Add deploy-camunda to PATH
+      if: inputs.binary-artifact-name != ''
       shell: bash
       run: |
         chmod +x "${RUNNER_TEMP}/bin/deploy-camunda"
@@ -258,6 +261,43 @@ runs:
         [[ -n "$MANAGEMENT_NAMESPACE" ]] && E2E_ARGS+=(--management-namespace "${MANAGEMENT_NAMESPACE}")
 
         ./run-e2e-tests.sh "${E2E_ARGS[@]}"
+
+    - name: Capture namespace diagnostics
+      if: ${{ failure() && !cancelled() }}
+      shell: bash
+      env:
+        TEST_NAMESPACE: ${{ env.TEST_NAMESPACE }}
+      run: |
+        mkdir -p "${GITHUB_WORKSPACE}/e2e-diagnostics"
+        out="${GITHUB_WORKSPACE}/e2e-diagnostics/namespace-diagnostics.txt"
+        if ! command -v deploy-camunda >/dev/null 2>&1; then
+          echo "deploy-camunda not on PATH; no diagnostics captured" | tee "$out"
+          exit 0
+        fi
+        deploy-camunda diagnostics print \
+          --namespace "${TEST_NAMESPACE}" \
+          --include-ready \
+          > "$out" 2>&1 || true
+        echo "::group::Namespace diagnostics"
+        cat "$out"
+        echo "::endgroup::"
+
+    - name: Compute diagnostics artifact name
+      id: e2e_diag_artifact
+      if: ${{ failure() && !cancelled() }}
+      shell: bash
+      run: |
+        raw="diagnostics-e2e-${{ inputs.identifier }}-${{ inputs.flow }}-${{ inputs.test-stage }}-${{ inputs.shard-index }}-${{ github.run_id }}-${{ github.run_attempt }}"
+        echo "name=${raw//[^a-zA-Z0-9._-]/-}" >> "$GITHUB_OUTPUT"
+
+    - name: Upload namespace diagnostics
+      if: ${{ failure() && !cancelled() }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      with:
+        name: ${{ steps.e2e_diag_artifact.outputs.name }}
+        path: e2e-diagnostics/
+        retention-days: 14
+        if-no-files-found: warn
 
     - name: Upload blob report to GitHub Actions Artifacts
       if: ${{ !cancelled() }}

--- a/.github/actions/playwright-e2e-tests/action.yaml
+++ b/.github/actions/playwright-e2e-tests/action.yaml
@@ -296,7 +296,7 @@ runs:
       with:
         name: ${{ steps.e2e_diag_artifact.outputs.name }}
         path: e2e-diagnostics/
-        retention-days: 14
+        retention-days: 1
         if-no-files-found: warn
 
     - name: Upload blob report to GitHub Actions Artifacts

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -1250,6 +1250,7 @@ jobs:
           ROSA_PASS:        ${{ secrets[inputs.password] }}
           CI_DEPLOYMENT_TTL: ${{ env.CI_DEPLOYMENT_TTL }}
         with:
+          binary-artifact-name: ${{ inputs.binary-artifact-name }}
           camunda-helm-git-ref: ${{ inputs.camunda-helm-git-ref }}
           camunda-helm-dir: ${{ inputs.camunda-helm-dir }}
           camunda-helm-upgrade-version: ${{ inputs.camunda-helm-upgrade-version }}
@@ -1327,6 +1328,7 @@ jobs:
           PLAYWRIGHT_POD_RETRY_MAX_ATTEMPTS: "1"
           PLAYWRIGHT_E2E_RETRIES: "0"
         with:
+          binary-artifact-name: ${{ inputs.binary-artifact-name }}
           camunda-helm-git-ref: ${{ inputs.camunda-helm-git-ref }}
           camunda-helm-dir: ${{ inputs.camunda-helm-dir }}
           camunda-helm-upgrade-version: ${{ inputs.camunda-helm-upgrade-version }}
@@ -1508,6 +1510,7 @@ jobs:
           ROSA_PASS:        ${{ secrets[inputs.password] }}
           CI_DEPLOYMENT_TTL: ${{ env.CI_DEPLOYMENT_TTL }}
         with:
+          binary-artifact-name: ${{ inputs.binary-artifact-name }}
           camunda-helm-git-ref: ${{ inputs.camunda-helm-git-ref }}
           camunda-helm-dir: ${{ inputs.camunda-helm-dir }}
           camunda-helm-upgrade-version: ${{ inputs.camunda-helm-upgrade-version }}

--- a/scripts/deploy-camunda/cmd/diagnostics.go
+++ b/scripts/deploy-camunda/cmd/diagnostics.go
@@ -28,6 +28,7 @@ type podDiagnosticsSource struct {
 	GetPVCs            func(ctx context.Context, kubeContext, namespace string) (string, error)
 	DescribePVCs       func(ctx context.Context, kubeContext, namespace string) (string, error)
 	GetNonReadyPods    func(ctx context.Context, kubeContext, namespace string) ([]string, error)
+	GetPodNames        func(ctx context.Context, kubeContext, namespace string) ([]string, error)
 	DescribePod        func(ctx context.Context, kubeContext, namespace, pod string) (string, error)
 	GetPodLogs         func(ctx context.Context, kubeContext, namespace, pod string, tail int) (string, error)
 	GetPodLogsPrevious func(ctx context.Context, kubeContext, namespace, pod string, tail int) (string, error)
@@ -40,6 +41,7 @@ func defaultPodDiagnosticsSource() podDiagnosticsSource {
 		GetPVCs:            kube.GetPVCs,
 		DescribePVCs:       kube.DescribePVCs,
 		GetNonReadyPods:    kube.GetNonReadyPods,
+		GetPodNames:        kube.GetPodNames,
 		DescribePod:        kube.DescribePod,
 		GetPodLogs:         kube.GetPodLogs,
 		GetPodLogsPrevious: kube.GetPodLogsPrevious,
@@ -61,19 +63,26 @@ func newDiagnosticsCommand() *cobra.Command {
 // for every non-ready pod — describe + current/previous logs. Non-ready is
 // determined by the Ready condition (via kube.GetNonReadyPods), so a `0/N Running`
 // pod (the common deploy-timeout shape) is captured, not just crashed ones.
+// --include-ready widens the describe+logs loop to every pod (kube.GetPodNames),
+// covering a Ready pod that is serving errors rather than crashing.
 func newDiagnosticsPrintCommand() *cobra.Command {
 	var namespace, kubeContext string
 	var tail int
+	var includeReady bool
 
 	cmd := &cobra.Command{
 		Use:   "print",
-		Short: "Print namespace diagnostics (pods, events, PVCs, non-ready pod describe+logs) to stdout",
+		Short: "Print namespace diagnostics (pods, events, PVCs, pod describe+logs) to stdout",
 		Long: `Print a best-effort namespace diagnostics dump for CI logs.
 
 Backs the failed-pods-info GitHub action. Structured diagnostics are also
 uploaded as the diagnostics-* artifact by the matrix runner; this command is the
 human-readable in-log fast path for the common failure shapes (crash, image
 pull, scheduling, and volume-mount/init hangs).
+
+By default only non-ready pods are described and their logs collected. Pass
+--include-ready to cover every pod in the namespace, which is what a
+Ready-but-misbehaving component (an HTTP 500 from a running pod) requires.
 
 All calls are best-effort: errors are printed inline and never abort the dump.`,
 		SilenceUsage:  true,
@@ -92,7 +101,7 @@ All calls are best-effort: errors are printed inline and never abort the dump.`,
 				return fmt.Errorf("--namespace is required")
 			}
 
-			printNamespaceDiagnostics(ctx, os.Stdout, defaultPodDiagnosticsSource(), kubeContext, namespace, tail)
+			printNamespaceDiagnostics(ctx, os.Stdout, defaultPodDiagnosticsSource(), kubeContext, namespace, tail, includeReady)
 			return nil
 		},
 	}
@@ -100,7 +109,8 @@ All calls are best-effort: errors are printed inline and never abort the dump.`,
 	f := cmd.Flags()
 	f.StringVarP(&namespace, "namespace", "n", "", "Namespace to inspect (required)")
 	f.StringVar(&kubeContext, "kube-context", "", "Kubernetes context")
-	f.IntVar(&tail, "tail", 500, "Log tail lines per non-ready pod")
+	f.IntVar(&tail, "tail", 500, "Log tail lines per pod")
+	f.BoolVar(&includeReady, "include-ready", false, "Describe and collect logs for every pod, not just non-ready ones")
 	f.StringVarP(&flags.LogLevel, "log-level", "l", "info", "Log level")
 
 	return cmd
@@ -108,7 +118,9 @@ All calls are best-effort: errors are printed inline and never abort the dump.`,
 
 // printNamespaceDiagnostics writes the diagnostics dump to w. It is pure
 // orchestration over src so it can be unit-tested with a fake source.
-func printNamespaceDiagnostics(ctx context.Context, w io.Writer, src podDiagnosticsSource, kubeContext, namespace string, tail int) {
+// includeReady selects src.GetPodNames over src.GetNonReadyPods for the
+// describe+logs loop.
+func printNamespaceDiagnostics(ctx context.Context, w io.Writer, src podDiagnosticsSource, kubeContext, namespace string, tail int, includeReady bool) {
 	section := func(title string) { fmt.Fprintf(w, "\n===== %s =====\n", title) }
 	emit := func(title string, out string, err error) {
 		section(title)
@@ -135,28 +147,33 @@ func printNamespaceDiagnostics(ctx context.Context, w io.Writer, src podDiagnost
 	pvcDesc, pvcDescErr := src.DescribePVCs(ctx, kubeContext, namespace)
 	emit("PVC describe", pvcDesc, pvcDescErr)
 
-	nonReady, err := src.GetNonReadyPods(ctx, kubeContext, namespace)
+	listPods, listTitle, podLabel := src.GetNonReadyPods, "Non-ready pods", "Non-ready pod: "
+	if includeReady {
+		listPods, listTitle, podLabel = src.GetPodNames, "All pods", "Pod: "
+	}
+
+	targets, err := listPods(ctx, kubeContext, namespace)
 	if err != nil {
-		section("Non-ready pods")
+		section(listTitle)
 		fmt.Fprintf(w, "(error: %v)\n", err)
 		return
 	}
-	sort.Strings(nonReady)
-	if len(nonReady) == 0 {
-		section("Non-ready pods")
+	sort.Strings(targets)
+	if len(targets) == 0 {
+		section(listTitle)
 		fmt.Fprintln(w, "(none)")
 		return
 	}
-	for _, pod := range nonReady {
+	for _, pod := range targets {
 		desc, descErr := src.DescribePod(ctx, kubeContext, namespace, pod)
-		emit("Non-ready pod: "+pod+" — describe", desc, descErr)
+		emit(podLabel+pod+" — describe", desc, descErr)
 
 		podLogs, logsErr := src.GetPodLogs(ctx, kubeContext, namespace, pod, tail)
-		emit("Non-ready pod: "+pod+" — logs", podLogs, logsErr)
+		emit(podLabel+pod+" — logs", podLogs, logsErr)
 
 		// --previous surfaces the prior crash; empty/erroring when the pod never restarted.
 		if prev, err := src.GetPodLogsPrevious(ctx, kubeContext, namespace, pod, tail); err == nil && prev != "" {
-			emit("Non-ready pod: "+pod+" — previous logs", prev, nil)
+			emit(podLabel+pod+" — previous logs", prev, nil)
 		}
 	}
 }

--- a/scripts/deploy-camunda/cmd/diagnostics_test.go
+++ b/scripts/deploy-camunda/cmd/diagnostics_test.go
@@ -31,7 +31,7 @@ func TestPrintNamespaceDiagnostics(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	printNamespaceDiagnostics(context.Background(), &buf, src, "", "ns", 500)
+	printNamespaceDiagnostics(context.Background(), &buf, src, "", "ns", 500, false)
 	out := buf.String()
 
 	for _, want := range []string{"Pods", "Events", "PersistentVolumeClaims", "PVC describe", "Non-ready pod: pod-a", "FailedMount", "pod-a current log"} {
@@ -60,10 +60,66 @@ func TestPrintNamespaceDiagnosticsErrorsAreInline(t *testing.T) {
 	}
 	var buf bytes.Buffer
 	// Must not panic and must surface the errors rather than aborting.
-	printNamespaceDiagnostics(context.Background(), &buf, src, "", "ns", 10)
+	printNamespaceDiagnostics(context.Background(), &buf, src, "", "ns", 10, false)
 	out := buf.String()
 	if !strings.Contains(out, "(error: boom)") || !strings.Contains(out, "(error: list failed)") {
 		t.Errorf("expected inline errors, got:\n%s", out)
+	}
+}
+
+func TestPrintNamespaceDiagnosticsIncludeReady(t *testing.T) {
+	t.Parallel()
+
+	var describedPods []string
+	nonReadyCalls := 0
+	src := podDiagnosticsSource{
+		GetPods:      func(_ context.Context, _, _ string) (string, error) { return "keycloak 1/1 Running", nil },
+		GetEvents:    func(_ context.Context, _, _ string) (string, error) { return "", nil },
+		GetPVCs:      func(_ context.Context, _, _ string) (string, error) { return "", nil },
+		DescribePVCs: func(_ context.Context, _, _ string) (string, error) { return "", nil },
+		GetNonReadyPods: func(_ context.Context, _, _ string) ([]string, error) {
+			nonReadyCalls++
+			return nil, nil
+		},
+		GetPodNames: func(_ context.Context, _, _ string) ([]string, error) {
+			return []string{"orchestration-0", "keycloak-0"}, nil
+		},
+		DescribePod: func(_ context.Context, _, _, pod string) (string, error) {
+			describedPods = append(describedPods, pod)
+			return "Name: " + pod, nil
+		},
+		GetPodLogs: func(_ context.Context, _, _, pod string, _ int) (string, error) {
+			return pod + ": Unexpected error when handling authentication request", nil
+		},
+		GetPodLogsPrevious: func(_ context.Context, _, _, _ string, _ int) (string, error) { return "", nil },
+	}
+
+	var buf bytes.Buffer
+	printNamespaceDiagnostics(context.Background(), &buf, src, "", "ns", 500, true)
+	out := buf.String()
+
+	// Every pod is Ready, so the default mode would have collected no logs at all.
+	for _, want := range []string{
+		"Pod: keycloak-0 — describe",
+		"Pod: orchestration-0 — describe",
+		"Unexpected error when handling authentication request",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+	if len(describedPods) != 2 {
+		t.Errorf("expected both pods described, got %v", describedPods)
+	}
+	// Sorted, so keycloak-0 precedes orchestration-0.
+	if describedPods[0] != "keycloak-0" {
+		t.Errorf("expected sorted pod order, got %v", describedPods)
+	}
+	if nonReadyCalls != 0 {
+		t.Errorf("include-ready must not call GetNonReadyPods, got %d calls", nonReadyCalls)
+	}
+	if strings.Contains(out, "Non-ready pod:") {
+		t.Errorf("include-ready output should not use the non-ready label:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
### Which problem does the PR fix?

A failing Playwright e2e job leaves no cluster-side evidence behind.

`Get failed Pods info` and the `diagnostics-*` artifact upload exist only in the
`install` and `upgrade` jobs. `playwright-e2e-tests-after-install` runs exactly three
steps — Checkout, Import Vault secrets, Run Playwright E2E Tests — and uploads nothing
about the namespace. Because `cleanup` depends on `merge-e2e-reports` → the e2e job,
the namespace is still alive while the test is failing, but it is deleted immediately
afterwards (`always-delete-namespace: true` for the alwaysgreen scenario). By the time
anyone opens the run, there is nothing left to inspect.

`diagnostics print` could not have supplied the missing evidence even if it had been
wired in: it describes and collects logs only for pods whose `Ready` condition is not
`True`. The failure shape this targets is a **Ready pod serving errors**.

Concretely: the most frequent AlwaysGreen e2e failure over the last three weeks (19 of
33 real failing jobs, 17 of them on 2026-07-23) was
`smoke-tests.spec.js › Most Common Flow User Flow With All Apps` timing out on
`locator('#kc-main-content-page-container')`. The captured screenshot shows Keycloak's
own error page — "Unexpected error when handling authentication request to identity
provider" — from a Running, Ready Keycloak. Pod and event state does not explain that.
The server log does, and nothing was collecting it.

Related: camunda/team-test-automation#138 (AlwaysGreen triage/fix agent), which needs
this evidence to exist as an artifact because it runs after the namespace is gone.

### What's in this PR?

**1. `diagnostics print` gains `--include-ready`**

Switches the describe+logs loop from `kube.GetNonReadyPods` to `kube.GetPodNames`.
Both helpers already existed with identical signatures, so this is a selection change
rather than new collection logic. Section labels follow the mode (`Pod:` vs
`Non-ready pod:`) so the output stays accurate.

**Default is off.** The `install` and `upgrade` jobs are unaffected — verified by the
pre-existing tests passing unchanged apart from the new positional argument.

**2. The composite action captures the dump on failure**

Three steps in `.github/actions/playwright-e2e-tests`, all gated on
`failure() && !cancelled()`, so green runs pay nothing: write the dump to a file, compute
a filename-safe artifact name, upload as `diagnostics-e2e-*` with 1-day retention
(the dump is consumed by the triage agent shortly after the run, and pod logs can carry
sensitive values, so the window is deliberately short). The dump is also echoed into a
collapsed log group for the in-log fast path.

Placed in the composite action rather than a single job, so all four e2e callers get it.

**3. `deploy-camunda` is put on PATH for the capture**

The download was gated on `management-namespace != ''` (multi-namespace topology only).
It is now gated on `binary-artifact-name != ''`, and the three callers that did not pass
`binary-artifact-name` now do (the topology caller already did). If the binary is
somehow absent the capture step writes a one-line note and exits 0 rather than failing.

**Validation**

- `gofmt`, `go vet` clean; `go test ./cmd/` passes, including a new
  `TestPrintNamespaceDiagnosticsIncludeReady` covering the Ready-but-erroring case
  (asserts both pods are described, `GetNonReadyPods` is not called, and the non-ready
  label is absent)
- `--include-ready` confirmed present in `deploy-camunda diagnostics print --help`
- Both YAML files parse; `actionlint` on `test-integration-runner.yaml` unchanged at 56
  findings before and after; `shellcheck` clean on both new `run:` blocks

**Verified end to end on a real GKE run.**

A throwaway branch (diagnostics change + a one-line forced failure *after* a healthy test
run, so every pod would be Ready when the capture fired) was dispatched via
`test-chart-version.yaml` with `manual-trigger=8.10`, `scenario=keycloak-original`,
`platforms=gke`, `flows=install`, `e2e-enabled=true`. That expanded to three scenarios —
`keyc`, `keorg`, `keyco` — giving three independent samples. The branch has since been
deleted.

Run: https://github.com/camunda/camunda-platform-helm/actions/runs/30448109964

All three `Playwright e2e after install` jobs failed as intended and all three produced a
diagnostics artifact:

| scenario | artifact | size |
|---|---|---|
| `keyc`  | `diagnostics-e2e--intg-8.10-gke-keyc-install-after-install-1-30448109964-1`  | 60,731 B |
| `keorg` | `diagnostics-e2e--intg-8.10-gke-keorg-install-after-install-1-30448109964-1` | 63,735 B |
| `keyco` | `diagnostics-e2e--intg-8.10-gke-keyco-install-after-install-1-30448109964-1` | 63,093 B |

In the `keyc` sample **all ten pods were `1/1 Running`**, so the pre-change code path would
have collected no logs at all and printed `Non-ready pods: (none)`. With `--include-ready`
the dump contains describe + logs for all ten, labelled `Pod:` rather than
`Non-ready pod:`, including Keycloak's own server output from the Ready pod:

```
Waiting for PostgreSQL at keycloak-postgresql:5432 ...
PostgreSQL is ready
Changes detected in configuration. Updating the server image.
2026-07-29 11:39:23,709 INFO  [io.quarkus.deployment.QuarkusAugmentor] (main) Quarkus augmentation completed in 18252ms
```

The `keorg` sample matches: 10 pod log sections, 10/10 pods Ready, Keycloak included.

The `Cleanup` job then ran and deleted the namespace while the artifacts remained, which is
the surviving-teardown property this change exists for.

Sizing, for the record: ~722 KB uncompressed / ~60 KB stored for a 10-pod namespace at the
default `--tail 500`. Scales roughly linearly with pod count — worth knowing before raising
the tail. Retention is 1 day.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

### To-Do

- [x] Trigger a deliberate failing e2e run and confirm the `diagnostics-e2e-*` artifact
      contains the Keycloak server log — done, see above (3/3 scenarios).
- [ ] `crev` review clean before marking ready.
