### PR TITLE
test: [UPGPATH 12/13] schedule companion services on the intended node pool

### DIFF
--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -772,16 +772,16 @@ integration:
           dependencies:
             - chart: charts/internal-keycloak-26
               release-name: keycloak
-              values-file: test/integration/companion-values/keycloak.yaml
+              values-file: test/integration/companion-values/keycloak-distroci.yaml
             - chart: elastic/elasticsearch
               version: 8.5.1
               release-name: elasticsearch
-              values-file: test/integration/companion-values/elasticsearch.yaml
+              values-file: test/integration/companion-values/elasticsearch-distroci.yaml
               repo-name: elastic
               repo-url: https://helm.elastic.co
             - chart: charts/internal-postgresql
               release-name: postgresql
-              values-file: test/integration/companion-values/postgresql.yaml
+              values-file: test/integration/companion-values/postgresql-distroci.yaml
               env-vars:
                 - RDBMS_POSTGRESQL_USERNAME
                 - RDBMS_POSTGRESQL_PASSWORD

--- a/charts/camunda-platform-8.10/test/ci/registry/dependencies/elasticsearch-distroci.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/dependencies/elasticsearch-distroci.yaml
@@ -1,0 +1,6 @@
+chart: elastic/elasticsearch
+version: 8.5.1
+release-name: elasticsearch
+values-file: test/integration/companion-values/elasticsearch-distroci.yaml
+repo-name: elastic
+repo-url: https://helm.elastic.co

--- a/charts/camunda-platform-8.10/test/ci/registry/dependencies/keycloak-distroci.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/dependencies/keycloak-distroci.yaml
@@ -1,0 +1,3 @@
+chart: charts/internal-keycloak-26
+release-name: keycloak
+values-file: test/integration/companion-values/keycloak-distroci.yaml

--- a/charts/camunda-platform-8.10/test/ci/registry/dependencies/postgresql-distroci.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/dependencies/postgresql-distroci.yaml
@@ -1,0 +1,6 @@
+chart: charts/internal-postgresql
+release-name: postgresql
+values-file: test/integration/companion-values/postgresql-distroci.yaml
+env-vars:
+  - RDBMS_POSTGRESQL_USERNAME
+  - RDBMS_POSTGRESQL_PASSWORD

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/upgrade-path-classic.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/upgrade-path-classic.yaml
@@ -13,7 +13,9 @@ infra-type:
   eks: preemptible
   gke: distroci
 post-infra: post-infra-bitnami-migration
+# The distroci pool is tainted, so companions need the toleration too or they
+# land on the untainted remainder and contend with unrelated workloads.
 dependencies:
-  - keycloak
-  - elasticsearch
-  - postgresql
+  - keycloak-distroci
+  - elasticsearch-distroci
+  - postgresql-distroci

