### PR TITLE
test: activate maintained Helm test assertions

### DIFF
--- a/charts/camunda-platform-8.8/go.mod
+++ b/charts/camunda-platform-8.8/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.36.2
+	k8s.io/client-go v0.36.2
 )
 
 require k8s.io/apimachinery v0.36.2
@@ -117,7 +118,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	k8s.io/client-go v0.36.2 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/streaming v0.36.2 // indirect

--- a/charts/camunda-platform-8.8/test/unit/common/documentstore_irsa_test.go
+++ b/charts/camunda-platform-8.8/test/unit/common/documentstore_irsa_test.go
@@ -122,9 +122,10 @@ func awsDocumentStoreValuesWithIRSA(irsaEnabled bool) map[string]string {
 	} else {
 		// Credentials mode: credentials are injected from secret
 		values["global.documentStore.type.aws.irsa.enabled"] = "false"
-		values["global.documentStore.type.aws.existingSecret"] = "aws-credentials"
-		values["global.documentStore.type.aws.accessKeyIdKey"] = "awsAccessKeyId"
-		values["global.documentStore.type.aws.secretAccessKeyKey"] = "awsSecretAccessKey"
+		values["global.documentStore.type.aws.accessKeyId.secret.existingSecret"] = "aws-credentials"
+		values["global.documentStore.type.aws.accessKeyId.secret.existingSecretKey"] = "awsAccessKeyId"
+		values["global.documentStore.type.aws.secretAccessKey.secret.existingSecret"] = "aws-credentials"
+		values["global.documentStore.type.aws.secretAccessKey.secret.existingSecretKey"] = "awsSecretAccessKey"
 	}
 	return values
 }

--- a/charts/camunda-platform-8.8/test/unit/common/helpers_normalize_secret_test.go
+++ b/charts/camunda-platform-8.8/test/unit/common/helpers_normalize_secret_test.go
@@ -78,6 +78,34 @@ func (s *normalizeSecretConfigTest) TestDeprecatedGlobalOpenSearchSecretCompatib
 			},
 		},
 		{
+			Name: "Deprecated global OpenSearch legacy existing-secret compatibility",
+			Values: map[string]string{
+				"orchestration.enabled":                    "true",
+				"global.elasticsearch.enabled":             "false",
+				"elasticsearch.enabled":                    "false",
+				"global.opensearch.enabled":                "true",
+				"global.opensearch.auth.existingSecret":    "legacy-secret",
+				"global.opensearch.auth.existingSecretKey": "legacy-key",
+			},
+			Expected: map[string]string{
+				"spec.template.spec.containers[0].env[?(@.name=='VALUES_OPENSEARCH_PASSWORD')].valueFrom.secretKeyRef.name": "legacy-secret",
+				"spec.template.spec.containers[0].env[?(@.name=='VALUES_OPENSEARCH_PASSWORD')].valueFrom.secretKeyRef.key":  "legacy-key",
+			},
+		},
+		{
+			Name: "Deprecated global OpenSearch plaintext-password compatibility",
+			Values: map[string]string{
+				"orchestration.enabled":           "true",
+				"global.elasticsearch.enabled":    "false",
+				"elasticsearch.enabled":           "false",
+				"global.opensearch.enabled":       "true",
+				"global.opensearch.auth.password": "plain-password",
+			},
+			Expected: map[string]string{
+				"spec.template.spec.containers[0].env[?(@.name=='VALUES_OPENSEARCH_PASSWORD')].value": "plain-password",
+			},
+		},
+		{
 			Name: "Deprecated global OpenSearch without secret omits password env",
 			Values: map[string]string{
 				"orchestration.enabled":        "true",
@@ -85,10 +113,10 @@ func (s *normalizeSecretConfigTest) TestDeprecatedGlobalOpenSearchSecretCompatib
 				"elasticsearch.enabled":        "false",
 				"global.opensearch.enabled":    "true",
 			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				require.NotContains(t, output, "VALUES_OPENSEARCH_PASSWORD")
+			Expected: map[string]string{
+				"spec.template.spec.containers[0].name": "orchestration",
 			},
+			Unexpected: []string{"spec.template.spec.containers[0].env[?(@.name=='VALUES_OPENSEARCH_PASSWORD')]"},
 		},
 		{
 			Name: "Deprecated disabled global OpenSearch omits password env",
@@ -97,10 +125,10 @@ func (s *normalizeSecretConfigTest) TestDeprecatedGlobalOpenSearchSecretCompatib
 				"global.opensearch.enabled":                  "false",
 				"global.opensearch.auth.secret.inlineSecret": "password",
 			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				require.NotContains(t, output, "VALUES_OPENSEARCH_PASSWORD")
+			Expected: map[string]string{
+				"spec.template.spec.containers[0].name": "orchestration",
 			},
+			Unexpected: []string{"spec.template.spec.containers[0].env[?(@.name=='VALUES_OPENSEARCH_PASSWORD')]"},
 		},
 	}
 
@@ -181,10 +209,12 @@ func (s *normalizeSecretConfigTest) TestAwsDocumentStoreSecretHelperFunctions() 
 				"orchestration.enabled":                 "true",
 				"global.documentStore.type.aws.enabled": "false",
 			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				require.NotContains(t, output, "AWS_ACCESS_KEY_ID")
-				require.NotContains(t, output, "AWS_SECRET_ACCESS_KEY")
+			Expected: map[string]string{
+				"spec.template.spec.containers[0].name": "orchestration",
+			},
+			Unexpected: []string{
+				"spec.template.spec.containers[0].env[?(@.name=='AWS_ACCESS_KEY_ID')]",
+				"spec.template.spec.containers[0].env[?(@.name=='AWS_SECRET_ACCESS_KEY')]",
 			},
 		},
 		{
@@ -195,10 +225,12 @@ func (s *normalizeSecretConfigTest) TestAwsDocumentStoreSecretHelperFunctions() 
 				"global.documentStore.type.aws.accessKeyId.secret.inlineSecret":     "access-key",
 				"global.documentStore.type.aws.secretAccessKey.secret.inlineSecret": "secret-key",
 			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				require.NotContains(t, output, "AWS_ACCESS_KEY_ID")
-				require.NotContains(t, output, "AWS_SECRET_ACCESS_KEY")
+			Expected: map[string]string{
+				"spec.template.spec.containers[0].name": "orchestration",
+			},
+			Unexpected: []string{
+				"spec.template.spec.containers[0].env[?(@.name=='AWS_ACCESS_KEY_ID')]",
+				"spec.template.spec.containers[0].env[?(@.name=='AWS_SECRET_ACCESS_KEY')]",
 			},
 		},
 	}
@@ -302,10 +334,10 @@ func (s *normalizeSecretConfigTest) TestEmitVolumeFromSecretConfig() {
 				"global.documentStore.type.gcp.secret.existingSecret":    "should-not-be-used",
 				"global.documentStore.type.gcp.secret.existingSecretKey": "should-not-be-used.json",
 			},
-			Verifier: func(t *testing.T, output string, err error) {
-				// Should not create any GCP volumes when GCP document store is disabled
-				require.NotContains(t, output, "gcp-credentials-volume")
+			Expected: map[string]string{
+				"spec.template.spec.containers[0].name": "connectors",
 			},
+			Unexpected: []string{"spec.template.spec.volumes[?(@.name=='gcp-credentials-volume')]"},
 		},
 	}
 

--- a/charts/camunda-platform-8.8/test/unit/common/helpers_normalize_secret_test.go
+++ b/charts/camunda-platform-8.8/test/unit/common/helpers_normalize_secret_test.go
@@ -335,7 +335,7 @@ func (s *normalizeSecretConfigTest) TestEmitVolumeFromSecretConfig() {
 				"global.documentStore.type.gcp.secret.existingSecretKey": "should-not-be-used.json",
 			},
 			Expected: map[string]string{
-				"spec.template.spec.containers[0].name": "connectors",
+				"spec.template.spec.containers[0].name": "orchestration",
 			},
 			Unexpected: []string{"spec.template.spec.volumes[?(@.name=='gcp-credentials-volume')]"},
 		},

--- a/charts/camunda-platform-8.8/test/unit/common/helpers_normalize_secret_test.go
+++ b/charts/camunda-platform-8.8/test/unit/common/helpers_normalize_secret_test.go
@@ -47,77 +47,59 @@ func TestNormalizeSecretConfigTemplate(t *testing.T) {
 	})
 }
 
