### PR TITLE
test: add multi-optimize reference values for Camunda 8.10

### DIFF
--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/multi-optimize/values-optimize-only.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/multi-optimize/values-optimize-only.yaml
@@ -1,0 +1,67 @@
+---
+global:
+  host: camunda.example.com
+  ingress:
+    enabled: true
+    className: nginx
+    tls:
+      enabled: true
+      secretName: camunda-platform-tls
+  elasticsearch:
+    enabled: false
+  identity:
+    service:
+      url: "http://platform-identity:80/identity"
+    keycloak:
+      url:
+        protocol: http
+        host: keycloak
+        port: "80"
+      contextPath: /auth/
+      realm: /realms/camunda-platform
+    auth:
+      enabled: true
+      type: KEYCLOAK
+      issuerBackendUrl: >-
+        http://keycloak:80/auth/realms/camunda-platform
+      publicIssuerUrl: >-
+        https://camunda.example.com/auth/realms/camunda-platform
+      optimize:
+        clientId: optimize-team-b
+        redirectUrl: "https://camunda.example.com/optimize-team-b"
+        secret:
+          existingSecret: multi-optimize-credentials
+          existingSecretKey: optimize-team-b-client-secret
+  security:
+    authentication:
+      method: oidc
+
+identity:
+  enabled: false
+
+camundaHub:
+  enabled: false
+
+webModeler:
+  enabled: false
+
+connectors:
+  enabled: false
+
+orchestration:
+  enabled: false
+
+optimize:
+  enabled: true
+  contextPath: /optimize-team-b
+  database:
+    elasticsearch:
+      enabled: true
+      external: true
+      url:
+        protocol: http
+        host: elasticsearch-master
+        port: 9200
+  env:
+    - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_PREFIX
+      value: optimize-team-b

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/multi-optimize/values-optimize-only.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/multi-optimize/values-optimize-only.yaml
@@ -27,7 +27,7 @@ global:
       publicIssuerUrl: >-
         https://camunda.example.com/auth/realms/camunda-platform
       optimize:
-        clientId: optimize-team-b
+        clientId: optimize_team_b
         redirectUrl: "https://camunda.example.com/optimize-team-b"
         secret:
           existingSecret: multi-optimize-credentials

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/multi-optimize/values-platform.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/multi-optimize/values-platform.yaml
@@ -1,0 +1,123 @@
+---
+global:
+  host: camunda.example.com
+  ingress:
+    enabled: true
+    className: nginx
+    tls:
+      enabled: true
+      secretName: camunda-platform-tls
+  elasticsearch:
+    enabled: false
+  identity:
+    service:
+      url: "http://platform-identity:80/identity"
+    keycloak:
+      internal: true
+      url:
+        protocol: http
+        host: keycloak
+        port: "80"
+      contextPath: /auth/
+      realm: /realms/camunda-platform
+      auth:
+        adminUser: admin
+        secret:
+          existingSecret: multi-optimize-credentials
+          existingSecretKey: keycloak-admin-password
+    auth:
+      enabled: true
+      type: KEYCLOAK
+      issuerBackendUrl: >-
+        http://keycloak:80/auth/realms/camunda-platform
+      publicIssuerUrl: >-
+        https://camunda.example.com/auth/realms/camunda-platform
+      camundaHub:
+        redirectUrl: "https://camunda.example.com/modeler"
+      optimize:
+        clientId: optimize-team-a
+        redirectUrl: "https://camunda.example.com/optimize-team-a"
+        secret:
+          existingSecret: multi-optimize-credentials
+          existingSecretKey: optimize-team-a-client-secret
+  security:
+    authentication:
+      method: oidc
+
+identity:
+  enabled: true
+  contextPath: /identity
+  firstUser:
+    secret:
+      existingSecret: multi-optimize-credentials
+      existingSecretKey: identity-first-user-password
+  clients:
+    - id: optimize-team-b
+      name: Optimize Team B
+      type: confidential
+      secret:
+        existingSecret: multi-optimize-credentials
+        existingSecretKey: optimize-team-b-client-secret
+      rootUrl: "https://camunda.example.com/optimize-team-b"
+      redirectUris: /api/authentication/callback
+      permissions:
+        - resourceServerId: optimize-api
+          definition: write:*
+        - resourceServerId: camunda-identity-resource-server
+          definition: read:users
+
+camundaHub:
+  enabled: true
+  contextPath: /modeler
+  restapi:
+    mail:
+      fromAddress: noreply@example.com
+    pusher:
+      secret:
+        existingSecret: multi-optimize-credentials
+        existingSecretKey: web-modeler-pusher-app-secret
+      client:
+        secret:
+          existingSecret: multi-optimize-credentials
+          existingSecretKey: web-modeler-pusher-app-key
+
+connectors:
+  enabled: true
+  contextPath: /connectors
+  security:
+    authentication:
+      oidc:
+        secret:
+          existingSecret: multi-optimize-credentials
+          existingSecretKey: connectors-client-secret
+
+orchestration:
+  enabled: true
+  contextPath: /orchestration
+  security:
+    authentication:
+      oidc:
+        redirectUrl: "https://camunda.example.com/orchestration"
+        secret:
+          existingSecret: multi-optimize-credentials
+          existingSecretKey: orchestration-client-secret
+  data:
+    secondaryStorage:
+      type: elasticsearch
+      elasticsearch:
+        url: "http://elasticsearch-master:9200"
+
+optimize:
+  enabled: true
+  contextPath: /optimize-team-a
+  database:
+    elasticsearch:
+      enabled: true
+      external: true
+      url:
+        protocol: http
+        host: elasticsearch-master
+        port: 9200
+  env:
+    - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_PREFIX
+      value: optimize-team-a

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/multi-optimize/values-platform.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/features/multi-optimize/values-platform.yaml
@@ -52,7 +52,7 @@ identity:
       existingSecret: multi-optimize-credentials
       existingSecretKey: identity-first-user-password
   clients:
-    - id: optimize-team-b
+    - id: optimize_team_b
       name: Optimize Team B
       type: confidential
       secret:

--- a/charts/camunda-platform-8.10/test/unit/common/multi_optimize_reference_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/multi_optimize_reference_test.go
@@ -66,8 +66,8 @@ func (s *MultiOptimizeReferenceTemplateTest) TestPlatformReleaseRegistersSecondO
 				helm.UnmarshalK8SYaml(t, output, &configMap)
 				application := configMap.Data["application.yaml"]
 
-				s.Require().Contains(application, "id: optimize-team-b")
-				s.Require().Contains(application, "secret: ${VALUES_OPTIMIZE-TEAM-B_CLIENT_SECRET:}")
+				s.Require().Contains(application, "id: optimize_team_b")
+				s.Require().Contains(application, "secret: ${VALUES_OPTIMIZE_TEAM_B_CLIENT_SECRET:}")
 				s.Require().Contains(application, "redirectUris: /api/authentication/callback")
 				s.Require().Contains(application, "rootUrl: https://camunda.example.com/optimize-team-b")
 				s.Require().Contains(application, "resourceServerId: optimize-api")
@@ -85,7 +85,7 @@ func (s *MultiOptimizeReferenceTemplateTest) TestPlatformReleaseRegistersSecondO
 
 				var deployment appsv1.Deployment
 				helm.UnmarshalK8SYaml(t, output, &deployment)
-				secretEnv := findEnvVar(deployment.Spec.Template.Spec.Containers[0].Env, "VALUES_OPTIMIZE-TEAM-B_CLIENT_SECRET")
+				secretEnv := findEnvVar(deployment.Spec.Template.Spec.Containers[0].Env, "VALUES_OPTIMIZE_TEAM_B_CLIENT_SECRET")
 
 				s.Require().NotNil(secretEnv.ValueFrom)
 				s.Require().NotNil(secretEnv.ValueFrom.SecretKeyRef)
