### PR TITLE
fix: honor component datastore TLS secret keys

### DIFF
--- a/charts/camunda-platform-8.10/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/common/_helpers.tpl
@@ -1282,7 +1282,7 @@ the last one, which becomes confusing to debug.
 {{- $compVals := (get $vals $comp) | default dict -}}
 {{- $javaOpts := (.javaOpts | default ((get $compVals "javaOpts") | default "")) | trim -}}
 {{- $truststoreDir := required "camundaPlatform._java_tool_options_tls_env: parameter 'truststoreDir' is required" .truststoreDir -}}
-{{- $secretKey := include "camundaPlatform.getTlsSecretKey" (dict "Values" $vals) -}}
+{{- $secretKey := include "camundaPlatform.getTlsSecretKey" (dict "Values" $vals "config" (.tlsConfig | default dict)) -}}
 {{- $truststorePath := printf "%s/%s" $truststoreDir $secretKey -}}
 {{- $jks := ((include "camundaPlatform._resolve_tls_jks_config" .) | fromYaml) | default dict -}}
 {{- if (eq (include "camundaPlatform.hasSecretConfig" (dict "config" $jks)) "true") -}}
@@ -1313,6 +1313,7 @@ the last one, which becomes confusing to debug.
   "Values" .Values
   "component" .component
   "javaOpts" .javaOpts
+  "tlsConfig" .tlsConfig
   "truststoreDir" "/usr/local/camunda/certificates"
 ) }}
 {{- end }}
@@ -1326,6 +1327,7 @@ See common.java_tool_options_tls_env for full documentation.
   "Values" .Values
   "component" .component
   "javaOpts" .javaOpts
+  "tlsConfig" .tlsConfig
   "truststoreDir" "/optimize/certificates"
 ) }}
 {{- end }}

--- a/charts/camunda-platform-8.10/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/common/_helpers.tpl
@@ -1264,10 +1264,12 @@ they adopt global.<engine>.tls.jks.secret.* — otherwise both flags are present
 the last one, which becomes confusing to debug.
 */}}
 
-{{- /* Internal: resolve the correct TLS JKS config for the currently enabled engine */ -}}
+{{- /* Internal: resolve JKS config from the selected TLS config, with global fallback for legacy callers */ -}}
 {{- define "camundaPlatform._resolve_tls_jks_config" -}}
 {{- $cfg := dict -}}
-{{- if (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.global.elasticsearch.tls)) "true") -}}
+{{- if .tlsConfig -}}
+{{-   $cfg = (.tlsConfig.jks | default dict) -}}
+{{- else if (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.global.elasticsearch.tls)) "true") -}}
 {{-   $cfg = (.Values.global.elasticsearch.tls.jks | default dict) -}}
 {{- else if (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.global.opensearch.tls)) "true") -}}
 {{-   $cfg = (.Values.global.opensearch.tls.jks | default dict) -}}

--- a/charts/camunda-platform-8.10/templates/optimize/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/optimize/_helpers.tpl
@@ -82,14 +82,25 @@ is still "non-empty" in Helm and `default` will never fall through.
 {{- end -}}
 {{- end -}}
 
