### PR TITLE
chore: document source-owned Helm test contracts

### DIFF
--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -45,6 +45,8 @@ bundling, no workarounds for application-level issues, 1:1 mapping to applicatio
 - **ALWAYS** flag changes that only apply to one chart version when the same change may be
   needed across multiple versions (8.8, 8.9, 8.10, etc.).
 - **ALWAYS** check that `extraConfiguration` support follows the `kindIs "slice"` dual-form pattern.
+- **ALWAYS** require a source-owned positive contract and the relevant negative or alternate
+  contract when a user-visible template or helper predicate changes.
 
 ---
 
@@ -117,6 +119,11 @@ metadata:
 
 - [ ] Is there a unit test for each new rendering path (e.g., enabled/disabled, with/without
   optional field)?
+- [ ] Are competing flags and backends explicit in branch tests, using current values for that
+  chart version rather than deprecated fixture scaffolding?
+- [ ] Does every absent leaf assertion use structural absence semantics (`Unexpected` with
+  `RunTestCasesE`, or a typed verifier when a legacy runner is retained) and a positive parent or
+  sibling anchor where deleting the whole structure would otherwise pass?
 - [ ] Does each new template file have a corresponding golden file test in
   `test/unit/<component>/goldenfiles_test.go`?
 - [ ] Are golden files in `test/unit/<component>/golden/` updated to match the new output?

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -49,6 +49,62 @@ For example, for the Orchestration StatefulSet manifest we have the test `charts
 
 It is always helpful to check existing tests to get a better understanding of how to write new tests, so do not hesitate to read and copy from them.
 
+### Source-owned branch contracts
+
+When a template or helper branches on a feature flag, backend, authentication mode, or TLS state, keep the semantic contract beside the test for the template that owns that predicate. Add a valid positive endpoint and the relevant negative or alternate endpoint. These rows describe intended behavior; generated combinations cannot infer that semantic oracle.
+
+Set competing values explicitly, including `false` values needed to neutralize another backend or a version-local fixture default. Use the current values for the chart version under test. Do not use deprecated global datastore values as ordinary test scaffolding.
+
+For Kubernetes object paths, the 8.8+ `RunTestCasesE` implementations apply deterministic semantics. Charts 8.7 and older do not execute ordinary `Expected` paths and do not provide `Unexpected`; use an explicit typed `Verifier` for those versions.
+
+- `Expected` paths must resolve to exactly one scalar value in exactly one rendered object.
+- `Unexpected` paths must resolve to zero values and therefore assert structural absence.
+- `Expected: ""` means a present empty string, not an absent field.
+- `Expected: "null"` matches the scalar representation `null`; it does not distinguish a YAML null from the literal string `"null"`. Use a typed verifier when the YAML type matters.
+- Empty maps and lists are present non-scalar values. Use a typed verifier when their exact shape matters.
+
+Anchor an absent leaf to a positive parent or sibling when deleting the whole structure would otherwise make the test pass. For example:
+
+```go
+testCases := []testhelpers.TestCase{
+	{
+		Name: "OpenSearch password is rendered for OpenSearch storage",
+		Values: map[string]string{
+			"orchestration.data.secondaryStorage.type":                                "opensearch",
+			"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "test-password",
+		},
+		Expected: map[string]string{
+			"spec.template.spec.containers[0].name": "orchestration",
+			"spec.template.spec.containers[0].env[?(@.name=='VALUES_OPENSEARCH_PASSWORD')].name": "VALUES_OPENSEARCH_PASSWORD",
+		},
+	},
+	{
+		Name: "OpenSearch password is absent for Elasticsearch storage",
+		Values: map[string]string{
+			"orchestration.data.secondaryStorage.type":                                "elasticsearch",
+			"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "test-password",
+		},
+		Expected: map[string]string{
+			"spec.template.spec.containers[0].name": "orchestration",
+		},
+		Unexpected: []string{
+			"spec.template.spec.containers[0].env[?(@.name=='VALUES_OPENSEARCH_PASSWORD')]",
+		},
+	},
+}
+```
+
+Use an explicit typed `Verifier` instead of Kubernetes paths for embedded payloads such as `ConfigMap.data["application.yaml"]`. Unmarshal the rendered Kubernetes object, then unmarshal the embedded YAML into a small struct containing the fields under test. A verifier must not be combined with `Expected`, `Unexpected`, or object assertions in the same test case.
+
+Current version-owned examples include:
+
+- [`TestOpenSearchPasswordEnv` in the 8.10 Orchestration StatefulSet tests](https://github.com/camunda/camunda-platform-helm/blob/main/charts/camunda-platform-8.10/test/unit/orchestration/statefulset_test.go)
+- [`TestCaBundleInitContainerSecurityContext` in the 8.9 TLS tests](https://github.com/camunda/camunda-platform-helm/blob/main/charts/camunda-platform-8.9/test/unit/common/tls_secrets_test.go)
+- [`TestGlobalIngressHostTemplating` in the 8.10 Web Modeler ConfigMap tests](https://github.com/camunda/camunda-platform-helm/blob/main/charts/camunda-platform-8.10/test/unit/web-modeler/configmap_restapi_test.go)
+- [8.7 document-store IRSA tests using explicit verifiers](https://github.com/camunda/camunda-platform-helm/blob/main/charts/camunda-platform-8.7/test/unit/common/documentstore_irsa_test.go)
+
+Exhaustively enumerate a branch domain only when it is genuinely tiny and local. Source predicates and the values schema can suggest factors and boundaries, but they cannot generate the expected behavior. Pairwise coverage, MC/DC percentages, mutation scores, metamorphic relations, and solver-selected rows are optional maintainer audit tools, not contributor or merge gates.
+
 ## Test license headers
 
 Make sure that new Go tests contain the Apache license headers, otherwise the CI license check will fail.


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6743.

Stacked on #6769 so the guidance links to concrete version-owned examples delivered by the preceding assertion-runner work.

### What's in this PR?

The Helm testing reference now documents source-owned branch contracts for feature flags, backend selection, authentication, and TLS predicates. It defines deterministic positive and structural-absence semantics, distinguishes absent/null/empty values, requires positive anchors for absent leaves, and shows when embedded application YAML needs a typed verifier.

The guide requires current, explicit competing values and explains that source predicates and schema identify factors but cannot generate the semantic oracle. Exhaustive enumeration is limited to tiny local domains; pairwise coverage, MC/DC, mutation scores, metamorphic machinery, and solver-selected rows remain optional audit tools rather than contributor or merge gates.

Review guidance now requires positive plus relevant negative/alternate contracts, explicit current backend values, and anchored structural absence checks.

Validated with `git diff --check`, the configured Lychee link checker (8/8 links valid), and a focused review against every issue acceptance criterion.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