-func (s *normalizeSecretConfigTest) TestSecretHelperFunctionsWithOpenSearch() {
+func (s *normalizeSecretConfigTest) TestDeprecatedGlobalOpenSearchSecretCompatibility() {
 	testCases := []testhelpers.TestCase{
 		{
-			Name: "opensearch new style secret creates env vars",
+			Name: "Deprecated global OpenSearch existing-secret compatibility",
 			Values: map[string]string{
 				"orchestration.enabled":                           "true",
+				"global.elasticsearch.enabled":                    "false",
+				"elasticsearch.enabled":                           "false",
 				"global.opensearch.enabled":                       "true",
 				"global.opensearch.auth.secret.existingSecret":    "my-opensearch-secret",
 				"global.opensearch.auth.secret.existingSecretKey": "my-key",
 			},
 			Expected: map[string]string{
-				"spec.template.spec.containers[0].env[?(@.name=='CAMUNDA_OPERATE_ZEEBE_OPENSEARCH_PASSWORD')].valueFrom.secretKeyRef.name": "my-opensearch-secret",
-				"spec.template.spec.containers[0].env[?(@.name=='CAMUNDA_OPERATE_ZEEBE_OPENSEARCH_PASSWORD')].valueFrom.secretKeyRef.key":  "my-key",
+				"spec.template.spec.containers[0].env[?(@.name=='VALUES_OPENSEARCH_PASSWORD')].valueFrom.secretKeyRef.name": "my-opensearch-secret",
+				"spec.template.spec.containers[0].env[?(@.name=='VALUES_OPENSEARCH_PASSWORD')].valueFrom.secretKeyRef.key":  "my-key",
 			},
 		},
 		{
-			Name: "opensearch inline secret creates env vars with direct values",
+			Name: "Deprecated global OpenSearch inline-secret compatibility",
 			Values: map[string]string{
 				"orchestration.enabled":                      "true",
+				"global.elasticsearch.enabled":               "false",
+				"elasticsearch.enabled":                      "false",
 				"global.opensearch.enabled":                  "true",
 				"global.opensearch.auth.secret.inlineSecret": "my-password",
 			},
 			Expected: map[string]string{
-				"spec.template.spec.containers[0].env[?(@.name=='CAMUNDA_OPERATE_ZEEBE_OPENSEARCH_PASSWORD')].value": "my-password",
+				"spec.template.spec.containers[0].env[?(@.name=='VALUES_OPENSEARCH_PASSWORD')].value": "my-password",
 			},
 		},
 		{
-			Name: "opensearch legacy secret format creates env vars",
+			Name: "Deprecated global OpenSearch without secret omits password env",
 			Values: map[string]string{
-				"orchestration.enabled":                    "true",
-				"global.opensearch.enabled":                "true",
-				"global.opensearch.auth.existingSecret":    "legacy-secret",
-				"global.opensearch.auth.existingSecretKey": "legacy-key",
-			},
-			Expected: map[string]string{
-				"spec.template.spec.containers[0].env[?(@.name=='CAMUNDA_OPERATE_ZEEBE_OPENSEARCH_PASSWORD')].valueFrom.secretKeyRef.name": "legacy-secret",
-				"spec.template.spec.containers[0].env[?(@.name=='CAMUNDA_OPERATE_ZEEBE_OPENSEARCH_PASSWORD')].valueFrom.secretKeyRef.key":  "legacy-key",
-			},
-		},
-		{
-			Name: "opensearch plaintext password creates env vars",
-			Values: map[string]string{
-				"orchestration.enabled":           "true",
-				"global.opensearch.enabled":       "true",
-				"global.opensearch.auth.password": "plain-password",
-			},
-			Expected: map[string]string{
-				"spec.template.spec.containers[0].env[?(@.name=='CAMUNDA_OPERATE_ZEEBE_OPENSEARCH_PASSWORD')].value": "plain-password",
-			},
-		},
-		{
-			Name: "no opensearch config means no env vars",
-			Values: map[string]string{
-				"orchestration.enabled":     "true",
-				"global.opensearch.enabled": "true",
+				"orchestration.enabled":        "true",
+				"global.elasticsearch.enabled": "false",
+				"elasticsearch.enabled":        "false",
+				"global.opensearch.enabled":    "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
-				// Should not create any opensearch password env vars
-				require.NotContains(t, output, "CAMUNDA_OPERATE_ZEEBE_OPENSEARCH_PASSWORD")
+				require.NoError(t, err)
+				require.NotContains(t, output, "VALUES_OPENSEARCH_PASSWORD")
 			},
 		},
 		{
-			Name: "opensearch disabled means no env vars",
+			Name: "Deprecated disabled global OpenSearch omits password env",
 			Values: map[string]string{
 				"orchestration.enabled":                      "true",
 				"global.opensearch.enabled":                  "false",
 				"global.opensearch.auth.secret.inlineSecret": "password",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
-				// Should not create any opensearch password env vars when opensearch is disabled
-				require.NotContains(t, output, "CAMUNDA_OPERATE_ZEEBE_OPENSEARCH_PASSWORD")
+				require.NoError(t, err)
+				require.NotContains(t, output, "VALUES_OPENSEARCH_PASSWORD")
 			},
 		},
 	}
@@ -158,7 +140,7 @@ func (s *normalizeSecretConfigTest) TestAwsDocumentStoreSecretHelperFunctions() 
 			},
 		},
 		{
-			Name: "aws document store legacy secret format creates env vars",
+			Name: "Deprecated AWS document store secret compatibility",
 			Values: map[string]string{
 				"orchestration.enabled":                            "true",
 				"global.documentStore.type.aws.enabled":            "true",
@@ -174,15 +156,13 @@ func (s *normalizeSecretConfigTest) TestAwsDocumentStoreSecretHelperFunctions() 
 			},
 		},
 		{
-			Name: "aws document store mixed configuration - new takes precedence",
+			Name: "Current AWS document store secrets override deprecated compatibility values",
 			Values: map[string]string{
-				"orchestration.enabled":                 "true",
-				"global.documentStore.type.aws.enabled": "true",
-				// Legacy configuration (should be ignored)
-				"global.documentStore.type.aws.existingSecret":     "legacy-aws-secret",
-				"global.documentStore.type.aws.accessKeyIdKey":     "legacy-access-key",
-				"global.documentStore.type.aws.secretAccessKeyKey": "legacy-secret-key",
-				// New configuration (should take precedence)
+				"orchestration.enabled":                                                  "true",
+				"global.documentStore.type.aws.enabled":                                  "true",
+				"global.documentStore.type.aws.existingSecret":                           "legacy-aws-secret",
+				"global.documentStore.type.aws.accessKeyIdKey":                           "legacy-access-key",
+				"global.documentStore.type.aws.secretAccessKeyKey":                       "legacy-secret-key",
 				"global.documentStore.type.aws.accessKeyId.secret.existingSecret":        "new-aws-secret",
 				"global.documentStore.type.aws.accessKeyId.secret.existingSecretKey":     "new-access-key",
 				"global.documentStore.type.aws.secretAccessKey.secret.existingSecret":    "new-aws-secret",
@@ -202,7 +182,7 @@ func (s *normalizeSecretConfigTest) TestAwsDocumentStoreSecretHelperFunctions() 
 				"global.documentStore.type.aws.enabled": "false",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
-				// Should not create any AWS env vars
+				require.NoError(t, err)
 				require.NotContains(t, output, "AWS_ACCESS_KEY_ID")
 				require.NotContains(t, output, "AWS_SECRET_ACCESS_KEY")
 			},
@@ -216,7 +196,7 @@ func (s *normalizeSecretConfigTest) TestAwsDocumentStoreSecretHelperFunctions() 
 				"global.documentStore.type.aws.secretAccessKey.secret.inlineSecret": "secret-key",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
-				// Should not create any AWS env vars when AWS document store is disabled
+				require.NoError(t, err)
 				require.NotContains(t, output, "AWS_ACCESS_KEY_ID")
 				require.NotContains(t, output, "AWS_SECRET_ACCESS_KEY")
 			},

--- a/charts/camunda-platform-8.8/test/unit/common/tls_secrets_test.go
+++ b/charts/camunda-platform-8.8/test/unit/common/tls_secrets_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package camunda
 
 import (
@@ -136,9 +150,11 @@ func (s *tlsSecretsTest) TestCaBundleInitContainerSecurityContext() {
 				"global.compatibility.openshift.adaptSecurityContext": "force",
 			},
 			Expected: map[string]string{
-				// dropped → extractor returns "" for an absent path
-				"spec.template.spec.initContainers[?(@.name=='ca-bundle-truststore-init')].securityContext.runAsUser":  "",
-				"spec.template.spec.initContainers[?(@.name=='ca-bundle-truststore-init')].securityContext.runAsGroup": "",
+				"spec.template.spec.initContainers[?(@.name=='ca-bundle-truststore-init')].name": "ca-bundle-truststore-init",
+			},
+			Unexpected: []string{
+				"spec.template.spec.initContainers[?(@.name=='ca-bundle-truststore-init')].securityContext.runAsUser",
+				"spec.template.spec.initContainers[?(@.name=='ca-bundle-truststore-init')].securityContext.runAsGroup",
 			},
 		},
 	}
@@ -170,8 +186,9 @@ func (s *tlsSecretsTest) TestCaBundleChecksumAnnotation() {
 				"global.tls.caBundle.secret.existingSecret": "my-ca-bundle",
 			},
 			Expected: map[string]string{
-				"spec.template.metadata.annotations.checksum/ca-bundle": "",
+				"kind": "StatefulSet",
 			},
+			Unexpected: []string{"spec.template.metadata.annotations.checksum/ca-bundle"},
 		},
 		{
 			Name:     "no checksum/ca-bundle annotation when caBundle is unset",
@@ -180,8 +197,9 @@ func (s *tlsSecretsTest) TestCaBundleChecksumAnnotation() {
 				"orchestration.enabled": "true",
 			},
 			Expected: map[string]string{
-				"spec.template.metadata.annotations.checksum/ca-bundle": "",
+				"kind": "StatefulSet",
 			},
+			Unexpected: []string{"spec.template.metadata.annotations.checksum/ca-bundle"},
 		},
 	}
 
@@ -231,8 +249,9 @@ func (s *tlsSecretsTest) TestCaBundleChecksumAnnotationWebModeler() {
 				"global.tls.caBundle.secret.existingSecret": "my-ca-bundle",
 			},
 			Expected: map[string]string{
-				"spec.template.metadata.annotations.checksum/ca-bundle": "",
+				"kind": "Deployment",
 			},
+			Unexpected: []string{"spec.template.metadata.annotations.checksum/ca-bundle"},
 		},
 	}
 

--- a/charts/camunda-platform-8.8/test/unit/orchestration/configmap_unified_test.go
+++ b/charts/camunda-platform-8.8/test/unit/orchestration/configmap_unified_test.go
@@ -20,10 +20,25 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
 )
+
+type orchestrationApplication struct {
+	Camunda struct {
+		Security struct {
+			Authentication struct {
+				OIDC struct {
+					GroupsClaim string `yaml:"groups-claim"`
+				} `yaml:"oidc"`
+			} `yaml:"authentication"`
+		} `yaml:"security"`
+	} `yaml:"camunda"`
+}
 
 type ConfigmapTemplateTest struct {
 	suite.Suite
@@ -341,8 +356,14 @@ func (s *ConfigmapTemplateTest) TestGroupsClaimConditionalRendering() {
 				"orchestration.security.authentication.method":           "oidc",
 				"orchestration.security.authentication.oidc.groupsClaim": "custom-groups",
 			},
-			Expected: map[string]string{
-				"configmapApplication.camunda.security.authentication.oidc.groups-claim": "custom-groups",
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				var configMap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(t, output, &configMap)
+				var application orchestrationApplication
+				require.NoError(t, yaml.Unmarshal([]byte(configMap.Data["application.yaml"]), &application))
+				require.Equal(t, "custom-groups", application.Camunda.Security.Authentication.OIDC.GroupsClaim)
 			},
 		},
 	}

