### PR TITLE
test: [UPGPATH 4/5] upgrade a real cluster with the customer's own values

### DIFF
--- a/.github/workflows/upgrade-paths.yaml
+++ b/.github/workflows/upgrade-paths.yaml
@@ -311,12 +311,16 @@ jobs:
             echo "args=--suppress-upgrade-hooks" >>"$GITHUB_OUTPUT"
           else
             delta=test/upgrade-paths/transitions/8.9-to-8.10/classic-bundled/delta.values.yaml
+            remedy=test/upgrade-paths/transitions/8.9-to-8.10/classic-bundled/remedy.sh
             test -f "$delta" || { echo "::error::delta not found: $delta"; exit 1; }
+            test -x "$remedy" || { echo "::error::executable migration remedy not found: $remedy"; exit 1; }
             echo "args=--upgrade-delta $delta" >>"$GITHUB_OUTPUT"
+            echo "remedy=$remedy" >>"$GITHUB_OUTPUT"
           fi
 
       # Run A is expected to fail: that is the finding, not a broken job. Run B
-      # must pass. Both outcomes are reported either way.
+      # validates the values delta plus the checked-in customer migration remedy;
+      # the scenario's post-infra hook invokes that same remedy implementation.
       - name: Run upgrade path on cluster
         id: run
         env:
@@ -347,6 +351,10 @@ jobs:
           {
             echo "### Cluster stage — ${{ matrix.run }}"
             echo
+            if [ "${{ matrix.run }}" = "remediated" ]; then
+              echo "Run B validates the values delta plus customer migration remedy: \`${{ steps.delta.outputs.remedy }}\`"
+              echo
+            fi
             grep -E "Step 1 complete|Applied upgrade delta|Suppressed .*hook|Step 2 complete|camunda\]\[error\]|Matrix entry failed|\[PASS\]|\[FAIL\]" \
               "${RUNNER_TEMP}/run.log" | tail -20 | sed 's/^/    /'
           } >>"$GITHUB_STEP_SUMMARY"
@@ -368,5 +376,5 @@ jobs:
             exit 1
           fi
           [ "$actual" = "0" ] && echo "Run B passed" && exit 0
-          echo "::error::Run B failed: the documented delta no longer remediates this path."
+          echo "::error::Run B failed: the documented delta plus migration remedy no longer remediates this path."
           exit 1

--- a/.github/workflows/upgrade-paths.yaml
+++ b/.github/workflows/upgrade-paths.yaml
@@ -238,7 +238,7 @@ jobs:
     needs: render
     if: >-
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && inputs.cluster-stage)
+      (github.event_name == 'workflow_dispatch' && inputs.cluster-stage && github.ref_protected)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -299,11 +299,11 @@ jobs:
       - name: Resolve delta for this run
         id: delta
         env:
+          REQUESTED_TRANSITIONS: ${{ inputs.transitions }}
           SHORTNAME: ${{ inputs.cluster-shortname || 'upclas' }}
         run: |
           set -euo pipefail
-          requested="${{ inputs.transitions }}"
-          if [ -n "${requested}" ] && [ "${requested}" != "8.9:8.10" ]; then
+          if [ -n "${REQUESTED_TRANSITIONS}" ] && [ "${REQUESTED_TRANSITIONS}" != "8.9:8.10" ]; then
             echo "::error::The cluster stage currently supports only transitions=8.9:8.10"
             exit 1
           fi
@@ -356,7 +356,7 @@ jobs:
         run: |
           actual="${{ steps.run.outputs.exit }}"
           if [ "${{ matrix.run }}" = "naive" ]; then
-            if [ "$actual" != "0" ] && grep -q "Step 1 complete" "${RUNNER_TEMP}/run.log" && grep -q "Step 2:" "${RUNNER_TEMP}/run.log"; then
+            if [ "$actual" != "0" ] && grep -q "Step 1 complete" "${RUNNER_TEMP}/run.log" && grep -qF '[camunda][error] The Helm values file key "global.ingress.host" has been removed.' "${RUNNER_TEMP}/run.log"; then
               echo "Run A reached the upgrade and failed as expected"
               exit 0
             fi

--- a/.github/workflows/upgrade-paths.yaml
+++ b/.github/workflows/upgrade-paths.yaml
@@ -33,8 +33,9 @@ on:
         options: [both, naive, remediated]
         default: both
       cluster-shortname:
-        description: "Scenario shortname for the cluster stage"
-        type: string
+        description: "Scenario archetype for the cluster stage"
+        type: choice
+        options: [upclas]
         default: upclas
 
 permissions:
@@ -299,6 +300,11 @@ jobs:
           SHORTNAME: ${{ inputs.cluster-shortname || 'upclas' }}
         run: |
           set -euo pipefail
+          requested="${{ inputs.transitions }}"
+          if [ -n "${requested}" ] && [ "${requested}" != "8.9:8.10" ]; then
+            echo "::error::The cluster stage currently supports only transitions=8.9:8.10"
+            exit 1
+          fi
           if [ "${{ matrix.run }}" = "naive" ]; then
             echo "args=--suppress-upgrade-hooks" >>"$GITHUB_OUTPUT"
           else
@@ -322,9 +328,10 @@ jobs:
             --shortname-filter "${SHORTNAME}" --include-disabled \
             --platform gke --ingress-base-domain-gke ci.distro.ultrawombat.com \
             --values-source carryover \
+            --namespace-prefix "upg-${{ matrix.run }}" \
             ${{ steps.delta.outputs.args }} \
             --ensure-docker-registry \
-            --delete-namespace --timeout 15 --yes 2>&1 | tee "${RUNNER_TEMP}/run.log"
+            --delete-namespace --cleanup --timeout 15 --yes 2>&1 | tee "${RUNNER_TEMP}/run.log"
           echo "exit=${PIPESTATUS[0]}" >>"$GITHUB_OUTPUT"
 
       - name: Report outcome
@@ -342,7 +349,14 @@ jobs:
         run: |
           actual="${{ steps.run.outputs.exit }}"
           if [ "${{ matrix.run }}" = "naive" ]; then
-            [ "$actual" != "0" ] && echo "Run A failed as expected" && exit 0
+            if [ "$actual" != "0" ] && grep -q "Step 1 complete" "${RUNNER_TEMP}/run.log" && grep -q "Step 2:" "${RUNNER_TEMP}/run.log"; then
+              echo "Run A reached the upgrade and failed as expected"
+              exit 0
+            fi
+            if [ "$actual" != "0" ]; then
+              echo "::error::Run A failed before the upgrade path was exercised."
+              exit 1
+            fi
             echo "::error::Run A succeeded. Either the carried-over values no longer break, or carryover is not in effect."
             exit 1
           fi

--- a/.github/workflows/upgrade-paths.yaml
+++ b/.github/workflows/upgrade-paths.yaml
@@ -23,6 +23,19 @@ on:
         description: "Space-separated from:to pairs, e.g. '8.9:8.10 8.8:8.9'. Empty runs all."
         type: string
         default: ""
+      cluster-stage:
+        description: "Also run the cluster stage (deploys to GKE; ~8 min per run)"
+        type: boolean
+        default: false
+      cluster-run:
+        description: "Which cluster run to perform"
+        type: choice
+        options: [both, naive, remediated]
+        default: both
+      cluster-shortname:
+        description: "Scenario shortname for the cluster stage"
+        type: string
+        default: upclas
 
 permissions:
   contents: read
@@ -216,3 +229,123 @@ jobs:
             fi
           done
           exit $status