+{{- define "optimize.effectiveTlsConfig" -}}
+{{- $esTls := include "optimize.effectiveEsTlsConfig" . | fromYaml -}}
+{{- $osTls := include "optimize.effectiveOsTlsConfig" . | fromYaml -}}
+{{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" $esTls)) "true" -}}
+  {{- toYaml $esTls -}}
+{{- else if eq (include "camundaPlatform.hasSecretConfig" (dict "config" $osTls)) "true" -}}
+  {{- toYaml $osTls -}}
+{{- else -}}
+  {{- toYaml (dict) -}}
+{{- end -}}
+{{- end -}}
+
 {{/*
 [optimize] Check if TLS is configured at either the optimize-database or global level
 for either Elasticsearch or OpenSearch. Returns "true" or "false".
 */}}
 {{- define "optimize.hasTlsConfig" -}}
-{{- $esTls := include "optimize.effectiveEsTlsConfig" . | fromYaml -}}
-{{- $osTls := include "optimize.effectiveOsTlsConfig" . | fromYaml -}}
-{{- if or (eq (include "camundaPlatform.hasSecretConfig" (dict "config" $esTls)) "true") (eq (include "camundaPlatform.hasSecretConfig" (dict "config" $osTls)) "true") -}}
+{{- $tlsConfig := include "optimize.effectiveTlsConfig" . | fromYaml -}}
+{{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" $tlsConfig)) "true" -}}
 true
 {{- else -}}
 false

--- a/charts/camunda-platform-8.10/templates/optimize/deployment.yaml
+++ b/charts/camunda-platform-8.10/templates/optimize/deployment.yaml
@@ -1,4 +1,5 @@
 {{- if and (eq (include "camundaPlatform.optimizeEnabled" .) "true") (not .Values.global.noSecondaryStorage) -}}
+{{- $tlsConfig := include "optimize.effectiveTlsConfig" . | fromYaml -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -80,7 +81,7 @@ spec:
             {{- end}}
             {{- end }}
             {{- if eq (include "optimize.hasTlsConfig" .) "true" }}
-            {{- include "optimize.java_tool_options_tls_env" (dict "Values" .Values "component" "optimize") | nindent 12 }}
+            {{- include "optimize.java_tool_options_tls_env" (dict "Values" .Values "component" "optimize" "tlsConfig" $tlsConfig) | nindent 12 }}
             {{- else if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
             - name: JAVA_TOOL_OPTIONS
               value: {{ printf "%s %s" .Values.optimize.javaOpts (include "camundaPlatform.caBundleJavaOpts" .) | trim | quote }}
@@ -135,8 +136,8 @@ spec:
             {{- end }}
             {{- if eq (include "optimize.hasTlsConfig" .) "true" }}
             - name: keystore
-              mountPath: {{ printf "/optimize/certificates/%s" (include "camundaPlatform.getTlsSecretKey" .) }}
-              subPath: {{ include "camundaPlatform.getTlsSecretKey" . }}
+              mountPath: {{ printf "/optimize/certificates/%s" (include "camundaPlatform.getTlsSecretKey" (dict "config" $tlsConfig)) }}
+              subPath: {{ include "camundaPlatform.getTlsSecretKey" (dict "config" $tlsConfig) }}
             {{- end }}
             {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
             {{- include "camundaPlatform.caBundleVolumeMount" . | nindent 12 }}
@@ -189,7 +190,7 @@ spec:
             {{- end}}
             {{- end }}
             {{- if eq (include "optimize.hasTlsConfig" .) "true" }}
-            {{- include "optimize.java_tool_options_tls_env" (dict "Values" .Values "component" "optimize") | nindent 12 }}
+            {{- include "optimize.java_tool_options_tls_env" (dict "Values" .Values "component" "optimize" "tlsConfig" $tlsConfig) | nindent 12 }}
             {{- else if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
             - name: JAVA_TOOL_OPTIONS
               value: {{ printf "%s %s" .Values.optimize.javaOpts (include "camundaPlatform.caBundleJavaOpts" .) | trim | quote }}
@@ -345,8 +346,8 @@ spec:
             {{- end }}
             {{- if eq (include "optimize.hasTlsConfig" .) "true" }}
             - name: keystore
-              mountPath: {{ printf "/optimize/certificates/%s" (include "camundaPlatform.getTlsSecretKey" .) }}
-              subPath: {{ include "camundaPlatform.getTlsSecretKey" . }}
+              mountPath: {{ printf "/optimize/certificates/%s" (include "camundaPlatform.getTlsSecretKey" (dict "config" $tlsConfig)) }}
+              subPath: {{ include "camundaPlatform.getTlsSecretKey" (dict "config" $tlsConfig) }}
             {{- end }}
             {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
             {{- include "camundaPlatform.caBundleVolumeMount" . | nindent 12 }}
@@ -388,17 +389,10 @@ spec:
           configMap:
             name: {{ include "optimize.fullname" . }}-configuration
             defaultMode: {{ .Values.optimize.configMap.defaultMode }}
-        {{- $esTls := include "optimize.effectiveEsTlsConfig" . | fromYaml -}}
-        {{- $osTls := include "optimize.effectiveOsTlsConfig" . | fromYaml -}}
-        {{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" $esTls)) "true" }}
+        {{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" $tlsConfig)) "true" }}
         {{- include "camundaPlatform.emitTlsVolumeFromSecretConfig" (dict
             "volumeName" "keystore"
-            "config" $esTls
-        ) | nindent 8 }}
-        {{- else if eq (include "camundaPlatform.hasSecretConfig" (dict "config" $osTls)) "true" }}
-        {{- include "camundaPlatform.emitTlsVolumeFromSecretConfig" (dict
-            "volumeName" "keystore"
-            "config" $osTls
+            "config" $tlsConfig
         ) | nindent 8 }}
         {{- end }}
         {{- if .Values.global.documentStore.type.gcp.enabled }}

--- a/charts/camunda-platform-8.10/templates/orchestration/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/orchestration/_helpers.tpl
@@ -298,6 +298,20 @@ Authentication.
     {{- end -}}
 {{- end -}}
 
+{{- define "orchestration.effectiveTlsConfig" -}}
+{{- $config := dict -}}
+{{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.global.elasticsearch.tls)) "true" -}}
+    {{- $config = .Values.global.elasticsearch.tls -}}
+{{- else if eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.global.opensearch.tls)) "true" -}}
+    {{- $config = .Values.global.opensearch.tls -}}
+{{- else if eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.orchestration.data.secondaryStorage.elasticsearch.tls)) "true" -}}
+    {{- $config = .Values.orchestration.data.secondaryStorage.elasticsearch.tls -}}
+{{- else if eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.orchestration.data.secondaryStorage.opensearch.tls)) "true" -}}
+    {{- $config = .Values.orchestration.data.secondaryStorage.opensearch.tls -}}
+{{- end -}}
+{{- toYaml $config -}}
+{{- end -}}
+
 {{- define "orchestration.persistentSessionsEnabled" -}}
     {{ not .Values.global.noSecondaryStorage -}}
 {{- end -}}

--- a/charts/camunda-platform-8.10/templates/orchestration/statefulset.yaml
+++ b/charts/camunda-platform-8.10/templates/orchestration/statefulset.yaml
@@ -1,4 +1,5 @@
 {{- if eq (include "camundaPlatform.orchestrationEnabled" .) "true" -}}
+{{- $tlsConfig := include "orchestration.effectiveTlsConfig" . | fromYaml -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -86,13 +87,8 @@ spec:
                 "config" (include "orchestration.hubPingClientSecretConfig" . | fromYaml)
             ) | nindent 12 }}
             {{- end }}
-            {{- if or
-              (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.global.elasticsearch.tls)) "true")
-              (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.global.opensearch.tls)) "true")
-              (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.orchestration.data.secondaryStorage.elasticsearch.tls)) "true")
-              (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.orchestration.data.secondaryStorage.opensearch.tls)) "true")
-            }}
-            {{- include "common.java_tool_options_tls_env" (dict "Values" .Values "component" "orchestration") | nindent 12 }}
+            {{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" $tlsConfig)) "true" }}
+            {{- include "common.java_tool_options_tls_env" (dict "Values" .Values "component" "orchestration" "tlsConfig" $tlsConfig) | nindent 12 }}
             {{- else if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
             - name: JAVA_TOOL_OPTIONS
               value: {{ printf "%s %s" .Values.orchestration.javaOpts (include "camundaPlatform.caBundleJavaOpts" .) | trim | quote }}
@@ -235,15 +231,10 @@ spec:
           resources:
             {{- toYaml .Values.orchestration.resources | nindent 12 }}
           volumeMounts:
-            {{- if or
-              (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.global.elasticsearch.tls)) "true")
-              (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.global.opensearch.tls)) "true")
-              (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.orchestration.data.secondaryStorage.elasticsearch.tls)) "true")
-              (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.orchestration.data.secondaryStorage.opensearch.tls)) "true")
-            }}
+            {{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" $tlsConfig)) "true" }}
             - name: keystore
-              mountPath: /usr/local/camunda/certificates/{{ include "camundaPlatform.getTlsSecretKey" . }}
-              subPath: {{ include "camundaPlatform.getTlsSecretKey" . }}
+              mountPath: /usr/local/camunda/certificates/{{ include "camundaPlatform.getTlsSecretKey" (dict "config" $tlsConfig) }}
+              subPath: {{ include "camundaPlatform.getTlsSecretKey" (dict "config" $tlsConfig) }}
             {{- end }}
             - name: config
               mountPath: /usr/local/bin/startup.sh
@@ -283,25 +274,10 @@ spec:
       {{- .Values.orchestration.sidecars | toYaml | nindent 8 }}
       {{- end }}
       volumes:
-        {{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.global.elasticsearch.tls)) "true" }}
+        {{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" $tlsConfig)) "true" }}
         {{- include "camundaPlatform.emitTlsVolumeFromSecretConfig" (dict
             "volumeName" "keystore"
-            "config" .Values.global.elasticsearch.tls
-        ) | nindent 8 }}
-        {{- else if eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.global.opensearch.tls)) "true" }}
-        {{- include "camundaPlatform.emitTlsVolumeFromSecretConfig" (dict
-            "volumeName" "keystore"
-            "config" .Values.global.opensearch.tls
-        ) | nindent 8 }}
-        {{- else if eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.orchestration.data.secondaryStorage.elasticsearch.tls)) "true" }}
-        {{- include "camundaPlatform.emitTlsVolumeFromSecretConfig" (dict
-            "volumeName" "keystore"
-            "config" .Values.orchestration.data.secondaryStorage.elasticsearch.tls
-        ) | nindent 8 }}
-        {{- else if eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.orchestration.data.secondaryStorage.opensearch.tls)) "true" }}
-        {{- include "camundaPlatform.emitTlsVolumeFromSecretConfig" (dict
-            "volumeName" "keystore"
-            "config" .Values.orchestration.data.secondaryStorage.opensearch.tls
+            "config" $tlsConfig
         ) | nindent 8 }}
         {{- end }}
         {{- if eq .Values.orchestration.persistenceType "memory" }}

