### PR TITLE
fix: remove publishNotReadyAddresses from orchestration client-facing service

### DIFF
--- a/charts/camunda-platform-8.10/templates/orchestration/service.yaml
+++ b/charts/camunda-platform-8.10/templates/orchestration/service.yaml
@@ -15,7 +15,6 @@ metadata:
     ) | nindent 4 }}
 spec:
   type: {{ .Values.orchestration.service.type }}
-  publishNotReadyAddresses: true
   {{- if .Values.orchestration.service.loadBalancerIP}}
   loadBalancerIP: {{ .Values.orchestration.service.loadBalancerIP }}
   {{- end }}

--- a/charts/camunda-platform-8.10/test/unit/orchestration/golden/service.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/golden/service.golden.yaml
@@ -16,7 +16,6 @@ metadata:
     {}
 spec:
   type: ClusterIP
-  publishNotReadyAddresses: true
   ports:
     - port: 9600
       protocol: TCP

--- a/charts/camunda-platform-8.10/test/unit/orchestration/service_headless_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/service_headless_test.go
@@ -57,9 +57,8 @@ func (s *GatewayServiceTest) TestGatewayServiceDifferentValuesInputs() {
 			Verifier: func(t *testing.T, output string, err error) {
 				var service coreV1.Service
 				helm.UnmarshalK8SYaml(s.T(), output, &service)
+				s.Require().NoError(err)
 
-				// Required for broker-to-broker cluster formation: peers must be
-				// reachable via this headless service before they become Ready.
 				s.Require().True(service.Spec.PublishNotReadyAddresses)
 			},
 		}, {

--- a/charts/camunda-platform-8.10/test/unit/orchestration/service_headless_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/service_headless_test.go
@@ -52,6 +52,17 @@ func TestGatewayServiceTemplate(t *testing.T) {
 func (s *GatewayServiceTest) TestGatewayServiceDifferentValuesInputs() {
 	testCases := []testhelpers.TestCase{
 		{
+			Name:   "TestPublishNotReadyAddressesEnabled",
+			Values: map[string]string{},
+			Verifier: func(t *testing.T, output string, err error) {
+				var service coreV1.Service
+				helm.UnmarshalK8SYaml(s.T(), output, &service)
+
+				// Required for broker-to-broker cluster formation: peers must be
+				// reachable via this headless service before they become Ready.
+				s.Require().True(service.Spec.PublishNotReadyAddresses)
+			},
+		}, {
 			Name: "TestContainerSetGlobalAnnotations",
 			Values: map[string]string{
 				"global.annotations.foo": "bar-global-annotation",

--- a/charts/camunda-platform-8.10/test/unit/orchestration/service_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/service_test.go
@@ -57,6 +57,7 @@ func (s *ServiceTest) TestDifferentValuesInputs() {
 			Verifier: func(t *testing.T, output string, err error) {
 				var service coreV1.Service
 				helm.UnmarshalK8SYaml(s.T(), output, &service)
+				s.Require().NoError(err)
 
 				// then
 				s.Require().False(service.Spec.PublishNotReadyAddresses)

--- a/charts/camunda-platform-8.10/test/unit/orchestration/service_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/service_test.go
@@ -52,6 +52,16 @@ func TestServiceTemplate(t *testing.T) {
 func (s *ServiceTest) TestDifferentValuesInputs() {
 	testCases := []testhelpers.TestCase{
 		{
+			Name:   "TestPublishNotReadyAddressesDisabled",
+			Values: map[string]string{},
+			Verifier: func(t *testing.T, output string, err error) {
+				var service coreV1.Service
+				helm.UnmarshalK8SYaml(s.T(), output, &service)
+
+				// then
+				s.Require().False(service.Spec.PublishNotReadyAddresses)
+			},
+		}, {
 			Name: "TestContainerSetGlobalAnnotations",
 			Values: map[string]string{
 				"global.annotations.foo": "bar-global-annotation",

--- a/charts/camunda-platform-8.8/templates/orchestration/service.yaml
+++ b/charts/camunda-platform-8.8/templates/orchestration/service.yaml
@@ -15,7 +15,6 @@ metadata:
     ) | nindent 4 }}
 spec:
   type: {{ .Values.orchestration.service.type }}
-  publishNotReadyAddresses: true
   {{- if .Values.orchestration.service.loadBalancerIP}}
   loadBalancerIP: {{ .Values.orchestration.service.loadBalancerIP }}
   {{- end }}

--- a/charts/camunda-platform-8.8/test/unit/orchestration/golden/service.golden.yaml
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/golden/service.golden.yaml
@@ -16,7 +16,6 @@ metadata:
     {}
 spec:
   type: ClusterIP
-  publishNotReadyAddresses: true
   ports:
     - port: 9600
       protocol: TCP

--- a/charts/camunda-platform-8.8/test/unit/orchestration/service_headless_test.go
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/service_headless_test.go
@@ -57,9 +57,8 @@ func (s *GatewayServiceTest) TestGatewayServiceDifferentValuesInputs() {
 			Verifier: func(t *testing.T, output string, err error) {
 				var service coreV1.Service
 				helm.UnmarshalK8SYaml(s.T(), output, &service)
+				s.Require().NoError(err)
 
-				// Required for broker-to-broker cluster formation: peers must be
-				// reachable via this headless service before they become Ready.
 				s.Require().True(service.Spec.PublishNotReadyAddresses)
 			},
 		}, {

--- a/charts/camunda-platform-8.8/test/unit/orchestration/service_headless_test.go
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/service_headless_test.go
@@ -52,6 +52,17 @@ func TestGatewayServiceTemplate(t *testing.T) {
 func (s *GatewayServiceTest) TestGatewayServiceDifferentValuesInputs() {
 	testCases := []testhelpers.TestCase{
 		{
+			Name:   "TestPublishNotReadyAddressesEnabled",
+			Values: map[string]string{},
+			Verifier: func(t *testing.T, output string, err error) {
+				var service coreV1.Service
+				helm.UnmarshalK8SYaml(s.T(), output, &service)
+
+				// Required for broker-to-broker cluster formation: peers must be
+				// reachable via this headless service before they become Ready.
+				s.Require().True(service.Spec.PublishNotReadyAddresses)
+			},
+		}, {
 			Name: "TestContainerSetGlobalAnnotations",
 			Values: map[string]string{
 				"global.annotations.foo": "bar-global-annotation",

--- a/charts/camunda-platform-8.8/test/unit/orchestration/service_test.go
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/service_test.go
@@ -57,6 +57,7 @@ func (s *ServiceTest) TestDifferentValuesInputs() {
 			Verifier: func(t *testing.T, output string, err error) {
 				var service coreV1.Service
 				helm.UnmarshalK8SYaml(s.T(), output, &service)
+				s.Require().NoError(err)
 
 				// then
 				s.Require().False(service.Spec.PublishNotReadyAddresses)

--- a/charts/camunda-platform-8.8/test/unit/orchestration/service_test.go
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/service_test.go
@@ -52,6 +52,16 @@ func TestServiceTemplate(t *testing.T) {
 func (s *ServiceTest) TestDifferentValuesInputs() {
 	testCases := []testhelpers.TestCase{
 		{
+			Name:   "TestPublishNotReadyAddressesDisabled",
+			Values: map[string]string{},
+			Verifier: func(t *testing.T, output string, err error) {
+				var service coreV1.Service
+				helm.UnmarshalK8SYaml(s.T(), output, &service)
+
+				// then
+				s.Require().False(service.Spec.PublishNotReadyAddresses)
+			},
+		}, {
 			Name: "TestContainerSetGlobalAnnotations",
 			Values: map[string]string{
 				"global.annotations.foo": "bar-global-annotation",

--- a/charts/camunda-platform-8.9/templates/orchestration/service.yaml
+++ b/charts/camunda-platform-8.9/templates/orchestration/service.yaml
@@ -15,7 +15,6 @@ metadata:
     ) | nindent 4 }}
 spec:
   type: {{ .Values.orchestration.service.type }}
-  publishNotReadyAddresses: true
   {{- if .Values.orchestration.service.loadBalancerIP}}
   loadBalancerIP: {{ .Values.orchestration.service.loadBalancerIP }}
   {{- end }}

--- a/charts/camunda-platform-8.9/test/unit/orchestration/golden/service.golden.yaml
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/golden/service.golden.yaml
@@ -16,7 +16,6 @@ metadata:
     {}
 spec:
   type: ClusterIP
-  publishNotReadyAddresses: true
   ports:
     - port: 9600
       protocol: TCP

--- a/charts/camunda-platform-8.9/test/unit/orchestration/service_headless_test.go
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/service_headless_test.go
@@ -57,9 +57,8 @@ func (s *GatewayServiceTest) TestGatewayServiceDifferentValuesInputs() {
 			Verifier: func(t *testing.T, output string, err error) {
 				var service coreV1.Service
 				helm.UnmarshalK8SYaml(s.T(), output, &service)
+				s.Require().NoError(err)
 
-				// Required for broker-to-broker cluster formation: peers must be
-				// reachable via this headless service before they become Ready.
 				s.Require().True(service.Spec.PublishNotReadyAddresses)
 			},
 		}, {

--- a/charts/camunda-platform-8.9/test/unit/orchestration/service_headless_test.go
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/service_headless_test.go
@@ -52,6 +52,17 @@ func TestGatewayServiceTemplate(t *testing.T) {
 func (s *GatewayServiceTest) TestGatewayServiceDifferentValuesInputs() {
 	testCases := []testhelpers.TestCase{
 		{
+			Name:   "TestPublishNotReadyAddressesEnabled",
+			Values: map[string]string{},
+			Verifier: func(t *testing.T, output string, err error) {
+				var service coreV1.Service
+				helm.UnmarshalK8SYaml(s.T(), output, &service)
+
+				// Required for broker-to-broker cluster formation: peers must be
+				// reachable via this headless service before they become Ready.
+				s.Require().True(service.Spec.PublishNotReadyAddresses)
+			},
+		}, {
 			Name: "TestContainerSetGlobalAnnotations",
 			Values: map[string]string{
 				"global.annotations.foo": "bar-global-annotation",

--- a/charts/camunda-platform-8.9/test/unit/orchestration/service_test.go
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/service_test.go
@@ -57,6 +57,7 @@ func (s *ServiceTest) TestDifferentValuesInputs() {
 			Verifier: func(t *testing.T, output string, err error) {
 				var service coreV1.Service
 				helm.UnmarshalK8SYaml(s.T(), output, &service)
+				s.Require().NoError(err)
 
 				// then
 				s.Require().False(service.Spec.PublishNotReadyAddresses)

--- a/charts/camunda-platform-8.9/test/unit/orchestration/service_test.go
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/service_test.go
@@ -52,6 +52,16 @@ func TestServiceTemplate(t *testing.T) {
 func (s *ServiceTest) TestDifferentValuesInputs() {
 	testCases := []testhelpers.TestCase{
 		{
+			Name:   "TestPublishNotReadyAddressesDisabled",
+			Values: map[string]string{},
+			Verifier: func(t *testing.T, output string, err error) {
+				var service coreV1.Service
+				helm.UnmarshalK8SYaml(s.T(), output, &service)
+
+				// then
+				s.Require().False(service.Spec.PublishNotReadyAddresses)
+			},
+		}, {
 			Name: "TestContainerSetGlobalAnnotations",
 			Values: map[string]string{
 				"global.annotations.foo": "bar-global-annotation",


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes #6736 (SUPPORT-33961): Zeebe gateway pod rotation causes intermittent "Connection refused" errors in downstream clients (Connectors, Operate/Tasklist importers) hitting `<release>-zeebe-gateway:8080` during rolling restarts or pod rescheduling.

### What's in this PR?

The client-facing orchestration `Service` (management/http/grpc ports, `templates/orchestration/service.yaml`) hardcoded `publishNotReadyAddresses: true` with no gate. This causes kube-proxy to add a pod's IP to the Service's routable endpoints as soon as the pod has an IP, without waiting for the readiness probe — so clients get routed to a pod that isn't accepting traffic yet, producing connection-refused errors.

Root cause: an accidental regression introduced during the 8.8 `orchestration/` unification refactor (#4190). Pre-8.8, the equivalent client-facing `zeebe-gateway` Service never had this flag; only the headless broker `Service` (`clusterIP: None`, used for broker-to-broker cluster bootstrap) correctly sets it, since peers must be reachable via DNS before the raft cluster forms and they become Ready. The unification accidentally carried the headless broker's flag onto the client-facing service.

Fix: remove `publishNotReadyAddresses: true` from `templates/orchestration/service.yaml` in 8.8, 8.9, and 8.10 (all versions using the unified `orchestration/` template). The headless service (`service-headless.yaml`) is untouched and correctly keeps the flag.

Added regression tests to `service_test.go` (asserts `false` on the client-facing Service) and `service_headless_test.go` (asserts `true` on the headless Service, guarding against the wrong service being "fixed" in the future) for all three affected chart versions.

**Validation:** reproduced the bug on a live GKE cluster (3-replica Zeebe cluster, rolling restart via `kubectl rollout restart statefulset`), confirming sustained connection-refused errors for the full ~30-60s pod-startup window before the fix. After the fix, the same rotation test dropped to brief sub-second failure bursts at pod-transition boundaries only (~1.8% of requests, consistent with normal kube-proxy endpoint-propagation lag on pod termination — unrelated to this bug) instead of sustained failures tracking the entire not-ready window.

### Checklist

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open pull request for the same update/change.
- [x] Tests for charts are added (if needed).
- [ ] In-repo documentation are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?