### PR TITLE
fix: write AWS document-store credentials to a file for connectors instead of env vars

### DIFF
--- a/charts/camunda-platform-8.7/templates/connectors/_helpers.tpl
+++ b/charts/camunda-platform-8.7/templates/connectors/_helpers.tpl
@@ -94,3 +94,111 @@ app.kubernetes.io/component: connectors
 {{- define "connectors.serviceHeadlessName" -}}
   {{ include "connectors.fullname" . }}-headless
 {{- end }}
+
+{{/*
+********************************************************************************
+AWS document-store credentials file.
+********************************************************************************
+*/}}
+
+{{/*
+[connectors] Whether the AWS document-store credentials are injected into
+this deployment. Mirrors the gate used by the main container's env block.
+*/}}
+{{- define "connectors.hasAwsDocumentStoreCredentials" -}}
+{{- if and .Values.global.documentStore.type.aws.enabled (not .Values.global.documentStore.type.aws.irsa.enabled) .Values.global.documentStore.type.aws.existingSecret -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{/*
+[connectors] Init container that writes the AWS document-store credentials
+to an AWS shared-credentials file, consumed via awsCredentialsFileEnv.
+
+Usage (inside .spec.initContainers):
+  {{- if eq (include "connectors.hasAwsDocumentStoreCredentials" .) "true" }}
+  {{- include "connectors.awsCredentialsFileInitContainer" (dict "context" $ "image" (include "camundaPlatform.imageByParams" (dict "base" $.Values.global "overlay" $.Values.connectors))) | nindent 8 }}
+  {{- end }}
+*/}}
+{{- define "connectors.awsCredentialsFileInitContainer" -}}
+{{- $ctx := .context -}}
+- name: aws-credentials-file-init
+  image: {{ .image | quote }}
+  imagePullPolicy: {{ $ctx.Values.global.image.pullPolicy | quote }}
+  {{- if $ctx.Values.connectors.containerSecurityContext }}
+  securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" $ctx.Values.connectors.containerSecurityContext "context" $ctx) | nindent 4 }}
+  {{- end }}
+  env:
+    - name: AWS_ACCESS_KEY_ID
+      valueFrom:
+        secretKeyRef:
+          name: {{ $ctx.Values.global.documentStore.type.aws.existingSecret | quote }}
+          key: {{ $ctx.Values.global.documentStore.type.aws.accessKeyIdKey | quote }}
+    - name: AWS_SECRET_ACCESS_KEY
+      valueFrom:
+        secretKeyRef:
+          name: {{ $ctx.Values.global.documentStore.type.aws.existingSecret | quote }}
+          key: {{ $ctx.Values.global.documentStore.type.aws.secretAccessKeyKey | quote }}
+  command: ["sh", "-c"]
+  args:
+    - |
+      set -eu
+      umask 077
+      if [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+        echo "[aws-credentials-file-init] ERROR: AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY resolved empty; check global.documentStore.type.aws.existingSecret / accessKeyIdKey / secretAccessKeyKey configuration." >&2
+        exit 1
+      fi
+      printf '[default]\naws_access_key_id=%s\naws_secret_access_key=%s\n' "$AWS_ACCESS_KEY_ID" "$AWS_SECRET_ACCESS_KEY" > /var/camunda/aws-credentials/credentials
+      chmod 0600 /var/camunda/aws-credentials/credentials
+  volumeMounts:
+    - name: aws-credentials-file
+      mountPath: /var/camunda/aws-credentials
+{{- end -}}
+
+{{/*
+[connectors] emptyDir backing the AWS credentials file written by
+awsCredentialsFileInitContainer.
+
+Usage (inside .spec.volumes):
+  {{- if eq (include "connectors.hasAwsDocumentStoreCredentials" .) "true" }}
+  {{- include "connectors.awsCredentialsFileVolume" . | nindent 8 }}
+  {{- end }}
+*/}}
+{{- define "connectors.awsCredentialsFileVolume" -}}
+- name: aws-credentials-file
+  emptyDir:
+    medium: Memory
+{{- end -}}
+
+{{/*
+[connectors] Main-container volumeMount for the AWS credentials file,
+read-only since the init container is the sole writer.
+
+Usage (inside container.volumeMounts):
+  {{- if eq (include "connectors.hasAwsDocumentStoreCredentials" .) "true" }}
+  {{- include "connectors.awsCredentialsFileVolumeMount" . | nindent 12 }}
+  {{- end }}
+*/}}
+{{- define "connectors.awsCredentialsFileVolumeMount" -}}
+- name: aws-credentials-file
+  mountPath: /var/camunda/aws-credentials
+  readOnly: true
+{{- end -}}
+
+{{/*
+[connectors] Sets AWS_SHARED_CREDENTIALS_FILE and AWS_CREDENTIAL_PROFILES_FILE
+to the credentials file written by awsCredentialsFileInitContainer.
+
+Usage (inside an env: list):
+  {{- if eq (include "connectors.hasAwsDocumentStoreCredentials" .) "true" }}
+  {{- include "connectors.awsCredentialsFileEnv" . | nindent 12 }}
+  {{- end }}
+*/}}
+{{- define "connectors.awsCredentialsFileEnv" -}}
+- name: AWS_SHARED_CREDENTIALS_FILE
+  value: /var/camunda/aws-credentials/credentials
+- name: AWS_CREDENTIAL_PROFILES_FILE
+  value: /var/camunda/aws-credentials/credentials
+{{- end -}}

--- a/charts/camunda-platform-8.7/templates/connectors/deployment.yaml
+++ b/charts/camunda-platform-8.7/templates/connectors/deployment.yaml
@@ -26,7 +26,12 @@ spec:
     spec:
       imagePullSecrets: {{- include "connectors.imagePullSecrets" . | nindent 8 }}
       initContainers:
-        {{- tpl (.Values.connectors.initContainers | default list | toYaml | nindent 8) $ }}
+        {{- if eq (include "connectors.hasAwsDocumentStoreCredentials" .) "true" }}
+        {{- include "connectors.awsCredentialsFileInitContainer" (dict "context" $ "image" (include "camundaPlatform.imageByParams" (dict "base" $.Values.global "overlay" $.Values.connectors))) | nindent 8 }}
+        {{- end }}
+        {{- with .Values.connectors.initContainers }}
+        {{- tpl (toYaml . | nindent 8) $ }}
+        {{- end }}
       containers:
         - name: connectors
           image: {{ include "camundaPlatform.imageByParams" (dict "base" .Values.global "overlay" .Values.connectors) }}
@@ -103,17 +108,8 @@ spec:
               value: {{ include "zeebe.authTokenScope" . | quote }}
             {{- end }}
           {{- end }}
-            {{- if and .Values.global.documentStore.type.aws.enabled (not .Values.global.documentStore.type.aws.irsa.enabled) .Values.global.documentStore.type.aws.existingSecret }}
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.global.documentStore.type.aws.existingSecret | quote }}
-                  key: {{ .Values.global.documentStore.type.aws.accessKeyIdKey | quote }}
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.global.documentStore.type.aws.existingSecret | quote }}
-                  key: {{ .Values.global.documentStore.type.aws.secretAccessKeyKey | quote }}
+            {{- if eq (include "connectors.hasAwsDocumentStoreCredentials" .) "true" }}
+            {{- include "connectors.awsCredentialsFileEnv" . | nindent 12 }}
             {{- end }}
             {{- if eq (lower .Values.global.documentStore.activeStoreId) "gcp" }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -189,6 +185,9 @@ spec:
               mountPath: {{ .Values.global.documentStore.type.gcp.mountPath | default "/var/secrets/gcp" | quote }}
               readOnly: true
             {{- end }}
+            {{- if eq (include "connectors.hasAwsDocumentStoreCredentials" .) "true" }}
+            {{- include "connectors.awsCredentialsFileVolumeMount" . | nindent 12 }}
+            {{- end }}
           {{- if .Values.connectors.extraVolumeMounts }}
             {{- .Values.connectors.extraVolumeMounts | toYaml | nindent 12 }}
           {{- end }}
@@ -208,6 +207,9 @@ spec:
             items:
               - key: {{ .Values.global.documentStore.type.gcp.credentialsKey | default "service-account.json" | quote }}
                 path: {{ .Values.global.documentStore.type.gcp.fileName | default "service-account.json" | quote }}
+        {{- end }}
+        {{- if eq (include "connectors.hasAwsDocumentStoreCredentials" .) "true" }}
+        {{- include "connectors.awsCredentialsFileVolume" . | nindent 8 }}
         {{- end }}
       {{- if .Values.connectors.extraVolumes }}
         {{- .Values.connectors.extraVolumes | toYaml | nindent 8 }}

--- a/charts/camunda-platform-8.7/test/unit/common/documentstore_irsa_test.go
+++ b/charts/camunda-platform-8.7/test/unit/common/documentstore_irsa_test.go
@@ -109,6 +109,37 @@ func hasEmptySecretKeyRefName(containers []corev1.Container) bool {
 	return false
 }
 
+// Helper function to check if AWS_SHARED_CREDENTIALS_FILE and AWS_CREDENTIAL_PROFILES_FILE both
+// point at the same credentials file path
+func hasAwsCredentialsFileEnvVars(containers []corev1.Container) bool {
+	const path = "/var/camunda/aws-credentials/credentials"
+	for _, container := range containers {
+		hasShared, hasProfiles := false, false
+		for _, env := range container.Env {
+			if env.Name == "AWS_SHARED_CREDENTIALS_FILE" && env.Value == path {
+				hasShared = true
+			}
+			if env.Name == "AWS_CREDENTIAL_PROFILES_FILE" && env.Value == path {
+				hasProfiles = true
+			}
+		}
+		if hasShared && hasProfiles {
+			return true
+		}
+	}
+	return false
+}
+
+// Helper function to check if a container with the given name exists
+func hasContainerNamed(containers []corev1.Container, name string) bool {
+	for _, container := range containers {
+		if container.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
 // baseValues returns common values needed for chart rendering
 func baseValues() map[string]string {
 	return map[string]string{
@@ -316,16 +347,21 @@ func (s *documentStoreIRSATest) TestConnectorsWithIRSA() {
 				helm.UnmarshalK8SYaml(t, output, &deployment)
 
 				containers := deployment.Spec.Template.Spec.Containers
+				initContainers := deployment.Spec.Template.Spec.InitContainers
 				require.False(t, hasAwsAccessKeyIdEnvVar(containers),
 					"AWS_ACCESS_KEY_ID should NOT be present when irsa.enabled is true")
 				require.False(t, hasAwsSecretAccessKeyEnvVar(containers),
 					"AWS_SECRET_ACCESS_KEY should NOT be present when irsa.enabled is true")
+				require.False(t, hasAwsCredentialsFileEnvVars(containers),
+					"AWS credentials file env vars should NOT be present when irsa.enabled is true")
+				require.False(t, hasContainerNamed(initContainers, "aws-credentials-file-init"),
+					"aws-credentials-file-init should NOT run when irsa.enabled is true")
 				require.False(t, hasDocumentStoreEnvFromRef(containers),
 					"connectors should not reference the documentstore-env-vars ConfigMap")
 			},
 		},
 		{
-			Name:   "Connectors: AWS credentials SHOULD be injected when irsa.enabled is false",
+			Name:   "Connectors: AWS credentials file SHOULD be used when irsa.enabled is false",
 			Values: awsDocumentStoreValuesWithIRSA(false),
 			Verifier: func(t *testing.T, output string, err error) {
 				require.NoError(t, err)
@@ -333,10 +369,19 @@ func (s *documentStoreIRSATest) TestConnectorsWithIRSA() {
 				helm.UnmarshalK8SYaml(t, output, &deployment)
 
 				containers := deployment.Spec.Template.Spec.Containers
-				require.True(t, hasAwsAccessKeyIdEnvVar(containers),
-					"AWS_ACCESS_KEY_ID should be present when irsa.enabled is false")
-				require.True(t, hasAwsSecretAccessKeyEnvVar(containers),
-					"AWS_SECRET_ACCESS_KEY should be present when irsa.enabled is false")
+				initContainers := deployment.Spec.Template.Spec.InitContainers
+				require.False(t, hasAwsAccessKeyIdEnvVar(containers),
+					"AWS_ACCESS_KEY_ID should NOT be present on the main container - it is FEEL-readable as a connector secret on this chart version")
+				require.False(t, hasAwsSecretAccessKeyEnvVar(containers),
+					"AWS_SECRET_ACCESS_KEY should NOT be present on the main container - it is FEEL-readable as a connector secret on this chart version")
+				require.True(t, hasAwsCredentialsFileEnvVars(containers),
+					"AWS_SHARED_CREDENTIALS_FILE and AWS_CREDENTIAL_PROFILES_FILE should be present on the main container so the AWS SDK default chain still resolves")
+				require.True(t, hasContainerNamed(initContainers, "aws-credentials-file-init"),
+					"aws-credentials-file-init should run to write the credentials file")
+				require.True(t, hasAwsAccessKeyIdEnvVar(initContainers),
+					"AWS_ACCESS_KEY_ID should be present on the init container, which writes it to the credentials file")
+				require.True(t, hasAwsSecretAccessKeyEnvVar(initContainers),
+					"AWS_SECRET_ACCESS_KEY should be present on the init container, which writes it to the credentials file")
 				require.False(t, hasDocumentStoreEnvFromRef(containers),
 					"connectors should not reference the documentstore-env-vars ConfigMap")
 			},
@@ -350,7 +395,12 @@ func (s *documentStoreIRSATest) TestConnectorsWithIRSA() {
 				helm.UnmarshalK8SYaml(t, output, &deployment)
 
 				containers := deployment.Spec.Template.Spec.Containers
+				initContainers := deployment.Spec.Template.Spec.InitContainers
 				requireNoAwsCredentialEnvVars(t, containers)
+				require.False(t, hasAwsCredentialsFileEnvVars(containers),
+					"AWS credentials file env vars should NOT be present when the secret is unset")
+				require.False(t, hasContainerNamed(initContainers, "aws-credentials-file-init"),
+					"aws-credentials-file-init should NOT run when the secret is unset")
 			},
 		},
 	}

--- a/charts/camunda-platform-8.7/test/unit/connectors/aws_credentials_file_test.go
+++ b/charts/camunda-platform-8.7/test/unit/connectors/aws_credentials_file_test.go
@@ -1,0 +1,253 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectors
+
+import (
+	"camunda-platform/test/unit/testhelpers"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+type AwsCredentialsFileTemplateTest struct {
+	suite.Suite
+	chartPath string
+	release   string
+	namespace string
+	templates []string
+}
+
+func TestAwsCredentialsFileTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../")
+	require.NoError(t, err)
+
+	suite.Run(t, &AwsCredentialsFileTemplateTest{
+		chartPath: chartPath,
+		release:   "camunda-platform-test",
+		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
+		templates: []string{"templates/connectors/deployment.yaml"},
+	})
+}
+
+func findContainerByName(containers []corev1.Container, name string) *corev1.Container {
+	for i := range containers {
+		if containers[i].Name == name {
+			return &containers[i]
+		}
+	}
+	return nil
+}
+
+func findVolumeByName(volumes []corev1.Volume, name string) *corev1.Volume {
+	for i := range volumes {
+		if volumes[i].Name == name {
+			return &volumes[i]
+		}
+	}
+	return nil
+}
+
+func findVolumeMountByName(mounts []corev1.VolumeMount, name string) *corev1.VolumeMount {
+	for i := range mounts {
+		if mounts[i].Name == name {
+			return &mounts[i]
+		}
+	}
+	return nil
+}
+
+func awsDocumentStoreCredentialsValues() map[string]string {
+	return map[string]string{
+		"connectors.enabled":                               "true",
+		"global.documentStore.activeStoreId":               "aws",
+		"global.documentStore.type.aws.enabled":            "true",
+		"global.documentStore.type.aws.bucket":             "test-bucket",
+		"global.documentStore.type.aws.region":             "us-east-1",
+		"global.documentStore.type.aws.irsa.enabled":       "false",
+		"global.documentStore.type.aws.existingSecret":     "aws-credentials",
+		"global.documentStore.type.aws.accessKeyIdKey":     "awsAccessKeyId",
+		"global.documentStore.type.aws.secretAccessKeyKey": "awsSecretAccessKey",
+	}
+}
+
+func (s *AwsCredentialsFileTemplateTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name:   "TestInitContainerPresentWithCorrectShape",
+			Values: awsDocumentStoreCredentialsValues(),
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				initContainer := findContainerByName(deployment.Spec.Template.Spec.InitContainers, "aws-credentials-file-init")
+				s.Require().NotNil(initContainer, "aws-credentials-file-init should be present")
+				s.Require().Equal("camunda/connectors-bundle:8.7.23", initContainer.Image)
+				s.Require().NotNil(initContainer.SecurityContext)
+				s.Require().True(*initContainer.SecurityContext.RunAsNonRoot)
+
+				var accessKeyEnv, secretKeyEnv *corev1.EnvVar
+				for i := range initContainer.Env {
+					switch initContainer.Env[i].Name {
+					case "AWS_ACCESS_KEY_ID":
+						accessKeyEnv = &initContainer.Env[i]
+					case "AWS_SECRET_ACCESS_KEY":
+						secretKeyEnv = &initContainer.Env[i]
+					}
+				}
+				s.Require().NotNil(accessKeyEnv)
+				s.Require().Equal("aws-credentials", accessKeyEnv.ValueFrom.SecretKeyRef.Name)
+				s.Require().Equal("awsAccessKeyId", accessKeyEnv.ValueFrom.SecretKeyRef.Key)
+				s.Require().NotNil(secretKeyEnv)
+				s.Require().Equal("aws-credentials", secretKeyEnv.ValueFrom.SecretKeyRef.Name)
+				s.Require().Equal("awsSecretAccessKey", secretKeyEnv.ValueFrom.SecretKeyRef.Key)
+
+				mount := findVolumeMountByName(initContainer.VolumeMounts, "aws-credentials-file")
+				s.Require().NotNil(mount, "init container should mount aws-credentials-file")
+				s.Require().Equal("/var/camunda/aws-credentials", mount.MountPath)
+			},
+		},
+		{
+			Name:   "TestMainContainerHasFileEnvVarsNotKeys",
+			Values: awsDocumentStoreCredentialsValues(),
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				container := findContainerByName(deployment.Spec.Template.Spec.Containers, "connectors")
+				s.Require().NotNil(container)
+
+				var hasAccessKey, hasSecretKey, hasSharedFile, hasProfilesFile bool
+				for _, env := range container.Env {
+					switch env.Name {
+					case "AWS_ACCESS_KEY_ID":
+						hasAccessKey = true
+					case "AWS_SECRET_ACCESS_KEY":
+						hasSecretKey = true
+					case "AWS_SHARED_CREDENTIALS_FILE":
+						hasSharedFile = env.Value == "/var/camunda/aws-credentials/credentials"
+					case "AWS_CREDENTIAL_PROFILES_FILE":
+						hasProfilesFile = env.Value == "/var/camunda/aws-credentials/credentials"
+					}
+				}
+				s.Require().False(hasAccessKey, "main container should not have AWS_ACCESS_KEY_ID")
+				s.Require().False(hasSecretKey, "main container should not have AWS_SECRET_ACCESS_KEY")
+				s.Require().True(hasSharedFile, "main container should have AWS_SHARED_CREDENTIALS_FILE")
+				s.Require().True(hasProfilesFile, "main container should have AWS_CREDENTIAL_PROFILES_FILE")
+
+				mount := findVolumeMountByName(container.VolumeMounts, "aws-credentials-file")
+				s.Require().NotNil(mount, "main container should mount aws-credentials-file")
+				s.Require().True(mount.ReadOnly)
+			},
+		},
+		{
+			Name:   "TestVolumeIsEmptyDirMemory",
+			Values: awsDocumentStoreCredentialsValues(),
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				volume := findVolumeByName(deployment.Spec.Template.Spec.Volumes, "aws-credentials-file")
+				s.Require().NotNil(volume, "aws-credentials-file volume should be present")
+				s.Require().NotNil(volume.EmptyDir)
+				s.Require().Equal(corev1.StorageMediumMemory, volume.EmptyDir.Medium)
+			},
+		},
+		{
+			Name: "TestNothingRendersWhenIrsaEnabled",
+			Values: func() map[string]string {
+				v := awsDocumentStoreCredentialsValues()
+				v["global.documentStore.type.aws.irsa.enabled"] = "true"
+				return v
+			}(),
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				s.Require().Nil(findContainerByName(deployment.Spec.Template.Spec.InitContainers, "aws-credentials-file-init"))
+				s.Require().Nil(findVolumeByName(deployment.Spec.Template.Spec.Volumes, "aws-credentials-file"))
+			},
+		},
+		{
+			Name: "TestNothingRendersWhenAwsDisabled",
+			Values: map[string]string{
+				"connectors.enabled":                    "true",
+				"global.documentStore.type.aws.enabled": "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				s.Require().Nil(findContainerByName(deployment.Spec.Template.Spec.InitContainers, "aws-credentials-file-init"))
+				s.Require().Nil(findVolumeByName(deployment.Spec.Template.Spec.Volumes, "aws-credentials-file"))
+			},
+		},
+		{
+			Name: "TestCustomSecretKeyNamesStillResolve",
+			Values: func() map[string]string {
+				v := awsDocumentStoreCredentialsValues()
+				v["global.documentStore.type.aws.existingSecret"] = "custom-secret"
+				v["global.documentStore.type.aws.accessKeyIdKey"] = "custom-access-key"
+				v["global.documentStore.type.aws.secretAccessKeyKey"] = "custom-secret-key"
+				return v
+			}(),
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				initContainer := findContainerByName(deployment.Spec.Template.Spec.InitContainers, "aws-credentials-file-init")
+				s.Require().NotNil(initContainer)
+
+				var accessKeyEnv *corev1.EnvVar
+				for i := range initContainer.Env {
+					if initContainer.Env[i].Name == "AWS_ACCESS_KEY_ID" {
+						accessKeyEnv = &initContainer.Env[i]
+					}
+				}
+				s.Require().NotNil(accessKeyEnv)
+				s.Require().Equal("custom-secret", accessKeyEnv.ValueFrom.SecretKeyRef.Name)
+				s.Require().Equal("custom-access-key", accessKeyEnv.ValueFrom.SecretKeyRef.Key)
+			},
+		},
+		{
+			Name: "TestCoexistsWithUserInitContainers",
+			Values: func() map[string]string {
+				v := awsDocumentStoreCredentialsValues()
+				v["connectors.initContainers[0].name"] = "nginx"
+				v["connectors.initContainers[0].image"] = "nginx:latest"
+				return v
+			}(),
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				initContainers := deployment.Spec.Template.Spec.InitContainers
+				s.Require().NotNil(findContainerByName(initContainers, "aws-credentials-file-init"))
+				s.Require().NotNil(findContainerByName(initContainers, "nginx"))
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}