--- a/charts/camunda-platform-8.10/test/unit/common/component_tls_custom_key_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/component_tls_custom_key_test.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package camunda
+
+import (
+	"camunda-platform/test/unit/testhelpers"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func requireTLSCustomKey(t *testing.T, podSpec corev1.PodSpec, secretName, secretKey, mountDirectory string, expectedMounts int) {
+	t.Helper()
+
+	var tlsVolume *corev1.Volume
+	for index := range podSpec.Volumes {
+		if podSpec.Volumes[index].Name == "keystore" {
+			tlsVolume = &podSpec.Volumes[index]
+			break
+		}
+	}
+	require.NotNil(t, tlsVolume)
+	require.NotNil(t, tlsVolume.Secret)
+	require.Equal(t, secretName, tlsVolume.Secret.SecretName)
+
+	containers := append([]corev1.Container{}, podSpec.InitContainers...)
+	containers = append(containers, podSpec.Containers...)
+	mounts := 0
+	for _, container := range containers {
+		var tlsMount *corev1.VolumeMount
+		for index := range container.VolumeMounts {
+			if container.VolumeMounts[index].Name == "keystore" {
+				tlsMount = &container.VolumeMounts[index]
+				break
+			}
+		}
+		if tlsMount == nil {
+			continue
+		}
+
+		mounts++
+		require.Equal(t, secretKey, tlsMount.SubPath)
+		require.Equal(t, mountDirectory+"/"+secretKey, tlsMount.MountPath)
+
+		javaOptions := ""
+		for _, envVar := range container.Env {
+			if envVar.Name == "JAVA_TOOL_OPTIONS" {
+				javaOptions = envVar.Value
+				break
+			}
+		}
+		require.Contains(t, javaOptions, "-Djavax.net.ssl.trustStore="+mountDirectory+"/"+secretKey)
+	}
+	require.Equal(t, expectedMounts, mounts)
+}
+
+func verifyOrchestrationTLSCustomKey(secretName, secretKey string) func(t *testing.T, output string, err error) {
+	return func(t *testing.T, output string, err error) {
+		require.NoError(t, err)
+
+		var statefulSet appsv1.StatefulSet
+		helm.UnmarshalK8SYaml(t, output, &statefulSet)
+		requireTLSCustomKey(t, statefulSet.Spec.Template.Spec, secretName, secretKey, "/usr/local/camunda/certificates", 1)
+	}
+}
+
+func verifyOptimizeTLSCustomKey(secretName, secretKey string) func(t *testing.T, output string, err error) {
+	return func(t *testing.T, output string, err error) {
+		require.NoError(t, err)
+
+		var deployment appsv1.Deployment
+		helm.UnmarshalK8SYaml(t, output, &deployment)
+		requireTLSCustomKey(t, deployment.Spec.Template.Spec, secretName, secretKey, "/optimize/certificates", 2)
+	}
+}
+
+func (s *tlsSecretsTest) TestComponentDatastoreTLSCustomKey() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name:     "Orchestration Elasticsearch uses component TLS custom key",
+			Template: "templates/orchestration/statefulset.yaml",
+			Values: map[string]string{
+				"orchestration.data.secondaryStorage.type":                                       "elasticsearch",
+				"orchestration.data.secondaryStorage.elasticsearch.tls.secret.existingSecret":    "orchestration-elasticsearch-tls",
+				"orchestration.data.secondaryStorage.elasticsearch.tls.secret.existingSecretKey": "orchestration-elasticsearch.jks",
+			},
+			Verifier: verifyOrchestrationTLSCustomKey("orchestration-elasticsearch-tls", "orchestration-elasticsearch.jks"),
+		},
+		{
+			Name:     "Orchestration OpenSearch uses component TLS custom key",
+			Template: "templates/orchestration/statefulset.yaml",
+			Values: map[string]string{
+				"orchestration.data.secondaryStorage.type":                                    "opensearch",
+				"orchestration.data.secondaryStorage.opensearch.tls.secret.existingSecret":    "orchestration-opensearch-tls",
+				"orchestration.data.secondaryStorage.opensearch.tls.secret.existingSecretKey": "orchestration-opensearch.jks",
+			},
+			Verifier: verifyOrchestrationTLSCustomKey("orchestration-opensearch-tls", "orchestration-opensearch.jks"),
+		},
+		{
+			Name:     "Optimize Elasticsearch uses component TLS custom key",
+			Template: "templates/optimize/deployment.yaml",
+			Values: map[string]string{
+				"identity.enabled":                                             "true",
+				"global.identity.auth.enabled":                                 "true",
+				"optimize.enabled":                                             "true",
+				"optimize.database.elasticsearch.enabled":                      "true",
+				"optimize.database.elasticsearch.external":                     "true",
+				"optimize.database.elasticsearch.tls.enabled":                  "true",
+				"optimize.database.elasticsearch.tls.secret.existingSecret":    "optimize-elasticsearch-tls",
+				"optimize.database.elasticsearch.tls.secret.existingSecretKey": "optimize-elasticsearch.jks",
+				"optimize.database.opensearch.enabled":                         "false",
+			},
+			Verifier: verifyOptimizeTLSCustomKey("optimize-elasticsearch-tls", "optimize-elasticsearch.jks"),
+		},
+		{
+			Name:     "Optimize OpenSearch uses component TLS custom key",
+			Template: "templates/optimize/deployment.yaml",
+			Values: map[string]string{
+				"identity.enabled":                                          "true",
+				"global.identity.auth.enabled":                              "true",
+				"optimize.enabled":                                          "true",
+				"optimize.database.elasticsearch.enabled":                   "false",
+				"optimize.database.opensearch.enabled":                      "true",
+				"optimize.database.opensearch.tls.enabled":                  "true",
+				"optimize.database.opensearch.tls.secret.existingSecret":    "optimize-opensearch-tls",
+				"optimize.database.opensearch.tls.secret.existingSecretKey": "optimize-opensearch.jks",
+			},
+			Verifier: verifyOptimizeTLSCustomKey("optimize-opensearch-tls", "optimize-opensearch.jks"),
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}

