### PR TITLE
fix: read external URLs from global.host when using the gateway api

### DIFF
--- a/charts/camunda-platform-8.10/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/common/_helpers.tpl
@@ -689,6 +689,9 @@ Zeebe templates.
   {{- if .Values.global.ingress.enabled -}}
     {{ $proto := ternary "https" "http" .Values.global.ingress.tls.enabled -}}
     {{- printf "%s://%s%s" $proto (tpl .Values.global.host $) (include "camundaPlatform.joinpath" (list .Values.orchestration.contextPath)) -}}
+  {{- else if .Values.global.gateway.enabled -}}
+    {{ $proto := ternary "https" "http" .Values.global.gateway.tls.enabled -}}
+    {{- printf "%s://%s%s" $proto (tpl .Values.global.host $ | required "global.host must be set when global.gateway.enabled is true") (include "camundaPlatform.joinpath" (list .Values.orchestration.contextPath)) -}}
   {{- else -}}
     {{- printf "http://localhost:8080" -}}
   {{- end -}}

--- a/charts/camunda-platform-8.10/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/common/_helpers.tpl
@@ -314,7 +314,7 @@ the chart host + contextPath. Otherwise return the configured external Keycloak 
 */}}
 {{- define "camundaPlatform.keycloakExternalURL" -}}
   {{- if .Values.global.identity.keycloak.internal -}}
-    {{- $proto := ternary "https" "http" .Values.global.ingress.tls.enabled -}}
+    {{- $proto := ternary "https" "http" (or .Values.global.ingress.tls.enabled .Values.global.gateway.tls.enabled) -}}
     {{- printf "%s://%s%s" $proto ((tpl .Values.global.host $) | default "localhost:18080") .Values.global.identity.keycloak.contextPath -}}
   {{- else if (.Values.global.identity.keycloak.url).host -}}
     {{- include "identity.keycloak.url" . -}}
