### PR TITLE
test: [UPGPATH 8/13] run the cluster stage nightly and on demand

### DIFF
--- a/.github/workflows/upgrade-paths.yaml
+++ b/.github/workflows/upgrade-paths.yaml
@@ -23,6 +23,19 @@ on:
         description: "Space-separated from:to pairs, e.g. '8.9:8.10 8.8:8.9'. Empty runs all."
         type: string
         default: ""
+      cluster-stage:
+        description: "Also run the cluster stage (deploys to GKE; ~8 min per run)"
+        type: boolean
+        default: false
+      cluster-run:
+        description: "Which cluster run to perform"
+        type: choice
+        options: [both, naive, remediated]
+        default: both
+      cluster-shortname:
+        description: "Scenario shortname for the cluster stage"
+        type: string
+        default: upclas
 
 permissions:
   contents: read
@@ -176,3 +189,123 @@ jobs:
             fi
           done
           exit $status
+
+  # The cluster stage deploys a full previous-version release and upgrades it,
+  # so it is nightly and on-demand only, never on a pull request.
+  cluster:
+    name: Cluster stage
+    needs: render
+    if: >-
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && inputs.cluster-stage)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        run: ${{ (github.event_name == 'workflow_dispatch' && inputs.cluster-run != 'both')
+          && fromJson(format('["{0}"]', inputs.cluster-run))
+          || fromJson('["naive","remediated"]') }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+
+      - name: Install tools
+        uses: ./.github/actions/install-tool-versions
+        with:
+          tools: |
+            helm
+            golang
+            kubectl
+
+      - name: Import Vault secrets
+        id: test-credentials-secret
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc  # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/distribution/ci DISTRO_CI_GCP_GKE_CLUSTER_NAME;
+            secret/data/products/distribution/ci DISTRO_CI_GCP_GKE_CLUSTER_LOCATION;
+            secret/data/products/distribution/ci DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER;
+            secret/data/products/distribution/ci DISTRO_CI_GCP_SERVICE_ACCOUNT;
+            secret/data/products/distribution/ci RDBMS_POSTGRESQL_USERNAME;
+            secret/data/products/distribution/ci RDBMS_POSTGRESQL_PASSWORD;
+          exportEnv: false
+
+      - name: Authenticate to cluster
+        uses: ./.github/actions/cluster-auth
+        with:
+          platform: gke
+        env:
+          GH_APP_ID: ${{ secrets.GH_APP_ID_DISTRO_CI_MANAGE_GH_ENVS }}
+          GH_APP_KEY: ${{ secrets.GH_APP_PRIVATE_KEY_DISTRO_CI_MANAGE_GH_ENVS }}
+          GKE_CLUSTER_NAME: ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_GKE_CLUSTER_NAME }}
+          GKE_CLUSTER_LOC: ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_GKE_CLUSTER_LOCATION }}
+          GKE_WIP: ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GKE_SA: ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_SERVICE_ACCOUNT }}
+
+      # Built from source every run. A stale binary silently exercises code that
+      # is no longer on disk, which is not detectable from the run's output.
+      - name: Build deploy-camunda
+        run: cd scripts/deploy-camunda && go build -o "${RUNNER_TEMP}/deploy-camunda" .
+
+      - name: Resolve delta for this run
+        id: delta
+        env:
+          SHORTNAME: ${{ inputs.cluster-shortname || 'upclas' }}
+        run: |
+          set -euo pipefail
+          if [ "${{ matrix.run }}" = "naive" ]; then
+            echo "args=--suppress-upgrade-hooks" >>"$GITHUB_OUTPUT"
+          else
+            delta=test/upgrade-paths/transitions/8.9-to-8.10/classic-bundled/delta.values.yaml
+            test -f "$delta" || { echo "::error::delta not found: $delta"; exit 1; }
+            echo "args=--upgrade-delta $delta" >>"$GITHUB_OUTPUT"
+          fi
+
+      # Run A is expected to fail: that is the finding, not a broken job. Run B
+      # must pass. Both outcomes are reported either way.
+      - name: Run upgrade path on cluster
+        id: run
+        env:
+          RDBMS_POSTGRESQL_USERNAME: ${{ steps.test-credentials-secret.outputs.RDBMS_POSTGRESQL_USERNAME }}
+          RDBMS_POSTGRESQL_PASSWORD: ${{ steps.test-credentials-secret.outputs.RDBMS_POSTGRESQL_PASSWORD }}
+          SHORTNAME: ${{ inputs.cluster-shortname || 'upclas' }}
+        run: |
+          set -uo pipefail
+          "${RUNNER_TEMP}/deploy-camunda" matrix run \
+            --repo-root . --versions 8.10 \
+            --shortname-filter "${SHORTNAME}" --include-disabled \
+            --platform gke --ingress-base-domain-gke ci.distro.ultrawombat.com \
+            --values-source carryover \
+            ${{ steps.delta.outputs.args }} \
+            --ensure-docker-registry \
+            --delete-namespace --timeout 15 --yes 2>&1 | tee "${RUNNER_TEMP}/run.log"
+          echo "exit=${PIPESTATUS[0]}" >>"$GITHUB_OUTPUT"
+
+      - name: Report outcome
+        if: always()
+        run: |
+          {
+            echo "### Cluster stage — ${{ matrix.run }}"
+            echo
+            grep -E "Step 1 complete|Applied upgrade delta|Suppressed .*hook|Step 2 complete|camunda\]\[error\]|Matrix entry failed|\[PASS\]|\[FAIL\]" \
+              "${RUNNER_TEMP}/run.log" | tail -20 | sed 's/^/    /'
+          } >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Enforce expected outcome
+        if: always()
+        run: |
+          actual="${{ steps.run.outputs.exit }}"
+          if [ "${{ matrix.run }}" = "naive" ]; then
+            [ "$actual" != "0" ] && echo "Run A failed as expected" && exit 0
+            echo "::error::Run A succeeded. Either the carried-over values no longer break, or carryover is not in effect."
+            exit 1
+          fi
+          [ "$actual" = "0" ] && echo "Run B passed" && exit 0
+          echo "::error::Run B failed: the documented delta no longer remediates this path."
+          exit 1

