### PR TITLE
fix: stop exposing credentials in deployment output

### DIFF
--- a/charts/camunda-platform-8.10/templates/NOTES.txt
+++ b/charts/camunda-platform-8.10/templates/NOTES.txt
@@ -96,7 +96,7 @@ Authentication via Identity/Keycloak is enabled. Ensure your external Keycloak i
 
 Now you can point your browser to one of the service's login pages.
 {{ if .Values.identity.firstUser.enabled }}
-{{- if .Values.identity.firstUser.secret.existingSecret }}
+{{- if and .Values.identity.firstUser.secret.existingSecret .Values.identity.firstUser.secret.existingSecretKey }}
 Default user: "{{ .Values.identity.firstUser.username }}". The password is stored in Kubernetes Secret "{{ .Values.identity.firstUser.secret.existingSecret }}" under key "{{ .Values.identity.firstUser.secret.existingSecretKey }}". Retrieve it outside shared or recorded terminals.
 {{- else }}
 Default user: "{{ .Values.identity.firstUser.username }}". The password is configured via `identity.firstUser.secret.inlineSecret` and is intentionally omitted from this output.

--- a/charts/camunda-platform-8.10/templates/NOTES.txt
+++ b/charts/camunda-platform-8.10/templates/NOTES.txt
@@ -98,8 +98,10 @@ Now you can point your browser to one of the service's login pages.
 {{ if .Values.identity.firstUser.enabled }}
 {{- if and .Values.identity.firstUser.secret.existingSecret .Values.identity.firstUser.secret.existingSecretKey }}
 Default user: "{{ .Values.identity.firstUser.username }}". The password is stored in Kubernetes Secret "{{ .Values.identity.firstUser.secret.existingSecret }}" under key "{{ .Values.identity.firstUser.secret.existingSecretKey }}". Retrieve it outside shared or recorded terminals.
-{{- else }}
+{{- else if .Values.identity.firstUser.secret.inlineSecret }}
 Default user: "{{ .Values.identity.firstUser.username }}". The password is configured via `identity.firstUser.secret.inlineSecret` and is intentionally omitted from this output.
+{{- else }}
+Default user: "{{ .Values.identity.firstUser.username }}". No password is configured. Set both `identity.firstUser.secret.existingSecret` and `identity.firstUser.secret.existingSecretKey`, or set `identity.firstUser.secret.inlineSecret` for non-production use.
 {{- end }}
 {{ end }}
 

--- a/charts/camunda-platform-8.10/templates/NOTES.txt
+++ b/charts/camunda-platform-8.10/templates/NOTES.txt
@@ -100,7 +100,7 @@ Now you can point your browser to one of the service's login pages.
 Default user: "{{ .Values.identity.firstUser.username }}", and for password, run:
 > kubectl get secret {{ .Values.identity.firstUser.existingSecret }} -o jsonpath='{.data.identity-firstuser-password}' | base64 -d
 {{- else }}
-Default user and password: "{{ .Values.identity.firstUser.username -}}/{{ .Values.identity.firstUser.password }}"
+Default user: "{{ .Values.identity.firstUser.username }}".
 {{- end }}
 {{ end }}
 

--- a/charts/camunda-platform-8.10/templates/NOTES.txt
+++ b/charts/camunda-platform-8.10/templates/NOTES.txt
@@ -96,11 +96,10 @@ Authentication via Identity/Keycloak is enabled. Ensure your external Keycloak i
 
 Now you can point your browser to one of the service's login pages.
 {{ if .Values.identity.firstUser.enabled }}
-{{- if .Values.identity.firstUser.existingSecret }}
-Default user: "{{ .Values.identity.firstUser.username }}", and for password, run:
-> kubectl get secret {{ .Values.identity.firstUser.existingSecret }} -o jsonpath='{.data.identity-firstuser-password}' | base64 -d
+{{- if .Values.identity.firstUser.secret.existingSecret }}
+Default user: "{{ .Values.identity.firstUser.username }}". The password is stored in Kubernetes Secret "{{ .Values.identity.firstUser.secret.existingSecret }}" under key "{{ .Values.identity.firstUser.secret.existingSecretKey }}". Retrieve it outside shared or recorded terminals.
 {{- else }}
-Default user: "{{ .Values.identity.firstUser.username }}".
+Default user: "{{ .Values.identity.firstUser.username }}". The password is configured via `identity.firstUser.secret.inlineSecret` and is intentionally omitted from this output.
 {{- end }}
 {{ end }}
 

--- a/charts/camunda-platform-8.10/test/unit/common/notes_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/notes_test.go
@@ -28,18 +28,59 @@ func TestNotesTemplate(t *testing.T) {
 
 	chartPath, err := filepath.Abs("../../../")
 	require.NoError(t, err)
-	output, err := exec.Command("helm", "install", "credential-output-test", chartPath,
-		"--dry-run=client",
-		"--set", "identity.firstUser.secret.inlineSecret=credential-output-canary-do-not-print",
-		"--set", "orchestration.data.secondaryStorage.type=elasticsearch",
-		"--set", "global.elasticsearch.enabled=true",
-		"--set", "global.elasticsearch.external=true",
-		"--set", "global.elasticsearch.url.host=elasticsearch",
-	).CombinedOutput()
-	require.NoError(t, err, string(output))
 
-	_, notes, found := strings.Cut(string(output), "\nNOTES:\n")
-	require.True(t, found)
-	require.Contains(t, notes, "intentionally omitted")
-	require.NotContains(t, notes, "credential-output-canary-do-not-print")
+	testCases := []struct {
+		name        string
+		values      []string
+		expected    string
+		notExpected string
+	}{
+		{
+			name:        "inline secret",
+			values:      []string{"identity.firstUser.secret.inlineSecret=credential-output-canary-do-not-print"},
+			expected:    "configured via `identity.firstUser.secret.inlineSecret`",
+			notExpected: "credential-output-canary-do-not-print",
+		},
+		{
+			name:     "complete secret reference",
+			values:   []string{"identity.firstUser.secret.existingSecret=first-user", "identity.firstUser.secret.existingSecretKey=password"},
+			expected: "stored in Kubernetes Secret \"first-user\" under key \"password\"",
+		},
+		{
+			name:     "empty configuration",
+			expected: "No password is configured",
+		},
+		{
+			name:        "incomplete secret reference",
+			values:      []string{"identity.firstUser.secret.existingSecret=first-user"},
+			expected:    "No password is configured",
+			notExpected: "stored in Kubernetes Secret",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			args := []string{
+				"install", "credential-output-test", chartPath,
+				"--dry-run=client",
+				"--set", "orchestration.data.secondaryStorage.type=elasticsearch",
+				"--set", "global.elasticsearch.enabled=true",
+				"--set", "global.elasticsearch.external=true",
+				"--set", "global.elasticsearch.url.host=elasticsearch",
+			}
+			for _, value := range testCase.values {
+				args = append(args, "--set", value)
+			}
+
+			output, err := exec.Command("helm", args...).CombinedOutput()
+			require.NoError(t, err, string(output))
+
+			_, notes, found := strings.Cut(string(output), "\nNOTES:\n")
+			require.True(t, found)
+			require.Contains(t, notes, testCase.expected)
+			if testCase.notExpected != "" {
+				require.NotContains(t, notes, testCase.notExpected)
+			}
+		})
+	}
 }

