### PR TITLE
fix: document camundaHub override maps in values schema [ready]

### DIFF
--- a/charts/camunda-platform-8.10/values.schema.extra.json
+++ b/charts/camunda-platform-8.10/values.schema.extra.json
@@ -1201,6 +1201,44 @@
                     "description": "can be used to override the automatic mounting of the service account token at the pod level. When unset, the ServiceAccount configuration is used.",
                     "default": null
                 },
+                "image": {
+                    "type": "object",
+                    "description": "override values for the Camunda Hub image; merged additively over the legacy webModeler.image map, so partial overrides keep the legacy values for the keys left unset.",
+                    "default": {},
+                    "additionalProperties": true
+                },
+                "security": {
+                    "type": "object",
+                    "description": "override values for the Camunda Hub security section; takes precedence over the legacy webModeler.security values.",
+                    "default": {},
+                    "additionalProperties": true,
+                    "properties": {
+                        "authentication": {
+                            "type": "object",
+                            "description": "override values for the Camunda Hub authentication section; takes precedence over the legacy webModeler.security.authentication values.",
+                            "default": {},
+                            "additionalProperties": true
+                        }
+                    }
+                },
+                "restapi": {
+                    "type": "object",
+                    "description": "override values for the Camunda Hub restapi component; takes precedence over the legacy webModeler.restapi values.",
+                    "default": {},
+                    "additionalProperties": true
+                },
+                "websockets": {
+                    "type": "object",
+                    "description": "override values for the Camunda Hub websockets component; takes precedence over the legacy webModeler.websockets values.",
+                    "default": {},
+                    "additionalProperties": true
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "description": "override values for the Camunda Hub service account; takes precedence over the legacy webModeler.serviceAccount values.",
+                    "default": {},
+                    "additionalProperties": true
+                },
                 "persistence": {
                     "properties": {
                         "deploymentStrategy": {

--- a/charts/camunda-platform-8.10/values.schema.extra.json
+++ b/charts/camunda-platform-8.10/values.schema.extra.json
@@ -1209,13 +1209,13 @@
                 },
                 "security": {
                     "type": "object",
-                    "description": "override values for the Camunda Hub security section; takes precedence over the legacy webModeler.security values.",
+                    "description": "override values for the Camunda Hub security section; set values take precedence over the legacy webModeler.security values. Overrides go through Helm's `or`, so falsy values (false, 0, \"\") do not override the legacy value \u2014 set those on webModeler.security directly.",
                     "default": {},
                     "additionalProperties": true,
                     "properties": {
                         "authentication": {
                             "type": "object",
-                            "description": "override values for the Camunda Hub authentication section; takes precedence over the legacy webModeler.security.authentication values.",
+                            "description": "override values for the Camunda Hub authentication section; set values take precedence over the legacy webModeler.security.authentication values. Overrides go through Helm's `or`, so falsy values (false, 0, \"\") do not override the legacy value \u2014 set those on webModeler.security.authentication directly.",
                             "default": {},
                             "additionalProperties": true
                         }
@@ -1223,19 +1223,19 @@
                 },
                 "restapi": {
                     "type": "object",
-                    "description": "override values for the Camunda Hub restapi component; takes precedence over the legacy webModeler.restapi values.",
+                    "description": "override values for the Camunda Hub restapi component; set values take precedence over the legacy webModeler.restapi values. Overrides go through Helm's `or`, so falsy values (false, 0, \"\") do not override the legacy value \u2014 set those on webModeler.restapi directly. The image and pusher maps are the exception: they are merged over their legacy counterparts, so falsy values do apply there.",
                     "default": {},
                     "additionalProperties": true
                 },
                 "websockets": {
                     "type": "object",
-                    "description": "override values for the Camunda Hub websockets component; takes precedence over the legacy webModeler.websockets values.",
+                    "description": "override values for the Camunda Hub websockets component; set values take precedence over the legacy webModeler.websockets values. Overrides go through Helm's `or`, so falsy values (false, 0, \"\") do not override the legacy value \u2014 set those on webModeler.websockets directly. The image map is the exception: it is merged over its legacy counterpart, so falsy values do apply there.",
                     "default": {},
                     "additionalProperties": true
                 },
                 "serviceAccount": {
                     "type": "object",
-                    "description": "override values for the Camunda Hub service account; takes precedence over the legacy webModeler.serviceAccount values.",
+                    "description": "override values for the Camunda Hub service account; set values take precedence over the legacy webModeler.serviceAccount values. Overrides go through Helm's `or`, so falsy values (false, 0, \"\") do not override the legacy value \u2014 set those on webModeler.serviceAccount directly.",
                     "default": {},
                     "additionalProperties": true
                 },

--- a/charts/camunda-platform-8.10/values.schema.json
+++ b/charts/camunda-platform-8.10/values.schema.json
@@ -2090,13 +2090,13 @@
                 },
                 "security": {
                     "type": "object",
-                    "description": "override values for the Camunda Hub security section; takes precedence over the legacy webModeler.security values.",
+                    "description": "override values for the Camunda Hub security section; set values take precedence over the legacy webModeler.security values. Overrides go through Helm's `or`, so falsy values (false, 0, \"\") do not override the legacy value — set those on webModeler.security directly.",
                     "default": {},
                     "additionalProperties": true,
                     "properties": {
                         "authentication": {
                             "type": "object",
-                            "description": "override values for the Camunda Hub authentication section; takes precedence over the legacy webModeler.security.authentication values.",
+                            "description": "override values for the Camunda Hub authentication section; set values take precedence over the legacy webModeler.security.authentication values. Overrides go through Helm's `or`, so falsy values (false, 0, \"\") do not override the legacy value — set those on webModeler.security.authentication directly.",
                             "default": {},
                             "additionalProperties": true
                         }
@@ -2104,19 +2104,19 @@
                 },
                 "restapi": {
                     "type": "object",
-                    "description": "override values for the Camunda Hub restapi component; takes precedence over the legacy webModeler.restapi values.",
+                    "description": "override values for the Camunda Hub restapi component; set values take precedence over the legacy webModeler.restapi values. Overrides go through Helm's `or`, so falsy values (false, 0, \"\") do not override the legacy value — set those on webModeler.restapi directly. The image and pusher maps are the exception: they are merged over their legacy counterparts, so falsy values do apply there.",
                     "default": {},
                     "additionalProperties": true
                 },
                 "websockets": {
                     "type": "object",
-                    "description": "override values for the Camunda Hub websockets component; takes precedence over the legacy webModeler.websockets values.",
+                    "description": "override values for the Camunda Hub websockets component; set values take precedence over the legacy webModeler.websockets values. Overrides go through Helm's `or`, so falsy values (false, 0, \"\") do not override the legacy value — set those on webModeler.websockets directly. The image map is the exception: it is merged over its legacy counterpart, so falsy values do apply there.",
                     "default": {},
                     "additionalProperties": true
                 },
                 "serviceAccount": {
                     "type": "object",
-                    "description": "override values for the Camunda Hub service account; takes precedence over the legacy webModeler.serviceAccount values.",
+                    "description": "override values for the Camunda Hub service account; set values take precedence over the legacy webModeler.serviceAccount values. Overrides go through Helm's `or`, so falsy values (false, 0, \"\") do not override the legacy value — set those on webModeler.serviceAccount directly.",
                     "default": {},
                     "additionalProperties": true
                 },

--- a/charts/camunda-platform-8.10/values.schema.json
+++ b/charts/camunda-platform-8.10/values.schema.json
@@ -2082,6 +2082,44 @@
                     "default": null,
                     "nullable": true
                 },
+                "image": {
+                    "type": "object",
+                    "description": "override values for the Camunda Hub image; merged additively over the legacy webModeler.image map, so partial overrides keep the legacy values for the keys left unset.",
+                    "default": {},
+                    "additionalProperties": true
+                },
+                "security": {
+                    "type": "object",
+                    "description": "override values for the Camunda Hub security section; takes precedence over the legacy webModeler.security values.",
+                    "default": {},
+                    "additionalProperties": true,
+                    "properties": {
+                        "authentication": {
+                            "type": "object",
+                            "description": "override values for the Camunda Hub authentication section; takes precedence over the legacy webModeler.security.authentication values.",
+                            "default": {},
+                            "additionalProperties": true
+                        }
+                    }
+                },
+                "restapi": {
+                    "type": "object",
+                    "description": "override values for the Camunda Hub restapi component; takes precedence over the legacy webModeler.restapi values.",
+                    "default": {},
+                    "additionalProperties": true
+                },
+                "websockets": {
+                    "type": "object",
+                    "description": "override values for the Camunda Hub websockets component; takes precedence over the legacy webModeler.websockets values.",
+                    "default": {},
+                    "additionalProperties": true
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "description": "override values for the Camunda Hub service account; takes precedence over the legacy webModeler.serviceAccount values.",
+                    "default": {},
+                    "additionalProperties": true
+                },
                 "persistence": {
                     "properties": {
                         "deploymentStrategy": {


### PR DESCRIPTION
### Which problem does the PR fix?

Closes the remaining part of #6558 (the other part — `defaultRoles.admin.clients` — is #6560).

`camundaHub.{image,security,restapi,websockets,serviceAccount}` are defined in `values.yaml` and consumed by the Web Modeler templates through the `or .Values.camundaHub.X .Values.webModeler.X` fallback (`templates/web-modeler/deployment-restapi.yaml`, `configmap-restapi.yaml`, `configmap-websockets.yaml`, `serviceaccount.yaml`, `service-monitor/web-modeler-service-monitor.yaml`). They all carry `## @skip`, so `values.schema.json` described only `camundaHub.enabled`, `camundaHub.contextPath` and `camundaHub.persistence`.

Consequence: a consumer that validates with `additionalProperties: false` (the use case of #4564) reports a perfectly valid `camundaHub.restapi: {...}` override as an unknown key. The shipped schema keeps `additionalProperties: true`, so neither `helm lint` nor `make helm.schema-validate-values` surfaces the gap.

### What's in this PR?

- Describe the five override maps in `values.schema.extra.json` (schema-only — no change to chart defaults, values.yaml or rendered output), plus `camundaHub.security.authentication`, which is the only sub-map `values.yaml` declares under `security`.
- Regenerate `values.schema.json` via `make helm.schema-update` (readme-generator 2.7.2).

Each map is described as a free-form object (`type: object`, `additionalProperties: true`) instead of a copy of the legacy `webModeler.*` schema. The override surface is the *entire* `webModeler.*` surface (`restapi.replicas`, `.podLabels`, `.env`, `.initContainers`, `.clusters`, `.extraConfiguration`, …), so mirroring it would duplicate several hundred lines of schema and drift on every `webModeler.*` change. This matches how the parent `camundaHub` node and `global.security.authentication.camundaHub` are already described.

`## @skip` is kept in `values.yaml`: these maps are pass-through override points with no defaults of their own, so listing them as `@param` in the README would add rows that document nothing. This mirrors `camundaHub.persistence`, which is `@skip`-ed in `values.yaml` and described in `values.schema.extra.json`.

8.10 only — `camundaHub` does not exist in 8.9 and earlier.

Verified with:
- `make helm.schema-validate-values chartPath=charts/camunda-platform-8.10` (passes)
- `make helm.lint chartPath=charts/camunda-platform-8.10` (passes)
- `helm template` with overrides set under `camundaHub.{image,security,restapi,websockets,serviceAccount}` — accepted by schema validation and correctly reflected in the rendered manifests
- re-running `make helm.schema-update` is a no-op on the committed schema

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
