### PR TITLE
test: [UPGPATH 4/13] separate harness scaffolding from customer steps

### DIFF
--- a/.github/workflows/upgrade-paths.yaml
+++ b/.github/workflows/upgrade-paths.yaml
@@ -1,0 +1,132 @@
+name: "Upgrade Paths - Render"
+
+# Renders each upgrade-path archetype against the target chart twice: once with
+# the source chart's values unchanged (Run A) and once with the transition's
+# delta applied (Run B). Cluster-stage checks (data survival, orphaned
+# resources, migration duration) are out of scope here.
+
+on:
+  pull_request:
+    paths:
+      - "charts/camunda-platform-*/values.yaml"
+      - "charts/camunda-platform-*/templates/common/constraints.tpl"
+      - "charts/camunda-platform-*/test/integration/scenarios/chart-full-setup/values/**"
+      - "test/upgrade-paths/**"
+      - "scripts/upgrade-paths/**"
+      - ".github/workflows/upgrade-paths.yaml"
+  merge_group: {}
+  schedule:
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+    inputs:
+      transitions:
+        description: "Space-separated from:to pairs, e.g. '8.9:8.10 8.8:8.9'. Empty runs all."
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: upgrade-paths-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  matrix:
+    name: Resolve transitions
+    runs-on: ubuntu-latest
+    outputs:
+      transitions: ${{ steps.resolve.outputs.transitions }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+
+      - name: Resolve transitions
+        id: resolve
+        env:
+          REQUESTED: ${{ inputs.transitions }}
+        run: |
+          set -euo pipefail
+          if [ -n "${REQUESTED}" ]; then
+            items=$(for p in ${REQUESTED}; do
+              printf '{"from":"%s","to":"%s"}\n' "${p%%:*}" "${p##*:}"
+            done | jq -sc .)
+          else
+            # Each transitions/<from>-to-<to> directory is one runnable pair.
+            items=$(find test/upgrade-paths/transitions -mindepth 1 -maxdepth 1 -type d -printf '%f\n' \
+              | sed -E 's/^(.+)-to-(.+)$/{"from":"\1","to":"\2"}/' \
+              | jq -sc .)
+          fi
+          echo "transitions=${items}" >>"$GITHUB_OUTPUT"
+          echo "Resolved: ${items}"
+
+  render:
+    name: ${{ matrix.transition.from }} to ${{ matrix.transition.to }}
+    needs: matrix
+    if: needs.matrix.outputs.transitions != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        transition: ${{ fromJson(needs.matrix.outputs.transitions) }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+
+      # Doc coverage compares each discovered key against the published upgrade
+      # guide. Without this checkout the column renders as "not checked".
+      - name: Checkout camunda-docs
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        continue-on-error: true
+        with:
+          repository: camunda/camunda-docs
+          path: .camunda-docs
+          fetch-depth: 1
+
+      - name: Install tools
+        uses: ./.github/actions/install-tool-versions
+        with:
+          tools: |
+            helm
+            golang
+
+      - name: Build upgrade-paths
+        run: cd scripts/upgrade-paths && go build -o "${RUNNER_TEMP}/upgrade-paths" .
+
+      - name: Render upgrade paths
+        id: render
+        env:
+          FROM: ${{ matrix.transition.from }}
+          TO: ${{ matrix.transition.to }}
+        run: |
+          set -uo pipefail
+          "${RUNNER_TEMP}/upgrade-paths" \
+            --from "${FROM}" --to "${TO}" \
+            --discover \
+            --docs-root "${GITHUB_WORKSPACE}/.camunda-docs" \
+            --quiet \
+            --markdown "${RUNNER_TEMP}/report-${FROM}-to-${TO}.md" \
+            --json "${RUNNER_TEMP}/report-${FROM}-to-${TO}.json"
+          echo "exit_code=$?" >>"$GITHUB_OUTPUT"
+
+      - name: Publish report
+        if: always()
+        env:
+          FROM: ${{ matrix.transition.from }}
+          TO: ${{ matrix.transition.to }}
+        run: cat "${RUNNER_TEMP}/report-${FROM}-to-${TO}.md" >>"$GITHUB_STEP_SUMMARY" || true
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: upgrade-path-report-${{ matrix.transition.from }}-to-${{ matrix.transition.to }}
+          path: ${{ runner.temp }}/report-*
+          if-no-files-found: warn
+
+      # UNREMEDIATED (no known remedy) and STALE_DELTA (fixture lies) fail.
+      # REMEDIATED does not: a break with a tested delta is the expected
+      # mid-cycle state, and the report is the deliverable.
+      - name: Enforce outcome
+        if: steps.render.outputs.exit_code != '0'
+        run: |
+          echo "::error::Upgrade path check failed - see the job summary for the outcome matrix."
+          exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ scripts/deploy-camunda/deploy-camunda
 scripts/deploy-camunda/.env
 scripts/release-tools/release-tools
 scripts/integration-tests-gate/integration-tests-gate
+scripts/upgrade-paths/upgrade-paths
 
 charts/camunda-platform*/test/e2e/package-lock.json
 

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,20 @@ build.release-tools:
 install.release-tools:
 	cd scripts/release-tools && go mod tidy && go install .
 
+.PHONY: build.upgrade-paths
+build.upgrade-paths:
+	cd scripts/upgrade-paths && go mod tidy && go build .
+
+.PHONY: install.upgrade-paths
+install.upgrade-paths:
+	cd scripts/upgrade-paths && go mod tidy && go install .
+
+.PHONY: upgrade-paths.report
+upgrade-paths.report: install.upgrade-paths
+	@test -n "$(from)" || (echo "usage: make upgrade-paths.report from=8.9 to=8.10" && exit 2)
+	@test -n "$(to)" || (echo "usage: make upgrade-paths.report from=8.9 to=8.10" && exit 2)
+	upgrade-paths --from $(from) --to $(to) --discover
+
 .PHONY: build.dx-tooling
 build.dx-tooling:
 	make build.prepare-helm-values

--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -752,6 +752,49 @@ integration:
               mode with SKIP_HELM_UPGRADE=true (data-only; the matrix runner performs the
               chart upgrade). This keeps users/realm alive across the upgrade that removes the
               bundled Bitnami subcharts.
+        - name: upgrade-path-classic
+          enabled: false
+          shortname: upclas
+          auth: keycloak
+          flow: upgrade-path
+          platforms:
+            - gke
+          exclude: []
+          tier: 2
+          infra-type:
+            eks: preemptible
+            gke: distroci
+          identity: keycloak
+          persistence: elasticsearch
+          features:
+            - hub-legacy
+            - postgresql-companion
+          dependencies:
+            - chart: charts/internal-keycloak-26
+              release-name: keycloak
+              values-file: test/integration/companion-values/keycloak.yaml
+            - chart: elastic/elasticsearch
+              version: 8.5.1
+              release-name: elasticsearch
+              values-file: test/integration/companion-values/elasticsearch.yaml
+              repo-name: elastic
+              repo-url: https://helm.elastic.co
+            - chart: charts/internal-postgresql
+              release-name: postgresql
+              values-file: test/integration/companion-values/postgresql.yaml
+              env-vars:
+                - RDBMS_POSTGRESQL_USERNAME
+                - RDBMS_POSTGRESQL_PASSWORD
+          post-infra:
+            script: post-infra-bitnami-migration.sh
+            description: |
+              After the companion PostgreSQL/Keycloak/Elasticsearch are deployed but before
+              the chart upgrade to 8.10, migrate the bundled (Bitnami) Keycloak realm and the
+              Elasticsearch authorization indices off the bundled backends onto the companion
+              services. Uses the camunda-deployment-references migration scripts in external
+              mode with SKIP_HELM_UPGRADE=true (data-only; the matrix runner performs the
+              chart upgrade). This keeps users/realm alive across the upgrade that removes the
+              bundled Bitnami subcharts.
         - name: hub-mixed
           enabled: true
           shortname: hubmu

--- a/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
@@ -101,6 +101,10 @@ integration:
       shortname: hublu
       tier: 2
       enabled: true
+    - id: upgrade-path-classic
+      shortname: upclas
+      tier: 2
+      enabled: false
     - id: hub-mixed
       shortname: hubmu
       tier: 2

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/upgrade-path-classic.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/upgrade-path-classic.yaml
@@ -1,0 +1,19 @@
+name: upgrade-path-classic
+auth: keycloak
+flows:
+  - upgrade-path
+identity: keycloak
+persistence: elasticsearch
+features:
+  - hub-legacy
+  - postgresql-companion
+platforms:
+  - gke
+infra-type:
+  eks: preemptible
+  gke: distroci
+post-infra: post-infra-bitnami-migration
+dependencies:
+  - keycloak
+  - elasticsearch
+  - postgresql

--- a/scripts/camunda-core/go.mod
+++ b/scripts/camunda-core/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/jwalton/gchalk v1.3.0
 	github.com/rs/zerolog v1.35.1
 	github.com/spf13/cobra v1.10.2
+	github.com/stretchr/testify v1.9.0
 	golang.org/x/term v0.45.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.31.1
@@ -39,6 +40,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	golang.org/x/net v0.55.0 // indirect

--- a/scripts/camunda-core/pkg/chartvalues/chartvalues.go
+++ b/scripts/camunda-core/pkg/chartvalues/chartvalues.go
@@ -1,0 +1,351 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package chartvalues consolidates Helm values documents and applies upgrade
+// deltas to them.
+//
+// Chart constraints test key presence with hasKey, so a key cannot be cleared
+// by layering an overlay that sets it to null — it must be removed from the
+// merged document. A delta therefore supports a "$remove" directive listing
+// dotted key paths to delete, alongside the keys it sets.
+package chartvalues
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Directive keys a delta may carry alongside the values it sets.
+const (
+	// RemoveDirective holds dotted paths to delete.
+	RemoveDirective = "$remove"
+	// RenameDirective maps an old dotted path to a new one, moving the value.
+	RenameDirective = "$rename"
+)
+
+// Values is a parsed Helm values document.
+type Values map[string]any
+
+// LoadFile reads a YAML values file. A file containing only comments or
+// whitespace yields an empty, non-nil Values.
+func LoadFile(path string) (Values, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read values %s: %w", path, err)
+	}
+	v := Values{}
+	if err := yaml.Unmarshal(b, &v); err != nil {
+		return nil, fmt.Errorf("parse values %s: %w", path, err)
+	}
+	if v == nil {
+		v = Values{}
+	}
+	return v, nil
+}
+
+// WriteFile serialises a values document.
+func WriteFile(path string, v Values) error {
+	b, err := yaml.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("marshal values: %w", err)
+	}
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		return fmt.Errorf("write values %s: %w", path, err)
+	}
+	return nil
+}
+
+// Merge deep-merges src into a copy of dst, matching how Helm layers successive
+// -f arguments: maps merge recursively, scalars and arrays are replaced.
+func Merge(dst, src Values) Values {
+	out := make(Values, len(dst)+len(src))
+	for k, v := range dst {
+		out[k] = v
+	}
+	for k, v := range src {
+		if existing, ok := out[k]; ok {
+			em, eok := toMap(existing)
+			vm, vok := toMap(v)
+			if eok && vok {
+				out[k] = Merge(em, vm)
+				continue
+			}
+		}
+		out[k] = v
+	}
+	return out
+}
+
+// DeepCopy returns a copy whose nested maps and slices are independent of the
+// original. Merge shares references to nested maps it does not have to merge,
+// so callers that mutate a merged document must copy first.
+func DeepCopy(v Values) Values {
+	out := make(Values, len(v))
+	for k, val := range v {
+		out[k] = deepCopyValue(val)
+	}
+	return out
+}
+
+func deepCopyValue(v any) any {
+	if m, ok := toMap(v); ok {
+		return DeepCopy(m)
+	}
+	if s, ok := v.([]any); ok {
+		out := make([]any, len(s))
+		for i, item := range s {
+			out[i] = deepCopyValue(item)
+		}
+		return out
+	}
+	return v
+}
+
+// MergeFiles loads and merges files left to right.
+func MergeFiles(paths []string) (Values, error) {
+	out := Values{}
+	for _, p := range paths {
+		v, err := LoadFile(p)
+		if err != nil {
+			return nil, err
+		}
+		out = Merge(out, v)
+	}
+	return out, nil
+}
+
+// DeleteKey removes a dotted key path, reporting whether anything was removed.
+// Only the leaf is removed; emptied parent maps are left in place.
+func DeleteKey(v Values, dotted string) bool {
+	parts := strings.Split(dotted, ".")
+	cur := v
+	for i, p := range parts {
+		if i == len(parts)-1 {
+			if _, ok := cur[p]; !ok {
+				return false
+			}
+			delete(cur, p)
+			return true
+		}
+		next, ok := toMap(cur[p])
+		if !ok {
+			return false
+		}
+		cur = next
+	}
+	return false
+}
+
+// HasKey reports whether a dotted key path is present.
+func HasKey(v Values, dotted string) bool {
+	parts := strings.Split(dotted, ".")
+	cur := v
+	for i, p := range parts {
+		if i == len(parts)-1 {
+			_, ok := cur[p]
+			return ok
+		}
+		next, ok := toMap(cur[p])
+		if !ok {
+			return false
+		}
+		cur = next
+	}
+	return false
+}
+
+// GetKey returns the value at a dotted key path.
+func GetKey(v Values, dotted string) (any, bool) {
+	parts := strings.Split(dotted, ".")
+	cur := v
+	for i, p := range parts {
+		if i == len(parts)-1 {
+			got, ok := cur[p]
+			return got, ok
+		}
+		next, ok := toMap(cur[p])
+		if !ok {
+			return nil, false
+		}
+		cur = next
+	}
+	return nil, false
+}
+
+// SetKey writes a value at a dotted key path, creating intermediate maps.
+// Returns false when an intermediate segment holds a non-map.
+func SetKey(v Values, dotted string, val any) bool {
+	parts := strings.Split(dotted, ".")
+	cur := v
+	for i, p := range parts {
+		if i == len(parts)-1 {
+			cur[p] = val
+			return true
+		}
+		next, ok := toMap(cur[p])
+		if !ok {
+			if _, exists := cur[p]; exists {
+				return false
+			}
+			next = Values{}
+			cur[p] = next
+		} else {
+			cur[p] = next
+		}
+		cur = next
+	}
+	return false
+}
+
+// Delta is an upgrade delta: keys to set, plus paths to remove.
+type Delta struct {
+	// Remove holds dotted key paths, sorted for deterministic application.
+	Remove []string
+	// Rename maps old dotted paths to new ones, moving the existing value.
+	Rename map[string]string
+	// Set holds the delta's remaining keys.
+	Set Values
+}
+
+// LoadDelta reads a delta file and splits its directives from the keys it sets.
+// A missing or empty file yields an empty Delta.
+func LoadDelta(path string) (Delta, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return Delta{Set: Values{}}, fmt.Errorf("read delta %s: %w", path, err)
+	}
+	return ParseDelta(b, path)
+}
+
+// ParseDelta splits directives from set keys in already-read delta content.
+// name is used only in error messages.
+func ParseDelta(data []byte, name string) (Delta, error) {
+	var d Delta
+	d.Set = Values{}
+
+	raw := Values{}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return d, fmt.Errorf("parse delta %s: %w", name, err)
+	}
+
+	for k, v := range raw {
+		switch k {
+		case RemoveDirective:
+			items, ok := v.([]any)
+			if !ok {
+				return d, fmt.Errorf("%s: %q must be a list of dotted key paths", name, RemoveDirective)
+			}
+			for _, item := range items {
+				s, ok := item.(string)
+				if !ok {
+					return d, fmt.Errorf("%s: %q entries must be strings, got %T", name, RemoveDirective, item)
+				}
+				if s = strings.TrimSpace(s); s != "" {
+					d.Remove = append(d.Remove, s)
+				}
+			}
+		case RenameDirective:
+			m, ok := toMap(v)
+			if !ok {
+				return d, fmt.Errorf("%s: %q must be a map of old to new dotted key paths", name, RenameDirective)
+			}
+			d.Rename = map[string]string{}
+			for old, newVal := range m {
+				s, ok := newVal.(string)
+				if !ok {
+					return d, fmt.Errorf("%s: %q target for %q must be a string, got %T",
+						name, RenameDirective, old, newVal)
+				}
+				d.Rename[old] = strings.TrimSpace(s)
+			}
+		default:
+			d.Set[k] = v
+		}
+	}
+	sort.Strings(d.Remove)
+	return d, nil
+}
+
+// Apply renames, then removes, then merges the delta's keys into base.
+//
+// Renames run first so a moved value survives a subsequent removal of its old
+// parent. A rename whose source is absent is skipped.
+func (d Delta) Apply(base Values) Values {
+	out := DeepCopy(base)
+
+	for _, old := range sortedKeys(d.Rename) {
+		val, ok := GetKey(out, old)
+		if !ok {
+			continue
+		}
+		if SetKey(out, d.Rename[old], val) {
+			DeleteKey(out, old)
+		}
+	}
+
+	for _, path := range d.Remove {
+		DeleteKey(out, path)
+	}
+	return Merge(out, d.Set)
+}
+
+func sortedKeys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// IsEmpty reports whether the delta would change nothing.
+func (d Delta) IsEmpty() bool {
+	return len(d.Remove) == 0 && len(d.Rename) == 0 && len(d.Set) == 0
+}
+
+// Consolidate merges layers, applies an optional delta, and writes the result
+// to outPath as a single values file.
+func Consolidate(layers []string, deltaPath, outPath string) (Values, error) {
+	merged, err := MergeFiles(layers)
+	if err != nil {
+		return nil, err
+	}
+	if deltaPath != "" {
+		d, err := LoadDelta(deltaPath)
+		if err != nil {
+			return nil, err
+		}
+		merged = d.Apply(merged)
+	}
+	if err := WriteFile(outPath, merged); err != nil {
+		return nil, err
+	}
+	return merged, nil
+}
+
+// toMap normalises the two map shapes yaml.v3 can produce.
+func toMap(v any) (Values, bool) {
+	switch m := v.(type) {
+	case Values:
+		return m, true
+	case map[string]any:
+		return Values(m), true
+	default:
+		return nil, false
+	}
+}