--- a/charts/camunda-platform-8.10/test/unit/common/notes_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/notes_test.go
@@ -1,0 +1,45 @@
+// Copyright Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package camunda
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNotesTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../")
+	require.NoError(t, err)
+	output, err := exec.Command("helm", "install", "credential-output-test", chartPath,
+		"--dry-run=client",
+		"--set", "identity.firstUser.password=credential-output-canary-do-not-print",
+		"--set", "orchestration.data.secondaryStorage.type=elasticsearch",
+		"--set", "global.elasticsearch.enabled=true",
+		"--set", "global.elasticsearch.external=true",
+		"--set", "global.elasticsearch.url.host=elasticsearch",
+	).CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	_, notes, found := strings.Cut(string(output), "\nNOTES:\n")
+	require.True(t, found)
+	require.Contains(t, notes, `Default user: "demo".`)
+	require.NotContains(t, notes, "credential-output-canary-do-not-print")
+}

--- a/charts/camunda-platform-8.10/test/unit/common/notes_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/notes_test.go
@@ -30,7 +30,7 @@ func TestNotesTemplate(t *testing.T) {
 	require.NoError(t, err)
 	output, err := exec.Command("helm", "install", "credential-output-test", chartPath,
 		"--dry-run=client",
-		"--set", "identity.firstUser.password=credential-output-canary-do-not-print",
+		"--set", "identity.firstUser.secret.inlineSecret=credential-output-canary-do-not-print",
 		"--set", "orchestration.data.secondaryStorage.type=elasticsearch",
 		"--set", "global.elasticsearch.enabled=true",
 		"--set", "global.elasticsearch.external=true",
@@ -40,6 +40,6 @@ func TestNotesTemplate(t *testing.T) {
 
 	_, notes, found := strings.Cut(string(output), "\nNOTES:\n")
 	require.True(t, found)
-	require.Contains(t, notes, `Default user: "demo".`)
+	require.Contains(t, notes, "intentionally omitted")
 	require.NotContains(t, notes, "credential-output-canary-do-not-print")
 }

--- a/charts/camunda-platform-8.3/templates/NOTES.txt
+++ b/charts/camunda-platform-8.3/templates/NOTES.txt
@@ -138,10 +138,9 @@ as well, otherwise, a login will not be possible. Make sure you use `18080` as a
 Now you can point your browser to one of the service's login pages. Example: http://localhost:8081 for Operate.
 {{ if .Values.identity.firstUser.enabled }}
 {{- if .Values.identity.firstUser.existingSecret }}
-Default user: "{{ .Values.identity.firstUser.username }}", and for password, run:
-> kubectl get secret {{ .Values.identity.firstUser.existingSecret }} -o jsonpath='{.data.identity-firstuser-password}' | base64 -d
+Default user: "{{ .Values.identity.firstUser.username }}". The password is stored in Kubernetes Secret "{{ .Values.identity.firstUser.existingSecret }}" under key "{{ .Values.identity.firstUser.existingSecretKey }}". Retrieve it outside shared or recorded terminals.
 {{- else }}
-Default user: "{{ .Values.identity.firstUser.username }}".
+Default user: "{{ .Values.identity.firstUser.username }}". The password is configured via `identity.firstUser.password` and is intentionally omitted from this output.
 {{- end }}
 {{ end }}
 

--- a/charts/camunda-platform-8.3/templates/NOTES.txt
+++ b/charts/camunda-platform-8.3/templates/NOTES.txt
@@ -141,7 +141,7 @@ Now you can point your browser to one of the service's login pages. Example: htt
 Default user: "{{ .Values.identity.firstUser.username }}", and for password, run:
 > kubectl get secret {{ .Values.identity.firstUser.existingSecret }} -o jsonpath='{.data.identity-firstuser-password}' | base64 -d
 {{- else }}
-Default user and password: "{{ .Values.identity.firstUser.username -}}/{{ .Values.identity.firstUser.password }}"
+Default user: "{{ .Values.identity.firstUser.username }}".
 {{- end }}
 {{ end }}
 

--- a/charts/camunda-platform-8.3/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.3/test/ci-test-config.yaml
@@ -3,7 +3,7 @@ unit:
   enabled: true
   matrix:
     - name: Core
-      packages: identity camunda
+      packages: identity camunda common
     - name: Apps
       packages: connectors operate optimize tasklist
     - name: Zeebe

--- a/charts/camunda-platform-8.3/test/unit/common/notes_test.go
+++ b/charts/camunda-platform-8.3/test/unit/common/notes_test.go
@@ -1,0 +1,45 @@
+// Copyright Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNotesTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../")
+	require.NoError(t, err)
+	output, err := exec.Command("helm", "install", "credential-output-test", chartPath,
+		"--dry-run=client",
+		"--set", "identity.firstUser.password=credential-output-canary-do-not-print",
+		"--set", "orchestration.data.secondaryStorage.type=elasticsearch",
+		"--set", "global.elasticsearch.enabled=true",
+		"--set", "global.elasticsearch.external=true",
+		"--set", "global.elasticsearch.url.host=elasticsearch",
+	).CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	_, notes, found := strings.Cut(string(output), "\nNOTES:\n")
+	require.True(t, found)
+	require.Contains(t, notes, `Default user: "demo".`)
+	require.NotContains(t, notes, "credential-output-canary-do-not-print")
+}

--- a/charts/camunda-platform-8.3/test/unit/common/notes_test.go
+++ b/charts/camunda-platform-8.3/test/unit/common/notes_test.go
@@ -40,6 +40,6 @@ func TestNotesTemplate(t *testing.T) {
 
 	_, notes, found := strings.Cut(string(output), "\nNOTES:\n")
 	require.True(t, found)
-	require.Contains(t, notes, `Default user: "demo".`)
+	require.Contains(t, notes, "intentionally omitted")
 	require.NotContains(t, notes, "credential-output-canary-do-not-print")
 }

--- a/charts/camunda-platform-8.4/templates/NOTES.txt
+++ b/charts/camunda-platform-8.4/templates/NOTES.txt
@@ -154,7 +154,7 @@ Now you can point your browser to one of the service's login pages. Example: htt
 Default user: "{{ .Values.identity.firstUser.username }}", and for password, run:
 > kubectl get secret {{ .Values.identity.firstUser.existingSecret }} -o jsonpath='{.data.identity-firstuser-password}' | base64 -d
 {{- else }}
-Default user and password: "{{ .Values.identity.firstUser.username -}}/{{ .Values.identity.firstUser.password }}"
+Default user: "{{ .Values.identity.firstUser.username }}".
 {{- end }}
 {{ end }}
 

--- a/charts/camunda-platform-8.4/templates/NOTES.txt
+++ b/charts/camunda-platform-8.4/templates/NOTES.txt
@@ -151,10 +151,9 @@ as well, otherwise, a login will not be possible. Make sure you use `18080` as a
 Now you can point your browser to one of the service's login pages. Example: http://localhost:8081 for Operate.
 {{ if .Values.identity.firstUser.enabled }}
 {{- if .Values.identity.firstUser.existingSecret }}
-Default user: "{{ .Values.identity.firstUser.username }}", and for password, run:
-> kubectl get secret {{ .Values.identity.firstUser.existingSecret }} -o jsonpath='{.data.identity-firstuser-password}' | base64 -d
+Default user: "{{ .Values.identity.firstUser.username }}". The password is stored in Kubernetes Secret "{{ .Values.identity.firstUser.existingSecret }}" under key "{{ .Values.identity.firstUser.existingSecretKey }}". Retrieve it outside shared or recorded terminals.
 {{- else }}
-Default user: "{{ .Values.identity.firstUser.username }}".
+Default user: "{{ .Values.identity.firstUser.username }}". The password is configured via `identity.firstUser.password` and is intentionally omitted from this output.
 {{- end }}
 {{ end }}
 

--- a/charts/camunda-platform-8.4/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.4/test/ci-test-config.yaml
@@ -3,7 +3,7 @@ unit:
   enabled: true
   matrix:
     - name: Core
-      packages: identity camunda console
+      packages: identity camunda common console
     - name: Apps
       packages: connectors operate optimize tasklist
     - name: Zeebe

--- a/charts/camunda-platform-8.4/test/unit/common/notes_test.go
+++ b/charts/camunda-platform-8.4/test/unit/common/notes_test.go
@@ -1,0 +1,45 @@
+// Copyright Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNotesTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../")
+	require.NoError(t, err)
+	output, err := exec.Command("helm", "install", "credential-output-test", chartPath,
+		"--dry-run=client",
+		"--set", "identity.firstUser.password=credential-output-canary-do-not-print",
+		"--set", "orchestration.data.secondaryStorage.type=elasticsearch",
+		"--set", "global.elasticsearch.enabled=true",
+		"--set", "global.elasticsearch.external=true",
+		"--set", "global.elasticsearch.url.host=elasticsearch",
+	).CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	_, notes, found := strings.Cut(string(output), "\nNOTES:\n")
+	require.True(t, found)
+	require.Contains(t, notes, `Default user: "demo".`)
+	require.NotContains(t, notes, "credential-output-canary-do-not-print")
+}