--- a/test/upgrade-paths/coverage.yaml
+++ b/test/upgrade-paths/coverage.yaml
@@ -6,6 +6,10 @@
 #
 # status: covered | partial | uncovered
 # stage:  render | cluster | none
+#
+# The render stage runs on every pull request. The cluster stage deploys a full
+# previous-version release and upgrades it, so it runs nightly and on demand
+# only — a merge-queue run would add roughly eight minutes per path.
 
 categories:
   - id: removed-values-keys


### PR DESCRIPTION
> | # | PR | Phase | Purpose |
> |---|---|---|---|
> | 1 | #6820 | shared library | `chartvalues`: consolidation, `$remove`/`$rename`/`$scaffolding` directives |
> | 2 | #6821 | render stage | `upgrade-paths` A/B harness, archetypes, fixtures, render workflow |
> | 3 | #6822 | cluster stage | `deploy-camunda` values carryover, `upgrade-path` flow, hook suppression |
> | 4 | #6824 | correctness | separate harness scaffolding from customer-facing steps |
> | 5 | #6825 | honesty | coverage manifest: report what the harness does not check |
> | 6 | #6826 | coverage | gate rendering against a real Helm v3 client |
> | 7 | #6827 | lifecycle | `--bootstrap` a new version transition at fork time |
> | **8** | **#6828** | **automation** | **run the cluster stage nightly and on demand** ← you are here |
> | 9 | #6829 | realism | make externally-provisioned shapes the primary archetypes |
> | 10 | #6830 | coverage | detect storage stranded by an upgrade |
> | 11 | #6831 | coverage | compare entity counts across an upgrade |
> | 12 | #6832 | infra | schedule companion services on the intended node pool |
> | 13 | #6834 | coverage | probe data survival and budget upgrade duration |

Merge in order. 2 onwards consume the package from 1; 4 corrects a limitation documented in 3; 6, 10, 11 and 13 close gaps named by 5; 8 automates what 3 made possible; 9 replaces the inferred archetypes with confirmed ones; 12 fixes node placement for the scenario 3 introduced; 13 wires the probes 11 defined.