--- a/scripts/camunda-core/pkg/chartvalues/chartvalues.go
+++ b/scripts/camunda-core/pkg/chartvalues/chartvalues.go
@@ -36,6 +36,11 @@ const (
 	RemoveDirective = "$remove"
 	// RenameDirective maps an old dotted path to a new one, moving the value.
 	RenameDirective = "$rename"
+	// ScaffoldingDirective holds values applied like any other, but excluded
+	// from the customer-facing change list. Baselines composed from CI scenario
+	// values carry test fixtures alongside product configuration; both must be
+	// applied for a run to succeed, only one belongs in an upgrade guide.
+	ScaffoldingDirective = "$scaffolding"
 )
 
 // Values is a parsed Helm values document.
@@ -220,6 +225,8 @@ type Delta struct {
 	Rename map[string]string
 	// Set holds the delta's remaining keys.
 	Set Values
+	// Scaffolding holds harness-only values, applied but not customer-facing.
+	Scaffolding Values
 }
 
 // LoadDelta reads a delta file and splits its directives from the keys it sets.
@@ -259,6 +266,12 @@ func ParseDelta(data []byte, name string) (Delta, error) {
 					d.Remove = append(d.Remove, s)
 				}
 			}
+		case ScaffoldingDirective:
+			m, ok := toMap(v)
+			if !ok {
+				return d, fmt.Errorf("%s: %q must be a map of values", name, ScaffoldingDirective)
+			}
+			d.Scaffolding = m
 		case RenameDirective:
 			m, ok := toMap(v)
 			if !ok {
@@ -301,7 +314,8 @@ func (d Delta) Apply(base Values) Values {
 	for _, path := range d.Remove {
 		DeleteKey(out, path)
 	}
-	return Merge(out, d.Set)
+	out = Merge(out, d.Set)
+	return Merge(out, d.Scaffolding)
 }
 
 func sortedKeys(m map[string]string) []string {
@@ -315,7 +329,37 @@ func sortedKeys(m map[string]string) []string {
 
 // IsEmpty reports whether the delta would change nothing.
 func (d Delta) IsEmpty() bool {
-	return len(d.Remove) == 0 && len(d.Rename) == 0 && len(d.Set) == 0
+	return len(d.Remove) == 0 && len(d.Rename) == 0 &&
+		len(d.Set) == 0 && len(d.Scaffolding) == 0
+}
+
+// LeafPaths returns the dotted paths of every non-map value, sorted. A path
+// stops descending at the first value that is not a map, so a list or scalar is
+// reported at the key that holds it.
+func LeafPaths(v Values) []string {
+	var out []string
+	var walk func(Values, string)
+	walk = func(n Values, pre string) {
+		for k, val := range n {
+			p := k
+			if pre != "" {
+				p = pre + "." + k
+			}
+			if m, ok := toMap(val); ok && len(m) > 0 {
+				walk(m, p)
+				continue
+			}
+			out = append(out, p)
+		}
+	}
+	walk(v, "")
+	sort.Strings(out)
+	return out
+}
+
+// HasScaffolding reports whether the delta carries harness-only values.
+func (d Delta) HasScaffolding() bool {
+	return len(d.Scaffolding) > 0
 }
 
 // Consolidate merges layers, applies an optional delta, and writes the result

--- a/scripts/camunda-core/pkg/chartvalues/chartvalues_test.go
+++ b/scripts/camunda-core/pkg/chartvalues/chartvalues_test.go
@@ -1,0 +1,359 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chartvalues
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func write(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+	require.NoError(t, os.WriteFile(p, []byte(body), 0o644))
+	return p
+}
+
+func TestLoadFile(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("parses keys", func(t *testing.T) {
+		v, err := LoadFile(write(t, dir, "a.yaml", "global:\n  host: example.com\n"))
+		require.NoError(t, err)
+		assert.True(t, HasKey(v, "global.host"))
+	})
+
+	t.Run("comment-only file yields empty non-nil", func(t *testing.T) {
+		v, err := LoadFile(write(t, dir, "c.yaml", "# nothing here\n"))
+		require.NoError(t, err)
+		require.NotNil(t, v)
+		assert.Empty(t, v)
+	})
+
+	t.Run("missing file errors", func(t *testing.T) {
+		_, err := LoadFile(filepath.Join(dir, "nope.yaml"))
+		require.Error(t, err)
+	})
+
+	t.Run("malformed yaml errors", func(t *testing.T) {
+		_, err := LoadFile(write(t, dir, "bad.yaml", "key: [unclosed\n"))
+		require.Error(t, err)
+	})
+}
+
+func TestMergeFiles(t *testing.T) {
+	dir := t.TempDir()
+	base := write(t, dir, "base.yaml",
+		"global:\n  a: 1\n  nested:\n    x: base\nlist:\n  - one\n  - two\n")
+	over := write(t, dir, "over.yaml",
+		"global:\n  b: 2\n  nested:\n    y: over\nlist:\n  - only\n")
+
+	got, err := MergeFiles([]string{base, over})
+	require.NoError(t, err)
+
+	g, ok := toMap(got["global"])
+	require.True(t, ok)
+	assert.Equal(t, 1, g["a"])
+	assert.Equal(t, 2, g["b"])
+
+	n, ok := toMap(g["nested"])
+	require.True(t, ok)
+	assert.Equal(t, "base", n["x"])
+	assert.Equal(t, "over", n["y"], "maps merge recursively")
+
+	assert.Len(t, got["list"], 1, "arrays are replaced wholesale, matching Helm")
+}
+
+func TestMergeDoesNotMutateInputs(t *testing.T) {
+	a := Values{"global": Values{"x": 1}}
+	b := Values{"global": Values{"y": 2}}
+
+	_ = Merge(a, b)
+
+	ag, _ := toMap(a["global"])
+	assert.Len(t, ag, 1, "merge must not write into its arguments")
+}
+
+func TestDeleteKey(t *testing.T) {
+	newVals := func() Values {
+		return Values{
+			"global": Values{"ingress": Values{"host": "example.com", "enabled": true}},
+			"top":    "value",
+		}
+	}
+
+	t.Run("removes a nested leaf and keeps siblings", func(t *testing.T) {
+		v := newVals()
+		assert.True(t, DeleteKey(v, "global.ingress.host"))
+		assert.False(t, HasKey(v, "global.ingress.host"))
+		assert.True(t, HasKey(v, "global.ingress.enabled"))
+	})
+
+	t.Run("removes a top-level key", func(t *testing.T) {
+		v := newVals()
+		assert.True(t, DeleteKey(v, "top"))
+		assert.False(t, HasKey(v, "top"))
+	})
+
+	t.Run("leaves the parent map in place", func(t *testing.T) {
+		v := newVals()
+		DeleteKey(v, "global.ingress.host")
+		DeleteKey(v, "global.ingress.enabled")
+		assert.True(t, HasKey(v, "global.ingress"), "emptied parents are meaningful to the chart")
+	})
+
+	t.Run("reports absent paths", func(t *testing.T) {
+		v := newVals()
+		assert.False(t, DeleteKey(v, "global.ingress.missing"))
+		assert.False(t, DeleteKey(v, "nope.nope"))
+		assert.False(t, DeleteKey(v, "top.deeper"), "cannot descend through a scalar")
+	})
+}
+
+func TestLoadDelta(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("splits remove directive from set keys", func(t *testing.T) {
+		p := write(t, dir, "d.yaml", `
+$remove:
+  - identityKeycloak
+  - global.ingress.host
+identity:
+  externalDatabase:
+    host: pg.example.com
+`)
+		d, err := LoadDelta(p)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"global.ingress.host", "identityKeycloak"}, d.Remove,
+			"sorted for deterministic application")
+		assert.True(t, HasKey(d.Set, "identity.externalDatabase.host"))
+		assert.NotContains(t, d.Set, RemoveDirective, "the directive is not a values key")
+		assert.False(t, d.IsEmpty())
+	})
+
+	t.Run("empty file is an empty delta", func(t *testing.T) {
+		d, err := LoadDelta(write(t, dir, "empty.yaml", "# no changes yet\n"))
+		require.NoError(t, err)
+		assert.True(t, d.IsEmpty())
+	})
+
+	t.Run("blank entries are skipped", func(t *testing.T) {
+		d, err := LoadDelta(write(t, dir, "blank.yaml", "$remove:\n  - \"\"\n  - a.b\n"))
+		require.NoError(t, err)
+		assert.Equal(t, []string{"a.b"}, d.Remove)
+	})
+
+	t.Run("non-list remove directive errors", func(t *testing.T) {
+		_, err := LoadDelta(write(t, dir, "bad1.yaml", "$remove: identityKeycloak\n"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be a list")
+	})
+
+	t.Run("non-string entry errors", func(t *testing.T) {
+		_, err := LoadDelta(write(t, dir, "bad2.yaml", "$remove:\n  - 42\n"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be strings")
+	})
+}
+
+func TestDeltaApply(t *testing.T) {
+	base := Values{
+		"global":           Values{"ingress": Values{"host": "old.example.com"}},
+		"identityKeycloak": Values{"enabled": true},
+		"keep":             "untouched",
+	}
+
+	d := Delta{
+		Remove: []string{"identityKeycloak", "global.ingress.host"},
+		Set:    Values{"identity": Values{"externalDatabase": Values{"host": "pg"}}},
+	}
+
+	got := d.Apply(base)
+
+	assert.False(t, HasKey(got, "identityKeycloak"))
+	assert.False(t, HasKey(got, "global.ingress.host"))
+	assert.True(t, HasKey(got, "identity.externalDatabase.host"))
+	assert.Equal(t, "untouched", got["keep"])
+
+	assert.True(t, HasKey(base, "identityKeycloak"), "Apply must not mutate its input")
+}
+
+func TestDeltaApplyRemovesBeforeSetting(t *testing.T) {
+	base := Values{"auth": Values{"legacy": true}}
+	d := Delta{
+		Remove: []string{"auth.legacy"},
+		Set:    Values{"auth": Values{"legacy": "re-added"}},
+	}
+
+	got := d.Apply(base)
+	assert.Equal(t, "re-added", mustMap(t, got["auth"])["legacy"],
+		"a delta can drop a key and re-add it")
+}
+
+func TestConsolidate(t *testing.T) {
+	dir := t.TempDir()
+	l1 := write(t, dir, "l1.yaml", "identityKeycloak:\n  enabled: true\nkeep: yes\n")
+	l2 := write(t, dir, "l2.yaml", "global:\n  ingress:\n    host: old\n")
+	delta := write(t, dir, "delta.yaml", "$remove:\n  - identityKeycloak\n  - global.ingress.host\nadded: true\n")
+	out := filepath.Join(dir, "out.yaml")
+
+	got, err := Consolidate([]string{l1, l2}, delta, out)
+	require.NoError(t, err)
+
+	assert.False(t, HasKey(got, "identityKeycloak"))
+	assert.False(t, HasKey(got, "global.ingress.host"))
+	assert.True(t, HasKey(got, "added"))
+
+	reread, err := LoadFile(out)
+	require.NoError(t, err)
+	assert.Equal(t, got, reread, "the written file matches the returned document")
+}
+
+func TestConsolidateWithoutDelta(t *testing.T) {
+	dir := t.TempDir()
+	l1 := write(t, dir, "l1.yaml", "identityKeycloak:\n  enabled: true\n")
+	out := filepath.Join(dir, "out.yaml")
+
+	got, err := Consolidate([]string{l1}, "", out)
+	require.NoError(t, err)
+	assert.True(t, HasKey(got, "identityKeycloak"), "no delta leaves the merge untouched")
+}
+
+func mustMap(t *testing.T, v any) Values {
+	t.Helper()
+	m, ok := toMap(v)
+	require.True(t, ok)
+	return m
+}
+
+func TestLoadDeltaRename(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("parses rename map", func(t *testing.T) {
+		p := write(t, dir, "r.yaml", "$rename:\n  global.ingress.host: global.host\n$remove:\n  - elasticsearch\nkeep: 1\n")
+		d, err := LoadDelta(p)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"global.ingress.host": "global.host"}, d.Rename)
+		assert.Equal(t, []string{"elasticsearch"}, d.Remove)
+		assert.NotContains(t, d.Set, RenameDirective)
+		assert.Contains(t, d.Set, "keep")
+	})
+
+	t.Run("non-map rename errors", func(t *testing.T) {
+		_, err := LoadDelta(write(t, dir, "r2.yaml", "$rename:\n  - a\n"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be a map")
+	})
+
+	t.Run("non-string target errors", func(t *testing.T) {
+		_, err := LoadDelta(write(t, dir, "r3.yaml", "$rename:\n  a.b: 42\n"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be a string")
+	})
+
+	t.Run("rename alone is not empty", func(t *testing.T) {
+		d, err := LoadDelta(write(t, dir, "r4.yaml", "$rename:\n  a: b\n"))
+		require.NoError(t, err)
+		assert.False(t, d.IsEmpty())
+	})
+}
+
+func TestDeltaApplyRename(t *testing.T) {
+	t.Run("moves the value and clears the old path", func(t *testing.T) {
+		base := Values{"global": Values{"ingress": Values{"host": "ns.example.com"}}}
+		d := Delta{Rename: map[string]string{"global.ingress.host": "global.host"}}
+
+		got := d.Apply(base)
+
+		v, ok := GetKey(got, "global.host")
+		require.True(t, ok)
+		assert.Equal(t, "ns.example.com", v, "the environment-specific value is preserved")
+		assert.False(t, HasKey(got, "global.ingress.host"))
+	})
+
+	t.Run("absent source is skipped", func(t *testing.T) {
+		base := Values{"other": 1}
+		d := Delta{Rename: map[string]string{"global.ingress.host": "global.host"}}
+
+		got := d.Apply(base)
+		assert.False(t, HasKey(got, "global.host"))
+	})
+
+	t.Run("rename runs before remove", func(t *testing.T) {
+		base := Values{"global": Values{"ingress": Values{"host": "h", "other": 1}}}
+		d := Delta{
+			Rename: map[string]string{"global.ingress.host": "global.host"},
+			Remove: []string{"global.ingress"},
+		}
+
+		got := d.Apply(base)
+		v, ok := GetKey(got, "global.host")
+		require.True(t, ok, "the moved value survives removal of its old parent")
+		assert.Equal(t, "h", v)
+		assert.False(t, HasKey(got, "global.ingress"))
+	})
+
+	t.Run("does not mutate its input", func(t *testing.T) {
+		base := Values{"global": Values{"ingress": Values{"host": "h"}}}
+		d := Delta{Rename: map[string]string{"global.ingress.host": "global.host"}}
+		_ = d.Apply(base)
+		assert.True(t, HasKey(base, "global.ingress.host"))
+	})
+}
+
+func TestSetKey(t *testing.T) {
+	t.Run("creates intermediate maps", func(t *testing.T) {
+		v := Values{}
+		assert.True(t, SetKey(v, "a.b.c", "x"))
+		got, ok := GetKey(v, "a.b.c")
+		require.True(t, ok)
+		assert.Equal(t, "x", got)
+	})
+
+	t.Run("refuses to descend through a scalar", func(t *testing.T) {
+		v := Values{"a": "scalar"}
+		assert.False(t, SetKey(v, "a.b", "x"))
+		assert.Equal(t, "scalar", v["a"])
+	})
+}
+
+func TestDeepCopyIsolatesNestedMutation(t *testing.T) {
+	base := Values{
+		"global": Values{"ingress": Values{"host": "h"}},
+		"list":   []any{Values{"name": "a"}},
+	}
+	cp := DeepCopy(base)
+
+	DeleteKey(cp, "global.ingress.host")
+	mustMap(t, cp["list"].([]any)[0])["name"] = "changed"
+
+	assert.True(t, HasKey(base, "global.ingress.host"), "nested maps are independent")
+	assert.Equal(t, "a", mustMap(t, base["list"].([]any)[0])["name"], "slices are independent")
+}
+
+func TestDeltaApplyDoesNotMutateNestedInput(t *testing.T) {
+	base := Values{"global": Values{"ingress": Values{"host": "h", "keep": 1}}}
+	d := Delta{Remove: []string{"global.ingress.host"}}
+
+	_ = d.Apply(base)
+
+	assert.True(t, HasKey(base, "global.ingress.host"),
+		"a nested removal must not reach back into the caller's document")
+}

--- a/scripts/camunda-core/pkg/chartvalues/chartvalues_test.go
+++ b/scripts/camunda-core/pkg/chartvalues/chartvalues_test.go
@@ -357,3 +357,82 @@ func TestDeltaApplyDoesNotMutateNestedInput(t *testing.T) {
 	assert.True(t, HasKey(base, "global.ingress.host"),
 		"a nested removal must not reach back into the caller's document")
 }
+
+func TestLoadDeltaScaffolding(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("splits scaffolding from customer-facing keys", func(t *testing.T) {
+		p := write(t, dir, "s.yaml", `
+$remove:
+  - identityKeycloak
+global:
+  host: example.com
+$scaffolding:
+  identity:
+    initContainers:
+      - name: wait-for-keycloak
+`)
+		d, err := LoadDelta(p)
+		require.NoError(t, err)
+		assert.True(t, HasKey(d.Set, "global.host"), "product config stays customer-facing")
+		assert.False(t, HasKey(d.Set, "identity.initContainers"), "scaffolding is not in Set")
+		assert.True(t, HasKey(d.Scaffolding, "identity.initContainers"))
+		assert.True(t, d.HasScaffolding())
+	})
+
+	t.Run("scaffolding alone is not an empty delta", func(t *testing.T) {
+		d, err := LoadDelta(write(t, dir, "s2.yaml", "$scaffolding:\n  a: 1\n"))
+		require.NoError(t, err)
+		assert.False(t, d.IsEmpty())
+	})
+
+	t.Run("non-map scaffolding errors", func(t *testing.T) {
+		_, err := LoadDelta(write(t, dir, "s3.yaml", "$scaffolding:\n  - a\n"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be a map")
+	})
+
+	t.Run("no scaffolding leaves it absent", func(t *testing.T) {
+		d, err := LoadDelta(write(t, dir, "s4.yaml", "$remove:\n  - a\n"))
+		require.NoError(t, err)
+		assert.False(t, d.HasScaffolding())
+	})
+}
+
+func TestDeltaApplyAppliesScaffolding(t *testing.T) {
+	base := Values{"identity": Values{"initContainers": []any{Values{"name": "old"}}}}
+	d := Delta{
+		Set:         Values{"global": Values{"host": "h"}},
+		Scaffolding: Values{"identity": Values{"initContainers": []any{Values{"name": "new"}}}},
+	}
+
+	got := d.Apply(base)
+
+	assert.True(t, HasKey(got, "global.host"))
+	ics := got["identity"].(Values)["initContainers"].([]any)
+	assert.Equal(t, "new", mustMap(t, ics[0])["name"],
+		"scaffolding is applied so the run can succeed, even though it is not customer-facing")
+}
+
+func TestLeafPaths(t *testing.T) {
+	v := Values{
+		"identity": Values{
+			"initContainers":   []any{Values{"name": "x"}},
+			"externalDatabase": Values{"host": "pg", "port": 5432},
+		},
+		"top":   "scalar",
+		"empty": Values{},
+	}
+
+	assert.Equal(t, []string{
+		"empty",
+		"identity.externalDatabase.host",
+		"identity.externalDatabase.port",
+		"identity.initContainers",
+		"top",
+	}, LeafPaths(v), "descent stops at the first non-map, so a list is named by its key")
+}
+
+func TestLeafPathsEmpty(t *testing.T) {
+	assert.Empty(t, LeafPaths(Values{}))
+}

--- a/scripts/camunda-core/pkg/versionmatrix/versionmatrix.go
+++ b/scripts/camunda-core/pkg/versionmatrix/versionmatrix.go
@@ -158,14 +158,14 @@ func ResolveUpgradeFromVersion(repoRoot, appVersion, flow string) (string, error
 	switch flow {
 	case "upgrade-patch":
 		lookupVersion = appVersion
-	case "upgrade-minor", "modular-upgrade-minor":
+	case "upgrade-minor", "modular-upgrade-minor", "upgrade-path":
 		prev, err := PreviousAppVersion(appVersion)
 		if err != nil {
 			return "", fmt.Errorf("resolve upgrade-minor from version: %w", err)
 		}
 		lookupVersion = prev
 	default:
-		return "", fmt.Errorf("unsupported upgrade flow %q: expected upgrade-patch, upgrade-minor, or modular-upgrade-minor", flow)
+		return "", fmt.Errorf("unsupported upgrade flow %q: expected upgrade-patch, upgrade-minor, modular-upgrade-minor, or upgrade-path", flow)
 	}
 
 	entries, err := LoadVersionMatrix(repoRoot, lookupVersion)
@@ -316,7 +316,8 @@ func preReleaseSuffix(v string) string {
 // (two-step or upgrade-only). Use IsTwoStepUpgradeFlow or IsUpgradeOnlyFlow for
 // more specific checks.
 func IsUpgradeFlow(flow string) bool {
-	return flow == "upgrade-patch" || flow == "upgrade-minor" || flow == "modular-upgrade-minor"
+	return flow == "upgrade-patch" || flow == "upgrade-minor" ||
+		flow == "modular-upgrade-minor" || flow == "upgrade-path"
 }
 
 // IsTwoStepUpgradeFlow returns true if the flow is a self-contained two-step upgrade:
@@ -326,7 +327,14 @@ func IsUpgradeFlow(flow string) bool {
 // "modular-upgrade-minor" is NOT a two-step flow — it assumes an existing deployment
 // from a prior "install" run and only performs the upgrade step.
 func IsTwoStepUpgradeFlow(flow string) bool {
-	return flow == "upgrade-patch" || flow == "upgrade-minor"
+	return flow == "upgrade-patch" || flow == "upgrade-minor" || flow == "upgrade-path"
+}
+
+// IsMinorUpgradeFlow returns true if Step 1 installs the PREVIOUS app version,
+// so Step 1 must use that version's values files. This covers "upgrade-minor",
+// "modular-upgrade-minor", and "upgrade-path".
+func IsMinorUpgradeFlow(flow string) bool {
+	return flow == "upgrade-minor" || flow == "modular-upgrade-minor" || flow == "upgrade-path"
 }
 
 // IsUpgradeOnlyFlow returns true if the flow performs only the upgrade step against

--- a/scripts/deploy-camunda/cmd/matrix.go
+++ b/scripts/deploy-camunda/cmd/matrix.go
@@ -124,7 +124,7 @@ version, and chart-only changes build just the affected versions.`,
 	f.StringVar(&allModifiedFiles, "all-modified-files", "", "changed files/dirs (whitespace-separated, as emitted by tj-actions/changed-files)")
 	f.StringVar(&manualTrigger, "manual-trigger", "none", "\"none\", \"all\", or a single chart version to build")
 	f.StringVar(&manualScenario, "manual-scenario", "none", "keep only this exact scenario (\"none\"/\"all\" keep everything)")
-	f.StringVar(&manualFlow, "manual-flow", "none", "override flows (comma-separated: install, upgrade-patch, upgrade-minor)")
+	f.StringVar(&manualFlow, "manual-flow", "none", "override flows (comma-separated: install, upgrade-patch, upgrade-minor, upgrade-path)")
 	f.StringVar(&tier, "tier", "", "filter scenarios by tier (1=PR CI, 2=merge-queue only; empty or 0=all)")
 	f.StringVar(&repoRoot, "repo-root", "", "repository root path (default: auto-detect)")
 	_ = cmd.MarkFlagRequired("active-versions")
@@ -270,6 +270,9 @@ func newMatrixRunCommand() *cobra.Command {
 		keycloakHost             string
 		keycloakProtocol         string
 		upgradeFromVersion       string
+		valuesSource             string
+		upgradeDelta             string
+		suppressUpgradeHooks     bool
 		helmTimeout              int
 		dockerUsername           string
 		dockerPassword           string
@@ -464,7 +467,10 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 					KeycloakHost:     &keycloakHost,
 					KeycloakProtocol: &keycloakProtocol,
 					// Upgrade
-					UpgradeFromVersion: &upgradeFromVersion,
+					UpgradeFromVersion:   &upgradeFromVersion,
+					ValuesSource:         &valuesSource,
+					UpgradeDelta:         &upgradeDelta,
+					SuppressUpgradeHooks: &suppressUpgradeHooks,
 				})
 			}
 
@@ -601,6 +607,9 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 						KeycloakHost:          keycloakHost,
 						KeycloakProtocol:      keycloakProtocol,
 						UpgradeFromVersion:    upgradeFromVersion,
+						ValuesSource:          matrix.ValuesSource(valuesSource),
+						UpgradeDelta:          upgradeDelta,
+						SuppressUpgradeHooks:  suppressUpgradeHooks,
 						HelmTimeout:           helmTimeout,
 						DockerUsername:        dockerUsername,
 						DockerPassword:        dockerPassword,
@@ -718,6 +727,13 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 				statusDisplay = matrix.NewStatusDisplay(os.Stdout, entries, stdoutIsTerminal, logDir)
 			}
 
+			if err := (matrix.RunOptions{
+				ValuesSource: matrix.ValuesSource(valuesSource),
+				UpgradeDelta: upgradeDelta,
+			}).ValidateUpgradeOptions(); err != nil {
+				return err
+			}
+
 			runStart := time.Now()
 			results, err := matrix.Run(ctx, entries, matrix.RunOptions{
 				DryRun:                     dryRun,
@@ -744,6 +760,9 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 				KeycloakHost:               keycloakHost,
 				KeycloakProtocol:           keycloakProtocol,
 				UpgradeFromVersion:         upgradeFromVersion,
+				ValuesSource:               matrix.ValuesSource(valuesSource),
+				UpgradeDelta:               upgradeDelta,
+				SuppressUpgradeHooks:       suppressUpgradeHooks,
 				HelmTimeout:                helmTimeout,
 				DockerUsername:             dockerUsername,
 				DockerPassword:             dockerPassword,
@@ -848,6 +867,9 @@ Under the hood this invokes deploy.Execute() for each matrix entry.`,
 	f.StringVar(&keycloakHost, "keycloak-host", "", "Keycloak external host")
 	f.StringVar(&keycloakProtocol, "keycloak-protocol", "", "Keycloak protocol (defaults to "+config.DefaultKeycloakProtocol+")")
 	f.StringVar(&upgradeFromVersion, "upgrade-from-version", "", "Override the auto-resolved 'from' chart version for upgrade flows (e.g., 13.5.0)")
+	f.StringVar(&valuesSource, "values-source", "", "Values files Step 2 of a two-step upgrade renders with: '' (target chart, default) or 'carryover' (source chart)")
+	f.StringVar(&upgradeDelta, "upgrade-delta", "", "Extra values file applied on top of carried-over values in Step 2 (requires --values-source=carryover)")
+	f.BoolVar(&suppressUpgradeHooks, "suppress-upgrade-hooks", false, "Skip pre-upgrade and post-infra lifecycle hooks so the upgrade runs without harness-only privileges")
 	f.IntVar(&helmTimeout, "timeout", 10, "Timeout in minutes for Helm deployment (applies to all entries)")
 	f.StringVar(&dockerUsername, "docker-username", "", "Harbor registry username (defaults to HARBOR_USERNAME, TEST_DOCKER_USERNAME_CAMUNDA_CLOUD, or NEXUS_USERNAME env var)")
 	f.StringVar(&dockerPassword, "docker-password", "", "Harbor registry password (defaults to HARBOR_PASSWORD, TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD, or NEXUS_PASSWORD env var)")

--- a/scripts/deploy-camunda/config/config.go
+++ b/scripts/deploy-camunda/config/config.go
@@ -146,7 +146,10 @@ type MatrixConfig struct {
 	KeycloakProtocol string `mapstructure:"keycloakProtocol" yaml:"keycloakProtocol,omitempty"`
 
 	// Upgrade
-	UpgradeFromVersion string `mapstructure:"upgradeFromVersion" yaml:"upgradeFromVersion,omitempty"`
+	UpgradeFromVersion   string `mapstructure:"upgradeFromVersion" yaml:"upgradeFromVersion,omitempty"`
+	ValuesSource         string `mapstructure:"valuesSource" yaml:"valuesSource,omitempty"`
+	UpgradeDelta         string `mapstructure:"upgradeDelta" yaml:"upgradeDelta,omitempty"`
+	SuppressUpgradeHooks *bool  `mapstructure:"suppressUpgradeHooks" yaml:"suppressUpgradeHooks,omitempty"`
 }
 
 // DeploymentConfig represents a single deployment profile.

--- a/scripts/deploy-camunda/config/matrix_merge.go
+++ b/scripts/deploy-camunda/config/matrix_merge.go
@@ -139,7 +139,10 @@ type MatrixRunFlags struct {
 	KeycloakProtocol *string
 
 	// Upgrade
-	UpgradeFromVersion *string
+	UpgradeFromVersion   *string
+	ValuesSource         *string
+	UpgradeDelta         *string
+	SuppressUpgradeHooks *bool
 }
 
 // ApplyMatrixRunConfig merges config-file values into the matrix run command flags.
@@ -252,6 +255,9 @@ func ApplyMatrixRunConfig(rc *RootConfig, changedFlags map[string]bool, f *Matri
 
 	// --- Upgrade ---
 	MergeStringField(f.UpgradeFromVersion, m.UpgradeFromVersion, "", changedFlags, "upgrade-from-version")
+	MergeStringField(f.ValuesSource, m.ValuesSource, "", changedFlags, "values-source")
+	MergeStringField(f.UpgradeDelta, m.UpgradeDelta, "", changedFlags, "upgrade-delta")
+	MergeBoolField(f.SuppressUpgradeHooks, m.SuppressUpgradeHooks, nil, changedFlags, "suppress-upgrade-hooks")
 }
 
 // LoadMatrixConfig loads the config file and returns the parsed RootConfig

--- a/scripts/deploy-camunda/config/merge.go
+++ b/scripts/deploy-camunda/config/merge.go
@@ -45,6 +45,9 @@ type DeploymentFlags struct {
 	RenderTemplates      bool
 	RenderOutputDir      string
 	ExtraValues          []string
+	// UpgradeDelta is a values file applied to the merged scenario values after
+	// layering. It may carry a $remove directive; see pkg/chartvalues.
+	UpgradeDelta string
 	// Extra helm arguments for advanced use cases (e.g., upgrade flows).
 	// These are appended to the helm command after all other arguments.
 	ExtraHelmArgs []string

--- a/scripts/deploy-camunda/deploy/merge.go
+++ b/scripts/deploy-camunda/deploy/merge.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"scripts/camunda-core/pkg/chartvalues"
 	"scripts/camunda-core/pkg/logging"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -217,4 +219,57 @@ func MergeLayeredValues(scenarioValueFiles []string, tempDir string) ([]string, 
 		return nil, fmt.Errorf("failed to merge layered values: %w", err)
 	}
 	return []string{merged}, nil
+}
+
+// applyUpgradeDelta rewrites the merged scenario values file in place with the
+// delta applied. The delta may set keys and, via a $remove directive, delete
+// dotted key paths — chart constraints test key presence, so a removed key
+// cannot be cleared by layering a null over it.
+//
+// No-op when no delta is configured or when layering produced no single merged
+// file to rewrite.
+func applyUpgradeDelta(mergedFiles []string, deltaPath string) error {
+	if deltaPath == "" || len(mergedFiles) != 1 {
+		return nil
+	}
+
+	raw, err := os.ReadFile(deltaPath)
+	if err != nil {
+		return fmt.Errorf("read upgrade delta: %w", err)
+	}
+	// Scenario layers are substituted by values.Process before merging; the
+	// delta is applied afterwards, so it needs the same treatment.
+	delta, err := chartvalues.ParseDelta([]byte(substituteManifestVars(string(raw), envMap())), deltaPath)
+	if err != nil {
+		return fmt.Errorf("parse upgrade delta: %w", err)
+	}
+	if delta.IsEmpty() {
+		return nil
+	}
+
+	merged, err := chartvalues.LoadFile(mergedFiles[0])
+	if err != nil {
+		return fmt.Errorf("load merged scenario values: %w", err)
+	}
+	if err := chartvalues.WriteFile(mergedFiles[0], delta.Apply(merged)); err != nil {
+		return fmt.Errorf("write merged scenario values: %w", err)
+	}
+
+	logging.Logger.Info().
+		Str("delta", deltaPath).
+		Strs("removed", delta.Remove).
+		Int("setKeys", len(delta.Set)).
+		Msg("Applied upgrade delta to merged scenario values")
+	return nil
+}
+
+// envMap snapshots the process environment for delta substitution.
+func envMap() map[string]string {
+	out := make(map[string]string, len(os.Environ()))
+	for _, kv := range os.Environ() {
+		if i := strings.IndexByte(kv, '='); i > 0 {
+			out[kv[:i]] = kv[i+1:]
+		}
+	}
+	return out
 }

--- a/scripts/deploy-camunda/deploy/values.go
+++ b/scripts/deploy-camunda/deploy/values.go
@@ -788,6 +788,11 @@ func prepareScenarioValues(ctx context.Context, scenarioCtx *ScenarioContext, fl
 		logging.Logger.Debug().
 			Strs("mergedFiles", scenarioValueFiles).
 			Msg("📋 [prepareScenarioValues] layered values merged")
+
+		if err := applyUpgradeDelta(scenarioValueFiles, flags.Deployment.UpgradeDelta); err != nil {
+			os.RemoveAll(tempDir)
+			return nil, err
+		}
 	} else {
 		// Legacy path: process auth and main scenario, then let BuildValuesList resolve
 		effectiveAuth := flags.Auth.Auth

--- a/scripts/deploy-camunda/matrix/plan.go
+++ b/scripts/deploy-camunda/matrix/plan.go
@@ -146,7 +146,7 @@ var buildAllTriggers = []buildAllTrigger{
 	},
 }
 
-var manualFlowPattern = regexp.MustCompile(`^(install|upgrade-patch|upgrade-minor)(,(install|upgrade-patch|upgrade-minor))*$`)
+var manualFlowPattern = regexp.MustCompile(`^(install|upgrade-patch|upgrade-minor|upgrade-path)(,(install|upgrade-patch|upgrade-minor|upgrade-path))*$`)
 
 // Plan computes the chart build matrix for a change set, replacing
 // scripts/generate-chart-matrix.sh + generate-chart-matrix.jq.
@@ -275,7 +275,7 @@ func applyManualFlow(entries []Entry, manualFlow string) ([]Entry, error) {
 		return entries, nil
 	}
 	if !manualFlowPattern.MatchString(manualFlow) {
-		return nil, fmt.Errorf("invalid flow %q; valid flows: install, upgrade-patch, upgrade-minor (modular-upgrade-minor only via integration-test-template.yaml)", manualFlow)
+		return nil, fmt.Errorf("invalid flow %q; valid flows: install, upgrade-patch, upgrade-minor, upgrade-path (modular-upgrade-minor only via integration-test-template.yaml)", manualFlow)
 	}
 	flows := strings.Split(manualFlow, ",")
 	var out []Entry

--- a/scripts/deploy-camunda/matrix/runner.go
+++ b/scripts/deploy-camunda/matrix/runner.go
@@ -494,7 +494,7 @@ func resolvePreUpgradeScriptQuiet(repoRoot string, entry Entry) string {
 // (including upgrade-patch, which uses the current version's values), returns empty string.
 // Errors are silently logged — dry-run is best-effort.
 func resolveStep1ValuesFromQuiet(entry Entry) string {
-	if entry.Flow != "upgrade-minor" {
+	if !versionmatrix.IsMinorUpgradeFlow(entry.Flow) {
 		return ""
 	}
 	prev, err := versionmatrix.PreviousAppVersion(entry.Version)
@@ -1073,6 +1073,7 @@ var flowAbbrevMap = map[string]string{
 	"upgrade-patch":         "upgp",
 	"upgrade-minor":         "upgm",
 	"modular-upgrade-minor": "mugm",
+	"upgrade-path":          "upth",
 }
 
 func flowAbbrev(flow string) string {

--- a/scripts/deploy-camunda/matrix/runner_options.go
+++ b/scripts/deploy-camunda/matrix/runner_options.go
@@ -1,5 +1,10 @@
 package matrix
 
+import (
+	"fmt"
+	"os"
+)
+
 // RunOptions controls matrix execution.
 type RunOptions struct {
 	// DryRun logs what would be done without executing.
@@ -81,6 +86,19 @@ type RunOptions struct {
 	// When set, this version is used instead of resolving from version-matrix JSON files.
 	// Only applies to entries with upgrade flows (upgrade-patch, upgrade-minor, modular-upgrade-minor).
 	UpgradeFromVersion string
+	// ValuesSource selects which chart's values files Step 2 of a two-step
+	// upgrade renders with. ValuesNative (default) preserves existing behaviour:
+	// Step 2 uses the target chart's own values. ValuesCarryover makes Step 2
+	// reuse the source chart's values, optionally overlaid with UpgradeDelta.
+	// Only meaningful for the upgrade-minor flow.
+	ValuesSource ValuesSource
+	// UpgradeDelta is an additional values file applied on top of the carried-over
+	// values in Step 2. Ignored unless ValuesSource is ValuesCarryover.
+	UpgradeDelta string
+	// SuppressUpgradeHooks skips the pre-upgrade and post-infra lifecycle hooks.
+	// These hooks perform work outside the chart that a customer running
+	// `helm upgrade` does not get.
+	SuppressUpgradeHooks bool
 	// HelmTimeout is the timeout in minutes for each Helm deployment.
 	// Applies uniformly to all matrix entries (install, upgrade Step 1, upgrade Step 2).
 	// When <= 0, deploy.Execute defaults to 5 minutes.
@@ -165,4 +183,42 @@ type RunOptions struct {
 	// IngressReadyTimeoutMinutes bounds how long WaitIngressReady polls before
 	// failing. When <= 0, config.DefaultIngressReadyTimeoutMinutes is used.
 	IngressReadyTimeoutMinutes int
+}
+
+// ValuesSource selects which chart's values files Step 2 of a two-step upgrade
+// renders with.
+type ValuesSource string
+
+const (
+	// ValuesNative renders Step 2 with the target chart's own values files.
+	ValuesNative ValuesSource = ""
+	// ValuesCarryover renders Step 2 with the source chart's values files.
+	ValuesCarryover ValuesSource = "carryover"
+)
+
+// Validate checks carryover option coherence.
+func (v ValuesSource) Validate() error {
+	switch v {
+	case ValuesNative, ValuesCarryover:
+		return nil
+	default:
+		return fmt.Errorf("invalid values source %q: expected \"\" (native) or %q", string(v), string(ValuesCarryover))
+	}
+}
+
+// ValidateUpgradeOptions rejects carryover flag combinations that cannot work,
+// so the failure surfaces before a cluster is provisioned.
+func (o RunOptions) ValidateUpgradeOptions() error {
+	if err := o.ValuesSource.Validate(); err != nil {
+		return err
+	}
+	if o.UpgradeDelta != "" && o.ValuesSource != ValuesCarryover {
+		return fmt.Errorf("--upgrade-delta requires --values-source=%s", string(ValuesCarryover))
+	}
+	if o.UpgradeDelta != "" {
+		if _, err := os.Stat(o.UpgradeDelta); err != nil {
+			return fmt.Errorf("--upgrade-delta %q: %w", o.UpgradeDelta, err)
+		}
+	}
+	return nil
 }

--- a/scripts/deploy-camunda/matrix/runner_upgrade.go
+++ b/scripts/deploy-camunda/matrix/runner_upgrade.go
@@ -212,8 +212,13 @@ func executeTwoStepUpgrade(ctx context.Context, entry Entry, flags *config.Runti
 	// In CI, test-type-vars sets CHART_PATH to charts/camunda-platform-<previous> for
 	// the install step of upgrade-minor, so values files come from the older chart.
 	// For upgrade-patch, Step 1 uses the current chart's values (same app version).
+	// Retained for Step 2 when ValuesCarryover is selected; empty for any flow
+	// that does not switch to the previous version's values.
+	var sourceScenarioDir string
+	var sourceFeatures []string
+
 	step1AppVersion := entry.Version
-	if entry.Flow == "upgrade-minor" {
+	if versionmatrix.IsMinorUpgradeFlow(entry.Flow) {
 		prevVersion, err := versionmatrix.PreviousAppVersion(entry.Version)
 		if err != nil {
 			return fmt.Errorf("step 1: resolve previous app version for %s: %w", entry.Version, err)
@@ -222,6 +227,7 @@ func executeTwoStepUpgrade(ctx context.Context, entry Entry, flags *config.Runti
 		prevChartDir := filepath.Join(opts.RepoRoot, "charts", "camunda-platform-"+prevVersion)
 		prevScenarioDir := filepath.Join(prevChartDir, "test/integration/scenarios/chart-full-setup")
 		step1Flags.Deployment.ScenarioPath = prevScenarioDir
+		sourceScenarioDir = prevScenarioDir
 
 		logging.Logger.Info().
 			Str("flow", entry.Flow).
@@ -240,6 +246,7 @@ func executeTwoStepUpgrade(ctx context.Context, entry Entry, flags *config.Runti
 			}
 			kept, dropped := filterKnownFeatures(step1Flags.Selection.Features, prevFeatures)
 			step1Flags.Selection.Features = kept
+			sourceFeatures = kept
 			if len(dropped) > 0 {
 				logging.Logger.Info().
 					Str("previousVersion", prevVersion).
@@ -274,7 +281,13 @@ func executeTwoStepUpgrade(ctx context.Context, entry Entry, flags *config.Runti
 	// Runs the declarative pre-upgrade hook (integration.flows.<flow>.pre-upgrade)
 	// resolved at matrix-generation time onto entry.PreUpgrade. Scoped to the
 	// target version (entry.Version is the version being upgraded to).
-	if err := runDeclarativePreUpgradeHook(ctx, flags, entry.PreUpgrade, opts.RepoRoot, entry.Version, entry.Flow); err != nil {
+	if opts.SuppressUpgradeHooks {
+		if entry.PreUpgrade != nil {
+			logging.Logger.Warn().
+				Str("hook", entry.PreUpgrade.Script).
+				Msg("Suppressed pre-upgrade hook: the upgrade must succeed without it")
+		}
+	} else if err := runDeclarativePreUpgradeHook(ctx, flags, entry.PreUpgrade, opts.RepoRoot, entry.Version, entry.Flow); err != nil {
 		return err
 	}
 
@@ -322,10 +335,30 @@ func executeTwoStepUpgrade(ctx context.Context, entry Entry, flags *config.Runti
 		}
 	}
 
+	if opts.ValuesSource == ValuesCarryover {
+		if sourceScenarioDir == "" {
+			return fmt.Errorf("step 2: values carryover requires the upgrade-minor flow, got %q", entry.Flow)
+		}
+		step2Flags.Deployment.ScenarioPath = sourceScenarioDir
+		step2Flags.Selection.Features = sourceFeatures
+		step2Flags.Deployment.UpgradeDelta = opts.UpgradeDelta
+		logging.Logger.Info().
+			Str("step", "2/2").
+			Str("scenarioDir", sourceScenarioDir).
+			Str("delta", opts.UpgradeDelta).
+			Msg("Step 2: carrying over the source chart's values files")
+	}
+
 	// --- Post-infra lifecycle hook (Step 2 of two-step upgrade) ---
 	// Registered against step2Flags so it fires after Step 2's companion charts
 	// are deployed but before the target chart upgrade.
-	if err := registerDeclarativePostInfraHook(&step2Flags, entry.PostInfra, opts.RepoRoot, entry.Version, entry.Scenario); err != nil {
+	if opts.SuppressUpgradeHooks {
+		if entry.PostInfra != nil {
+			logging.Logger.Warn().
+				Str("hook", entry.PostInfra.Script).
+				Msg("Suppressed post-infra hook: the upgrade must succeed without it")
+		}
+	} else if err := registerDeclarativePostInfraHook(&step2Flags, entry.PostInfra, opts.RepoRoot, entry.Version, entry.Scenario); err != nil {
 		return err
 	}
 

--- a/scripts/deploy-camunda/matrix/values_source_test.go
+++ b/scripts/deploy-camunda/matrix/values_source_test.go
@@ -1,0 +1,154 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package matrix
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"scripts/camunda-core/pkg/versionmatrix"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValuesSourceZeroValueIsNative(t *testing.T) {
+	var opts RunOptions
+	require.Equal(t, ValuesNative, opts.ValuesSource,
+		"the zero value must preserve existing upgrade-minor and upgrade-patch behaviour")
+	assert.Empty(t, opts.UpgradeDelta)
+	assert.False(t, opts.SuppressUpgradeHooks)
+}
+
+func TestValuesSourceConstants(t *testing.T) {
+	assert.Equal(t, ValuesSource(""), ValuesNative)
+	assert.Equal(t, ValuesSource("carryover"), ValuesCarryover)
+	assert.NotEqual(t, ValuesNative, ValuesCarryover)
+}
+
+func TestFilterKnownFeaturesPreservesRequestedOrder(t *testing.T) {
+	kept, dropped := filterKnownFeatures(
+		[]string{"z", "new-in-target", "a"},
+		[]string{"a", "z"},
+	)
+	assert.Equal(t, []string{"z", "a"}, kept,
+		"carryover reuses this ordering for Step 2, so it must follow the requested list")
+	assert.Equal(t, []string{"new-in-target"}, dropped)
+}
+
+func TestUpgradePathFlowClassification(t *testing.T) {
+	tests := []struct {
+		flow           string
+		isUpgrade      bool
+		isTwoStep      bool
+		isMinorUpgrade bool
+		isUpgradeOnly  bool
+	}{
+		{"install", false, false, false, false},
+		{"upgrade-patch", true, true, false, false},
+		{"upgrade-minor", true, true, true, false},
+		{"modular-upgrade-minor", true, false, true, true},
+		{"upgrade-path", true, true, true, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.flow, func(t *testing.T) {
+			assert.Equal(t, tt.isUpgrade, versionmatrix.IsUpgradeFlow(tt.flow), "IsUpgradeFlow")
+			assert.Equal(t, tt.isTwoStep, versionmatrix.IsTwoStepUpgradeFlow(tt.flow), "IsTwoStepUpgradeFlow")
+			assert.Equal(t, tt.isMinorUpgrade, versionmatrix.IsMinorUpgradeFlow(tt.flow), "IsMinorUpgradeFlow")
+			assert.Equal(t, tt.isUpgradeOnly, versionmatrix.IsUpgradeOnlyFlow(tt.flow), "IsUpgradeOnlyFlow")
+		})
+	}
+}
+
+func TestUpgradePathHasNamespaceAbbrev(t *testing.T) {
+	abbrev := flowAbbrev("upgrade-path")
+	assert.Equal(t, "upth", abbrev)
+	seen := map[string]string{}
+	for flow, a := range flowAbbrevMap {
+		if prev, dup := seen[a]; dup {
+			t.Fatalf("abbreviation %q collides between %q and %q", a, prev, flow)
+		}
+		seen[a] = flow
+	}
+}
+
+func TestApplyManualFlowAcceptsUpgradePath(t *testing.T) {
+	entries := []Entry{{Version: "8.10", Scenario: "elasticsearch"}}
+
+	out, err := applyManualFlow(entries, "upgrade-path")
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, "upgrade-path", out[0].Flow)
+
+	out, err = applyManualFlow(entries, "install,upgrade-path")
+	require.NoError(t, err)
+	require.Len(t, out, 2)
+
+	_, err = applyManualFlow(entries, "not-a-flow")
+	require.Error(t, err)
+}
+
+func TestValidateUpgradeOptions(t *testing.T) {
+	delta := filepath.Join(t.TempDir(), "delta.values.yaml")
+	require.NoError(t, os.WriteFile(delta, []byte("key: value\n"), 0o644))
+
+	tests := []struct {
+		name    string
+		opts    RunOptions
+		wantErr string
+	}{
+		{
+			name: "defaults are valid",
+			opts: RunOptions{},
+		},
+		{
+			name: "carryover without delta is valid",
+			opts: RunOptions{ValuesSource: ValuesCarryover},
+		},
+		{
+			name: "carryover with an existing delta is valid",
+			opts: RunOptions{ValuesSource: ValuesCarryover, UpgradeDelta: delta},
+		},
+		{
+			name:    "unknown values source",
+			opts:    RunOptions{ValuesSource: ValuesSource("bogus")},
+			wantErr: "invalid values source",
+		},
+		{
+			name:    "delta without carryover",
+			opts:    RunOptions{UpgradeDelta: delta},
+			wantErr: "requires --values-source=carryover",
+		},
+		{
+			name:    "delta file missing",
+			opts:    RunOptions{ValuesSource: ValuesCarryover, UpgradeDelta: "/nonexistent/delta.yaml"},
+			wantErr: "--upgrade-delta",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.opts.ValidateUpgradeOptions()
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}

--- a/scripts/upgrade-paths/discover.go
+++ b/scripts/upgrade-paths/discover.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"regexp"
+
+	"scripts/camunda-core/pkg/chartvalues"
+)
+
+var (
+	reKeyRemoved = regexp.MustCompile(`The Helm values file key \"([^\"]+)\" has been removed`)
+	reKeyRenamed = regexp.MustCompile(`The Helm values file key changed from \"([^\"]+)\" to \"([^\"]+)\"`)
+)
+
+// KeyChange is one values key the customer must act on.
+type KeyChange struct {
+	Old  string `json:"old"`
+	New  string `json:"new,omitempty"` // empty for a pure removal
+	Kind string `json:"kind"`          // "removed" | "renamed"
+}
+
+// DiscoveryResult is the outcome of iterating a path to a fixpoint.
+type DiscoveryResult struct {
+	Changes []KeyChange `json:"changes"`
+	// Final is the render result after every discovered key was deleted.
+	Final RenderResult `json:"final"`
+	// Residual is the error remaining once deletion stops making progress.
+	Residual string `json:"residual,omitempty"`
+	// Truncated reports that the loop hit maxDiscoveryRounds, so Changes is
+	// incomplete.
+	Truncated bool `json:"truncated"`
+}
+
+const maxDiscoveryRounds = 50
+
+// Discover renders a path repeatedly, deleting each removed or renamed key it
+// reports, until the render succeeds or fails for another reason. Renames are
+// recorded but not applied: the replacement value cannot be inferred.
+func Discover(ctx context.Context, r Renderer, t Transition, repoRoot, workDir string) (DiscoveryResult, error) {
+	var out DiscoveryResult
+	seen := map[string]bool{}
+
+	base := append([]string{}, t.BaselineLayers...)
+	if t.DeltaPath != "" {
+		base = append(base, t.DeltaPath)
+	}
+
+	// Guards test key presence, so keys must be deleted from a consolidated
+	// document rather than nulled in an overlay.
+	merged, err := chartvalues.MergeFiles(base)
+	if err != nil {
+		return out, err
+	}
+
+	for round := 0; round < maxDiscoveryRounds; round++ {
+		p := filepath.Join(workDir, fmt.Sprintf("consolidated-%s-%d.yaml", t.Archetype.Name, round))
+		if err := chartvalues.WriteFile(p, merged); err != nil {
+			return out, err
+		}
+
+		res := Render(ctx, r, Transition{
+			From: t.From, To: t.To, Archetype: t.Archetype, BaselineLayers: []string{p},
+		}, RunA, repoRoot, workDir)
+
+		if res.Succeeded {
+			out.Final = res
+			return out, nil
+		}
+
+		change, ok := parseKeyChange(res.Stderr)
+		if !ok {
+			out.Final = res
+			out.Residual = Signature(res.Stderr).Title
+			return out, nil
+		}
+		if seen[change.Old] {
+			out.Final = res
+			out.Residual = fmt.Sprintf("guard for %q did not clear after deletion", change.Old)
+			return out, nil
+		}
+
+		seen[change.Old] = true
+		out.Changes = append(out.Changes, change)
+
+		if !chartvalues.DeleteKey(merged, change.Old) {
+			out.Final = res
+			out.Residual = fmt.Sprintf("guard names %q but it is absent from the merged values; "+
+				"the condition is not simple key presence", change.Old)
+			return out, nil
+		}
+	}
+
+	out.Truncated = true
+	out.Residual = fmt.Sprintf("stopped after %d rounds; more keys may remain", maxDiscoveryRounds)
+	return out, nil
+}
+
+// parseKeyChange extracts a removed or renamed key from render stderr.
+func parseKeyChange(stderr string) (KeyChange, bool) {
+	if m := reKeyRenamed.FindStringSubmatch(stderr); m != nil {
+		return KeyChange{Old: m[1], New: m[2], Kind: "renamed"}, true
+	}
+	if m := reKeyRemoved.FindStringSubmatch(stderr); m != nil {
+		return KeyChange{Old: m[1], Kind: "removed"}, true
+	}
+	return KeyChange{}, false
+}

--- a/scripts/upgrade-paths/docs.go
+++ b/scripts/upgrade-paths/docs.go
@@ -1,0 +1,146 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// DocsCoverage records whether each discovered key is named in the published
+// upgrade guide for this transition.
+type DocsCoverage struct {
+	// Checked is false when no docs root was supplied or no guide was found,
+	// which must be rendered differently from "checked and undocumented".
+	Checked bool `json:"checked"`
+	// Guides are the guide files consulted, relative to the docs root.
+	Guides []string `json:"guides,omitempty"`
+	// Documented maps a values key to whether the guide names it.
+	Documented map[string]bool `json:"documented,omitempty"`
+}
+
+// IsDocumented reports coverage for a key, defaulting to true when unchecked so
+// callers never present an unchecked key as a documentation gap.
+func (d DocsCoverage) IsDocumented(key string) bool {
+	if !d.Checked {
+		return true
+	}
+	return d.Documented[key]
+}
+
+// UndocumentedCount returns how many of the given keys the guide omits.
+func (d DocsCoverage) UndocumentedCount(keys []string) int {
+	if !d.Checked {
+		return 0
+	}
+	n := 0
+	for _, k := range keys {
+		if !d.Documented[k] {
+			n++
+		}
+	}
+	return n
+}
+
+// versionSlug converts an app version to the guide filename form: 8.9 -> 890,
+// 8.10 -> 8100.
+func versionSlug(version string) string {
+	return strings.ReplaceAll(version, ".", "") + "0"
+}
+
+// findGuides locates every upgrade guide for a transition under docsRoot.
+//
+// Guides are not stored at a single predictable path — the same transition can
+// appear under docs/ and under one or more versioned_docs/version-*/ trees — so
+// match on filename and take the union.
+func findGuides(docsRoot, from, to string) ([]string, error) {
+	want := versionSlug(from) + "-to-" + versionSlug(to) + ".md"
+	var out []string
+
+	err := filepath.WalkDir(docsRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case "node_modules", ".git", "build", ".docusaurus":
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if d.Name() == want {
+			rel, relErr := filepath.Rel(docsRoot, path)
+			if relErr != nil {
+				rel = path
+			}
+			out = append(out, rel)
+		}
+		return nil
+	})
+	return out, err
+}
+
+// CheckDocsCoverage tests each key for a literal mention in any guide.
+//
+// A literal substring match is intentional: the guide is prose and tables, and
+// a key that is not written out verbatim is not actionable for a customer
+// searching for it.
+func CheckDocsCoverage(docsRoot, from, to string, keys []string) (DocsCoverage, error) {
+	var cov DocsCoverage
+	if docsRoot == "" || len(keys) == 0 {
+		return cov, nil
+	}
+	if _, err := os.Stat(docsRoot); err != nil {
+		return cov, nil
+	}
+
+	guides, err := findGuides(docsRoot, from, to)
+	if err != nil {
+		return cov, err
+	}
+	if len(guides) == 0 {
+		return cov, nil
+	}
+
+	var corpus strings.Builder
+	for _, g := range guides {
+		b, err := os.ReadFile(filepath.Join(docsRoot, g))
+		if err != nil {
+			continue
+		}
+		corpus.Write(b)
+		corpus.WriteByte('\n')
+	}
+	text := corpus.String()
+
+	cov.Checked = true
+	cov.Guides = guides
+	cov.Documented = make(map[string]bool, len(keys))
+	for _, k := range keys {
+		cov.Documented[k] = strings.Contains(text, k)
+	}
+	return cov, nil
+}
+
+// defaultDocsRoot resolves a sibling camunda-docs checkout next to repoRoot.
+func defaultDocsRoot(repoRoot string) string {
+	candidate := filepath.Join(filepath.Dir(repoRoot), "camunda-docs")
+	if _, err := os.Stat(candidate); err == nil {
+		return candidate
+	}
+	return ""
+}

--- a/scripts/upgrade-paths/finding.go
+++ b/scripts/upgrade-paths/finding.go
@@ -85,6 +85,8 @@ type PathResult struct {
 	Findings     []Finding        `json:"findings"`
 	Discovery    *DiscoveryResult `json:"discovery,omitempty"`
 	DocsCoverage DocsCoverage     `json:"docsCoverage"`
+	// ScaffoldingKeys are top-level delta keys that are harness-only.
+	ScaffoldingKeys []string `json:"scaffoldingKeys,omitempty"`
 }
 
 // Classify applies the A/B state machine.

--- a/scripts/upgrade-paths/finding.go
+++ b/scripts/upgrade-paths/finding.go
@@ -1,0 +1,209 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// Outcome is the result of the A/B state machine for one path.
+type Outcome string
+
+const (
+	// OutcomeClean: neither run failed.
+	OutcomeClean Outcome = "CLEAN"
+	// OutcomeRemediated: Run A failed, Run B succeeded.
+	OutcomeRemediated Outcome = "REMEDIATED"
+	// OutcomeUnremediated: both runs failed.
+	OutcomeUnremediated Outcome = "UNREMEDIATED"
+	// OutcomeStaleDelta: Run A succeeded, Run B failed.
+	OutcomeStaleDelta Outcome = "STALE_DELTA"
+)
+
+// Class buckets a finding by what it means for the customer.
+type Class string
+
+const (
+	ClassBlocks   Class = "BLOCKS"
+	ClassDestroys Class = "DESTROYS"
+	ClassChanges  Class = "CHANGES"
+	ClassNoise    Class = "NOISE"
+)
+
+// Finding is one reportable item.
+type Finding struct {
+	ID          string   `json:"id"`
+	Transition  string   `json:"transition"`
+	Path        string   `json:"path"`
+	Detector    string   `json:"detector"`
+	Class       Class    `json:"class"`
+	Severity    string   `json:"severity"`
+	Title       string   `json:"title"`
+	Evidence    Evidence `json:"evidence"`
+	Remedy      Remedy   `json:"remedy"`
+	Confidence  string   `json:"confidence"`
+	Fingerprint string   `json:"fingerprint"`
+}
+
+type Evidence struct {
+	Stage  string `json:"stage"`
+	Error  string `json:"error,omitempty"`
+	Source string `json:"source,omitempty"`
+}
+
+type Remedy struct {
+	Kind      string `json:"kind"`
+	Available bool   `json:"available"`
+	OutOfBand bool   `json:"outOfBand"`
+	Diff      string `json:"diff,omitempty"`
+}
+
+// PathResult is the full A/B result for one archetype in one transition.
+type PathResult struct {
+	Transition   string           `json:"transition"`
+	Path         string           `json:"path"`
+	Outcome      Outcome          `json:"outcome"`
+	RunA         RenderResult     `json:"runA"`
+	RunB         RenderResult     `json:"runB"`
+	HasDelta     bool             `json:"hasDelta"`
+	HasRemedy    bool             `json:"hasRemedy"`
+	Findings     []Finding        `json:"findings"`
+	Discovery    *DiscoveryResult `json:"discovery,omitempty"`
+	DocsCoverage DocsCoverage     `json:"docsCoverage"`
+}
+
+// Classify applies the A/B state machine.
+func Classify(a, b RenderResult) Outcome {
+	switch {
+	case a.Succeeded && b.Succeeded:
+		return OutcomeClean
+	case !a.Succeeded && b.Succeeded:
+		return OutcomeRemediated
+	case !a.Succeeded && !b.Succeeded:
+		return OutcomeUnremediated
+	default:
+		return OutcomeStaleDelta
+	}
+}
+
+// Fingerprint produces a stable ID for de-duplicating a failure across runs.
+// Derived from the archetype and error title only, never from stderr.
+func Fingerprint(path, title string) string {
+	sum := sha256.Sum256([]byte(path + "\x00" + title))
+	return hex.EncodeToString(sum[:])[:12]
+}
+
+// BuildFindings turns an A/B result into reportable findings. Only failures
+// produce findings; a clean path appears in the summary matrix only.
+func BuildFindings(t Transition, a, b RenderResult, outcome Outcome) []Finding {
+	transition := fmt.Sprintf("%s-to-%s", t.From, t.To)
+	path := t.Archetype.Name
+
+	switch outcome {
+	case OutcomeClean:
+		return nil
+
+	case OutcomeRemediated:
+		sig := Signature(a.Stderr)
+		return []Finding{{
+			ID:         findingID(transition, path, sig.Title),
+			Transition: transition,
+			Path:       path,
+			Detector:   "upgrade-path-render",
+			Class:      ClassBlocks,
+			Severity:   "high",
+			Title:      sig.Title,
+			Evidence:   Evidence{Stage: "render", Error: sig.Raw, Source: sig.Source},
+			Remedy: Remedy{
+				Kind:      "values-delta",
+				Available: true,
+				OutOfBand: t.RemedyPath != "",
+				Diff:      t.DeltaPath,
+			},
+			Confidence:  "confirmed",
+			Fingerprint: Fingerprint(path, sig.Title),
+		}}
+
+	case OutcomeUnremediated:
+		sig := Signature(b.Stderr)
+		return []Finding{{
+			ID:         findingID(transition, path, sig.Title),
+			Transition: transition,
+			Path:       path,
+			Detector:   "upgrade-path-render",
+			Class:      ClassBlocks,
+			Severity:   "critical",
+			Title:      sig.Title,
+			Evidence:   Evidence{Stage: "render", Error: sig.Raw, Source: sig.Source},
+			Remedy: Remedy{
+				Kind:      "none",
+				Available: false,
+				OutOfBand: false,
+			},
+			Confidence:  "confirmed",
+			Fingerprint: Fingerprint(path, sig.Title),
+		}}
+
+	default: // OutcomeStaleDelta
+		sig := Signature(b.Stderr)
+		return []Finding{{
+			ID:         findingID(transition, path, "stale-delta"),
+			Transition: transition,
+			Path:       path,
+			Detector:   "upgrade-path-render",
+			Class:      ClassNoise,
+			Severity:   "medium",
+			Title:      "Delta is stale: baseline renders but baseline+delta fails",
+			Evidence:   Evidence{Stage: "render", Error: sig.Raw, Source: sig.Source},
+			Remedy: Remedy{
+				Kind:      "fix-fixture",
+				Available: false,
+			},
+			Confidence:  "confirmed",
+			Fingerprint: Fingerprint(path, "stale-delta"),
+		}}
+	}
+}
+
+func findingID(transition, path, title string) string {
+	return fmt.Sprintf("%s/%s/%s", transition, path, slug(title))
+}
+
+func slug(s string) string {
+	s = strings.ToLower(collapseSpace(s))
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == ' ' || r == '-' || r == '_':
+			b.WriteByte('-')
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	for strings.Contains(out, "--") {
+		out = strings.ReplaceAll(out, "--", "-")
+	}
+	if len(out) > 60 {
+		out = strings.Trim(out[:60], "-")
+	}
+	if out == "" {
+		out = "unknown"
+	}
+	return out
+}

--- a/scripts/upgrade-paths/fixture.go
+++ b/scripts/upgrade-paths/fixture.go
@@ -1,0 +1,168 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Archetype describes a shape of customer deployment, independent of any
+// particular version transition. Layers name values files in the source
+// chart's chart-full-setup/values directory; the baseline is composed from
+// them rather than checked in.
+type Archetype struct {
+	Name        string   `yaml:"name"`
+	Description string   `yaml:"description"`
+	Tier        int      `yaml:"tier"`
+	Platforms   []string `yaml:"platforms"`
+	// Layers are paths relative to the source chart's values dir, applied in order.
+	Layers []string `yaml:"layers"`
+}
+
+// Transition is one (from, to) version pair for one archetype.
+type Transition struct {
+	From      string
+	To        string
+	Archetype Archetype
+
+	// BaselineLayers are absolute paths to the source chart's values layers.
+	BaselineLayers []string
+	// DeltaPath is the absolute path to delta.values.yaml, or "" when absent or empty.
+	DeltaPath string
+	// RemedyPath is the absolute path to remedy.sh, or "" when none.
+	RemedyPath string
+}
+
+// TransitionDir is the on-disk home of a (from,to,archetype) fixture.
+func TransitionDir(repoRoot, from, to, archetype string) string {
+	return filepath.Join(repoRoot, "test", "upgrade-paths", "transitions",
+		fmt.Sprintf("%s-to-%s", from, to), archetype)
+}
+
+// ArchetypeDir is the on-disk home of an archetype definition.
+func ArchetypeDir(repoRoot, name string) string {
+	return filepath.Join(repoRoot, "test", "upgrade-paths", "archetypes", name)
+}
+
+// ChartDir returns the chart directory for a given app version.
+func ChartDir(repoRoot, version string) string {
+	return filepath.Join(repoRoot, "charts", "camunda-platform-"+version)
+}
+
+// valuesDir returns a chart's scenario values directory, the source of baseline layers.
+func valuesDir(repoRoot, version string) string {
+	return filepath.Join(ChartDir(repoRoot, version),
+		"test", "integration", "scenarios", "chart-full-setup", "values")
+}
+
+// LoadArchetype reads and validates an archetype definition.
+func LoadArchetype(repoRoot, name string) (Archetype, error) {
+	var a Archetype
+	p := filepath.Join(ArchetypeDir(repoRoot, name), "archetype.yaml")
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return a, fmt.Errorf("read archetype %s: %w", name, err)
+	}
+	if err := yaml.Unmarshal(b, &a); err != nil {
+		return a, fmt.Errorf("parse archetype %s: %w", name, err)
+	}
+	if a.Name == "" {
+		return a, fmt.Errorf("archetype %s: name is required", name)
+	}
+	if a.Name != name {
+		return a, fmt.Errorf("archetype %s: name field %q does not match directory", name, a.Name)
+	}
+	if len(a.Layers) == 0 {
+		return a, fmt.Errorf("archetype %s: at least one values layer is required", name)
+	}
+	return a, nil
+}
+
+// ListArchetypes returns all archetype names, sorted.
+func ListArchetypes(repoRoot string) ([]string, error) {
+	root := filepath.Join(repoRoot, "test", "upgrade-paths", "archetypes")
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, fmt.Errorf("list archetypes: %w", err)
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// LoadTransition resolves an archetype against a version pair. A baseline
+// layer missing from the source chart is an error, not a skip.
+func LoadTransition(repoRoot, from, to, archetypeName string) (Transition, error) {
+	t := Transition{From: from, To: to}
+
+	a, err := LoadArchetype(repoRoot, archetypeName)
+	if err != nil {
+		return t, err
+	}
+	t.Archetype = a
+
+	vd := valuesDir(repoRoot, from)
+	if _, err := os.Stat(vd); err != nil {
+		return t, fmt.Errorf("source chart values dir not found for %s: %w", from, err)
+	}
+	for _, layer := range a.Layers {
+		p := filepath.Join(vd, layer)
+		if _, err := os.Stat(p); err != nil {
+			return t, fmt.Errorf("archetype %s: layer %q missing in chart %s (%s)",
+				archetypeName, layer, from, p)
+		}
+		t.BaselineLayers = append(t.BaselineLayers, p)
+	}
+
+	td := TransitionDir(repoRoot, from, to, archetypeName)
+	if p := filepath.Join(td, "delta.values.yaml"); fileHasContent(p) {
+		t.DeltaPath = p
+	}
+	if p := filepath.Join(td, "remedy.sh"); fileExists(p) {
+		t.RemedyPath = p
+	}
+
+	return t, nil
+}
+
+// fileHasContent reports whether a path exists and holds more than whitespace.
+// Empty and absent are treated identically.
+func fileHasContent(p string) bool {
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return false
+	}
+	for _, c := range b {
+		if c != ' ' && c != '\t' && c != '\n' && c != '\r' {
+			return true
+		}
+	}
+	return false
+}
+
+func fileExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}

--- a/scripts/upgrade-paths/fixture.go
+++ b/scripts/upgrade-paths/fixture.go
@@ -21,6 +21,8 @@ import (
 	"sort"
 
 	"gopkg.in/yaml.v3"
+
+	"scripts/camunda-core/pkg/chartvalues"
 )
 
 // Archetype describes a shape of customer deployment, independent of any
@@ -48,6 +50,8 @@ type Transition struct {
 	DeltaPath string
 	// RemedyPath is the absolute path to remedy.sh, or "" when none.
 	RemedyPath string
+	// Delta is the parsed delta, empty when DeltaPath is unset.
+	Delta chartvalues.Delta
 }
 
 // TransitionDir is the on-disk home of a (from,to,archetype) fixture.
@@ -139,6 +143,11 @@ func LoadTransition(repoRoot, from, to, archetypeName string) (Transition, error
 	td := TransitionDir(repoRoot, from, to, archetypeName)
 	if p := filepath.Join(td, "delta.values.yaml"); fileHasContent(p) {
 		t.DeltaPath = p
+		d, err := chartvalues.LoadDelta(p)
+		if err != nil {
+			return t, err
+		}
+		t.Delta = d
 	}
 	if p := filepath.Join(td, "remedy.sh"); fileExists(p) {
 		t.RemedyPath = p

--- a/scripts/upgrade-paths/go.mod
+++ b/scripts/upgrade-paths/go.mod
@@ -1,0 +1,16 @@
+module scripts/upgrade-paths
+
+go 1.26.0
+
+require (
+	github.com/stretchr/testify v1.11.1
+	gopkg.in/yaml.v3 v3.0.1
+	scripts/camunda-core v0.0.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+)
+
+replace scripts/camunda-core => ../camunda-core

--- a/scripts/upgrade-paths/go.sum
+++ b/scripts/upgrade-paths/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
+github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/scripts/upgrade-paths/main.go
+++ b/scripts/upgrade-paths/main.go
@@ -49,6 +49,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"scripts/camunda-core/pkg/chartvalues"
 )
 
 func main() {
@@ -140,6 +142,7 @@ func main() {
 			HasRemedy:  t.RemedyPath != "",
 			Findings:   BuildFindings(t, a, b, outcome),
 		}
+		pr.ScaffoldingKeys = chartvalues.LeafPaths(t.Delta.Scaffolding)
 
 		if *discover && !a.Succeeded {
 			workDir, err := os.MkdirTemp("", "upgrade-paths-"+name+"-")

--- a/scripts/upgrade-paths/main.go
+++ b/scripts/upgrade-paths/main.go
@@ -1,0 +1,231 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command upgrade-paths answers, for a given minor-version transition, "what
+// breaks for a customer, and what must they do about it?"
+//
+// Each upgrade path is run twice against the target chart:
+//
+//	Run A (naive)      target chart + the SOURCE chart's values, unchanged.
+//	                   The customer who upgrades without reading release notes.
+//	Run B (remediated) the same, plus the transition's delta.values.yaml.
+//	                   The customer who follows the upgrade guide.
+//
+// The delta starts empty at each minor fork; whatever accumulates in it by GA
+// is that path's upgrade guide, kept honest by CI. Comparing the two runs
+// yields one of four outcomes (see Classify): clean, remediated, unremediated,
+// or a stale fixture.
+//
+// This command implements the render-only stage: it stops after `helm
+// template`, so it needs no cluster and completes in seconds. Values-shaped
+// breaks (removed keys, schema violations, the Helm CLI version constraint)
+// surface here. Data loss, orphaned resources, and migration duration need the
+// cluster stage and are not covered by this command.
+//
+// Usage:
+//
+//	upgrade-paths --from 8.9 --to 8.10                 # every archetype
+//	upgrade-paths --from 8.8 --to 8.9 --path classic-bundled
+//	upgrade-paths --from 8.9 --to 8.10 --json out.json --markdown out.md
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func main() {
+	var (
+		from     = flag.String("from", "", "source app version, e.g. 8.9 (required)")
+		to       = flag.String("to", "", "target app version, e.g. 8.10 (required)")
+		pathList = flag.String("path", "", "comma-separated archetypes; default all")
+		repoRoot = flag.String("repo-root", "", "chart repo root; default auto-detected")
+		discover = flag.Bool("discover", false,
+			"after a Run A failure, iterate to find every removed/renamed key rather than only the first")
+		docsRoot = flag.String("docs-root", "",
+			"camunda-docs checkout; default is a sibling directory. Empty disables doc-coverage checking")
+		jsonOut = flag.String("json", "", "write findings JSON to this file")
+		mdOut   = flag.String("markdown", "", "write markdown report to this file")
+		timeout = flag.Duration("timeout", 5*time.Minute, "overall timeout")
+		quiet   = flag.Bool("quiet", false, "suppress the markdown report on stdout")
+	)
+	flag.Parse()
+
+	if *from == "" || *to == "" {
+		fmt.Fprintln(os.Stderr, "error: --from and --to are required")
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	root, err := resolveRepoRoot(*repoRoot)
+	if err != nil {
+		fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
+	defer cancel()
+
+	archetypes, err := selectArchetypes(root, *pathList)
+	if err != nil {
+		fatal(err)
+	}
+	if len(archetypes) == 0 {
+		fatal(fmt.Errorf("no archetypes found under test/upgrade-paths/archetypes"))
+	}
+
+	docs := *docsRoot
+	if docs == "" {
+		docs = defaultDocsRoot(root)
+	}
+
+	runDir, err := os.MkdirTemp("", "upgrade-paths-run-")
+	if err != nil {
+		fatal(fmt.Errorf("create work dir: %w", err))
+	}
+	defer os.RemoveAll(runDir)
+
+	renderer := NewHelmRenderer()
+
+	// Non-fatal: charts vendor their dependencies, so this is normally a no-op.
+	if err := renderer.DependencyBuild(ctx, ChartDir(root, *to)); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: %v (continuing; dependencies may be vendored)\n", err)
+	}
+
+	report := Report{
+		Transition: fmt.Sprintf("%s-to-%s", *from, *to),
+		From:       *from,
+		To:         *to,
+		Stage:      "render",
+	}
+
+	for _, name := range archetypes {
+		t, err := LoadTransition(root, *from, *to, name)
+		if err != nil {
+			fatal(err)
+		}
+
+		a := Render(ctx, renderer, t, RunA, root, runDir)
+		b := Render(ctx, renderer, t, RunB, root, runDir)
+
+		if t.DeltaPath == "" {
+			b = a
+			b.Kind = RunB
+		}
+
+		outcome := Classify(a, b)
+		pr := PathResult{
+			Transition: report.Transition,
+			Path:       name,
+			Outcome:    outcome,
+			RunA:       a,
+			RunB:       b,
+			HasDelta:   t.DeltaPath != "",
+			HasRemedy:  t.RemedyPath != "",
+			Findings:   BuildFindings(t, a, b, outcome),
+		}
+
+		if *discover && !a.Succeeded {
+			workDir, err := os.MkdirTemp("", "upgrade-paths-"+name+"-")
+			if err != nil {
+				fatal(fmt.Errorf("create work dir: %w", err))
+			}
+			d, err := Discover(ctx, renderer, t, root, workDir)
+			os.RemoveAll(workDir)
+			if err != nil {
+				fatal(err)
+			}
+			pr.Discovery = &d
+
+			keys := make([]string, 0, len(d.Changes))
+			for _, c := range d.Changes {
+				keys = append(keys, c.Old)
+			}
+			cov, err := CheckDocsCoverage(docs, *from, *to, keys)
+			if err != nil {
+				fatal(fmt.Errorf("check docs coverage: %w", err))
+			}
+			pr.DocsCoverage = cov
+		}
+
+		report.Results = append(report.Results, pr)
+	}
+
+	md := report.Markdown()
+	if !*quiet {
+		fmt.Print(md)
+	}
+	if *mdOut != "" {
+		if err := os.WriteFile(*mdOut, []byte(md), 0o644); err != nil {
+			fatal(fmt.Errorf("write markdown: %w", err))
+		}
+	}
+	if *jsonOut != "" {
+		b, err := json.MarshalIndent(report, "", "  ")
+		if err != nil {
+			fatal(fmt.Errorf("marshal findings: %w", err))
+		}
+		if err := os.WriteFile(*jsonOut, append(b, '\n'), 0o644); err != nil {
+			fatal(fmt.Errorf("write json: %w", err))
+		}
+	}
+
+	os.Exit(report.ExitCode())
+}
+
+// selectArchetypes resolves the --path flag to a concrete list.
+func selectArchetypes(root, list string) ([]string, error) {
+	if strings.TrimSpace(list) == "" {
+		return ListArchetypes(root)
+	}
+	var out []string
+	for _, p := range strings.Split(list, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
+
+// resolveRepoRoot finds the chart repo root by walking up for a charts/ dir.
+func resolveRepoRoot(override string) (string, error) {
+	if override != "" {
+		return filepath.Abs(override)
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	dir := wd
+	for {
+		if fileExists(filepath.Join(dir, "charts")) && fileExists(filepath.Join(dir, "Makefile")) {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("could not locate chart repo root from %s (pass --repo-root)", wd)
+		}
+		dir = parent
+	}
+}
+
+func fatal(err error) {
+	fmt.Fprintf(os.Stderr, "error: %v\n", err)
+	os.Exit(2)
+}

--- a/scripts/upgrade-paths/main_test.go
+++ b/scripts/upgrade-paths/main_test.go
@@ -1,0 +1,341 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const removedKeyStderr = `Error: execution error at (camunda-platform/templates/common/constraints.tpl:1243:3):
+[camunda][error] The Helm values file key "global.ingress.host" has been removed. For more details, please check Camunda Helm chart documentation. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/
+
+Use --debug flag to render out invalid YAML`
+
+const renamedKeyStderr = `Error: execution error at (camunda-platform/templates/common/constraints.tpl:761:3):
+[camunda][error] The Helm values file key changed from "identity.firstUser.existingSecret" to "identity.firstUser.secret.existingSecret". For more details, please check Camunda Helm chart documentation.`
+
+func TestSignature(t *testing.T) {
+	tests := []struct {
+		name       string
+		stderr     string
+		wantTitle  string
+		wantSource string
+	}{
+		{
+			name:       "camunda error line preferred over helm error line",
+			stderr:     removedKeyStderr,
+			wantTitle:  `The Helm values file key "global.ingress.host" has been removed. For more details, please check Camunda Helm chart documentation. https://docs.camunda.io/docs/self-managed/deployment/helm/upgrade/`,
+			wantSource: "camunda-platform/templates/common/constraints.tpl:1243:3",
+		},
+		{
+			name:       "falls back to helm error when no camunda marker",
+			stderr:     "Error: could not find chart\n",
+			wantTitle:  "could not find chart",
+			wantSource: "",
+		},
+		{
+			name:      "empty stderr yields empty title",
+			stderr:    "",
+			wantTitle: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Signature(tt.stderr)
+			assert.Equal(t, tt.wantTitle, got.Title)
+			assert.Equal(t, tt.wantSource, got.Source)
+		})
+	}
+}
+
+func TestSignatureIsPathIndependent(t *testing.T) {
+	a := Signature(removedKeyStderr)
+	b := Signature(removedKeyStderr + "\n  in /home/runner/work/checkout/values.yaml")
+	assert.Equal(t, a.Title, b.Title, "signature must not vary with local paths")
+}
+
+func TestParseKeyChange(t *testing.T) {
+	tests := []struct {
+		name   string
+		stderr string
+		want   KeyChange
+		wantOK bool
+	}{
+		{
+			name:   "removed",
+			stderr: removedKeyStderr,
+			want:   KeyChange{Old: "global.ingress.host", Kind: "removed"},
+			wantOK: true,
+		},
+		{
+			name:   "renamed",
+			stderr: renamedKeyStderr,
+			want:   KeyChange{Old: "identity.firstUser.existingSecret", New: "identity.firstUser.secret.existingSecret", Kind: "renamed"},
+			wantOK: true,
+		},
+		{
+			name:   "unrelated failure is not a key change",
+			stderr: "Error: template: parse error at line 3",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseKeyChange(tt.stderr)
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestClassify(t *testing.T) {
+	ok := RenderResult{Succeeded: true}
+	bad := RenderResult{Succeeded: false}
+
+	tests := []struct {
+		name string
+		a, b RenderResult
+		want Outcome
+	}{
+		{"both pass", ok, ok, OutcomeClean},
+		{"delta fixes it", bad, ok, OutcomeRemediated},
+		{"nothing fixes it", bad, bad, OutcomeUnremediated},
+		{"delta breaks a working baseline", ok, bad, OutcomeStaleDelta},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, Classify(tt.a, tt.b))
+		})
+	}
+}
+
+func TestReportExitCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		outcomes []Outcome
+		want     int
+	}{
+		{"all clean", []Outcome{OutcomeClean, OutcomeClean}, 0},
+		{"remediated does not fail CI", []Outcome{OutcomeClean, OutcomeRemediated}, 0},
+		{"unremediated fails", []Outcome{OutcomeClean, OutcomeUnremediated}, 1},
+		{"stale delta fails", []Outcome{OutcomeStaleDelta}, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var r Report
+			for _, o := range tt.outcomes {
+				r.Results = append(r.Results, PathResult{Outcome: o})
+			}
+			assert.Equal(t, tt.want, r.ExitCode())
+		})
+	}
+}
+
+// fakeRenderer fails with a scripted stderr per call, then succeeds.
+type fakeRenderer struct {
+	responses []string
+	calls     int
+}
+
+func (f *fakeRenderer) Template(_ context.Context, _ string, _ []string) (string, string, error) {
+	i := f.calls
+	f.calls++
+	if i < len(f.responses) {
+		return "", f.responses[i], fmt.Errorf("exit status 1")
+	}
+	return "rendered: true", "", nil
+}
+
+func (f *fakeRenderer) DependencyBuild(context.Context, string) error { return nil }
+
+func testTransition(t *testing.T, values string) Transition {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "baseline.yaml")
+	require.NoError(t, os.WriteFile(p, []byte(values), 0o644))
+	return Transition{
+		From:           "8.9",
+		To:             "8.10",
+		Archetype:      Archetype{Name: "test"},
+		BaselineLayers: []string{p},
+	}
+}
+
+func TestDiscoverEnumeratesEveryGuard(t *testing.T) {
+	tr := testTransition(t, "global:\n  ingress:\n    host: example.com\nidentityKeycloak:\n  enabled: true\n")
+
+	f := &fakeRenderer{responses: []string{
+		removedKeyStderr,
+		`[camunda][error] The Helm values file key "identityKeycloak" has been removed.`,
+	}}
+
+	got, err := Discover(context.Background(), f, tr, t.TempDir(), t.TempDir())
+	require.NoError(t, err)
+
+	require.Len(t, got.Changes, 2, "one render alone would report only the first guard")
+	assert.Equal(t, "global.ingress.host", got.Changes[0].Old)
+	assert.Equal(t, "identityKeycloak", got.Changes[1].Old)
+	assert.True(t, got.Final.Succeeded)
+	assert.Empty(t, got.Residual)
+	assert.False(t, got.Truncated)
+}
+
+func TestDiscoverStopsOnNonKeyFailure(t *testing.T) {
+	tr := testTransition(t, "global:\n  ingress:\n    host: example.com\n")
+
+	f := &fakeRenderer{responses: []string{
+		removedKeyStderr,
+		"Error: YAML parse error on camunda-platform/templates/x.yaml",
+	}}
+
+	got, err := Discover(context.Background(), f, tr, t.TempDir(), t.TempDir())
+	require.NoError(t, err)
+
+	assert.Len(t, got.Changes, 1)
+	assert.False(t, got.Final.Succeeded)
+	assert.Contains(t, got.Residual, "YAML parse error")
+}
+
+func TestDiscoverReportsGuardNamingAbsentKey(t *testing.T) {
+	tr := testTransition(t, "unrelated: true\n")
+
+	f := &fakeRenderer{responses: []string{removedKeyStderr, removedKeyStderr}}
+
+	got, err := Discover(context.Background(), f, tr, t.TempDir(), t.TempDir())
+	require.NoError(t, err)
+
+	assert.Len(t, got.Changes, 1)
+	assert.Contains(t, got.Residual, "absent from the merged values")
+}
+
+func TestFingerprintIsStableAndDistinct(t *testing.T) {
+	a := Fingerprint("classic-bundled", "key X removed")
+	assert.Equal(t, a, Fingerprint("classic-bundled", "key X removed"))
+	assert.NotEqual(t, a, Fingerprint("other-path", "key X removed"))
+	assert.NotEqual(t, a, Fingerprint("classic-bundled", "key Y removed"))
+}
+
+func TestSlug(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{`The Helm values file key "global.ingress.host" has been removed.`, "the-helm-values-file-key-globalingresshost-has-been-removed"},
+		{"", "unknown"},
+		{"multiple   spaces", "multiple-spaces"},
+		{"punctuation!@#$only", "punctuationonly"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, slug(tt.in))
+	}
+}
+
+func TestSlugTruncatesLongTitles(t *testing.T) {
+	got := slug(strings.Repeat("verylongword ", 20))
+	assert.LessOrEqual(t, len(got), 60)
+	assert.NotEmpty(t, got)
+	assert.False(t, strings.HasSuffix(got, "-"), "truncation must not leave a trailing separator")
+}
+
+func TestFileHasContent(t *testing.T) {
+	dir := t.TempDir()
+	empty := filepath.Join(dir, "empty.yaml")
+	comment := filepath.Join(dir, "comment.yaml")
+	real := filepath.Join(dir, "real.yaml")
+	require.NoError(t, os.WriteFile(empty, []byte("\n  \n\t\n"), 0o644))
+	require.NoError(t, os.WriteFile(comment, []byte("# just a comment\n"), 0o644))
+	require.NoError(t, os.WriteFile(real, []byte("key: value\n"), 0o644))
+
+	assert.False(t, fileHasContent(empty), "whitespace-only counts as no delta")
+	assert.True(t, fileHasContent(comment), "comments count as content")
+	assert.True(t, fileHasContent(real))
+	assert.False(t, fileHasContent(filepath.Join(dir, "missing.yaml")))
+}
+
+func TestVersionSlug(t *testing.T) {
+	assert.Equal(t, "880", versionSlug("8.8"))
+	assert.Equal(t, "890", versionSlug("8.9"))
+	assert.Equal(t, "8100", versionSlug("8.10"))
+}
+
+func writeGuide(t *testing.T, root, rel, body string) {
+	t.Helper()
+	p := filepath.Join(root, rel)
+	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+	require.NoError(t, os.WriteFile(p, []byte(body), 0o644))
+}
+
+func TestCheckDocsCoverage(t *testing.T) {
+	root := t.TempDir()
+	writeGuide(t, root, "docs/self-managed/upgrade/helm/890-to-8100.md",
+		"Remove `identityKeycloak` before upgrading.\n")
+	writeGuide(t, root, "versioned_docs/version-8.9/self-managed/upgrade/helm/890-to-8100.md",
+		"Also remove `elasticsearch`.\n")
+	writeGuide(t, root, "node_modules/junk/890-to-8100.md", "`shouldBeIgnored`\n")
+
+	cov, err := CheckDocsCoverage(root, "8.9", "8.10",
+		[]string{"identityKeycloak", "elasticsearch", "webModelerPostgresql", "shouldBeIgnored"})
+	require.NoError(t, err)
+
+	require.True(t, cov.Checked)
+	assert.Len(t, cov.Guides, 2, "node_modules must be skipped")
+	assert.True(t, cov.Documented["identityKeycloak"])
+	assert.True(t, cov.Documented["elasticsearch"], "guides are unioned across trees")
+	assert.False(t, cov.Documented["webModelerPostgresql"])
+	assert.False(t, cov.Documented["shouldBeIgnored"], "excluded dirs must not count as coverage")
+	assert.Equal(t, 2, cov.UndocumentedCount(
+		[]string{"identityKeycloak", "elasticsearch", "webModelerPostgresql", "shouldBeIgnored"}))
+}
+
+func TestCheckDocsCoverageUncheckedCases(t *testing.T) {
+	tests := []struct {
+		name string
+		root func(t *testing.T) string
+	}{
+		{"no docs root", func(*testing.T) string { return "" }},
+		{"missing docs root", func(*testing.T) string { return "/nonexistent/docs" }},
+		{"no guide for transition", func(t *testing.T) string { return t.TempDir() }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cov, err := CheckDocsCoverage(tt.root(t), "8.9", "8.10", []string{"someKey"})
+			require.NoError(t, err)
+			assert.False(t, cov.Checked)
+			assert.True(t, cov.IsDocumented("someKey"),
+				"unchecked keys must not be reported as documentation gaps")
+			assert.Equal(t, 0, cov.UndocumentedCount([]string{"someKey"}))
+		})
+	}
+}
+
+func TestDocMark(t *testing.T) {
+	unchecked := DocsCoverage{}
+	checked := DocsCoverage{Checked: true, Documented: map[string]bool{"a": true, "b": false}}
+
+	assert.Equal(t, "—", docMark(unchecked, "a"))
+	assert.Equal(t, "yes", docMark(checked, "a"))
+	assert.Equal(t, "**NO**", docMark(checked, "b"))
+}

--- a/scripts/upgrade-paths/render.go
+++ b/scripts/upgrade-paths/render.go
@@ -1,0 +1,166 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"scripts/camunda-core/pkg/chartvalues"
+)
+
+// RunKind distinguishes the naive customer upgrade from the remediated one.
+type RunKind string
+
+const (
+	// RunA renders the target chart with the source chart's values, unchanged.
+	RunA RunKind = "A"
+	// RunB additionally applies the transition's delta.
+	RunB RunKind = "B"
+)
+
+// RenderResult captures one `helm template` invocation.
+type RenderResult struct {
+	Kind      RunKind       `json:"kind"`
+	Succeeded bool          `json:"succeeded"`
+	Stderr    string        `json:"stderr,omitempty"`
+	Duration  time.Duration `json:"durationMs"`
+	// Manifest is retained only on success.
+	Manifest string `json:"-"`
+	// ValuesFiles is the ordered -f list.
+	ValuesFiles []string `json:"valuesFiles"`
+}
+
+// Renderer invokes Helm.
+type Renderer interface {
+	Template(ctx context.Context, chartDir string, valuesFiles []string) (stdout string, stderr string, err error)
+	DependencyBuild(ctx context.Context, chartDir string) error
+}
+
+// HelmRenderer shells out to the real helm binary.
+type HelmRenderer struct {
+	Bin         string
+	ReleaseName string
+}
+
+func NewHelmRenderer() *HelmRenderer {
+	return &HelmRenderer{Bin: "helm", ReleaseName: "upgrade-path"}
+}
+
+func (h *HelmRenderer) Template(ctx context.Context, chartDir string, valuesFiles []string) (string, string, error) {
+	args := []string{"template", h.ReleaseName, chartDir}
+	for _, f := range valuesFiles {
+		args = append(args, "-f", f)
+	}
+	cmd := exec.CommandContext(ctx, h.Bin, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return stdout.String(), stderr.String(), err
+}
+
+// DependencyBuild resolves chart dependencies from Chart.lock.
+func (h *HelmRenderer) DependencyBuild(ctx context.Context, chartDir string) error {
+	cmd := exec.CommandContext(ctx, h.Bin, "dependency", "build", chartDir)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("helm dependency build: %w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
+// Render performs one A or B run.
+//
+// For Run B the delta is applied by consolidating the baseline layers into a
+// single document and rewriting it, because a delta may remove keys and Helm
+// cannot express removal through an additional -f.
+func Render(ctx context.Context, r Renderer, t Transition, kind RunKind, repoRoot, workDir string) RenderResult {
+	files := append([]string{}, t.BaselineLayers...)
+	if kind == RunB && t.DeltaPath != "" {
+		out := filepath.Join(workDir, fmt.Sprintf("run-b-%s.yaml", t.Archetype.Name))
+		if _, err := chartvalues.Consolidate(t.BaselineLayers, t.DeltaPath, out); err != nil {
+			return RenderResult{Kind: kind, ValuesFiles: files, Stderr: err.Error()}
+		}
+		files = []string{out}
+	}
+
+	res := RenderResult{Kind: kind, ValuesFiles: files}
+	start := time.Now()
+	stdout, stderr, err := r.Template(ctx, ChartDir(repoRoot, t.To), files)
+	res.Duration = time.Since(start)
+	res.Stderr = strings.TrimSpace(stderr)
+	if err == nil {
+		res.Succeeded = true
+		res.Manifest = stdout
+	}
+	return res
+}
+
+var (
+	reCamundaError = regexp.MustCompile(`\[camunda\]\[error\]\s*(.+)`)
+	reTemplateAt   = regexp.MustCompile(`execution error at \(([^)]+)\)`)
+	reHelmError    = regexp.MustCompile(`(?m)^Error:\s*(.+)$`)
+)
+
+// ErrorSignature is a stable, de-duplicatable summary of a render failure.
+type ErrorSignature struct {
+	Title  string
+	Source string
+	Raw    string
+}
+
+// Signature extracts a comparable signature from render stderr. The result
+// must not vary with filesystem paths, timing, or ordering.
+func Signature(stderr string) ErrorSignature {
+	sig := ErrorSignature{Raw: strings.TrimSpace(stderr)}
+
+	if m := reCamundaError.FindStringSubmatch(stderr); m != nil {
+		sig.Title = collapseSpace(m[1])
+	} else if m := reHelmError.FindStringSubmatch(stderr); m != nil {
+		sig.Title = collapseSpace(m[1])
+	} else if sig.Raw != "" {
+		sig.Title = collapseSpace(firstLine(sig.Raw))
+	}
+
+	if m := reTemplateAt.FindStringSubmatch(stderr); m != nil {
+		sig.Source = m[1]
+	}
+
+	// Helm prefixes the fail() message with "execution error at (...)".
+	if sig.Source != "" {
+		sig.Title = strings.TrimSpace(strings.TrimPrefix(sig.Title,
+			fmt.Sprintf("execution error at (%s):", sig.Source)))
+	}
+	return sig
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+func collapseSpace(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}

--- a/scripts/upgrade-paths/report.go
+++ b/scripts/upgrade-paths/report.go
@@ -127,6 +127,11 @@ func (r Report) Markdown() string {
 		} else {
 			b.WriteString("_Doc coverage not checked: no upgrade guide found for this transition._\n\n")
 		}
+		if len(res.ScaffoldingKeys) > 0 {
+			fmt.Fprintf(&b, "> Harness-only, **not** customer steps: %s. These exist in the CI "+
+				"scenario's values, not in the chart, and must be excluded from the upgrade guide.\n\n",
+				"`"+strings.Join(res.ScaffoldingKeys, "`, `")+"`")
+		}
 		if d.Final.Succeeded {
 			b.WriteString("After these changes the chart renders. Note that a clean render proves only " +
 				"that values are accepted — not that data survives the upgrade.\n\n")

--- a/scripts/upgrade-paths/report.go
+++ b/scripts/upgrade-paths/report.go
@@ -1,0 +1,208 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Report is the aggregate of every path run for one transition.
+type Report struct {
+	Transition string       `json:"transition"`
+	From       string       `json:"from"`
+	To         string       `json:"to"`
+	Stage      string       `json:"stage"`
+	Results    []PathResult `json:"results"`
+}
+
+// ExitCode returns 1 for UNREMEDIATED or STALE_DELTA outcomes, 0 otherwise.
+// REMEDIATED is not a failure.
+func (r Report) ExitCode() int {
+	for _, res := range r.Results {
+		if res.Outcome == OutcomeUnremediated || res.Outcome == OutcomeStaleDelta {
+			return 1
+		}
+	}
+	return 0
+}
+
+// Counts summarises outcomes for the header line.
+func (r Report) Counts() map[Outcome]int {
+	m := map[Outcome]int{}
+	for _, res := range r.Results {
+		m[res.Outcome]++
+	}
+	return m
+}
+
+// Markdown renders the human-facing report.
+func (r Report) Markdown() string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "# Upgrade path report — %s → %s\n\n", r.From, r.To)
+	fmt.Fprintf(&b, "Stage: `%s`\n\n", r.Stage)
+
+	c := r.Counts()
+	fmt.Fprintf(&b, "**%d clean · %d remediated · %d unremediated · %d stale**\n\n",
+		c[OutcomeClean], c[OutcomeRemediated], c[OutcomeUnremediated], c[OutcomeStaleDelta])
+
+	if c[OutcomeClean] == len(r.Results) && len(r.Results) > 0 {
+		b.WriteString("> All paths upgrade with no customer action required.\n\n")
+	}
+
+	b.WriteString("## Summary\n\n")
+	b.WriteString("| Path | Run A (naïve) | Run B (remediated) | Outcome | Customer action |\n")
+	b.WriteString("|---|---|---|---|---|\n")
+
+	results := append([]PathResult{}, r.Results...)
+	sort.Slice(results, func(i, j int) bool { return results[i].Path < results[j].Path })
+
+	for _, res := range results {
+		action := "none"
+		switch res.Outcome {
+		case OutcomeRemediated:
+			action = "values change required"
+			if res.HasRemedy {
+				action = "values change **+ out-of-band procedure**"
+			}
+		case OutcomeUnremediated:
+			action = "**unknown — no remedy**"
+		case OutcomeStaleDelta:
+			action = "_fixture bug_"
+		}
+		fmt.Fprintf(&b, "| `%s` | %s | %s | %s | %s |\n",
+			res.Path, mark(res.RunA.Succeeded), mark(res.RunB.Succeeded), res.Outcome, action)
+	}
+	b.WriteString("\n")
+
+	for _, res := range results {
+		d := res.Discovery
+		if d == nil || len(d.Changes) == 0 {
+			continue
+		}
+		fmt.Fprintf(&b, "## Required values changes — `%s`\n\n", res.Path)
+		if d.Truncated {
+			b.WriteString("> ⚠️ Discovery hit its round limit — this list is **incomplete**.\n\n")
+		}
+		cov := res.DocsCoverage
+		b.WriteString("| Key | Change | Action | Documented |\n|---|---|---|---|\n")
+		for _, c := range d.Changes {
+			action := "delete; migrate to an external service if applicable"
+			kind := "removed"
+			if c.Kind == "renamed" {
+				kind = "renamed"
+				action = fmt.Sprintf("move value to `%s`", c.New)
+			}
+			fmt.Fprintf(&b, "| `%s` | %s | %s | %s |\n", c.Old, kind, action, docMark(cov, c.Old))
+		}
+		b.WriteString("\n")
+
+		if cov.Checked {
+			keys := make([]string, 0, len(d.Changes))
+			for _, c := range d.Changes {
+				keys = append(keys, c.Old)
+			}
+			if n := cov.UndocumentedCount(keys); n > 0 {
+				fmt.Fprintf(&b, "> ⚠️ **%d of %d changes are not named in the published upgrade guide** "+
+					"(%s). A customer following the guide alone will not learn about them.\n\n",
+					n, len(keys), strings.Join(cov.Guides, ", "))
+			} else {
+				fmt.Fprintf(&b, "All changes are named in the published upgrade guide (%s).\n\n",
+					strings.Join(cov.Guides, ", "))
+			}
+		} else {
+			b.WriteString("_Doc coverage not checked: no upgrade guide found for this transition._\n\n")
+		}
+		if d.Final.Succeeded {
+			b.WriteString("After these changes the chart renders. Note that a clean render proves only " +
+				"that values are accepted — not that data survives the upgrade.\n\n")
+		} else if d.Residual != "" {
+			fmt.Fprintf(&b, "**Not resolved by values changes alone:** %s\n\n", d.Residual)
+		}
+	}
+
+	var findings []Finding
+	for _, res := range results {
+		findings = append(findings, res.Findings...)
+	}
+	if len(findings) == 0 {
+		return b.String()
+	}
+
+	sort.SliceStable(findings, func(i, j int) bool {
+		return severityRank(findings[i].Severity) < severityRank(findings[j].Severity)
+	})
+
+	b.WriteString("## Findings\n\n")
+	for _, f := range findings {
+		fmt.Fprintf(&b, "### `%s` — %s\n\n", f.Path, f.Title)
+		fmt.Fprintf(&b, "- **Class:** %s · **Severity:** %s · **Fingerprint:** `%s`\n",
+			f.Class, f.Severity, f.Fingerprint)
+		if f.Evidence.Source != "" {
+			fmt.Fprintf(&b, "- **Raised by:** `%s`\n", f.Evidence.Source)
+		}
+		switch {
+		case f.Remedy.Kind == "none":
+			b.WriteString("- **Remedy:** none known — escalate\n")
+		case f.Remedy.OutOfBand:
+			fmt.Fprintf(&b, "- **Remedy:** values delta **plus an out-of-band procedure** (`%s`)\n", f.Remedy.Diff)
+		case f.Remedy.Available:
+			fmt.Fprintf(&b, "- **Remedy:** values delta (`%s`)\n", f.Remedy.Diff)
+		default:
+			b.WriteString("- **Remedy:** fix the fixture\n")
+		}
+		if f.Evidence.Error != "" {
+			b.WriteString("\n<details><summary>Error the customer sees</summary>\n\n```\n")
+			b.WriteString(f.Evidence.Error)
+			b.WriteString("\n```\n\n</details>\n")
+		}
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+// docMark renders a coverage cell, distinguishing unchecked from undocumented.
+func docMark(cov DocsCoverage, key string) string {
+	if !cov.Checked {
+		return "—"
+	}
+	if cov.Documented[key] {
+		return "yes"
+	}
+	return "**NO**"
+}
+
+func mark(ok bool) string {
+	if ok {
+		return "✅"
+	}
+	return "❌"
+}
+
+func severityRank(s string) int {
+	switch s {
+	case "critical":
+		return 0
+	case "high":
+		return 1
+	case "medium":
+		return 2
+	default:
+		return 3
+	}
+}

--- a/test/upgrade-paths/archetypes/classic-bundled/archetype.yaml
+++ b/test/upgrade-paths/archetypes/classic-bundled/archetype.yaml
@@ -1,0 +1,12 @@
+name: classic-bundled
+description: >-
+  Bundled Keycloak plus the bundled Elasticsearch subchart, full component set.
+  The legacy default shape: the deployment most likely to exist at a customer
+  who has upgraded in place since an early 8.x, and the one 8.10 stresses hardest
+  because both bundled backends were removed.
+tier: 1
+platforms: [gke]
+layers:
+  - base.yaml
+  - identity/keycloak.yaml
+  - persistence/elasticsearch.yaml

--- a/test/upgrade-paths/archetypes/oidc-external-storage/archetype.yaml
+++ b/test/upgrade-paths/archetypes/oidc-external-storage/archetype.yaml
@@ -1,0 +1,11 @@
+name: oidc-external-storage
+description: >-
+  External OIDC provider with externally managed secondary storage (no bundled
+  Elasticsearch subchart). The recommended production shape, and the control
+  case: breaks that appear here are not attributable to bundled infrastructure.
+tier: 1
+platforms: [gke]
+layers:
+  - base.yaml
+  - identity/oidc.yaml
+  - persistence/no-elasticsearch.yaml

--- a/test/upgrade-paths/transitions/8.8-to-8.9/classic-bundled/delta.values.yaml
+++ b/test/upgrade-paths/transitions/8.8-to-8.9/classic-bundled/delta.values.yaml
@@ -1,0 +1,5 @@
+# Delta for classic-bundled, 8.8-to-8.9
+#
+# Empty means: a customer on this path upgrades with no values changes.
+# Every key added here is a change the customer MUST make, and is emitted
+# verbatim into the upgrade guide. Keep it minimal and justified.

--- a/test/upgrade-paths/transitions/8.8-to-8.9/oidc-external-storage/delta.values.yaml
+++ b/test/upgrade-paths/transitions/8.8-to-8.9/oidc-external-storage/delta.values.yaml
@@ -1,0 +1,5 @@
+# Delta for oidc-external-storage, 8.8-to-8.9
+#
+# Empty means: a customer on this path upgrades with no values changes.
+# Every key added here is a change the customer MUST make, and is emitted
+# verbatim into the upgrade guide. Keep it minimal and justified.

--- a/test/upgrade-paths/transitions/8.9-to-8.10/classic-bundled/delta.values.yaml
+++ b/test/upgrade-paths/transitions/8.9-to-8.10/classic-bundled/delta.values.yaml
@@ -1,0 +1,103 @@
+# Delta for classic-bundled, 8.9-to-8.10
+#
+# Every entry is a change the customer MUST make. Directives:
+#   $rename  moves a value to a new path, preserving it. Used where the value is
+#            environment-specific and cannot be restated statically.
+#   $remove  deletes dotted paths. Chart constraints test key presence, so these
+#            cannot be cleared by setting them to null.
+# Remaining keys are merged in as normal values.
+#
+# Removing the bundled-subchart keys makes the chart render. It does NOT migrate
+# the data those subcharts held — see remedy.sh.
+
+$rename:
+  global.ingress.host: global.host
+
+$remove:
+  - identityKeycloak
+  - identityPostgresql
+  - webModelerPostgresql
+  - elasticsearch
+
+# Values that named the old ingress path must be updated too: removing the key
+# alone renders the gRPC ingress host as "grpc-", which the API server rejects
+# as an invalid RFC 1123 subdomain.
+orchestration:
+  ingress:
+    grpc:
+      host: "grpc-{{ .Values.global.host }}"
+  data:
+    secondaryStorage:
+      type: elasticsearch
+      elasticsearch:
+        url: http://elasticsearch-master:9200
+
+# The bundled Keycloak supplied its own URL implicitly. With the subchart gone,
+# the connection to the externally managed instance must be stated explicitly,
+# or OIDC discovery builds a relative URL and every component fails to start.
+global:
+  identity:
+    keycloak:
+      internal: true
+      url:
+        protocol: http
+        host: "keycloak.{{ .Release.Namespace }}.svc.cluster.local"
+        port: "80"
+      auth:
+        adminUser: admin
+        secret:
+          existingSecret: integration-test-credentials
+          existingSecretKey: identity-keycloak-admin-password
+
+# The bundled Elasticsearch subchart is gone, so components must be pointed at
+# the external cluster. In 8.9 the subchart supplied the connection implicitly
+# via global.elasticsearch.enabled; 8.10 moves the orchestration cluster onto
+# orchestration.data.secondaryStorage and needs an explicit host, or Optimize's
+# migration init container resolves the old bundled service name and crashloops.
+  elasticsearch:
+    url:
+      host: elasticsearch-master
+
+# Likewise the bundled PostgreSQL subcharts: Identity and Web Modeler must now
+# point at externally managed databases.
+identity:
+  # SCENARIO SCAFFOLDING, not a customer-facing step: the CI values carry an
+  # init container that polls the bundled Keycloak service by name. Real
+  # deployments do not ship this container. Retargeted so the archetype can
+  # reach a healthy state; see FINDINGS on separating CI-only scaffolding.
+  initContainers:
+    - name: wait-for-keycloak
+      image: busybox:1.36
+      command:
+        - sh
+        - -c
+        - |
+          echo "Waiting for Keycloak at keycloak:80/auth/ ..."
+          until wget -q --spider --timeout=2 "http://keycloak:80/auth/"; do
+            sleep 2
+          done
+          echo "Keycloak is ready"
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 1000
+  externalDatabase:
+    enabled: true
+    host: postgresql
+    port: 5432
+    database: identity
+    username: $RDBMS_POSTGRESQL_USERNAME
+    secret:
+      inlineSecret: $RDBMS_POSTGRESQL_PASSWORD
+
+webModeler:
+  restapi:
+    externalDatabase:
+      enabled: true
+      host: postgresql
+      port: 5432
+      database: webmodeler
+      username: $RDBMS_POSTGRESQL_USERNAME
+      secret:
+        inlineSecret: $RDBMS_POSTGRESQL_PASSWORD

--- a/test/upgrade-paths/transitions/8.9-to-8.10/classic-bundled/delta.values.yaml
+++ b/test/upgrade-paths/transitions/8.9-to-8.10/classic-bundled/delta.values.yaml
@@ -61,27 +61,6 @@ global:
 # Likewise the bundled PostgreSQL subcharts: Identity and Web Modeler must now
 # point at externally managed databases.
 identity:
-  # SCENARIO SCAFFOLDING, not a customer-facing step: the CI values carry an
-  # init container that polls the bundled Keycloak service by name. Real
-  # deployments do not ship this container. Retargeted so the archetype can
-  # reach a healthy state; see FINDINGS on separating CI-only scaffolding.
-  initContainers:
-    - name: wait-for-keycloak
-      image: busybox:1.36
-      command:
-        - sh
-        - -c
-        - |
-          echo "Waiting for Keycloak at keycloak:80/auth/ ..."
-          until wget -q --spider --timeout=2 "http://keycloak:80/auth/"; do
-            sleep 2
-          done
-          echo "Keycloak is ready"
-      securityContext:
-        allowPrivilegeEscalation: false
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
-        runAsUser: 1000
   externalDatabase:
     enabled: true
     host: postgresql
@@ -101,3 +80,26 @@ webModeler:
       username: $RDBMS_POSTGRESQL_USERNAME
       secret:
         inlineSecret: $RDBMS_POSTGRESQL_PASSWORD
+
+# Harness-only. The CI scenario's values carry an init container that polls the
+# bundled Keycloak service by name; the chart does not ship it and no customer
+# has it. Applied so the run can succeed, excluded from the change list.
+$scaffolding:
+  identity:
+    initContainers:
+      - name: wait-for-keycloak
+        image: busybox:1.36
+        command:
+          - sh
+          - -c
+          - |
+            echo "Waiting for Keycloak at keycloak:80/auth/ ..."
+            until wget -q --spider --timeout=2 "http://keycloak:80/auth/"; do
+              sleep 2
+            done
+            echo "Keycloak is ready"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000

--- a/test/upgrade-paths/transitions/8.9-to-8.10/oidc-external-storage/delta.values.yaml
+++ b/test/upgrade-paths/transitions/8.9-to-8.10/oidc-external-storage/delta.values.yaml
@@ -1,0 +1,103 @@
+# Delta for oidc-external-storage, 8.9-to-8.10
+#
+# Every entry is a change the customer MUST make. Directives:
+#   $rename  moves a value to a new path, preserving it. Used where the value is
+#            environment-specific and cannot be restated statically.
+#   $remove  deletes dotted paths. Chart constraints test key presence, so these
+#            cannot be cleared by setting them to null.
+# Remaining keys are merged in as normal values.
+#
+# Removing the bundled-subchart keys makes the chart render. It does NOT migrate
+# the data those subcharts held — see remedy.sh.
+
+$rename:
+  global.ingress.host: global.host
+
+$remove:
+  - identityKeycloak
+  - identityPostgresql
+  - webModelerPostgresql
+  - elasticsearch
+
+# Values that named the old ingress path must be updated too: removing the key
+# alone renders the gRPC ingress host as "grpc-", which the API server rejects
+# as an invalid RFC 1123 subdomain.
+orchestration:
+  ingress:
+    grpc:
+      host: "grpc-{{ .Values.global.host }}"
+  data:
+    secondaryStorage:
+      type: elasticsearch
+      elasticsearch:
+        url: http://elasticsearch-master:9200
+
+# The bundled Keycloak supplied its own URL implicitly. With the subchart gone,
+# the connection to the externally managed instance must be stated explicitly,
+# or OIDC discovery builds a relative URL and every component fails to start.
+global:
+  identity:
+    keycloak:
+      internal: true
+      url:
+        protocol: http
+        host: "keycloak.{{ .Release.Namespace }}.svc.cluster.local"
+        port: "80"
+      auth:
+        adminUser: admin
+        secret:
+          existingSecret: integration-test-credentials
+          existingSecretKey: identity-keycloak-admin-password
+
+# The bundled Elasticsearch subchart is gone, so components must be pointed at
+# the external cluster. In 8.9 the subchart supplied the connection implicitly
+# via global.elasticsearch.enabled; 8.10 moves the orchestration cluster onto
+# orchestration.data.secondaryStorage and needs an explicit host, or Optimize's
+# migration init container resolves the old bundled service name and crashloops.
+  elasticsearch:
+    url:
+      host: elasticsearch-master
+
+# Likewise the bundled PostgreSQL subcharts: Identity and Web Modeler must now
+# point at externally managed databases.
+identity:
+  # SCENARIO SCAFFOLDING, not a customer-facing step: the CI values carry an
+  # init container that polls the bundled Keycloak service by name. Real
+  # deployments do not ship this container. Retargeted so the archetype can
+  # reach a healthy state; see FINDINGS on separating CI-only scaffolding.
+  initContainers:
+    - name: wait-for-keycloak
+      image: busybox:1.36
+      command:
+        - sh
+        - -c
+        - |
+          echo "Waiting for Keycloak at keycloak:80/auth/ ..."
+          until wget -q --spider --timeout=2 "http://keycloak:80/auth/"; do
+            sleep 2
+          done
+          echo "Keycloak is ready"
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 1000
+  externalDatabase:
+    enabled: true
+    host: postgresql
+    port: 5432
+    database: identity
+    username: $RDBMS_POSTGRESQL_USERNAME
+    secret:
+      inlineSecret: $RDBMS_POSTGRESQL_PASSWORD
+
+webModeler:
+  restapi:
+    externalDatabase:
+      enabled: true
+      host: postgresql
+      port: 5432
+      database: webmodeler
+      username: $RDBMS_POSTGRESQL_USERNAME
+      secret:
+        inlineSecret: $RDBMS_POSTGRESQL_PASSWORD

--- a/test/upgrade-paths/transitions/8.9-to-8.10/oidc-external-storage/delta.values.yaml
+++ b/test/upgrade-paths/transitions/8.9-to-8.10/oidc-external-storage/delta.values.yaml
@@ -61,27 +61,6 @@ global:
 # Likewise the bundled PostgreSQL subcharts: Identity and Web Modeler must now
 # point at externally managed databases.
 identity:
-  # SCENARIO SCAFFOLDING, not a customer-facing step: the CI values carry an
-  # init container that polls the bundled Keycloak service by name. Real
-  # deployments do not ship this container. Retargeted so the archetype can
-  # reach a healthy state; see FINDINGS on separating CI-only scaffolding.
-  initContainers:
-    - name: wait-for-keycloak
-      image: busybox:1.36
-      command:
-        - sh
-        - -c
-        - |
-          echo "Waiting for Keycloak at keycloak:80/auth/ ..."
-          until wget -q --spider --timeout=2 "http://keycloak:80/auth/"; do
-            sleep 2
-          done
-          echo "Keycloak is ready"
-      securityContext:
-        allowPrivilegeEscalation: false
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
-        runAsUser: 1000
   externalDatabase:
     enabled: true
     host: postgresql
@@ -101,3 +80,26 @@ webModeler:
       username: $RDBMS_POSTGRESQL_USERNAME
       secret:
         inlineSecret: $RDBMS_POSTGRESQL_PASSWORD
+
+# Harness-only. The CI scenario's values carry an init container that polls the
+# bundled Keycloak service by name; the chart does not ship it and no customer
+# has it. Applied so the run can succeed, excluded from the change list.
+$scaffolding:
+  identity:
+    initContainers:
+      - name: wait-for-keycloak
+        image: busybox:1.36
+        command:
+          - sh
+          - -c
+          - |
+            echo "Waiting for Keycloak at keycloak:80/auth/ ..."
+            until wget -q --spider --timeout=2 "http://keycloak:80/auth/"; do
+              sleep 2
+            done
+            echo "Keycloak is ready"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000


### PR DESCRIPTION
> | # | PR | Phase | Purpose |
> |---|---|---|---|
> | 1 | #6820 | shared library | `chartvalues`: consolidation, `$remove`/`$rename`/`$scaffolding` directives |
> | 2 | #6821 | render stage | `upgrade-paths` A/B harness, archetypes, fixtures, render workflow |
> | 3 | #6822 | cluster stage | `deploy-camunda` values carryover, `upgrade-path` flow, hook suppression |
> | **4** | **#6824** | **correctness** | **separate harness scaffolding from customer-facing steps** ← you are here |
> | 5 | #6825 | honesty | coverage manifest: report what the harness does not check |
> | 6 | #6826 | coverage | gate rendering against a real Helm v3 client |
> | 7 | #6827 | lifecycle | `--bootstrap` a new version transition at fork time |
> | 8 | #6828 | automation | run the cluster stage nightly and on demand |
> | 9 | #6829 | realism | make externally-provisioned shapes the primary archetypes |
> | 10 | #6830 | coverage | detect storage stranded by an upgrade |
> | 11 | #6831 | coverage | compare entity counts across an upgrade |
> | 12 | #6832 | infra | schedule companion services on the intended node pool |
> | 13 | #6834 | coverage | probe data survival and budget upgrade duration |

Merge in order. 2 onwards consume the package from 1; 4 corrects a limitation documented in 3; 6, 10, 11 and 13 close gaps named by 5; 8 automates what 3 made possible; 9 replaces the inferred archetypes with confirmed ones; 12 fixes node placement for the scenario 3 introduced; 13 wires the probes 11 defined.

