### PR TITLE
chore: store registry credentials in OS keyring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ c8e2e-results/
 
 # crev (code-review tool) local run artifacts
 .crev/
+
+# deploy-camunda local run state (matrix run/watch tracking, may contain generated secrets)
+.deploy-camunda/

--- a/scripts/deploy-camunda/README.md
+++ b/scripts/deploy-camunda/README.md
@@ -516,7 +516,10 @@ For images from `registry.camunda.cloud` (Harbor):
 Set `--ensure-docker-registry` (or `ensureDockerRegistry: true`) to
 create the Harbor pull secret. `deploy-camunda doctor` reports both
 registries' credentials as ✓/✗ and only fails when the matching
-`--ensure-docker-*` flag makes the pull secret mandatory.
+`--ensure-docker-*` flag makes the pull secret mandatory. In
+`matrix run`, topology entries always create the Harbor pull secret
+regardless of `--ensure-docker-registry`, since they pull Camunda images
+from Harbor.
 
 ### Persisting credentials
 
@@ -533,7 +536,10 @@ deploy-camunda credentials status
 The password/token prompt disables terminal echo. Use a Harbor robot
 credential and a Docker Hub access token rather than account passwords.
 Headless CI continues to use environment variables; unavailable desktop
-keyrings are treated as not configured during implicit lookup.
+keyrings, and corrupt or incomplete entries, are treated as not
+configured during implicit lookup. `deploy-camunda credentials status`
+still surfaces such entries; run `deploy-camunda credentials delete
+--registry <harbor|dockerhub>` to reset a bad one.
 
 Credential precedence is CLI/config pair, environment or `.env` pair,
 then OS keyring. `deploy-camunda config env --show-origin`

--- a/scripts/deploy-camunda/README.md
+++ b/scripts/deploy-camunda/README.md
@@ -520,9 +520,23 @@ registries' credentials as ✓/✗ and only fails when the matching
 
 ### Persisting credentials
 
-Never commit credentials to `.deploy-camunda.yaml`. Persist them in
-`.env` (which `deploy-camunda config init` writes for you) or set them
-via your shell's env-manager. `deploy-camunda config env --show-origin`
+Never commit credentials to `.deploy-camunda.yaml`. For local use, store
+them once in macOS Keychain, Linux Secret Service, or Windows Credential
+Manager:
+
+```bash
+deploy-camunda credentials configure --registry harbor
+deploy-camunda credentials configure --registry dockerhub
+deploy-camunda credentials status
+```
+
+The password/token prompt disables terminal echo. Use a Harbor robot
+credential and a Docker Hub access token rather than account passwords.
+Headless CI continues to use environment variables; unavailable desktop
+keyrings are treated as not configured during implicit lookup.
+
+Credential precedence is CLI/config pair, environment or `.env` pair,
+then OS keyring. `deploy-camunda config env --show-origin`
 prints which layer each variable resolved from — process env vs `.env`
 vs per-entry override.
 

