### PR TITLE
test: [UPGPATH 7/13] add bootstrap for a new version transition

### DIFF
--- a/scripts/upgrade-paths/bootstrap.go
+++ b/scripts/upgrade-paths/bootstrap.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// BootstrapResult reports what a bootstrap run did.
+type BootstrapResult struct {
+	Created  []string
+	Existing []string
+}
+
+// Bootstrap prepares a transition directory for every archetype, writing an
+// empty delta for each. An empty delta is the fork-day contract: as of today,
+// customers on this path need do nothing.
+//
+// Every archetype's layers are resolved against the source chart first, so a
+// layer renamed between versions fails here rather than midway through a run.
+func Bootstrap(repoRoot, from, to string, archetypes []string) (BootstrapResult, error) {
+	var res BootstrapResult
+
+	// The CI matrix discovers transitions from this directory, so bootstrapping
+	// a pair whose target chart does not exist yet would add a job that can
+	// never render. Bootstrap belongs at fork time, once the chart is cut.
+	for _, v := range []string{from, to} {
+		if _, err := os.Stat(ChartDir(repoRoot, v)); err != nil {
+			return res, fmt.Errorf("chart %s does not exist yet (%s); bootstrap a transition only "+
+				"once both charts are cut, or CI will discover a job it cannot run",
+				v, ChartDir(repoRoot, v))
+		}
+	}
+
+	// Validate every archetype before writing anything: a failure partway
+	// through would leave some paths bootstrapped and others not.
+	loaded := make([]Archetype, 0, len(archetypes))
+	vd := valuesDir(repoRoot, from)
+	for _, name := range archetypes {
+		a, err := LoadArchetype(repoRoot, name)
+		if err != nil {
+			return res, err
+		}
+		for _, layer := range a.Layers {
+			if _, err := os.Stat(filepath.Join(vd, layer)); err != nil {
+				return res, fmt.Errorf(
+					"archetype %s: layer %q missing in chart %s; the layer was renamed or removed "+
+						"and the archetype needs updating before %s-to-%s can run",
+					name, layer, from, from, to)
+			}
+		}
+		loaded = append(loaded, a)
+	}
+
+	for _, a := range loaded {
+		dir := TransitionDir(repoRoot, from, to, a.Name)
+		delta := filepath.Join(dir, "delta.values.yaml")
+		if fileExists(delta) {
+			res.Existing = append(res.Existing, delta)
+			continue
+		}
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return res, fmt.Errorf("create %s: %w", dir, err)
+		}
+		if err := os.WriteFile(delta, []byte(emptyDelta(a.Name, from, to)), 0o644); err != nil {
+			return res, fmt.Errorf("write %s: %w", delta, err)
+		}
+		res.Created = append(res.Created, delta)
+	}
+
+	return res, nil
+}
+
+func emptyDelta(archetype, from, to string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# Delta for %s, %s-to-%s\n", archetype, from, to)
+	b.WriteString(`#
+# Empty means: a customer on this path upgrades with no values changes. Every
+# entry added here is a change the customer MUST make, and is emitted into the
+# upgrade guide, so keep it minimal and justified.
+#
+# Directives:
+#   $rename        moves a value to a new path, preserving it. Use where the
+#                  value is environment-specific and cannot be restated.
+#   $remove        deletes dotted paths. Chart constraints test key presence,
+#                  so these cannot be cleared by setting them to null.
+#   $scaffolding   harness-only values, applied but excluded from the change
+#                  list. For CI fixtures that no customer has.
+#
+# Remaining keys merge in as normal values.
+`)
+	return b.String()
+}

--- a/scripts/upgrade-paths/fixture.go
+++ b/scripts/upgrade-paths/fixture.go
@@ -141,13 +141,18 @@ func LoadTransition(repoRoot, from, to, archetypeName string) (Transition, error
 	}
 
 	td := TransitionDir(repoRoot, from, to, archetypeName)