--- a/charts/camunda-platform-8.10/test/unit/common/component_tls_custom_key_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/component_tls_custom_key_test.go
@@ -89,6 +89,27 @@ func verifyOptimizeTLSCustomKey(secretName, secretKey string) func(t *testing.T,
 	}
 }
 
+func verifyOptimizeTLSCustomKeyWithoutGlobalPassword(secretName, secretKey string) func(t *testing.T, output string, err error) {
+	return func(t *testing.T, output string, err error) {
+		require.NoError(t, err)
+
+		var deployment appsv1.Deployment
+		helm.UnmarshalK8SYaml(t, output, &deployment)
+		requireTLSCustomKey(t, deployment.Spec.Template.Spec, secretName, secretKey, "/optimize/certificates", 2)
+
+		containers := append([]corev1.Container{}, deployment.Spec.Template.Spec.InitContainers...)
+		containers = append(containers, deployment.Spec.Template.Spec.Containers...)
+		for _, container := range containers {
+			for _, envVar := range container.Env {
+				require.NotEqual(t, "TRUSTSTORE_PASSWORD", envVar.Name)
+				if envVar.Name == "JAVA_TOOL_OPTIONS" {
+					require.NotContains(t, envVar.Value, "-Djavax.net.ssl.trustStorePassword=")
+				}
+			}
+		}
+	}
+}
+
 func (s *tlsSecretsTest) TestComponentDatastoreTLSCustomKey() {
 	testCases := []testhelpers.TestCase{
 		{
@@ -126,6 +147,26 @@ func (s *tlsSecretsTest) TestComponentDatastoreTLSCustomKey() {
 				"optimize.database.opensearch.enabled":                         "false",
 			},
 			Verifier: verifyOptimizeTLSCustomKey("optimize-elasticsearch-tls", "optimize-elasticsearch.jks"),
+		},
+		{
+			Name:     "Optimize component TLS does not inherit global JKS password",
+			Template: "templates/optimize/deployment.yaml",
+			Values: map[string]string{
+				"identity.enabled":                                             "true",
+				"global.identity.auth.enabled":                                 "true",
+				"global.elasticsearch.tls.secret.existingSecret":               "global-elasticsearch-tls",
+				"global.elasticsearch.tls.secret.existingSecretKey":            "global-elasticsearch.jks",
+				"global.elasticsearch.tls.jks.secret.existingSecret":           "global-jks-password",
+				"global.elasticsearch.tls.jks.secret.existingSecretKey":        "password",
+				"optimize.enabled":                                             "true",
+				"optimize.database.elasticsearch.enabled":                      "true",
+				"optimize.database.elasticsearch.external":                     "true",
+				"optimize.database.elasticsearch.tls.enabled":                  "true",
+				"optimize.database.elasticsearch.tls.secret.existingSecret":    "optimize-elasticsearch-tls",
+				"optimize.database.elasticsearch.tls.secret.existingSecretKey": "optimize-elasticsearch.jks",
+				"optimize.database.opensearch.enabled":                         "false",
+			},
+			Verifier: verifyOptimizeTLSCustomKeyWithoutGlobalPassword("optimize-elasticsearch-tls", "optimize-elasticsearch.jks"),
 		},
 		{
 			Name:     "Optimize OpenSearch uses component TLS custom key",

--- a/charts/camunda-platform-8.9/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/common/_helpers.tpl
@@ -1075,7 +1075,7 @@ they adopt global.<engine>.tls.jks.secret.* — otherwise both flags are present
 the last one, which becomes confusing to debug.
 */}}
 
-{{- /* Internal: resolve the correct TLS JKS config for the currently enabled engine */ -}}
+{{- /* Internal: resolve JKS config from the selected TLS config, with global fallback for legacy callers */ -}}
 {{/*
 Activates the JKS block for whichever engine has TLS configured.
 Honours both the legacy single-string `tls.existingSecret` and the 8.9 normalized
@@ -1084,6 +1084,9 @@ when they set the matching `tls.jks.secret.*`.
 */}}
 {{- define "camundaPlatform._resolve_tls_jks_config" -}}
 {{- $cfg := dict -}}
+{{- if .tlsConfig -}}
+{{-   $cfg = (.tlsConfig.jks | default dict) -}}
+{{- else -}}
 {{- $esTls := (.Values.global.elasticsearch.tls | default dict) -}}
 {{- $osTls := (.Values.global.opensearch.tls | default dict) -}}
 {{- $esSecret := ($esTls.secret | default dict) -}}
@@ -1092,6 +1095,7 @@ when they set the matching `tls.jks.secret.*`.
 {{-   $cfg = ($esTls.jks | default dict) -}}
 {{- else if or $osTls.existingSecret $osSecret.existingSecret -}}
 {{-   $cfg = ($osTls.jks | default dict) -}}
+{{- end -}}
 {{- end -}}
 {{- toYaml $cfg -}}
 {{- end -}}

--- a/charts/camunda-platform-8.9/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/common/_helpers.tpl
@@ -1103,7 +1103,7 @@ when they set the matching `tls.jks.secret.*`.
 {{- $compVals := (get $vals $comp) | default dict -}}
 {{- $javaOpts := (.javaOpts | default ((get $compVals "javaOpts") | default "")) | trim -}}
 {{- $truststoreDir := required "camundaPlatform._java_tool_options_tls_env: parameter 'truststoreDir' is required" .truststoreDir -}}
-{{- $secretKey := include "camundaPlatform.getTlsSecretKey" (dict "Values" $vals) -}}
+{{- $secretKey := include "camundaPlatform.getTlsSecretKey" (dict "Values" $vals "config" (.tlsConfig | default dict)) -}}
 {{- $truststorePath := printf "%s/%s" $truststoreDir $secretKey -}}
 {{- $jks := ((include "camundaPlatform._resolve_tls_jks_config" .) | fromYaml) | default dict -}}
 {{- if (eq (include "camundaPlatform.hasSecretConfig" (dict "config" $jks)) "true") -}}
@@ -1134,6 +1134,7 @@ when they set the matching `tls.jks.secret.*`.
   "Values" .Values
   "component" .component
   "javaOpts" .javaOpts
+  "tlsConfig" .tlsConfig
   "truststoreDir" "/usr/local/camunda/certificates"
 ) }}
 {{- end }}