--- a/charts/camunda-platform-8.7/test/unit/connectors/golden/deployment.golden.yaml
+++ b/charts/camunda-platform-8.7/test/unit/connectors/golden/deployment.golden.yaml
@@ -41,7 +41,6 @@ spec:
       imagePullSecrets:
         []
       initContainers:
-        []
       containers:
         - name: connectors
           image: camunda/connectors-bundle:8.7.23

--- a/charts/camunda-platform-8.8/templates/connectors/_helpers.tpl
+++ b/charts/camunda-platform-8.8/templates/connectors/_helpers.tpl
@@ -107,3 +107,107 @@ Authentication.
 {{- define "connectors.authTokenScope" -}}
     {{- .Values.connectors.security.authentication.oidc.tokenScope -}}
 {{- end -}}
+
+{{/*
+********************************************************************************
+AWS document-store credentials file.
+********************************************************************************
+*/}}
+
+{{/*
+[connectors] Whether the AWS document-store credentials are injected into
+this deployment. Mirrors the gate used by camundaPlatform.emitAwsDocumentStoreSecret's
+callers, so the init container only ever runs where credentials would
+otherwise have rendered as env vars.
+*/}}
+{{- define "connectors.hasAwsDocumentStoreCredentials" -}}
+{{- if and .Values.global.documentStore.type.aws.enabled (not .Values.global.documentStore.type.aws.irsa.enabled) -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{/*
+[connectors] Init container that writes the AWS document-store credentials
+to an AWS shared-credentials file, consumed via awsCredentialsFileEnv.
+
+Usage (inside .spec.initContainers):
+  {{- if eq (include "connectors.hasAwsDocumentStoreCredentials" .) "true" }}
+  {{- include "connectors.awsCredentialsFileInitContainer" (dict "context" $ "image" (include "camundaPlatform.imageByParams" (dict "base" $.Values.global "overlay" $.Values.connectors))) | nindent 8 }}
+  {{- end }}
+*/}}
+{{- define "connectors.awsCredentialsFileInitContainer" -}}
+{{- $ctx := .context -}}
+- name: aws-credentials-file-init
+  image: {{ .image | quote }}
+  imagePullPolicy: {{ $ctx.Values.global.image.pullPolicy | quote }}
+  {{- if $ctx.Values.connectors.containerSecurityContext }}
+  securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" $ctx.Values.connectors.containerSecurityContext "context" $ctx) | nindent 4 }}
+  {{- end }}
+  env:
+    - name: AWS_ACCESS_KEY_ID
+      {{- include "camundaPlatform.emitAwsDocumentStoreSecret" (dict "secretType" "accessKeyId" "context" $ctx) | nindent 6 }}
+    - name: AWS_SECRET_ACCESS_KEY
+      {{- include "camundaPlatform.emitAwsDocumentStoreSecret" (dict "secretType" "secretAccessKey" "context" $ctx) | nindent 6 }}
+  command: ["sh", "-c"]
+  args:
+    - |
+      set -eu
+      umask 077
+      if [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+        echo "[aws-credentials-file-init] ERROR: AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY resolved empty; check global.documentStore.type.aws.accessKeyId / secretAccessKey configuration." >&2
+        exit 1
+      fi
+      printf '[default]\naws_access_key_id=%s\naws_secret_access_key=%s\n' "$AWS_ACCESS_KEY_ID" "$AWS_SECRET_ACCESS_KEY" > /var/camunda/aws-credentials/credentials
+      chmod 0600 /var/camunda/aws-credentials/credentials
+  volumeMounts:
+    - name: aws-credentials-file
+      mountPath: /var/camunda/aws-credentials
+{{- end -}}
+
+{{/*
+[connectors] emptyDir backing the AWS credentials file written by
+awsCredentialsFileInitContainer.
+
+Usage (inside .spec.volumes):
+  {{- if eq (include "connectors.hasAwsDocumentStoreCredentials" .) "true" }}
+  {{- include "connectors.awsCredentialsFileVolume" . | nindent 8 }}
+  {{- end }}
+*/}}
+{{- define "connectors.awsCredentialsFileVolume" -}}
+- name: aws-credentials-file
+  emptyDir:
+    medium: Memory
+{{- end -}}
+
+{{/*
+[connectors] Main-container volumeMount for the AWS credentials file,
+read-only since the init container is the sole writer.
+
+Usage (inside container.volumeMounts):
+  {{- if eq (include "connectors.hasAwsDocumentStoreCredentials" .) "true" }}
+  {{- include "connectors.awsCredentialsFileVolumeMount" . | nindent 12 }}
+  {{- end }}
+*/}}
+{{- define "connectors.awsCredentialsFileVolumeMount" -}}
+- name: aws-credentials-file
+  mountPath: /var/camunda/aws-credentials
+  readOnly: true
+{{- end -}}
+
+{{/*
+[connectors] Sets AWS_SHARED_CREDENTIALS_FILE and AWS_CREDENTIAL_PROFILES_FILE
+to the credentials file written by awsCredentialsFileInitContainer.
+
+Usage (inside an env: list):
+  {{- if eq (include "connectors.hasAwsDocumentStoreCredentials" .) "true" }}
+  {{- include "connectors.awsCredentialsFileEnv" . | nindent 12 }}
+  {{- end }}
+*/}}
+{{- define "connectors.awsCredentialsFileEnv" -}}
+- name: AWS_SHARED_CREDENTIALS_FILE
+  value: /var/camunda/aws-credentials/credentials
+- name: AWS_CREDENTIAL_PROFILES_FILE
+  value: /var/camunda/aws-credentials/credentials
+{{- end -}}

--- a/charts/camunda-platform-8.8/templates/connectors/deployment.yaml
+++ b/charts/camunda-platform-8.8/templates/connectors/deployment.yaml
@@ -30,6 +30,9 @@ spec:
         {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
         {{- include "camundaPlatform.caBundleInitContainer" (dict "context" $ "image" (include "camundaPlatform.imageByParams" (dict "base" $.Values.global "overlay" $.Values.connectors))) | nindent 8 }}
         {{- end }}
+        {{- if eq (include "connectors.hasAwsDocumentStoreCredentials" .) "true" }}
+        {{- include "connectors.awsCredentialsFileInitContainer" (dict "context" $ "image" (include "camundaPlatform.imageByParams" (dict "base" $.Values.global "overlay" $.Values.connectors))) | nindent 8 }}
+        {{- end }}
         {{- with .Values.connectors.initContainers }}
         {{- tpl (toYaml . | nindent 8) $ }}
         {{- end }}
@@ -56,17 +59,8 @@ spec:
                 "config" .Values.connectors.security.authentication.oidc
             ) | nindent 12 }}
             {{- end }}
