### PR TITLE
ci: publish complete image inventory to artifact hub

### DIFF
--- a/.github/workflows/chart-build-dev.yaml
+++ b/.github/workflows/chart-build-dev.yaml
@@ -444,16 +444,24 @@ jobs:
           make -C ../.. helm.dependency-update \
             chartPath=${{ matrix.chart.directory }}
 
-      - name: Record chart-images annotation
+      - name: Record chart image annotations
         if: env.SKIP_BUILD == 'false'
         run: |
-          # Record the full image set (components + bundled subcharts), read from
-          # values.yaml, as the camunda.io/chart-images annotation. Runs after the
-          # dependency update so the vendored subchart values are present to read.
-          /tmp/release-tools chart-images --chart-dir "$(pwd)" > /tmp/chart-images.txt
-          yq -i '.annotations."camunda.io/chart-images" = load_str("/tmp/chart-images.txt")' Chart.yaml
+          # Record components and bundled subcharts from finalized values and
+          # vendored dependencies in the internal and Artifact Hub formats.
+          /tmp/release-tools chart-images --chart-dir "$(pwd)" \
+            --artifacthub-out /tmp/artifacthub-images.yaml \
+            > /tmp/chart-images.txt
+          yq -i '
+            .annotations."camunda.io/chart-images" =
+              load_str("/tmp/chart-images.txt") |
+            .annotations."artifacthub.io/images" =
+              load_str("/tmp/artifacthub-images.yaml")
+          ' Chart.yaml
           echo "Added camunda.io/chart-images annotation:"
           yq '.annotations."camunda.io/chart-images"' Chart.yaml
+          echo "Added artifacthub.io/images annotation:"
+          yq '.annotations."artifacthub.io/images"' Chart.yaml
 
       #
       # Generate release notes

--- a/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
+++ b/charts/camunda-platform-8.7/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
@@ -97,7 +97,7 @@ identityKeycloak:
   #     - name: index-docker-io
   #     - name: ghcr-io
   image:
-    registry: registry.camunda.cloud
+    registry: docker.io
     repository: camunda/keycloak
     tag: "26.3.3"
     pullSecrets:

--- a/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
+++ b/charts/camunda-platform-8.8/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
@@ -85,7 +85,7 @@ identityKeycloak:
   #     - name: index-docker-io
   #     - name: ghcr-io
   image:
-    registry: registry.camunda.cloud
+    registry: docker.io
     repository: camunda/keycloak
     tag: "26.3.3"
     pullSecrets:

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/identity/keycloak.yaml
@@ -98,7 +98,7 @@ identityKeycloak:
   #     - name: index-docker-io
   #     - name: ghcr-io
   image:
-    registry: registry.camunda.cloud
+    registry: docker.io
     repository: camunda/keycloak
     tag: "26.3.3"
     pullSecrets:

--- a/scripts/release-tools/chart_images.go
+++ b/scripts/release-tools/chart_images.go
@@ -20,8 +20,21 @@ import (
 	"os"
 	"strings"
 
+	"gopkg.in/yaml.v3"
 	"scripts/camunda-core/pkg/chartmeta"
 )
+
+type artifactHubImage struct {
+	Image string `yaml:"image"`
+}
+
+func artifactHubImagesYAML(images []string) ([]byte, error) {
+	entries := make([]artifactHubImage, len(images))
+	for i, image := range images {
+		entries[i] = artifactHubImage{Image: image}
+	}
+	return yaml.Marshal(entries)
+}
 
 // runChartImages derives the chart's declared image set from its values.yaml
 // (plus the chart-full-setup scenario layers) and prints it one fully-qualified