@@ -397,6 +397,9 @@ Usage: {{ include "camundaPlatform.getExternalURL" (dict "component" "identity" 
     {{- if $.context.Values.global.ingress.enabled -}}
       {{ $proto := ternary "https" "http" .context.Values.global.ingress.tls.enabled -}}
       {{- printf "%s://%s%s" $proto (tpl .context.Values.global.host .context) (index .context.Values .component "contextPath") -}}
+    {{- else if $.context.Values.global.gateway.enabled -}}
+      {{ $proto := ternary "https" "http" .context.Values.global.gateway.tls.enabled -}}
+      {{- printf "%s://%s%s" $proto (tpl .context.Values.global.host .context | required "global.host must be set when global.gateway.enabled is true") (index .context.Values .component "contextPath") -}}
     {{- else -}}
       {{- $portMapping := (dict
       "identity" "8080"
@@ -487,6 +490,13 @@ Web Modeler templates.
         {{- printf "%s://%s%s" $proto (tpl .context.Values.global.host .context) (include "webModeler.websocketContextPath" .context) -}}
       {{- else -}}
         {{- printf "%s://%s%s" $proto (tpl .context.Values.global.host .context) (or .context.Values.camundaHub.contextPath .context.Values.webModeler.contextPath) -}}
+      {{- end -}}
+    {{- else if $.context.Values.global.gateway.enabled -}}
+      {{ $proto := ternary "https" "http" .context.Values.global.gateway.tls.enabled -}}
+      {{- if eq .component "websockets" }}
+        {{- printf "%s://%s%s" $proto (tpl .context.Values.global.host .context | required "global.host must be set when global.gateway.enabled is true") (include "webModeler.websocketContextPath" .context) -}}
+      {{- else -}}
+        {{- printf "%s://%s%s" $proto (tpl .context.Values.global.host .context | required "global.host must be set when global.gateway.enabled is true") (or .context.Values.camundaHub.contextPath .context.Values.webModeler.contextPath) -}}
       {{- end -}}
     {{- else -}}
       {{- if eq .component "websockets" -}}
@@ -701,8 +711,13 @@ Zeebe templates.
 [camunda-platform] Zeebe Gateway GRPC external URL.
 */}}
 {{- define "camundaPlatform.orchestrationGRPCExternalURL" -}}
-  {{ $proto := ternary "https" "http" .Values.orchestration.ingress.grpc.tls.enabled -}}
-  {{- printf "%s://%s" $proto (tpl .Values.orchestration.ingress.grpc.host . | default "localhost:26500") -}}
+  {{- if .Values.global.gateway.enabled -}}
+    {{ $proto := ternary "https" "http" .Values.global.gateway.tls.enabled -}}
+    {{- printf "%s://%s" $proto (tpl .Values.orchestration.gateway.grpc.host $) -}}
+  {{- else -}}
+    {{ $proto := ternary "https" "http" .Values.orchestration.ingress.grpc.tls.enabled -}}
+    {{- printf "%s://%s" $proto (tpl .Values.orchestration.ingress.grpc.host . | default "localhost:26500") -}}
+  {{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform-8.10/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/common/_helpers.tpl
@@ -308,15 +308,34 @@ NOTE: This is for Management Identity config, all new types will be supported vi
 {{- end -}}
 
 {{/*
+[camunda-platform] Gateway external URL prefix.
+*/}}
+{{- define "camundaPlatform.gatewayExternalURL" -}}
+  {{- $tlsEnabled := .context.Values.global.gateway.tls.enabled -}}
+  {{- $proto := ternary "https" "http" $tlsEnabled -}}
+  {{- $port := ternary .context.Values.global.gateway.tls.port .context.Values.global.gateway.port $tlsEnabled -}}
+  {{- $defaultPort := ternary 443 80 $tlsEnabled -}}
+  {{- $host := tpl .host .context | required "global.host must be set when global.gateway.enabled is true" -}}
+  {{- if eq (int $port) $defaultPort -}}
+    {{- printf "%s://%s" $proto $host -}}
+  {{- else -}}
+    {{- printf "%s://%s:%v" $proto $host $port -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Get the externally-reachable Keycloak URL for display in Camunda Hub and NOTES.txt.
 When the chart proxies Keycloak through its combined Ingress (internal: true), use
 the chart host + contextPath. Otherwise return the configured external Keycloak URL.
 */}}
 {{- define "camundaPlatform.keycloakExternalURL" -}}
   {{- if .Values.global.identity.keycloak.internal -}}
-    {{- $tlsEnabled := ternary .Values.global.gateway.tls.enabled .Values.global.ingress.tls.enabled .Values.global.gateway.enabled -}}
-    {{- $proto := ternary "https" "http" $tlsEnabled -}}
-    {{- printf "%s://%s%s" $proto ((tpl .Values.global.host $) | default "localhost:18080") .Values.global.identity.keycloak.contextPath -}}
+    {{- if .Values.global.gateway.enabled -}}
+      {{- printf "%s%s" (include "camundaPlatform.gatewayExternalURL" (dict "context" . "host" .Values.global.host)) .Values.global.identity.keycloak.contextPath -}}
+    {{- else -}}
+      {{- $proto := ternary "https" "http" .Values.global.ingress.tls.enabled -}}
+      {{- printf "%s://%s%s" $proto ((tpl .Values.global.host $) | default "localhost:18080") .Values.global.identity.keycloak.contextPath -}}
+    {{- end -}}
   {{- else if (.Values.global.identity.keycloak.url).host -}}
     {{- include "identity.keycloak.url" . -}}
   {{- end -}}
@@ -399,8 +418,7 @@ Usage: {{ include "camundaPlatform.getExternalURL" (dict "component" "identity" 
       {{ $proto := ternary "https" "http" .context.Values.global.ingress.tls.enabled -}}
       {{- printf "%s://%s%s" $proto (tpl .context.Values.global.host .context) (index .context.Values .component "contextPath") -}}
     {{- else if $.context.Values.global.gateway.enabled -}}
-      {{ $proto := ternary "https" "http" .context.Values.global.gateway.tls.enabled -}}
-      {{- printf "%s://%s%s" $proto (tpl .context.Values.global.host .context | required "global.host must be set when global.gateway.enabled is true") (index .context.Values .component "contextPath") -}}
+      {{- printf "%s%s" (include "camundaPlatform.gatewayExternalURL" (dict "context" .context "host" .context.Values.global.host)) (index .context.Values .component "contextPath") -}}
     {{- else -}}
       {{- $portMapping := (dict
       "identity" "8080"
@@ -493,11 +511,11 @@ Web Modeler templates.
         {{- printf "%s://%s%s" $proto (tpl .context.Values.global.host .context) (or .context.Values.camundaHub.contextPath .context.Values.webModeler.contextPath) -}}
       {{- end -}}
     {{- else if $.context.Values.global.gateway.enabled -}}
-      {{ $proto := ternary "https" "http" .context.Values.global.gateway.tls.enabled -}}
+      {{- $baseURL := include "camundaPlatform.gatewayExternalURL" (dict "context" .context "host" .context.Values.global.host) -}}
       {{- if eq .component "websockets" }}
-        {{- printf "%s://%s%s" $proto (tpl .context.Values.global.host .context | required "global.host must be set when global.gateway.enabled is true") (include "webModeler.websocketContextPath" .context) -}}
+        {{- printf "%s%s" $baseURL (include "webModeler.websocketContextPath" .context) -}}
       {{- else -}}
-        {{- printf "%s://%s%s" $proto (tpl .context.Values.global.host .context | required "global.host must be set when global.gateway.enabled is true") (or .context.Values.camundaHub.contextPath .context.Values.webModeler.contextPath) -}}
+        {{- printf "%s%s" $baseURL (or .context.Values.camundaHub.contextPath .context.Values.webModeler.contextPath) -}}
       {{- end -}}
     {{- else -}}
       {{- if eq .component "websockets" -}}
@@ -701,8 +719,7 @@ Zeebe templates.
     {{ $proto := ternary "https" "http" .Values.global.ingress.tls.enabled -}}
     {{- printf "%s://%s%s" $proto (tpl .Values.global.host $) (include "camundaPlatform.joinpath" (list .Values.orchestration.contextPath)) -}}
   {{- else if .Values.global.gateway.enabled -}}
-    {{ $proto := ternary "https" "http" .Values.global.gateway.tls.enabled -}}
-    {{- printf "%s://%s%s" $proto (tpl .Values.global.host $ | required "global.host must be set when global.gateway.enabled is true") (include "camundaPlatform.joinpath" (list .Values.orchestration.contextPath)) -}}
+    {{- printf "%s%s" (include "camundaPlatform.gatewayExternalURL" (dict "context" . "host" .Values.global.host)) (include "camundaPlatform.joinpath" (list .Values.orchestration.contextPath)) -}}
   {{- else -}}
     {{- printf "http://localhost:8080" -}}
   {{- end -}}
@@ -713,8 +730,7 @@ Zeebe templates.
 */}}
 {{- define "camundaPlatform.orchestrationGRPCExternalURL" -}}
   {{- if and .Values.global.gateway.enabled .Values.orchestration.gateway.grpc.enabled -}}
-    {{ $proto := ternary "https" "http" .Values.global.gateway.tls.enabled -}}
-    {{- printf "%s://%s" $proto (tpl .Values.orchestration.gateway.grpc.host $) -}}
+    {{- include "camundaPlatform.gatewayExternalURL" (dict "context" . "host" .Values.orchestration.gateway.grpc.host) -}}
   {{- else -}}
     {{ $proto := ternary "https" "http" .Values.orchestration.ingress.grpc.tls.enabled -}}
     {{- printf "%s://%s" $proto (tpl .Values.orchestration.ingress.grpc.host . | default "localhost:26500") -}}

--- a/charts/camunda-platform-8.10/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/common/_helpers.tpl
@@ -314,7 +314,8 @@ the chart host + contextPath. Otherwise return the configured external Keycloak 
 */}}
 {{- define "camundaPlatform.keycloakExternalURL" -}}
   {{- if .Values.global.identity.keycloak.internal -}}
-    {{- $proto := ternary "https" "http" (or .Values.global.ingress.tls.enabled .Values.global.gateway.tls.enabled) -}}
+    {{- $tlsEnabled := ternary .Values.global.gateway.tls.enabled .Values.global.ingress.tls.enabled .Values.global.gateway.enabled -}}
+    {{- $proto := ternary "https" "http" $tlsEnabled -}}
     {{- printf "%s://%s%s" $proto ((tpl .Values.global.host $) | default "localhost:18080") .Values.global.identity.keycloak.contextPath -}}
   {{- else if (.Values.global.identity.keycloak.url).host -}}
     {{- include "identity.keycloak.url" . -}}
@@ -711,7 +712,7 @@ Zeebe templates.
 [camunda-platform] Zeebe Gateway GRPC external URL.
 */}}
 {{- define "camundaPlatform.orchestrationGRPCExternalURL" -}}
-  {{- if .Values.global.gateway.enabled -}}
+  {{- if and .Values.global.gateway.enabled .Values.orchestration.gateway.grpc.enabled -}}
     {{ $proto := ternary "https" "http" .Values.global.gateway.tls.enabled -}}
     {{- printf "%s://%s" $proto (tpl .Values.orchestration.gateway.grpc.host $) -}}
   {{- else -}}

--- a/charts/camunda-platform-8.10/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/common/_helpers.tpl
@@ -315,7 +315,7 @@ NOTE: This is for Management Identity config, all new types will be supported vi
   {{- $proto := ternary "https" "http" $tlsEnabled -}}
   {{- $port := ternary .context.Values.global.gateway.tls.port .context.Values.global.gateway.port $tlsEnabled -}}
   {{- $defaultPort := ternary 443 80 $tlsEnabled -}}
-  {{- $host := tpl .host .context | required "global.host must be set when global.gateway.enabled is true" -}}
+  {{- $host := tpl .host .context -}}
   {{- if eq (int $port) $defaultPort -}}
     {{- printf "%s://%s" $proto $host -}}
   {{- else -}}
@@ -330,7 +330,7 @@ the chart host + contextPath. Otherwise return the configured external Keycloak 
 */}}
 {{- define "camundaPlatform.keycloakExternalURL" -}}
   {{- if .Values.global.identity.keycloak.internal -}}
-    {{- if .Values.global.gateway.enabled -}}
+    {{- if and .Values.global.gateway.enabled (tpl .Values.global.host $) -}}
       {{- printf "%s%s" (include "camundaPlatform.gatewayExternalURL" (dict "context" . "host" .Values.global.host)) .Values.global.identity.keycloak.contextPath -}}
     {{- else -}}
       {{- $proto := ternary "https" "http" .Values.global.ingress.tls.enabled -}}
@@ -417,7 +417,7 @@ Usage: {{ include "camundaPlatform.getExternalURL" (dict "component" "identity" 
     {{- if $.context.Values.global.ingress.enabled -}}
       {{ $proto := ternary "https" "http" .context.Values.global.ingress.tls.enabled -}}
       {{- printf "%s://%s%s" $proto (tpl .context.Values.global.host .context) (index .context.Values .component "contextPath") -}}
-    {{- else if $.context.Values.global.gateway.enabled -}}
+    {{- else if and $.context.Values.global.gateway.enabled (tpl .context.Values.global.host .context) -}}
       {{- printf "%s%s" (include "camundaPlatform.gatewayExternalURL" (dict "context" .context "host" .context.Values.global.host)) (index .context.Values .component "contextPath") -}}
     {{- else -}}
       {{- $portMapping := (dict
@@ -510,7 +510,7 @@ Web Modeler templates.
       {{- else -}}
         {{- printf "%s://%s%s" $proto (tpl .context.Values.global.host .context) (or .context.Values.camundaHub.contextPath .context.Values.webModeler.contextPath) -}}
       {{- end -}}
-    {{- else if $.context.Values.global.gateway.enabled -}}
+    {{- else if and $.context.Values.global.gateway.enabled (tpl .context.Values.global.host .context) -}}
       {{- $baseURL := include "camundaPlatform.gatewayExternalURL" (dict "context" .context "host" .context.Values.global.host) -}}
       {{- if eq .component "websockets" }}
         {{- printf "%s%s" $baseURL (include "webModeler.websocketContextPath" .context) -}}
@@ -718,7 +718,7 @@ Zeebe templates.
   {{- if .Values.global.ingress.enabled -}}
     {{ $proto := ternary "https" "http" .Values.global.ingress.tls.enabled -}}
     {{- printf "%s://%s%s" $proto (tpl .Values.global.host $) (include "camundaPlatform.joinpath" (list .Values.orchestration.contextPath)) -}}
-  {{- else if .Values.global.gateway.enabled -}}
+  {{- else if and .Values.global.gateway.enabled (tpl .Values.global.host $) -}}
     {{- printf "%s%s" (include "camundaPlatform.gatewayExternalURL" (dict "context" . "host" .Values.global.host)) (include "camundaPlatform.joinpath" (list .Values.orchestration.contextPath)) -}}
   {{- else -}}
     {{- printf "http://localhost:8080" -}}
@@ -729,7 +729,7 @@ Zeebe templates.
 [camunda-platform] Zeebe Gateway GRPC external URL.
 */}}
 {{- define "camundaPlatform.orchestrationGRPCExternalURL" -}}
-  {{- if and .Values.global.gateway.enabled .Values.orchestration.gateway.grpc.enabled -}}
+  {{- if and .Values.global.gateway.enabled .Values.orchestration.gateway.grpc.enabled (tpl .Values.global.host $) -}}
     {{- include "camundaPlatform.gatewayExternalURL" (dict "context" . "host" .Values.orchestration.gateway.grpc.host) -}}
   {{- else -}}
     {{ $proto := ternary "https" "http" .Values.orchestration.ingress.grpc.tls.enabled -}}

--- a/charts/camunda-platform-8.10/test/unit/common/release_info_gateway_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/release_info_gateway_test.go
@@ -1,0 +1,78 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package camunda
+
+import (
+	"camunda-platform/test/unit/testhelpers"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+// ReleaseInfoGatewayTest verifies the release-info external URLs resolve to
+// global.host (not localhost) when the Gateway API is used instead of Ingress.
+type ReleaseInfoGatewayTest struct {
+	suite.Suite
+	chartPath string
+	release   string
+	namespace string
+}
+
+func TestReleaseInfoGateway(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../")
+	require.NoError(t, err)
+
+	suite.Run(t, &ReleaseInfoGatewayTest{
+		chartPath: chartPath,
+		release:   "camunda-platform-test",
+		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
+	})
+}
+
+func (s *ReleaseInfoGatewayTest) TestExternalURLsUseGlobalHost() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "GatewayTLSExternalURLsUseGlobalHost",
+			Values: map[string]string{
+				"global.ingress.enabled":                   "false",
+				"global.gateway.enabled":                   "true",
+				"global.gateway.tls.enabled":               "true",
+				"global.gateway.tls.secretName":            "camunda-tls",
+				"global.host":                              "camunda.example.com",
+				"optimize.enabled":                         "true",
+				"orchestration.data.secondaryStorage.type": "elasticsearch",
+			},
+			Template: "templates/common/configmap-release.yaml",
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.Contains(t, output, "url: https://camunda.example.com/operate")
+				require.Contains(t, output, "url: https://camunda.example.com/tasklist")
+				require.Contains(t, output, "grpc: https://grpc-camunda.example.com")
+				require.Contains(t, output, "http: https://camunda.example.com")
+				require.NotContains(t, output, "http://localhost:8080")
+				require.NotContains(t, output, "http://localhost:26500")
+				require.NotContains(t, output, "http://localhost:8083")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, nil, testCases)
+}

--- a/charts/camunda-platform-8.10/test/unit/common/release_info_gateway_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/release_info_gateway_test.go
@@ -57,8 +57,11 @@ func (s *ReleaseInfoGatewayTest) TestExternalURLsUseGlobalHost() {
 				"global.gateway.tls.enabled":               "true",
 				"global.gateway.tls.secretName":            "camunda-tls",
 				"global.host":                              "camunda.example.com",
+				"global.identity.keycloak.internal":        "true",
+				"identity.enabled":                         "true",
 				"optimize.enabled":                         "true",
 				"orchestration.data.secondaryStorage.type": "elasticsearch",
+				"orchestration.gateway.grpc.enabled":       "true",
 			},
 			Template: "templates/common/configmap-release.yaml",
 			Verifier: func(t *testing.T, output string, err error) {
@@ -67,9 +70,44 @@ func (s *ReleaseInfoGatewayTest) TestExternalURLsUseGlobalHost() {
 				require.Contains(t, output, "url: https://camunda.example.com/tasklist")
 				require.Contains(t, output, "grpc: https://grpc-camunda.example.com")
 				require.Contains(t, output, "http: https://camunda.example.com")
+				require.Contains(t, output, "https://camunda.example.com/auth")
 				require.NotContains(t, output, "http://localhost:8080")
 				require.NotContains(t, output, "http://localhost:26500")
 				require.NotContains(t, output, "http://localhost:8083")
+			},
+		},
+		{
+			Name: "GatewayWithoutGRPCRouteUsesLocalEndpoint",
+			Values: map[string]string{
+				"global.ingress.enabled":        "false",
+				"global.gateway.enabled":        "true",
+				"global.gateway.tls.enabled":    "true",
+				"global.gateway.tls.secretName": "camunda-tls",
+				"global.host":                   "camunda.example.com",
+			},
+			Template: "templates/common/configmap-release.yaml",
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.Contains(t, output, "grpc: http://localhost:26500")
+				require.NotContains(t, output, "grpc: https://grpc-camunda.example.com")
+			},
+		},
+		{
+			Name: "PlaintextGatewayIgnoresInactiveIngressTLS",
+			Values: map[string]string{
+				"global.ingress.enabled":            "false",
+				"global.ingress.tls.enabled":        "true",
+				"global.gateway.enabled":            "true",
+				"global.gateway.tls.enabled":        "false",
+				"global.host":                       "camunda.example.com",
+				"global.identity.keycloak.internal": "true",
+				"identity.enabled":                  "true",
+			},
+			Template: "templates/common/configmap-release.yaml",
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.Contains(t, output, "http://camunda.example.com/auth")
+				require.NotContains(t, output, "https://camunda.example.com/auth")
 			},
 		},
 	}

--- a/charts/camunda-platform-8.10/test/unit/common/release_info_gateway_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/release_info_gateway_test.go
@@ -86,6 +86,34 @@ func (s *ReleaseInfoGatewayTest) TestExternalURLsUseGlobalHost() {
 			},
 		},
 		{
+			Name: "ExternalGatewayWithoutHostUsesLocalEndpoints",
+			Values: map[string]string{
+				"global.gateway.enabled":                   "true",
+				"global.gateway.external":                  "true",
+				"global.gateway.tls.enabled":               "true",
+				"global.identity.keycloak.internal":        "true",
+				"identity.enabled":                         "true",
+				"optimize.enabled":                         "true",
+				"orchestration.data.secondaryStorage.type": "elasticsearch",
+				"orchestration.gateway.grpc.enabled":       "true",
+				"webModeler.enabled":                       "true",
+				"webModeler.restapi.mail.fromAddress":      "test@example.com",
+			},
+			Template: "templates/common/configmap-release.yaml",
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.Contains(t, output, "url: http://localhost:18080/auth")
+				require.Contains(t, output, "url: http://localhost:8080")
+				require.Contains(t, output, "url: http://localhost:8070")
+				require.Contains(t, output, "url: http://localhost:8083")
+				require.Contains(t, output, "url: http://localhost:8080/operate")
+				require.Contains(t, output, "url: http://localhost:8080/tasklist")
+				require.Contains(t, output, "url: http://localhost:8080/admin")
+				require.Contains(t, output, "grpc: http://localhost:26500")
+				require.Contains(t, output, "http: http://localhost:8080")
+			},
+		},
+		{
 			Name: "GatewayWithoutGRPCRouteUsesLocalEndpoint",
 			Values: map[string]string{
 				"global.ingress.enabled":        "false",

--- a/charts/camunda-platform-8.10/test/unit/common/release_info_gateway_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/release_info_gateway_test.go
@@ -50,27 +50,36 @@ func TestReleaseInfoGateway(t *testing.T) {
 func (s *ReleaseInfoGatewayTest) TestExternalURLsUseGlobalHost() {
 	testCases := []testhelpers.TestCase{
 		{
-			Name: "GatewayTLSExternalURLsUseGlobalHost",
+			Name: "GatewayTLSExternalURLsUseGlobalHostAndCustomPort",
 			Values: map[string]string{
 				"global.ingress.enabled":                   "false",
 				"global.gateway.enabled":                   "true",
 				"global.gateway.tls.enabled":               "true",
+				"global.gateway.tls.port":                  "8443",
 				"global.gateway.tls.secretName":            "camunda-tls",
 				"global.host":                              "camunda.example.com",
 				"global.identity.keycloak.internal":        "true",
+				"identity.contextPath":                     "/identity",
 				"identity.enabled":                         "true",
+				"optimize.contextPath":                     "/optimize",
 				"optimize.enabled":                         "true",
 				"orchestration.data.secondaryStorage.type": "elasticsearch",
 				"orchestration.gateway.grpc.enabled":       "true",
+				"webModeler.enabled":                       "true",
+				"webModeler.contextPath":                   "/modeler",
+				"webModeler.restapi.mail.fromAddress":      "test@example.com",
 			},
 			Template: "templates/common/configmap-release.yaml",
 			Verifier: func(t *testing.T, output string, err error) {
 				require.NoError(t, err)
-				require.Contains(t, output, "url: https://camunda.example.com/operate")
-				require.Contains(t, output, "url: https://camunda.example.com/tasklist")
-				require.Contains(t, output, "grpc: https://grpc-camunda.example.com")
-				require.Contains(t, output, "http: https://camunda.example.com")
-				require.Contains(t, output, "https://camunda.example.com/auth")
+				require.Contains(t, output, "url: https://camunda.example.com:8443/identity")
+				require.Contains(t, output, "url: https://camunda.example.com:8443/modeler")
+				require.Contains(t, output, "url: https://camunda.example.com:8443/operate")
+				require.Contains(t, output, "url: https://camunda.example.com:8443/optimize")
+				require.Contains(t, output, "url: https://camunda.example.com:8443/tasklist")
+				require.Contains(t, output, "grpc: https://grpc-camunda.example.com:8443")
+				require.Contains(t, output, "http: https://camunda.example.com:8443")
+				require.Contains(t, output, "https://camunda.example.com:8443/auth")
 				require.NotContains(t, output, "http://localhost:8080")
 				require.NotContains(t, output, "http://localhost:26500")
 				require.NotContains(t, output, "http://localhost:8083")
@@ -93,11 +102,12 @@ func (s *ReleaseInfoGatewayTest) TestExternalURLsUseGlobalHost() {
 			},
 		},
 		{
-			Name: "PlaintextGatewayIgnoresInactiveIngressTLS",
+			Name: "PlaintextGatewayUsesCustomPortAndIgnoresInactiveIngressTLS",
 			Values: map[string]string{
 				"global.ingress.enabled":            "false",
 				"global.ingress.tls.enabled":        "true",
 				"global.gateway.enabled":            "true",
+				"global.gateway.port":               "8080",
 				"global.gateway.tls.enabled":        "false",
 				"global.host":                       "camunda.example.com",
 				"global.identity.keycloak.internal": "true",
@@ -106,7 +116,8 @@ func (s *ReleaseInfoGatewayTest) TestExternalURLsUseGlobalHost() {
 			Template: "templates/common/configmap-release.yaml",
 			Verifier: func(t *testing.T, output string, err error) {
 				require.NoError(t, err)
-				require.Contains(t, output, "http://camunda.example.com/auth")
+				require.Contains(t, output, "url: http://camunda.example.com:8080/operate")
+				require.Contains(t, output, "http://camunda.example.com:8080/auth")
 				require.NotContains(t, output, "https://camunda.example.com/auth")
 			},
 		},

--- a/charts/camunda-platform-8.9/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/common/_helpers.tpl
@@ -330,7 +330,7 @@ Get the external url for keycloak
     {{- $proto := ternary "https" "http" .Values.identityKeycloak.ingress.tls -}}
     {{- printf "%s://%s%s" $proto .Values.identityKeycloak.ingress.hostname .Values.identityKeycloak.httpRelativePath -}}
   {{ else if .Values.identityKeycloak.enabled -}}
-    {{- $proto := ternary "https" "http" .Values.global.ingress.tls.enabled -}}
+    {{- $proto := ternary "https" "http" (or .Values.global.ingress.tls.enabled .Values.global.gateway.tls.enabled) -}}
     {{- printf "%s://%s%s" $proto ((tpl .Values.global.host $) | default (tpl .Values.global.ingress.host $) | default "localhost:18080") .Values.global.identity.keycloak.contextPath -}}
   {{- end -}}
 {{- end -}}
@@ -411,6 +411,9 @@ Usage: {{ include "camundaPlatform.getExternalURL" (dict "component" "identity" 
     {{- if $.context.Values.global.ingress.enabled -}}
       {{ $proto := ternary "https" "http" .context.Values.global.ingress.tls.enabled -}}
       {{- printf "%s://%s%s" $proto (tpl .context.Values.global.host .context | default (tpl .context.Values.global.ingress.host .context)) (index .context.Values .component "contextPath") -}}
+    {{- else if $.context.Values.global.gateway.enabled -}}
+      {{ $proto := ternary "https" "http" .context.Values.global.gateway.tls.enabled -}}
+      {{- printf "%s://%s%s" $proto (tpl .context.Values.global.host .context | required "global.host must be set when global.gateway.enabled is true") (index .context.Values .component "contextPath") -}}
     {{- else -}}
       {{- $portMapping := (dict
       "identity" "8080"
@@ -502,6 +505,13 @@ Web Modeler templates.
         {{- printf "%s://%s%s" $proto (tpl .context.Values.global.host .context | default (tpl .context.Values.global.ingress.host .context)) (include "webModeler.websocketContextPath" .context) -}}
       {{- else -}}
         {{- printf "%s://%s%s" $proto (tpl .context.Values.global.host .context | default (tpl .context.Values.global.ingress.host .context)) (index .context.Values.webModeler "contextPath") -}}
+      {{- end -}}
+    {{- else if $.context.Values.global.gateway.enabled -}}
+      {{ $proto := ternary "https" "http" .context.Values.global.gateway.tls.enabled -}}
+      {{- if eq .component "websockets" }}
+        {{- printf "%s://%s%s" $proto (tpl .context.Values.global.host .context | required "global.host must be set when global.gateway.enabled is true") (include "webModeler.websocketContextPath" .context) -}}
+      {{- else -}}
+        {{- printf "%s://%s%s" $proto (tpl .context.Values.global.host .context | required "global.host must be set when global.gateway.enabled is true") (index .context.Values.webModeler "contextPath") -}}
       {{- end -}}
     {{- else -}}
       {{- if eq .component "websockets" -}}
@@ -646,8 +656,13 @@ Zeebe templates.
 [camunda-platform] Zeebe Gateway GRPC external URL.
 */}}
 {{- define "camundaPlatform.orchestrationGRPCExternalURL" -}}
-  {{ $proto := ternary "https" "http" .Values.orchestration.ingress.grpc.tls.enabled -}}
-  {{- printf "%s://%s" $proto (tpl .Values.orchestration.ingress.grpc.host . | default "localhost:26500") -}}
+  {{- if .Values.global.gateway.enabled -}}
+    {{ $proto := ternary "https" "http" .Values.global.gateway.tls.enabled -}}
+    {{- printf "%s://%s" $proto (tpl .Values.orchestration.gateway.grpc.host $) -}}
+  {{- else -}}
+    {{ $proto := ternary "https" "http" .Values.orchestration.ingress.grpc.tls.enabled -}}
+    {{- printf "%s://%s" $proto (tpl .Values.orchestration.ingress.grpc.host . | default "localhost:26500") -}}
+  {{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform-8.9/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/common/_helpers.tpl
@@ -636,7 +636,7 @@ Zeebe templates.
     {{- printf "%s://%s%s" $proto (tpl .Values.global.host $ | default (tpl .Values.global.ingress.host $)) (include "camundaPlatform.joinpath" (list .Values.orchestration.contextPath)) -}}
   {{- else if .Values.global.gateway.enabled -}}
     {{ $proto := ternary "https" "http" .Values.global.gateway.tls.enabled -}}
-    {{- printf "%s://%s%s" $proto (tpl .Values.global.host $) (include "camundaPlatform.joinpath" (list .Values.orchestration.contextPath)) -}}
+    {{- printf "%s://%s%s" $proto (tpl .Values.global.host $ | required "global.host must be set when global.gateway.enabled is true") (include "camundaPlatform.joinpath" (list .Values.orchestration.contextPath)) -}}
   {{- else -}}
     {{- printf "http://localhost:8080" -}}
   {{- end -}}

--- a/charts/camunda-platform-8.9/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/common/_helpers.tpl
@@ -634,6 +634,9 @@ Zeebe templates.
   {{- if .Values.global.ingress.enabled -}}
     {{ $proto := ternary "https" "http" .Values.global.ingress.tls.enabled -}}
     {{- printf "%s://%s%s" $proto (tpl .Values.global.host $ | default (tpl .Values.global.ingress.host $)) (include "camundaPlatform.joinpath" (list .Values.orchestration.contextPath)) -}}
+  {{- else if .Values.global.gateway.enabled -}}
+    {{ $proto := ternary "https" "http" .Values.global.gateway.tls.enabled -}}
+    {{- printf "%s://%s%s" $proto (tpl .Values.global.host $) (include "camundaPlatform.joinpath" (list .Values.orchestration.contextPath)) -}}
   {{- else -}}
     {{- printf "http://localhost:8080" -}}
   {{- end -}}

--- a/charts/camunda-platform-8.9/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/common/_helpers.tpl
@@ -330,7 +330,7 @@ NOTE: This is for Management Identity config, all new types will be supported vi
   {{- $proto := ternary "https" "http" $tlsEnabled -}}
   {{- $port := ternary .context.Values.global.gateway.tls.port .context.Values.global.gateway.port $tlsEnabled -}}
   {{- $defaultPort := ternary 443 80 $tlsEnabled -}}
-  {{- $host := tpl .host .context | required "global.host must be set when global.gateway.enabled is true" -}}
+  {{- $host := tpl .host .context -}}
   {{- if eq (int $port) $defaultPort -}}
     {{- printf "%s://%s" $proto $host -}}
   {{- else -}}
@@ -346,7 +346,7 @@ Get the external url for keycloak
     {{- $proto := ternary "https" "http" .Values.identityKeycloak.ingress.tls -}}
     {{- printf "%s://%s%s" $proto .Values.identityKeycloak.ingress.hostname .Values.identityKeycloak.httpRelativePath -}}
   {{ else if .Values.identityKeycloak.enabled -}}
-    {{- if .Values.global.gateway.enabled -}}
+    {{- if and .Values.global.gateway.enabled (tpl .Values.global.host $) -}}
       {{- printf "%s%s" (include "camundaPlatform.gatewayExternalURL" (dict "context" . "host" .Values.global.host)) .Values.global.identity.keycloak.contextPath -}}
     {{- else -}}
       {{- $proto := ternary "https" "http" .Values.global.ingress.tls.enabled -}}
@@ -431,7 +431,7 @@ Usage: {{ include "camundaPlatform.getExternalURL" (dict "component" "identity" 
     {{- if $.context.Values.global.ingress.enabled -}}
       {{ $proto := ternary "https" "http" .context.Values.global.ingress.tls.enabled -}}
       {{- printf "%s://%s%s" $proto (tpl .context.Values.global.host .context | default (tpl .context.Values.global.ingress.host .context)) (index .context.Values .component "contextPath") -}}
-    {{- else if $.context.Values.global.gateway.enabled -}}
+    {{- else if and $.context.Values.global.gateway.enabled (tpl .context.Values.global.host .context) -}}
       {{- printf "%s%s" (include "camundaPlatform.gatewayExternalURL" (dict "context" .context "host" .context.Values.global.host)) (index .context.Values .component "contextPath") -}}
     {{- else -}}
       {{- $portMapping := (dict
@@ -525,7 +525,7 @@ Web Modeler templates.
       {{- else -}}
         {{- printf "%s://%s%s" $proto (tpl .context.Values.global.host .context | default (tpl .context.Values.global.ingress.host .context)) (index .context.Values.webModeler "contextPath") -}}
       {{- end -}}
-    {{- else if $.context.Values.global.gateway.enabled -}}
+    {{- else if and $.context.Values.global.gateway.enabled (tpl .context.Values.global.host .context) -}}
       {{- $baseURL := include "camundaPlatform.gatewayExternalURL" (dict "context" .context "host" .context.Values.global.host) -}}
       {{- if eq .component "websockets" }}
         {{- printf "%s%s" $baseURL (include "webModeler.websocketContextPath" .context) -}}
@@ -663,7 +663,7 @@ Zeebe templates.
   {{- if .Values.global.ingress.enabled -}}
     {{ $proto := ternary "https" "http" .Values.global.ingress.tls.enabled -}}
     {{- printf "%s://%s%s" $proto (tpl .Values.global.host $ | default (tpl .Values.global.ingress.host $)) (include "camundaPlatform.joinpath" (list .Values.orchestration.contextPath)) -}}
-  {{- else if .Values.global.gateway.enabled -}}
+  {{- else if and .Values.global.gateway.enabled (tpl .Values.global.host $) -}}
     {{- printf "%s%s" (include "camundaPlatform.gatewayExternalURL" (dict "context" . "host" .Values.global.host)) (include "camundaPlatform.joinpath" (list .Values.orchestration.contextPath)) -}}
   {{- else -}}
     {{- printf "http://localhost:8080" -}}
@@ -674,7 +674,7 @@ Zeebe templates.
 [camunda-platform] Zeebe Gateway GRPC external URL.
 */}}
 {{- define "camundaPlatform.orchestrationGRPCExternalURL" -}}
-  {{- if and .Values.global.gateway.enabled .Values.orchestration.gateway.grpc.enabled -}}
+  {{- if and .Values.global.gateway.enabled .Values.orchestration.gateway.grpc.enabled (tpl .Values.global.host $) -}}
     {{- include "camundaPlatform.gatewayExternalURL" (dict "context" . "host" .Values.orchestration.gateway.grpc.host) -}}
   {{- else -}}
     {{ $proto := ternary "https" "http" .Values.orchestration.ingress.grpc.tls.enabled -}}

--- a/charts/camunda-platform-8.9/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/common/_helpers.tpl
@@ -323,6 +323,22 @@ NOTE: This is for Management Identity config, all new types will be supported vi
 {{- end -}}
 
 {{/*
+[camunda-platform] Gateway external URL prefix.
+*/}}
+{{- define "camundaPlatform.gatewayExternalURL" -}}
+  {{- $tlsEnabled := .context.Values.global.gateway.tls.enabled -}}
+  {{- $proto := ternary "https" "http" $tlsEnabled -}}
+  {{- $port := ternary .context.Values.global.gateway.tls.port .context.Values.global.gateway.port $tlsEnabled -}}
+  {{- $defaultPort := ternary 443 80 $tlsEnabled -}}
+  {{- $host := tpl .host .context | required "global.host must be set when global.gateway.enabled is true" -}}
+  {{- if eq (int $port) $defaultPort -}}
+    {{- printf "%s://%s" $proto $host -}}
+  {{- else -}}
+    {{- printf "%s://%s:%v" $proto $host $port -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Get the external url for keycloak
 */}}
 {{- define "camundaPlatform.keycloakExternalURL" -}}
@@ -330,9 +346,12 @@ Get the external url for keycloak
     {{- $proto := ternary "https" "http" .Values.identityKeycloak.ingress.tls -}}
     {{- printf "%s://%s%s" $proto .Values.identityKeycloak.ingress.hostname .Values.identityKeycloak.httpRelativePath -}}
   {{ else if .Values.identityKeycloak.enabled -}}
-    {{- $tlsEnabled := ternary .Values.global.gateway.tls.enabled .Values.global.ingress.tls.enabled .Values.global.gateway.enabled -}}
-    {{- $proto := ternary "https" "http" $tlsEnabled -}}
-    {{- printf "%s://%s%s" $proto ((tpl .Values.global.host $) | default (tpl .Values.global.ingress.host $) | default "localhost:18080") .Values.global.identity.keycloak.contextPath -}}
+    {{- if .Values.global.gateway.enabled -}}
+      {{- printf "%s%s" (include "camundaPlatform.gatewayExternalURL" (dict "context" . "host" .Values.global.host)) .Values.global.identity.keycloak.contextPath -}}
+    {{- else -}}
+      {{- $proto := ternary "https" "http" .Values.global.ingress.tls.enabled -}}
+      {{- printf "%s://%s%s" $proto ((tpl .Values.global.host $) | default (tpl .Values.global.ingress.host $) | default "localhost:18080") .Values.global.identity.keycloak.contextPath -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 
@@ -413,8 +432,7 @@ Usage: {{ include "camundaPlatform.getExternalURL" (dict "component" "identity" 
       {{ $proto := ternary "https" "http" .context.Values.global.ingress.tls.enabled -}}
       {{- printf "%s://%s%s" $proto (tpl .context.Values.global.host .context | default (tpl .context.Values.global.ingress.host .context)) (index .context.Values .component "contextPath") -}}
     {{- else if $.context.Values.global.gateway.enabled -}}
-      {{ $proto := ternary "https" "http" .context.Values.global.gateway.tls.enabled -}}
-      {{- printf "%s://%s%s" $proto (tpl .context.Values.global.host .context | required "global.host must be set when global.gateway.enabled is true") (index .context.Values .component "contextPath") -}}
+      {{- printf "%s%s" (include "camundaPlatform.gatewayExternalURL" (dict "context" .context "host" .context.Values.global.host)) (index .context.Values .component "contextPath") -}}
     {{- else -}}
       {{- $portMapping := (dict
       "identity" "8080"
@@ -508,11 +526,11 @@ Web Modeler templates.
         {{- printf "%s://%s%s" $proto (tpl .context.Values.global.host .context | default (tpl .context.Values.global.ingress.host .context)) (index .context.Values.webModeler "contextPath") -}}
       {{- end -}}
     {{- else if $.context.Values.global.gateway.enabled -}}
-      {{ $proto := ternary "https" "http" .context.Values.global.gateway.tls.enabled -}}
+      {{- $baseURL := include "camundaPlatform.gatewayExternalURL" (dict "context" .context "host" .context.Values.global.host) -}}
       {{- if eq .component "websockets" }}
-        {{- printf "%s://%s%s" $proto (tpl .context.Values.global.host .context | required "global.host must be set when global.gateway.enabled is true") (include "webModeler.websocketContextPath" .context) -}}
+        {{- printf "%s%s" $baseURL (include "webModeler.websocketContextPath" .context) -}}
       {{- else -}}
-        {{- printf "%s://%s%s" $proto (tpl .context.Values.global.host .context | required "global.host must be set when global.gateway.enabled is true") (index .context.Values.webModeler "contextPath") -}}
+        {{- printf "%s%s" $baseURL (index .context.Values.webModeler "contextPath") -}}
       {{- end -}}
     {{- else -}}
       {{- if eq .component "websockets" -}}
@@ -646,8 +664,7 @@ Zeebe templates.
     {{ $proto := ternary "https" "http" .Values.global.ingress.tls.enabled -}}
     {{- printf "%s://%s%s" $proto (tpl .Values.global.host $ | default (tpl .Values.global.ingress.host $)) (include "camundaPlatform.joinpath" (list .Values.orchestration.contextPath)) -}}
   {{- else if .Values.global.gateway.enabled -}}
-    {{ $proto := ternary "https" "http" .Values.global.gateway.tls.enabled -}}
-    {{- printf "%s://%s%s" $proto (tpl .Values.global.host $ | required "global.host must be set when global.gateway.enabled is true") (include "camundaPlatform.joinpath" (list .Values.orchestration.contextPath)) -}}
+    {{- printf "%s%s" (include "camundaPlatform.gatewayExternalURL" (dict "context" . "host" .Values.global.host)) (include "camundaPlatform.joinpath" (list .Values.orchestration.contextPath)) -}}
   {{- else -}}
     {{- printf "http://localhost:8080" -}}
   {{- end -}}
@@ -658,8 +675,7 @@ Zeebe templates.
 */}}
 {{- define "camundaPlatform.orchestrationGRPCExternalURL" -}}
   {{- if and .Values.global.gateway.enabled .Values.orchestration.gateway.grpc.enabled -}}
-    {{ $proto := ternary "https" "http" .Values.global.gateway.tls.enabled -}}
-    {{- printf "%s://%s" $proto (tpl .Values.orchestration.gateway.grpc.host $) -}}
+    {{- include "camundaPlatform.gatewayExternalURL" (dict "context" . "host" .Values.orchestration.gateway.grpc.host) -}}
   {{- else -}}
     {{ $proto := ternary "https" "http" .Values.orchestration.ingress.grpc.tls.enabled -}}
     {{- printf "%s://%s" $proto (tpl .Values.orchestration.ingress.grpc.host . | default "localhost:26500") -}}

--- a/charts/camunda-platform-8.9/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/common/_helpers.tpl
@@ -330,7 +330,8 @@ Get the external url for keycloak
     {{- $proto := ternary "https" "http" .Values.identityKeycloak.ingress.tls -}}
     {{- printf "%s://%s%s" $proto .Values.identityKeycloak.ingress.hostname .Values.identityKeycloak.httpRelativePath -}}
   {{ else if .Values.identityKeycloak.enabled -}}
-    {{- $proto := ternary "https" "http" (or .Values.global.ingress.tls.enabled .Values.global.gateway.tls.enabled) -}}
+    {{- $tlsEnabled := ternary .Values.global.gateway.tls.enabled .Values.global.ingress.tls.enabled .Values.global.gateway.enabled -}}
+    {{- $proto := ternary "https" "http" $tlsEnabled -}}
     {{- printf "%s://%s%s" $proto ((tpl .Values.global.host $) | default (tpl .Values.global.ingress.host $) | default "localhost:18080") .Values.global.identity.keycloak.contextPath -}}
   {{- end -}}
 {{- end -}}
@@ -656,7 +657,7 @@ Zeebe templates.
 [camunda-platform] Zeebe Gateway GRPC external URL.
 */}}
 {{- define "camundaPlatform.orchestrationGRPCExternalURL" -}}
-  {{- if .Values.global.gateway.enabled -}}
+  {{- if and .Values.global.gateway.enabled .Values.orchestration.gateway.grpc.enabled -}}
     {{ $proto := ternary "https" "http" .Values.global.gateway.tls.enabled -}}
     {{- printf "%s://%s" $proto (tpl .Values.orchestration.gateway.grpc.host $) -}}
   {{- else -}}

--- a/charts/camunda-platform-8.9/test/unit/common/release_info_gateway_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/release_info_gateway_test.go
@@ -1,0 +1,78 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package camunda
+
+import (
+	"camunda-platform/test/unit/testhelpers"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+// ReleaseInfoGatewayTest verifies the release-info external URLs resolve to
+// global.host (not localhost) when the Gateway API is used instead of Ingress.
+type ReleaseInfoGatewayTest struct {
+	suite.Suite
+	chartPath string
+	release   string
+	namespace string
+}
+
+func TestReleaseInfoGateway(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../")
+	require.NoError(t, err)
+
+	suite.Run(t, &ReleaseInfoGatewayTest{
+		chartPath: chartPath,
+		release:   "camunda-platform-test",
+		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
+	})
+}
+
+func (s *ReleaseInfoGatewayTest) TestExternalURLsUseGlobalHost() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "GatewayTLSExternalURLsUseGlobalHost",
+			Values: map[string]string{
+				"global.ingress.enabled":                   "false",
+				"global.gateway.enabled":                   "true",
+				"global.gateway.tls.enabled":               "true",
+				"global.gateway.tls.secretName":            "camunda-tls",
+				"global.host":                              "camunda.example.com",
+				"optimize.enabled":                         "true",
+				"orchestration.data.secondaryStorage.type": "elasticsearch",
+			},
+			Template: "templates/common/configmap-release.yaml",
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.Contains(t, output, "url: https://camunda.example.com/operate")
+				require.Contains(t, output, "url: https://camunda.example.com/tasklist")
+				require.Contains(t, output, "grpc: https://grpc-camunda.example.com")
+				require.Contains(t, output, "http: https://camunda.example.com")
+				require.NotContains(t, output, "http://localhost:8080")
+				require.NotContains(t, output, "http://localhost:26500")
+				require.NotContains(t, output, "http://localhost:8083")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, nil, testCases)
+}

--- a/charts/camunda-platform-8.9/test/unit/common/release_info_gateway_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/release_info_gateway_test.go
@@ -86,6 +86,33 @@ func (s *ReleaseInfoGatewayTest) TestExternalURLsUseGlobalHost() {
 			},
 		},
 		{
+			Name: "ExternalGatewayWithoutHostUsesLocalEndpoints",
+			Values: map[string]string{
+				"global.gateway.enabled":                   "true",
+				"global.gateway.external":                  "true",
+				"global.gateway.tls.enabled":               "true",
+				"identity.enabled":                         "true",
+				"identityKeycloak.enabled":                 "true",
+				"optimize.enabled":                         "true",
+				"orchestration.data.secondaryStorage.type": "elasticsearch",
+				"orchestration.gateway.grpc.enabled":       "true",
+				"webModeler.enabled":                       "true",
+				"webModeler.restapi.mail.fromAddress":      "test@example.com",
+			},
+			Template: "templates/common/configmap-release.yaml",
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.Contains(t, output, "url: http://localhost:18080/auth")
+				require.Contains(t, output, "url: http://localhost:8080")
+				require.Contains(t, output, "url: http://localhost:8070")
+				require.Contains(t, output, "url: http://localhost:8083")
+				require.Contains(t, output, "url: http://localhost:8080/operate")
+				require.Contains(t, output, "url: http://localhost:8080/tasklist")
+				require.Contains(t, output, "grpc: http://localhost:26500")
+				require.Contains(t, output, "http: http://localhost:8080")
+			},
+		},
+		{
 			Name: "GatewayWithoutGRPCRouteUsesLocalEndpoint",
 			Values: map[string]string{
 				"global.ingress.enabled":        "false",

--- a/charts/camunda-platform-8.9/test/unit/common/release_info_gateway_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/release_info_gateway_test.go
@@ -57,8 +57,11 @@ func (s *ReleaseInfoGatewayTest) TestExternalURLsUseGlobalHost() {
 				"global.gateway.tls.enabled":               "true",
 				"global.gateway.tls.secretName":            "camunda-tls",
 				"global.host":                              "camunda.example.com",
+				"identity.enabled":                         "true",
+				"identityKeycloak.enabled":                 "true",
 				"optimize.enabled":                         "true",
 				"orchestration.data.secondaryStorage.type": "elasticsearch",
+				"orchestration.gateway.grpc.enabled":       "true",
 			},
 			Template: "templates/common/configmap-release.yaml",
 			Verifier: func(t *testing.T, output string, err error) {
@@ -67,9 +70,44 @@ func (s *ReleaseInfoGatewayTest) TestExternalURLsUseGlobalHost() {
 				require.Contains(t, output, "url: https://camunda.example.com/tasklist")
 				require.Contains(t, output, "grpc: https://grpc-camunda.example.com")
 				require.Contains(t, output, "http: https://camunda.example.com")
+				require.Contains(t, output, "https://camunda.example.com/auth")
 				require.NotContains(t, output, "http://localhost:8080")
 				require.NotContains(t, output, "http://localhost:26500")
 				require.NotContains(t, output, "http://localhost:8083")
+			},
+		},
+		{
+			Name: "GatewayWithoutGRPCRouteUsesLocalEndpoint",
+			Values: map[string]string{
+				"global.ingress.enabled":        "false",
+				"global.gateway.enabled":        "true",
+				"global.gateway.tls.enabled":    "true",
+				"global.gateway.tls.secretName": "camunda-tls",
+				"global.host":                   "camunda.example.com",
+			},
+			Template: "templates/common/configmap-release.yaml",
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.Contains(t, output, "grpc: http://localhost:26500")
+				require.NotContains(t, output, "grpc: https://grpc-camunda.example.com")
+			},
+		},
+		{
+			Name: "PlaintextGatewayIgnoresInactiveIngressTLS",
+			Values: map[string]string{
+				"global.ingress.enabled":     "false",
+				"global.ingress.tls.enabled": "true",
+				"global.gateway.enabled":     "true",
+				"global.gateway.tls.enabled": "false",
+				"global.host":                "camunda.example.com",
+				"identity.enabled":           "true",
+				"identityKeycloak.enabled":   "true",
+			},
+			Template: "templates/common/configmap-release.yaml",
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.Contains(t, output, "http://camunda.example.com/auth")
+				require.NotContains(t, output, "https://camunda.example.com/auth")
 			},
 		},
 	}

--- a/charts/camunda-platform-8.9/test/unit/common/release_info_gateway_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/release_info_gateway_test.go
@@ -50,27 +50,36 @@ func TestReleaseInfoGateway(t *testing.T) {
 func (s *ReleaseInfoGatewayTest) TestExternalURLsUseGlobalHost() {
 	testCases := []testhelpers.TestCase{
 		{
-			Name: "GatewayTLSExternalURLsUseGlobalHost",
+			Name: "GatewayTLSExternalURLsUseGlobalHostAndCustomPort",
 			Values: map[string]string{
 				"global.ingress.enabled":                   "false",
 				"global.gateway.enabled":                   "true",
 				"global.gateway.tls.enabled":               "true",
+				"global.gateway.tls.port":                  "8443",
 				"global.gateway.tls.secretName":            "camunda-tls",
 				"global.host":                              "camunda.example.com",
+				"identity.contextPath":                     "/identity",
 				"identity.enabled":                         "true",
 				"identityKeycloak.enabled":                 "true",
+				"optimize.contextPath":                     "/optimize",
 				"optimize.enabled":                         "true",
 				"orchestration.data.secondaryStorage.type": "elasticsearch",
 				"orchestration.gateway.grpc.enabled":       "true",
+				"webModeler.enabled":                       "true",
+				"webModeler.contextPath":                   "/modeler",
+				"webModeler.restapi.mail.fromAddress":      "test@example.com",
 			},
 			Template: "templates/common/configmap-release.yaml",
 			Verifier: func(t *testing.T, output string, err error) {
 				require.NoError(t, err)
-				require.Contains(t, output, "url: https://camunda.example.com/operate")
-				require.Contains(t, output, "url: https://camunda.example.com/tasklist")
-				require.Contains(t, output, "grpc: https://grpc-camunda.example.com")
-				require.Contains(t, output, "http: https://camunda.example.com")
-				require.Contains(t, output, "https://camunda.example.com/auth")
+				require.Contains(t, output, "url: https://camunda.example.com:8443/identity")
+				require.Contains(t, output, "url: https://camunda.example.com:8443/modeler")
+				require.Contains(t, output, "url: https://camunda.example.com:8443/operate")
+				require.Contains(t, output, "url: https://camunda.example.com:8443/optimize")
+				require.Contains(t, output, "url: https://camunda.example.com:8443/tasklist")
+				require.Contains(t, output, "grpc: https://grpc-camunda.example.com:8443")
+				require.Contains(t, output, "http: https://camunda.example.com:8443")
+				require.Contains(t, output, "https://camunda.example.com:8443/auth")
 				require.NotContains(t, output, "http://localhost:8080")
 				require.NotContains(t, output, "http://localhost:26500")
 				require.NotContains(t, output, "http://localhost:8083")
@@ -93,11 +102,12 @@ func (s *ReleaseInfoGatewayTest) TestExternalURLsUseGlobalHost() {
 			},
 		},
 		{
-			Name: "PlaintextGatewayIgnoresInactiveIngressTLS",
+			Name: "PlaintextGatewayUsesCustomPortAndIgnoresInactiveIngressTLS",
 			Values: map[string]string{
 				"global.ingress.enabled":     "false",
 				"global.ingress.tls.enabled": "true",
 				"global.gateway.enabled":     "true",
+				"global.gateway.port":        "8080",
 				"global.gateway.tls.enabled": "false",
 				"global.host":                "camunda.example.com",
 				"identity.enabled":           "true",
@@ -106,7 +116,8 @@ func (s *ReleaseInfoGatewayTest) TestExternalURLsUseGlobalHost() {
 			Template: "templates/common/configmap-release.yaml",
 			Verifier: func(t *testing.T, output string, err error) {
 				require.NoError(t, err)
-				require.Contains(t, output, "http://camunda.example.com/auth")
+				require.Contains(t, output, "url: http://camunda.example.com:8080/operate")
+				require.Contains(t, output, "http://camunda.example.com:8080/auth")
 				require.NotContains(t, output, "https://camunda.example.com/auth")
 			},
 		},


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6181.

Supersedes #6255. The original pull request came from a fork where required Vault-backed CI could not run; this successor is hosted in the upstream repository and rebased onto current `main`.

### What's in this PR?

Reads external Identity, Optimize, Web Modeler, and gRPC URLs from `global.host` when Gateway API is enabled, including custom Gateway API ports.

The rebased series preserves the original authorship, and `git range-diff` confirms that all six commits are patch-equivalent to #6255.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