+	// A bootstrapped delta is comment-only and parses to nothing. Deciding on
+	// the parsed delta rather than the file's bytes keeps Run B from repeating
+	// Run A and keeps the report from claiming a delta that changes nothing.
 	if p := filepath.Join(td, "delta.values.yaml"); fileHasContent(p) {
-		t.DeltaPath = p
 		d, err := chartvalues.LoadDelta(p)
 		if err != nil {
 			return t, err
 		}
-		t.Delta = d
+		if !d.IsEmpty() {
+			t.DeltaPath = p
+			t.Delta = d
+		}
 	}
 	if p := filepath.Join(td, "remedy.sh"); fileExists(p) {
 		t.RemedyPath = p

--- a/scripts/upgrade-paths/main.go
+++ b/scripts/upgrade-paths/main.go
@@ -63,10 +63,12 @@ func main() {
 			"after a Run A failure, iterate to find every removed/renamed key rather than only the first")
 		docsRoot = flag.String("docs-root", "",
 			"camunda-docs checkout; default is a sibling directory. Empty disables doc-coverage checking")
-		jsonOut = flag.String("json", "", "write findings JSON to this file")
-		mdOut   = flag.String("markdown", "", "write markdown report to this file")
-		timeout = flag.Duration("timeout", 5*time.Minute, "overall timeout")
-		quiet   = flag.Bool("quiet", false, "suppress the markdown report on stdout")
+		jsonOut   = flag.String("json", "", "write findings JSON to this file")
+		mdOut     = flag.String("markdown", "", "write markdown report to this file")
+		timeout   = flag.Duration("timeout", 5*time.Minute, "overall timeout")
+		quiet     = flag.Bool("quiet", false, "suppress the markdown report on stdout")
+		bootstrap = flag.Bool("bootstrap", false,
+			"create an empty delta for every archetype for this transition, then exit")
 	)
 	flag.Parse()
 