@@ -155,7 +155,7 @@ func (s *MultiOptimizeReferenceTemplateTest) TestOptimizeOnlyRelease() {
 				s.Require().Contains(configuration, `contextPath: "/optimize-team-b"`)
 				s.Require().Contains(configuration, `host: "elasticsearch-master"`)
 				s.Require().Contains(configuration, `redirectRootUrl: "https://camunda.example.com/optimize-team-b"`)
-				s.Require().Contains(authConfiguration, `clientId: "optimize-team-b"`)
+				s.Require().Contains(authConfiguration, `clientId: "optimize_team_b"`)
 			},
 		},
 		{

--- a/charts/camunda-platform-8.10/test/unit/common/multi_optimize_reference_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/multi_optimize_reference_test.go
@@ -1,0 +1,262 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package camunda
+
+import (
+	"camunda-platform/test/unit/testhelpers"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+type MultiOptimizeReferenceTemplateTest struct {
+	suite.Suite
+	chartPath          string
+	platformValues     string
+	optimizeOnlyValues string
+}
+
+func TestMultiOptimizeReferenceTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../")
+	require.NoError(t, err)
+
+	valuesPath := filepath.Join(chartPath, "test/integration/scenarios/chart-full-setup/values/features/multi-optimize")
+	suite.Run(t, &MultiOptimizeReferenceTemplateTest{
+		chartPath:          chartPath,
+		platformValues:     filepath.Join(valuesPath, "values-platform.yaml"),
+		optimizeOnlyValues: filepath.Join(valuesPath, "values-optimize-only.yaml"),
+	})
+}
+
+func (s *MultiOptimizeReferenceTemplateTest) TestPlatformReleaseRegistersSecondOptimize() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name:        "TestIdentityClientConfiguration",
+			Template:    "templates/identity/configmap.yaml",
+			Values:      map[string]string{"global.elasticsearch.enabled": "false"},
+			ValuesFiles: []string{s.platformValues},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+
+				var configMap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(t, output, &configMap)
+				application := configMap.Data["application.yaml"]
+
+				s.Require().Contains(application, "id: optimize-team-b")
+				s.Require().Contains(application, "secret: ${VALUES_OPTIMIZE-TEAM-B_CLIENT_SECRET:}")
+				s.Require().Contains(application, "redirectUris: /api/authentication/callback")
+				s.Require().Contains(application, "rootUrl: https://camunda.example.com/optimize-team-b")
+				s.Require().Contains(application, "resourceServerId: optimize-api")
+				s.Require().Contains(application, "resourceServerId: camunda-identity-resource-server")
+				s.Require().Contains(application, `root-url: "https://camunda.example.com/modeler"`)
+			},
+		},
+		{
+			Name:        "TestIdentityClientSecretReference",
+			Template:    "templates/identity/deployment.yaml",
+			Values:      map[string]string{"global.elasticsearch.enabled": "false"},
+			ValuesFiles: []string{s.platformValues},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(t, output, &deployment)
+				secretEnv := findEnvVar(deployment.Spec.Template.Spec.Containers[0].Env, "VALUES_OPTIMIZE-TEAM-B_CLIENT_SECRET")
+
+				s.Require().NotNil(secretEnv.ValueFrom)
+				s.Require().NotNil(secretEnv.ValueFrom.SecretKeyRef)
+				s.Require().Equal("multi-optimize-credentials", secretEnv.ValueFrom.SecretKeyRef.Name)
+				s.Require().Equal("optimize-team-b-client-secret", secretEnv.ValueFrom.SecretKeyRef.Key)
+			},
+		},
+		{
+			Name:        "TestPlatformOptimizeDeployment",
+			Template:    "templates/optimize/deployment.yaml",
+			Values:      map[string]string{"global.elasticsearch.enabled": "false"},
+			ValuesFiles: []string{s.platformValues},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(t, output, &deployment)
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+
+				s.Require().Equal("elasticsearch-master", findEnvVar(env, "OPTIMIZE_ELASTICSEARCH_HOST").Value)
+				s.Require().Equal("optimize-team-a", findEnvVar(env, "CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_PREFIX").Value)
+
+				clientSecret := findEnvVar(env, "CAMUNDA_IDENTITY_CLIENT_SECRET")
+				s.Require().NotNil(clientSecret.ValueFrom)
+				s.Require().NotNil(clientSecret.ValueFrom.SecretKeyRef)
+				s.Require().Equal("multi-optimize-credentials", clientSecret.ValueFrom.SecretKeyRef.Name)
+				s.Require().Equal("optimize-team-a-client-secret", clientSecret.ValueFrom.SecretKeyRef.Key)
+			},
+		},
+		{
+			Name:        "TestPlatformIngress",
+			Template:    "templates/common/ingress-http.yaml",
+			Values:      map[string]string{"global.elasticsearch.enabled": "false"},
+			ValuesFiles: []string{s.platformValues},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+
+				var ingress netv1.Ingress
+				helm.UnmarshalK8SYaml(t, output, &ingress)
+				backends := ingressBackends(ingress)
+
+				s.Require().Equal("keycloak", backends["/auth/"])
+				s.Require().Equal("platform-identity", backends["/identity"])
+				s.Require().Equal("platform-optimize", backends["/optimize-team-a"])
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, "platform", "multi-optimize-reference", nil, testCases)
+}
+
+func (s *MultiOptimizeReferenceTemplateTest) TestOptimizeOnlyRelease() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name:        "TestOptimizeConfiguration",
+			Template:    "templates/optimize/configmap.yaml",
+			Values:      map[string]string{"global.elasticsearch.enabled": "false"},
+			ValuesFiles: []string{s.optimizeOnlyValues},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+
+				var configMap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(t, output, &configMap)
+				configuration := configMap.Data["environment-config.yaml"]
+				authConfiguration := configMap.Data["application-ccsm.yaml"]
+
+				s.Require().Contains(configuration, `contextPath: "/optimize-team-b"`)
+				s.Require().Contains(configuration, `host: "elasticsearch-master"`)
+				s.Require().Contains(configuration, `redirectRootUrl: "https://camunda.example.com/optimize-team-b"`)
+				s.Require().Contains(authConfiguration, `clientId: "optimize-team-b"`)
+			},
+		},
+		{
+			Name:        "TestIdentityServiceConfiguration",
+			Template:    "templates/common/configmap-identity-auth.yaml",
+			Values:      map[string]string{"global.elasticsearch.enabled": "false"},
+			ValuesFiles: []string{s.optimizeOnlyValues},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+
+				var configMap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(t, output, &configMap)
+				s.Require().Equal("http://platform-identity:80/identity", configMap.Data["CAMUNDA_IDENTITY_BASEURL"])
+				s.Require().Equal("http://keycloak:80/auth/realms/camunda-platform", configMap.Data["CAMUNDA_IDENTITY_ISSUER_BACKEND_URL"])
+			},
+		},
+		{
+			Name:        "TestOptimizeDeployment",
+			Template:    "templates/optimize/deployment.yaml",
+			Values:      map[string]string{"global.elasticsearch.enabled": "false"},
+			ValuesFiles: []string{s.optimizeOnlyValues},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(t, output, &deployment)
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+
+				s.Require().Equal("elasticsearch-master", findEnvVar(env, "OPTIMIZE_ELASTICSEARCH_HOST").Value)
+				s.Require().Equal("optimize-team-b", findEnvVar(env, "CAMUNDA_OPTIMIZE_ELASTICSEARCH_SETTINGS_INDEX_PREFIX").Value)
+
+				clientSecret := findEnvVar(env, "CAMUNDA_IDENTITY_CLIENT_SECRET")
+				s.Require().NotNil(clientSecret.ValueFrom)
+				s.Require().NotNil(clientSecret.ValueFrom.SecretKeyRef)
+				s.Require().Equal("multi-optimize-credentials", clientSecret.ValueFrom.SecretKeyRef.Name)
+				s.Require().Equal("optimize-team-b-client-secret", clientSecret.ValueFrom.SecretKeyRef.Key)
+			},
+		},
+		{
+			Name:        "TestOptimizeIngress",
+			Template:    "templates/common/ingress-http.yaml",
+			Values:      map[string]string{"global.elasticsearch.enabled": "false"},
+			ValuesFiles: []string{s.optimizeOnlyValues},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+
+				var ingress netv1.Ingress
+				helm.UnmarshalK8SYaml(t, output, &ingress)
+				s.Require().Equal("camunda.example.com", ingress.Spec.Rules[0].Host)
+				s.Require().Len(ingress.Spec.Rules[0].HTTP.Paths, 1)
+				s.Require().Equal("/optimize-team-b", ingress.Spec.Rules[0].HTTP.Paths[0].Path)
+				s.Require().Equal("optimize-team-b", ingress.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Name)
+			},
+		},
+		{
+			Name:        "TestOnlyOptimizeWorkloadRenders",
+			Values:      map[string]string{"global.elasticsearch.enabled": "false"},
+			ValuesFiles: []string{s.optimizeOnlyValues},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				s.Require().Equal([]string{"optimize-team-b"}, workloadNames(t, output))
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, "optimize-team-b", "multi-optimize-reference", nil, testCases)
+}
+
+func findEnvVar(env []corev1.EnvVar, name string) corev1.EnvVar {
+	for _, envVar := range env {
+		if envVar.Name == name {
+			return envVar
+		}
+	}
+
+	return corev1.EnvVar{}
+}
+
+func ingressBackends(ingress netv1.Ingress) map[string]string {
+	backends := map[string]string{}
+	for _, path := range ingress.Spec.Rules[0].HTTP.Paths {
+		backends[path.Path] = path.Backend.Service.Name
+	}
+	return backends
+}
+
+func workloadNames(t *testing.T, output string) []string {
+	decoder := yaml.NewYAMLOrJSONDecoder(strings.NewReader(output), 4096)
+	workloads := []string{}
+
+	for {
+		var object unstructured.Unstructured
+		err := decoder.Decode(&object)
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		if object.GetKind() == "Deployment" || object.GetKind() == "StatefulSet" {
+			workloads = append(workloads, object.GetName())
+		}
+	}
+
+	return workloads
+}