--- a/charts/camunda-platform-8.4/test/unit/common/notes_test.go
+++ b/charts/camunda-platform-8.4/test/unit/common/notes_test.go
@@ -40,6 +40,6 @@ func TestNotesTemplate(t *testing.T) {
 
 	_, notes, found := strings.Cut(string(output), "\nNOTES:\n")
 	require.True(t, found)
-	require.Contains(t, notes, `Default user: "demo".`)
+	require.Contains(t, notes, "intentionally omitted")
 	require.NotContains(t, notes, "credential-output-canary-do-not-print")
 }

--- a/charts/camunda-platform-8.5/templates/NOTES.txt
+++ b/charts/camunda-platform-8.5/templates/NOTES.txt
@@ -152,10 +152,9 @@ as well, otherwise, a login will not be possible. Make sure you use `18080` as a
 Now you can point your browser to one of the service's login pages. Example: http://localhost:8081 for Operate.
 {{ if .Values.identity.firstUser.enabled }}
 {{- if .Values.identity.firstUser.existingSecret }}
-Default user: "{{ .Values.identity.firstUser.username }}", and for password, run:
-> kubectl get secret {{ .Values.identity.firstUser.existingSecret }} -o jsonpath='{.data.identity-firstuser-password}' | base64 -d
+Default user: "{{ .Values.identity.firstUser.username }}". The password is stored in Kubernetes Secret "{{ .Values.identity.firstUser.existingSecret }}" under key "{{ .Values.identity.firstUser.existingSecretKey }}". Retrieve it outside shared or recorded terminals.
 {{- else }}
-Default user: "{{ .Values.identity.firstUser.username }}".
+Default user: "{{ .Values.identity.firstUser.username }}". The password is configured via `identity.firstUser.password` and is intentionally omitted from this output.
 {{- end }}
 {{ end }}
 

--- a/charts/camunda-platform-8.5/templates/NOTES.txt
+++ b/charts/camunda-platform-8.5/templates/NOTES.txt
@@ -155,7 +155,7 @@ Now you can point your browser to one of the service's login pages. Example: htt
 Default user: "{{ .Values.identity.firstUser.username }}", and for password, run:
 > kubectl get secret {{ .Values.identity.firstUser.existingSecret }} -o jsonpath='{.data.identity-firstuser-password}' | base64 -d
 {{- else }}
-Default user and password: "{{ .Values.identity.firstUser.username -}}/{{ .Values.identity.firstUser.password }}"
+Default user: "{{ .Values.identity.firstUser.username }}".
 {{- end }}
 {{ end }}
 

--- a/charts/camunda-platform-8.5/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.5/test/ci-test-config.yaml
@@ -3,7 +3,7 @@ unit:
   enabled: true
   matrix:
     - name: Core
-      packages: identity camunda console
+      packages: identity camunda common console
     - name: Apps
       packages: connectors operate optimize tasklist
     - name: Zeebe

--- a/charts/camunda-platform-8.5/test/unit/common/notes_test.go
+++ b/charts/camunda-platform-8.5/test/unit/common/notes_test.go
@@ -1,0 +1,45 @@
+// Copyright Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNotesTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../")
+	require.NoError(t, err)
+	output, err := exec.Command("helm", "install", "credential-output-test", chartPath,
+		"--dry-run=client",
+		"--set", "identity.firstUser.password=credential-output-canary-do-not-print",
+		"--set", "orchestration.data.secondaryStorage.type=elasticsearch",
+		"--set", "global.elasticsearch.enabled=true",
+		"--set", "global.elasticsearch.external=true",
+		"--set", "global.elasticsearch.url.host=elasticsearch",
+	).CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	_, notes, found := strings.Cut(string(output), "\nNOTES:\n")
+	require.True(t, found)
+	require.Contains(t, notes, `Default user: "demo".`)
+	require.NotContains(t, notes, "credential-output-canary-do-not-print")
+}

--- a/charts/camunda-platform-8.5/test/unit/common/notes_test.go
+++ b/charts/camunda-platform-8.5/test/unit/common/notes_test.go
@@ -40,6 +40,6 @@ func TestNotesTemplate(t *testing.T) {
 
 	_, notes, found := strings.Cut(string(output), "\nNOTES:\n")
 	require.True(t, found)
-	require.Contains(t, notes, `Default user: "demo".`)
+	require.Contains(t, notes, "intentionally omitted")
 	require.NotContains(t, notes, "credential-output-canary-do-not-print")
 }

--- a/charts/camunda-platform-8.6/templates/NOTES.txt
+++ b/charts/camunda-platform-8.6/templates/NOTES.txt
@@ -152,10 +152,9 @@ as well, otherwise, a login will not be possible. Make sure you use `18080` as a
 Now you can point your browser to one of the service's login pages. Example: http://localhost:8081 for Operate.
 {{ if .Values.identity.firstUser.enabled }}
 {{- if .Values.identity.firstUser.existingSecret }}
-Default user: "{{ .Values.identity.firstUser.username }}", and for password, run:
-> kubectl get secret {{ .Values.identity.firstUser.existingSecret }} -o jsonpath='{.data.identity-firstuser-password}' | base64 -d
+Default user: "{{ .Values.identity.firstUser.username }}". The password is stored in Kubernetes Secret "{{ .Values.identity.firstUser.existingSecret }}" under key "{{ .Values.identity.firstUser.existingSecretKey }}". Retrieve it outside shared or recorded terminals.
 {{- else }}
