### PR TITLE
test: [UPGPATH 3/5] publish a coverage ledger and gate the Helm v3 constraint

### DIFF
--- a/.github/workflows/upgrade-paths.yaml
+++ b/.github/workflows/upgrade-paths.yaml
@@ -170,6 +170,7 @@ jobs:
         env:
           MARKER: requires Helm CLI v4 or later
           PREEMPTED: an error occurred while checking for chart dependencies
+          KNOWN_BARE_RENDER: invalid value; expected string
         run: |
           set -uo pipefail
           status=0
@@ -205,7 +206,7 @@ jobs:
               if echo "${out}" | grep -qF "${MARKER}"; then
                 echo "::error::${chart} still supports v3 but a v3 render reported the v4 constraint"
                 status=1
-              elif [ "${render_status}" -ne 0 ] && ! echo "${out}" | grep -qE '\[camunda\]\[error\]|execution error at'; then
+              elif [ "${render_status}" -ne 0 ] && ! echo "${out}" | grep -qE "\[camunda\]\[error\]|execution error at|${KNOWN_BARE_RENDER}"; then
                 echo "::error::${chart} Helm v3 render failed before a chart constraint produced a verdict"
                 echo "${out}" | head -3
                 status=1

--- a/.github/workflows/upgrade-paths.yaml
+++ b/.github/workflows/upgrade-paths.yaml
@@ -146,8 +146,11 @@ jobs:
           HELM_V3_VERSION: v3.20.2
         run: |
           set -euo pipefail
-          curl -fsSL "https://get.helm.sh/helm-${HELM_V3_VERSION}-linux-amd64.tar.gz" \
-            | tar -xz -C "${RUNNER_TEMP}" --strip-components=1 linux-amd64/helm
+          archive="helm-${HELM_V3_VERSION}-linux-amd64.tar.gz"
+          curl --retry 3 -fsSLO "https://get.helm.sh/${archive}"
+          curl --retry 3 -fsSLO "https://get.helm.sh/${archive}.sha256sum"
+          sha256sum --check "${archive}.sha256sum"
+          tar -xzf "${archive}" -C "${RUNNER_TEMP}" --strip-components=1 linux-amd64/helm
           "${RUNNER_TEMP}/helm" version --short
 
       # The guard is asserted on the message, not the exit code: a chart can
@@ -179,7 +182,8 @@ jobs:
             fi
 
             requires=$(grep -oE 'camunda\.io/helmCLIVersion: *"[^"]*"' "${chart}Chart.yaml" | head -1) || true
-            out=$("${RUNNER_TEMP}/helm" template t "${chart}" 2>&1) || true
+            render_status=0
+            out=$("${RUNNER_TEMP}/helm" template t "${chart}" 2>&1) || render_status=$?
 
             # Belt and braces: if rendering still died before the constraints
             # ran, say so instead of drawing a conclusion from a missing marker.
@@ -200,6 +204,10 @@ jobs:
             else
               if echo "${out}" | grep -qF "${MARKER}"; then
                 echo "::error::${chart} still supports v3 but a v3 render reported the v4 constraint"
+                status=1
+              elif [ "${render_status}" -ne 0 ] && ! echo "${out}" | grep -qE '\[camunda\]\[error\]|execution error at'; then
+                echo "::error::${chart} Helm v3 render failed before a chart constraint produced a verdict"
+                echo "${out}" | head -3
                 status=1
               else
                 echo "✓ ${chart} does not reject Helm v3"

--- a/.github/workflows/upgrade-paths.yaml
+++ b/.github/workflows/upgrade-paths.yaml
@@ -134,3 +134,76 @@ jobs:
         run: |
           echo "::error::Upgrade path check failed - see the job summary for the outcome matrix."
           exit 1
+
+  helm-v3-gate:
+    name: Helm v3 rejection
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+
+      - name: Install pinned Helm v3
+        env:
+          HELM_V3_VERSION: v3.20.2
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://get.helm.sh/helm-${HELM_V3_VERSION}-linux-amd64.tar.gz" \
+            | tar -xz -C "${RUNNER_TEMP}" --strip-components=1 linux-amd64/helm
+          "${RUNNER_TEMP}/helm" version --short
+
+      # The guard is asserted on the message, not the exit code: a chart can
+      # fail a bare render for unrelated reasons, such as required values that
+      # a scenario would normally supply.
+      #
+      # That tolerance is not enough on its own. An error raised BEFORE any
+      # template is evaluated suppresses the message entirely, and the absence
+      # of the marker then reads as "this chart does not reject v3" — a pass,
+      # for every chart that is not v4-only. Vendored subcharts are gitignored
+      # (*.tgz), so on a fresh checkout `helm template` fails dependency
+      # resolution and the whole gate silently asserts nothing.
+      #
+      # Dependencies are therefore built first, and any chart that never
+      # reaches template evaluation is a hard failure rather than a pass.
+      - name: Charts requiring v4 must reject a v3 client
+        env:
+          MARKER: requires Helm CLI v4 or later
+          PREEMPTED: an error occurred while checking for chart dependencies
+        run: |
+          set -uo pipefail
+          status=0
+          for chart in charts/camunda-platform-*/; do
+            if ! build=$("${RUNNER_TEMP}/helm" dependency build "${chart}" 2>&1); then
+              echo "::error::${chart} dependency build failed; the v3 check cannot run"
+              echo "${build}"
+              status=1
+              continue
+            fi
+
+            requires=$(grep -oE 'camunda\.io/helmCLIVersion: *"[^"]*"' "${chart}Chart.yaml" | head -1) || true
+            out=$("${RUNNER_TEMP}/helm" template t "${chart}" 2>&1) || true
+
+            # Belt and braces: if rendering still died before the constraints
+            # ran, say so instead of drawing a conclusion from a missing marker.
+            if echo "${out}" | grep -qF "${PREEMPTED}"; then
+              echo "::error::${chart} render was preempted before constraints were evaluated; result is not a verdict"
+              echo "${out}" | head -3
+              status=1
+              continue
+            fi
+
+            if echo "${requires}" | grep -q '"4'  && ! echo "${requires}" | grep -q '3\.'; then
+              if echo "${out}" | grep -qF "${MARKER}"; then
+                echo "✓ ${chart} rejects Helm v3"
+              else
+                echo "::error::${chart} declares v4-only but a v3 render did not report it"
+                status=1
+              fi
+            else
+              if echo "${out}" | grep -qF "${MARKER}"; then
+                echo "::error::${chart} still supports v3 but a v3 render reported the v4 constraint"
+                status=1
+              else
+                echo "✓ ${chart} does not reject Helm v3"
+              fi
+            fi
+          done
+          exit $status