### PR DESCRIPTION
### Which problem does the PR fix?

Closes https://github.com/camunda/camunda-platform-helm/issues/6760.

Related documentation task: https://github.com/camunda/camunda-platform-helm/issues/6239.

Companion documentation PR: https://github.com/camunda/camunda-docs/pull/9531

### What's in this PR?

Adds two tested Camunda 8.10 reference values files for running a platform release and an Optimize-only release in the same namespace. The second release shares Elasticsearch, Keycloak, and Management Identity with the platform release while using a distinct OIDC client, context path, client secret, and Optimize index prefix.

Validation:

- `go test ./common -run '^TestMultiOptimizeReferenceTemplate$'`: passed.
- `make go.fmt`: passed.
- `yamllint <values-platform.yaml> <values-optimize-only.yaml>`: passed.
- `addlicense -check -l apache charts/camunda-platform-8.10/test/unit/common/multi_optimize_reference_test.go`: passed.
- `make helm.lint chartPath=charts/camunda-platform-8.10`: passed.
- `make go.test chartPath=charts/camunda-platform-8.10`: passed.
- `make go.update-golden-only chartPath=charts/camunda-platform-8.10`: passed with no generated diff.

Live GKE verification used the existing 8.10 Elasticsearch/Keycloak matrix topology, then installed the two reference configurations as separate Helm releases. Both Optimize pods were ready, both same-host ingress paths authenticated with their intended client IDs in fresh browser contexts, a process instance completed, and both `optimize-team-a-*` and `optimize-team-b-*` index families contained documents for that process. The unique namespace was deleted afterward.

