### PR TITLE
chore: drop "contact your csm" wording from version-matrix extended support section

### DIFF
--- a/scripts/camunda-core/pkg/versionmatrix/readme.go
+++ b/scripts/camunda-core/pkg/versionmatrix/readme.go
@@ -50,7 +50,6 @@ const indexNotes = "" +
 	"- The `Camunda` column is the chart's core application version — find your exact Camunda patch (for example, 8.8.5) there. Pre-release charts carry an `-alpha`/`-rc` suffix in the chart version: previews, not for production use and without a support SLA.\n" +
 	"- The Camunda `application version` (`appVersion` in the chart) is different from the Helm `chart version` (`version` in the chart). Without `--devel`, `helm search repo` hides the pre-release charts listed on this page.\n" +
 	"- The `Helm CLI` column lists the Helm CLI version(s) each chart was released and tested with (recorded at release in the chart annotation `camunda.io/helmCLIVersion`). Camunda 8.9 (chart 14.x) is the last minor that supports Helm v3; Camunda 8.10 (chart 15.x) and later require Helm v4. Older CLI versions may lack template functions the chart uses (for example, `toYamlPretty` requires 3.17+).\n" +
-	"- Extended support is available under contract — contact your Customer Success Manager (CSM).\n" +
 	"- For a rollback option when upgrading, take a [backup](https://docs.camunda.io/docs/self-managed/operational-guides/backup-restore/backup-and-restore/) before each hop.\n"
 
 // indexFooter closes the page with the generation FYI.
@@ -186,7 +185,7 @@ func minorStatusLine(bucket string, lc Lifecycle) string {
 	case BucketSupportStandard:
 		return fmt.Sprintf("Standard support until %s", lc.StdSupportUntil)
 	case BucketSupportExtended:
-		return "Extended support — contact your CSM"
+		return "Extended support"
 	case BucketEndOfLife:
 		return fmt.Sprintf("End of life since %s", lc.EOLSince)
 	}
@@ -247,7 +246,7 @@ func RenderIndex(cfg *ChartVersionsConfig, entriesByApp map[string][]ChartEntry)
 	}
 
 	if minors := cfg.CamundaVersions.SupportExtended; len(minors) > 0 {
-		b.WriteString("\n## Extended support — contact your CSM\n\n")
+		b.WriteString("\n## Extended support\n\n")
 		b.WriteString("| Camunda | Released | Latest chart | Full matrix |\n|---|---|---|---|\n")
 		for _, app := range SortAppVersionsDescending(minors) {
 			lc := cfg.CamundaSupportLifecycle[app]

--- a/scripts/camunda-core/pkg/versionmatrix/readme_test.go
+++ b/scripts/camunda-core/pkg/versionmatrix/readme_test.go
@@ -245,7 +245,7 @@ func TestRenderIndex(t *testing.T) {
 		"[All 7 chart versions for Camunda 8.9 →](./camunda-8.9/)",
 		"## Camunda 8.8 — Standard support until 2027-04-13",
 		// Extended support: one compact row per minor.
-		"## Extended support — contact your CSM",
+		"## Extended support",
 		"| Camunda | Released | Latest chart | Full matrix |",
 		"| 8.6 | 2024-10-08 | [11.12.3](./camunda-8.6/#helm-chart-11123) | [camunda-8.6](./camunda-8.6/) |",
 		// EOL: compact row from lifecycle data (no JSON needed).

--- a/version-matrix/README.md
+++ b/version-matrix/README.md
@@ -61,7 +61,7 @@ helm search repo camunda/camunda-platform --devel --versions
 
 [All 36 chart versions for Camunda 8.7 →](./camunda-8.7/)
 
-## Extended support — contact your CSM
+## Extended support
 
 | Camunda | Released | Latest chart | Full matrix |
 |---|---|---|---|
@@ -83,7 +83,6 @@ helm search repo camunda/camunda-platform --devel --versions
 - The `Camunda` column is the chart's core application version — find your exact Camunda patch (for example, 8.8.5) there. Pre-release charts carry an `-alpha`/`-rc` suffix in the chart version: previews, not for production use and without a support SLA.
 - The Camunda `application version` (`appVersion` in the chart) is different from the Helm `chart version` (`version` in the chart). Without `--devel`, `helm search repo` hides the pre-release charts listed on this page.
 - The `Helm CLI` column lists the Helm CLI version(s) each chart was released and tested with (recorded at release in the chart annotation `camunda.io/helmCLIVersion`). Camunda 8.9 (chart 14.x) is the last minor that supports Helm v3; Camunda 8.10 (chart 15.x) and later require Helm v4. Older CLI versions may lack template functions the chart uses (for example, `toYamlPretty` requires 3.17+).
-- Extended support is available under contract — contact your Customer Success Manager (CSM).
 - For a rollback option when upgrading, take a [backup](https://docs.camunda.io/docs/self-managed/operational-guides/backup-restore/backup-and-restore/) before each hop.
 
 ---

--- a/version-matrix/camunda-8.3/README.md
+++ b/version-matrix/camunda-8.3/README.md
@@ -3,7 +3,7 @@
 
 # Camunda 8.3 Helm Chart Version Matrix
 
-Extended support — contact your CSM
+Extended support
 
 | Helm Chart | Camunda | Released | Helm CLI | Helm Values | Release Notes |
 |---|---|---|---|---|---|

--- a/version-matrix/camunda-8.4/README.md
+++ b/version-matrix/camunda-8.4/README.md
@@ -3,7 +3,7 @@
 
 # Camunda 8.4 Helm Chart Version Matrix
 
-Extended support — contact your CSM
+Extended support
 
 | Helm Chart | Camunda | Released | Helm CLI | Helm Values | Release Notes |
 |---|---|---|---|---|---|

--- a/version-matrix/camunda-8.5/README.md
+++ b/version-matrix/camunda-8.5/README.md
@@ -3,7 +3,7 @@
 
 # Camunda 8.5 Helm Chart Version Matrix
 
-Extended support — contact your CSM
+Extended support
 
 | Helm Chart | Camunda | Released | Helm CLI | Helm Values | Release Notes |
 |---|---|---|---|---|---|

--- a/version-matrix/camunda-8.6/README.md
+++ b/version-matrix/camunda-8.6/README.md
@@ -3,7 +3,7 @@
 
 # Camunda 8.6 Helm Chart Version Matrix
 
-Extended support — contact your CSM
+Extended support
 
 | Helm Chart | Camunda | Released | Helm CLI | Helm Values | Release Notes |
 |---|---|---|---|---|---|


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes #6747.

### What's in this PR?

Support feedback on the new Helm version matrix layout (PR #6724 follow-up, product-hub epic camunda/product-hub#3381) flagged that not all customers have a CSM, so telling them to "contact your CSM" for extended support doesn't work for everyone.

Removes the "contact your CSM" wording from the three places it was generated in `scripts/camunda-core/pkg/versionmatrix/readme.go` (index notes bullet, per-minor status line, extended-support section heading), updates the corresponding `readme_test.go` assertion, and regenerates the affected `version-matrix/**/README.md` files. Dropped rather than reworded, per decision to wait for actual customer demand before adding new contact guidance.

### Checklist

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`. (n/a — no chart templates touched)
- [x] There is no other open pull request for the same update/change.
- [ ] Tests for charts are added (if needed). (n/a — no chart changes)
- [ ] In-repo documentation are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?