--- a/scripts/upgrade-paths/bootstrap.go
+++ b/scripts/upgrade-paths/bootstrap.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// BootstrapResult reports what a bootstrap run did.
+type BootstrapResult struct {
+	Created  []string
+	Existing []string
+}
+
+// Bootstrap prepares a transition directory for every archetype, writing an
+// empty delta for each. An empty delta is the fork-day contract: as of today,
+// customers on this path need do nothing.
+//
+// Every archetype's layers are resolved against the source chart first, so a
+// layer renamed between versions fails here rather than midway through a run.
+func Bootstrap(repoRoot, from, to string, archetypes []string) (BootstrapResult, error) {
+	var res BootstrapResult
+
+	// The CI matrix discovers transitions from this directory, so bootstrapping
+	// a pair whose target chart does not exist yet would add a job that can
+	// never render. Bootstrap belongs at fork time, once the chart is cut.
+	for _, v := range []string{from, to} {
+		if _, err := os.Stat(ChartDir(repoRoot, v)); err != nil {
+			return res, fmt.Errorf("chart %s does not exist yet (%s); bootstrap a transition only "+
+				"once both charts are cut, or CI will discover a job it cannot run",
+				v, ChartDir(repoRoot, v))
+		}
+	}
+
+	// Validate every archetype before writing anything: a failure partway
+	// through would leave some paths bootstrapped and others not.
+	loaded := make([]Archetype, 0, len(archetypes))
+	vd := valuesDir(repoRoot, from)
+	for _, name := range archetypes {
+		a, err := LoadArchetype(repoRoot, name)
+		if err != nil {
+			return res, err
+		}
+		for _, layer := range a.Layers {
+			if _, err := os.Stat(filepath.Join(vd, layer)); err != nil {
+				return res, fmt.Errorf(
+					"archetype %s: layer %q missing in chart %s; the layer was renamed or removed "+
+						"and the archetype needs updating before %s-to-%s can run",
+					name, layer, from, from, to)
+			}
+		}
+		loaded = append(loaded, a)
+	}
+
+	for _, a := range loaded {
+		dir := TransitionDir(repoRoot, from, to, a.Name)
+		delta := filepath.Join(dir, "delta.values.yaml")
+		if fileExists(delta) {
+			res.Existing = append(res.Existing, delta)
+			continue
+		}
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return res, fmt.Errorf("create %s: %w", dir, err)
+		}
+		if err := os.WriteFile(delta, []byte(emptyDelta(a.Name, from, to)), 0o644); err != nil {
+			return res, fmt.Errorf("write %s: %w", delta, err)
+		}
+		res.Created = append(res.Created, delta)
+	}
+
+	return res, nil
+}
+
+func emptyDelta(archetype, from, to string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Delta for %s, %s-to-%s\n", archetype, from, to)
+	b.WriteString(`#
+# Empty means: a customer on this path upgrades with no values changes. Every
+# entry added here is a change the customer MUST make, and is emitted into the
+# upgrade guide, so keep it minimal and justified.
+#
+# Directives:
+#   $rename        moves a value to a new path, preserving it. Use where the
+#                  value is environment-specific and cannot be restated.
+#   $remove        deletes dotted paths. Chart constraints test key presence,
+#                  so these cannot be cleared by setting them to null.
+#   $scaffolding   harness-only values, applied but excluded from the change
+#                  list. For CI fixtures that no customer has.
+#
+# Remaining keys merge in as normal values.
+`)
+	return b.String()
+}

--- a/scripts/upgrade-paths/coverage.go
+++ b/scripts/upgrade-paths/coverage.go
@@ -43,6 +43,22 @@ type Coverage struct {
 	Categories []CoverageCategory `yaml:"categories" json:"categories"`
 }
 
