### PR TITLE
ci: redact sensitive diagnostics and artifacts

### DIFF
--- a/.github/actions/cluster-auth/action.yaml
+++ b/.github/actions/cluster-auth/action.yaml
@@ -8,6 +8,12 @@ outputs:
   token:
     description: GitHub token
     value: ${{ steps.generate-github-token.outputs.token }}
+  gcp-access-token:
+    description: |
+      Short-lived GCP OAuth2 access token, set only on the GKE Workload Identity
+      path. Empty for every other platform, so consumers must treat it as
+      optional and skip the work it would authorise.
+    value: ${{ steps.gke-auth.outputs.access-token }}
 
 env:
   GH_APP_ID:        {}
@@ -33,6 +39,7 @@ runs:
         private_key: ${{ env.GH_APP_KEY }}
 
     - name: Authenticate to GKE
+      id: gke-auth
       if: inputs.platform == 'gke' && inputs.auth-data == ''
       uses: ./.github/actions/gke-login
       with:

--- a/.github/actions/failed-pods-info/action.yaml
+++ b/.github/actions/failed-pods-info/action.yaml
@@ -9,13 +9,12 @@ runs:
     # Structured diagnostics are also uploaded as the `diagnostics-*` artifact by the
     # deploy-camunda matrix runner. This step prints an in-log fast path for the common
     # failure shapes. The dump logic lives in Go (`deploy-camunda diagnostics print`,
-    # unit-tested) per AGENTS.md; this is a thin wrapper with a kubectl fallback for
-    # jobs where the CLI is not yet on PATH.
+    # unit-tested) per AGENTS.md. Raw kubectl events and descriptions are not
+    # printed when the sanitizer is unavailable.
     run: |
       if command -v deploy-camunda >/dev/null 2>&1; then
         deploy-camunda diagnostics print --namespace "$TEST_NAMESPACE" || true
       else
         kubectl -n "$TEST_NAMESPACE" get po -o wide || true
-        kubectl -n "$TEST_NAMESPACE" get events --sort-by=.lastTimestamp | tail -n 40 || true
         kubectl -n "$TEST_NAMESPACE" get pvc -o wide || true
       fi

--- a/.github/actions/gke-login/action.yaml
+++ b/.github/actions/gke-login/action.yaml
@@ -17,10 +17,18 @@ inputs:
   service-account:
     description: GKE Service Account used in the Workload Identity auth
 
+outputs:
+  access-token:
+    description: |
+      Short-lived GCP OAuth2 access token from the Workload Identity exchange.
+      Empty when auth-method is credentials-json, which mints no token.
+    value: ${{ steps.auth-workload-identity.outputs.access_token }}
+
 runs:
   using: composite
   steps:
   - name: Authenticate to Google Cloud - Workload Identity
+    id: auth-workload-identity
     if: ${{ inputs.auth-method == 'workload-identity' }}
     uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
     with:

--- a/.github/actions/playwright-e2e-tests/action.yaml
+++ b/.github/actions/playwright-e2e-tests/action.yaml
@@ -301,3 +301,38 @@ runs:
         path: e2e-diagnostics/
         retention-days: 1
         if-no-files-found: warn
+
+    # Playwright's JSON results are the only test-level evidence retained: they
+    # carry the failing assertion, locator, timeout, and call log, which is what
+    # triage needs. Redacted first because error messages can quote response
+    # bodies and headers.
+    #
+    # Deliberately NOT published: test-results/**/error-context.md. It adds only
+    # an ARIA page snapshot on top of what the JSON already has, and that snapshot
+    # renders form-control values verbatim (a password field appears as
+    # `textbox: <value>`), which no text-level redactor can classify.
+    - name: Redact Playwright JSON results
+      id: e2e_text_results
+      if: ${{ failure() && !cancelled() }}
+      shell: bash
+      env:
+        ABSOLUTE_TEST_CHART_DIR: ${{ env.ABSOLUTE_TEST_CHART_DIR }}
+      run: |
+        # Fail closed: without the sanitizer nothing is published.
+        if ! command -v deploy-camunda >/dev/null 2>&1; then
+          echo "deploy-camunda not on PATH; Playwright JSON results are not published"
+          exit 0
+        fi
+        results="${ABSOLUTE_TEST_CHART_DIR}/test/e2e/test-results/playwright-results.json"
+        [[ -f "$results" ]] || exit 0
+        deploy-camunda redact --in "$results" --out "$results"
+        echo "publish=true" >> "$GITHUB_OUTPUT"
+
+    - name: Upload Playwright JSON results
+      if: ${{ failure() && !cancelled() && steps.e2e_text_results.outputs.publish == 'true' }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      with:
+        name: ${{ steps.e2e_diag_artifact.outputs.name }}-results-json
+        path: ${{ env.ABSOLUTE_TEST_CHART_DIR }}/test/e2e/test-results/playwright-results.json
+        retention-days: 5
+        if-no-files-found: ignore

--- a/.github/actions/playwright-e2e-tests/action.yaml
+++ b/.github/actions/playwright-e2e-tests/action.yaml
@@ -233,6 +233,7 @@ runs:
         TEST_AUTH_TYPE: ${{ inputs.auth }}
         HUB_NAMESPACE: ${{ inputs.hub-namespace }}
         REQUIRE_SM_810_TEST_SUITE: ${{ inputs.hub-namespace != '' }}
+        PLAYWRIGHT_E2E_SCREENSHOT: "off"
       run: |
         cd "$GITHUB_WORKSPACE/scripts"
         # Unset KEYCLOAK_REALM to avoid conflicts with the integration tests
@@ -257,7 +258,7 @@ runs:
 
         E2E_ARGS=(--absolute-chart-path "${ABSOLUTE_TEST_CHART_DIR}" --namespace "${TEST_NAMESPACE}")
         [[ -n "$SMOKE_FLAG" ]] && E2E_ARGS+=("$SMOKE_FLAG")
-        E2E_ARGS+=(--trace off --verbose)
+        E2E_ARGS+=(--trace off --video off --verbose)
         [[ -n "$EXTRA_FLAGS" ]] && E2E_ARGS+=("$EXTRA_FLAGS")
         [[ -n "$HUB_NAMESPACE" ]] && E2E_ARGS+=(--hub-namespace "${HUB_NAMESPACE}")
 

--- a/.github/actions/playwright-e2e-tests/action.yaml
+++ b/.github/actions/playwright-e2e-tests/action.yaml
@@ -234,6 +234,7 @@ runs:
         HUB_NAMESPACE: ${{ inputs.hub-namespace }}
         REQUIRE_SM_810_TEST_SUITE: ${{ inputs.hub-namespace != '' }}
         PLAYWRIGHT_E2E_SCREENSHOT: "off"
+        PLAYWRIGHT_E2E_VIDEO: "off"
       run: |
         cd "$GITHUB_WORKSPACE/scripts"
         # Unset KEYCLOAK_REALM to avoid conflicts with the integration tests
@@ -258,7 +259,7 @@ runs:
 
         E2E_ARGS=(--absolute-chart-path "${ABSOLUTE_TEST_CHART_DIR}" --namespace "${TEST_NAMESPACE}")
         [[ -n "$SMOKE_FLAG" ]] && E2E_ARGS+=("$SMOKE_FLAG")
-        E2E_ARGS+=(--trace off --video off --verbose)
+        E2E_ARGS+=(--trace off --verbose)
         [[ -n "$EXTRA_FLAGS" ]] && E2E_ARGS+=("$EXTRA_FLAGS")
         [[ -n "$HUB_NAMESPACE" ]] && E2E_ARGS+=(--hub-namespace "${HUB_NAMESPACE}")
 

--- a/.github/actions/playwright-e2e-tests/action.yaml
+++ b/.github/actions/playwright-e2e-tests/action.yaml
@@ -299,26 +299,3 @@ runs:
         path: e2e-diagnostics/
         retention-days: 1
         if-no-files-found: warn
-
-    - name: Upload blob report to GitHub Actions Artifacts
-      if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-      with:
-        name: blob-report-${{ inputs.identifier }}-${{ inputs.flow }}-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.test-stage }}-${{ inputs.shard-index }}
-        path: ${{ env.ABSOLUTE_TEST_CHART_DIR }}/test/e2e/blob-report
-        retention-days: 1
-
-    - name: Set report date
-      id: report_date
-      if: ${{ !cancelled() }}
-      shell: bash
-      run: echo "date=$(date +'%Y-%m-%d_%H-%M-%S')" >> "$GITHUB_OUTPUT"
-
-    - name: Upload Playwright JSON results
-      if: ${{ !cancelled() }}
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-      with:
-        name: playwright-results-json-${{ github.run_id }}-${{ inputs.identifier }}-${{ inputs.flow }}-${{ inputs.distro-platform }}-${{ inputs.test-stage }}-${{ inputs.shard-index }}-${{ steps.report_date.outputs.date }}
-        path: ${{ env.ABSOLUTE_TEST_CHART_DIR }}/test/e2e/test-results/playwright-results.json
-        if-no-files-found: warn
-        retention-days: 5

--- a/.github/actions/playwright-e2e-tests/action.yaml
+++ b/.github/actions/playwright-e2e-tests/action.yaml
@@ -257,7 +257,7 @@ runs:
 
         E2E_ARGS=(--absolute-chart-path "${ABSOLUTE_TEST_CHART_DIR}" --namespace "${TEST_NAMESPACE}")
         [[ -n "$SMOKE_FLAG" ]] && E2E_ARGS+=("$SMOKE_FLAG")
-        E2E_ARGS+=(--trace retain-on-failure --verbose)
+        E2E_ARGS+=(--trace off --verbose)
         [[ -n "$EXTRA_FLAGS" ]] && E2E_ARGS+=("$EXTRA_FLAGS")
         [[ -n "$MANAGEMENT_NAMESPACE" ]] && E2E_ARGS+=(--management-namespace "${MANAGEMENT_NAMESPACE}")
 
@@ -321,15 +321,4 @@ runs:
         name: playwright-results-json-${{ github.run_id }}-${{ inputs.identifier }}-${{ inputs.flow }}-${{ inputs.distro-platform }}-${{ inputs.test-stage }}-${{ inputs.shard-index }}-${{ steps.report_date.outputs.date }}
         path: ${{ env.ABSOLUTE_TEST_CHART_DIR }}/test/e2e/test-results/playwright-results.json
         if-no-files-found: warn
-        retention-days: 5
-
-    - name: Upload Playwright traces for failed tests
-      if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-      with:
-        name: playwright-traces-${{ github.run_id }}-${{ inputs.identifier }}-${{ inputs.flow }}-${{ inputs.distro-platform }}-${{ inputs.test-stage }}-${{ inputs.shard-index }}-${{ steps.report_date.outputs.date }}
-        path: |
-          ${{ env.ABSOLUTE_TEST_CHART_DIR }}/test/e2e/test-results/**/trace.zip
-          ${{ env.ABSOLUTE_TEST_CHART_DIR }}/test/e2e/test-results/**/*.png
-        if-no-files-found: ignore
         retention-days: 5

--- a/.github/actions/playwright-e2e-tests/action.yaml
+++ b/.github/actions/playwright-e2e-tests/action.yaml
@@ -257,7 +257,7 @@ runs:
 
         E2E_ARGS=(--absolute-chart-path "${ABSOLUTE_TEST_CHART_DIR}" --namespace "${TEST_NAMESPACE}")
         [[ -n "$SMOKE_FLAG" ]] && E2E_ARGS+=("$SMOKE_FLAG")
-        E2E_ARGS+=(--trace retain-on-failure --verbose)
+        E2E_ARGS+=(--trace off --verbose)
         [[ -n "$EXTRA_FLAGS" ]] && E2E_ARGS+=("$EXTRA_FLAGS")
         [[ -n "$HUB_NAMESPACE" ]] && E2E_ARGS+=(--hub-namespace "${HUB_NAMESPACE}")
 
@@ -321,15 +321,4 @@ runs:
         name: playwright-results-json-${{ github.run_id }}-${{ inputs.identifier }}-${{ inputs.flow }}-${{ inputs.distro-platform }}-${{ inputs.test-stage }}-${{ inputs.shard-index }}-${{ steps.report_date.outputs.date }}
         path: ${{ env.ABSOLUTE_TEST_CHART_DIR }}/test/e2e/test-results/playwright-results.json
         if-no-files-found: warn
-        retention-days: 5
-
-    - name: Upload Playwright traces for failed tests
-      if: ${{ failure() && !cancelled() }}
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-      with:
-        name: playwright-traces-${{ github.run_id }}-${{ inputs.identifier }}-${{ inputs.flow }}-${{ inputs.distro-platform }}-${{ inputs.test-stage }}-${{ inputs.shard-index }}-${{ steps.report_date.outputs.date }}
-        path: |
-          ${{ env.ABSOLUTE_TEST_CHART_DIR }}/test/e2e/test-results/**/trace.zip
-          ${{ env.ABSOLUTE_TEST_CHART_DIR }}/test/e2e/test-results/**/*.png
-        if-no-files-found: ignore
         retention-days: 5

--- a/.github/actions/playwright-e2e-tests/action.yaml
+++ b/.github/actions/playwright-e2e-tests/action.yaml
@@ -77,6 +77,16 @@ inputs:
       way to derive on its own.
     required: false
     default: ""
+  trace-bucket:
+    description: >-
+      Private Cloud Storage bucket that receives Playwright traces for a failed
+      run. Traces are never uploaded as a GitHub artifact: this repository is
+      public, so artifacts are world-readable, and a trace embeds the per-run
+      cluster's request headers and cookies. Empty (the default) disables trace
+      capture entirely, so the whole path is inert until the bucket exists.
+      Requires the GKE Workload Identity auth path, which mints the token.
+    required: false
+    default: ""
   binary-artifact-name:
     description: >
       Name of the uploaded deploy-camunda binary artifact to download. When set, the
@@ -235,6 +245,8 @@ runs:
         REQUIRE_SM_810_TEST_SUITE: ${{ inputs.hub-namespace != '' }}
         PLAYWRIGHT_E2E_SCREENSHOT: "off"
         PLAYWRIGHT_E2E_VIDEO: "off"
+        # Traces are only captured when there is a private bucket to put them in.
+        TRACE_MODE: ${{ inputs.trace-bucket != '' && 'retain-on-failure' || 'off' }}
       run: |
         cd "$GITHUB_WORKSPACE/scripts"
         # Unset KEYCLOAK_REALM to avoid conflicts with the integration tests
@@ -259,7 +271,7 @@ runs:
 
         E2E_ARGS=(--absolute-chart-path "${ABSOLUTE_TEST_CHART_DIR}" --namespace "${TEST_NAMESPACE}")
         [[ -n "$SMOKE_FLAG" ]] && E2E_ARGS+=("$SMOKE_FLAG")
-        E2E_ARGS+=(--trace off --verbose)
+        E2E_ARGS+=(--trace "${TRACE_MODE}" --verbose)
         [[ -n "$EXTRA_FLAGS" ]] && E2E_ARGS+=("$EXTRA_FLAGS")
         [[ -n "$HUB_NAMESPACE" ]] && E2E_ARGS+=(--hub-namespace "${HUB_NAMESPACE}")
 
@@ -336,3 +348,32 @@ runs:
         path: ${{ env.ABSOLUTE_TEST_CHART_DIR }}/test/e2e/test-results/playwright-results.json
         retention-days: 5
         if-no-files-found: ignore
+
+    # Traces go to a private bucket, never to a GitHub artifact: they cannot be
+    # redacted and this repository's artifacts are world-readable. Best-effort —
+    # a failed upload must not mask the test failure that produced it.
+    - name: Upload Playwright traces to private storage
+      if: ${{ failure() && !cancelled() && inputs.trace-bucket != '' }}
+      shell: bash
+      env:
+        ABSOLUTE_TEST_CHART_DIR: ${{ env.ABSOLUTE_TEST_CHART_DIR }}
+        TRACE_BUCKET: ${{ inputs.trace-bucket }}
+        GCS_ACCESS_TOKEN: ${{ steps.cluster-auth.outputs.gcp-access-token }}
+        TRACE_PREFIX: ${{ github.run_id }}/${{ github.run_attempt }}/${{ inputs.identifier }}-${{ inputs.flow }}-${{ inputs.test-stage }}-${{ inputs.shard-index }}
+      run: |
+        if ! command -v deploy-camunda >/dev/null 2>&1; then
+          echo "deploy-camunda not on PATH; traces are not retained"
+          exit 0
+        fi
+        if [[ -z "${GCS_ACCESS_TOKEN}" ]]; then
+          echo "no GCP access token on this platform; traces are not retained"
+          exit 0
+        fi
+        echo "::group::Playwright trace upload"
+        deploy-camunda artifacts upload \
+          --bucket "${TRACE_BUCKET}" \
+          --source "${ABSOLUTE_TEST_CHART_DIR}/test/e2e/test-results" \
+          --prefix "${TRACE_PREFIX}" \
+          --pattern 'trace.zip' \
+          --content-type application/zip || echo "trace upload failed; continuing"
+        echo "::endgroup::"

