### PR TITLE
test: [UPGPATH 1/5] add chartvalues package for values consolidation

### DIFF
--- a/scripts/camunda-core/go.mod
+++ b/scripts/camunda-core/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/jwalton/gchalk v1.3.0
 	github.com/rs/zerolog v1.35.1
 	github.com/spf13/cobra v1.10.2
+	github.com/stretchr/testify v1.9.0
 	golang.org/x/term v0.45.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.31.1
@@ -39,6 +40,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	golang.org/x/net v0.55.0 // indirect

--- a/scripts/camunda-core/pkg/chartvalues/chartvalues.go
+++ b/scripts/camunda-core/pkg/chartvalues/chartvalues.go
@@ -1,0 +1,351 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package chartvalues consolidates Helm values documents and applies upgrade
+// deltas to them.
+//
+// Chart constraints test key presence with hasKey, so a key cannot be cleared
+// by layering an overlay that sets it to null — it must be removed from the
+// merged document. A delta therefore supports a "$remove" directive listing
+// dotted key paths to delete, alongside the keys it sets.
+package chartvalues
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Directive keys a delta may carry alongside the values it sets.
+const (
+	// RemoveDirective holds dotted paths to delete.
+	RemoveDirective = "$remove"
+	// RenameDirective maps an old dotted path to a new one, moving the value.
+	RenameDirective = "$rename"
+)
+
+// Values is a parsed Helm values document.
+type Values map[string]any
+
+// LoadFile reads a YAML values file. A file containing only comments or
+// whitespace yields an empty, non-nil Values.
+func LoadFile(path string) (Values, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read values %s: %w", path, err)
+	}
+	v := Values{}
+	if err := yaml.Unmarshal(b, &v); err != nil {
+		return nil, fmt.Errorf("parse values %s: %w", path, err)
+	}
+	if v == nil {
+		v = Values{}
+	}
+	return v, nil
+}
+
+// WriteFile serialises a values document.
+func WriteFile(path string, v Values) error {
+	b, err := yaml.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("marshal values: %w", err)
+	}
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		return fmt.Errorf("write values %s: %w", path, err)
+	}
+	return nil
+}
+
+// Merge deep-merges src into a copy of dst, matching how Helm layers successive
+// -f arguments: maps merge recursively, scalars and arrays are replaced.
+func Merge(dst, src Values) Values {
+	out := make(Values, len(dst)+len(src))
+	for k, v := range dst {
+		out[k] = v
+	}
+	for k, v := range src {
+		if existing, ok := out[k]; ok {
+			em, eok := toMap(existing)
+			vm, vok := toMap(v)
+			if eok && vok {
+				out[k] = Merge(em, vm)
+				continue
+			}
+		}
+		out[k] = v
+	}
+	return out
+}
+
+// DeepCopy returns a copy whose nested maps and slices are independent of the
+// original. Merge shares references to nested maps it does not have to merge,
+// so callers that mutate a merged document must copy first.
+func DeepCopy(v Values) Values {
+	out := make(Values, len(v))
+	for k, val := range v {
+		out[k] = deepCopyValue(val)
+	}
+	return out
+}
+
+func deepCopyValue(v any) any {
+	if m, ok := toMap(v); ok {
+		return DeepCopy(m)
+	}
+	if s, ok := v.([]any); ok {
+		out := make([]any, len(s))
+		for i, item := range s {
+			out[i] = deepCopyValue(item)
+		}
+		return out
+	}
+	return v
+}
+
+// MergeFiles loads and merges files left to right.
+func MergeFiles(paths []string) (Values, error) {
+	out := Values{}
+	for _, p := range paths {
+		v, err := LoadFile(p)
+		if err != nil {
+			return nil, err
+		}
+		out = Merge(out, v)
+	}
+	return out, nil
+}
+
+// DeleteKey removes a dotted key path, reporting whether anything was removed.
+// Only the leaf is removed; emptied parent maps are left in place.
+func DeleteKey(v Values, dotted string) bool {
+	parts := strings.Split(dotted, ".")
+	cur := v
+	for i, p := range parts {
+		if i == len(parts)-1 {
+			if _, ok := cur[p]; !ok {
+				return false
+			}
+			delete(cur, p)
+			return true
+		}
+		next, ok := toMap(cur[p])
+		if !ok {
+			return false
+		}
+		cur = next
+	}
+	return false
+}
+
+// HasKey reports whether a dotted key path is present.
+func HasKey(v Values, dotted string) bool {
+	parts := strings.Split(dotted, ".")
+	cur := v
+	for i, p := range parts {
+		if i == len(parts)-1 {
+			_, ok := cur[p]
+			return ok
+		}
+		next, ok := toMap(cur[p])
+		if !ok {
+			return false
+		}
+		cur = next
+	}
+	return false
+}
+
+// GetKey returns the value at a dotted key path.
+func GetKey(v Values, dotted string) (any, bool) {
+	parts := strings.Split(dotted, ".")
+	cur := v
+	for i, p := range parts {
+		if i == len(parts)-1 {
+			got, ok := cur[p]
+			return got, ok
+		}
+		next, ok := toMap(cur[p])
+		if !ok {
+			return nil, false
+		}
+		cur = next
+	}
+	return nil, false
+}
+
+// SetKey writes a value at a dotted key path, creating intermediate maps.
+// Returns false when an intermediate segment holds a non-map.
+func SetKey(v Values, dotted string, val any) bool {
+	parts := strings.Split(dotted, ".")
+	cur := v
+	for i, p := range parts {
+		if i == len(parts)-1 {
+			cur[p] = val
+			return true
+		}
+		next, ok := toMap(cur[p])
+		if !ok {
+			if _, exists := cur[p]; exists {
+				return false
+			}
+			next = Values{}
+			cur[p] = next
+		} else {
+			cur[p] = next
+		}
+		cur = next
+	}
+	return false
+}
+
+// Delta is an upgrade delta: keys to set, plus paths to remove.
+type Delta struct {
+	// Remove holds dotted key paths, sorted for deterministic application.
+	Remove []string
+	// Rename maps old dotted paths to new ones, moving the existing value.
+	Rename map[string]string
+	// Set holds the delta's remaining keys.
+	Set Values
+}
+
+// LoadDelta reads a delta file and splits its directives from the keys it sets.
+// A missing or empty file yields an empty Delta.
+func LoadDelta(path string) (Delta, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return Delta{Set: Values{}}, fmt.Errorf("read delta %s: %w", path, err)
+	}
+	return ParseDelta(b, path)
+}
+
+// ParseDelta splits directives from set keys in already-read delta content.
+// name is used only in error messages.
+func ParseDelta(data []byte, name string) (Delta, error) {
+	var d Delta
+	d.Set = Values{}
+
+	raw := Values{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return d, fmt.Errorf("parse delta %s: %w", name, err)
+	}
+
+	for k, v := range raw {
+		switch k {
+		case RemoveDirective:
+			items, ok := v.([]any)
+			if !ok {
+				return d, fmt.Errorf("%s: %q must be a list of dotted key paths", name, RemoveDirective)
+			}
+			for _, item := range items {
+				s, ok := item.(string)
+				if !ok {
+					return d, fmt.Errorf("%s: %q entries must be strings, got %T", name, RemoveDirective, item)
+				}
+				if s = strings.TrimSpace(s); s != "" {
+					d.Remove = append(d.Remove, s)
+				}
+			}
+		case RenameDirective:
+			m, ok := toMap(v)
+			if !ok {
+				return d, fmt.Errorf("%s: %q must be a map of old to new dotted key paths", name, RenameDirective)
+			}
+			d.Rename = map[string]string{}
+			for old, newVal := range m {
+				s, ok := newVal.(string)
+				if !ok {
+					return d, fmt.Errorf("%s: %q target for %q must be a string, got %T",
+						name, RenameDirective, old, newVal)
+				}
+				d.Rename[old] = strings.TrimSpace(s)
+			}
+		default:
+			d.Set[k] = v
+		}
+	}
+	sort.Strings(d.Remove)
+	return d, nil
+}
+
+// Apply renames, then removes, then merges the delta's keys into base.
+//
+// Renames run first so a moved value survives a subsequent removal of its old
+// parent. A rename whose source is absent is skipped.
+func (d Delta) Apply(base Values) Values {
+	out := DeepCopy(base)
+
+	for _, old := range sortedKeys(d.Rename) {
+		val, ok := GetKey(out, old)
+		if !ok {
+			continue
+		}
+		if SetKey(out, d.Rename[old], val) {
+			DeleteKey(out, old)
+		}
+	}
+
+	for _, path := range d.Remove {
+		DeleteKey(out, path)
+	}
+	return Merge(out, d.Set)
+}
+
+func sortedKeys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// IsEmpty reports whether the delta would change nothing.
+func (d Delta) IsEmpty() bool {
+	return len(d.Remove) == 0 && len(d.Rename) == 0 && len(d.Set) == 0
+}
+
+// Consolidate merges layers, applies an optional delta, and writes the result
+// to outPath as a single values file.
+func Consolidate(layers []string, deltaPath, outPath string) (Values, error) {
+	merged, err := MergeFiles(layers)
+	if err != nil {
+		return nil, err
+	}
+	if deltaPath != "" {
+		d, err := LoadDelta(deltaPath)
+		if err != nil {
+			return nil, err
+		}
+		merged = d.Apply(merged)
+	}
+	if err := WriteFile(outPath, merged); err != nil {
+		return nil, err
+	}
+	return merged, nil
+}
+
+// toMap normalises the two map shapes yaml.v3 can produce.
+func toMap(v any) (Values, bool) {
+	switch m := v.(type) {
+	case Values:
+		return m, true
+	case map[string]any:
+		return Values(m), true
+	default:
+		return nil, false
+	}
+}