@@ -1147,6 +1148,7 @@ See common.java_tool_options_tls_env for full documentation.
   "Values" .Values
   "component" .component
   "javaOpts" .javaOpts
+  "tlsConfig" .tlsConfig
   "truststoreDir" "/optimize/certificates"
 ) }}
 {{- end }}

--- a/charts/camunda-platform-8.9/templates/optimize/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/optimize/_helpers.tpl
@@ -78,14 +78,25 @@ is still "non-empty" in Helm and `default` will never fall through.
 {{- end -}}
 {{- end -}}
 
+{{- define "optimize.effectiveTlsConfig" -}}
+{{- $esTls := include "optimize.effectiveEsTlsConfig" . | fromYaml -}}
+{{- $osTls := include "optimize.effectiveOsTlsConfig" . | fromYaml -}}
+{{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" $esTls)) "true" -}}
+  {{- toYaml $esTls -}}
+{{- else if eq (include "camundaPlatform.hasSecretConfig" (dict "config" $osTls)) "true" -}}
+  {{- toYaml $osTls -}}
+{{- else -}}
+  {{- toYaml (dict) -}}
+{{- end -}}
+{{- end -}}
+
 {{/*
 [optimize] Check if TLS is configured at either the optimize-database or global level
 for either Elasticsearch or OpenSearch. Returns "true" or "false".
 */}}
 {{- define "optimize.hasTlsConfig" -}}
-{{- $esTls := include "optimize.effectiveEsTlsConfig" . | fromYaml -}}
-{{- $osTls := include "optimize.effectiveOsTlsConfig" . | fromYaml -}}
-{{- if or (eq (include "camundaPlatform.hasSecretConfig" (dict "config" $esTls)) "true") (eq (include "camundaPlatform.hasSecretConfig" (dict "config" $osTls)) "true") -}}
+{{- $tlsConfig := include "optimize.effectiveTlsConfig" . | fromYaml -}}
+{{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" $tlsConfig)) "true" -}}
 true
 {{- else -}}
 false

--- a/charts/camunda-platform-8.9/templates/optimize/deployment.yaml
+++ b/charts/camunda-platform-8.9/templates/optimize/deployment.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.optimize.enabled (not .Values.global.noSecondaryStorage) -}}
+{{- $tlsConfig := include "optimize.effectiveTlsConfig" . | fromYaml -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -80,7 +81,7 @@ spec:
             {{- end}}
             {{- end }}
             {{- if eq (include "optimize.hasTlsConfig" .) "true" }}
-            {{- include "optimize.java_tool_options_tls_env" (dict "Values" .Values "component" "optimize") | nindent 12 }}
+            {{- include "optimize.java_tool_options_tls_env" (dict "Values" .Values "component" "optimize" "tlsConfig" $tlsConfig) | nindent 12 }}
             {{- else if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
             - name: JAVA_TOOL_OPTIONS
               value: {{ printf "%s %s" .Values.optimize.javaOpts (include "camundaPlatform.caBundleJavaOpts" .) | trim | quote }}
@@ -135,8 +136,8 @@ spec:
             {{- end }}
             {{- if eq (include "optimize.hasTlsConfig" .) "true" }}
             - name: keystore
-              mountPath: {{ printf "/optimize/certificates/%s" (include "camundaPlatform.getTlsSecretKey" .) }}
-              subPath: {{ include "camundaPlatform.getTlsSecretKey" . }}
+              mountPath: {{ printf "/optimize/certificates/%s" (include "camundaPlatform.getTlsSecretKey" (dict "config" $tlsConfig)) }}
+              subPath: {{ include "camundaPlatform.getTlsSecretKey" (dict "config" $tlsConfig) }}
             {{- end }}
             {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
             {{- include "camundaPlatform.caBundleVolumeMount" . | nindent 12 }}
@@ -189,7 +190,7 @@ spec:
             {{- end}}
             {{- end }}
             {{- if eq (include "optimize.hasTlsConfig" .) "true" }}
-            {{- include "optimize.java_tool_options_tls_env" (dict "Values" .Values "component" "optimize") | nindent 12 }}
+            {{- include "optimize.java_tool_options_tls_env" (dict "Values" .Values "component" "optimize" "tlsConfig" $tlsConfig) | nindent 12 }}
             {{- else if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
             - name: JAVA_TOOL_OPTIONS
               value: {{ printf "%s %s" .Values.optimize.javaOpts (include "camundaPlatform.caBundleJavaOpts" .) | trim | quote }}
@@ -339,8 +340,8 @@ spec:
             {{- end }}
             {{- if eq (include "optimize.hasTlsConfig" .) "true" }}
             - name: keystore
-              mountPath: {{ printf "/optimize/certificates/%s" (include "camundaPlatform.getTlsSecretKey" .) }}
-              subPath: {{ include "camundaPlatform.getTlsSecretKey" . }}
+              mountPath: {{ printf "/optimize/certificates/%s" (include "camundaPlatform.getTlsSecretKey" (dict "config" $tlsConfig)) }}
+              subPath: {{ include "camundaPlatform.getTlsSecretKey" (dict "config" $tlsConfig) }}
             {{- end }}
             {{- if .Values.global.documentStore.type.gcp.enabled }}
             - name: gcp-credentials-volume
@@ -382,17 +383,10 @@ spec:
           configMap:
             name: {{ include "optimize.fullname" . }}-configuration
             defaultMode: {{ .Values.optimize.configMap.defaultMode }}
-        {{- $esTls := include "optimize.effectiveEsTlsConfig" . | fromYaml -}}
-        {{- $osTls := include "optimize.effectiveOsTlsConfig" . | fromYaml -}}
-        {{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" $esTls)) "true" }}
+        {{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" $tlsConfig)) "true" }}
         {{- include "camundaPlatform.emitTlsVolumeFromSecretConfig" (dict
             "volumeName" "keystore"
-            "config" $esTls
-        ) | nindent 8 }}
-        {{- else if eq (include "camundaPlatform.hasSecretConfig" (dict "config" $osTls)) "true" }}
-        {{- include "camundaPlatform.emitTlsVolumeFromSecretConfig" (dict
-            "volumeName" "keystore"
-            "config" $osTls
+            "config" $tlsConfig
         ) | nindent 8 }}
         {{- end }}
         {{- if .Values.global.documentStore.type.gcp.enabled }}

--- a/charts/camunda-platform-8.9/templates/orchestration/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/orchestration/_helpers.tpl
@@ -269,6 +269,20 @@ Authentication.
     {{- end -}}
 {{- end -}}
 
+{{- define "orchestration.effectiveTlsConfig" -}}
+{{- $config := dict -}}
+{{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.global.elasticsearch.tls)) "true" -}}
+    {{- $config = .Values.global.elasticsearch.tls -}}
+{{- else if eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.global.opensearch.tls)) "true" -}}
+    {{- $config = .Values.global.opensearch.tls -}}
+{{- else if eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.orchestration.data.secondaryStorage.elasticsearch.tls)) "true" -}}
+    {{- $config = .Values.orchestration.data.secondaryStorage.elasticsearch.tls -}}
+{{- else if eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.orchestration.data.secondaryStorage.opensearch.tls)) "true" -}}
+    {{- $config = .Values.orchestration.data.secondaryStorage.opensearch.tls -}}
+{{- end -}}
+{{- toYaml $config -}}
+{{- end -}}
+
 {{- define "orchestration.persistentSessionsEnabled" -}}
     {{ not .Values.global.noSecondaryStorage -}}
 {{- end -}}

--- a/charts/camunda-platform-8.9/templates/orchestration/statefulset.yaml
+++ b/charts/camunda-platform-8.9/templates/orchestration/statefulset.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.orchestration.enabled -}}
+{{- $tlsConfig := include "orchestration.effectiveTlsConfig" . | fromYaml -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -79,13 +80,8 @@ spec:
                 "config" .Values.orchestration.security.authentication.oidc
             ) | nindent 12 }}
             {{- end }}
-            {{- if or
-              (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.global.elasticsearch.tls)) "true")
-              (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.global.opensearch.tls)) "true")
-              (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.orchestration.data.secondaryStorage.elasticsearch.tls)) "true")
-              (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.orchestration.data.secondaryStorage.opensearch.tls)) "true")
-            }}
-            {{- include "common.java_tool_options_tls_env" (dict "Values" .Values "component" "orchestration") | nindent 12 }}
+            {{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" $tlsConfig)) "true" }}
+            {{- include "common.java_tool_options_tls_env" (dict "Values" .Values "component" "orchestration" "tlsConfig" $tlsConfig) | nindent 12 }}
             {{- else if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
             - name: JAVA_TOOL_OPTIONS
               value: {{ printf "%s %s" .Values.orchestration.javaOpts (include "camundaPlatform.caBundleJavaOpts" .) | trim | quote }}
@@ -216,15 +212,10 @@ spec:
           resources:
             {{- toYaml .Values.orchestration.resources | nindent 12 }}
           volumeMounts:
-            {{- if or
-              (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.global.elasticsearch.tls)) "true")
-              (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.global.opensearch.tls)) "true")
-              (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.orchestration.data.secondaryStorage.elasticsearch.tls)) "true")
-              (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.orchestration.data.secondaryStorage.opensearch.tls)) "true")
-            }}
+            {{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" $tlsConfig)) "true" }}
             - name: keystore
-              mountPath: /usr/local/camunda/certificates/{{ include "camundaPlatform.getTlsSecretKey" . }}
-              subPath: {{ include "camundaPlatform.getTlsSecretKey" . }}
+              mountPath: /usr/local/camunda/certificates/{{ include "camundaPlatform.getTlsSecretKey" (dict "config" $tlsConfig) }}
+              subPath: {{ include "camundaPlatform.getTlsSecretKey" (dict "config" $tlsConfig) }}
             {{- end }}
             - name: config
               mountPath: /usr/local/bin/startup.sh
@@ -264,25 +255,10 @@ spec:
       {{- .Values.orchestration.sidecars | toYaml | nindent 8 }}
       {{- end }}
       volumes:
-        {{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.global.elasticsearch.tls)) "true" }}
+        {{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" $tlsConfig)) "true" }}
         {{- include "camundaPlatform.emitTlsVolumeFromSecretConfig" (dict
             "volumeName" "keystore"
-            "config" .Values.global.elasticsearch.tls
-        ) | nindent 8 }}
-        {{- else if eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.global.opensearch.tls)) "true" }}
-        {{- include "camundaPlatform.emitTlsVolumeFromSecretConfig" (dict
-            "volumeName" "keystore"
-            "config" .Values.global.opensearch.tls
-        ) | nindent 8 }}
-        {{- else if eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.orchestration.data.secondaryStorage.elasticsearch.tls)) "true" }}
-        {{- include "camundaPlatform.emitTlsVolumeFromSecretConfig" (dict
-            "volumeName" "keystore"
-            "config" .Values.orchestration.data.secondaryStorage.elasticsearch.tls
-        ) | nindent 8 }}
-        {{- else if eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.orchestration.data.secondaryStorage.opensearch.tls)) "true" }}
-        {{- include "camundaPlatform.emitTlsVolumeFromSecretConfig" (dict
-            "volumeName" "keystore"
-            "config" .Values.orchestration.data.secondaryStorage.opensearch.tls
+            "config" $tlsConfig
         ) | nindent 8 }}
         {{- end }}
         {{- if eq .Values.orchestration.persistenceType "memory" }}