--- a/.github/workflows/test-integration-diagnostics-template.yaml
+++ b/.github/workflows/test-integration-diagnostics-template.yaml
@@ -141,4 +141,4 @@ jobs:
         name: e2e-readiness-cluster-diagnostics-${{ inputs.namespace }}-${{ env.ARTIFACT_SUFFIX }}
         path: diagnostics/**
         if-no-files-found: ignore
-        retention-days: 14
+        retention-days: 5

--- a/.github/workflows/test-integration-diagnostics-template.yaml
+++ b/.github/workflows/test-integration-diagnostics-template.yaml
@@ -121,7 +121,6 @@ jobs:
           {
             echo "deploy-camunda unavailable; kubectl fallback"
             kubectl -n "$TEST_NAMESPACE" get pods -o wide
-            kubectl -n "$TEST_NAMESPACE" get events --sort-by=.lastTimestamp | tail -n 40
             kubectl -n "$TEST_NAMESPACE" get pvc -o wide
           } | tee -a diagnostics/e2e-readiness/cluster-diagnostics.txt || true
         fi

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -325,21 +325,6 @@ jobs:
       TEST_CLUSTER_TYPE: ${{ inputs.distro-type || inputs.cluster-type }}
 
     steps:
-      - name: Info - ℹ️ Print workflow inputs ℹ️
-        env:
-          GITHUB_CONTEXT: ${{ toJson(inputs) }}
-        run: |
-          if [[ -n "${INITIAL_CLAIM_VALUE}" ]]; then
-            echo "::add-mask::${INITIAL_CLAIM_VALUE}"
-          fi
-          # Collapse the multi-KB input dump into a log group so it does not bury
-          # the meaningful lines; expand it in the UI when needed.
-          echo "::group::Workflow Inputs"
-          echo "${GITHUB_CONTEXT}" | jq '."extra-values" = "<Check below>"'
-          echo "Workflow Inputs - Extra Values:"
-          echo "${GITHUB_CONTEXT}" | jq -r '."extra-values"'
-          echo "::endgroup::"
-
       - name: CI Setup - Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -802,7 +787,7 @@ jobs:
         with:
           name: ${{ steps.diag-artifact.outputs.name }}
           path: diagnostics/
-          retention-days: 14
+          retention-days: 5
           if-no-files-found: ignore
 
   upgrade:
@@ -834,21 +819,6 @@ jobs:
       TEST_CLUSTER_TYPE: ${{ inputs.distro-type || inputs.cluster-type }}
 
     steps:
-      - name: Info - ℹ️ Print workflow inputs ℹ️
-        env:
-          GITHUB_CONTEXT: ${{ toJson(inputs) }}
-        run: |
-          if [[ -n "${INITIAL_CLAIM_VALUE}" ]]; then
-            echo "::add-mask::${INITIAL_CLAIM_VALUE}"
-          fi
-          # Collapse the multi-KB input dump into a log group so it does not bury
-          # the meaningful lines; expand it in the UI when needed.
-          echo "::group::Workflow Inputs"
-          echo "${GITHUB_CONTEXT}" | jq '."extra-values" = "<Check below>"'
-          echo "Workflow Inputs - Extra Values:"
-          echo "${GITHUB_CONTEXT}" | jq -r '."extra-values"'
-          echo "::endgroup::"
-
       - name: CI Setup - Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -1186,7 +1156,7 @@ jobs:
         with:
           name: ${{ steps.diag-artifact.outputs.name }}
           path: diagnostics/
-          retention-days: 14
+          retention-days: 5
           if-no-files-found: ignore
 
   playwright-e2e-tests-after-install:
@@ -1602,7 +1572,7 @@ jobs:
         with:
           name: e2e-html-report-${{ inputs.identifier }}-${{ inputs.flow }}-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.shortname }}
           path: playwright-report
-          retention-days: 14
+          retention-days: 5
 
   # Record a successful scenario result as a commit status on the PR HEAD commit.
   # This enables progressive CI result caching: future merge queue attempts can

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -350,21 +350,6 @@ jobs:
       TEST_CLUSTER_TYPE: ${{ inputs.distro-type || inputs.cluster-type }}
 
     steps:
-      - name: Info - ℹ️ Print workflow inputs ℹ️
-        env:
-          GITHUB_CONTEXT: ${{ toJson(inputs) }}
-        run: |
-          if [[ -n "${INITIAL_CLAIM_VALUE}" ]]; then
-            echo "::add-mask::${INITIAL_CLAIM_VALUE}"
-          fi
-          # Collapse the multi-KB input dump into a log group so it does not bury
-          # the meaningful lines; expand it in the UI when needed.
-          echo "::group::Workflow Inputs"
-          echo "${GITHUB_CONTEXT}" | jq '."extra-values" = "<Check below>"'
-          echo "Workflow Inputs - Extra Values:"
-          echo "${GITHUB_CONTEXT}" | jq -r '."extra-values"'
-          echo "::endgroup::"
-
       - name: CI Setup - Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -841,7 +826,7 @@ jobs:
         with:
           name: ${{ steps.diag-artifact.outputs.name }}
           path: diagnostics/
-          retention-days: 14
+          retention-days: 5
           if-no-files-found: ignore
 
   upgrade:
@@ -873,21 +858,6 @@ jobs:
       TEST_CLUSTER_TYPE: ${{ inputs.distro-type || inputs.cluster-type }}
 
     steps:
-      - name: Info - ℹ️ Print workflow inputs ℹ️
-        env:
-          GITHUB_CONTEXT: ${{ toJson(inputs) }}
-        run: |
-          if [[ -n "${INITIAL_CLAIM_VALUE}" ]]; then
-            echo "::add-mask::${INITIAL_CLAIM_VALUE}"
-          fi
-          # Collapse the multi-KB input dump into a log group so it does not bury
-          # the meaningful lines; expand it in the UI when needed.
-          echo "::group::Workflow Inputs"
-          echo "${GITHUB_CONTEXT}" | jq '."extra-values" = "<Check below>"'
-          echo "Workflow Inputs - Extra Values:"
-          echo "${GITHUB_CONTEXT}" | jq -r '."extra-values"'
-          echo "::endgroup::"
-
       - name: CI Setup - Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -1225,7 +1195,7 @@ jobs:
         with:
           name: ${{ steps.diag-artifact.outputs.name }}
           path: diagnostics/
-          retention-days: 14
+          retention-days: 5
           if-no-files-found: ignore
 
   playwright-e2e-tests-after-install:
@@ -1650,7 +1620,7 @@ jobs:
         with:
           name: e2e-html-report-${{ inputs.identifier }}-${{ inputs.flow }}-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.shortname }}
           path: playwright-report
-          retention-days: 14
+          retention-days: 5
 
   # Record a successful scenario result as a commit status on the PR HEAD commit.
   # This enables progressive CI result caching: future merge queue attempts can

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -1263,6 +1263,7 @@ jobs:
           CI_DEPLOYMENT_TTL: ${{ env.CI_DEPLOYMENT_TTL }}
         with:
           binary-artifact-name: ${{ inputs.binary-artifact-name }}
+          trace-bucket: ${{ vars.E2E_TRACE_BUCKET }}
           camunda-helm-git-ref: ${{ inputs.camunda-helm-git-ref }}
           camunda-helm-dir: ${{ inputs.camunda-helm-dir }}
           camunda-helm-upgrade-version: ${{ inputs.camunda-helm-upgrade-version }}
@@ -1342,6 +1343,7 @@ jobs:
           PLAYWRIGHT_E2E_RETRIES: "0"
         with:
           binary-artifact-name: ${{ inputs.binary-artifact-name }}
+          trace-bucket: ${{ vars.E2E_TRACE_BUCKET }}
           camunda-helm-git-ref: ${{ inputs.camunda-helm-git-ref }}
           camunda-helm-dir: ${{ inputs.camunda-helm-dir }}
           camunda-helm-upgrade-version: ${{ inputs.camunda-helm-upgrade-version }}
@@ -1458,6 +1460,7 @@ jobs:
           namespace-override: "${{ steps.base-vars.outputs.namespace }}-${{ matrix.orchestration_suffix }}"
           hub-namespace: "${{ steps.base-vars.outputs.namespace }}-${{ inputs.topology-hub-suffix }}"
           binary-artifact-name: ${{ inputs.binary-artifact-name }}
+          trace-bucket: ${{ vars.E2E_TRACE_BUCKET }}
           deployment-ttl: ${{ env.CI_DEPLOYMENT_TTL }}
           auth: ${{ inputs.auth }}
           auth-data: ${{ inputs.auth-data }}
@@ -1529,6 +1532,7 @@ jobs:
           CI_DEPLOYMENT_TTL: ${{ env.CI_DEPLOYMENT_TTL }}
         with:
           binary-artifact-name: ${{ inputs.binary-artifact-name }}
+          trace-bucket: ${{ vars.E2E_TRACE_BUCKET }}
           camunda-helm-git-ref: ${{ inputs.camunda-helm-git-ref }}
           camunda-helm-dir: ${{ inputs.camunda-helm-dir }}
           camunda-helm-upgrade-version: ${{ inputs.camunda-helm-upgrade-version }}

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -1498,81 +1498,12 @@ jobs:
           scenario: ${{ inputs.scenario }}
 
   merge-e2e-reports:
-    name: Merge E2E Reports - ${{ inputs.flow }} on ${{ inputs.distro-platform }} - ${{ inputs.shortname }}
-    # Run if e2e is enabled AND at least one test job completed (success or failure, not skipped/cancelled)
+    name: E2E Reports Disabled - ${{ inputs.flow }} on ${{ inputs.distro-platform }} - ${{ inputs.shortname }}
     if: ${{ !cancelled() && inputs.e2e-enabled && (needs.playwright-e2e-tests-after-install.result == 'success' || needs.playwright-e2e-tests-after-install.result == 'failure' || needs.playwright-e2e-tests-after-upgrade.result == 'success' || needs.playwright-e2e-tests-after-upgrade.result == 'failure') }}
     needs: [playwright-e2e-tests-after-install, playwright-e2e-tests-after-upgrade]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          repository: camunda/camunda-platform-helm
-          ref: ${{ inputs.camunda-helm-git-ref }}
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          node-version: lts/*
-
-      - name: Download blob reports from GitHub Actions Artifacts
-        id: download-reports
-        continue-on-error: true
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          path: all-blob-reports
-          pattern: blob-report-${{ inputs.identifier }}-${{ inputs.flow }}-${{ github.run_id }}-${{ github.run_attempt }}-*
-          merge-multiple: true
-
-      - name: Validate and cleanup blob reports
-        run: |
-          echo "Validating blob report ZIP files..."
-
-          # Check if download succeeded and directory exists with files
-          if [[ "${{ steps.download-reports.outcome }}" != "success" ]] || [[ ! -d "all-blob-reports" ]]; then
-            echo "⚠️ No blob reports were downloaded (download outcome: ${{ steps.download-reports.outcome }})"
-            mkdir -p all-blob-reports
-            exit 0
-          fi
-
-          cd all-blob-reports
-
-          for zip_file in *.zip; do
-            if [[ -f "$zip_file" ]]; then
-              if ! unzip -t "$zip_file" > /dev/null 2>&1; then
-                echo "⚠️ Removing corrupted/incomplete zip file: $zip_file"
-                rm -f "$zip_file"
-              else
-                echo "✅ Valid: $zip_file"
-              fi
-            fi
-          done
-
-          remaining_files=$(ls -1 *.zip 2>/dev/null | wc -l || echo "0")
-          echo "Valid blob reports remaining: $remaining_files"
-
-          if [[ "$remaining_files" -eq 0 ]]; then
-            echo "⚠️ No valid blob reports found to merge"
-            exit 0
-          fi
-
-      - name: Merge into HTML Report
-        run: |
-          # Check if there are any valid reports to merge
-          if [[ ! -d "all-blob-reports" ]] || [[ -z "$(ls -A all-blob-reports/*.zip 2>/dev/null)" ]]; then
-            echo "No valid blob reports found, skipping merge"
-            mkdir -p playwright-report
-            echo "<html><body><h1>No E2E test reports available</h1><p>All blob reports were corrupted or no tests ran.</p></body></html>" > playwright-report/index.html
-            exit 0
-          fi
-
-          npm install -g playwright
-          npx playwright merge-reports --reporter html ./all-blob-reports
-
-      - name: Upload HTML report
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: e2e-html-report-${{ inputs.identifier }}-${{ inputs.flow }}-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.shortname }}
-          path: playwright-report
-          retention-days: 5
+      - run: echo "Raw Playwright reports are not retained because they can contain authentication data."
 
   # Record a successful scenario result as a commit status on the PR HEAD commit.
   # This enables progressive CI result caching: future merge queue attempts can

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -1546,81 +1546,12 @@ jobs:
           scenario: ${{ inputs.scenario }}
 
   merge-e2e-reports:
-    name: Merge E2E Reports - ${{ inputs.flow }} on ${{ inputs.distro-platform }} - ${{ inputs.shortname }}
-    # Run if e2e is enabled AND at least one test job completed (success or failure, not skipped/cancelled)
+    name: E2E Reports Disabled - ${{ inputs.flow }} on ${{ inputs.distro-platform }} - ${{ inputs.shortname }}
     if: ${{ !cancelled() && inputs.e2e-enabled && (needs.playwright-e2e-tests-after-install.result == 'success' || needs.playwright-e2e-tests-after-install.result == 'failure' || needs.playwright-e2e-tests-after-upgrade.result == 'success' || needs.playwright-e2e-tests-after-upgrade.result == 'failure' || needs.e2e-topology-smoke.result == 'success' || needs.e2e-topology-smoke.result == 'failure') }}
     needs: [playwright-e2e-tests-after-install, playwright-e2e-tests-after-upgrade, e2e-topology-smoke]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          repository: camunda/camunda-platform-helm
-          ref: ${{ inputs.camunda-helm-git-ref }}
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          node-version: lts/*
-
-      - name: Download blob reports from GitHub Actions Artifacts
-        id: download-reports
-        continue-on-error: true
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          path: all-blob-reports
-          pattern: blob-report-${{ inputs.identifier }}-${{ inputs.flow }}-${{ github.run_id }}-${{ github.run_attempt }}-*
-          merge-multiple: true
-
-      - name: Validate and cleanup blob reports
-        run: |
-          echo "Validating blob report ZIP files..."
-
-          # Check if download succeeded and directory exists with files
-          if [[ "${{ steps.download-reports.outcome }}" != "success" ]] || [[ ! -d "all-blob-reports" ]]; then
-            echo "⚠️ No blob reports were downloaded (download outcome: ${{ steps.download-reports.outcome }})"
-            mkdir -p all-blob-reports
-            exit 0
-          fi
-
-          cd all-blob-reports
-
-          for zip_file in *.zip; do
-            if [[ -f "$zip_file" ]]; then
-              if ! unzip -t "$zip_file" > /dev/null 2>&1; then
-                echo "⚠️ Removing corrupted/incomplete zip file: $zip_file"
-                rm -f "$zip_file"
-              else
-                echo "✅ Valid: $zip_file"
-              fi
-            fi
-          done
-
-          remaining_files=$(ls -1 *.zip 2>/dev/null | wc -l || echo "0")
-          echo "Valid blob reports remaining: $remaining_files"
-
-          if [[ "$remaining_files" -eq 0 ]]; then
-            echo "⚠️ No valid blob reports found to merge"
-            exit 0
-          fi
-
-      - name: Merge into HTML Report
-        run: |
-          # Check if there are any valid reports to merge
-          if [[ ! -d "all-blob-reports" ]] || [[ -z "$(ls -A all-blob-reports/*.zip 2>/dev/null)" ]]; then
-            echo "No valid blob reports found, skipping merge"
-            mkdir -p playwright-report
-            echo "<html><body><h1>No E2E test reports available</h1><p>All blob reports were corrupted or no tests ran.</p></body></html>" > playwright-report/index.html
-            exit 0
-          fi
-
-          npm install -g playwright
-          npx playwright merge-reports --reporter html ./all-blob-reports
-
-      - name: Upload HTML report
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: e2e-html-report-${{ inputs.identifier }}-${{ inputs.flow }}-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.shortname }}
-          path: playwright-report
-          retention-days: 5
+      - run: echo "Raw Playwright reports are not retained because they can contain authentication data."
 
   # Record a successful scenario result as a commit status on the PR HEAD commit.
   # This enables progressive CI result caching: future merge queue attempts can

--- a/charts/camunda-platform-8.10/test/e2e/playwright.config.ts
+++ b/charts/camunda-platform-8.10/test/e2e/playwright.config.ts
@@ -99,9 +99,9 @@ export default defineConfig({
     baseURL: getBaseURL(),
     actionTimeout: 10000,
     // Also applies to flaky tests
-    screenshot: "only-on-failure",
-    video: "retain-on-failure",
-    trace: "on-first-retry",
+    screenshot: "off",
+    video: "off",
+    trace: "off",
   },
 });
 

--- a/charts/camunda-platform-8.10/test/e2e/playwright.config.ts
+++ b/charts/camunda-platform-8.10/test/e2e/playwright.config.ts
@@ -99,9 +99,19 @@ export default defineConfig({
     baseURL: getBaseURL(),
     actionTimeout: 10000,
     // Also applies to flaky tests
-    screenshot: "off",
-    video: "off",
-    trace: "off",
+    screenshot: (process.env.PLAYWRIGHT_E2E_SCREENSHOT || "only-on-failure") as
+      | "off"
+      | "on"
+      | "only-on-failure",
+    video: (process.env.PLAYWRIGHT_E2E_VIDEO || "retain-on-failure") as
+      | "off"
+      | "on"
+      | "retain-on-failure",
+    trace: (process.env.PLAYWRIGHT_E2E_TRACE || "on-first-retry") as
+      | "off"
+      | "on"
+      | "retain-on-failure"
+      | "on-first-retry",
   },
 });
 

--- a/charts/camunda-platform-8.6/test/e2e/playwright.config.ts
+++ b/charts/camunda-platform-8.6/test/e2e/playwright.config.ts
@@ -24,9 +24,9 @@ export default defineConfig({
     baseURL: getBaseURL(),
     actionTimeout: 10000,
     // Also applies to flaky tests
-    screenshot: "only-on-failure",
-    video: "retain-on-failure",
-    trace: "on-first-retry",
+    screenshot: "off",
+    video: "off",
+    trace: "off",
   },
 });
 

--- a/charts/camunda-platform-8.6/test/e2e/playwright.config.ts
+++ b/charts/camunda-platform-8.6/test/e2e/playwright.config.ts
@@ -24,9 +24,19 @@ export default defineConfig({
     baseURL: getBaseURL(),
     actionTimeout: 10000,
     // Also applies to flaky tests
-    screenshot: "off",
-    video: "off",
-    trace: "off",
+    screenshot: (process.env.PLAYWRIGHT_E2E_SCREENSHOT || "only-on-failure") as
+      | "off"
+      | "on"
+      | "only-on-failure",
+    video: (process.env.PLAYWRIGHT_E2E_VIDEO || "retain-on-failure") as
+      | "off"
+      | "on"
+      | "retain-on-failure",
+    trace: (process.env.PLAYWRIGHT_E2E_TRACE || "on-first-retry") as
+      | "off"
+      | "on"
+      | "retain-on-failure"
+      | "on-first-retry",
   },
 });
 

--- a/charts/camunda-platform-8.7/test/e2e/playwright.config.ts
+++ b/charts/camunda-platform-8.7/test/e2e/playwright.config.ts
@@ -30,9 +30,9 @@ export default defineConfig({
   use: {
     baseURL: getBaseURL(),
     actionTimeout: 10000,
-    screenshot: "only-on-failure",
-    video: "retain-on-failure",
-    trace: "on-first-retry",
+    screenshot: "off",
+    video: "off",
+    trace: "off",
   },
 });
 

--- a/charts/camunda-platform-8.7/test/e2e/playwright.config.ts
+++ b/charts/camunda-platform-8.7/test/e2e/playwright.config.ts
@@ -30,9 +30,19 @@ export default defineConfig({
   use: {
     baseURL: getBaseURL(),
     actionTimeout: 10000,
-    screenshot: "off",
-    video: "off",
-    trace: "off",
+    screenshot: (process.env.PLAYWRIGHT_E2E_SCREENSHOT || "only-on-failure") as
+      | "off"
+      | "on"
+      | "only-on-failure",
+    video: (process.env.PLAYWRIGHT_E2E_VIDEO || "retain-on-failure") as
+      | "off"
+      | "on"
+      | "retain-on-failure",
+    trace: (process.env.PLAYWRIGHT_E2E_TRACE || "on-first-retry") as
+      | "off"
+      | "on"
+      | "retain-on-failure"
+      | "on-first-retry",
   },
 });
 

--- a/charts/camunda-platform-8.8/test/e2e/playwright.config.ts
+++ b/charts/camunda-platform-8.8/test/e2e/playwright.config.ts
@@ -24,9 +24,9 @@ export default defineConfig({
     baseURL: getBaseURL(),
     actionTimeout: 10000,
     // Also applies to flaky tests
-    screenshot: "only-on-failure",
-    video: "retain-on-failure",
-    trace: "on-first-retry",
+    screenshot: "off",
+    video: "off",
+    trace: "off",
   },
 });
 

--- a/charts/camunda-platform-8.8/test/e2e/playwright.config.ts
+++ b/charts/camunda-platform-8.8/test/e2e/playwright.config.ts
@@ -37,9 +37,9 @@ export default defineConfig({
     baseURL: getBaseURL(),
     actionTimeout: 10000,
     // Also applies to flaky tests
-    screenshot: "only-on-failure",
-    video: "retain-on-failure",
-    trace: "on-first-retry",
+    screenshot: "off",
+    video: "off",
+    trace: "off",
   },
 });
 

--- a/charts/camunda-platform-8.8/test/e2e/playwright.config.ts
+++ b/charts/camunda-platform-8.8/test/e2e/playwright.config.ts
@@ -37,9 +37,19 @@ export default defineConfig({
     baseURL: getBaseURL(),
     actionTimeout: 10000,
     // Also applies to flaky tests
-    screenshot: "off",
-    video: "off",
-    trace: "off",
+    screenshot: (process.env.PLAYWRIGHT_E2E_SCREENSHOT || "only-on-failure") as
+      | "off"
+      | "on"
+      | "only-on-failure",
+    video: (process.env.PLAYWRIGHT_E2E_VIDEO || "retain-on-failure") as
+      | "off"
+      | "on"
+      | "retain-on-failure",
+    trace: (process.env.PLAYWRIGHT_E2E_TRACE || "on-first-retry") as
+      | "off"
+      | "on"
+      | "retain-on-failure"
+      | "on-first-retry",
   },
 });
 

--- a/charts/camunda-platform-8.9/test/e2e/playwright.config.ts
+++ b/charts/camunda-platform-8.9/test/e2e/playwright.config.ts
@@ -32,9 +32,9 @@ export default defineConfig({
     baseURL: getBaseURL(),
     actionTimeout: 10000,
     // Also applies to flaky tests
-    screenshot: "only-on-failure",
-    video: "retain-on-failure",
-    trace: "on-first-retry",
+    screenshot: "off",
+    video: "off",
+    trace: "off",
   },
 });
 

--- a/charts/camunda-platform-8.9/test/e2e/playwright.config.ts
+++ b/charts/camunda-platform-8.9/test/e2e/playwright.config.ts
@@ -37,9 +37,9 @@ export default defineConfig({
     baseURL: getBaseURL(),
     actionTimeout: 10000,
     // Also applies to flaky tests
-    screenshot: "only-on-failure",
-    video: "retain-on-failure",
-    trace: "on-first-retry",
+    screenshot: "off",
+    video: "off",
+    trace: "off",
   },
 });
 

--- a/charts/camunda-platform-8.9/test/e2e/playwright.config.ts
+++ b/charts/camunda-platform-8.9/test/e2e/playwright.config.ts
@@ -37,9 +37,19 @@ export default defineConfig({
     baseURL: getBaseURL(),
     actionTimeout: 10000,
     // Also applies to flaky tests
-    screenshot: "off",
-    video: "off",
-    trace: "off",
+    screenshot: (process.env.PLAYWRIGHT_E2E_SCREENSHOT || "only-on-failure") as
+      | "off"
+      | "on"
+      | "only-on-failure",
+    video: (process.env.PLAYWRIGHT_E2E_VIDEO || "retain-on-failure") as
+      | "off"
+      | "on"
+      | "retain-on-failure",
+    trace: (process.env.PLAYWRIGHT_E2E_TRACE || "on-first-retry") as
+      | "off"
+      | "on"
+      | "retain-on-failure"
+      | "on-first-retry",
   },
 });
 

--- a/docs/skills/reproducing-ci-e2e-failures.md
+++ b/docs/skills/reproducing-ci-e2e-failures.md
@@ -99,12 +99,17 @@ unzip test-artifacts/<name>.zip -d test-artifacts/<name>/
 
 Artifacts to prioritize for Playwright e2e failures:
 
-| Artifact suffix | Why you want it |
+| Artifact prefix | Why you want it |
 |-----------------|-----------------|
-| `*-playwright-results-json` | Machine-readable test outcomes + error messages |
-| `*-e2e-html-report` | Interactive report with screenshots, videos, traces |
-| `*-playwright-report-runner` | Runner-level summary |
-| `*-blob-report` | Raw Playwright blobs (large; only if merging reports) |
+| `diagnostics-e2e-*` | Sanitized `namespace-diagnostics.txt` captured when the e2e step failed (pod state, events, pod descriptions) |
+| `diagnostics-*` | Sanitized deploy-stage diagnostics bundle (`summary.json` + `logs/<pod>.log`) |
+
+CI does not retain Playwright HTML reports, blob reports, JSON results, traces,
+screenshots, or videos: they can embed authentication data (tokens, cookies,
+authorization headers) that cannot be reliably redacted, especially in binary
+browser artifacts. Job logs plus the diagnostics bundles above are the CI-side
+evidence; reproduce locally (Steps 4–6) to get a full report with traces and
+screenshots, which the local Playwright config still produces.
 
 ## Step 4 — Decode the Scenario Shortname
 

--- a/docs/skills/reproducing-ci-e2e-failures.md
+++ b/docs/skills/reproducing-ci-e2e-failures.md
@@ -101,15 +101,23 @@ Artifacts to prioritize for Playwright e2e failures:
 
 | Artifact prefix | Why you want it |
 |-----------------|-----------------|
+| `diagnostics-e2e-*-results-json` | Sanitized Playwright JSON results: per-test outcome, failing assertion, locator, timeout, and call log |
 | `diagnostics-e2e-*` | Sanitized `namespace-diagnostics.txt` captured when the e2e step failed (pod state, events, pod descriptions) |
 | `diagnostics-*` | Sanitized deploy-stage diagnostics bundle (`summary.json` + `logs/<pod>.log`) |
 
-CI does not retain Playwright HTML reports, blob reports, JSON results, traces,
-screenshots, or videos: they can embed authentication data (tokens, cookies,
-authorization headers) that cannot be reliably redacted, especially in binary
-browser artifacts. Job logs plus the diagnostics bundles above are the CI-side
-evidence; reproduce locally (Steps 4–6) to get a full report with traces and
-screenshots, which the local Playwright config still produces.
+The job log is also first-class here: the `blob` reporter prints the failing
+assertion, the expected/received values, and the source frame directly into the
+log, so `deploy-camunda triage` often needs nothing else.
+
+CI does not retain Playwright HTML reports, blob reports, traces, screenshots, or
+videos: they embed authentication data (tokens, cookies, authorization headers)
+that cannot be reliably redacted, and binary browser artifacts cannot be
+sanitized at all. `test-results/**/error-context.md` is also withheld — its ARIA
+page snapshot renders form-control values verbatim, so a password field shows up
+as `textbox: <value>`.
+
+For page state, reproduce locally (Steps 4–6): the local Playwright config still
+captures traces, screenshots, and video at full fidelity.
 
 ## Step 4 — Decode the Scenario Shortname
 

--- a/docs/skills/reproducing-ci-e2e-failures.md
+++ b/docs/skills/reproducing-ci-e2e-failures.md
@@ -109,15 +109,34 @@ The job log is also first-class here: the `blob` reporter prints the failing
 assertion, the expected/received values, and the source frame directly into the
 log, so `deploy-camunda triage` often needs nothing else.
 
-CI does not retain Playwright HTML reports, blob reports, traces, screenshots, or
-videos: they embed authentication data (tokens, cookies, authorization headers)
-that cannot be reliably redacted, and binary browser artifacts cannot be
+CI does not retain Playwright HTML reports, blob reports, screenshots, or videos
+as artifacts: they embed authentication data (tokens, cookies, authorization
+headers) that cannot be reliably redacted, and binary browser artifacts cannot be
 sanitized at all. `test-results/**/error-context.md` is also withheld — its ARIA
 page snapshot renders form-control values verbatim, so a password field shows up
 as `textbox: <value>`.
 
-For page state, reproduce locally (Steps 4–6): the local Playwright config still
-captures traces, screenshots, and video at full fidelity.
+### Traces
+
+Traces are not artifacts either, but they are retained — in a **private Cloud
+Storage bucket**, because this repository is public and its artifacts are
+downloadable by any GitHub user. When the `E2E_TRACE_BUCKET` repository variable
+is set, a failed e2e job uploads `trace.zip` and logs the `gs://` URI. Objects are
+deleted after 5 days and CI holds write-only access.
+
+`deploy-camunda triage` prints any URIs it finds along with the fetch and view
+commands. Manually:
+
+```bash
+gcloud storage cp gs://<bucket>/<run-id>/<run-attempt>/<leg>/<test>/trace.zip .
+npx playwright show-trace trace.zip
+```
+
+Read access is granted to the distribution team group. If `E2E_TRACE_BUCKET` is
+unset, trace capture is disabled entirely and nothing is uploaded.
+
+For screenshots and video, reproduce locally (Steps 4–6): the local Playwright
+config still captures all three at full fidelity.
 
 ## Step 4 — Decode the Scenario Shortname
 

