### PR TITLE
fix: revert vendor-ee/elasticsearch to 8.19.18 to restore amd64 image pulls

### DIFF
--- a/charts/camunda-platform-8.7/values-enterprise.yaml
+++ b/charts/camunda-platform-8.7/values-enterprise.yaml
@@ -107,7 +107,7 @@ elasticsearch:
   image:
     registry: registry.camunda.cloud
     repository: vendor-ee/elasticsearch
-    tag: 8.19.19
+    tag: 8.19.18
     pullSecrets:
       - name: registry-camunda-cloud
 

--- a/charts/camunda-platform-8.8/values-enterprise.yaml
+++ b/charts/camunda-platform-8.8/values-enterprise.yaml
@@ -112,7 +112,7 @@ elasticsearch:
   image:
     registry: registry.camunda.cloud
     repository: vendor-ee/elasticsearch
-    tag: 8.19.19
+    tag: 8.19.18
     pullSecrets:
       - name: registry-camunda-cloud
 

--- a/charts/camunda-platform-8.9/values-enterprise.yaml
+++ b/charts/camunda-platform-8.9/values-enterprise.yaml
@@ -112,7 +112,7 @@ elasticsearch:
   image:
     registry: registry.camunda.cloud
     repository: vendor-ee/elasticsearch
-    tag: 8.19.19
+    tag: 8.19.18
     pullSecrets:
       - name: registry-camunda-cloud
 


### PR DESCRIPTION
### Which problem does the PR fix?

`Init:ImagePullBackOff` on GKE (amd64) for `vendor-ee/elasticsearch` in the
8.7/8.8/8.9 enterprise (`entv`) integration tests, e.g.
[run 30993715884](https://github.com/camunda/camunda-platform-helm/actions/runs/30993715884/job/92272710768)
(merge queue, `8.7 - entv - install - gke`):

```
Failed to pull image "registry.camunda.cloud/vendor-ee/elasticsearch:8.19.19":
failed to copy: httpReadSeeker: failed open: content at
https://registry.camunda.cloud/v2/vendor-ee/elasticsearch/manifests/
sha256:4cc859fc3d730babc412d7a21a91a4170a76d7380275fb236c617ee018c28a02
not found: not found
```

Elasticsearch never starts, so the Operate/Optimize init containers crash-loop,
the Tasklist/Zeebe-gateway/Identity startup probes stay red and
`helm upgrade --install --wait --timeout 1200s` ends with
`Error: context deadline exceeded` after ~20 min. The bumps in the affected
merge-queue PRs are unrelated collateral.

### What's in this PR?

Reverts the `vendor-ee/elasticsearch` tag from `8.19.19` back to `8.19.18` in
`values-enterprise.yaml` for charts 8.7, 8.8 and 8.9. `8.19.19` was introduced
by #6753 and passed `entv` on 2026-07-31, so the content was pullable at the
time.

**Root cause: registry-side data loss, not a bad upstream image.**

`registry.camunda.cloud` is a Harbor instance and `vendor-ee` is a proxy cache
of the Broadcom-hosted Bitnami backend
(`vmw-app-catalog/hosted-registry-.../containers/debian-12/<image>`). Querying
that backend directly shows the artifact is complete:

| ref | result |
| --- | --- |
| `elasticsearch:8.19.19` | HTTP 200, index `sha256:36abf2ca...` |
| child `sha256:4cc859fc...` (linux/amd64) | **HTTP 200** — the manifest the CI pull cannot find |
| child `sha256:ac287cf8...` (linux/arm64) | HTTP 200 |
| `elasticsearch:8.19.19-debian-12-r0` | same index digest — no re-push, no tag rotation |

So the tag was not rotated and nothing was deleted upstream: the proxy cache
serves the tagged index from its local copy but no longer has (and does not
re-fetch) the amd64 child manifest, which is why the failure is permanent
rather than transient (16 min of identical retries in the job).

This is the same signature as the `vendor-ee/postgresql` `-r14` incident
(#6622): index cached, amd64 child missing, arm64 fine. Note that the upstream
data for that case is healthy too — `postgresql:15.18.0-debian-12-r14`
(`sha256:d28589cd...`) still serves its amd64 child `sha256:a02381...` with
HTTP 200 — so that incident was also registry-side, and the `crane` checks
reported there were run against the proxy rather than the backend.

**Consequences**

- This pin revert only moves CI to a digest that is still healthy in the cache;
  it does not fix the cache. Escalation to the `registry.camunda.cloud` owners
  is being raised separately: drop the broken cached artifact for
  `vendor-ee/elasticsearch:8.19.19` so the next pull re-proxies the backend, and
  review the GC/retention settings of the proxy-cache project (untagged child
  manifests of an image index must not be collected).
- Renovate may re-propose `8.19.19`; it will only be safe once the cached
  artifact has been purged registry-side.

### Checklist

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`. — not needed, no
  golden file references the enterprise Elasticsearch tag (same scope as #6622).
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed). — n/a, tag-only change.
- [x] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed). — n/a.

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
