### PR TITLE
chore: add build_status_v2 resource monitoring for repositories

### DIFF
--- a/.github/actions/observe-build-status/action.yml
+++ b/.github/actions/observe-build-status/action.yml
@@ -1,0 +1,95 @@
+name: Observe Build Status
+
+description: Records the build status remotely for analytic purposes
+
+inputs:
+  build_status:
+    description: 'The status of the job, one of: success, failure, aborted, cancelled'
+    required: true
+  user_reason:
+    description: 'Optional string (200 chars max) the user can submit to indicate the reason why a build ended with a certain status.'
+    required: false
+  user_description:
+    description: 'Optional string (200 chars max) for the build entry. When empty, falls back to the TEST_OWNER environment variable.'
+    required: false
+  job_name:
+    description: 'Optional string, the job whose status is being observed; defaults to $GITHUB_JOB when omitted'
+    required: false
+  detailed_junit_tests:
+    description: 'Optional boolean, if true search for TEST-*.xml files and submit their details to dedicated analytics endpoint'
+    required: false
+    default: 'false'
+  secret_vault_address:
+    description: 'Vault server URL'
+    required: false
+  secret_vault_jwt_path:
+    description: 'Vault JWT auth mount path'
+    required: false
+  secret_vault_jwt_role:
+    description: 'Vault JWT auth role'
+    required: false
+  secret_vault_jwt_audience:
+    description: 'Vault JWT GitHub audience'
+    required: false
+
+runs:
+  using: composite
+  steps:
+  - name: Import Secrets
+    id: secrets
+    # Composite actions cannot access the secrets context directly; callers must
+    # pass vault config as inputs so they resolve correctly here via inputs.*.
+    continue-on-error: true
+    uses: hashicorp/vault-action@v4.0.0
+    if: |
+      inputs.secret_vault_address != ''
+      && inputs.secret_vault_jwt_path != ''
+      && inputs.secret_vault_jwt_role != ''
+    with:
+      url: ${{ inputs.secret_vault_address }}
+      method: jwt
+      path: ${{ inputs.secret_vault_jwt_path }}
+      role: ${{ inputs.secret_vault_jwt_role }}
+      jwtGithubAudience: ${{ inputs.secret_vault_jwt_audience }}
+      exportEnv: false  # we rely on step outputs, no need for environment variables
+      secrets: |
+        secret/data/products/distribution/ci/ci-analytics gcloud_sa_key;
+
+  - name: Check secrets availability
+    if: ${{ steps.secrets.outputs.gcloud_sa_key == '' }}
+    shell: bash
+    run: echo "::warning::Not sending any CI health metrics since no access to GHA secrets!"
+
+  ######################## Calculate build duration #########################
+  - name: Get build duration in milliseconds
+    id: get-build-duration-millis
+    if: ${{ steps.secrets.outputs.gcloud_sa_key != '' }}
+    shell: bash
+    run: |
+      # Prefer the start-build-monitor PID file mtime as the job-start anchor;
+      # fall back to the action directory mtime (roughly checkout time) if absent.
+      if [ -f /tmp/_monitor-start.pid ]; then
+        start=$(date -r /tmp/_monitor-start.pid +"%s")
+      else
+        start=$(date -r "$GITHUB_ACTION_PATH" +"%s")
+      fi
+      now=$(date +'%s')
+      duration=$(( now - start ))
+
+      # only submit plausible durations between 0 and 72 hours
+      if (( duration >= 0 && duration <= 259200 )); then
+        echo "result=$(( duration * 1000 ))" >> $GITHUB_OUTPUT
+      else
+        echo "result=" >> $GITHUB_OUTPUT
+      fi
+
+  ######################## Report build result #############################
+  - uses: camunda/infra-global-github-actions/submit-build-status@main
+    if: ${{ always() && steps.secrets.outputs.gcloud_sa_key != '' }}
+    with:
+      job_name_override: "${{ inputs.job_name || github.job }}"
+      build_status: "${{ inputs.build_status }}"
+      build_duration_millis: "${{ steps.get-build-duration-millis.outputs.result }}"
+      user_reason: "${{ inputs.user_reason }}"
+      user_description: "${{ inputs.user_description != '' && inputs.user_description || env.TEST_OWNER }}"
+      gcp_credentials_json: "${{ steps.secrets.outputs.gcloud_sa_key }}"

