### PR TITLE
fix: gate OpenSearch password env vars on effective backend

### DIFF
--- a/charts/camunda-platform-8.10/templates/orchestration/statefulset.yaml
+++ b/charts/camunda-platform-8.10/templates/orchestration/statefulset.yaml
@@ -150,7 +150,8 @@ spec:
                 "config" .Values.global.opensearch.auth
             ) | nindent 12 }}
             {{- end }}
-            {{- if (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.orchestration.data.secondaryStorage.opensearch.auth)) "true") }}
+            {{- $hasOpenSearchConsumer := or (eq (include "orchestration.secondaryStorage" .) "opensearch") (eq (include "orchestration.hasLegacyOpenSearchExporter" .) "true") }}
+            {{- if and $hasOpenSearchConsumer (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.orchestration.data.secondaryStorage.opensearch.auth)) "true") }}
             {{- include "camundaPlatform.emitEnvVarFromSecretConfig" (dict
                 "envName" "VALUES_OPENSEARCH_PASSWORD"
                 "config" .Values.orchestration.data.secondaryStorage.opensearch.auth

--- a/charts/camunda-platform-8.10/templates/orchestration/statefulset.yaml
+++ b/charts/camunda-platform-8.10/templates/orchestration/statefulset.yaml
@@ -150,7 +150,13 @@ spec:
                 "config" .Values.global.opensearch.auth
             ) | nindent 12 }}
             {{- end }}