+// ForStage marks checks owned by another stage as not exercised by this run.
+func (c Coverage) ForStage(stage string) Coverage {
+	out := Coverage{Categories: make([]CoverageCategory, len(c.Categories))}
+	copy(out.Categories, c.Categories)
+	for i := range out.Categories {
+		cat := &out.Categories[i]
+		if cat.Stage != "" && cat.Stage != stage {
+			cat.Status = StatusUncovered
+			if cat.Stage != "none" {
+				cat.Detail = fmt.Sprintf("Checked by the %s stage, not this %s run. %s", cat.Stage, stage, cat.Detail)
+			}
+		}
+	}
+	return out
+}
+
 // CoveragePath is the manifest location.
 func CoveragePath(repoRoot string) string {
 	return filepath.Join(repoRoot, "test", "upgrade-paths", "coverage.yaml")

--- a/scripts/upgrade-paths/coverage.go
+++ b/scripts/upgrade-paths/coverage.go
@@ -1,0 +1,101 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Coverage status values.
+const (
+	StatusCovered   = "covered"
+	StatusPartial   = "partial"
+	StatusUncovered = "uncovered"
+)
+
+// CoverageCategory is one class of breaking change and how the harness treats it.
+type CoverageCategory struct {
+	ID     string `yaml:"id" json:"id"`
+	Title  string `yaml:"title" json:"title"`
+	Status string `yaml:"status" json:"status"`
+	Stage  string `yaml:"stage" json:"stage"`
+	Detail string `yaml:"detail" json:"detail"`
+}
+
+// Coverage is the parsed manifest.
+type Coverage struct {
+	Categories []CoverageCategory `yaml:"categories" json:"categories"`
+}
+
+// CoveragePath is the manifest location.
+func CoveragePath(repoRoot string) string {
+	return filepath.Join(repoRoot, "test", "upgrade-paths", "coverage.yaml")
+}
+
+// LoadCoverage reads and validates the manifest. A missing manifest is not an
+// error; the report then omits the coverage section.
+func LoadCoverage(repoRoot string) (Coverage, error) {
+	var c Coverage
+	b, err := os.ReadFile(CoveragePath(repoRoot))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return c, nil
+		}
+		return c, fmt.Errorf("read coverage manifest: %w", err)
+	}
+	if err := yaml.Unmarshal(b, &c); err != nil {
+		return c, fmt.Errorf("parse coverage manifest: %w", err)
+	}
+	seen := map[string]bool{}
+	for _, cat := range c.Categories {
+		if cat.ID == "" || cat.Title == "" {
+			return Coverage{}, fmt.Errorf("coverage manifest: id and title are required")
+		}
+		if seen[cat.ID] {
+			return Coverage{}, fmt.Errorf("coverage manifest: duplicate id %q", cat.ID)
+		}
+		seen[cat.ID] = true
+		switch cat.Status {
+		case StatusCovered, StatusPartial, StatusUncovered:
+		default:
+			return Coverage{}, fmt.Errorf("coverage manifest: %s has unknown status %q", cat.ID, cat.Status)
+		}
+	}
+	return c, nil
+}
+
+// Gaps returns the categories this run does not fully check.
+func (c Coverage) Gaps() []CoverageCategory {
+	var out []CoverageCategory
+	for _, cat := range c.Categories {
+		if cat.Status != StatusCovered {
+			out = append(out, cat)
+		}
+	}
+	return out
+}
+
+// Counts tallies categories by status.
+func (c Coverage) Counts() map[string]int {
+	m := map[string]int{}
+	for _, cat := range c.Categories {
+		m[cat.Status]++
+	}
+	return m
+}

--- a/scripts/upgrade-paths/fixture.go
+++ b/scripts/upgrade-paths/fixture.go
@@ -176,13 +176,18 @@ func LoadTransition(repoRoot, from, to, archetypeName string) (Transition, error
 	}
 
 	td := TransitionDir(repoRoot, from, to, archetypeName)
+	// A bootstrapped delta is comment-only and parses to nothing. Deciding on
+	// the parsed delta rather than the file's bytes keeps Run B from repeating
+	// Run A and keeps the report from claiming a delta that changes nothing.
 	if p := filepath.Join(td, "delta.values.yaml"); fileHasContent(p) {
-		t.DeltaPath = p
 		d, err := chartvalues.LoadDelta(p)
 		if err != nil {
 			return t, err
 		}
-		t.Delta = d
+		if !d.IsEmpty() {
+			t.DeltaPath = p
+			t.Delta = d
+		}
 	}
 	if p := filepath.Join(td, "remedy.sh"); fileExists(p) {
 		t.RemedyPath = p

--- a/scripts/upgrade-paths/main.go
+++ b/scripts/upgrade-paths/main.go
@@ -64,10 +64,12 @@ func main() {
 			"after a Run A failure, iterate to find every removed/renamed key rather than only the first")
 		docsRoot = flag.String("docs-root", "",
 			"camunda-docs checkout; default is a sibling directory. Empty disables doc-coverage checking")
-		jsonOut = flag.String("json", "", "write findings JSON to this file")
-		mdOut   = flag.String("markdown", "", "write markdown report to this file")
-		timeout = flag.Duration("timeout", 5*time.Minute, "overall timeout")
-		quiet   = flag.Bool("quiet", false, "suppress the markdown report on stdout")
+		jsonOut   = flag.String("json", "", "write findings JSON to this file")
+		mdOut     = flag.String("markdown", "", "write markdown report to this file")
+		timeout   = flag.Duration("timeout", 5*time.Minute, "overall timeout")
+		quiet     = flag.Bool("quiet", false, "suppress the markdown report on stdout")
+		bootstrap = flag.Bool("bootstrap", false,
+			"create an empty delta for every archetype for this transition, then exit")
 	)
 	flag.Parse()
 
@@ -98,6 +100,22 @@ func main() {
 		docs = defaultDocsRoot(root)
 	}
 