--- a/.github/actions/observe-build-status/action.yml
+++ b/.github/actions/observe-build-status/action.yml
@@ -40,7 +40,7 @@ runs:
     # Composite actions cannot access the secrets context directly; callers must
     # pass vault config as inputs so they resolve correctly here via inputs.*.
     continue-on-error: true
-    uses: hashicorp/vault-action@v4.0.0
+    uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
     if: |
       inputs.secret_vault_address != ''
       && inputs.secret_vault_jwt_path != ''

--- a/.github/actions/observe-build-status/action.yml
+++ b/.github/actions/observe-build-status/action.yml
@@ -10,15 +10,11 @@ inputs:
     description: 'Optional string (200 chars max) the user can submit to indicate the reason why a build ended with a certain status.'
     required: false
   user_description:
-    description: 'Optional string (200 chars max) for the build entry. When empty, falls back to the TEST_OWNER environment variable.'
+    description: 'Optional string (200 chars max) for the build entry.'
     required: false
   job_name:
     description: 'Optional string, the job whose status is being observed; defaults to $GITHUB_JOB when omitted'
     required: false
-  detailed_junit_tests:
-    description: 'Optional boolean, if true search for TEST-*.xml files and submit their details to dedicated analytics endpoint'
-    required: false
-    default: 'false'
   secret_vault_address:
     description: 'Vault server URL'
     required: false
@@ -91,5 +87,5 @@ runs:
       build_status: "${{ inputs.build_status }}"
       build_duration_millis: "${{ steps.get-build-duration-millis.outputs.result }}"
       user_reason: "${{ inputs.user_reason }}"
-      user_description: "${{ inputs.user_description != '' && inputs.user_description || env.TEST_OWNER }}"
+      user_description: "${{ inputs.user_description }}"
       gcp_credentials_json: "${{ steps.secrets.outputs.gcloud_sa_key }}"

--- a/.github/actions/observe-build-status/action.yml
+++ b/.github/actions/observe-build-status/action.yml
@@ -84,7 +84,7 @@ runs:
       fi
 
   ######################## Report build result #############################
-  - uses: camunda/infra-global-github-actions/submit-build-status@main
+  - uses: camunda/infra-global-github-actions/submit-build-status@9d9d444bc36d39a6c78c94b85ddbea411f7e71a4 # main
     if: ${{ always() && steps.secrets.outputs.gcloud_sa_key != '' }}
     with:
       job_name_override: "${{ inputs.job_name || github.job }}"

--- a/.github/workflows/test-chart-version.yaml
+++ b/.github/workflows/test-chart-version.yaml
@@ -223,6 +223,7 @@ jobs:
       fail-fast: false
       matrix:
         version: ${{ fromJson(needs.init.outputs.camunda-versions) }}
+    secrets: inherit
     uses: ./.github/workflows/test-unit-template.yaml
     with:
       identifier: "${{ github.event.pull_request.number || github.ref }}-unit-${{ matrix.version }}"
@@ -253,6 +254,7 @@ jobs:
         version: ${{ fromJson(needs.init.outputs.camunda-versions) }}
     permissions:
       contents: read
+      id-token: write
     secrets: inherit
     uses: ./.github/workflows/test-local-template.yaml
     with:

--- a/.github/workflows/test-chart-version.yaml
+++ b/.github/workflows/test-chart-version.yaml
@@ -223,7 +223,11 @@ jobs:
       fail-fast: false
       matrix:
         version: ${{ fromJson(needs.init.outputs.camunda-versions) }}
-    secrets: inherit
+    secrets:
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_JWT_PATH: ${{ secrets.VAULT_JWT_PATH }}
+      VAULT_JWT_ROLE: ${{ secrets.VAULT_JWT_ROLE }}
+      VAULT_JWT_AUDIENCE: ${{ secrets.VAULT_JWT_AUDIENCE }}
     uses: ./.github/workflows/test-unit-template.yaml
     with:
       identifier: "${{ github.event.pull_request.number || github.ref }}-unit-${{ matrix.version }}"

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -350,6 +350,7 @@ jobs:
       TEST_CLUSTER_TYPE: ${{ inputs.distro-type || inputs.cluster-type }}
 
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - name: Info - ℹ️ Print workflow inputs ℹ️
         env:
           GITHUB_CONTEXT: ${{ toJson(inputs) }}