@@ -95,6 +97,22 @@ func main() {
 	docs := *docsRoot
 	if docs == "" {
 		docs = defaultDocsRoot(root)
+	}
+
+	if *bootstrap {
+		res, err := Bootstrap(root, *from, *to, archetypes)
+		if err != nil {
+			fatal(err)
+		}
+		for _, p := range res.Created {
+			fmt.Printf("created  %s\n", p)
+		}
+		for _, p := range res.Existing {
+			fmt.Printf("exists   %s\n", p)
+		}
+		fmt.Printf("\n%d created, %d already present. All archetype layers resolve against chart %s.\n",
+			len(res.Created), len(res.Existing), *from)
+		return
 	}
 
 	runDir, err := os.MkdirTemp("", "upgrade-paths-run-")

--- a/scripts/upgrade-paths/main_test.go
+++ b/scripts/upgrade-paths/main_test.go
@@ -419,3 +419,84 @@ func TestReportWithoutCoverageOmitsSection(t *testing.T) {
 	r := Report{From: "8.9", To: "8.10", Results: []PathResult{{Path: "p", Outcome: OutcomeClean}}}
 	assert.NotContains(t, r.Markdown(), "## Coverage")
 }
+
+// bootstrapRepo builds a minimal repo: two charts, and archetypes whose layers
+// exist only in the versions named.
+func bootstrapRepo(t *testing.T, layersByVersion map[string][]string, archetypes map[string][]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for v, layers := range layersByVersion {
+		vd := filepath.Join(root, "charts", "camunda-platform-"+v,
+			"test", "integration", "scenarios", "chart-full-setup", "values")
+		for _, l := range layers {
+			p := filepath.Join(vd, l)
+			require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+			require.NoError(t, os.WriteFile(p, []byte("{}\n"), 0o644))
+		}
+	}
+	for name, layers := range archetypes {
+		dir := filepath.Join(root, "test", "upgrade-paths", "archetypes", name)
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		body := "name: " + name + "\nlayers:\n"
+		for _, l := range layers {
+			body += "  - " + l + "\n"
+		}
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "archetype.yaml"), []byte(body), 0o644))
+	}
+	return root
+}
+
+func TestBootstrapCreatesEmptyDeltas(t *testing.T) {
+	root := bootstrapRepo(t,
+		map[string][]string{"8.9": {"base.yaml"}, "8.10": {"base.yaml"}},
+		map[string][]string{"a": {"base.yaml"}, "b": {"base.yaml"}})
+
+	res, err := Bootstrap(root, "8.9", "8.10", []string{"a", "b"})
+	require.NoError(t, err)
+	assert.Len(t, res.Created, 2)
+	assert.Empty(t, res.Existing)
+
+	require.FileExists(t, filepath.Join(TransitionDir(root, "8.9", "8.10", "a"), "delta.values.yaml"))
+
+	tr, err := LoadTransition(root, "8.9", "8.10", "a")
+	require.NoError(t, err)
+	assert.Empty(t, tr.DeltaPath,
+		"a bootstrapped delta is comment-only, so it must count as no delta")
+}
+
+func TestBootstrapIsIdempotent(t *testing.T) {
+	root := bootstrapRepo(t,
+		map[string][]string{"8.9": {"base.yaml"}, "8.10": {"base.yaml"}},
+		map[string][]string{"a": {"base.yaml"}})
+
+	_, err := Bootstrap(root, "8.9", "8.10", []string{"a"})
+	require.NoError(t, err)
+	res, err := Bootstrap(root, "8.9", "8.10", []string{"a"})
+	require.NoError(t, err)
+	assert.Empty(t, res.Created)
+	assert.Len(t, res.Existing, 1, "an existing delta is never overwritten")
+}
+
+func TestBootstrapRejectsMissingChart(t *testing.T) {
+	root := bootstrapRepo(t,
+		map[string][]string{"8.10": {"base.yaml"}},
+		map[string][]string{"a": {"base.yaml"}})
+
+	_, err := Bootstrap(root, "8.10", "8.11", []string{"a"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not exist yet",
+		"CI discovers transitions from disk, so a job it cannot run must not be created")
+}
+
+func TestBootstrapWritesNothingWhenAnArchetypeFails(t *testing.T) {
+	root := bootstrapRepo(t,
+		map[string][]string{"8.9": {"base.yaml"}, "8.10": {"base.yaml"}},
+		map[string][]string{"ok": {"base.yaml"}, "broken": {"base.yaml", "gone.yaml"}})
+
+	_, err := Bootstrap(root, "8.9", "8.10", []string{"ok", "broken"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gone.yaml")
+
+	assert.NoFileExists(t, filepath.Join(TransitionDir(root, "8.9", "8.10", "ok"), "delta.values.yaml"),
+		"validation precedes writing, so a later failure leaves no partial state")
+}


### PR DESCRIPTION
> | # | PR | Phase | Purpose |
> |---|---|---|---|
> | 1 | #6820 | shared library | `chartvalues`: consolidation, `$remove`/`$rename`/`$scaffolding` directives |
> | 2 | #6821 | render stage | `upgrade-paths` A/B harness, archetypes, fixtures, render workflow |
> | 3 | #6822 | cluster stage | `deploy-camunda` values carryover, `upgrade-path` flow, hook suppression |
> | 4 | #6824 | correctness | separate harness scaffolding from customer-facing steps |
> | 5 | #6825 | honesty | coverage manifest: report what the harness does not check |
> | 6 | #6826 | coverage | gate rendering against a real Helm v3 client |
> | **7** | **#6827** | **lifecycle** | **`--bootstrap` a new version transition at fork time** ← you are here |
> | 8 | #6828 | automation | run the cluster stage nightly and on demand |
> | 9 | #6829 | realism | make externally-provisioned shapes the primary archetypes |
> | 10 | #6830 | coverage | detect storage stranded by an upgrade |
> | 11 | #6831 | coverage | compare entity counts across an upgrade |
> | 12 | #6832 | infra | schedule companion services on the intended node pool |
> | 13 | #6834 | coverage | probe data survival and budget upgrade duration |

Merge in order. 2 onwards consume the package from 1; 4 corrects a limitation documented in 3; 6, 10, 11 and 13 close gaps named by 5; 8 automates what 3 made possible; 9 replaces the inferred archetypes with confirmed ones; 12 fixes node placement for the scenario 3 introduced; 13 wires the probes 11 defined.