@@ -30,12 +43,14 @@ import (
 //	release-tools chart-images --chart-dir "$chart_dir" > /tmp/chart-images.txt
 //	yq -i '.annotations."camunda.io/chart-images" = load_str("/tmp/chart-images.txt")' "$chart_dir/Chart.yaml"
 //
-// It fails loud on an empty result rather than recording an empty set: a valid
-// chart always declares images.
+// With --artifacthub-out, it also writes the same references in the structured
+// artifacthub.io/images format. It fails loud on an empty result rather than
+// recording an empty set: a valid chart always declares images.
 func runChartImages(args []string) error {
 	fs := flag.NewFlagSet("chart-images", flag.ContinueOnError)
-	var chartDir string
+	var chartDir, artifactHubOut string
 	fs.StringVar(&chartDir, "chart-dir", "", "chart directory (the finalized chart, e.g. charts/camunda-platform-<v>)")
+	fs.StringVar(&artifactHubOut, "artifacthub-out", "", "file to write artifacthub.io/images YAML")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -49,6 +64,15 @@ func runChartImages(args []string) error {
 	}
 	if len(images) == 0 {
 		return fmt.Errorf("no images declared in %s/values.yaml; refusing to record an empty chart-images set", chartDir)
+	}
+	if artifactHubOut != "" {
+		artifactHubImages, err := artifactHubImagesYAML(images)
+		if err != nil {
+			return fmt.Errorf("serialize Artifact Hub images: %w", err)
+		}
+		if err := os.WriteFile(artifactHubOut, artifactHubImages, 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", artifactHubOut, err)
+		}
 	}
 
 	_, err = fmt.Fprintln(os.Stdout, strings.Join(images, "\n"))

--- a/scripts/release-tools/chart_images.go
+++ b/scripts/release-tools/chart_images.go
@@ -26,28 +26,15 @@ import (
 )
 
 type artifactHubImage struct {
-	Name  string `yaml:"name"`
 	Image string `yaml:"image"`
 }
 
 func artifactHubImagesYAML(images []string) ([]byte, error) {
 	entries := make([]artifactHubImage, len(images))
 	for i, image := range images {
-		entries[i] = artifactHubImage{Name: imageName(image), Image: image}
+		entries[i] = artifactHubImage{Image: image}
 	}
 	return yaml.Marshal(entries)
-}
-
-// imageName extracts the repo basename Artifact Hub's security-report UI
-// labels the image with, e.g. "docker.io/camunda/keycloak:26.3.3" -> "keycloak".
-func imageName(ref string) string {
-	if i := strings.LastIndex(ref, "/"); i != -1 {
-		ref = ref[i+1:]
-	}
-	if i := strings.IndexAny(ref, "@:"); i != -1 {
-		ref = ref[:i]
-	}
-	return ref
 }
 
 // validateImageRefs rejects any ref carrying an unresolved placeholder (e.g. a

--- a/scripts/release-tools/chart_images.go
+++ b/scripts/release-tools/chart_images.go
@@ -17,6 +17,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -25,15 +26,42 @@ import (
 )
 
 type artifactHubImage struct {
+	Name  string `yaml:"name"`
 	Image string `yaml:"image"`
 }
 
 func artifactHubImagesYAML(images []string) ([]byte, error) {
 	entries := make([]artifactHubImage, len(images))
 	for i, image := range images {
-		entries[i] = artifactHubImage{Image: image}
+		entries[i] = artifactHubImage{Name: imageName(image), Image: image}
 	}
 	return yaml.Marshal(entries)
+}
+
+// imageName extracts the repo basename Artifact Hub's security-report UI
+// labels the image with, e.g. "docker.io/camunda/keycloak:26.3.3" -> "keycloak".
+func imageName(ref string) string {
+	if i := strings.LastIndex(ref, "/"); i != -1 {
+		ref = ref[i+1:]
+	}
+	if i := strings.IndexAny(ref, "@:"); i != -1 {
+		ref = ref[:i]
+	}
+	return ref
+}
+
+// validateImageRefs rejects any ref carrying an unresolved placeholder (e.g. a
+// literal "$E2E_TESTS_CONSOLE_IMAGE_TAG" from a QA-only scenario layer that
+// ResolvePaths should have excluded). Both annotations are publication
+// artifacts now, so a ref that would never resolve to a real image must fail
+// loud rather than get published.
+func validateImageRefs(images []string) error {
+	for _, ref := range images {
+		if strings.ContainsAny(ref, "$ \t{}") {
+			return fmt.Errorf("image ref %q looks unresolved; refusing to publish", ref)
+		}
+	}
+	return nil
 }
 
 // runChartImages derives the chart's declared image set from its values.yaml
@@ -46,7 +74,7 @@ func artifactHubImagesYAML(images []string) ([]byte, error) {
 // With --artifacthub-out, it also writes the same references in the structured
 // artifacthub.io/images format. It fails loud on an empty result rather than
 // recording an empty set: a valid chart always declares images.
-func runChartImages(args []string) error {
+func runChartImages(args []string, stdout io.Writer) error {
 	fs := flag.NewFlagSet("chart-images", flag.ContinueOnError)
 	var chartDir, artifactHubOut string
 	fs.StringVar(&chartDir, "chart-dir", "", "chart directory (the finalized chart, e.g. charts/camunda-platform-<v>)")
@@ -65,16 +93,28 @@ func runChartImages(args []string) error {
 	if len(images) == 0 {
 		return fmt.Errorf("no images declared in %s/values.yaml; refusing to record an empty chart-images set", chartDir)
 	}
+	if err := validateImageRefs(images); err != nil {
+		return err
+	}
+
+	// Both outputs are serialized from the same validated `images` slice before
+	// either is written, so a failure here never leaves one annotation stale
+	// relative to the other.
+	var artifactHubImages []byte
 	if artifactHubOut != "" {
-		artifactHubImages, err := artifactHubImagesYAML(images)
+		artifactHubImages, err = artifactHubImagesYAML(images)
 		if err != nil {
 			return fmt.Errorf("serialize Artifact Hub images: %w", err)
 		}
+	}
+
+	if _, err := fmt.Fprintln(stdout, strings.Join(images, "\n")); err != nil {
+		return err
+	}
+	if artifactHubOut != "" {
 		if err := os.WriteFile(artifactHubOut, artifactHubImages, 0o644); err != nil {
 			return fmt.Errorf("write %s: %w", artifactHubOut, err)
 		}
 	}
-
-	_, err = fmt.Fprintln(os.Stdout, strings.Join(images, "\n"))
-	return err
+	return nil
 }

--- a/scripts/release-tools/chart_images_test.go
+++ b/scripts/release-tools/chart_images_test.go
@@ -29,7 +29,6 @@ func TestArtifactHubImagesYAML(t *testing.T) {
 		"docker.io/camunda/camunda:8.9.13",
 		"docker.io/camunda/connectors-bundle@sha256:abc123",
 	}
-	wantNames := []string{"camunda", "connectors-bundle"}
 
 	got, err := artifactHubImagesYAML(images)
 	if err != nil {
@@ -46,22 +45,6 @@ func TestArtifactHubImagesYAML(t *testing.T) {
 	for i, entry := range entries {
 		if entry.Image != images[i] {
 			t.Errorf("entry %d image = %q, want %q", i, entry.Image, images[i])
-		}
-		if entry.Name != wantNames[i] {
-			t.Errorf("entry %d name = %q, want %q", i, entry.Name, wantNames[i])
-		}
-	}
-}
-
-func TestImageName(t *testing.T) {
-	for _, tc := range []struct{ ref, want string }{
-		{"docker.io/camunda/keycloak:26.3.3", "keycloak"},
-		{"docker.io/camunda/connectors-bundle@sha256:abc123", "connectors-bundle"},
-		{"registry.camunda.cloud/camunda/camunda:8.9.13", "camunda"},
-		{"busybox:1.36", "busybox"},
-	} {
-		if got := imageName(tc.ref); got != tc.want {
-			t.Errorf("imageName(%q) = %q, want %q", tc.ref, got, tc.want)
 		}
 	}
 }
@@ -102,7 +85,7 @@ orchestration:
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, want := string(artifactHub), "- name: camunda\n  image: docker.io/camunda/camunda:8.9.13\n"; got != want {
+	if got, want := string(artifactHub), "- image: docker.io/camunda/camunda:8.9.13\n"; got != want {
 		t.Errorf("Artifact Hub output = %q, want %q", got, want)
 	}
 }

--- a/scripts/release-tools/chart_images_test.go
+++ b/scripts/release-tools/chart_images_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,6 +29,7 @@ func TestArtifactHubImagesYAML(t *testing.T) {
 		"docker.io/camunda/camunda:8.9.13",
 		"docker.io/camunda/connectors-bundle@sha256:abc123",
 	}
+	wantNames := []string{"camunda", "connectors-bundle"}
 
 	got, err := artifactHubImagesYAML(images)
 	if err != nil {
@@ -45,6 +47,33 @@ func TestArtifactHubImagesYAML(t *testing.T) {
 		if entry.Image != images[i] {
 			t.Errorf("entry %d image = %q, want %q", i, entry.Image, images[i])
 		}
+		if entry.Name != wantNames[i] {
+			t.Errorf("entry %d name = %q, want %q", i, entry.Name, wantNames[i])
+		}
+	}
+}
+
+func TestImageName(t *testing.T) {
+	for _, tc := range []struct{ ref, want string }{
+		{"docker.io/camunda/keycloak:26.3.3", "keycloak"},
+		{"docker.io/camunda/connectors-bundle@sha256:abc123", "connectors-bundle"},
+		{"registry.camunda.cloud/camunda/camunda:8.9.13", "camunda"},
+		{"busybox:1.36", "busybox"},
+	} {
+		if got := imageName(tc.ref); got != tc.want {
+			t.Errorf("imageName(%q) = %q, want %q", tc.ref, got, tc.want)
+		}
+	}
+}
+
+func TestValidateImageRefsRejectsPlaceholders(t *testing.T) {
+	err := validateImageRefs([]string{"docker.io/camunda/console:$E2E_TESTS_CONSOLE_IMAGE_TAG"})
+	if err == nil || !strings.Contains(err.Error(), "unresolved") {
+		t.Fatalf("err = %v, want an unresolved-placeholder error", err)
+	}
+
+	if err := validateImageRefs([]string{"docker.io/camunda/camunda:8.9.13"}); err != nil {
+		t.Errorf("valid ref rejected: %v", err)
 	}
 }
 
@@ -60,26 +89,12 @@ orchestration:
 	}
 
 	artifactHubOut := filepath.Join(t.TempDir(), "artifacthub-images.yaml")
-	stdout, err := os.CreateTemp(t.TempDir(), "chart-images-*.txt")
-	if err != nil {
-		t.Fatal(err)
-	}
-	originalStdout := os.Stdout
-	os.Stdout = stdout
-	runErr := runChartImages([]string{"--chart-dir", chartDir, "--artifacthub-out", artifactHubOut})
-	os.Stdout = originalStdout
-	if err := stdout.Close(); err != nil {
-		t.Fatal(err)
-	}
-	if runErr != nil {
-		t.Fatalf("runChartImages: %v", runErr)
+	var stdout bytes.Buffer
+	if err := runChartImages([]string{"--chart-dir", chartDir, "--artifacthub-out", artifactHubOut}, &stdout); err != nil {
+		t.Fatalf("runChartImages: %v", err)
 	}
 
-	canonical, err := os.ReadFile(stdout.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got, want := string(canonical), "docker.io/camunda/camunda:8.9.13\n"; got != want {
+	if got, want := stdout.String(), "docker.io/camunda/camunda:8.9.13\n"; got != want {
 		t.Errorf("canonical output = %q, want %q", got, want)
 	}
 
@@ -87,47 +102,7 @@ orchestration:
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, want := string(artifactHub), "- image: docker.io/camunda/camunda:8.9.13\n"; got != want {
+	if got, want := string(artifactHub), "- name: camunda\n  image: docker.io/camunda/camunda:8.9.13\n"; got != want {
 		t.Errorf("Artifact Hub output = %q, want %q", got, want)
-	}
-}
-
-func TestBuildWorkflowRecordsImageAnnotations(t *testing.T) {
-	workflowPath := filepath.Join("..", "..", ".github", "workflows", "chart-build-dev.yaml")
-	data, err := os.ReadFile(workflowPath)
-	if err != nil {
-		t.Fatalf("read build workflow: %v", err)
-	}
-
-	var workflow struct {
-		Jobs map[string]struct {
-			Steps []struct {
-				Name string `yaml:"name"`
-				Run  string `yaml:"run"`
-			} `yaml:"steps"`
-		} `yaml:"jobs"`
-	}
-	if err := yaml.Unmarshal(data, &workflow); err != nil {
-		t.Fatalf("parse build workflow: %v", err)
-	}
-
-	var annotationStep string
-	for _, step := range workflow.Jobs["build"].Steps {
-		if step.Name == "Record chart image annotations" {
-			annotationStep = step.Run
-			break
-		}
-	}
-	if annotationStep == "" {
-		t.Fatal("build workflow has no image annotation step")
-	}
-	for _, required := range []string{
-		"--artifacthub-out /tmp/artifacthub-images.yaml",
-		`.annotations."camunda.io/chart-images"`,
-		`.annotations."artifacthub.io/images"`,
-	} {
-		if !strings.Contains(annotationStep, required) {
-			t.Errorf("image annotation step missing %q", required)
-		}
 	}
 }

--- a/scripts/release-tools/chart_images_test.go
+++ b/scripts/release-tools/chart_images_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestArtifactHubImagesYAML(t *testing.T) {
+	images := []string{
+		"docker.io/camunda/camunda:8.9.13",
+		"docker.io/camunda/connectors-bundle@sha256:abc123",
+	}
+
+	got, err := artifactHubImagesYAML(images)
+	if err != nil {
+		t.Fatalf("artifactHubImagesYAML: %v", err)
+	}
+
+	var entries []artifactHubImage
+	if err := yaml.Unmarshal(got, &entries); err != nil {
+		t.Fatalf("unmarshal Artifact Hub images: %v", err)
+	}
+	if len(entries) != len(images) {
+		t.Fatalf("got %d entries, want %d", len(entries), len(images))
+	}
+	for i, entry := range entries {
+		if entry.Image != images[i] {
+			t.Errorf("entry %d image = %q, want %q", i, entry.Image, images[i])
+		}
+	}
+}
+
+func TestRunChartImagesWritesArtifactHubOutput(t *testing.T) {
+	chartDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(chartDir, "values.yaml"), []byte(`
+orchestration:
+  image:
+    repository: camunda/camunda
+    tag: 8.9.13
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	artifactHubOut := filepath.Join(t.TempDir(), "artifacthub-images.yaml")
+	stdout, err := os.CreateTemp(t.TempDir(), "chart-images-*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalStdout := os.Stdout
+	os.Stdout = stdout
+	runErr := runChartImages([]string{"--chart-dir", chartDir, "--artifacthub-out", artifactHubOut})
+	os.Stdout = originalStdout
+	if err := stdout.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if runErr != nil {
+		t.Fatalf("runChartImages: %v", runErr)
+	}
+
+	canonical, err := os.ReadFile(stdout.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(canonical), "docker.io/camunda/camunda:8.9.13\n"; got != want {
+		t.Errorf("canonical output = %q, want %q", got, want)
+	}
+
+	artifactHub, err := os.ReadFile(artifactHubOut)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(artifactHub), "- image: docker.io/camunda/camunda:8.9.13\n"; got != want {
+		t.Errorf("Artifact Hub output = %q, want %q", got, want)
+	}
+}

--- a/scripts/release-tools/chart_images_test.go
+++ b/scripts/release-tools/chart_images_test.go
@@ -17,6 +17,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -88,5 +89,45 @@ orchestration:
 	}
 	if got, want := string(artifactHub), "- image: docker.io/camunda/camunda:8.9.13\n"; got != want {
 		t.Errorf("Artifact Hub output = %q, want %q", got, want)
+	}
+}
+
+func TestBuildWorkflowRecordsImageAnnotations(t *testing.T) {
+	workflowPath := filepath.Join("..", "..", ".github", "workflows", "chart-build-dev.yaml")
+	data, err := os.ReadFile(workflowPath)
+	if err != nil {
+		t.Fatalf("read build workflow: %v", err)
+	}
+
+	var workflow struct {
+		Jobs map[string]struct {
+			Steps []struct {
+				Name string `yaml:"name"`
+				Run  string `yaml:"run"`
+			} `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(data, &workflow); err != nil {
+		t.Fatalf("parse build workflow: %v", err)
+	}
+
+	var annotationStep string
+	for _, step := range workflow.Jobs["build"].Steps {
+		if step.Name == "Record chart image annotations" {
+			annotationStep = step.Run
+			break
+		}
+	}
+	if annotationStep == "" {
+		t.Fatal("build workflow has no image annotation step")
+	}
+	for _, required := range []string{
+		"--artifacthub-out /tmp/artifacthub-images.yaml",
+		`.annotations."camunda.io/chart-images"`,
+		`.annotations."artifacthub.io/images"`,
+	} {
+		if !strings.Contains(annotationStep, required) {
+			t.Errorf("image annotation step missing %q", required)
+		}
 	}
 }

--- a/scripts/release-tools/go.mod
+++ b/scripts/release-tools/go.mod
@@ -2,7 +2,10 @@ module scripts/release-tools
 
 go 1.25.0
 
-require scripts/camunda-core v0.0.0
+require (
+	gopkg.in/yaml.v3 v3.0.1
+	scripts/camunda-core v0.0.0
+)
 
 require (
 	github.com/jwalton/gchalk v1.3.0 // indirect
@@ -12,7 +15,6 @@ require (
 	github.com/rs/zerolog v1.35.1 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace scripts/camunda-core => ../camunda-core

--- a/scripts/release-tools/main.go
+++ b/scripts/release-tools/main.go
@@ -33,7 +33,7 @@ func main() {
 	var err error
 	switch sub := os.Args[1]; sub {
 	case "chart-images":
-		err = runChartImages(os.Args[2:])
+		err = runChartImages(os.Args[2:], os.Stdout)
 	case "update-matrix":
 		err = runUpdateMatrix(os.Args[2:])
 	case "resolve-tag":


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6758.

Artifact Hub extracts Helm chart images from a default-values render. Since 8.8, that omits optional components; for 8.9, the required secondary-storage choice prevents the default render entirely.

### What's in this PR?

The release-ready build now publishes the complete standard image inventory through `artifacthub.io/images`. The Artifact Hub payload is generated from the same finalized image set as the publication-neutral `camunda.io/chart-images` artifact contract, after image overrides and dependency vendoring.

RC promotion, release notes, and version-matrix generation continue to consume `camunda.io/chart-images`, so existing Harbor artifacts remain compatible and publication-specific metadata stays at the build boundary.

Validation:

- 378 affected-module tests, plus focused release-tooling and workflow-contract tests
- `go vet` for `camunda-core/pkg/chartmeta` and `release-tools`
- tracked-file `gofmt`, `git diff --check`, and `actionlint`
- exact internal/Artifact Hub image parity for charts 8.7, 8.8, 8.9, and 8.10
- [Pipeline 1 Build Dev run](https://github.com/camunda/camunda-platform-helm/actions/runs/30798107913) succeeded on exact head `9559024bd1702f73145400498e32945bd63e5cab` with the orchestration image override
- Harbor artifact `14.8.1-dev-9559024` contains 12 matching images in both annotations, records `orchestration: 8.9.13` in `camunda.io/imageOverrides`, and includes optional components plus bundled dependencies
- no Pipeline 2 or Pipeline 3 workflow was dispatched
- `crev` completed with no verified findings

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->