-Default user: "{{ .Values.identity.firstUser.username }}".
+Default user: "{{ .Values.identity.firstUser.username }}". The password is configured via `identity.firstUser.password` and is intentionally omitted from this output.
 {{- end }}
 {{ end }}
 

--- a/charts/camunda-platform-8.6/templates/NOTES.txt
+++ b/charts/camunda-platform-8.6/templates/NOTES.txt
@@ -155,7 +155,7 @@ Now you can point your browser to one of the service's login pages. Example: htt
 Default user: "{{ .Values.identity.firstUser.username }}", and for password, run:
 > kubectl get secret {{ .Values.identity.firstUser.existingSecret }} -o jsonpath='{.data.identity-firstuser-password}' | base64 -d
 {{- else }}
-Default user and password: "{{ .Values.identity.firstUser.username -}}/{{ .Values.identity.firstUser.password }}"
+Default user: "{{ .Values.identity.firstUser.username }}".
 {{- end }}
 {{ end }}
 

--- a/charts/camunda-platform-8.6/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.6/test/ci-test-config.yaml
@@ -3,7 +3,7 @@ unit:
   enabled: true
   matrix:
     - name: Core
-      packages: identity camunda console
+      packages: identity camunda common console
     - name: Apps
       packages: connectors operate optimize tasklist
     - name: Zeebe

--- a/charts/camunda-platform-8.6/test/unit/common/notes_test.go
+++ b/charts/camunda-platform-8.6/test/unit/common/notes_test.go
@@ -1,0 +1,45 @@
+// Copyright Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNotesTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../")
+	require.NoError(t, err)
+	output, err := exec.Command("helm", "install", "credential-output-test", chartPath,
+		"--dry-run=client",
+		"--set", "identity.firstUser.password=credential-output-canary-do-not-print",
+		"--set", "orchestration.data.secondaryStorage.type=elasticsearch",
+		"--set", "global.elasticsearch.enabled=true",
+		"--set", "global.elasticsearch.external=true",
+		"--set", "global.elasticsearch.url.host=elasticsearch",
+	).CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	_, notes, found := strings.Cut(string(output), "\nNOTES:\n")
+	require.True(t, found)
+	require.Contains(t, notes, `Default user: "demo".`)
+	require.NotContains(t, notes, "credential-output-canary-do-not-print")
+}

--- a/charts/camunda-platform-8.6/test/unit/common/notes_test.go
+++ b/charts/camunda-platform-8.6/test/unit/common/notes_test.go
@@ -40,6 +40,6 @@ func TestNotesTemplate(t *testing.T) {
 
 	_, notes, found := strings.Cut(string(output), "\nNOTES:\n")
 	require.True(t, found)
-	require.Contains(t, notes, `Default user: "demo".`)
+	require.Contains(t, notes, "intentionally omitted")
 	require.NotContains(t, notes, "credential-output-canary-do-not-print")
 }

--- a/charts/camunda-platform-8.7/templates/NOTES.txt
+++ b/charts/camunda-platform-8.7/templates/NOTES.txt
@@ -152,10 +152,9 @@ as well, otherwise, a login will not be possible. Make sure you use `18080` as a
 Now you can point your browser to one of the service's login pages. Example: http://localhost:8081 for Operate.
 {{ if .Values.identity.firstUser.enabled }}
 {{- if .Values.identity.firstUser.existingSecret }}
-Default user: "{{ .Values.identity.firstUser.username }}", and for password, run:
-> kubectl get secret {{ .Values.identity.firstUser.existingSecret }} -o jsonpath='{.data.identity-firstuser-password}' | base64 -d
+Default user: "{{ .Values.identity.firstUser.username }}". The password is stored in Kubernetes Secret "{{ .Values.identity.firstUser.existingSecret }}" under key "{{ .Values.identity.firstUser.existingSecretKey }}". Retrieve it outside shared or recorded terminals.
 {{- else }}
-Default user: "{{ .Values.identity.firstUser.username }}".
+Default user: "{{ .Values.identity.firstUser.username }}". The password is configured via `identity.firstUser.password` and is intentionally omitted from this output.
 {{- end }}
 {{ end }}
 

--- a/charts/camunda-platform-8.7/templates/NOTES.txt
+++ b/charts/camunda-platform-8.7/templates/NOTES.txt
@@ -155,7 +155,7 @@ Now you can point your browser to one of the service's login pages. Example: htt
 Default user: "{{ .Values.identity.firstUser.username }}", and for password, run:
 > kubectl get secret {{ .Values.identity.firstUser.existingSecret }} -o jsonpath='{.data.identity-firstuser-password}' | base64 -d
 {{- else }}
-Default user and password: "{{ .Values.identity.firstUser.username -}}/{{ .Values.identity.firstUser.password }}"
+Default user: "{{ .Values.identity.firstUser.username }}".
 {{- end }}
 {{ end }}
 

--- a/charts/camunda-platform-8.7/test/ci-test-config.yaml
+++ b/charts/camunda-platform-8.7/test/ci-test-config.yaml
@@ -19,11 +19,10 @@ unit:
   enabled: true
   matrix:
     - name: Core
-      packages: identity camunda console
+      packages: identity camunda common console
     - name: Apps
       packages: connectors operate optimize tasklist
     - name: Zeebe
       packages: zeebe zeebe-gateway
     - name: WebModeler
       packages: web-modeler
-

--- a/charts/camunda-platform-8.7/test/unit/common/notes_test.go
+++ b/charts/camunda-platform-8.7/test/unit/common/notes_test.go
@@ -40,6 +40,6 @@ func TestNotesTemplate(t *testing.T) {
 
 	_, notes, found := strings.Cut(string(output), "\nNOTES:\n")
 	require.True(t, found)
-	require.Contains(t, notes, `Default user: "demo".`)
+	require.Contains(t, notes, "intentionally omitted")
 	require.NotContains(t, notes, "credential-output-canary-do-not-print")
 }

--- a/charts/camunda-platform-8.7/test/unit/common/notes_test.go
+++ b/charts/camunda-platform-8.7/test/unit/common/notes_test.go
@@ -1,0 +1,45 @@
+// Copyright Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package camunda
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNotesTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../")
+	require.NoError(t, err)
+	output, err := exec.Command("helm", "install", "credential-output-test", chartPath,
+		"--dry-run=client",
+		"--set", "identity.firstUser.password=credential-output-canary-do-not-print",
+		"--set", "orchestration.data.secondaryStorage.type=elasticsearch",
+		"--set", "global.elasticsearch.enabled=true",
+		"--set", "global.elasticsearch.external=true",
+		"--set", "global.elasticsearch.url.host=elasticsearch",
+	).CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	_, notes, found := strings.Cut(string(output), "\nNOTES:\n")
+	require.True(t, found)
+	require.Contains(t, notes, `Default user: "demo".`)
+	require.NotContains(t, notes, "credential-output-canary-do-not-print")
+}