--- a/scripts/camunda-core/pkg/chartvalues/chartvalues.go
+++ b/scripts/camunda-core/pkg/chartvalues/chartvalues.go
@@ -36,6 +36,8 @@ const (
 	RemoveDirective = "$remove"
 	// RenameDirective maps an old dotted path to a new one, moving the value.
 	RenameDirective = "$rename"
+	// ScaffoldingDirective holds harness-only values that are applied separately.
+	ScaffoldingDirective = "$scaffolding"
 )
 
 // Values is a parsed Helm values document.
@@ -220,6 +222,8 @@ type Delta struct {
 	Rename map[string]string
 	// Set holds the delta's remaining keys.
 	Set Values
+	// Scaffolding holds harness-only values, applied but not customer-facing.
+	Scaffolding Values
 }
 
 // LoadDelta reads a delta file and splits its directives from the keys it sets.
@@ -227,6 +231,9 @@ type Delta struct {
 func LoadDelta(path string) (Delta, error) {
 	b, err := os.ReadFile(path)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return Delta{Set: Values{}}, nil
+		}
 		return Delta{Set: Values{}}, fmt.Errorf("read delta %s: %w", path, err)
 	}
 	return ParseDelta(b, path)
@@ -266,13 +273,30 @@ func ParseDelta(data []byte, name string) (Delta, error) {
 			}
 			d.Rename = map[string]string{}
 			for old, newVal := range m {
+				old = strings.TrimSpace(old)
+				if old == "" {
+					return d, fmt.Errorf("%s: %q source path must not be empty", name, RenameDirective)
+				}
 				s, ok := newVal.(string)
 				if !ok {
 					return d, fmt.Errorf("%s: %q target for %q must be a string, got %T",
 						name, RenameDirective, old, newVal)
 				}
-				d.Rename[old] = strings.TrimSpace(s)
+				target := strings.TrimSpace(s)
+				if target == "" {
+					return d, fmt.Errorf("%s: %q target for %q must not be empty", name, RenameDirective, old)
+				}
+				if target == old {
+					return d, fmt.Errorf("%s: %q source and target must differ: %q", name, RenameDirective, old)
+				}
+				d.Rename[old] = target
 			}