@@ -843,6 +844,16 @@ jobs:
           path: diagnostics/
           retention-days: 14
           if-no-files-found: ignore
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_jwt_path: ${{ secrets.VAULT_JWT_PATH }}
+          secret_vault_jwt_role: ${{ secrets.VAULT_JWT_ROLE }}
+          secret_vault_jwt_audience: ${{ secrets.VAULT_JWT_AUDIENCE }}
 
   upgrade:
     if: always() && github.event.action != 'closed' && (needs.install.result == 'success' || needs.install.result == 'skipped') && inputs.flow != 'install'
@@ -873,6 +884,7 @@ jobs:
       TEST_CLUSTER_TYPE: ${{ inputs.distro-type || inputs.cluster-type }}
 
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - name: Info - ℹ️ Print workflow inputs ℹ️
         env:
           GITHUB_CONTEXT: ${{ toJson(inputs) }}
@@ -1227,6 +1239,16 @@ jobs:
           path: diagnostics/
           retention-days: 14
           if-no-files-found: ignore
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_jwt_path: ${{ secrets.VAULT_JWT_PATH }}
+          secret_vault_jwt_role: ${{ secrets.VAULT_JWT_ROLE }}
+          secret_vault_jwt_audience: ${{ secrets.VAULT_JWT_AUDIENCE }}
 
   playwright-e2e-tests-after-install:
     name: Playwright e2e ${{ matrix.suite }} after install - ${{ inputs.flow }} on ${{ inputs.distro-platform }} - ${{ inputs.shortname }} (${{ matrix.shard_index }} of ${{ matrix.shard_total }})
@@ -1257,6 +1279,7 @@ jobs:
       deployments: write
       packages: read
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -1309,6 +1332,16 @@ jobs:
           shard-index: ${{ matrix.shard_index }}
           scenario: ${{ inputs.scenario }}
           run-smoke-tests: ${{ matrix.suite == 'smoke' }}
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_jwt_path: ${{ secrets.VAULT_JWT_PATH }}
+          secret_vault_jwt_role: ${{ secrets.VAULT_JWT_ROLE }}
+          secret_vault_jwt_audience: ${{ secrets.VAULT_JWT_AUDIENCE }}
 
   # Shadow job: runs the full E2E suite for the dedicated 'shadow-e2e' scenario.
   # Tier 2 (merge queue only). Non-blocking during observation period.
@@ -1334,6 +1367,7 @@ jobs:
       deployments: write
       packages: read
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -1388,6 +1422,16 @@ jobs:
           shard-index: "1"
           scenario: ${{ inputs.scenario }}
           run-smoke-tests: "false"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_jwt_path: ${{ secrets.VAULT_JWT_PATH }}
+          secret_vault_jwt_role: ${{ secrets.VAULT_JWT_ROLE }}
+          secret_vault_jwt_audience: ${{ secrets.VAULT_JWT_AUDIENCE }}
 
   # Multi-namespace topology job: runs the smoke suite against each
   # topology scenario's orchestration releases, with credentials
@@ -1420,6 +1464,7 @@ jobs:
       deployments: write
       packages: read
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -1495,6 +1540,16 @@ jobs:
           shard-index: ${{ matrix.shard_index }}
           scenario: ${{ inputs.scenario }}
           run-smoke-tests: "true"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_jwt_path: ${{ secrets.VAULT_JWT_PATH }}
+          secret_vault_jwt_role: ${{ secrets.VAULT_JWT_ROLE }}
+          secret_vault_jwt_audience: ${{ secrets.VAULT_JWT_AUDIENCE }}
 
   playwright-e2e-tests-after-upgrade:
     name: Playwright e2e after upgrade - ${{ inputs.flow }} on ${{ inputs.distro-platform }} - ${{ inputs.shortname }} (${{ matrix.shardIndex }} of ${{ matrix.shardTotal }})
@@ -1522,6 +1577,7 @@ jobs:
       deployments: write
       packages: read
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -1574,6 +1630,16 @@ jobs:
           test-stage: after-upgrade
           shard-index: ${{ matrix.shardIndex }}
           scenario: ${{ inputs.scenario }}
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_jwt_path: ${{ secrets.VAULT_JWT_PATH }}
+          secret_vault_jwt_role: ${{ secrets.VAULT_JWT_ROLE }}
+          secret_vault_jwt_audience: ${{ secrets.VAULT_JWT_AUDIENCE }}
 
   merge-e2e-reports:
     name: Merge E2E Reports - ${{ inputs.flow }} on ${{ inputs.distro-platform }} - ${{ inputs.shortname }}

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -350,7 +350,7 @@ jobs:
       TEST_CLUSTER_TYPE: ${{ inputs.distro-type || inputs.cluster-type }}
 
     steps:
-      - uses: camunda/infra-global-github-actions/start-build-monitor@main
+      - uses: camunda/infra-global-github-actions/start-build-monitor@02b3f0e49b00b98fffc76af690ebc83c28f24dae # main
       - name: Info - ℹ️ Print workflow inputs ℹ️
         env:
           GITHUB_CONTEXT: ${{ toJson(inputs) }}
@@ -884,7 +884,7 @@ jobs:
       TEST_CLUSTER_TYPE: ${{ inputs.distro-type || inputs.cluster-type }}
 
     steps:
-      - uses: camunda/infra-global-github-actions/start-build-monitor@main
+      - uses: camunda/infra-global-github-actions/start-build-monitor@02b3f0e49b00b98fffc76af690ebc83c28f24dae # main
       - name: Info - ℹ️ Print workflow inputs ℹ️
         env:
           GITHUB_CONTEXT: ${{ toJson(inputs) }}
@@ -1279,7 +1279,7 @@ jobs:
       deployments: write
       packages: read
     steps:
-      - uses: camunda/infra-global-github-actions/start-build-monitor@main
+      - uses: camunda/infra-global-github-actions/start-build-monitor@02b3f0e49b00b98fffc76af690ebc83c28f24dae # main
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -1368,7 +1368,7 @@ jobs:
       deployments: write
       packages: read
     steps:
-      - uses: camunda/infra-global-github-actions/start-build-monitor@main
+      - uses: camunda/infra-global-github-actions/start-build-monitor@02b3f0e49b00b98fffc76af690ebc83c28f24dae # main
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -1465,7 +1465,7 @@ jobs:
       deployments: write
       packages: read
     steps:
-      - uses: camunda/infra-global-github-actions/start-build-monitor@main
+      - uses: camunda/infra-global-github-actions/start-build-monitor@02b3f0e49b00b98fffc76af690ebc83c28f24dae # main
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -1578,7 +1578,7 @@ jobs:
       deployments: write
       packages: read
     steps:
-      - uses: camunda/infra-global-github-actions/start-build-monitor@main
+      - uses: camunda/infra-global-github-actions/start-build-monitor@02b3f0e49b00b98fffc76af690ebc83c28f24dae # main
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -345,7 +345,7 @@ jobs:
       TEST_CLUSTER_TYPE: ${{ inputs.distro-type || inputs.cluster-type }}
 
     steps:
-      - uses: camunda/infra-global-github-actions/start-build-monitor@main
+      - uses: camunda/infra-global-github-actions/start-build-monitor@02b3f0e49b00b98fffc76af690ebc83c28f24dae # main
       - name: Info - ℹ️ Print workflow inputs ℹ️
         env:
           GITHUB_CONTEXT: ${{ toJson(inputs) }}
@@ -879,7 +879,7 @@ jobs:
       TEST_CLUSTER_TYPE: ${{ inputs.distro-type || inputs.cluster-type }}
 
     steps:
-      - uses: camunda/infra-global-github-actions/start-build-monitor@main
+      - uses: camunda/infra-global-github-actions/start-build-monitor@02b3f0e49b00b98fffc76af690ebc83c28f24dae # main
       - name: Info - ℹ️ Print workflow inputs ℹ️
         env:
           GITHUB_CONTEXT: ${{ toJson(inputs) }}
@@ -1271,7 +1271,7 @@ jobs:
       deployments: write
       packages: read
     steps:
-      - uses: camunda/infra-global-github-actions/start-build-monitor@main
+      - uses: camunda/infra-global-github-actions/start-build-monitor@02b3f0e49b00b98fffc76af690ebc83c28f24dae # main
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -1359,7 +1359,7 @@ jobs:
       deployments: write
       packages: read
     steps:
-      - uses: camunda/infra-global-github-actions/start-build-monitor@main
+      - uses: camunda/infra-global-github-actions/start-build-monitor@02b3f0e49b00b98fffc76af690ebc83c28f24dae # main
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -1456,7 +1456,7 @@ jobs:
       deployments: write
       packages: read
     steps:
