### PR TITLE
test: execute declared Helm unit test assertions

### DIFF
--- a/charts/camunda-platform-8.10/go.mod
+++ b/charts/camunda-platform-8.10/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.36.2
+	k8s.io/client-go v0.36.2
 )
 
 require k8s.io/apimachinery v0.36.2
@@ -117,7 +118,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	k8s.io/client-go v0.36.2 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/streaming v0.36.2 // indirect

--- a/charts/camunda-platform-8.10/test/unit/common/configmap_warnings_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/configmap_warnings_test.go
@@ -73,11 +73,7 @@ func (s *ConfigMapWarningsTemplateTest) TestDifferentValuesInputs() {
 		},
 		{
 			Name: "TestWarningsConfigMapAbsentWhenNoWarnings",
-			// global.elasticsearch.enabled=false avoids the legacy-option deprecation warning
-			// (the test helper otherwise defaults it to true); the new secondaryStorage key
-			// satisfies the storage-type constraint.
 			Values: map[string]string{
-				"global.elasticsearch.enabled":             "false",
 				"orchestration.data.secondaryStorage.type": "elasticsearch",
 			},
 			Verifier: func(t *testing.T, output string, err error) {

--- a/charts/camunda-platform-8.10/test/unit/common/constraints_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/constraints_test.go
@@ -442,6 +442,40 @@ func (s *ConstraintTemplateTest) TestCamundaHubConsolidationDeprecationWarningsR
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
+
+func (s *ConstraintTemplateTest) TestWebModelerExternalDatabaseUserRemovedGate() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "TestRemovedKeyFailsViaCamundaHubEnabled",
+			Values: map[string]string{
+				"orchestration.data.secondaryStorage.type": "elasticsearch",
+				"identity.enabled":                         "true",
+				"camundaHub.enabled":                       "true",
+				"webModeler.restapi.mail.fromAddress":      "noreply@example.com",
+				"webModeler.restapi.externalDatabase.user": "modeler-user",
+			},
+			Expected: map[string]string{
+				"ERROR": `The Helm values file key "webModeler.restapi.externalDatabase.user" has been removed.`,
+			},
+		},
+		{
+			Name: "TestRemovedKeyFailsViaLegacyWebModelerEnabled",
+			Values: map[string]string{
+				"orchestration.data.secondaryStorage.type": "elasticsearch",
+				"identity.enabled":                         "true",
+				"webModeler.enabled":                       "true",
+				"webModeler.restapi.mail.fromAddress":      "noreply@example.com",
+				"webModeler.restapi.externalDatabase.user": "modeler-user",
+			},
+			Expected: map[string]string{
+				"ERROR": `The Helm values file key "webModeler.restapi.externalDatabase.user" has been removed.`,
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
 func (s *ConstraintTemplateTest) TestCamundaHubWebModelerKeyRenamedGuards() {
 	testCases := []testhelpers.TestCase{
 		{

--- a/charts/camunda-platform-8.10/test/unit/common/constraints_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/constraints_test.go
@@ -105,9 +105,8 @@ func (s *ConstraintTemplateTest) TestSecondaryStorageConstraint() {
 		{
 			Name: "TestSecondaryStorageConstraintFailsWhenOrchestrationEnabledAndNoStorageConfigured",
 			Values: map[string]string{
-				"orchestration.enabled":        "true",
-				"global.elasticsearch.enabled": "false",
-				"global.opensearch.enabled":    "false",
+				"orchestration.enabled":                    "true",
+				"orchestration.data.secondaryStorage.type": "",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				s.Require().ErrorContains(err, "Please configure an expected secondary storage type under `orchestration.data.secondaryStorage.type`")
@@ -116,42 +115,38 @@ func (s *ConstraintTemplateTest) TestSecondaryStorageConstraint() {
 		{
 			Name: "TestSecondaryStorageConstraintDoesNotFireWhenOrchestrationDisabled",
 			Values: map[string]string{
-				"orchestration.enabled":        "false",
-				"global.elasticsearch.enabled": "false",
-				"global.opensearch.enabled":    "false",
+				"orchestration.enabled":                    "false",
+				"orchestration.data.secondaryStorage.type": "",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				s.Require().Nil(err)
 			},
 		},
 		{
-			Name: "TestSecondaryStorageConstraintDoesNotFireWhenElasticsearchEnabled",
-			Values: map[string]string{
-				"orchestration.enabled":        "true",
-				"global.elasticsearch.enabled": "true",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				s.Require().Nil(err)
-			},
-		},
-		{
-			Name: "TestSecondaryStorageConstraintDoesNotFireWhenOpensearchEnabled",
-			Values: map[string]string{
-				"orchestration.enabled":        "true",
-				"global.elasticsearch.enabled": "false",
-				"global.opensearch.enabled":    "true",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				s.Require().Nil(err)
-			},
-		},
-		{
-			Name: "TestSecondaryStorageConstraintDoesNotFireWhenStorageTypeExplicitlySet",
+			Name: "TestSecondaryStorageConstraintDoesNotFireForElasticsearch",
 			Values: map[string]string{
 				"orchestration.enabled":                    "true",
 				"orchestration.data.secondaryStorage.type": "elasticsearch",
-				"global.elasticsearch.enabled":             "false",
-				"global.opensearch.enabled":                "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().Nil(err)
+			},
+		},
+		{
+			Name: "TestSecondaryStorageConstraintDoesNotFireForOpenSearch",
+			Values: map[string]string{
+				"orchestration.enabled":                    "true",
+				"orchestration.data.secondaryStorage.type": "opensearch",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().Nil(err)
+			},
+		},
+		{
+			Name: "TestSecondaryStorageConstraintDoesNotFireForRDBMS",
+			Values: map[string]string{
+				"orchestration.enabled":                    "true",
+				"orchestration.data.secondaryStorage.type": "rdbms",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				s.Require().Nil(err)
@@ -289,7 +284,7 @@ func (s *ConstraintTemplateTest) TestHelmVersionConstraint() {
 // `helm template` (the framework these tests use), so warning-content
 // assertions live only in manual `helm install --dry-run` / production
 // install verification — same constraint that applies to the existing
-// global.elasticsearch.tls.secret and Bitnami subchart deprecation
+// datastore TLS secret and Bitnami subchart deprecation
 // warnings.
 func (s *ConstraintTemplateTest) TestLegacyJksTruststoreFieldsRenderWithoutCrash() {
 	testCases := []testhelpers.TestCase{
@@ -326,72 +321,6 @@ func (s *ConstraintTemplateTest) TestLegacyJksTruststoreFieldsRenderWithoutCrash
 			Name: "TestOptimizeOpensearchTlsSecretRendersOk",
 			Values: map[string]string{
 				"optimize.database.opensearch.tls.secret.existingSecret": "my-legacy-jks",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				s.Require().Nil(err)
-			},
-		},
-		{
-			// Minimal config: only existingSecret set, existingSecretKey defaults to "".
-			// Pins the round-2 P1 fix: deprecation gate must fire on existingSecret-only,
-			// not require both fields (which the old hasSecretConfig-based gate did).
-			Name: "TestGlobalElasticsearchTlsJksSecretRendersOk_ExistingSecretOnly",
-			Values: map[string]string{
-				"orchestration.data.secondaryStorage.type":           "elasticsearch",
-				"global.elasticsearch.tls.jks.secret.existingSecret": "my-jks-pw-secret",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				s.Require().Nil(err)
-			},
-		},
-		{
-			Name: "TestGlobalOpensearchTlsJksSecretRendersOk_ExistingSecretOnly",
-			Values: map[string]string{
-				"orchestration.data.secondaryStorage.type":        "opensearch",
-				"global.opensearch.tls.jks.secret.existingSecret": "my-jks-pw-secret",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				s.Require().Nil(err)
-			},
-		},
-		{
-			// Exercises the inlineSecret branch of the gate
-			// (or .secret.existingSecret .secret.inlineSecret).
-			// Both branches must fire the warning independently.
-			Name: "TestGlobalElasticsearchTlsJksSecretRendersOk_InlineSecret",
-			Values: map[string]string{
-				"orchestration.data.secondaryStorage.type":         "elasticsearch",
-				"global.elasticsearch.tls.jks.secret.inlineSecret": "changeit",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				s.Require().Nil(err)
-			},
-		},
-		{
-			Name: "TestGlobalOpensearchTlsJksSecretRendersOk_InlineSecret",
-			Values: map[string]string{
-				"orchestration.data.secondaryStorage.type":      "opensearch",
-				"global.opensearch.tls.jks.secret.inlineSecret": "changeit",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				s.Require().Nil(err)
-			},
-		},
-		{
-			Name: "TestGlobalElasticsearchTlsSecretRendersOk",
-			Values: map[string]string{
-				"orchestration.data.secondaryStorage.type":       "elasticsearch",
-				"global.elasticsearch.tls.secret.existingSecret": "my-legacy-jks",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				s.Require().Nil(err)
-			},
-		},
-		{
-			Name: "TestGlobalOpensearchTlsSecretRendersOk",
-			Values: map[string]string{
-				"orchestration.data.secondaryStorage.type":    "opensearch",
-				"global.opensearch.tls.secret.existingSecret": "my-legacy-jks",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				s.Require().Nil(err)
@@ -459,9 +388,7 @@ func (s *ConstraintTemplateTest) TestBitnamiSubchartDeprecationWarnings() {
 	testCases := []testhelpers.TestCase{
 		{
 			Name:   "TestBitnamiDeprecationWarningDoesNotPreventInstallWithElasticsearch",
-			Values: map[string]string{
-				// elasticsearch.enabled and global.elasticsearch.enabled default to true via test helper
-			},
+			Values: map[string]string{},
 			Verifier: func(t *testing.T, output string, err error) {
 				s.Require().Nil(err)
 			},
@@ -469,7 +396,6 @@ func (s *ConstraintTemplateTest) TestBitnamiSubchartDeprecationWarnings() {
 		{
 			Name: "TestRenderSucceedsWithAllBitnamiSubchartsDisabled",
 			Values: map[string]string{
-				"global.elasticsearch.enabled":             "false",
 				"orchestration.data.secondaryStorage.type": "rdbms",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
@@ -516,46 +442,6 @@ func (s *ConstraintTemplateTest) TestCamundaHubConsolidationDeprecationWarningsR
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
-
-// TestWebModelerExternalDatabaseUserRemovedGate verifies the
-// webModeler.restapi.externalDatabase.user removal check (camundaPlatform.keyRemoved,
-// which calls fail and IS surfaced by helm template) fires on both enablement
-// paths: the legacy webModeler.enabled key and the new camundaHub.enabled key.
-func (s *ConstraintTemplateTest) TestWebModelerExternalDatabaseUserRemovedGate() {
-	testCases := []testhelpers.TestCase{
-		{
-			Name: "TestRemovedKeyFailsViaCamundaHubEnabled",
-			Values: map[string]string{
-				"orchestration.data.secondaryStorage.type": "elasticsearch",
-				"identity.enabled":                         "true",
-				"camundaHub.enabled":                       "true",
-				"webModeler.restapi.mail.fromAddress":      "noreply@example.com",
-				"webModeler.restapi.externalDatabase.user": "modeler-user",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				s.Require().ErrorContains(err, "webModeler.restapi.externalDatabase.user")
-				s.Require().ErrorContains(err, "has been removed")
-			},
-		},
-		{
-			Name: "TestRemovedKeyFailsViaLegacyWebModelerEnabled",
-			Values: map[string]string{
-				"orchestration.data.secondaryStorage.type": "elasticsearch",
-				"identity.enabled":                         "true",
-				"webModeler.enabled":                       "true",
-				"webModeler.restapi.mail.fromAddress":      "noreply@example.com",
-				"webModeler.restapi.externalDatabase.user": "modeler-user",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				s.Require().ErrorContains(err, "webModeler.restapi.externalDatabase.user")
-				s.Require().ErrorContains(err, "has been removed")
-			},
-		},
-	}
-
-	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
-}
-
 func (s *ConstraintTemplateTest) TestCamundaHubWebModelerKeyRenamedGuards() {
 	testCases := []testhelpers.TestCase{
 		{

--- a/charts/camunda-platform-8.10/test/unit/common/helpers_normalize_secret_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/helpers_normalize_secret_test.go
@@ -52,48 +52,48 @@ func (s *normalizeSecretConfigTest) TestSecretHelperFunctionsWithOpenSearch() {
 		{
 			Name: "opensearch new style secret creates env vars",
 			Values: map[string]string{
-				"orchestration.enabled":                           "true",
-				"global.opensearch.enabled":                       "true",
-				"global.opensearch.auth.secret.existingSecret":    "my-opensearch-secret",
-				"global.opensearch.auth.secret.existingSecretKey": "my-key",
+				"orchestration.enabled":                                                        "true",
+				"orchestration.data.secondaryStorage.type":                                     "opensearch",
+				"orchestration.data.secondaryStorage.opensearch.auth.secret.existingSecret":    "my-opensearch-secret",
+				"orchestration.data.secondaryStorage.opensearch.auth.secret.existingSecretKey": "my-key",
 			},
 			Expected: map[string]string{
-				"spec.template.spec.containers[0].env[?(@.name=='CAMUNDA_OPERATE_ZEEBE_OPENSEARCH_PASSWORD')].valueFrom.secretKeyRef.name": "my-opensearch-secret",
-				"spec.template.spec.containers[0].env[?(@.name=='CAMUNDA_OPERATE_ZEEBE_OPENSEARCH_PASSWORD')].valueFrom.secretKeyRef.key":  "my-key",
+				"spec.template.spec.containers[0].env[?(@.name=='VALUES_OPENSEARCH_PASSWORD')].valueFrom.secretKeyRef.name": "my-opensearch-secret",
+				"spec.template.spec.containers[0].env[?(@.name=='VALUES_OPENSEARCH_PASSWORD')].valueFrom.secretKeyRef.key":  "my-key",
 			},
 		},
 		{
 			Name: "opensearch inline secret creates env vars with direct values",
 			Values: map[string]string{
-				"orchestration.enabled":                      "true",
-				"global.opensearch.enabled":                  "true",
-				"global.opensearch.auth.secret.inlineSecret": "my-password",
+				"orchestration.enabled":                                                   "true",
+				"orchestration.data.secondaryStorage.type":                                "opensearch",
+				"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "my-password",
 			},
 			Expected: map[string]string{
-				"spec.template.spec.containers[0].env[?(@.name=='CAMUNDA_OPERATE_ZEEBE_OPENSEARCH_PASSWORD')].value": "my-password",
+				"spec.template.spec.containers[0].env[?(@.name=='VALUES_OPENSEARCH_PASSWORD')].value": "my-password",
 			},
 		},
 		{
 			Name: "no opensearch config means no env vars",
 			Values: map[string]string{
-				"orchestration.enabled":     "true",
-				"global.opensearch.enabled": "true",
+				"orchestration.enabled":                    "true",
+				"orchestration.data.secondaryStorage.type": "opensearch",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
-				// Should not create any opensearch password env vars
-				require.NotContains(t, output, "CAMUNDA_OPERATE_ZEEBE_OPENSEARCH_PASSWORD")
+				require.NoError(t, err)
+				require.NotContains(t, output, "VALUES_OPENSEARCH_PASSWORD")
 			},
 		},
 		{
 			Name: "opensearch disabled means no env vars",
 			Values: map[string]string{
-				"orchestration.enabled":                      "true",
-				"global.opensearch.enabled":                  "false",
-				"global.opensearch.auth.secret.inlineSecret": "password",
+				"orchestration.enabled":                                                   "true",
+				"orchestration.data.secondaryStorage.type":                                "elasticsearch",
+				"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "password",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
-				// Should not create any opensearch password env vars when opensearch is disabled
-				require.NotContains(t, output, "CAMUNDA_OPERATE_ZEEBE_OPENSEARCH_PASSWORD")
+				require.NoError(t, err)
+				require.NotContains(t, output, "VALUES_OPENSEARCH_PASSWORD")
 			},
 		},
 	}

--- a/charts/camunda-platform-8.10/test/unit/common/no_secondary_storage_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/no_secondary_storage_test.go
@@ -54,8 +54,6 @@ func (s *NoSecondaryStorageTemplateTest) TestNoSecondaryStorageGlobalValue() {
 			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
 			Values: map[string]string{
 				"global.noSecondaryStorage":                    "true",
-				"global.elasticsearch.enabled":                 "false",
-				"global.opensearch.enabled":                    "false",
 				"orchestration.security.authentication.method": "oidc",
 			},
 			Verifier: func(t *testing.T, output string, err error) {

--- a/charts/camunda-platform-8.10/test/unit/common/tls_secrets_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/tls_secrets_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package camunda
 
 import (
@@ -21,263 +35,6 @@ func (s *tlsSecretsTest) SetupTest() {
 	s.release = "test-release"
 	s.namespace = "test-namespace"
 	s.templates = []string{"templates"}
-}
-
-// Elasticsearch TLS Tests
-func (s *tlsSecretsTest) TestElasticsearchTLSNewPatternCustomKey() {
-	testCases := []testhelpers.TestCase{
-		{
-			Name:     "elasticsearch new TLS secret pattern with custom key",
-			Template: "templates/orchestration/statefulset.yaml",
-			Values: map[string]string{
-				"orchestration.enabled":                             "true",
-				"global.elasticsearch.enabled":                      "true",
-				"global.elasticsearch.external":                     "true",
-				"global.elasticsearch.tls.enabled":                  "true",
-				"global.elasticsearch.tls.secret.existingSecret":    "new-es-tls-abc123",
-				"global.elasticsearch.tls.secret.existingSecretKey": "custom-truststore.jks",
-			},
-			Expected: map[string]string{
-				// Volume should use new secret name
-				"spec.template.spec.volumes[?(@.name=='keystore')].secret.secretName": "new-es-tls-abc123",
-				// SubPath should use custom key
-				"spec.template.spec.containers[0].volumeMounts[?(@.name=='keystore')].subPath": "custom-truststore.jks",
-				// MountPath should use custom key
-				"spec.template.spec.containers[0].volumeMounts[?(@.name=='keystore')].mountPath": "/usr/local/camunda/certificates/custom-truststore.jks",
-				// JAVA_TOOL_OPTIONS should include trustStore with custom key
-				"spec.template.spec.containers[0].env[?(@.name=='JAVA_TOOL_OPTIONS')].value": "-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/camunda_error%p.log -XX:+ExitOnOutOfMemoryError -Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/custom-truststore.jks",
-			},
-		},
-	}
-
-	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
-}
-
-func (s *tlsSecretsTest) TestElasticsearchTLSNewPatternDefaultKey() {
-	testCases := []testhelpers.TestCase{
-		{
-			Name:     "elasticsearch new TLS secret pattern with default key",
-			Template: "templates/orchestration/statefulset.yaml",
-			Values: map[string]string{
-				"orchestration.enabled":                          "true",
-				"global.elasticsearch.enabled":                   "true",
-				"global.elasticsearch.external":                  "true",
-				"global.elasticsearch.tls.enabled":               "true",
-				"global.elasticsearch.tls.secret.existingSecret": "es-secret-def456",
-			},
-			Expected: map[string]string{
-				// Volume should use new secret name
-				"spec.template.spec.volumes[?(@.name=='keystore')].secret.secretName": "es-secret-def456",
-				// SubPath should use default from values.yaml (externaldb.jks)
-				"spec.template.spec.containers[0].volumeMounts[?(@.name=='keystore')].subPath": "externaldb.jks",
-				// MountPath should use default key
-				"spec.template.spec.containers[0].volumeMounts[?(@.name=='keystore')].mountPath": "/usr/local/camunda/certificates/externaldb.jks",
-				// JAVA_TOOL_OPTIONS should include trustStore with default key
-				"spec.template.spec.containers[0].env[?(@.name=='JAVA_TOOL_OPTIONS')].value": "-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/camunda_error%p.log -XX:+ExitOnOutOfMemoryError -Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/externaldb.jks",
-			},
-		},
-	}
-
-	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
-}
-
-// OpenSearch TLS Tests
-func (s *tlsSecretsTest) TestOpenSearchTLSNewPatternCustomKey() {
-	testCases := []testhelpers.TestCase{
-		{
-			Name:     "opensearch new TLS secret pattern with custom key",
-			Template: "templates/orchestration/statefulset.yaml",
-			Values: map[string]string{
-				"orchestration.enabled":                          "true",
-				"global.opensearch.enabled":                      "true",
-				"global.opensearch.external":                     "true",
-				"global.opensearch.tls.enabled":                  "true",
-				"global.opensearch.tls.secret.existingSecret":    "os-certificates-jkl012",
-				"global.opensearch.tls.secret.existingSecretKey": "ca-bundle-prod.jks",
-			},
-			Expected: map[string]string{
-				"spec.template.spec.volumes[?(@.name=='keystore')].secret.secretName":            "os-certificates-jkl012",
-				"spec.template.spec.containers[0].volumeMounts[?(@.name=='keystore')].subPath":   "ca-bundle-prod.jks",
-				"spec.template.spec.containers[0].volumeMounts[?(@.name=='keystore')].mountPath": "/usr/local/camunda/certificates/ca-bundle-prod.jks",
-				"spec.template.spec.containers[0].env[?(@.name=='JAVA_TOOL_OPTIONS')].value":     "-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/camunda_error%p.log -XX:+ExitOnOutOfMemoryError -Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/ca-bundle-prod.jks",
-			},
-		},
-	}
-
-	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
-}
-
-func (s *tlsSecretsTest) TestOpenSearchTLSNewPatternDefaultKey() {
-	testCases := []testhelpers.TestCase{
-		{
-			Name:     "opensearch new TLS secret pattern with default key",
-			Template: "templates/orchestration/statefulset.yaml",
-			Values: map[string]string{
-				"orchestration.enabled":                       "true",
-				"global.opensearch.enabled":                   "true",
-				"global.opensearch.external":                  "true",
-				"global.opensearch.tls.enabled":               "true",
-				"global.opensearch.tls.secret.existingSecret": "os-secret-mno345",
-			},
-			Expected: map[string]string{
-				"spec.template.spec.volumes[?(@.name=='keystore')].secret.secretName":            "os-secret-mno345",
-				"spec.template.spec.containers[0].volumeMounts[?(@.name=='keystore')].subPath":   "externaldb.jks",
-				"spec.template.spec.containers[0].volumeMounts[?(@.name=='keystore')].mountPath": "/usr/local/camunda/certificates/externaldb.jks",
-				"spec.template.spec.containers[0].env[?(@.name=='JAVA_TOOL_OPTIONS')].value":     "-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/camunda_error%p.log -XX:+ExitOnOutOfMemoryError -Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/externaldb.jks",
-			},
-		},
-	}
-
-	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
-}
-
-// Disabled State Tests
-func (s *tlsSecretsTest) TestElasticsearchTLSEnabledNoSecret() {
-	testCases := []testhelpers.TestCase{
-		{
-			Name:     "elasticsearch TLS enabled but no secret provided",
-			Template: "templates/orchestration/statefulset.yaml",
-			Values: map[string]string{
-				"orchestration.enabled":            "true",
-				"global.elasticsearch.enabled":     "true",
-				"global.elasticsearch.external":    "true",
-				"global.elasticsearch.tls.enabled": "true",
-			},
-			Expected: map[string]string{
-				// Volume should not exist when no secret is provided
-				"spec.template.spec.volumes[?(@.name=='keystore')]": "null",
-			},
-		},
-	}
-
-	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
-}
-
-// Optimize TLS Tests (uses same global ES/OS config)
-func (s *tlsSecretsTest) TestOptimizeElasticsearchTLSNewPatternCustomKey() {
-	testCases := []testhelpers.TestCase{
-		{
-			Name:     "optimize elasticsearch new TLS secret pattern with custom key",
-			Template: "templates/optimize/deployment.yaml",
-			Values: map[string]string{
-				"optimize.enabled":                                  "true",
-				"identity.enabled":                                  "true",
-				"global.identity.auth.enabled":                      "true",
-				"global.elasticsearch.enabled":                      "true",
-				"global.elasticsearch.external":                     "true",
-				"global.elasticsearch.tls.enabled":                  "true",
-				"global.elasticsearch.tls.secret.existingSecret":    "new-optimize-es-uvw345",
-				"global.elasticsearch.tls.secret.existingSecretKey": "optimize-truststore.jks",
-			},
-			Expected: map[string]string{
-				"spec.template.spec.volumes[?(@.name=='keystore')].secret.secretName": "new-optimize-es-uvw345",
-				// Init container with custom key
-				"spec.template.spec.initContainers[0].volumeMounts[?(@.name=='keystore')].subPath":   "optimize-truststore.jks",
-				"spec.template.spec.initContainers[0].volumeMounts[?(@.name=='keystore')].mountPath": "/optimize/certificates/optimize-truststore.jks",
-				"spec.template.spec.initContainers[0].env[?(@.name=='JAVA_TOOL_OPTIONS')].value":     "-Djavax.net.ssl.trustStore=/optimize/certificates/optimize-truststore.jks",
-				// Main container with custom key
-				"spec.template.spec.containers[0].volumeMounts[?(@.name=='keystore')].subPath":   "optimize-truststore.jks",
-				"spec.template.spec.containers[0].volumeMounts[?(@.name=='keystore')].mountPath": "/optimize/certificates/optimize-truststore.jks",
-				"spec.template.spec.containers[0].env[?(@.name=='JAVA_TOOL_OPTIONS')].value":     "-Djavax.net.ssl.trustStore=/optimize/certificates/optimize-truststore.jks",
-			},
-		},
-	}
-
-	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
-}
-
-func (s *tlsSecretsTest) TestOptimizeOpenSearchTLSNewPatternCustomKey() {
-	testCases := []testhelpers.TestCase{
-		{
-			Name:     "optimize opensearch new TLS secret pattern with custom key",
-			Template: "templates/optimize/deployment.yaml",
-			Values: map[string]string{
-				"optimize.enabled":                               "true",
-				"identity.enabled":                               "true",
-				"global.identity.auth.enabled":                   "true",
-				"global.opensearch.enabled":                      "true",
-				"global.opensearch.external":                     "true",
-				"global.opensearch.tls.enabled":                  "true",
-				"global.opensearch.tls.secret.existingSecret":    "new-optimize-os-xyz678",
-				"global.opensearch.tls.secret.existingSecretKey": "opensearch-certs.jks",
-			},
-			Expected: map[string]string{
-				"spec.template.spec.volumes[?(@.name=='keystore')].secret.secretName": "new-optimize-os-xyz678",
-				// Init container with custom key
-				"spec.template.spec.initContainers[0].volumeMounts[?(@.name=='keystore')].subPath":   "opensearch-certs.jks",
-				"spec.template.spec.initContainers[0].volumeMounts[?(@.name=='keystore')].mountPath": "/optimize/certificates/opensearch-certs.jks",
-				"spec.template.spec.initContainers[0].env[?(@.name=='JAVA_TOOL_OPTIONS')].value":     "-Djavax.net.ssl.trustStore=/optimize/certificates/opensearch-certs.jks",
-				// Main container with custom key
-				"spec.template.spec.containers[0].volumeMounts[?(@.name=='keystore')].subPath":   "opensearch-certs.jks",
-				"spec.template.spec.containers[0].volumeMounts[?(@.name=='keystore')].mountPath": "/optimize/certificates/opensearch-certs.jks",
-				"spec.template.spec.containers[0].env[?(@.name=='JAVA_TOOL_OPTIONS')].value":     "-Djavax.net.ssl.trustStore=/optimize/certificates/opensearch-certs.jks",
-			},
-		},
-	}
-
-	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
-}
-
-func (s *tlsSecretsTest) TestOptimizeElasticsearchTLSNewPatternDefaultKey() {
-	testCases := []testhelpers.TestCase{
-		{
-			Name:     "optimize elasticsearch new TLS secret pattern with default key",
-			Template: "templates/optimize/deployment.yaml",
-			Values: map[string]string{
-				"optimize.enabled":                               "true",
-				"identity.enabled":                               "true",
-				"global.identity.auth.enabled":                   "true",
-				"global.elasticsearch.enabled":                   "true",
-				"global.elasticsearch.external":                  "true",
-				"global.elasticsearch.tls.enabled":               "true",
-				"global.elasticsearch.tls.secret.existingSecret": "new-optimize-es-default-key",
-			},
-			Expected: map[string]string{
-				"spec.template.spec.volumes[?(@.name=='keystore')].secret.secretName": "new-optimize-es-default-key",
-				// Init container with default key (externaldb.jks)
-				"spec.template.spec.initContainers[0].volumeMounts[?(@.name=='keystore')].subPath":   "externaldb.jks",
-				"spec.template.spec.initContainers[0].volumeMounts[?(@.name=='keystore')].mountPath": "/optimize/certificates/externaldb.jks",
-				"spec.template.spec.initContainers[0].env[?(@.name=='JAVA_TOOL_OPTIONS')].value":     "-Djavax.net.ssl.trustStore=/optimize/certificates/externaldb.jks",
-				// Main container with default key
-				"spec.template.spec.containers[0].volumeMounts[?(@.name=='keystore')].subPath":   "externaldb.jks",
-				"spec.template.spec.containers[0].volumeMounts[?(@.name=='keystore')].mountPath": "/optimize/certificates/externaldb.jks",
-				"spec.template.spec.containers[0].env[?(@.name=='JAVA_TOOL_OPTIONS')].value":     "-Djavax.net.ssl.trustStore=/optimize/certificates/externaldb.jks",
-			},
-		},
-	}
-
-	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
-}
-
-func (s *tlsSecretsTest) TestOptimizeOpenSearchTLSNewPatternDefaultKey() {
-	testCases := []testhelpers.TestCase{
-		{
-			Name:     "optimize opensearch new TLS secret pattern with default key",
-			Template: "templates/optimize/deployment.yaml",
-			Values: map[string]string{
-				"optimize.enabled":                            "true",
-				"identity.enabled":                            "true",
-				"global.identity.auth.enabled":                "true",
-				"global.opensearch.enabled":                   "true",
-				"global.opensearch.external":                  "true",
-				"global.opensearch.tls.enabled":               "true",
-				"global.opensearch.tls.secret.existingSecret": "new-optimize-os-default-key",
-			},
-			Expected: map[string]string{
-				"spec.template.spec.volumes[?(@.name=='keystore')].secret.secretName": "new-optimize-os-default-key",
-				// Init container with default key
-				"spec.template.spec.initContainers[0].volumeMounts[?(@.name=='keystore')].subPath":   "externaldb.jks",
-				"spec.template.spec.initContainers[0].volumeMounts[?(@.name=='keystore')].mountPath": "/optimize/certificates/externaldb.jks",
-				"spec.template.spec.initContainers[0].env[?(@.name=='JAVA_TOOL_OPTIONS')].value":     "-Djavax.net.ssl.trustStore=/optimize/certificates/externaldb.jks",
-				// Main container with default key
-				"spec.template.spec.containers[0].volumeMounts[?(@.name=='keystore')].subPath":   "externaldb.jks",
-				"spec.template.spec.containers[0].volumeMounts[?(@.name=='keystore')].mountPath": "/optimize/certificates/externaldb.jks",
-				"spec.template.spec.containers[0].env[?(@.name=='JAVA_TOOL_OPTIONS')].value":     "-Djavax.net.ssl.trustStore=/optimize/certificates/externaldb.jks",
-			},
-		},
-	}
-
-	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
 
 // global.tls.caBundle tests
@@ -393,9 +150,11 @@ func (s *tlsSecretsTest) TestCaBundleInitContainerSecurityContext() {
 				"global.compatibility.openshift.adaptSecurityContext": "force",
 			},
 			Expected: map[string]string{
-				// dropped → extractor returns "" for an absent path
-				"spec.template.spec.initContainers[?(@.name=='ca-bundle-truststore-init')].securityContext.runAsUser":  "",
-				"spec.template.spec.initContainers[?(@.name=='ca-bundle-truststore-init')].securityContext.runAsGroup": "",
+				"spec.template.spec.initContainers[?(@.name=='ca-bundle-truststore-init')].name": "ca-bundle-truststore-init",
+			},
+			Unexpected: []string{
+				"spec.template.spec.initContainers[?(@.name=='ca-bundle-truststore-init')].securityContext.runAsUser",
+				"spec.template.spec.initContainers[?(@.name=='ca-bundle-truststore-init')].securityContext.runAsGroup",
 			},
 		},
 	}
@@ -427,8 +186,9 @@ func (s *tlsSecretsTest) TestCaBundleChecksumAnnotation() {
 				"global.tls.caBundle.secret.existingSecret": "my-ca-bundle",
 			},
 			Expected: map[string]string{
-				"spec.template.metadata.annotations.checksum/ca-bundle": "",
+				"kind": "StatefulSet",
 			},
+			Unexpected: []string{"spec.template.metadata.annotations.checksum/ca-bundle"},
 		},
 		{
 			Name:     "no checksum/ca-bundle annotation when caBundle is unset",
@@ -437,8 +197,9 @@ func (s *tlsSecretsTest) TestCaBundleChecksumAnnotation() {
 				"orchestration.enabled": "true",
 			},
 			Expected: map[string]string{
-				"spec.template.metadata.annotations.checksum/ca-bundle": "",
+				"kind": "StatefulSet",
 			},
+			Unexpected: []string{"spec.template.metadata.annotations.checksum/ca-bundle"},
 		},
 	}
 
@@ -488,8 +249,9 @@ func (s *tlsSecretsTest) TestCaBundleChecksumAnnotationWebModeler() {
 				"global.tls.caBundle.secret.existingSecret": "my-ca-bundle",
 			},
 			Expected: map[string]string{
-				"spec.template.metadata.annotations.checksum/ca-bundle": "",
+				"kind": "Deployment",
 			},
+			Unexpected: []string{"spec.template.metadata.annotations.checksum/ca-bundle"},
 		},
 	}
 

--- a/charts/camunda-platform-8.10/test/unit/connectors/deployment_test.go
+++ b/charts/camunda-platform-8.10/test/unit/connectors/deployment_test.go
@@ -517,8 +517,8 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 				var deploymentBefore appsv1.Deployment
 				before := helm.RenderTemplate(s.T(), &helm.Options{
 					SetValues: map[string]string{
-						"connectors.enabled":           "true",
-						"global.elasticsearch.enabled": "true",
+						"connectors.enabled":                       "true",
+						"orchestration.data.secondaryStorage.type": "elasticsearch",
 					},
 				}, s.chartPath, s.release, s.templates)
 				helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
@@ -551,8 +551,8 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 				var deploymentBefore appsv1.Deployment
 				before := helm.RenderTemplate(s.T(), &helm.Options{
 					SetValues: map[string]string{
-						"connectors.enabled":           "true",
-						"global.elasticsearch.enabled": "true",
+						"connectors.enabled":                       "true",
+						"orchestration.data.secondaryStorage.type": "elasticsearch",
 					},
 				}, s.chartPath, s.release, s.templates)
 				helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)

--- a/charts/camunda-platform-8.10/test/unit/connectors/persistence_test.go
+++ b/charts/camunda-platform-8.10/test/unit/connectors/persistence_test.go
@@ -239,7 +239,7 @@ func (s *PersistenceTemplateTest) TestPersistenceConfiguration() {
 
 			// Merge test values with required elasticsearch flags
 			mergedValues := make(map[string]string)
-			mergedValues["global.elasticsearch.enabled"] = "true"
+			mergedValues["orchestration.data.secondaryStorage.type"] = "elasticsearch"
 			for k, v := range testCase.Values {
 				mergedValues[k] = v
 			}

--- a/charts/camunda-platform-8.10/test/unit/connectors/resources_cpu_test.go
+++ b/charts/camunda-platform-8.10/test/unit/connectors/resources_cpu_test.go
@@ -55,13 +55,13 @@ func (s *ResourcesCPUTemplateTest) TestCPUResourcesAsString() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"connectors.enabled":                   "true",
-			"orchestration.enabled":                "true",
-			"global.elasticsearch.enabled":         "true",
-			"connectors.resources.requests.cpu":    "500m",
-			"connectors.resources.limits.cpu":      "1.5",
-			"connectors.resources.requests.memory": "512Mi",
-			"connectors.resources.limits.memory":   "1Gi",
+			"connectors.enabled":                       "true",
+			"orchestration.enabled":                    "true",
+			"orchestration.data.secondaryStorage.type": "elasticsearch",
+			"connectors.resources.requests.cpu":        "500m",
+			"connectors.resources.limits.cpu":          "1.5",
+			"connectors.resources.requests.memory":     "512Mi",
+			"connectors.resources.limits.memory":       "1Gi",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 	}
@@ -95,13 +95,13 @@ func (s *ResourcesCPUTemplateTest) TestCPUResourcesBackwardCompatibility() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"connectors.enabled":                   "true",
-			"orchestration.enabled":                "true",
-			"global.elasticsearch.enabled":         "true",
-			"connectors.resources.requests.cpu":    "1000m",
-			"connectors.resources.limits.cpu":      "2000m",
-			"connectors.resources.requests.memory": "1Gi",
-			"connectors.resources.limits.memory":   "2Gi",
+			"connectors.enabled":                       "true",
+			"orchestration.enabled":                    "true",
+			"orchestration.data.secondaryStorage.type": "elasticsearch",
+			"connectors.resources.requests.cpu":        "1000m",
+			"connectors.resources.limits.cpu":          "2000m",
+			"connectors.resources.requests.memory":     "1Gi",
+			"connectors.resources.limits.memory":       "2Gi",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 	}

--- a/charts/camunda-platform-8.10/test/unit/connectors/testdata/values-templated-labels.yaml
+++ b/charts/camunda-platform-8.10/test/unit/connectors/testdata/values-templated-labels.yaml
@@ -1,8 +1,3 @@
-global:
-  elasticsearch:
-    enabled: true
-
-
 orchestration:
   data:
     secondaryStorage:

--- a/charts/camunda-platform-8.10/test/unit/identity/deployment_test.go
+++ b/charts/camunda-platform-8.10/test/unit/identity/deployment_test.go
@@ -325,7 +325,7 @@ func (s *deploymentTemplateTest) TestDifferentValuesInputs() {
 			Verifier: func(t *testing.T, output string, err error) {
 				// finding out the length of volumes array before addition of new volume
 				var deploymentBefore appsv1.Deployment
-				before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates, "--set", "identity.enabled=true", "--set", "global.elasticsearch.enabled=true")
+				before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates, "--set", "identity.enabled=true", "--set", "orchestration.data.secondaryStorage.type=elasticsearch")
 				helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
 				volumeLenBefore := len(deploymentBefore.Spec.Template.Spec.Volumes)
 				// given
@@ -353,7 +353,7 @@ func (s *deploymentTemplateTest) TestDifferentValuesInputs() {
 			Verifier: func(t *testing.T, output string, err error) {
 				// finding out the length of containers and volumeMounts array before addition of new volumeMount
 				var deploymentBefore appsv1.Deployment
-				before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates, "--set", "identity.enabled=true", "--set", "global.elasticsearch.enabled=true")
+				before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates, "--set", "identity.enabled=true", "--set", "orchestration.data.secondaryStorage.type=elasticsearch")
 				helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
 				containerLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers)
 				volumeMountLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
@@ -384,7 +384,7 @@ func (s *deploymentTemplateTest) TestDifferentValuesInputs() {
 			Verifier: func(t *testing.T, output string, err error) {
 				// finding out the length of volumes, volumemounts array before addition of new volume
 				var deploymentBefore appsv1.Deployment
-				before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates, "--set", "identity.enabled=true", "--set", "global.elasticsearch.enabled=true")
+				before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates, "--set", "identity.enabled=true", "--set", "orchestration.data.secondaryStorage.type=elasticsearch")
 				helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
 				volumeLenBefore := len(deploymentBefore.Spec.Template.Spec.Volumes)
 				volumeMountLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers[0].VolumeMounts)

--- a/charts/camunda-platform-8.10/test/unit/identity/persistence_test.go
+++ b/charts/camunda-platform-8.10/test/unit/identity/persistence_test.go
@@ -157,7 +157,7 @@ func (s *PersistenceTemplateTest) TestPersistenceConfiguration() {
 
 			// Merge test values with required elasticsearch flags
 			mergedValues := make(map[string]string)
-			mergedValues["global.elasticsearch.enabled"] = "true"
+			mergedValues["orchestration.data.secondaryStorage.type"] = "elasticsearch"
 			for k, v := range testCase.Values {
 				mergedValues[k] = v
 			}

--- a/charts/camunda-platform-8.10/test/unit/identity/resources_cpu_test.go
+++ b/charts/camunda-platform-8.10/test/unit/identity/resources_cpu_test.go
@@ -55,12 +55,12 @@ func (s *ResourcesCPUTemplateTest) TestCPUResourcesAsString() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"identity.enabled":                   "true",
-			"global.elasticsearch.enabled":       "true",
-			"identity.resources.requests.cpu":    "200m",
-			"identity.resources.limits.cpu":      "1.5",
-			"identity.resources.requests.memory": "512Mi",
-			"identity.resources.limits.memory":   "1Gi",
+			"identity.enabled":                         "true",
+			"orchestration.data.secondaryStorage.type": "elasticsearch",
+			"identity.resources.requests.cpu":          "200m",
+			"identity.resources.limits.cpu":            "1.5",
+			"identity.resources.requests.memory":       "512Mi",
+			"identity.resources.limits.memory":         "1Gi",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 	}
@@ -94,12 +94,12 @@ func (s *ResourcesCPUTemplateTest) TestCPUResourcesAsMillicores() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"identity.enabled":                   "true",
-			"global.elasticsearch.enabled":       "true",
-			"identity.resources.requests.cpu":    "600m",
-			"identity.resources.limits.cpu":      "2000m",
-			"identity.resources.requests.memory": "400Mi",
-			"identity.resources.limits.memory":   "2Gi",
+			"identity.enabled":                         "true",
+			"orchestration.data.secondaryStorage.type": "elasticsearch",
+			"identity.resources.requests.cpu":          "600m",
+			"identity.resources.limits.cpu":            "2000m",
+			"identity.resources.requests.memory":       "400Mi",
+			"identity.resources.limits.memory":         "2Gi",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 	}

--- a/charts/camunda-platform-8.10/test/unit/identity/testdata/values-templated-labels.yaml
+++ b/charts/camunda-platform-8.10/test/unit/identity/testdata/values-templated-labels.yaml
@@ -1,8 +1,3 @@
-global:
-  elasticsearch:
-    enabled: true
-
-
 orchestration:
   data:
     secondaryStorage:

--- a/charts/camunda-platform-8.10/test/unit/optimize/configmap_test.go
+++ b/charts/camunda-platform-8.10/test/unit/optimize/configmap_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package optimize
 
 import (
@@ -63,9 +77,10 @@ func (s *ConfigMapTemplateTest) TestDifferentValuesInputs() {
 			Name:                 "TestCustomZeebeName",
 			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
 			Values: map[string]string{
-				"identity.enabled":                       "true",
-				"optimize.enabled":                       "true",
-				"optimize.database.elasticsearch.prefix": "custom-prefix",
+				"identity.enabled":                        "true",
+				"optimize.enabled":                        "true",
+				"optimize.database.elasticsearch.enabled": "true",
+				"optimize.database.elasticsearch.prefix":  "custom-prefix",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var configmap corev1.ConfigMap
@@ -89,12 +104,12 @@ func (s *ConfigMapTemplateTest) TestDifferentValuesInputs() {
 func (s *ConfigMapTemplateTest) TestDatabaseOverrides() {
 	testCases := []testhelpers.TestCase{
 		{
-			Name: "TestElasticsearchPrefixOverriddenByOptimizeDatabase",
+			Name: "TestElasticsearchPrefixFromOptimizeDatabase",
 			Values: map[string]string{
-				"identity.enabled":                       "true",
-				"optimize.enabled":                       "true",
-				"global.elasticsearch.prefix":            "global-prefix",
-				"optimize.database.elasticsearch.prefix": "optimize-prefix",
+				"identity.enabled":                        "true",
+				"optimize.enabled":                        "true",
+				"optimize.database.elasticsearch.enabled": "true",
+				"optimize.database.elasticsearch.prefix":  "component-prefix",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				require.NoError(t, err)
@@ -107,37 +122,15 @@ func (s *ConfigMapTemplateTest) TestDatabaseOverrides() {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
 
-				s.Require().Equal("optimize-prefix", configmapApplication.Zeebe.Name)
-			},
-		},
-		{
-			Name: "TestElasticsearchPrefixUsesComponentKeyDirectly",
-			Values: map[string]string{
-				"identity.enabled":                       "true",
-				"optimize.enabled":                       "true",
-				"global.elasticsearch.prefix":            "global-prefix",
-				"optimize.database.elasticsearch.prefix": "component-prefix",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				var configmap corev1.ConfigMap
-				var configmapApplication OptimizeConfigYAML
-				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-				e := yaml.Unmarshal([]byte(configmap.Data["environment-config.yaml"]), &configmapApplication)
-				if e != nil {
-					s.Fail("Failed to unmarshal yaml. error=", e)
-				}
-
-				// In 8.10 global keys are deprecated; component key takes effect directly
 				s.Require().Equal("component-prefix", configmapApplication.Zeebe.Name)
 			},
 		},
 		{
-			Name: "TestElasticsearchPortOverriddenInConfigMap",
+			Name: "TestElasticsearchPortFromOptimizeDatabase",
 			Values: map[string]string{
 				"identity.enabled":                         "true",
 				"optimize.enabled":                         "true",
+				"optimize.database.elasticsearch.enabled":  "true",
 				"optimize.database.elasticsearch.url.port": "9201",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
@@ -155,33 +148,12 @@ func (s *ConfigMapTemplateTest) TestDatabaseOverrides() {
 			},
 		},
 		{
-			Name: "TestElasticsearchPortFallsBackToGlobalInConfigMap",
-			Values: map[string]string{
-				"identity.enabled":              "true",
-				"optimize.enabled":              "true",
-				"global.elasticsearch.url.port": "9300",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				var configmap corev1.ConfigMap
-				var configmapApplication OptimizeConfigYAML
-				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-				e := yaml.Unmarshal([]byte(configmap.Data["environment-config.yaml"]), &configmapApplication)
-				if e != nil {
-					s.Fail("Failed to unmarshal yaml. error=", e)
-				}
-
-				s.Require().Equal(9300, configmapApplication.Es.Connection.Nodes[0].HttpPort)
-			},
-		},
-		{
 			Name: "TestElasticsearchExternalSecurityUsernameFromOptimizeDatabase",
 			Values: map[string]string{
 				"identity.enabled":                              "true",
 				"optimize.enabled":                              "true",
-				"global.elasticsearch.external":                 "true",
-				"global.elasticsearch.auth.username":            "global-es-user",
+				"optimize.database.elasticsearch.enabled":       "true",
+				"optimize.database.elasticsearch.external":      "true",
 				"optimize.database.elasticsearch.auth.username": "optimize-es-user",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
@@ -199,33 +171,12 @@ func (s *ConfigMapTemplateTest) TestDatabaseOverrides() {
 			},
 		},
 		{
-			Name: "TestElasticsearchExternalSecurityUsernameFallsBackToGlobal",
-			Values: map[string]string{
-				"identity.enabled":                   "true",
-				"optimize.enabled":                   "true",
-				"global.elasticsearch.external":      "true",
-				"global.elasticsearch.auth.username": "global-es-user",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				var configmap corev1.ConfigMap
-				var configmapApplication OptimizeConfigYAML
-				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-				e := yaml.Unmarshal([]byte(configmap.Data["environment-config.yaml"]), &configmapApplication)
-				if e != nil {
-					s.Fail("Failed to unmarshal yaml. error=", e)
-				}
-
-				s.Require().Equal("global-es-user", configmapApplication.Es.Security.Username)
-			},
-		},
-		{
 			Name: "TestElasticsearchSslEnabledWhenProtocolHttpsFromOptimizeDatabase",
 			Values: map[string]string{
 				"identity.enabled":                             "true",
 				"optimize.enabled":                             "true",
-				"global.elasticsearch.external":                "true",
+				"optimize.database.elasticsearch.enabled":      "true",
+				"optimize.database.elasticsearch.external":     "true",
 				"optimize.database.elasticsearch.url.protocol": "https",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
@@ -245,8 +196,9 @@ func (s *ConfigMapTemplateTest) TestDatabaseOverrides() {
 		{
 			Name: "TestElasticsearchNoSecuritySectionWhenNotExternal",
 			Values: map[string]string{
-				"identity.enabled": "true",
-				"optimize.enabled": "true",
+				"identity.enabled":                        "true",
+				"optimize.enabled":                        "true",
+				"optimize.database.elasticsearch.enabled": "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				require.NoError(t, err)
@@ -263,14 +215,13 @@ func (s *ConfigMapTemplateTest) TestDatabaseOverrides() {
 			},
 		},
 		{
-			Name: "TestOpensearchPrefixUsesComponentKeyDirectly",
+			Name: "TestOpensearchPrefixFromOptimizeDatabase",
 			Values: map[string]string{
-				"identity.enabled":                    "true",
-				"optimize.enabled":                    "true",
-				"global.elasticsearch.enabled":        "false",
-				"global.opensearch.enabled":           "true",
-				"global.opensearch.url.host":          "opensearch-host",
-				"optimize.database.opensearch.prefix": "os-component-prefix",
+				"identity.enabled":                      "true",
+				"optimize.enabled":                      "true",
+				"optimize.database.opensearch.enabled":  "true",
+				"optimize.database.opensearch.url.host": "opensearch-host",
+				"optimize.database.opensearch.prefix":   "os-component-prefix",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				require.NoError(t, err)
@@ -283,32 +234,7 @@ func (s *ConfigMapTemplateTest) TestDatabaseOverrides() {
 					s.Fail("Failed to unmarshal yaml. error=", e)
 				}
 
-				// In 8.10 global keys are deprecated; component key takes effect directly
 				s.Require().Equal("os-component-prefix", configmapApplication.Zeebe.Name)
-			},
-		},
-		{
-			Name: "TestOpensearchPrefixOverriddenByOptimizeDatabase",
-			Values: map[string]string{
-				"identity.enabled":                    "true",
-				"optimize.enabled":                    "true",
-				"global.elasticsearch.enabled":        "false",
-				"global.opensearch.enabled":           "true",
-				"global.opensearch.url.host":          "opensearch-host",
-				"optimize.database.opensearch.prefix": "my-optimize-os-prefix",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				var configmap corev1.ConfigMap
-				var configmapApplication OptimizeConfigYAML
-				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
-
-				e := yaml.Unmarshal([]byte(configmap.Data["environment-config.yaml"]), &configmapApplication)
-				if e != nil {
-					s.Fail("Failed to unmarshal yaml. error=", e)
-				}
-
-				s.Require().Equal("my-optimize-os-prefix", configmapApplication.Zeebe.Name)
 			},
 		},
 	}

--- a/charts/camunda-platform-8.10/test/unit/optimize/deployment_test.go
+++ b/charts/camunda-platform-8.10/test/unit/optimize/deployment_test.go
@@ -270,7 +270,7 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 			Verifier: func(t *testing.T, output string, err error) {
 				// finding out the length of volumes array before addition of new volume
 				var deploymentBefore appsv1.Deployment
-				before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates, "--set", "identity.enabled=true", "--set", "optimize.enabled=true", "--set", "global.elasticsearch.enabled=true")
+				before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates, "--set", "identity.enabled=true", "--set", "optimize.enabled=true", "--set", "orchestration.data.secondaryStorage.type=elasticsearch")
 				helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
 				volumeLenBefore := len(deploymentBefore.Spec.Template.Spec.Volumes)
 				// given
@@ -299,7 +299,7 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 			Verifier: func(t *testing.T, output string, err error) {
 				// finding out the length of containers and volumeMounts array before addition of new volumeMount
 				var deploymentBefore appsv1.Deployment
-				before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates, "--set", "identity.enabled=true", "--set", "optimize.enabled=true", "--set", "global.elasticsearch.enabled=true")
+				before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates, "--set", "identity.enabled=true", "--set", "optimize.enabled=true", "--set", "orchestration.data.secondaryStorage.type=elasticsearch")
 				helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
 				containerLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers)
 				volumeMountLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
@@ -331,7 +331,7 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 			Verifier: func(t *testing.T, output string, err error) {
 				// finding out the length of volumes, volumemounts array before addition of new volume
 				var deploymentBefore appsv1.Deployment
-				before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates, "--set", "optimize.enabled=true", "--set", "identity.enabled=true", "--set", "global.elasticsearch.enabled=true")
+				before := helm.RenderTemplate(s.T(), &helm.Options{}, s.chartPath, s.release, s.templates, "--set", "optimize.enabled=true", "--set", "identity.enabled=true", "--set", "orchestration.data.secondaryStorage.type=elasticsearch")
 				helm.UnmarshalK8SYaml(s.T(), before, &deploymentBefore)
 				volumeLenBefore := len(deploymentBefore.Spec.Template.Spec.Volumes)
 				volumeMountLenBefore := len(deploymentBefore.Spec.Template.Spec.Containers[0].VolumeMounts)
@@ -876,176 +876,76 @@ es:
 			},
 		},
 		{
-			Name: "TestOptimizeOpenSearchTLSWithJKSSecretRefEmitsPasswordAndFlag",
+			Name: "TestOptimizeCaBundlePreservesJavaOptsAndInjectsTrustConfiguration",
 			Values: map[string]string{
-				"identity.enabled": "true",
-				"optimize.enabled": "true",
-				"global.opensearch.tls.secret.existingSecret":        "os-tls-secret",
-				"global.opensearch.tls.jks.secret.existingSecret":    "truststore-secret",
-				"global.opensearch.tls.jks.secret.existingSecretKey": "truststore-password",
+				"identity.enabled":                             "true",
+				"optimize.enabled":                             "true",
+				"optimize.javaOpts":                            "-Xmx512m -Xms256m",
+				"global.tls.caBundle.secret.existingSecret":    "ca-bundle-secret",
+				"global.tls.caBundle.secret.existingSecretKey": "custom-ca.pem",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
 				var deployment appsv1.Deployment
 				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-				env := deployment.Spec.Template.Spec.Containers[0].Env
-				var javaToolOptions *corev1.EnvVar
-				var truststorePassword *corev1.EnvVar
-				for i := range env {
-					if env[i].Name == "JAVA_TOOL_OPTIONS" {
-						javaToolOptions = &env[i]
-					}
-					if env[i].Name == "TRUSTSTORE_PASSWORD" {
-						truststorePassword = &env[i]
+
+				var truststoreInitContainer *corev1.Container
+				for i := range deployment.Spec.Template.Spec.InitContainers {
+					if deployment.Spec.Template.Spec.InitContainers[i].Name == "ca-bundle-truststore-init" {
+						truststoreInitContainer = &deployment.Spec.Template.Spec.InitContainers[i]
+						break
 					}
 				}
-				require.NotNil(s.T(), javaToolOptions)
-				require.Contains(s.T(), javaToolOptions.Value, "-Djavax.net.ssl.trustStore=/optimize/certificates/externaldb.jks")
-				require.Contains(s.T(), javaToolOptions.Value, "-Djavax.net.ssl.trustStorePassword=$(TRUSTSTORE_PASSWORD)")
-				require.NotNil(s.T(), truststorePassword)
-				require.NotNil(s.T(), truststorePassword.ValueFrom)
-				require.NotNil(s.T(), truststorePassword.ValueFrom.SecretKeyRef)
-				require.Equal(s.T(), "truststore-secret", truststorePassword.ValueFrom.SecretKeyRef.Name)
-				require.Equal(s.T(), "truststore-password", truststorePassword.ValueFrom.SecretKeyRef.Key)
-			},
-		},
-		{
-			Name: "TestOptimizeOpenSearchTLSWithJKSInlineEmitsPasswordAndFlag",
-			Values: map[string]string{
-				"identity.enabled": "true",
-				"optimize.enabled": "true",
-				"global.opensearch.tls.secret.existingSecret":   "os-tls-secret",
-				"global.opensearch.tls.jks.secret.inlineSecret": "changeit",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				var deployment appsv1.Deployment
-				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-				env := deployment.Spec.Template.Spec.Containers[0].Env
-				var javaToolOptions *corev1.EnvVar
-				var truststorePassword *corev1.EnvVar
-				for i := range env {
-					if env[i].Name == "JAVA_TOOL_OPTIONS" {
-						javaToolOptions = &env[i]
-					}
-					if env[i].Name == "TRUSTSTORE_PASSWORD" {
-						truststorePassword = &env[i]
+				s.Require().NotNil(truststoreInitContainer)
+
+				var optimizeContainer *corev1.Container
+				for i := range deployment.Spec.Template.Spec.Containers {
+					if deployment.Spec.Template.Spec.Containers[i].Name == "optimize" {
+						optimizeContainer = &deployment.Spec.Template.Spec.Containers[i]
+						break
 					}
 				}
-				require.NotNil(s.T(), javaToolOptions)
-				require.Contains(s.T(), javaToolOptions.Value, "-Djavax.net.ssl.trustStore=/optimize/certificates/externaldb.jks")
-				require.Contains(s.T(), javaToolOptions.Value, "-Djavax.net.ssl.trustStorePassword=$(TRUSTSTORE_PASSWORD)")
-				require.NotNil(s.T(), truststorePassword)
-				require.Equal(s.T(), "changeit", truststorePassword.Value)
-			},
-		},
-		{
-			Name: "TestOptimizeOpenSearchTLSWithoutJKSDoesNotEmitPassword",
-			Values: map[string]string{
-				"identity.enabled": "true",
-				"optimize.enabled": "true",
-				"global.opensearch.tls.secret.existingSecret": "os-tls-secret",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				var deployment appsv1.Deployment
-				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().NotNil(optimizeContainer)
+				s.Require().Contains(optimizeContainer.Env, corev1.EnvVar{Name: "SSL_CERT_FILE", Value: "/etc/camunda/tls/ca.crt"})
+
 				var javaToolOptions *corev1.EnvVar
-				var truststoreFound bool
-				for i := range env {
-					if env[i].Name == "JAVA_TOOL_OPTIONS" {
-						javaToolOptions = &env[i]
-					}
-					if env[i].Name == "TRUSTSTORE_PASSWORD" {
-						truststoreFound = true
+				for i := range optimizeContainer.Env {
+					if optimizeContainer.Env[i].Name == "JAVA_TOOL_OPTIONS" {
+						javaToolOptions = &optimizeContainer.Env[i]
+						break
 					}
 				}
-				require.NotNil(s.T(), javaToolOptions)
-				require.Contains(s.T(), javaToolOptions.Value, "-Djavax.net.ssl.trustStore=/optimize/certificates/externaldb.jks")
-				require.NotContains(s.T(), javaToolOptions.Value, "-Djavax.net.ssl.trustStorePassword=$(TRUSTSTORE_PASSWORD)")
-				require.False(s.T(), truststoreFound)
-			},
-		},
-		{
-			Name: "TestOptimizeElasticsearchTLSWithJKSSecretRefEmitsPasswordAndFlag",
-			Values: map[string]string{
-				"identity.enabled": "true",
-				"optimize.enabled": "true",
-				"global.elasticsearch.tls.secret.existingSecret":        "es-tls-secret",
-				"global.elasticsearch.tls.jks.secret.existingSecret":    "truststore-secret",
-				"global.elasticsearch.tls.jks.secret.existingSecretKey": "truststore-password",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				var deployment appsv1.Deployment
-				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-				env := deployment.Spec.Template.Spec.Containers[0].Env
-				var javaToolOptions *corev1.EnvVar
-				var truststorePassword *corev1.EnvVar
-				for i := range env {
-					if env[i].Name == "JAVA_TOOL_OPTIONS" {
-						javaToolOptions = &env[i]
-					}
-					if env[i].Name == "TRUSTSTORE_PASSWORD" {
-						truststorePassword = &env[i]
+				s.Require().NotNil(javaToolOptions)
+				s.Require().Contains(javaToolOptions.Value, "-Xmx512m -Xms256m")
+				s.Require().Contains(javaToolOptions.Value, "-Djavax.net.ssl.trustStore=/var/camunda/tls-truststore/cacerts")
+
+				s.Require().Contains(optimizeContainer.VolumeMounts, corev1.VolumeMount{
+					Name:      "ca-bundle",
+					MountPath: "/etc/camunda/tls",
+					ReadOnly:  true,
+				})
+				s.Require().Contains(optimizeContainer.VolumeMounts, corev1.VolumeMount{
+					Name:      "ca-bundle-truststore",
+					MountPath: "/var/camunda/tls-truststore",
+					ReadOnly:  true,
+				})
+
+				var caBundleVolume *corev1.Volume
+				var truststoreVolume *corev1.Volume
+				for i := range deployment.Spec.Template.Spec.Volumes {
+					switch deployment.Spec.Template.Spec.Volumes[i].Name {
+					case "ca-bundle":
+						caBundleVolume = &deployment.Spec.Template.Spec.Volumes[i]
+					case "ca-bundle-truststore":
+						truststoreVolume = &deployment.Spec.Template.Spec.Volumes[i]
 					}
 				}
-				require.NotNil(s.T(), javaToolOptions)
-				require.Contains(s.T(), javaToolOptions.Value, "-Djavax.net.ssl.trustStore=/optimize/certificates/externaldb.jks")
-				require.Contains(s.T(), javaToolOptions.Value, "-Djavax.net.ssl.trustStorePassword=$(TRUSTSTORE_PASSWORD)")
-				require.NotNil(s.T(), truststorePassword)
-				require.NotNil(s.T(), truststorePassword.ValueFrom)
-				require.NotNil(s.T(), truststorePassword.ValueFrom.SecretKeyRef)
-				require.Equal(s.T(), "truststore-secret", truststorePassword.ValueFrom.SecretKeyRef.Name)
-				require.Equal(s.T(), "truststore-password", truststorePassword.ValueFrom.SecretKeyRef.Key)
-			},
-		},
-		{
-			Name: "TestOptimizeElasticsearchTLSWithoutJKSDoesNotEmitPassword",
-			Values: map[string]string{
-				"identity.enabled": "true",
-				"optimize.enabled": "true",
-				"global.elasticsearch.tls.secret.existingSecret": "es-tls-secret",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				var deployment appsv1.Deployment
-				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-				env := deployment.Spec.Template.Spec.Containers[0].Env
-				var javaToolOptions *corev1.EnvVar
-				var truststoreFound bool
-				for i := range env {
-					if env[i].Name == "JAVA_TOOL_OPTIONS" {
-						javaToolOptions = &env[i]
-					}
-					if env[i].Name == "TRUSTSTORE_PASSWORD" {
-						truststoreFound = true
-					}
-				}
-				require.NotNil(s.T(), javaToolOptions)
-				require.Contains(s.T(), javaToolOptions.Value, "-Djavax.net.ssl.trustStore=/optimize/certificates/externaldb.jks")
-				require.NotContains(s.T(), javaToolOptions.Value, "-Djavax.net.ssl.trustStorePassword=$(TRUSTSTORE_PASSWORD)")
-				require.False(s.T(), truststoreFound)
-			},
-		},
-		{
-			Name: "TestOptimizeOpenSearchTLSRespectsJavaOptsWithAndWithoutJKS",
-			Values: map[string]string{
-				"identity.enabled":                            "true",
-				"optimize.enabled":                            "true",
-				"optimize.javaOpts":                           "-Xmx512m -Xms256m",
-				"global.opensearch.tls.secret.existingSecret": "os-tls-secret",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				var deployment appsv1.Deployment
-				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-				env := deployment.Spec.Template.Spec.Containers[0].Env
-				var javaToolOptions *corev1.EnvVar
-				for i := range env {
-					if env[i].Name == "JAVA_TOOL_OPTIONS" {
-						javaToolOptions = &env[i]
-					}
-				}
-				require.NotNil(s.T(), javaToolOptions)
-				require.Contains(s.T(), javaToolOptions.Value, "-Xmx512m -Xms256m")
-				require.Contains(s.T(), javaToolOptions.Value, "-Djavax.net.ssl.trustStore=/optimize/certificates/externaldb.jks")
-				require.NotContains(s.T(), javaToolOptions.Value, "-Djavax.net.ssl.trustStorePassword=$(TRUSTSTORE_PASSWORD)")
+				s.Require().NotNil(caBundleVolume)
+				s.Require().NotNil(caBundleVolume.Secret)
+				s.Require().Equal("ca-bundle-secret", caBundleVolume.Secret.SecretName)
+				s.Require().Contains(caBundleVolume.Secret.Items, corev1.KeyToPath{Key: "custom-ca.pem", Path: "ca.crt"})
+				s.Require().NotNil(truststoreVolume)
+				s.Require().NotNil(truststoreVolume.EmptyDir)
 			},
 		},
 	}
@@ -1055,27 +955,153 @@ es:
 
 func (s *DeploymentTemplateTest) TestDatabaseOverrides() {
 	testCases := []testhelpers.TestCase{
-		// ---- Elasticsearch overrides ----
 		{
-			Name: "TestElasticsearchPortUsesGlobalDefault",
+			Name: "Component OpenSearch settings",
 			Values: map[string]string{
-				"identity.enabled": "true",
-				"optimize.enabled": "true",
+				"identity.enabled":                                           "true",
+				"optimize.enabled":                                           "true",
+				"optimize.database.elasticsearch.enabled":                    "false",
+				"optimize.database.opensearch.enabled":                       "true",
+				"optimize.database.opensearch.url.protocol":                  "https",
+				"optimize.database.opensearch.url.host":                      "opensearch-host",
+				"optimize.database.opensearch.url.port":                      "9211",
+				"optimize.database.opensearch.auth.username":                 "opensearch-user",
+				"optimize.database.opensearch.auth.secret.existingSecret":    "opensearch-auth",
+				"optimize.database.opensearch.auth.secret.existingSecretKey": "password",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				require.NoError(t, err)
-				var deployment appsv1.Deployment
-				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
 
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(t, output, &deployment)
 				env := deployment.Spec.Template.Spec.Containers[0].Env
-				s.Require().Contains(env, corev1.EnvVar{Name: "OPTIMIZE_ELASTICSEARCH_HTTP_PORT", Value: "9200"})
+				s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_OPTIMIZE_OPENSEARCH_HOST", Value: "opensearch-host"})
+				s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_OPTIMIZE_OPENSEARCH_HTTP_PORT", Value: "9211"})
+				s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_OPTIMIZE_OPENSEARCH_SECURITY_USERNAME", Value: "opensearch-user"})
+				s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_OPTIMIZE_OPENSEARCH_SSL_ENABLED", Value: "true"})
+				s.Require().Contains(env, corev1.EnvVar{
+					Name: "CAMUNDA_OPTIMIZE_OPENSEARCH_SECURITY_PASSWORD",
+					ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "opensearch-auth"},
+						Key:                  "password",
+					}},
+				})
 			},
 		},
 		{
-			Name: "TestElasticsearchPortOverriddenByOptimizeDatabase",
+			Name: "Component OpenSearch HTTP settings omit SSL",
+			Values: map[string]string{
+				"identity.enabled":                                           "true",
+				"optimize.enabled":                                           "true",
+				"optimize.database.elasticsearch.enabled":                    "false",
+				"optimize.database.opensearch.enabled":                       "true",
+				"optimize.database.opensearch.url.protocol":                  "http",
+				"optimize.database.opensearch.url.host":                      "component-os-host",
+				"optimize.database.opensearch.url.port":                      "9222",
+				"optimize.database.opensearch.auth.username":                 "component-user",
+				"optimize.database.opensearch.auth.secret.existingSecret":    "component-os-auth",
+				"optimize.database.opensearch.auth.secret.existingSecretKey": "component-password",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(t, output, &deployment)
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_OPTIMIZE_OPENSEARCH_HOST", Value: "component-os-host"})
+				s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_OPTIMIZE_OPENSEARCH_HTTP_PORT", Value: "9222"})
+				s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_OPTIMIZE_OPENSEARCH_SECURITY_USERNAME", Value: "component-user"})
+				s.Require().Contains(env, corev1.EnvVar{
+					Name: "CAMUNDA_OPTIMIZE_OPENSEARCH_SECURITY_PASSWORD",
+					ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "component-os-auth"},
+						Key:                  "component-password",
+					}},
+				})
+				for _, envVar := range env {
+					s.Require().NotEqual("CAMUNDA_OPTIMIZE_OPENSEARCH_SSL_ENABLED", envVar.Name)
+				}
+			},
+		},
+		{
+			Name: "Component Elasticsearch settings",
+			Values: map[string]string{
+				"identity.enabled":                                              "true",
+				"optimize.enabled":                                              "true",
+				"optimize.database.elasticsearch.enabled":                       "true",
+				"optimize.database.elasticsearch.external":                      "true",
+				"optimize.database.opensearch.enabled":                          "false",
+				"optimize.database.elasticsearch.url.protocol":                  "https",
+				"optimize.database.elasticsearch.url.host":                      "elasticsearch-host",
+				"optimize.database.elasticsearch.url.port":                      "9211",
+				"optimize.database.elasticsearch.auth.username":                 "elasticsearch-user",
+				"optimize.database.elasticsearch.auth.secret.existingSecret":    "elasticsearch-auth",
+				"optimize.database.elasticsearch.auth.secret.existingSecretKey": "password",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(t, output, &deployment)
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env, corev1.EnvVar{Name: "OPTIMIZE_ELASTICSEARCH_HOST", Value: "elasticsearch-host"})
+				s.Require().Contains(env, corev1.EnvVar{Name: "OPTIMIZE_ELASTICSEARCH_HTTP_PORT", Value: "9211"})
+				s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_OPTIMIZE_ELASTICSEARCH_SECURITY_USERNAME", Value: "elasticsearch-user"})
+				s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_OPTIMIZE_ELASTICSEARCH_SSL_ENABLED", Value: "true"})
+				s.Require().Contains(env, corev1.EnvVar{
+					Name: "CAMUNDA_OPTIMIZE_ELASTICSEARCH_SECURITY_PASSWORD",
+					ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "elasticsearch-auth"},
+						Key:                  "password",
+					}},
+				})
+			},
+		},
+		{
+			Name: "Component Elasticsearch HTTP settings omit SSL",
+			Values: map[string]string{
+				"identity.enabled":                                              "true",
+				"optimize.enabled":                                              "true",
+				"optimize.database.elasticsearch.enabled":                       "true",
+				"optimize.database.elasticsearch.external":                      "true",
+				"optimize.database.opensearch.enabled":                          "false",
+				"optimize.database.elasticsearch.url.protocol":                  "http",
+				"optimize.database.elasticsearch.url.host":                      "component-es-host",
+				"optimize.database.elasticsearch.url.port":                      "9222",
+				"optimize.database.elasticsearch.auth.username":                 "component-user",
+				"optimize.database.elasticsearch.auth.secret.existingSecret":    "component-es-auth",
+				"optimize.database.elasticsearch.auth.secret.existingSecretKey": "component-password",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(t, output, &deployment)
+				env := deployment.Spec.Template.Spec.Containers[0].Env
+				s.Require().Contains(env, corev1.EnvVar{Name: "OPTIMIZE_ELASTICSEARCH_HOST", Value: "component-es-host"})
+				s.Require().Contains(env, corev1.EnvVar{Name: "OPTIMIZE_ELASTICSEARCH_HTTP_PORT", Value: "9222"})
+				s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_OPTIMIZE_ELASTICSEARCH_SECURITY_USERNAME", Value: "component-user"})
+				s.Require().Contains(env, corev1.EnvVar{
+					Name: "CAMUNDA_OPTIMIZE_ELASTICSEARCH_SECURITY_PASSWORD",
+					ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "component-es-auth"},
+						Key:                  "component-password",
+					}},
+				})
+				for _, envVar := range env {
+					s.Require().NotEqual("CAMUNDA_OPTIMIZE_ELASTICSEARCH_SSL_ENABLED", envVar.Name)
+				}
+			},
+		},
+		// ---- Elasticsearch overrides ----
+		{
+			Name: "TestElasticsearchPortFromOptimizeDatabase",
 			Values: map[string]string{
 				"identity.enabled":                         "true",
 				"optimize.enabled":                         "true",
+				"optimize.database.elasticsearch.enabled":  "true",
+				"optimize.database.elasticsearch.external": "true",
+				"optimize.database.elasticsearch.url.host": "elasticsearch-host",
 				"optimize.database.elasticsearch.url.port": "9201",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
@@ -1088,11 +1114,13 @@ func (s *DeploymentTemplateTest) TestDatabaseOverrides() {
 			},
 		},
 		{
-			Name: "TestElasticsearchExternalAuthFromOptimizeDatabaseConfig",
+			Name: "TestElasticsearchSecretPasswordFromOptimizeDatabase",
 			Values: map[string]string{
-				"identity.enabled":              "true",
-				"optimize.enabled":              "true",
-				"global.elasticsearch.external": "true",
+				"identity.enabled":                                              "true",
+				"optimize.enabled":                                              "true",
+				"optimize.database.elasticsearch.enabled":                       "true",
+				"optimize.database.elasticsearch.external":                      "true",
+				"optimize.database.elasticsearch.url.host":                      "elasticsearch-host",
 				"optimize.database.elasticsearch.auth.secret.existingSecret":    "my-es-secret",
 				"optimize.database.elasticsearch.auth.secret.existingSecretKey": "es-password",
 			},
@@ -1114,36 +1142,13 @@ func (s *DeploymentTemplateTest) TestDatabaseOverrides() {
 			},
 		},
 		{
-			Name: "TestElasticsearchExternalAuthSetAtOptimizeLevelOnly",
-			Values: map[string]string{
-				"identity.enabled":              "true",
-				"optimize.enabled":              "true",
-				"global.elasticsearch.external": "true",
-				"optimize.database.elasticsearch.auth.secret.existingSecret":    "optimize-es-secret",
-				"optimize.database.elasticsearch.auth.secret.existingSecretKey": "optimize-password",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				var deployment appsv1.Deployment
-				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-				env := deployment.Spec.Template.Spec.Containers[0].Env
-				s.Require().Contains(env, corev1.EnvVar{
-					Name: "CAMUNDA_OPTIMIZE_ELASTICSEARCH_SECURITY_PASSWORD",
-					ValueFrom: &corev1.EnvVarSource{
-						SecretKeyRef: &corev1.SecretKeySelector{
-							LocalObjectReference: corev1.LocalObjectReference{Name: "optimize-es-secret"},
-							Key:                  "optimize-password",
-						},
-					},
-				})
-			},
-		},
-		{
 			Name: "TestElasticsearchPortInMigrationInitContainer",
 			Values: map[string]string{
 				"identity.enabled":                         "true",
 				"optimize.enabled":                         "true",
+				"optimize.database.elasticsearch.enabled":  "true",
+				"optimize.database.elasticsearch.external": "true",
+				"optimize.database.elasticsearch.url.host": "elasticsearch-host",
 				"optimize.database.elasticsearch.url.port": "9300",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
@@ -1168,32 +1173,14 @@ func (s *DeploymentTemplateTest) TestDatabaseOverrides() {
 		},
 		// ---- OpenSearch overrides ----
 		{
-			Name: "TestOpensearchPortUsesGlobalDefault",
+			Name: "TestOpensearchPortFromOptimizeDatabase",
 			Values: map[string]string{
-				"identity.enabled":             "true",
-				"optimize.enabled":             "true",
-				"global.elasticsearch.enabled": "false",
-				"global.opensearch.enabled":    "true",
-				"global.opensearch.url.host":   "opensearch-host",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				var deployment appsv1.Deployment
-				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-				env := deployment.Spec.Template.Spec.Containers[0].Env
-				s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_OPTIMIZE_OPENSEARCH_HTTP_PORT", Value: "443"})
-			},
-		},
-		{
-			Name: "TestOpensearchPortOverriddenByOptimizeDatabase",
-			Values: map[string]string{
-				"identity.enabled":                      "true",
-				"optimize.enabled":                      "true",
-				"global.elasticsearch.enabled":          "false",
-				"global.opensearch.enabled":             "true",
-				"global.opensearch.url.host":            "opensearch-host",
-				"optimize.database.opensearch.url.port": "9200",
+				"identity.enabled":                        "true",
+				"optimize.enabled":                        "true",
+				"optimize.database.elasticsearch.enabled": "false",
+				"optimize.database.opensearch.enabled":    "true",
+				"optimize.database.opensearch.url.host":   "opensearch-host",
+				"optimize.database.opensearch.url.port":   "9200",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				require.NoError(t, err)
@@ -1205,33 +1192,13 @@ func (s *DeploymentTemplateTest) TestDatabaseOverrides() {
 			},
 		},
 		{
-			Name: "TestOpensearchUsernameUsesGlobalDefault",
-			Values: map[string]string{
-				"identity.enabled":                "true",
-				"optimize.enabled":                "true",
-				"global.elasticsearch.enabled":    "false",
-				"global.opensearch.enabled":       "true",
-				"global.opensearch.url.host":      "opensearch-host",
-				"global.opensearch.auth.username": "globaluser",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				var deployment appsv1.Deployment
-				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-				env := deployment.Spec.Template.Spec.Containers[0].Env
-				s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_OPTIMIZE_OPENSEARCH_SECURITY_USERNAME", Value: "globaluser"})
-			},
-		},
-		{
-			Name: "TestOpensearchUsernameOverriddenByOptimizeDatabase",
+			Name: "TestOpensearchUsernameFromOptimizeDatabase",
 			Values: map[string]string{
 				"identity.enabled":                           "true",
 				"optimize.enabled":                           "true",
-				"global.elasticsearch.enabled":               "false",
-				"global.opensearch.enabled":                  "true",
-				"global.opensearch.url.host":                 "opensearch-host",
-				"global.opensearch.auth.username":            "globaluser",
+				"optimize.database.elasticsearch.enabled":    "false",
+				"optimize.database.opensearch.enabled":       "true",
+				"optimize.database.opensearch.url.host":      "opensearch-host",
 				"optimize.database.opensearch.auth.username": "optimizeuser",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
@@ -1246,11 +1213,11 @@ func (s *DeploymentTemplateTest) TestDatabaseOverrides() {
 		{
 			Name: "TestOpensearchDatabaseTypeSetWhenHostConfigured",
 			Values: map[string]string{
-				"identity.enabled":             "true",
-				"optimize.enabled":             "true",
-				"global.elasticsearch.enabled": "false",
-				"global.opensearch.enabled":    "true",
-				"global.opensearch.url.host":   "opensearch-host",
+				"identity.enabled":                        "true",
+				"optimize.enabled":                        "true",
+				"optimize.database.elasticsearch.enabled": "false",
+				"optimize.database.opensearch.enabled":    "true",
+				"optimize.database.opensearch.url.host":   "opensearch-host",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				require.NoError(t, err)
@@ -1265,12 +1232,12 @@ func (s *DeploymentTemplateTest) TestDatabaseOverrides() {
 		{
 			Name: "TestOpensearchSslEnabledWhenProtocolIsHttps",
 			Values: map[string]string{
-				"identity.enabled":               "true",
-				"optimize.enabled":               "true",
-				"global.elasticsearch.enabled":   "false",
-				"global.opensearch.enabled":      "true",
-				"global.opensearch.url.host":     "opensearch-host",
-				"global.opensearch.url.protocol": "https",
+				"identity.enabled":                          "true",
+				"optimize.enabled":                          "true",
+				"optimize.database.elasticsearch.enabled":   "false",
+				"optimize.database.opensearch.enabled":      "true",
+				"optimize.database.opensearch.url.host":     "opensearch-host",
+				"optimize.database.opensearch.url.protocol": "https",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				require.NoError(t, err)
@@ -1282,14 +1249,13 @@ func (s *DeploymentTemplateTest) TestDatabaseOverrides() {
 			},
 		},
 		{
-			Name: "TestOpensearchSslNotSetWhenProtocolOverriddenToHttp",
+			Name: "TestOpensearchSslNotSetWhenProtocolIsHttp",
 			Values: map[string]string{
 				"identity.enabled":                          "true",
 				"optimize.enabled":                          "true",
-				"global.elasticsearch.enabled":              "false",
-				"global.opensearch.enabled":                 "true",
-				"global.opensearch.url.host":                "opensearch-host",
-				"global.opensearch.url.protocol":            "https",
+				"optimize.database.elasticsearch.enabled":   "false",
+				"optimize.database.opensearch.enabled":      "true",
+				"optimize.database.opensearch.url.host":     "opensearch-host",
 				"optimize.database.opensearch.url.protocol": "http",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
@@ -1305,33 +1271,13 @@ func (s *DeploymentTemplateTest) TestDatabaseOverrides() {
 			},
 		},
 		{
-			Name: "TestOpensearchAwsEnabledFromGlobal",
-			Values: map[string]string{
-				"identity.enabled":              "true",
-				"optimize.enabled":              "true",
-				"global.elasticsearch.enabled":  "false",
-				"global.opensearch.enabled":     "true",
-				"global.opensearch.url.host":    "opensearch-host",
-				"global.opensearch.aws.enabled": "true",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				var deployment appsv1.Deployment
-				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-				env := deployment.Spec.Template.Spec.Containers[0].Env
-				s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_OPTIMIZE_OPENSEARCH_AWS_ENABLED", Value: "true"})
-			},
-		},
-		{
-			Name: "TestOpensearchAwsEnabledOverriddenByOptimizeDatabase",
+			Name: "TestOpensearchAwsEnabledFromOptimizeDatabase",
 			Values: map[string]string{
 				"identity.enabled":                         "true",
 				"optimize.enabled":                         "true",
-				"global.elasticsearch.enabled":             "false",
-				"global.opensearch.enabled":                "true",
-				"global.opensearch.url.host":               "opensearch-host",
-				"global.opensearch.aws.enabled":            "false",
+				"optimize.database.elasticsearch.enabled":  "false",
+				"optimize.database.opensearch.enabled":     "true",
+				"optimize.database.opensearch.url.host":    "opensearch-host",
 				"optimize.database.opensearch.aws.enabled": "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
@@ -1343,152 +1289,14 @@ func (s *DeploymentTemplateTest) TestDatabaseOverrides() {
 				s.Require().Contains(env, corev1.EnvVar{Name: "CAMUNDA_OPTIMIZE_OPENSEARCH_AWS_ENABLED", Value: "true"})
 			},
 		},
-		// ---- TLS overrides ----
 		{
-			Name: "TestElasticsearchTlsVolumeFromGlobal",
-			Values: map[string]string{
-				"identity.enabled": "true",
-				"optimize.enabled": "true",
-				"global.elasticsearch.tls.secret.existingSecret":    "my-es-tls-secret",
-				"global.elasticsearch.tls.secret.existingSecretKey": "externaldb.jks",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				var deployment appsv1.Deployment
-				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-				// Check that the keystore volume exists
-				volumes := deployment.Spec.Template.Spec.Volumes
-				var keystoreVolume *corev1.Volume
-				for i := range volumes {
-					if volumes[i].Name == "keystore" {
-						keystoreVolume = &volumes[i]
-						break
-					}
-				}
-				s.Require().NotNil(keystoreVolume, "keystore volume should be present")
-				s.Require().Equal("my-es-tls-secret", keystoreVolume.Secret.SecretName)
-			},
-		},
-		{
-			Name: "TestElasticsearchTlsVolumeOverriddenByOptimizeDatabase",
-			Values: map[string]string{
-				"identity.enabled": "true",
-				"optimize.enabled": "true",
-				"global.elasticsearch.tls.secret.existingSecret":               "global-es-tls-secret",
-				"global.elasticsearch.tls.secret.existingSecretKey":            "externaldb.jks",
-				"optimize.database.elasticsearch.tls.secret.existingSecret":    "optimize-es-tls-secret",
-				"optimize.database.elasticsearch.tls.secret.existingSecretKey": "externaldb.jks",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				var deployment appsv1.Deployment
-				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-				// Check that the keystore volume uses the optimize override
-				volumes := deployment.Spec.Template.Spec.Volumes
-				var keystoreVolume *corev1.Volume
-				for i := range volumes {
-					if volumes[i].Name == "keystore" {
-						keystoreVolume = &volumes[i]
-						break
-					}
-				}
-				s.Require().NotNil(keystoreVolume, "keystore volume should be present")
-				s.Require().Equal("optimize-es-tls-secret", keystoreVolume.Secret.SecretName)
-			},
-		},
-		{
-			Name: "TestElasticsearchTlsJavaOptsInContainerFromGlobal",
-			Values: map[string]string{
-				"identity.enabled": "true",
-				"optimize.enabled": "true",
-				"global.elasticsearch.tls.secret.existingSecret":    "my-es-tls-secret",
-				"global.elasticsearch.tls.secret.existingSecretKey": "externaldb.jks",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				var deployment appsv1.Deployment
-				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-				env := deployment.Spec.Template.Spec.Containers[0].Env
-				var javaToolOptions *corev1.EnvVar
-				for i := range env {
-					if env[i].Name == "JAVA_TOOL_OPTIONS" {
-						javaToolOptions = &env[i]
-						break
-					}
-				}
-				s.Require().NotNil(javaToolOptions, "JAVA_TOOL_OPTIONS should be set when TLS is configured")
-				s.Require().Contains(javaToolOptions.Value, "-Djavax.net.ssl.trustStore=/optimize/certificates/externaldb.jks")
-			},
-		},
-		{
-			Name: "TestOpensearchTlsVolumeFromGlobal",
-			Values: map[string]string{
-				"identity.enabled":                               "true",
-				"optimize.enabled":                               "true",
-				"global.elasticsearch.enabled":                   "false",
-				"global.opensearch.enabled":                      "true",
-				"global.opensearch.url.host":                     "opensearch-host",
-				"global.opensearch.tls.secret.existingSecret":    "my-os-tls-secret",
-				"global.opensearch.tls.secret.existingSecretKey": "externaldb.jks",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				var deployment appsv1.Deployment
-				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-				volumes := deployment.Spec.Template.Spec.Volumes
-				var keystoreVolume *corev1.Volume
-				for i := range volumes {
-					if volumes[i].Name == "keystore" {
-						keystoreVolume = &volumes[i]
-						break
-					}
-				}
-				s.Require().NotNil(keystoreVolume, "keystore volume should be present for opensearch TLS")
-				s.Require().Equal("my-os-tls-secret", keystoreVolume.Secret.SecretName)
-			},
-		},
-		{
-			Name: "TestOpensearchSecretPasswordFromGlobal",
-			Values: map[string]string{
-				"identity.enabled":                                "true",
-				"optimize.enabled":                                "true",
-				"global.elasticsearch.enabled":                    "false",
-				"global.opensearch.enabled":                       "true",
-				"global.opensearch.url.host":                      "opensearch-host",
-				"global.opensearch.auth.secret.existingSecret":    "my-os-auth-secret",
-				"global.opensearch.auth.secret.existingSecretKey": "os-password",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				var deployment appsv1.Deployment
-				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
-
-				env := deployment.Spec.Template.Spec.Containers[0].Env
-				s.Require().Contains(env, corev1.EnvVar{
-					Name: "CAMUNDA_OPTIMIZE_OPENSEARCH_SECURITY_PASSWORD",
-					ValueFrom: &corev1.EnvVarSource{
-						SecretKeyRef: &corev1.SecretKeySelector{
-							LocalObjectReference: corev1.LocalObjectReference{Name: "my-os-auth-secret"},
-							Key:                  "os-password",
-						},
-					},
-				})
-			},
-		},
-		{
-			Name: "TestOpensearchSecretPasswordOverriddenByOptimizeDatabase",
+			Name: "TestOpensearchSecretPasswordFromOptimizeDatabase",
 			Values: map[string]string{
 				"identity.enabled":                                           "true",
 				"optimize.enabled":                                           "true",
-				"global.elasticsearch.enabled":                               "false",
-				"global.opensearch.enabled":                                  "true",
-				"global.opensearch.url.host":                                 "opensearch-host",
-				"global.opensearch.auth.secret.existingSecret":               "global-os-auth-secret",
-				"global.opensearch.auth.secret.existingSecretKey":            "global-password",
+				"optimize.database.elasticsearch.enabled":                    "false",
+				"optimize.database.opensearch.enabled":                       "true",
+				"optimize.database.opensearch.url.host":                      "opensearch-host",
 				"optimize.database.opensearch.auth.secret.existingSecret":    "optimize-os-auth-secret",
 				"optimize.database.opensearch.auth.secret.existingSecretKey": "optimize-password",
 			},

--- a/charts/camunda-platform-8.10/test/unit/optimize/goldenfiles_test.go
+++ b/charts/camunda-platform-8.10/test/unit/optimize/goldenfiles_test.go
@@ -44,8 +44,9 @@ func TestGoldenDefaultsTemplateOptimize(t *testing.T) {
 				`\s+checksum/.+?:\s+.*`, // ignore configmap checksum.
 			},
 			SetValues: map[string]string{
-				"optimize.enabled": "true",
-				"identity.enabled": "true",
+				"optimize.enabled":                        "true",
+				"optimize.database.elasticsearch.enabled": "true",
+				"identity.enabled":                        "true",
 			},
 		})
 	}

--- a/charts/camunda-platform-8.10/test/unit/optimize/persistence_test.go
+++ b/charts/camunda-platform-8.10/test/unit/optimize/persistence_test.go
@@ -178,9 +178,9 @@ func (s *PersistenceTemplateTest) TestPersistenceConfiguration() {
 			helmChartPath, err := filepath.Abs(s.chartPath)
 			s.Require().NoError(err)
 
-			// Merge test values with required elasticsearch flags
+			// Merge test values with the required secondary storage type
 			mergedValues := make(map[string]string)
-			mergedValues["global.elasticsearch.enabled"] = "true"
+			mergedValues["orchestration.data.secondaryStorage.type"] = "elasticsearch"
 			for k, v := range testCase.Values {
 				mergedValues[k] = v
 			}

--- a/charts/camunda-platform-8.10/test/unit/optimize/resources_cpu_test.go
+++ b/charts/camunda-platform-8.10/test/unit/optimize/resources_cpu_test.go
@@ -55,13 +55,13 @@ func (s *ResourcesCPUTemplateTest) TestCPUResourcesAsString() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"optimize.enabled":                   "true",
-			"identity.enabled":                   "true",
-			"global.elasticsearch.enabled":       "true",
-			"optimize.resources.requests.cpu":    "500m",
-			"optimize.resources.limits.cpu":      "1.5",
-			"optimize.resources.requests.memory": "512Mi",
-			"optimize.resources.limits.memory":   "1Gi",
+			"optimize.enabled":                         "true",
+			"identity.enabled":                         "true",
+			"orchestration.data.secondaryStorage.type": "elasticsearch",
+			"optimize.resources.requests.cpu":          "500m",
+			"optimize.resources.limits.cpu":            "1.5",
+			"optimize.resources.requests.memory":       "512Mi",
+			"optimize.resources.limits.memory":         "1Gi",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 	}
@@ -95,13 +95,13 @@ func (s *ResourcesCPUTemplateTest) TestCPUResourcesBackwardCompatibility() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"optimize.enabled":                   "true",
-			"identity.enabled":                   "true",
-			"global.elasticsearch.enabled":       "true",
-			"optimize.resources.requests.cpu":    "600m",
-			"optimize.resources.limits.cpu":      "2000m",
-			"optimize.resources.requests.memory": "1Gi",
-			"optimize.resources.limits.memory":   "2Gi",
+			"optimize.enabled":                         "true",
+			"identity.enabled":                         "true",
+			"orchestration.data.secondaryStorage.type": "elasticsearch",
+			"optimize.resources.requests.cpu":          "600m",
+			"optimize.resources.limits.cpu":            "2000m",
+			"optimize.resources.requests.memory":       "1Gi",
+			"optimize.resources.limits.memory":         "2Gi",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 	}

--- a/charts/camunda-platform-8.10/test/unit/optimize/testdata/values-templated-labels.yaml
+++ b/charts/camunda-platform-8.10/test/unit/optimize/testdata/values-templated-labels.yaml
@@ -1,8 +1,3 @@
-global:
-  elasticsearch:
-    enabled: true
-
-
 orchestration:
   data:
     secondaryStorage:

--- a/charts/camunda-platform-8.10/test/unit/orchestration/configmap_unified_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/configmap_unified_test.go
@@ -20,9 +20,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
 )
 
 type ConfigmapTemplateTest struct {
@@ -31,6 +34,21 @@ type ConfigmapTemplateTest struct {
 	release   string
 	namespace string
 	templates []string
+}
+
+type orchestrationApplication struct {
+	Camunda struct {
+		Security struct {
+			Authentication struct {
+				OIDC struct {
+					GroupsClaim string `yaml:"groups-claim"`
+				} `yaml:"oidc"`
+				Basic struct {
+					AllowUnauthenticatedAPIAccess bool `yaml:"allow-unauthenticated-api-access"`
+				} `yaml:"basic"`
+			} `yaml:"authentication"`
+		} `yaml:"security"`
+	} `yaml:"camunda"`
 }
 
 func TestConfigmapUnifiedTemplate(t *testing.T) {
@@ -89,8 +107,8 @@ func (s *ConfigmapTemplateTest) TestDifferentValuesInputsUnified() {
 		{
 			Name: "TestApplicationYamlShouldContainSecondaryStorageOpenSearchEnabled",
 			Values: map[string]string{
-				"global.opensearch.enabled":  "true",
-				"global.opensearch.url.host": "opensearch.example.com",
+				"orchestration.data.secondaryStorage.type":           "opensearch",
+				"orchestration.data.secondaryStorage.opensearch.url": "https://opensearch.example.com:443",
 			},
 			Expected: map[string]string{
 				"configmapApplication.camunda.data.secondary-storage.opensearch.url": "https://opensearch.example.com:443",
@@ -129,7 +147,6 @@ func (s *ConfigmapTemplateTest) TestDifferentValuesInputsUnified() {
 			Name: "TestApplicationYamlNoWebAppProfilesWhenNoSecondaryStorageEnabled",
 			Values: map[string]string{
 				"global.noSecondaryStorage":                    "true",
-				"global.elasticsearch.enabled":                 "false",
 				"orchestration.security.authentication.method": "oidc",
 			},
 			Expected: map[string]string{
@@ -247,8 +264,8 @@ func (s *ConfigmapTemplateTest) TestDifferentValuesInputsUnifiedOpenSearchAWS() 
 		{
 			Name: "TestApplicationYamlShouldContainOpenSearchAwsEnabledFalseByDefault",
 			Values: map[string]string{
-				"global.opensearch.enabled":  "true",
-				"global.opensearch.url.host": "opensearch.example.com",
+				"orchestration.data.secondaryStorage.type":           "opensearch",
+				"orchestration.data.secondaryStorage.opensearch.url": "https://opensearch.example.com:443",
 			},
 			Expected: map[string]string{
 				"configmapApplication.camunda.data.secondary-storage.opensearch.aws-enabled": "false",
@@ -257,20 +274,9 @@ func (s *ConfigmapTemplateTest) TestDifferentValuesInputsUnifiedOpenSearchAWS() 
 		{
 			Name: "TestApplicationYamlShouldContainOpenSearchAwsEnabledViaSecondaryStorage",
 			Values: map[string]string{
-				"global.opensearch.enabled":                                  "true",
-				"global.opensearch.url.host":                                 "opensearch.example.com",
+				"orchestration.data.secondaryStorage.type":                   "opensearch",
+				"orchestration.data.secondaryStorage.opensearch.url":         "https://opensearch.example.com:443",
 				"orchestration.data.secondaryStorage.opensearch.aws.enabled": "true",
-			},
-			Expected: map[string]string{
-				"configmapApplication.camunda.data.secondary-storage.opensearch.aws-enabled": "true",
-			},
-		},
-		{
-			Name: "TestApplicationYamlShouldContainOpenSearchAwsEnabledViaDeprecatedGlobal",
-			Values: map[string]string{
-				"global.opensearch.enabled":     "true",
-				"global.opensearch.url.host":    "opensearch.example.com",
-				"global.opensearch.aws.enabled": "true",
 			},
 			Expected: map[string]string{
 				"configmapApplication.camunda.data.secondary-storage.opensearch.aws-enabled": "true",
@@ -286,7 +292,7 @@ func (s *ConfigmapTemplateTest) TestDifferentValuesInputsUnifiedElasticsearchAWS
 		{
 			Name: "TestApplicationYamlShouldContainElasticsearchAwsEnabledFalseByDefault",
 			Values: map[string]string{
-				"global.elasticsearch.enabled": "true",
+				"orchestration.data.secondaryStorage.type": "elasticsearch",
 			},
 			Expected: map[string]string{
 				"configmapApplication.camunda.data.secondary-storage.elasticsearch.aws-enabled": "false",
@@ -295,7 +301,7 @@ func (s *ConfigmapTemplateTest) TestDifferentValuesInputsUnifiedElasticsearchAWS
 		{
 			Name: "TestApplicationYamlShouldContainElasticsearchAwsEnabledViaSecondaryStorage",
 			Values: map[string]string{
-				"global.elasticsearch.enabled":                                  "true",
+				"orchestration.data.secondaryStorage.type":                      "elasticsearch",
 				"orchestration.data.secondaryStorage.elasticsearch.aws.enabled": "true",
 			},
 			Expected: map[string]string{
@@ -480,8 +486,14 @@ func (s *ConfigmapTemplateTest) TestGroupsClaimConditionalRendering() {
 				"orchestration.security.authentication.oidc.groupsClaim": "custom-groups",
 				"orchestration.data.secondaryStorage.type":               "elasticsearch",
 			},
-			Expected: map[string]string{
-				"configmapApplication.camunda.security.authentication.oidc.groups-claim": "custom-groups",
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				var configMap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(t, output, &configMap)
+				var application orchestrationApplication
+				require.NoError(t, yaml.Unmarshal([]byte(configMap.Data["application.yaml"]), &application))
+				require.Equal(t, "custom-groups", application.Camunda.Security.Authentication.OIDC.GroupsClaim)
 			},
 		},
 	}
@@ -528,8 +540,14 @@ func (s *ConfigmapTemplateTest) TestUnprotectedApiConditionalRendering() {
 				"orchestration.security.authentication.method":         "basic",
 				"orchestration.security.authentication.unprotectedApi": "true",
 			},
-			Expected: map[string]string{
-				"configmapApplication.camunda.security.authentication.basic.allow-unauthenticated-api-access": "true",
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				var configMap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(t, output, &configMap)
+				var application orchestrationApplication
+				require.NoError(t, yaml.Unmarshal([]byte(configMap.Data["application.yaml"]), &application))
+				require.True(t, application.Camunda.Security.Authentication.Basic.AllowUnauthenticatedAPIAccess)
 			},
 		},
 		{
@@ -600,15 +618,14 @@ func (s *ConfigmapTemplateTest) TestHasLegacyElasticsearchExporter() {
 		{
 			Name: "TestLegacyESExporterAbsentWhenRdbmsAndOptimizeButNoElasticsearch",
 			Values: map[string]string{
-				"global.elasticsearch.enabled":                                  "false",
-				"global.opensearch.enabled":                                     "true",
-				"global.opensearch.url.host":                                    "opensearch.example.com",
+				"orchestration.data.secondaryStorage.type":                      "rdbms",
 				"orchestration.exporters.rdbms.enabled":                         "true",
 				"orchestration.data.secondaryStorage.rdbms.url":                 "jdbc:postgresql://localhost:5432/camunda",
 				"orchestration.data.secondaryStorage.rdbms.username":            "camunda",
 				"orchestration.data.secondaryStorage.rdbms.secret.inlineSecret": "my-password",
-				"optimize.enabled":                                              "true",
-				"optimize.database.opensearch.enabled":                          "true",
+				"optimize.enabled":                      "true",
+				"optimize.database.opensearch.enabled":  "true",
+				"optimize.database.opensearch.url.host": "opensearch.example.com",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				require.NoError(t, err)
@@ -617,33 +634,16 @@ func (s *ConfigmapTemplateTest) TestHasLegacyElasticsearchExporter() {
 			},
 		},
 		{
-			Name: "TestLegacyESExporterPresentWhenRdbmsAndOptimizeAndGlobalElasticsearch",
-			Values: map[string]string{
-				"orchestration.exporters.rdbms.enabled":                         "true",
-				"orchestration.data.secondaryStorage.rdbms.url":                 "jdbc:postgresql://localhost:5432/camunda",
-				"orchestration.data.secondaryStorage.rdbms.username":            "camunda",
-				"orchestration.data.secondaryStorage.rdbms.secret.inlineSecret": "my-password",
-				"optimize.enabled": "true",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				require.Contains(t, output, "io.camunda.zeebe.exporter.ElasticsearchExporter",
-					"rdbms+optimize with global.elasticsearch.enabled must render legacy ES exporter")
-			},
-		},
-		{
 			Name: "TestLegacyESExporterPresentWhenRdbmsAndOptimizeDatabaseElasticsearchOnly",
 			Values: map[string]string{
-				"global.elasticsearch.enabled":                                  "false",
-				"global.opensearch.enabled":                                     "true",
-				"global.opensearch.url.host":                                    "opensearch.example.com",
+				"orchestration.data.secondaryStorage.type":                      "rdbms",
 				"orchestration.exporters.rdbms.enabled":                         "true",
 				"orchestration.data.secondaryStorage.rdbms.url":                 "jdbc:postgresql://localhost:5432/camunda",
 				"orchestration.data.secondaryStorage.rdbms.username":            "camunda",
 				"orchestration.data.secondaryStorage.rdbms.secret.inlineSecret": "my-password",
-				"optimize.enabled":                                              "true",
-				"optimize.database.elasticsearch.enabled":                       "true",
-				"optimize.database.elasticsearch.external":                      "true",
+				"optimize.enabled":                         "true",
+				"optimize.database.elasticsearch.enabled":  "true",
+				"optimize.database.elasticsearch.external": "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				require.NoError(t, err)
@@ -654,16 +654,15 @@ func (s *ConfigmapTemplateTest) TestHasLegacyElasticsearchExporter() {
 		{
 			Name: "TestLegacyESExporterAbsentForSupport32901CustomerConfig",
 			Values: map[string]string{
-				"global.elasticsearch.enabled":                                  "false",
-				"global.opensearch.enabled":                                     "true",
-				"global.opensearch.url.host":                                    "opensearch.example.com",
+				"orchestration.data.secondaryStorage.type":                      "rdbms",
 				"orchestration.exporters.rdbms.enabled":                         "true",
 				"orchestration.exporters.zeebe.enabled":                         "true",
 				"orchestration.data.secondaryStorage.rdbms.url":                 "jdbc:postgresql://localhost:5432/camunda",
 				"orchestration.data.secondaryStorage.rdbms.username":            "camunda",
 				"orchestration.data.secondaryStorage.rdbms.secret.inlineSecret": "my-password",
-				"optimize.enabled":                                              "true",
-				"optimize.database.opensearch.enabled":                          "true",
+				"optimize.enabled":                      "true",
+				"optimize.database.opensearch.enabled":  "true",
+				"optimize.database.opensearch.url.host": "opensearch.example.com",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				require.NoError(t, err)
@@ -676,9 +675,7 @@ func (s *ConfigmapTemplateTest) TestHasLegacyElasticsearchExporter() {
 		{
 			Name: "TestLegacyESExporterAbsentWhenOnlyRdbmsNoOptimize",
 			Values: map[string]string{
-				"global.elasticsearch.enabled":                                  "false",
-				"global.opensearch.enabled":                                     "true",
-				"global.opensearch.url.host":                                    "opensearch.example.com",
+				"orchestration.data.secondaryStorage.type":                      "rdbms",
 				"orchestration.exporters.rdbms.enabled":                         "true",
 				"orchestration.data.secondaryStorage.rdbms.url":                 "jdbc:postgresql://localhost:5432/camunda",
 				"orchestration.data.secondaryStorage.rdbms.username":            "camunda",
@@ -700,8 +697,9 @@ func (s *ConfigmapTemplateTest) TestLegacyZeebeExporterReplicas() {
 		{
 			Name: "ESExporterReplicasInheritIndexReplicasByDefault",
 			Values: map[string]string{
-				"orchestration.exporters.zeebe.enabled": "true",
-				"global.elasticsearch.enabled":          "true",
+				"orchestration.exporters.zeebe.enabled":   "true",
+				"optimize.enabled":                        "true",
+				"optimize.database.elasticsearch.enabled": "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				require.NoError(t, err)
@@ -713,9 +711,10 @@ func (s *ConfigmapTemplateTest) TestLegacyZeebeExporterReplicas() {
 		{
 			Name: "ESExporterReplicasInheritCustomIndexReplicas",
 			Values: map[string]string{
-				"orchestration.exporters.zeebe.enabled": "true",
-				"global.elasticsearch.enabled":          "true",
-				"orchestration.index.replicas":          "3",
+				"orchestration.exporters.zeebe.enabled":   "true",
+				"optimize.enabled":                        "true",
+				"optimize.database.elasticsearch.enabled": "true",
+				"orchestration.index.replicas":            "3",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				require.NoError(t, err)
@@ -726,10 +725,11 @@ func (s *ConfigmapTemplateTest) TestLegacyZeebeExporterReplicas() {
 		{
 			Name: "ESExporterReplicasIndependentOverride",
 			Values: map[string]string{
-				"orchestration.exporters.zeebe.enabled":  "true",
-				"global.elasticsearch.enabled":           "true",
-				"orchestration.index.replicas":           "3",
-				"orchestration.exporters.zeebe.replicas": "2",
+				"orchestration.exporters.zeebe.enabled":   "true",
+				"optimize.enabled":                        "true",
+				"optimize.database.elasticsearch.enabled": "true",
+				"orchestration.index.replicas":            "3",
+				"orchestration.exporters.zeebe.replicas":  "2",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				require.NoError(t, err)
@@ -740,9 +740,10 @@ func (s *ConfigmapTemplateTest) TestLegacyZeebeExporterReplicas() {
 		{
 			Name: "ESExporterReplicasExplicitZero",
 			Values: map[string]string{
-				"orchestration.exporters.zeebe.enabled":  "true",
-				"global.elasticsearch.enabled":           "true",
-				"orchestration.exporters.zeebe.replicas": "0",
+				"orchestration.exporters.zeebe.enabled":   "true",
+				"optimize.enabled":                        "true",
+				"optimize.database.elasticsearch.enabled": "true",
+				"orchestration.exporters.zeebe.replicas":  "0",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				require.NoError(t, err)
@@ -754,10 +755,10 @@ func (s *ConfigmapTemplateTest) TestLegacyZeebeExporterReplicas() {
 			Name: "OSExporterReplicas",
 			Values: map[string]string{
 				"orchestration.exporters.zeebe.enabled":  "true",
-				"global.elasticsearch.enabled":           "false",
-				"global.opensearch.enabled":              "true",
-				"global.opensearch.url.host":             "opensearch.example.com",
 				"orchestration.exporters.zeebe.replicas": "5",
+				"optimize.enabled":                       "true",
+				"optimize.database.opensearch.enabled":   "true",
+				"optimize.database.opensearch.url.host":  "opensearch.example.com",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				require.NoError(t, err)

--- a/charts/camunda-platform-8.10/test/unit/orchestration/goldenfiles_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/goldenfiles_test.go
@@ -45,33 +45,6 @@ func TestGoldenDefaultsTemplateOrchestration(t *testing.T) {
 			Namespace:      "camunda-platform-" + strings.ToLower(random.UniqueId()),
 			GoldenFileName: name,
 			Templates:      []string{"templates/orchestration/" + name + ".yaml"},
-			SetValues: map[string]string{
-				"global.elasticsearch.enabled": "true",
-			},
-			IgnoredLines: []string{
-				`\s+checksum/.+?:\s+.*`, // ignore configmap checksum.
-			},
-		})
-	}
-}
-
-func TestGoldenDefaultsTemplateOrchestrationMigrationIdentity(t *testing.T) {
-	t.Parallel()
-
-	chartPath, err := filepath.Abs("../../../")
-	require.NoError(t, err)
-	templateNames := []string{}
-
-	for _, name := range templateNames {
-		suite.Run(t, &utils.TemplateGoldenTest{
-			ChartPath:      chartPath,
-			Release:        "camunda-platform-test",
-			Namespace:      "camunda-platform-" + strings.ToLower(random.UniqueId()),
-			GoldenFileName: name,
-			Templates:      []string{"templates/orchestration/" + name + ".yaml"},
-			SetValues: map[string]string{
-				"global.elasticsearch.enabled": "true",
-			},
 			IgnoredLines: []string{
 				`\s+checksum/.+?:\s+.*`, // ignore configmap checksum.
 			},

--- a/charts/camunda-platform-8.10/test/unit/orchestration/resources_cpu_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/resources_cpu_test.go
@@ -55,12 +55,12 @@ func (s *ResourcesCPUTemplateTest) TestCPUResourcesAsString() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"orchestration.enabled":                   "true",
-			"global.elasticsearch.enabled":            "true",
-			"orchestration.resources.requests.cpu":    "500m",
-			"orchestration.resources.limits.cpu":      "1.5",
-			"orchestration.resources.requests.memory": "1Gi",
-			"orchestration.resources.limits.memory":   "2Gi",
+			"orchestration.enabled":                    "true",
+			"orchestration.data.secondaryStorage.type": "elasticsearch",
+			"orchestration.resources.requests.cpu":     "500m",
+			"orchestration.resources.limits.cpu":       "1.5",
+			"orchestration.resources.requests.memory":  "1Gi",
+			"orchestration.resources.limits.memory":    "2Gi",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 	}
@@ -94,12 +94,12 @@ func (s *ResourcesCPUTemplateTest) TestCPUResourcesBackwardCompatibility() {
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"orchestration.enabled":                   "true",
-			"global.elasticsearch.enabled":            "true",
-			"orchestration.resources.requests.cpu":    "1000m",
-			"orchestration.resources.limits.cpu":      "2000m",
-			"orchestration.resources.requests.memory": "1500Mi",
-			"orchestration.resources.limits.memory":   "3000Mi",
+			"orchestration.enabled":                    "true",
+			"orchestration.data.secondaryStorage.type": "elasticsearch",
+			"orchestration.resources.requests.cpu":     "1000m",
+			"orchestration.resources.limits.cpu":       "2000m",
+			"orchestration.resources.requests.memory":  "1500Mi",
+			"orchestration.resources.limits.memory":    "3000Mi",
 		},
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 	}

--- a/charts/camunda-platform-8.10/test/unit/orchestration/statefulset_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/statefulset_test.go
@@ -200,13 +200,13 @@ func (s *StatefulSetTest) TestDifferentValuesInputs() {
 		}, {
 			Name: "TestContainerSetExtraInitContainers",
 			Values: map[string]string{
-				"orchestration.extraInitContainers[0].name":                      "init-container-{{ .Release.Name }}",
-				"orchestration.extraInitContainers[0].image":                     "busybox:1.28",
-				"orchestration.extraInitContainers[0].command[0]":                "sh",
-				"orchestration.extraInitContainers[0].command[1]":                "-c",
-				"orchestration.extraInitContainers[0].command[2]":                "top",
-				"orchestration.extraInitContainers[0].volumeMounts[0].name":      "exporters",
-				"orchestration.extraInitContainers[0].volumeMounts[0].mountPath": "/exporters/",
+				"orchestration.initContainers[0].name":                      "init-container-{{ .Release.Name }}",
+				"orchestration.initContainers[0].image":                     "busybox:1.28",
+				"orchestration.initContainers[0].command[0]":                "sh",
+				"orchestration.initContainers[0].command[1]":                "-c",
+				"orchestration.initContainers[0].command[2]":                "top",
+				"orchestration.initContainers[0].volumeMounts[0].name":      "exporters",
+				"orchestration.initContainers[0].volumeMounts[0].mountPath": "/exporters/",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var statefulSet appsv1.StatefulSet
@@ -308,7 +308,7 @@ func (s *StatefulSetTest) TestDifferentValuesInputs() {
 				var statefulSetBefore appsv1.StatefulSet
 				before := helm.RenderTemplate(s.T(), &helm.Options{
 					SetValues: map[string]string{
-						"global.elasticsearch.enabled": "true",
+						"orchestration.data.secondaryStorage.type": "elasticsearch",
 					},
 				}, s.chartPath, s.release, s.templates)
 				helm.UnmarshalK8SYaml(s.T(), before, &statefulSetBefore)
@@ -337,7 +337,7 @@ func (s *StatefulSetTest) TestDifferentValuesInputs() {
 				var statefulSetBefore appsv1.StatefulSet
 				before := helm.RenderTemplate(s.T(), &helm.Options{
 					SetValues: map[string]string{
-						"global.elasticsearch.enabled": "true",
+						"orchestration.data.secondaryStorage.type": "elasticsearch",
 					},
 				}, s.chartPath, s.release, s.templates)
 				helm.UnmarshalK8SYaml(s.T(), before, &statefulSetBefore)
@@ -368,7 +368,7 @@ func (s *StatefulSetTest) TestDifferentValuesInputs() {
 				var statefulSetBefore appsv1.StatefulSet
 				before := helm.RenderTemplate(s.T(), &helm.Options{
 					SetValues: map[string]string{
-						"global.elasticsearch.enabled": "true",
+						"orchestration.data.secondaryStorage.type": "elasticsearch",
 					},
 				}, s.chartPath, s.release, s.templates)
 				helm.UnmarshalK8SYaml(s.T(), before, &statefulSetBefore)
@@ -398,7 +398,7 @@ func (s *StatefulSetTest) TestDifferentValuesInputs() {
 				var statefulSetBefore appsv1.StatefulSet
 				before := helm.RenderTemplate(s.T(), &helm.Options{
 					SetValues: map[string]string{
-						"global.elasticsearch.enabled": "true",
+						"orchestration.data.secondaryStorage.type": "elasticsearch",
 					},
 				}, s.chartPath, s.release, s.templates)
 				helm.UnmarshalK8SYaml(s.T(), before, &statefulSetBefore)
@@ -603,7 +603,7 @@ func (s *StatefulSetTest) TestDifferentValuesInputs() {
 				var statefulSetBefore appsv1.StatefulSet
 				before := helm.RenderTemplate(s.T(), &helm.Options{
 					SetValues: map[string]string{
-						"global.elasticsearch.enabled": "true",
+						"orchestration.data.secondaryStorage.type": "elasticsearch",
 					},
 				}, s.chartPath, s.release, s.templates)
 				helm.UnmarshalK8SYaml(s.T(), before, &statefulSetBefore)
@@ -640,7 +640,7 @@ func (s *StatefulSetTest) TestDifferentValuesInputs() {
 				var statefulSetBefore appsv1.StatefulSet
 				before := helm.RenderTemplate(s.T(), &helm.Options{
 					SetValues: map[string]string{
-						"global.elasticsearch.enabled": "true",
+						"orchestration.data.secondaryStorage.type": "elasticsearch",
 					},
 				}, s.chartPath, s.release, s.templates)
 				helm.UnmarshalK8SYaml(s.T(), before, &statefulSetBefore)
@@ -1138,306 +1138,6 @@ func (s *StatefulSetTest) TestOpenSearchPasswordEnv() {
 				"orchestration.data.secondaryStorage.type":              "elasticsearch",
 			},
 			Verifier: verifyOpenSearchPasswordEnv("", ""),
-		},
-	}
-
-	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
-}
-
-func (s *StatefulSetTest) TestWithJKSSecretReference() {
-	testCases := []testhelpers.TestCase{
-		{
-			Name: "TLS with JKS secret reference emits password env and flag",
-			Values: map[string]string{
-				"orchestration.enabled":                              "true",
-				"global.opensearch.tls.secret.existingSecret":        "os-tls-secret",
-				"global.opensearch.tls.jks.secret.existingSecret":    "truststore-secret",
-				"global.opensearch.tls.jks.secret.existingSecretKey": "truststore-password",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				require.Contains(t, output, "- name: JAVA_TOOL_OPTIONS")
-				require.Contains(t, output, "-Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/externaldb.jks")
-				require.Contains(t, output, "-Djavax.net.ssl.trustStorePassword=$(TRUSTSTORE_PASSWORD)")
-				require.Contains(t, output, "name: TRUSTSTORE_PASSWORD")
-				require.Contains(t, output, "secretKeyRef:")
-				require.Contains(t, output, "name: truststore-secret")
-				require.Contains(t, output, "key: truststore-password")
-			},
-		},
-	}
-
-	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
-}
-
-func (s *StatefulSetTest) TestWithJKSInlineSecret() {
-	testCases := []testhelpers.TestCase{
-		{
-			Name: "TLS with JKS inline secret emits password env with value and flag",
-			Values: map[string]string{
-				"orchestration.enabled":                         "true",
-				"global.opensearch.tls.secret.existingSecret":   "os-tls-secret",
-				"global.opensearch.tls.jks.secret.inlineSecret": "changeit",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				require.Contains(t, output, "- name: JAVA_TOOL_OPTIONS")
-				require.Contains(t, output, "-Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/externaldb.jks")
-				require.Contains(t, output, "-Djavax.net.ssl.trustStorePassword=$(TRUSTSTORE_PASSWORD)")
-				require.Contains(t, output, "name: TRUSTSTORE_PASSWORD")
-				require.Contains(t, output, "value: \"changeit\"")
-			},
-		},
-	}
-
-	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
-}
-
-func (s *StatefulSetTest) TestWithoutJKSConfig() {
-	testCases := []testhelpers.TestCase{
-		{
-			Name: "TLS without JKS omits password flag and env var",
-			Values: map[string]string{
-				"orchestration.enabled":                       "true",
-				"global.opensearch.tls.secret.existingSecret": "os-tls-secret",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				require.Contains(t, output, "- name: JAVA_TOOL_OPTIONS")
-				require.Contains(t, output, "-Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/externaldb.jks")
-				require.NotContains(t, output, "-Djavax.net.ssl.trustStorePassword=$(TRUSTSTORE_PASSWORD)")
-				require.NotContains(t, output, "name: TRUSTSTORE_PASSWORD")
-			},
-		},
-	}
-
-	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
-}
-
-func (s *StatefulSetTest) TestRespectsComponentJavaOpts_NoJKS() {
-	testCases := []testhelpers.TestCase{
-		{
-			Name: "Component javaOpts preserved with trustStore path only when no JKS",
-			Values: map[string]string{
-				"orchestration.enabled":                       "true",
-				"orchestration.javaOpts":                      "-Xmx512m -Xms256m",
-				"global.opensearch.tls.secret.existingSecret": "os-tls-secret",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				require.Contains(t, output, "-Xmx512m -Xms256m")
-				require.Contains(t, output, "-Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/externaldb.jks")
-				require.NotContains(t, output, "-Djavax.net.ssl.trustStorePassword=$(TRUSTSTORE_PASSWORD)")
-				require.NotContains(t, output, "name: TRUSTSTORE_PASSWORD")
-			},
-		},
-	}
-
-	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
-}
-
-func (s *StatefulSetTest) TestRespectsComponentJavaOpts_WithJKS() {
-	testCases := []testhelpers.TestCase{
-		{
-			Name: "Component javaOpts preserved with trustStore path and password when JKS provided",
-			Values: map[string]string{
-				"orchestration.enabled":                              "true",
-				"orchestration.javaOpts":                             "-Xmx1g -Xms512m",
-				"global.opensearch.tls.secret.existingSecret":        "os-tls-secret",
-				"global.opensearch.tls.jks.secret.existingSecret":    "truststore-secret",
-				"global.opensearch.tls.jks.secret.existingSecretKey": "truststore-password",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				require.Contains(t, output, "-Xmx1g -Xms512m")
-				require.Contains(t, output, "-Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/externaldb.jks")
-				require.Contains(t, output, "-Djavax.net.ssl.trustStorePassword=$(TRUSTSTORE_PASSWORD)")
-				require.Contains(t, output, "name: TRUSTSTORE_PASSWORD")
-			},
-		},
-	}
-
-	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
-}
-
-func (s *StatefulSetTest) TestWithJKSSecretReference_Elasticsearch() {
-	testCases := []testhelpers.TestCase{
-		{
-			Name: "Elasticsearch TLS with JKS secret reference emits password env and flag",
-			Values: map[string]string{
-				"orchestration.enabled":                                 "true",
-				"global.elasticsearch.tls.secret.existingSecret":        "es-tls-secret",
-				"global.elasticsearch.tls.jks.secret.existingSecret":    "truststore-secret",
-				"global.elasticsearch.tls.jks.secret.existingSecretKey": "truststore-password",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				require.Contains(t, output, "- name: JAVA_TOOL_OPTIONS")
-				require.Contains(t, output, "-Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/externaldb.jks")
-				require.Contains(t, output, "-Djavax.net.ssl.trustStorePassword=$(TRUSTSTORE_PASSWORD)")
-				require.Contains(t, output, "name: TRUSTSTORE_PASSWORD")
-				require.Contains(t, output, "secretKeyRef:")
-				require.Contains(t, output, "name: truststore-secret")
-				require.Contains(t, output, "key: truststore-password")
-			},
-		},
-	}
-
-	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
-}
-
-func (s *StatefulSetTest) TestWithJKSInlineSecret_Elasticsearch() {
-	testCases := []testhelpers.TestCase{
-		{
-			Name: "Elasticsearch TLS with JKS inline secret emits password env with value and flag",
-			Values: map[string]string{
-				"orchestration.enabled":                            "true",
-				"global.elasticsearch.tls.secret.existingSecret":   "es-tls-secret",
-				"global.elasticsearch.tls.jks.secret.inlineSecret": "changeit",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				require.Contains(t, output, "- name: JAVA_TOOL_OPTIONS")
-				require.Contains(t, output, "-Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/externaldb.jks")
-				require.Contains(t, output, "-Djavax.net.ssl.trustStorePassword=$(TRUSTSTORE_PASSWORD)")
-				require.Contains(t, output, "name: TRUSTSTORE_PASSWORD")
-				require.Contains(t, output, "value: \"changeit\"")
-			},
-		},
-	}
-
-	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
-}
-
-func (s *StatefulSetTest) TestWithoutJKSConfig_Elasticsearch() {
-	testCases := []testhelpers.TestCase{
-		{
-			Name: "Elasticsearch TLS without JKS omits password flag and env var",
-			Values: map[string]string{
-				"orchestration.enabled":                          "true",
-				"global.elasticsearch.tls.secret.existingSecret": "es-tls-secret",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				require.Contains(t, output, "- name: JAVA_TOOL_OPTIONS")
-				require.Contains(t, output, "-Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/externaldb.jks")
-				require.NotContains(t, output, "-Djavax.net.ssl.trustStorePassword=$(TRUSTSTORE_PASSWORD)")
-				require.NotContains(t, output, "name: TRUSTSTORE_PASSWORD")
-			},
-		},
-	}
-
-	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
-}
-
-func (s *StatefulSetTest) TestRespectsComponentJavaOpts_NoJKS_Elasticsearch() {
-	testCases := []testhelpers.TestCase{
-		{
-			Name: "Elasticsearch: Component javaOpts preserved with trustStore path only when no JKS",
-			Values: map[string]string{
-				"orchestration.enabled":                          "true",
-				"orchestration.javaOpts":                         "-Xmx512m -Xms256m",
-				"global.elasticsearch.tls.secret.existingSecret": "es-tls-secret",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				require.Contains(t, output, "-Xmx512m -Xms256m")
-				require.Contains(t, output, "-Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/externaldb.jks")
-				require.NotContains(t, output, "-Djavax.net.ssl.trustStorePassword=$(TRUSTSTORE_PASSWORD)")
-				require.NotContains(t, output, "name: TRUSTSTORE_PASSWORD")
-			},
-		},
-	}
-
-	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
-}
-
-func (s *StatefulSetTest) TestRespectsComponentJavaOpts_WithJKS_Elasticsearch() {
-	testCases := []testhelpers.TestCase{
-		{
-			Name: "Elasticsearch: Component javaOpts preserved with trustStore path and password when JKS provided",
-			Values: map[string]string{
-				"orchestration.enabled":                                 "true",
-				"orchestration.javaOpts":                                "-Xmx1g -Xms512m",
-				"global.elasticsearch.tls.secret.existingSecret":        "es-tls-secret",
-				"global.elasticsearch.tls.jks.secret.existingSecret":    "truststore-secret",
-				"global.elasticsearch.tls.jks.secret.existingSecretKey": "truststore-password",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				require.Contains(t, output, "-Xmx1g -Xms512m")
-				require.Contains(t, output, "-Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/externaldb.jks")
-				require.Contains(t, output, "-Djavax.net.ssl.trustStorePassword=$(TRUSTSTORE_PASSWORD)")
-				require.Contains(t, output, "name: TRUSTSTORE_PASSWORD")
-			},
-		},
-	}
-
-	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
-}
-
-func (s *StatefulSetTest) TestJKSEmitsExactlyOneTruststorePasswordEnv() {
-	testCases := []testhelpers.TestCase{
-		{
-			Name: "Helper emits TRUSTSTORE_PASSWORD exactly once (no collision in normal use)",
-			Values: map[string]string{
-				"orchestration.enabled":                            "true",
-				"global.elasticsearch.tls.secret.existingSecret":   "es-tls",
-				"global.elasticsearch.tls.jks.secret.inlineSecret": "newpw",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				count := strings.Count(output, "name: TRUSTSTORE_PASSWORD")
-				require.Equalf(t, 1, count,
-					"Expected TRUSTSTORE_PASSWORD env var to appear exactly once; "+
-						"duplicate entries are rejected by AKS. Found %d.", count)
-			},
-		},
-	}
-
-	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
-}
-
-func (s *StatefulSetTest) TestJKSCoexistenceWithLegacyJavaOptsWorkaround() {
-	testCases := []testhelpers.TestCase{
-		{
-			Name: "Migrating customer keeps trustStorePassword in javaOpts AND adds new jks block",
-			Values: map[string]string{
-				"orchestration.enabled":                            "true",
-				"orchestration.javaOpts":                           "-Xmx2g -Djavax.net.ssl.trustStorePassword=oldworkaround",
-				"global.elasticsearch.tls.secret.existingSecret":   "es-tls",
-				"global.elasticsearch.tls.jks.secret.inlineSecret": "newpw",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				require.Contains(t, output, "-Djavax.net.ssl.trustStorePassword=oldworkaround")
-				require.Contains(t, output, "-Djavax.net.ssl.trustStorePassword=$(TRUSTSTORE_PASSWORD)")
-				require.Contains(t, output, "name: TRUSTSTORE_PASSWORD")
-				require.Contains(t, output, "value: \"newpw\"")
-				require.Equal(t, 1, strings.Count(output, "-Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/"))
-			},
-		},
-	}
-
-	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
-}
-
-func (s *StatefulSetTest) TestJKSDoesNotFireForSecondaryStorageOnlyTLS() {
-	testCases := []testhelpers.TestCase{
-		{
-			Name: "secondaryStorage TLS triggers truststore path injection but NOT password — documented limit",
-			Values: map[string]string{
-				"orchestration.enabled": "true",
-				"orchestration.data.secondaryStorage.elasticsearch.tls.secret.existingSecret":    "ssec-tls",
-				"orchestration.data.secondaryStorage.elasticsearch.tls.secret.existingSecretKey": "externaldb.jks",
-				"global.elasticsearch.tls.jks.secret.inlineSecret":                               "newpw",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				require.Contains(t, output, "-Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/")
-				require.NotContains(t, output, "name: TRUSTSTORE_PASSWORD")
-				require.NotContains(t, output, "-Djavax.net.ssl.trustStorePassword=$(TRUSTSTORE_PASSWORD)")
-			},
 		},
 	}
 

--- a/charts/camunda-platform-8.10/test/unit/orchestration/statefulset_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/statefulset_test.go
@@ -200,13 +200,13 @@ func (s *StatefulSetTest) TestDifferentValuesInputs() {
 		}, {
 			Name: "TestContainerSetExtraInitContainers",
 			Values: map[string]string{
-				"orchestration.initContainers[0].name":                      "init-container-{{ .Release.Name }}",
-				"orchestration.initContainers[0].image":                     "busybox:1.28",
-				"orchestration.initContainers[0].command[0]":                "sh",
-				"orchestration.initContainers[0].command[1]":                "-c",
-				"orchestration.initContainers[0].command[2]":                "top",
-				"orchestration.initContainers[0].volumeMounts[0].name":      "exporters",
-				"orchestration.initContainers[0].volumeMounts[0].mountPath": "/exporters/",
+				"orchestration.extraInitContainers[0].name":                      "init-container-{{ .Release.Name }}",
+				"orchestration.extraInitContainers[0].image":                     "busybox:1.28",
+				"orchestration.extraInitContainers[0].command[0]":                "sh",
+				"orchestration.extraInitContainers[0].command[1]":                "-c",
+				"orchestration.extraInitContainers[0].command[2]":                "top",
+				"orchestration.extraInitContainers[0].volumeMounts[0].name":      "exporters",
+				"orchestration.extraInitContainers[0].volumeMounts[0].mountPath": "/exporters/",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var statefulSet appsv1.StatefulSet

--- a/charts/camunda-platform-8.10/test/unit/orchestration/testdata/values-templated-labels.yaml
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/testdata/values-templated-labels.yaml
@@ -1,8 +1,3 @@
-global:
-  elasticsearch:
-    enabled: true
-
-
 orchestration:
   enabled: true
   data:

--- a/charts/camunda-platform-8.10/test/unit/testhelpers/testhelpers.go
+++ b/charts/camunda-platform-8.10/test/unit/testhelpers/testhelpers.go
@@ -134,10 +134,11 @@ func quietLogger() *logger.Logger {
 }
 
 type storageFixtureState struct {
-	typeSet            bool
-	noSecondaryStorage bool
-	rdbmsEnabled       bool
-	openSearchEnabled  bool
+	typeSet              bool
+	noSecondaryStorage   bool
+	rdbmsEnabled         bool
+	elasticsearchEnabled bool
+	openSearchEnabled    bool
 }
 
 func mergeStorageFixtureValues(base, overlay map[string]any) {
@@ -213,6 +214,9 @@ func loadStorageFixtureState(valuesFiles []string, values map[string]string) (st
 	if state.rdbmsEnabled, _, err = storageFixtureBool(mergedValues, "orchestration", "exporters", "rdbms", "enabled"); err != nil {
 		return state, err
 	}
+	if state.elasticsearchEnabled, _, err = storageFixtureBool(mergedValues, "optimize", "database", "elasticsearch", "enabled"); err != nil {
+		return state, err
+	}
 	if state.openSearchEnabled, _, err = storageFixtureBool(mergedValues, "optimize", "database", "opensearch", "enabled"); err != nil {
 		return state, err
 	}
@@ -225,6 +229,9 @@ func loadStorageFixtureState(valuesFiles []string, values map[string]string) (st
 	}
 	if value, ok := values["orchestration.exporters.rdbms.enabled"]; ok {
 		state.rdbmsEnabled = strings.EqualFold(value, "true")
+	}
+	if value, ok := values["optimize.database.elasticsearch.enabled"]; ok {
+		state.elasticsearchEnabled = strings.EqualFold(value, "true")
 	}
 	if value, ok := values["optimize.database.opensearch.enabled"]; ok {
 		state.openSearchEnabled = strings.EqualFold(value, "true")
@@ -244,7 +251,7 @@ func setupHelmOptions(namespace string, values map[string]string, valuesFiles []
 	}
 	if !storageState.typeSet && !storageState.noSecondaryStorage && !storageState.rdbmsEnabled {
 		secondaryStorageType := "elasticsearch"
-		if storageState.openSearchEnabled {
+		if !storageState.elasticsearchEnabled && storageState.openSearchEnabled {
 			secondaryStorageType = "opensearch"
 		}
 		values["orchestration.data.secondaryStorage.type"] = secondaryStorageType
@@ -265,6 +272,7 @@ func validateStorageFixtureRenderArgs(renderTemplateExtraArgs []string) error {
 		"global.noSecondaryStorage",
 		"orchestration.data.secondaryStorage.type",
 		"orchestration.exporters.rdbms.enabled",
+		"optimize.database.elasticsearch.enabled",
 		"optimize.database.opensearch.enabled",
 		"global",
 		"orchestration.data.secondaryStorage",
@@ -272,12 +280,13 @@ func validateStorageFixtureRenderArgs(renderTemplateExtraArgs []string) error {
 		"orchestration.exporters.rdbms",
 		"orchestration.exporters",
 		"orchestration",
+		"optimize.database.elasticsearch",
 		"optimize.database.opensearch",
 		"optimize.database",
 		"optimize",
 	}
 	for _, argument := range renderTemplateExtraArgs {
-		if argument == "--values" || argument == "-f" || strings.HasPrefix(argument, "--values=") || strings.HasPrefix(argument, "-f=") {
+		if argument == "--values" || strings.HasPrefix(argument, "--values=") || strings.HasPrefix(argument, "-f") {
 			return fmt.Errorf("values files must be provided through TestCase.ValuesFiles, not RenderTemplateExtraArgs")
 		}
 		for _, key := range storageKeys {

--- a/charts/camunda-platform-8.10/test/unit/testhelpers/testhelpers.go
+++ b/charts/camunda-platform-8.10/test/unit/testhelpers/testhelpers.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package testhelpers provides utilities for testing Helm charts.
 // To enable verbose logging, set the VERBOSE_TEST_LOGGING environment variable to "true".
 // Example: VERBOSE_TEST_LOGGING=true go test ./...
@@ -5,7 +19,11 @@ package testhelpers
 
 import (
 	"fmt"
+	"io"
+	"maps"
 	"os"
+	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
@@ -15,6 +33,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/util/jsonpath"
 )
 
 type CaseTemplate struct {
@@ -61,7 +81,7 @@ type TestCase struct {
 	// For ConfigMap tests, keys can be direct data keys or dot-notation paths into application.yaml
 	Expected map[string]string
 
-	// Unexpected contains direct ConfigMap data keys that must NOT be present in the rendered output
+	// Unexpected contains paths that must NOT be present in the rendered output
 	Unexpected []string
 
 	// Verifier is a custom function for complex validation scenarios
@@ -74,6 +94,35 @@ type TestCase struct {
 	ObjectAsserter func(t *testing.T, obj any)
 }
 
+func validateTestCase(tc TestCase) error {
+	expectedError, expectsError := tc.Expected["ERROR"]
+	hasDeclarativeAssertions := len(tc.Unexpected) > 0 || len(tc.Expected) > 0 && (!expectsError || len(tc.Expected) > 1)
+	hasObject := tc.ExpectedObject != nil
+	hasObjectAsserter := tc.ObjectAsserter != nil
+	hasObjectAssertions := hasObject || hasObjectAsserter
+
+	if tc.Verifier != nil && (len(tc.Expected) > 0 || len(tc.Unexpected) > 0 || hasObjectAssertions) {
+		return fmt.Errorf("Verifier cannot be combined with declarative, error, or object assertions")
+	}
+	if expectsError && (len(tc.Expected) > 1 || len(tc.Unexpected) > 0 || hasObjectAssertions) {
+		return fmt.Errorf("ERROR assertion cannot be combined with output or object assertions")
+	}
+	if expectsError && strings.TrimSpace(expectedError) == "" {
+		return fmt.Errorf("ERROR assertion must not be empty")
+	}
+	if hasObject != hasObjectAsserter {
+		return fmt.Errorf("ExpectedObject and ObjectAsserter must be set together")
+	}
+	if hasDeclarativeAssertions && hasObjectAssertions {
+		return fmt.Errorf("declarative assertions cannot be combined with object assertions")
+	}
+	if tc.Verifier == nil && !expectsError && !hasDeclarativeAssertions && !hasObjectAssertions {
+		return fmt.Errorf("test case must declare an assertion")
+	}
+
+	return nil
+}
+
 // quietLogger returns a logger that only logs errors
 func quietLogger() *logger.Logger {
 	// Check if verbose logging is enabled via environment variable
@@ -84,14 +133,121 @@ func quietLogger() *logger.Logger {
 	return logger.Discard
 }
 
-func setupHelmOptions(namespace string, values map[string]string, valuesFiles []string, helmOptionsExtraArgs map[string][]string) *helm.Options {
-	// Initialize values map if nil
+type storageFixtureState struct {
+	typeSet            bool
+	noSecondaryStorage bool
+	rdbmsEnabled       bool
+	openSearchEnabled  bool
+}
+
+func mergeStorageFixtureValues(base, overlay map[string]any) {
+	for key, overlayValue := range overlay {
+		if overlayValue == nil {
+			delete(base, key)
+			continue
+		}
+
+		overlayMap, overlayIsMap := overlayValue.(map[string]any)
+		baseMap, baseIsMap := base[key].(map[string]any)
+		if overlayIsMap && baseIsMap {
+			mergeStorageFixtureValues(baseMap, overlayMap)
+			continue
+		}
+		base[key] = overlayValue
+	}
+}
+
+func storageFixtureValue(values map[string]any, path ...string) (any, bool) {
+	var current any = values
+	for _, key := range path {
+		mapping, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current, ok = mapping[key]
+		if !ok {
+			return nil, false
+		}
+	}
+	return current, true
+}
+
+func storageFixtureBool(values map[string]any, path ...string) (bool, bool, error) {
+	rawValue, ok := storageFixtureValue(values, path...)
+	if !ok {
+		return false, false, nil
+	}
+	value, ok := rawValue.(bool)
+	if !ok {
+		return false, false, fmt.Errorf("storage fixture value %s must be a boolean", strings.Join(path, "."))
+	}
+	return value, true, nil
+}
+
+func loadStorageFixtureState(valuesFiles []string, values map[string]string) (storageFixtureState, error) {
+	state := storageFixtureState{}
+	mergedValues := make(map[string]any)
+	for _, valuesFile := range valuesFiles {
+		data, err := os.ReadFile(valuesFile)
+		if err != nil {
+			return state, fmt.Errorf("read values file %s: %w", valuesFile, err)
+		}
+
+		var fileValues map[string]any
+		if err := yaml.Unmarshal(data, &fileValues); err != nil {
+			return state, fmt.Errorf("parse values file %s: %w", valuesFile, err)
+		}
+		mergeStorageFixtureValues(mergedValues, fileValues)
+	}
+
+	if storageType, ok := storageFixtureValue(mergedValues, "orchestration", "data", "secondaryStorage", "type"); ok {
+		if _, ok := storageType.(string); !ok {
+			return state, fmt.Errorf("storage fixture value orchestration.data.secondaryStorage.type must be a string")
+		}
+		state.typeSet = true
+	}
+	var err error
+	if state.noSecondaryStorage, _, err = storageFixtureBool(mergedValues, "global", "noSecondaryStorage"); err != nil {
+		return state, err
+	}
+	if state.rdbmsEnabled, _, err = storageFixtureBool(mergedValues, "orchestration", "exporters", "rdbms", "enabled"); err != nil {
+		return state, err
+	}
+	if state.openSearchEnabled, _, err = storageFixtureBool(mergedValues, "optimize", "database", "opensearch", "enabled"); err != nil {
+		return state, err
+	}
+
+	if _, ok := values["orchestration.data.secondaryStorage.type"]; ok {
+		state.typeSet = true
+	}
+	if value, ok := values["global.noSecondaryStorage"]; ok {
+		state.noSecondaryStorage = strings.EqualFold(value, "true")
+	}
+	if value, ok := values["orchestration.exporters.rdbms.enabled"]; ok {
+		state.rdbmsEnabled = strings.EqualFold(value, "true")
+	}
+	if value, ok := values["optimize.database.opensearch.enabled"]; ok {
+		state.openSearchEnabled = strings.EqualFold(value, "true")
+	}
+
+	return state, nil
+}
+
+func setupHelmOptions(namespace string, values map[string]string, valuesFiles []string, helmOptionsExtraArgs map[string][]string) (*helm.Options, error) {
+	values = maps.Clone(values)
 	if values == nil {
 		values = make(map[string]string)
 	}
-	// Add default Elasticsearch flag if not already present
-	if _, hasGlobalES := values["global.elasticsearch.enabled"]; !hasGlobalES {
-		values["global.elasticsearch.enabled"] = "true"
+	storageState, err := loadStorageFixtureState(valuesFiles, values)
+	if err != nil {
+		return nil, err
+	}
+	if !storageState.typeSet && !storageState.noSecondaryStorage && !storageState.rdbmsEnabled {
+		secondaryStorageType := "elasticsearch"
+		if storageState.openSearchEnabled {
+			secondaryStorageType = "opensearch"
+		}
+		values["orchestration.data.secondaryStorage.type"] = secondaryStorageType
 	}
 
 	options := &helm.Options{
@@ -101,11 +257,46 @@ func setupHelmOptions(namespace string, values map[string]string, valuesFiles []
 		Logger:         quietLogger(), // Use quiet logger to reduce verbosity
 		ExtraArgs:      helmOptionsExtraArgs,
 	}
-	return options
+	return options, nil
+}
+
+func validateStorageFixtureRenderArgs(renderTemplateExtraArgs []string) error {
+	storageKeys := []string{
+		"global.noSecondaryStorage",
+		"orchestration.data.secondaryStorage.type",
+		"orchestration.exporters.rdbms.enabled",
+		"optimize.database.opensearch.enabled",
+		"global",
+		"orchestration.data.secondaryStorage",
+		"orchestration.data",
+		"orchestration.exporters.rdbms",
+		"orchestration.exporters",
+		"orchestration",
+		"optimize.database.opensearch",
+		"optimize.database",
+		"optimize",
+	}
+	for _, argument := range renderTemplateExtraArgs {
+		if argument == "--values" || argument == "-f" || strings.HasPrefix(argument, "--values=") || strings.HasPrefix(argument, "-f=") {
+			return fmt.Errorf("values files must be provided through TestCase.ValuesFiles, not RenderTemplateExtraArgs")
+		}
+		for _, key := range storageKeys {
+			if strings.Contains(argument, key+"=") {
+				return fmt.Errorf("storage fixture value %s must be provided through TestCase.Values, not RenderTemplateExtraArgs", key)
+			}
+		}
+	}
+	return nil
 }
 
 func renderTemplateE(t *testing.T, chartPath, release string, namespace string, templates []string, values map[string]string, valuesFiles []string, extraArgs map[string][]string, renderTemplateExtraArgs []string) (string, error) {
-	options := setupHelmOptions(namespace, values, valuesFiles, extraArgs)
+	if err := validateStorageFixtureRenderArgs(renderTemplateExtraArgs); err != nil {
+		return "", err
+	}
+	options, err := setupHelmOptions(namespace, values, valuesFiles, extraArgs)
+	if err != nil {
+		return "", err
+	}
 
 	output, err := helm.RenderTemplateE(t, options, chartPath, release, templates, renderTemplateExtraArgs...)
 	return output, err
@@ -128,6 +319,8 @@ func RunTestCasesE(t *testing.T, chartPath, release, namespace string, templates
 }
 
 func runTestCaseE(t *testing.T, chartPath, release, namespace string, templates []string, tc TestCase) {
+	require.NoError(t, validateTestCase(tc), "invalid test case %q", tc.Name)
+
 	var caseTemplates []string
 	if tc.Template != "" {
 		caseTemplates = []string{tc.Template}
@@ -147,21 +340,134 @@ func runTestCaseE(t *testing.T, chartPath, release, namespace string, templates 
 
 	if expectedErr, ok := tc.Expected["ERROR"]; ok {
 		require.ErrorContains(t, err, expectedErr)
-	} else if err != nil {
+		return
+	}
+	if err != nil {
 		t.Fatalf("Unexpected error during rendering: %v", err)
 	}
 
-	if tc.ExpectedObject != nil && err == nil {
+	if len(tc.Expected) > 0 || len(tc.Unexpected) > 0 {
+		verifyRenderedPaths(t, output, tc.Expected, tc.Unexpected)
+		return
+	}
+
+	if tc.ExpectedObject != nil {
 		helm.UnmarshalK8SYaml(t, output, tc.ExpectedObject)
-		if tc.ObjectAsserter != nil {
-			tc.ObjectAsserter(t, tc.ExpectedObject)
+		tc.ObjectAsserter(t, tc.ExpectedObject)
+	}
+}
+
+type pathMatch struct {
+	objectIndex int
+	value       reflect.Value
+}
+
+func decodeRenderedObjects(output string) ([]any, error) {
+	decoder := k8syaml.NewYAMLOrJSONDecoder(strings.NewReader(output), 4096)
+	objects := []any{}
+	for {
+		var object any
+		if err := decoder.Decode(&object); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("decode rendered object: %w", err)
 		}
+		if object == nil {
+			continue
+		}
+		objectValue := reflect.ValueOf(object)
+		if objectValue.Kind() == reflect.Map && objectValue.Len() == 0 {
+			continue
+		}
+		objects = append(objects, object)
+	}
+	return objects, nil
+}
+
+func findPathMatches(objects []any, path string) ([]pathMatch, error) {
+	query := jsonpath.New(path).AllowMissingKeys(true)
+	if err := query.Parse("{." + path + "}"); err != nil {
+		return nil, fmt.Errorf("parse path %q: %w", path, err)
+	}
+
+	matches := []pathMatch{}
+	for objectIndex, object := range objects {
+		results, err := query.FindResults(object)
+		if err != nil {
+			return nil, fmt.Errorf("evaluate path %q in rendered object %d: %w", path, objectIndex, err)
+		}
+		for _, result := range results {
+			for _, value := range result {
+				matches = append(matches, pathMatch{objectIndex: objectIndex, value: value})
+			}
+		}
+	}
+	return matches, nil
+}
+
+func resolveScalarPath(objects []any, path string) (string, error) {
+	matches, err := findPathMatches(objects, path)
+	if err != nil {
+		return "", err
+	}
+	if len(matches) != 1 {
+		return "", fmt.Errorf("path %q resolved to %d values across %d rendered objects; expected exactly one", path, len(matches), len(objects))
+	}
+
+	value := matches[0].value
+	for value.IsValid() && (value.Kind() == reflect.Interface || value.Kind() == reflect.Pointer) {
+		if value.IsNil() {
+			return "null", nil
+		}
+		value = value.Elem()
+	}
+	if !value.IsValid() {
+		return "null", nil
+	}
+
+	switch value.Kind() {
+	case reflect.Bool,
+		reflect.Float32, reflect.Float64,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.String,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return fmt.Sprint(value.Interface()), nil
+	default:
+		return "", fmt.Errorf("path %q must resolve to a scalar, got %s", path, value.Kind())
+	}
+}
+
+func verifyRenderedPaths(t *testing.T, output string, expected map[string]string, unexpected []string) {
+	t.Helper()
+
+	objects, err := decodeRenderedObjects(output)
+	require.NoError(t, err)
+
+	expectedPaths := make([]string, 0, len(expected))
+	for path := range expected {
+		expectedPaths = append(expectedPaths, path)
+	}
+	sort.Strings(expectedPaths)
+	for _, path := range expectedPaths {
+		actual, err := resolveScalarPath(objects, path)
+		require.NoError(t, err)
+		require.Equal(t, expected[path], actual, "path %q", path)
+	}
+
+	unexpectedPaths := append([]string(nil), unexpected...)
+	sort.Strings(unexpectedPaths)
+	for _, path := range unexpectedPaths {
+		matches, err := findPathMatches(objects, path)
+		require.NoError(t, err)
+		require.Empty(t, matches, "path %q must be structurally absent", path)
 	}
 }
 
 // renderTemplate renders the specified Helm templates into a Kubernetes ConfigMap
 func renderTemplate(t *testing.T, chartPath, release string, namespace string, templates []string, values map[string]string, valuesFiles []string) corev1.ConfigMap {
-	options := setupHelmOptions(namespace, values, valuesFiles, nil)
+	options, err := setupHelmOptions(namespace, values, valuesFiles, nil)
+	require.NoError(t, err)
 
 	output := helm.RenderTemplate(t, options, chartPath, release, templates)
 	var configmap corev1.ConfigMap

--- a/charts/camunda-platform-8.10/test/unit/testhelpers/testhelpers_test.go
+++ b/charts/camunda-platform-8.10/test/unit/testhelpers/testhelpers_test.go
@@ -247,6 +247,14 @@ func TestSetupHelmOptionsUsesSupportedStorageDefaults(t *testing.T) {
 			expected: "opensearch",
 		},
 		{
+			name: "prefers Elasticsearch when both Optimize selectors are enabled",
+			values: map[string]string{
+				"optimize.database.elasticsearch.enabled": "true",
+				"optimize.database.opensearch.enabled":    "true",
+			},
+			expected: "elasticsearch",
+		},
+		{
 			name: "preserves an explicit type",
 			values: map[string]string{
 				"orchestration.data.secondaryStorage.type": "rdbms",
@@ -316,6 +324,17 @@ func TestSetupHelmOptionsHonorsValuesFileStorageSelection(t *testing.T) {
       enabled: true
 `,
 			expectedSetValue: "opensearch",
+		},
+		{
+			name: "Optimize Elasticsearch takes precedence over OpenSearch",
+			valuesYAML: `optimize:
+  database:
+    elasticsearch:
+      enabled: true
+    opensearch:
+      enabled: true
+`,
+			expectedSetValue: "elasticsearch",
 		},
 	}
 
@@ -434,6 +453,11 @@ func TestValidateStorageFixtureRenderArgs(t *testing.T) {
 			expectedErr: "optimize.database.opensearch.enabled must be provided through TestCase.Values",
 		},
 		{
+			name:        "combined Optimize Elasticsearch set",
+			args:        []string{"--set", "identity.enabled=true,optimize.database.elasticsearch.enabled=true"},
+			expectedErr: "optimize.database.elasticsearch.enabled must be provided through TestCase.Values",
+		},
+		{
 			name:        "set JSON secondary storage parent",
 			args:        []string{"--set-json", `orchestration.data.secondaryStorage={"type":"opensearch"}`},
 			expectedErr: "orchestration.data.secondaryStorage must be provided through TestCase.Values",
@@ -456,6 +480,11 @@ func TestValidateStorageFixtureRenderArgs(t *testing.T) {
 		{
 			name:        "values file",
 			args:        []string{"--values", "storage.yaml"},
+			expectedErr: "values files must be provided through TestCase.ValuesFiles",
+		},
+		{
+			name:        "compact values file",
+			args:        []string{"-fstorage.yaml"},
 			expectedErr: "values files must be provided through TestCase.ValuesFiles",
 		},
 	}

--- a/charts/camunda-platform-8.10/test/unit/testhelpers/testhelpers_test.go
+++ b/charts/camunda-platform-8.10/test/unit/testhelpers/testhelpers_test.go
@@ -1,0 +1,472 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testhelpers
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var _ = flag.Bool("update-golden", false, "accepted for chart-wide golden updates")
+
+func TestValidateTestCase(t *testing.T) {
+	t.Parallel()
+
+	validCases := []TestCase{
+		{Verifier: func(*testing.T, string, error) {}},
+		{Expected: map[string]string{"ERROR": "render failed"}},
+		{Expected: map[string]string{"metadata.name": "test"}},
+		{Unexpected: []string{"metadata.annotations.optional"}},
+		{
+			ExpectedObject: &struct{}{},
+			ObjectAsserter: func(*testing.T, any) {},
+		},
+	}
+	for _, testCase := range validCases {
+		require.NoError(t, validateTestCase(testCase))
+	}
+
+	invalidCases := []struct {
+		name        string
+		testCase    TestCase
+		expectedErr string
+	}{
+		{
+			name:        "assertion-free",
+			testCase:    TestCase{},
+			expectedErr: "must declare an assertion",
+		},
+		{
+			name: "empty error assertion",
+			testCase: TestCase{
+				Expected: map[string]string{"ERROR": "  "},
+			},
+			expectedErr: "ERROR assertion must not be empty",
+		},
+		{
+			name: "verifier and declarative",
+			testCase: TestCase{
+				Verifier: func(*testing.T, string, error) {},
+				Expected: map[string]string{"metadata.name": "test"},
+			},
+			expectedErr: "Verifier cannot be combined",
+		},
+		{
+			name: "verifier and object",
+			testCase: TestCase{
+				Verifier:       func(*testing.T, string, error) {},
+				ExpectedObject: &struct{}{},
+				ObjectAsserter: func(*testing.T, any) {},
+			},
+			expectedErr: "Verifier cannot be combined",
+		},
+		{
+			name: "error and output",
+			testCase: TestCase{
+				Expected: map[string]string{
+					"ERROR":         "render failed",
+					"metadata.name": "test",
+				},
+			},
+			expectedErr: "ERROR assertion cannot be combined",
+		},
+		{
+			name: "error and absence",
+			testCase: TestCase{
+				Expected:   map[string]string{"ERROR": "render failed"},
+				Unexpected: []string{"metadata.name"},
+			},
+			expectedErr: "ERROR assertion cannot be combined",
+		},
+		{
+			name: "declarative and object",
+			testCase: TestCase{
+				Expected:       map[string]string{"metadata.name": "test"},
+				ExpectedObject: &struct{}{},
+				ObjectAsserter: func(*testing.T, any) {},
+			},
+			expectedErr: "declarative assertions cannot be combined",
+		},
+		{
+			name: "object without asserter",
+			testCase: TestCase{
+				ExpectedObject: &struct{}{},
+			},
+			expectedErr: "ExpectedObject and ObjectAsserter must be set together",
+		},
+		{
+			name: "asserter without object",
+			testCase: TestCase{
+				ObjectAsserter: func(*testing.T, any) {},
+			},
+			expectedErr: "ExpectedObject and ObjectAsserter must be set together",
+		},
+	}
+
+	for _, testCase := range invalidCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := validateTestCase(testCase.testCase)
+			require.ErrorContains(t, err, testCase.expectedErr)
+		})
+	}
+}
+
+func TestRenderedPathResolution(t *testing.T) {
+	t.Parallel()
+
+	objects, err := decodeRenderedObjects(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    checksum/ca-bundle: abc123
+spec:
+  emptyString: ""
+  nullValue: null
+  emptyMap: {}
+  emptyList: []
+  env:
+    - name: TEST_VALUE
+      value: present
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test
+`)
+	require.NoError(t, err)
+	require.Len(t, objects, 2)
+
+	resolved, err := resolveScalarPath(objects, "spec.env[?(@.name=='TEST_VALUE')].value")
+	require.NoError(t, err)
+	require.Equal(t, "present", resolved)
+
+	resolved, err = resolveScalarPath(objects, "metadata.annotations.checksum/ca-bundle")
+	require.NoError(t, err)
+	require.Equal(t, "abc123", resolved)
+
+	resolved, err = resolveScalarPath(objects, "spec.emptyString")
+	require.NoError(t, err)
+	require.Equal(t, "", resolved)
+
+	resolved, err = resolveScalarPath(objects, "spec.nullValue")
+	require.NoError(t, err)
+	require.Equal(t, "null", resolved)
+
+	_, err = resolveScalarPath(objects, "spec.missing")
+	require.ErrorContains(t, err, "resolved to 0 values")
+
+	_, err = resolveScalarPath(objects, "kind")
+	require.ErrorContains(t, err, "resolved to 2 values")
+
+	_, err = resolveScalarPath(objects, "spec.emptyMap")
+	require.ErrorContains(t, err, "must resolve to a scalar")
+
+	_, err = resolveScalarPath(objects, "spec.emptyList")
+	require.ErrorContains(t, err, "must resolve to a scalar")
+
+	_, err = resolveScalarPath(objects, "spec.env[")
+	require.Error(t, err)
+}
+
+func TestRenderedPathAbsenceDistinguishesPresentStates(t *testing.T) {
+	t.Parallel()
+
+	objects, err := decodeRenderedObjects(`
+apiVersion: v1
+kind: ConfigMap
+data:
+  nullValue: null
+  emptyString: ""
+  emptyMap: {}
+  emptyList: []
+`)
+	require.NoError(t, err)
+
+	for _, path := range []string{"data.nullValue", "data.emptyString", "data.emptyMap", "data.emptyList"} {
+		matches, err := findPathMatches(objects, path)
+		require.NoError(t, err)
+		require.Len(t, matches, 1, path)
+	}
+
+	matches, err := findPathMatches(objects, "data.missing")
+	require.NoError(t, err)
+	require.Empty(t, matches)
+}
+
+func TestSetupHelmOptionsClonesValues(t *testing.T) {
+	t.Parallel()
+
+	values := map[string]string{"provided": "original"}
+	options, err := setupHelmOptions("test", values, nil, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, map[string]string{"provided": "original"}, values)
+	require.Equal(t, map[string]string{
+		"orchestration.data.secondaryStorage.type": "elasticsearch",
+		"provided": "original",
+	}, options.SetValues)
+
+	options.SetValues["provided"] = "changed"
+	require.Equal(t, "original", values["provided"])
+}
+
+func TestSetupHelmOptionsUsesSupportedStorageDefaults(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		values   map[string]string
+		expected string
+	}{
+		{
+			name:     "defaults to Elasticsearch",
+			expected: "elasticsearch",
+		},
+		{
+			name: "derives OpenSearch from Optimize",
+			values: map[string]string{
+				"optimize.database.opensearch.enabled": "true",
+			},
+			expected: "opensearch",
+		},
+		{
+			name: "preserves an explicit type",
+			values: map[string]string{
+				"orchestration.data.secondaryStorage.type": "rdbms",
+			},
+			expected: "rdbms",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			options, err := setupHelmOptions("test", testCase.values, nil, nil)
+			require.NoError(t, err)
+
+			expectedValues := make(map[string]string, len(testCase.values)+1)
+			for key, value := range testCase.values {
+				expectedValues[key] = value
+			}
+			expectedValues["orchestration.data.secondaryStorage.type"] = testCase.expected
+			require.Equal(t, expectedValues, options.SetValues)
+		})
+	}
+}
+
+func TestSetupHelmOptionsHonorsValuesFileStorageSelection(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name             string
+		valuesYAML       string
+		expectedSetValue string
+	}{
+		{
+			name: "explicit OpenSearch type",
+			valuesYAML: `orchestration:
+  data:
+    secondaryStorage:
+      type: opensearch
+`,
+		},
+		{
+			name: "explicit empty type",
+			valuesYAML: `orchestration:
+  data:
+    secondaryStorage:
+      type: ""
+`,
+		},
+		{
+			name: "no secondary storage",
+			valuesYAML: `global:
+  noSecondaryStorage: true
+`,
+		},
+		{
+			name: "RDBMS exporter",
+			valuesYAML: `orchestration:
+  exporters:
+    rdbms:
+      enabled: true
+`,
+		},
+		{
+			name: "Optimize OpenSearch",
+			valuesYAML: `optimize:
+  database:
+    opensearch:
+      enabled: true
+`,
+			expectedSetValue: "opensearch",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			valuesFile := filepath.Join(t.TempDir(), "values.yaml")
+			require.NoError(t, os.WriteFile(valuesFile, []byte(testCase.valuesYAML), 0o600))
+
+			options, err := setupHelmOptions("test", nil, []string{valuesFile}, nil)
+			require.NoError(t, err)
+			if testCase.expectedSetValue == "" {
+				require.NotContains(t, options.SetValues, "orchestration.data.secondaryStorage.type")
+			} else {
+				require.Equal(t, testCase.expectedSetValue, options.SetValues["orchestration.data.secondaryStorage.type"])
+			}
+		})
+	}
+}
+
+func TestSetupHelmOptionsHonorsLayeredNullOverrides(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		baseYAML    string
+		overlayYAML string
+	}{
+		{
+			name: "clears explicit storage type",
+			baseYAML: `orchestration:
+  data:
+    secondaryStorage:
+      type: opensearch
+`,
+			overlayYAML: `orchestration:
+  data:
+    secondaryStorage:
+      type: null
+`,
+		},
+		{
+			name: "clears no-secondary-storage parent",
+			baseYAML: `global:
+  noSecondaryStorage: true
+`,
+			overlayYAML: `global: null
+`,
+		},
+		{
+			name: "clears RDBMS exporter parent",
+			baseYAML: `orchestration:
+  exporters:
+    rdbms:
+      enabled: true
+`,
+			overlayYAML: `orchestration:
+  exporters: null
+`,
+		},
+		{
+			name: "clears Optimize OpenSearch selection",
+			baseYAML: `optimize:
+  database:
+    opensearch:
+      enabled: true
+`,
+			overlayYAML: `optimize:
+  database:
+    opensearch:
+      enabled: null
+`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			baseFile := filepath.Join(tempDir, "base.yaml")
+			overlayFile := filepath.Join(tempDir, "overlay.yaml")
+			require.NoError(t, os.WriteFile(baseFile, []byte(testCase.baseYAML), 0o600))
+			require.NoError(t, os.WriteFile(overlayFile, []byte(testCase.overlayYAML), 0o600))
+
+			options, err := setupHelmOptions("test", nil, []string{baseFile, overlayFile}, nil)
+			require.NoError(t, err)
+			require.Equal(t, "elasticsearch", options.SetValues["orchestration.data.secondaryStorage.type"])
+		})
+	}
+}
+
+func TestValidateStorageFixtureRenderArgs(t *testing.T) {
+	t.Parallel()
+
+	rejectedArgs := []struct {
+		name        string
+		args        []string
+		expectedErr string
+	}{
+		{
+			name:        "set no secondary storage",
+			args:        []string{"--set", "global.noSecondaryStorage=true"},
+			expectedErr: "global.noSecondaryStorage must be provided through TestCase.Values",
+		},
+		{
+			name:        "inline set storage type",
+			args:        []string{"--set=orchestration.data.secondaryStorage.type=rdbms"},
+			expectedErr: "orchestration.data.secondaryStorage.type must be provided through TestCase.Values",
+		},
+		{
+			name:        "set string RDBMS exporter",
+			args:        []string{"--set-string", "orchestration.exporters.rdbms.enabled=true"},
+			expectedErr: "orchestration.exporters.rdbms.enabled must be provided through TestCase.Values",
+		},
+		{
+			name:        "combined Optimize OpenSearch set",
+			args:        []string{"--set", "identity.enabled=true,optimize.database.opensearch.enabled=true"},
+			expectedErr: "optimize.database.opensearch.enabled must be provided through TestCase.Values",
+		},
+		{
+			name:        "set JSON secondary storage parent",
+			args:        []string{"--set-json", `orchestration.data.secondaryStorage={"type":"opensearch"}`},
+			expectedErr: "orchestration.data.secondaryStorage must be provided through TestCase.Values",
+		},
+		{
+			name:        "inline set JSON Optimize OpenSearch parent",
+			args:        []string{`--set-json=optimize.database.opensearch={"enabled":true}`},
+			expectedErr: "optimize.database.opensearch must be provided through TestCase.Values",
+		},
+		{
+			name:        "set JSON orchestration ancestor",
+			args:        []string{"--set-json", `orchestration={"data":{"secondaryStorage":{"type":"opensearch"}}}`},
+			expectedErr: "orchestration must be provided through TestCase.Values",
+		},
+		{
+			name:        "inline set JSON Optimize ancestor",
+			args:        []string{`--set-json=optimize={"database":{"opensearch":{"enabled":true}}}`},
+			expectedErr: "optimize must be provided through TestCase.Values",
+		},
+		{
+			name:        "values file",
+			args:        []string{"--values", "storage.yaml"},
+			expectedErr: "values files must be provided through TestCase.ValuesFiles",
+		},
+	}
+
+	for _, testCase := range rejectedArgs {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.ErrorContains(t, validateStorageFixtureRenderArgs(testCase.args), testCase.expectedErr)
+		})
+	}
+
+	require.NoError(t, validateStorageFixtureRenderArgs([]string{
+		"--set-string", "orchestration.env[0].value=true",
+	}))
+}

--- a/charts/camunda-platform-8.10/test/unit/utils/goldenfiles.go
+++ b/charts/camunda-platform-8.10/test/unit/utils/goldenfiles.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 	"maps"
 	"regexp"
+	"strings"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
@@ -52,7 +53,12 @@ func goldenValues(setValues map[string]string) map[string]string {
 	values["global.identity.auth.console.existingSecret.name"] = "camunda-credentials"
 	values["global.identity.auth.optimize.secret.existingSecret"] = "camunda-credentials"
 	values["global.identity.auth.optimize.secret.existingSecretKey"] = "identity-optimize-client-token"
-	if _, ok := values["orchestration.data.secondaryStorage.type"]; !ok {
+	_, hasStorageType := values["orchestration.data.secondaryStorage.type"]
+	hasNoSecondaryStorage := strings.EqualFold(values["global.noSecondaryStorage"], "true")
+	hasRDBMS := strings.EqualFold(values["orchestration.exporters.rdbms.enabled"], "true")
+	hasOptimizeElasticsearch := strings.EqualFold(values["optimize.database.elasticsearch.enabled"], "true")
+	hasOptimizeOpenSearch := strings.EqualFold(values["optimize.database.opensearch.enabled"], "true")
+	if !hasStorageType && !hasNoSecondaryStorage && !hasRDBMS && !hasOptimizeElasticsearch && !hasOptimizeOpenSearch {
 		values["orchestration.data.secondaryStorage.type"] = "elasticsearch"
 	}
 	return values

--- a/charts/camunda-platform-8.10/test/unit/utils/goldenfiles.go
+++ b/charts/camunda-platform-8.10/test/unit/utils/goldenfiles.go
@@ -17,6 +17,7 @@ package utils
 import (
 	"flag"
 	"io/ioutil"
+	"maps"
 	"regexp"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
@@ -39,19 +40,11 @@ type TemplateGoldenTest struct {
 	ExtraHelmArgs  []string
 }
 
-func (s *TemplateGoldenTest) TestContainerGoldenTestDefaults() {
-	if s.SetValues == nil {
-		s.SetValues = map[string]string{
-			"connectors.security.authentication.oidc.secret.existingSecret":       "camunda-credentials",
-			"connectors.security.authentication.oidc.secret.existingSecretKey":    "client-secret",
-			"orchestration.security.authentication.oidc.secret.existingSecret":    "camunda-credentials",
-			"orchestration.security.authentication.oidc.secret.existingSecretKey": "client-secret",
-			"global.identity.auth.console.existingSecret.name":                    "camunda-credentials",
-			"global.identity.auth.optimize.secret.existingSecret":                 "camunda-credentials",
-			"global.identity.auth.optimize.secret.existingSecretKey":              "identity-optimize-client-token",
-		}
+func goldenValues(setValues map[string]string) map[string]string {
+	values := maps.Clone(setValues)
+	if values == nil {
+		values = make(map[string]string)
 	}
-	values := s.SetValues
 	values["connectors.security.authentication.oidc.secret.existingSecret"] = "camunda-credentials"
 	values["connectors.security.authentication.oidc.secret.existingSecretKey"] = "client-secret"
 	values["orchestration.security.authentication.oidc.secret.existingSecret"] = "camunda-credentials"
@@ -59,7 +52,19 @@ func (s *TemplateGoldenTest) TestContainerGoldenTestDefaults() {
 	values["global.identity.auth.console.existingSecret.name"] = "camunda-credentials"
 	values["global.identity.auth.optimize.secret.existingSecret"] = "camunda-credentials"
 	values["global.identity.auth.optimize.secret.existingSecretKey"] = "identity-optimize-client-token"
-	values["global.elasticsearch.enabled"] = "true"
+	if _, ok := values["orchestration.data.secondaryStorage.type"]; !ok {
+		values["orchestration.data.secondaryStorage.type"] = "elasticsearch"
+	}
+	return values
+}
+
+func goldenIgnoredLines(ignoredLines []string) []string {
+	lines := append([]string(nil), ignoredLines...)
+	return append(lines, `\s+helm.sh/chart:\s+.*`)
+}
+
+func (s *TemplateGoldenTest) TestContainerGoldenTestDefaults() {
+	values := goldenValues(s.SetValues)
 	options := &helm.Options{
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.Namespace),
 		SetValues:      values,
@@ -67,9 +72,8 @@ func (s *TemplateGoldenTest) TestContainerGoldenTestDefaults() {
 	}
 	output := helm.RenderTemplate(s.T(), options, s.ChartPath, s.Release, s.Templates, s.ExtraHelmArgs...)
 
-	s.IgnoredLines = append(s.IgnoredLines, `\s+helm.sh/chart:\s+.*`)
 	bytes := []byte(output)
-	for _, ignoredLine := range s.IgnoredLines {
+	for _, ignoredLine := range goldenIgnoredLines(s.IgnoredLines) {
 		regex := regexp.MustCompile(ignoredLine)
 		bytes = regex.ReplaceAll(bytes, []byte(""))
 	}

--- a/charts/camunda-platform-8.10/test/unit/utils/goldenfiles_test.go
+++ b/charts/camunda-platform-8.10/test/unit/utils/goldenfiles_test.go
@@ -53,6 +53,42 @@ func TestGoldenValuesPreservesStorageType(t *testing.T) {
 	require.Equal(t, "opensearch", values["orchestration.data.secondaryStorage.type"])
 }
 
+func TestGoldenValuesDoesNotOverrideStorageSelectors(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{name: "no secondary storage", key: "global.noSecondaryStorage", value: "true"},
+		{name: "RDBMS", key: "orchestration.exporters.rdbms.enabled", value: "true"},
+		{name: "Optimize Elasticsearch", key: "optimize.database.elasticsearch.enabled", value: "true"},
+		{name: "Optimize OpenSearch", key: "optimize.database.opensearch.enabled", value: "true"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			values := goldenValues(map[string]string{testCase.key: testCase.value})
+
+			require.NotContains(t, values, "orchestration.data.secondaryStorage.type")
+		})
+	}
+}
+
+func TestGoldenValuesDefaultsStorageWhenSelectorsAreDisabled(t *testing.T) {
+	t.Parallel()
+
+	values := goldenValues(map[string]string{
+		"global.noSecondaryStorage":               "false",
+		"orchestration.exporters.rdbms.enabled":   "false",
+		"optimize.database.elasticsearch.enabled": "false",
+		"optimize.database.opensearch.enabled":    "false",
+	})
+
+	require.Equal(t, "elasticsearch", values["orchestration.data.secondaryStorage.type"])
+}
+
 func TestGoldenIgnoredLinesClonesInput(t *testing.T) {
 	t.Parallel()
 

--- a/charts/camunda-platform-8.10/test/unit/utils/goldenfiles_test.go
+++ b/charts/camunda-platform-8.10/test/unit/utils/goldenfiles_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGoldenValuesClonesInput(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]string{"provided": "original"}
+	values := goldenValues(input)
+
+	require.Equal(t, map[string]string{"provided": "original"}, input)
+	require.Equal(t, map[string]string{
+		"connectors.security.authentication.oidc.secret.existingSecret":       "camunda-credentials",
+		"connectors.security.authentication.oidc.secret.existingSecretKey":    "client-secret",
+		"global.identity.auth.console.existingSecret.name":                    "camunda-credentials",
+		"global.identity.auth.optimize.secret.existingSecret":                 "camunda-credentials",
+		"global.identity.auth.optimize.secret.existingSecretKey":              "identity-optimize-client-token",
+		"orchestration.data.secondaryStorage.type":                            "elasticsearch",
+		"orchestration.security.authentication.oidc.secret.existingSecret":    "camunda-credentials",
+		"orchestration.security.authentication.oidc.secret.existingSecretKey": "client-secret",
+		"provided": "original",
+	}, values)
+
+	values["provided"] = "changed"
+	require.Equal(t, "original", input["provided"])
+}
+
+func TestGoldenValuesPreservesStorageType(t *testing.T) {
+	t.Parallel()
+
+	values := goldenValues(map[string]string{
+		"orchestration.data.secondaryStorage.type": "opensearch",
+	})
+
+	require.Equal(t, "opensearch", values["orchestration.data.secondaryStorage.type"])
+}
+
+func TestGoldenIgnoredLinesClonesInput(t *testing.T) {
+	t.Parallel()
+
+	input := make([]string, 1, 4)
+	input[0] = "caller-pattern"
+	ignoredLines := goldenIgnoredLines(input)
+
+	require.Equal(t, []string{"caller-pattern"}, input)
+	require.Equal(t, []string{"caller-pattern", `\s+helm.sh/chart:\s+.*`}, ignoredLines)
+
+	ignoredLines[0] = "changed"
+	require.Equal(t, "caller-pattern", input[0])
+}

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/camunda_hub_shim_test.go
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/camunda_hub_shim_test.go
@@ -66,10 +66,9 @@ func (s *CamundaHubShimTemplateTest) TestEnablementMatrix() {
 		{
 			name: "HubDisabledLegacyFalse",
 			values: map[string]string{
-				"camundaHub.enabled":           "false",
-				"webModeler.enabled":           "false",
-				"console.enabled":              "false",
-				"global.elasticsearch.enabled": "true",
+				"camundaHub.enabled": "false",
+				"webModeler.enabled": "false",
+				"console.enabled":    "false",
 			},
 		},
 		{
@@ -286,10 +285,10 @@ func (s *CamundaHubShimTemplateTest) TestOIDCClientIDPreserved() {
 	for _, camundaHubEnabled := range []string{"false", "true"} {
 		s.Run("camundaHub.enabled="+camundaHubEnabled, func() {
 			values := map[string]string{
-				"camundaHub.enabled":           camundaHubEnabled,
-				"webModeler.enabled":           "true",
-				"global.identity.auth.enabled": "true",
-				"global.elasticsearch.enabled": "true",
+				"camundaHub.enabled":                       camundaHubEnabled,
+				"webModeler.enabled":                       "true",
+				"global.identity.auth.enabled":             "true",
+				"orchestration.data.secondaryStorage.type": "elasticsearch",
 			}
 			config := s.renderRestAPIConfigMap(values)
 			s.Require().Equal("web-modeler", config.Camunda.Modeler.OAuth2.ClientId)
@@ -362,9 +361,9 @@ func (s *CamundaHubShimTemplateTest) renderWebModelerRestAPI(values map[string]s
 
 func (s *CamundaHubShimTemplateTest) renderWebModeler(values map[string]string, templates []string) (string, error) {
 	for key, value := range map[string]string{
-		"global.elasticsearch.enabled":        "true",
-		"identity.enabled":                    "true",
-		"webModeler.restapi.mail.fromAddress": "example@example.com",
+		"orchestration.data.secondaryStorage.type": "elasticsearch",
+		"identity.enabled":                         "true",
+		"webModeler.restapi.mail.fromAddress":      "example@example.com",
 	} {
 		if _, ok := values[key]; !ok {
 			values[key] = value

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/configmap_restapi_test.go
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/configmap_restapi_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package web_modeler
 
 import (
@@ -29,6 +43,7 @@ var requiredValues = map[string]string{
 	"webModeler.restapi.mail.fromAddress":                              "example@example.com",
 	"connectors.security.authentication.oidc.secret.existingSecret":    "foo",
 	"orchestration.security.authentication.oidc.secret.existingSecret": "foo",
+	"orchestration.data.secondaryStorage.type":                         "elasticsearch",
 	"global.identity.keycloak.auth.adminUser":                          "admin",
 	"global.identity.keycloak.auth.secret.existingSecret":              "kc-secret",
 	"global.identity.keycloak.auth.secret.existingSecretKey":           "password",
@@ -54,7 +69,6 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectAuthClientAp
 		"identity.enabled":                                  "true",
 		"global.identity.auth.enabled":                      "true",
 		"global.identity.auth.webModeler.clientApiAudience": "custom-audience",
-		"global.elasticsearch.enabled":                      "true",
 	}
 	maps.Insert(values, maps.All(requiredValues))
 	options := &helm.Options{
@@ -88,7 +102,6 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectCamundaHubAu
 		"global.identity.auth.webModeler.clientApiAudience": "legacy-audience",
 		"global.identity.auth.webModeler.clientId":          "legacy-clientId",
 		"global.identity.auth.webModeler.redirectUrl":       "https://legacy.example.com",
-		"global.elasticsearch.enabled":                      "true",
 	}
 	maps.Insert(values, maps.All(requiredValues))
 	options := &helm.Options{
@@ -119,7 +132,6 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectAuthPublicAp
 		"identity.enabled":                                  "true",
 		"global.identity.auth.enabled":                      "true",
 		"global.identity.auth.webModeler.publicApiAudience": "custom-audience",
-		"global.elasticsearch.enabled":                      "true",
 	}
 	maps.Insert(values, maps.All(requiredValues))
 	options := &helm.Options{
@@ -148,7 +160,6 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectAuthClientId
 		"identity.enabled":                         "true",
 		"global.identity.auth.enabled":             "true",
 		"global.identity.auth.webModeler.clientId": "custom-clientId",
-		"global.elasticsearch.enabled":             "true",
 	}
 	maps.Insert(values, maps.All(requiredValues))
 	options := &helm.Options{
@@ -176,7 +187,6 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectAuthTokenUse
 	values := map[string]string{
 		"identity.enabled":                                         "true",
 		"global.identity.auth.enabled":                             "true",
-		"global.elasticsearch.enabled":                             "true",
 		"orchestration.security.authentication.oidc.usernameClaim": "example-claim",
 	}
 	maps.Insert(values, maps.All(requiredValues))
@@ -206,7 +216,6 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectIdentityServ
 		"global.identity.auth.enabled": "true",
 		"identity.enabled":             "true",
 		"identity.fullnameOverride":    "custom-identity-fullname",
-		"global.elasticsearch.enabled": "true",
 	}
 	maps.Insert(values, maps.All(requiredValues))
 	options := &helm.Options{
@@ -235,7 +244,6 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectIdentityServ
 		"global.identity.auth.enabled": "true",
 		"identity.enabled":             "true",
 		"identity.nameOverride":        "custom-identity",
-		"global.elasticsearch.enabled": "true",
 	}
 	maps.Insert(values, maps.All(requiredValues))
 	options := &helm.Options{
@@ -270,7 +278,6 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectIdentityType
 		"global.identity.auth.authUrl":                        "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/authorize",
 		"global.identity.auth.tokenUrl":                       "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token",
 		"global.identity.auth.jwksUrl":                        "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/discovery/v2.0/keys",
-		"global.elasticsearch.enabled":                        "true",
 	}
 	maps.Insert(values, maps.All(requiredValues))
 	options := &helm.Options{
@@ -301,7 +308,6 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectKeycloakServ
 		"global.identity.keycloak.url.protocol": "http",
 		"global.identity.keycloak.url.host":     "keycloak",
 		"global.identity.keycloak.url.port":     "80",
-		"global.elasticsearch.enabled":          "true",
 	}
 	maps.Insert(values, maps.All(requiredValues))
 	options := &helm.Options{
@@ -332,7 +338,6 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectKeycloakServ
 		"global.identity.keycloak.url.protocol": "http",
 		"global.identity.keycloak.url.host":     "keycloak",
 		"global.identity.keycloak.url.port":     "8888",
-		"global.elasticsearch.enabled":          "true",
 	}
 	maps.Insert(values, maps.All(requiredValues))
 	options := &helm.Options{
@@ -360,7 +365,6 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetSmtpCredentials() {
 	values := map[string]string{
 		"identity.enabled":                 "true",
 		"webModeler.restapi.mail.smtpUser": "modeler-user",
-		"global.elasticsearch.enabled":     "true",
 	}
 	maps.Insert(values, maps.All(requiredValues))
 	options := &helm.Options{
@@ -389,7 +393,6 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetExternalDatabaseCon
 		"identity.enabled":                             "true",
 		"webModeler.restapi.externalDatabase.url":      "jdbc:postgresql://postgres.example.com:65432/modeler-database",
 		"webModeler.restapi.externalDatabase.username": "modeler-user",
-		"global.elasticsearch.enabled":                 "true",
 	}
 	maps.Insert(values, maps.All(requiredValues))
 	options := &helm.Options{
@@ -420,7 +423,6 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetExternalDatabaseCon
 		"webModeler.restapi.externalDatabase.url":                 "jdbc:postgresql://postgres.example.com:65432/modeler-database",
 		"webModeler.restapi.externalDatabase.username":            "modeler-user-new",
 		"webModeler.restapi.externalDatabase.secret.inlineSecret": "modeler-password",
-		"global.elasticsearch.enabled":                            "true",
 	}
 	maps.Insert(values, maps.All(requiredValues))
 	options := &helm.Options{
@@ -487,7 +489,6 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldConfigureClusterFromSa
 				"orchestration.service.grpcPort":                "26600",
 				"orchestration.service.httpPort":                "8090",
 				"orchestration.security.authorizations.enabled": "false",
-				"global.elasticsearch.enabled":                  "true",
 			}
 			maps.Insert(values, maps.All(requiredValues))
 			options := &helm.Options{
@@ -554,7 +555,6 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldConfigureClusterRestUr
 		"orchestration.service.grpcPort":                "26600",
 		"orchestration.service.httpPort":                "8090",
 		"orchestration.security.authorizations.enabled": "false",
-		"global.elasticsearch.enabled":                  "true",
 	}
 	maps.Insert(values, maps.All(requiredValues))
 	options := &helm.Options{
@@ -591,7 +591,6 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldConfigureClusterRestUr
 func (s *configmapRestAPITemplateTest) TestContainerShouldUseSecureGrpcUrlWhenOrchestrationGrpcTlsIsEnabled() {
 	values := map[string]string{
 		"identity.enabled":                              "true",
-		"global.elasticsearch.enabled":                  "true",
 		"global.zeebeClusterName":                       "test-zeebe",
 		"global.ingress.enabled":                        "true",
 		"global.ingress.tls.enabled":                    "true",
@@ -659,7 +658,6 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldUseClustersFromCustomC
 		"webModeler.restapi.clusters[2].url.grpc":       "grpc://orchestration.test-3:26500",
 		"webModeler.restapi.clusters[2].url.rest":       "http://orchestration.test-3:8080",
 		"webModeler.restapi.clusters[2].url.web-app":    "http://localhost:8088",
-		"global.elasticsearch.enabled":                  "true",
 	}
 	maps.Insert(values, maps.All(requiredValues))
 	options := &helm.Options{
@@ -706,10 +704,9 @@ func (s *configmapRestAPITemplateTest) TestManagementClusterContainsBothIdentity
 	// management-cluster must include both identity and hub so that WebModeler
 	// can reach Identity and register itself as a known component.
 	values := map[string]string{
-		"identity.enabled":                              "true",
-		"global.elasticsearch.enabled":                  "true",
-		"global.ingress.enabled":                        "true",
-		"global.host":                                   "example.com",
+		"identity.enabled":       "true",
+		"global.ingress.enabled": "true",
+		"global.host":            "example.com",
 		"orchestration.security.authorizations.enabled": "false",
 	}
 	maps.Insert(values, maps.All(requiredValues))
@@ -750,9 +747,8 @@ func (s *configmapRestAPITemplateTest) TestManagementClusterContainsBothIdentity
 func (s *configmapRestAPITemplateTest) TestContainerShouldNotConfigureClustersIfZeebeDisabledAndNoCustomConfiguration() {
 	// given
 	values := map[string]string{
-		"identity.enabled":             "true",
-		"orchestration.enabled":        "false",
-		"global.elasticsearch.enabled": "true",
+		"identity.enabled":      "true",
+		"orchestration.enabled": "false",
 	}
 	maps.Insert(values, maps.All(requiredValues))
 	options := &helm.Options{
@@ -781,7 +777,6 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetJwkSetUriFromJwksUr
 		"identity.enabled":             "true",
 		"global.identity.auth.enabled": "true",
 		"global.identity.auth.jwksUrl": "https://example.com/auth/realms/test/protocol/openid-connect/certs",
-		"global.elasticsearch.enabled": "true",
 	}
 	maps.Insert(values, maps.All(requiredValues))
 	options := &helm.Options{
@@ -810,7 +805,6 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetJwkSetUriFromIssuer
 		"identity.enabled":                      "true",
 		"global.identity.auth.enabled":          "true",
 		"global.identity.auth.issuerBackendUrl": "http://test-keycloak/auth/realms/test",
-		"global.elasticsearch.enabled":          "true",
 	}
 	maps.Insert(values, maps.All(requiredValues))
 	options := &helm.Options{
@@ -843,7 +837,6 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetJwkSetUriFromKeyclo
 		"global.identity.keycloak.url.port":     "443",
 		"global.identity.keycloak.contextPath":  "/",
 		"global.identity.keycloak.realm":        "test",
-		"global.elasticsearch.enabled":          "true",
 	}
 	maps.Insert(values, maps.All(requiredValues))
 	options := &helm.Options{
@@ -873,7 +866,6 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetJdbcUrlFromHostPort
 		"webModeler.restapi.externalDatabase.host":     "custom-db.example.com",
 		"webModeler.restapi.externalDatabase.port":     "65432",
 		"webModeler.restapi.externalDatabase.database": "custom-modeler-db",
-		"global.elasticsearch.enabled":                 "true",
 	}
 	maps.Insert(values, maps.All(requiredValues))
 	options := &helm.Options{
@@ -901,7 +893,6 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectServerUrlAnd
 	values := map[string]string{
 		"identity.enabled":                            "true",
 		"global.identity.auth.enabled":                "true",
-		"global.elasticsearch.enabled":                "true",
 		"global.identity.auth.webModeler.redirectUrl": "https://modeler.example.com",
 	}
 	maps.Insert(values, maps.All(requiredValues))
@@ -931,7 +922,6 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectContextPath(
 	values := map[string]string{
 		"identity.enabled":             "true",
 		"global.identity.auth.enabled": "true",
-		"global.elasticsearch.enabled": "true",
 		"webModeler.contextPath":       "/modeler",
 	}
 	maps.Insert(values, maps.All(requiredValues))
@@ -961,7 +951,6 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectClientPusher
 	values := map[string]string{
 		"identity.enabled":                 "true",
 		"global.identity.auth.enabled":     "true",
-		"global.elasticsearch.enabled":     "true",
 		"webModeler.websockets.publicPort": "8082",
 	}
 	maps.Insert(values, maps.All(requiredValues))
@@ -990,7 +979,6 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectClientPusher
 	values := map[string]string{
 		"identity.enabled":             "true",
 		"global.identity.auth.enabled": "true",
-		"global.elasticsearch.enabled": "true",
 		"webModeler.contextPath":       "/modeler",
 		"global.ingress.enabled":       "true",
 		"global.host":                  "c8.example.com",
@@ -1025,7 +1013,6 @@ func (s *configmapRestAPITemplateTest) TestContainerShouldSetCorrectClientPusher
 	values := map[string]string{
 		"identity.enabled":             "true",
 		"global.identity.auth.enabled": "true",
-		"global.elasticsearch.enabled": "true",
 		"webModeler.contextPath":       "/modeler",
 		"global.ingress.enabled":       "true",
 		"global.host":                  "c8.example.com",
@@ -1115,7 +1102,6 @@ func (s *configmapRestAPITemplateTest) TestExtraConfigurationSpringImport() {
 				"webModeler.restapi.mail.fromAddress":              "example@example.com",
 				"webModeler.restapi.extraConfiguration[0].file":    "custom-spring.yaml",
 				"webModeler.restapi.extraConfiguration[0].content": "some: config",
-				"global.elasticsearch.enabled":                     "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var configmap corev1.ConfigMap
@@ -1139,7 +1125,6 @@ func (s *configmapRestAPITemplateTest) TestExtraConfigurationSpringImport() {
 				"webModeler.restapi.extraConfiguration[0].file":         "log4j2-spring.xml",
 				"webModeler.restapi.extraConfiguration[0].springImport": "false",
 				"webModeler.restapi.extraConfiguration[0].content":      "<Configuration/>",
-				"global.elasticsearch.enabled":                          "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var configmap corev1.ConfigMap
@@ -1168,7 +1153,6 @@ func (s *configmapRestAPITemplateTest) TestExtraConfigurationSpringImport() {
 				"webModeler.restapi.extraConfiguration[1].file":         "log4j2-spring.xml",
 				"webModeler.restapi.extraConfiguration[1].springImport": "false",
 				"webModeler.restapi.extraConfiguration[1].content":      "<Configuration/>",
-				"global.elasticsearch.enabled":                          "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var configmap corev1.ConfigMap
@@ -1197,9 +1181,8 @@ func (s *configmapRestAPITemplateTest) TestMailFromAddressOptionalForExtraConfig
 		{
 			Name: "TestFromAddressRequiredWhenUnsetAndNotMigrated",
 			Values: map[string]string{
-				"identity.enabled":             "true",
-				"webModeler.enabled":           "true",
-				"global.elasticsearch.enabled": "true",
+				"identity.enabled":   "true",
+				"webModeler.enabled": "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				s.Require().ErrorContains(err, "webModeler.restapi.mail.fromAddress' is required",
@@ -1227,7 +1210,6 @@ func (s *configmapRestAPITemplateTest) TestMailFromAddressOptionalForExtraConfig
 			Values: map[string]string{
 				"identity.enabled":                    "true",
 				"webModeler.enabled":                  "true",
-				"global.elasticsearch.enabled":        "true",
 				"webModeler.restapi.mail.fromAddress": "deprecated@example.com",
 			},
 			Verifier: func(t *testing.T, output string, err error) {

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/deployment_test.go
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/deployment_test.go
@@ -123,7 +123,6 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 				"webModeler.enabled":                  "true",
 				"camundaHub.restapi.mail.fromAddress": "example@example.com",
 				"camundaHub.nameOverride":             "foo",
-				"global.elasticsearch.enabled":        "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var deployment appsv1.Deployment
@@ -139,7 +138,6 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 				"webModeler.enabled":                  "true",
 				"camundaHub.restapi.mail.fromAddress": "example@example.com",
 				"camundaHub.fullnameOverride":         "foo",
-				"global.elasticsearch.enabled":        "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var deployment appsv1.Deployment
@@ -155,7 +153,6 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 				"webModeler.enabled":                           "true",
 				"camundaHub.restapi.mail.fromAddress":          "example@example.com",
 				"camundaHub." + s.component + ".podLabels.foo": "bar",
-				"global.elasticsearch.enabled":                 "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var deployment appsv1.Deployment
@@ -172,7 +169,6 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 				"camundaHub.restapi.mail.fromAddress":               "example@example.com",
 				"camundaHub." + s.component + ".podAnnotations.foo": "bar",
 				"camundaHub." + s.component + ".podAnnotations.foz": "baz",
-				"global.elasticsearch.enabled":                      "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var deployment appsv1.Deployment
@@ -200,7 +196,6 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 				"webModeler.enabled":                  "true",
 				"camundaHub.restapi.mail.fromAddress": "example@example.com",
 				"global.annotations.foo":              "bar",
-				"global.elasticsearch.enabled":        "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var deployment appsv1.Deployment
@@ -219,7 +214,6 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 				"camundaHub.image.registry":                       "subchart.custom.registry.io",
 				"camundaHub.image.tag":                            "snapshot",
 				"camundaHub." + s.component + ".image.repository": "web-modeler/modeler-" + s.component,
-				"global.elasticsearch.enabled":                    "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var deployment appsv1.Deployment
@@ -239,7 +233,6 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 				"camundaHub.image.registry":                       "",
 				"camundaHub.image.tag":                            "snapshot",
 				"camundaHub." + s.component + ".image.repository": "web-modeler/modeler-" + s.component,
-				"global.elasticsearch.enabled":                    "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var deployment appsv1.Deployment
@@ -256,7 +249,6 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 				"webModeler.enabled":                  "true",
 				"camundaHub.restapi.mail.fromAddress": "example@example.com",
 				"global.image.pullSecrets[0].name":    "SecretName",
-				"global.elasticsearch.enabled":        "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var deployment appsv1.Deployment
@@ -274,7 +266,6 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 				"global.image.pullSecrets[0].name":     "SecretName",
 				"camundaHub.image.pullSecrets[0].name": "SecretNameSubChart",
 				"camundaHub.image.tag":                 "snapshot",
-				"global.elasticsearch.enabled":         "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var deployment appsv1.Deployment
@@ -290,7 +281,6 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 				"webModeler.enabled":                  "true",
 				"camundaHub.restapi.mail.fromAddress": "example@example.com",
 				"camundaHub.image.repository":         "camunda/custom-web-modeler",
-				"global.elasticsearch.enabled":        "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var deployment appsv1.Deployment
@@ -305,7 +295,6 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 				"webModeler.enabled":                  "true",
 				"camundaHub.restapi.mail.fromAddress": "example@example.com",
 				"camundaHub.image.tag":                "a.b.c",
-				"global.elasticsearch.enabled":        "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var deployment appsv1.Deployment
@@ -324,7 +313,6 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 				"webModeler.enabled":                  "true",
 				"camundaHub.restapi.mail.fromAddress": "example@example.com",
 				"camundaHub.image.tag":                "a.b.c",
-				"global.elasticsearch.enabled":        "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var deployment appsv1.Deployment
@@ -343,7 +331,6 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 				"webModeler.enabled":                        "true",
 				"camundaHub.restapi.mail.fromAddress":       "example@example.com",
 				"camundaHub." + s.component + ".command[0]": "printenv",
-				"global.elasticsearch.enabled":              "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var deployment appsv1.Deployment
@@ -364,15 +351,14 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 				"camundaHub." + s.component + ".extraVolumes[0].name":                  "extraVolume",
 				"camundaHub." + s.component + ".extraVolumes[0].configMap.name":        "otherConfigMap",
 				"camundaHub." + s.component + ".extraVolumes[0].configMap.defaultMode": "744",
-				"global.elasticsearch.enabled":                                         "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				// finding out the length of volumes array before addition of new volume
 				optionsBefore := &helm.Options{
 					SetValues: map[string]string{
-						"webModeler.enabled":                  "true",
-						"camundaHub.restapi.mail.fromAddress": "example@example.com",
-						"global.elasticsearch.enabled":        "true",
+						"webModeler.enabled":                       "true",
+						"camundaHub.restapi.mail.fromAddress":      "example@example.com",
+						"orchestration.data.secondaryStorage.type": "elasticsearch",
 					},
 					KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 				}
@@ -400,15 +386,14 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 				"camundaHub.restapi.mail.fromAddress":                           "example@example.com",
 				"camundaHub." + s.component + ".extraVolumeMounts[0].name":      "otherConfigMap",
 				"camundaHub." + s.component + ".extraVolumeMounts[0].mountPath": "/usr/local/config",
-				"global.elasticsearch.enabled":                                  "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				// finding out the length of containers and volumeMounts array before addition of new volumeMount
 				optionsBefore := &helm.Options{
 					SetValues: map[string]string{
-						"webModeler.enabled":                  "true",
-						"camundaHub.restapi.mail.fromAddress": "example@example.com",
-						"global.elasticsearch.enabled":        "true",
+						"webModeler.enabled":                       "true",
+						"camundaHub.restapi.mail.fromAddress":      "example@example.com",
+						"orchestration.data.secondaryStorage.type": "elasticsearch",
 					},
 					KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
 				}
@@ -437,7 +422,6 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 				"webModeler.enabled":                  "true",
 				"camundaHub.restapi.mail.fromAddress": "example@example.com",
 				"camundaHub.serviceAccount.name":      "accName",
-				"global.elasticsearch.enabled":        "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var deployment appsv1.Deployment
@@ -454,7 +438,6 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 				"webModeler.enabled":                  "true",
 				"camundaHub.restapi.mail.fromAddress": "example@example.com",
 				"camundaHub." + s.component + ".podSecurityContext.runAsUser": "1000",
-				"global.elasticsearch.enabled":                                "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var deployment appsv1.Deployment
@@ -471,7 +454,6 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 				"webModeler.enabled":                  "true",
 				"camundaHub.restapi.mail.fromAddress": "example@example.com",
 				"camundaHub." + s.component + ".containerSecurityContext.privileged": "true",
-				"global.elasticsearch.enabled":                                       "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var deployment appsv1.Deployment
@@ -490,7 +472,6 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 				"camundaHub.restapi.mail.fromAddress":                  "example@example.com",
 				"camundaHub." + s.component + ".nodeSelector.disktype": "ssd",
 				"camundaHub." + s.component + ".nodeSelector.cputype":  "arm",
-				"global.elasticsearch.enabled":                         "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var deployment appsv1.Deployment
@@ -533,7 +514,6 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 				"camundaHub." + s.component + ".affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].key":             "another-node-label-key",
 				"camundaHub." + s.component + ".affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].operator":        "In",
 				"camundaHub." + s.component + ".affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].preference.matchExpressions[0].values[0]":       "another-node-label-value",
-				"global.elasticsearch.enabled": "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var deployment appsv1.Deployment
@@ -576,7 +556,6 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 				"camundaHub." + s.component + ".tolerations[0].operator": "Equal",
 				"camundaHub." + s.component + ".tolerations[0].value":    "Value1",
 				"camundaHub." + s.component + ".tolerations[0].effect":   "NoSchedule",
-				"global.elasticsearch.enabled":                           "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var deployment appsv1.Deployment
@@ -599,7 +578,6 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 				"webModeler.enabled":                  "true",
 				"camundaHub.restapi.mail.fromAddress": "example@example.com",
 				"global.image.pullPolicy":             "Always",
-				"global.elasticsearch.enabled":        "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var deployment appsv1.Deployment
@@ -624,7 +602,6 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 				"camundaHub." + s.component + ".startupProbe.successThreshold":    "1",
 				"camundaHub." + s.component + ".startupProbe.failureThreshold":    "5",
 				"camundaHub." + s.component + ".startupProbe.timeoutSeconds":      "1",
-				"global.elasticsearch.enabled":                                    "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var deployment appsv1.Deployment
@@ -651,7 +628,6 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 				"camundaHub." + s.component + ".readinessProbe.successThreshold":    "1",
 				"camundaHub." + s.component + ".readinessProbe.failureThreshold":    "5",
 				"camundaHub." + s.component + ".readinessProbe.timeoutSeconds":      "1",
-				"global.elasticsearch.enabled":                                      "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var deployment appsv1.Deployment
@@ -678,7 +654,6 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 				"camundaHub." + s.component + ".livenessProbe.successThreshold":    "1",
 				"camundaHub." + s.component + ".livenessProbe.failureThreshold":    "5",
 				"camundaHub." + s.component + ".livenessProbe.timeoutSeconds":      "1",
-				"global.elasticsearch.enabled":                                     "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var deployment appsv1.Deployment
@@ -702,7 +677,6 @@ func (s *DeploymentTemplateTest) TestDifferentValuesInputs() {
 				"camundaHub.restapi.extraConfiguration[0].file":     "testFile",
 				"camundaHub.restapi.extraConfiguration[0].content":  "this is a test",
 				"camundaHub.websockets.extraConfiguration.testFile": "this is a test",
-				"global.elasticsearch.enabled":                      "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var deployment appsv1.Deployment

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/goldenfiles_test.go
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/goldenfiles_test.go
@@ -52,7 +52,6 @@ func TestGoldenDefaultsTemplateWebModeler(t *testing.T) {
 				"orchestration.security.authentication.oidc.secret.existingSecret": "foo",
 				"global.identity.auth.enabled":                                     "true",
 				"identity.enabled":                                                 "true",
-				"global.elasticsearch.enabled":                                     "true",
 				"global.identity.keycloak.url.protocol":                            "https",
 				"global.identity.keycloak.url.host":                                "keycloak.example.com",
 				"global.identity.keycloak.url.port":                                "8443",

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/persistence_test.go
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/persistence_test.go
@@ -58,10 +58,10 @@ func (s *PersistenceTemplateTest) TestPersistenceConfiguration() {
 		{
 			Name: "TestPersistenceDisabledUsesEmptyDir",
 			Values: map[string]string{
-				"identity.enabled":                    "true",
-				"global.elasticsearch.enabled":        "true",
-				"camundaHub.enabled":                  "true",
-				"camundaHub.restapi.mail.fromAddress": "example@example.com",
+				"identity.enabled":                         "true",
+				"orchestration.data.secondaryStorage.type": "elasticsearch",
+				"camundaHub.enabled":                       "true",
+				"camundaHub.restapi.mail.fromAddress":      "example@example.com",
 				// persistence.enabled defaults to false
 			},
 			Verifier: func(t *testing.T, output string, err error) {
@@ -86,13 +86,13 @@ func (s *PersistenceTemplateTest) TestPersistenceConfiguration() {
 		{
 			Name: "TestPersistenceEnabledCreatesVolume",
 			Values: map[string]string{
-				"identity.enabled":                      "true",
-				"global.elasticsearch.enabled":          "true",
-				"camundaHub.enabled":                    "true",
-				"camundaHub.restapi.mail.fromAddress":   "example@example.com",
-				"camundaHub.persistence.enabled":        "true",
-				"camundaHub.persistence.size":           "5Gi",
-				"camundaHub.persistence.accessModes[0]": "ReadWriteOnce",
+				"identity.enabled":                         "true",
+				"orchestration.data.secondaryStorage.type": "elasticsearch",
+				"camundaHub.enabled":                       "true",
+				"camundaHub.restapi.mail.fromAddress":      "example@example.com",
+				"camundaHub.persistence.enabled":           "true",
+				"camundaHub.persistence.size":              "5Gi",
+				"camundaHub.persistence.accessModes[0]":    "ReadWriteOnce",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var deployment appsv1.Deployment
@@ -120,12 +120,12 @@ func (s *PersistenceTemplateTest) TestPersistenceConfiguration() {
 		{
 			Name: "TestPersistenceWithExistingClaimCreatesVolume",
 			Values: map[string]string{
-				"identity.enabled":                     "true",
-				"global.elasticsearch.enabled":         "true",
-				"camundaHub.enabled":                   "true",
-				"camundaHub.restapi.mail.fromAddress":  "example@example.com",
-				"camundaHub.persistence.enabled":       "true",
-				"camundaHub.persistence.existingClaim": "my-existing-pvc",
+				"identity.enabled":                         "true",
+				"orchestration.data.secondaryStorage.type": "elasticsearch",
+				"camundaHub.enabled":                       "true",
+				"camundaHub.restapi.mail.fromAddress":      "example@example.com",
+				"camundaHub.persistence.enabled":           "true",
+				"camundaHub.persistence.existingClaim":     "my-existing-pvc",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var deployment appsv1.Deployment
@@ -149,12 +149,12 @@ func (s *PersistenceTemplateTest) TestPersistenceConfiguration() {
 		{
 			Name: "TestPersistenceDisabledWhenComponentDisabled",
 			Values: map[string]string{
-				"identity.enabled":                    "true",
-				"global.elasticsearch.enabled":        "true",
-				"webModeler.enabled":                  "false",
-				"camundaHub.restapi.mail.fromAddress": "example@example.com",
-				"camundaHub.persistence.enabled":      "true",
-				"camundaHub.persistence.size":         "5Gi",
+				"identity.enabled":                         "true",
+				"orchestration.data.secondaryStorage.type": "elasticsearch",
+				"webModeler.enabled":                       "false",
+				"camundaHub.restapi.mail.fromAddress":      "example@example.com",
+				"camundaHub.persistence.enabled":           "true",
+				"camundaHub.persistence.size":              "5Gi",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				// When component is disabled, no deployment should be created
@@ -198,7 +198,6 @@ func TestDeploymentStrategyDefaultsToRollingUpdate(t *testing.T) {
 		Name: "TestDeploymentStrategyDefaultsToRollingUpdate",
 		Values: map[string]string{
 			"identity.enabled":                    "true",
-			"global.elasticsearch.enabled":        "true",
 			"webModeler.enabled":                  "true",
 			"camundaHub.restapi.mail.fromAddress": "example@example.com",
 		},
@@ -224,7 +223,6 @@ func TestDeploymentStrategyRecreateOptIn(t *testing.T) {
 		Name: "TestDeploymentStrategyRecreateOptIn",
 		Values: map[string]string{
 			"identity.enabled":                          "true",
-			"global.elasticsearch.enabled":              "true",
 			"webModeler.enabled":                        "true",
 			"camundaHub.restapi.mail.fromAddress":       "example@example.com",
 			"camundaHub.persistence.enabled":            "true",
@@ -248,7 +246,6 @@ func TestDeploymentStrategyInvalidValueFails(t *testing.T) {
 		Name: "TestDeploymentStrategyInvalidValueFails",
 		Values: map[string]string{
 			"identity.enabled":                          "true",
-			"global.elasticsearch.enabled":              "true",
 			"webModeler.enabled":                        "true",
 			"camundaHub.restapi.mail.fromAddress":       "example@example.com",
 			"camundaHub.persistence.deploymentStrategy": "InvalidStrategy",
@@ -271,7 +268,6 @@ func TestDeploymentStrategyRecreateRequiresPersistence(t *testing.T) {
 		Name: "TestDeploymentStrategyRecreateRequiresPersistence",
 		Values: map[string]string{
 			"identity.enabled":                          "true",
-			"global.elasticsearch.enabled":              "true",
 			"webModeler.enabled":                        "true",
 			"camundaHub.restapi.mail.fromAddress":       "example@example.com",
 			"camundaHub.persistence.deploymentStrategy": "Recreate",

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/resources_cpu_restapi_test.go
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/resources_cpu_restapi_test.go
@@ -56,7 +56,7 @@ func (s *RestapiResourcesCPUTemplateTest) TestCPUResourcesAsString() {
 		SetValues: map[string]string{
 			"webModeler.enabled":                           "true",
 			"identity.enabled":                             "true",
-			"global.elasticsearch.enabled":                 "true",
+			"orchestration.data.secondaryStorage.type":     "elasticsearch",
 			"camundaHub.restapi.mail.fromAddress":          "test@example.com",
 			"camundaHub.restapi.resources.requests.cpu":    "300m",
 			"camundaHub.restapi.resources.limits.cpu":      "1.5",
@@ -95,7 +95,7 @@ func (s *RestapiResourcesCPUTemplateTest) TestCPUResourcesCustomValues() {
 		SetValues: map[string]string{
 			"webModeler.enabled":                           "true",
 			"identity.enabled":                             "true",
-			"global.elasticsearch.enabled":                 "true",
+			"orchestration.data.secondaryStorage.type":     "elasticsearch",
 			"camundaHub.restapi.mail.fromAddress":          "test@example.com",
 			"camundaHub.restapi.resources.requests.cpu":    "500m",
 			"camundaHub.restapi.resources.limits.cpu":      "1000m",

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/resources_cpu_websockets_test.go
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/resources_cpu_websockets_test.go
@@ -56,7 +56,7 @@ func (s *WebsocketsResourcesCPUTemplateTest) TestCPUResourcesAsString() {
 		SetValues: map[string]string{
 			"webModeler.enabled":                              "true",
 			"identity.enabled":                                "true",
-			"global.elasticsearch.enabled":                    "true",
+			"orchestration.data.secondaryStorage.type":        "elasticsearch",
 			"camundaHub.restapi.mail.fromAddress":             "test@example.com",
 			"camundaHub.websockets.resources.requests.cpu":    "50m",
 			"camundaHub.websockets.resources.limits.cpu":      "0.3",
@@ -95,7 +95,7 @@ func (s *WebsocketsResourcesCPUTemplateTest) TestCPUResourcesCustomValues() {
 		SetValues: map[string]string{
 			"webModeler.enabled":                              "true",
 			"identity.enabled":                                "true",
-			"global.elasticsearch.enabled":                    "true",
+			"orchestration.data.secondaryStorage.type":        "elasticsearch",
 			"camundaHub.restapi.mail.fromAddress":             "test@example.com",
 			"camundaHub.websockets.resources.requests.cpu":    "100m",
 			"camundaHub.websockets.resources.limits.cpu":      "200m",

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/service_test.go
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/service_test.go
@@ -64,7 +64,6 @@ func (s *ServiceTest) TestDifferentValuesInputs() {
 				"webModeler.enabled":                  "true",
 				"camundaHub.restapi.mail.fromAddress": "example@example.com",
 				"global.annotations.foo":              "bar",
-				"global.elasticsearch.enabled":        "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var service coreV1.Service
@@ -80,7 +79,6 @@ func (s *ServiceTest) TestDifferentValuesInputs() {
 				"webModeler.enabled":                                     "true",
 				"camundaHub.restapi.mail.fromAddress":                    "example@example.com",
 				"camundaHub." + s.component + ".service.annotations.foo": "bar",
-				"global.elasticsearch.enabled":                           "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var service coreV1.Service
@@ -99,12 +97,12 @@ func (s *ServiceTest) TestLegacyServiceAccountEnabledOverrideDoesNotBreakDeploym
 	// given
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"identity.enabled":                    "true",
-			"webModeler.enabled":                  "true",
-			"webModeler.serviceAccount.enabled":   "false",
-			"camundaHub.serviceAccount.enabled":   "true",
-			"camundaHub.restapi.mail.fromAddress": "example@example.com",
-			"global.elasticsearch.enabled":        "true",
+			"identity.enabled":                         "true",
+			"webModeler.enabled":                       "true",
+			"webModeler.serviceAccount.enabled":        "false",
+			"camundaHub.serviceAccount.enabled":        "true",
+			"camundaHub.restapi.mail.fromAddress":      "example@example.com",
+			"orchestration.data.secondaryStorage.type": "elasticsearch",
 		},
 	}
 	templates := []string{

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/testdata/values-mail-from-address-migrated.yaml
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/testdata/values-mail-from-address-migrated.yaml
@@ -3,9 +3,10 @@
 # from-address must be omitted (so the imported file wins) and helm install must not fail.
 identity:
   enabled: true
-global:
-  elasticsearch:
-    enabled: true
+orchestration:
+  data:
+    secondaryStorage:
+      type: elasticsearch
 webModeler:
   enabled: true
   restapi:

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/testdata/values-templated-labels.yaml
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/testdata/values-templated-labels.yaml
@@ -1,8 +1,3 @@
-global:
-  elasticsearch:
-    enabled: true
-
-
 orchestration:
   data:
     secondaryStorage:


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6741 

Stacked on #6802, which fixes the component datastore TLS custom-key behavior exposed while preserving these assertions. #6767 is merged, and #6802 is rebased onto main.

This PR's unique diff changes test code, test fixtures, and test dependencies only; production chart templates remain owned by #6767 and #6802.

### What's in this PR?

`RunTestCasesE` now executes declared Kubernetes-path expectations, treats `Unexpected` entries as structural absence, and requires positive paths to resolve to exactly one scalar in one rendered object. It rejects assertion-free cases, empty error assertions, incompatible assertion modes, and incomplete object assertion pairs.

The fixture helpers clone caller-owned data and derive supported datastore defaults without injecting deprecated global Elasticsearch/OpenSearch values. Layered values files and `TestCase.Values` overrides are handled deterministically; storage selectors hidden in raw render arguments are rejected. Golden helpers likewise avoid mutating caller maps and slices.

The affected 8.10 tests now execute their semantic contracts. Embedded `application.yaml` checks use typed verifiers, absence checks have positive anchors, and stale fixtures are corrected. Every 8.10 Go unit test and YAML unit fixture was audited against values declared deprecated in chart 8.9; all such inputs were removed or migrated to supported component-owned values. Compatibility-only rows for APIs being removed were dropped rather than carried into the 8.10 test contract.

Validated with the complete 8.10 unit module, chart-scoped Go tests, matrix tests, golden and registry regeneration, Helm lint, Go formatting, changed-file license checks, and declaration-based scans of Go and YAML test inputs. Regeneration produces no tracked snapshot changes.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?