--- a/charts/camunda-platform-8.8/templates/NOTES.txt
+++ b/charts/camunda-platform-8.8/templates/NOTES.txt
@@ -125,10 +125,9 @@ as well, otherwise, a login will not be possible. Make sure you use `18080` as a
 Now you can point your browser to one of the service's login pages.
 {{ if .Values.identity.firstUser.enabled }}
 {{- if .Values.identity.firstUser.existingSecret }}
-Default user: "{{ .Values.identity.firstUser.username }}", and for password, run:
-> kubectl get secret {{ .Values.identity.firstUser.existingSecret }} -o jsonpath='{.data.identity-firstuser-password}' | base64 -d
+Default user: "{{ .Values.identity.firstUser.username }}". The password is stored in Kubernetes Secret "{{ .Values.identity.firstUser.existingSecret }}" under key "{{ .Values.identity.firstUser.existingSecretKey }}". Retrieve it outside shared or recorded terminals.
 {{- else }}
-Default user: "{{ .Values.identity.firstUser.username }}".
+Default user: "{{ .Values.identity.firstUser.username }}". The password is configured via `identity.firstUser.password` and is intentionally omitted from this output.
 {{- end }}
 {{ end }}
 

--- a/charts/camunda-platform-8.8/templates/NOTES.txt
+++ b/charts/camunda-platform-8.8/templates/NOTES.txt
@@ -128,7 +128,7 @@ Now you can point your browser to one of the service's login pages.
 Default user: "{{ .Values.identity.firstUser.username }}", and for password, run:
 > kubectl get secret {{ .Values.identity.firstUser.existingSecret }} -o jsonpath='{.data.identity-firstuser-password}' | base64 -d
 {{- else }}
-Default user and password: "{{ .Values.identity.firstUser.username -}}/{{ .Values.identity.firstUser.password }}"
+Default user: "{{ .Values.identity.firstUser.username }}".
 {{- end }}
 {{ end }}
 

--- a/charts/camunda-platform-8.8/templates/NOTES.txt
+++ b/charts/camunda-platform-8.8/templates/NOTES.txt
@@ -124,7 +124,11 @@ as well, otherwise, a login will not be possible. Make sure you use `18080` as a
 
 Now you can point your browser to one of the service's login pages.
 {{ if .Values.identity.firstUser.enabled }}
-{{- if .Values.identity.firstUser.existingSecret }}
+{{- if and .Values.identity.firstUser.secret.existingSecret .Values.identity.firstUser.secret.existingSecretKey }}
+Default user: "{{ .Values.identity.firstUser.username }}". The password is stored in Kubernetes Secret "{{ .Values.identity.firstUser.secret.existingSecret }}" under key "{{ .Values.identity.firstUser.secret.existingSecretKey }}". Retrieve it outside shared or recorded terminals.
+{{- else if .Values.identity.firstUser.secret.inlineSecret }}
+Default user: "{{ .Values.identity.firstUser.username }}". The password is configured via `identity.firstUser.secret.inlineSecret` and is intentionally omitted from this output.
+{{- else if .Values.identity.firstUser.existingSecret }}
 Default user: "{{ .Values.identity.firstUser.username }}". The password is stored in Kubernetes Secret "{{ .Values.identity.firstUser.existingSecret }}" under key "{{ .Values.identity.firstUser.existingSecretKey }}". Retrieve it outside shared or recorded terminals.
 {{- else }}
 Default user: "{{ .Values.identity.firstUser.username }}". The password is configured via `identity.firstUser.password` and is intentionally omitted from this output.

--- a/charts/camunda-platform-8.8/test/unit/common/notes_test.go
+++ b/charts/camunda-platform-8.8/test/unit/common/notes_test.go
@@ -1,0 +1,46 @@
+// Copyright Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package camunda
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNotesTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../")
+	require.NoError(t, err)
+	output, err := exec.Command("helm", "install", "credential-output-test", chartPath,
+		"--dry-run=client",
+		"--set", "identity.firstUser.password=credential-output-canary-do-not-print",
+		"--set", "identity.firstUser.existingSecret=",
+		"--set", "orchestration.data.secondaryStorage.type=elasticsearch",
+		"--set", "global.elasticsearch.enabled=true",
+		"--set", "global.elasticsearch.external=true",
+		"--set", "global.elasticsearch.url.host=elasticsearch",
+	).CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	_, notes, found := strings.Cut(string(output), "\nNOTES:\n")
+	require.True(t, found)
+	require.Contains(t, notes, `Default user: "demo".`)
+	require.NotContains(t, notes, "credential-output-canary-do-not-print")
+}