--- a/scripts/base_playwright_script.sh
+++ b/scripts/base_playwright_script.sh
@@ -1077,7 +1077,8 @@ run_playwright_tests() {
   )
   [[ -n "$test_exclude" ]] && playwright_args+=(--grep-invert="$test_exclude")
   [[ -n "$trace_flag" ]] && playwright_args+=($trace_flag)
-  [[ -n "${PLAYWRIGHT_E2E_VIDEO:-}" ]] && playwright_args+=(--video="$PLAYWRIGHT_E2E_VIDEO")
+  # playwright test has no --video option; PLAYWRIGHT_E2E_VIDEO is consumed by
+  # playwright.config.ts instead.
   [[ -n "${PLAYWRIGHT_E2E_TRACE:-}" ]] && playwright_args+=(--trace="$PLAYWRIGHT_E2E_TRACE")
   [[ -n "${PLAYWRIGHT_E2E_RETRIES:-}" ]] && playwright_args+=(--retries="$PLAYWRIGHT_E2E_RETRIES")
   # smoke-tests uses a low worker count by default; other projects keep the

--- a/scripts/deploy-camunda/cmd/artifacts.go
+++ b/scripts/deploy-camunda/cmd/artifacts.go
@@ -1,0 +1,250 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// gcsUploadBaseURL is the Cloud Storage JSON API upload endpoint. It is a
+// variable so tests can point it at an httptest server.
+var gcsUploadBaseURL = "https://storage.googleapis.com"
+
+// artifactUploadTimeout bounds the whole upload set. A stuck upload must not
+// hold a CI job open, and the artifacts are best-effort evidence.
+const artifactUploadTimeout = 5 * time.Minute
+
+// tokenEnvDefault is where the GCP OAuth2 access token is read from. The token
+// is never taken as a flag: argv is world-readable via /proc on the runner.
+const tokenEnvDefault = "GCS_ACCESS_TOKEN"
+
+// newArtifactsCommand creates the `artifacts` parent command.
+func newArtifactsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "artifacts",
+		Short: "Upload CI evidence that cannot be published as a public artifact",
+	}
+	cmd.AddCommand(newArtifactsUploadCommand())
+	return cmd
+}
+
+// newArtifactsUploadCommand creates `artifacts upload`: a minimal Cloud Storage
+// writer for evidence that must not become a public GitHub artifact.
+//
+// Playwright traces are the motivating case. camunda-platform-helm is public, so
+// its workflow artifacts are world-readable, and a trace embeds the per-run
+// cluster's request headers and cookies. A trace cannot be redacted, so the only
+// safe retention is a private bucket with a short lifecycle.
+//
+// This speaks the JSON API over net/http rather than depending on the Cloud
+// Storage SDK: the playwright-runner image deliberately ships only the 9 MB
+// gke-gcloud-auth-plugin instead of the 370 MB gcloud SDK, and deploy-camunda is
+// already on PATH there.
+func newArtifactsUploadCommand() *cobra.Command {
+	var (
+		bucket      string
+		source      string
+		prefix      string
+		pattern     string
+		tokenEnv    string
+		contentType string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "upload",
+		Short: "Upload files to a private Cloud Storage bucket",
+		Long: `Upload files to a private Cloud Storage bucket.
+
+Walks --source for files matching --pattern and writes each to
+gs://<bucket>/<prefix>/<path-relative-to-source>. Prints one gs:// URI per
+uploaded object so a CI log records where the evidence went.
+
+The OAuth2 access token is read from the environment (default GCS_ACCESS_TOKEN),
+never from a flag, because process arguments are readable by other processes on
+the runner. On GitHub Actions the token comes from the gke-login action, which
+already performs a Workload Identity exchange.
+
+Does nothing and succeeds when --bucket is empty, so a caller can wire the step
+up before the bucket exists.`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Args:          cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if bucket == "" {
+				fmt.Fprintln(cmd.OutOrStdout(), "no bucket configured; skipping artifact upload")
+				return nil
+			}
+			token := os.Getenv(tokenEnv)
+			if token == "" {
+				return fmt.Errorf("no access token in %s; refusing to upload", tokenEnv)
+			}
+
+			ctx, cancel := context.WithTimeout(cmd.Context(), artifactUploadTimeout)
+			defer cancel()
+
+			uploaded, err := uploadArtifacts(ctx, artifactUploadOptions{
+				Bucket:      bucket,
+				Source:      source,
+				Prefix:      prefix,
+				Pattern:     pattern,
+				Token:       token,
+				ContentType: contentType,
+				Client:      http.DefaultClient,
+			}, cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			if uploaded == 0 {
+				fmt.Fprintf(cmd.OutOrStdout(), "no files matching %q under %s\n", pattern, source)
+			}
+			return nil
+		},
+	}
+
+	f := cmd.Flags()
+	f.StringVar(&bucket, "bucket", "", "Target bucket name; empty skips the upload")
+	f.StringVar(&source, "source", "", "Directory to walk (required)")
+	f.StringVar(&prefix, "prefix", "", "Object name prefix (required)")
+	f.StringVar(&pattern, "pattern", "*", "Base-name glob selecting files to upload")
+	f.StringVar(&tokenEnv, "token-env", tokenEnvDefault, "Environment variable holding the OAuth2 access token")
+	f.StringVar(&contentType, "content-type", "application/octet-stream", "Content-Type recorded on each object")
+	_ = cmd.MarkFlagRequired("source")
+	_ = cmd.MarkFlagRequired("prefix")
+
+	return cmd
+}
+
+type artifactUploadOptions struct {
+	Bucket      string
+	Source      string
+	Prefix      string
+	Pattern     string
+	Token       string
+	ContentType string
+	Client      *http.Client
+}
+
+// uploadArtifacts walks Source and uploads every matching file, returning the
+// number of objects written. Files are uploaded in a stable order so a failure
+// is reproducible.
+func uploadArtifacts(ctx context.Context, opts artifactUploadOptions, out io.Writer) (int, error) {
+	info, err := os.Stat(opts.Source)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("stat %s: %w", opts.Source, err)
+	}
+	if !info.IsDir() {
+		return 0, fmt.Errorf("%s is not a directory", opts.Source)
+	}
+
+	var matches []string
+	walkErr := filepath.WalkDir(opts.Source, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		// A symlink is reported as an irregular file by WalkDir, so this also
+		// keeps the walk from following a link out of the source tree.
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		ok, matchErr := filepath.Match(opts.Pattern, d.Name())
+		if matchErr != nil {
+			return fmt.Errorf("bad --pattern %q: %w", opts.Pattern, matchErr)
+		}
+		if ok {
+			matches = append(matches, path)
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return 0, walkErr
+	}
+	sort.Strings(matches)
+
+	uploaded := 0
+	for _, path := range matches {
+		rel, err := filepath.Rel(opts.Source, path)
+		if err != nil {
+			return uploaded, fmt.Errorf("resolve %s: %w", path, err)
+		}
+		object := gcsObjectName(opts.Prefix, rel)
+		if err := uploadOneArtifact(ctx, opts, path, object); err != nil {
+			return uploaded, err
+		}
+		uploaded++
+		fmt.Fprintf(out, "gs://%s/%s\n", opts.Bucket, object)
+	}
+	return uploaded, nil
+}
+
+// gcsObjectName joins the prefix and a source-relative path into an object name,
+// normalising Windows separators and collapsing empty segments.
+func gcsObjectName(prefix, rel string) string {
+	segments := make([]string, 0, 2)
+	if trimmed := strings.Trim(prefix, "/"); trimmed != "" {
+		segments = append(segments, trimmed)
+	}
+	segments = append(segments, filepath.ToSlash(rel))
+	return strings.Join(segments, "/")
+}
+
+func uploadOneArtifact(ctx context.Context, opts artifactUploadOptions, path, object string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", path, err)
+	}
+
+	endpoint := fmt.Sprintf("%s/upload/storage/v1/b/%s/o?uploadType=media&name=%s",
+		strings.TrimSuffix(gcsUploadBaseURL, "/"),
+		url.PathEscape(opts.Bucket),
+		url.QueryEscape(object),
+	)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, f)
+	if err != nil {
+		return fmt.Errorf("build request for %s: %w", object, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+opts.Token)
+	req.Header.Set("Content-Type", opts.ContentType)
+	req.ContentLength = info.Size()
+
+	client := opts.Client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("upload %s: %w", object, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		// The body can echo request metadata, so surface the status and a short
+		// excerpt rather than the whole response.
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("upload %s: %s: %s", object, resp.Status, strings.TrimSpace(string(body)))
+	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
+	return nil
+}

--- a/scripts/deploy-camunda/cmd/artifacts_test.go
+++ b/scripts/deploy-camunda/cmd/artifacts_test.go
@@ -1,0 +1,290 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type capturedUpload struct {
+	object      string
+	bucket      string
+	body        string
+	authz       string
+	contentType string
+}
+
+// newUploadRecorder stands in for the Cloud Storage JSON API and records what a
+// real upload would have received.
+func newUploadRecorder(t *testing.T, status int) (*httptest.Server, func() []capturedUpload) {
+	t.Helper()
+
+	var (
+		mu   sync.Mutex
+		seen []capturedUpload
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := make([]byte, r.ContentLength)
+		if r.ContentLength > 0 {
+			if _, err := r.Body.Read(body); err != nil && err.Error() != "EOF" {
+				t.Errorf("read body: %v", err)
+			}
+		}
+		// /upload/storage/v1/b/<bucket>/o
+		parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+		bucket := ""
+		if len(parts) >= 5 {
+			bucket = parts[4]
+		}
+		mu.Lock()
+		seen = append(seen, capturedUpload{
+			object:      r.URL.Query().Get("name"),
+			bucket:      bucket,
+			body:        string(body),
+			authz:       r.Header.Get("Authorization"),
+			contentType: r.Header.Get("Content-Type"),
+		})
+		mu.Unlock()
+
+		w.WriteHeader(status)
+		if status > 299 {
+			fmt.Fprint(w, `{"error":{"message":"denied"}}`)
+			return
+		}
+		fmt.Fprint(w, `{"kind":"storage#object"}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv, func() []capturedUpload {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]capturedUpload, len(seen))
+		copy(out, seen)
+		return out
+	}
+}
+
+func withUploadEndpoint(t *testing.T, base string) {
+	t.Helper()
+	previous := gcsUploadBaseURL
+	gcsUploadBaseURL = base
+	t.Cleanup(func() { gcsUploadBaseURL = previous })
+}
+
+func seedTraceTree(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	for path, body := range map[string]string{
+		"login-flow/trace.zip":  "trace-one",
+		"upload-flow/trace.zip": "trace-two",
+		"login-flow/stdout.txt": "not-a-trace",
+	} {
+		full := filepath.Join(root, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o700); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o600); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	return root
+}
+
+func TestUploadArtifactsUploadsOnlyMatchingFiles(t *testing.T) {
+	srv, captured := newUploadRecorder(t, http.StatusOK)
+	withUploadEndpoint(t, srv.URL)
+
+	var out strings.Builder
+	n, err := uploadArtifacts(context.Background(), artifactUploadOptions{
+		Bucket:      "camunda-ci-e2e-traces",
+		Source:      seedTraceTree(t),
+		Prefix:      "123/1/eske-install",
+		Pattern:     "trace.zip",
+		Token:       "test-token",
+		ContentType: "application/zip",
+		Client:      srv.Client(),
+	}, &out)
+	if err != nil {
+		t.Fatalf("uploadArtifacts: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("uploaded %d objects, want 2", n)
+	}
+
+	got := captured()
+	if len(got) != 2 {
+		t.Fatalf("server saw %d requests, want 2", len(got))
+	}
+
+	objects := []string{got[0].object, got[1].object}
+	want := []string{
+		"123/1/eske-install/login-flow/trace.zip",
+		"123/1/eske-install/upload-flow/trace.zip",
+	}
+	for i := range want {
+		if objects[i] != want[i] {
+			t.Errorf("object[%d] = %q, want %q", i, objects[i], want[i])
+		}
+	}
+	for _, u := range got {
+		if u.bucket != "camunda-ci-e2e-traces" {
+			t.Errorf("bucket = %q", u.bucket)
+		}
+		if u.authz != "Bearer test-token" {
+			t.Errorf("authorization = %q", u.authz)
+		}
+		if u.contentType != "application/zip" {
+			t.Errorf("content-type = %q", u.contentType)
+		}
+		if strings.Contains(u.body, "not-a-trace") {
+			t.Errorf("uploaded a non-matching file: %q", u.body)
+		}
+	}
+
+	// The gs:// URIs are the only record a triage session gets, so they must be
+	// printed for every object.
+	for _, uri := range want {
+		if !strings.Contains(out.String(), "gs://camunda-ci-e2e-traces/"+uri) {
+			t.Errorf("missing gs:// URI for %s in:\n%s", uri, out.String())
+		}
+	}
+}
+
+func TestUploadArtifactsMissingSourceIsNotAnError(t *testing.T) {
+	srv, captured := newUploadRecorder(t, http.StatusOK)
+	withUploadEndpoint(t, srv.URL)
+
+	var out strings.Builder
+	n, err := uploadArtifacts(context.Background(), artifactUploadOptions{
+		Bucket: "b",
+		Source: filepath.Join(t.TempDir(), "never-created"),
+		Prefix: "p",
+		// A passing run leaves no trace directory behind; that must not fail the
+		// job on top of whatever else happened.
+		Pattern: "trace.zip",
+		Token:   "t",
+		Client:  srv.Client(),
+	}, &out)
+	if err != nil {
+		t.Fatalf("expected nil error for a missing source, got %v", err)
+	}
+	if n != 0 {
+		t.Errorf("uploaded %d objects, want 0", n)
+	}
+	if len(captured()) != 0 {
+		t.Errorf("server received requests for a missing source")
+	}
+}
+
+func TestUploadArtifactsSurfacesServerRejection(t *testing.T) {
+	srv, _ := newUploadRecorder(t, http.StatusForbidden)
+	withUploadEndpoint(t, srv.URL)
+
+	var out strings.Builder
+	_, err := uploadArtifacts(context.Background(), artifactUploadOptions{
+		Bucket:  "b",
+		Source:  seedTraceTree(t),
+		Prefix:  "p",
+		Pattern: "trace.zip",
+		Token:   "t",
+		Client:  srv.Client(),
+	}, &out)
+	if err == nil {
+		t.Fatal("expected an error when the API rejects the upload")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Errorf("error should carry the status, got: %v", err)
+	}
+}
+
+func TestUploadArtifactsSkipsSymlinks(t *testing.T) {
+	srv, captured := newUploadRecorder(t, http.StatusOK)
+	withUploadEndpoint(t, srv.URL)
+
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "secret.zip")
+	if err := os.WriteFile(outside, []byte("outside-the-tree"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "trace.zip")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	var out strings.Builder
+	n, err := uploadArtifacts(context.Background(), artifactUploadOptions{
+		Bucket:  "b",
+		Source:  root,
+		Prefix:  "p",
+		Pattern: "trace.zip",
+		Token:   "t",
+		Client:  srv.Client(),
+	}, &out)
+	if err != nil {
+		t.Fatalf("uploadArtifacts: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("uploaded %d objects via symlink, want 0", n)
+	}
+	for _, u := range captured() {
+		if strings.Contains(u.body, "outside-the-tree") {
+			t.Error("followed a symlink out of the source tree")
+		}
+	}
+}
+
+func TestGCSObjectName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct{ prefix, rel, want string }{
+		{"123/1/leg", "dir/trace.zip", "123/1/leg/dir/trace.zip"},
+		{"/123/1/leg/", "trace.zip", "123/1/leg/trace.zip"},
+		{"", "trace.zip", "trace.zip"},
+	}
+	for _, tt := range tests {
+		if got := gcsObjectName(tt.prefix, tt.rel); got != tt.want {
+			t.Errorf("gcsObjectName(%q, %q) = %q, want %q", tt.prefix, tt.rel, got, tt.want)
+		}
+	}
+}
+
+// An object name with a space or a '#' must survive the round trip, otherwise the
+// upload silently lands under a different key than the log reports.
+func TestUploadArtifactsEscapesObjectNames(t *testing.T) {
+	srv, captured := newUploadRecorder(t, http.StatusOK)
+	withUploadEndpoint(t, srv.URL)
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "trace copy#1.zip"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	var out strings.Builder
+	if _, err := uploadArtifacts(context.Background(), artifactUploadOptions{
+		Bucket:  "b",
+		Source:  root,
+		Prefix:  "p",
+		Pattern: "*.zip",
+		Token:   "t",
+		Client:  srv.Client(),
+	}, &out); err != nil {
+		t.Fatalf("uploadArtifacts: %v", err)
+	}
+
+	got := captured()
+	if len(got) != 1 {
+		t.Fatalf("saw %d requests, want 1", len(got))
+	}
+	if got[0].object != "p/trace copy#1.zip" {
+		t.Errorf("object = %q, want %q", got[0].object, "p/trace copy#1.zip")
+	}
+	if _, err := url.Parse(srv.URL + "/x?name=" + url.QueryEscape(got[0].object)); err != nil {
+		t.Errorf("object name does not round-trip through a URL: %v", err)
+	}
+}

--- a/scripts/deploy-camunda/cmd/diagnostics.go
+++ b/scripts/deploy-camunda/cmd/diagnostics.go
@@ -12,6 +12,7 @@ import (
 
 	"scripts/camunda-core/pkg/kube"
 	"scripts/camunda-core/pkg/logging"
+	"scripts/deploy-camunda/pkg/redaction"
 
 	"github.com/spf13/cobra"
 )
@@ -125,14 +126,14 @@ func printNamespaceDiagnostics(ctx context.Context, w io.Writer, src podDiagnost
 	emit := func(title string, out string, err error) {
 		section(title)
 		if err != nil {
-			fmt.Fprintf(w, "(error: %v)\n", err)
+			fmt.Fprintf(w, "(error: %s)\n", redaction.Text(err.Error()))
 			return
 		}
 		if out == "" {
 			fmt.Fprintln(w, "(none)")
 			return
 		}
-		fmt.Fprintln(w, out)
+		fmt.Fprintln(w, redaction.Text(out))
 	}
 
 	pods, podsErr := src.GetPods(ctx, kubeContext, namespace)
@@ -155,7 +156,7 @@ func printNamespaceDiagnostics(ctx context.Context, w io.Writer, src podDiagnost
 	targets, err := listPods(ctx, kubeContext, namespace)
 	if err != nil {
 		section(listTitle)
-		fmt.Fprintf(w, "(error: %v)\n", err)
+		fmt.Fprintf(w, "(error: %s)\n", redaction.Text(err.Error()))
 		return
 	}
 	sort.Strings(targets)

--- a/scripts/deploy-camunda/cmd/diagnostics_test.go
+++ b/scripts/deploy-camunda/cmd/diagnostics_test.go
@@ -135,3 +135,32 @@ func TestLastLines(t *testing.T) {
 		t.Errorf("empty input should stay empty, got %q", got)
 	}
 }
+
+func TestPrintNamespaceDiagnosticsRedactsSecrets(t *testing.T) {
+	t.Parallel()
+
+	src := podDiagnosticsSource{
+		GetPods:         func(_ context.Context, _, _ string) (string, error) { return "pod-a 0/1 Running", nil },
+		GetEvents:       func(_ context.Context, _, _ string) (string, error) { return "API_TOKEN=event-secret", nil },
+		GetPVCs:         func(_ context.Context, _, _ string) (string, error) { return "", nil },
+		DescribePVCs:    func(_ context.Context, _, _ string) (string, error) { return "", nil },
+		GetNonReadyPods: func(_ context.Context, _, _ string) ([]string, error) { return []string{"pod-a"}, nil },
+		DescribePod:     func(_ context.Context, _, _, _ string) (string, error) { return "clientSecret: describe-secret", nil },
+		GetPodLogs: func(_ context.Context, _, _, _ string, _ int) (string, error) {
+			return "Authorization: Bearer log-secret", nil
+		},
+		GetPodLogsPrevious: func(_ context.Context, _, _, _ string, _ int) (string, error) { return "", nil },
+	}
+
+	var buf bytes.Buffer
+	printNamespaceDiagnostics(context.Background(), &buf, src, "", "ns", 10, false)
+	out := buf.String()
+	for _, secret := range []string{"event-secret", "describe-secret", "log-secret"} {
+		if strings.Contains(out, secret) {
+			t.Errorf("output contains secret %q:\n%s", secret, out)
+		}
+	}
+	if !strings.Contains(out, "[REDACTED]") || !strings.Contains(out, "pod-a 0/1 Running") {
+		t.Errorf("output should retain diagnostics with redaction:\n%s", out)
+	}
+}

--- a/scripts/deploy-camunda/cmd/redact.go
+++ b/scripts/deploy-camunda/cmd/redact.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"scripts/deploy-camunda/pkg/redaction"
+
+	"github.com/spf13/cobra"
+)
+
+// newRedactCommand creates `redact`: the persistence boundary for text artifacts
+// that are produced by third-party tooling and therefore cannot be sanitized at
+// the point of generation. Playwright's JSON results are the motivating case —
+// they carry the per-test outcomes and error messages CI needs for triage, but
+// they are written by the test runner, not by this tool.
+//
+// Binary artifacts (traces, videos, screenshots) are deliberately out of scope:
+// they cannot be reliably redacted and are not retained by CI at all.
+func newRedactCommand() *cobra.Command {
+	var inPath, outPath string
+
+	cmd := &cobra.Command{
+		Use:   "redact",
+		Short: "Redact credentials from a text file or stream",
+		Long: `Apply the shared redactor to a text file or stream.
+
+Reads --in (default stdin) and writes --out (default stdout), replacing
+authorization headers, bearer tokens, JWTs, private keys, URL credentials, and
+sensitive key=value / "key": "value" assignments with a placeholder.
+
+Intended for text artifacts produced by third-party tooling that CI needs to
+retain, where sanitizing at the point of generation is not possible. Output
+files are created owner-only (0600).
+
+This is a text-level redactor, not a guarantee: never use it to justify
+publishing binary artifacts, which cannot be reliably sanitized.`,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		Args:          cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRedact(inPath, outPath, cmd.InOrStdin(), cmd.OutOrStdout())
+		},
+	}
+
+	f := cmd.Flags()
+	f.StringVar(&inPath, "in", "", "Input file (default stdin)")
+	f.StringVar(&outPath, "out", "", "Output file, created 0600 (default stdout); may equal --in for in-place rewrite")
+
+	return cmd
+}
+
+// runRedact reads the input, redacts it, and writes the result. An --out equal
+// to --in is supported by buffering the whole input before the write, so an
+// in-place rewrite cannot truncate the file it is still reading.
+func runRedact(inPath, outPath string, stdin io.Reader, stdout io.Writer) error {
+	var (
+		raw []byte
+		err error
+	)
+	if inPath == "" {
+		raw, err = io.ReadAll(stdin)
+		if err != nil {
+			return fmt.Errorf("read stdin: %w", err)
+		}
+	} else {
+		raw, err = os.ReadFile(inPath)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", inPath, err)
+		}
+	}
+
+	redacted := redaction.Text(string(raw))
+
+	if outPath == "" {
+		if _, err := io.WriteString(stdout, redacted); err != nil {
+			return fmt.Errorf("write stdout: %w", err)
+		}
+		return nil
+	}
+
+	if fi, statErr := os.Lstat(outPath); statErr == nil && fi.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to write %s through a symbolic link", outPath)
+	}
+	if dir := filepath.Dir(outPath); dir != "." {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return fmt.Errorf("create %s: %w", dir, err)
+		}
+	}
+	if err := os.WriteFile(outPath, []byte(redacted), 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", outPath, err)
+	}
+	if err := os.Chmod(outPath, 0o600); err != nil {
+		return fmt.Errorf("chmod %s: %w", outPath, err)
+	}
+	return nil
+}

--- a/scripts/deploy-camunda/cmd/redact_test.go
+++ b/scripts/deploy-camunda/cmd/redact_test.go
@@ -1,0 +1,185 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const playwrightResultsFixture = `{
+  "suites": [
+    {
+      "title": "smoke-tests.spec.js",
+      "specs": [
+        {
+          "title": "logs in to Operate",
+          "ok": false,
+          "tests": [
+            {
+              "results": [
+                {
+                  "status": "failed",
+                  "error": {
+                    "message": "expect(received).toBe(expected)\n\nExpected: 200\nReceived: 401",
+                    "stack": "at smoke-tests.spec.js:42:19"
+                  },
+                  "stdout": [
+                    "request headers: authorization: Bearer eyJhbGciOiJIUzI1NiJ9.cGF5bG9hZHBheWxvYWQ.c2lnbmF0dXJl",
+                    "ZEEBE_CLIENT_SECRET=super-secret-value"
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+`
+
+func TestRunRedactStreamRedactsCredentialsAndKeepsDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	var out strings.Builder
+	if err := runRedact("", "", strings.NewReader(playwrightResultsFixture), &out); err != nil {
+		t.Fatalf("runRedact returned error: %v", err)
+	}
+	got := out.String()
+
+	for _, secret := range []string{
+		"super-secret-value",
+		"eyJhbGciOiJIUzI1NiJ9.cGF5bG9hZHBheWxvYWQ.c2lnbmF0dXJl",
+	} {
+		if strings.Contains(got, secret) {
+			t.Errorf("output still contains %q:\n%s", secret, got)
+		}
+	}
+
+	// The whole point of retaining this artifact is the triage signal, so the
+	// test identity and assertion detail must survive redaction.
+	for _, keep := range []string{
+		"smoke-tests.spec.js",
+		"logs in to Operate",
+		"expect(received).toBe(expected)",
+		"Expected: 200",
+		"Received: 401",
+		"at smoke-tests.spec.js:42:19",
+		`"status": "failed"`,
+	} {
+		if !strings.Contains(got, keep) {
+			t.Errorf("output dropped triage detail %q:\n%s", keep, got)
+		}
+	}
+}
+
+// The artifact is only useful to triage tooling if it still parses, so redaction
+// must not swallow the quotes that delimit the values it rewrites.
+func TestRunRedactKeepsOutputValidJSON(t *testing.T) {
+	t.Parallel()
+
+	var out strings.Builder
+	if err := runRedact("", "", strings.NewReader(playwrightResultsFixture), &out); err != nil {
+		t.Fatalf("runRedact returned error: %v", err)
+	}
+
+	var parsed any
+	if err := json.Unmarshal([]byte(out.String()), &parsed); err != nil {
+		t.Fatalf("redacted output is not valid JSON: %v\n%s", err, out.String())
+	}
+}
+
+func TestRunRedactWritesOwnerOnlyFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "nested", "playwright-results.json")
+
+	if err := runRedact("", outPath, strings.NewReader(playwrightResultsFixture), nil); err != nil {
+		t.Fatalf("runRedact returned error: %v", err)
+	}
+
+	info, err := os.Stat(outPath)
+	if err != nil {
+		t.Fatalf("stat output: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("output mode = %#o, want 0600", perm)
+	}
+	body, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if strings.Contains(string(body), "super-secret-value") {
+		t.Errorf("written file still contains the secret:\n%s", body)
+	}
+}
+
+func TestRunRedactInPlaceRewrite(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "results.json")
+	if err := os.WriteFile(path, []byte(playwrightResultsFixture), 0o600); err != nil {
+		t.Fatalf("seed input: %v", err)
+	}
+
+	if err := runRedact(path, path, nil, nil); err != nil {
+		t.Fatalf("runRedact returned error: %v", err)
+	}
+
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if strings.Contains(string(body), "super-secret-value") {
+		t.Errorf("in-place rewrite kept the secret:\n%s", body)
+	}
+	if !strings.Contains(string(body), "logs in to Operate") {
+		t.Errorf("in-place rewrite lost triage detail:\n%s", body)
+	}
+}
+
+func TestRunRedactRefusesSymlinkOutput(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	link := filepath.Join(dir, "link")
+	if err := os.WriteFile(target, []byte("UNTOUCHED=1\n"), 0o600); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	err := runRedact("", link, strings.NewReader(playwrightResultsFixture), nil)
+	if err == nil {
+		t.Fatal("expected an error when --out is a symbolic link")
+	}
+	if !strings.Contains(err.Error(), "symbolic link") {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	body, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(body) != "UNTOUCHED=1\n" {
+		t.Errorf("symlink target was modified: %q", body)
+	}
+}
+
+func TestRunRedactReportsMissingInput(t *testing.T) {
+	t.Parallel()
+
+	err := runRedact(filepath.Join(t.TempDir(), "absent.json"), "", nil, nil)
+	if err == nil {
+		t.Fatal("expected an error for a missing --in file")
+	}
+	if !strings.Contains(err.Error(), "absent.json") {
+		t.Errorf("error should name the missing file, got: %v", err)
+	}
+}

--- a/scripts/deploy-camunda/cmd/root.go
+++ b/scripts/deploy-camunda/cmd/root.go
@@ -97,6 +97,11 @@ func NewRootCommand() *cobra.Command {
 				if cmd.Name() == "diagnostics" || (cmd.Parent() != nil && cmd.Parent().Name() == "diagnostics") {
 					return nil
 				}
+				// redact is a pure text filter over a file or stream; no
+				// chart/namespace config needed.
+				if cmd.Name() == "redact" {
+					return nil
+				}
 				// ci subcommands compute GitHub Actions step variables; no
 				// chart/namespace config needed.
 				if cmd.Name() == "ci" || (cmd.Parent() != nil && cmd.Parent().Name() == "ci") {
@@ -573,6 +578,7 @@ func Execute() error {
 	rootCmd.AddCommand(newDoctorCommand())
 	rootCmd.AddCommand(newTriageCommand())
 	rootCmd.AddCommand(newDiagnosticsCommand())
+	rootCmd.AddCommand(newRedactCommand())
 	rootCmd.AddCommand(newCICommand())
 	rootCmd.AddCommand(newE2EEnvCommand())
 	rootCmd.AddCommand(newTopologyCommand())

--- a/scripts/deploy-camunda/cmd/root.go
+++ b/scripts/deploy-camunda/cmd/root.go
@@ -102,6 +102,11 @@ func NewRootCommand() *cobra.Command {
 				if cmd.Name() == "redact" {
 					return nil
 				}
+				// artifacts subcommands upload CI evidence to object storage; no
+				// chart/namespace config needed.
+				if cmd.Name() == "artifacts" || (cmd.Parent() != nil && cmd.Parent().Name() == "artifacts") {
+					return nil
+				}
 				// ci subcommands compute GitHub Actions step variables; no
 				// chart/namespace config needed.
 				if cmd.Name() == "ci" || (cmd.Parent() != nil && cmd.Parent().Name() == "ci") {
@@ -579,6 +584,7 @@ func Execute() error {
 	rootCmd.AddCommand(newTriageCommand())
 	rootCmd.AddCommand(newDiagnosticsCommand())
 	rootCmd.AddCommand(newRedactCommand())
+	rootCmd.AddCommand(newArtifactsCommand())
 	rootCmd.AddCommand(newCICommand())
 	rootCmd.AddCommand(newE2EEnvCommand())
 	rootCmd.AddCommand(newTopologyCommand())

--- a/scripts/deploy-camunda/cmd/triage.go
+++ b/scripts/deploy-camunda/cmd/triage.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -56,6 +57,7 @@ type failureRecord struct {
 	HelmCommand    string
 	Reason         string
 	DiagnosticsDir string
+	TraceURIs      []string
 	Signals        []string
 }
 
@@ -91,6 +93,11 @@ var (
 	repoURLRe = regexp.MustCompile(`github\.com/([^/]+)/([^/]+)`)
 	// diagnosticsRe matches the "Diagnostics: diagnostics/<ns>/<ts>" hint.
 	diagnosticsRe = regexp.MustCompile(`Diagnostics:\s*(\S+)`)
+
+	// traceURIRe matches the gs:// URIs the playwright action logs after pushing
+	// Playwright traces to private storage. Traces are never GitHub artifacts, so
+	// the log line is the only pointer to them.
+	traceURIRe = regexp.MustCompile(`gs://[A-Za-z0-9._-]+/\S*trace\.zip`)
 	// quotedHelmCmdRe matches a quoted command="helm ..." field, which the matrix
 	// runner emits with the exact failing invocation.
 	quotedHelmCmdRe = regexp.MustCompile(`command="(helm [^"]*)"`)
@@ -124,6 +131,7 @@ for merge-queue runs), strips the env-var noise, and prints:
   - the failing step and the helm command that failed,
   - the error/reason and notable log signals,
   - the Diagnostics bundle path (download with: gh run download <run-id> --name 'diagnostics-*'),
+  - any Playwright trace URIs in private storage, with the commands to fetch and view them,
   - a ready-to-run local reproduction command.
 
 Requires the GitHub CLI (gh) to be installed and authenticated.`,
@@ -373,6 +381,7 @@ func extractFailureRecord(rawLog string) failureRecord {
 		rec.DiagnosticsDir = m[1]
 	}
 	rec.Reason = extractReason(log)
+	rec.TraceURIs = uniqueStrings(traceURIRe.FindAllString(log, -1))
 	rec.Signals = collectSignals(log)
 	return rec
 }
@@ -453,6 +462,24 @@ func extractReason(log string) string {
 		}
 	}
 	return ""
+}
+
+// uniqueStrings drops duplicates while preserving first-seen order. Sharded legs
+// can log the same URI more than once when a step is retried.
+func uniqueStrings(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
 }
 
 // signalPatterns are notable failure fingerprints worth surfacing verbatim.
@@ -550,6 +577,15 @@ func renderTriageReport(ref runRef, rec failureRecord) string {
 	if rec.DiagnosticsDir != "" {
 		fmt.Fprintf(&b, "Diagnostics:  %s\n", rec.DiagnosticsDir)
 		fmt.Fprintf(&b, "  download:   gh run download %s --repo %s/%s --name 'diagnostics-*'\n", ref.RunID, ref.Owner, ref.Repo)
+	}
+
+	if len(rec.TraceURIs) > 0 {
+		fmt.Fprintf(&b, "Traces:       %d in private storage (not a GitHub artifact)\n", len(rec.TraceURIs))
+		for _, uri := range rec.TraceURIs {
+			fmt.Fprintf(&b, "  %s\n", uri)
+		}
+		fmt.Fprintf(&b, "  download:   gcloud storage cp %s .\n", rec.TraceURIs[0])
+		fmt.Fprintf(&b, "  view:       npx playwright show-trace %s\n", filepath.Base(rec.TraceURIs[0]))
 	}
 
 	if repro := reproCommand(rec.Cell); repro != "" {

--- a/scripts/deploy-camunda/cmd/triage_test.go
+++ b/scripts/deploy-camunda/cmd/triage_test.go
@@ -404,3 +404,54 @@ func TestExtractFailureRecordEmptyLog(t *testing.T) {
 		t.Errorf("expected empty record for a boring log, got %+v", rec)
 	}
 }
+
+func TestExtractFailureRecordCollectsTraceURIs(t *testing.T) {
+	t.Parallel()
+
+	log := strings.Join([]string{
+		"2026-08-12T09:00:00.000Z ##[group]Playwright trace upload",
+		"2026-08-12T09:00:01.000Z gs://camunda-ci-e2e-traces/123/1/eske-install/login-flow/trace.zip",
+		"2026-08-12T09:00:02.000Z gs://camunda-ci-e2e-traces/123/1/eske-install/login-flow/trace.zip",
+		"2026-08-12T09:00:03.000Z gs://camunda-ci-e2e-traces/123/1/eske-install/upload-flow/trace.zip",
+		"2026-08-12T09:00:04.000Z ##[endgroup]",
+	}, "\n")
+
+	rec := extractFailureRecord(log)
+
+	if len(rec.TraceURIs) != 2 {
+		t.Fatalf("TraceURIs = %v, want 2 unique entries", rec.TraceURIs)
+	}
+	if rec.TraceURIs[0] != "gs://camunda-ci-e2e-traces/123/1/eske-install/login-flow/trace.zip" {
+		t.Errorf("unexpected first URI: %q", rec.TraceURIs[0])
+	}
+	if rec.TraceURIs[1] != "gs://camunda-ci-e2e-traces/123/1/eske-install/upload-flow/trace.zip" {
+		t.Errorf("unexpected second URI: %q", rec.TraceURIs[1])
+	}
+}
+
+func TestExtractFailureRecordWithoutTracesLeavesURIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	rec := extractFailureRecord("nothing interesting here\nDiagnostics: diagnostics/ns/ts\n")
+	if len(rec.TraceURIs) != 0 {
+		t.Errorf("TraceURIs = %v, want empty", rec.TraceURIs)
+	}
+}
+
+func TestUniqueStrings(t *testing.T) {
+	t.Parallel()
+
+	if got := uniqueStrings(nil); got != nil {
+		t.Errorf("uniqueStrings(nil) = %v, want nil", got)
+	}
+	got := uniqueStrings([]string{"b", "a", "b", "a", "c"})
+	want := []string{"b", "a", "c"}
+	if len(got) != len(want) {
+		t.Fatalf("uniqueStrings = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("uniqueStrings[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/scripts/deploy-camunda/matrix/matrix_test.go
+++ b/scripts/deploy-camunda/matrix/matrix_test.go
@@ -728,6 +728,30 @@ func TestPrintRunSummary(t *testing.T) {
 	}
 }
 
+func TestPrintRunSummaryRedactsErrors(t *testing.T) {
+	t.Parallel()
+
+	results := []RunResult{{
+		Entry: Entry{Version: "8.10", Scenario: "es", Shortname: "eske", Flow: "install"},
+		Error: fmt.Errorf("request failed API_TOKEN=summary-secret"),
+	}}
+
+	summary := PrintRunSummary(results, time.Second, "")
+	if strings.Contains(summary, "summary-secret") || !strings.Contains(summary, "API_TOKEN=[REDACTED]") {
+		t.Errorf("PrintRunSummary should redact errors: %s", summary)
+	}
+}
+
+func TestApplyResultRedactsErrors(t *testing.T) {
+	t.Parallel()
+
+	state := &entryState{}
+	applyResult(state, RunResult{Error: fmt.Errorf("API_TOKEN=status-secret")})
+	if strings.Contains(state.Error, "status-secret") || !strings.Contains(state.Error, "[REDACTED]") {
+		t.Errorf("applyResult should redact errors, got %q", state.Error)
+	}
+}
+
 func TestPrintRunSummaryParallelShowsSum(t *testing.T) {
 	// Simulate parallel execution: two entries each took 30s, but wall-clock was 30s.
 	results := []RunResult{

--- a/scripts/deploy-camunda/matrix/matrix_test.go
+++ b/scripts/deploy-camunda/matrix/matrix_test.go
@@ -1733,7 +1733,7 @@ func TestAppendTestOutputToDiagnostics_AppendToExistingRunDirectory(t *testing.T
 
 	te := &deploy.TestError{
 		Err:    fmt.Errorf("integration tests failed"),
-		Output: "FAIL: TestSomething\nexpected 200, got 500\n",
+		Output: "FAIL: TestSomething\nexpected 200, got 500\nAPI_TOKEN=test-secret\n",
 	}
 
 	result := appendTestOutputToDiagnostics(te, "test-ns", runDir)
@@ -1747,6 +1747,9 @@ func TestAppendTestOutputToDiagnostics_AppendToExistingRunDirectory(t *testing.T
 	}
 	if !strings.Contains(string(content), "FAIL: TestSomething") {
 		t.Errorf("test-output.txt should contain test output, got:\n%s", string(content))
+	}
+	if strings.Contains(string(content), "test-secret") {
+		t.Errorf("test-output.txt contains an unredacted secret:\n%s", string(content))
 	}
 
 	summaryBytes, err := os.ReadFile(filepath.Join(runDir, "summary.json"))
@@ -1762,6 +1765,9 @@ func TestAppendTestOutputToDiagnostics_AppendToExistingRunDirectory(t *testing.T
 	}
 	if !strings.Contains(summary.TestOutputLast200, "FAIL: TestSomething") {
 		t.Errorf("summary should contain test output, got:\n%s", summary.TestOutputLast200)
+	}
+	if strings.Contains(summary.TestOutputLast200, "test-secret") {
+		t.Errorf("summary contains an unredacted secret:\n%s", summary.TestOutputLast200)
 	}
 }
 

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -1248,6 +1248,7 @@ func writeDiagnosticsSummary(runDir string, summary diagnosticsSummary) error {
 	if err := os.WriteFile(summaryPath, append(b, '\n'), 0o600); err != nil {
 		return fmt.Errorf("write diagnostics summary: %w", err)
 	}
+	_ = os.Chmod(summaryPath, 0o600)
 	return nil
 }
 
@@ -1269,6 +1270,7 @@ func writeDiagnosticsReadme(runDir string, summary diagnosticsSummary) error {
 	if err := os.WriteFile(readmePath, []byte(b.String()), 0o600); err != nil {
 		return fmt.Errorf("write diagnostics readme: %w", err)
 	}
+	_ = os.Chmod(readmePath, 0o600)
 	return nil
 }
 
@@ -1339,6 +1341,7 @@ func collectDiagnostics(namespace, kubeContext string) string {
 					entry.Error = fmt.Sprintf("write log file: %v", err)
 					summary.Errors = append(summary.Errors, fmt.Sprintf("write pod logs (%s): %v", pod, err))
 				} else {
+					_ = os.Chmod(absPath, 0o600)
 					entry.File = relPath
 				}
 			}
@@ -1429,6 +1432,7 @@ func appendTestOutputToDiagnostics(err error, namespace, diagPath string) string
 		logging.Logger.Warn().Err(err).Str("path", testOutputPath).Msg("failed to write test output file")
 		summary.Errors = append(summary.Errors, fmt.Sprintf("write test output: %v", err))
 	}
+	_ = os.Chmod(testOutputPath, 0o600)
 
 	if err := writeDiagnosticsSummary(runDir, summary); err != nil {
 		logging.Logger.Warn().Err(err).Str("path", summaryPath).Msg("failed to write diagnostics summary with test output")

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -1245,8 +1245,7 @@ func writeDiagnosticsSummary(runDir string, summary diagnosticsSummary) error {
 	if err != nil {
 		return fmt.Errorf("marshal diagnostics summary: %w", err)
 	}
-	b = []byte(redaction.Text(string(b)))
-	if err := os.WriteFile(summaryPath, append(b, '\n'), 0o644); err != nil {
+	if err := os.WriteFile(summaryPath, append(b, '\n'), 0o600); err != nil {
 		return fmt.Errorf("write diagnostics summary: %w", err)
 	}
 	return nil
@@ -1267,7 +1266,7 @@ func writeDiagnosticsReadme(runDir string, summary diagnosticsSummary) error {
 	}
 
 	readmePath := filepath.Join(runDir, "README.txt")
-	if err := os.WriteFile(readmePath, []byte(b.String()), 0o644); err != nil {
+	if err := os.WriteFile(readmePath, []byte(b.String()), 0o600); err != nil {
 		return fmt.Errorf("write diagnostics readme: %w", err)
 	}
 	return nil
@@ -1289,7 +1288,7 @@ func collectDiagnostics(namespace, kubeContext string) string {
 
 	runDir := diagnosticsRunDir(namespace, time.Now())
 	logsDir := filepath.Join(runDir, "logs")
-	if err := os.MkdirAll(logsDir, 0o755); err != nil {
+	if err := os.MkdirAll(logsDir, 0o700); err != nil {
 		logging.Logger.Warn().Err(err).Str("path", logsDir).Msg("failed to create diagnostics logs directory")
 		return ""
 	}
@@ -1336,7 +1335,7 @@ func collectDiagnostics(namespace, kubeContext string) string {
 			if logs != "" {
 				relPath := filepath.Join("logs", sanitizeDiagnosticsFilename(pod)+".log")
 				absPath := filepath.Join(runDir, relPath)
-				if err := os.WriteFile(absPath, []byte(redaction.Text(logs)), 0o644); err != nil {
+				if err := os.WriteFile(absPath, []byte(redaction.Text(logs)), 0o600); err != nil {
 					entry.Error = fmt.Sprintf("write log file: %v", err)
 					summary.Errors = append(summary.Errors, fmt.Sprintf("write pod logs (%s): %v", pod, err))
 				} else {
@@ -1397,7 +1396,7 @@ func appendTestOutputToDiagnostics(err error, namespace, diagPath string) string
 	runDir := diagPath
 	if runDir == "" {
 		runDir = diagnosticsRunDir(namespace, time.Now())
-		if err := os.MkdirAll(filepath.Join(runDir, "logs"), 0o755); err != nil {
+		if err := os.MkdirAll(filepath.Join(runDir, "logs"), 0o700); err != nil {
 			logging.Logger.Warn().Err(err).Str("path", runDir).Msg("failed to create diagnostics directory for test output")
 			return ""
 		}
@@ -1426,7 +1425,7 @@ func appendTestOutputToDiagnostics(err error, namespace, diagPath string) string
 	summary.TestOutputLast200 = output
 
 	testOutputPath := filepath.Join(runDir, "test-output.txt")
-	if err := os.WriteFile(testOutputPath, []byte(output), 0o644); err != nil {
+	if err := os.WriteFile(testOutputPath, []byte(output), 0o600); err != nil {
 		logging.Logger.Warn().Err(err).Str("path", testOutputPath).Msg("failed to write test output file")
 		summary.Errors = append(summary.Errors, fmt.Sprintf("write test output: %v", err))
 	}

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -1638,6 +1638,7 @@ func PrintRunSummary(results []RunResult, wallClock time.Duration, logDir string
 					baseName := entryLogFileName(r.Entry)
 					fmt.Fprintf(&b, "    %s\n", dryKey("Logs:"))
 					fmt.Fprintf(&b, "      deploy:  %s\n", filepath.Join(logDir, baseName+".deploy.log"))
+					fmt.Fprintf(&b, "      e2e:     %s\n", filepath.Join(logDir, baseName+".e2e.log"))
 				}
 			}
 		}

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -27,6 +27,7 @@ import (
 	"scripts/deploy-camunda/deploy"
 	"scripts/deploy-camunda/entra"
 	"scripts/deploy-camunda/pkg/deployer"
+	"scripts/deploy-camunda/pkg/redaction"
 	"scripts/prepare-helm-values/pkg/env"
 )
 
@@ -1244,6 +1245,7 @@ func writeDiagnosticsSummary(runDir string, summary diagnosticsSummary) error {
 	if err != nil {
 		return fmt.Errorf("marshal diagnostics summary: %w", err)
 	}
+	b = []byte(redaction.Text(string(b)))
 	if err := os.WriteFile(summaryPath, append(b, '\n'), 0o644); err != nil {
 		return fmt.Errorf("write diagnostics summary: %w", err)
 	}
@@ -1301,9 +1303,9 @@ func collectDiagnostics(namespace, kubeContext string) string {
 
 	// Pods
 	if pods, err := kube.GetPods(ctx, kubeContext, namespace); err == nil && pods != "" {
-		summary.Pods = pods
+		summary.Pods = redaction.Text(pods)
 	} else if err != nil {
-		summary.Errors = append(summary.Errors, fmt.Sprintf("get pods: %v", err))
+		summary.Errors = append(summary.Errors, redaction.Text(fmt.Sprintf("get pods: %v", err)))
 	}
 
 	// Events (truncate to last 20 lines)
@@ -1312,9 +1314,9 @@ func collectDiagnostics(namespace, kubeContext string) string {
 		if len(lines) > 21 { // 1 header + 20 events
 			lines = append(lines[:1], lines[len(lines)-20:]...)
 		}
-		summary.Events = strings.Join(lines, "\n")
+		summary.Events = redaction.Text(strings.Join(lines, "\n"))
 	} else if err != nil {
-		summary.Errors = append(summary.Errors, fmt.Sprintf("get events: %v", err))
+		summary.Errors = append(summary.Errors, redaction.Text(fmt.Sprintf("get events: %v", err)))
 	}
 
 	// Logs from all pods: one file per pod under logs/.
@@ -1325,16 +1327,16 @@ func collectDiagnostics(namespace, kubeContext string) string {
 
 			logs, logErr := kube.GetPodLogs(ctx, kubeContext, namespace, pod, diagnosticsPodTailLines)
 			if logErr != nil {
-				entry.Error = logErr.Error()
+				entry.Error = redaction.Text(logErr.Error())
 				summary.PodLogs = append(summary.PodLogs, entry)
-				summary.Errors = append(summary.Errors, fmt.Sprintf("get pod logs (%s): %v", pod, logErr))
+				summary.Errors = append(summary.Errors, redaction.Text(fmt.Sprintf("get pod logs (%s): %v", pod, logErr)))
 				continue
 			}
 
 			if logs != "" {
 				relPath := filepath.Join("logs", sanitizeDiagnosticsFilename(pod)+".log")
 				absPath := filepath.Join(runDir, relPath)
-				if err := os.WriteFile(absPath, []byte(logs), 0o644); err != nil {
+				if err := os.WriteFile(absPath, []byte(redaction.Text(logs)), 0o644); err != nil {
 					entry.Error = fmt.Sprintf("write log file: %v", err)
 					summary.Errors = append(summary.Errors, fmt.Sprintf("write pod logs (%s): %v", pod, err))
 				} else {
@@ -1345,7 +1347,7 @@ func collectDiagnostics(namespace, kubeContext string) string {
 			summary.PodLogs = append(summary.PodLogs, entry)
 		}
 	} else {
-		summary.Errors = append(summary.Errors, fmt.Sprintf("list pod names: %v", err))
+		summary.Errors = append(summary.Errors, redaction.Text(fmt.Sprintf("list pod names: %v", err)))
 	}
 
 	// PVCs: state + describe. Key evidence for volume-mount and provisioning hangs
@@ -1353,14 +1355,14 @@ func collectDiagnostics(namespace, kubeContext string) string {
 	// after per-pod logs so that, under the shared collection deadline, the
 	// higher-value pod logs are not starved by the slower `describe pvc`.
 	if pvcs, err := kube.GetPVCs(ctx, kubeContext, namespace); err == nil && pvcs != "" {
-		summary.PVCs = pvcs
+		summary.PVCs = redaction.Text(pvcs)
 	} else if err != nil {
-		summary.Errors = append(summary.Errors, fmt.Sprintf("get pvc: %v", err))
+		summary.Errors = append(summary.Errors, redaction.Text(fmt.Sprintf("get pvc: %v", err)))
 	}
 	if pvcDesc, err := kube.DescribePVCs(ctx, kubeContext, namespace); err == nil && pvcDesc != "" {
-		summary.PVCDescribe = pvcDesc
+		summary.PVCDescribe = redaction.Text(pvcDesc)
 	} else if err != nil {
-		summary.Errors = append(summary.Errors, fmt.Sprintf("describe pvc: %v", err))
+		summary.Errors = append(summary.Errors, redaction.Text(fmt.Sprintf("describe pvc: %v", err)))
 	}
 
 	if err := writeDiagnosticsSummary(runDir, summary); err != nil {
@@ -1391,7 +1393,7 @@ func appendTestOutputToDiagnostics(err error, namespace, diagPath string) string
 	}
 
 	// Truncate test output to the last 200 lines to keep diagnostics files manageable.
-	output := lastNLines(testErr.Output, 200)
+	output := redaction.Text(lastNLines(testErr.Output, 200))
 	runDir := diagPath
 	if runDir == "" {
 		runDir = diagnosticsRunDir(namespace, time.Now())

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -900,7 +900,7 @@ func runSequential(ctx context.Context, entries []Entry, opts RunOptions) ([]Run
 
 			if result.Error != nil {
 				logEvent := logging.Logger.Error().
-					Err(result.Error).
+					Err(errors.New(redaction.Text(result.Error.Error()))).
 					Str("version", entry.Version).
 					Str("scenario", entry.Scenario).
 					Str("flow", entry.Flow)
@@ -980,7 +980,7 @@ func runParallel(ctx context.Context, entries []Entry, opts RunOptions) ([]RunRe
 
 			if result.Error != nil {
 				logEvent := logging.Logger.Error().
-					Err(result.Error).
+					Err(errors.New(redaction.Text(result.Error.Error()))).
 					Str("version", e.Version).
 					Str("scenario", e.Scenario).
 					Str("flow", e.Flow)
@@ -1622,12 +1622,12 @@ func PrintRunSummary(results []RunResult, wallClock time.Duration, logDir string
 					helmMsg := helmErr.Error()
 					if prefix := strings.TrimSuffix(fullMsg, helmMsg); prefix != "" {
 						prefix = strings.TrimRight(prefix, ": ")
-						fmt.Fprintf(&b, "    %s    %s\n", dryKey("Step:"), dryWarn(prefix))
+						fmt.Fprintf(&b, "    %s    %s\n", dryKey("Step:"), dryWarn(redaction.Text(prefix)))
 					}
-					fmt.Fprintf(&b, "    %s  %s\n", dryKey("Reason:"), dryFail(fmt.Sprintf("%s: %v", helmErr.Reason, helmErr.Cause)))
+					fmt.Fprintf(&b, "    %s  %s\n", dryKey("Reason:"), dryFail(redaction.Text(fmt.Sprintf("%s: %v", helmErr.Reason, helmErr.Cause))))
 					fmt.Fprintf(&b, "    %s %s\n", dryKey("Command:"), helmErr.ShortCommand())
 				} else {
-					fmt.Fprintf(&b, "    %s %s\n", dryKey("Error:"), dryFail(fmt.Sprintf("%v", r.Error)))
+					fmt.Fprintf(&b, "    %s %s\n", dryKey("Error:"), dryFail(redaction.Text(r.Error.Error())))
 				}
 
 				if r.Diagnostics != "" {
@@ -1638,7 +1638,6 @@ func PrintRunSummary(results []RunResult, wallClock time.Duration, logDir string
 					baseName := entryLogFileName(r.Entry)
 					fmt.Fprintf(&b, "    %s\n", dryKey("Logs:"))
 					fmt.Fprintf(&b, "      deploy:  %s\n", filepath.Join(logDir, baseName+".deploy.log"))
-					fmt.Fprintf(&b, "      e2e:     %s\n", filepath.Join(logDir, baseName+".e2e.log"))
 				}
 			}
 		}

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -318,6 +318,7 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) RunResult {
 			logging.Logger.Warn().Err(err).Msg("Failed to create e2e log file, output will go to terminal")
 		} else {
 			defer e2eFile.Close()
+			_ = e2eFile.Chmod(0o600)
 			flags.E2EOutputWriter = e2eFile
 		}
 
@@ -328,6 +329,7 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) RunResult {
 			logging.Logger.Warn().Err(err).Msg("Failed to create deploy log file")
 		} else {
 			defer deployLog.Close()
+			_ = deployLog.Chmod(0o600)
 			writeEntryLog := func(level, msg string) {
 				if !logging.ShouldLog(logLevel, level) {
 					return

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -3,7 +3,6 @@ package matrix
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -315,7 +314,13 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) RunResult {
 	// This keeps output out of the terminal so the status table stays clean.
 	if opts.LogDir != "" {
 		baseName := entryLogFileName(entry)
-		flags.E2EOutputWriter = io.Discard
+		if e2eFile, err := os.OpenFile(filepath.Join(opts.LogDir, baseName+".e2e.log"), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600); err != nil {
+			logging.Logger.Warn().Err(err).Msg("Failed to create e2e log file, output will go to terminal")
+		} else {
+			defer e2eFile.Close()
+			_ = e2eFile.Chmod(0o600)
+			flags.E2EOutputWriter = e2eFile
+		}
 
 		// Per-entry deploy log: captures all subprocess output (helm, kubectl, etc.)
 		// plus lifecycle events, giving a complete timeline for this entry.

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -15,6 +15,7 @@ import (
 	"scripts/deploy-camunda/config"
 	"scripts/deploy-camunda/deploy"
 	"scripts/deploy-camunda/entra"
+	"scripts/deploy-camunda/pkg/redaction"
 	"scripts/prepare-helm-values/pkg/env"
 )
 
@@ -313,7 +314,7 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) RunResult {
 	// This keeps output out of the terminal so the status table stays clean.
 	if opts.LogDir != "" {
 		baseName := entryLogFileName(entry)
-		if e2eFile, err := os.Create(filepath.Join(opts.LogDir, baseName+".e2e.log")); err != nil {
+		if e2eFile, err := os.OpenFile(filepath.Join(opts.LogDir, baseName+".e2e.log"), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600); err != nil {
 			logging.Logger.Warn().Err(err).Msg("Failed to create e2e log file, output will go to terminal")
 		} else {
 			defer e2eFile.Close()
@@ -323,7 +324,7 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) RunResult {
 		// Per-entry deploy log: captures all subprocess output (helm, kubectl, etc.)
 		// plus lifecycle events, giving a complete timeline for this entry.
 		deployLogPath := filepath.Join(opts.LogDir, baseName+".deploy.log")
-		if deployLog, err := os.Create(deployLogPath); err != nil {
+		if deployLog, err := os.OpenFile(deployLogPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600); err != nil {
 			logging.Logger.Warn().Err(err).Msg("Failed to create deploy log file")
 		} else {
 			defer deployLog.Close()
@@ -332,7 +333,7 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) RunResult {
 					return
 				}
 				ts := time.Now().Format("15:04:05")
-				fmt.Fprintf(deployLog, "[%s] %s: %s\n", ts, strings.ToUpper(level), msg)
+				fmt.Fprintf(deployLog, "[%s] %s: %s\n", ts, strings.ToUpper(level), redaction.Text(msg))
 			}
 			writeEntryLog("info", fmt.Sprintf("entry=%s namespace=%s platform=%s flow=%s", entryID(entry), namespace, platform, entry.Flow))
 
@@ -340,6 +341,7 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) RunResult {
 			// The callback tees lines to both the per-entry file and the normal logger.
 			ctx = executil.ContextWithBuffer(ctx, func(level, line string) {
 				writeEntryLog(level, line)
+				line = redaction.Text(line)
 				prefix := logging.BuildPrefix(logging.FieldsFromContext(ctx), "")
 				switch strings.ToLower(level) {
 				case "trace":

--- a/scripts/deploy-camunda/matrix/runner_execute.go
+++ b/scripts/deploy-camunda/matrix/runner_execute.go
@@ -3,6 +3,7 @@ package matrix
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -314,13 +315,7 @@ func executeEntry(ctx context.Context, entry Entry, opts RunOptions) RunResult {
 	// This keeps output out of the terminal so the status table stays clean.
 	if opts.LogDir != "" {
 		baseName := entryLogFileName(entry)
-		if e2eFile, err := os.OpenFile(filepath.Join(opts.LogDir, baseName+".e2e.log"), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600); err != nil {
-			logging.Logger.Warn().Err(err).Msg("Failed to create e2e log file, output will go to terminal")
-		} else {
-			defer e2eFile.Close()
-			_ = e2eFile.Chmod(0o600)
-			flags.E2EOutputWriter = e2eFile
-		}
+		flags.E2EOutputWriter = io.Discard
 
 		// Per-entry deploy log: captures all subprocess output (helm, kubectl, etc.)
 		// plus lifecycle events, giving a complete timeline for this entry.

--- a/scripts/deploy-camunda/matrix/status.go
+++ b/scripts/deploy-camunda/matrix/status.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"scripts/deploy-camunda/pkg/redaction"
 	"strings"
 	"sync"
 	"time"
@@ -235,7 +236,7 @@ func (d *StatusDisplay) writeEntrySummary(entry Entry, result RunResult) {
 
 	if result.Error != nil {
 		fmt.Fprintf(&b, "Status:    FAIL\n")
-		fmt.Fprintf(&b, "Error:     %s\n", result.Error)
+		fmt.Fprintf(&b, "Error:     %s\n", redaction.Text(result.Error.Error()))
 		if result.Diagnostics != "" {
 			fmt.Fprintf(&b, "Diagnostics: %s\n", result.Diagnostics)
 		}
@@ -243,7 +244,7 @@ func (d *StatusDisplay) writeEntrySummary(entry Entry, result RunResult) {
 		fmt.Fprintf(&b, "Status:    PASS\n")
 	}
 
-	_ = os.WriteFile(path, []byte(b.String()), 0o644)
+	_ = os.WriteFile(path, []byte(b.String()), 0o600)
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────

--- a/scripts/deploy-camunda/matrix/status.go
+++ b/scripts/deploy-camunda/matrix/status.go
@@ -209,7 +209,7 @@ func applyResult(s *entryState, result RunResult) {
 			s.Status = StatusSkipped
 		} else {
 			s.Status = StatusFailed
-			errMsg := result.Error.Error()
+			errMsg := redaction.Text(result.Error.Error())
 			if len(errMsg) > 72 {
 				errMsg = errMsg[:69] + "..."
 			}

--- a/scripts/deploy-camunda/matrix/status.go
+++ b/scripts/deploy-camunda/matrix/status.go
@@ -245,6 +245,7 @@ func (d *StatusDisplay) writeEntrySummary(entry Entry, result RunResult) {
 	}
 
 	_ = os.WriteFile(path, []byte(b.String()), 0o600)
+	_ = os.Chmod(path, 0o600)
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────

--- a/scripts/deploy-camunda/pkg/deployer/helm.go
+++ b/scripts/deploy-camunda/pkg/deployer/helm.go
@@ -93,11 +93,14 @@ func (e *HelmError) ShortCommand() string {
 func shortenArgs(args []string) string {
 	parts := append([]string(nil), args...)
 	for i := range parts {
+		if redactSensitiveFlag(parts, i) {
+			continue
+		}
 		if i > 0 && isHelmSetFlag(parts[i-1]) {
 			parts[i] = redactHelmSetArg(parts[i])
 			continue
 		}
-		for _, flag := range []string{"--set=", "--set-string=", "--set-json="} {
+		for _, flag := range []string{"--set=", "--set-string=", "--set-json=", "--set-literal="} {
 			if strings.HasPrefix(parts[i], flag) {
 				parts[i] = flag + redactHelmSetArg(strings.TrimPrefix(parts[i], flag))
 			}
@@ -118,11 +121,14 @@ func shortenArgs(args []string) string {
 func shortenPaths(cmd string) string {
 	parts := strings.Fields(cmd)
 	for i := range parts {
+		if redactSensitiveFlag(parts, i) {
+			continue
+		}
 		if i > 0 && isHelmSetFlag(parts[i-1]) {
 			parts[i] = redactHelmSetArg(parts[i])
 			continue
 		}
-		for _, flag := range []string{"--set=", "--set-string=", "--set-json="} {
+		for _, flag := range []string{"--set=", "--set-string=", "--set-json=", "--set-literal="} {
 			if strings.HasPrefix(parts[i], flag) {
 				parts[i] = flag + redactHelmSetArg(strings.TrimPrefix(parts[i], flag))
 			}
@@ -141,7 +147,7 @@ func shortenPaths(cmd string) string {
 }
 
 func isHelmSetFlag(arg string) bool {
-	return arg == "--set" || arg == "--set-string" || arg == "--set-json"
+	return arg == "--set" || arg == "--set-string" || arg == "--set-json" || arg == "--set-literal"
 }
 
 func redactHelmSetArg(arg string) string {
@@ -152,6 +158,20 @@ func redactHelmSetArg(arg string) string {
 		}
 	}
 	return redaction.Text(arg)
+}
+
+func redactSensitiveFlag(parts []string, i int) bool {
+	for _, flag := range []string{"--password", "--kube-token", "--username"} {
+		if parts[i] == flag && i+1 < len(parts) {
+			parts[i+1] = redaction.Placeholder
+			return true
+		}
+		if strings.HasPrefix(parts[i], flag+"=") {
+			parts[i] = flag + "=" + redaction.Placeholder
+			return true
+		}
+	}
+	return false
 }
 
 // upgradeInstall builds and executes helm upgrade --install with deployer's opinionated policies

--- a/scripts/deploy-camunda/pkg/deployer/helm.go
+++ b/scripts/deploy-camunda/pkg/deployer/helm.go
@@ -66,6 +66,8 @@ type HelmError struct {
 	Reason string
 	// Command is the full helm command that was executed
 	Command string
+	// Args preserves argument boundaries for safe diagnostic rendering.
+	Args []string
 	// Cause is the underlying error (e.g. exit status 1)
 	Cause error
 }
@@ -82,7 +84,33 @@ func (e *HelmError) Unwrap() error {
 // base filenames for readability. Full paths in -f values file args and chart
 // paths are replaced with just the filename.
 func (e *HelmError) ShortCommand() string {
+	if len(e.Args) > 0 {
+		return shortenArgs(e.Args)
+	}
 	return shortenPaths(e.Command)
+}
+
+func shortenArgs(args []string) string {
+	parts := append([]string(nil), args...)
+	for i := range parts {
+		if i > 0 && isHelmSetFlag(parts[i-1]) {
+			parts[i] = redactHelmSetArg(parts[i])
+			continue
+		}
+		for _, flag := range []string{"--set=", "--set-string=", "--set-json="} {
+			if strings.HasPrefix(parts[i], flag) {
+				parts[i] = flag + redactHelmSetArg(strings.TrimPrefix(parts[i], flag))
+			}
+		}
+		if i > 0 && parts[i-1] == "-f" && strings.Contains(parts[i], "/") {
+			parts[i] = filepath.Base(parts[i])
+			continue
+		}
+		if strings.HasPrefix(parts[i], "/") && !strings.HasPrefix(parts[i], "--") {
+			parts[i] = filepath.Base(parts[i])
+		}
+	}
+	return "helm " + formatArgs(parts)
 }
 
 // shortenPaths replaces long absolute/relative file paths with just basenames.
@@ -117,11 +145,13 @@ func isHelmSetFlag(arg string) bool {
 }
 
 func redactHelmSetArg(arg string) string {
-	key, _, found := strings.Cut(arg, "=")
-	if !found || !redaction.IsSensitiveName(key) {
-		return redaction.Text(arg)
+	for _, assignment := range strings.Split(arg, ",") {
+		key, _, found := strings.Cut(assignment, "=")
+		if found && redaction.IsSensitiveName(key) {
+			return redaction.Placeholder
+		}
 	}
-	return key + "=" + redaction.Placeholder
+	return redaction.Text(arg)
 }
 
 // upgradeInstall builds and executes helm upgrade --install with deployer's opinionated policies
@@ -203,6 +233,7 @@ func upgradeInstall(ctx context.Context, o types.Options) error {
 		return &HelmError{
 			Reason:  "helm upgrade --install failed",
 			Command: "helm " + formatArgs(args),
+			Args:    args,
 			Cause:   runErr,
 		}
 	}
@@ -343,6 +374,7 @@ func deployCompanionChart(ctx context.Context, cc types.CompanionChart, o types.
 	return &HelmError{
 		Reason:  fmt.Sprintf("companion chart %q helm upgrade --install failed", cc.ReleaseName),
 		Command: "helm " + formatArgs(args),
+		Args:    args,
 		Cause:   runErr,
 	}
 }

--- a/scripts/deploy-camunda/pkg/deployer/helm.go
+++ b/scripts/deploy-camunda/pkg/deployer/helm.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"scripts/camunda-core/pkg/helm"
 	"scripts/camunda-core/pkg/logging"
+	"scripts/deploy-camunda/pkg/redaction"
 	"scripts/deploy-camunda/pkg/types"
 	"strings"
 	"sync"
@@ -89,6 +90,15 @@ func (e *HelmError) ShortCommand() string {
 func shortenPaths(cmd string) string {
 	parts := strings.Fields(cmd)
 	for i := range parts {
+		if i > 0 && isHelmSetFlag(parts[i-1]) {
+			parts[i] = redactHelmSetArg(parts[i])
+			continue
+		}
+		for _, flag := range []string{"--set=", "--set-string=", "--set-json="} {
+			if strings.HasPrefix(parts[i], flag) {
+				parts[i] = flag + redactHelmSetArg(strings.TrimPrefix(parts[i], flag))
+			}
+		}
 		// Shorten -f value file paths
 		if i > 0 && parts[i-1] == "-f" && len(parts[i]) > 0 && (parts[i][0] == '/' || strings.Contains(parts[i], "/")) {
 			parts[i] = filepath.Base(parts[i])
@@ -100,6 +110,18 @@ func shortenPaths(cmd string) string {
 		}
 	}
 	return strings.Join(parts, " ")
+}
+
+func isHelmSetFlag(arg string) bool {
+	return arg == "--set" || arg == "--set-string" || arg == "--set-json"
+}
+
+func redactHelmSetArg(arg string) string {
+	key, _, found := strings.Cut(arg, "=")
+	if !found || !redaction.IsSensitiveName(key) {
+		return redaction.Text(arg)
+	}
+	return key + "=" + redaction.Placeholder
 }
 
 // upgradeInstall builds and executes helm upgrade --install with deployer's opinionated policies

--- a/scripts/deploy-camunda/pkg/deployer/helm_test.go
+++ b/scripts/deploy-camunda/pkg/deployer/helm_test.go
@@ -93,11 +93,11 @@ func TestHelmErrorShortCommandRedactsSensitiveSetValues(t *testing.T) {
 
 	err := &HelmError{
 		Command: "helm upgrade release chart --set global.identity.clientSecret=super-secret --set global.ingress.host=example.com --set-string=database.password=another-secret",
-		Args:    []string{"upgrade", "release", "chart", "--set", "global.identity.clientSecret=super secret", "--set", "global.ingress.host=example.com,database.password=combined-secret", "--set-string=database.password=another-secret"},
+		Args:    []string{"upgrade", "release", "chart", "--set", "global.identity.clientSecret=super secret", "--set", "global.ingress.host=example.com,database.password=combined-secret", "--set-string=database.password=another-secret", "--password", "registry-secret", "--kube-token=cluster-secret"},
 	}
 	got := err.ShortCommand()
 
-	for _, secret := range []string{"super secret", "combined-secret", "another-secret"} {
+	for _, secret := range []string{"super secret", "combined-secret", "another-secret", "registry-secret", "cluster-secret"} {
 		if strings.Contains(got, secret) {
 			t.Errorf("ShortCommand contains secret %q: %s", secret, got)
 		}

--- a/scripts/deploy-camunda/pkg/deployer/helm_test.go
+++ b/scripts/deploy-camunda/pkg/deployer/helm_test.go
@@ -93,15 +93,16 @@ func TestHelmErrorShortCommandRedactsSensitiveSetValues(t *testing.T) {
 
 	err := &HelmError{
 		Command: "helm upgrade release chart --set global.identity.clientSecret=super-secret --set global.ingress.host=example.com --set-string=database.password=another-secret",
+		Args:    []string{"upgrade", "release", "chart", "--set", "global.identity.clientSecret=super secret", "--set", "global.ingress.host=example.com,database.password=combined-secret", "--set-string=database.password=another-secret"},
 	}
 	got := err.ShortCommand()
 
-	for _, secret := range []string{"super-secret", "another-secret"} {
+	for _, secret := range []string{"super secret", "combined-secret", "another-secret"} {
 		if strings.Contains(got, secret) {
 			t.Errorf("ShortCommand contains secret %q: %s", secret, got)
 		}
 	}
-	for _, want := range []string{"global.identity.clientSecret=[REDACTED]", "global.ingress.host=example.com", "database.password=[REDACTED]"} {
+	for _, want := range []string{"[REDACTED]", "--set-string=[REDACTED]"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("ShortCommand missing %q: %s", want, got)
 		}

--- a/scripts/deploy-camunda/pkg/deployer/helm_test.go
+++ b/scripts/deploy-camunda/pkg/deployer/helm_test.go
@@ -88,6 +88,26 @@ func TestHelmError_ShortCommand(t *testing.T) {
 	}
 }
 
+func TestHelmErrorShortCommandRedactsSensitiveSetValues(t *testing.T) {
+	t.Parallel()
+
+	err := &HelmError{
+		Command: "helm upgrade release chart --set global.identity.clientSecret=super-secret --set global.ingress.host=example.com --set-string=database.password=another-secret",
+	}
+	got := err.ShortCommand()
+
+	for _, secret := range []string{"super-secret", "another-secret"} {
+		if strings.Contains(got, secret) {
+			t.Errorf("ShortCommand contains secret %q: %s", secret, got)
+		}
+	}
+	for _, want := range []string{"global.identity.clientSecret=[REDACTED]", "global.ingress.host=example.com", "database.password=[REDACTED]"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("ShortCommand missing %q: %s", want, got)
+		}
+	}
+}
+
 func TestShortenPaths_NoAbsolutePaths(t *testing.T) {
 	cmd := "helm upgrade --install integration camunda/camunda-platform -n ns --version 13.5.0 --wait"
 	got := shortenPaths(cmd)

--- a/scripts/deploy-camunda/pkg/redaction/redaction.go
+++ b/scripts/deploy-camunda/pkg/redaction/redaction.go
@@ -25,7 +25,7 @@ var (
 	sensitiveNamePattern = regexp.MustCompile(`(?i)(password|passwd|pwd|secret|token|credential|api[-_.]?key|private[-_.]?key)`)
 	assignmentPattern    = regexp.MustCompile(`(?im)^(\s*(?:[-*]\s*)?)([A-Za-z0-9_.-]+)(\s*(?::|=)\s*)(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\r\n]+)`)
 	jsonPattern          = regexp.MustCompile(`(?i)"((?:\\.|[^"\\])*)"\s*:\s*("(?:\\.|[^"\\])*"|[^,}\r\n]+)`)
-	authHeaderPattern    = regexp.MustCompile(`(?im)(^\s*(?:(?:proxy-)?authorization|cookie|set-cookie|x-api-key)\s*:\s*)[^\r\n]+`)
+	authHeaderPattern    = regexp.MustCompile(`(?im)(^\s*(?:[<>*]\s*)?(?:(?:proxy-)?authorization|cookie|set-cookie|x-api-key)\s*:\s*)[^\r\n]+`)
 	bearerPattern        = regexp.MustCompile(`(?i)\bbearer\s+[A-Za-z0-9._~+/-]+=*`)
 	jwtPattern           = regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+`)
 	urlUserInfoPattern   = regexp.MustCompile(`(://[^\s/:@]+:)[^\s/@]+(@)`)

--- a/scripts/deploy-camunda/pkg/redaction/redaction.go
+++ b/scripts/deploy-camunda/pkg/redaction/redaction.go
@@ -30,12 +30,13 @@ var (
 	jwtPattern           = regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+`)
 	urlUserInfoPattern   = regexp.MustCompile(`(://[^\s/:@]+:)[^\s/@]+(@)`)
 	queryPattern         = regexp.MustCompile(`(?i)([?&][A-Za-z0-9_.-]*(?:password|passwd|pwd|secret|token|credential|api[-_.]?key|private[-_.]?key)[A-Za-z0-9_.-]*=)[^&#\s]+`)
+	inlineAssignment     = regexp.MustCompile(`(^|[ \t])([A-Za-z0-9_.-]+)=([^\s,]+)`)
 	privateKeyPattern    = regexp.MustCompile(`(?s)-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----`)
 )
 
 func IsSensitiveName(name string) bool {
 	normalized := strings.ToLower(strings.NewReplacer("-", "", "_", "", ".", "").Replace(name))
-	for _, suffix := range []string{"secretname", "secretkey", "secretkeyref", "tokenurl", "passwordpolicy"} {
+	for _, suffix := range []string{"secretname", "secretkeyref", "tokenurl", "passwordpolicy"} {
 		if strings.HasSuffix(normalized, suffix) {
 			return false
 		}
@@ -58,11 +59,22 @@ func Text(value string) string {
 		colon := strings.Index(match, ":")
 		return match[:colon+1] + ` "` + Placeholder + `"`
 	})
+	value = redactInlineAssignments(value)
 	return assignmentPattern.ReplaceAllStringFunc(value, func(match string) string {
 		parts := assignmentPattern.FindStringSubmatch(match)
 		if len(parts) != 4 || !IsSensitiveName(parts[2]) {
 			return match
 		}
 		return parts[1] + parts[2] + parts[3] + Placeholder
+	})
+}
+
+func redactInlineAssignments(value string) string {
+	return inlineAssignment.ReplaceAllStringFunc(value, func(match string) string {
+		parts := inlineAssignment.FindStringSubmatch(match)
+		if len(parts) != 4 || !IsSensitiveName(parts[2]) {
+			return match
+		}
+		return parts[1] + parts[2] + "=" + Placeholder
 	})
 }

--- a/scripts/deploy-camunda/pkg/redaction/redaction.go
+++ b/scripts/deploy-camunda/pkg/redaction/redaction.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redaction
+
+import "regexp"
+
+const Placeholder = "[REDACTED]"
+
+var (
+	sensitiveNamePattern = regexp.MustCompile(`(?i)(password|passwd|pwd|secret|token|credential|api[-_.]?key|private[-_.]?key)`)
+	assignmentPattern    = regexp.MustCompile(`(?im)(^\s*(?:[-*]\s*)?[A-Za-z0-9_.-]*(?:password|passwd|pwd|secret|token|credential|api[-_.]?key|private[-_.]?key)[A-Za-z0-9_.-]*\s*(?::|=)\s*)(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s,\r\n]+)`)
+	jsonPattern          = regexp.MustCompile(`(?i)("[^"]*(?:password|passwd|pwd|secret|token|credential|api[-_.]?key|private[-_.]?key)[^"]*"\s*:\s*)"[^"]*"`)
+	authHeaderPattern    = regexp.MustCompile(`(?i)(\b(?:proxy-)?authorization\s*:\s*)(?:bearer\s+)?[^\s,;]+`)
+	bearerPattern        = regexp.MustCompile(`(?i)\bbearer\s+[A-Za-z0-9._~+/-]+=*`)
+	jwtPattern           = regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+`)
+	urlUserInfoPattern   = regexp.MustCompile(`(://[^\s/:@]+:)[^\s/@]+(@)`)
+	privateKeyPattern    = regexp.MustCompile(`(?s)-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----`)
+)
+
+func IsSensitiveName(name string) bool {
+	return sensitiveNamePattern.MatchString(name)
+}
+
+func Text(value string) string {
+	value = privateKeyPattern.ReplaceAllString(value, Placeholder)
+	value = authHeaderPattern.ReplaceAllString(value, `${1}`+Placeholder)
+	value = bearerPattern.ReplaceAllString(value, "Bearer "+Placeholder)
+	value = jwtPattern.ReplaceAllString(value, Placeholder)
+	value = urlUserInfoPattern.ReplaceAllString(value, `${1}`+Placeholder+`${2}`)
+	value = jsonPattern.ReplaceAllString(value, `${1}"`+Placeholder+`"`)
+	return assignmentPattern.ReplaceAllString(value, `${1}`+Placeholder)
+}

--- a/scripts/deploy-camunda/pkg/redaction/redaction.go
+++ b/scripts/deploy-camunda/pkg/redaction/redaction.go
@@ -31,8 +31,11 @@ var (
 	jwtPattern           = regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+`)
 	urlUserInfoPattern   = regexp.MustCompile(`(://[^\s/:@]+:)[^\s/@]+(@)`)
 	queryPattern         = regexp.MustCompile(`(?i)([?&][A-Za-z0-9_.-]*(?:password|passwd|pwd|secret|token|credential|api[-_.]?key|private[-_.]?key)[A-Za-z0-9_.-]*=)[^&#\s]+`)
-	inlineAssignment     = regexp.MustCompile(`(^|[ \t])([A-Za-z0-9_.-]+)=([^\s,]+)`)
-	privateKeyPattern    = regexp.MustCompile(`(?s)-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----`)
+	// The leading boundary accepts quotes and brackets so an assignment embedded
+	// in a serialized JSON string is still matched; the value stops at a quote so
+	// the replacement cannot swallow a closing delimiter and corrupt the document.
+	inlineAssignment  = regexp.MustCompile(`(^|[\s"'\[(,])([A-Za-z0-9_.-]+)=([^\s,"']+)`)
+	privateKeyPattern = regexp.MustCompile(`(?s)-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----`)
 )
 
 func IsSensitiveName(name string) bool {

--- a/scripts/deploy-camunda/pkg/redaction/redaction.go
+++ b/scripts/deploy-camunda/pkg/redaction/redaction.go
@@ -14,22 +14,32 @@
 
 package redaction
 
-import "regexp"
+import (
+	"regexp"
+	"strings"
+)
 
 const Placeholder = "[REDACTED]"
 
 var (
 	sensitiveNamePattern = regexp.MustCompile(`(?i)(password|passwd|pwd|secret|token|credential|api[-_.]?key|private[-_.]?key)`)
-	assignmentPattern    = regexp.MustCompile(`(?im)(^\s*(?:[-*]\s*)?[A-Za-z0-9_.-]*(?:password|passwd|pwd|secret|token|credential|api[-_.]?key|private[-_.]?key)[A-Za-z0-9_.-]*\s*(?::|=)\s*)(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s,\r\n]+)`)
-	jsonPattern          = regexp.MustCompile(`(?i)("[^"]*(?:password|passwd|pwd|secret|token|credential|api[-_.]?key|private[-_.]?key)[^"]*"\s*:\s*)"[^"]*"`)
-	authHeaderPattern    = regexp.MustCompile(`(?i)(\b(?:proxy-)?authorization\s*:\s*)(?:bearer\s+)?[^\s,;]+`)
+	assignmentPattern    = regexp.MustCompile(`(?im)^(\s*(?:[-*]\s*)?)([A-Za-z0-9_.-]+)(\s*(?::|=)\s*)(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\r\n]+)`)
+	jsonPattern          = regexp.MustCompile(`(?i)"((?:\\.|[^"\\])*)"\s*:\s*("(?:\\.|[^"\\])*"|[^,}\r\n]+)`)
+	authHeaderPattern    = regexp.MustCompile(`(?im)(^\s*(?:(?:proxy-)?authorization|cookie|set-cookie|x-api-key)\s*:\s*)[^\r\n]+`)
 	bearerPattern        = regexp.MustCompile(`(?i)\bbearer\s+[A-Za-z0-9._~+/-]+=*`)
 	jwtPattern           = regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+`)
 	urlUserInfoPattern   = regexp.MustCompile(`(://[^\s/:@]+:)[^\s/@]+(@)`)
+	queryPattern         = regexp.MustCompile(`(?i)([?&][A-Za-z0-9_.-]*(?:password|passwd|pwd|secret|token|credential|api[-_.]?key|private[-_.]?key)[A-Za-z0-9_.-]*=)[^&#\s]+`)
 	privateKeyPattern    = regexp.MustCompile(`(?s)-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----`)
 )
 
 func IsSensitiveName(name string) bool {
+	normalized := strings.ToLower(strings.NewReplacer("-", "", "_", "", ".", "").Replace(name))
+	for _, suffix := range []string{"secretname", "secretkey", "secretkeyref", "tokenurl", "passwordpolicy"} {
+		if strings.HasSuffix(normalized, suffix) {
+			return false
+		}
+	}
 	return sensitiveNamePattern.MatchString(name)
 }
 
@@ -39,6 +49,20 @@ func Text(value string) string {
 	value = bearerPattern.ReplaceAllString(value, "Bearer "+Placeholder)
 	value = jwtPattern.ReplaceAllString(value, Placeholder)
 	value = urlUserInfoPattern.ReplaceAllString(value, `${1}`+Placeholder+`${2}`)
-	value = jsonPattern.ReplaceAllString(value, `${1}"`+Placeholder+`"`)
-	return assignmentPattern.ReplaceAllString(value, `${1}`+Placeholder)
+	value = queryPattern.ReplaceAllString(value, `${1}`+Placeholder)
+	value = jsonPattern.ReplaceAllStringFunc(value, func(match string) string {
+		parts := jsonPattern.FindStringSubmatch(match)
+		if len(parts) != 3 || !IsSensitiveName(parts[1]) {
+			return match
+		}
+		colon := strings.Index(match, ":")
+		return match[:colon+1] + ` "` + Placeholder + `"`
+	})
+	return assignmentPattern.ReplaceAllStringFunc(value, func(match string) string {
+		parts := assignmentPattern.FindStringSubmatch(match)
+		if len(parts) != 4 || !IsSensitiveName(parts[2]) {
+			return match
+		}
+		return parts[1] + parts[2] + parts[3] + Placeholder
+	})
 }

--- a/scripts/deploy-camunda/pkg/redaction/redaction.go
+++ b/scripts/deploy-camunda/pkg/redaction/redaction.go
@@ -26,6 +26,7 @@ var (
 	assignmentPattern    = regexp.MustCompile(`(?im)^(\s*(?:[-*]\s*)?)([A-Za-z0-9_.-]+)(\s*(?::|=)\s*)(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\r\n]+)`)
 	jsonPattern          = regexp.MustCompile(`(?i)"((?:\\.|[^"\\])*)"\s*:\s*("(?:\\.|[^"\\])*"|[^,}\r\n]+)`)
 	authHeaderPattern    = regexp.MustCompile(`(?im)(^\s*(?:[<>*]\s*)?(?:(?:proxy-)?authorization|cookie|set-cookie|x-api-key)\s*:\s*)[^\r\n]+`)
+	inlineAuthPattern    = regexp.MustCompile(`(?i)(((?:proxy-)?authorization)\s*:\s*)(?:basic|bearer)\s+[^\s'";]+`)
 	bearerPattern        = regexp.MustCompile(`(?i)\bbearer\s+[A-Za-z0-9._~+/-]+=*`)
 	jwtPattern           = regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+`)
 	urlUserInfoPattern   = regexp.MustCompile(`(://[^\s/:@]+:)[^\s/@]+(@)`)
@@ -47,6 +48,7 @@ func IsSensitiveName(name string) bool {
 func Text(value string) string {
 	value = privateKeyPattern.ReplaceAllString(value, Placeholder)
 	value = authHeaderPattern.ReplaceAllString(value, `${1}`+Placeholder)
+	value = inlineAuthPattern.ReplaceAllString(value, `${1}`+Placeholder)
 	value = bearerPattern.ReplaceAllString(value, "Bearer "+Placeholder)
 	value = jwtPattern.ReplaceAllString(value, Placeholder)
 	value = urlUserInfoPattern.ReplaceAllString(value, `${1}`+Placeholder+`${2}`)

--- a/scripts/deploy-camunda/pkg/redaction/redaction_test.go
+++ b/scripts/deploy-camunda/pkg/redaction/redaction_test.go
@@ -25,6 +25,7 @@ func TestText(t *testing.T) {
 		want string
 	}{
 		{name: "env assignment", in: "DB_PASSWORD=super-secret", want: "DB_PASSWORD=" + Placeholder},
+		{name: "prefixed env assignment", in: "2026-08-05 INFO API_TOKEN=secret", want: "2026-08-05 INFO API_TOKEN=" + Placeholder},
 		{name: "yaml assignment", in: "  clientSecret: 'secret value'", want: "  clientSecret: " + Placeholder},
 		{name: "json value", in: `{"access_token":"secret-token","status":"failed"}`, want: `{"access_token": "[REDACTED]","status":"failed"}`},
 		{name: "authorization header", in: "Authorization: Bearer abc.def-123", want: "Authorization: " + Placeholder},
@@ -57,6 +58,7 @@ func TestIsSensitiveName(t *testing.T) {
 		{name: "global.identity.clientSecret", want: true},
 		{name: "database.password", want: true},
 		{name: "secretKeyRef", want: false},
+		{name: "SECRET_KEY", want: true},
 		{name: "oauth.tokenUrl", want: false},
 		{name: "global.ingress.host", want: false},
 	} {

--- a/scripts/deploy-camunda/pkg/redaction/redaction_test.go
+++ b/scripts/deploy-camunda/pkg/redaction/redaction_test.go
@@ -30,6 +30,7 @@ func TestText(t *testing.T) {
 		{name: "json value", in: `{"access_token":"secret-token","status":"failed"}`, want: `{"access_token": "[REDACTED]","status":"failed"}`},
 		{name: "authorization header", in: "Authorization: Bearer abc.def-123", want: "Authorization: " + Placeholder},
 		{name: "basic authorization header", in: "Authorization: Basic dXNlcjpwYXNz", want: "Authorization: " + Placeholder},
+		{name: "curl authorization header", in: "> Authorization: Basic dXNlcjpwYXNz", want: "> Authorization: " + Placeholder},
 		{name: "cookie header", in: "Set-Cookie: session=secret; Secure", want: "Set-Cookie: " + Placeholder},
 		{name: "standalone bearer", in: "request failed with Bearer abc.def-123", want: "request failed with Bearer " + Placeholder},
 		{name: "URL user info", in: "postgres://user:secret@database:5432/app", want: "postgres://user:" + Placeholder + "@database:5432/app"},

--- a/scripts/deploy-camunda/pkg/redaction/redaction_test.go
+++ b/scripts/deploy-camunda/pkg/redaction/redaction_test.go
@@ -31,6 +31,7 @@ func TestText(t *testing.T) {
 		{name: "authorization header", in: "Authorization: Bearer abc.def-123", want: "Authorization: " + Placeholder},
 		{name: "basic authorization header", in: "Authorization: Basic dXNlcjpwYXNz", want: "Authorization: " + Placeholder},
 		{name: "curl authorization header", in: "> Authorization: Basic dXNlcjpwYXNz", want: "> Authorization: " + Placeholder},
+		{name: "inline curl authorization header", in: `curl -H 'Authorization: Basic dXNlcjpwYXNz' https://example.test`, want: `curl -H 'Authorization: ` + Placeholder + `' https://example.test`},
 		{name: "cookie header", in: "Set-Cookie: session=secret; Secure", want: "Set-Cookie: " + Placeholder},
 		{name: "standalone bearer", in: "request failed with Bearer abc.def-123", want: "request failed with Bearer " + Placeholder},
 		{name: "URL user info", in: "postgres://user:secret@database:5432/app", want: "postgres://user:" + Placeholder + "@database:5432/app"},

--- a/scripts/deploy-camunda/pkg/redaction/redaction_test.go
+++ b/scripts/deploy-camunda/pkg/redaction/redaction_test.go
@@ -38,6 +38,13 @@ func TestText(t *testing.T) {
 		{name: "query token", in: "https://example.test/callback?code=ok&access_token=secret", want: "https://example.test/callback?code=ok&access_token=" + Placeholder},
 		{name: "private key", in: "before\n-----BEGIN PRIVATE KEY-----\nsecret\n-----END PRIVATE KEY-----\nafter", want: "before\n" + Placeholder + "\nafter"},
 		{name: "ordinary diagnostics", in: "pod-a 0/1 Running\nFailedMount: secret volume unavailable", want: "pod-a 0/1 Running\nFailedMount: secret volume unavailable"},
+		{name: "assignment inside a json string", in: `"stdout": "ZEEBE_CLIENT_SECRET=super-secret"`, want: `"stdout": "ZEEBE_CLIENT_SECRET=` + Placeholder + `"`},
+		{name: "assignment inside a json array element", in: `["API_TOKEN=abc123", "ok"]`, want: `["API_TOKEN=` + Placeholder + `", "ok"]`},
+		// Only quotes are excluded from the value, so a trailing non-quote
+		// delimiter is consumed with it. That is deliberate: narrowing the value
+		// class further would leak the remainder of any secret containing one of
+		// those characters, and over-redacting is the safer failure.
+		{name: "bracketed assignment consumes the closing delimiter", in: "helm(DB_PASSWORD=hunter2)", want: "helm(DB_PASSWORD=" + Placeholder},
 	}
 
 	for _, tt := range tests {

--- a/scripts/deploy-camunda/pkg/redaction/redaction_test.go
+++ b/scripts/deploy-camunda/pkg/redaction/redaction_test.go
@@ -26,10 +26,13 @@ func TestText(t *testing.T) {
 	}{
 		{name: "env assignment", in: "DB_PASSWORD=super-secret", want: "DB_PASSWORD=" + Placeholder},
 		{name: "yaml assignment", in: "  clientSecret: 'secret value'", want: "  clientSecret: " + Placeholder},
-		{name: "json value", in: `{"access_token":"secret-token","status":"failed"}`, want: `{"access_token":"[REDACTED]","status":"failed"}`},
+		{name: "json value", in: `{"access_token":"secret-token","status":"failed"}`, want: `{"access_token": "[REDACTED]","status":"failed"}`},
 		{name: "authorization header", in: "Authorization: Bearer abc.def-123", want: "Authorization: " + Placeholder},
+		{name: "basic authorization header", in: "Authorization: Basic dXNlcjpwYXNz", want: "Authorization: " + Placeholder},
+		{name: "cookie header", in: "Set-Cookie: session=secret; Secure", want: "Set-Cookie: " + Placeholder},
 		{name: "standalone bearer", in: "request failed with Bearer abc.def-123", want: "request failed with Bearer " + Placeholder},
 		{name: "URL user info", in: "postgres://user:secret@database:5432/app", want: "postgres://user:" + Placeholder + "@database:5432/app"},
+		{name: "query token", in: "https://example.test/callback?code=ok&access_token=secret", want: "https://example.test/callback?code=ok&access_token=" + Placeholder},
 		{name: "private key", in: "before\n-----BEGIN PRIVATE KEY-----\nsecret\n-----END PRIVATE KEY-----\nafter", want: "before\n" + Placeholder + "\nafter"},
 		{name: "ordinary diagnostics", in: "pod-a 0/1 Running\nFailedMount: secret volume unavailable", want: "pod-a 0/1 Running\nFailedMount: secret volume unavailable"},
 	}
@@ -53,6 +56,8 @@ func TestIsSensitiveName(t *testing.T) {
 	}{
 		{name: "global.identity.clientSecret", want: true},
 		{name: "database.password", want: true},
+		{name: "secretKeyRef", want: false},
+		{name: "oauth.tokenUrl", want: false},
 		{name: "global.ingress.host", want: false},
 	} {
 		if got := IsSensitiveName(tt.name); got != tt.want {

--- a/scripts/deploy-camunda/pkg/redaction/redaction_test.go
+++ b/scripts/deploy-camunda/pkg/redaction/redaction_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redaction
+
+import "testing"
+
+func TestText(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "env assignment", in: "DB_PASSWORD=super-secret", want: "DB_PASSWORD=" + Placeholder},
+		{name: "yaml assignment", in: "  clientSecret: 'secret value'", want: "  clientSecret: " + Placeholder},
+		{name: "json value", in: `{"access_token":"secret-token","status":"failed"}`, want: `{"access_token":"[REDACTED]","status":"failed"}`},
+		{name: "authorization header", in: "Authorization: Bearer abc.def-123", want: "Authorization: " + Placeholder},
+		{name: "standalone bearer", in: "request failed with Bearer abc.def-123", want: "request failed with Bearer " + Placeholder},
+		{name: "URL user info", in: "postgres://user:secret@database:5432/app", want: "postgres://user:" + Placeholder + "@database:5432/app"},
+		{name: "private key", in: "before\n-----BEGIN PRIVATE KEY-----\nsecret\n-----END PRIVATE KEY-----\nafter", want: "before\n" + Placeholder + "\nafter"},
+		{name: "ordinary diagnostics", in: "pod-a 0/1 Running\nFailedMount: secret volume unavailable", want: "pod-a 0/1 Running\nFailedMount: secret volume unavailable"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := Text(tt.in); got != tt.want {
+				t.Fatalf("Text() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsSensitiveName(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name string
+		want bool
+	}{
+		{name: "global.identity.clientSecret", want: true},
+		{name: "database.password", want: true},
+		{name: "global.ingress.host", want: false},
+	} {
+		if got := IsSensitiveName(tt.name); got != tt.want {
+			t.Errorf("IsSensitiveName(%q) = %t, want %t", tt.name, got, tt.want)
+		}
+	}
+}

--- a/scripts/render-e2e-env.sh
+++ b/scripts/render-e2e-env.sh
@@ -244,6 +244,12 @@ render_env_file() {
   local is_auth0="${11:-false}"
   local kubectl_cmd="kubectl"
 
+  umask 077
+  if [[ -L "$env_file" ]]; then
+    log "ERROR: Refusing to write env file through a symbolic link: $env_file"
+    return 1
+  fi
+
   if [[ -n "$kube_context" ]]; then
     kubectl_cmd="kubectl --context=$kube_context"
   fi
@@ -263,7 +269,6 @@ render_env_file() {
   # Generate base .env from template
   export TEST_INGRESS_HOST="$hostname"
   envsubst < "$test_suite_path"/.env.template > "$env_file"
-  chmod 600 "$env_file"
 
   # Auth0 scenario short-circuit. The auth0-smoke Playwright project only
   # needs the Auth0 issuer + per-component client_ids; the matrix runner

--- a/scripts/render-e2e-env.sh
+++ b/scripts/render-e2e-env.sh
@@ -244,9 +244,8 @@ render_env_file() {
   local is_auth0="${11:-false}"
   local kubectl_cmd="kubectl"
 
-  umask 077
   if [[ -L "$env_file" ]]; then
-    log "ERROR: Refusing to write env file through a symbolic link: $env_file"
+    echo "Error: refusing to write env file through a symbolic link: $env_file" >&2
     return 1
   fi
 
@@ -266,10 +265,13 @@ render_env_file() {
     log "DEBUG: No Optimize pods found in namespace — setting IS_OPTIMIZE=false"
   fi
 
-  # Generate base .env from template
+  # Generate base .env from template. Pre-create the file owner-only in a
+  # subshell so the umask change stays scoped and no world-readable window
+  # exists between creation and chmod.
+  rm -f "$env_file"
+  (umask 077 && : > "$env_file") || return 1
   export TEST_INGRESS_HOST="$hostname"
   envsubst < "$test_suite_path"/.env.template > "$env_file"
-  chmod 600 "$env_file"
 
   # Auth0 scenario short-circuit. The auth0-smoke Playwright project only
   # needs the Auth0 issuer + per-component client_ids; the matrix runner
@@ -318,7 +320,9 @@ render_env_file() {
       [[ -n "${AUTH0_INITIAL_ADMIN_EMAIL:-}" ]] && echo "AUTH0_INITIAL_ADMIN_EMAIL=${AUTH0_INITIAL_ADMIN_EMAIL}"
     } >> "$env_file"
     log "DEBUG: Auth0 env file setup complete (Keycloak resolution skipped)"
-    [[ "$VERBOSE" == "true" ]] && log "DEBUG: Env file written to $env_file"
+    if [[ "$VERBOSE" == "true" ]]; then
+      log "DEBUG: Env file written to $env_file"
+    fi
     return 0
   fi
 
@@ -384,7 +388,9 @@ render_env_file() {
   } >> "$env_file"
 
   log "DEBUG: Env file setup complete"
-  [[ "$VERBOSE" == "true" ]] && log "DEBUG: Env file written to $env_file"
+  if [[ "$VERBOSE" == "true" ]]; then
+    log "DEBUG: Env file written to $env_file"
+  fi
 }
 
 # ------------------------------------------------------------------------------

--- a/scripts/render-e2e-env.sh
+++ b/scripts/render-e2e-env.sh
@@ -269,6 +269,7 @@ render_env_file() {
   # Generate base .env from template
   export TEST_INGRESS_HOST="$hostname"
   envsubst < "$test_suite_path"/.env.template > "$env_file"
+  chmod 600 "$env_file"
 
   # Auth0 scenario short-circuit. The auth0-smoke Playwright project only
   # needs the Auth0 issuer + per-component client_ids; the matrix runner

--- a/scripts/render-e2e-env.sh
+++ b/scripts/render-e2e-env.sh
@@ -263,6 +263,7 @@ render_env_file() {
   # Generate base .env from template
   export TEST_INGRESS_HOST="$hostname"
   envsubst < "$test_suite_path"/.env.template > "$env_file"
+  chmod 600 "$env_file"
 
   # Auth0 scenario short-circuit. The auth0-smoke Playwright project only
   # needs the Auth0 issuer + per-component client_ids; the matrix runner
@@ -311,10 +312,7 @@ render_env_file() {
       [[ -n "${AUTH0_INITIAL_ADMIN_EMAIL:-}" ]] && echo "AUTH0_INITIAL_ADMIN_EMAIL=${AUTH0_INITIAL_ADMIN_EMAIL}"
     } >> "$env_file"
     log "DEBUG: Auth0 env file setup complete (Keycloak resolution skipped)"
-    if [[ "$VERBOSE" == "true" ]]; then
-      log "DEBUG: Contents of .env file:"
-      cat "$env_file"
-    fi
+    [[ "$VERBOSE" == "true" ]] && log "DEBUG: Env file written to $env_file"
     return 0
   fi
 
@@ -380,10 +378,7 @@ render_env_file() {
   } >> "$env_file"
 
   log "DEBUG: Env file setup complete"
-  if [[ "$VERBOSE" == "true" ]]; then
-    log "DEBUG: Contents of .env file:"
-    cat "$env_file"
-  fi
+  [[ "$VERBOSE" == "true" ]] && log "DEBUG: Env file written to $env_file"
 }
 
 # ------------------------------------------------------------------------------

--- a/test/scripts/render_e2e_env.bats
+++ b/test/scripts/render_e2e_env.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+
+setup() {
+  if ROOT="$(git -C "$here" rev-parse --show-toplevel 2>/dev/null)"; then
+    :
+  else
+    ROOT="$(cd "$here/../.." && pwd)"
+  fi
+  export ROOT
+  export VERBOSE=false
+
+  SUITE_DIR="$BATS_TEST_TMPDIR/suite"
+  mkdir -p "$SUITE_DIR"
+  printf 'PLAYWRIGHT_BASE_URL=https://${TEST_INGRESS_HOST}\n' > "$SUITE_DIR/.env.template"
+  export SUITE_DIR
+
+  export AUTH0_ISSUER_URL="https://tenant.example.auth0.com/"
+  export AUTH0_AUDIENCE="camunda"
+  export AUTH0_IDENTITY_CLIENT_ID="identity-client"
+  export AUTH0_ORCHESTRATION_CLIENT_ID="orchestration-client"
+  export AUTH0_OPTIMIZE_CLIENT_ID="optimize-client"
+  export AUTH0_CONNECTORS_CLIENT_ID="connectors-client"
+  export AUTH0_WEB_MODELER_CLIENT_ID="web-modeler-client"
+  export AUTH0_CONSOLE_CLIENT_ID="console-client"
+
+  # render-e2e-env.sh resolves its base-script path from $0, which is the bats
+  # binary here; sourcing the base script first satisfies its `declare -f log` guard.
+  source "$ROOT/scripts/base_playwright_script.sh"
+  source "$ROOT/scripts/render-e2e-env.sh"
+}
+
+kubectl() {
+  case "$*" in
+    *"get pods"*)
+      return 0
+      ;;
+    *"get secret"*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+render_auth0_env() {
+  render_env_file "$1" "$SUITE_DIR" "camunda.example.com" test-namespace \
+    true false false false true "" true
+}
+
+@test "rendered env file is owner-readable only" {
+  env_file="$BATS_TEST_TMPDIR/.env"
+
+  run render_auth0_env "$env_file"
+
+  [ "$status" -eq 0 ]
+  [ -f "$env_file" ]
+  [ "$(stat -f '%Lp' "$env_file" 2>/dev/null || stat -c '%a' "$env_file")" = "600" ]
+  grep -q "PLAYWRIGHT_BASE_URL=https://camunda.example.com" "$env_file"
+  grep -q "AUTH0_IDENTITY_CLIENT_ID=identity-client" "$env_file"
+}
+
+@test "rendered env file is tightened even when a world-readable file already exists" {
+  env_file="$BATS_TEST_TMPDIR/.env"
+  printf 'STALE=1\n' > "$env_file"
+  chmod 644 "$env_file"
+
+  run render_auth0_env "$env_file"
+
+  [ "$status" -eq 0 ]
+  [ "$(stat -f '%Lp' "$env_file" 2>/dev/null || stat -c '%a' "$env_file")" = "600" ]
+  ! grep -q "STALE=1" "$env_file"
+}
+
+@test "writing the env file through a symbolic link is refused" {
+  target="$BATS_TEST_TMPDIR/target"
+  env_file="$BATS_TEST_TMPDIR/link"
+  printf 'UNTOUCHED=1\n' > "$target"
+  ln -s "$target" "$env_file"
+
+  run render_auth0_env "$env_file"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"refusing to write env file through a symbolic link"* ]]
+  grep -q "UNTOUCHED=1" "$target"
+}
+
+@test "env file contents are not echoed when verbose is enabled" {
+  env_file="$BATS_TEST_TMPDIR/.env"
+  export VERBOSE=true
+
+  run render_auth0_env "$env_file"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Env file written to $env_file"* ]]
+  [[ "$output" != *"identity-client"* ]]
+}

--- a/test/scripts/render_e2e_env.bats
+++ b/test/scripts/render_e2e_env.bats
@@ -48,6 +48,12 @@ render_auth0_env() {
     true false false false true "" true
 }
 
+# GNU stat -f reports filesystem status and succeeds, so it must not be the
+# probe; try the GNU mode format first and fall back to the BSD one.
+file_mode() {
+  stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"
+}
+
 @test "rendered env file is owner-readable only" {
   env_file="$BATS_TEST_TMPDIR/.env"
 
@@ -55,7 +61,7 @@ render_auth0_env() {
 
   [ "$status" -eq 0 ]
   [ -f "$env_file" ]
-  [ "$(stat -f '%Lp' "$env_file" 2>/dev/null || stat -c '%a' "$env_file")" = "600" ]
+  [ "$(file_mode "$env_file")" = "600" ]
   grep -q "PLAYWRIGHT_BASE_URL=https://camunda.example.com" "$env_file"
   grep -q "AUTH0_IDENTITY_CLIENT_ID=identity-client" "$env_file"
 }
@@ -68,7 +74,7 @@ render_auth0_env() {
   run render_auth0_env "$env_file"
 
   [ "$status" -eq 0 ]
-  [ "$(stat -f '%Lp' "$env_file" 2>/dev/null || stat -c '%a' "$env_file")" = "600" ]
+  [ "$(file_mode "$env_file")" = "600" ]
   ! grep -q "STALE=1" "$env_file"
 }
 


### PR DESCRIPTION
### Which problem does the PR fix?

Integration workflow input dumps, Kubernetes diagnostics, Helm failure commands, and generated E2E environment files could expose credentials or derived authentication data in retained job logs and artifacts.

### What's in this PR?

The integration runner no longer prints complete workflow inputs or extra values. A shared redactor sanitizes diagnostics written to logs and artifact bundles, test output, authorization data, tokens, private keys, URL credentials, and sensitive Helm `--set` values in failure messages. Generated E2E environment files are no longer dumped and are restricted to mode `0600`. Diagnostics and merged Playwright report retention is reduced from 14 to 5 days.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

### Security considerations

- Redaction is applied at text output and persistence boundaries; actual Helm execution still receives original arguments.
- Diagnostic and per-entry files are owner-only (0600, directories 0700).
- Raw Kubernetes event fallbacks are omitted when the sanitizer is unavailable.
- CI Playwright traces, screenshots, and videos are disabled because binary browser artifacts cannot be reliably sanitized.
- This PR complements #6796; deployment-summary credential removal remains isolated there.