-            {{- if and .Values.global.documentStore.type.aws.enabled (not .Values.global.documentStore.type.aws.irsa.enabled) }}
-            - name: AWS_ACCESS_KEY_ID
-              {{- include "camundaPlatform.emitAwsDocumentStoreSecret" (dict
-                  "secretType" "accessKeyId"
-                  "context" .
-              ) | nindent 14 }}
-            - name: AWS_SECRET_ACCESS_KEY
-              {{- include "camundaPlatform.emitAwsDocumentStoreSecret" (dict
-                  "secretType" "secretAccessKey"
-                  "context" .
-              ) | nindent 14 }}
+            {{- if eq (include "connectors.hasAwsDocumentStoreCredentials" .) "true" }}
+            {{- include "connectors.awsCredentialsFileEnv" . | nindent 12 }}
             {{- end }}
             {{- if eq (lower .Values.global.documentStore.activeStoreId) "gcp" }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -150,6 +144,9 @@ spec:
             {{- include "camundaPlatform.caBundleVolumeMount" . | nindent 12 }}
             {{- include "camundaPlatform.caBundleTruststoreVolumeMount" . | nindent 12 }}
           {{- end }}
+          {{- if eq (include "connectors.hasAwsDocumentStoreCredentials" .) "true" }}
+            {{- include "connectors.awsCredentialsFileVolumeMount" . | nindent 12 }}
+          {{- end }}
           {{- if .Values.connectors.extraVolumeMounts }}
             {{- .Values.connectors.extraVolumeMounts | toYaml | nindent 12 }}
           {{- end }}
@@ -177,6 +174,9 @@ spec:
             "legacyKeyField" "credentialsKey"
             "fileName" .Values.global.documentStore.type.gcp.fileName
         ) | nindent 8 }}