+
+  # The cluster stage deploys a full previous-version release and upgrades it,
+  # so it is nightly and on-demand only, never on a pull request.
+  cluster:
+    name: Cluster stage
+    needs: render
+    if: >-
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && inputs.cluster-stage)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        run: ${{ (github.event_name == 'workflow_dispatch' && inputs.cluster-run != 'both')
+          && fromJson(format('["{0}"]', inputs.cluster-run))
+          || fromJson('["naive","remediated"]') }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+
+      - name: Install tools
+        uses: ./.github/actions/install-tool-versions
+        with:
+          tools: |
+            helm
+            golang
+            kubectl
+
+      - name: Import Vault secrets
+        id: test-credentials-secret
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc  # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/distribution/ci DISTRO_CI_GCP_GKE_CLUSTER_NAME;
+            secret/data/products/distribution/ci DISTRO_CI_GCP_GKE_CLUSTER_LOCATION;
+            secret/data/products/distribution/ci DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER;
+            secret/data/products/distribution/ci DISTRO_CI_GCP_SERVICE_ACCOUNT;
+            secret/data/products/distribution/ci RDBMS_POSTGRESQL_USERNAME;
+            secret/data/products/distribution/ci RDBMS_POSTGRESQL_PASSWORD;
+          exportEnv: false
+
+      - name: Authenticate to cluster
+        uses: ./.github/actions/cluster-auth
+        with:
+          platform: gke
+        env:
+          GH_APP_ID: ${{ secrets.GH_APP_ID_DISTRO_CI_MANAGE_GH_ENVS }}
+          GH_APP_KEY: ${{ secrets.GH_APP_PRIVATE_KEY_DISTRO_CI_MANAGE_GH_ENVS }}
+          GKE_CLUSTER_NAME: ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_GKE_CLUSTER_NAME }}
+          GKE_CLUSTER_LOC: ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_GKE_CLUSTER_LOCATION }}
+          GKE_WIP: ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GKE_SA: ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_SERVICE_ACCOUNT }}
+
+      # Built from source every run. A stale binary silently exercises code that
+      # is no longer on disk, which is not detectable from the run's output.
+      - name: Build deploy-camunda
+        run: cd scripts/deploy-camunda && go build -o "${RUNNER_TEMP}/deploy-camunda" .
+
+      - name: Resolve delta for this run
+        id: delta
+        env:
+          SHORTNAME: ${{ inputs.cluster-shortname || 'upclas' }}
+        run: |
+          set -euo pipefail
+          if [ "${{ matrix.run }}" = "naive" ]; then
+            echo "args=--suppress-upgrade-hooks" >>"$GITHUB_OUTPUT"
+          else
+            delta=test/upgrade-paths/transitions/8.9-to-8.10/classic-bundled/delta.values.yaml
+            test -f "$delta" || { echo "::error::delta not found: $delta"; exit 1; }
+            echo "args=--upgrade-delta $delta" >>"$GITHUB_OUTPUT"
+          fi
+
+      # Run A is expected to fail: that is the finding, not a broken job. Run B
+      # must pass. Both outcomes are reported either way.
+      - name: Run upgrade path on cluster
+        id: run
+        env:
+          RDBMS_POSTGRESQL_USERNAME: ${{ steps.test-credentials-secret.outputs.RDBMS_POSTGRESQL_USERNAME }}
+          RDBMS_POSTGRESQL_PASSWORD: ${{ steps.test-credentials-secret.outputs.RDBMS_POSTGRESQL_PASSWORD }}
+          SHORTNAME: ${{ inputs.cluster-shortname || 'upclas' }}
+        run: |
+          set -uo pipefail
+          "${RUNNER_TEMP}/deploy-camunda" matrix run \
+            --repo-root . --versions 8.10 \
+            --shortname-filter "${SHORTNAME}" --include-disabled \
+            --platform gke --ingress-base-domain-gke ci.distro.ultrawombat.com \
+            --values-source carryover \
+            ${{ steps.delta.outputs.args }} \
+            --ensure-docker-registry \
+            --delete-namespace --timeout 15 --yes 2>&1 | tee "${RUNNER_TEMP}/run.log"
+          echo "exit=${PIPESTATUS[0]}" >>"$GITHUB_OUTPUT"
+
+      - name: Report outcome
+        if: always()
+        run: |
+          {
+            echo "### Cluster stage — ${{ matrix.run }}"
+            echo
+            grep -E "Step 1 complete|Applied upgrade delta|Suppressed .*hook|Step 2 complete|camunda\]\[error\]|Matrix entry failed|\[PASS\]|\[FAIL\]" \
+              "${RUNNER_TEMP}/run.log" | tail -20 | sed 's/^/    /'
+          } >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Enforce expected outcome
+        if: always()
+        run: |
+          actual="${{ steps.run.outputs.exit }}"
+          if [ "${{ matrix.run }}" = "naive" ]; then
+            [ "$actual" != "0" ] && echo "Run A failed as expected" && exit 0
+            echo "::error::Run A succeeded. Either the carried-over values no longer break, or carryover is not in effect."
+            exit 1
+          fi
+          [ "$actual" = "0" ] && echo "Run B passed" && exit 0
+          echo "::error::Run B failed: the documented delta no longer remediates this path."
+          exit 1

--- a/.github/workflows/upgrade-paths.yaml
+++ b/.github/workflows/upgrade-paths.yaml
@@ -275,6 +275,8 @@ jobs:
             secret/data/products/distribution/ci DISTRO_CI_GCP_SERVICE_ACCOUNT;
             secret/data/products/distribution/ci RDBMS_POSTGRESQL_USERNAME;
             secret/data/products/distribution/ci RDBMS_POSTGRESQL_PASSWORD;
+            secret/data/products/distribution/ci HARBOR_REGISTRY_USER | TEST_DOCKER_USERNAME_CAMUNDA_CLOUD;
+            secret/data/products/distribution/ci HARBOR_REGISTRY_PASSWORD | TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD;
           exportEnv: false
 
       - name: Authenticate to cluster
@@ -320,9 +322,12 @@ jobs:
         env:
           RDBMS_POSTGRESQL_USERNAME: ${{ steps.test-credentials-secret.outputs.RDBMS_POSTGRESQL_USERNAME }}
           RDBMS_POSTGRESQL_PASSWORD: ${{ steps.test-credentials-secret.outputs.RDBMS_POSTGRESQL_PASSWORD }}
+          TEST_DOCKER_USERNAME_CAMUNDA_CLOUD: ${{ steps.test-credentials-secret.outputs.TEST_DOCKER_USERNAME_CAMUNDA_CLOUD }}
+          TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD: ${{ steps.test-credentials-secret.outputs.TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD }}
           SHORTNAME: ${{ inputs.cluster-shortname || 'upclas' }}
         run: |
           set -uo pipefail
+          set +e
           "${RUNNER_TEMP}/deploy-camunda" matrix run \
             --repo-root . --versions 8.10 \
             --shortname-filter "${SHORTNAME}" --include-disabled \
@@ -332,7 +337,9 @@ jobs:
             ${{ steps.delta.outputs.args }} \
             --ensure-docker-registry \
             --delete-namespace --cleanup --timeout 15 --yes 2>&1 | tee "${RUNNER_TEMP}/run.log"
-          echo "exit=${PIPESTATUS[0]}" >>"$GITHUB_OUTPUT"
+          actual=${PIPESTATUS[0]}
+          set -e
+          echo "exit=${actual}" >>"$GITHUB_OUTPUT"
 
       - name: Report outcome
         if: always()

--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -752,6 +752,49 @@ integration:
               mode with SKIP_HELM_UPGRADE=true (data-only; the matrix runner performs the
               chart upgrade). This keeps users/realm alive across the upgrade that removes the
               bundled Bitnami subcharts.
+        - name: upgrade-path-classic
+          enabled: false
+          shortname: upclas
+          auth: keycloak
+          flow: upgrade-path
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            eks: preemptible
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - hub-legacy
+            - postgresql-companion
+          dependencies:
+            - chart: charts/internal-keycloak-26
+              release-name: keycloak
+              values-file: test/integration/companion-values/keycloak-distroci.yaml
+            - chart: elastic/elasticsearch
+              version: 8.5.1
+              release-name: elasticsearch
+              values-file: test/integration/companion-values/elasticsearch-distroci.yaml
+              repo-name: elastic
+              repo-url: https://helm.elastic.co
+            - chart: charts/internal-postgresql
+              release-name: postgresql
+              values-file: test/integration/companion-values/postgresql-distroci.yaml
+              env-vars:
+                - RDBMS_POSTGRESQL_USERNAME
+                - RDBMS_POSTGRESQL_PASSWORD
+          post-infra:
+            script: post-infra-bitnami-migration.sh
+            description: |
+              After the companion PostgreSQL/Keycloak/Elasticsearch are deployed but before
+              the chart upgrade to 8.10, migrate the bundled (Bitnami) Keycloak realm and the
+              Elasticsearch authorization indices off the bundled backends onto the companion
+              services. Uses the camunda-deployment-references migration scripts in external
+              mode with SKIP_HELM_UPGRADE=true (data-only; the matrix runner performs the
+              chart upgrade). This keeps users/realm alive across the upgrade that removes the
+              bundled Bitnami subcharts.
         - name: hub-mixed
           enabled: true
           shortname: hubmu

--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -752,6 +752,49 @@ integration:
               mode with SKIP_HELM_UPGRADE=true (data-only; the matrix runner performs the
               chart upgrade). This keeps users/realm alive across the upgrade that removes the
               bundled Bitnami subcharts.
+        - name: upgrade-path-classic
+          enabled: false
+          shortname: upclas
+          auth: keycloak
+          flow: upgrade-path
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            eks: preemptible
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - hub-legacy
+            - postgresql-companion
+          dependencies:
+            - chart: charts/internal-keycloak-26
+              release-name: keycloak
+              values-file: test/integration/companion-values/keycloak.yaml
+            - chart: elastic/elasticsearch
+              version: 8.5.1
+              release-name: elasticsearch
+              values-file: test/integration/companion-values/elasticsearch.yaml
+              repo-name: elastic
+              repo-url: https://helm.elastic.co
+            - chart: charts/internal-postgresql
+              release-name: postgresql
+              values-file: test/integration/companion-values/postgresql.yaml
+              env-vars:
+                - RDBMS_POSTGRESQL_USERNAME
+                - RDBMS_POSTGRESQL_PASSWORD
+          post-infra:
+            script: post-infra-bitnami-migration.sh
+            description: |
+              After the companion PostgreSQL/Keycloak/Elasticsearch are deployed but before
+              the chart upgrade to 8.10, migrate the bundled (Bitnami) Keycloak realm and the
+              Elasticsearch authorization indices off the bundled backends onto the companion
+              services. Uses the camunda-deployment-references migration scripts in external
+              mode with SKIP_HELM_UPGRADE=true (data-only; the matrix runner performs the
+              chart upgrade). This keeps users/realm alive across the upgrade that removes the
+              bundled Bitnami subcharts.
         - name: hub-mixed
           enabled: true
           shortname: hubmu

--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -750,8 +750,9 @@ integration:
               Elasticsearch authorization indices off the bundled backends onto the companion
               services. Uses the camunda-deployment-references migration scripts in external
               mode with SKIP_HELM_UPGRADE=true (data-only; the matrix runner performs the
-              chart upgrade). This keeps users/realm alive across the upgrade that removes the
-              bundled Bitnami subcharts.
+              chart upgrade). This is the implementation behind the transition's checked-in
+              remedy.sh customer procedure, not an implicit values-only remediation. This
+              keeps users/realm alive across the upgrade that removes the bundled subcharts.
         - name: upgrade-path-classic
           enabled: false
           shortname: upclas
@@ -793,8 +794,9 @@ integration:
               Elasticsearch authorization indices off the bundled backends onto the companion
               services. Uses the camunda-deployment-references migration scripts in external
               mode with SKIP_HELM_UPGRADE=true (data-only; the matrix runner performs the
-              chart upgrade). This keeps users/realm alive across the upgrade that removes the
-              bundled Bitnami subcharts.
+              chart upgrade). This is the implementation behind the transition's checked-in
+              remedy.sh customer procedure, not an implicit values-only remediation. This
+              keeps users/realm alive across the upgrade that removes the bundled subcharts.
         - name: hub-mixed
           enabled: true
           shortname: hubmu