--- a/charts/camunda-platform-8.9/test/unit/common/component_tls_custom_key_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/component_tls_custom_key_test.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package camunda
+
+import (
+	"camunda-platform/test/unit/testhelpers"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func requireTLSCustomKey(t *testing.T, podSpec corev1.PodSpec, secretName, secretKey, mountDirectory string, expectedMounts int) {
+	t.Helper()
+
+	var tlsVolume *corev1.Volume
+	for index := range podSpec.Volumes {
+		if podSpec.Volumes[index].Name == "keystore" {
+			tlsVolume = &podSpec.Volumes[index]
+			break
+		}
+	}
+	require.NotNil(t, tlsVolume)
+	require.NotNil(t, tlsVolume.Secret)
+	require.Equal(t, secretName, tlsVolume.Secret.SecretName)
+
+	containers := append([]corev1.Container{}, podSpec.InitContainers...)
+	containers = append(containers, podSpec.Containers...)
+	mounts := 0
+	for _, container := range containers {
+		var tlsMount *corev1.VolumeMount
+		for index := range container.VolumeMounts {
+			if container.VolumeMounts[index].Name == "keystore" {
+				tlsMount = &container.VolumeMounts[index]
+				break
+			}
+		}
+		if tlsMount == nil {
+			continue
+		}
+
+		mounts++
+		require.Equal(t, secretKey, tlsMount.SubPath)
+		require.Equal(t, mountDirectory+"/"+secretKey, tlsMount.MountPath)
+
+		javaOptions := ""
+		for _, envVar := range container.Env {
+			if envVar.Name == "JAVA_TOOL_OPTIONS" {
+				javaOptions = envVar.Value
+				break
+			}
+		}
+		require.Contains(t, javaOptions, "-Djavax.net.ssl.trustStore="+mountDirectory+"/"+secretKey)
+	}
+	require.Equal(t, expectedMounts, mounts)
+}
+
+func verifyOrchestrationTLSCustomKey(secretName, secretKey string) func(t *testing.T, output string, err error) {
+	return func(t *testing.T, output string, err error) {
+		require.NoError(t, err)
+
+		var statefulSet appsv1.StatefulSet
+		helm.UnmarshalK8SYaml(t, output, &statefulSet)
+		requireTLSCustomKey(t, statefulSet.Spec.Template.Spec, secretName, secretKey, "/usr/local/camunda/certificates", 1)
+	}
+}
+
+func verifyOptimizeTLSCustomKey(secretName, secretKey string) func(t *testing.T, output string, err error) {
+	return func(t *testing.T, output string, err error) {
+		require.NoError(t, err)
+
+		var deployment appsv1.Deployment
+		helm.UnmarshalK8SYaml(t, output, &deployment)
+		requireTLSCustomKey(t, deployment.Spec.Template.Spec, secretName, secretKey, "/optimize/certificates", 2)
+	}
+}
+
+func (s *tlsSecretsTest) TestComponentDatastoreTLSCustomKey() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name:     "Orchestration Elasticsearch uses component TLS custom key",
+			Template: "templates/orchestration/statefulset.yaml",
+			Values: map[string]string{
+				"orchestration.data.secondaryStorage.type":                                       "elasticsearch",
+				"orchestration.data.secondaryStorage.elasticsearch.tls.secret.existingSecret":    "orchestration-elasticsearch-tls",
+				"orchestration.data.secondaryStorage.elasticsearch.tls.secret.existingSecretKey": "orchestration-elasticsearch.jks",
+			},
+			Verifier: verifyOrchestrationTLSCustomKey("orchestration-elasticsearch-tls", "orchestration-elasticsearch.jks"),
+		},
+		{
+			Name:     "Orchestration OpenSearch uses component TLS custom key",
+			Template: "templates/orchestration/statefulset.yaml",
+			Values: map[string]string{
+				"orchestration.data.secondaryStorage.type":                                    "opensearch",
+				"orchestration.data.secondaryStorage.opensearch.tls.secret.existingSecret":    "orchestration-opensearch-tls",
+				"orchestration.data.secondaryStorage.opensearch.tls.secret.existingSecretKey": "orchestration-opensearch.jks",
+			},
+			Verifier: verifyOrchestrationTLSCustomKey("orchestration-opensearch-tls", "orchestration-opensearch.jks"),
+		},
+		{
+			Name:     "Optimize Elasticsearch uses component TLS custom key",
+			Template: "templates/optimize/deployment.yaml",
+			Values: map[string]string{
+				"identity.enabled":                                             "true",
+				"global.identity.auth.enabled":                                 "true",
+				"optimize.enabled":                                             "true",
+				"optimize.database.elasticsearch.enabled":                      "true",
+				"optimize.database.elasticsearch.external":                     "true",
+				"optimize.database.elasticsearch.tls.enabled":                  "true",
+				"optimize.database.elasticsearch.tls.secret.existingSecret":    "optimize-elasticsearch-tls",
+				"optimize.database.elasticsearch.tls.secret.existingSecretKey": "optimize-elasticsearch.jks",
+				"optimize.database.opensearch.enabled":                         "false",
+			},
+			Verifier: verifyOptimizeTLSCustomKey("optimize-elasticsearch-tls", "optimize-elasticsearch.jks"),
+		},
+		{
+			Name:     "Optimize OpenSearch uses component TLS custom key",
+			Template: "templates/optimize/deployment.yaml",
+			Values: map[string]string{
+				"identity.enabled":                                          "true",
+				"global.identity.auth.enabled":                              "true",
+				"optimize.enabled":                                          "true",
+				"optimize.database.elasticsearch.enabled":                   "false",
+				"optimize.database.opensearch.enabled":                      "true",
+				"optimize.database.opensearch.tls.enabled":                  "true",
+				"optimize.database.opensearch.tls.secret.existingSecret":    "optimize-opensearch-tls",
+				"optimize.database.opensearch.tls.secret.existingSecretKey": "optimize-opensearch.jks",
+			},
+			Verifier: verifyOptimizeTLSCustomKey("optimize-opensearch-tls", "optimize-opensearch.jks"),
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}

