### PR TITLE
ci: harden checkout credential handling for INC-7027

### DIFF
--- a/.github/workflows/chart-chores.yaml
+++ b/.github/workflows/chart-chores.yaml
@@ -83,18 +83,29 @@ jobs:
       - name: Set vars
         run: |
           echo "CHANGED_CHARTS=$(ct list-changed | tr '\n' ' ')" | tee -a $GITHUB_ENV
+      # An empty chartPath is indistinguishable from an unset one in the Makefile, which
+      # then falls back to charts/camunda-platform-* and rewrites every chart version.
       - name: Update golden files
         run: |
-          chartPath="${CHANGED_CHARTS}" \
-            make go.update-golden-only
+          if [ -n "${CHANGED_CHARTS}" ]; then
+            chartPath="${CHANGED_CHARTS}" make go.update-golden-only
+          else
+            echo "No chart changes, skipping golden file update."
+          fi
       - name: Update README
         run: |
-          chartPath="${CHANGED_CHARTS}" \
-            make helm.readme-update
+          if [ -n "${CHANGED_CHARTS}" ]; then
+            chartPath="${CHANGED_CHARTS}" make helm.readme-update
+          else
+            echo "No chart changes, skipping README update."
+          fi
       - name: Update Schema
         run: |
-          chartPath="${CHANGED_CHARTS}" \
-            make helm.schema-update
+          if [ -n "${CHANGED_CHARTS}" ]; then
+            chartPath="${CHANGED_CHARTS}" make helm.schema-update
+          else
+            echo "No chart changes, skipping schema update."
+          fi
       - name: Git pull
         run: git pull --rebase --autostash .
       - uses: EndBug/add-and-commit@cc9c08ba6c8df3b93a8f2db63e89b98368ae2ae8 # v11.1.1

--- a/.github/workflows/chart-chores.yaml
+++ b/.github/workflows/chart-chores.yaml
@@ -46,6 +46,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
           token: "${{ steps.generate-github-token.outputs.token }}"
+          # Credentials are re-introduced only in the final push step.
+          persist-credentials: false
       - name: Configure curl and wget
         uses: ./.github/actions/setup-curl
       #
@@ -96,7 +98,23 @@ jobs:
       - name: Git pull
         run: git pull --rebase --autostash .
       - uses: EndBug/add-and-commit@cc9c08ba6c8df3b93a8f2db63e89b98368ae2ae8 # v11.1.1
+        id: commit
         with:
           author_name: "distro-ci[bot]"
           author_email: "122795778+distro-ci[bot]@users.noreply.github.com"
           message: "chore: chart chores"
+          # Pushing is done by the next step; checkout does not persist credentials.
+          push: false
+      - name: Push changes
+        if: steps.commit.outputs.committed == 'true'
+        env:
+          GH_APP_TOKEN: ${{ steps.generate-github-token.outputs.token }}
+          TARGET_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          TARGET_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+          # Credential is supplied per-command via a helper reading the step env, so the token is
+          # neither written to .git/config nor visible in the process arguments.
+          git -c credential.helper= \
+              -c credential.helper='!f() { echo username=x-access-token; echo "password=${GH_APP_TOKEN}"; }; f' \
+              push origin "HEAD:refs/heads/${TARGET_REF}"

--- a/.github/workflows/chart-chores.yaml
+++ b/.github/workflows/chart-chores.yaml
@@ -46,6 +46,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
           token: "${{ steps.generate-github-token.outputs.token }}"
+          # Credentials are re-introduced only in the final push step.
+          persist-credentials: false
       - name: Configure curl and wget
         uses: ./.github/actions/setup-curl
       #
@@ -96,7 +98,23 @@ jobs:
       - name: Git pull
         run: git pull --rebase --autostash .
       - uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
+        id: commit
         with:
           author_name: "distro-ci[bot]"
           author_email: "122795778+distro-ci[bot]@users.noreply.github.com"
           message: "chore: chart chores"
+          # Pushing is done by the next step; checkout does not persist credentials.
+          push: false
+      - name: Push changes
+        if: steps.commit.outputs.committed == 'true'
+        env:
+          GH_APP_TOKEN: ${{ steps.generate-github-token.outputs.token }}
+          TARGET_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          TARGET_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+          # Credential is supplied per-command via a helper reading the step env, so the token is
+          # neither written to .git/config nor visible in the process arguments.
+          git -c credential.helper= \
+              -c credential.helper='!f() { echo username=x-access-token; echo "password=${GH_APP_TOKEN}"; }; f' \
+              push origin "HEAD:refs/heads/${TARGET_REF}"

--- a/.github/workflows/chart-chores.yaml
+++ b/.github/workflows/chart-chores.yaml
@@ -103,18 +103,21 @@ jobs:
           author_name: "distro-ci[bot]"
           author_email: "122795778+distro-ci[bot]@users.noreply.github.com"
           message: "chore: chart chores"
-          # Pushing is done by the next step; checkout does not persist credentials.
+          # Pushing is done by the next step; checkout does not persist credentials, so the
+          # action's own fetch and push must both be disabled.
+          fetch: false
           push: false
       - name: Push changes
         if: steps.commit.outputs.committed == 'true'
         env:
           GH_APP_TOKEN: ${{ steps.generate-github-token.outputs.token }}
-          TARGET_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           TARGET_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           set -euo pipefail
           # Credential is supplied per-command via a helper reading the step env, so the token is
