### PR TITLE
test: [UPGPATH 10/13] detect storage stranded by an upgrade

### DIFF
--- a/scripts/camunda-core/pkg/kube/inventory.go
+++ b/scripts/camunda-core/pkg/kube/inventory.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"scripts/camunda-core/pkg/orphans"
+)
+
+// ClaimInventory reads the namespace state that orphan detection needs: every
+// claim, the claims pods currently mount, and the templates each StatefulSet
+// would generate.
+func (c *Client) ClaimInventory(ctx context.Context, namespace string) (orphans.Inventory, error) {
+	var inv orphans.Inventory
+
+	pvcs, err := c.clientset.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return inv, fmt.Errorf("list persistentvolumeclaims in %s: %w", namespace, err)
+	}
+	for _, p := range pvcs.Items {
+		inv.Claims = append(inv.Claims, p.Name)
+	}
+
+	pods, err := c.clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return inv, fmt.Errorf("list pods in %s: %w", namespace, err)
+	}
+	for _, p := range pods.Items {
+		for _, v := range p.Spec.Volumes {
+			if v.PersistentVolumeClaim != nil {
+				inv.PodClaims = append(inv.PodClaims, v.PersistentVolumeClaim.ClaimName)
+			}
+		}
+	}
+
+	sts, err := c.clientset.AppsV1().StatefulSets(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return inv, fmt.Errorf("list statefulsets in %s: %w", namespace, err)
+	}
+	for _, s := range sts.Items {
+		ref := orphans.StatefulSetRef{Name: s.Name}
+		if s.Spec.Replicas != nil {
+			ref.Replicas = *s.Spec.Replicas
+		}
+		for _, t := range s.Spec.VolumeClaimTemplates {
+			ref.ClaimTemplates = append(ref.ClaimTemplates, t.Name)
+		}
+		if len(ref.ClaimTemplates) > 0 {
+			inv.StatefulSets = append(inv.StatefulSets, ref)
+		}
+	}
+
+	return inv, nil
+}

--- a/scripts/camunda-core/pkg/orphans/orphans.go
+++ b/scripts/camunda-core/pkg/orphans/orphans.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package orphans identifies PersistentVolumeClaims left behind by an upgrade.
+//
+// Kubernetes never deletes a claim created from a StatefulSet's
+// volumeClaimTemplates, so removing a subchart strands its storage: the
+// workload goes, the data stays, and nothing surfaces it. Detection is by
+// reference rather than by label, because claims created by the StatefulSet
+// controller carry the workload's labels, not Helm's release metadata.
+package orphans
+
+import (
+	"fmt"
+	"sort"
+)
+
+// StatefulSetRef describes a StatefulSet's claim-generating templates.
+type StatefulSetRef struct {
+	Name string
+	// ClaimTemplates are volumeClaimTemplate names, which combine with the
+	// StatefulSet name and an ordinal to form claim names.
+	ClaimTemplates []string
+	// Replicas bounds the ordinals considered live.
+	Replicas int32
+}
+
+// Inventory is the namespace state orphan detection reads.
+type Inventory struct {
+	// Claims is every PersistentVolumeClaim in the namespace.
+	Claims []string
+	// PodClaims are claims referenced by a pod's volumes.
+	PodClaims []string
+	// StatefulSets generate claims whose pods may not currently exist, so a
+	// scaled-down workload still counts as referencing its storage.
+	StatefulSets []StatefulSetRef
+}
+
+// Orphan is a claim nothing references.
+type Orphan struct {
+	Claim string `json:"claim"`
+}
+
+// Detect returns claims that no pod references and no StatefulSet would
+// generate, sorted by name.
+func Detect(inv Inventory) []Orphan {
+	referenced := map[string]bool{}
+	for _, c := range inv.PodClaims {
+		referenced[c] = true
+	}
+	for _, sts := range inv.StatefulSets {
+		for _, tpl := range sts.ClaimTemplates {
+			for i := int32(0); i < sts.Replicas; i++ {
+				referenced[fmt.Sprintf("%s-%s-%d", tpl, sts.Name, i)] = true
+			}
+		}
+	}
+
+	var out []Orphan
+	for _, c := range inv.Claims {
+		if !referenced[c] {
+			out = append(out, Orphan{Claim: c})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Claim < out[j].Claim })
+	return out
+}
+
+// Names returns just the claim names.
+func Names(o []Orphan) []string {
+	out := make([]string, 0, len(o))
+	for _, x := range o {
+		out = append(out, x.Claim)
+	}
+	return out
+}
+
+// Appeared returns orphans present in after but not before, so an upgrade is
+// judged on the storage it strands rather than on storage that was already
+// stranded when it started.
+func Appeared(before, after []Orphan) []Orphan {
+	was := map[string]bool{}
+	for _, o := range before {
+		was[o.Claim] = true
+	}
+	var out []Orphan
+	for _, o := range after {
+		if !was[o.Claim] {
+			out = append(out, o)
+		}
+	}
+	return out
+}