@@ -836,8 +838,9 @@ integration:
               Elasticsearch authorization indices off the bundled backends onto the companion
               services. Uses the camunda-deployment-references migration scripts in external
               mode with SKIP_HELM_UPGRADE=true (data-only; the matrix runner performs the
-              chart upgrade). This keeps users/realm alive across the upgrade that removes the
-              bundled Bitnami subcharts.
+              chart upgrade). This is the implementation behind the transition's checked-in
+              remedy.sh customer procedure, not an implicit values-only remediation. This
+              keeps users/realm alive across the upgrade that removes the bundled subcharts.
         - name: hub-webmodeler-only
           enabled: true
           shortname: hubwo
@@ -945,8 +948,9 @@ integration:
               Elasticsearch authorization indices off the bundled backends onto the companion
               services. Uses the camunda-deployment-references migration scripts in external
               mode with SKIP_HELM_UPGRADE=true (data-only; the matrix runner performs the
-              chart upgrade). This keeps users/realm alive across the upgrade that removes the
-              bundled Bitnami subcharts.
+              chart upgrade). This is the implementation behind the transition's checked-in
+              remedy.sh customer procedure, not an implicit values-only remediation. This
+              keeps users/realm alive across the upgrade that removes the bundled subcharts.
         - name: hub-pinned-images
           enabled: true
           shortname: hubpi
@@ -988,8 +992,9 @@ integration:
               Elasticsearch authorization indices off the bundled backends onto the companion
               services. Uses the camunda-deployment-references migration scripts in external
               mode with SKIP_HELM_UPGRADE=true (data-only; the matrix runner performs the
-              chart upgrade). This keeps users/realm alive across the upgrade that removes the
-              bundled Bitnami subcharts.
+              chart upgrade). This is the implementation behind the transition's checked-in
+              remedy.sh customer procedure, not an implicit values-only remediation. This
+              keeps users/realm alive across the upgrade that removes the bundled subcharts.
         - name: hub-external-db
           enabled: true
           shortname: hubdb
@@ -1165,8 +1170,9 @@ integration:
               Elasticsearch authorization indices off the bundled backends onto the companion
               services. Uses the camunda-deployment-references migration scripts in external
               mode with SKIP_HELM_UPGRADE=true (data-only; the matrix runner performs the
-              chart upgrade). This keeps users/realm alive across the upgrade that removes the
-              bundled Bitnami subcharts.
+              chart upgrade). This is the implementation behind the transition's checked-in
+              remedy.sh customer procedure, not an implicit values-only remediation. This
+              keeps users/realm alive across the upgrade that removes the bundled subcharts.
         - name: qa-elasticsearch
           enabled: false
           shortname: qael
@@ -1404,8 +1410,9 @@ integration:
               Elasticsearch authorization indices off the bundled backends onto the companion
               services. Uses the camunda-deployment-references migration scripts in external
               mode with SKIP_HELM_UPGRADE=true (data-only; the matrix runner performs the
-              chart upgrade). This keeps users/realm alive across the upgrade that removes the
-              bundled Bitnami subcharts.
+              chart upgrade). This is the implementation behind the transition's checked-in
+              remedy.sh customer procedure, not an implicit values-only remediation. This
+              keeps users/realm alive across the upgrade that removes the bundled subcharts.
         - name: qa-elasticsearch-rba
           enabled: false
           shortname: qaelrba
@@ -1612,8 +1619,9 @@ integration:
               Elasticsearch authorization indices off the bundled backends onto the companion
               services. Uses the camunda-deployment-references migration scripts in external
               mode with SKIP_HELM_UPGRADE=true (data-only; the matrix runner performs the
-              chart upgrade). This keeps users/realm alive across the upgrade that removes the
-              bundled Bitnami subcharts.
+              chart upgrade). This is the implementation behind the transition's checked-in
+              remedy.sh customer procedure, not an implicit values-only remediation. This
+              keeps users/realm alive across the upgrade that removes the bundled subcharts.
         - name: qa-document-store-upg
           enabled: false
           shortname: qadocupg
@@ -1655,8 +1663,9 @@ integration:
               Elasticsearch authorization indices off the bundled backends onto the companion
               services. Uses the camunda-deployment-references migration scripts in external
               mode with SKIP_HELM_UPGRADE=true (data-only; the matrix runner performs the
-              chart upgrade). This keeps users/realm alive across the upgrade that removes the
-              bundled Bitnami subcharts.
+              chart upgrade). This is the implementation behind the transition's checked-in
+              remedy.sh customer procedure, not an implicit values-only remediation. This
+              keeps users/realm alive across the upgrade that removes the bundled subcharts.
         - name: qa-license
           enabled: false
           shortname: lic

--- a/charts/camunda-platform-8.10/test/ci/registry/dependencies/elasticsearch-distroci.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/dependencies/elasticsearch-distroci.yaml
@@ -1,0 +1,6 @@
+chart: elastic/elasticsearch
+version: 8.5.1
+release-name: elasticsearch
+values-file: test/integration/companion-values/elasticsearch-distroci.yaml
+repo-name: elastic
+repo-url: https://helm.elastic.co

--- a/charts/camunda-platform-8.10/test/ci/registry/dependencies/keycloak-distroci.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/dependencies/keycloak-distroci.yaml
@@ -1,0 +1,3 @@
+chart: charts/internal-keycloak-26
+release-name: keycloak
+values-file: test/integration/companion-values/keycloak-distroci.yaml

--- a/charts/camunda-platform-8.10/test/ci/registry/dependencies/postgresql-distroci.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/dependencies/postgresql-distroci.yaml
@@ -1,0 +1,6 @@
+chart: charts/internal-postgresql
+release-name: postgresql
+values-file: test/integration/companion-values/postgresql-distroci.yaml
+env-vars:
+  - RDBMS_POSTGRESQL_USERNAME
+  - RDBMS_POSTGRESQL_PASSWORD

--- a/charts/camunda-platform-8.10/test/ci/registry/hooks/post-infra-bitnami-migration.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/hooks/post-infra-bitnami-migration.yaml
@@ -5,5 +5,6 @@ description: |
   Elasticsearch authorization indices off the bundled backends onto the companion
   services. Uses the camunda-deployment-references migration scripts in external
   mode with SKIP_HELM_UPGRADE=true (data-only; the matrix runner performs the
-  chart upgrade). This keeps users/realm alive across the upgrade that removes the
-  bundled Bitnami subcharts.
+  chart upgrade). This is the implementation behind the transition's checked-in
+  remedy.sh customer procedure, not an implicit values-only remediation. This
+  keeps users/realm alive across the upgrade that removes the bundled subcharts.

--- a/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
@@ -101,6 +101,10 @@ integration:
       shortname: hublu
       tier: 2
       enabled: true
+    - id: upgrade-path-classic
+      shortname: upclas
+      tier: 2
+      enabled: false
     - id: hub-mixed
       shortname: hubmu
       tier: 2

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/upgrade-path-classic.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/upgrade-path-classic.yaml
@@ -1,0 +1,19 @@
+name: upgrade-path-classic
+auth: keycloak
+flows:
+  - upgrade-path
+identity: keycloak
+persistence: elasticsearch
+features:
+  - hub-legacy
+  - postgresql-companion
+platforms:
+  - gke
+infra-type:
+  eks: preemptible
+  gke: distroci
+post-infra: post-infra-bitnami-migration
+dependencies:
+  - keycloak
+  - elasticsearch
+  - postgresql

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/upgrade-path-classic.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/upgrade-path-classic.yaml
@@ -1,0 +1,21 @@
+name: upgrade-path-classic
+auth: keycloak
+flows:
+  - upgrade-path
+identity: keycloak
+persistence: elasticsearch
+features:
+  - hub-legacy
+  - postgresql-companion
+platforms:
+  - gke
+infra-type:
+  eks: preemptible
+  gke: distroci
+post-infra: post-infra-bitnami-migration
+# The distroci pool is tainted, so companions need the toleration too or they
+# land on the untainted remainder and contend with unrelated workloads.
+dependencies:
+  - keycloak-distroci
+  - elasticsearch-distroci
+  - postgresql-distroci

--- a/charts/camunda-platform-8.10/test/integration/scenarios/pre-setup-scripts/post-infra-bitnami-migration.sh
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/pre-setup-scripts/post-infra-bitnami-migration.sh
@@ -20,7 +20,7 @@
 # (it was removed from main). Pin to a tag/SHA once a release is cut.
 set -euo pipefail
 
-REF="${CAMUNDA_DEPLOYMENT_REFERENCES_REF:-stable/8.9}"
+REF="${CAMUNDA_DEPLOYMENT_REFERENCES_REF:-96322091bcc3909366c7c33ec464966d369902b9}"
 REPO="${CAMUNDA_DEPLOYMENT_REFERENCES_REPO:-https://github.com/camunda/camunda-deployment-references.git}"
 NS="${NAMESPACE:-${TEST_NAMESPACE}}"
 RELEASE="${RELEASE_NAME:-integration}"
@@ -32,7 +32,8 @@ ln -s "$(asdf which helm)" "${workdir}/bin/helm"
 export PATH="${workdir}/bin:${PATH}"
 
 echo "Cloning ${REPO}@${REF} ..."
-git clone --depth 1 --branch "${REF}" "${REPO}" "${workdir}/refs"
+git clone --filter=blob:none "${REPO}" "${workdir}/refs"
+git -C "${workdir}/refs" checkout --detach "${REF}"
 migration_dir="${workdir}/refs/generic/kubernetes/migration"
 
 # --- Secrets the external-mode migration validates -------------------------
@@ -46,20 +47,6 @@ for secret in external-pg-identity external-pg-webmodeler; do
         --from-literal=password="${RDBMS_POSTGRESQL_PASSWORD}" \
         --dry-run=client -o yaml | kubectl apply -f -
 done