-          # neither written to .git/config nor visible in the process arguments.
-          git -c credential.helper= \
+          # neither written to .git/config nor visible in the process arguments. hooksPath is
+          # neutralized so no repo-provided hook runs with the token in its environment.
+          git -c core.hooksPath=/dev/null \
+              -c credential.helper= \
               -c credential.helper='!f() { echo username=x-access-token; echo "password=${GH_APP_TOKEN}"; }; f' \
               push origin "HEAD:refs/heads/${TARGET_REF}"

--- a/.github/workflows/renovate-post-upgrade.yaml
+++ b/.github/workflows/renovate-post-upgrade.yaml
@@ -55,6 +55,8 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          # Credentials are re-introduced only in the final push step.
+          persist-credentials: false
       - name: Configure curl and wget
         uses: ./.github/actions/setup-curl
       #
@@ -134,7 +136,24 @@ jobs:
       - name: Git pull
         run: git pull --rebase --autostash .
       - uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
+        id: commit
         with:
           author_name: "renovate[bot]"
           author_email: "29139614+renovate[bot]@users.noreply.github.com"
           message: "chore(deps): post upgrade tasks - go mod tidy, update golden files, readme, and schema"
+          # Pushing is done by the next step; checkout does not persist credentials.
+          push: false
+      - name: Push changes
+        if: steps.commit.outputs.committed == 'true'
+        env:
+          GH_APP_TOKEN: ${{ steps.generate-github-token.outputs.token }}
+          # Mirrors how actions/checkout resolved its own repository/ref inputs.
+          TARGET_REPO: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          TARGET_REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
+        run: |
+          set -euo pipefail
+          # Credential is supplied per-command via a helper reading the step env, so the token is
+          # neither written to .git/config nor visible in the process arguments.
+          git -c credential.helper= \
+              -c credential.helper='!f() { echo username=x-access-token; echo "password=${GH_APP_TOKEN}"; }; f' \
+              push origin "HEAD:refs/heads/${TARGET_REF}"

--- a/.github/workflows/renovate-post-upgrade.yaml
+++ b/.github/workflows/renovate-post-upgrade.yaml
@@ -55,6 +55,8 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          # Credentials are re-introduced only in the final push step.
+          persist-credentials: false
       - name: Configure curl and wget
         uses: ./.github/actions/setup-curl
       #
@@ -134,7 +136,24 @@ jobs:
       - name: Git pull
         run: git pull --rebase --autostash .
       - uses: EndBug/add-and-commit@cc9c08ba6c8df3b93a8f2db63e89b98368ae2ae8 # v11.1.1
+        id: commit
         with:
           author_name: "renovate[bot]"
           author_email: "29139614+renovate[bot]@users.noreply.github.com"
           message: "chore(deps): post upgrade tasks - go mod tidy, update golden files, readme, and schema"
+          # Pushing is done by the next step; checkout does not persist credentials.
+          push: false
+      - name: Push changes
+        if: steps.commit.outputs.committed == 'true'
+        env:
+          GH_APP_TOKEN: ${{ steps.generate-github-token.outputs.token }}
+          # Mirrors how actions/checkout resolved its own repository/ref inputs.
+          TARGET_REPO: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          TARGET_REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
+        run: |
+          set -euo pipefail
+          # Credential is supplied per-command via a helper reading the step env, so the token is
+          # neither written to .git/config nor visible in the process arguments.
+          git -c credential.helper= \
+              -c credential.helper='!f() { echo username=x-access-token; echo "password=${GH_APP_TOKEN}"; }; f' \
+              push origin "HEAD:refs/heads/${TARGET_REF}"

--- a/.github/workflows/renovate-post-upgrade.yaml
+++ b/.github/workflows/renovate-post-upgrade.yaml
@@ -141,19 +141,21 @@ jobs:
           author_name: "renovate[bot]"
           author_email: "29139614+renovate[bot]@users.noreply.github.com"
           message: "chore(deps): post upgrade tasks - go mod tidy, update golden files, readme, and schema"
-          # Pushing is done by the next step; checkout does not persist credentials.
+          # Pushing is done by the next step; checkout does not persist credentials, so the
+          # action's own fetch and push must both be disabled.
+          fetch: false
           push: false
       - name: Push changes
         if: steps.commit.outputs.committed == 'true'
         env:
           GH_APP_TOKEN: ${{ steps.generate-github-token.outputs.token }}
-          # Mirrors how actions/checkout resolved its own repository/ref inputs.
-          TARGET_REPO: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-          TARGET_REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          TARGET_REF: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           # Credential is supplied per-command via a helper reading the step env, so the token is
-          # neither written to .git/config nor visible in the process arguments.
-          git -c credential.helper= \
+          # neither written to .git/config nor visible in the process arguments. hooksPath is
+          # neutralized so no repo-provided hook runs with the token in its environment.
+          git -c core.hooksPath=/dev/null \
+              -c credential.helper= \
               -c credential.helper='!f() { echo username=x-access-token; echo "password=${GH_APP_TOKEN}"; }; f' \
               push origin "HEAD:refs/heads/${TARGET_REF}"


### PR DESCRIPTION
Workflow credential-handling hardening.

Tracked under **INC-7027** — rationale, analysis and review notes are in the incident ticket and are intentionally not repeated here.

**Not tested.** YAML and step ordering were validated; the runtime path has not been exercised. Please confirm on a throwaway run before merging.

Questions to the incident channel or the ticket, please — not this thread.