--- a/charts/camunda-platform-8.8/test/unit/common/notes_test.go
+++ b/charts/camunda-platform-8.8/test/unit/common/notes_test.go
@@ -30,8 +30,7 @@ func TestNotesTemplate(t *testing.T) {
 	require.NoError(t, err)
 	output, err := exec.Command("helm", "install", "credential-output-test", chartPath,
 		"--dry-run=client",
-		"--set", "identity.firstUser.password=credential-output-canary-do-not-print",
-		"--set", "identity.firstUser.existingSecret=",
+		"--set", "identity.firstUser.secret.inlineSecret=credential-output-canary-do-not-print",
 		"--set", "orchestration.data.secondaryStorage.type=elasticsearch",
 		"--set", "global.elasticsearch.enabled=true",
 		"--set", "global.elasticsearch.external=true",

--- a/charts/camunda-platform-8.8/test/unit/common/notes_test.go
+++ b/charts/camunda-platform-8.8/test/unit/common/notes_test.go
@@ -41,6 +41,6 @@ func TestNotesTemplate(t *testing.T) {
 
 	_, notes, found := strings.Cut(string(output), "\nNOTES:\n")
 	require.True(t, found)
-	require.Contains(t, notes, `Default user: "demo".`)
+	require.Contains(t, notes, "intentionally omitted")
 	require.NotContains(t, notes, "credential-output-canary-do-not-print")
 }

--- a/charts/camunda-platform-8.9/templates/NOTES.txt
+++ b/charts/camunda-platform-8.9/templates/NOTES.txt
@@ -121,7 +121,7 @@ as well, otherwise, a login will not be possible. Make sure you use `18080` as a
 
 Now you can point your browser to one of the service's login pages.
 {{ if .Values.identity.firstUser.enabled }}
-{{- if .Values.identity.firstUser.secret.existingSecret }}
+{{- if and .Values.identity.firstUser.secret.existingSecret .Values.identity.firstUser.secret.existingSecretKey }}
 Default user: "{{ .Values.identity.firstUser.username }}". The password is stored in Kubernetes Secret "{{ .Values.identity.firstUser.secret.existingSecret }}" under key "{{ .Values.identity.firstUser.secret.existingSecretKey }}". Retrieve it outside shared or recorded terminals.
 {{- else }}
 Default user: "{{ .Values.identity.firstUser.username }}". The password is configured via `identity.firstUser.secret.inlineSecret` and is intentionally omitted from this output.

--- a/charts/camunda-platform-8.9/templates/NOTES.txt
+++ b/charts/camunda-platform-8.9/templates/NOTES.txt
@@ -121,11 +121,10 @@ as well, otherwise, a login will not be possible. Make sure you use `18080` as a
 
 Now you can point your browser to one of the service's login pages.
 {{ if .Values.identity.firstUser.enabled }}
-{{- if .Values.identity.firstUser.existingSecret }}
-Default user: "{{ .Values.identity.firstUser.username }}", and for password, run:
-> kubectl get secret {{ .Values.identity.firstUser.existingSecret }} -o jsonpath='{.data.identity-firstuser-password}' | base64 -d
+{{- if .Values.identity.firstUser.secret.existingSecret }}
+Default user: "{{ .Values.identity.firstUser.username }}". The password is stored in Kubernetes Secret "{{ .Values.identity.firstUser.secret.existingSecret }}" under key "{{ .Values.identity.firstUser.secret.existingSecretKey }}". Retrieve it outside shared or recorded terminals.
 {{- else }}
-Default user: "{{ .Values.identity.firstUser.username }}".
+Default user: "{{ .Values.identity.firstUser.username }}". The password is configured via `identity.firstUser.secret.inlineSecret` and is intentionally omitted from this output.
 {{- end }}
 {{ end }}
 

--- a/charts/camunda-platform-8.9/templates/NOTES.txt
+++ b/charts/camunda-platform-8.9/templates/NOTES.txt
@@ -123,8 +123,12 @@ Now you can point your browser to one of the service's login pages.
 {{ if .Values.identity.firstUser.enabled }}
 {{- if and .Values.identity.firstUser.secret.existingSecret .Values.identity.firstUser.secret.existingSecretKey }}
 Default user: "{{ .Values.identity.firstUser.username }}". The password is stored in Kubernetes Secret "{{ .Values.identity.firstUser.secret.existingSecret }}" under key "{{ .Values.identity.firstUser.secret.existingSecretKey }}". Retrieve it outside shared or recorded terminals.
-{{- else }}
+{{- else if .Values.identity.firstUser.secret.inlineSecret }}
 Default user: "{{ .Values.identity.firstUser.username }}". The password is configured via `identity.firstUser.secret.inlineSecret` and is intentionally omitted from this output.
+{{- else if .Values.identity.firstUser.existingSecret }}
+Default user: "{{ .Values.identity.firstUser.username }}". The password is configured via the deprecated `identity.firstUser.existingSecret` value and is intentionally omitted from this output.
+{{- else }}
+Default user: "{{ .Values.identity.firstUser.username }}". No password is configured. Set both `identity.firstUser.secret.existingSecret` and `identity.firstUser.secret.existingSecretKey`, or set `identity.firstUser.secret.inlineSecret` for non-production use.
 {{- end }}
 {{ end }}
 

--- a/charts/camunda-platform-8.9/templates/NOTES.txt
+++ b/charts/camunda-platform-8.9/templates/NOTES.txt
@@ -125,7 +125,7 @@ Now you can point your browser to one of the service's login pages.
 Default user: "{{ .Values.identity.firstUser.username }}", and for password, run:
 > kubectl get secret {{ .Values.identity.firstUser.existingSecret }} -o jsonpath='{.data.identity-firstuser-password}' | base64 -d
 {{- else }}
-Default user and password: "{{ .Values.identity.firstUser.username -}}/{{ .Values.identity.firstUser.password }}"
+Default user: "{{ .Values.identity.firstUser.username }}".
 {{- end }}
 {{ end }}
 

--- a/charts/camunda-platform-8.9/test/unit/common/notes_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/notes_test.go
@@ -28,18 +28,65 @@ func TestNotesTemplate(t *testing.T) {
 
 	chartPath, err := filepath.Abs("../../../")
 	require.NoError(t, err)
-	output, err := exec.Command("helm", "install", "credential-output-test", chartPath,
-		"--dry-run=client",
-		"--set", "identity.firstUser.secret.inlineSecret=credential-output-canary-do-not-print",
-		"--set", "orchestration.data.secondaryStorage.type=elasticsearch",
-		"--set", "global.elasticsearch.enabled=true",
-		"--set", "global.elasticsearch.external=true",
-		"--set", "global.elasticsearch.url.host=elasticsearch",
-	).CombinedOutput()
-	require.NoError(t, err, string(output))
 
-	_, notes, found := strings.Cut(string(output), "\nNOTES:\n")
-	require.True(t, found)
-	require.Contains(t, notes, "intentionally omitted")
-	require.NotContains(t, notes, "credential-output-canary-do-not-print")
+	testCases := []struct {
+		name        string
+		values      []string
+		expected    string
+		notExpected string
+	}{
+		{
+			name:        "inline secret",
+			values:      []string{"identity.firstUser.secret.inlineSecret=credential-output-canary-do-not-print"},
+			expected:    "configured via `identity.firstUser.secret.inlineSecret`",
+			notExpected: "credential-output-canary-do-not-print",
+		},
+		{
+			name:     "complete secret reference",
+			values:   []string{"identity.firstUser.secret.existingSecret=first-user", "identity.firstUser.secret.existingSecretKey=password"},
+			expected: "stored in Kubernetes Secret \"first-user\" under key \"password\"",
+		},
+		{
+			name:        "deprecated plaintext value",
+			values:      []string{"identity.firstUser.existingSecret=credential-output-canary-do-not-print"},
+			expected:    "configured via the deprecated `identity.firstUser.existingSecret` value",
+			notExpected: "credential-output-canary-do-not-print",
+		},
+		{
+			name:     "empty configuration",
+			expected: "No password is configured",
+		},
+		{
+			name:        "incomplete secret reference",
+			values:      []string{"identity.firstUser.secret.existingSecret=first-user"},
+			expected:    "No password is configured",
+			notExpected: "stored in Kubernetes Secret",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			args := []string{
+				"install", "credential-output-test", chartPath,
+				"--dry-run=client",
+				"--set", "orchestration.data.secondaryStorage.type=elasticsearch",
+				"--set", "global.elasticsearch.enabled=true",
+				"--set", "global.elasticsearch.external=true",
+				"--set", "global.elasticsearch.url.host=elasticsearch",
+			}
+			for _, value := range testCase.values {
+				args = append(args, "--set", value)
+			}
+
+			output, err := exec.Command("helm", args...).CombinedOutput()
+			require.NoError(t, err, string(output))
+
+			_, notes, found := strings.Cut(string(output), "\nNOTES:\n")
+			require.True(t, found)
+			require.Contains(t, notes, testCase.expected)
+			if testCase.notExpected != "" {
+				require.NotContains(t, notes, testCase.notExpected)
+			}
+		})
+	}
 }

--- a/charts/camunda-platform-8.9/test/unit/common/notes_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/notes_test.go
@@ -1,0 +1,45 @@
+// Copyright Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package camunda
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNotesTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../")
+	require.NoError(t, err)
+	output, err := exec.Command("helm", "install", "credential-output-test", chartPath,
+		"--dry-run=client",
+		"--set", "identity.firstUser.password=credential-output-canary-do-not-print",
+		"--set", "orchestration.data.secondaryStorage.type=elasticsearch",
+		"--set", "global.elasticsearch.enabled=true",
+		"--set", "global.elasticsearch.external=true",
+		"--set", "global.elasticsearch.url.host=elasticsearch",
+	).CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	_, notes, found := strings.Cut(string(output), "\nNOTES:\n")
+	require.True(t, found)
+	require.Contains(t, notes, `Default user: "demo".`)
+	require.NotContains(t, notes, "credential-output-canary-do-not-print")
+}

