### PR TITLE
test: [UPGPATH 11/13] compare entity counts across an upgrade

### DIFF
--- a/scripts/camunda-core/pkg/kube/exec.go
+++ b/scripts/camunda-core/pkg/kube/exec.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"scripts/camunda-core/pkg/executil"
+)
+
+// ExecRunner runs commands in pods via the kubectl binary.
+//
+// kubectl rather than the client-go remotecommand API: the Client does not
+// retain a rest.Config, and the lifecycle scripts this sits alongside already
+// shell out to kubectl, so the auth path is the one already proven in CI.
+type ExecRunner struct {
+	KubeContext string
+}
+
+// ExecInPod runs command under sh -c in the first ready pod matching selector
+// and returns its stdout.
+func (e ExecRunner) ExecInPod(ctx context.Context, namespace, selector, container, command string) (string, error) {
+	args := []string{"exec", "-n", namespace}
+	if e.KubeContext != "" {
+		args = append([]string{"--context", e.KubeContext}, args...)
+	}
+
+	pod, err := e.firstReadyPod(ctx, namespace, selector)
+	if err != nil {
+		return "", err
+	}
+	args = append(args, pod)
+	if container != "" {
+		args = append(args, "-c", container)
+	}
+	args = append(args, "--", "sh", "-c", command)
+
+	out, err := executil.RunCommandCapture(ctx, "kubectl", args, nil, "")
+	if err != nil {
+		return "", fmt.Errorf("exec in %s/%s: %w", namespace, pod, err)
+	}
+	return string(out), nil
+}
+
+// firstReadyPod resolves a selector to a pod name, preferring a ready pod so a
+// probe does not run against a container that is still starting.
+func (e ExecRunner) firstReadyPod(ctx context.Context, namespace, selector string) (string, error) {
+	client, err := NewClient("", e.KubeContext)
+	if err != nil {
+		return "", err
+	}
+	pods, err := client.clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return "", fmt.Errorf("list pods %q in %s: %w", selector, namespace, err)
+	}
+	if len(pods.Items) == 0 {
+		return "", fmt.Errorf("no pod matches %q in %s", selector, namespace)
+	}
+	for _, p := range pods.Items {
+		for _, c := range p.Status.Conditions {
+			if c.Type == "Ready" && c.Status == "True" {
+				return p.Name, nil
+			}
+		}
+	}
+	names := make([]string, 0, len(pods.Items))
+	for _, p := range pods.Items {
+		names = append(names, p.Name)
+	}
+	return "", fmt.Errorf("no ready pod matches %q in %s (found %s)", selector, namespace, strings.Join(names, ", "))
+}

--- a/scripts/camunda-core/pkg/survival/probe.go
+++ b/scripts/camunda-core/pkg/survival/probe.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package survival
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Probe counts one kind of entity by running a command in a pod. The command
+// must print a single integer on stdout.
+type Probe struct {
+	// Name identifies the entity in the report, e.g. "keycloak-users".
+	Name string `yaml:"name" json:"name"`
+	// Selector picks the pod to run in, e.g. "app.kubernetes.io/name=postgresql".
+	Selector string `yaml:"selector" json:"selector"`
+	// Container is optional when the pod has one container.
+	Container string `yaml:"container,omitempty" json:"container,omitempty"`
+	// Command is passed to sh -c inside the pod.
+	Command string `yaml:"command" json:"command"`
+}
+
+// Runner executes a command in a pod chosen by label selector.
+type Runner interface {
+	ExecInPod(ctx context.Context, namespace, selector, container, command string) (string, error)
+}
+
+// Run executes every probe and returns a snapshot.
+//
+// A probe that fails is omitted rather than recorded as zero. A missing entry
+// compares as NotProbed, so a broken probe reads as "unknown" instead of
+// manufacturing a wipe — the report must not invent data loss.
+func Run(ctx context.Context, r Runner, namespace string, probes []Probe) (Snapshot, []error) {
+	snap := Snapshot{}
+	var errs []error
+
+	for _, p := range probes {
+		out, err := r.ExecInPod(ctx, namespace, p.Selector, p.Container, p.Command)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("probe %s: %w", p.Name, err))
+			continue
+		}
+		n, err := ParseCount(out)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("probe %s: %w", p.Name, err))
+			continue
+		}
+		snap[p.Name] = n
+	}
+	return snap, errs
+}
+
+// ParseCount reads a single integer from command output, tolerating the
+// surrounding whitespace and blank lines that psql and similar tools emit.
+func ParseCount(out string) (int, error) {
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		n, err := strconv.Atoi(line)
+		if err != nil {
+			return 0, fmt.Errorf("expected a count, got %q", line)
+		}
+		return n, nil
+	}
+	return 0, fmt.Errorf("no output")
+}