-      - uses: camunda/infra-global-github-actions/start-build-monitor@main
+      - uses: camunda/infra-global-github-actions/start-build-monitor@02b3f0e49b00b98fffc76af690ebc83c28f24dae # main
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -1569,7 +1569,7 @@ jobs:
       deployments: write
       packages: read
     steps:
-      - uses: camunda/infra-global-github-actions/start-build-monitor@main
+      - uses: camunda/infra-global-github-actions/start-build-monitor@02b3f0e49b00b98fffc76af690ebc83c28f24dae # main
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -1338,6 +1338,7 @@ jobs:
         uses: ./.github/actions/observe-build-status
         with:
           build_status: ${{ job.status }}
+          job_name: "${{ github.job }}/${{ matrix.shardIndex }}-of-${{ matrix.shardTotal }}"
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_jwt_path: ${{ secrets.VAULT_JWT_PATH }}
           secret_vault_jwt_role: ${{ secrets.VAULT_JWT_ROLE }}
@@ -1636,6 +1637,7 @@ jobs:
         uses: ./.github/actions/observe-build-status
         with:
           build_status: ${{ job.status }}
+          job_name: "${{ github.job }}/${{ matrix.shardIndex }}-of-${{ matrix.shardTotal }}"
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_jwt_path: ${{ secrets.VAULT_JWT_PATH }}
           secret_vault_jwt_role: ${{ secrets.VAULT_JWT_ROLE }}

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -345,6 +345,7 @@ jobs:
       TEST_CLUSTER_TYPE: ${{ inputs.distro-type || inputs.cluster-type }}
 
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - name: Info - ℹ️ Print workflow inputs ℹ️
         env:
           GITHUB_CONTEXT: ${{ toJson(inputs) }}
@@ -838,6 +839,16 @@ jobs:
           path: diagnostics/
           retention-days: 14
           if-no-files-found: ignore
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_jwt_path: ${{ secrets.VAULT_JWT_PATH }}
+          secret_vault_jwt_role: ${{ secrets.VAULT_JWT_ROLE }}
+          secret_vault_jwt_audience: ${{ secrets.VAULT_JWT_AUDIENCE }}
 
   upgrade:
     if: always() && github.event.action != 'closed' && (needs.install.result == 'success' || needs.install.result == 'skipped') && inputs.flow != 'install'
@@ -868,6 +879,7 @@ jobs:
       TEST_CLUSTER_TYPE: ${{ inputs.distro-type || inputs.cluster-type }}
 
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - name: Info - ℹ️ Print workflow inputs ℹ️
         env:
           GITHUB_CONTEXT: ${{ toJson(inputs) }}
@@ -1222,6 +1234,16 @@ jobs:
           path: diagnostics/
           retention-days: 14
           if-no-files-found: ignore
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_jwt_path: ${{ secrets.VAULT_JWT_PATH }}
+          secret_vault_jwt_role: ${{ secrets.VAULT_JWT_ROLE }}
+          secret_vault_jwt_audience: ${{ secrets.VAULT_JWT_AUDIENCE }}
 
   playwright-e2e-tests-after-install:
     name: Playwright e2e after install - ${{ inputs.flow }} on ${{ inputs.distro-platform }} - ${{ inputs.shortname }} (${{ matrix.shardIndex }} of ${{ matrix.shardTotal }})
@@ -1249,6 +1271,7 @@ jobs:
       deployments: write
       packages: read
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -1300,6 +1323,16 @@ jobs:
           test-stage: after-install
           shard-index: ${{ matrix.shardIndex }}
           scenario: ${{ inputs.scenario }}
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_jwt_path: ${{ secrets.VAULT_JWT_PATH }}
+          secret_vault_jwt_role: ${{ secrets.VAULT_JWT_ROLE }}
+          secret_vault_jwt_audience: ${{ secrets.VAULT_JWT_AUDIENCE }}
 
   # Shadow job: runs the full E2E suite for the dedicated 'shadow-e2e' scenario.
   # Tier 2 (merge queue only). Non-blocking during observation period.
@@ -1325,6 +1358,7 @@ jobs:
       deployments: write
       packages: read
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -1379,6 +1413,16 @@ jobs:
           shard-index: "1"
           scenario: ${{ inputs.scenario }}
           run-smoke-tests: "false"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_jwt_path: ${{ secrets.VAULT_JWT_PATH }}