--- a/scripts/deploy-camunda/cmd/config_init.go
+++ b/scripts/deploy-camunda/cmd/config_init.go
@@ -308,13 +308,16 @@ func promptLine(ctx context.Context, out io.Writer, r *bufio.Reader, label, def 
 func promptSecret(ctx context.Context, out io.Writer, r *bufio.Reader, label string) (string, error) {
 	fmt.Fprintf(out, "%s: ", label)
 	// On a real terminal, read with echo disabled so the secret never appears on
-	// screen or in scrollback. Read directly from the fd unconditionally: a shared
-	// bufio.Reader may have pre-buffered the secret bytes while reading an earlier
-	// line, and honoring r.Buffered() there would silently fall back to the
-	// echo-enabled reader. Piped/redirected input (tests, scripts) has nothing to
-	// hide and uses the buffered line reader.
+	// screen or in scrollback. This only helps when r has nothing buffered yet: a
+	// cooked-mode tty echoes each keystroke as it arrives, before any Go code
+	// runs, so if a prior read already pulled the secret's bytes into r's buffer
+	// (a fast paste of "user\npass\n" delivered in one chunk), those bytes were
+	// echoed at type time and disabling echo now can't retroactively hide them —
+	// it would only strand the buffered bytes and hang waiting on the raw fd for
+	// input the user already sent. Piped/redirected input (tests, scripts) has
+	// nothing to hide and always uses the buffered line reader.
 	stdinFd := int(os.Stdin.Fd())
-	if term.IsTerminal(stdinFd) {
+	if r.Buffered() == 0 && term.IsTerminal(stdinFd) {
 		secret, err := readSecretCtx(ctx, stdinFd)
 		fmt.Fprintln(out)
 		return secret, err

--- a/scripts/deploy-camunda/cmd/config_init.go
+++ b/scripts/deploy-camunda/cmd/config_init.go
@@ -308,10 +308,13 @@ func promptLine(ctx context.Context, out io.Writer, r *bufio.Reader, label, def 
 func promptSecret(ctx context.Context, out io.Writer, r *bufio.Reader, label string) (string, error) {
 	fmt.Fprintf(out, "%s: ", label)
 	// On a real terminal, read with echo disabled so the secret never appears on
-	// screen or in scrollback. Piped/redirected input (tests, scripts) has
-	// nothing to hide and falls back to the buffered line reader.
+	// screen or in scrollback. Read directly from the fd unconditionally: a shared
+	// bufio.Reader may have pre-buffered the secret bytes while reading an earlier
+	// line, and honoring r.Buffered() there would silently fall back to the
+	// echo-enabled reader. Piped/redirected input (tests, scripts) has nothing to
+	// hide and uses the buffered line reader.
 	stdinFd := int(os.Stdin.Fd())
-	if r.Buffered() == 0 && term.IsTerminal(stdinFd) {
+	if term.IsTerminal(stdinFd) {
 		secret, err := readSecretCtx(ctx, stdinFd)
 		fmt.Fprintln(out)
 		return secret, err

--- a/scripts/deploy-camunda/cmd/credentials.go
+++ b/scripts/deploy-camunda/cmd/credentials.go
@@ -160,27 +160,31 @@ func resolveRegistryCredentialsFromEnvFiles(docker *config.DockerFlags, entries 
 	if err := resolveRegistryCredentialsFromEnvironment(docker); err != nil {
 		return err
 	}
-	paths := map[string]bool{}
+	resolveHarborFromFiles := docker.EnsureDockerRegistry && docker.DockerUsername == ""
+	resolveDockerHubFromFiles := docker.EnsureDockerHub && docker.DockerHubUsername == ""
+	seenPaths := map[string]bool{}
+	var paths []string
 	for _, entry := range entries {
 		path := envFiles[entry.Version]
 		if path == "" {
 			path = fallback
 		}
-		if path != "" {
-			paths[path] = true
+		if path != "" && !seenPaths[path] {
+			seenPaths[path] = true
+			paths = append(paths, path)
 		}
 	}
-	for path := range paths {
+	for _, path := range paths {
 		values, err := env.ReadFile(path)
 		if err != nil {
 			continue
 		}
-		if docker.EnsureDockerRegistry && docker.DockerUsername == "" {
+		if resolveHarborFromFiles {
 			if err := mergeCredentialPair("Harbor", values, &docker.DockerUsername, &docker.DockerPassword, [][2]string{{"HARBOR_USERNAME", "HARBOR_PASSWORD"}, {"TEST_DOCKER_USERNAME_CAMUNDA_CLOUD", "TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD"}, {"NEXUS_USERNAME", "NEXUS_PASSWORD"}}); err != nil {
 				return fmt.Errorf("%s: %w", path, err)
 			}
 		}
-		if docker.EnsureDockerHub && docker.DockerHubUsername == "" {
+		if resolveDockerHubFromFiles {
 			if err := mergeCredentialPair("Docker Hub", values, &docker.DockerHubUsername, &docker.DockerHubPassword, [][2]string{{"DOCKERHUB_USERNAME", "DOCKERHUB_PASSWORD"}, {"TEST_DOCKER_USERNAME", "TEST_DOCKER_PASSWORD"}}); err != nil {
 				return fmt.Errorf("%s: %w", path, err)
 			}

--- a/scripts/deploy-camunda/cmd/credentials.go
+++ b/scripts/deploy-camunda/cmd/credentials.go
@@ -1,0 +1,184 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"scripts/deploy-camunda/config"
+	"scripts/deploy-camunda/credentials"
+	"scripts/deploy-camunda/matrix"
+	"scripts/prepare-helm-values/pkg/env"
+)
+
+var credentialStore credentials.Store = credentials.KeyringStore{}
+
+func newCredentialsCommand() *cobra.Command {
+	cmd := &cobra.Command{Use: "credentials", Short: "Manage registry credentials in the OS keyring"}
+	cmd.AddCommand(newCredentialsConfigureCommand(), newCredentialsStatusCommand(), newCredentialsDeleteCommand())
+	return cmd
+}
+
+func newCredentialsConfigureCommand() *cobra.Command {
+	var registry string
+	cmd := &cobra.Command{Use: "configure", Short: "Securely store Harbor or Docker Hub credentials", Args: cobra.NoArgs, RunE: func(cmd *cobra.Command, args []string) error {
+		registry, err := canonicalCredentialRegistry(registry)
+		if err != nil {
+			return err
+		}
+		reader := bufio.NewReader(cmd.InOrStdin())
+		username, err := promptLine(cmd.Context(), cmd.OutOrStdout(), reader, "Username", "")
+		if err != nil {
+			return err
+		}
+		password, err := promptSecret(cmd.Context(), cmd.OutOrStdout(), reader, "Password or access token")
+		if err != nil {
+			return err
+		}
+		if err := credentialStore.Set(registry, credentials.Credential{Username: username, Password: password}); err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Stored %s credentials in the OS keyring.\n", registry)
+		return nil
+	}}
+	cmd.Flags().StringVar(&registry, "registry", "", "Registry: harbor or dockerhub")
+	_ = cmd.MarkFlagRequired("registry")
+	return cmd
+}
+
+func newCredentialsStatusCommand() *cobra.Command {
+	return &cobra.Command{Use: "status", Short: "Show which registry credentials are configured", Args: cobra.NoArgs, RunE: func(cmd *cobra.Command, args []string) error {
+		for _, registry := range []string{credentials.HarborRegistry, credentials.DockerHubRegistry} {
+			credential, found, err := credentialStore.Get(registry)
+			if err != nil {
+				return err
+			}
+			if found {
+				fmt.Fprintf(cmd.OutOrStdout(), "%s: configured (%s)\n", registry, credential.Username)
+			} else {
+				fmt.Fprintf(cmd.OutOrStdout(), "%s: not configured\n", registry)
+			}
+		}
+		return nil
+	}}
+}
+
+func newCredentialsDeleteCommand() *cobra.Command {
+	var registry string
+	cmd := &cobra.Command{Use: "delete", Short: "Delete registry credentials from the OS keyring", Args: cobra.NoArgs, RunE: func(cmd *cobra.Command, args []string) error {
+		registry, err := canonicalCredentialRegistry(registry)
+		if err != nil {
+			return err
+		}
+		if err := credentialStore.Delete(registry); err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Deleted %s credentials from the OS keyring.\n", registry)
+		return nil
+	}}
+	cmd.Flags().StringVar(&registry, "registry", "", "Registry: harbor or dockerhub")
+	_ = cmd.MarkFlagRequired("registry")
+	return cmd
+}
+
+func canonicalCredentialRegistry(value string) (string, error) {
+	switch value {
+	case "harbor", credentials.HarborRegistry:
+		return credentials.HarborRegistry, nil
+	case "dockerhub", credentials.DockerHubRegistry:
+		return credentials.DockerHubRegistry, nil
+	default:
+		return "", fmt.Errorf("unsupported registry %q; use harbor or dockerhub", value)
+	}
+}
+
+func resolveRegistryCredentials(docker *config.DockerFlags) error {
+	for _, item := range []struct {
+		registry           string
+		username, password *string
+		required           bool
+		envPairs           [][2]string
+	}{{credentials.HarborRegistry, &docker.DockerUsername, &docker.DockerPassword, docker.EnsureDockerRegistry, [][2]string{{"HARBOR_USERNAME", "HARBOR_PASSWORD"}, {"TEST_DOCKER_USERNAME_CAMUNDA_CLOUD", "TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD"}, {"NEXUS_USERNAME", "NEXUS_PASSWORD"}}}, {credentials.DockerHubRegistry, &docker.DockerHubUsername, &docker.DockerHubPassword, docker.EnsureDockerHub, [][2]string{{"DOCKERHUB_USERNAME", "DOCKERHUB_PASSWORD"}, {"TEST_DOCKER_USERNAME", "TEST_DOCKER_PASSWORD"}}}} {
+		if !item.required {
+			continue
+		}
+		if (*item.username == "") != (*item.password == "") {
+			return fmt.Errorf("%s flags/config must provide both username and password/token", item.registry)
+		}
+		if *item.username != "" {
+			continue
+		}
+		for _, pair := range item.envPairs {
+			username, password := os.Getenv(pair[0]), os.Getenv(pair[1])
+			if username == "" && password == "" {
+				continue
+			}
+			if username == "" || password == "" {
+				return fmt.Errorf("%s/%s must both be set", pair[0], pair[1])
+			}
+			*item.username, *item.password = username, password
+			break
+		}
+		if *item.username != "" {
+			continue
+		}
+		credential, found, err := credentials.GetOptional(credentialStore, item.registry)
+		if err != nil {
+			return err
+		}
+		if found {
+			*item.username, *item.password = credential.Username, credential.Password
+		}
+	}
+	return nil
+}
+
+func resolveRegistryCredentialsFromEnvFiles(docker *config.DockerFlags, entries []matrix.Entry, envFiles map[string]string, fallback string) error {
+	paths := map[string]bool{}
+	for _, entry := range entries {
+		path := envFiles[entry.Version]
+		if path == "" {
+			path = fallback
+		}
+		if path != "" {
+			paths[path] = true
+		}
+	}
+	for path := range paths {
+		values, err := env.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		if docker.EnsureDockerRegistry {
+			if err := mergeCredentialPair("Harbor", values, &docker.DockerUsername, &docker.DockerPassword, [][2]string{{"HARBOR_USERNAME", "HARBOR_PASSWORD"}, {"TEST_DOCKER_USERNAME_CAMUNDA_CLOUD", "TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD"}, {"NEXUS_USERNAME", "NEXUS_PASSWORD"}}); err != nil {
+				return fmt.Errorf("%s: %w", path, err)
+			}
+		}
+		if docker.EnsureDockerHub {
+			if err := mergeCredentialPair("Docker Hub", values, &docker.DockerHubUsername, &docker.DockerHubPassword, [][2]string{{"DOCKERHUB_USERNAME", "DOCKERHUB_PASSWORD"}, {"TEST_DOCKER_USERNAME", "TEST_DOCKER_PASSWORD"}}); err != nil {
+				return fmt.Errorf("%s: %w", path, err)
+			}
+		}
+	}
+	return resolveRegistryCredentials(docker)
+}
+
+func mergeCredentialPair(name string, values map[string]string, username, password *string, pairs [][2]string) error {
+	for _, pair := range pairs {
+		user, pass := values[pair[0]], values[pair[1]]
+		if user == "" && pass == "" {
+			continue
+		}
+		if user == "" || pass == "" {
+			return fmt.Errorf("%s credential pair %s/%s is incomplete", name, pair[0], pair[1])
+		}
+		if *username != "" && (*username != user || *password != pass) {
+			return fmt.Errorf("conflicting %s credentials", name)
+		}
+		*username, *password = user, pass
+		return nil
+	}
+	return nil
+}

--- a/scripts/deploy-camunda/cmd/credentials.go
+++ b/scripts/deploy-camunda/cmd/credentials.go
@@ -15,6 +15,13 @@ import (
 
 var credentialStore credentials.Store = credentials.KeyringStore{}
 
+type registryCredentialSource struct {
+	registry           string
+	username, password *string
+	required           bool
+	envPairs           [][2]string
+}
+
 func newCredentialsCommand() *cobra.Command {
 	cmd := &cobra.Command{Use: "credentials", Short: "Manage registry credentials in the OS keyring"}
 	cmd.AddCommand(newCredentialsConfigureCommand(), newCredentialsStatusCommand(), newCredentialsDeleteCommand())
@@ -95,12 +102,26 @@ func canonicalCredentialRegistry(value string) (string, error) {
 }
 
 func resolveRegistryCredentials(docker *config.DockerFlags) error {
-	for _, item := range []struct {
-		registry           string
-		username, password *string
-		required           bool
-		envPairs           [][2]string
-	}{{credentials.HarborRegistry, &docker.DockerUsername, &docker.DockerPassword, docker.EnsureDockerRegistry, [][2]string{{"HARBOR_USERNAME", "HARBOR_PASSWORD"}, {"TEST_DOCKER_USERNAME_CAMUNDA_CLOUD", "TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD"}, {"NEXUS_USERNAME", "NEXUS_PASSWORD"}}}, {credentials.DockerHubRegistry, &docker.DockerHubUsername, &docker.DockerHubPassword, docker.EnsureDockerHub, [][2]string{{"DOCKERHUB_USERNAME", "DOCKERHUB_PASSWORD"}, {"TEST_DOCKER_USERNAME", "TEST_DOCKER_PASSWORD"}}}} {
+	if err := resolveRegistryCredentialsFromEnvironment(docker); err != nil {
+		return err
+	}
+	for _, item := range registryCredentialSources(docker) {
+		if !item.required || *item.username != "" {
+			continue
+		}
+		credential, found, err := credentials.GetOptional(credentialStore, item.registry)
+		if err != nil {
+			return err
+		}
+		if found {
+			*item.username, *item.password = credential.Username, credential.Password
+		}
+	}
+	return nil
+}
+
+func resolveRegistryCredentialsFromEnvironment(docker *config.DockerFlags) error {
+	for _, item := range registryCredentialSources(docker) {
 		if !item.required {
 			continue
 		}
@@ -124,18 +145,21 @@ func resolveRegistryCredentials(docker *config.DockerFlags) error {
 		if *item.username != "" {
 			continue
 		}
-		credential, found, err := credentials.GetOptional(credentialStore, item.registry)
-		if err != nil {
-			return err
-		}
-		if found {
-			*item.username, *item.password = credential.Username, credential.Password
-		}
 	}
 	return nil
 }
 
+func registryCredentialSources(docker *config.DockerFlags) []registryCredentialSource {
+	return []registryCredentialSource{
+		{credentials.HarborRegistry, &docker.DockerUsername, &docker.DockerPassword, docker.EnsureDockerRegistry, [][2]string{{"HARBOR_USERNAME", "HARBOR_PASSWORD"}, {"TEST_DOCKER_USERNAME_CAMUNDA_CLOUD", "TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD"}, {"NEXUS_USERNAME", "NEXUS_PASSWORD"}}},
+		{credentials.DockerHubRegistry, &docker.DockerHubUsername, &docker.DockerHubPassword, docker.EnsureDockerHub, [][2]string{{"DOCKERHUB_USERNAME", "DOCKERHUB_PASSWORD"}, {"TEST_DOCKER_USERNAME", "TEST_DOCKER_PASSWORD"}}},
+	}
+}
+
 func resolveRegistryCredentialsFromEnvFiles(docker *config.DockerFlags, entries []matrix.Entry, envFiles map[string]string, fallback string) error {
+	if err := resolveRegistryCredentialsFromEnvironment(docker); err != nil {
+		return err
+	}
 	paths := map[string]bool{}
 	for _, entry := range entries {
 		path := envFiles[entry.Version]
@@ -151,12 +175,12 @@ func resolveRegistryCredentialsFromEnvFiles(docker *config.DockerFlags, entries 
 		if err != nil {
 			continue
 		}
-		if docker.EnsureDockerRegistry {
+		if docker.EnsureDockerRegistry && docker.DockerUsername == "" {
 			if err := mergeCredentialPair("Harbor", values, &docker.DockerUsername, &docker.DockerPassword, [][2]string{{"HARBOR_USERNAME", "HARBOR_PASSWORD"}, {"TEST_DOCKER_USERNAME_CAMUNDA_CLOUD", "TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD"}, {"NEXUS_USERNAME", "NEXUS_PASSWORD"}}); err != nil {
 				return fmt.Errorf("%s: %w", path, err)
 			}
 		}
-		if docker.EnsureDockerHub {
+		if docker.EnsureDockerHub && docker.DockerHubUsername == "" {
 			if err := mergeCredentialPair("Docker Hub", values, &docker.DockerHubUsername, &docker.DockerHubPassword, [][2]string{{"DOCKERHUB_USERNAME", "DOCKERHUB_PASSWORD"}, {"TEST_DOCKER_USERNAME", "TEST_DOCKER_PASSWORD"}}); err != nil {
 				return fmt.Errorf("%s: %w", path, err)
 			}

--- a/scripts/deploy-camunda/cmd/credentials.go
+++ b/scripts/deploy-camunda/cmd/credentials.go
@@ -177,7 +177,7 @@ func resolveRegistryCredentialsFromEnvFiles(docker *config.DockerFlags, entries 
 	for _, path := range paths {
 		values, err := env.ReadFile(path)
 		if err != nil {
-			continue
+			return fmt.Errorf("%s: %w", path, err)
 		}
 		if resolveHarborFromFiles {
 			if err := mergeCredentialPair("Harbor", values, &docker.DockerUsername, &docker.DockerPassword, [][2]string{{"HARBOR_USERNAME", "HARBOR_PASSWORD"}, {"TEST_DOCKER_USERNAME_CAMUNDA_CLOUD", "TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD"}, {"NEXUS_USERNAME", "NEXUS_PASSWORD"}}); err != nil {

--- a/scripts/deploy-camunda/cmd/credentials.go
+++ b/scripts/deploy-camunda/cmd/credentials.go
@@ -177,7 +177,11 @@ func resolveRegistryCredentialsFromEnvFiles(docker *config.DockerFlags, entries 
 	for _, path := range paths {
 		values, err := env.ReadFile(path)
 		if err != nil {
-			return fmt.Errorf("%s: %w", path, err)
+			// Deliberately not %w-wrapping err: godotenv parse errors quote the
+			// offending raw line, which can contain a credential value. This error
+			// reaches CI logs via matrix run, so the underlying message must never
+			// be echoed.
+			return fmt.Errorf("%s: unreadable or malformed env file; check permissions and syntax", path)
 		}
 		if resolveHarborFromFiles {
 			if err := mergeCredentialPair("Harbor", values, &docker.DockerUsername, &docker.DockerPassword, [][2]string{{"HARBOR_USERNAME", "HARBOR_PASSWORD"}, {"TEST_DOCKER_USERNAME_CAMUNDA_CLOUD", "TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD"}, {"NEXUS_USERNAME", "NEXUS_PASSWORD"}}); err != nil {

--- a/scripts/deploy-camunda/cmd/credentials.go
+++ b/scripts/deploy-camunda/cmd/credentials.go
@@ -177,11 +177,7 @@ func resolveRegistryCredentialsFromEnvFiles(docker *config.DockerFlags, entries 
 	for _, path := range paths {
 		values, err := env.ReadFile(path)
 		if err != nil {
-			// Deliberately not %w-wrapping err: godotenv parse errors quote the
-			// offending raw line, which can contain a credential value. This error
-			// reaches CI logs via matrix run, so the underlying message must never
-			// be echoed.
-			return fmt.Errorf("%s: unreadable or malformed env file; check permissions and syntax", path)
+			return err
 		}
 		if resolveHarborFromFiles {
 			if err := mergeCredentialPair("Harbor", values, &docker.DockerUsername, &docker.DockerPassword, [][2]string{{"HARBOR_USERNAME", "HARBOR_PASSWORD"}, {"TEST_DOCKER_USERNAME_CAMUNDA_CLOUD", "TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD"}, {"NEXUS_USERNAME", "NEXUS_PASSWORD"}}); err != nil {

--- a/scripts/deploy-camunda/cmd/credentials_test.go
+++ b/scripts/deploy-camunda/cmd/credentials_test.go
@@ -118,6 +118,38 @@ func TestResolveRegistryCredentialsFromVersionEnvFile(t *testing.T) {
 	}
 }
 
+func TestResolveRegistryCredentialsFromEnvFilesPreservesExplicitPair(t *testing.T) {
+	useMemoryCredentialStore(t)
+	path := t.TempDir() + "/8.10.env"
+	if err := os.WriteFile(path, []byte("HARBOR_USERNAME=file\nHARBOR_PASSWORD=file-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	flags := config.DockerFlags{EnsureDockerRegistry: true, DockerUsername: "explicit", DockerPassword: "explicit-token"}
+	if err := resolveRegistryCredentialsFromEnvFiles(&flags, []matrix.Entry{{Version: "8.10"}}, map[string]string{"8.10": path}, ""); err != nil {
+		t.Fatal(err)
+	}
+	if flags.DockerUsername != "explicit" || flags.DockerPassword != "explicit-token" {
+		t.Fatalf("flags=%#v", flags)
+	}
+}
+
+func TestResolveRegistryCredentialsFromEnvFilesPrefersEnvironmentPair(t *testing.T) {
+	useMemoryCredentialStore(t)
+	path := t.TempDir() + "/8.10.env"
+	if err := os.WriteFile(path, []byte("HARBOR_USERNAME=file\nHARBOR_PASSWORD=file-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HARBOR_USERNAME", "environment")
+	t.Setenv("HARBOR_PASSWORD", "environment-token")
+	flags := config.DockerFlags{EnsureDockerRegistry: true}
+	if err := resolveRegistryCredentialsFromEnvFiles(&flags, []matrix.Entry{{Version: "8.10"}}, map[string]string{"8.10": path}, ""); err != nil {
+		t.Fatal(err)
+	}
+	if flags.DockerUsername != "environment" || flags.DockerPassword != "environment-token" {
+		t.Fatalf("flags=%#v", flags)
+	}
+}
+
 func TestCredentialsConfigureStoresPairWithoutPrintingSecret(t *testing.T) {
 	store := useMemoryCredentialStore(t)
 	cmd := newCredentialsConfigureCommand()

--- a/scripts/deploy-camunda/cmd/credentials_test.go
+++ b/scripts/deploy-camunda/cmd/credentials_test.go
@@ -1,0 +1,137 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"testing"
+
+	"scripts/deploy-camunda/config"
+	"scripts/deploy-camunda/credentials"
+	"scripts/deploy-camunda/matrix"
+)
+
+type memoryCredentialStore struct {
+	values map[string]credentials.Credential
+	err    error
+}
+
+func (s *memoryCredentialStore) Get(registry string) (credentials.Credential, bool, error) {
+	if s.err != nil {
+		return credentials.Credential{}, false, s.err
+	}
+	value, ok := s.values[registry]
+	return value, ok, nil
+}
+func (s *memoryCredentialStore) Set(registry string, credential credentials.Credential) error {
+	if credential.Username == "" || credential.Password == "" {
+		return errors.New("incomplete")
+	}
+	s.values[registry] = credential
+	return nil
+}
+func (s *memoryCredentialStore) Delete(registry string) error { delete(s.values, registry); return nil }
+func useMemoryCredentialStore(t *testing.T) *memoryCredentialStore {
+	store := &memoryCredentialStore{values: map[string]credentials.Credential{}}
+	original := credentialStore
+	credentialStore = store
+	t.Cleanup(func() { credentialStore = original })
+	return store
+}
+
+func TestResolveRegistryCredentials(t *testing.T) {
+	store := useMemoryCredentialStore(t)
+	store.values[credentials.HarborRegistry] = credentials.Credential{Username: "robot", Password: "token"}
+	flags := config.DockerFlags{EnsureDockerRegistry: true}
+	if err := resolveRegistryCredentials(&flags); err != nil {
+		t.Fatal(err)
+	}
+	if flags.DockerUsername != "robot" || flags.DockerPassword != "token" {
+		t.Fatalf("flags=%#v", flags)
+	}
+}
+
+func TestResolveRegistryCredentialsPreservesExplicitPair(t *testing.T) {
+	store := useMemoryCredentialStore(t)
+	store.values[credentials.HarborRegistry] = credentials.Credential{Username: "stored", Password: "stored-token"}
+	flags := config.DockerFlags{EnsureDockerRegistry: true, DockerUsername: "explicit", DockerPassword: "explicit-token"}
+	if err := resolveRegistryCredentials(&flags); err != nil {
+		t.Fatal(err)
+	}
+	if flags.DockerUsername != "explicit" {
+		t.Fatal("stored credentials replaced explicit pair")
+	}
+}
+
+func TestResolveRegistryCredentialsPrefersEnvironmentPair(t *testing.T) {
+	store := useMemoryCredentialStore(t)
+	store.values[credentials.HarborRegistry] = credentials.Credential{Username: "stored", Password: "stored-token"}
+	t.Setenv("HARBOR_USERNAME", "environment")
+	t.Setenv("HARBOR_PASSWORD", "environment-token")
+	flags := config.DockerFlags{EnsureDockerRegistry: true}
+	if err := resolveRegistryCredentials(&flags); err != nil {
+		t.Fatal(err)
+	}
+	if flags.DockerUsername != "environment" || flags.DockerPassword != "environment-token" {
+		t.Fatalf("flags=%#v", flags)
+	}
+}
+
+func TestCredentialsStatusDoesNotPrintSecrets(t *testing.T) {
+	store := useMemoryCredentialStore(t)
+	store.values[credentials.HarborRegistry] = credentials.Credential{Username: "robot", Password: "secret-token"}
+	cmd := newCredentialsStatusCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(out.Bytes(), []byte("secret-token")) {
+		t.Fatal("status exposed secret")
+	}
+}
+
+func TestCredentialsStatusReportsUnavailableKeyring(t *testing.T) {
+	original := credentialStore
+	credentialStore = &memoryCredentialStore{err: &credentials.UnavailableError{Err: errors.New("no session bus")}}
+	t.Cleanup(func() { credentialStore = original })
+	cmd := newCredentialsStatusCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected explicit status backend error")
+	}
+}
+
+func TestResolveRegistryCredentialsFromVersionEnvFile(t *testing.T) {
+	useMemoryCredentialStore(t)
+	path := t.TempDir() + "/8.10.env"
+	if err := os.WriteFile(path, []byte("HARBOR_USERNAME=robot\nHARBOR_PASSWORD=token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	flags := config.DockerFlags{EnsureDockerRegistry: true}
+	if err := resolveRegistryCredentialsFromEnvFiles(&flags, []matrix.Entry{{Version: "8.10"}}, map[string]string{"8.10": path}, ""); err != nil {
+		t.Fatal(err)
+	}
+	if flags.DockerUsername != "robot" || flags.DockerPassword != "token" {
+		t.Fatalf("flags=%#v", flags)
+	}
+}
+
+func TestCredentialsConfigureStoresPairWithoutPrintingSecret(t *testing.T) {
+	store := useMemoryCredentialStore(t)
+	cmd := newCredentialsConfigureCommand()
+	cmd.SetArgs([]string{"--registry", "harbor"})
+	cmd.SetIn(bytes.NewBufferString("robot\nsecret-token\n"))
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if store.values[credentials.HarborRegistry].Password != "secret-token" {
+		t.Fatal("token not stored")
+	}
+	if bytes.Contains(out.Bytes(), []byte("secret-token")) {
+		t.Fatal("configure output exposed secret")
+	}
+}

--- a/scripts/deploy-camunda/cmd/credentials_test.go
+++ b/scripts/deploy-camunda/cmd/credentials_test.go
@@ -150,6 +150,24 @@ func TestResolveRegistryCredentialsFromEnvFilesPrefersEnvironmentPair(t *testing
 	}
 }
 
+func TestResolveRegistryCredentialsFromEnvFilesRejectsConflictingVersionPairs(t *testing.T) {
+	useMemoryCredentialStore(t)
+	dir := t.TempDir()
+	firstPath := dir + "/8.9.env"
+	secondPath := dir + "/8.10.env"
+	if err := os.WriteFile(firstPath, []byte("HARBOR_USERNAME=first\nHARBOR_PASSWORD=first-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(secondPath, []byte("HARBOR_USERNAME=second\nHARBOR_PASSWORD=second-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	flags := config.DockerFlags{EnsureDockerRegistry: true}
+	err := resolveRegistryCredentialsFromEnvFiles(&flags, []matrix.Entry{{Version: "8.9"}, {Version: "8.10"}}, map[string]string{"8.9": firstPath, "8.10": secondPath}, "")
+	if err == nil {
+		t.Fatal("expected conflicting version credentials error")
+	}
+}
+
 func TestCredentialsConfigureStoresPairWithoutPrintingSecret(t *testing.T) {
 	store := useMemoryCredentialStore(t)
 	cmd := newCredentialsConfigureCommand()

--- a/scripts/deploy-camunda/cmd/credentials_test.go
+++ b/scripts/deploy-camunda/cmd/credentials_test.go
@@ -168,6 +168,18 @@ func TestResolveRegistryCredentialsFromEnvFilesRejectsConflictingVersionPairs(t 
 	}
 }
 
+func TestResolveRegistryCredentialsFromEnvFilesSurfacesReadError(t *testing.T) {
+	useMemoryCredentialStore(t)
+	// A directory in place of an env file makes env.ReadFile return a genuine
+	// read error (not file-not-found), which must not be silently swallowed.
+	dir := t.TempDir()
+	flags := config.DockerFlags{EnsureDockerRegistry: true}
+	err := resolveRegistryCredentialsFromEnvFiles(&flags, []matrix.Entry{{Version: "8.10"}}, map[string]string{"8.10": dir}, "")
+	if err == nil {
+		t.Fatal("expected unreadable env file error to surface")
+	}
+}
+
 func TestCredentialsConfigureStoresPairWithoutPrintingSecret(t *testing.T) {
 	store := useMemoryCredentialStore(t)
 	cmd := newCredentialsConfigureCommand()

--- a/scripts/deploy-camunda/cmd/doctor.go
+++ b/scripts/deploy-camunda/cmd/doctor.go
@@ -11,6 +11,7 @@ import (
 	"scripts/camunda-core/pkg/logging"
 	"scripts/deploy-camunda/config"
 	"scripts/deploy-camunda/deploy"
+	"scripts/prepare-helm-values/pkg/env"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -62,6 +63,14 @@ Exits non-zero if any required check fails.`,
 					flags.Chart.RepoRoot = detected
 				}
 			}
+			envFileToLoad := flags.EnvFile
+			if envFileToLoad == "" {
+				envFileToLoad = ".env"
+			}
+			_ = env.Load(envFileToLoad)
+			if err := resolveRegistryCredentials(&flags.Docker); err != nil {
+				return err
+			}
 
 			report := deploy.Preflight(ctx, &flags, deploy.PreflightOptions{
 				ConfigPath:           cfgRes.Path,
@@ -111,6 +120,8 @@ Exits non-zero if any required check fails.`,
 	f.StringVar(&flags.Docker.DockerPassword, "docker-password", "", "Harbor registry password")
 	f.BoolVar(&flags.Docker.EnsureDockerRegistry, "ensure-docker-registry", false, "Treat Harbor pull secret as required")
 	f.BoolVar(&flags.Docker.EnsureDockerHub, "ensure-docker-hub", false, "Treat Docker Hub pull secret as required")
+	f.StringVar(&flags.Docker.DockerHubUsername, "dockerhub-username", "", "Docker Hub registry username")
+	f.StringVar(&flags.Docker.DockerHubPassword, "dockerhub-password", "", "Docker Hub registry password")
 	f.StringVarP(&flags.LogLevel, "log-level", "l", "info", "Log level")
 	f.BoolVar(&skipKube, "skip-kube-check", false, "Skip the cluster reachability probe")
 	f.BoolVar(&fix, "fix", false, "Prompt for missing variables and write them to the .env file")

--- a/scripts/deploy-camunda/cmd/doctor.go
+++ b/scripts/deploy-camunda/cmd/doctor.go
@@ -67,7 +67,9 @@ Exits non-zero if any required check fails.`,
 			if envFileToLoad == "" {
 				envFileToLoad = ".env"
 			}
-			_ = env.Load(envFileToLoad)
+			if err := env.Load(envFileToLoad); err != nil {
+				logging.Logger.Warn().Err(err).Str("envFile", envFileToLoad).Msg("Failed to load environment file")
+			}
 			if err := resolveRegistryCredentials(&flags.Docker); err != nil {
 				return err
 			}

--- a/scripts/deploy-camunda/cmd/matrix.go
+++ b/scripts/deploy-camunda/cmd/matrix.go
@@ -604,7 +604,7 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 						HelmTimeout:           helmTimeout,
 						DockerUsername:        dockerUsername,
 						DockerPassword:        dockerPassword,
-						EnsureDockerRegistry:  true,
+						EnsureDockerRegistry:  ensureDockerRegistry || len(topologyEntries) > 0,
 						DockerHubUsername:     dockerHubUsername,
 						DockerHubPassword:     dockerHubPassword,
 						EnsureDockerHub:       ensureDockerHub,
@@ -851,7 +851,7 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 	f.IntVar(&helmTimeout, "timeout", 10, "Timeout in minutes for Helm deployment (applies to all entries)")
 	f.StringVar(&dockerUsername, "docker-username", "", "Harbor registry username (defaults to HARBOR_USERNAME, TEST_DOCKER_USERNAME_CAMUNDA_CLOUD, or NEXUS_USERNAME env var)")
 	f.StringVar(&dockerPassword, "docker-password", "", "Harbor registry password (defaults to HARBOR_PASSWORD, TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD, or NEXUS_PASSWORD env var)")
-	f.BoolVar(&ensureDockerRegistry, "ensure-docker-registry", false, "Ensure Harbor registry pull secret is created in each entry's namespace")
+	f.BoolVar(&ensureDockerRegistry, "ensure-docker-registry", false, "Ensure Harbor registry pull secret is created in each entry's namespace (always enabled for topology entries, which pull Camunda images from Harbor)")
 	f.StringVar(&dockerHubUsername, "dockerhub-username", "", "Docker Hub registry username (defaults to DOCKERHUB_USERNAME or TEST_DOCKER_USERNAME env var)")
 	f.StringVar(&dockerHubPassword, "dockerhub-password", "", "Docker Hub registry password (defaults to DOCKERHUB_PASSWORD or TEST_DOCKER_PASSWORD env var)")
 	f.BoolVar(&ensureDockerHub, "ensure-docker-hub", false, "Ensure Docker Hub registry pull secret is created in each entry's namespace")

--- a/scripts/deploy-camunda/cmd/matrix.go
+++ b/scripts/deploy-camunda/cmd/matrix.go
@@ -548,6 +548,12 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 				}
 			}
 			entries = singleEntries
+			dockerFlags := config.DockerFlags{DockerUsername: dockerUsername, DockerPassword: dockerPassword, EnsureDockerRegistry: ensureDockerRegistry || len(topologyEntries) > 0, DockerHubUsername: dockerHubUsername, DockerHubPassword: dockerHubPassword, EnsureDockerHub: ensureDockerHub}
+			allEntries := append(append([]matrix.Entry{}, entries...), topologyEntries...)
+			if err := resolveRegistryCredentialsFromEnvFiles(&dockerFlags, allEntries, envFiles, envFile); err != nil {
+				return err
+			}
+			dockerUsername, dockerPassword, dockerHubUsername, dockerHubPassword = dockerFlags.DockerUsername, dockerFlags.DockerPassword, dockerFlags.DockerHubUsername, dockerFlags.DockerHubPassword
 
 			if len(topologyEntries) > 0 {
 				if dryRun || coverage {
@@ -598,7 +604,7 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 						HelmTimeout:           helmTimeout,
 						DockerUsername:        dockerUsername,
 						DockerPassword:        dockerPassword,
-						EnsureDockerRegistry:  ensureDockerRegistry,
+						EnsureDockerRegistry:  true,
 						DockerHubUsername:     dockerHubUsername,
 						DockerHubPassword:     dockerHubPassword,
 						EnsureDockerHub:       ensureDockerHub,

--- a/scripts/deploy-camunda/cmd/root.go
+++ b/scripts/deploy-camunda/cmd/root.go
@@ -67,6 +67,9 @@ func NewRootCommand() *cobra.Command {
 				if cmd.Name() == "config" || (cmd.Parent() != nil && cmd.Parent().Name() == "config") {
 					return nil
 				}
+				if cmd.Name() == "credentials" || (cmd.Parent() != nil && cmd.Parent().Name() == "credentials") {
+					return nil
+				}
 				if cmd.Name() == "matrix" || (cmd.Parent() != nil && cmd.Parent().Name() == "matrix") {
 					return nil
 				}
@@ -168,6 +171,9 @@ func NewRootCommand() *cobra.Command {
 				Msg("Loading environment file")
 			if err := env.Load(envFileToLoad); err != nil {
 				logging.Logger.Warn().Err(err).Str("envFile", envFileToLoad).Msg("Failed to load environment file")
+			}
+			if err := resolveRegistryCredentials(&flags.Docker); err != nil {
+				return err
 			}
 
 			// Validate merged configuration
@@ -558,6 +564,7 @@ func Execute() error {
 	rootCmd := NewRootCommand()
 	rootCmd.AddCommand(newCompletionCommand(rootCmd))
 	rootCmd.AddCommand(newConfigCommand())
+	rootCmd.AddCommand(newCredentialsCommand())
 	rootCmd.AddCommand(newMatrixCommand())
 	rootCmd.AddCommand(newPrepareValuesCommand())
 	rootCmd.AddCommand(newEntraCommand())

--- a/scripts/deploy-camunda/credentials/store.go
+++ b/scripts/deploy-camunda/credentials/store.go
@@ -1,0 +1,85 @@
+package credentials
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	keyring "github.com/zalando/go-keyring"
+)
+
+const Service = "camunda-deploy-camunda"
+
+const (
+	HarborRegistry    = "registry.camunda.cloud"
+	DockerHubRegistry = "docker.io"
+)
+
+type Credential struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+type Store interface {
+	Get(registry string) (Credential, bool, error)
+	Set(registry string, credential Credential) error
+	Delete(registry string) error
+}
+
+type KeyringStore struct{}
+type UnavailableError struct{ Err error }
+
+func (e *UnavailableError) Error() string { return e.Err.Error() }
+func (e *UnavailableError) Unwrap() error { return e.Err }
+
+func (KeyringStore) Get(registry string) (Credential, bool, error) {
+	value, err := keyring.Get(Service, registry)
+	if errors.Is(err, keyring.ErrNotFound) {
+		return Credential{}, false, nil
+	}
+	if err != nil {
+		return Credential{}, false, &UnavailableError{Err: fmt.Errorf("read %s credential from OS keyring: %w", registry, err)}
+	}
+	var credential Credential
+	if err := json.Unmarshal([]byte(value), &credential); err != nil {
+		return Credential{}, false, fmt.Errorf("decode %s credential from OS keyring: %w", registry, err)
+	}
+	if credential.Username == "" || credential.Password == "" {
+		return Credential{}, false, fmt.Errorf("OS keyring entry for %s is incomplete", registry)
+	}
+	return credential, true, nil
+}
+
+func (KeyringStore) Set(registry string, credential Credential) error {
+	if credential.Username == "" || credential.Password == "" {
+		return errors.New("username and password/token are required")
+	}
+	value, err := json.Marshal(credential)
+	if err != nil {
+		return err
+	}
+	if err := keyring.Set(Service, registry, string(value)); err != nil {
+		return fmt.Errorf("store %s credential in OS keyring: %w", registry, err)
+	}
+	return nil
+}
+
+func (KeyringStore) Delete(registry string) error {
+	err := keyring.Delete(Service, registry)
+	if errors.Is(err, keyring.ErrNotFound) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("delete %s credential from OS keyring: %w", registry, err)
+	}
+	return nil
+}
+
+func GetOptional(store Store, registry string) (Credential, bool, error) {
+	credential, found, err := store.Get(registry)
+	var unavailable *UnavailableError
+	if errors.As(err, &unavailable) {
+		return Credential{}, false, nil
+	}
+	return credential, found, err
+}

--- a/scripts/deploy-camunda/credentials/store.go
+++ b/scripts/deploy-camunda/credentials/store.go
@@ -32,6 +32,15 @@ type UnavailableError struct{ Err error }
 func (e *UnavailableError) Error() string { return e.Err.Error() }
 func (e *UnavailableError) Unwrap() error { return e.Err }
 
+// CorruptError marks a keyring entry that exists but cannot be used (unparseable
+// or missing a username/password). Like UnavailableError, implicit deploy lookup
+// treats it as "not configured" so a single bad entry never blocks every command,
+// while explicit credentials status/configure/delete still surface it.
+type CorruptError struct{ Err error }
+
+func (e *CorruptError) Error() string { return e.Err.Error() }
+func (e *CorruptError) Unwrap() error { return e.Err }
+
 func (KeyringStore) Get(registry string) (Credential, bool, error) {
 	value, err := keyring.Get(Service, registry)
 	if errors.Is(err, keyring.ErrNotFound) {
@@ -42,10 +51,10 @@ func (KeyringStore) Get(registry string) (Credential, bool, error) {
 	}
 	var credential Credential
 	if err := json.Unmarshal([]byte(value), &credential); err != nil {
-		return Credential{}, false, fmt.Errorf("decode %s credential from OS keyring: %w", registry, err)
+		return Credential{}, false, &CorruptError{Err: fmt.Errorf("decode %s credential from OS keyring: %w; run 'deploy-camunda credentials delete --registry %s' to reset", registry, err, registry)}
 	}
 	if credential.Username == "" || credential.Password == "" {
-		return Credential{}, false, fmt.Errorf("OS keyring entry for %s is incomplete", registry)
+		return Credential{}, false, &CorruptError{Err: fmt.Errorf("OS keyring entry for %s is incomplete; run 'deploy-camunda credentials delete --registry %s' to reset", registry, registry)}
 	}
 	return credential, true, nil
 }
@@ -78,7 +87,8 @@ func (KeyringStore) Delete(registry string) error {
 func GetOptional(store Store, registry string) (Credential, bool, error) {
 	credential, found, err := store.Get(registry)
 	var unavailable *UnavailableError
-	if errors.As(err, &unavailable) {
+	var corrupt *CorruptError
+	if errors.As(err, &unavailable) || errors.As(err, &corrupt) {
 		return Credential{}, false, nil
 	}
 	return credential, found, err

--- a/scripts/deploy-camunda/credentials/store_test.go
+++ b/scripts/deploy-camunda/credentials/store_test.go
@@ -27,3 +27,18 @@ func TestGetOptionalIgnoresUnavailableBackend(t *testing.T) {
 		t.Fatalf("found=%v err=%v", found, err)
 	}
 }
+
+type corruptStore struct{}
+
+func (corruptStore) Get(string) (Credential, bool, error) {
+	return Credential{}, false, &CorruptError{Err: errors.New("bad entry")}
+}
+func (corruptStore) Set(string, Credential) error { return nil }
+func (corruptStore) Delete(string) error          { return nil }
+
+func TestGetOptionalIgnoresCorruptEntry(t *testing.T) {
+	_, found, err := GetOptional(corruptStore{}, HarborRegistry)
+	if err != nil || found {
+		t.Fatalf("found=%v err=%v", found, err)
+	}
+}

--- a/scripts/deploy-camunda/credentials/store_test.go
+++ b/scripts/deploy-camunda/credentials/store_test.go
@@ -1,0 +1,29 @@
+package credentials
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestCredentialRequiresCompletePair(t *testing.T) {
+	for _, credential := range []Credential{{}, {Username: "user"}, {Password: "token"}} {
+		if err := (KeyringStore{}).Set("", credential); err == nil {
+			t.Fatal("expected incomplete credential error")
+		}
+	}
+}
+
+type unavailableStore struct{}
+
+func (unavailableStore) Get(string) (Credential, bool, error) {
+	return Credential{}, false, &UnavailableError{Err: errors.New("no session bus")}
+}
+func (unavailableStore) Set(string, Credential) error { return nil }
+func (unavailableStore) Delete(string) error          { return nil }
+
+func TestGetOptionalIgnoresUnavailableBackend(t *testing.T) {
+	_, found, err := GetOptional(unavailableStore{}, HarborRegistry)
+	if err != nil || found {
+		t.Fatalf("found=%v err=%v", found, err)
+	}
+}

--- a/scripts/deploy-camunda/deploy/preflight.go
+++ b/scripts/deploy-camunda/deploy/preflight.go
@@ -258,7 +258,7 @@ func checkDockerCredentials(flags *config.RuntimeFlags, envMap map[string]string
 	harborPass := firstNonEmptyEnv(envMap, flags.Docker.DockerPassword, "HARBOR_PASSWORD", "TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD", "NEXUS_PASSWORD")
 	checks = append(checks, dockerCredCheck(
 		"docker creds (Harbor)", harborUser, harborPass, flags.Docker.EnsureDockerRegistry,
-		"set --docker-username/--docker-password or HARBOR_USERNAME/HARBOR_PASSWORD (or TEST_DOCKER_*_CAMUNDA_CLOUD)"))
+		"run `deploy-camunda credentials configure --registry harbor`, or set --docker-username/--docker-password or HARBOR_USERNAME/HARBOR_PASSWORD"))
 
 	// Only probe Docker Hub when its pull secret is requested.
 	if flags.Docker.EnsureDockerHub {
@@ -266,7 +266,7 @@ func checkDockerCredentials(flags *config.RuntimeFlags, envMap map[string]string
 		hubPass := firstNonEmptyEnv(envMap, flags.Docker.DockerHubPassword, "DOCKERHUB_PASSWORD", "TEST_DOCKER_PASSWORD")
 		checks = append(checks, dockerCredCheck(
 			"docker creds (Docker Hub)", hubUser, hubPass, true,
-			"set --dockerhub-username/--dockerhub-password or DOCKERHUB_USERNAME/DOCKERHUB_PASSWORD"))
+			"run `deploy-camunda credentials configure --registry dockerhub`, or set --dockerhub-username/--dockerhub-password or DOCKERHUB_USERNAME/DOCKERHUB_PASSWORD"))
 	}
 
 	return checks

--- a/scripts/deploy-camunda/go.mod
+++ b/scripts/deploy-camunda/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
+	github.com/zalando/go-keyring v0.2.6
 	golang.org/x/sync v0.22.0
 	golang.org/x/term v0.45.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -20,6 +21,7 @@ require (
 )
 
 require (
+	al.essio.dev/pkg/shellescape v1.5.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260703014108-f5a850f9c2b7 // indirect
 	github.com/charmbracelet/x/ansi v0.11.7 // indirect
@@ -28,6 +30,7 @@ require (
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
+	github.com/danieljoos/wincred v1.2.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
@@ -35,6 +38,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.22.4 // indirect
+	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect

--- a/scripts/deploy-camunda/go.sum
+++ b/scripts/deploy-camunda/go.sum
@@ -1,3 +1,5 @@
+al.essio.dev/pkg/shellescape v1.5.1 h1:86HrALUujYS/h+GtqoB26SBEdkWfmMI6FubjXlsXyho=
+al.essio.dev/pkg/shellescape v1.5.1/go.mod h1:6sIqp7X2P6mThCQ7twERpZTuigpr6KbZWtls1U8I890=
 charm.land/bubbletea/v2 v2.0.8 h1:SxTJMhCAI3lbPmy4SgX5LWZ24AdINr4I6UEqzZvYJuY=
 charm.land/bubbletea/v2 v2.0.8/go.mod h1:2SkdgoTXluXJHOUwAoRlRXF/28vklb1rFl6GcgV1/ss=
 charm.land/lipgloss/v2 v2.0.5 h1:kbNxgeeUOYv5J0YdpxFjfvf3dFvqH8Aci4zB6xqFtrY=
@@ -24,6 +26,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/danieljoos/wincred v1.2.2 h1:774zMFJrqaeYCK2W57BgAem/MLi6mtSE47MB6BOJ0i0=
+github.com/danieljoos/wincred v1.2.2/go.mod h1:w7w4Utbrz8lqeMbDAK0lkNJUv5sAOkFi7nd/ogr0Uh8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -43,6 +47,8 @@ github.com/go-openapi/swag v0.22.4 h1:QLMzNJnMGPRNDCbySlcj1x01tzU8/9LTTL9hZZZogB
 github.com/go-openapi/swag v0.22.4/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
+github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
+github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
@@ -57,6 +63,8 @@ github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20240525223248-4bfdf5a9a2af h1:kmjWCqn2qkEml422C2Rrd27c3VGxi6a/6HNq8QmHRKM=
 github.com/google/pprof v0.0.0-20240525223248-4bfdf5a9a2af/go.mod h1:K1liHPHnj73Fdn/EKuT8nrFqBihUSKXoLYU0BuatOYo=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
@@ -125,6 +133,8 @@ github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3A
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -137,6 +147,8 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavM
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/zalando/go-keyring v0.2.6 h1:r7Yc3+H+Ux0+M72zacZoItR3UDxeWfKTcabvkI8ua9s=
+github.com/zalando/go-keyring v0.2.6/go.mod h1:2TCrxYrbUNYfNS/Kgy/LSrkSQzZ5UPVH85RwfczwvcI=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/scripts/prepare-helm-values/pkg/env/env.go
+++ b/scripts/prepare-helm-values/pkg/env/env.go
@@ -3,6 +3,7 @@ package env
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -19,7 +20,7 @@ func Load(path string) error {
 	if err := godotenv.Load(path); err != nil {
 		// Only return error if it's not a "path not found" type of error
 		if !os.IsNotExist(err) {
-			return err
+			return sanitizeParseError(path, err)
 		}
 		logging.Logger.Debug().Str("path", path).Msg(".env file not found, skipping")
 	} else {
@@ -38,10 +39,26 @@ func ReadFile(path string) (map[string]string, error) {
 			logging.Logger.Debug().Str("path", path).Msg(".env file not found, returning empty map")
 			return make(map[string]string), nil
 		}
-		return nil, err
+		return nil, sanitizeParseError(path, err)
 	}
 	logging.Logger.Debug().Str("path", path).Int("count", len(m)).Msg("Read .env file into map")
 	return m, nil
+}
+
+// sanitizeParseError makes a godotenv failure safe to log or print. File-open
+// failures (permission denied, is-a-directory, ...) surface as *os.PathError
+// and carry no file content, so they pass through unchanged. Malformed-syntax
+// failures are plain errors from godotenv's line parser, which quotes the
+// offending raw line in its message — for a credentials .env file, that line
+// can be "HARBOR_PASSWORD=<token>", so its text must never reach a caller that
+// logs or prints it (e.g. matrix run's stderr, which CI captures). Those are
+// replaced with a generic message; the path alone is enough to locate the fix.
+func sanitizeParseError(path string, err error) error {
+	var pathErr *os.PathError
+	if errors.As(err, &pathErr) {
+		return err
+	}
+	return fmt.Errorf("%s: malformed .env syntax; check the file by hand", path)
 }
 
 // fileMutexes provides per-file locking so that concurrent goroutines

--- a/scripts/prepare-helm-values/pkg/env/env_test.go
+++ b/scripts/prepare-helm-values/pkg/env/env_test.go
@@ -30,6 +30,54 @@ func readFile(t *testing.T, path string) string {
 }
 
 // ---------------------------------------------------------------------------
+// Load / ReadFile — parse-error sanitization
+// ---------------------------------------------------------------------------
+
+func TestReadFileSanitizesParseErrorContent(t *testing.T) {
+	p := writeTempEnv(t, `HARBOR_PASSWORD="supersecrettoken`+"\n")
+	_, err := ReadFile(p)
+	if err == nil {
+		t.Fatal("expected a parse error for the unterminated quote")
+	}
+	if strings.Contains(err.Error(), "supersecrettoken") {
+		t.Fatalf("parse error leaked file content: %v", err)
+	}
+	if !strings.Contains(err.Error(), p) {
+		t.Fatalf("expected error to reference the path %q: %v", p, err)
+	}
+}
+
+func TestLoadSanitizesParseErrorContent(t *testing.T) {
+	p := writeTempEnv(t, `HARBOR_PASSWORD="supersecrettoken`+"\n")
+	err := Load(p)
+	if err == nil {
+		t.Fatal("expected a parse error for the unterminated quote")
+	}
+	if strings.Contains(err.Error(), "supersecrettoken") {
+		t.Fatalf("parse error leaked file content: %v", err)
+	}
+}
+
+func TestReadFilePreservesPermissionError(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root ignores file permissions")
+	}
+	p := writeTempEnv(t, "FOO=bar\n")
+	if err := os.Chmod(p, 0o000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(p, 0o644) })
+
+	_, err := ReadFile(p)
+	if err == nil {
+		t.Fatal("expected a permission error")
+	}
+	if !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("expected permission error to pass through, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // extractKey
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
### Which problem does the PR fix?

Part of #6712.

Local `deploy-camunda` users currently have to keep Harbor and Docker Hub credentials in shell variables, `.env`, or command flags. That is awkward for humans and particularly unsafe for AI-assisted workflows: the CLI needs the raw pair both for registry login and Kubernetes pull-secret creation, but an agent should never ask for or handle secret values.

This PR adds a one-time, OS-backed registry credential setup and integrates it into existing deploy and preflight paths without adding matrix state, resume, cleanup, Docker-config import, or other #6712 lifecycle work.

### What's in this PR?

- Adds:

```bash
deploy-camunda credentials configure --registry harbor
deploy-camunda credentials configure --registry dockerhub
deploy-camunda credentials status
deploy-camunda credentials delete --registry <harbor|dockerhub>
```

- Stores complete username/token pairs in:
  - macOS Keychain
  - Linux Secret Service
  - Windows Credential Manager
- Uses an echo-suppressed terminal prompt for passwords/access tokens.
- Exposes only configured usernames through `credentials status`.
- Integrates one pair-atomic resolver into:
  - ordinary `deploy-camunda`
  - root `deploy-camunda doctor`
  - `deploy-camunda matrix run`
- Resolution precedence:

```text
CLI/config pair > process environment or loaded .env pair > selected matrix version env files > OS keyring
```

- Reads the keyring only when the corresponding `--ensure-docker-registry` or `--ensure-docker-hub` requirement is enabled.
- Treats an unavailable desktop keyring as not configured for implicit deploy lookup, preserving headless CI behavior.
- Keeps explicit `credentials status/configure/delete` errors visible so users can diagnose a locked or unavailable keyring.
- Updates preflight remediation with the exact human setup command.

Deliberately excluded:

- Docker `auths`/credential-helper import
- Matrix-wide doctor
- PostgreSQL credential bootstrap
- Durable state, resume, replay, ownership, or cleanup
- Entra/Auth0 lifecycle work

Validation performed locally:

- `cd scripts/deploy-camunda && go test ./...`
- `cd scripts/deploy-camunda && go test -race ./credentials ./cmd`
- `cd scripts/deploy-camunda && go build .`
- Cross-compiled credential package tests for Linux and Windows.
- With every Harbor/Docker Hub environment variable removed, a real 8.10 `eske` matrix dry-run resolved both required registry pairs from macOS Keychain.
- `credentials status` displayed only usernames, never tokens.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