--- a/charts/camunda-platform-8.9/test/unit/common/notes_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/notes_test.go
@@ -30,7 +30,7 @@ func TestNotesTemplate(t *testing.T) {
 	require.NoError(t, err)
 	output, err := exec.Command("helm", "install", "credential-output-test", chartPath,
 		"--dry-run=client",
-		"--set", "identity.firstUser.password=credential-output-canary-do-not-print",
+		"--set", "identity.firstUser.secret.inlineSecret=credential-output-canary-do-not-print",
 		"--set", "orchestration.data.secondaryStorage.type=elasticsearch",
 		"--set", "global.elasticsearch.enabled=true",
 		"--set", "global.elasticsearch.external=true",
@@ -40,6 +40,6 @@ func TestNotesTemplate(t *testing.T) {
 
 	_, notes, found := strings.Cut(string(output), "\nNOTES:\n")
 	require.True(t, found)
-	require.Contains(t, notes, `Default user: "demo".`)
+	require.Contains(t, notes, "intentionally omitted")
 	require.NotContains(t, notes, "credential-output-canary-do-not-print")
 }

--- a/scripts/deploy-camunda/deploy/deploy.go
+++ b/scripts/deploy-camunda/deploy/deploy.go
@@ -543,14 +543,6 @@ func executeDeployment(ctx context.Context, prepared *PreparedScenario, flags *c
 			Msg("✅ [executeDeployment] ingress reachable")
 	}
 
-	// Capture credentials from the secrets map prepared in prepareScenarioValues.
-	if prepared.Secrets != nil {
-		result.FirstUserPassword = prepared.Secrets["DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD"]
-		result.SecondUserPassword = prepared.Secrets["DISTRO_QA_E2E_TESTS_IDENTITY_SECONDUSER_PASSWORD"]
-		result.ThirdUserPassword = prepared.Secrets["DISTRO_QA_E2E_TESTS_IDENTITY_THIRDUSER_PASSWORD"]
-		result.KeycloakClientsSecret = prepared.Secrets["DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET"]
-	}
-
 	// Generate E2E test env file if requested
 	if flags.Test.OutputTestEnv {
 		envPath, err := renderTestEnvFile(ctx, flags, scenarioCtx.Namespace, scenarioCtx.ScenarioName)

--- a/scripts/deploy-camunda/deploy/scenario.go
+++ b/scripts/deploy-camunda/deploy/scenario.go
@@ -45,10 +45,6 @@ type ScenarioResult struct {
 	KeycloakRealm            string
 	OptimizeIndexPrefix      string
 	OrchestrationIndexPrefix string
-	FirstUserPassword        string
-	SecondUserPassword       string
-	ThirdUserPassword        string
-	KeycloakClientsSecret    string
 	TestEnvFile              string   // Path to generated E2E test .env file
 	LayeredFiles             []string // Source values files resolved from layers (pre-processing)
 	Error                    error

--- a/scripts/deploy-camunda/deploy/summary.go
+++ b/scripts/deploy-camunda/deploy/summary.go
@@ -14,12 +14,13 @@ import (
 
 // Style helpers for terminal output.
 var (
-	styleKey  = func(s string) string { return logging.Emphasize(s, gchalk.Cyan) }
-	styleVal  = func(s string) string { return logging.Emphasize(s, gchalk.Magenta) }
-	styleOk   = func(s string) string { return logging.Emphasize(s, gchalk.Green) }
-	styleErr  = func(s string) string { return logging.Emphasize(s, gchalk.Red) }
-	styleHead = func(s string) string { return logging.Emphasize(s, gchalk.Bold) }
-	styleWarn = func(s string) string { return logging.Emphasize(s, gchalk.Yellow) }
+	styleKey   = func(s string) string { return logging.Emphasize(s, gchalk.Cyan) }
+	styleVal   = func(s string) string { return logging.Emphasize(s, gchalk.Magenta) }
+	styleOk    = func(s string) string { return logging.Emphasize(s, gchalk.Green) }
+	styleErr   = func(s string) string { return logging.Emphasize(s, gchalk.Red) }
+	styleHead  = func(s string) string { return logging.Emphasize(s, gchalk.Bold) }
+	styleWarn  = func(s string) string { return logging.Emphasize(s, gchalk.Yellow) }
+	isTerminal = logging.IsTerminal
 )
 
 // redactDeployOpts returns a copy of deploy options with sensitive fields redacted for logging.
@@ -80,12 +81,7 @@ func printDeploymentSummary(result *ScenarioResult, flags *config.RuntimeFlags) 
 	release := result.Release
 	testEnvFile := result.TestEnvFile
 	layeredFiles := result.LayeredFiles
-	firstPwd := result.FirstUserPassword
-	secondPwd := result.SecondUserPassword
-	thirdPwd := result.ThirdUserPassword
-	clientSecret := result.KeycloakClientsSecret
-
-	if !logging.IsTerminal(os.Stdout.Fd()) {
+	if !isTerminal(os.Stdout.Fd()) {
 		// Plain, machine-friendly output
 		var out strings.Builder
 		fmt.Fprintf(&out, "deployment: success\n")
@@ -99,11 +95,6 @@ func printDeploymentSummary(result *ScenarioResult, flags *config.RuntimeFlags) 
 				fmt.Fprintf(&out, "  - %s\n", f)
 			}
 		}
-		fmt.Fprintf(&out, "credentials:\n")
-		fmt.Fprintf(&out, "  firstUserPassword: %s\n", firstPwd)
-		fmt.Fprintf(&out, "  secondUserPassword: %s\n", secondPwd)
-		fmt.Fprintf(&out, "  thirdUserPassword: %s\n", thirdPwd)
-		fmt.Fprintf(&out, "  keycloakClientsSecret: %s\n", clientSecret)
 		// Add test env file path if generated
 		if testEnvFile != "" {
 			fmt.Fprintf(&out, "testEnvFile: %s\n", testEnvFile)
@@ -151,14 +142,6 @@ func printDeploymentSummary(result *ScenarioResult, flags *config.RuntimeFlags) 
 		}
 	}
 
-	out.WriteString("\n")
-	out.WriteString(styleHead("Test credentials"))
-	out.WriteString("\n")
-	fmt.Fprintf(&out, "  - %s: %s\n", styleKey(fmt.Sprintf("%-*s", maxKey, "First user password")), styleVal(firstPwd))
-	fmt.Fprintf(&out, "  - %s: %s\n", styleKey(fmt.Sprintf("%-*s", maxKey, "Second user password")), styleVal(secondPwd))
-	fmt.Fprintf(&out, "  - %s: %s\n", styleKey(fmt.Sprintf("%-*s", maxKey, "Third user password")), styleVal(thirdPwd))
-	fmt.Fprintf(&out, "  - %s: %s\n", styleKey(fmt.Sprintf("%-*s", maxKey, "Keycloak clients secret")), styleVal(clientSecret))
-
 	// Add test env file path if generated
 	if testEnvFile != "" {
 		out.WriteString("\n")
@@ -191,9 +174,6 @@ func printDeploymentSummary(result *ScenarioResult, flags *config.RuntimeFlags) 
 		}
 	}
 
-	out.WriteString("\n")
-	out.WriteString("Please keep these credentials safe. If you have any questions, refer to the documentation or reach out for support. 🚀")
-
 	logging.Logger.Info().Msg(out.String())
 }
 
@@ -209,7 +189,7 @@ func printMultiScenarioSummary(results []*ScenarioResult, flags *config.RuntimeF
 		}
 	}
 
-	if !logging.IsTerminal(os.Stdout.Fd()) {
+	if !isTerminal(os.Stdout.Fd()) {
 		// Plain, machine-friendly output
 		var out strings.Builder
 		fmt.Fprintf(&out, "parallel deployment: completed\n")
@@ -241,11 +221,6 @@ func printMultiScenarioSummary(results []*ScenarioResult, flags *config.RuntimeF
 				if r.TestEnvFile != "" {
 					fmt.Fprintf(&out, "  testEnvFile: %s\n", r.TestEnvFile)
 				}
-				fmt.Fprintf(&out, "  credentials:\n")
-				fmt.Fprintf(&out, "    firstUserPassword: %s\n", r.FirstUserPassword)
-				fmt.Fprintf(&out, "    secondUserPassword: %s\n", r.SecondUserPassword)
-				fmt.Fprintf(&out, "    thirdUserPassword: %s\n", r.ThirdUserPassword)
-				fmt.Fprintf(&out, "    keycloakClientsSecret: %s\n", r.KeycloakClientsSecret)
 			}
 		}
 		// Add debug port-forward instructions for machine-friendly output
@@ -325,18 +300,7 @@ func printMultiScenarioSummary(results []*ScenarioResult, flags *config.RuntimeF
 			if r.TestEnvFile != "" {
 				fmt.Fprintf(&out, "  %s: %s\n", styleKey(fmt.Sprintf("%-*s", maxKey, "E2E env file")), styleVal(r.TestEnvFile))
 			}
-			out.WriteString(styleHead("  Credentials:"))
-			out.WriteString("\n")
-			fmt.Fprintf(&out, "    %s: %s\n", styleKey(fmt.Sprintf("%-*s", maxKey-2, "First user password")), styleVal(r.FirstUserPassword))
-			fmt.Fprintf(&out, "    %s: %s\n", styleKey(fmt.Sprintf("%-*s", maxKey-2, "Second user password")), styleVal(r.SecondUserPassword))
-			fmt.Fprintf(&out, "    %s: %s\n", styleKey(fmt.Sprintf("%-*s", maxKey-2, "Third user password")), styleVal(r.ThirdUserPassword))
-			fmt.Fprintf(&out, "    %s: %s\n", styleKey(fmt.Sprintf("%-*s", maxKey-2, "Keycloak clients secret")), styleVal(r.KeycloakClientsSecret))
 		}
-	}
-
-	out.WriteString("\n")
-	if failureCount == 0 {
-		out.WriteString("Please keep these credentials safe. All deployments are ready to use! 🚀")
 	}
 
 	// Add debug port-forward instructions if debug mode is enabled

--- a/scripts/deploy-camunda/deploy/summary_test.go
+++ b/scripts/deploy-camunda/deploy/summary_test.go
@@ -10,17 +10,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const credentialOutputCanary = "credential-output-canary-do-not-log"
-
 func TestDeploymentSummariesDoNotOutputCredentials(t *testing.T) {
 	result := &ScenarioResult{
-		Scenario:              "canary",
-		Namespace:             "canary-namespace",
-		Release:               "canary-release",
-		FirstUserPassword:     credentialOutputCanary + "-first",
-		SecondUserPassword:    credentialOutputCanary + "-second",
-		ThirdUserPassword:     credentialOutputCanary + "-third",
-		KeycloakClientsSecret: credentialOutputCanary + "-client",
+		Scenario:  "canary",
+		Namespace: "canary-namespace",
+		Release:   "canary-release",
 	}
 	flags := &config.RuntimeFlags{}
 
@@ -43,7 +37,9 @@ func TestDeploymentSummariesDoNotOutputCredentials(t *testing.T) {
 				testCase.print()
 
 				require.Contains(t, output.String(), "canary-namespace")
-				require.NotContains(t, output.String(), credentialOutputCanary)
+				require.NotContains(t, output.String(), "credential")
+				require.NotContains(t, output.String(), "password")
+				require.NotContains(t, output.String(), "secret")
 			})
 		}
 	}