+          secret_vault_jwt_role: ${{ secrets.VAULT_JWT_ROLE }}
+          secret_vault_jwt_audience: ${{ secrets.VAULT_JWT_AUDIENCE }}
 
   # Multi-namespace topology job: runs the smoke suite against each
   # topology scenario's orchestration releases, with credentials
@@ -1411,6 +1455,7 @@ jobs:
       deployments: write
       packages: read
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -1486,6 +1531,16 @@ jobs:
           shard-index: ${{ matrix.shard_index }}
           scenario: ${{ inputs.scenario }}
           run-smoke-tests: "true"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_jwt_path: ${{ secrets.VAULT_JWT_PATH }}
+          secret_vault_jwt_role: ${{ secrets.VAULT_JWT_ROLE }}
+          secret_vault_jwt_audience: ${{ secrets.VAULT_JWT_AUDIENCE }}
 
   playwright-e2e-tests-after-upgrade:
     name: Playwright e2e after upgrade - ${{ inputs.flow }} on ${{ inputs.distro-platform }} - ${{ inputs.shortname }} (${{ matrix.shardIndex }} of ${{ matrix.shardTotal }})
@@ -1513,6 +1568,7 @@ jobs:
       deployments: write
       packages: read
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -1565,6 +1621,16 @@ jobs:
           test-stage: after-upgrade
           shard-index: ${{ matrix.shardIndex }}
           scenario: ${{ inputs.scenario }}
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_jwt_path: ${{ secrets.VAULT_JWT_PATH }}
+          secret_vault_jwt_role: ${{ secrets.VAULT_JWT_ROLE }}
+          secret_vault_jwt_audience: ${{ secrets.VAULT_JWT_AUDIENCE }}
 
   merge-e2e-reports:
     name: Merge E2E Reports - ${{ inputs.flow }} on ${{ inputs.distro-platform }} - ${{ inputs.shortname }}

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -1329,6 +1329,7 @@ jobs:
         uses: ./.github/actions/observe-build-status
         with:
           build_status: ${{ job.status }}
+          job_name: "${{ github.job }}/${{ matrix.shardIndex }}-of-${{ matrix.shardTotal }}"
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_jwt_path: ${{ secrets.VAULT_JWT_PATH }}
           secret_vault_jwt_role: ${{ secrets.VAULT_JWT_ROLE }}
@@ -1627,6 +1628,7 @@ jobs:
         uses: ./.github/actions/observe-build-status
         with:
           build_status: ${{ job.status }}
+          job_name: "${{ github.job }}/${{ matrix.shardIndex }}-of-${{ matrix.shardTotal }}"
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_jwt_path: ${{ secrets.VAULT_JWT_PATH }}
           secret_vault_jwt_role: ${{ secrets.VAULT_JWT_ROLE }}

--- a/.github/workflows/test-local-template.yaml
+++ b/.github/workflows/test-local-template.yaml
@@ -32,7 +32,7 @@ jobs:
     env:
       TEST_NAMESPACE: camunda-platform
     steps:
-      - uses: camunda/infra-global-github-actions/start-build-monitor@main
+      - uses: camunda/infra-global-github-actions/start-build-monitor@02b3f0e49b00b98fffc76af690ebc83c28f24dae # main
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: "${{ inputs.camunda-helm-git-ref }}"

--- a/.github/workflows/test-local-template.yaml
+++ b/.github/workflows/test-local-template.yaml
@@ -21,6 +21,7 @@ concurrency:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   local:
@@ -31,6 +32,7 @@ jobs:
     env:
       TEST_NAMESPACE: camunda-platform
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: "${{ inputs.camunda-helm-git-ref }}"
@@ -137,3 +139,13 @@ jobs:
         run: |
           kubectl get pods --namespace ${{ env.TEST_NAMESPACE }} -o yaml
           kubectl describe pods --namespace ${{ env.TEST_NAMESPACE }}
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_jwt_path: ${{ secrets.VAULT_JWT_PATH }}
+          secret_vault_jwt_role: ${{ secrets.VAULT_JWT_ROLE }}
+          secret_vault_jwt_audience: ${{ secrets.VAULT_JWT_AUDIENCE }}