--- a/scripts/camunda-core/pkg/orphans/orphans_test.go
+++ b/scripts/camunda-core/pkg/orphans/orphans_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orphans
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The 8.9-to-8.10 upgrade of the classic-bundled path, as observed on GKE.
+// Removing the bundled subcharts stranded three claims while zeebe's and the
+// companion Elasticsearch's remained in use.
+func TestDetectReproducesObservedUpgrade(t *testing.T) {
+	inv := Inventory{
+		Claims: []string{
+			"data-integration-elasticsearch-master-0",
+			"data-integration-postgresql-0",
+			"data-integration-postgresql-web-modeler-0",
+			"data-integration-zeebe-0",
+			"elasticsearch-master-elasticsearch-master-0",
+			"migration-backup-pvc",
+		},
+		PodClaims: []string{"migration-backup-pvc"},
+		StatefulSets: []StatefulSetRef{
+			{Name: "integration-zeebe", ClaimTemplates: []string{"data"}, Replicas: 1},
+			{Name: "elasticsearch-master", ClaimTemplates: []string{"elasticsearch-master"}, Replicas: 1},
+		},
+	}
+
+	assert.Equal(t, []string{
+		"data-integration-elasticsearch-master-0",
+		"data-integration-postgresql-0",
+		"data-integration-postgresql-web-modeler-0",
+	}, Names(Detect(inv)))
+}
+
+func TestDetect(t *testing.T) {
+	tests := []struct {
+		name string
+		inv  Inventory
+		want []string
+	}{
+		{
+			name: "no claims",
+			inv:  Inventory{},
+			want: []string{},
+		},
+		{
+			name: "claim referenced by a pod is not orphaned",
+			inv:  Inventory{Claims: []string{"a"}, PodClaims: []string{"a"}},
+			want: []string{},
+		},
+		{
+			name: "claim with nothing referencing it is orphaned",
+			inv:  Inventory{Claims: []string{"a"}},
+			want: []string{"a"},
+		},
+		{
+			name: "a scaled-down StatefulSet still claims its storage",
+			inv: Inventory{
+				Claims:       []string{"data-db-0", "data-db-1"},
+				StatefulSets: []StatefulSetRef{{Name: "db", ClaimTemplates: []string{"data"}, Replicas: 2}},
+			},
+			want: []string{},
+		},
+		{
+			name: "claims beyond the replica count are orphaned",
+			inv: Inventory{
+				Claims:       []string{"data-db-0", "data-db-1", "data-db-2"},
+				StatefulSets: []StatefulSetRef{{Name: "db", ClaimTemplates: []string{"data"}, Replicas: 2}},
+			},
+			want: []string{"data-db-2"},
+		},
+		{
+			name: "multiple templates on one StatefulSet",
+			inv: Inventory{
+				Claims: []string{"data-db-0", "logs-db-0", "stale-db-0"},
+				StatefulSets: []StatefulSetRef{
+					{Name: "db", ClaimTemplates: []string{"data", "logs"}, Replicas: 1},
+				},
+			},
+			want: []string{"stale-db-0"},
+		},
+		{
+			name: "a StatefulSet scaled to zero references nothing",
+			inv: Inventory{
+				Claims:       []string{"data-db-0"},
+				StatefulSets: []StatefulSetRef{{Name: "db", ClaimTemplates: []string{"data"}, Replicas: 0}},
+			},
+			want: []string{"data-db-0"},
+		},
+		{
+			name: "results are sorted",
+			inv:  Inventory{Claims: []string{"c", "a", "b"}},
+			want: []string{"a", "b", "c"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, Names(Detect(tt.inv)))
+		})
+	}
+}
+
+func TestAppeared(t *testing.T) {
+	before := []Orphan{{Claim: "already-stranded"}}
+	after := []Orphan{{Claim: "already-stranded"}, {Claim: "newly-stranded"}}
+
+	assert.Equal(t, []string{"newly-stranded"}, Names(Appeared(before, after)),
+		"an upgrade is judged on what it strands, not on what it inherited")
+}
+
+func TestAppearedWithNoPriorOrphans(t *testing.T) {
+	assert.Equal(t, []string{"a"}, Names(Appeared(nil, []Orphan{{Claim: "a"}})))
+	assert.Empty(t, Names(Appeared([]Orphan{{Claim: "a"}}, nil)))
+}