+	if *bootstrap {
+		res, err := Bootstrap(root, *from, *to, archetypes)
+		if err != nil {
+			fatal(err)
+		}
+		for _, p := range res.Created {
+			fmt.Printf("created  %s\n", p)
+		}
+		for _, p := range res.Existing {
+			fmt.Printf("exists   %s\n", p)
+		}
+		fmt.Printf("\n%d created, %d already present. All archetype layers resolve against chart %s.\n",
+			len(res.Created), len(res.Existing), *from)
+		return
+	}
+
 	runDir, err := os.MkdirTemp("", "upgrade-paths-run-")
 	if err != nil {
 		fatal(fmt.Errorf("create work dir: %w", err))
@@ -111,11 +129,17 @@ func main() {
 		fmt.Fprintf(os.Stderr, "warning: %v (continuing; dependencies may be vendored)\n", err)
 	}
 
+	coverage, err := LoadCoverage(root)
+	if err != nil {
+		fatal(err)
+	}
+
 	report := Report{
 		Transition: fmt.Sprintf("%s-to-%s", *from, *to),
 		From:       *from,
 		To:         *to,
 		Stage:      "render",
+		Coverage:   coverage,
 	}
 
 	for _, name := range archetypes {

--- a/scripts/upgrade-paths/main.go
+++ b/scripts/upgrade-paths/main.go
@@ -110,11 +110,17 @@ func main() {
 		fmt.Fprintf(os.Stderr, "warning: %v (continuing; dependencies may be vendored)\n", err)
 	}
 
+	coverage, err := LoadCoverage(root)
+	if err != nil {
+		fatal(err)
+	}
+
 	report := Report{
 		Transition: fmt.Sprintf("%s-to-%s", *from, *to),
 		From:       *from,
 		To:         *to,
 		Stage:      "render",
+		Coverage:   coverage,
 	}
 
 	for _, name := range archetypes {

--- a/scripts/upgrade-paths/main_test.go
+++ b/scripts/upgrade-paths/main_test.go
@@ -483,6 +483,19 @@ func TestReportWithoutCoverageOmitsSection(t *testing.T) {
 	assert.NotContains(t, r.Markdown(), "## Coverage")
 }
 
+func TestCoverageForStageDoesNotClaimFutureChecks(t *testing.T) {
+	c := Coverage{Categories: []CoverageCategory{
+		{ID: "render", Title: "Render", Status: StatusCovered, Stage: "render"},
+		{ID: "cluster", Title: "Cluster", Status: StatusCovered, Stage: "cluster", Detail: "Applied to Kubernetes."},
+	}}
+
+	got := c.ForStage("render")
+	assert.Equal(t, StatusCovered, got.Categories[0].Status)
+	assert.Equal(t, StatusUncovered, got.Categories[1].Status)
+	assert.Contains(t, got.Categories[1].Detail, "not this render run")
+	assert.Equal(t, StatusCovered, c.Categories[1].Status, "the manifest remains unchanged")
+}
+
 // bootstrapRepo builds a minimal repo: two charts, and archetypes whose layers
 // exist only in the versions named.
 func bootstrapRepo(t *testing.T, layersByVersion map[string][]string, archetypes map[string][]string) string {

--- a/scripts/upgrade-paths/main_test.go
+++ b/scripts/upgrade-paths/main_test.go
@@ -339,3 +339,83 @@ func TestDocMark(t *testing.T) {
 	assert.Equal(t, "yes", docMark(checked, "a"))
 	assert.Equal(t, "**NO**", docMark(checked, "b"))
 }
+
+func writeCoverage(t *testing.T, body string) string {
+	t.Helper()
+	root := t.TempDir()
+	dir := filepath.Join(root, "test", "upgrade-paths")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "coverage.yaml"), []byte(body), 0o644))
+	return root
+}
+
+func TestLoadCoverage(t *testing.T) {
+	root := writeCoverage(t, `
+categories:
+  - id: a
+    title: Covered thing
+    status: covered
+    stage: render
+    detail: does the thing
+  - id: b
+    title: Missing thing
+    status: uncovered
+    stage: none
+    detail: does not do the thing
+`)
+	c, err := LoadCoverage(root)
+	require.NoError(t, err)
+	require.Len(t, c.Categories, 2)
+	assert.Equal(t, map[string]int{"covered": 1, "uncovered": 1}, c.Counts())
+
+	gaps := c.Gaps()
+	require.Len(t, gaps, 1)
+	assert.Equal(t, "b", gaps[0].ID, "only non-covered categories are gaps")
+}
+
+func TestLoadCoverageMissingFileIsNotAnError(t *testing.T) {
+	c, err := LoadCoverage(t.TempDir())
+	require.NoError(t, err)
+	assert.Empty(t, c.Categories)
+}
+
+func TestLoadCoverageRejectsBadManifests(t *testing.T) {
+	tests := []struct {
+		name, body, wantErr string
+	}{
+		{"unknown status", "categories:\n  - id: a\n    title: T\n    status: maybe\n", "unknown status"},
+		{"duplicate id", "categories:\n  - id: a\n    title: T\n    status: covered\n  - id: a\n    title: U\n    status: covered\n", "duplicate id"},
+		{"missing title", "categories:\n  - id: a\n    status: covered\n", "id and title are required"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := LoadCoverage(writeCoverage(t, tt.body))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestReportCoverageSectionNamesGaps(t *testing.T) {
+	r := Report{
+		From: "8.9", To: "8.10", Stage: "render",
+		Results: []PathResult{{Path: "p", Outcome: OutcomeClean}},
+		Coverage: Coverage{Categories: []CoverageCategory{
+			{ID: "a", Title: "Checked", Status: StatusCovered},
+			{ID: "b", Title: "Data survival", Status: StatusUncovered, Detail: "no seeding\n  at all"},
+		}},
+	}
+	md := r.Markdown()
+
+	assert.Contains(t, md, "## Coverage")
+	assert.Contains(t, md, "Data survival", "gaps are named")
+	assert.NotContains(t, md, "| Checked |", "covered categories are not listed as gaps")
+	assert.Contains(t, md, "no seeding at all", "multi-line detail is flattened for the table")
+	assert.Contains(t, md, "for the categories this harness checks",
+		"an all-clean run is qualified rather than absolute")
+}
+
+func TestReportWithoutCoverageOmitsSection(t *testing.T) {
+	r := Report{From: "8.9", To: "8.10", Results: []PathResult{{Path: "p", Outcome: OutcomeClean}}}
+	assert.NotContains(t, r.Markdown(), "## Coverage")
+}

--- a/scripts/upgrade-paths/main_test.go
+++ b/scripts/upgrade-paths/main_test.go
@@ -402,3 +402,164 @@ func TestDocMark(t *testing.T) {
 	assert.Equal(t, "yes", docMark(checked, "a"))
 	assert.Equal(t, "**NO**", docMark(checked, "b"))
 }
+
+func writeCoverage(t *testing.T, body string) string {
+	t.Helper()
+	root := t.TempDir()
+	dir := filepath.Join(root, "test", "upgrade-paths")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "coverage.yaml"), []byte(body), 0o644))
+	return root
+}
+
+func TestLoadCoverage(t *testing.T) {
+	root := writeCoverage(t, `
+categories:
+  - id: a
+    title: Covered thing
+    status: covered
+    stage: render
+    detail: does the thing
+  - id: b
+    title: Missing thing
+    status: uncovered
+    stage: none
+    detail: does not do the thing
+`)
+	c, err := LoadCoverage(root)
+	require.NoError(t, err)
+	require.Len(t, c.Categories, 2)
+	assert.Equal(t, map[string]int{"covered": 1, "uncovered": 1}, c.Counts())
+
+	gaps := c.Gaps()
+	require.Len(t, gaps, 1)
+	assert.Equal(t, "b", gaps[0].ID, "only non-covered categories are gaps")
+}
+
+func TestLoadCoverageMissingFileIsNotAnError(t *testing.T) {
+	c, err := LoadCoverage(t.TempDir())
+	require.NoError(t, err)
+	assert.Empty(t, c.Categories)
+}
+
+func TestLoadCoverageRejectsBadManifests(t *testing.T) {
+	tests := []struct {
+		name, body, wantErr string
+	}{
+		{"unknown status", "categories:\n  - id: a\n    title: T\n    status: maybe\n", "unknown status"},
+		{"duplicate id", "categories:\n  - id: a\n    title: T\n    status: covered\n  - id: a\n    title: U\n    status: covered\n", "duplicate id"},
+		{"missing title", "categories:\n  - id: a\n    status: covered\n", "id and title are required"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := LoadCoverage(writeCoverage(t, tt.body))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestReportCoverageSectionNamesGaps(t *testing.T) {
+	r := Report{
+		From: "8.9", To: "8.10", Stage: "render",
+		Results: []PathResult{{Path: "p", Outcome: OutcomeClean}},
+		Coverage: Coverage{Categories: []CoverageCategory{
+			{ID: "a", Title: "Checked", Status: StatusCovered},
+			{ID: "b", Title: "Data survival", Status: StatusUncovered, Detail: "no seeding\n  at all"},
+		}},
+	}
+	md := r.Markdown()
+
+	assert.Contains(t, md, "## Coverage")
+	assert.Contains(t, md, "Data survival", "gaps are named")
+	assert.NotContains(t, md, "| Checked |", "covered categories are not listed as gaps")
+	assert.Contains(t, md, "no seeding at all", "multi-line detail is flattened for the table")
+	assert.Contains(t, md, "for the categories this harness checks",
+		"an all-clean run is qualified rather than absolute")
+}
+
+func TestReportWithoutCoverageOmitsSection(t *testing.T) {
+	r := Report{From: "8.9", To: "8.10", Results: []PathResult{{Path: "p", Outcome: OutcomeClean}}}
+	assert.NotContains(t, r.Markdown(), "## Coverage")
+}
+
+// bootstrapRepo builds a minimal repo: two charts, and archetypes whose layers
+// exist only in the versions named.
+func bootstrapRepo(t *testing.T, layersByVersion map[string][]string, archetypes map[string][]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for v, layers := range layersByVersion {
+		vd := filepath.Join(root, "charts", "camunda-platform-"+v,
+			"test", "integration", "scenarios", "chart-full-setup", "values")
+		for _, l := range layers {
+			p := filepath.Join(vd, l)
+			require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+			require.NoError(t, os.WriteFile(p, []byte("{}\n"), 0o644))
+		}
+	}
+	for name, layers := range archetypes {
+		dir := filepath.Join(root, "test", "upgrade-paths", "archetypes", name)
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		body := "name: " + name + "\nlayers:\n"
+		for _, l := range layers {
+			body += "  - " + l + "\n"
+		}
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "archetype.yaml"), []byte(body), 0o644))
+	}
+	return root
+}
+
+func TestBootstrapCreatesEmptyDeltas(t *testing.T) {
+	root := bootstrapRepo(t,
+		map[string][]string{"8.9": {"base.yaml"}, "8.10": {"base.yaml"}},
+		map[string][]string{"a": {"base.yaml"}, "b": {"base.yaml"}})
+
+	res, err := Bootstrap(root, "8.9", "8.10", []string{"a", "b"})
+	require.NoError(t, err)
+	assert.Len(t, res.Created, 2)
+	assert.Empty(t, res.Existing)
+
+	require.FileExists(t, filepath.Join(TransitionDir(root, "8.9", "8.10", "a"), "delta.values.yaml"))
+
+	tr, err := LoadTransition(root, "8.9", "8.10", "a")
+	require.NoError(t, err)
+	assert.Empty(t, tr.DeltaPath,
+		"a bootstrapped delta is comment-only, so it must count as no delta")
+}
+
+func TestBootstrapIsIdempotent(t *testing.T) {
+	root := bootstrapRepo(t,
+		map[string][]string{"8.9": {"base.yaml"}, "8.10": {"base.yaml"}},
+		map[string][]string{"a": {"base.yaml"}})
+
+	_, err := Bootstrap(root, "8.9", "8.10", []string{"a"})
+	require.NoError(t, err)
+	res, err := Bootstrap(root, "8.9", "8.10", []string{"a"})
+	require.NoError(t, err)
+	assert.Empty(t, res.Created)
+	assert.Len(t, res.Existing, 1, "an existing delta is never overwritten")
+}
+
+func TestBootstrapRejectsMissingChart(t *testing.T) {
+	root := bootstrapRepo(t,
+		map[string][]string{"8.10": {"base.yaml"}},
+		map[string][]string{"a": {"base.yaml"}})
+
+	_, err := Bootstrap(root, "8.10", "8.11", []string{"a"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not exist yet",
+		"CI discovers transitions from disk, so a job it cannot run must not be created")
+}
+
+func TestBootstrapWritesNothingWhenAnArchetypeFails(t *testing.T) {
+	root := bootstrapRepo(t,
+		map[string][]string{"8.9": {"base.yaml"}, "8.10": {"base.yaml"}},
+		map[string][]string{"ok": {"base.yaml"}, "broken": {"base.yaml", "gone.yaml"}})
+
+	_, err := Bootstrap(root, "8.9", "8.10", []string{"ok", "broken"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gone.yaml")
+
+	assert.NoFileExists(t, filepath.Join(TransitionDir(root, "8.9", "8.10", "ok"), "delta.values.yaml"),
+		"validation precedes writing, so a later failure leaves no partial state")
+}

--- a/scripts/upgrade-paths/report.go
+++ b/scripts/upgrade-paths/report.go
@@ -247,13 +247,14 @@ func (r Report) coverageSection() string {
 		return ""
 	}
 	var b strings.Builder
-	counts := r.Coverage.Counts()
+	coverage := r.Coverage.ForStage(r.Stage)
+	counts := coverage.Counts()
 
 	b.WriteString("## Coverage\n\n")
 	fmt.Fprintf(&b, "%d covered · %d partial · %d not checked\n\n",
 		counts[StatusCovered], counts[StatusPartial], counts[StatusUncovered])
 
-	gaps := r.Coverage.Gaps()
+	gaps := coverage.Gaps()
 	if len(gaps) == 0 {
 		b.WriteString("Every category is checked by this run.\n\n")
 		return b.String()

--- a/scripts/upgrade-paths/report.go
+++ b/scripts/upgrade-paths/report.go
@@ -36,6 +36,7 @@ type Report struct {
 	Stage         string          `json:"stage"`
 	Results       []PathResult    `json:"results"`
 	NotApplicable []NotApplicable `json:"notApplicable,omitempty"`
+	Coverage      Coverage        `json:"coverage"`
 }
 
 // ExitCode returns 1 for UNREMEDIATED or STALE_DELTA outcomes, 0 otherwise.
@@ -74,7 +75,7 @@ func (r Report) Markdown() string {
 		if len(r.NotApplicable) > 0 {
 			fmt.Fprintf(&b, " — of the %d archetype(s) this transition can express", len(r.Results))
 		}
-		b.WriteString(".\n\n")
+		b.WriteString(", for the categories this harness checks. See coverage below.\n\n")
 	}
 
 	b.WriteString("## Summary\n\n")
@@ -172,7 +173,7 @@ func (r Report) Markdown() string {
 		findings = append(findings, res.Findings...)
 	}
 	if len(findings) == 0 {
-		return b.String()
+		return b.String() + r.coverageSection()
 	}
 
 	sort.SliceStable(findings, func(i, j int) bool {
@@ -205,7 +206,7 @@ func (r Report) Markdown() string {
 		b.WriteString("\n")
 	}
 
-	return b.String()
+	return b.String() + r.coverageSection()
 }
 
 // docMark renders a coverage cell, distinguishing unchecked from undocumented.
@@ -237,4 +238,36 @@ func severityRank(s string) int {
 	default:
 		return 3
 	}
+}
+
+// coverageSection states what the run did not check, so a green result is not
+// read as "nothing breaks".
+func (r Report) coverageSection() string {
+	if len(r.Coverage.Categories) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	counts := r.Coverage.Counts()
+
+	b.WriteString("## Coverage\n\n")
+	fmt.Fprintf(&b, "%d covered · %d partial · %d not checked\n\n",
+		counts[StatusCovered], counts[StatusPartial], counts[StatusUncovered])
+
+	gaps := r.Coverage.Gaps()
+	if len(gaps) == 0 {
+		b.WriteString("Every category is checked by this run.\n\n")
+		return b.String()
+	}
+
+	b.WriteString("**A pass above means these categories were not exercised:**\n\n")
+	b.WriteString("| Category | Status | Why it is not covered |\n|---|---|---|\n")
+	for _, cat := range gaps {
+		fmt.Fprintf(&b, "| %s | %s | %s |\n", cat.Title, cat.Status, oneLine(cat.Detail))
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
+func oneLine(s string) string {
+	return strings.Join(strings.Fields(s), " ")
 }

--- a/scripts/upgrade-paths/report.go
+++ b/scripts/upgrade-paths/report.go
@@ -27,6 +27,7 @@ type Report struct {
 	To         string       `json:"to"`
 	Stage      string       `json:"stage"`
 	Results    []PathResult `json:"results"`
+	Coverage   Coverage     `json:"coverage"`
 }
 
 // ExitCode returns 1 for UNREMEDIATED or STALE_DELTA outcomes, 0 otherwise.
@@ -61,7 +62,8 @@ func (r Report) Markdown() string {
 		c[OutcomeClean], c[OutcomeRemediated], c[OutcomeUnremediated], c[OutcomeStaleDelta])
 
 	if c[OutcomeClean] == len(r.Results) && len(r.Results) > 0 {
-		b.WriteString("> All paths upgrade with no customer action required.\n\n")
+		b.WriteString("> All paths upgrade with no customer action required, " +
+			"for the categories this harness checks. See coverage below.\n\n")
 	}
 
 	b.WriteString("## Summary\n\n")
@@ -145,7 +147,7 @@ func (r Report) Markdown() string {
 		findings = append(findings, res.Findings...)
 	}
 	if len(findings) == 0 {
-		return b.String()
+		return b.String() + r.coverageSection()
 	}
 
 	sort.SliceStable(findings, func(i, j int) bool {
@@ -178,7 +180,7 @@ func (r Report) Markdown() string {
 		b.WriteString("\n")
 	}
 
-	return b.String()
+	return b.String() + r.coverageSection()
 }
 
 // docMark renders a coverage cell, distinguishing unchecked from undocumented.
@@ -210,4 +212,36 @@ func severityRank(s string) int {
 	default:
 		return 3
 	}
+}
+
+// coverageSection states what the run did not check, so a green result is not
+// read as "nothing breaks".
+func (r Report) coverageSection() string {
+	if len(r.Coverage.Categories) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	counts := r.Coverage.Counts()
+
+	b.WriteString("## Coverage\n\n")
+	fmt.Fprintf(&b, "%d covered · %d partial · %d not checked\n\n",
+		counts[StatusCovered], counts[StatusPartial], counts[StatusUncovered])
+
+	gaps := r.Coverage.Gaps()
+	if len(gaps) == 0 {
+		b.WriteString("Every category is checked by this run.\n\n")
+		return b.String()
+	}
+
+	b.WriteString("**A pass above means these categories were not exercised:**\n\n")
+	b.WriteString("| Category | Status | Why it is not covered |\n|---|---|---|\n")
+	for _, cat := range gaps {
+		fmt.Fprintf(&b, "| %s | %s | %s |\n", cat.Title, cat.Status, oneLine(cat.Detail))
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
+func oneLine(s string) string {
+	return strings.Join(strings.Fields(s), " ")
 }

--- a/test/upgrade-paths/coverage.yaml
+++ b/test/upgrade-paths/coverage.yaml
@@ -1,0 +1,82 @@
+# What the harness checks, and what it does not.
+#
+# A green report means "nothing we test for breaks", not "nothing breaks". This
+# manifest makes that difference explicit: every category is rendered into the
+# report, and uncovered ones are listed as gaps rather than left unmentioned.
+#
+# status: covered | partial | uncovered
+# stage:  render | cluster | none
+
+# Archetypes model deployment shapes, and the shape decides which breaks are
+# reachable. Customers run external auth and external storage in production, so
+# the external archetypes are primary; classic-bundled is retained at tier 2 as
+# a legacy shape rather than a representative one.
+
+categories:
+  - id: removed-values-keys
+    title: Removed or renamed values keys
+    status: covered
+    stage: render
+    detail: Run A renders the target chart with carried-over values; --discover enumerates every guard.
+
+  - id: manifest-validity
+    title: Rendered manifests rejected by the API server
+    status: covered
+    stage: cluster
+    detail: A valid render can still produce an invalid object; only apply catches it.
+
+  - id: runtime-config
+    title: Components fail to start on carried-over configuration
+    status: covered
+    stage: cluster
+    detail: Upgrade waits for readiness, so a component that cannot boot fails the run.
+
+  - id: orphaned-resources
+    title: Resources stranded by removed subcharts
+    status: partial
+    stage: cluster
+    detail: >-
+      Orphaned PVCs are produced by the upgrade and observable, but nothing
+      asserts on them. A run leaving stranded volumes still reports green.
+
+  - id: data-survival
+    title: Data present before the upgrade is still present after
+    status: uncovered
+    stage: none
+    detail: >-
+      No seeding and no pre/post comparison. This is the gap that hides a
+      wiped Keycloak realm behind a passing upgrade.
+
+  - id: migration-cost
+    title: Migrations that are correct but ruinously slow
+    status: uncovered
+    stage: none
+    detail: >-
+      Destructive migrations are correct on an empty database and only harmful
+      on a large one. Fixtures run at trivial volume with no duration budget.
+
+  - id: helm-cli-version
+    title: Helm CLI version constraint
+    status: partial
+    stage: render
+    detail: >-
+      A dedicated job renders every chart with a real, pinned Helm v3 and
+      asserts that v4-only charts report the constraint and older charts do
+      not. No ArgoCD render path exists, so the GitOps failure mode — the most
+      likely way a customer meets this — is still untested.
+
+  - id: strict-config
+    title: Configuration that is newly rejected at startup
+    status: uncovered
+    stage: none
+    detail: >-
+      Scenarios only ever set valid keys. Nothing asserts that a stale or
+      misspelled key now fails, so strict-validation changes go unnoticed.
+
+  - id: behavioural
+    title: Behaviour changes in a successfully upgraded cluster
+    status: uncovered
+    stage: none
+    detail: >-
+      The cluster stage proves the upgrade succeeds, not that the result behaves
+      as before. Removed APIs and changed defaults are out of reach.

--- a/test/upgrade-paths/coverage.yaml
+++ b/test/upgrade-paths/coverage.yaml
@@ -1,0 +1,76 @@
+# What the harness checks, and what it does not.
+#
+# A green report means "nothing we test for breaks", not "nothing breaks". This
+# manifest makes that difference explicit: every category is rendered into the
+# report, and uncovered ones are listed as gaps rather than left unmentioned.
+#
+# status: covered | partial | uncovered
+# stage:  render | cluster | none
+
+categories:
+  - id: removed-values-keys
+    title: Removed or renamed values keys
+    status: covered
+    stage: render
+    detail: Run A renders the target chart with carried-over values; --discover enumerates every guard.
+
+  - id: manifest-validity
+    title: Rendered manifests rejected by the API server
+    status: covered
+    stage: cluster
+    detail: A valid render can still produce an invalid object; only apply catches it.
+
+  - id: runtime-config
+    title: Components fail to start on carried-over configuration
+    status: covered
+    stage: cluster
+    detail: Upgrade waits for readiness, so a component that cannot boot fails the run.
+
+  - id: orphaned-resources
+    title: Resources stranded by removed subcharts
+    status: partial
+    stage: cluster
+    detail: >-
+      Orphaned PVCs are produced by the upgrade and observable, but nothing
+      asserts on them. A run leaving stranded volumes still reports green.
+
+  - id: data-survival
+    title: Data present before the upgrade is still present after
+    status: uncovered
+    stage: none
+    detail: >-
+      No seeding and no pre/post comparison. This is the gap that hides a
+      wiped Keycloak realm behind a passing upgrade.
+
+  - id: migration-cost
+    title: Migrations that are correct but ruinously slow
+    status: uncovered
+    stage: none
+    detail: >-
+      Destructive migrations are correct on an empty database and only harmful
+      on a large one. Fixtures run at trivial volume with no duration budget.
+
+  - id: helm-cli-version
+    title: Helm CLI version constraint
+    status: uncovered
+    stage: none
+    detail: >-
+      A unit test asserts the failure message against a mocked Capabilities
+      object. No job runs a real Helm v3 binary, and no ArgoCD render path
+      exists, so the GitOps failure mode is untested.
+
+  - id: strict-config
+    title: Configuration that is newly rejected at startup
+    status: uncovered
+    stage: none
+    detail: >-
+      Scenarios only ever set valid keys. Nothing asserts that a stale or
+      misspelled key now fails, so strict-validation changes go unnoticed.
+
+  - id: behavioural
+    title: Behaviour changes in a successfully upgraded cluster
+    status: uncovered
+    stage: none
+    detail: >-
+      The cluster stage proves the upgrade succeeds, not that the result behaves
+      as before. Removed APIs and changed defaults are out of reach.


### PR DESCRIPTION
> | # | PR | Phase | Purpose |
> |---|---|---|---|
> | 1 | #6820 | library | `chartvalues`: layer consolidation, `$remove` / `$rename` / `$scaffolding` |
> | 2 | #6821 | render stage | A/B render of a carried-over values file; archetypes and fixtures |
> | **3** | **#6825** | **honesty** | **coverage ledger, real Helm v3 gate, transition bootstrap** ← you are here |
> | 4 | #6822 | cluster stage | real two-step upgrade on GKE, nightly and on demand |
> | 5 | #6834 | assertions | orphaned storage, data survival, migration cost |

Merge in order; each builds on the one above. 2 consumes the package from 1. 3 adds the coverage ledger that 4 and 5 both update. 5 asserts against the cluster 4 deploys.

### Which problem does the PR fix?

Part of #6819.

A green report invites the reading *"nothing breaks"*, when it can only ever mean *"nothing we test for breaks"*. Left implicit, that gap is how a harness turns into false reassurance — and this one is about to grow several more checks, each of which widens it.

### What's in this PR?

**A coverage ledger.** `test/upgrade-paths/coverage.yaml` is rendered into every report. Each category carries a status of `covered`, `partial` or `uncovered` and the stage that checks it. Uncovered categories are **printed as gaps rather than omitted**, so the report states its own limits.

Two are uncovered today, and both are deliberate rather than oversights:

- **`strict-config`** — scenarios only ever set valid keys, so nothing asserts that a stale or misspelled key is now rejected at startup.
- **`behavioural`** — the cluster stage proves an upgrade *succeeds*, not that the result behaves as it did before. Removed APIs and changed defaults are out of reach.

Saying so is more useful than a green tick that implies otherwise.

**A real Helm v3 gate.** A dedicated job renders every chart with a real, pinned v3 client and asserts that v4-only charts report the constraint while older charts do not. A version constraint is only meaningful if something actually runs the older client. Recorded as `partial`: no ArgoCD render path exists, and GitOps is the most likely way a customer meets this.

The gate builds chart dependencies before rendering, and treats a render that never reached template evaluation as a **failure rather than a pass**. Both matter. Vendored subcharts are gitignored (`*.tgz`), so on a fresh CI checkout `helm template` dies in dependency resolution before any template runs; the marker is then absent for *every* chart, which the naive reading scores as "does not reject v3" — a pass. Asserting on the message rather than the exit code does not save it, because the message never gets a chance to be emitted.

Verified against a real Helm v3.20.2: 8.10 rejects it, 8.9 does not. The chart constraint was working the whole time; the gate was not.

**`--bootstrap`.** Creates a transition's fixtures at fork time with an empty delta. Whatever accumulates in that delta before GA is that release's upgrade guide.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [x] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [x] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