--- a/test/integration/companion-values/elasticsearch-distroci.yaml
+++ b/test/integration/companion-values/elasticsearch-distroci.yaml
@@ -1,0 +1,129 @@
+# elasticsearch companion for GKE distroci scenarios.
+#
+# Identical to elasticsearch.yaml plus node placement. The distroci pool is
+# tainted workload=distroci:NoSchedule, so a companion without the toleration
+# cannot schedule there and is squeezed onto the small untainted remainder,
+# where it contends with unrelated workloads.
+# CI values for the embedded Elasticsearch companion chart (elastic/elasticsearch).
+# Security/X-Pack disabled, single node, minimal resources for CI/dev environments.
+#
+# Deployed as a separate Helm release by deploy-camunda before the main
+# Camunda chart. Referenced from ci-test-config.yaml dependencies.
+
+clusterName: "elasticsearch"
+
+replicas: 1
+minimumMasterNodes: 1
+
+protocol: http
+
+# Use ES 8.18.0 — the elastic/elasticsearch Helm chart 8.5.1 defaults to its
+# own app version (8.5.1) but Camunda 8.10 requires ES 8.6+ (specifically for
+# the unassignedPrimaryShards field in HealthResponse). The Bitnami subchart
+# this replaces bundled ES 8.18.0.
+imageTag: "8.18.0"
+
+# Disable automatic TLS certificate generation. When createCert=true (default),
+# the chart injects env vars that force xpack.security.enabled=true and
+# xpack.security.{http,transport}.ssl.enabled=true, overriding any esConfig
+# settings. Setting createCert=false prevents cert creation, volume mounts, AND
+# the env var injection — letting our esConfig settings take effect.
+createCert: false
+
+# Keep the credentials secret enabled even though security is disabled.
+# The chart's readiness probe script checks [ -z "${ELASTIC_PASSWORD}" ] and
+# exits 1 if unset. The password is injected from this secret but ignored by
+# ES when xpack.security.enabled=false.
+secret:
+  enabled: true
+
+# Single-node disco + disable HTTP TLS + disable X-Pack security so Camunda
+# can talk to the cluster anonymously over plain HTTP (mirrors the OpenSearch
+# companion chart's "security disabled" stance).
+#
+# NOTE: discovery.type: single-node is NOT set here because the
+# elastic/elasticsearch chart injects cluster.initial_master_nodes via an env
+# var in the StatefulSet template, and ES 8.x rejects having both. With
+# replicas=1 the chart bootstraps correctly without the explicit single-node
+# setting.
+esConfig:
+  elasticsearch.yml: |
+    cluster.name: elasticsearch
+    network.host: 0.0.0.0
+    xpack.security.enabled: false
+    xpack.security.http.ssl.enabled: false
+    # Allow _reindex-from-remote to pull data from the source (bundled Bitnami)
+    # Elasticsearch during the Bitnami→companion migration (upgrade-minor flows).
+    # Harmless for install scenarios, which never issue a remote reindex.
+    reindex.remote.whitelist: "*:9200"
+    xpack.security.transport.ssl.enabled: false
+
+extraEnvs:
+  - name: ES_JAVA_OPTS
+    value: "-Xms512m -Xmx512m"
+
+# Single-node clusters cannot allocate index replicas. Camunda components
+# create indices with number_of_replicas=1, which leaves every replica
+# unassigned, drives the cluster to yellow, and causes intermittent "all
+# shards failed" 503s on _search calls.
+#
+# auto_expand_replicas dynamically adjusts replicas based on cluster size:
+# on a 1-node cluster it settles at 0; on a 2-node cluster it scales to 1.
+# It overrides any explicit number_of_replicas setting.
+#
+# Priority MUST be lower than the application's own index templates:
+#   - Zeebe-record templates: priority 20 (define aliases for Optimize)
+#   - Operate/Tasklist/Camunda templates: priority 0
+# Setting priority=1 ensures:
+#   - Zeebe-record templates (p20) win → their aliases are applied correctly
+#   - Our template (p1) wins over operate/tasklist/camunda (p0) → auto_expand
+#     applies to those indices
+# Zeebe-record indices already set number_of_replicas=0 in their templates,
+# so they don't need auto_expand_replicas to be green on a single node.
+#
+# Index patterns are intentionally substring globs (e.g. "*operate*") rather
+# than prefix globs ("operate-*"). CI prepends $GITHUB_WORKFLOW_JOB_ID to
+# every component prefix, and deploy-camunda matrix uses shortened prefixes
+# ("op-*", "opt-*", "orch-*") for index naming.
+lifecycle:
+  postStart:
+    exec:
+      command:
+        - bash
+        - -c
+        - |
+          max=60
+          n=0
+          until curl -fsS --connect-timeout 5 "http://localhost:9200/_cluster/health" >/dev/null 2>&1; do
+            n=$((n + 1))
+            if [ "$n" -ge "$max" ]; then
+              echo "elasticsearch not reachable after $max attempts" >&2
+              exit 1
+            fi
+            sleep 2
+          done
+          curl -fsS --connect-timeout 5 -X PUT "http://localhost:9200/_index_template/camunda-ci-auto-expand-replicas" \
+            -H 'Content-Type: application/json' \
+            -d '{"index_patterns":["*operate*","*orchestration*","*optimize*","*tasklist*","*camunda*","*zeebe*","op-*","opt-*","orch-*"],"priority":1,"template":{"settings":{"index.auto_expand_replicas":"0-1"}}}'
+
+resources:
+  requests:
+    cpu: "500m"
+    memory: "1Gi"
+  limits:
+    cpu: "1"
+    memory: "2Gi"
+
+volumeClaimTemplate:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 4Gi
+
+nodeSelector:
+  workload: distroci
+tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: distroci

--- a/test/integration/companion-values/keycloak-distroci.yaml
+++ b/test/integration/companion-values/keycloak-distroci.yaml
@@ -1,0 +1,54 @@
+# keycloak companion for GKE distroci scenarios.
+#
+# Identical to keycloak.yaml plus node placement. The distroci pool is tainted
+# workload=distroci:NoSchedule, so a companion without the toleration cannot
+# schedule there and is squeezed onto the small untainted remainder, where it
+# contends with unrelated workloads.
+# Companion values for internal-keycloak-26 chart.
+# Deployed as a separate Helm release before the Camunda chart.
+# Uses the same credential secret that the matrix runner provisions.
+
+fullnameOverride: keycloak
+
+image:
+  registry: quay.io
+  repository: keycloak/keycloak
+  tag: "26.3.3"
+
+auth:
+  adminUser: admin
+  existingSecret: integration-test-credentials
+  passwordSecretKey: identity-keycloak-admin-password
+
+httpRelativePath: "/auth/"
+proxy: edge
+
+resources:
+  requests:
+    cpu: 200m
+    memory: 512Mi
+  limits:
+    cpu: "1"
+    memory: 1Gi
+
+postgresql:
+  enabled: true
+  auth:
+    database: keycloak
+    username: keycloak
+    password: "keycloak-ci-password"
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+
+nodeSelector:
+  workload: distroci
+tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: distroci