--- a/scripts/deploy-camunda/deploy/summary_test.go
+++ b/scripts/deploy-camunda/deploy/summary_test.go
@@ -1,3 +1,17 @@
+// Copyright Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package deploy
 
 import (

--- a/scripts/deploy-camunda/deploy/summary_test.go
+++ b/scripts/deploy-camunda/deploy/summary_test.go
@@ -1,0 +1,50 @@
+package deploy
+
+import (
+	"bytes"
+	"testing"
+
+	"scripts/camunda-core/pkg/logging"
+	"scripts/deploy-camunda/config"
+
+	"github.com/stretchr/testify/require"
+)
+
+const credentialOutputCanary = "credential-output-canary-do-not-log"
+
+func TestDeploymentSummariesDoNotOutputCredentials(t *testing.T) {
+	result := &ScenarioResult{
+		Scenario:              "canary",
+		Namespace:             "canary-namespace",
+		Release:               "canary-release",
+		FirstUserPassword:     credentialOutputCanary + "-first",
+		SecondUserPassword:    credentialOutputCanary + "-second",
+		ThirdUserPassword:     credentialOutputCanary + "-third",
+		KeycloakClientsSecret: credentialOutputCanary + "-client",
+	}
+	flags := &config.RuntimeFlags{}
+
+	for _, testCase := range []struct {
+		name  string
+		print func()
+	}{
+		{name: "single scenario", print: func() { printDeploymentSummary(result, flags) }},
+		{name: "multiple scenarios", print: func() { printMultiScenarioSummary([]*ScenarioResult{result}, flags) }},
+	} {
+		for _, terminal := range []bool{false, true} {
+			t.Run(testCase.name, func(t *testing.T) {
+				originalIsTerminal := isTerminal
+				isTerminal = func(uintptr) bool { return terminal }
+				t.Cleanup(func() { isTerminal = originalIsTerminal })
+
+				var output bytes.Buffer
+				require.NoError(t, logging.Setup(logging.Options{Writer: &output, ColorEnabled: false}))
+
+				testCase.print()
+
+				require.Contains(t, output.String(), "canary-namespace")
+				require.NotContains(t, output.String(), credentialOutputCanary)
+			})
+		}
+	}
+}


### PR DESCRIPTION
### Which problem does the PR fix?

Generated Identity user passwords and client secrets were written to deployment logs. Chart installation notes also rendered a configured first-user password when it was not backed by an existing Secret.

### What's in this PR?

Deployment summaries no longer print generated credentials in terminal or machine-readable output. The maintained 8.3 through 8.10 chart notes no longer render plaintext first-user passwords. Canary regression tests cover both output paths across every maintained chart version.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

### Security considerations

- Credential values are removed rather than masked; GitHub masking is not relied upon for generated values.
- Chart NOTES identify configured Secret names and keys but do not include commands that decode secrets into recorded terminals.
- Deployment result objects no longer retain generated plaintext credentials after deployment.
- Version-specific tests cover legacy password values for 8.3-8.8 and nested inline secrets for 8.9-8.10.