### PR TITLE
fix: gate 8.9 OpenSearch password env vars on active consumers

### DIFF
--- a/charts/camunda-platform-8.9/templates/orchestration/statefulset.yaml
+++ b/charts/camunda-platform-8.9/templates/orchestration/statefulset.yaml
@@ -134,13 +134,15 @@ spec:
                 "config" .Values.orchestration.data.secondaryStorage.elasticsearch.auth
             ) | nindent 12 }}
             {{- end }}
-            {{- if (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.global.opensearch.auth)) "true") }}
+            {{- $hasTasklistGlobalOpenSearchReader := and .Values.orchestration.profiles.tasklist .Values.global.opensearch.enabled }}
+            {{- $hasOpenSearchConsumer := or (eq (include "orchestration.secondaryStorage" .) "opensearch") (eq (include "orchestration.hasLegacyOpenSearchExporter" .) "true") $hasTasklistGlobalOpenSearchReader }}
+            {{- if and $hasOpenSearchConsumer (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.global.opensearch.auth)) "true") }}
             {{- include "camundaPlatform.emitEnvVarFromSecretConfig" (dict
                 "envName" "VALUES_OPENSEARCH_PASSWORD"
                 "config" .Values.global.opensearch.auth
             ) | nindent 12 }}
             {{- end }}
-            {{- if (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.orchestration.data.secondaryStorage.opensearch.auth)) "true") }}
+            {{- if and $hasOpenSearchConsumer (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.orchestration.data.secondaryStorage.opensearch.auth)) "true") }}
             {{- include "camundaPlatform.emitEnvVarFromSecretConfig" (dict
                 "envName" "VALUES_OPENSEARCH_PASSWORD"
                 "config" .Values.orchestration.data.secondaryStorage.opensearch.auth

--- a/charts/camunda-platform-8.9/templates/orchestration/statefulset.yaml
+++ b/charts/camunda-platform-8.9/templates/orchestration/statefulset.yaml
@@ -135,7 +135,14 @@ spec:
             ) | nindent 12 }}
             {{- end }}
             {{- $hasTasklistGlobalOpenSearchReader := and .Values.orchestration.profiles.tasklist .Values.global.opensearch.enabled }}