--- a/scripts/deploy-camunda/matrix/runner_upgrade.go
+++ b/scripts/deploy-camunda/matrix/runner_upgrade.go
@@ -8,6 +8,7 @@ import (
 	"scripts/camunda-core/pkg/helm"
 	"scripts/camunda-core/pkg/kube"
 	"scripts/camunda-core/pkg/logging"
+	"scripts/camunda-core/pkg/orphans"
 	"scripts/camunda-core/pkg/scenarios"
 	"scripts/camunda-core/pkg/versionmatrix"
 	"scripts/deploy-camunda/config"
@@ -291,6 +292,8 @@ func executeTwoStepUpgrade(ctx context.Context, entry Entry, flags *config.Runti
 		return err
 	}
 
+	orphansBefore := claimOrphans(ctx, flags.EffectiveNamespace(), flags.Test.KubeContext)
+
 	// --- Step 2: Upgrade to current on-disk chart (or external chart-ref when set) ---
 	if flags.OnPhase != nil {
 		flags.OnPhase("step-2")
@@ -384,7 +387,41 @@ func executeTwoStepUpgrade(ctx context.Context, entry Entry, flags *config.Runti
 		Str("step", "2/2").
 		Msg("Step 2 complete: upgrade to current version succeeded")
 
+	reportStrandedClaims(ctx, flags.EffectiveNamespace(), flags.Test.KubeContext, orphansBefore)
+
 	return nil
+}
+
+// claimOrphans reads the namespace's unreferenced claims. Failures are logged
+// and treated as an empty set: orphan reporting is diagnostic and must not
+// decide the outcome of an upgrade.
+func claimOrphans(ctx context.Context, namespace, kubeContext string) []orphans.Orphan {
+	client, err := kube.NewClient("", kubeContext)
+	if err != nil {
+		logging.Logger.Warn().Err(err).Msg("Orphan detection skipped: could not create kube client")
+		return nil
+	}
+	inv, err := client.ClaimInventory(ctx, namespace)
+	if err != nil {
+		logging.Logger.Warn().Err(err).Msg("Orphan detection skipped: could not read claim inventory")
+		return nil
+	}
+	return orphans.Detect(inv)
+}
+
+// reportStrandedClaims names claims this upgrade left unreferenced. Kubernetes
+// never deletes a claim created from a StatefulSet's volumeClaimTemplates, so
+// removing a subchart leaves its storage behind with nothing pointing at it.
+func reportStrandedClaims(ctx context.Context, namespace, kubeContext string, before []orphans.Orphan) {
+	appeared := orphans.Appeared(before, claimOrphans(ctx, namespace, kubeContext))
+	if len(appeared) == 0 {
+		return
+	}
+	logging.Logger.Warn().
+		Strs("claims", orphans.Names(appeared)).
+		Int("count", len(appeared)).
+		Str("namespace", namespace).
+		Msg("Upgrade stranded persistent volume claims: storage remains but nothing references it")
 }
 
 // executeUpgradeOnly performs a single-step upgrade against an already-running deployment.

--- a/test/upgrade-paths/coverage.yaml
+++ b/test/upgrade-paths/coverage.yaml
@@ -37,11 +37,13 @@ categories:
 
   - id: orphaned-resources
     title: Resources stranded by removed subcharts
-    status: partial
+    status: covered
     stage: cluster
     detail: >-
-      Orphaned PVCs are produced by the upgrade and observable, but nothing
-      asserts on them. A run leaving stranded volumes still reports green.
+      Claim inventory is read before and after the upgrade; claims that no pod
+      mounts and no StatefulSet would generate are reported, diffed so only what
+      this upgrade stranded is attributed to it. Reported, not failed: stranded
+      storage is sometimes the intended outcome of removing a subchart.
 
   - id: data-survival
     title: Data present before the upgrade is still present after


### PR DESCRIPTION
> | # | PR | Phase | Purpose |
> |---|---|---|---|
> | 1 | #6820 | shared library | `chartvalues`: consolidation, `$remove`/`$rename`/`$scaffolding` directives |
> | 2 | #6821 | render stage | `upgrade-paths` A/B harness, archetypes, fixtures, render workflow |
> | 3 | #6822 | cluster stage | `deploy-camunda` values carryover, `upgrade-path` flow, hook suppression |
> | 4 | #6824 | correctness | separate harness scaffolding from customer-facing steps |
> | 5 | #6825 | honesty | coverage manifest: report what the harness does not check |
> | 6 | #6826 | coverage | gate rendering against a real Helm v3 client |
> | 7 | #6827 | lifecycle | `--bootstrap` a new version transition at fork time |
> | 8 | #6828 | automation | run the cluster stage nightly and on demand |
> | 9 | #6829 | realism | make externally-provisioned shapes the primary archetypes |
> | **10** | **#6830** | **coverage** | **detect storage stranded by an upgrade** ← you are here |
> | 11 | #6831 | coverage | compare entity counts across an upgrade |
> | 12 | #6832 | infra | schedule companion services on the intended node pool |
> | 13 | #6834 | coverage | probe data survival and budget upgrade duration |

Merge in order. 2 onwards consume the package from 1; 4 corrects a limitation documented in 3; 6, 10, 11 and 13 close gaps named by 5; 8 automates what 3 made possible; 9 replaces the inferred archetypes with confirmed ones; 12 fixes node placement for the scenario 3 introduced; 13 wires the probes 11 defined.