- `deploy-camunda matrix run --versions 8.10 --shortname-filter eske --shortname-exact --flow-filter install --platform gke ...`: passed (`1/1` matrix entry).
- `helm upgrade integration ... -f values-platform.yaml --wait`: deployed revision 2; all platform and companion pods ready.
- `helm install optimize-team-b ... -f values-optimize-only.yaml --wait`: deployed; exactly one workload (`Deployment/optimize-team-b`) ready.
- OIDC redirect and fresh Chromium login checks: `optimize-team-a` and `optimize-team-b` each authenticated with its intended `client_id` and context path.
- `POST /orchestration/v2/deployments` and `POST /orchestration/v2/process-instances`: process deployed and completed.
- Elasticsearch `_search` across `optimize-team-a-*` and `optimize-team-b-*`: two matching process documents in each index family.
- `kubectl delete namespace issue6239multiopt20260803-810-eske-inst-gke --wait=true`: cleanup completed.

A fresh independent verifier reported no material documentation findings after checking the final guide against the current 8.10 chart.

`crev https://github.com/camunda/camunda-platform-helm/pull/6761` completed successfully. It found no hard-rule, security, cross-version, or scope violations. Its one P2 recommendation was continuous composed-runtime coverage; that broader matrix-runner work is tracked separately in #6762, while this PR retains the scoped rendering tests and completed live GKE verification required by #6760.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