--- a/charts/camunda-platform-8.9/test/unit/common/component_tls_custom_key_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/component_tls_custom_key_test.go
@@ -89,6 +89,27 @@ func verifyOptimizeTLSCustomKey(secretName, secretKey string) func(t *testing.T,
 	}
 }
 
+func verifyOptimizeTLSCustomKeyWithoutGlobalPassword(secretName, secretKey string) func(t *testing.T, output string, err error) {
+	return func(t *testing.T, output string, err error) {
+		require.NoError(t, err)
+
+		var deployment appsv1.Deployment
+		helm.UnmarshalK8SYaml(t, output, &deployment)
+		requireTLSCustomKey(t, deployment.Spec.Template.Spec, secretName, secretKey, "/optimize/certificates", 2)
+
+		containers := append([]corev1.Container{}, deployment.Spec.Template.Spec.InitContainers...)
+		containers = append(containers, deployment.Spec.Template.Spec.Containers...)
+		for _, container := range containers {
+			for _, envVar := range container.Env {
+				require.NotEqual(t, "TRUSTSTORE_PASSWORD", envVar.Name)
+				if envVar.Name == "JAVA_TOOL_OPTIONS" {
+					require.NotContains(t, envVar.Value, "-Djavax.net.ssl.trustStorePassword=")
+				}
+			}
+		}
+	}
+}
+
 func (s *tlsSecretsTest) TestComponentDatastoreTLSCustomKey() {
 	testCases := []testhelpers.TestCase{
 		{
@@ -126,6 +147,26 @@ func (s *tlsSecretsTest) TestComponentDatastoreTLSCustomKey() {
 				"optimize.database.opensearch.enabled":                         "false",
 			},
 			Verifier: verifyOptimizeTLSCustomKey("optimize-elasticsearch-tls", "optimize-elasticsearch.jks"),
+		},
+		{
+			Name:     "Optimize component TLS does not inherit global JKS password",
+			Template: "templates/optimize/deployment.yaml",
+			Values: map[string]string{
+				"identity.enabled":                                             "true",
+				"global.identity.auth.enabled":                                 "true",
+				"global.elasticsearch.tls.secret.existingSecret":               "global-elasticsearch-tls",
+				"global.elasticsearch.tls.secret.existingSecretKey":            "global-elasticsearch.jks",
+				"global.elasticsearch.tls.jks.secret.existingSecret":           "global-jks-password",
+				"global.elasticsearch.tls.jks.secret.existingSecretKey":        "password",
+				"optimize.enabled":                                             "true",
+				"optimize.database.elasticsearch.enabled":                      "true",
+				"optimize.database.elasticsearch.external":                     "true",
+				"optimize.database.elasticsearch.tls.enabled":                  "true",
+				"optimize.database.elasticsearch.tls.secret.existingSecret":    "optimize-elasticsearch-tls",
+				"optimize.database.elasticsearch.tls.secret.existingSecretKey": "optimize-elasticsearch.jks",
+				"optimize.database.opensearch.enabled":                         "false",
+			},
+			Verifier: verifyOptimizeTLSCustomKeyWithoutGlobalPassword("optimize-elasticsearch-tls", "optimize-elasticsearch.jks"),
 		},
 		{
 			Name:     "Optimize OpenSearch uses component TLS custom key",


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6783.

#6767 is merged; this PR is rebased onto main.

### What's in this PR?

Charts 8.9 and 8.10 now resolve one effective datastore TLS configuration per component and use it consistently for the Secret volume, mount `subPath`, mount path, JVM truststore path, and JKS password source. Component-owned Optimize TLS no longer inherits an unrelated global JKS password. The existing global compatibility precedence remains unchanged, including the legacy 8.9 TLS secret form.

Typed regression tests cover component-scoped Elasticsearch and OpenSearch custom keys for Orchestration and for both Optimize containers, including component-vs-global TLS conflicts.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?