-# Keycloak DB password = the companion Keycloak's bundled-PG password
-# (keycloak-qa.yaml: postgresql.auth.password). Read it from the companion's
-# own secret so the value is never hardcoded.
-kc_pg_pass="$(kubectl get secret keycloak-postgresql -n "${NS}" \
-    -o jsonpath='{.data.postgresql-password}' 2>/dev/null | base64 -d || true)"
-kubectl create secret generic external-pg-keycloak -n "${NS}" \
-    --from-literal=password="${kc_pg_pass}" \
-    --dry-run=client -o yaml | kubectl apply -f -
-for _ in {1..10}; do
-    kubectl get secret external-pg-keycloak -n "${NS}" >/dev/null 2>&1 && break
-    sleep 1
-done
-kubectl get secret external-pg-keycloak -n "${NS}" >/dev/null
-
 # --- Migration configuration (external mode, data-only) --------------------
 export NAMESPACE="${NS}"
 export CAMUNDA_RELEASE_NAME="${RELEASE}"
@@ -121,6 +108,13 @@ cd "${migration_dir}"
 # assigns every variable with a ${VAR:-default} guard.
 # shellcheck disable=SC1091
 source ./env.sh
+# Create this after sourcing the pinned migration environment so validation and
+# restore use the same namespace and Kubernetes context.
+kc_pg_pass="$(kubectl get secret keycloak-postgresql -n "${NS}" \
+    -o jsonpath='{.data.postgresql-password}' | base64 -d)"
+kubectl create secret generic external-pg-keycloak -n "${NS}" \
+    --from-literal=password="${kc_pg_pass}" \
+    --dry-run=client -o yaml | kubectl apply -f -
 bash 1-deploy-targets.sh --yes
 bash 2-backup.sh --yes
 

--- a/charts/camunda-platform-8.10/test/integration/scenarios/pre-setup-scripts/post-infra-bitnami-migration.sh
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/pre-setup-scripts/post-infra-bitnami-migration.sh
@@ -27,6 +27,9 @@ RELEASE="${RELEASE_NAME:-integration}"
 
 workdir="$(mktemp -d)"
 trap 'rm -rf "${workdir}"' EXIT
+mkdir -p "${workdir}/bin"
+ln -s "$(asdf which helm)" "${workdir}/bin/helm"
+export PATH="${workdir}/bin:${PATH}"
 
 echo "Cloning ${REPO}@${REF} ..."
 git clone --depth 1 --branch "${REF}" "${REPO}" "${workdir}/refs"
@@ -51,6 +54,11 @@ kc_pg_pass="$(kubectl get secret keycloak-postgresql -n "${NS}" \
 kubectl create secret generic external-pg-keycloak -n "${NS}" \
     --from-literal=password="${kc_pg_pass}" \
     --dry-run=client -o yaml | kubectl apply -f -
+for _ in {1..10}; do
+    kubectl get secret external-pg-keycloak -n "${NS}" >/dev/null 2>&1 && break
+    sleep 1
+done
+kubectl get secret external-pg-keycloak -n "${NS}" >/dev/null
 
 # --- Migration configuration (external mode, data-only) --------------------
 export NAMESPACE="${NS}"