--- a/charts/camunda-platform-8.8/test/unit/testhelpers/assertions.go
+++ b/charts/camunda-platform-8.8/test/unit/testhelpers/assertions.go
@@ -1,0 +1,164 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testhelpers
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/util/jsonpath"
+)
+
+func validateTestCase(tc TestCase) error {
+	expectedError, expectsError := tc.Expected["ERROR"]
+	hasDeclarativeAssertions := len(tc.Unexpected) > 0 || len(tc.Expected) > 0 && (!expectsError || len(tc.Expected) > 1)
+	hasObject := tc.ExpectedObject != nil
+	hasObjectAsserter := tc.ObjectAsserter != nil
+	hasObjectAssertions := hasObject || hasObjectAsserter
+
+	if tc.Verifier != nil && (len(tc.Expected) > 0 || len(tc.Unexpected) > 0 || hasObjectAssertions) {
+		return fmt.Errorf("Verifier cannot be combined with declarative, error, or object assertions")
+	}
+	if expectsError && (len(tc.Expected) > 1 || len(tc.Unexpected) > 0 || hasObjectAssertions) {
+		return fmt.Errorf("ERROR assertion cannot be combined with output or object assertions")
+	}
+	if expectsError && strings.TrimSpace(expectedError) == "" {
+		return fmt.Errorf("ERROR assertion must not be empty")
+	}
+	if hasObject != hasObjectAsserter {
+		return fmt.Errorf("ExpectedObject and ObjectAsserter must be set together")
+	}
+	if hasDeclarativeAssertions && hasObjectAssertions {
+		return fmt.Errorf("declarative assertions cannot be combined with object assertions")
+	}
+	if tc.Verifier == nil && !expectsError && !hasDeclarativeAssertions && !hasObjectAssertions {
+		return fmt.Errorf("test case must declare an assertion")
+	}
+
+	return nil
+}
+
+type pathMatch struct {
+	objectIndex int
+	value       reflect.Value
+}
+
+func decodeRenderedObjects(output string) ([]any, error) {
+	decoder := k8syaml.NewYAMLOrJSONDecoder(strings.NewReader(output), 4096)
+	objects := []any{}
+	for {
+		var object any
+		if err := decoder.Decode(&object); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("decode rendered object: %w", err)
+		}
+		if object == nil {
+			continue
+		}
+		objectValue := reflect.ValueOf(object)
+		if objectValue.Kind() == reflect.Map && objectValue.Len() == 0 {
+			continue
+		}
+		objects = append(objects, object)
+	}
+	return objects, nil
+}
+
+func findPathMatches(objects []any, path string) ([]pathMatch, error) {
+	query := jsonpath.New(path).AllowMissingKeys(true)
+	if err := query.Parse("{." + path + "}"); err != nil {
+		return nil, fmt.Errorf("parse path %q: %w", path, err)
+	}
+
+	matches := []pathMatch{}
+	for objectIndex, object := range objects {
+		results, err := query.FindResults(object)
+		if err != nil {
+			return nil, fmt.Errorf("evaluate path %q in rendered object %d: %w", path, objectIndex, err)
+		}
+		for _, result := range results {
+			for _, value := range result {
+				matches = append(matches, pathMatch{objectIndex: objectIndex, value: value})
+			}
+		}
+	}
+	return matches, nil
+}
+
+func resolveScalarPath(objects []any, path string) (string, error) {
+	matches, err := findPathMatches(objects, path)
+	if err != nil {
+		return "", err
+	}
+	if len(matches) != 1 {
+		return "", fmt.Errorf("path %q resolved to %d values across %d rendered objects; expected exactly one", path, len(matches), len(objects))
+	}
+
+	value := matches[0].value
+	for value.IsValid() && (value.Kind() == reflect.Interface || value.Kind() == reflect.Pointer) {
+		if value.IsNil() {
+			return "null", nil
+		}
+		value = value.Elem()
+	}
+	if !value.IsValid() {
+		return "null", nil
+	}
+
+	switch value.Kind() {
+	case reflect.Bool,
+		reflect.Float32, reflect.Float64,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.String,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return fmt.Sprint(value.Interface()), nil
+	default:
+		return "", fmt.Errorf("path %q must resolve to a scalar, got %s", path, value.Kind())
+	}
+}
+
+func verifyRenderedPaths(t *testing.T, output string, expected map[string]string, unexpected []string) {
+	t.Helper()
+
+	objects, err := decodeRenderedObjects(output)
+	require.NoError(t, err)
+
+	expectedPaths := make([]string, 0, len(expected))
+	for path := range expected {
+		expectedPaths = append(expectedPaths, path)
+	}
+	sort.Strings(expectedPaths)
+	for _, path := range expectedPaths {
+		actual, err := resolveScalarPath(objects, path)
+		require.NoError(t, err)
+		require.Equal(t, expected[path], actual, "path %q", path)
+	}
+
+	unexpectedPaths := append([]string(nil), unexpected...)
+	sort.Strings(unexpectedPaths)
+	for _, path := range unexpectedPaths {
+		matches, err := findPathMatches(objects, path)
+		require.NoError(t, err)
+		require.Empty(t, matches, "path %q must be structurally absent", path)
+	}
+}