--- a/test/integration/companion-values/postgresql-distroci.yaml
+++ b/test/integration/companion-values/postgresql-distroci.yaml
@@ -1,0 +1,35 @@
+# postgresql companion for GKE distroci scenarios.
+#
+# Identical to postgresql.yaml plus node placement. The distroci pool is tainted
+# workload=distroci:NoSchedule, so a companion without the toleration cannot
+# schedule there and is squeezed onto the small untainted remainder, where it
+# contends with unrelated workloads.
+# Companion values for internal-postgresql chart.
+# Provides Identity and Web Modeler databases without Bitnami or CNPG.
+
+fullnameOverride: postgresql
+
+auth:
+  username: "$RDBMS_POSTGRESQL_USERNAME"
+  password: "$RDBMS_POSTGRESQL_PASSWORD"
+  database: identity
+
+databases:
+  - identity
+  - webmodeler
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+nodeSelector:
+  workload: distroci
+tolerations:
+  - effect: NoSchedule
+    key: workload
+    operator: Equal
+    value: distroci


### PR DESCRIPTION
> | # | PR | Phase | Purpose |
> |---|---|---|---|
> | 1 | #6820 | shared library | `chartvalues`: consolidation, `$remove`/`$rename`/`$scaffolding` directives |
> | 2 | #6821 | render stage | `upgrade-paths` A/B harness, archetypes, fixtures, render workflow |
> | 3 | #6822 | cluster stage | `deploy-camunda` values carryover, `upgrade-path` flow, hook suppression |
> | 4 | #6824 | correctness | separate harness scaffolding from customer-facing steps |
> | 5 | #6825 | honesty | coverage manifest: report what the harness does not check |
> | 6 | #6826 | coverage | gate rendering against a real Helm v3 client |
> | 7 | #6827 | lifecycle | `--bootstrap` a new version transition at fork time |
> | 8 | #6828 | automation | run the cluster stage nightly and on demand |
> | 9 | #6829 | realism | make externally-provisioned shapes the primary archetypes |
> | 10 | #6830 | coverage | detect storage stranded by an upgrade |
> | 11 | #6831 | coverage | compare entity counts across an upgrade |
> | **12** | **#6832** | **infra** | **schedule companion services on the intended node pool** ← you are here |
> | 13 | #6834 | coverage | probe data survival and budget upgrade duration |

Merge in order. 2 onwards consume the package from 1; 4 corrects a limitation documented in 3; 6, 10, 11 and 13 close gaps named by 5; 8 automates what 3 made possible; 9 replaces the inferred archetypes with confirmed ones; 12 fixes node placement for the scenario 3 introduced; 13 wires the probes 11 defined.

### Which problem does the PR fix?

Part of #6819.

The `distroci` pool is **34 of the cluster's 47 nodes** and is tainted `workload=distroci:NoSchedule`. The companion Keycloak, PostgreSQL and Elasticsearch releases carried neither the `nodeSelector` nor the toleration, so they were *structurally excluded* from the pool their own scenario targets and squeezed onto the ~13 untainted remainder, contending with unrelated workloads.

Observed as repeated scheduling failures:

```
0/47 nodes are available: 18 Insufficient cpu, 26 node(s) had untolerated taint
```

and a verification run that took **14m09s** against a previous **7m33s** for identical work.

### What's in this PR?

`*-distroci` companion values and dependency definitions, with `upgrade-path-classic` pointed at them. The `-qa` variants already carried placement, but for the `qa-workloads` pool, so there was no `distroci` equivalent to reuse.

### Verified on GKE

```
elasticsearch-master-0    distroci
keycloak-...              distroci
postgresql-...            distroci

FailedScheduling events:  0     (previously many)
[PASS] upgrade-path-classic     9m43s   (previously 14m09s)
```

### Not addressed here

**`keycloak-postgresql` remains unplaced.** `charts/internal-keycloak-26/templates/postgresql-deployment.yaml` has no `nodeSelector` or `tolerations` support at all, so no values change can place it. That is a template change to a chart shared with other scenarios and deserves its own review rather than riding along here.

**The migration backup Job** comes from the external `camunda-deployment-references` scripts and is short-lived.

### Worth raising separately

This is **pre-existing, not introduced by this stack**. `hub-legacy-upgrade` uses the same unplaced dependencies, so its companion Keycloak, PostgreSQL and Elasticsearch have been scheduling off-pool on every nightly run. This PR only fixes the new scenario; the existing one would benefit from the same change.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