--- a/scripts/camunda-core/pkg/versionmatrix/versionmatrix.go
+++ b/scripts/camunda-core/pkg/versionmatrix/versionmatrix.go
@@ -158,14 +158,14 @@ func ResolveUpgradeFromVersion(repoRoot, appVersion, flow string) (string, error
 	switch flow {
 	case "upgrade-patch":
 		lookupVersion = appVersion
-	case "upgrade-minor", "modular-upgrade-minor":
+	case "upgrade-minor", "modular-upgrade-minor", "upgrade-path":
 		prev, err := PreviousAppVersion(appVersion)
 		if err != nil {
 			return "", fmt.Errorf("resolve upgrade-minor from version: %w", err)
 		}
 		lookupVersion = prev
 	default:
-		return "", fmt.Errorf("unsupported upgrade flow %q: expected upgrade-patch, upgrade-minor, or modular-upgrade-minor", flow)
+		return "", fmt.Errorf("unsupported upgrade flow %q: expected upgrade-patch, upgrade-minor, modular-upgrade-minor, or upgrade-path", flow)
 	}
 
 	entries, err := LoadVersionMatrix(repoRoot, lookupVersion)
@@ -316,7 +316,8 @@ func preReleaseSuffix(v string) string {
 // (two-step or upgrade-only). Use IsTwoStepUpgradeFlow or IsUpgradeOnlyFlow for
 // more specific checks.
 func IsUpgradeFlow(flow string) bool {
-	return flow == "upgrade-patch" || flow == "upgrade-minor" || flow == "modular-upgrade-minor"
+	return flow == "upgrade-patch" || flow == "upgrade-minor" ||
+		flow == "modular-upgrade-minor" || flow == "upgrade-path"
 }
 
 // IsTwoStepUpgradeFlow returns true if the flow is a self-contained two-step upgrade:
@@ -326,7 +327,14 @@ func IsUpgradeFlow(flow string) bool {
 // "modular-upgrade-minor" is NOT a two-step flow — it assumes an existing deployment
 // from a prior "install" run and only performs the upgrade step.
 func IsTwoStepUpgradeFlow(flow string) bool {
-	return flow == "upgrade-patch" || flow == "upgrade-minor"
+	return flow == "upgrade-patch" || flow == "upgrade-minor" || flow == "upgrade-path"
+}
+
+// IsMinorUpgradeFlow returns true if Step 1 installs the PREVIOUS app version,
+// so Step 1 must use that version's values files. This covers "upgrade-minor",
+// "modular-upgrade-minor", and "upgrade-path".
+func IsMinorUpgradeFlow(flow string) bool {
+	return flow == "upgrade-minor" || flow == "modular-upgrade-minor" || flow == "upgrade-path"
 }
 
 // IsUpgradeOnlyFlow returns true if the flow performs only the upgrade step against

--- a/scripts/deploy-camunda/cmd/matrix.go
+++ b/scripts/deploy-camunda/cmd/matrix.go
@@ -124,7 +124,7 @@ version, and chart-only changes build just the affected versions.`,
 	f.StringVar(&allModifiedFiles, "all-modified-files", "", "changed files/dirs (whitespace-separated, as emitted by tj-actions/changed-files)")
 	f.StringVar(&manualTrigger, "manual-trigger", "none", "\"none\", \"all\", or a single chart version to build")
 	f.StringVar(&manualScenario, "manual-scenario", "none", "keep only this exact scenario (\"none\"/\"all\" keep everything)")
-	f.StringVar(&manualFlow, "manual-flow", "none", "override flows (comma-separated: install, upgrade-patch, upgrade-minor)")
+	f.StringVar(&manualFlow, "manual-flow", "none", "override flows (comma-separated: install, upgrade-patch, upgrade-minor, upgrade-path)")
 	f.StringVar(&tier, "tier", "", "filter scenarios by tier (1=PR CI, 2=merge-queue only; empty or 0=all)")
 	f.StringVar(&repoRoot, "repo-root", "", "repository root path (default: auto-detect)")
 	_ = cmd.MarkFlagRequired("active-versions")
@@ -270,6 +270,9 @@ func newMatrixRunCommand() *cobra.Command {
 		keycloakHost             string
 		keycloakProtocol         string
 		upgradeFromVersion       string
+		valuesSource             string
+		upgradeDelta             string
+		suppressUpgradeHooks     bool
 		helmTimeout              int
 		dockerUsername           string
 		dockerPassword           string
@@ -464,7 +467,10 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 					KeycloakHost:     &keycloakHost,
 					KeycloakProtocol: &keycloakProtocol,
 					// Upgrade
-					UpgradeFromVersion: &upgradeFromVersion,
+					UpgradeFromVersion:   &upgradeFromVersion,
+					ValuesSource:         &valuesSource,
+					UpgradeDelta:         &upgradeDelta,
+					SuppressUpgradeHooks: &suppressUpgradeHooks,
 				})
 			}
 
@@ -601,6 +607,9 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 						KeycloakHost:          keycloakHost,
 						KeycloakProtocol:      keycloakProtocol,
 						UpgradeFromVersion:    upgradeFromVersion,
+						ValuesSource:          matrix.ValuesSource(valuesSource),
+						UpgradeDelta:          upgradeDelta,
+						SuppressUpgradeHooks:  suppressUpgradeHooks,
 						HelmTimeout:           helmTimeout,
 						DockerUsername:        dockerUsername,
 						DockerPassword:        dockerPassword,
@@ -718,6 +727,13 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 				statusDisplay = matrix.NewStatusDisplay(os.Stdout, entries, stdoutIsTerminal, logDir)
 			}
 
+			if err := (matrix.RunOptions{
+				ValuesSource: matrix.ValuesSource(valuesSource),
+				UpgradeDelta: upgradeDelta,
+			}).ValidateUpgradeOptions(); err != nil {
+				return err
+			}
+
 			runStart := time.Now()
 			results, err := matrix.Run(ctx, entries, matrix.RunOptions{
 				DryRun:                     dryRun,
@@ -744,6 +760,9 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 				KeycloakHost:               keycloakHost,
 				KeycloakProtocol:           keycloakProtocol,
 				UpgradeFromVersion:         upgradeFromVersion,
+				ValuesSource:               matrix.ValuesSource(valuesSource),
+				UpgradeDelta:               upgradeDelta,
+				SuppressUpgradeHooks:       suppressUpgradeHooks,
 				HelmTimeout:                helmTimeout,
 				DockerUsername:             dockerUsername,
 				DockerPassword:             dockerPassword,
@@ -848,6 +867,9 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 	f.StringVar(&keycloakHost, "keycloak-host", "", "Keycloak external host")
 	f.StringVar(&keycloakProtocol, "keycloak-protocol", "", "Keycloak protocol (defaults to "+config.DefaultKeycloakProtocol+")")
 	f.StringVar(&upgradeFromVersion, "upgrade-from-version", "", "Override the auto-resolved 'from' chart version for upgrade flows (e.g., 13.5.0)")
+	f.StringVar(&valuesSource, "values-source", "", "Values files Step 2 of a two-step upgrade renders with: '' (target chart, default) or 'carryover' (source chart)")
+	f.StringVar(&upgradeDelta, "upgrade-delta", "", "Extra values file applied on top of carried-over values in Step 2 (requires --values-source=carryover)")
+	f.BoolVar(&suppressUpgradeHooks, "suppress-upgrade-hooks", false, "Skip pre-upgrade and post-infra lifecycle hooks so the upgrade runs without harness-only privileges")
 	f.IntVar(&helmTimeout, "timeout", 10, "Timeout in minutes for Helm deployment (applies to all entries)")
 	f.StringVar(&dockerUsername, "docker-username", "", "Harbor registry username (defaults to HARBOR_USERNAME, TEST_DOCKER_USERNAME_CAMUNDA_CLOUD, or NEXUS_USERNAME env var)")
 	f.StringVar(&dockerPassword, "docker-password", "", "Harbor registry password (defaults to HARBOR_PASSWORD, TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD, or NEXUS_PASSWORD env var)")

--- a/scripts/deploy-camunda/config/config.go
+++ b/scripts/deploy-camunda/config/config.go
@@ -146,7 +146,10 @@ type MatrixConfig struct {
 	KeycloakProtocol string `mapstructure:"keycloakProtocol" yaml:"keycloakProtocol,omitempty"`
 
 	// Upgrade
-	UpgradeFromVersion string `mapstructure:"upgradeFromVersion" yaml:"upgradeFromVersion,omitempty"`
+	UpgradeFromVersion   string `mapstructure:"upgradeFromVersion" yaml:"upgradeFromVersion,omitempty"`
+	ValuesSource         string `mapstructure:"valuesSource" yaml:"valuesSource,omitempty"`
+	UpgradeDelta         string `mapstructure:"upgradeDelta" yaml:"upgradeDelta,omitempty"`
+	SuppressUpgradeHooks *bool  `mapstructure:"suppressUpgradeHooks" yaml:"suppressUpgradeHooks,omitempty"`
 }
 
 // DeploymentConfig represents a single deployment profile.

--- a/scripts/deploy-camunda/config/matrix_merge.go
+++ b/scripts/deploy-camunda/config/matrix_merge.go
@@ -139,7 +139,10 @@ type MatrixRunFlags struct {
 	KeycloakProtocol *string
 
 	// Upgrade
-	UpgradeFromVersion *string
+	UpgradeFromVersion   *string
+	ValuesSource         *string
+	UpgradeDelta         *string
+	SuppressUpgradeHooks *bool
 }
 
 // ApplyMatrixRunConfig merges config-file values into the matrix run command flags.
@@ -252,6 +255,9 @@ func ApplyMatrixRunConfig(rc *RootConfig, changedFlags map[string]bool, f *Matri
 
 	// --- Upgrade ---
 	MergeStringField(f.UpgradeFromVersion, m.UpgradeFromVersion, "", changedFlags, "upgrade-from-version")
+	MergeStringField(f.ValuesSource, m.ValuesSource, "", changedFlags, "values-source")
+	MergeStringField(f.UpgradeDelta, m.UpgradeDelta, "", changedFlags, "upgrade-delta")
+	MergeBoolField(f.SuppressUpgradeHooks, m.SuppressUpgradeHooks, nil, changedFlags, "suppress-upgrade-hooks")
 }
 
 // LoadMatrixConfig loads the config file and returns the parsed RootConfig

--- a/scripts/deploy-camunda/config/merge.go
+++ b/scripts/deploy-camunda/config/merge.go
@@ -45,6 +45,9 @@ type DeploymentFlags struct {
 	RenderTemplates      bool
 	RenderOutputDir      string
 	ExtraValues          []string
+	// UpgradeDelta is a values file applied to the merged scenario values after
+	// layering. It may carry a $remove directive; see pkg/chartvalues.
+	UpgradeDelta string
 	// Extra helm arguments for advanced use cases (e.g., upgrade flows).
 	// These are appended to the helm command after all other arguments.
 	ExtraHelmArgs []string

--- a/scripts/deploy-camunda/deploy/merge.go
+++ b/scripts/deploy-camunda/deploy/merge.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"scripts/camunda-core/pkg/chartvalues"
 	"scripts/camunda-core/pkg/logging"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -217,4 +219,57 @@ func MergeLayeredValues(scenarioValueFiles []string, tempDir string) ([]string, 
 		return nil, fmt.Errorf("failed to merge layered values: %w", err)
 	}
 	return []string{merged}, nil
+}
+
+// applyUpgradeDelta rewrites the merged scenario values file in place with the
+// delta applied. The delta may set keys and, via a $remove directive, delete
+// dotted key paths — chart constraints test key presence, so a removed key
+// cannot be cleared by layering a null over it.
+//
+// No-op when no delta is configured or when layering produced no single merged
+// file to rewrite.
+func applyUpgradeDelta(mergedFiles []string, deltaPath string) error {
+	if deltaPath == "" || len(mergedFiles) != 1 {
+		return nil
+	}
+
+	raw, err := os.ReadFile(deltaPath)
+	if err != nil {
+		return fmt.Errorf("read upgrade delta: %w", err)
+	}
+	// Scenario layers are substituted by values.Process before merging; the
+	// delta is applied afterwards, so it needs the same treatment.
+	delta, err := chartvalues.ParseDelta([]byte(substituteManifestVars(string(raw), envMap())), deltaPath)
+	if err != nil {
+		return fmt.Errorf("parse upgrade delta: %w", err)
+	}
+	if delta.IsEmpty() {
+		return nil
+	}
+
+	merged, err := chartvalues.LoadFile(mergedFiles[0])
+	if err != nil {
+		return fmt.Errorf("load merged scenario values: %w", err)
+	}
+	if err := chartvalues.WriteFile(mergedFiles[0], delta.Apply(merged)); err != nil {
+		return fmt.Errorf("write merged scenario values: %w", err)
+	}
+
+	logging.Logger.Info().
+		Str("delta", deltaPath).
+		Strs("removed", delta.Remove).
+		Int("setKeys", len(delta.Set)).
+		Msg("Applied upgrade delta to merged scenario values")
+	return nil
+}
+
+// envMap snapshots the process environment for delta substitution.
+func envMap() map[string]string {
+	out := make(map[string]string, len(os.Environ()))
+	for _, kv := range os.Environ() {
+		if i := strings.IndexByte(kv, '='); i > 0 {
+			out[kv[:i]] = kv[i+1:]
+		}
+	}
+	return out
 }

--- a/scripts/deploy-camunda/deploy/merge.go
+++ b/scripts/deploy-camunda/deploy/merge.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"scripts/camunda-core/pkg/chartvalues"
 	"scripts/camunda-core/pkg/logging"
+	"scripts/prepare-helm-values/pkg/env"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -228,7 +229,7 @@ func MergeLayeredValues(scenarioValueFiles []string, tempDir string) ([]string, 
 //
 // No-op when no delta is configured or when layering produced no single merged
 // file to rewrite.
-func applyUpgradeDelta(mergedFiles []string, deltaPath string) error {
+func applyUpgradeDelta(mergedFiles []string, deltaPath, envFile string) error {
 	if deltaPath == "" || len(mergedFiles) != 1 {
 		return nil
 	}
@@ -239,7 +240,18 @@ func applyUpgradeDelta(mergedFiles []string, deltaPath string) error {
 	}
 	// Scenario layers are substituted by values.Process before merging; the
 	// delta is applied afterwards, so it needs the same treatment.
-	delta, err := chartvalues.ParseDelta([]byte(substituteManifestVars(string(raw), envMap())), deltaPath)
+	vars := envMap()
+	if envFile == "" {
+		envFile = ".env"
+	}
+	dotenv, err := env.ReadFile(envFile)
+	if err != nil {
+		return fmt.Errorf("read env file for upgrade delta: %w", err)
+	}
+	for k, v := range dotenv {
+		vars[k] = v
+	}
+	delta, err := chartvalues.ParseDelta([]byte(substituteManifestVars(string(raw), vars)), deltaPath)
 	if err != nil {
 		return fmt.Errorf("parse upgrade delta: %w", err)
 	}

--- a/scripts/deploy-camunda/deploy/merge_test.go
+++ b/scripts/deploy-camunda/deploy/merge_test.go
@@ -255,6 +255,20 @@ identity:
 	}
 }
 
+func TestApplyUpgradeDeltaUsesEnvFile(t *testing.T) {
+	dir := t.TempDir()
+	merged := writeTempYAML(t, dir, "merged.yaml", "database:\n  username: old\n")
+	delta := writeTempYAML(t, dir, "delta.yaml", "database:\n  username: $DB_USER\n")
+	envFile := writeTempYAML(t, dir, ".env", "DB_USER=from-file\n")
+
+	if err := applyUpgradeDelta([]string{merged}, delta, envFile); err != nil {
+		t.Fatal(err)
+	}
+	if got := getPath(readYAMLMap(t, merged), "database", "username"); got != "from-file" {
+		t.Fatalf("database.username = %v, want from-file", got)
+	}
+}
+
 // TestMergeYAMLFiles_EnvOverrideSameName verifies that when two layers define
 // the same env var name, the later layer's value wins.
 func TestMergeYAMLFiles_EnvOverrideSameName(t *testing.T) {

--- a/scripts/deploy-camunda/deploy/values.go
+++ b/scripts/deploy-camunda/deploy/values.go
@@ -789,7 +789,7 @@ func prepareScenarioValues(ctx context.Context, scenarioCtx *ScenarioContext, fl
 			Strs("mergedFiles", scenarioValueFiles).
 			Msg("📋 [prepareScenarioValues] layered values merged")
 
-		if err := applyUpgradeDelta(scenarioValueFiles, flags.Deployment.UpgradeDelta); err != nil {
+		if err := applyUpgradeDelta(scenarioValueFiles, flags.Deployment.UpgradeDelta, flags.EnvFile); err != nil {
 			os.RemoveAll(tempDir)
 			return nil, err
 		}

--- a/scripts/deploy-camunda/deploy/values.go
+++ b/scripts/deploy-camunda/deploy/values.go
@@ -788,6 +788,11 @@ func prepareScenarioValues(ctx context.Context, scenarioCtx *ScenarioContext, fl
 		logging.Logger.Debug().
 			Strs("mergedFiles", scenarioValueFiles).
 			Msg("📋 [prepareScenarioValues] layered values merged")
+
+		if err := applyUpgradeDelta(scenarioValueFiles, flags.Deployment.UpgradeDelta); err != nil {
+			os.RemoveAll(tempDir)
+			return nil, err
+		}
 	} else {
 		// Legacy path: process auth and main scenario, then let BuildValuesList resolve
 		effectiveAuth := flags.Auth.Auth

--- a/scripts/deploy-camunda/matrix/plan.go
+++ b/scripts/deploy-camunda/matrix/plan.go
@@ -146,7 +146,7 @@ var buildAllTriggers = []buildAllTrigger{
 	},
 }
 
-var manualFlowPattern = regexp.MustCompile(`^(install|upgrade-patch|upgrade-minor)(,(install|upgrade-patch|upgrade-minor))*$`)
+var manualFlowPattern = regexp.MustCompile(`^(install|upgrade-patch|upgrade-minor|upgrade-path)(,(install|upgrade-patch|upgrade-minor|upgrade-path))*$`)
 
 // Plan computes the chart build matrix for a change set, replacing
 // scripts/generate-chart-matrix.sh + generate-chart-matrix.jq.
@@ -275,7 +275,7 @@ func applyManualFlow(entries []Entry, manualFlow string) ([]Entry, error) {
 		return entries, nil
 	}
 	if !manualFlowPattern.MatchString(manualFlow) {
-		return nil, fmt.Errorf("invalid flow %q; valid flows: install, upgrade-patch, upgrade-minor (modular-upgrade-minor only via integration-test-template.yaml)", manualFlow)
+		return nil, fmt.Errorf("invalid flow %q; valid flows: install, upgrade-patch, upgrade-minor, upgrade-path (modular-upgrade-minor only via integration-test-template.yaml)", manualFlow)
 	}
 	flows := strings.Split(manualFlow, ",")
 	var out []Entry

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -494,7 +494,7 @@ func resolvePreUpgradeScriptQuiet(repoRoot string, entry Entry) string {
 // (including upgrade-patch, which uses the current version's values), returns empty string.
 // Errors are silently logged — dry-run is best-effort.
 func resolveStep1ValuesFromQuiet(entry Entry) string {
-	if entry.Flow != "upgrade-minor" {
+	if !versionmatrix.IsMinorUpgradeFlow(entry.Flow) {
 		return ""
 	}
 	prev, err := versionmatrix.PreviousAppVersion(entry.Version)
@@ -1073,6 +1073,7 @@ var flowAbbrevMap = map[string]string{
 	"upgrade-patch":         "upgp",
 	"upgrade-minor":         "upgm",
 	"modular-upgrade-minor": "mugm",
+	"upgrade-path":          "upth",
 }
 
 func flowAbbrev(flow string) string {

--- a/scripts/deploy-camunda/matrix/runner_options.go
+++ b/scripts/deploy-camunda/matrix/runner_options.go
@@ -1,5 +1,10 @@
 package matrix
 
+import (
+	"fmt"
+	"os"
+)
+
 // RunOptions controls matrix execution.
 type RunOptions struct {
 	// DryRun logs what would be done without executing.
@@ -81,6 +86,19 @@ type RunOptions struct {
 	// When set, this version is used instead of resolving from version-matrix JSON files.
 	// Only applies to entries with upgrade flows (upgrade-patch, upgrade-minor, modular-upgrade-minor).
 	UpgradeFromVersion string
+	// ValuesSource selects which chart's values files Step 2 of a two-step
+	// upgrade renders with. ValuesNative (default) preserves existing behaviour:
+	// Step 2 uses the target chart's own values. ValuesCarryover makes Step 2
+	// reuse the source chart's values, optionally overlaid with UpgradeDelta.
+	// Only meaningful for the upgrade-minor flow.
+	ValuesSource ValuesSource
+	// UpgradeDelta is an additional values file applied on top of the carried-over
+	// values in Step 2. Ignored unless ValuesSource is ValuesCarryover.
+	UpgradeDelta string
+	// SuppressUpgradeHooks skips the pre-upgrade and post-infra lifecycle hooks.
+	// These hooks perform work outside the chart that a customer running
+	// `helm upgrade` does not get.
+	SuppressUpgradeHooks bool
 	// HelmTimeout is the timeout in minutes for each Helm deployment.
 	// Applies uniformly to all matrix entries (install, upgrade Step 1, upgrade Step 2).
 	// When <= 0, deploy.Execute defaults to 5 minutes.
@@ -165,4 +183,42 @@ type RunOptions struct {
 	// IngressReadyTimeoutMinutes bounds how long WaitIngressReady polls before
 	// failing. When <= 0, config.DefaultIngressReadyTimeoutMinutes is used.
 	IngressReadyTimeoutMinutes int
+}
+
+// ValuesSource selects which chart's values files Step 2 of a two-step upgrade
+// renders with.
+type ValuesSource string
+
+const (
+	// ValuesNative renders Step 2 with the target chart's own values files.
+	ValuesNative ValuesSource = ""
+	// ValuesCarryover renders Step 2 with the source chart's values files.
+	ValuesCarryover ValuesSource = "carryover"
+)
+
+// Validate checks carryover option coherence.
+func (v ValuesSource) Validate() error {
+	switch v {
+	case ValuesNative, ValuesCarryover:
+		return nil
+	default:
+		return fmt.Errorf("invalid values source %q: expected \"\" (native) or %q", string(v), string(ValuesCarryover))
+	}
+}
+
+// ValidateUpgradeOptions rejects carryover flag combinations that cannot work,
+// so the failure surfaces before a cluster is provisioned.
+func (o RunOptions) ValidateUpgradeOptions() error {
+	if err := o.ValuesSource.Validate(); err != nil {
+		return err
+	}
+	if o.UpgradeDelta != "" && o.ValuesSource != ValuesCarryover {
+		return fmt.Errorf("--upgrade-delta requires --values-source=%s", string(ValuesCarryover))
+	}
+	if o.UpgradeDelta != "" {
+		if _, err := os.Stat(o.UpgradeDelta); err != nil {
+			return fmt.Errorf("--upgrade-delta %q: %w", o.UpgradeDelta, err)
+		}
+	}
+	return nil
 }

--- a/scripts/deploy-camunda/matrix/runner_upgrade.go
+++ b/scripts/deploy-camunda/matrix/runner_upgrade.go
@@ -212,8 +212,13 @@ func executeTwoStepUpgrade(ctx context.Context, entry Entry, flags *config.Runti
 	// In CI, test-type-vars sets CHART_PATH to charts/camunda-platform-<previous> for
 	// the install step of upgrade-minor, so values files come from the older chart.
 	// For upgrade-patch, Step 1 uses the current chart's values (same app version).
+	// Retained for Step 2 when ValuesCarryover is selected; empty for any flow
+	// that does not switch to the previous version's values.
+	var sourceScenarioDir string
+	var sourceFeatures []string
+
 	step1AppVersion := entry.Version
-	if entry.Flow == "upgrade-minor" {
+	if versionmatrix.IsMinorUpgradeFlow(entry.Flow) {
 		prevVersion, err := versionmatrix.PreviousAppVersion(entry.Version)
 		if err != nil {
 			return fmt.Errorf("step 1: resolve previous app version for %s: %w", entry.Version, err)
@@ -222,6 +227,7 @@ func executeTwoStepUpgrade(ctx context.Context, entry Entry, flags *config.Runti
 		prevChartDir := filepath.Join(opts.RepoRoot, "charts", "camunda-platform-"+prevVersion)
 		prevScenarioDir := filepath.Join(prevChartDir, "test/integration/scenarios/chart-full-setup")
 		step1Flags.Deployment.ScenarioPath = prevScenarioDir
+		sourceScenarioDir = prevScenarioDir
 
 		logging.Logger.Info().
 			Str("flow", entry.Flow).
@@ -240,6 +246,7 @@ func executeTwoStepUpgrade(ctx context.Context, entry Entry, flags *config.Runti
 			}
 			kept, dropped := filterKnownFeatures(step1Flags.Selection.Features, prevFeatures)
 			step1Flags.Selection.Features = kept
+			sourceFeatures = kept
 			if len(dropped) > 0 {
 				logging.Logger.Info().
 					Str("previousVersion", prevVersion).
@@ -274,7 +281,13 @@ func executeTwoStepUpgrade(ctx context.Context, entry Entry, flags *config.Runti
 	// Runs the declarative pre-upgrade hook (integration.flows.<flow>.pre-upgrade)
 	// resolved at matrix-generation time onto entry.PreUpgrade. Scoped to the
 	// target version (entry.Version is the version being upgraded to).
-	if err := runDeclarativePreUpgradeHook(ctx, flags, entry.PreUpgrade, opts.RepoRoot, entry.Version, entry.Flow); err != nil {
+	if opts.SuppressUpgradeHooks {
+		if entry.PreUpgrade != nil {
+			logging.Logger.Warn().
+				Str("hook", entry.PreUpgrade.Script).
+				Msg("Suppressed pre-upgrade hook: the upgrade must succeed without it")
+		}
+	} else if err := runDeclarativePreUpgradeHook(ctx, flags, entry.PreUpgrade, opts.RepoRoot, entry.Version, entry.Flow); err != nil {
 		return err
 	}
 
@@ -322,10 +335,30 @@ func executeTwoStepUpgrade(ctx context.Context, entry Entry, flags *config.Runti
 		}
 	}
 
+	if opts.ValuesSource == ValuesCarryover {
+		if sourceScenarioDir == "" {
+			return fmt.Errorf("step 2: values carryover requires the upgrade-minor flow, got %q", entry.Flow)
+		}
+		step2Flags.Deployment.ScenarioPath = sourceScenarioDir
+		step2Flags.Selection.Features = sourceFeatures
+		step2Flags.Deployment.UpgradeDelta = opts.UpgradeDelta
+		logging.Logger.Info().
+			Str("step", "2/2").
+			Str("scenarioDir", sourceScenarioDir).
+			Str("delta", opts.UpgradeDelta).
+			Msg("Step 2: carrying over the source chart's values files")
+	}
+
 	// --- Post-infra lifecycle hook (Step 2 of two-step upgrade) ---
 	// Registered against step2Flags so it fires after Step 2's companion charts
 	// are deployed but before the target chart upgrade.
-	if err := registerDeclarativePostInfraHook(&step2Flags, entry.PostInfra, opts.RepoRoot, entry.Version, entry.Scenario); err != nil {
+	if opts.SuppressUpgradeHooks {
+		if entry.PostInfra != nil {
+			logging.Logger.Warn().
+				Str("hook", entry.PostInfra.Script).
+				Msg("Suppressed post-infra hook: the upgrade must succeed without it")
+		}
+	} else if err := registerDeclarativePostInfraHook(&step2Flags, entry.PostInfra, opts.RepoRoot, entry.Version, entry.Scenario); err != nil {
 		return err
 	}
 

--- a/scripts/deploy-camunda/matrix/values_source_test.go
+++ b/scripts/deploy-camunda/matrix/values_source_test.go
@@ -1,0 +1,154 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matrix
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"scripts/camunda-core/pkg/versionmatrix"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValuesSourceZeroValueIsNative(t *testing.T) {
+	var opts RunOptions
+	require.Equal(t, ValuesNative, opts.ValuesSource,
+		"the zero value must preserve existing upgrade-minor and upgrade-patch behaviour")
+	assert.Empty(t, opts.UpgradeDelta)
+	assert.False(t, opts.SuppressUpgradeHooks)
+}
+
+func TestValuesSourceConstants(t *testing.T) {
+	assert.Equal(t, ValuesSource(""), ValuesNative)
+	assert.Equal(t, ValuesSource("carryover"), ValuesCarryover)
+	assert.NotEqual(t, ValuesNative, ValuesCarryover)
+}
+
+func TestFilterKnownFeaturesPreservesRequestedOrder(t *testing.T) {
+	kept, dropped := filterKnownFeatures(
+		[]string{"z", "new-in-target", "a"},
+		[]string{"a", "z"},
+	)
+	assert.Equal(t, []string{"z", "a"}, kept,
+		"carryover reuses this ordering for Step 2, so it must follow the requested list")
+	assert.Equal(t, []string{"new-in-target"}, dropped)
+}
+
+func TestUpgradePathFlowClassification(t *testing.T) {
+	tests := []struct {
+		flow           string
+		isUpgrade      bool
+		isTwoStep      bool
+		isMinorUpgrade bool
+		isUpgradeOnly  bool
+	}{
+		{"install", false, false, false, false},
+		{"upgrade-patch", true, true, false, false},
+		{"upgrade-minor", true, true, true, false},
+		{"modular-upgrade-minor", true, false, true, true},
+		{"upgrade-path", true, true, true, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.flow, func(t *testing.T) {
+			assert.Equal(t, tt.isUpgrade, versionmatrix.IsUpgradeFlow(tt.flow), "IsUpgradeFlow")
+			assert.Equal(t, tt.isTwoStep, versionmatrix.IsTwoStepUpgradeFlow(tt.flow), "IsTwoStepUpgradeFlow")
+			assert.Equal(t, tt.isMinorUpgrade, versionmatrix.IsMinorUpgradeFlow(tt.flow), "IsMinorUpgradeFlow")
+			assert.Equal(t, tt.isUpgradeOnly, versionmatrix.IsUpgradeOnlyFlow(tt.flow), "IsUpgradeOnlyFlow")
+		})
+	}
+}
+
+func TestUpgradePathHasNamespaceAbbrev(t *testing.T) {
+	abbrev := flowAbbrev("upgrade-path")
+	assert.Equal(t, "upth", abbrev)
+	seen := map[string]string{}
+	for flow, a := range flowAbbrevMap {
+		if prev, dup := seen[a]; dup {
+			t.Fatalf("abbreviation %q collides between %q and %q", a, prev, flow)
+		}
+		seen[a] = flow
+	}
+}
+
+func TestApplyManualFlowAcceptsUpgradePath(t *testing.T) {
+	entries := []Entry{{Version: "8.10", Scenario: "elasticsearch"}}
+
+	out, err := applyManualFlow(entries, "upgrade-path")
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, "upgrade-path", out[0].Flow)
+
+	out, err = applyManualFlow(entries, "install,upgrade-path")
+	require.NoError(t, err)
+	require.Len(t, out, 2)
+
+	_, err = applyManualFlow(entries, "not-a-flow")
+	require.Error(t, err)
+}
+
+func TestValidateUpgradeOptions(t *testing.T) {
+	delta := filepath.Join(t.TempDir(), "delta.values.yaml")
+	require.NoError(t, os.WriteFile(delta, []byte("key: value\n"), 0o644))
+
+	tests := []struct {
+		name    string
+		opts    RunOptions
+		wantErr string
+	}{
+		{
+			name: "defaults are valid",
+			opts: RunOptions{},
+		},
+		{
+			name: "carryover without delta is valid",
+			opts: RunOptions{ValuesSource: ValuesCarryover},
+		},
+		{
+			name: "carryover with an existing delta is valid",
+			opts: RunOptions{ValuesSource: ValuesCarryover, UpgradeDelta: delta},
+		},
+		{
+			name:    "unknown values source",
+			opts:    RunOptions{ValuesSource: ValuesSource("bogus")},
+			wantErr: "invalid values source",
+		},
+		{
+			name:    "delta without carryover",
+			opts:    RunOptions{UpgradeDelta: delta},
+			wantErr: "requires --values-source=carryover",
+		},
+		{
+			name:    "delta file missing",
+			opts:    RunOptions{ValuesSource: ValuesCarryover, UpgradeDelta: "/nonexistent/delta.yaml"},
+			wantErr: "--upgrade-delta",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.opts.ValidateUpgradeOptions()
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}

--- a/test/integration/companion-values/elasticsearch-distroci.yaml
+++ b/test/integration/companion-values/elasticsearch-distroci.yaml
@@ -1,0 +1,129 @@
+# elasticsearch companion for GKE distroci scenarios.
+#
+# Identical to elasticsearch.yaml plus node placement. The distroci pool is
+# tainted workload=distroci:NoSchedule, so a companion without the toleration
+# cannot schedule there and is squeezed onto the small untainted remainder,
+# where it contends with unrelated workloads.
+# CI values for the embedded Elasticsearch companion chart (elastic/elasticsearch).
+# Security/X-Pack disabled, single node, minimal resources for CI/dev environments.
+#
+# Deployed as a separate Helm release by deploy-camunda before the main
+# Camunda chart. Referenced from ci-test-config.yaml dependencies.
+
+clusterName: "elasticsearch"
+
+replicas: 1
+minimumMasterNodes: 1
+
+protocol: http
+
+# Use ES 8.18.0 — the elastic/elasticsearch Helm chart 8.5.1 defaults to its
+# own app version (8.5.1) but Camunda 8.10 requires ES 8.6+ (specifically for
+# the unassignedPrimaryShards field in HealthResponse). The Bitnami subchart
+# this replaces bundled ES 8.18.0.
+imageTag: "8.18.0"
+
+# Disable automatic TLS certificate generation. When createCert=true (default),
+# the chart injects env vars that force xpack.security.enabled=true and
+# xpack.security.{http,transport}.ssl.enabled=true, overriding any esConfig
+# settings. Setting createCert=false prevents cert creation, volume mounts, AND
+# the env var injection — letting our esConfig settings take effect.
+createCert: false
+
+# Keep the credentials secret enabled even though security is disabled.
+# The chart's readiness probe script checks [ -z "${ELASTIC_PASSWORD}" ] and
+# exits 1 if unset. The password is injected from this secret but ignored by
+# ES when xpack.security.enabled=false.
+secret:
+  enabled: true
+
+# Single-node disco + disable HTTP TLS + disable X-Pack security so Camunda
+# can talk to the cluster anonymously over plain HTTP (mirrors the OpenSearch
+# companion chart's "security disabled" stance).
+#
+# NOTE: discovery.type: single-node is NOT set here because the
+# elastic/elasticsearch chart injects cluster.initial_master_nodes via an env
+# var in the StatefulSet template, and ES 8.x rejects having both. With
+# replicas=1 the chart bootstraps correctly without the explicit single-node
+# setting.
+esConfig:
+  elasticsearch.yml: |
+    cluster.name: elasticsearch
+    network.host: 0.0.0.0
+    xpack.security.enabled: false
+    xpack.security.http.ssl.enabled: false
+    # Allow _reindex-from-remote to pull data from the source (bundled Bitnami)
+    # Elasticsearch during the Bitnami→companion migration (upgrade-minor flows).
+    # Harmless for install scenarios, which never issue a remote reindex.
+    reindex.remote.whitelist: "*:9200"
+    xpack.security.transport.ssl.enabled: false
+
+extraEnvs:
+  - name: ES_JAVA_OPTS
+    value: "-Xms512m -Xmx512m"
+
+# Single-node clusters cannot allocate index replicas. Camunda components
+# create indices with number_of_replicas=1, which leaves every replica
+# unassigned, drives the cluster to yellow, and causes intermittent "all
+# shards failed" 503s on _search calls.
+#
+# auto_expand_replicas dynamically adjusts replicas based on cluster size:
+# on a 1-node cluster it settles at 0; on a 2-node cluster it scales to 1.
+# It overrides any explicit number_of_replicas setting.
+#
+# Priority MUST be lower than the application's own index templates:
+#   - Zeebe-record templates: priority 20 (define aliases for Optimize)
+#   - Operate/Tasklist/Camunda templates: priority 0
+# Setting priority=1 ensures:
+#   - Zeebe-record templates (p20) win → their aliases are applied correctly
+#   - Our template (p1) wins over operate/tasklist/camunda (p0) → auto_expand
+#     applies to those indices
+# Zeebe-record indices already set number_of_replicas=0 in their templates,
+# so they don't need auto_expand_replicas to be green on a single node.
+#
+# Index patterns are intentionally substring globs (e.g. "*operate*") rather
+# than prefix globs ("operate-*"). CI prepends $GITHUB_WORKFLOW_JOB_ID to
+# every component prefix, and deploy-camunda matrix uses shortened prefixes
+# ("op-*", "opt-*", "orch-*") for index naming.
+lifecycle:
+  postStart:
+    exec:
+      command:
+        - bash
+        - -c
+        - |
+          max=60
+          n=0
+          until curl -fsS --connect-timeout 5 "http://localhost:9200/_cluster/health" >/dev/null 2>&1; do
+            n=$((n + 1))
+            if [ "$n" -ge "$max" ]; then
+              echo "elasticsearch not reachable after $max attempts" >&2
+              exit 1
+            fi
+            sleep 2
+          done
+          curl -fsS --connect-timeout 5 -X PUT "http://localhost:9200/_index_template/camunda-ci-auto-expand-replicas" \
+            -H 'Content-Type: application/json' \
+            -d '{"index_patterns":["*operate*","*orchestration*","*optimize*","*tasklist*","*camunda*","*zeebe*","op-*","opt-*","orch-*"],"priority":1,"template":{"settings":{"index.auto_expand_replicas":"0-1"}}}'
+
+resources:
+  requests:
+    cpu: "500m"
+    memory: "1Gi"
+  limits:
+    cpu: "1"
+    memory: "2Gi"
+
+volumeClaimTemplate:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 4Gi
+
+nodeSelector:
+  workload: distroci
+tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: distroci

--- a/test/integration/companion-values/keycloak-distroci.yaml
+++ b/test/integration/companion-values/keycloak-distroci.yaml
@@ -1,0 +1,54 @@
+# keycloak companion for GKE distroci scenarios.
+#
+# Identical to keycloak.yaml plus node placement. The distroci pool is tainted
+# workload=distroci:NoSchedule, so a companion without the toleration cannot
+# schedule there and is squeezed onto the small untainted remainder, where it
+# contends with unrelated workloads.
+# Companion values for internal-keycloak-26 chart.
+# Deployed as a separate Helm release before the Camunda chart.
+# Uses the same credential secret that the matrix runner provisions.
+
+fullnameOverride: keycloak
+
+image:
+  registry: quay.io
+  repository: keycloak/keycloak
+  tag: "26.3.3"
+
+auth:
+  adminUser: admin
+  existingSecret: integration-test-credentials
+  passwordSecretKey: identity-keycloak-admin-password
+
+httpRelativePath: "/auth/"
+proxy: edge
+
+resources:
+  requests:
+    cpu: 200m
+    memory: 512Mi
+  limits:
+    cpu: "1"
+    memory: 1Gi
+
+postgresql:
+  enabled: true
+  auth:
+    database: keycloak
+    username: keycloak
+    password: "keycloak-ci-password"
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+
+nodeSelector:
+  workload: distroci
+tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: distroci

--- a/test/integration/companion-values/postgresql-distroci.yaml
+++ b/test/integration/companion-values/postgresql-distroci.yaml
@@ -1,0 +1,35 @@
+# postgresql companion for GKE distroci scenarios.
+#
+# Identical to postgresql.yaml plus node placement. The distroci pool is tainted
+# workload=distroci:NoSchedule, so a companion without the toleration cannot
+# schedule there and is squeezed onto the small untainted remainder, where it
+# contends with unrelated workloads.
+# Companion values for internal-postgresql chart.
+# Provides Identity and Web Modeler databases without Bitnami or CNPG.
+
+fullnameOverride: postgresql
+
+auth:
+  username: "$RDBMS_POSTGRESQL_USERNAME"
+  password: "$RDBMS_POSTGRESQL_PASSWORD"
+  database: identity
+
+databases:
+  - identity
+  - webmodeler
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+nodeSelector:
+  workload: distroci
+tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: distroci

--- a/test/upgrade-paths/coverage.yaml
+++ b/test/upgrade-paths/coverage.yaml
@@ -6,6 +6,10 @@
 #
 # status: covered | partial | uncovered
 # stage:  render | cluster | none
+#
+# The render stage runs on every pull request. The cluster stage deploys a full
+# previous-version release and upgrades it, so it runs nightly and on demand
+# only — a merge-queue run would add roughly eight minutes per path.
 
 # Archetypes model deployment shapes, and the shape decides which breaks are
 # reachable. Customers run external auth and external storage in production, so

--- a/test/upgrade-paths/transitions/8.9-to-8.10/classic-bundled/delta.values.yaml
+++ b/test/upgrade-paths/transitions/8.9-to-8.10/classic-bundled/delta.values.yaml
@@ -8,7 +8,8 @@
 # Remaining keys are merged in as normal values.
 #
 # Removing the bundled-subchart keys makes the chart render. It does NOT migrate
-# the data those subcharts held — see remedy.sh.
+# the data those subcharts held. Run the adjacent executable remedy.sh before
+# applying this delta; Run B validates that combined customer procedure.
 
 $rename:
   global.ingress.host: global.host

--- a/test/upgrade-paths/transitions/8.9-to-8.10/classic-bundled/remedy.sh
+++ b/test/upgrade-paths/transitions/8.9-to-8.10/classic-bundled/remedy.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Copyright 2026 Camunda Services GmbH
+# Licensed under the Apache License, Version 2.0.
+
+set -euo pipefail
+
+: "${NAMESPACE:?set NAMESPACE to the Camunda release namespace}"
+: "${RDBMS_POSTGRESQL_USERNAME:?set RDBMS_POSTGRESQL_USERNAME}"
+: "${RDBMS_POSTGRESQL_PASSWORD:?set RDBMS_POSTGRESQL_PASSWORD}"
+
+export TEST_NAMESPACE="${NAMESPACE}"
+export RELEASE_NAME="${RELEASE_NAME:-integration}"
+
+repo_root="$(git rev-parse --show-toplevel)"
+exec "${repo_root}/charts/camunda-platform-8.10/test/integration/scenarios/pre-setup-scripts/post-infra-bitnami-migration.sh"


### PR DESCRIPTION
> | # | PR | Phase | Purpose |
> |---|---|---|---|
> | 1 | #6820 | library | `chartvalues`: layer consolidation, `$remove` / `$rename` / `$scaffolding` |
> | 2 | #6821 | render stage | A/B render of a carried-over values file; archetypes and fixtures |
> | 3 | #6825 | honesty | coverage ledger, real Helm v3 gate, transition bootstrap |
> | **4** | **#6822** | **cluster stage** | **real two-step upgrade on GKE, nightly and on demand** ← you are here |
> | 5 | #6834 | assertions | orphaned storage, data survival, migration cost |

Merge in order; each builds on the one above. 2 consumes the package from 1. 3 adds the coverage ledger that 4 and 5 both update. 5 asserts against the cluster 4 deploys.

### Which problem does the PR fix?

Part of #6819.

Rendering catches values-shaped breaks. It cannot catch a manifest the API server rejects, or a component that renders correctly and then fails to boot on carried-over configuration. A manual 8.9→8.10 investigation found that a carried-over values file fails in **five distinct ways, only two of which are reachable by rendering**.

### What's in this PR?

The cluster stage. `deploy-camunda` installs the source version, then upgrades in place to the target using the same carried-over values the render stage uses, **with harness privileges suppressed** so the run has no capability a customer would not have. Readiness is waited on, so a component that cannot start fails the run.

Runs nightly and on `workflow_dispatch` rather than in the merge queue — roughly eight minutes per path. Dispatch selects the transition, the archetype, and whether to run the naive arm, the remediated arm or both.

### Node placement

Companion Keycloak, PostgreSQL and Elasticsearch releases are placed on the `distroci` pool. That pool is **34 of the cluster's 47 nodes** and is tainted `workload=distroci:NoSchedule`, so carrying neither the `nodeSelector` nor the toleration excluded them *structurally* from the pool their own scenario targets and squeezed them onto the untainted remainder:

```
0/47 nodes are available: 18 Insufficient cpu, 26 node(s) had untolerated taint
```

Verified on GKE — placement removes the scheduling failures entirely:

```
elasticsearch-master-0    distroci
keycloak-...              distroci
postgresql-...            distroci

FailedScheduling events:  0     (previously many)
[PASS] upgrade-path-classic     9m43s   (previously 14m09s)
```

### Not addressed here

**`keycloak-postgresql` remains unplaced.** `charts/internal-keycloak-26/templates/postgresql-deployment.yaml` has no `nodeSelector` or `tolerations` support at all, so no values change can place it. That is a template change to a chart shared with other scenarios and deserves its own review rather than riding along here.

**Worth raising separately, pre-existing:** `hub-legacy-upgrade` uses the same unplaced dependencies, so its companion Keycloak, PostgreSQL and Elasticsearch have been scheduling off-pool on every nightly run. Not introduced by this stack; would benefit from the same fix.

### Known limitation

The stage currently defaults to the `classic-bundled` archetype (`upclas`), which #6821 marks tier 2. The tier-1 external shapes are render-only for now. Pointing the cluster stage at a tier-1 archetype is the obvious next step and is tracked on #6819.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