--- a/charts/camunda-platform-8.8/test/unit/testhelpers/assertions_test.go
+++ b/charts/camunda-platform-8.8/test/unit/testhelpers/assertions_test.go
@@ -1,0 +1,75 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testhelpers
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var _ = flag.Bool("update-golden", false, "accepted for chart-wide golden updates")
+
+func TestDeclarativeAssertions(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, validateTestCase(TestCase{Expected: map[string]string{"metadata.name": "test"}}))
+	require.NoError(t, validateTestCase(TestCase{Unexpected: []string{"metadata.annotations.optional"}}))
+	require.ErrorContains(t, validateTestCase(TestCase{}), "must declare an assertion")
+	require.ErrorContains(t, validateTestCase(TestCase{Expected: map[string]string{"ERROR": ""}}), "must not be empty")
+
+	objects, err := decodeRenderedObjects(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    checksum/ca-bundle: abc123
+spec:
+  emptyString: ""
+  nullValue: null
+  emptyMap: {}
+  env:
+    - name: TEST_VALUE
+      value: present
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test
+`)
+	require.NoError(t, err)
+
+	resolved, err := resolveScalarPath(objects, "spec.env[?(@.name=='TEST_VALUE')].value")
+	require.NoError(t, err)
+	require.Equal(t, "present", resolved)
+	resolved, err = resolveScalarPath(objects, "metadata.annotations.checksum/ca-bundle")
+	require.NoError(t, err)
+	require.Equal(t, "abc123", resolved)
+	resolved, err = resolveScalarPath(objects, "spec.emptyString")
+	require.NoError(t, err)
+	require.Equal(t, "", resolved)
+	resolved, err = resolveScalarPath(objects, "spec.nullValue")
+	require.NoError(t, err)
+	require.Equal(t, "null", resolved)
+
+	matches, err := findPathMatches(objects, "spec.missing")
+	require.NoError(t, err)
+	require.Empty(t, matches)
+	_, err = resolveScalarPath(objects, "kind")
+	require.ErrorContains(t, err, "resolved to 2 values")
+	_, err = resolveScalarPath(objects, "spec.emptyMap")
+	require.ErrorContains(t, err, "must resolve to a scalar")
+}

--- a/charts/camunda-platform-8.8/test/unit/testhelpers/testhelpers.go
+++ b/charts/camunda-platform-8.8/test/unit/testhelpers/testhelpers.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package testhelpers provides utilities for testing Helm charts.
 // To enable verbose logging, set the VERBOSE_TEST_LOGGING environment variable to "true".
 // Example: VERBOSE_TEST_LOGGING=true go test ./...
@@ -61,6 +75,9 @@ type TestCase struct {
 	// For ConfigMap tests, keys can be direct data keys or dot-notation paths into application.yaml
 	Expected map[string]string
 
+	// Unexpected contains paths that must NOT be present in the rendered output
+	Unexpected []string
+
 	// Verifier is a custom function for complex validation scenarios
 	// When provided, it overrides the default validation logic
 	// It receives the rendered output and any error that occurred during rendering
@@ -116,6 +133,8 @@ func RunTestCasesE(t *testing.T, chartPath, release, namespace string, templates
 }
 
 func runTestCaseE(t *testing.T, chartPath, release, namespace string, templates []string, tc TestCase) {
+	require.NoError(t, validateTestCase(tc), "invalid test case %q", tc.Name)
+
 	var caseTemplates []string
 	if tc.Template != "" {
 		caseTemplates = []string{tc.Template}
@@ -135,15 +154,20 @@ func runTestCaseE(t *testing.T, chartPath, release, namespace string, templates 
 
 	if expectedErr, ok := tc.Expected["ERROR"]; ok {
 		require.ErrorContains(t, err, expectedErr)
-	} else if err != nil {
+		return
+	}
+	if err != nil {
 		t.Fatalf("Unexpected error during rendering: %v", err)
 	}
 
-	if tc.ExpectedObject != nil && err == nil {
+	if len(tc.Expected) > 0 || len(tc.Unexpected) > 0 {
+		verifyRenderedPaths(t, output, tc.Expected, tc.Unexpected)
+		return
+	}
+
+	if tc.ExpectedObject != nil {
 		helm.UnmarshalK8SYaml(t, output, tc.ExpectedObject)
-		if tc.ObjectAsserter != nil {
-			tc.ObjectAsserter(t, tc.ExpectedObject)
-		}
+		tc.ObjectAsserter(t, tc.ExpectedObject)
 	}
 }
 

--- a/charts/camunda-platform-8.9/go.mod
+++ b/charts/camunda-platform-8.9/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.36.2
+	k8s.io/client-go v0.36.2
 )
 
 require k8s.io/apimachinery v0.36.2
@@ -117,7 +118,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	k8s.io/client-go v0.36.2 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/streaming v0.36.2 // indirect

--- a/charts/camunda-platform-8.9/test/unit/common/constraints_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/constraints_test.go
@@ -199,9 +199,9 @@ func (s *ConstraintTemplateTest) TestGatewayConstraints() {
 func (s *ConstraintTemplateTest) TestBitnamiSubchartDeprecationWarnings() {
 	testCases := []testhelpers.TestCase{
 		{
-			Name:   "TestBitnamiDeprecationWarningDoesNotPreventInstallWithElasticsearch",
+			Name: "TestBitnamiDeprecationWarningDoesNotPreventInstallWithElasticsearch",
 			Values: map[string]string{
-				// elasticsearch.enabled and global.elasticsearch.enabled default to true via test helper
+				"elasticsearch.enabled": "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				s.Require().Nil(err)
@@ -210,7 +210,7 @@ func (s *ConstraintTemplateTest) TestBitnamiSubchartDeprecationWarnings() {
 		{
 			Name: "TestBitnamiDeprecationWarningDoesNotPreventInstallWithMultipleSubcharts",
 			Values: map[string]string{
-				// elasticsearch.enabled and global.elasticsearch.enabled default to true via test helper
+				"elasticsearch.enabled":      "true",
 				"identityPostgresql.enabled": "true",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
@@ -220,7 +220,7 @@ func (s *ConstraintTemplateTest) TestBitnamiSubchartDeprecationWarnings() {
 		{
 			Name: "TestBitnamiDeprecationWarningDoesNotPreventInstallWithAllSubcharts",
 			Values: map[string]string{
-				// elasticsearch.enabled and global.elasticsearch.enabled default to true via test helper
+				"elasticsearch.enabled":        "true",
 				"identityPostgresql.enabled":   "true",
 				"identityKeycloak.enabled":     "true",
 				"identity.enabled":             "true",

--- a/charts/camunda-platform-8.9/test/unit/common/elasticsearch_statefulset_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/elasticsearch_statefulset_test.go
@@ -34,6 +34,9 @@ func TestGoldenElasticsearchDefaults(t *testing.T) {
 		Release:        "camunda-platform-test",
 		Namespace:      "camunda",
 		GoldenFileName: "elasticsearch-statefulset",
+		SetValues: map[string]string{
+			"elasticsearch.enabled": "true",
+		},
 		IgnoredLines: []string{
 			`\s+.*-secret:\s+.*`,    // ignore auto-generated secrets
 			`\s+checksum/.+?:\s+.*`, // ignore configmap checksums

--- a/charts/camunda-platform-8.9/test/unit/common/helpers_normalize_secret_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/helpers_normalize_secret_test.go
@@ -52,48 +52,48 @@ func (s *normalizeSecretConfigTest) TestSecretHelperFunctionsWithOpenSearch() {
 		{
 			Name: "opensearch new style secret creates env vars",
 			Values: map[string]string{
-				"orchestration.enabled":                           "true",
-				"global.opensearch.enabled":                       "true",
-				"global.opensearch.auth.secret.existingSecret":    "my-opensearch-secret",
-				"global.opensearch.auth.secret.existingSecretKey": "my-key",
+				"orchestration.enabled":                                                        "true",
+				"orchestration.data.secondaryStorage.type":                                     "opensearch",
+				"orchestration.data.secondaryStorage.opensearch.auth.secret.existingSecret":    "my-opensearch-secret",
+				"orchestration.data.secondaryStorage.opensearch.auth.secret.existingSecretKey": "my-key",
 			},
 			Expected: map[string]string{
-				"spec.template.spec.containers[0].env[?(@.name=='CAMUNDA_OPERATE_ZEEBE_OPENSEARCH_PASSWORD')].valueFrom.secretKeyRef.name": "my-opensearch-secret",
-				"spec.template.spec.containers[0].env[?(@.name=='CAMUNDA_OPERATE_ZEEBE_OPENSEARCH_PASSWORD')].valueFrom.secretKeyRef.key":  "my-key",
+				"spec.template.spec.containers[0].env[?(@.name=='VALUES_OPENSEARCH_PASSWORD')].valueFrom.secretKeyRef.name": "my-opensearch-secret",
+				"spec.template.spec.containers[0].env[?(@.name=='VALUES_OPENSEARCH_PASSWORD')].valueFrom.secretKeyRef.key":  "my-key",
 			},
 		},
 		{
 			Name: "opensearch inline secret creates env vars with direct values",
 			Values: map[string]string{
-				"orchestration.enabled":                      "true",
-				"global.opensearch.enabled":                  "true",
-				"global.opensearch.auth.secret.inlineSecret": "my-password",
+				"orchestration.enabled":                                                   "true",
+				"orchestration.data.secondaryStorage.type":                                "opensearch",
+				"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "my-password",
 			},
 			Expected: map[string]string{
-				"spec.template.spec.containers[0].env[?(@.name=='CAMUNDA_OPERATE_ZEEBE_OPENSEARCH_PASSWORD')].value": "my-password",
+				"spec.template.spec.containers[0].env[?(@.name=='VALUES_OPENSEARCH_PASSWORD')].value": "my-password",
 			},
 		},
 		{
 			Name: "no opensearch config means no env vars",
 			Values: map[string]string{
-				"orchestration.enabled":     "true",
-				"global.opensearch.enabled": "true",
+				"orchestration.enabled":                    "true",
+				"orchestration.data.secondaryStorage.type": "opensearch",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
-				// Should not create any opensearch password env vars
-				require.NotContains(t, output, "CAMUNDA_OPERATE_ZEEBE_OPENSEARCH_PASSWORD")
+				require.NoError(t, err)
+				require.NotContains(t, output, "VALUES_OPENSEARCH_PASSWORD")
 			},
 		},
 		{
 			Name: "opensearch disabled means no env vars",
 			Values: map[string]string{
-				"orchestration.enabled":                      "true",
-				"global.opensearch.enabled":                  "false",
-				"global.opensearch.auth.secret.inlineSecret": "password",
+				"orchestration.enabled":                                                   "true",
+				"orchestration.data.secondaryStorage.type":                                "elasticsearch",
+				"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "password",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
-				// Should not create any opensearch password env vars when opensearch is disabled
-				require.NotContains(t, output, "CAMUNDA_OPERATE_ZEEBE_OPENSEARCH_PASSWORD")
+				require.NoError(t, err)
+				require.NotContains(t, output, "VALUES_OPENSEARCH_PASSWORD")
 			},
 		},
 	}

--- a/charts/camunda-platform-8.9/test/unit/common/tls_secrets_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/tls_secrets_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package camunda
 
 import (
@@ -328,9 +342,9 @@ func (s *tlsSecretsTest) TestElasticsearchTLSEnabledNoSecret() {
 				"global.elasticsearch.tls.enabled": "true",
 			},
 			Expected: map[string]string{
-				// Volume should not exist when no secret is provided
-				"spec.template.spec.volumes[?(@.name=='keystore')]": "null",
+				"kind": "StatefulSet",
 			},
+			Unexpected: []string{"spec.template.spec.volumes[?(@.name=='keystore')]"},
 		},
 	}
 
@@ -351,11 +365,9 @@ func (s *tlsSecretsTest) TestConsoleTLSEnabledNoSecret() {
 				"console.tls.certKeyFilename":  "ca.crt",
 			},
 			Expected: map[string]string{
-				// Volume should not exist when no secret is provided
-				"spec.template.spec.volumes[?(@.name=='console-certificates')]": "null",
-				// But NODE_EXTRA_CA_CERTS should still be rendered
 				"spec.template.spec.containers[0].env[?(@.name=='NODE_EXTRA_CA_CERTS')].value": "/usr/local/console/certificates/ca.crt",
 			},
+			Unexpected: []string{"spec.template.spec.volumes[?(@.name=='console-certificates')]"},
 		},
 	}
 
@@ -376,11 +388,9 @@ func (s *tlsSecretsTest) TestConsoleTLSDisabled() {
 				"console.tls.certKeyFilename":  "ca.crt",
 			},
 			Expected: map[string]string{
-				// Volume should not exist when TLS is disabled
-				"spec.template.spec.volumes[?(@.name=='console-certificates')]": "null",
-				// But NODE_EXTRA_CA_CERTS should still be rendered (reference doc says "always rendered")
 				"spec.template.spec.containers[0].env[?(@.name=='NODE_EXTRA_CA_CERTS')].value": "/usr/local/console/certificates/ca.crt",
 			},
+			Unexpected: []string{"spec.template.spec.volumes[?(@.name=='console-certificates')]"},
 		},
 	}
 
@@ -762,9 +772,11 @@ func (s *tlsSecretsTest) TestCaBundleInitContainerSecurityContext() {
 				"global.compatibility.openshift.adaptSecurityContext": "force",
 			},
 			Expected: map[string]string{
-				// dropped → extractor returns "" for an absent path
-				"spec.template.spec.initContainers[?(@.name=='ca-bundle-truststore-init')].securityContext.runAsUser":  "",
-				"spec.template.spec.initContainers[?(@.name=='ca-bundle-truststore-init')].securityContext.runAsGroup": "",
+				"spec.template.spec.initContainers[?(@.name=='ca-bundle-truststore-init')].name": "ca-bundle-truststore-init",
+			},
+			Unexpected: []string{
+				"spec.template.spec.initContainers[?(@.name=='ca-bundle-truststore-init')].securityContext.runAsUser",
+				"spec.template.spec.initContainers[?(@.name=='ca-bundle-truststore-init')].securityContext.runAsGroup",
 			},
 		},
 	}
@@ -796,8 +808,9 @@ func (s *tlsSecretsTest) TestCaBundleChecksumAnnotation() {
 				"global.tls.caBundle.secret.existingSecret": "my-ca-bundle",
 			},
 			Expected: map[string]string{
-				"spec.template.metadata.annotations.checksum/ca-bundle": "",
+				"kind": "StatefulSet",
 			},
+			Unexpected: []string{"spec.template.metadata.annotations.checksum/ca-bundle"},
 		},
 		{
 			Name:     "no checksum/ca-bundle annotation when caBundle is unset",
@@ -806,8 +819,9 @@ func (s *tlsSecretsTest) TestCaBundleChecksumAnnotation() {
 				"orchestration.enabled": "true",
 			},
 			Expected: map[string]string{
-				"spec.template.metadata.annotations.checksum/ca-bundle": "",
+				"kind": "StatefulSet",
 			},
+			Unexpected: []string{"spec.template.metadata.annotations.checksum/ca-bundle"},
 		},
 	}
 
@@ -857,8 +871,9 @@ func (s *tlsSecretsTest) TestCaBundleChecksumAnnotationWebModeler() {
 				"global.tls.caBundle.secret.existingSecret": "my-ca-bundle",
 			},
 			Expected: map[string]string{
-				"spec.template.metadata.annotations.checksum/ca-bundle": "",
+				"kind": "Deployment",
 			},
+			Unexpected: []string{"spec.template.metadata.annotations.checksum/ca-bundle"},
 		},
 	}
 

--- a/charts/camunda-platform-8.9/test/unit/optimize/configmap_test.go
+++ b/charts/camunda-platform-8.9/test/unit/optimize/configmap_test.go
@@ -108,6 +108,7 @@ func (s *ConfigMapTemplateTest) TestDatabaseOverrides() {
 			Values: map[string]string{
 				"identity.enabled":                        "true",
 				"optimize.enabled":                        "true",
+				"global.elasticsearch.prefix":             "global-prefix",
 				"optimize.database.elasticsearch.enabled": "true",
 				"optimize.database.elasticsearch.prefix":  "optimize-prefix",
 			},

--- a/charts/camunda-platform-8.9/test/unit/optimize/configmap_test.go
+++ b/charts/camunda-platform-8.9/test/unit/optimize/configmap_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package optimize
 
 import (
@@ -63,9 +77,10 @@ func (s *ConfigMapTemplateTest) TestDifferentValuesInputs() {
 			Name:                 "TestCustomZeebeName",
 			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
 			Values: map[string]string{
-				"identity.enabled":            "true",
-				"optimize.enabled":            "true",
-				"global.elasticsearch.prefix": "custom-prefix",
+				"identity.enabled":                        "true",
+				"optimize.enabled":                        "true",
+				"optimize.database.elasticsearch.enabled": "true",
+				"optimize.database.elasticsearch.prefix":  "custom-prefix",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				var configmap corev1.ConfigMap
@@ -89,12 +104,12 @@ func (s *ConfigMapTemplateTest) TestDifferentValuesInputs() {
 func (s *ConfigMapTemplateTest) TestDatabaseOverrides() {
 	testCases := []testhelpers.TestCase{
 		{
-			Name: "TestElasticsearchPrefixOverriddenByOptimizeDatabase",
+			Name: "TestElasticsearchPrefixFromOptimizeDatabase",
 			Values: map[string]string{
-				"identity.enabled":                       "true",
-				"optimize.enabled":                       "true",
-				"global.elasticsearch.prefix":            "global-prefix",
-				"optimize.database.elasticsearch.prefix": "optimize-prefix",
+				"identity.enabled":                        "true",
+				"optimize.enabled":                        "true",
+				"optimize.database.elasticsearch.enabled": "true",
+				"optimize.database.elasticsearch.prefix":  "optimize-prefix",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				require.NoError(t, err)
@@ -113,9 +128,10 @@ func (s *ConfigMapTemplateTest) TestDatabaseOverrides() {
 		{
 			Name: "TestElasticsearchPrefixFallsBackToGlobal",
 			Values: map[string]string{
-				"identity.enabled":            "true",
-				"optimize.enabled":            "true",
-				"global.elasticsearch.prefix": "global-prefix",
+				"identity.enabled":             "true",
+				"optimize.enabled":             "true",
+				"global.elasticsearch.enabled": "true",
+				"global.elasticsearch.prefix":  "global-prefix",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
 				require.NoError(t, err)
@@ -136,6 +152,7 @@ func (s *ConfigMapTemplateTest) TestDatabaseOverrides() {
 			Values: map[string]string{
 				"identity.enabled":                         "true",
 				"optimize.enabled":                         "true",
+				"optimize.database.elasticsearch.enabled":  "true",
 				"optimize.database.elasticsearch.url.port": "9201",
 			},
 			Verifier: func(t *testing.T, output string, err error) {
@@ -157,6 +174,7 @@ func (s *ConfigMapTemplateTest) TestDatabaseOverrides() {
 			Values: map[string]string{
 				"identity.enabled":              "true",
 				"optimize.enabled":              "true",
+				"global.elasticsearch.enabled":  "true",
 				"global.elasticsearch.url.port": "9300",
 			},
 			Verifier: func(t *testing.T, output string, err error) {

--- a/charts/camunda-platform-8.9/test/unit/optimize/goldenfiles_test.go
+++ b/charts/camunda-platform-8.9/test/unit/optimize/goldenfiles_test.go
@@ -44,8 +44,9 @@ func TestGoldenDefaultsTemplateOptimize(t *testing.T) {
 				`\s+checksum/.+?:\s+.*`, // ignore configmap checksum.
 			},
 			SetValues: map[string]string{
-				"optimize.enabled": "true",
-				"identity.enabled": "true",
+				"optimize.enabled":                        "true",
+				"optimize.database.elasticsearch.enabled": "true",
+				"identity.enabled":                        "true",
 			},
 		})
 	}

--- a/charts/camunda-platform-8.9/test/unit/orchestration/configmap_unified_test.go
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/configmap_unified_test.go
@@ -566,6 +566,26 @@ func (s *ConfigmapTemplateTest) TestHasLegacyElasticsearchExporter() {
 			},
 		},
 		{
+			Name: "TestDeprecatedGlobalElasticsearchCompatibilityRendersLegacyExporterWithRdbmsAndOptimize",
+			Values: map[string]string{
+				"global.elasticsearch.enabled":                                  "true",
+				"elasticsearch.enabled":                                         "false",
+				"global.opensearch.enabled":                                     "false",
+				"orchestration.exporters.rdbms.enabled":                         "true",
+				"orchestration.data.secondaryStorage.rdbms.url":                 "jdbc:postgresql://localhost:5432/camunda",
+				"orchestration.data.secondaryStorage.rdbms.username":            "camunda",
+				"orchestration.data.secondaryStorage.rdbms.secret.inlineSecret": "my-password",
+				"optimize.enabled":                                              "true",
+				"optimize.database.elasticsearch.enabled":                       "false",
+				"optimize.database.opensearch.enabled":                          "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.Contains(t, output, "io.camunda.zeebe.exporter.ElasticsearchExporter",
+					"rdbms+optimize with global.elasticsearch.enabled must render legacy ES exporter")
+			},
+		},
+		{
 			Name: "TestLegacyESExporterPresentWhenRdbmsAndOptimizeDatabaseElasticsearchOnly",
 			Values: map[string]string{
 				"global.elasticsearch.enabled":                                  "false",

--- a/charts/camunda-platform-8.9/test/unit/orchestration/configmap_unified_test.go
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/configmap_unified_test.go
@@ -20,10 +20,28 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
 )
+
+type orchestrationApplication struct {
+	Camunda struct {
+		Security struct {
+			Authentication struct {
+				OIDC struct {
+					GroupsClaim string `yaml:"groups-claim"`
+				} `yaml:"oidc"`
+				Basic struct {
+					AllowUnauthenticatedAPIAccess bool `yaml:"allow-unauthenticated-api-access"`
+				} `yaml:"basic"`
+			} `yaml:"authentication"`
+		} `yaml:"security"`
+	} `yaml:"camunda"`
+}
 
 type ConfigmapTemplateTest struct {
 	suite.Suite
@@ -398,8 +416,14 @@ func (s *ConfigmapTemplateTest) TestGroupsClaimConditionalRendering() {
 				"orchestration.security.authentication.oidc.groupsClaim": "custom-groups",
 				"orchestration.data.secondaryStorage.type":               "elasticsearch",
 			},
-			Expected: map[string]string{
-				"configmapApplication.camunda.security.authentication.oidc.groups-claim": "custom-groups",
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				var configMap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(t, output, &configMap)
+				var application orchestrationApplication
+				require.NoError(t, yaml.Unmarshal([]byte(configMap.Data["application.yaml"]), &application))
+				require.Equal(t, "custom-groups", application.Camunda.Security.Authentication.OIDC.GroupsClaim)
 			},
 		},
 	}
@@ -446,8 +470,14 @@ func (s *ConfigmapTemplateTest) TestUnprotectedApiConditionalRendering() {
 				"orchestration.security.authentication.method":         "basic",
 				"orchestration.security.authentication.unprotectedApi": "true",
 			},
-			Expected: map[string]string{
-				"configmapApplication.camunda.security.authentication.basic.allow-unauthenticated-api-access": "true",
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				var configMap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(t, output, &configMap)
+				var application orchestrationApplication
+				require.NoError(t, yaml.Unmarshal([]byte(configMap.Data["application.yaml"]), &application))
+				require.True(t, application.Camunda.Security.Authentication.Basic.AllowUnauthenticatedAPIAccess)
 			},
 		},
 		{
@@ -533,21 +563,6 @@ func (s *ConfigmapTemplateTest) TestHasLegacyElasticsearchExporter() {
 				require.NoError(t, err)
 				require.NotContains(t, output, "io.camunda.zeebe.exporter.ElasticsearchExporter",
 					"rdbms+optimize without elasticsearch must not render legacy ES exporter")
-			},
-		},
-		{
-			Name: "TestLegacyESExporterPresentWhenRdbmsAndOptimizeAndGlobalElasticsearch",
-			Values: map[string]string{
-				"orchestration.exporters.rdbms.enabled":                         "true",
-				"orchestration.data.secondaryStorage.rdbms.url":                 "jdbc:postgresql://localhost:5432/camunda",
-				"orchestration.data.secondaryStorage.rdbms.username":            "camunda",
-				"orchestration.data.secondaryStorage.rdbms.secret.inlineSecret": "my-password",
-				"optimize.enabled": "true",
-			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-				require.Contains(t, output, "io.camunda.zeebe.exporter.ElasticsearchExporter",
-					"rdbms+optimize with global.elasticsearch.enabled must render legacy ES exporter")
 			},
 		},
 		{

--- a/charts/camunda-platform-8.9/test/unit/testhelpers/assertions.go
+++ b/charts/camunda-platform-8.9/test/unit/testhelpers/assertions.go
@@ -1,0 +1,164 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testhelpers
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/util/jsonpath"
+)
+
+func validateTestCase(tc TestCase) error {
+	expectedError, expectsError := tc.Expected["ERROR"]
+	hasDeclarativeAssertions := len(tc.Unexpected) > 0 || len(tc.Expected) > 0 && (!expectsError || len(tc.Expected) > 1)
+	hasObject := tc.ExpectedObject != nil
+	hasObjectAsserter := tc.ObjectAsserter != nil
+	hasObjectAssertions := hasObject || hasObjectAsserter
+
+	if tc.Verifier != nil && (len(tc.Expected) > 0 || len(tc.Unexpected) > 0 || hasObjectAssertions) {
+		return fmt.Errorf("Verifier cannot be combined with declarative, error, or object assertions")
+	}
+	if expectsError && (len(tc.Expected) > 1 || len(tc.Unexpected) > 0 || hasObjectAssertions) {
+		return fmt.Errorf("ERROR assertion cannot be combined with output or object assertions")
+	}
+	if expectsError && strings.TrimSpace(expectedError) == "" {
+		return fmt.Errorf("ERROR assertion must not be empty")
+	}
+	if hasObject != hasObjectAsserter {
+		return fmt.Errorf("ExpectedObject and ObjectAsserter must be set together")
+	}
+	if hasDeclarativeAssertions && hasObjectAssertions {
+		return fmt.Errorf("declarative assertions cannot be combined with object assertions")
+	}
+	if tc.Verifier == nil && !expectsError && !hasDeclarativeAssertions && !hasObjectAssertions {
+		return fmt.Errorf("test case must declare an assertion")
+	}
+
+	return nil
+}
+
+type pathMatch struct {
+	objectIndex int
+	value       reflect.Value
+}
+
+func decodeRenderedObjects(output string) ([]any, error) {
+	decoder := k8syaml.NewYAMLOrJSONDecoder(strings.NewReader(output), 4096)
+	objects := []any{}
+	for {
+		var object any
+		if err := decoder.Decode(&object); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("decode rendered object: %w", err)
+		}
+		if object == nil {
+			continue
+		}
+		objectValue := reflect.ValueOf(object)
+		if objectValue.Kind() == reflect.Map && objectValue.Len() == 0 {
+			continue
+		}
+		objects = append(objects, object)
+	}
+	return objects, nil
+}
+
+func findPathMatches(objects []any, path string) ([]pathMatch, error) {
+	query := jsonpath.New(path).AllowMissingKeys(true)
+	if err := query.Parse("{." + path + "}"); err != nil {
+		return nil, fmt.Errorf("parse path %q: %w", path, err)
+	}
+
+	matches := []pathMatch{}
+	for objectIndex, object := range objects {
+		results, err := query.FindResults(object)
+		if err != nil {
+			return nil, fmt.Errorf("evaluate path %q in rendered object %d: %w", path, objectIndex, err)
+		}
+		for _, result := range results {
+			for _, value := range result {
+				matches = append(matches, pathMatch{objectIndex: objectIndex, value: value})
+			}
+		}
+	}
+	return matches, nil
+}
+
+func resolveScalarPath(objects []any, path string) (string, error) {
+	matches, err := findPathMatches(objects, path)
+	if err != nil {
+		return "", err
+	}
+	if len(matches) != 1 {
+		return "", fmt.Errorf("path %q resolved to %d values across %d rendered objects; expected exactly one", path, len(matches), len(objects))
+	}
+
+	value := matches[0].value
+	for value.IsValid() && (value.Kind() == reflect.Interface || value.Kind() == reflect.Pointer) {
+		if value.IsNil() {
+			return "null", nil
+		}
+		value = value.Elem()
+	}
+	if !value.IsValid() {
+		return "null", nil
+	}
+
+	switch value.Kind() {
+	case reflect.Bool,
+		reflect.Float32, reflect.Float64,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.String,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return fmt.Sprint(value.Interface()), nil
+	default:
+		return "", fmt.Errorf("path %q must resolve to a scalar, got %s", path, value.Kind())
+	}
+}
+
+func verifyRenderedPaths(t *testing.T, output string, expected map[string]string, unexpected []string) {
+	t.Helper()
+
+	objects, err := decodeRenderedObjects(output)
+	require.NoError(t, err)
+
+	expectedPaths := make([]string, 0, len(expected))
+	for path := range expected {
+		expectedPaths = append(expectedPaths, path)
+	}
+	sort.Strings(expectedPaths)
+	for _, path := range expectedPaths {
+		actual, err := resolveScalarPath(objects, path)
+		require.NoError(t, err)
+		require.Equal(t, expected[path], actual, "path %q", path)
+	}
+
+	unexpectedPaths := append([]string(nil), unexpected...)
+	sort.Strings(unexpectedPaths)
+	for _, path := range unexpectedPaths {
+		matches, err := findPathMatches(objects, path)
+		require.NoError(t, err)
+		require.Empty(t, matches, "path %q must be structurally absent", path)
+	}
+}

--- a/charts/camunda-platform-8.9/test/unit/testhelpers/assertions_test.go
+++ b/charts/camunda-platform-8.9/test/unit/testhelpers/assertions_test.go
@@ -94,6 +94,14 @@ func TestSetupHelmOptionsUsesCurrentStorageFixtures(t *testing.T) {
 			expectedSetValue: "opensearch",
 		},
 		{
+			name: "prefers Elasticsearch when both Optimize selectors are enabled",
+			values: map[string]string{
+				"optimize.database.elasticsearch.enabled": "true",
+				"optimize.database.opensearch.enabled":    "true",
+			},
+			expectedSetValue: "elasticsearch",
+		},
+		{
 			name: "preserves explicit current type",
 			values: map[string]string{
 				"orchestration.data.secondaryStorage.type": "rdbms",
@@ -145,6 +153,42 @@ func TestSetupHelmOptionsHonorsValuesFileStorageSelection(t *testing.T) {
 	require.NoError(t, err)
 	require.NotContains(t, options.SetValues, "orchestration.data.secondaryStorage.type")
 	require.NotContains(t, options.SetValues, "global.elasticsearch.enabled")
+}
+
+func TestSetupHelmOptionsPreservesValuesFileStoragePrecedence(t *testing.T) {
+	t.Parallel()
+
+	valuesFile := filepath.Join(t.TempDir(), "values.yaml")
+	require.NoError(t, os.WriteFile(valuesFile, []byte(`optimize:
+  database:
+    elasticsearch:
+      enabled: true
+    opensearch:
+      enabled: true
+`), 0o600))
+
+	options, err := setupHelmOptions("test", nil, []string{valuesFile}, nil)
+	require.NoError(t, err)
+	require.Equal(t, "elasticsearch", options.SetValues["orchestration.data.secondaryStorage.type"])
+	require.NotContains(t, options.SetValues, "global.elasticsearch.enabled")
+}
+
+func TestValidateStorageFixtureRenderArgs(t *testing.T) {
+	t.Parallel()
+
+	require.ErrorContains(
+		t,
+		validateStorageFixtureRenderArgs([]string{"--set", "optimize.database.elasticsearch.enabled=true"}),
+		"optimize.database.elasticsearch.enabled must be provided through TestCase.Values",
+	)
+	require.ErrorContains(
+		t,
+		validateStorageFixtureRenderArgs([]string{"-fstorage.yaml"}),
+		"values files must be provided through TestCase.ValuesFiles",
+	)
+	require.NoError(t, validateStorageFixtureRenderArgs([]string{
+		"--set-string", "orchestration.env[0].value=true",
+	}))
 }
 
 func TestSetupHelmOptionsHonorsLayeredNullOverrides(t *testing.T) {

--- a/charts/camunda-platform-8.9/test/unit/testhelpers/assertions_test.go
+++ b/charts/camunda-platform-8.9/test/unit/testhelpers/assertions_test.go
@@ -15,7 +15,6 @@
 package testhelpers
 
 import (
-	"flag"
 	"maps"
 	"os"
 	"path/filepath"
@@ -23,8 +22,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
-
-var _ = flag.Bool("update-golden", false, "accepted for chart-wide golden updates")
 
 func TestDeclarativeAssertions(t *testing.T) {
 	t.Parallel()

--- a/charts/camunda-platform-8.9/test/unit/testhelpers/assertions_test.go
+++ b/charts/camunda-platform-8.9/test/unit/testhelpers/assertions_test.go
@@ -1,0 +1,229 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testhelpers
+
+import (
+	"flag"
+	"maps"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var _ = flag.Bool("update-golden", false, "accepted for chart-wide golden updates")
+
+func TestDeclarativeAssertions(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, validateTestCase(TestCase{Expected: map[string]string{"metadata.name": "test"}}))
+	require.NoError(t, validateTestCase(TestCase{Unexpected: []string{"metadata.annotations.optional"}}))
+	require.ErrorContains(t, validateTestCase(TestCase{}), "must declare an assertion")
+	require.ErrorContains(t, validateTestCase(TestCase{Expected: map[string]string{"ERROR": ""}}), "must not be empty")
+
+	objects, err := decodeRenderedObjects(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    checksum/ca-bundle: abc123
+spec:
+  emptyString: ""
+  nullValue: null
+  emptyMap: {}
+  env:
+    - name: TEST_VALUE
+      value: present
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test
+`)
+	require.NoError(t, err)
+
+	resolved, err := resolveScalarPath(objects, "spec.env[?(@.name=='TEST_VALUE')].value")
+	require.NoError(t, err)
+	require.Equal(t, "present", resolved)
+	resolved, err = resolveScalarPath(objects, "metadata.annotations.checksum/ca-bundle")
+	require.NoError(t, err)
+	require.Equal(t, "abc123", resolved)
+	resolved, err = resolveScalarPath(objects, "spec.emptyString")
+	require.NoError(t, err)
+	require.Equal(t, "", resolved)
+	resolved, err = resolveScalarPath(objects, "spec.nullValue")
+	require.NoError(t, err)
+	require.Equal(t, "null", resolved)
+
+	matches, err := findPathMatches(objects, "spec.missing")
+	require.NoError(t, err)
+	require.Empty(t, matches)
+	_, err = resolveScalarPath(objects, "kind")
+	require.ErrorContains(t, err, "resolved to 2 values")
+	_, err = resolveScalarPath(objects, "spec.emptyMap")
+	require.ErrorContains(t, err, "must resolve to a scalar")
+}
+
+func TestSetupHelmOptionsUsesCurrentStorageFixtures(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name             string
+		values           map[string]string
+		expectedSetValue string
+	}{
+		{name: "defaults to Elasticsearch", expectedSetValue: "elasticsearch"},
+		{
+			name: "derives OpenSearch from Optimize",
+			values: map[string]string{
+				"optimize.database.opensearch.enabled": "true",
+			},
+			expectedSetValue: "opensearch",
+		},
+		{
+			name: "preserves explicit current type",
+			values: map[string]string{
+				"orchestration.data.secondaryStorage.type": "rdbms",
+			},
+			expectedSetValue: "rdbms",
+		},
+		{
+			name: "does not override explicit compatibility selector",
+			values: map[string]string{
+				"global.elasticsearch.enabled": "false",
+			},
+		},
+		{
+			name: "does not override no secondary storage",
+			values: map[string]string{
+				"global.noSecondaryStorage": "true",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			original := maps.Clone(testCase.values)
+
+			options, err := setupHelmOptions("test", testCase.values, nil, nil)
+			require.NoError(t, err)
+			require.Equal(t, original, testCase.values)
+			if testCase.expectedSetValue == "" {
+				require.NotContains(t, options.SetValues, "orchestration.data.secondaryStorage.type")
+			} else {
+				require.Equal(t, testCase.expectedSetValue, options.SetValues["orchestration.data.secondaryStorage.type"])
+			}
+			require.NotContains(t, options.SetValues, "elasticsearch.enabled")
+		})
+	}
+}
+
+func TestSetupHelmOptionsHonorsValuesFileStorageSelection(t *testing.T) {
+	t.Parallel()
+
+	valuesFile := filepath.Join(t.TempDir(), "values.yaml")
+	require.NoError(t, os.WriteFile(valuesFile, []byte(`orchestration:
+  data:
+    secondaryStorage:
+      type: opensearch
+`), 0o600))
+
+	options, err := setupHelmOptions("test", nil, []string{valuesFile}, nil)
+	require.NoError(t, err)
+	require.NotContains(t, options.SetValues, "orchestration.data.secondaryStorage.type")
+	require.NotContains(t, options.SetValues, "global.elasticsearch.enabled")
+}
+
+func TestSetupHelmOptionsHonorsLayeredNullOverrides(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		baseYAML    string
+		overlayYAML string
+	}{
+		{
+			name: "clears explicit storage type",
+			baseYAML: `orchestration:
+  data:
+    secondaryStorage:
+      type: opensearch
+`,
+			overlayYAML: `orchestration:
+  data:
+    secondaryStorage:
+      type: null
+`,
+		},
+		{
+			name: "clears legacy selector",
+			baseYAML: `global:
+  elasticsearch:
+    enabled: false
+`,
+			overlayYAML: `global:
+  elasticsearch:
+    enabled: null
+`,
+		},
+		{
+			name: "clears no-secondary-storage parent",
+			baseYAML: `global:
+  noSecondaryStorage: true
+`,
+			overlayYAML: `global: null
+`,
+		},
+		{
+			name: "clears RDBMS exporter parent",
+			baseYAML: `orchestration:
+  exporters:
+    rdbms:
+      enabled: true
+`,
+			overlayYAML: `orchestration:
+  exporters: null
+`,
+		},
+		{
+			name: "clears Optimize OpenSearch selection",
+			baseYAML: `optimize:
+  database:
+    opensearch:
+      enabled: true
+`,
+			overlayYAML: `optimize:
+  database:
+    opensearch:
+      enabled: null
+`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			baseFile := filepath.Join(tempDir, "base.yaml")
+			overlayFile := filepath.Join(tempDir, "overlay.yaml")
+			require.NoError(t, os.WriteFile(baseFile, []byte(testCase.baseYAML), 0o600))
+			require.NoError(t, os.WriteFile(overlayFile, []byte(testCase.overlayYAML), 0o600))
+
+			options, err := setupHelmOptions("test", nil, []string{baseFile, overlayFile}, nil)
+			require.NoError(t, err)
+			require.Equal(t, "elasticsearch", options.SetValues["orchestration.data.secondaryStorage.type"])
+		})
+	}
+}