--- a/scripts/camunda-core/pkg/survival/survival.go
+++ b/scripts/camunda-core/pkg/survival/survival.go
@@ -1,0 +1,121 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package survival compares entity counts taken before and after an upgrade.
+//
+// An upgrade that completes is not an upgrade that preserved anything. Removing
+// a subchart can strand the storage its replacement never reads, leaving a
+// healthy cluster with an empty realm — a state indistinguishable from success
+// unless something counted first.
+package survival
+
+import (
+	"fmt"
+	"sort"
+)
+
+// Snapshot maps an entity name to how many of it existed.
+type Snapshot map[string]int
+
+// Verdict classifies one entity's change across an upgrade.
+type Verdict string
+
+const (
+	// Preserved: the count did not fall.
+	Preserved Verdict = "preserved"
+	// Lost: the count fell but is not zero.
+	Lost Verdict = "lost"
+	// Wiped: the count fell to zero from a non-zero start.
+	Wiped Verdict = "wiped"
+	// NotProbed: the entity was counted on only one side, so nothing can be said.
+	NotProbed Verdict = "not-probed"
+)
+
+// Result is one entity's outcome.
+type Result struct {
+	Entity  string  `json:"entity"`
+	Before  int     `json:"before"`
+	After   int     `json:"after"`
+	Verdict Verdict `json:"verdict"`
+}
+
+// Lost reports whether this result represents data loss.
+func (r Result) IsLoss() bool {
+	return r.Verdict == Lost || r.Verdict == Wiped
+}
+
+// Compare pairs the two snapshots, sorted by entity name.
+//
+// A count that rises is Preserved rather than an anomaly: an upgrade may
+// legitimately create records, and treating growth as failure would make the
+// check unusable on a live system.
+func Compare(before, after Snapshot) []Result {
+	seen := map[string]bool{}
+	for k := range before {
+		seen[k] = true
+	}
+	for k := range after {
+		seen[k] = true
+	}
+
+	names := make([]string, 0, len(seen))
+	for k := range seen {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+
+	out := make([]Result, 0, len(names))
+	for _, n := range names {
+		b, okB := before[n]
+		a, okA := after[n]
+		r := Result{Entity: n, Before: b, After: a}
+		switch {
+		case !okB || !okA:
+			r.Verdict = NotProbed
+		case a >= b:
+			r.Verdict = Preserved
+		case a == 0:
+			r.Verdict = Wiped
+		default:
+			r.Verdict = Lost
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+// Losses filters to entities that lost data.
+func Losses(rs []Result) []Result {
+	var out []Result
+	for _, r := range rs {
+		if r.IsLoss() {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// Summary renders a one-line description of each result.
+func Summary(rs []Result) []string {
+	out := make([]string, 0, len(rs))
+	for _, r := range rs {
+		switch r.Verdict {
+		case NotProbed:
+			out = append(out, fmt.Sprintf("%s: not probed on both sides", r.Entity))
+		default:
+			out = append(out, fmt.Sprintf("%s: %d -> %d (%s)", r.Entity, r.Before, r.After, r.Verdict))
+		}
+	}
+	return out
+}

--- a/scripts/camunda-core/pkg/survival/survival_test.go
+++ b/scripts/camunda-core/pkg/survival/survival_test.go
@@ -1,0 +1,182 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package survival
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The failure this package exists for: the upgrade succeeds, every pod is
+// healthy, and the realm is empty.
+func TestCompareCatchesAWipedRealm(t *testing.T) {
+	got := Compare(
+		Snapshot{"keycloak-users": 25, "process-instances": 200},
+		Snapshot{"keycloak-users": 0, "process-instances": 200},
+	)
+
+	assert.Equal(t, []Result{
+		{Entity: "keycloak-users", Before: 25, After: 0, Verdict: Wiped},
+		{Entity: "process-instances", Before: 200, After: 200, Verdict: Preserved},
+	}, got)
+
+	losses := Losses(got)
+	assert.Len(t, losses, 1)
+	assert.Equal(t, "keycloak-users", losses[0].Entity)
+}
+
+func TestCompare(t *testing.T) {
+	tests := []struct {
+		name          string
+		before, after Snapshot
+		want          []Result
+	}{
+		{
+			name:   "unchanged counts are preserved",
+			before: Snapshot{"a": 5}, after: Snapshot{"a": 5},
+			want: []Result{{Entity: "a", Before: 5, After: 5, Verdict: Preserved}},
+		},
+		{
+			name:   "a partial drop is a loss",
+			before: Snapshot{"a": 10}, after: Snapshot{"a": 3},
+			want: []Result{{Entity: "a", Before: 10, After: 3, Verdict: Lost}},
+		},
+		{
+			name:   "dropping to zero is a wipe",
+			before: Snapshot{"a": 10}, after: Snapshot{"a": 0},
+			want: []Result{{Entity: "a", Before: 10, After: 0, Verdict: Wiped}},
+		},
+		{
+			name:   "growth is preserved, not an anomaly",
+			before: Snapshot{"a": 1}, after: Snapshot{"a": 9},
+			want: []Result{{Entity: "a", Before: 1, After: 9, Verdict: Preserved}},
+		},
+		{
+			name:   "zero to zero is preserved, not a wipe",
+			before: Snapshot{"a": 0}, after: Snapshot{"a": 0},
+			want: []Result{{Entity: "a", Before: 0, After: 0, Verdict: Preserved}},
+		},
+		{
+			name:   "probed only before",
+			before: Snapshot{"a": 5}, after: Snapshot{},
+			want: []Result{{Entity: "a", Before: 5, After: 0, Verdict: NotProbed}},
+		},
+		{
+			name:   "probed only after",
+			before: Snapshot{}, after: Snapshot{"a": 5},
+			want: []Result{{Entity: "a", Before: 0, After: 5, Verdict: NotProbed}},
+		},
+		{
+			name:   "results are sorted by entity",
+			before: Snapshot{"c": 1, "a": 1, "b": 1}, after: Snapshot{"c": 1, "a": 1, "b": 1},
+			want: []Result{
+				{Entity: "a", Before: 1, After: 1, Verdict: Preserved},
+				{Entity: "b", Before: 1, After: 1, Verdict: Preserved},
+				{Entity: "c", Before: 1, After: 1, Verdict: Preserved},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, Compare(tt.before, tt.after))
+		})
+	}
+}
+
+func TestNotProbedIsNeverALoss(t *testing.T) {
+	got := Compare(Snapshot{"a": 100}, Snapshot{})
+	assert.Empty(t, Losses(got),
+		"a probe that failed on one side must not be reported as data loss")
+}
+
+func TestSummary(t *testing.T) {
+	got := Summary(Compare(
+		Snapshot{"users": 25, "orphaned": 1},
+		Snapshot{"users": 0},
+	))
+	assert.Equal(t, []string{
+		"orphaned: not probed on both sides",
+		"users: 25 -> 0 (wiped)",
+	}, got)
+}
+
+func TestCompareEmpty(t *testing.T) {
+	assert.Empty(t, Compare(Snapshot{}, Snapshot{}))
+}
+
+type fakeRunner struct {
+	out  map[string]string
+	fail map[string]error
+}
+
+func (f fakeRunner) ExecInPod(_ context.Context, _, selector, _, _ string) (string, error) {
+	if err, ok := f.fail[selector]; ok {
+		return "", err
+	}
+	return f.out[selector], nil
+}
+
+func TestParseCount(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    int
+		wantErr bool
+	}{
+		{in: "42", want: 42},
+		{in: "\n   7 \n\n", want: 7},
+		{in: "0", want: 0},
+		{in: "", wantErr: true},
+		{in: "   \n  \n", wantErr: true},
+		{in: "not-a-number", wantErr: true},
+	}
+	for _, tt := range tests {
+		got, err := ParseCount(tt.in)
+		if tt.wantErr {
+			assert.Error(t, err, "input %q", tt.in)
+			continue
+		}
+		assert.NoError(t, err)
+		assert.Equal(t, tt.want, got)
+	}
+}
+
+func TestRunOmitsFailedProbes(t *testing.T) {
+	r := fakeRunner{
+		out:  map[string]string{"ok": "12"},
+		fail: map[string]error{"broken": assert.AnError},
+	}
+	snap, errs := Run(context.Background(), r, "ns", []Probe{
+		{Name: "good", Selector: "ok", Command: "x"},
+		{Name: "bad", Selector: "broken", Command: "x"},
+	})
+
+	assert.Equal(t, Snapshot{"good": 12}, snap)
+	assert.Len(t, errs, 1)
+
+	// The failed probe must read as unknown, never as a wipe.
+	res := Compare(Snapshot{"good": 12, "bad": 99}, snap)
+	assert.Empty(t, Losses(res), "a broken probe must not manufacture data loss")
+}
+
+func TestRunRejectsNonNumericOutput(t *testing.T) {
+	r := fakeRunner{out: map[string]string{"s": "ERROR: relation does not exist"}}
+	snap, errs := Run(context.Background(), r, "ns", []Probe{{Name: "n", Selector: "s", Command: "x"}})
+	assert.Empty(t, snap)
+	assert.Len(t, errs, 1)
+	assert.Contains(t, errs[0].Error(), "expected a count")
+}


### PR DESCRIPTION
> | # | PR | Phase | Purpose |
> |---|---|---|---|
> | 1 | #6820 | shared library | `chartvalues`: consolidation, `$remove`/`$rename`/`$scaffolding` directives |
> | 2 | #6821 | render stage | `upgrade-paths` A/B harness, archetypes, fixtures, render workflow |
> | 3 | #6822 | cluster stage | `deploy-camunda` values carryover, `upgrade-path` flow, hook suppression |
> | 4 | #6824 | correctness | separate harness scaffolding from customer-facing steps |
> | 5 | #6825 | honesty | coverage manifest: report what the harness does not check |
> | 6 | #6826 | coverage | gate rendering against a real Helm v3 client |
> | 7 | #6827 | lifecycle | `--bootstrap` a new version transition at fork time |
> | 8 | #6828 | automation | run the cluster stage nightly and on demand |
> | 9 | #6829 | realism | make externally-provisioned shapes the primary archetypes |
> | 10 | #6830 | coverage | detect storage stranded by an upgrade |
> | **11** | **#6831** | **coverage** | **compare entity counts across an upgrade** ← you are here |
> | 12 | #6832 | infra | schedule companion services on the intended node pool |
> | 13 | #6834 | coverage | probe data survival and budget upgrade duration |

Merge in order. 2 onwards consume the package from 1; 4 corrects a limitation documented in 3; 6, 10, 11 and 13 close gaps named by 5; 8 automates what 3 made possible; 9 replaces the inferred archetypes with confirmed ones; 12 fixes node placement for the scenario 3 introduced; 13 wires the probes 11 defined.

### Which problem does the PR fix?

Part of #6819. First half of the `data-survival` gap in the coverage manifest (#6825).

An upgrade that completes is not an upgrade that preserved anything. Removing a subchart can strand the storage its replacement never reads, leaving a healthy cluster with an empty realm — **a state indistinguishable from success unless something counted first**. This is precisely the gap that let the Keycloak realm wipe pass as a green run during development of #6822.

### What's in this PR?

The comparison core: entity counts snapshotted either side of the upgrade, classified as `preserved`, `lost`, `wiped` or `not-probed`.

Three judgements are encoded deliberately, because each could reasonably have gone the other way:

**A count that rises is preserved, not an anomaly.** An upgrade may legitimately create records; treating growth as failure would make the check unusable on a live system.

**Zero to zero is preserved, not a wipe.** Only a fall from a non-zero start counts.

**A failed probe is omitted, not recorded as zero.** It then compares as `not-probed`. A broken query must read as *unknown* — manufacturing a wipe out of a connection error would be worse than not checking at all, because it would train people to ignore the output.

Probes count by running a command in a pod and reading a single integer, which suits the database-level access the Bitnami migration already relies on. The runner shells out to `kubectl` rather than using client-go `remotecommand`: `Client` keeps no `rest.Config`, and the lifecycle scripts this sits alongside already take the kubectl auth path proven in CI.

### Not wired yet

Probes need declaring per scenario, and that wants a cluster run to verify rather than an assumption. The comparison logic is pure and fully covered — including the wiped-realm case, written from the actual incident:

```go
Compare(
    Snapshot{"keycloak-users": 25, "process-instances": 200},
    Snapshot{"keycloak-users": 0,  "process-instances": 200},
)
// keycloak-users: 25 -> 0 (wiped)
```

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