+        {{- end }}
+        {{- if eq (include "connectors.hasAwsDocumentStoreCredentials" .) "true" }}
+        {{- include "connectors.awsCredentialsFileVolume" . | nindent 8 }}
         {{- end }}
       {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
         {{- include "camundaPlatform.caBundleVolume" . | nindent 8 }}

--- a/charts/camunda-platform-8.8/test/unit/common/documentstore_irsa_test.go
+++ b/charts/camunda-platform-8.8/test/unit/common/documentstore_irsa_test.go
@@ -100,6 +100,37 @@ func hasEmptySecretKeyRefName(containers []corev1.Container) bool {
 	return false
 }
 
+// Helper function to check if AWS_SHARED_CREDENTIALS_FILE and AWS_CREDENTIAL_PROFILES_FILE both
+// point at the same credentials file path
+func hasAwsCredentialsFileEnvVars(containers []corev1.Container) bool {
+	const path = "/var/camunda/aws-credentials/credentials"
+	for _, container := range containers {
+		hasShared, hasProfiles := false, false
+		for _, env := range container.Env {
+			if env.Name == "AWS_SHARED_CREDENTIALS_FILE" && env.Value == path {
+				hasShared = true
+			}
+			if env.Name == "AWS_CREDENTIAL_PROFILES_FILE" && env.Value == path {
+				hasProfiles = true
+			}
+		}
+		if hasShared && hasProfiles {
+			return true
+		}
+	}
+	return false
+}
+
+// Helper function to check if a container with the given name exists
+func hasContainerNamed(containers []corev1.Container, name string) bool {
+	for _, container := range containers {
+		if container.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
 // baseValues returns common values needed for chart rendering
 func baseValues() map[string]string {
 	return map[string]string{
@@ -272,16 +303,21 @@ func (s *documentStoreIRSATest) TestConnectorsWithIRSA() {
 				helm.UnmarshalK8SYaml(t, output, &deployment)
 
 				containers := deployment.Spec.Template.Spec.Containers
+				initContainers := deployment.Spec.Template.Spec.InitContainers
 				require.False(t, hasAwsAccessKeyIdEnvVar(containers),
 					"AWS_ACCESS_KEY_ID should NOT be present when irsa.enabled is true")
 				require.False(t, hasAwsSecretAccessKeyEnvVar(containers),
 					"AWS_SECRET_ACCESS_KEY should NOT be present when irsa.enabled is true")
+				require.False(t, hasAwsCredentialsFileEnvVars(containers),
+					"AWS credentials file env vars should NOT be present when irsa.enabled is true")
+				require.False(t, hasContainerNamed(initContainers, "aws-credentials-file-init"),
+					"aws-credentials-file-init should NOT run when irsa.enabled is true")
 				require.False(t, hasDocumentStoreEnvFromRef(containers),
 					"connectors should not reference the documentstore-env-vars ConfigMap")
 			},
 		},
 		{
-			Name:     "Connectors: AWS credentials SHOULD be injected when irsa.enabled is false",
+			Name:     "Connectors: AWS credentials file SHOULD be used when irsa.enabled is false",
 			Template: "templates/connectors/deployment.yaml",
 			Values:   awsDocumentStoreValuesWithIRSA(false),
 			Verifier: func(t *testing.T, output string, err error) {
@@ -290,10 +326,19 @@ func (s *documentStoreIRSATest) TestConnectorsWithIRSA() {
 				helm.UnmarshalK8SYaml(t, output, &deployment)
 
 				containers := deployment.Spec.Template.Spec.Containers
-				require.True(t, hasAwsAccessKeyIdEnvVar(containers),
-					"AWS_ACCESS_KEY_ID should be present when irsa.enabled is false")
-				require.True(t, hasAwsSecretAccessKeyEnvVar(containers),
-					"AWS_SECRET_ACCESS_KEY should be present when irsa.enabled is false")
+				initContainers := deployment.Spec.Template.Spec.InitContainers
+				require.False(t, hasAwsAccessKeyIdEnvVar(containers),
+					"AWS_ACCESS_KEY_ID should NOT be present on the main container - it is FEEL-readable as a connector secret on this chart version")
+				require.False(t, hasAwsSecretAccessKeyEnvVar(containers),
+					"AWS_SECRET_ACCESS_KEY should NOT be present on the main container - it is FEEL-readable as a connector secret on this chart version")
+				require.True(t, hasAwsCredentialsFileEnvVars(containers),
+					"AWS_SHARED_CREDENTIALS_FILE and AWS_CREDENTIAL_PROFILES_FILE should be present on the main container so the AWS SDK default chain still resolves")
+				require.True(t, hasContainerNamed(initContainers, "aws-credentials-file-init"),
+					"aws-credentials-file-init should run to write the credentials file")
+				require.True(t, hasAwsAccessKeyIdEnvVar(initContainers),
+					"AWS_ACCESS_KEY_ID should be present on the init container, which writes it to the credentials file")
+				require.True(t, hasAwsSecretAccessKeyEnvVar(initContainers),
+					"AWS_SECRET_ACCESS_KEY should be present on the init container, which writes it to the credentials file")
 				require.False(t, hasDocumentStoreEnvFromRef(containers),
 					"connectors should not reference the documentstore-env-vars ConfigMap")
 			},

--- a/charts/camunda-platform-8.8/test/unit/connectors/aws_credentials_file_test.go
+++ b/charts/camunda-platform-8.8/test/unit/connectors/aws_credentials_file_test.go
@@ -1,0 +1,255 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectors
+
+import (
+	"camunda-platform/test/unit/testhelpers"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+type AwsCredentialsFileTemplateTest struct {
+	suite.Suite
+	chartPath string
+	release   string
+	namespace string
+	templates []string
+}
+
+func TestAwsCredentialsFileTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../")
+	require.NoError(t, err)
+
+	suite.Run(t, &AwsCredentialsFileTemplateTest{
+		chartPath: chartPath,
+		release:   "camunda-platform-test",
+		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
+		templates: []string{"templates/connectors/deployment.yaml"},
+	})
+}
+
+func findContainerByName(containers []corev1.Container, name string) *corev1.Container {
+	for i := range containers {
+		if containers[i].Name == name {
+			return &containers[i]
+		}
+	}
+	return nil
+}
+
+func findVolumeByName(volumes []corev1.Volume, name string) *corev1.Volume {
+	for i := range volumes {
+		if volumes[i].Name == name {
+			return &volumes[i]
+		}
+	}
+	return nil
+}
+
+func findVolumeMountByName(mounts []corev1.VolumeMount, name string) *corev1.VolumeMount {
+	for i := range mounts {
+		if mounts[i].Name == name {
+			return &mounts[i]
+		}
+	}
+	return nil
+}
+
+func awsDocumentStoreCredentialsValues() map[string]string {
+	return map[string]string{
+		"connectors.enabled":                                                     "true",
+		"global.documentStore.activeStoreId":                                     "aws",
+		"global.documentStore.type.aws.enabled":                                  "true",
+		"global.documentStore.type.aws.bucket":                                   "test-bucket",
+		"global.documentStore.type.aws.region":                                   "us-east-1",
+		"global.documentStore.type.aws.irsa.enabled":                             "false",
+		"global.documentStore.type.aws.accessKeyId.secret.existingSecret":        "aws-credentials",
+		"global.documentStore.type.aws.accessKeyId.secret.existingSecretKey":     "access-key-id",
+		"global.documentStore.type.aws.secretAccessKey.secret.existingSecret":    "aws-credentials",
+		"global.documentStore.type.aws.secretAccessKey.secret.existingSecretKey": "secret-access-key",
+	}
+}
+
+func (s *AwsCredentialsFileTemplateTest) TestDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name:   "TestInitContainerPresentWithCorrectShape",
+			Values: awsDocumentStoreCredentialsValues(),
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				initContainer := findContainerByName(deployment.Spec.Template.Spec.InitContainers, "aws-credentials-file-init")
+				s.Require().NotNil(initContainer, "aws-credentials-file-init should be present")
+				s.Require().Equal("camunda/connectors-bundle:8.8.16", initContainer.Image)
+				s.Require().NotNil(initContainer.SecurityContext)
+				s.Require().True(*initContainer.SecurityContext.RunAsNonRoot)
+
+				var accessKeyEnv, secretKeyEnv *corev1.EnvVar
+				for i := range initContainer.Env {
+					switch initContainer.Env[i].Name {
+					case "AWS_ACCESS_KEY_ID":
+						accessKeyEnv = &initContainer.Env[i]
+					case "AWS_SECRET_ACCESS_KEY":
+						secretKeyEnv = &initContainer.Env[i]
+					}
+				}
+				s.Require().NotNil(accessKeyEnv)
+				s.Require().Equal("aws-credentials", accessKeyEnv.ValueFrom.SecretKeyRef.Name)
+				s.Require().Equal("access-key-id", accessKeyEnv.ValueFrom.SecretKeyRef.Key)
+				s.Require().NotNil(secretKeyEnv)
+				s.Require().Equal("aws-credentials", secretKeyEnv.ValueFrom.SecretKeyRef.Name)
+				s.Require().Equal("secret-access-key", secretKeyEnv.ValueFrom.SecretKeyRef.Key)
+
+				mount := findVolumeMountByName(initContainer.VolumeMounts, "aws-credentials-file")
+				s.Require().NotNil(mount, "init container should mount aws-credentials-file")
+				s.Require().Equal("/var/camunda/aws-credentials", mount.MountPath)
+			},
+		},
+		{
+			Name:   "TestMainContainerHasFileEnvVarsNotKeys",
+			Values: awsDocumentStoreCredentialsValues(),
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				container := findContainerByName(deployment.Spec.Template.Spec.Containers, "connectors")
+				s.Require().NotNil(container)
+
+				var hasAccessKey, hasSecretKey, hasSharedFile, hasProfilesFile bool
+				for _, env := range container.Env {
+					switch env.Name {
+					case "AWS_ACCESS_KEY_ID":
+						hasAccessKey = true
+					case "AWS_SECRET_ACCESS_KEY":
+						hasSecretKey = true
+					case "AWS_SHARED_CREDENTIALS_FILE":
+						hasSharedFile = env.Value == "/var/camunda/aws-credentials/credentials"
+					case "AWS_CREDENTIAL_PROFILES_FILE":
+						hasProfilesFile = env.Value == "/var/camunda/aws-credentials/credentials"
+					}
+				}
+				s.Require().False(hasAccessKey, "main container should not have AWS_ACCESS_KEY_ID")
+				s.Require().False(hasSecretKey, "main container should not have AWS_SECRET_ACCESS_KEY")
+				s.Require().True(hasSharedFile, "main container should have AWS_SHARED_CREDENTIALS_FILE")
+				s.Require().True(hasProfilesFile, "main container should have AWS_CREDENTIAL_PROFILES_FILE")
+
+				mount := findVolumeMountByName(container.VolumeMounts, "aws-credentials-file")
+				s.Require().NotNil(mount, "main container should mount aws-credentials-file")
+				s.Require().True(mount.ReadOnly)
+			},
+		},
+		{
+			Name:   "TestVolumeIsEmptyDirMemory",
+			Values: awsDocumentStoreCredentialsValues(),
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				volume := findVolumeByName(deployment.Spec.Template.Spec.Volumes, "aws-credentials-file")
+				s.Require().NotNil(volume, "aws-credentials-file volume should be present")
+				s.Require().NotNil(volume.EmptyDir)
+				s.Require().Equal(corev1.StorageMediumMemory, volume.EmptyDir.Medium)
+			},
+		},
+		{
+			Name: "TestNothingRendersWhenIrsaEnabled",
+			Values: func() map[string]string {
+				v := awsDocumentStoreCredentialsValues()
+				v["global.documentStore.type.aws.irsa.enabled"] = "true"
+				return v
+			}(),
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				s.Require().Nil(findContainerByName(deployment.Spec.Template.Spec.InitContainers, "aws-credentials-file-init"))
+				s.Require().Nil(findVolumeByName(deployment.Spec.Template.Spec.Volumes, "aws-credentials-file"))
+			},
+		},
+		{
+			Name: "TestNothingRendersWhenAwsDisabled",
+			Values: map[string]string{
+				"connectors.enabled":                    "true",
+				"global.documentStore.type.aws.enabled": "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				s.Require().Nil(findContainerByName(deployment.Spec.Template.Spec.InitContainers, "aws-credentials-file-init"))
+				s.Require().Nil(findVolumeByName(deployment.Spec.Template.Spec.Volumes, "aws-credentials-file"))
+			},
+		},
+		{
+			Name: "TestCustomSecretKeyNamesStillResolve",
+			Values: func() map[string]string {
+				v := awsDocumentStoreCredentialsValues()
+				v["global.documentStore.type.aws.accessKeyId.secret.existingSecret"] = "custom-secret"
+				v["global.documentStore.type.aws.accessKeyId.secret.existingSecretKey"] = "custom-access-key"
+				return v
+			}(),
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				initContainer := findContainerByName(deployment.Spec.Template.Spec.InitContainers, "aws-credentials-file-init")
+				s.Require().NotNil(initContainer)
+
+				var accessKeyEnv *corev1.EnvVar
+				for i := range initContainer.Env {
+					if initContainer.Env[i].Name == "AWS_ACCESS_KEY_ID" {
+						accessKeyEnv = &initContainer.Env[i]
+					}
+				}
+				s.Require().NotNil(accessKeyEnv)
+				s.Require().Equal("custom-secret", accessKeyEnv.ValueFrom.SecretKeyRef.Name)
+				s.Require().Equal("custom-access-key", accessKeyEnv.ValueFrom.SecretKeyRef.Key)
+			},
+		},
+		{
+			Name: "TestCoexistsWithUserInitContainersAndCaBundle",
+			Values: func() map[string]string {
+				v := awsDocumentStoreCredentialsValues()
+				v["global.tls.caBundle.secret.existingSecret"] = "my-ca-secret"
+				v["connectors.initContainers[0].name"] = "nginx"
+				v["connectors.initContainers[0].image"] = "nginx:latest"
+				return v
+			}(),
+			Verifier: func(t *testing.T, output string, err error) {
+				var deployment appsv1.Deployment
+				helm.UnmarshalK8SYaml(s.T(), output, &deployment)
+
+				initContainers := deployment.Spec.Template.Spec.InitContainers
+				s.Require().NotNil(findContainerByName(initContainers, "aws-credentials-file-init"))
+				s.Require().NotNil(findContainerByName(initContainers, "ca-bundle-truststore-init"))
+				s.Require().NotNil(findContainerByName(initContainers, "nginx"))
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}


### PR DESCRIPTION
### Which problem does the PR fix?

_No linked issue._

### What's in this PR?

- Connectors' AWS document-store credentials are now written to a shared-credentials file by a new `aws-credentials-file-init` init container, instead of being set as `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` env vars on the main container.
- Main container gets `AWS_SHARED_CREDENTIALS_FILE` and `AWS_CREDENTIAL_PROFILES_FILE` instead. Both AWS SDK generations Connectors depends on include a profile-file step in their default credential chain, so "Default Credentials Chain" connector tasks keep resolving unchanged.
- Fixes an 8.7-only `initContainers:` rendering bug (trailing `[]` collided with a second init container) — switched to the same `{{- with }}`-guarded pattern already used on 8.8.
- Scoped to 8.7 and 8.8 only.
- Tests updated/added on both versions (`TestConnectorsWithIRSA`, new `aws_credentials_file_test.go`); manually verified on a live GKE cluster on both versions.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?