+		case ScaffoldingDirective:
+			m, ok := toMap(v)
+			if !ok {
+				return d, fmt.Errorf("%s: %q must be a map of values", name, ScaffoldingDirective)
+			}
+			d.Scaffolding = m
 		default:
 			d.Set[k] = v
 		}
@@ -301,7 +325,8 @@ func (d Delta) Apply(base Values) Values {
 	for _, path := range d.Remove {
 		DeleteKey(out, path)
 	}
-	return Merge(out, d.Set)
+	out = Merge(out, d.Set)
+	return Merge(out, d.Scaffolding)
 }
 
 func sortedKeys(m map[string]string) []string {
@@ -315,7 +340,35 @@ func sortedKeys(m map[string]string) []string {
 
 // IsEmpty reports whether the delta would change nothing.
 func (d Delta) IsEmpty() bool {
-	return len(d.Remove) == 0 && len(d.Rename) == 0 && len(d.Set) == 0
+	return len(d.Remove) == 0 && len(d.Rename) == 0 &&
+		len(d.Set) == 0 && len(d.Scaffolding) == 0
+}
+
+// LeafPaths returns the sorted dotted paths of every non-map value.
+func LeafPaths(v Values) []string {
+	var out []string
+	var walk func(Values, string)
+	walk = func(n Values, prefix string) {
+		for k, val := range n {
+			path := k
+			if prefix != "" {
+				path = prefix + "." + k
+			}
+			if m, ok := toMap(val); ok && len(m) > 0 {
+				walk(m, path)
+				continue
+			}
+			out = append(out, path)
+		}
+	}
+	walk(v, "")
+	sort.Strings(out)
+	return out
+}
+
+// HasScaffolding reports whether the delta carries harness-only values.
+func (d Delta) HasScaffolding() bool {
+	return len(d.Scaffolding) > 0
 }
 
 // Consolidate merges layers, applies an optional delta, and writes the result

--- a/scripts/camunda-core/pkg/chartvalues/chartvalues_test.go
+++ b/scripts/camunda-core/pkg/chartvalues/chartvalues_test.go
@@ -1,0 +1,359 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chartvalues
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func write(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+	require.NoError(t, os.WriteFile(p, []byte(body), 0o644))
+	return p
+}
+
+func TestLoadFile(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("parses keys", func(t *testing.T) {
+		v, err := LoadFile(write(t, dir, "a.yaml", "global:\n  host: example.com\n"))
+		require.NoError(t, err)
+		assert.True(t, HasKey(v, "global.host"))
+	})
+
+	t.Run("comment-only file yields empty non-nil", func(t *testing.T) {
+		v, err := LoadFile(write(t, dir, "c.yaml", "# nothing here\n"))
+		require.NoError(t, err)
+		require.NotNil(t, v)
+		assert.Empty(t, v)
+	})
+
+	t.Run("missing file errors", func(t *testing.T) {
+		_, err := LoadFile(filepath.Join(dir, "nope.yaml"))
+		require.Error(t, err)
+	})
+
+	t.Run("malformed yaml errors", func(t *testing.T) {
+		_, err := LoadFile(write(t, dir, "bad.yaml", "key: [unclosed\n"))
+		require.Error(t, err)
+	})
+}
+
+func TestMergeFiles(t *testing.T) {
+	dir := t.TempDir()
+	base := write(t, dir, "base.yaml",
+		"global:\n  a: 1\n  nested:\n    x: base\nlist:\n  - one\n  - two\n")
+	over := write(t, dir, "over.yaml",
+		"global:\n  b: 2\n  nested:\n    y: over\nlist:\n  - only\n")
+
+	got, err := MergeFiles([]string{base, over})
+	require.NoError(t, err)
+
+	g, ok := toMap(got["global"])
+	require.True(t, ok)
+	assert.Equal(t, 1, g["a"])
+	assert.Equal(t, 2, g["b"])
+
+	n, ok := toMap(g["nested"])
+	require.True(t, ok)
+	assert.Equal(t, "base", n["x"])
+	assert.Equal(t, "over", n["y"], "maps merge recursively")
+
+	assert.Len(t, got["list"], 1, "arrays are replaced wholesale, matching Helm")
+}
+
+func TestMergeDoesNotMutateInputs(t *testing.T) {
+	a := Values{"global": Values{"x": 1}}
+	b := Values{"global": Values{"y": 2}}
+
+	_ = Merge(a, b)
+
+	ag, _ := toMap(a["global"])
+	assert.Len(t, ag, 1, "merge must not write into its arguments")
+}
+
+func TestDeleteKey(t *testing.T) {
+	newVals := func() Values {
+		return Values{
+			"global": Values{"ingress": Values{"host": "example.com", "enabled": true}},
+			"top":    "value",
+		}
+	}
+
+	t.Run("removes a nested leaf and keeps siblings", func(t *testing.T) {
+		v := newVals()
+		assert.True(t, DeleteKey(v, "global.ingress.host"))
+		assert.False(t, HasKey(v, "global.ingress.host"))
+		assert.True(t, HasKey(v, "global.ingress.enabled"))
+	})
+
+	t.Run("removes a top-level key", func(t *testing.T) {
+		v := newVals()
+		assert.True(t, DeleteKey(v, "top"))
+		assert.False(t, HasKey(v, "top"))
+	})
+
+	t.Run("leaves the parent map in place", func(t *testing.T) {
+		v := newVals()
+		DeleteKey(v, "global.ingress.host")
+		DeleteKey(v, "global.ingress.enabled")
+		assert.True(t, HasKey(v, "global.ingress"), "emptied parents are meaningful to the chart")
+	})
+
+	t.Run("reports absent paths", func(t *testing.T) {
+		v := newVals()
+		assert.False(t, DeleteKey(v, "global.ingress.missing"))
+		assert.False(t, DeleteKey(v, "nope.nope"))
+		assert.False(t, DeleteKey(v, "top.deeper"), "cannot descend through a scalar")
+	})
+}
+
+func TestLoadDelta(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("splits remove directive from set keys", func(t *testing.T) {
+		p := write(t, dir, "d.yaml", `
+$remove:
+  - identityKeycloak
+  - global.ingress.host
+identity:
+  externalDatabase:
+    host: pg.example.com
+`)
+		d, err := LoadDelta(p)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"global.ingress.host", "identityKeycloak"}, d.Remove,
+			"sorted for deterministic application")
+		assert.True(t, HasKey(d.Set, "identity.externalDatabase.host"))
+		assert.NotContains(t, d.Set, RemoveDirective, "the directive is not a values key")
+		assert.False(t, d.IsEmpty())
+	})
+
+	t.Run("empty file is an empty delta", func(t *testing.T) {
+		d, err := LoadDelta(write(t, dir, "empty.yaml", "# no changes yet\n"))
+		require.NoError(t, err)
+		assert.True(t, d.IsEmpty())
+	})
+
+	t.Run("blank entries are skipped", func(t *testing.T) {
+		d, err := LoadDelta(write(t, dir, "blank.yaml", "$remove:\n  - \"\"\n  - a.b\n"))
+		require.NoError(t, err)
+		assert.Equal(t, []string{"a.b"}, d.Remove)
+	})
+
+	t.Run("non-list remove directive errors", func(t *testing.T) {
+		_, err := LoadDelta(write(t, dir, "bad1.yaml", "$remove: identityKeycloak\n"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be a list")
+	})
+
+	t.Run("non-string entry errors", func(t *testing.T) {
+		_, err := LoadDelta(write(t, dir, "bad2.yaml", "$remove:\n  - 42\n"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be strings")
+	})
+}
+
+func TestDeltaApply(t *testing.T) {
+	base := Values{
+		"global":           Values{"ingress": Values{"host": "old.example.com"}},
+		"identityKeycloak": Values{"enabled": true},
+		"keep":             "untouched",
+	}
+
+	d := Delta{
+		Remove: []string{"identityKeycloak", "global.ingress.host"},
+		Set:    Values{"identity": Values{"externalDatabase": Values{"host": "pg"}}},
+	}
+
+	got := d.Apply(base)
+
+	assert.False(t, HasKey(got, "identityKeycloak"))
+	assert.False(t, HasKey(got, "global.ingress.host"))
+	assert.True(t, HasKey(got, "identity.externalDatabase.host"))
+	assert.Equal(t, "untouched", got["keep"])
+
+	assert.True(t, HasKey(base, "identityKeycloak"), "Apply must not mutate its input")
+}
+
+func TestDeltaApplyRemovesBeforeSetting(t *testing.T) {
+	base := Values{"auth": Values{"legacy": true}}
+	d := Delta{
+		Remove: []string{"auth.legacy"},
+		Set:    Values{"auth": Values{"legacy": "re-added"}},
+	}
+
+	got := d.Apply(base)
+	assert.Equal(t, "re-added", mustMap(t, got["auth"])["legacy"],
+		"a delta can drop a key and re-add it")
+}
+
+func TestConsolidate(t *testing.T) {
+	dir := t.TempDir()
+	l1 := write(t, dir, "l1.yaml", "identityKeycloak:\n  enabled: true\nkeep: yes\n")
+	l2 := write(t, dir, "l2.yaml", "global:\n  ingress:\n    host: old\n")
+	delta := write(t, dir, "delta.yaml", "$remove:\n  - identityKeycloak\n  - global.ingress.host\nadded: true\n")
+	out := filepath.Join(dir, "out.yaml")
+
+	got, err := Consolidate([]string{l1, l2}, delta, out)
+	require.NoError(t, err)
+
+	assert.False(t, HasKey(got, "identityKeycloak"))
+	assert.False(t, HasKey(got, "global.ingress.host"))
+	assert.True(t, HasKey(got, "added"))
+
+	reread, err := LoadFile(out)
+	require.NoError(t, err)
+	assert.Equal(t, got, reread, "the written file matches the returned document")
+}
+
+func TestConsolidateWithoutDelta(t *testing.T) {
+	dir := t.TempDir()
+	l1 := write(t, dir, "l1.yaml", "identityKeycloak:\n  enabled: true\n")
+	out := filepath.Join(dir, "out.yaml")
+
+	got, err := Consolidate([]string{l1}, "", out)
+	require.NoError(t, err)
+	assert.True(t, HasKey(got, "identityKeycloak"), "no delta leaves the merge untouched")
+}
+
+func mustMap(t *testing.T, v any) Values {
+	t.Helper()
+	m, ok := toMap(v)
+	require.True(t, ok)
+	return m
+}
+
+func TestLoadDeltaRename(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("parses rename map", func(t *testing.T) {
+		p := write(t, dir, "r.yaml", "$rename:\n  global.ingress.host: global.host\n$remove:\n  - elasticsearch\nkeep: 1\n")
+		d, err := LoadDelta(p)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"global.ingress.host": "global.host"}, d.Rename)
+		assert.Equal(t, []string{"elasticsearch"}, d.Remove)
+		assert.NotContains(t, d.Set, RenameDirective)
+		assert.Contains(t, d.Set, "keep")
+	})
+
+	t.Run("non-map rename errors", func(t *testing.T) {
+		_, err := LoadDelta(write(t, dir, "r2.yaml", "$rename:\n  - a\n"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be a map")
+	})
+
+	t.Run("non-string target errors", func(t *testing.T) {
+		_, err := LoadDelta(write(t, dir, "r3.yaml", "$rename:\n  a.b: 42\n"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be a string")
+	})
+
+	t.Run("rename alone is not empty", func(t *testing.T) {
+		d, err := LoadDelta(write(t, dir, "r4.yaml", "$rename:\n  a: b\n"))
+		require.NoError(t, err)
+		assert.False(t, d.IsEmpty())
+	})
+}
+
+func TestDeltaApplyRename(t *testing.T) {
+	t.Run("moves the value and clears the old path", func(t *testing.T) {
+		base := Values{"global": Values{"ingress": Values{"host": "ns.example.com"}}}
+		d := Delta{Rename: map[string]string{"global.ingress.host": "global.host"}}
+
+		got := d.Apply(base)
+
+		v, ok := GetKey(got, "global.host")
+		require.True(t, ok)
+		assert.Equal(t, "ns.example.com", v, "the environment-specific value is preserved")
+		assert.False(t, HasKey(got, "global.ingress.host"))
+	})
+
+	t.Run("absent source is skipped", func(t *testing.T) {
+		base := Values{"other": 1}
+		d := Delta{Rename: map[string]string{"global.ingress.host": "global.host"}}
+
+		got := d.Apply(base)
+		assert.False(t, HasKey(got, "global.host"))
+	})
+
+	t.Run("rename runs before remove", func(t *testing.T) {
+		base := Values{"global": Values{"ingress": Values{"host": "h", "other": 1}}}
+		d := Delta{
+			Rename: map[string]string{"global.ingress.host": "global.host"},
+			Remove: []string{"global.ingress"},
+		}
+
+		got := d.Apply(base)
+		v, ok := GetKey(got, "global.host")
+		require.True(t, ok, "the moved value survives removal of its old parent")
+		assert.Equal(t, "h", v)
+		assert.False(t, HasKey(got, "global.ingress"))
+	})
+
+	t.Run("does not mutate its input", func(t *testing.T) {
+		base := Values{"global": Values{"ingress": Values{"host": "h"}}}
+		d := Delta{Rename: map[string]string{"global.ingress.host": "global.host"}}
+		_ = d.Apply(base)
+		assert.True(t, HasKey(base, "global.ingress.host"))
+	})
+}
+
+func TestSetKey(t *testing.T) {
+	t.Run("creates intermediate maps", func(t *testing.T) {
+		v := Values{}
+		assert.True(t, SetKey(v, "a.b.c", "x"))
+		got, ok := GetKey(v, "a.b.c")
+		require.True(t, ok)
+		assert.Equal(t, "x", got)
+	})
+
+	t.Run("refuses to descend through a scalar", func(t *testing.T) {
+		v := Values{"a": "scalar"}
+		assert.False(t, SetKey(v, "a.b", "x"))
+		assert.Equal(t, "scalar", v["a"])
+	})
+}
+
+func TestDeepCopyIsolatesNestedMutation(t *testing.T) {
+	base := Values{
+		"global": Values{"ingress": Values{"host": "h"}},
+		"list":   []any{Values{"name": "a"}},
+	}
+	cp := DeepCopy(base)
+
+	DeleteKey(cp, "global.ingress.host")
+	mustMap(t, cp["list"].([]any)[0])["name"] = "changed"
+
+	assert.True(t, HasKey(base, "global.ingress.host"), "nested maps are independent")
+	assert.Equal(t, "a", mustMap(t, base["list"].([]any)[0])["name"], "slices are independent")
+}
+
+func TestDeltaApplyDoesNotMutateNestedInput(t *testing.T) {
+	base := Values{"global": Values{"ingress": Values{"host": "h", "keep": 1}}}
+	d := Delta{Remove: []string{"global.ingress.host"}}
+
+	_ = d.Apply(base)
+
+	assert.True(t, HasKey(base, "global.ingress.host"),
+		"a nested removal must not reach back into the caller's document")
+}

--- a/scripts/camunda-core/pkg/chartvalues/chartvalues_test.go
+++ b/scripts/camunda-core/pkg/chartvalues/chartvalues_test.go
@@ -273,6 +273,23 @@ func TestLoadDeltaRename(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, d.IsEmpty())
 	})
+
+	for name, body := range map[string]string{
+		"empty source": "$rename:\n  ' ': b\n",
+		"empty target": "$rename:\n  a: ' '\n",
+		"same path":    "$rename:\n  a: a\n",
+	} {
+		t.Run(name+" errors", func(t *testing.T) {
+			_, err := LoadDelta(write(t, dir, name+".yaml", body))
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestLoadDeltaMissingFileIsEmpty(t *testing.T) {
+	d, err := LoadDelta(filepath.Join(t.TempDir(), "missing.yaml"))
+	require.NoError(t, err)
+	assert.True(t, d.IsEmpty())
 }
 
 func TestDeltaApplyRename(t *testing.T) {
@@ -356,4 +373,28 @@ func TestDeltaApplyDoesNotMutateNestedInput(t *testing.T) {
 
 	assert.True(t, HasKey(base, "global.ingress.host"),
 		"a nested removal must not reach back into the caller's document")
+}
+
+func TestLoadDeltaScaffolding(t *testing.T) {
+	d, err := ParseDelta([]byte("$scaffolding:\n  identity:\n    enabled: true\n"), "delta.yaml")
+	require.NoError(t, err)
+	assert.True(t, HasKey(d.Scaffolding, "identity.enabled"))
+	assert.False(t, HasKey(d.Set, "identity.enabled"))
+	assert.True(t, d.HasScaffolding())
+	assert.False(t, d.IsEmpty())
+
+	_, err = ParseDelta([]byte("$scaffolding:\n  - invalid\n"), "delta.yaml")
+	require.Error(t, err)
+}
+
+func TestDeltaApplyAppliesScaffolding(t *testing.T) {
+	d := Delta{Set: Values{"global": Values{"host": "h"}}, Scaffolding: Values{"identity": Values{"enabled": true}}}
+	got := d.Apply(Values{})
+	assert.True(t, HasKey(got, "global.host"))
+	assert.True(t, HasKey(got, "identity.enabled"))
+}
+
+func TestLeafPaths(t *testing.T) {
+	v := Values{"nested": Values{"leaf": 1, "list": []any{"a"}}, "empty": Values{}, "top": true}
+	assert.Equal(t, []string{"empty", "nested.leaf", "nested.list", "top"}, LeafPaths(v))
 }


### PR DESCRIPTION
> | # | PR | Phase | Purpose |
> |---|---|---|---|
> | **1** | **#6820** | **library** | **`chartvalues`: layer consolidation, `$remove` / `$rename` / `$scaffolding`** ← you are here |
> | 2 | #6821 | render stage | A/B render of a carried-over values file; archetypes and fixtures |
> | 3 | #6825 | honesty | coverage ledger, real Helm v3 gate, transition bootstrap |
> | 4 | #6822 | cluster stage | real two-step upgrade on GKE, nightly and on demand |
> | 5 | #6834 | assertions | orphaned storage, data survival, migration cost |

Merge in order; each builds on the one above. 2 consumes the package from 1. 3 adds the coverage ledger that 4 and 5 both update. 5 asserts against the cluster 4 deploys.

### Which problem does the PR fix?

Part of #6819.

The upgrade-path harness needs to build one values file from an archetype's layers and then apply a transition delta to it, and no existing package does either. `deploy-camunda` merges values, but only for its own scenario layout and with no way to express a removal.

### What's in this PR?

`scripts/camunda-core/pkg/chartvalues`: layer consolidation plus the `$remove`, `$rename` and `$scaffolding` directives a delta file needs in order to describe what a customer must change.

`$scaffolding` is the one worth a second look. It marks keys the harness itself injects — ingress hosts, image pull secrets, test credentials — so they can be excluded from anything presented as customer-facing advice. Without it the reported "required changes" list is contaminated with CI plumbing, which is how a harness starts producing an upgrade guide nobody can follow.

Pure library, fully unit-tested, **no callers yet**. Reviewable entirely on its own; consumed from #6821 onwards.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