-            {{- $hasOpenSearchConsumer := or (eq (include "orchestration.secondaryStorage" .) "opensearch") (eq (include "orchestration.hasLegacyOpenSearchExporter" .) "true") $hasTasklistGlobalOpenSearchReader }}
+            {{- $hasOpenSearchConsumer := or
+              (eq (include "orchestration.secondaryStorage" .) "opensearch")
+              (and
+                (ne (include "orchestration.hasLegacyElasticsearchExporter" .) "true")
+                (eq (include "orchestration.hasLegacyOpenSearchExporter" .) "true")
+              )
+              $hasTasklistGlobalOpenSearchReader
+            -}}
             {{- if and $hasOpenSearchConsumer (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.global.opensearch.auth)) "true") }}
             {{- include "camundaPlatform.emitEnvVarFromSecretConfig" (dict
                 "envName" "VALUES_OPENSEARCH_PASSWORD"

--- a/charts/camunda-platform-8.9/test/unit/common/configmap_warnings_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/configmap_warnings_test.go
@@ -54,6 +54,8 @@ func (s *ConfigMapWarningsTemplateTest) TestDifferentValuesInputs() {
 		{
 			Name: "TestWarningsConfigMapRendersWhenWarningPresent",
 			Values: map[string]string{
+				"elasticsearch.enabled":                                         "true",
+				"global.elasticsearch.enabled":                                  "true",
 				"orchestration.data.secondaryStorage.type":                      "elasticsearch",
 				"identity.enabled":                                              "true",
 				"global.identity.auth.enabled":                                  "true",
@@ -69,6 +71,8 @@ func (s *ConfigMapWarningsTemplateTest) TestDifferentValuesInputs() {
 				s.Require().True(strings.HasSuffix(configmap.Name, "-warnings"))
 				s.Require().Contains(configmap.Data["warnings"],
 					"the Camunda Helm chart will no longer automatically generate passwords for the Identity component")
+				s.Require().Contains(configmap.Data["warnings"],
+					"The following Bitnami-based subcharts are deprecated and will be removed in Camunda 8.10: [elasticsearch].")
 			},
 		},
 		{

--- a/charts/camunda-platform-8.9/test/unit/orchestration/statefulset_test.go
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/statefulset_test.go
@@ -15,6 +15,7 @@
 package orchestration
 
 import (
+	camunda "camunda-platform/test/unit/common"
 	"camunda-platform/test/unit/testhelpers"
 	"path/filepath"
 	"strings"
@@ -934,6 +935,51 @@ func (s *StatefulSetTest) TestOpenSearchPasswordEnv() {
 				"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "component-password",
 			},
 			Verifier: verifyOpenSearchPasswordEnv(corev1.EnvVar{Name: "VALUES_OPENSEARCH_PASSWORD", Value: "component-password"}),
+		},
+		{
+			Name: "Legacy Elasticsearch exporter takes precedence over OpenSearch credentials",
+			CaseTemplates: &testhelpers.CaseTemplate{
+				Templates: []string{
+					"templates/orchestration/configmap.yaml",
+					"templates/orchestration/statefulset.yaml",
+				},
+			},
+			Values: map[string]string{
+				"global.elasticsearch.enabled":                                            "true",
+				"elasticsearch.enabled":                                                   "true",
+				"optimize.enabled":                                                        "true",
+				"optimize.database.elasticsearch.enabled":                                 "false",
+				"optimize.database.opensearch.enabled":                                    "true",
+				"orchestration.data.secondaryStorage.type":                                "elasticsearch",
+				"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "component-password",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+
+				var configMaps []corev1.ConfigMap
+				helm.UnmarshalK8SYamls(t, output, &configMaps, func(configMap corev1.ConfigMap) bool {
+					return configMap.Data["application.yaml"] != ""
+				})
+				s.Require().Len(configMaps, 1)
+
+				var application camunda.OrchestrationApplicationYAML
+				helm.UnmarshalK8SYaml(t, configMaps[0].Data["application.yaml"], &application)
+				s.Require().Equal("io.camunda.zeebe.exporter.ElasticsearchExporter", application.Zeebe.Broker.Exporters.Elasticsearch.ClassName)
+
+				var statefulSets []appsv1.StatefulSet
+				helm.UnmarshalK8SYamls(t, output, &statefulSets, func(statefulSet appsv1.StatefulSet) bool {
+					return statefulSet.Kind == "StatefulSet"
+				})
+				s.Require().Len(statefulSets, 1)
+
+				var openSearchPasswordEnv []corev1.EnvVar
+				for _, envVar := range statefulSets[0].Spec.Template.Spec.Containers[0].Env {
+					if envVar.Name == "VALUES_OPENSEARCH_PASSWORD" {
+						openSearchPasswordEnv = append(openSearchPasswordEnv, envVar)
+					}
+				}
+				s.Require().Empty(openSearchPasswordEnv)
+			},
 		},
 		{
 			Name: "Deprecated global OpenSearch compatibility emits active password",

--- a/charts/camunda-platform-8.9/test/unit/orchestration/statefulset_test.go
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/statefulset_test.go
@@ -882,6 +882,102 @@ func (s *StatefulSetTest) TestDifferentValuesInputs() {
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
 
+func (s *StatefulSetTest) TestOpenSearchPasswordEnv() {
+	verifyOpenSearchPasswordEnv := func(expected ...corev1.EnvVar) func(t *testing.T, output string, err error) {
+		return func(t *testing.T, output string, err error) {
+			require.NoError(t, err)
+
+			var statefulSet appsv1.StatefulSet
+			helm.UnmarshalK8SYaml(t, output, &statefulSet)
+			require.NotEmpty(t, statefulSet.Spec.Template.Spec.Containers)
+
+			var actual []corev1.EnvVar
+			for _, envVar := range statefulSet.Spec.Template.Spec.Containers[0].Env {
+				if envVar.Name == "VALUES_OPENSEARCH_PASSWORD" {
+					actual = append(actual, envVar)
+				}
+			}
+			require.Equal(t, expected, actual)
+		}
+	}
+
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "Component OpenSearch emits the configured password",
+			Values: map[string]string{
+				"optimize.enabled":                                                        "false",
+				"optimize.database.elasticsearch.enabled":                                 "false",
+				"optimize.database.opensearch.enabled":                                    "false",
+				"orchestration.data.secondaryStorage.type":                                "opensearch",
+				"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "component-password",
+			},
+			Verifier: verifyOpenSearchPasswordEnv(corev1.EnvVar{Name: "VALUES_OPENSEARCH_PASSWORD", Value: "component-password"}),
+		},
+		{
+			Name: "Component OpenSearch credentials are omitted for inactive backend",
+			Values: map[string]string{
+				"optimize.enabled":                                                        "false",
+				"optimize.database.elasticsearch.enabled":                                 "false",
+				"optimize.database.opensearch.enabled":                                    "false",
+				"orchestration.data.secondaryStorage.type":                                "elasticsearch",
+				"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "component-password",
+			},
+			Verifier: verifyOpenSearchPasswordEnv(),
+		},
+		{
+			Name: "Legacy OpenSearch exporter retains component password compatibility",
+			Values: map[string]string{
+				"optimize.enabled":                                                        "true",
+				"optimize.database.elasticsearch.enabled":                                 "false",
+				"optimize.database.opensearch.enabled":                                    "true",
+				"orchestration.data.secondaryStorage.type":                                "elasticsearch",
+				"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "component-password",
+			},
+			Verifier: verifyOpenSearchPasswordEnv(corev1.EnvVar{Name: "VALUES_OPENSEARCH_PASSWORD", Value: "component-password"}),
+		},
+		{
+			Name: "Deprecated global OpenSearch compatibility emits active password",
+			Values: map[string]string{
+				"global.opensearch.enabled":                  "true",
+				"global.opensearch.auth.secret.inlineSecret": "global-password",
+				"optimize.enabled":                           "false",
+				"optimize.database.elasticsearch.enabled":    "false",
+				"optimize.database.opensearch.enabled":       "false",
+				"orchestration.data.secondaryStorage.type":   "opensearch",
+			},
+			Verifier: verifyOpenSearchPasswordEnv(corev1.EnvVar{Name: "VALUES_OPENSEARCH_PASSWORD", Value: "global-password"}),
+		},
+		{
+			Name: "Deprecated global OpenSearch compatibility omits inactive password",
+			Values: map[string]string{
+				"global.opensearch.enabled":                  "false",
+				"global.opensearch.auth.secret.inlineSecret": "global-password",
+				"optimize.enabled":                           "false",
+				"optimize.database.elasticsearch.enabled":    "false",
+				"optimize.database.opensearch.enabled":       "false",
+				"orchestration.data.secondaryStorage.type":   "elasticsearch",
+			},
+			Verifier: verifyOpenSearchPasswordEnv(),
+		},
+		{
+			Name: "Deprecated global OpenSearch Tasklist compatibility retains multiregion password",
+			Values: map[string]string{
+				"global.multiregion.regions":                 "2",
+				"global.opensearch.enabled":                  "true",
+				"global.opensearch.auth.secret.inlineSecret": "global-password",
+				"optimize.enabled":                           "false",
+				"optimize.database.elasticsearch.enabled":    "false",
+				"optimize.database.opensearch.enabled":       "false",
+				"orchestration.profiles.tasklist":            "true",
+				"orchestration.data.secondaryStorage.type":   "elasticsearch",
+			},
+			Verifier: verifyOpenSearchPasswordEnv(corev1.EnvVar{Name: "VALUES_OPENSEARCH_PASSWORD", Value: "global-password"}),
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
 func (s *StatefulSetTest) TestWithJKSSecretReference() {
 	testCases := []testhelpers.TestCase{
 		{

--- a/charts/camunda-platform-8.9/test/unit/testhelpers/testhelpers.go
+++ b/charts/camunda-platform-8.9/test/unit/testhelpers/testhelpers.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package testhelpers provides utilities for testing Helm charts.
 // To enable verbose logging, set the VERBOSE_TEST_LOGGING environment variable to "true".
 // Example: VERBOSE_TEST_LOGGING=true go test ./...
@@ -86,11 +100,12 @@ func setupHelmOptions(namespace string, values map[string]string, valuesFiles []
 	if values == nil {
 		values = make(map[string]string)
 	}
-	// Add default Elasticsearch flags if not already present
-	if _, hasGlobalES := values["global.elasticsearch.enabled"]; !hasGlobalES {
+	_, hasSecondaryStorageType := values["orchestration.data.secondaryStorage.type"]
+	// Add default Elasticsearch flags if no current storage selector is provided.
+	if _, hasGlobalES := values["global.elasticsearch.enabled"]; !hasGlobalES && !hasSecondaryStorageType {
 		values["global.elasticsearch.enabled"] = "true"
 	}
-	if _, hasES := values["elasticsearch.enabled"]; !hasES {
+	if _, hasES := values["elasticsearch.enabled"]; !hasES && !hasSecondaryStorageType {
 		values["elasticsearch.enabled"] = "true"
 	}
 

--- a/charts/camunda-platform-8.9/test/unit/testhelpers/testhelpers.go
+++ b/charts/camunda-platform-8.9/test/unit/testhelpers/testhelpers.go
@@ -19,6 +19,7 @@ package testhelpers
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"strings"
 	"testing"
@@ -95,17 +96,112 @@ func quietLogger() *logger.Logger {
 	return logger.Discard
 }
 
-func setupHelmOptions(namespace string, values map[string]string, valuesFiles []string, helmOptionsExtraArgs map[string][]string) *helm.Options {
-	// Initialize values map if nil
+type storageFixtureState struct {
+	typeSet                bool
+	globalElasticsearchSet bool
+	elasticsearchSet       bool
+}
+
+func mergeStorageFixtureValues(base, overlay map[string]any) {
+	for key, overlayValue := range overlay {
+		if overlayValue == nil {
+			delete(base, key)
+			continue
+		}
+
+		overlayMap, overlayIsMap := overlayValue.(map[string]any)
+		baseMap, baseIsMap := base[key].(map[string]any)
+		if overlayIsMap && baseIsMap {
+			mergeStorageFixtureValues(baseMap, overlayMap)
+			continue
+		}
+		base[key] = overlayValue
+	}
+}
+
+func storageFixtureValue(values map[string]any, path ...string) (any, bool) {
+	var current any = values
+	for _, key := range path {
+		mapping, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current, ok = mapping[key]
+		if !ok {
+			return nil, false
+		}
+	}
+	return current, true
+}
+
+func storageFixtureBoolSet(values map[string]any, path ...string) (bool, error) {
+	rawValue, ok := storageFixtureValue(values, path...)
+	if !ok {
+		return false, nil
+	}
+	if _, ok := rawValue.(bool); !ok {
+		return false, fmt.Errorf("storage fixture value %s must be a boolean", strings.Join(path, "."))
+	}
+	return true, nil
+}
+
+func loadStorageFixtureState(valuesFiles []string, values map[string]string) (storageFixtureState, error) {
+	state := storageFixtureState{}
+	mergedValues := make(map[string]any)
+	for _, valuesFile := range valuesFiles {
+		data, err := os.ReadFile(valuesFile)
+		if err != nil {
+			return state, fmt.Errorf("read values file %s: %w", valuesFile, err)
+		}
+
+		var fileValues map[string]any
+		if err := yaml.Unmarshal(data, &fileValues); err != nil {
+			return state, fmt.Errorf("parse values file %s: %w", valuesFile, err)
+		}
+		mergeStorageFixtureValues(mergedValues, fileValues)
+	}
+
+	if storageType, ok := storageFixtureValue(mergedValues, "orchestration", "data", "secondaryStorage", "type"); ok {
+		if _, ok := storageType.(string); !ok {
+			return state, fmt.Errorf("storage fixture value orchestration.data.secondaryStorage.type must be a string")
+		}
+		state.typeSet = true
+	}
+	var err error
+	if state.globalElasticsearchSet, err = storageFixtureBoolSet(mergedValues, "global", "elasticsearch", "enabled"); err != nil {
+		return state, err
+	}
+	if state.elasticsearchSet, err = storageFixtureBoolSet(mergedValues, "elasticsearch", "enabled"); err != nil {
+		return state, err
+	}
+
+	if _, ok := values["orchestration.data.secondaryStorage.type"]; ok {
+		state.typeSet = true
+	}
+	if _, ok := values["global.elasticsearch.enabled"]; ok {
+		state.globalElasticsearchSet = true
+	}
+	if _, ok := values["elasticsearch.enabled"]; ok {
+		state.elasticsearchSet = true
+	}
+
+	return state, nil
+}
+
+func setupHelmOptions(namespace string, values map[string]string, valuesFiles []string, helmOptionsExtraArgs map[string][]string) (*helm.Options, error) {
+	values = maps.Clone(values)
 	if values == nil {
 		values = make(map[string]string)
 	}
-	_, hasSecondaryStorageType := values["orchestration.data.secondaryStorage.type"]
+	storageState, err := loadStorageFixtureState(valuesFiles, values)
+	if err != nil {
+		return nil, err
+	}
 	// Add default Elasticsearch flags if no current storage selector is provided.
-	if _, hasGlobalES := values["global.elasticsearch.enabled"]; !hasGlobalES && !hasSecondaryStorageType {
+	if !storageState.typeSet && !storageState.globalElasticsearchSet {
 		values["global.elasticsearch.enabled"] = "true"
 	}
-	if _, hasES := values["elasticsearch.enabled"]; !hasES && !hasSecondaryStorageType {
+	if !storageState.typeSet && !storageState.elasticsearchSet {
 		values["elasticsearch.enabled"] = "true"
 	}
 
@@ -116,11 +212,14 @@ func setupHelmOptions(namespace string, values map[string]string, valuesFiles []
 		Logger:         quietLogger(), // Use quiet logger to reduce verbosity
 		ExtraArgs:      helmOptionsExtraArgs,
 	}
-	return options
+	return options, nil
 }
 
 func renderTemplateE(t *testing.T, chartPath, release string, namespace string, templates []string, values map[string]string, valuesFiles []string, extraArgs map[string][]string, renderTemplateExtraArgs []string) (string, error) {
-	options := setupHelmOptions(namespace, values, valuesFiles, extraArgs)
+	options, err := setupHelmOptions(namespace, values, valuesFiles, extraArgs)
+	if err != nil {
+		return "", err
+	}
 
 	output, err := helm.RenderTemplateE(t, options, chartPath, release, templates, renderTemplateExtraArgs...)
 	return output, err
@@ -176,7 +275,8 @@ func runTestCaseE(t *testing.T, chartPath, release, namespace string, templates 
 
 // renderTemplate renders the specified Helm templates into a Kubernetes ConfigMap
 func renderTemplate(t *testing.T, chartPath, release string, namespace string, templates []string, values map[string]string, valuesFiles []string) corev1.ConfigMap {
-	options := setupHelmOptions(namespace, values, valuesFiles, nil)
+	options, err := setupHelmOptions(namespace, values, valuesFiles, nil)
+	require.NoError(t, err)
 
 	output := helm.RenderTemplate(t, options, chartPath, release, templates)
 	var configmap corev1.ConfigMap

--- a/charts/camunda-platform-8.9/test/unit/testhelpers/testhelpers_test.go
+++ b/charts/camunda-platform-8.9/test/unit/testhelpers/testhelpers_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testhelpers
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var _ = flag.Bool("update-golden", false, "accepted for chart-wide golden updates")
+
+func writeStorageValuesFile(t *testing.T, name, content string) string {
+	t.Helper()
+
+	valuesFile := filepath.Join(t.TempDir(), name)
+	require.NoError(t, os.WriteFile(valuesFile, []byte(content), 0o600))
+	return valuesFile
+}
+
+func TestSetupHelmOptionsClonesValues(t *testing.T) {
+	t.Parallel()
+
+	values := map[string]string{
+		"orchestration.data.secondaryStorage.type": "opensearch",
+	}
+	options, err := setupHelmOptions("test", values, nil, nil)
+	require.NoError(t, err)
+
+	options.SetValues["orchestration.data.secondaryStorage.type"] = "elasticsearch"
+	require.Equal(t, "opensearch", values["orchestration.data.secondaryStorage.type"])
+}
+
+func TestStorageFixturePreservesHelmPrecedence(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../")
+	require.NoError(t, err)
+	templates := []string{"templates/orchestration/configmap.yaml"}
+
+	baseValues := writeStorageValuesFile(t, "base.yaml", `global:
+  elasticsearch:
+    enabled: true
+elasticsearch:
+  enabled: true
+orchestration:
+  data:
+    secondaryStorage:
+      type: elasticsearch
+`)
+	overlayValues := writeStorageValuesFile(t, "overlay.yaml", `global:
+  elasticsearch:
+    enabled: false
+elasticsearch:
+  enabled: false
+orchestration:
+  data:
+    secondaryStorage:
+      type: opensearch
+`)
+	directOpenSearchValues := map[string]string{
+		"global.elasticsearch.enabled":             "false",
+		"elasticsearch.enabled":                    "false",
+		"orchestration.data.secondaryStorage.type": "opensearch",
+	}
+
+	fileOutput, err := renderTemplateE(t, chartPath, "test", "test", templates, nil, []string{baseValues, overlayValues}, nil, nil)
+	require.NoError(t, err)
+	directOutput, err := renderTemplateE(t, chartPath, "test", "test", templates, directOpenSearchValues, nil, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, directOutput, fileOutput)
+	require.Contains(t, fileOutput, `type: "opensearch"`)
+
+	directElasticsearchValues := map[string]string{
+		"global.elasticsearch.enabled":             "false",
+		"elasticsearch.enabled":                    "false",
+		"orchestration.data.secondaryStorage.type": "elasticsearch",
+	}
+	mixedOutput, err := renderTemplateE(t, chartPath, "test", "test", templates, directElasticsearchValues, []string{baseValues, overlayValues}, nil, nil)
+	require.NoError(t, err)
+	directOutput, err = renderTemplateE(t, chartPath, "test", "test", templates, directElasticsearchValues, nil, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, directOutput, mixedOutput)
+	require.Contains(t, mixedOutput, `type: "elasticsearch"`)
+}


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6772

This defect was exposed by the maintained-version assertion activation in #6742 and is kept separate because #6740 is scoped to chart 8.10.

Stacked on #6768 so #6769 can remain test-only while its newly active 8.9 negative assertion consumes this fix.

### What's in this PR?

The 8.9 Orchestration StatefulSet now emits the existing `VALUES_OPENSEARCH_PASSWORD` variable only when OpenSearch is selected for secondary storage, the legacy OpenSearch exporter is active, or Tasklist uses the active global OpenSearch compatibility reader. It does not introduce dedicated credential variables or source-alignment behavior; that separate concurrent-consumer defect is tracked by #6773.

Focused contracts cover current component-scoped active and inactive paths, preserve the existing legacy-exporter path, and keep deprecated global coverage explicitly named as 8.9 compatibility. They also cover the multiregion Tasklist global reader, which still renders the generic password placeholder even when the legacy exporter is disabled. A narrow test-helper guard stops legacy Elasticsearch defaults from overriding an explicit current secondary-storage selector.

Validated with the complete 8.9 chart-scoped Go suite, matrix tests, golden regeneration, Helm lint, Go formatting, changed-file license checks, and direct inactive-backend rendering. Regeneration produces no tracked snapshot changes.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
