### PR TITLE
chore: remove departed maintainer from Chart.yaml

### DIFF
--- a/charts/camunda-platform-8.10/Chart.yaml
+++ b/charts/camunda-platform-8.10/Chart.yaml
@@ -33,8 +33,6 @@ dependencies:
 maintainers:
   - name: eamonnmoloney
     email: eamonn.moloney@camunda.com
-  - name: Ian-wang-liyang
-    email: ian.wang@camunda.com
   - name: hisImminence
     email: immanuel.monma@camunda.com
   - name: bkenez

--- a/charts/camunda-platform-8.7/Chart.yaml
+++ b/charts/camunda-platform-8.7/Chart.yaml
@@ -55,8 +55,6 @@ dependencies:
 maintainers:
   - name: eamonnmoloney
     email: eamonn.moloney@camunda.com
-  - name: Ian-wang-liyang
-    email: ian.wang@camunda.com
   - name: hisImminence
     email: immanuel.monma@camunda.com
   - name: bkenez

--- a/charts/camunda-platform-8.8/Chart.yaml
+++ b/charts/camunda-platform-8.8/Chart.yaml
@@ -55,8 +55,6 @@ dependencies:
 maintainers:
   - name: eamonnmoloney
     email: eamonn.moloney@camunda.com
-  - name: Ian-wang-liyang
-    email: ian.wang@camunda.com
   - name: hisImminence
     email: immanuel.monma@camunda.com
   - name: bkenez

--- a/charts/camunda-platform-8.9/Chart.yaml
+++ b/charts/camunda-platform-8.9/Chart.yaml
@@ -55,8 +55,6 @@ dependencies:
 maintainers:
   - name: eamonnmoloney
     email: eamonn.moloney@camunda.com
-  - name: Ian-wang-liyang
-    email: ian.wang@camunda.com
   - name: hisImminence
     email: immanuel.monma@camunda.com
   - name: bkenez


### PR DESCRIPTION
### Which problem does the PR fix?

The maintainers list in Chart.yaml no longer reflects the current team.

### What's in this PR?

Removes an entry from the `maintainers` field in Chart.yaml for chart versions 8.7, 8.8, 8.9, and 8.10.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?