-            {{- $hasOpenSearchConsumer := or (eq (include "orchestration.secondaryStorage" .) "opensearch") (eq (include "orchestration.hasLegacyOpenSearchExporter" .) "true") }}
+            {{- $hasOpenSearchConsumer := or
+              (eq (include "orchestration.secondaryStorage" .) "opensearch")
+              (and
+                (ne (include "orchestration.hasLegacyElasticsearchExporter" .) "true")
+                (eq (include "orchestration.hasLegacyOpenSearchExporter" .) "true")
+              )
+            -}}
             {{- if and $hasOpenSearchConsumer (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.orchestration.data.secondaryStorage.opensearch.auth)) "true") }}
             {{- include "camundaPlatform.emitEnvVarFromSecretConfig" (dict
                 "envName" "VALUES_OPENSEARCH_PASSWORD"

--- a/charts/camunda-platform-8.10/test/unit/orchestration/statefulset_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/statefulset_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -960,12 +961,33 @@ func (s *StatefulSetTest) TestDifferentValuesInputs() {
 }
 
 func (s *StatefulSetTest) TestOpenSearchPasswordEnv() {
-	verifyOpenSearchPasswordEnv := func(expected ...corev1.EnvVar) func(t *testing.T, output string, err error) {
+	const (
+		legacyElasticsearchExporterClass = "io.camunda.zeebe.exporter.ElasticsearchExporter"
+		legacyOpenSearchExporterClass    = "io.camunda.zeebe.exporter.opensearch.OpensearchExporter"
+	)
+
+	verifyOpenSearchPasswordEnv := func(expectedExporterClass, unexpectedExporterClass string, expected ...corev1.EnvVar) func(t *testing.T, output string, err error) {
 		return func(t *testing.T, output string, err error) {
 			require.NoError(t, err)
 
 			var statefulSet appsv1.StatefulSet
-			helm.UnmarshalK8SYaml(t, output, &statefulSet)
+			var configMap corev1.ConfigMap
+			for _, manifest := range strings.Split(output, "---") {
+				if strings.TrimSpace(manifest) == "" {
+					continue
+				}
+
+				var renderedObject struct {
+					Kind string `yaml:"kind"`
+				}
+				require.NoError(t, yaml.Unmarshal([]byte(manifest), &renderedObject))
+				switch renderedObject.Kind {
+				case "ConfigMap":
+					helm.UnmarshalK8SYaml(t, manifest, &configMap)
+				case "StatefulSet":
+					helm.UnmarshalK8SYaml(t, manifest, &statefulSet)
+				}
+			}
 			require.NotEmpty(t, statefulSet.Spec.Template.Spec.Containers)
 
 			var actual []corev1.EnvVar
@@ -975,6 +997,12 @@ func (s *StatefulSetTest) TestOpenSearchPasswordEnv() {
 				}
 			}
 			require.Equal(t, expected, actual)
+			if expectedExporterClass != "" {
+				require.Contains(t, configMap.Data["application.yaml"], expectedExporterClass)
+			}
+			if unexpectedExporterClass != "" {
+				require.NotContains(t, configMap.Data["application.yaml"], unexpectedExporterClass)
+			}
 		}
 	}
 
@@ -988,22 +1016,32 @@ func (s *StatefulSetTest) TestOpenSearchPasswordEnv() {
 				"orchestration.data.secondaryStorage.type":                                "opensearch",
 				"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "orchestration-password",
 			},
-			Verifier: verifyOpenSearchPasswordEnv(corev1.EnvVar{Name: "VALUES_OPENSEARCH_PASSWORD", Value: "orchestration-password"}),
+			Verifier: verifyOpenSearchPasswordEnv("", "", corev1.EnvVar{Name: "VALUES_OPENSEARCH_PASSWORD", Value: "orchestration-password"}),
 		},
 		{
 			Name: "Optimize OpenSearch legacy exporter retains component password",
+			CaseTemplates: &testhelpers.CaseTemplate{Templates: []string{
+				"templates/orchestration/configmap.yaml",
+				"templates/orchestration/statefulset.yaml",
+			}},
 			Values: map[string]string{
+				"global.elasticsearch.enabled":                                            "false",
 				"optimize.enabled":                                                        "true",
 				"optimize.database.elasticsearch.enabled":                                 "false",
 				"optimize.database.opensearch.enabled":                                    "true",
 				"orchestration.data.secondaryStorage.type":                                "elasticsearch",
 				"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "orchestration-password",
 			},
-			Verifier: verifyOpenSearchPasswordEnv(corev1.EnvVar{Name: "VALUES_OPENSEARCH_PASSWORD", Value: "orchestration-password"}),
+			Verifier: verifyOpenSearchPasswordEnv(legacyOpenSearchExporterClass, legacyElasticsearchExporterClass, corev1.EnvVar{Name: "VALUES_OPENSEARCH_PASSWORD", Value: "orchestration-password"}),
 		},
 		{
 			Name: "Optimize OpenSearch legacy exporter retains component secret reference",
+			CaseTemplates: &testhelpers.CaseTemplate{Templates: []string{
+				"templates/orchestration/configmap.yaml",
+				"templates/orchestration/statefulset.yaml",
+			}},
 			Values: map[string]string{
+				"global.elasticsearch.enabled":                                                 "false",
 				"optimize.enabled":                                                             "true",
 				"optimize.database.elasticsearch.enabled":                                      "false",
 				"optimize.database.opensearch.enabled":                                         "true",
@@ -1011,13 +1049,29 @@ func (s *StatefulSetTest) TestOpenSearchPasswordEnv() {
 				"orchestration.data.secondaryStorage.opensearch.auth.secret.existingSecret":    "orchestration-secret",
 				"orchestration.data.secondaryStorage.opensearch.auth.secret.existingSecretKey": "password",
 			},
-			Verifier: verifyOpenSearchPasswordEnv(corev1.EnvVar{
+			Verifier: verifyOpenSearchPasswordEnv(legacyOpenSearchExporterClass, legacyElasticsearchExporterClass, corev1.EnvVar{
 				Name: "VALUES_OPENSEARCH_PASSWORD",
 				ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{Name: "orchestration-secret"},
 					Key:                  "password",
 				}},
 			}),
+		},
+		{
+			Name: "Elasticsearch exporter precedence omits configured OpenSearch password",
+			CaseTemplates: &testhelpers.CaseTemplate{Templates: []string{
+				"templates/orchestration/configmap.yaml",
+				"templates/orchestration/statefulset.yaml",
+			}},
+			Values: map[string]string{
+				"global.elasticsearch.enabled":                                            "true",
+				"optimize.enabled":                                                        "true",
+				"optimize.database.elasticsearch.enabled":                                 "false",
+				"optimize.database.opensearch.enabled":                                    "true",
+				"orchestration.data.secondaryStorage.type":                                "elasticsearch",
+				"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "component-password",
+			},
+			Verifier: verifyOpenSearchPasswordEnv(legacyElasticsearchExporterClass, legacyOpenSearchExporterClass),
 		},
 		{
 			Name: "Orchestration Elasticsearch omits configured OpenSearch password",
@@ -1028,7 +1082,7 @@ func (s *StatefulSetTest) TestOpenSearchPasswordEnv() {
 				"orchestration.data.secondaryStorage.type":                                "elasticsearch",
 				"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "component-password",
 			},
-			Verifier: verifyOpenSearchPasswordEnv(),
+			Verifier: verifyOpenSearchPasswordEnv("", ""),
 		},
 		{
 			Name: "Disabled Optimize OpenSearch omits configured password",
@@ -1039,7 +1093,7 @@ func (s *StatefulSetTest) TestOpenSearchPasswordEnv() {
 				"optimize.database.opensearch.auth.secret.inlineSecret": "optimize-password",
 				"orchestration.data.secondaryStorage.type":              "elasticsearch",
 			},
-			Verifier: verifyOpenSearchPasswordEnv(),
+			Verifier: verifyOpenSearchPasswordEnv("", ""),
 		},
 	}
 

--- a/charts/camunda-platform-8.10/test/unit/orchestration/statefulset_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/statefulset_test.go
@@ -959,6 +959,93 @@ func (s *StatefulSetTest) TestDifferentValuesInputs() {
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
 
+func (s *StatefulSetTest) TestOpenSearchPasswordEnv() {
+	verifyOpenSearchPasswordEnv := func(expected ...corev1.EnvVar) func(t *testing.T, output string, err error) {
+		return func(t *testing.T, output string, err error) {
+			require.NoError(t, err)
+
+			var statefulSet appsv1.StatefulSet
+			helm.UnmarshalK8SYaml(t, output, &statefulSet)
+			require.NotEmpty(t, statefulSet.Spec.Template.Spec.Containers)
+
+			var actual []corev1.EnvVar
+			for _, envVar := range statefulSet.Spec.Template.Spec.Containers[0].Env {
+				if envVar.Name == "VALUES_OPENSEARCH_PASSWORD" {
+					actual = append(actual, envVar)
+				}
+			}
+			require.Equal(t, expected, actual)
+		}
+	}
+
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "Orchestration OpenSearch emits the configured password",
+			Values: map[string]string{
+				"optimize.enabled":                                                        "false",
+				"optimize.database.elasticsearch.enabled":                                 "false",
+				"optimize.database.opensearch.enabled":                                    "false",
+				"orchestration.data.secondaryStorage.type":                                "opensearch",
+				"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "orchestration-password",
+			},
+			Verifier: verifyOpenSearchPasswordEnv(corev1.EnvVar{Name: "VALUES_OPENSEARCH_PASSWORD", Value: "orchestration-password"}),
+		},
+		{
+			Name: "Optimize OpenSearch legacy exporter retains component password",
+			Values: map[string]string{
+				"optimize.enabled":                                                        "true",
+				"optimize.database.elasticsearch.enabled":                                 "false",
+				"optimize.database.opensearch.enabled":                                    "true",
+				"orchestration.data.secondaryStorage.type":                                "elasticsearch",
+				"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "orchestration-password",
+			},
+			Verifier: verifyOpenSearchPasswordEnv(corev1.EnvVar{Name: "VALUES_OPENSEARCH_PASSWORD", Value: "orchestration-password"}),
+		},
+		{
+			Name: "Optimize OpenSearch legacy exporter retains component secret reference",
+			Values: map[string]string{
+				"optimize.enabled":                                                             "true",
+				"optimize.database.elasticsearch.enabled":                                      "false",
+				"optimize.database.opensearch.enabled":                                         "true",
+				"orchestration.data.secondaryStorage.type":                                     "elasticsearch",
+				"orchestration.data.secondaryStorage.opensearch.auth.secret.existingSecret":    "orchestration-secret",
+				"orchestration.data.secondaryStorage.opensearch.auth.secret.existingSecretKey": "password",
+			},
+			Verifier: verifyOpenSearchPasswordEnv(corev1.EnvVar{
+				Name: "VALUES_OPENSEARCH_PASSWORD",
+				ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "orchestration-secret"},
+					Key:                  "password",
+				}},
+			}),
+		},
+		{
+			Name: "Orchestration Elasticsearch omits configured OpenSearch password",
+			Values: map[string]string{
+				"optimize.enabled":                                                        "false",
+				"optimize.database.elasticsearch.enabled":                                 "false",
+				"optimize.database.opensearch.enabled":                                    "false",
+				"orchestration.data.secondaryStorage.type":                                "elasticsearch",
+				"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "component-password",
+			},
+			Verifier: verifyOpenSearchPasswordEnv(),
+		},
+		{
+			Name: "Disabled Optimize OpenSearch omits configured password",
+			Values: map[string]string{
+				"optimize.enabled":                                      "false",
+				"optimize.database.elasticsearch.enabled":               "false",
+				"optimize.database.opensearch.enabled":                  "true",
+				"optimize.database.opensearch.auth.secret.inlineSecret": "optimize-password",
+				"orchestration.data.secondaryStorage.type":              "elasticsearch",
+			},
+			Verifier: verifyOpenSearchPasswordEnv(),
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
 func (s *StatefulSetTest) TestWithJKSSecretReference() {
 	testCases := []testhelpers.TestCase{
 		{


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6740.

This is the current-value chart bug exposed by the investigation in camunda/self-managed-experience#4.

### What's in this PR?

The 8.10 Orchestration StatefulSet now gates the existing component-scoped `VALUES_OPENSEARCH_PASSWORD` emission on an effective OpenSearch consumer: OpenSearch secondary storage or the legacy OpenSearch exporter. Configured component OpenSearch credentials no longer leak into an Elasticsearch-only deployment.

The change deliberately preserves the existing generic variable, credential precedence, connection-source behavior, and deprecated global branch. Distinct concurrent OpenSearch consumers are a separately reproduced defect tracked by #6773, and the 8.9 counterpart is owned by #6772 / #6774.

Focused tests cover current component-scoped secondary OpenSearch, the active legacy exporter with current component inline and existing-secret credentials, configured inactive component credentials, and disabled Optimize. Every backend fixture sets current competing Optimize flags explicitly. No 8.10 test supplies a value deprecated in 8.9.

The original deprecated-global reproduction is explicitly owned by mandatory pre-GA removal in #6766. It is not carried into this PR or its tests because the controlling deprecation policy forbids values deprecated in 8.9 from appearing in 8.10 tests.

Validated with the complete 8.10 chart-scoped Go suite, matrix tests, golden regeneration, Helm lint, Go formatting, changed-file license checks, and direct inactive component rendering. Regeneration produces no tracked snapshot changes.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