--- a/charts/camunda-platform-8.9/test/unit/testhelpers/testhelpers.go
+++ b/charts/camunda-platform-8.9/test/unit/testhelpers/testhelpers.go
@@ -76,6 +76,9 @@ type TestCase struct {
 	// For ConfigMap tests, keys can be direct data keys or dot-notation paths into application.yaml
 	Expected map[string]string
 
+	// Unexpected contains paths that must NOT be present in the rendered output
+	Unexpected []string
+
 	// Verifier is a custom function for complex validation scenarios
 	// When provided, it overrides the default validation logic
 	// It receives the rendered output and any error that occurred during rendering
@@ -97,9 +100,11 @@ func quietLogger() *logger.Logger {
 }
 
 type storageFixtureState struct {
-	typeSet                bool
-	globalElasticsearchSet bool
-	elasticsearchSet       bool
+	typeSet            bool
+	legacySelectionSet bool
+	noSecondaryStorage bool
+	rdbmsEnabled       bool
+	openSearchEnabled  bool
 }
 
 func mergeStorageFixtureValues(base, overlay map[string]any) {
@@ -134,15 +139,16 @@ func storageFixtureValue(values map[string]any, path ...string) (any, bool) {
 	return current, true
 }
 
-func storageFixtureBoolSet(values map[string]any, path ...string) (bool, error) {
+func storageFixtureBool(values map[string]any, path ...string) (bool, bool, error) {
 	rawValue, ok := storageFixtureValue(values, path...)
 	if !ok {
-		return false, nil
+		return false, false, nil
 	}
-	if _, ok := rawValue.(bool); !ok {
-		return false, fmt.Errorf("storage fixture value %s must be a boolean", strings.Join(path, "."))
+	value, ok := rawValue.(bool)
+	if !ok {
+		return false, false, fmt.Errorf("storage fixture value %s must be a boolean", strings.Join(path, "."))
 	}
-	return true, nil
+	return value, true, nil
 }
 
 func loadStorageFixtureState(valuesFiles []string, values map[string]string) (storageFixtureState, error) {
@@ -167,11 +173,18 @@ func loadStorageFixtureState(valuesFiles []string, values map[string]string) (st
 		}
 		state.typeSet = true
 	}
+	_, elasticsearchSet := storageFixtureValue(mergedValues, "global", "elasticsearch", "enabled")
+	_, openSearchSet := storageFixtureValue(mergedValues, "global", "opensearch", "enabled")
+	state.legacySelectionSet = elasticsearchSet || openSearchSet
+
 	var err error
-	if state.globalElasticsearchSet, err = storageFixtureBoolSet(mergedValues, "global", "elasticsearch", "enabled"); err != nil {
+	if state.noSecondaryStorage, _, err = storageFixtureBool(mergedValues, "global", "noSecondaryStorage"); err != nil {
 		return state, err
 	}
-	if state.elasticsearchSet, err = storageFixtureBoolSet(mergedValues, "elasticsearch", "enabled"); err != nil {
+	if state.rdbmsEnabled, _, err = storageFixtureBool(mergedValues, "orchestration", "exporters", "rdbms", "enabled"); err != nil {
+		return state, err
+	}
+	if state.openSearchEnabled, _, err = storageFixtureBool(mergedValues, "optimize", "database", "opensearch", "enabled"); err != nil {
 		return state, err
 	}
 
@@ -179,10 +192,19 @@ func loadStorageFixtureState(valuesFiles []string, values map[string]string) (st
 		state.typeSet = true
 	}
 	if _, ok := values["global.elasticsearch.enabled"]; ok {
-		state.globalElasticsearchSet = true
+		state.legacySelectionSet = true
 	}
-	if _, ok := values["elasticsearch.enabled"]; ok {
-		state.elasticsearchSet = true
+	if _, ok := values["global.opensearch.enabled"]; ok {
+		state.legacySelectionSet = true
+	}
+	if value, ok := values["global.noSecondaryStorage"]; ok {
+		state.noSecondaryStorage = strings.EqualFold(value, "true")
+	}
+	if value, ok := values["orchestration.exporters.rdbms.enabled"]; ok {
+		state.rdbmsEnabled = strings.EqualFold(value, "true")
+	}
+	if value, ok := values["optimize.database.opensearch.enabled"]; ok {
+		state.openSearchEnabled = strings.EqualFold(value, "true")
 	}
 
 	return state, nil
@@ -197,12 +219,12 @@ func setupHelmOptions(namespace string, values map[string]string, valuesFiles []
 	if err != nil {
 		return nil, err
 	}
-	// Add default Elasticsearch flags if no current storage selector is provided.
-	if !storageState.typeSet && !storageState.globalElasticsearchSet {
-		values["global.elasticsearch.enabled"] = "true"
-	}
-	if !storageState.typeSet && !storageState.elasticsearchSet {
-		values["elasticsearch.enabled"] = "true"
+	if !storageState.typeSet && !storageState.legacySelectionSet && !storageState.noSecondaryStorage && !storageState.rdbmsEnabled {
+		secondaryStorageType := "elasticsearch"
+		if storageState.openSearchEnabled {
+			secondaryStorageType = "opensearch"
+		}
+		values["orchestration.data.secondaryStorage.type"] = secondaryStorageType
 	}
 
 	options := &helm.Options{
@@ -242,6 +264,8 @@ func RunTestCasesE(t *testing.T, chartPath, release, namespace string, templates
 }
 
 func runTestCaseE(t *testing.T, chartPath, release, namespace string, templates []string, tc TestCase) {
+	require.NoError(t, validateTestCase(tc), "invalid test case %q", tc.Name)
+
 	var caseTemplates []string
 	if tc.Template != "" {
 		caseTemplates = []string{tc.Template}
@@ -261,15 +285,20 @@ func runTestCaseE(t *testing.T, chartPath, release, namespace string, templates 
 
 	if expectedErr, ok := tc.Expected["ERROR"]; ok {
 		require.ErrorContains(t, err, expectedErr)
-	} else if err != nil {
+		return
+	}
+	if err != nil {
 		t.Fatalf("Unexpected error during rendering: %v", err)
 	}
 
-	if tc.ExpectedObject != nil && err == nil {
+	if len(tc.Expected) > 0 || len(tc.Unexpected) > 0 {
+		verifyRenderedPaths(t, output, tc.Expected, tc.Unexpected)
+		return
+	}
+
+	if tc.ExpectedObject != nil {
 		helm.UnmarshalK8SYaml(t, output, tc.ExpectedObject)
-		if tc.ObjectAsserter != nil {
-			tc.ObjectAsserter(t, tc.ExpectedObject)
-		}
+		tc.ObjectAsserter(t, tc.ExpectedObject)
 	}
 }
 

--- a/charts/camunda-platform-8.9/test/unit/testhelpers/testhelpers.go
+++ b/charts/camunda-platform-8.9/test/unit/testhelpers/testhelpers.go
@@ -100,11 +100,12 @@ func quietLogger() *logger.Logger {
 }
 
 type storageFixtureState struct {
-	typeSet            bool
-	legacySelectionSet bool
-	noSecondaryStorage bool
-	rdbmsEnabled       bool
-	openSearchEnabled  bool
+	typeSet              bool
+	legacySelectionSet   bool
+	noSecondaryStorage   bool
+	rdbmsEnabled         bool
+	elasticsearchEnabled bool
+	openSearchEnabled    bool
 }
 
 func mergeStorageFixtureValues(base, overlay map[string]any) {
@@ -184,6 +185,9 @@ func loadStorageFixtureState(valuesFiles []string, values map[string]string) (st
 	if state.rdbmsEnabled, _, err = storageFixtureBool(mergedValues, "orchestration", "exporters", "rdbms", "enabled"); err != nil {
 		return state, err
 	}
+	if state.elasticsearchEnabled, _, err = storageFixtureBool(mergedValues, "optimize", "database", "elasticsearch", "enabled"); err != nil {
+		return state, err
+	}
 	if state.openSearchEnabled, _, err = storageFixtureBool(mergedValues, "optimize", "database", "opensearch", "enabled"); err != nil {
 		return state, err
 	}
@@ -203,6 +207,9 @@ func loadStorageFixtureState(valuesFiles []string, values map[string]string) (st
 	if value, ok := values["orchestration.exporters.rdbms.enabled"]; ok {
 		state.rdbmsEnabled = strings.EqualFold(value, "true")
 	}
+	if value, ok := values["optimize.database.elasticsearch.enabled"]; ok {
+		state.elasticsearchEnabled = strings.EqualFold(value, "true")
+	}
 	if value, ok := values["optimize.database.opensearch.enabled"]; ok {
 		state.openSearchEnabled = strings.EqualFold(value, "true")
 	}
@@ -221,7 +228,7 @@ func setupHelmOptions(namespace string, values map[string]string, valuesFiles []
 	}
 	if !storageState.typeSet && !storageState.legacySelectionSet && !storageState.noSecondaryStorage && !storageState.rdbmsEnabled {
 		secondaryStorageType := "elasticsearch"
-		if storageState.openSearchEnabled {
+		if !storageState.elasticsearchEnabled && storageState.openSearchEnabled {
 			secondaryStorageType = "opensearch"
 		}
 		values["orchestration.data.secondaryStorage.type"] = secondaryStorageType
@@ -237,7 +244,45 @@ func setupHelmOptions(namespace string, values map[string]string, valuesFiles []
 	return options, nil
 }
 
+func validateStorageFixtureRenderArgs(renderTemplateExtraArgs []string) error {
+	storageKeys := []string{
+		"global.elasticsearch.enabled",
+		"global.opensearch.enabled",
+		"global.noSecondaryStorage",
+		"orchestration.data.secondaryStorage.type",
+		"orchestration.exporters.rdbms.enabled",
+		"optimize.database.elasticsearch.enabled",
+		"optimize.database.opensearch.enabled",
+		"global.elasticsearch",
+		"global.opensearch",
+		"global",
+		"orchestration.data.secondaryStorage",
+		"orchestration.data",
+		"orchestration.exporters.rdbms",
+		"orchestration.exporters",
+		"orchestration",
+		"optimize.database.elasticsearch",
+		"optimize.database.opensearch",
+		"optimize.database",
+		"optimize",
+	}
+	for _, argument := range renderTemplateExtraArgs {
+		if argument == "--values" || strings.HasPrefix(argument, "--values=") || strings.HasPrefix(argument, "-f") {
+			return fmt.Errorf("values files must be provided through TestCase.ValuesFiles, not RenderTemplateExtraArgs")
+		}
+		for _, key := range storageKeys {
+			if strings.Contains(argument, key+"=") {
+				return fmt.Errorf("storage fixture value %s must be provided through TestCase.Values, not RenderTemplateExtraArgs", key)
+			}
+		}
+	}
+	return nil
+}
+
 func renderTemplateE(t *testing.T, chartPath, release string, namespace string, templates []string, values map[string]string, valuesFiles []string, extraArgs map[string][]string, renderTemplateExtraArgs []string) (string, error) {
+	if err := validateStorageFixtureRenderArgs(renderTemplateExtraArgs); err != nil {
+		return "", err
+	}
 	options, err := setupHelmOptions(namespace, values, valuesFiles, extraArgs)
 	if err != nil {
 		return "", err

--- a/charts/camunda-platform-8.9/test/unit/utils/goldenfiles.go
+++ b/charts/camunda-platform-8.9/test/unit/utils/goldenfiles.go
@@ -17,6 +17,7 @@ package utils
 import (
 	"flag"
 	"io/ioutil"
+	"maps"
 	"regexp"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
@@ -40,8 +41,9 @@ type TemplateGoldenTest struct {
 }
 
 func (s *TemplateGoldenTest) TestContainerGoldenTestDefaults() {
-	if s.SetValues == nil {
-		s.SetValues = map[string]string{
+	values := maps.Clone(s.SetValues)
+	if values == nil {
+		values = map[string]string{
 			"connectors.security.authentication.oidc.secret.existingSecret":       "camunda-credentials",
 			"connectors.security.authentication.oidc.secret.existingSecretKey":    "client-secret",
 			"orchestration.security.authentication.oidc.secret.existingSecret":    "camunda-credentials",
@@ -51,7 +53,6 @@ func (s *TemplateGoldenTest) TestContainerGoldenTestDefaults() {
 			"global.identity.auth.optimize.secret.existingSecretKey":              "identity-optimize-client-token",
 		}
 	}
-	values := s.SetValues
 	values["connectors.security.authentication.oidc.secret.existingSecret"] = "camunda-credentials"
 	values["connectors.security.authentication.oidc.secret.existingSecretKey"] = "client-secret"
 	values["orchestration.security.authentication.oidc.secret.existingSecret"] = "camunda-credentials"
@@ -59,8 +60,9 @@ func (s *TemplateGoldenTest) TestContainerGoldenTestDefaults() {
 	values["global.identity.auth.console.existingSecret.name"] = "camunda-credentials"
 	values["global.identity.auth.optimize.secret.existingSecret"] = "camunda-credentials"
 	values["global.identity.auth.optimize.secret.existingSecretKey"] = "identity-optimize-client-token"
-	values["global.elasticsearch.enabled"] = "true"
-	values["elasticsearch.enabled"] = "true"
+	if _, ok := values["orchestration.data.secondaryStorage.type"]; !ok {
+		values["orchestration.data.secondaryStorage.type"] = "elasticsearch"
+	}
 	options := &helm.Options{
 		KubectlOptions: k8s.NewKubectlOptions("", "", s.Namespace),
 		SetValues:      values,


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6742.

Stacked on #6774, which fixes the 8.9 production defect exposed by the newly active assertions. #6774 is itself stacked on #6768, the reviewed 8.10 assertion contract.

This PR's unique diff changes test code and direct test dependencies only. Production templates remain owned by #6767 (8.10) and #6774 (8.9).

### What's in this PR?

The 8.7 document-store IRSA suite now uses the verifier-aware runner, activating all 20 existing callbacks.

Charts 8.8 and 8.9 gain version-local deterministic Kubernetes path assertions, explicit structural absence through `Unexpected`, strict assertion-mode validation, and focused runner contract tests. All audited dormant expectations now execute. Embedded `application.yaml` assertions use typed verifiers, and negative leaf assertions have positive workload or container anchors.

Ordinary 8.8 and 8.9 fixtures use current secret and datastore shapes. Deprecated inputs remain only in explicitly named compatibility contracts for versions where compatibility still exists, including the 8.9 global-Elasticsearch legacy-exporter predicate. The 8.9 runner and golden helper no longer inject deprecated Elasticsearch selectors or mutate caller-owned maps; current storage defaults respect layered values files. The 8.9 Bitnami deprecation-warning rows now enable the bundled Elasticsearch compatibility input explicitly instead of relying on helper defaults.

Validated with complete chart-scoped Go suites for 8.7, 8.8, and 8.9, shared matrix tests, golden/registry regeneration, Helm lint for all three versions, Go formatting, changed-file license checks, module tidiness, and focused Bitnami-warning and legacy-exporter suites. Regeneration produces no tracked snapshot changes.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