--- a/.github/workflows/test-unit-template.yaml
+++ b/.github/workflows/test-unit-template.yaml
@@ -21,6 +21,7 @@ concurrency:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   init:
@@ -48,6 +49,7 @@ jobs:
     name: UnitTest Scripts
     runs-on: ubuntu-latest
     steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@main
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install tools
         uses: ./.github/actions/install-tool-versions
@@ -61,6 +63,16 @@ jobs:
       - name: Run bats
         run: |
           bats test/scripts/*.bats
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_jwt_path: ${{ secrets.VAULT_JWT_PATH }}
+          secret_vault_jwt_role: ${{ secrets.VAULT_JWT_ROLE }}
+          secret_vault_jwt_audience: ${{ secrets.VAULT_JWT_AUDIENCE }}
 
   unit:
     name: Unit - ${{ matrix.test.name }}
@@ -74,6 +86,7 @@ jobs:
     env:
       chartPath: "charts/${{ inputs.camunda-helm-dir }}"
     steps:
+    - uses: camunda/infra-global-github-actions/start-build-monitor@main
     - name: ℹ️ Print workflow inputs ℹ️
       env:
         GITHUB_CONTEXT: ${{ toJson(inputs) }}
@@ -118,3 +131,13 @@ jobs:
       run: |
         cd charts/${{ inputs.camunda-helm-dir }}/test/unit
         go test $(printf "./%s " ${{ matrix.test.packages }})
+    - name: Observe build status
+      if: always()
+      continue-on-error: true
+      uses: ./.github/actions/observe-build-status
+      with:
+        build_status: ${{ job.status }}
+        secret_vault_address: ${{ secrets.VAULT_ADDR }}
+        secret_vault_jwt_path: ${{ secrets.VAULT_JWT_PATH }}
+        secret_vault_jwt_role: ${{ secrets.VAULT_JWT_ROLE }}
+        secret_vault_jwt_audience: ${{ secrets.VAULT_JWT_AUDIENCE }}

--- a/.github/workflows/test-unit-template.yaml
+++ b/.github/workflows/test-unit-template.yaml
@@ -14,6 +14,15 @@ on:
       camunda-helm-dir:
         required: true
         type: string
+    secrets:
+      VAULT_ADDR:
+        required: false
+      VAULT_JWT_PATH:
+        required: false
+      VAULT_JWT_ROLE:
+        required: false
+      VAULT_JWT_AUDIENCE:
+        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.identifier }}

--- a/.github/workflows/test-unit-template.yaml
+++ b/.github/workflows/test-unit-template.yaml
@@ -49,7 +49,7 @@ jobs:
     name: UnitTest Scripts
     runs-on: ubuntu-latest
     steps:
-      - uses: camunda/infra-global-github-actions/start-build-monitor@main
+      - uses: camunda/infra-global-github-actions/start-build-monitor@02b3f0e49b00b98fffc76af690ebc83c28f24dae # main
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install tools
         uses: ./.github/actions/install-tool-versions
@@ -86,7 +86,7 @@ jobs:
     env:
       chartPath: "charts/${{ inputs.camunda-helm-dir }}"
     steps:
-    - uses: camunda/infra-global-github-actions/start-build-monitor@main
+    - uses: camunda/infra-global-github-actions/start-build-monitor@02b3f0e49b00b98fffc76af690ebc83c28f24dae # main
     - name: ℹ️ Print workflow inputs ℹ️
       env:
         GITHUB_CONTEXT: ${{ toJson(inputs) }}

--- a/.github/workflows/test-unit-template.yaml
+++ b/.github/workflows/test-unit-template.yaml
@@ -137,6 +137,7 @@ jobs:
       uses: ./.github/actions/observe-build-status
       with:
         build_status: ${{ job.status }}
+        job_name: "${{ github.job }}/${{ matrix.test.name }}"
         secret_vault_address: ${{ secrets.VAULT_ADDR }}
         secret_vault_jwt_path: ${{ secrets.VAULT_JWT_PATH }}
         secret_vault_jwt_role: ${{ secrets.VAULT_JWT_ROLE }}


### PR DESCRIPTION
### Which problem does the PR fix?

This PR doesn't fix any problem

### What's in this PR?

This PR adds the start-build-monitoring step to workflows to track resource and network usage and submit to `build_status_v2` table

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

**Before opening the PR:**

- [x] There is no other open [pull request](../pulls) for the same update/change.

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

<!--
### To-Do

- [ ] If the PR is not complete but you want to discuss the approach,
  list what remains to be done here.
-->
