### PR TITLE
fix: align legacy exporter with its component datastore source

### DIFF
--- a/charts/camunda-platform-8.10/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/common/_helpers.tpl
@@ -400,11 +400,12 @@ Elasticsearch and Opensearch templates.
 
 {{/*
 [camunda-platform] Elasticsearch URL for the legacy Zeebe exporter that feeds Optimize.
-Prefers the Optimize component endpoint, falling back to the secondary-storage URL.
+Resolves the Optimize component chain when the exporter is Optimize-owned, and the
+secondary-storage/compatibility URL otherwise.
 */}}
 {{- define "camundaPlatform.legacyExporterElasticsearchURL" -}}
-{{- if (tpl .Values.optimize.database.elasticsearch.url.host $) -}}
-  {{ .Values.optimize.database.elasticsearch.url.protocol | default .Values.global.elasticsearch.url.protocol }}://{{ include "camundaPlatform.elasticsearchHost" . }}:{{ include "camundaPlatform.elasticsearchPort" . }}
+{{- if eq (include "orchestration.legacyElasticsearchExporterUsesOptimizeSource" .) "true" -}}
+  {{ include "optimize.effectiveEsURL" . }}
 {{- else -}}
   {{ include "camundaPlatform.elasticsearchURL" . }}
 {{- end -}}
@@ -412,11 +413,12 @@ Prefers the Optimize component endpoint, falling back to the secondary-storage U
 
 {{/*
 [camunda-platform] OpenSearch URL for the legacy Zeebe exporter that feeds Optimize.
-Prefers the Optimize component endpoint, falling back to the secondary-storage URL.
+Resolves the Optimize component chain when the exporter is Optimize-owned, and the
+secondary-storage/compatibility URL otherwise.
 */}}
 {{- define "camundaPlatform.legacyExporterOpensearchURL" -}}
-{{- if (tpl .Values.optimize.database.opensearch.url.host $) -}}
-  {{ .Values.optimize.database.opensearch.url.protocol | default .Values.global.opensearch.url.protocol }}://{{ include "camundaPlatform.opensearchHost" . }}:{{ include "camundaPlatform.opensearchPort" . }}
+{{- if eq (include "orchestration.legacyOpenSearchExporterUsesOptimizeSource" .) "true" -}}
+  {{ include "optimize.effectiveOsURL" . }}
 {{- else -}}
   {{ include "camundaPlatform.opensearchURL" . }}
 {{- end -}}

--- a/charts/camunda-platform-8.10/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/common/_helpers.tpl
@@ -398,6 +398,30 @@ Elasticsearch and Opensearch templates.
 {{- end -}}
 {{- end -}}
 
+{{/*
+[camunda-platform] Elasticsearch URL for the legacy Zeebe exporter that feeds Optimize.
+Prefers the Optimize component endpoint, falling back to the secondary-storage URL.
+*/}}
+{{- define "camundaPlatform.legacyExporterElasticsearchURL" -}}
+{{- if (tpl .Values.optimize.database.elasticsearch.url.host $) -}}
+  {{ .Values.optimize.database.elasticsearch.url.protocol | default .Values.global.elasticsearch.url.protocol }}://{{ include "camundaPlatform.elasticsearchHost" . }}:{{ include "camundaPlatform.elasticsearchPort" . }}
+{{- else -}}
+  {{ include "camundaPlatform.elasticsearchURL" . }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+[camunda-platform] OpenSearch URL for the legacy Zeebe exporter that feeds Optimize.
+Prefers the Optimize component endpoint, falling back to the secondary-storage URL.
+*/}}
+{{- define "camundaPlatform.legacyExporterOpensearchURL" -}}
+{{- if (tpl .Values.optimize.database.opensearch.url.host $) -}}
+  {{ .Values.optimize.database.opensearch.url.protocol | default .Values.global.opensearch.url.protocol }}://{{ include "camundaPlatform.opensearchHost" . }}:{{ include "camundaPlatform.opensearchPort" . }}
+{{- else -}}
+  {{ include "camundaPlatform.opensearchURL" . }}
+{{- end -}}
+{{- end -}}
+
 
 
 

--- a/charts/camunda-platform-8.10/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.10/templates/common/constraints.tpl
@@ -462,6 +462,28 @@ The following values inside your values.yaml need to be set but were not:
     {{- end }}
   {{- end }}
 
+  {{/* Optimize-owned legacy exporter truststore conflict: the Orchestration JVM mounts a single
+       truststore, so when the exporter carries its own component TLS secret, a differing
+       global/secondary-storage truststore cannot be mounted alongside it. */}}
+  {{- $legacyExporterTls := include "orchestration.legacyExporterTlsConfig" . | fromYaml }}
+  {{- $sharedTls := include "orchestration.sharedTlsConfig" . | fromYaml }}
+  {{- if and
+        (eq (include "camundaPlatform.hasSecretConfig" (dict "config" $legacyExporterTls)) "true")
+        (eq (include "camundaPlatform.hasSecretConfig" (dict "config" $sharedTls)) "true")
+        (ne
+          (include "camundaPlatform.normalizeSecretConfiguration" (dict "config" $legacyExporterTls))
+          (include "camundaPlatform.normalizeSecretConfiguration" (dict "config" $sharedTls))
+        )
+  }}
+    {{- $warningMessage := printf "%s %s %s %s"
+        "[camunda][warning]"
+        "TRUSTSTORE CONFLICT: the legacy exporter mounts the Optimize datastore truststore (optimize.database.*.tls.secret), which differs from the truststore configured for the global/secondary-storage connection."
+        "The Orchestration JVM supports a single truststore, so the Optimize one applies to the whole pod and the other connection cannot use its own CA."
+        "To trust multiple CAs on one pod, provide a combined PEM bundle via 'global.tls.caBundle.secret.*' and remove the per-component JKS truststore secrets."
+    -}}
+    {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
+  {{- end }}
+
   {{/* global.tls.caBundle guardrails: surface the three silent failure modes
        a caBundle user can hit (JKS precedence, trust!=encryption, env override). */}}
   {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" }}

--- a/charts/camunda-platform-8.10/templates/optimize/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/optimize/_helpers.tpl
@@ -149,6 +149,20 @@ When neither backend is explicitly enabled, falls back to "zeebe-record".
 {{- end -}}
 
 {{/*
+[optimize] Resolve the effective Elasticsearch URL from the component-first host/port/protocol chain.
+*/}}
+{{- define "optimize.effectiveEsURL" -}}
+{{- .Values.optimize.database.elasticsearch.url.protocol | default .Values.global.elasticsearch.url.protocol }}://{{ include "camundaPlatform.elasticsearchHost" . }}:{{ include "camundaPlatform.elasticsearchPort" . -}}
+{{- end -}}
+
+{{/*
+[optimize] Resolve the effective OpenSearch URL from the component-first host/port/protocol chain.
+*/}}
+{{- define "optimize.effectiveOsURL" -}}
+{{- .Values.optimize.database.opensearch.url.protocol | default .Values.global.opensearch.url.protocol }}://{{ include "camundaPlatform.opensearchHost" . }}:{{ include "camundaPlatform.opensearchPort" . -}}
+{{- end -}}
+
+{{/*
 [optimize] Build a comma-separated spring.config.import line from extraConfiguration files.
 Entries with springImport: false are excluded.
 */}}

--- a/charts/camunda-platform-8.10/templates/optimize/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/optimize/_helpers.tpl
@@ -149,6 +149,20 @@ When neither backend is explicitly enabled, falls back to "zeebe-record".
 {{- end -}}
 
 {{/*
+[optimize] Resolve the effective Elasticsearch username from the component-first chain.
+*/}}
+{{- define "optimize.effectiveEsUsername" -}}
+{{- .Values.optimize.database.elasticsearch.auth.username | default .Values.global.elasticsearch.auth.username -}}
+{{- end -}}
+
+{{/*
+[optimize] Resolve the effective OpenSearch username from the component-first chain.
+*/}}
+{{- define "optimize.effectiveOsUsername" -}}
+{{- .Values.optimize.database.opensearch.auth.username | default .Values.global.opensearch.auth.username -}}
+{{- end -}}
+
+{{/*
 [optimize] Resolve the effective Elasticsearch URL from the component-first host/port/protocol chain.
 */}}
 {{- define "optimize.effectiveEsURL" -}}

--- a/charts/camunda-platform-8.10/templates/optimize/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/optimize/_helpers.tpl
@@ -149,6 +149,13 @@ When neither backend is explicitly enabled, falls back to "zeebe-record".
 {{- end -}}
 
 {{/*
+[optimize] Resolve the effective OpenSearch AWS mode from the component-first chain.
+*/}}
+{{- define "optimize.effectiveOsAwsEnabled" -}}
+{{- or .Values.optimize.database.opensearch.aws.enabled .Values.global.opensearch.aws.enabled -}}
+{{- end -}}
+
+{{/*
 [optimize] Resolve the effective Elasticsearch username from the component-first chain.
 */}}
 {{- define "optimize.effectiveEsUsername" -}}

--- a/charts/camunda-platform-8.10/templates/optimize/deployment.yaml
+++ b/charts/camunda-platform-8.10/templates/optimize/deployment.yaml
@@ -103,7 +103,7 @@ spec:
               value: {{ include "optimize.effectiveEsUsername" . | quote }}
             {{- end }}
             {{- end }}
-            {{- if or .Values.optimize.database.opensearch.aws.enabled .Values.global.opensearch.aws.enabled }}
+            {{- if eq (include "optimize.effectiveOsAwsEnabled" .) "true" }}
             - name: CAMUNDA_OPTIMIZE_OPENSEARCH_AWS_ENABLED
               value: "true"
             {{- end }}
@@ -233,7 +233,7 @@ spec:
             - name: CAMUNDA_OPTIMIZE_CACHES_CLOUD_TENANT_AUTHORIZATIONS_MIN_FETCH_INTERVAL_SECONDS
               value: {{ include "camundaPlatform.effectiveExtraConfigValue" (dict "default" (.Values.optimize.caches.cloudTenantAuthorizations.minFetchIntervalSeconds | default "600000") "extraConfiguration" .Values.optimize.extraConfiguration "path" (list "camunda" "optimize" "caches" "cloud-tenant-authorizations" "min-fetch-interval-seconds")) | quote }}
             {{- end }}
-            {{- if or .Values.optimize.database.opensearch.aws.enabled .Values.global.opensearch.aws.enabled }}
+            {{- if eq (include "optimize.effectiveOsAwsEnabled" .) "true" }}
             - name: CAMUNDA_OPTIMIZE_OPENSEARCH_AWS_ENABLED
               value: "true"
             {{- end }}

--- a/charts/camunda-platform-8.10/templates/optimize/deployment.yaml
+++ b/charts/camunda-platform-8.10/templates/optimize/deployment.yaml
@@ -68,9 +68,9 @@ spec:
               value: {{ .Values.optimize.database.opensearch.url.port | default .Values.global.opensearch.url.port | quote }}
             - name: CAMUNDA_OPTIMIZE_OPENSEARCH_HOST
               value: {{ include "camundaPlatform.opensearchHost" . | quote }}
-            {{- if or .Values.optimize.database.opensearch.auth.username .Values.global.opensearch.auth.username }}
+            {{- if (include "optimize.effectiveOsUsername" .) }}
             - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SECURITY_USERNAME
-              value: {{ .Values.optimize.database.opensearch.auth.username | default .Values.global.opensearch.auth.username | quote }}
+              value: {{ include "optimize.effectiveOsUsername" . | quote }}
             {{- end }}
             {{- $osAuth := include "optimize.effectiveOsAuthConfig" . | fromYaml -}}
             {{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" $osAuth)) "true" }}
@@ -98,9 +98,9 @@ spec:
               value: {{ include "camundaPlatform.elasticsearchHost" . | quote }}
             - name: OPTIMIZE_ELASTICSEARCH_HTTP_PORT
               value: {{ .Values.optimize.database.elasticsearch.url.port | default .Values.global.elasticsearch.url.port | quote }}
-            {{- if or .Values.optimize.database.elasticsearch.auth.username .Values.global.elasticsearch.auth.username }}
+            {{- if (include "optimize.effectiveEsUsername" .) }}
             - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SECURITY_USERNAME
-              value: {{ .Values.optimize.database.elasticsearch.auth.username | default .Values.global.elasticsearch.auth.username | quote }}
+              value: {{ include "optimize.effectiveEsUsername" . | quote }}
             {{- end }}
             {{- end }}
             {{- if or .Values.optimize.database.opensearch.aws.enabled .Values.global.opensearch.aws.enabled }}
@@ -177,9 +177,9 @@ spec:
               value: {{ .Values.optimize.database.opensearch.url.port | default .Values.global.opensearch.url.port | quote }}
             - name: CAMUNDA_OPTIMIZE_OPENSEARCH_HOST
               value: {{ include "camundaPlatform.opensearchHost" . | quote }}
-            {{- if or .Values.optimize.database.opensearch.auth.username .Values.global.opensearch.auth.username }}
+            {{- if (include "optimize.effectiveOsUsername" .) }}
             - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SECURITY_USERNAME
-              value: {{ .Values.optimize.database.opensearch.auth.username | default .Values.global.opensearch.auth.username | quote }}
+              value: {{ include "optimize.effectiveOsUsername" . | quote }}
             {{- end }}
             {{- $osAuth := include "optimize.effectiveOsAuthConfig" . | fromYaml -}}
             {{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" $osAuth)) "true" }}
@@ -211,9 +211,9 @@ spec:
               value: {{ include "camundaPlatform.elasticsearchHost" . | quote }}
             - name: OPTIMIZE_ELASTICSEARCH_HTTP_PORT
               value: {{ .Values.optimize.database.elasticsearch.url.port | default .Values.global.elasticsearch.url.port | quote }}
-            {{- if or .Values.optimize.database.elasticsearch.auth.username .Values.global.elasticsearch.auth.username }}
+            {{- if (include "optimize.effectiveEsUsername" .) }}
             - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SECURITY_USERNAME
-              value: {{ .Values.optimize.database.elasticsearch.auth.username | default .Values.global.elasticsearch.auth.username | quote }}
+              value: {{ include "optimize.effectiveEsUsername" . | quote }}
             {{- end }}
             {{- end }}
             - name: SPRING_PROFILES_ACTIVE

--- a/charts/camunda-platform-8.10/templates/optimize/files/_environment-config.yaml
+++ b/charts/camunda-platform-8.10/templates/optimize/files/_environment-config.yaml
@@ -23,7 +23,7 @@ es:
     {{- end }}
   {{- if or .Values.global.elasticsearch.external .Values.optimize.database.elasticsearch.external }}
   security:
-    username: {{ .Values.optimize.database.elasticsearch.auth.username | default .Values.global.elasticsearch.auth.username | quote }}
+    username: {{ include "optimize.effectiveEsUsername" . | quote }}
     {{- if eq (.Values.optimize.database.elasticsearch.url.protocol | default .Values.global.elasticsearch.url.protocol) "https" }}
     ssl:
       enabled: "true"

--- a/charts/camunda-platform-8.10/templates/orchestration/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/orchestration/_helpers.tpl
@@ -442,16 +442,15 @@ ${VALUES_OPENSEARCH_PASSWORD:}
 {{- end -}}
 
 {{/*
-NOTE: the legacy OpenSearch exporter resolves AWS mode from the same endpoint source, retaining the
-shared fallback only when neither component defines an endpoint.
+NOTE: the legacy OpenSearch exporter resolves AWS mode from the same source as its endpoint and
+credentials: the Optimize component chain when Optimize-owned, the secondary-storage/global pair
+otherwise.
 */}}
 {{- define "orchestration.legacyOpenSearchExporterAwsEnabled" -}}
-{{- if (tpl .Values.optimize.database.opensearch.url.host $) -}}
-{{- .Values.optimize.database.opensearch.aws.enabled -}}
-{{- else if .Values.orchestration.data.secondaryStorage.opensearch.url -}}
-{{- or .Values.orchestration.data.secondaryStorage.opensearch.aws.enabled .Values.global.opensearch.aws.enabled -}}
+{{- if eq (include "orchestration.legacyOpenSearchExporterUsesOptimizeSource" .) "true" -}}
+{{- include "optimize.effectiveOsAwsEnabled" . -}}
 {{- else -}}
-{{- or .Values.orchestration.data.secondaryStorage.opensearch.aws.enabled .Values.global.opensearch.aws.enabled .Values.optimize.database.opensearch.aws.enabled -}}
+{{- or .Values.orchestration.data.secondaryStorage.opensearch.aws.enabled .Values.global.opensearch.aws.enabled -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/camunda-platform-8.10/templates/orchestration/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/orchestration/_helpers.tpl
@@ -373,6 +373,39 @@ and
 -}}
 {{- end -}}
 
+{{/*
+NOTE: the legacy exporters resolve their password from the Optimize component secret when one is
+configured, and fall back to the generic engine-wide variable otherwise. Both the emission in
+statefulset.yaml and the substitution here key off the same hasSecretConfig predicate.
+*/}}
+{{- define "orchestration.legacyElasticsearchExporterPasswordRef" -}}
+{{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.optimize.database.elasticsearch.auth)) "true" -}}
+${VALUES_OPTIMIZE_DATABASE_ELASTICSEARCH_PASSWORD:}
+{{- else -}}
+${VALUES_ELASTICSEARCH_PASSWORD:}
+{{- end -}}
+{{- end -}}
+
+{{- define "orchestration.legacyOpenSearchExporterPasswordRef" -}}
+{{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.optimize.database.opensearch.auth)) "true" -}}
+${VALUES_OPTIMIZE_DATABASE_OPENSEARCH_PASSWORD:}
+{{- else -}}
+${VALUES_OPENSEARCH_PASSWORD:}
+{{- end -}}
+{{- end -}}
+
+{{/*
+NOTE: when the legacy OpenSearch exporter targets the Optimize component endpoint, its AWS mode is
+owned by that component; otherwise it keeps the shared-endpoint resolution across all three sources.
+*/}}
+{{- define "orchestration.legacyOpenSearchExporterAwsEnabled" -}}
+{{- if (tpl .Values.optimize.database.opensearch.url.host $) -}}
+{{- .Values.optimize.database.opensearch.aws.enabled -}}
+{{- else -}}
+{{- or .Values.orchestration.data.secondaryStorage.opensearch.aws.enabled .Values.global.opensearch.aws.enabled .Values.optimize.database.opensearch.aws.enabled -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "orchestration.hasAppIntegrations" -}}
 {{- include "camundaPlatform.hasSecretConfig" (dict "config" .Values.orchestration.exporters.appIntegrations.apiKey) -}}
 {{- end -}}

--- a/charts/camunda-platform-8.10/templates/orchestration/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/orchestration/_helpers.tpl
@@ -374,6 +374,29 @@ and
 {{- end -}}
 
 {{/*
+NOTE: the legacy exporters connect to the datastore Optimize reads, so their endpoint, credentials,
+AWS mode, and TLS all resolve from the Optimize component chain whenever these predicates hold.
+The host term mirrors the gate the Optimize deployment uses to render its own connection env vars;
+when no host resolves, the exporter keeps the secondary-storage/global compatibility source.
+*/}}
+{{- define "orchestration.legacyElasticsearchExporterUsesOptimizeSource" -}}
+{{- and
+      (eq (include "orchestration.hasLegacyElasticsearchExporter" .) "true")
+      (eq (include "camundaPlatform.optimizeEnabled" .) "true")
+      (ne (include "camundaPlatform.elasticsearchHost" .) "")
+-}}
+{{- end -}}
+
+{{- define "orchestration.legacyOpenSearchExporterUsesOptimizeSource" -}}
+{{- and
+      (ne (include "orchestration.hasLegacyElasticsearchExporter" .) "true")
+      (eq (include "orchestration.hasLegacyOpenSearchExporter" .) "true")
+      (eq (include "camundaPlatform.optimizeEnabled" .) "true")
+      (ne (include "camundaPlatform.opensearchHost" .) "")
+-}}
+{{- end -}}
+
+{{/*
 NOTE: the legacy exporters resolve their password from the Optimize component secret when one is
 configured, and fall back to the generic engine-wide variable otherwise. Both the emission in
 statefulset.yaml and the substitution here key off the same hasSecretConfig predicate.

--- a/charts/camunda-platform-8.10/templates/orchestration/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/orchestration/_helpers.tpl
@@ -395,12 +395,14 @@ ${VALUES_OPENSEARCH_PASSWORD:}
 {{- end -}}
 
 {{/*
-NOTE: when the legacy OpenSearch exporter targets the Optimize component endpoint, its AWS mode is
-owned by that component; otherwise it keeps the shared-endpoint resolution across all three sources.
+NOTE: the legacy OpenSearch exporter resolves AWS mode from the same endpoint source, retaining the
+shared fallback only when neither component defines an endpoint.
 */}}
 {{- define "orchestration.legacyOpenSearchExporterAwsEnabled" -}}
 {{- if (tpl .Values.optimize.database.opensearch.url.host $) -}}
 {{- .Values.optimize.database.opensearch.aws.enabled -}}
+{{- else if .Values.orchestration.data.secondaryStorage.opensearch.url -}}
+{{- or .Values.orchestration.data.secondaryStorage.opensearch.aws.enabled .Values.global.opensearch.aws.enabled -}}
 {{- else -}}
 {{- or .Values.orchestration.data.secondaryStorage.opensearch.aws.enabled .Values.global.opensearch.aws.enabled .Values.optimize.database.opensearch.aws.enabled -}}
 {{- end -}}

--- a/charts/camunda-platform-8.10/templates/orchestration/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/orchestration/_helpers.tpl
@@ -298,7 +298,7 @@ Authentication.
     {{- end -}}
 {{- end -}}
 
-{{- define "orchestration.effectiveTlsConfig" -}}
+{{- define "orchestration.sharedTlsConfig" -}}
 {{- $config := dict -}}
 {{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.global.elasticsearch.tls)) "true" -}}
     {{- $config = .Values.global.elasticsearch.tls -}}
@@ -310,6 +310,36 @@ Authentication.
     {{- $config = .Values.orchestration.data.secondaryStorage.opensearch.tls -}}
 {{- end -}}
 {{- toYaml $config -}}
+{{- end -}}
+
+{{- define "orchestration.legacyExporterTlsConfig" -}}
+{{- $config := dict -}}
+{{- if and
+      (eq (include "orchestration.legacyElasticsearchExporterUsesOptimizeSource" .) "true")
+      (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.optimize.database.elasticsearch.tls)) "true")
+-}}
+    {{- $config = .Values.optimize.database.elasticsearch.tls -}}
+{{- else if and
+      (eq (include "orchestration.legacyOpenSearchExporterUsesOptimizeSource" .) "true")
+      (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.optimize.database.opensearch.tls)) "true")
+-}}
+    {{- $config = .Values.optimize.database.opensearch.tls -}}
+{{- end -}}
+{{- toYaml $config -}}
+{{- end -}}
+
+{{- /*
+NOTE: the Orchestration JVM mounts a single truststore, so the first matching source wins for the
+whole pod. An Optimize-owned legacy exporter contributes its component TLS secret first; the chain
+falls through to the shared global/secondary-storage sources otherwise.
+*/ -}}
+{{- define "orchestration.effectiveTlsConfig" -}}
+{{- $exporterTls := include "orchestration.legacyExporterTlsConfig" . | fromYaml -}}
+{{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" $exporterTls)) "true" -}}
+{{- toYaml $exporterTls -}}
+{{- else -}}
+{{- include "orchestration.sharedTlsConfig" . -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "orchestration.persistentSessionsEnabled" -}}

--- a/charts/camunda-platform-8.10/templates/orchestration/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/orchestration/_helpers.tpl
@@ -397,12 +397,12 @@ when no host resolves, the exporter keeps the secondary-storage/global compatibi
 {{- end -}}
 
 {{/*
-NOTE: the legacy exporters resolve their password from the Optimize component secret when one is
-configured, and fall back to the generic engine-wide variable otherwise. Both the emission in
-statefulset.yaml and the substitution here key off the same hasSecretConfig predicate.
+NOTE: Optimize-owned exporters substitute the Optimize-scoped password variable and resolve their
+username from the Optimize component chain; otherwise both keep the generic engine-wide sources.
+The emission in statefulset.yaml keys off the same predicates as the substitution here.
 */}}
 {{- define "orchestration.legacyElasticsearchExporterPasswordRef" -}}
-{{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.optimize.database.elasticsearch.auth)) "true" -}}
+{{- if eq (include "orchestration.legacyElasticsearchExporterUsesOptimizeSource" .) "true" -}}
 ${VALUES_OPTIMIZE_DATABASE_ELASTICSEARCH_PASSWORD:}
 {{- else -}}
 ${VALUES_ELASTICSEARCH_PASSWORD:}
@@ -410,11 +410,35 @@ ${VALUES_ELASTICSEARCH_PASSWORD:}
 {{- end -}}
 
 {{- define "orchestration.legacyOpenSearchExporterPasswordRef" -}}
-{{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.optimize.database.opensearch.auth)) "true" -}}
+{{- if eq (include "orchestration.legacyOpenSearchExporterUsesOptimizeSource" .) "true" -}}
 ${VALUES_OPTIMIZE_DATABASE_OPENSEARCH_PASSWORD:}
 {{- else -}}
 ${VALUES_OPENSEARCH_PASSWORD:}
 {{- end -}}
+{{- end -}}
+
+{{- define "orchestration.legacyElasticsearchExporterUsername" -}}
+{{- if eq (include "orchestration.legacyElasticsearchExporterUsesOptimizeSource" .) "true" -}}
+{{- include "optimize.effectiveEsUsername" . -}}
+{{- else -}}
+{{- .Values.optimize.database.elasticsearch.auth.username | default .Values.orchestration.data.secondaryStorage.elasticsearch.auth.username | default .Values.global.elasticsearch.auth.username -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "orchestration.legacyOpenSearchExporterUsername" -}}
+{{- if eq (include "orchestration.legacyOpenSearchExporterUsesOptimizeSource" .) "true" -}}
+{{- include "optimize.effectiveOsUsername" . -}}
+{{- else -}}
+{{- .Values.optimize.database.opensearch.auth.username | default .Values.orchestration.data.secondaryStorage.opensearch.auth.username | default .Values.global.opensearch.auth.username -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "orchestration.legacyElasticsearchExporterAuthenticationEnabled" -}}
+{{- or .Values.global.elasticsearch.external .Values.optimize.database.elasticsearch.external -}}
+{{- end -}}
+
+{{- define "orchestration.legacyOpenSearchExporterAuthenticationEnabled" -}}
+{{- ne (include "orchestration.legacyOpenSearchExporterAwsEnabled" .) "true" -}}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform-8.10/templates/orchestration/files/_application.yaml
+++ b/charts/camunda-platform-8.10/templates/orchestration/files/_application.yaml
@@ -350,9 +350,9 @@ zeebe:
       elasticsearch:
         className: "io.camunda.zeebe.exporter.ElasticsearchExporter"
         args:
-          {{- if or .Values.global.elasticsearch.external .Values.optimize.database.elasticsearch.external }}
+          {{- if eq (include "orchestration.legacyElasticsearchExporterAuthenticationEnabled" .) "true" }}
           authentication:
-            username: {{ .Values.optimize.database.elasticsearch.auth.username | default .Values.orchestration.data.secondaryStorage.elasticsearch.auth.username | default .Values.global.elasticsearch.auth.username | quote }}
+            username: {{ include "orchestration.legacyElasticsearchExporterUsername" . | quote }}
             password: "{{ include "orchestration.legacyElasticsearchExporterPasswordRef" . }}"
           {{- end }}
           url: {{ include "camundaPlatform.legacyExporterElasticsearchURL" . | quote }}
@@ -369,9 +369,9 @@ zeebe:
       opensearch:
         className: "io.camunda.zeebe.exporter.opensearch.OpensearchExporter"
         args:
-          {{- if ne (include "orchestration.legacyOpenSearchExporterAwsEnabled" .) "true" }}
+          {{- if eq (include "orchestration.legacyOpenSearchExporterAuthenticationEnabled" .) "true" }}
           authentication:
-            username: {{ .Values.optimize.database.opensearch.auth.username | default .Values.orchestration.data.secondaryStorage.opensearch.auth.username | default .Values.global.opensearch.auth.username | quote }}
+            username: {{ include "orchestration.legacyOpenSearchExporterUsername" . | quote }}
             password: "{{ include "orchestration.legacyOpenSearchExporterPasswordRef" . }}"
           {{- end }}
           url: {{ include "camundaPlatform.legacyExporterOpensearchURL" . | quote }}

--- a/charts/camunda-platform-8.10/templates/orchestration/files/_application.yaml
+++ b/charts/camunda-platform-8.10/templates/orchestration/files/_application.yaml
@@ -353,9 +353,9 @@ zeebe:
           {{- if or .Values.global.elasticsearch.external .Values.optimize.database.elasticsearch.external }}
           authentication:
             username: {{ .Values.optimize.database.elasticsearch.auth.username | default .Values.orchestration.data.secondaryStorage.elasticsearch.auth.username | default .Values.global.elasticsearch.auth.username | quote }}
-            password: "${VALUES_ELASTICSEARCH_PASSWORD:}"
+            password: "{{ include "orchestration.legacyElasticsearchExporterPasswordRef" . }}"
           {{- end }}
-          url: {{ include "camundaPlatform.elasticsearchURL" . | quote }}
+          url: {{ include "camundaPlatform.legacyExporterElasticsearchURL" . | quote }}
           index:
             prefix: {{ .Values.optimize.database.elasticsearch.prefix | default .Values.global.elasticsearch.prefix | quote }}
             numberOfReplicas: {{ ternary .Values.orchestration.index.replicas .Values.orchestration.exporters.zeebe.replicas (kindIs "invalid" .Values.orchestration.exporters.zeebe.replicas) | quote }}
@@ -369,16 +369,16 @@ zeebe:
       opensearch:
         className: "io.camunda.zeebe.exporter.opensearch.OpensearchExporter"
         args:
-          {{- if and (not (or .Values.orchestration.data.secondaryStorage.opensearch.aws.enabled .Values.global.opensearch.aws.enabled)) (not .Values.optimize.database.opensearch.aws.enabled) }}
+          {{- if ne (include "orchestration.legacyOpenSearchExporterAwsEnabled" .) "true" }}
           authentication:
             username: {{ .Values.optimize.database.opensearch.auth.username | default .Values.orchestration.data.secondaryStorage.opensearch.auth.username | default .Values.global.opensearch.auth.username | quote }}
-            password: "${VALUES_OPENSEARCH_PASSWORD:}"
+            password: "{{ include "orchestration.legacyOpenSearchExporterPasswordRef" . }}"
           {{- end }}
-          url: {{ include "camundaPlatform.opensearchURL" . | quote }}
+          url: {{ include "camundaPlatform.legacyExporterOpensearchURL" . | quote }}
           index:
             prefix: {{ .Values.optimize.database.opensearch.prefix | default .Values.global.opensearch.prefix | quote }}
             numberOfReplicas: {{ ternary .Values.orchestration.index.replicas .Values.orchestration.exporters.zeebe.replicas (kindIs "invalid" .Values.orchestration.exporters.zeebe.replicas) | quote }}
-          {{- if or .Values.orchestration.data.secondaryStorage.opensearch.aws.enabled .Values.global.opensearch.aws.enabled .Values.optimize.database.opensearch.aws.enabled }}
+          {{- if eq (include "orchestration.legacyOpenSearchExporterAwsEnabled" .) "true" }}
           aws:
             enabled: true
           {{- end }}

--- a/charts/camunda-platform-8.10/templates/orchestration/statefulset.yaml
+++ b/charts/camunda-platform-8.10/templates/orchestration/statefulset.yaml
@@ -163,6 +163,26 @@ spec:
                 "config" .Values.orchestration.data.secondaryStorage.opensearch.auth
             ) | nindent 12 }}
             {{- end }}
+            {{- if and
+                (eq (include "orchestration.hasLegacyElasticsearchExporter" .) "true")
+                (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.optimize.database.elasticsearch.auth)) "true")
+            }}
+            {{- include "camundaPlatform.emitEnvVarFromSecretConfig" (dict
+                "envName" "VALUES_OPTIMIZE_DATABASE_ELASTICSEARCH_PASSWORD"
+                "config" .Values.optimize.database.elasticsearch.auth
+            ) | nindent 12 }}
+            {{- end }}
+            {{- if and
+                (ne (include "orchestration.hasLegacyElasticsearchExporter" .) "true")
+                (eq (include "orchestration.hasLegacyOpenSearchExporter" .) "true")
+                (ne (include "orchestration.legacyOpenSearchExporterAwsEnabled" .) "true")
+                (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.optimize.database.opensearch.auth)) "true")
+            }}
+            {{- include "camundaPlatform.emitEnvVarFromSecretConfig" (dict
+                "envName" "VALUES_OPTIMIZE_DATABASE_OPENSEARCH_PASSWORD"
+                "config" .Values.optimize.database.opensearch.auth
+            ) | nindent 12 }}
+            {{- end }}
             {{- if and .Values.orchestration.exporters.rdbms.enabled (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.orchestration.data.secondaryStorage.rdbms)) "true") }}
             {{- include "camundaPlatform.emitEnvVarFromSecretConfig" (dict
                 "envName" "VALUES_ORCHESTRATION_DATA_SECONDARYSTORAGE_RDBMS_PASSWORD"

--- a/charts/camunda-platform-8.10/templates/orchestration/statefulset.yaml
+++ b/charts/camunda-platform-8.10/templates/orchestration/statefulset.yaml
@@ -163,24 +163,26 @@ spec:
                 "config" .Values.orchestration.data.secondaryStorage.opensearch.auth
             ) | nindent 12 }}
             {{- end }}
+            {{- $legacyElasticsearchExporterAuth := include "optimize.effectiveEsAuthConfig" . | fromYaml }}
             {{- if and
-                (eq (include "orchestration.hasLegacyElasticsearchExporter" .) "true")
-                (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.optimize.database.elasticsearch.auth)) "true")
+                (eq (include "orchestration.legacyElasticsearchExporterUsesOptimizeSource" .) "true")
+                (eq (include "orchestration.legacyElasticsearchExporterAuthenticationEnabled" .) "true")
+                (eq (include "camundaPlatform.hasSecretConfig" (dict "config" $legacyElasticsearchExporterAuth)) "true")
             }}
             {{- include "camundaPlatform.emitEnvVarFromSecretConfig" (dict
                 "envName" "VALUES_OPTIMIZE_DATABASE_ELASTICSEARCH_PASSWORD"
-                "config" .Values.optimize.database.elasticsearch.auth
+                "config" $legacyElasticsearchExporterAuth
             ) | nindent 12 }}
             {{- end }}
+            {{- $legacyOpenSearchExporterAuth := include "optimize.effectiveOsAuthConfig" . | fromYaml }}
             {{- if and
-                (ne (include "orchestration.hasLegacyElasticsearchExporter" .) "true")
-                (eq (include "orchestration.hasLegacyOpenSearchExporter" .) "true")
-                (ne (include "orchestration.legacyOpenSearchExporterAwsEnabled" .) "true")
-                (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.optimize.database.opensearch.auth)) "true")
+                (eq (include "orchestration.legacyOpenSearchExporterUsesOptimizeSource" .) "true")
+                (eq (include "orchestration.legacyOpenSearchExporterAuthenticationEnabled" .) "true")
+                (eq (include "camundaPlatform.hasSecretConfig" (dict "config" $legacyOpenSearchExporterAuth)) "true")
             }}
             {{- include "camundaPlatform.emitEnvVarFromSecretConfig" (dict
                 "envName" "VALUES_OPTIMIZE_DATABASE_OPENSEARCH_PASSWORD"
-                "config" .Values.optimize.database.opensearch.auth
+                "config" $legacyOpenSearchExporterAuth
             ) | nindent 12 }}
             {{- end }}
             {{- if and .Values.orchestration.exporters.rdbms.enabled (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.orchestration.data.secondaryStorage.rdbms)) "true") }}

--- a/charts/camunda-platform-8.10/test/unit/common/configmap_warnings_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/configmap_warnings_test.go
@@ -86,3 +86,57 @@ func (s *ConfigMapWarningsTemplateTest) TestDifferentValuesInputs() {
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
+
+func (s *ConfigMapWarningsTemplateTest) TestLegacyExporterTruststoreConflict() {
+	conflictingTruststores := map[string]string{
+		"optimize.enabled":                                                            "true",
+		"optimize.database.elasticsearch.enabled":                                     "false",
+		"optimize.database.opensearch.enabled":                                        "true",
+		"optimize.database.opensearch.url.host":                                       "optimize-host",
+		"optimize.database.opensearch.tls.secret.existingSecret":                      "optimize-tls-secret",
+		"optimize.database.opensearch.tls.secret.existingSecretKey":                   "optimize-ca.jks",
+		"orchestration.data.secondaryStorage.type":                                    "opensearch",
+		"orchestration.data.secondaryStorage.opensearch.url":                          "https://secondary-host:9443",
+		"orchestration.data.secondaryStorage.opensearch.tls.secret.existingSecret":    "secondary-tls-secret",
+		"orchestration.data.secondaryStorage.opensearch.tls.secret.existingSecretKey": "secondary-ca.jks",
+	}
+
+	testCases := []testhelpers.TestCase{
+		{
+			Name:   "Legacy exporter and secondary storage truststores conflict",
+			Values: conflictingTruststores,
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().Contains(configmap.Data["warnings"], "TRUSTSTORE CONFLICT")
+			},
+		},
+		{
+			Name: "Shared truststore secret does not warn",
+			Values: mergeMaps(conflictingTruststores, map[string]string{
+				"orchestration.data.secondaryStorage.opensearch.tls.secret.existingSecret":    "optimize-tls-secret",
+				"orchestration.data.secondaryStorage.opensearch.tls.secret.existingSecretKey": "optimize-ca.jks",
+			}),
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().NotContains(configmap.Data["warnings"], "TRUSTSTORE CONFLICT")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
+func mergeMaps(base map[string]string, overrides map[string]string) map[string]string {
+	merged := make(map[string]string, len(base)+len(overrides))
+	for key, value := range base {
+		merged[key] = value
+	}
+	for key, value := range overrides {
+		merged[key] = value
+	}
+	return merged
+}

--- a/charts/camunda-platform-8.10/test/unit/orchestration/configmap_unified_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/configmap_unified_test.go
@@ -353,6 +353,27 @@ func (s *ConfigmapTemplateTest) TestLegacyExporterDatastoreSourceAlignment() {
 			},
 		},
 		{
+			Name: "TestLegacyOpenSearchExporterWithoutSecretKeepsOptimizePasswordRef",
+			Values: map[string]string{
+				"optimize.enabled":                                                        "true",
+				"optimize.database.elasticsearch.enabled":                                 "false",
+				"optimize.database.opensearch.enabled":                                    "true",
+				"optimize.database.opensearch.url.protocol":                               "https",
+				"optimize.database.opensearch.url.host":                                   "optimize-host",
+				"optimize.database.opensearch.url.port":                                   "9555",
+				"optimize.database.opensearch.auth.username":                              "optimize-user",
+				"orchestration.data.secondaryStorage.type":                                "opensearch",
+				"orchestration.data.secondaryStorage.opensearch.url":                      "https://secondary-host:9443",
+				"orchestration.data.secondaryStorage.opensearch.auth.username":            "secondary-user",
+				"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "secondary-password",
+			},
+			Expected: map[string]string{
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.url":                     "https://optimize-host:9555",
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.authentication.username": "optimize-user",
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.authentication.password": "${VALUES_OPTIMIZE_DATABASE_OPENSEARCH_PASSWORD:}",
+			},
+		},
+		{
 			Name: "TestLegacyOpenSearchExporterUsesOptimizeAwsMode",
 			Values: mergeValues(distinctOpenSearchSources, map[string]string{
 				"optimize.database.opensearch.aws.enabled":                   "true",

--- a/charts/camunda-platform-8.10/test/unit/orchestration/configmap_unified_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/configmap_unified_test.go
@@ -404,6 +404,62 @@ func (s *ConfigmapTemplateTest) TestLegacyExporterDatastoreSourceAlignment() {
 	testhelpers.RunTestCases(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
 
+func (s *ConfigmapTemplateTest) TestLegacyOpenSearchExporterIgnoresOptimizeAwsModeForSecondaryStorageSource() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "Optimize AWS does not cross explicit secondary source",
+			Values: map[string]string{
+				"optimize.enabled":                                                        "true",
+				"optimize.database.elasticsearch.enabled":                                 "false",
+				"optimize.database.opensearch.enabled":                                    "true",
+				"optimize.database.opensearch.aws.enabled":                                "true",
+				"orchestration.data.secondaryStorage.type":                                "opensearch",
+				"orchestration.data.secondaryStorage.opensearch.url":                      "https://secondary-host:9443",
+				"orchestration.data.secondaryStorage.opensearch.aws.enabled":              "false",
+				"orchestration.data.secondaryStorage.opensearch.auth.username":            "secondary-user",
+				"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "secondary-password",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				var configMap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(t, output, &configMap)
+
+				var application struct {
+					Zeebe struct {
+						Broker struct {
+							Exporters struct {
+								OpenSearch struct {
+									Args struct {
+										Authentication *struct {
+											Username string `yaml:"username"`
+											Password string `yaml:"password"`
+										} `yaml:"authentication"`
+										URL string `yaml:"url"`
+										AWS *struct {
+											Enabled bool `yaml:"enabled"`
+										} `yaml:"aws"`
+									} `yaml:"args"`
+								} `yaml:"opensearch"`
+							} `yaml:"exporters"`
+						} `yaml:"broker"`
+					} `yaml:"zeebe"`
+				}
+				require.NoError(t, yaml.Unmarshal([]byte(configMap.Data["application.yaml"]), &application))
+
+				args := application.Zeebe.Broker.Exporters.OpenSearch.Args
+				require.Equal(t, "https://secondary-host:9443", args.URL)
+				require.NotNil(t, args.Authentication)
+				require.Equal(t, "secondary-user", args.Authentication.Username)
+				require.Equal(t, "${VALUES_OPENSEARCH_PASSWORD:}", args.Authentication.Password)
+				require.Nil(t, args.AWS)
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
 func mergeValues(base map[string]string, overrides map[string]string) map[string]string {
 	merged := make(map[string]string, len(base)+len(overrides))
 	for key, value := range base {

--- a/charts/camunda-platform-8.10/test/unit/orchestration/configmap_unified_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/configmap_unified_test.go
@@ -287,6 +287,134 @@ func (s *ConfigmapTemplateTest) TestDifferentValuesInputsUnifiedOpenSearchAWS() 
 	testhelpers.RunTestCases(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
 
+func (s *ConfigmapTemplateTest) TestLegacyExporterDatastoreSourceAlignment() {
+	distinctOpenSearchSources := map[string]string{
+		"optimize.enabled":                                                        "true",
+		"optimize.database.elasticsearch.enabled":                                 "false",
+		"optimize.database.opensearch.enabled":                                    "true",
+		"optimize.database.opensearch.url.protocol":                               "https",
+		"optimize.database.opensearch.url.host":                                   "optimize-host",
+		"optimize.database.opensearch.url.port":                                   "9555",
+		"optimize.database.opensearch.auth.username":                              "optimize-user",
+		"optimize.database.opensearch.auth.secret.inlineSecret":                   "optimize-password",
+		"orchestration.data.secondaryStorage.type":                                "opensearch",
+		"orchestration.data.secondaryStorage.opensearch.url":                      "https://secondary-host:9443",
+		"orchestration.data.secondaryStorage.opensearch.auth.username":            "secondary-user",
+		"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "secondary-password",
+	}
+
+	testCases := []testhelpers.TestCase{
+		{
+			Name:   "TestLegacyOpenSearchExporterUsesOptimizeSource",
+			Values: distinctOpenSearchSources,
+			Expected: map[string]string{
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.url":                     "https://optimize-host:9555",
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.authentication.username": "optimize-user",
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.authentication.password": "${VALUES_OPTIMIZE_DATABASE_OPENSEARCH_PASSWORD:}",
+				"configmapApplication.camunda.data.secondary-storage.opensearch.url":                  "https://secondary-host:9443",
+				"configmapApplication.camunda.data.secondary-storage.opensearch.username":             "secondary-user",
+				"configmapApplication.camunda.data.secondary-storage.opensearch.password":             "${VALUES_OPENSEARCH_PASSWORD:}",
+			},
+		},
+		{
+			Name: "TestLegacyOpenSearchExporterUsesOptimizePasswordOnSharedEndpoint",
+			Values: map[string]string{
+				"optimize.enabled":                                      "true",
+				"optimize.database.elasticsearch.enabled":               "false",
+				"optimize.database.opensearch.enabled":                  "true",
+				"optimize.database.opensearch.url.protocol":             "https",
+				"optimize.database.opensearch.url.host":                 "opensearch.example.com",
+				"optimize.database.opensearch.url.port":                 "443",
+				"optimize.database.opensearch.auth.username":            "optimize-user",
+				"optimize.database.opensearch.auth.secret.inlineSecret": "optimize-password",
+				"orchestration.data.secondaryStorage.type":              "opensearch",
+				"orchestration.data.secondaryStorage.opensearch.url":    "https://opensearch.example.com:443",
+			},
+			Expected: map[string]string{
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.url":                     "https://opensearch.example.com:443",
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.authentication.password": "${VALUES_OPTIMIZE_DATABASE_OPENSEARCH_PASSWORD:}",
+			},
+		},
+		{
+			Name: "TestLegacyOpenSearchExporterFallsBackToSecondaryStorageSource",
+			Values: map[string]string{
+				"optimize.enabled":                                                        "true",
+				"optimize.database.elasticsearch.enabled":                                 "false",
+				"optimize.database.opensearch.enabled":                                    "true",
+				"orchestration.data.secondaryStorage.type":                                "opensearch",
+				"orchestration.data.secondaryStorage.opensearch.url":                      "https://secondary-host:9443",
+				"orchestration.data.secondaryStorage.opensearch.auth.username":            "secondary-user",
+				"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "secondary-password",
+			},
+			Expected: map[string]string{
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.url":                     "https://secondary-host:9443",
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.authentication.username": "secondary-user",
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.authentication.password": "${VALUES_OPENSEARCH_PASSWORD:}",
+			},
+		},
+		{
+			Name: "TestLegacyOpenSearchExporterUsesOptimizeAwsMode",
+			Values: mergeValues(distinctOpenSearchSources, map[string]string{
+				"optimize.database.opensearch.aws.enabled":                   "true",
+				"orchestration.data.secondaryStorage.opensearch.aws.enabled": "false",
+			}),
+			Expected: map[string]string{
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.aws.enabled":             "true",
+				"configmapApplication.camunda.data.secondary-storage.opensearch.aws-enabled":          "false",
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.authentication.username": "",
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.authentication.password": "",
+			},
+		},
+		{
+			Name: "TestLegacyOpenSearchExporterIgnoresSecondaryStorageAwsMode",
+			Values: mergeValues(distinctOpenSearchSources, map[string]string{
+				"optimize.database.opensearch.aws.enabled":                   "false",
+				"orchestration.data.secondaryStorage.opensearch.aws.enabled": "true",
+			}),
+			Expected: map[string]string{
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.authentication.username": "optimize-user",
+				"configmapApplication.camunda.data.secondary-storage.opensearch.aws-enabled":          "true",
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.aws.enabled":             "",
+			},
+		},
+		{
+			Name: "TestLegacyElasticsearchExporterUsesOptimizeSource",
+			Values: map[string]string{
+				"optimize.enabled":                                         "true",
+				"optimize.database.opensearch.enabled":                     "false",
+				"optimize.database.elasticsearch.enabled":                  "true",
+				"optimize.database.elasticsearch.external":                 "true",
+				"optimize.database.elasticsearch.url.protocol":             "https",
+				"optimize.database.elasticsearch.url.host":                 "optimize-host",
+				"optimize.database.elasticsearch.url.port":                 "9555",
+				"optimize.database.elasticsearch.auth.username":            "optimize-user",
+				"optimize.database.elasticsearch.auth.secret.inlineSecret": "optimize-password",
+				"orchestration.data.secondaryStorage.type":                 "elasticsearch",
+				"orchestration.data.secondaryStorage.elasticsearch.url":    "https://secondary-host:9443",
+			},
+			Expected: map[string]string{
+				"configmapApplication.zeebe.broker.exporters.elasticsearch.args.url":                     "https://optimize-host:9555",
+				"configmapApplication.zeebe.broker.exporters.elasticsearch.args.authentication.username": "optimize-user",
+				"configmapApplication.zeebe.broker.exporters.elasticsearch.args.authentication.password": "${VALUES_OPTIMIZE_DATABASE_ELASTICSEARCH_PASSWORD:}",
+				"configmapApplication.camunda.data.secondary-storage.elasticsearch.url":                  "https://secondary-host:9443",
+			},
+		},
+	}
+
+	testhelpers.RunTestCases(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
+func mergeValues(base map[string]string, overrides map[string]string) map[string]string {
+	merged := make(map[string]string, len(base)+len(overrides))
+	for key, value := range base {
+		merged[key] = value
+	}
+	for key, value := range overrides {
+		merged[key] = value
+	}
+	return merged
+}
+
 func (s *ConfigmapTemplateTest) TestDifferentValuesInputsUnifiedElasticsearchAWS() {
 	testCases := []testhelpers.TestCase{
 		{

--- a/charts/camunda-platform-8.10/test/unit/orchestration/configmap_unified_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/configmap_unified_test.go
@@ -374,31 +374,6 @@ func (s *ConfigmapTemplateTest) TestLegacyExporterDatastoreSourceAlignment() {
 			},
 		},
 		{
-			Name: "TestLegacyOpenSearchExporterUsesOptimizeAwsMode",
-			Values: mergeValues(distinctOpenSearchSources, map[string]string{
-				"optimize.database.opensearch.aws.enabled":                   "true",
-				"orchestration.data.secondaryStorage.opensearch.aws.enabled": "false",
-			}),
-			Expected: map[string]string{
-				"configmapApplication.zeebe.broker.exporters.opensearch.args.aws.enabled":             "true",
-				"configmapApplication.camunda.data.secondary-storage.opensearch.aws-enabled":          "false",
-				"configmapApplication.zeebe.broker.exporters.opensearch.args.authentication.username": "",
-				"configmapApplication.zeebe.broker.exporters.opensearch.args.authentication.password": "",
-			},
-		},
-		{
-			Name: "TestLegacyOpenSearchExporterIgnoresSecondaryStorageAwsMode",
-			Values: mergeValues(distinctOpenSearchSources, map[string]string{
-				"optimize.database.opensearch.aws.enabled":                   "false",
-				"orchestration.data.secondaryStorage.opensearch.aws.enabled": "true",
-			}),
-			Expected: map[string]string{
-				"configmapApplication.zeebe.broker.exporters.opensearch.args.authentication.username": "optimize-user",
-				"configmapApplication.camunda.data.secondary-storage.opensearch.aws-enabled":          "true",
-				"configmapApplication.zeebe.broker.exporters.opensearch.args.aws.enabled":             "",
-			},
-		},
-		{
 			Name: "TestLegacyElasticsearchExporterUsesOptimizeSource",
 			Values: map[string]string{
 				"optimize.enabled":                                         "true",
@@ -425,8 +400,99 @@ func (s *ConfigmapTemplateTest) TestLegacyExporterDatastoreSourceAlignment() {
 	testhelpers.RunTestCases(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
 
-func (s *ConfigmapTemplateTest) TestLegacyOpenSearchExporterIgnoresOptimizeAwsModeForSecondaryStorageSource() {
+type legacyOpenSearchExporterArgs struct {
+	Authentication *struct {
+		Username string `yaml:"username"`
+		Password string `yaml:"password"`
+	} `yaml:"authentication"`
+	URL string `yaml:"url"`
+	AWS *struct {
+		Enabled bool `yaml:"enabled"`
+	} `yaml:"aws"`
+}
+
+type legacyExporterApplicationConfig struct {
+	Zeebe struct {
+		Broker struct {
+			Exporters struct {
+				OpenSearch struct {
+					Args legacyOpenSearchExporterArgs `yaml:"args"`
+				} `yaml:"opensearch"`
+			} `yaml:"exporters"`
+		} `yaml:"broker"`
+	} `yaml:"zeebe"`
+	Camunda struct {
+		Data struct {
+			SecondaryStorage struct {
+				OpenSearch struct {
+					AwsEnabled bool `yaml:"aws-enabled"`
+				} `yaml:"opensearch"`
+			} `yaml:"secondary-storage"`
+		} `yaml:"data"`
+	} `yaml:"camunda"`
+}
+
+func verifyLegacyExporterApplication(verify func(t *testing.T, application legacyExporterApplicationConfig)) func(t *testing.T, output string, err error) {
+	return func(t *testing.T, output string, err error) {
+		require.NoError(t, err)
+
+		var configMap corev1.ConfigMap
+		helm.UnmarshalK8SYaml(t, output, &configMap)
+
+		var application legacyExporterApplicationConfig
+		require.NoError(t, yaml.Unmarshal([]byte(configMap.Data["application.yaml"]), &application))
+		verify(t, application)
+	}
+}
+
+func (s *ConfigmapTemplateTest) TestLegacyOpenSearchExporterAwsSourceAlignment() {
+	distinctOpenSearchSources := map[string]string{
+		"optimize.enabled":                                                        "true",
+		"optimize.database.elasticsearch.enabled":                                 "false",
+		"optimize.database.opensearch.enabled":                                    "true",
+		"optimize.database.opensearch.url.protocol":                               "https",
+		"optimize.database.opensearch.url.host":                                   "optimize-host",
+		"optimize.database.opensearch.url.port":                                   "9555",
+		"optimize.database.opensearch.auth.username":                              "optimize-user",
+		"optimize.database.opensearch.auth.secret.inlineSecret":                   "optimize-password",
+		"orchestration.data.secondaryStorage.type":                                "opensearch",
+		"orchestration.data.secondaryStorage.opensearch.url":                      "https://secondary-host:9443",
+		"orchestration.data.secondaryStorage.opensearch.auth.username":            "secondary-user",
+		"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "secondary-password",
+	}
+
 	testCases := []testhelpers.TestCase{
+		{
+			Name: "Optimize AWS mode drops exporter authentication",
+			Values: mergeValues(distinctOpenSearchSources, map[string]string{
+				"optimize.database.opensearch.aws.enabled":                   "true",
+				"orchestration.data.secondaryStorage.opensearch.aws.enabled": "false",
+			}),
+			Verifier: verifyLegacyExporterApplication(func(t *testing.T, application legacyExporterApplicationConfig) {
+				args := application.Zeebe.Broker.Exporters.OpenSearch.Args
+				require.Equal(t, "https://optimize-host:9555", args.URL)
+				require.Nil(t, args.Authentication)
+				require.NotNil(t, args.AWS)
+				require.True(t, args.AWS.Enabled)
+				require.False(t, application.Camunda.Data.SecondaryStorage.OpenSearch.AwsEnabled)
+			}),
+		},
+		{
+			Name: "Secondary AWS mode does not cross to the Optimize source",
+			Values: mergeValues(distinctOpenSearchSources, map[string]string{
+				"optimize.database.opensearch.aws.enabled":                   "false",
+				"orchestration.data.secondaryStorage.opensearch.aws.enabled": "true",
+			}),
+			Verifier: verifyLegacyExporterApplication(func(t *testing.T, application legacyExporterApplicationConfig) {
+				args := application.Zeebe.Broker.Exporters.OpenSearch.Args
+				require.Equal(t, "https://optimize-host:9555", args.URL)
+				require.Nil(t, args.AWS)
+				require.NotNil(t, args.Authentication)
+				require.Equal(t, "optimize-user", args.Authentication.Username)
+				require.Equal(t, "${VALUES_OPTIMIZE_DATABASE_OPENSEARCH_PASSWORD:}", args.Authentication.Password)
+				require.True(t, application.Camunda.Data.SecondaryStorage.OpenSearch.AwsEnabled)
+			}),
+		},
 		{
 			Name: "Optimize AWS does not cross explicit secondary source",
 			Values: map[string]string{
@@ -440,41 +506,14 @@ func (s *ConfigmapTemplateTest) TestLegacyOpenSearchExporterIgnoresOptimizeAwsMo
 				"orchestration.data.secondaryStorage.opensearch.auth.username":            "secondary-user",
 				"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "secondary-password",
 			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-
-				var configMap corev1.ConfigMap
-				helm.UnmarshalK8SYaml(t, output, &configMap)
-
-				var application struct {
-					Zeebe struct {
-						Broker struct {
-							Exporters struct {
-								OpenSearch struct {
-									Args struct {
-										Authentication *struct {
-											Username string `yaml:"username"`
-											Password string `yaml:"password"`
-										} `yaml:"authentication"`
-										URL string `yaml:"url"`
-										AWS *struct {
-											Enabled bool `yaml:"enabled"`
-										} `yaml:"aws"`
-									} `yaml:"args"`
-								} `yaml:"opensearch"`
-							} `yaml:"exporters"`
-						} `yaml:"broker"`
-					} `yaml:"zeebe"`
-				}
-				require.NoError(t, yaml.Unmarshal([]byte(configMap.Data["application.yaml"]), &application))
-
+			Verifier: verifyLegacyExporterApplication(func(t *testing.T, application legacyExporterApplicationConfig) {
 				args := application.Zeebe.Broker.Exporters.OpenSearch.Args
 				require.Equal(t, "https://secondary-host:9443", args.URL)
 				require.NotNil(t, args.Authentication)
 				require.Equal(t, "secondary-user", args.Authentication.Username)
 				require.Equal(t, "${VALUES_OPENSEARCH_PASSWORD:}", args.Authentication.Password)
 				require.Nil(t, args.AWS)
-			},
+			}),
 		},
 	}
 

--- a/charts/camunda-platform-8.10/test/unit/orchestration/statefulset_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/statefulset_test.go
@@ -1315,6 +1315,79 @@ func (s *StatefulSetTest) TestLegacyExporterComponentPasswordEnv() {
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
 
+func (s *StatefulSetTest) TestLegacyExporterComponentTls() {
+	optimizeOpenSearchSource := map[string]string{
+		"optimize.enabled":                                   "true",
+		"optimize.database.elasticsearch.enabled":            "false",
+		"optimize.database.opensearch.enabled":               "true",
+		"optimize.database.opensearch.url.host":              "optimize-host",
+		"orchestration.data.secondaryStorage.type":           "opensearch",
+		"orchestration.data.secondaryStorage.opensearch.url": "https://secondary-host:9443",
+	}
+
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "Optimize OpenSearch TLS reaches the Orchestration truststore",
+			Values: mergeValues(optimizeOpenSearchSource, map[string]string{
+				"optimize.database.opensearch.tls.secret.existingSecret":    "optimize-tls-secret",
+				"optimize.database.opensearch.tls.secret.existingSecretKey": "optimize-ca.jks",
+			}),
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.Contains(t, output, "-Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/optimize-ca.jks")
+				require.Contains(t, output, "secretName: \"optimize-tls-secret\"")
+			},
+		},
+		{
+			Name: "Optimize OpenSearch source ignores secondary storage TLS config",
+			Values: mergeValues(optimizeOpenSearchSource, map[string]string{
+				"optimize.database.opensearch.tls.secret.existingSecret":                      "optimize-tls-secret",
+				"optimize.database.opensearch.tls.secret.existingSecretKey":                   "optimize-ca.jks",
+				"orchestration.data.secondaryStorage.opensearch.tls.secret.existingSecret":    "secondary-tls-secret",
+				"orchestration.data.secondaryStorage.opensearch.tls.secret.existingSecretKey": "secondary-ca.jks",
+			}),
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.Contains(t, output, "-Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/optimize-ca.jks")
+				require.NotContains(t, output, "secondary-ca.jks")
+				require.NotContains(t, output, "secretName: \"secondary-tls-secret\"")
+			},
+		},
+		{
+			Name: "Optimize source without TLS keeps the secondary storage truststore",
+			Values: mergeValues(optimizeOpenSearchSource, map[string]string{
+				"orchestration.data.secondaryStorage.opensearch.tls.secret.existingSecret":    "secondary-tls-secret",
+				"orchestration.data.secondaryStorage.opensearch.tls.secret.existingSecretKey": "secondary-ca.jks",
+			}),
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.Contains(t, output, "-Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/secondary-ca.jks")
+				require.Contains(t, output, "secretName: \"secondary-tls-secret\"")
+			},
+		},
+		{
+			Name: "Optimize Elasticsearch TLS reaches the Orchestration truststore",
+			Values: map[string]string{
+				"optimize.enabled":                                             "true",
+				"optimize.database.opensearch.enabled":                         "false",
+				"optimize.database.elasticsearch.enabled":                      "true",
+				"optimize.database.elasticsearch.url.host":                     "optimize-host",
+				"optimize.database.elasticsearch.tls.secret.existingSecret":    "optimize-tls-secret",
+				"optimize.database.elasticsearch.tls.secret.existingSecretKey": "optimize-ca.jks",
+				"orchestration.data.secondaryStorage.type":                     "elasticsearch",
+				"orchestration.data.secondaryStorage.elasticsearch.url":        "https://secondary-host:9443",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.Contains(t, output, "-Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/optimize-ca.jks")
+				require.Contains(t, output, "secretName: \"optimize-tls-secret\"")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
 func (s *StatefulSetTest) TestDocumentStoreEnvFromGatedByExtraConfiguration() {
 	testCases := []testhelpers.TestCase{
 		{

--- a/charts/camunda-platform-8.10/test/unit/orchestration/statefulset_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/statefulset_test.go
@@ -1097,7 +1097,6 @@ func (s *StatefulSetTest) TestOpenSearchPasswordEnv() {
 				"templates/orchestration/statefulset.yaml",
 			}},
 			Values: map[string]string{
-				"global.elasticsearch.enabled":                                            "false",
 				"optimize.enabled":                                                        "true",
 				"optimize.database.elasticsearch.enabled":                                 "false",
 				"optimize.database.opensearch.enabled":                                    "true",
@@ -1113,7 +1112,6 @@ func (s *StatefulSetTest) TestOpenSearchPasswordEnv() {
 				"templates/orchestration/statefulset.yaml",
 			}},
 			Values: map[string]string{
-				"global.elasticsearch.enabled":                                                 "false",
 				"optimize.enabled":                                                             "true",
 				"optimize.database.elasticsearch.enabled":                                      "false",
 				"optimize.database.opensearch.enabled":                                         "true",
@@ -1136,9 +1134,8 @@ func (s *StatefulSetTest) TestOpenSearchPasswordEnv() {
 				"templates/orchestration/statefulset.yaml",
 			}},
 			Values: map[string]string{
-				"global.elasticsearch.enabled":                                            "true",
 				"optimize.enabled":                                                        "true",
-				"optimize.database.elasticsearch.enabled":                                 "false",
+				"optimize.database.elasticsearch.enabled":                                 "true",
 				"optimize.database.opensearch.enabled":                                    "true",
 				"orchestration.data.secondaryStorage.type":                                "elasticsearch",
 				"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "component-password",
@@ -1231,9 +1228,8 @@ func (s *StatefulSetTest) TestLegacyExporterComponentPasswordEnv() {
 		{
 			Name: "Elasticsearch exporter precedence omits the Optimize OpenSearch password",
 			Values: map[string]string{
-				"global.elasticsearch.enabled":                          "true",
 				"optimize.enabled":                                      "true",
-				"optimize.database.elasticsearch.enabled":               "false",
+				"optimize.database.elasticsearch.enabled":               "true",
 				"optimize.database.opensearch.enabled":                  "true",
 				"optimize.database.opensearch.url.host":                 "optimize-host",
 				"optimize.database.opensearch.auth.secret.inlineSecret": "optimize-password",

--- a/charts/camunda-platform-8.10/test/unit/orchestration/statefulset_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/statefulset_test.go
@@ -1242,6 +1242,31 @@ func (s *StatefulSetTest) TestLegacyExporterComponentPasswordEnv() {
 			Verifier: collectDatastorePasswordEnv(map[string]string{}),
 		},
 		{
+			Name: "Optimize source without any secret emits no password env",
+			Values: map[string]string{
+				"optimize.enabled":                                   "true",
+				"optimize.database.elasticsearch.enabled":            "false",
+				"optimize.database.opensearch.enabled":               "true",
+				"optimize.database.opensearch.url.host":              "optimize-host",
+				"optimize.database.opensearch.auth.username":         "optimize-user",
+				"orchestration.data.secondaryStorage.type":           "opensearch",
+				"orchestration.data.secondaryStorage.opensearch.url": "https://secondary-host:9443",
+			},
+			Verifier: collectDatastorePasswordEnv(map[string]string{}),
+		},
+		{
+			Name: "Elasticsearch authentication disabled omits the Optimize password",
+			Values: map[string]string{
+				"optimize.enabled":                                         "true",
+				"optimize.database.opensearch.enabled":                     "false",
+				"optimize.database.elasticsearch.enabled":                  "true",
+				"optimize.database.elasticsearch.url.host":                 "optimize-host",
+				"optimize.database.elasticsearch.auth.secret.inlineSecret": "optimize-password",
+				"orchestration.data.secondaryStorage.type":                 "elasticsearch",
+			},
+			Verifier: collectDatastorePasswordEnv(map[string]string{}),
+		},
+		{
 			Name: "AWS mode omits the Optimize OpenSearch password",
 			Values: map[string]string{
 				"optimize.enabled":                                      "true",

--- a/charts/camunda-platform-8.10/test/unit/orchestration/statefulset_test.go
+++ b/charts/camunda-platform-8.10/test/unit/orchestration/statefulset_test.go
@@ -1172,6 +1172,124 @@ func (s *StatefulSetTest) TestOpenSearchPasswordEnv() {
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
 
+func (s *StatefulSetTest) TestLegacyExporterComponentPasswordEnv() {
+	collectDatastorePasswordEnv := func(expected map[string]string) func(t *testing.T, output string, err error) {
+		return func(t *testing.T, output string, err error) {
+			require.NoError(t, err)
+
+			var statefulSet appsv1.StatefulSet
+			helm.UnmarshalK8SYaml(t, output, &statefulSet)
+			require.NotEmpty(t, statefulSet.Spec.Template.Spec.Containers)
+
+			actual := map[string]string{}
+			for _, envVar := range statefulSet.Spec.Template.Spec.Containers[0].Env {
+				switch envVar.Name {
+				case "VALUES_OPENSEARCH_PASSWORD",
+					"VALUES_ELASTICSEARCH_PASSWORD",
+					"VALUES_OPTIMIZE_DATABASE_OPENSEARCH_PASSWORD",
+					"VALUES_OPTIMIZE_DATABASE_ELASTICSEARCH_PASSWORD":
+					actual[envVar.Name] = envVar.Value
+				}
+			}
+			require.Equal(t, expected, actual)
+		}
+	}
+
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "Distinct OpenSearch sources emit both passwords",
+			Values: map[string]string{
+				"optimize.enabled":                                                        "true",
+				"optimize.database.elasticsearch.enabled":                                 "false",
+				"optimize.database.opensearch.enabled":                                    "true",
+				"optimize.database.opensearch.url.host":                                   "optimize-host",
+				"optimize.database.opensearch.auth.secret.inlineSecret":                   "optimize-password",
+				"orchestration.data.secondaryStorage.type":                                "opensearch",
+				"orchestration.data.secondaryStorage.opensearch.url":                      "https://secondary-host:9443",
+				"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "secondary-password",
+			},
+			Verifier: collectDatastorePasswordEnv(map[string]string{
+				"VALUES_OPENSEARCH_PASSWORD":                   "secondary-password",
+				"VALUES_OPTIMIZE_DATABASE_OPENSEARCH_PASSWORD": "optimize-password",
+			}),
+		},
+		{
+			Name: "Optimize OpenSearch credentials alone emit the component password",
+			Values: map[string]string{
+				"optimize.enabled":                                      "true",
+				"optimize.database.elasticsearch.enabled":               "false",
+				"optimize.database.opensearch.enabled":                  "true",
+				"optimize.database.opensearch.url.host":                 "opensearch.example.com",
+				"optimize.database.opensearch.auth.secret.inlineSecret": "optimize-password",
+				"orchestration.data.secondaryStorage.type":              "opensearch",
+				"orchestration.data.secondaryStorage.opensearch.url":    "https://opensearch.example.com:443",
+			},
+			Verifier: collectDatastorePasswordEnv(map[string]string{
+				"VALUES_OPTIMIZE_DATABASE_OPENSEARCH_PASSWORD": "optimize-password",
+			}),
+		},
+		{
+			Name: "Elasticsearch exporter precedence omits the Optimize OpenSearch password",
+			Values: map[string]string{
+				"global.elasticsearch.enabled":                          "true",
+				"optimize.enabled":                                      "true",
+				"optimize.database.elasticsearch.enabled":               "false",
+				"optimize.database.opensearch.enabled":                  "true",
+				"optimize.database.opensearch.url.host":                 "optimize-host",
+				"optimize.database.opensearch.auth.secret.inlineSecret": "optimize-password",
+				"orchestration.data.secondaryStorage.type":              "elasticsearch",
+			},
+			Verifier: collectDatastorePasswordEnv(map[string]string{}),
+		},
+		{
+			Name: "AWS mode omits the Optimize OpenSearch password",
+			Values: map[string]string{
+				"optimize.enabled":                                      "true",
+				"optimize.database.elasticsearch.enabled":               "false",
+				"optimize.database.opensearch.enabled":                  "true",
+				"optimize.database.opensearch.url.host":                 "optimize-host",
+				"optimize.database.opensearch.aws.enabled":              "true",
+				"optimize.database.opensearch.auth.secret.inlineSecret": "optimize-password",
+				"orchestration.data.secondaryStorage.type":              "opensearch",
+				"orchestration.data.secondaryStorage.opensearch.url":    "https://secondary-host:9443",
+			},
+			Verifier: collectDatastorePasswordEnv(map[string]string{}),
+		},
+		{
+			Name: "Disabled Optimize omits the component OpenSearch password",
+			Values: map[string]string{
+				"optimize.enabled":                                      "false",
+				"optimize.database.elasticsearch.enabled":               "false",
+				"optimize.database.opensearch.enabled":                  "true",
+				"optimize.database.opensearch.url.host":                 "optimize-host",
+				"optimize.database.opensearch.auth.secret.inlineSecret": "optimize-password",
+				"orchestration.data.secondaryStorage.type":              "elasticsearch",
+			},
+			Verifier: collectDatastorePasswordEnv(map[string]string{}),
+		},
+		{
+			Name: "Distinct Elasticsearch sources emit both passwords",
+			Values: map[string]string{
+				"optimize.enabled":                                                           "true",
+				"optimize.database.opensearch.enabled":                                       "false",
+				"optimize.database.elasticsearch.enabled":                                    "true",
+				"optimize.database.elasticsearch.external":                                   "true",
+				"optimize.database.elasticsearch.url.host":                                   "optimize-host",
+				"optimize.database.elasticsearch.auth.secret.inlineSecret":                   "optimize-password",
+				"orchestration.data.secondaryStorage.type":                                   "elasticsearch",
+				"orchestration.data.secondaryStorage.elasticsearch.url":                      "https://secondary-host:9443",
+				"orchestration.data.secondaryStorage.elasticsearch.auth.secret.inlineSecret": "secondary-password",
+			},
+			Verifier: collectDatastorePasswordEnv(map[string]string{
+				"VALUES_ELASTICSEARCH_PASSWORD":                   "secondary-password",
+				"VALUES_OPTIMIZE_DATABASE_ELASTICSEARCH_PASSWORD": "optimize-password",
+			}),
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
 func (s *StatefulSetTest) TestDocumentStoreEnvFromGatedByExtraConfiguration() {
 	testCases := []testhelpers.TestCase{
 		{

--- a/charts/camunda-platform-8.9/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/common/_helpers.tpl
@@ -412,6 +412,30 @@ Elasticsearch and Opensearch templates.
 {{- end -}}
 {{- end -}}
 
+{{/*
+[camunda-platform] Elasticsearch URL for the legacy Zeebe exporter that feeds Optimize.
+Prefers the Optimize component endpoint, falling back to the secondary-storage URL.
+*/}}
+{{- define "camundaPlatform.legacyExporterElasticsearchURL" -}}
+{{- if (tpl .Values.optimize.database.elasticsearch.url.host $) -}}
+  {{ .Values.optimize.database.elasticsearch.url.protocol | default .Values.global.elasticsearch.url.protocol }}://{{ include "camundaPlatform.elasticsearchHost" . }}:{{ include "camundaPlatform.elasticsearchPort" . }}
+{{- else -}}
+  {{ include "camundaPlatform.elasticsearchURL" . }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+[camunda-platform] OpenSearch URL for the legacy Zeebe exporter that feeds Optimize.
+Prefers the Optimize component endpoint, falling back to the secondary-storage URL.
+*/}}
+{{- define "camundaPlatform.legacyExporterOpensearchURL" -}}
+{{- if (tpl .Values.optimize.database.opensearch.url.host $) -}}
+  {{ .Values.optimize.database.opensearch.url.protocol | default .Values.global.opensearch.url.protocol }}://{{ include "camundaPlatform.opensearchHost" . }}:{{ include "camundaPlatform.opensearchPort" . }}
+{{- else -}}
+  {{ include "camundaPlatform.opensearchURL" . }}
+{{- end -}}
+{{- end -}}
+
 
 
 

--- a/charts/camunda-platform-8.9/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/common/_helpers.tpl
@@ -414,11 +414,12 @@ Elasticsearch and Opensearch templates.
 
 {{/*
 [camunda-platform] Elasticsearch URL for the legacy Zeebe exporter that feeds Optimize.
-Prefers the Optimize component endpoint, falling back to the secondary-storage URL.
+Resolves the Optimize component chain when the exporter is Optimize-owned, and the
+secondary-storage/compatibility URL otherwise.
 */}}
 {{- define "camundaPlatform.legacyExporterElasticsearchURL" -}}
-{{- if (tpl .Values.optimize.database.elasticsearch.url.host $) -}}
-  {{ .Values.optimize.database.elasticsearch.url.protocol | default .Values.global.elasticsearch.url.protocol }}://{{ include "camundaPlatform.elasticsearchHost" . }}:{{ include "camundaPlatform.elasticsearchPort" . }}
+{{- if eq (include "orchestration.legacyElasticsearchExporterUsesOptimizeSource" .) "true" -}}
+  {{ include "optimize.effectiveEsURL" . }}
 {{- else -}}
   {{ include "camundaPlatform.elasticsearchURL" . }}
 {{- end -}}
@@ -426,11 +427,12 @@ Prefers the Optimize component endpoint, falling back to the secondary-storage U
 
 {{/*
 [camunda-platform] OpenSearch URL for the legacy Zeebe exporter that feeds Optimize.
-Prefers the Optimize component endpoint, falling back to the secondary-storage URL.
+Resolves the Optimize component chain when the exporter is Optimize-owned, and the
+secondary-storage/compatibility URL otherwise.
 */}}
 {{- define "camundaPlatform.legacyExporterOpensearchURL" -}}
-{{- if (tpl .Values.optimize.database.opensearch.url.host $) -}}
-  {{ .Values.optimize.database.opensearch.url.protocol | default .Values.global.opensearch.url.protocol }}://{{ include "camundaPlatform.opensearchHost" . }}:{{ include "camundaPlatform.opensearchPort" . }}
+{{- if eq (include "orchestration.legacyOpenSearchExporterUsesOptimizeSource" .) "true" -}}
+  {{ include "optimize.effectiveOsURL" . }}
 {{- else -}}
   {{ include "camundaPlatform.opensearchURL" . }}
 {{- end -}}

--- a/charts/camunda-platform-8.9/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.9/templates/common/constraints.tpl
@@ -331,6 +331,28 @@ The following values inside your values.yaml need to be set but were not:
     {{- end }}
   {{- end }}
 
+  {{/* Optimize-owned legacy exporter truststore conflict: the Orchestration JVM mounts a single
+       truststore, so when the exporter carries its own component TLS secret, a differing
+       global/secondary-storage truststore cannot be mounted alongside it. */}}
+  {{- $legacyExporterTls := include "orchestration.legacyExporterTlsConfig" . | fromYaml }}
+  {{- $sharedTls := include "orchestration.sharedTlsConfig" . | fromYaml }}
+  {{- if and
+        (eq (include "camundaPlatform.hasSecretConfig" (dict "config" $legacyExporterTls)) "true")
+        (eq (include "camundaPlatform.hasSecretConfig" (dict "config" $sharedTls)) "true")
+        (ne
+          (include "camundaPlatform.normalizeSecretConfiguration" (dict "config" $legacyExporterTls))
+          (include "camundaPlatform.normalizeSecretConfiguration" (dict "config" $sharedTls))
+        )
+  }}
+    {{- $warningMessage := printf "%s %s %s %s"
+        "[camunda][warning]"
+        "TRUSTSTORE CONFLICT: the legacy exporter mounts the Optimize datastore truststore (optimize.database.*.tls.secret), which differs from the truststore configured for the global/secondary-storage connection."
+        "The Orchestration JVM supports a single truststore, so the Optimize one applies to the whole pod and the other connection cannot use its own CA."
+        "To trust multiple CAs on one pod, provide a combined PEM bundle via 'global.tls.caBundle.secret.*' and remove the per-component JKS truststore secrets."
+    -}}
+    {{ printf "\n%s" $warningMessage | trimSuffix "\n" }}
+  {{- end }}
+
   {{/* global.tls.caBundle guardrails: surface the three silent failure modes
        a caBundle user can hit (JKS precedence, trust!=encryption, env override). */}}
   {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" }}

--- a/charts/camunda-platform-8.9/templates/optimize/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/optimize/_helpers.tpl
@@ -145,6 +145,13 @@ When neither backend is explicitly enabled, falls back to "zeebe-record".
 {{- end -}}
 
 {{/*
+[optimize] Resolve the effective OpenSearch AWS mode from the component-first chain.
+*/}}
+{{- define "optimize.effectiveOsAwsEnabled" -}}
+{{- or .Values.optimize.database.opensearch.aws.enabled .Values.global.opensearch.aws.enabled -}}
+{{- end -}}
+
+{{/*
 [optimize] Resolve the effective Elasticsearch username from the component-first chain.
 */}}
 {{- define "optimize.effectiveEsUsername" -}}

--- a/charts/camunda-platform-8.9/templates/optimize/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/optimize/_helpers.tpl
@@ -145,6 +145,20 @@ When neither backend is explicitly enabled, falls back to "zeebe-record".
 {{- end -}}
 
 {{/*
+[optimize] Resolve the effective Elasticsearch URL from the component-first host/port/protocol chain.
+*/}}
+{{- define "optimize.effectiveEsURL" -}}
+{{- .Values.optimize.database.elasticsearch.url.protocol | default .Values.global.elasticsearch.url.protocol }}://{{ include "camundaPlatform.elasticsearchHost" . }}:{{ include "camundaPlatform.elasticsearchPort" . -}}
+{{- end -}}
+
+{{/*
+[optimize] Resolve the effective OpenSearch URL from the component-first host/port/protocol chain.
+*/}}
+{{- define "optimize.effectiveOsURL" -}}
+{{- .Values.optimize.database.opensearch.url.protocol | default .Values.global.opensearch.url.protocol }}://{{ include "camundaPlatform.opensearchHost" . }}:{{ include "camundaPlatform.opensearchPort" . -}}
+{{- end -}}
+
+{{/*
 [optimize] Build a comma-separated spring.config.import line from extraConfiguration files.
 Entries with springImport: false are excluded.
 */}}

--- a/charts/camunda-platform-8.9/templates/optimize/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/optimize/_helpers.tpl
@@ -145,6 +145,20 @@ When neither backend is explicitly enabled, falls back to "zeebe-record".
 {{- end -}}
 
 {{/*
+[optimize] Resolve the effective Elasticsearch username from the component-first chain.
+*/}}
+{{- define "optimize.effectiveEsUsername" -}}
+{{- .Values.optimize.database.elasticsearch.auth.username | default .Values.global.elasticsearch.auth.username -}}
+{{- end -}}
+
+{{/*
+[optimize] Resolve the effective OpenSearch username from the component-first chain.
+*/}}
+{{- define "optimize.effectiveOsUsername" -}}
+{{- .Values.optimize.database.opensearch.auth.username | default .Values.global.opensearch.auth.username -}}
+{{- end -}}
+
+{{/*
 [optimize] Resolve the effective Elasticsearch URL from the component-first host/port/protocol chain.
 */}}
 {{- define "optimize.effectiveEsURL" -}}

--- a/charts/camunda-platform-8.9/templates/optimize/deployment.yaml
+++ b/charts/camunda-platform-8.9/templates/optimize/deployment.yaml
@@ -68,9 +68,9 @@ spec:
               value: {{ .Values.optimize.database.opensearch.url.port | default .Values.global.opensearch.url.port | quote }}
             - name: CAMUNDA_OPTIMIZE_OPENSEARCH_HOST
               value: {{ include "camundaPlatform.opensearchHost" . | quote }}
-            {{- if or .Values.optimize.database.opensearch.auth.username .Values.global.opensearch.auth.username }}
+            {{- if (include "optimize.effectiveOsUsername" .) }}
             - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SECURITY_USERNAME
-              value: {{ .Values.optimize.database.opensearch.auth.username | default .Values.global.opensearch.auth.username | quote }}
+              value: {{ include "optimize.effectiveOsUsername" . | quote }}
             {{- end }}
             {{- $osAuth := include "optimize.effectiveOsAuthConfig" . | fromYaml -}}
             {{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" $osAuth)) "true" }}
@@ -98,9 +98,9 @@ spec:
               value: {{ include "camundaPlatform.elasticsearchHost" . | quote }}
             - name: OPTIMIZE_ELASTICSEARCH_HTTP_PORT
               value: {{ .Values.optimize.database.elasticsearch.url.port | default .Values.global.elasticsearch.url.port | quote }}
-            {{- if or .Values.optimize.database.elasticsearch.auth.username .Values.global.elasticsearch.auth.username }}
+            {{- if (include "optimize.effectiveEsUsername" .) }}
             - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SECURITY_USERNAME
-              value: {{ .Values.optimize.database.elasticsearch.auth.username | default .Values.global.elasticsearch.auth.username | quote }}
+              value: {{ include "optimize.effectiveEsUsername" . | quote }}
             {{- end }}
             {{- end }}
             {{- if or .Values.optimize.database.opensearch.aws.enabled .Values.global.opensearch.aws.enabled }}
@@ -177,9 +177,9 @@ spec:
               value: {{ .Values.optimize.database.opensearch.url.port | default .Values.global.opensearch.url.port | quote }}
             - name: CAMUNDA_OPTIMIZE_OPENSEARCH_HOST
               value: {{ include "camundaPlatform.opensearchHost" . | quote }}
-            {{- if or .Values.optimize.database.opensearch.auth.username .Values.global.opensearch.auth.username }}
+            {{- if (include "optimize.effectiveOsUsername" .) }}
             - name: CAMUNDA_OPTIMIZE_OPENSEARCH_SECURITY_USERNAME
-              value: {{ .Values.optimize.database.opensearch.auth.username | default .Values.global.opensearch.auth.username | quote }}
+              value: {{ include "optimize.effectiveOsUsername" . | quote }}
             {{- end }}
             {{- $osAuth := include "optimize.effectiveOsAuthConfig" . | fromYaml -}}
             {{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" $osAuth)) "true" }}
@@ -211,9 +211,9 @@ spec:
               value: {{ include "camundaPlatform.elasticsearchHost" . | quote }}
             - name: OPTIMIZE_ELASTICSEARCH_HTTP_PORT
               value: {{ .Values.optimize.database.elasticsearch.url.port | default .Values.global.elasticsearch.url.port | quote }}
-            {{- if or .Values.optimize.database.elasticsearch.auth.username .Values.global.elasticsearch.auth.username }}
+            {{- if (include "optimize.effectiveEsUsername" .) }}
             - name: CAMUNDA_OPTIMIZE_ELASTICSEARCH_SECURITY_USERNAME
-              value: {{ .Values.optimize.database.elasticsearch.auth.username | default .Values.global.elasticsearch.auth.username | quote }}
+              value: {{ include "optimize.effectiveEsUsername" . | quote }}
             {{- end }}
             {{- end }}
             - name: SPRING_PROFILES_ACTIVE

--- a/charts/camunda-platform-8.9/templates/optimize/deployment.yaml
+++ b/charts/camunda-platform-8.9/templates/optimize/deployment.yaml
@@ -103,7 +103,7 @@ spec:
               value: {{ include "optimize.effectiveEsUsername" . | quote }}
             {{- end }}
             {{- end }}
-            {{- if or .Values.optimize.database.opensearch.aws.enabled .Values.global.opensearch.aws.enabled }}
+            {{- if eq (include "optimize.effectiveOsAwsEnabled" .) "true" }}
             - name: CAMUNDA_OPTIMIZE_OPENSEARCH_AWS_ENABLED
               value: "true"
             {{- end }}
@@ -232,7 +232,7 @@ spec:
             - name: CAMUNDA_OPTIMIZE_CACHES_CLOUD_TENANT_AUTHORIZATIONS_MIN_FETCH_INTERVAL_SECONDS
               value: {{ .Values.optimize.caches.cloudTenantAuthorizations.minFetchIntervalSeconds | default "600000" | quote }}
             {{- end }}
-            {{- if or .Values.optimize.database.opensearch.aws.enabled .Values.global.opensearch.aws.enabled }}
+            {{- if eq (include "optimize.effectiveOsAwsEnabled" .) "true" }}
             - name: CAMUNDA_OPTIMIZE_OPENSEARCH_AWS_ENABLED
               value: "true"
             {{- end }}

--- a/charts/camunda-platform-8.9/templates/optimize/files/_environment-config.yaml
+++ b/charts/camunda-platform-8.9/templates/optimize/files/_environment-config.yaml
@@ -23,7 +23,7 @@ es:
     {{- end }}
   {{- if or .Values.global.elasticsearch.external .Values.optimize.database.elasticsearch.external }}
   security:
-    username: {{ .Values.optimize.database.elasticsearch.auth.username | default .Values.global.elasticsearch.auth.username | quote }}
+    username: {{ include "optimize.effectiveEsUsername" . | quote }}
     {{- if eq (.Values.optimize.database.elasticsearch.url.protocol | default .Values.global.elasticsearch.url.protocol) "https" }}
     ssl:
       enabled: "true"

--- a/charts/camunda-platform-8.9/templates/orchestration/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/orchestration/_helpers.tpl
@@ -354,12 +354,12 @@ when no host resolves, the exporter keeps the secondary-storage/global compatibi
 {{- end -}}
 
 {{/*
-NOTE: the legacy exporters resolve their password from the Optimize component secret when one is
-configured, and fall back to the generic engine-wide variable otherwise. Both the emission in
-statefulset.yaml and the substitution here key off the same hasSecretConfig predicate.
+NOTE: Optimize-owned exporters substitute the Optimize-scoped password variable and resolve their
+username from the Optimize component chain; otherwise both keep the generic engine-wide sources.
+The emission in statefulset.yaml keys off the same predicates as the substitution here.
 */}}
 {{- define "orchestration.legacyElasticsearchExporterPasswordRef" -}}
-{{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.optimize.database.elasticsearch.auth)) "true" -}}
+{{- if eq (include "orchestration.legacyElasticsearchExporterUsesOptimizeSource" .) "true" -}}
 ${VALUES_OPTIMIZE_DATABASE_ELASTICSEARCH_PASSWORD:}
 {{- else -}}
 ${VALUES_ELASTICSEARCH_PASSWORD:}
@@ -367,11 +367,35 @@ ${VALUES_ELASTICSEARCH_PASSWORD:}
 {{- end -}}
 
 {{- define "orchestration.legacyOpenSearchExporterPasswordRef" -}}
-{{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.optimize.database.opensearch.auth)) "true" -}}
+{{- if eq (include "orchestration.legacyOpenSearchExporterUsesOptimizeSource" .) "true" -}}
 ${VALUES_OPTIMIZE_DATABASE_OPENSEARCH_PASSWORD:}
 {{- else -}}
 ${VALUES_OPENSEARCH_PASSWORD:}
 {{- end -}}
+{{- end -}}
+
+{{- define "orchestration.legacyElasticsearchExporterUsername" -}}
+{{- if eq (include "orchestration.legacyElasticsearchExporterUsesOptimizeSource" .) "true" -}}
+{{- include "optimize.effectiveEsUsername" . -}}
+{{- else -}}
+{{- .Values.optimize.database.elasticsearch.auth.username | default .Values.orchestration.data.secondaryStorage.elasticsearch.auth.username | default .Values.global.elasticsearch.auth.username -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "orchestration.legacyOpenSearchExporterUsername" -}}
+{{- if eq (include "orchestration.legacyOpenSearchExporterUsesOptimizeSource" .) "true" -}}
+{{- include "optimize.effectiveOsUsername" . -}}
+{{- else -}}
+{{- .Values.optimize.database.opensearch.auth.username | default .Values.orchestration.data.secondaryStorage.opensearch.auth.username | default .Values.global.opensearch.auth.username -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "orchestration.legacyElasticsearchExporterAuthenticationEnabled" -}}
+{{- or .Values.global.elasticsearch.external .Values.optimize.database.elasticsearch.external -}}
+{{- end -}}
+
+{{- define "orchestration.legacyOpenSearchExporterAuthenticationEnabled" -}}
+{{- ne (include "orchestration.legacyOpenSearchExporterAwsEnabled" .) "true" -}}
 {{- end -}}
 
 {{/*

--- a/charts/camunda-platform-8.9/templates/orchestration/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/orchestration/_helpers.tpl
@@ -269,7 +269,7 @@ Authentication.
     {{- end -}}
 {{- end -}}
 
-{{- define "orchestration.effectiveTlsConfig" -}}
+{{- define "orchestration.sharedTlsConfig" -}}
 {{- $config := dict -}}
 {{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.global.elasticsearch.tls)) "true" -}}
     {{- $config = .Values.global.elasticsearch.tls -}}
@@ -281,6 +281,36 @@ Authentication.
     {{- $config = .Values.orchestration.data.secondaryStorage.opensearch.tls -}}
 {{- end -}}
 {{- toYaml $config -}}
+{{- end -}}
+
+{{- define "orchestration.legacyExporterTlsConfig" -}}
+{{- $config := dict -}}
+{{- if and
+      (eq (include "orchestration.legacyElasticsearchExporterUsesOptimizeSource" .) "true")
+      (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.optimize.database.elasticsearch.tls)) "true")
+-}}
+    {{- $config = .Values.optimize.database.elasticsearch.tls -}}
+{{- else if and
+      (eq (include "orchestration.legacyOpenSearchExporterUsesOptimizeSource" .) "true")
+      (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.optimize.database.opensearch.tls)) "true")
+-}}
+    {{- $config = .Values.optimize.database.opensearch.tls -}}
+{{- end -}}
+{{- toYaml $config -}}
+{{- end -}}
+
+{{- /*
+NOTE: the Orchestration JVM mounts a single truststore, so the first matching source wins for the
+whole pod. An Optimize-owned legacy exporter contributes its component TLS secret first; the chain
+falls through to the shared global/secondary-storage sources otherwise.
+*/ -}}
+{{- define "orchestration.effectiveTlsConfig" -}}
+{{- $exporterTls := include "orchestration.legacyExporterTlsConfig" . | fromYaml -}}
+{{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" $exporterTls)) "true" -}}
+{{- toYaml $exporterTls -}}
+{{- else -}}
+{{- include "orchestration.sharedTlsConfig" . -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "orchestration.persistentSessionsEnabled" -}}

--- a/charts/camunda-platform-8.9/templates/orchestration/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/orchestration/_helpers.tpl
@@ -330,6 +330,39 @@ and
 -}}
 {{- end -}}
 
+{{/*
+NOTE: the legacy exporters resolve their password from the Optimize component secret when one is
+configured, and fall back to the generic engine-wide variable otherwise. Both the emission in
+statefulset.yaml and the substitution here key off the same hasSecretConfig predicate.
+*/}}
+{{- define "orchestration.legacyElasticsearchExporterPasswordRef" -}}
+{{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.optimize.database.elasticsearch.auth)) "true" -}}
+${VALUES_OPTIMIZE_DATABASE_ELASTICSEARCH_PASSWORD:}
+{{- else -}}
+${VALUES_ELASTICSEARCH_PASSWORD:}
+{{- end -}}
+{{- end -}}
+
+{{- define "orchestration.legacyOpenSearchExporterPasswordRef" -}}
+{{- if eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.optimize.database.opensearch.auth)) "true" -}}
+${VALUES_OPTIMIZE_DATABASE_OPENSEARCH_PASSWORD:}
+{{- else -}}
+${VALUES_OPENSEARCH_PASSWORD:}
+{{- end -}}
+{{- end -}}
+
+{{/*
+NOTE: when the legacy OpenSearch exporter targets the Optimize component endpoint, its AWS mode is
+owned by that component; otherwise it keeps the shared-endpoint resolution across all three sources.
+*/}}
+{{- define "orchestration.legacyOpenSearchExporterAwsEnabled" -}}
+{{- if (tpl .Values.optimize.database.opensearch.url.host $) -}}
+{{- .Values.optimize.database.opensearch.aws.enabled -}}
+{{- else -}}
+{{- or .Values.orchestration.data.secondaryStorage.opensearch.aws.enabled .Values.global.opensearch.aws.enabled .Values.optimize.database.opensearch.aws.enabled -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "orchestration.hasAppIntegrations" -}}
 {{- include "camundaPlatform.hasSecretConfig" (dict "config" .Values.orchestration.exporters.appIntegrations.apiKey) -}}
 {{- end -}}

--- a/charts/camunda-platform-8.9/templates/orchestration/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/orchestration/_helpers.tpl
@@ -399,16 +399,15 @@ ${VALUES_OPENSEARCH_PASSWORD:}
 {{- end -}}
 
 {{/*
-NOTE: the legacy OpenSearch exporter resolves AWS mode from the same endpoint source, retaining the
-shared fallback only when neither component defines an endpoint.
+NOTE: the legacy OpenSearch exporter resolves AWS mode from the same source as its endpoint and
+credentials: the Optimize component chain when Optimize-owned, the secondary-storage/global pair
+otherwise.
 */}}
 {{- define "orchestration.legacyOpenSearchExporterAwsEnabled" -}}
-{{- if (tpl .Values.optimize.database.opensearch.url.host $) -}}
-{{- .Values.optimize.database.opensearch.aws.enabled -}}
-{{- else if .Values.orchestration.data.secondaryStorage.opensearch.url -}}
-{{- or .Values.orchestration.data.secondaryStorage.opensearch.aws.enabled .Values.global.opensearch.aws.enabled -}}
+{{- if eq (include "orchestration.legacyOpenSearchExporterUsesOptimizeSource" .) "true" -}}
+{{- include "optimize.effectiveOsAwsEnabled" . -}}
 {{- else -}}
-{{- or .Values.orchestration.data.secondaryStorage.opensearch.aws.enabled .Values.global.opensearch.aws.enabled .Values.optimize.database.opensearch.aws.enabled -}}
+{{- or .Values.orchestration.data.secondaryStorage.opensearch.aws.enabled .Values.global.opensearch.aws.enabled -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/camunda-platform-8.9/templates/orchestration/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/orchestration/_helpers.tpl
@@ -331,6 +331,29 @@ and
 {{- end -}}
 
 {{/*
+NOTE: the legacy exporters connect to the datastore Optimize reads, so their endpoint, credentials,
+AWS mode, and TLS all resolve from the Optimize component chain whenever these predicates hold.
+The host term mirrors the gate the Optimize deployment uses to render its own connection env vars;
+when no host resolves, the exporter keeps the secondary-storage/global compatibility source.
+*/}}
+{{- define "orchestration.legacyElasticsearchExporterUsesOptimizeSource" -}}
+{{- and
+      (eq (include "orchestration.hasLegacyElasticsearchExporter" .) "true")
+      .Values.optimize.enabled
+      (ne (include "camundaPlatform.elasticsearchHost" .) "")
+-}}
+{{- end -}}
+
+{{- define "orchestration.legacyOpenSearchExporterUsesOptimizeSource" -}}
+{{- and
+      (ne (include "orchestration.hasLegacyElasticsearchExporter" .) "true")
+      (eq (include "orchestration.hasLegacyOpenSearchExporter" .) "true")
+      .Values.optimize.enabled
+      (ne (include "camundaPlatform.opensearchHost" .) "")
+-}}
+{{- end -}}
+
+{{/*
 NOTE: the legacy exporters resolve their password from the Optimize component secret when one is
 configured, and fall back to the generic engine-wide variable otherwise. Both the emission in
 statefulset.yaml and the substitution here key off the same hasSecretConfig predicate.

--- a/charts/camunda-platform-8.9/templates/orchestration/_helpers.tpl
+++ b/charts/camunda-platform-8.9/templates/orchestration/_helpers.tpl
@@ -352,12 +352,14 @@ ${VALUES_OPENSEARCH_PASSWORD:}
 {{- end -}}
 
 {{/*
-NOTE: when the legacy OpenSearch exporter targets the Optimize component endpoint, its AWS mode is
-owned by that component; otherwise it keeps the shared-endpoint resolution across all three sources.
+NOTE: the legacy OpenSearch exporter resolves AWS mode from the same endpoint source, retaining the
+shared fallback only when neither component defines an endpoint.
 */}}
 {{- define "orchestration.legacyOpenSearchExporterAwsEnabled" -}}
 {{- if (tpl .Values.optimize.database.opensearch.url.host $) -}}
 {{- .Values.optimize.database.opensearch.aws.enabled -}}
+{{- else if .Values.orchestration.data.secondaryStorage.opensearch.url -}}
+{{- or .Values.orchestration.data.secondaryStorage.opensearch.aws.enabled .Values.global.opensearch.aws.enabled -}}
 {{- else -}}
 {{- or .Values.orchestration.data.secondaryStorage.opensearch.aws.enabled .Values.global.opensearch.aws.enabled .Values.optimize.database.opensearch.aws.enabled -}}
 {{- end -}}

--- a/charts/camunda-platform-8.9/templates/orchestration/files/_application.yaml
+++ b/charts/camunda-platform-8.9/templates/orchestration/files/_application.yaml
@@ -331,9 +331,9 @@ zeebe:
           {{- if or .Values.global.elasticsearch.external .Values.optimize.database.elasticsearch.external }}
           authentication:
             username: {{ .Values.optimize.database.elasticsearch.auth.username | default .Values.orchestration.data.secondaryStorage.elasticsearch.auth.username | default .Values.global.elasticsearch.auth.username | quote }}
-            password: "${VALUES_ELASTICSEARCH_PASSWORD:}"
+            password: "{{ include "orchestration.legacyElasticsearchExporterPasswordRef" . }}"
           {{- end }}
-          url: {{ include "camundaPlatform.elasticsearchURL" . | quote }}
+          url: {{ include "camundaPlatform.legacyExporterElasticsearchURL" . | quote }}
           index:
             prefix: {{ .Values.optimize.database.elasticsearch.prefix | default .Values.global.elasticsearch.prefix | quote }}
             numberOfReplicas: {{ ternary .Values.orchestration.index.replicas .Values.orchestration.exporters.zeebe.replicas (kindIs "invalid" .Values.orchestration.exporters.zeebe.replicas) | quote }}
@@ -347,16 +347,16 @@ zeebe:
       opensearch:
         className: "io.camunda.zeebe.exporter.opensearch.OpensearchExporter"
         args:
-          {{- if and (not (or .Values.orchestration.data.secondaryStorage.opensearch.aws.enabled .Values.global.opensearch.aws.enabled)) (not .Values.optimize.database.opensearch.aws.enabled) }}
+          {{- if ne (include "orchestration.legacyOpenSearchExporterAwsEnabled" .) "true" }}
           authentication:
             username: {{ .Values.optimize.database.opensearch.auth.username | default .Values.orchestration.data.secondaryStorage.opensearch.auth.username | default .Values.global.opensearch.auth.username | quote }}
-            password: "${VALUES_OPENSEARCH_PASSWORD:}"
+            password: "{{ include "orchestration.legacyOpenSearchExporterPasswordRef" . }}"
           {{- end }}
-          url: {{ include "camundaPlatform.opensearchURL" . | quote }}
+          url: {{ include "camundaPlatform.legacyExporterOpensearchURL" . | quote }}
           index:
             prefix: {{ .Values.optimize.database.opensearch.prefix | default .Values.global.opensearch.prefix | quote }}
             numberOfReplicas: {{ ternary .Values.orchestration.index.replicas .Values.orchestration.exporters.zeebe.replicas (kindIs "invalid" .Values.orchestration.exporters.zeebe.replicas) | quote }}
-          {{- if or .Values.orchestration.data.secondaryStorage.opensearch.aws.enabled .Values.global.opensearch.aws.enabled .Values.optimize.database.opensearch.aws.enabled }}
+          {{- if eq (include "orchestration.legacyOpenSearchExporterAwsEnabled" .) "true" }}
           aws:
             enabled: true
           {{- end }}

--- a/charts/camunda-platform-8.9/templates/orchestration/files/_application.yaml
+++ b/charts/camunda-platform-8.9/templates/orchestration/files/_application.yaml
@@ -328,9 +328,9 @@ zeebe:
       elasticsearch:
         className: "io.camunda.zeebe.exporter.ElasticsearchExporter"
         args:
-          {{- if or .Values.global.elasticsearch.external .Values.optimize.database.elasticsearch.external }}
+          {{- if eq (include "orchestration.legacyElasticsearchExporterAuthenticationEnabled" .) "true" }}
           authentication:
-            username: {{ .Values.optimize.database.elasticsearch.auth.username | default .Values.orchestration.data.secondaryStorage.elasticsearch.auth.username | default .Values.global.elasticsearch.auth.username | quote }}
+            username: {{ include "orchestration.legacyElasticsearchExporterUsername" . | quote }}
             password: "{{ include "orchestration.legacyElasticsearchExporterPasswordRef" . }}"
           {{- end }}
           url: {{ include "camundaPlatform.legacyExporterElasticsearchURL" . | quote }}
@@ -347,9 +347,9 @@ zeebe:
       opensearch:
         className: "io.camunda.zeebe.exporter.opensearch.OpensearchExporter"
         args:
-          {{- if ne (include "orchestration.legacyOpenSearchExporterAwsEnabled" .) "true" }}
+          {{- if eq (include "orchestration.legacyOpenSearchExporterAuthenticationEnabled" .) "true" }}
           authentication:
-            username: {{ .Values.optimize.database.opensearch.auth.username | default .Values.orchestration.data.secondaryStorage.opensearch.auth.username | default .Values.global.opensearch.auth.username | quote }}
+            username: {{ include "orchestration.legacyOpenSearchExporterUsername" . | quote }}
             password: "{{ include "orchestration.legacyOpenSearchExporterPasswordRef" . }}"
           {{- end }}
           url: {{ include "camundaPlatform.legacyExporterOpensearchURL" . | quote }}

--- a/charts/camunda-platform-8.9/templates/orchestration/statefulset.yaml
+++ b/charts/camunda-platform-8.9/templates/orchestration/statefulset.yaml
@@ -155,24 +155,26 @@ spec:
                 "config" .Values.orchestration.data.secondaryStorage.opensearch.auth
             ) | nindent 12 }}
             {{- end }}
+            {{- $legacyElasticsearchExporterAuth := include "optimize.effectiveEsAuthConfig" . | fromYaml }}
             {{- if and
-                (eq (include "orchestration.hasLegacyElasticsearchExporter" .) "true")
-                (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.optimize.database.elasticsearch.auth)) "true")
+                (eq (include "orchestration.legacyElasticsearchExporterUsesOptimizeSource" .) "true")
+                (eq (include "orchestration.legacyElasticsearchExporterAuthenticationEnabled" .) "true")
+                (eq (include "camundaPlatform.hasSecretConfig" (dict "config" $legacyElasticsearchExporterAuth)) "true")
             }}
             {{- include "camundaPlatform.emitEnvVarFromSecretConfig" (dict
                 "envName" "VALUES_OPTIMIZE_DATABASE_ELASTICSEARCH_PASSWORD"
-                "config" .Values.optimize.database.elasticsearch.auth
+                "config" $legacyElasticsearchExporterAuth
             ) | nindent 12 }}
             {{- end }}
+            {{- $legacyOpenSearchExporterAuth := include "optimize.effectiveOsAuthConfig" . | fromYaml }}
             {{- if and
-                (ne (include "orchestration.hasLegacyElasticsearchExporter" .) "true")
-                (eq (include "orchestration.hasLegacyOpenSearchExporter" .) "true")
-                (ne (include "orchestration.legacyOpenSearchExporterAwsEnabled" .) "true")
-                (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.optimize.database.opensearch.auth)) "true")
+                (eq (include "orchestration.legacyOpenSearchExporterUsesOptimizeSource" .) "true")
+                (eq (include "orchestration.legacyOpenSearchExporterAuthenticationEnabled" .) "true")
+                (eq (include "camundaPlatform.hasSecretConfig" (dict "config" $legacyOpenSearchExporterAuth)) "true")
             }}
             {{- include "camundaPlatform.emitEnvVarFromSecretConfig" (dict
                 "envName" "VALUES_OPTIMIZE_DATABASE_OPENSEARCH_PASSWORD"
-                "config" .Values.optimize.database.opensearch.auth
+                "config" $legacyOpenSearchExporterAuth
             ) | nindent 12 }}
             {{- end }}
             {{- if and .Values.orchestration.exporters.rdbms.enabled (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.orchestration.data.secondaryStorage.rdbms)) "true") }}

--- a/charts/camunda-platform-8.9/templates/orchestration/statefulset.yaml
+++ b/charts/camunda-platform-8.9/templates/orchestration/statefulset.yaml
@@ -155,6 +155,26 @@ spec:
                 "config" .Values.orchestration.data.secondaryStorage.opensearch.auth
             ) | nindent 12 }}
             {{- end }}
+            {{- if and
+                (eq (include "orchestration.hasLegacyElasticsearchExporter" .) "true")
+                (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.optimize.database.elasticsearch.auth)) "true")
+            }}
+            {{- include "camundaPlatform.emitEnvVarFromSecretConfig" (dict
+                "envName" "VALUES_OPTIMIZE_DATABASE_ELASTICSEARCH_PASSWORD"
+                "config" .Values.optimize.database.elasticsearch.auth
+            ) | nindent 12 }}
+            {{- end }}
+            {{- if and
+                (ne (include "orchestration.hasLegacyElasticsearchExporter" .) "true")
+                (eq (include "orchestration.hasLegacyOpenSearchExporter" .) "true")
+                (ne (include "orchestration.legacyOpenSearchExporterAwsEnabled" .) "true")
+                (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.optimize.database.opensearch.auth)) "true")
+            }}
+            {{- include "camundaPlatform.emitEnvVarFromSecretConfig" (dict
+                "envName" "VALUES_OPTIMIZE_DATABASE_OPENSEARCH_PASSWORD"
+                "config" .Values.optimize.database.opensearch.auth
+            ) | nindent 12 }}
+            {{- end }}
             {{- if and .Values.orchestration.exporters.rdbms.enabled (eq (include "camundaPlatform.hasSecretConfig" (dict "config" .Values.orchestration.data.secondaryStorage.rdbms)) "true") }}
             {{- include "camundaPlatform.emitEnvVarFromSecretConfig" (dict
                 "envName" "VALUES_ORCHESTRATION_DATA_SECONDARYSTORAGE_RDBMS_PASSWORD"

--- a/charts/camunda-platform-8.9/test/unit/common/configmap_warnings_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/configmap_warnings_test.go
@@ -95,3 +95,57 @@ func (s *ConfigMapWarningsTemplateTest) TestDifferentValuesInputs() {
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
+
+func (s *ConfigMapWarningsTemplateTest) TestLegacyExporterTruststoreConflict() {
+	conflictingTruststores := map[string]string{
+		"optimize.enabled":                                                            "true",
+		"optimize.database.elasticsearch.enabled":                                     "false",
+		"optimize.database.opensearch.enabled":                                        "true",
+		"optimize.database.opensearch.url.host":                                       "optimize-host",
+		"optimize.database.opensearch.tls.secret.existingSecret":                      "optimize-tls-secret",
+		"optimize.database.opensearch.tls.secret.existingSecretKey":                   "optimize-ca.jks",
+		"orchestration.data.secondaryStorage.type":                                    "opensearch",
+		"orchestration.data.secondaryStorage.opensearch.url":                          "https://secondary-host:9443",
+		"orchestration.data.secondaryStorage.opensearch.tls.secret.existingSecret":    "secondary-tls-secret",
+		"orchestration.data.secondaryStorage.opensearch.tls.secret.existingSecretKey": "secondary-ca.jks",
+	}
+
+	testCases := []testhelpers.TestCase{
+		{
+			Name:   "Legacy exporter and secondary storage truststores conflict",
+			Values: conflictingTruststores,
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().Contains(configmap.Data["warnings"], "TRUSTSTORE CONFLICT")
+			},
+		},
+		{
+			Name: "Shared truststore secret does not warn",
+			Values: mergeMaps(conflictingTruststores, map[string]string{
+				"orchestration.data.secondaryStorage.opensearch.tls.secret.existingSecret":    "optimize-tls-secret",
+				"orchestration.data.secondaryStorage.opensearch.tls.secret.existingSecretKey": "optimize-ca.jks",
+			}),
+			Verifier: func(t *testing.T, output string, err error) {
+				s.Require().NoError(err)
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(s.T(), output, &configmap)
+				s.Require().NotContains(configmap.Data["warnings"], "TRUSTSTORE CONFLICT")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
+func mergeMaps(base map[string]string, overrides map[string]string) map[string]string {
+	merged := make(map[string]string, len(base)+len(overrides))
+	for key, value := range base {
+		merged[key] = value
+	}
+	for key, value := range overrides {
+		merged[key] = value
+	}
+	return merged
+}

--- a/charts/camunda-platform-8.9/test/unit/orchestration/configmap_unified_test.go
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/configmap_unified_test.go
@@ -218,6 +218,134 @@ func (s *ConfigmapTemplateTest) TestDifferentValuesInputsUnifiedOpenSearchAWS() 
 	testhelpers.RunTestCases(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
 
+func (s *ConfigmapTemplateTest) TestLegacyExporterDatastoreSourceAlignment() {
+	distinctOpenSearchSources := map[string]string{
+		"optimize.enabled":                                                        "true",
+		"optimize.database.elasticsearch.enabled":                                 "false",
+		"optimize.database.opensearch.enabled":                                    "true",
+		"optimize.database.opensearch.url.protocol":                               "https",
+		"optimize.database.opensearch.url.host":                                   "optimize-host",
+		"optimize.database.opensearch.url.port":                                   "9555",
+		"optimize.database.opensearch.auth.username":                              "optimize-user",
+		"optimize.database.opensearch.auth.secret.inlineSecret":                   "optimize-password",
+		"orchestration.data.secondaryStorage.type":                                "opensearch",
+		"orchestration.data.secondaryStorage.opensearch.url":                      "https://secondary-host:9443",
+		"orchestration.data.secondaryStorage.opensearch.auth.username":            "secondary-user",
+		"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "secondary-password",
+	}
+
+	testCases := []testhelpers.TestCase{
+		{
+			Name:   "TestLegacyOpenSearchExporterUsesOptimizeSource",
+			Values: distinctOpenSearchSources,
+			Expected: map[string]string{
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.url":                     "https://optimize-host:9555",
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.authentication.username": "optimize-user",
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.authentication.password": "${VALUES_OPTIMIZE_DATABASE_OPENSEARCH_PASSWORD:}",
+				"configmapApplication.camunda.data.secondary-storage.opensearch.url":                  "https://secondary-host:9443",
+				"configmapApplication.camunda.data.secondary-storage.opensearch.username":             "secondary-user",
+				"configmapApplication.camunda.data.secondary-storage.opensearch.password":             "${VALUES_OPENSEARCH_PASSWORD:}",
+			},
+		},
+		{
+			Name: "TestLegacyOpenSearchExporterUsesOptimizePasswordOnSharedEndpoint",
+			Values: map[string]string{
+				"optimize.enabled":                                      "true",
+				"optimize.database.elasticsearch.enabled":               "false",
+				"optimize.database.opensearch.enabled":                  "true",
+				"optimize.database.opensearch.url.protocol":             "https",
+				"optimize.database.opensearch.url.host":                 "opensearch.example.com",
+				"optimize.database.opensearch.url.port":                 "443",
+				"optimize.database.opensearch.auth.username":            "optimize-user",
+				"optimize.database.opensearch.auth.secret.inlineSecret": "optimize-password",
+				"orchestration.data.secondaryStorage.type":              "opensearch",
+				"orchestration.data.secondaryStorage.opensearch.url":    "https://opensearch.example.com:443",
+			},
+			Expected: map[string]string{
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.url":                     "https://opensearch.example.com:443",
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.authentication.password": "${VALUES_OPTIMIZE_DATABASE_OPENSEARCH_PASSWORD:}",
+			},
+		},
+		{
+			Name: "TestLegacyOpenSearchExporterFallsBackToSecondaryStorageSource",
+			Values: map[string]string{
+				"optimize.enabled":                                                        "true",
+				"optimize.database.elasticsearch.enabled":                                 "false",
+				"optimize.database.opensearch.enabled":                                    "true",
+				"orchestration.data.secondaryStorage.type":                                "opensearch",
+				"orchestration.data.secondaryStorage.opensearch.url":                      "https://secondary-host:9443",
+				"orchestration.data.secondaryStorage.opensearch.auth.username":            "secondary-user",
+				"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "secondary-password",
+			},
+			Expected: map[string]string{
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.url":                     "https://secondary-host:9443",
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.authentication.username": "secondary-user",
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.authentication.password": "${VALUES_OPENSEARCH_PASSWORD:}",
+			},
+		},
+		{
+			Name: "TestLegacyOpenSearchExporterUsesOptimizeAwsMode",
+			Values: mergeValues(distinctOpenSearchSources, map[string]string{
+				"optimize.database.opensearch.aws.enabled":                   "true",
+				"orchestration.data.secondaryStorage.opensearch.aws.enabled": "false",
+			}),
+			Expected: map[string]string{
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.aws.enabled":             "true",
+				"configmapApplication.camunda.data.secondary-storage.opensearch.aws-enabled":          "false",
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.authentication.username": "",
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.authentication.password": "",
+			},
+		},
+		{
+			Name: "TestLegacyOpenSearchExporterIgnoresSecondaryStorageAwsMode",
+			Values: mergeValues(distinctOpenSearchSources, map[string]string{
+				"optimize.database.opensearch.aws.enabled":                   "false",
+				"orchestration.data.secondaryStorage.opensearch.aws.enabled": "true",
+			}),
+			Expected: map[string]string{
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.authentication.username": "optimize-user",
+				"configmapApplication.camunda.data.secondary-storage.opensearch.aws-enabled":          "true",
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.aws.enabled":             "",
+			},
+		},
+		{
+			Name: "TestLegacyElasticsearchExporterUsesOptimizeSource",
+			Values: map[string]string{
+				"optimize.enabled":                                         "true",
+				"optimize.database.opensearch.enabled":                     "false",
+				"optimize.database.elasticsearch.enabled":                  "true",
+				"optimize.database.elasticsearch.external":                 "true",
+				"optimize.database.elasticsearch.url.protocol":             "https",
+				"optimize.database.elasticsearch.url.host":                 "optimize-host",
+				"optimize.database.elasticsearch.url.port":                 "9555",
+				"optimize.database.elasticsearch.auth.username":            "optimize-user",
+				"optimize.database.elasticsearch.auth.secret.inlineSecret": "optimize-password",
+				"orchestration.data.secondaryStorage.type":                 "elasticsearch",
+				"orchestration.data.secondaryStorage.elasticsearch.url":    "https://secondary-host:9443",
+			},
+			Expected: map[string]string{
+				"configmapApplication.zeebe.broker.exporters.elasticsearch.args.url":                     "https://optimize-host:9555",
+				"configmapApplication.zeebe.broker.exporters.elasticsearch.args.authentication.username": "optimize-user",
+				"configmapApplication.zeebe.broker.exporters.elasticsearch.args.authentication.password": "${VALUES_OPTIMIZE_DATABASE_ELASTICSEARCH_PASSWORD:}",
+				"configmapApplication.camunda.data.secondary-storage.elasticsearch.url":                  "https://secondary-host:9443",
+			},
+		},
+	}
+
+	testhelpers.RunTestCases(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
+func mergeValues(base map[string]string, overrides map[string]string) map[string]string {
+	merged := make(map[string]string, len(base)+len(overrides))
+	for key, value := range base {
+		merged[key] = value
+	}
+	for key, value := range overrides {
+		merged[key] = value
+	}
+	return merged
+}
+
 func (s *ConfigmapTemplateTest) TestDifferentValuesInputsUnifiedElasticsearchAWS() {
 	testCases := []testhelpers.TestCase{
 		{

--- a/charts/camunda-platform-8.9/test/unit/orchestration/configmap_unified_test.go
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/configmap_unified_test.go
@@ -312,6 +312,27 @@ func (s *ConfigmapTemplateTest) TestLegacyExporterDatastoreSourceAlignment() {
 			},
 		},
 		{
+			Name: "TestLegacyOpenSearchExporterGlobalFallbackRemainsIsolatedFromSecondaryPassword",
+			Values: map[string]string{
+				"optimize.enabled":                                                        "true",
+				"global.opensearch.enabled":                                               "true",
+				"global.opensearch.url.host":                                              "global-opensearch-host",
+				"global.opensearch.auth.username":                                         "global-user",
+				"global.opensearch.auth.secret.inlineSecret":                              "global-password",
+				"orchestration.data.secondaryStorage.type":                                "opensearch",
+				"orchestration.data.secondaryStorage.opensearch.url":                      "https://secondary-host:9443",
+				"orchestration.data.secondaryStorage.opensearch.auth.username":            "secondary-user",
+				"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "secondary-password",
+			},
+			Expected: map[string]string{
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.url":                     "https://global-opensearch-host:443",
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.authentication.username": "global-user",
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.authentication.password": "${VALUES_OPTIMIZE_DATABASE_OPENSEARCH_PASSWORD:}",
+				"configmapApplication.camunda.data.secondary-storage.opensearch.username":             "secondary-user",
+				"configmapApplication.camunda.data.secondary-storage.opensearch.password":             "${VALUES_OPENSEARCH_PASSWORD:}",
+			},
+		},
+		{
 			Name: "TestLegacyOpenSearchExporterRetainsSecondaryStorageCompatibilitySource",
 			Values: map[string]string{
 				"optimize.enabled":                                                        "false",

--- a/charts/camunda-platform-8.9/test/unit/orchestration/configmap_unified_test.go
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/configmap_unified_test.go
@@ -351,31 +351,6 @@ func (s *ConfigmapTemplateTest) TestLegacyExporterDatastoreSourceAlignment() {
 			},
 		},
 		{
-			Name: "TestLegacyOpenSearchExporterUsesOptimizeAwsMode",
-			Values: mergeValues(distinctOpenSearchSources, map[string]string{
-				"optimize.database.opensearch.aws.enabled":                   "true",
-				"orchestration.data.secondaryStorage.opensearch.aws.enabled": "false",
-			}),
-			Expected: map[string]string{
-				"configmapApplication.zeebe.broker.exporters.opensearch.args.aws.enabled":             "true",
-				"configmapApplication.camunda.data.secondary-storage.opensearch.aws-enabled":          "false",
-				"configmapApplication.zeebe.broker.exporters.opensearch.args.authentication.username": "",
-				"configmapApplication.zeebe.broker.exporters.opensearch.args.authentication.password": "",
-			},
-		},
-		{
-			Name: "TestLegacyOpenSearchExporterIgnoresSecondaryStorageAwsMode",
-			Values: mergeValues(distinctOpenSearchSources, map[string]string{
-				"optimize.database.opensearch.aws.enabled":                   "false",
-				"orchestration.data.secondaryStorage.opensearch.aws.enabled": "true",
-			}),
-			Expected: map[string]string{
-				"configmapApplication.zeebe.broker.exporters.opensearch.args.authentication.username": "optimize-user",
-				"configmapApplication.camunda.data.secondary-storage.opensearch.aws-enabled":          "true",
-				"configmapApplication.zeebe.broker.exporters.opensearch.args.aws.enabled":             "",
-			},
-		},
-		{
 			Name: "TestLegacyElasticsearchExporterUsesOptimizeSource",
 			Values: map[string]string{
 				"optimize.enabled":                                         "true",
@@ -402,8 +377,113 @@ func (s *ConfigmapTemplateTest) TestLegacyExporterDatastoreSourceAlignment() {
 	testhelpers.RunTestCases(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
 
-func (s *ConfigmapTemplateTest) TestLegacyOpenSearchExporterIgnoresOptimizeAwsModeForSecondaryStorageSource() {
+type legacyOpenSearchExporterArgs struct {
+	Authentication *struct {
+		Username string `yaml:"username"`
+		Password string `yaml:"password"`
+	} `yaml:"authentication"`
+	URL string `yaml:"url"`
+	AWS *struct {
+		Enabled bool `yaml:"enabled"`
+	} `yaml:"aws"`
+}
+
+type legacyExporterApplicationConfig struct {
+	Zeebe struct {
+		Broker struct {
+			Exporters struct {
+				OpenSearch struct {
+					Args legacyOpenSearchExporterArgs `yaml:"args"`
+				} `yaml:"opensearch"`
+			} `yaml:"exporters"`
+		} `yaml:"broker"`
+	} `yaml:"zeebe"`
+	Camunda struct {
+		Data struct {
+			SecondaryStorage struct {
+				OpenSearch struct {
+					AwsEnabled bool `yaml:"aws-enabled"`
+				} `yaml:"opensearch"`
+			} `yaml:"secondary-storage"`
+		} `yaml:"data"`
+	} `yaml:"camunda"`
+}
+
+func verifyLegacyExporterApplication(verify func(t *testing.T, application legacyExporterApplicationConfig)) func(t *testing.T, output string, err error) {
+	return func(t *testing.T, output string, err error) {
+		require.NoError(t, err)
+
+		var configMap corev1.ConfigMap
+		helm.UnmarshalK8SYaml(t, output, &configMap)
+
+		var application legacyExporterApplicationConfig
+		require.NoError(t, yaml.Unmarshal([]byte(configMap.Data["application.yaml"]), &application))
+		verify(t, application)
+	}
+}
+
+func (s *ConfigmapTemplateTest) TestLegacyOpenSearchExporterAwsSourceAlignment() {
+	distinctOpenSearchSources := map[string]string{
+		"optimize.enabled":                                                        "true",
+		"optimize.database.elasticsearch.enabled":                                 "false",
+		"optimize.database.opensearch.enabled":                                    "true",
+		"optimize.database.opensearch.url.protocol":                               "https",
+		"optimize.database.opensearch.url.host":                                   "optimize-host",
+		"optimize.database.opensearch.url.port":                                   "9555",
+		"optimize.database.opensearch.auth.username":                              "optimize-user",
+		"optimize.database.opensearch.auth.secret.inlineSecret":                   "optimize-password",
+		"orchestration.data.secondaryStorage.type":                                "opensearch",
+		"orchestration.data.secondaryStorage.opensearch.url":                      "https://secondary-host:9443",
+		"orchestration.data.secondaryStorage.opensearch.auth.username":            "secondary-user",
+		"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "secondary-password",
+	}
+
 	testCases := []testhelpers.TestCase{
+		{
+			Name: "Optimize AWS mode drops exporter authentication",
+			Values: mergeValues(distinctOpenSearchSources, map[string]string{
+				"optimize.database.opensearch.aws.enabled":                   "true",
+				"orchestration.data.secondaryStorage.opensearch.aws.enabled": "false",
+			}),
+			Verifier: verifyLegacyExporterApplication(func(t *testing.T, application legacyExporterApplicationConfig) {
+				args := application.Zeebe.Broker.Exporters.OpenSearch.Args
+				require.Equal(t, "https://optimize-host:9555", args.URL)
+				require.Nil(t, args.Authentication)
+				require.NotNil(t, args.AWS)
+				require.True(t, args.AWS.Enabled)
+				require.False(t, application.Camunda.Data.SecondaryStorage.OpenSearch.AwsEnabled)
+			}),
+		},
+		{
+			Name: "Secondary AWS mode does not cross to the Optimize source",
+			Values: mergeValues(distinctOpenSearchSources, map[string]string{
+				"optimize.database.opensearch.aws.enabled":                   "false",
+				"orchestration.data.secondaryStorage.opensearch.aws.enabled": "true",
+			}),
+			Verifier: verifyLegacyExporterApplication(func(t *testing.T, application legacyExporterApplicationConfig) {
+				args := application.Zeebe.Broker.Exporters.OpenSearch.Args
+				require.Equal(t, "https://optimize-host:9555", args.URL)
+				require.Nil(t, args.AWS)
+				require.NotNil(t, args.Authentication)
+				require.Equal(t, "optimize-user", args.Authentication.Username)
+				require.Equal(t, "${VALUES_OPTIMIZE_DATABASE_OPENSEARCH_PASSWORD:}", args.Authentication.Password)
+				require.True(t, application.Camunda.Data.SecondaryStorage.OpenSearch.AwsEnabled)
+			}),
+		},
+		{
+			Name: "Global AWS fallback applies to the Optimize source",
+			Values: mergeValues(distinctOpenSearchSources, map[string]string{
+				"global.opensearch.aws.enabled":                              "true",
+				"orchestration.data.secondaryStorage.opensearch.aws.enabled": "false",
+			}),
+			Verifier: verifyLegacyExporterApplication(func(t *testing.T, application legacyExporterApplicationConfig) {
+				args := application.Zeebe.Broker.Exporters.OpenSearch.Args
+				require.Equal(t, "https://optimize-host:9555", args.URL)
+				require.Nil(t, args.Authentication)
+				require.NotNil(t, args.AWS)
+				require.True(t, args.AWS.Enabled)
+			}),
+		},
 		{
 			Name: "Optimize AWS does not cross explicit secondary source",
 			Values: map[string]string{
@@ -417,41 +497,14 @@ func (s *ConfigmapTemplateTest) TestLegacyOpenSearchExporterIgnoresOptimizeAwsMo
 				"orchestration.data.secondaryStorage.opensearch.auth.username":            "secondary-user",
 				"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "secondary-password",
 			},
-			Verifier: func(t *testing.T, output string, err error) {
-				require.NoError(t, err)
-
-				var configMap corev1.ConfigMap
-				helm.UnmarshalK8SYaml(t, output, &configMap)
-
-				var application struct {
-					Zeebe struct {
-						Broker struct {
-							Exporters struct {
-								OpenSearch struct {
-									Args struct {
-										Authentication *struct {
-											Username string `yaml:"username"`
-											Password string `yaml:"password"`
-										} `yaml:"authentication"`
-										URL string `yaml:"url"`
-										AWS *struct {
-											Enabled bool `yaml:"enabled"`
-										} `yaml:"aws"`
-									} `yaml:"args"`
-								} `yaml:"opensearch"`
-							} `yaml:"exporters"`
-						} `yaml:"broker"`
-					} `yaml:"zeebe"`
-				}
-				require.NoError(t, yaml.Unmarshal([]byte(configMap.Data["application.yaml"]), &application))
-
+			Verifier: verifyLegacyExporterApplication(func(t *testing.T, application legacyExporterApplicationConfig) {
 				args := application.Zeebe.Broker.Exporters.OpenSearch.Args
 				require.Equal(t, "https://secondary-host:9443", args.URL)
 				require.NotNil(t, args.Authentication)
 				require.Equal(t, "secondary-user", args.Authentication.Username)
 				require.Equal(t, "${VALUES_OPENSEARCH_PASSWORD:}", args.Authentication.Password)
 				require.Nil(t, args.AWS)
-			},
+			}),
 		},
 	}
 

--- a/charts/camunda-platform-8.9/test/unit/orchestration/configmap_unified_test.go
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/configmap_unified_test.go
@@ -506,6 +506,28 @@ func (s *ConfigmapTemplateTest) TestLegacyOpenSearchExporterAwsSourceAlignment()
 				require.Nil(t, args.AWS)
 			}),
 		},
+		{
+			Name: "Optimize AWS does not apply to the compatibility source when Optimize is disabled",
+			Values: map[string]string{
+				"optimize.enabled":                                                        "false",
+				"global.opensearch.enabled":                                               "true",
+				"global.opensearch.url.host":                                              "global-opensearch-host",
+				"orchestration.exporters.zeebe.enabled":                                   "true",
+				"optimize.database.opensearch.aws.enabled":                                "true",
+				"orchestration.data.secondaryStorage.type":                                "opensearch",
+				"orchestration.data.secondaryStorage.opensearch.url":                      "https://secondary-host:9443",
+				"orchestration.data.secondaryStorage.opensearch.auth.username":            "secondary-user",
+				"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "secondary-password",
+			},
+			Verifier: verifyLegacyExporterApplication(func(t *testing.T, application legacyExporterApplicationConfig) {
+				args := application.Zeebe.Broker.Exporters.OpenSearch.Args
+				require.Equal(t, "https://secondary-host:9443", args.URL)
+				require.Nil(t, args.AWS)
+				require.NotNil(t, args.Authentication)
+				require.Equal(t, "secondary-user", args.Authentication.Username)
+				require.Equal(t, "${VALUES_OPENSEARCH_PASSWORD:}", args.Authentication.Password)
+			}),
+		},
 	}
 
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)

--- a/charts/camunda-platform-8.9/test/unit/orchestration/configmap_unified_test.go
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/configmap_unified_test.go
@@ -335,6 +335,62 @@ func (s *ConfigmapTemplateTest) TestLegacyExporterDatastoreSourceAlignment() {
 	testhelpers.RunTestCases(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
 
+func (s *ConfigmapTemplateTest) TestLegacyOpenSearchExporterIgnoresOptimizeAwsModeForSecondaryStorageSource() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "Optimize AWS does not cross explicit secondary source",
+			Values: map[string]string{
+				"optimize.enabled":                                                        "true",
+				"optimize.database.elasticsearch.enabled":                                 "false",
+				"optimize.database.opensearch.enabled":                                    "true",
+				"optimize.database.opensearch.aws.enabled":                                "true",
+				"orchestration.data.secondaryStorage.type":                                "opensearch",
+				"orchestration.data.secondaryStorage.opensearch.url":                      "https://secondary-host:9443",
+				"orchestration.data.secondaryStorage.opensearch.aws.enabled":              "false",
+				"orchestration.data.secondaryStorage.opensearch.auth.username":            "secondary-user",
+				"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "secondary-password",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				var configMap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(t, output, &configMap)
+
+				var application struct {
+					Zeebe struct {
+						Broker struct {
+							Exporters struct {
+								OpenSearch struct {
+									Args struct {
+										Authentication *struct {
+											Username string `yaml:"username"`
+											Password string `yaml:"password"`
+										} `yaml:"authentication"`
+										URL string `yaml:"url"`
+										AWS *struct {
+											Enabled bool `yaml:"enabled"`
+										} `yaml:"aws"`
+									} `yaml:"args"`
+								} `yaml:"opensearch"`
+							} `yaml:"exporters"`
+						} `yaml:"broker"`
+					} `yaml:"zeebe"`
+				}
+				require.NoError(t, yaml.Unmarshal([]byte(configMap.Data["application.yaml"]), &application))
+
+				args := application.Zeebe.Broker.Exporters.OpenSearch.Args
+				require.Equal(t, "https://secondary-host:9443", args.URL)
+				require.NotNil(t, args.Authentication)
+				require.Equal(t, "secondary-user", args.Authentication.Username)
+				require.Equal(t, "${VALUES_OPENSEARCH_PASSWORD:}", args.Authentication.Password)
+				require.Nil(t, args.AWS)
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
 func mergeValues(base map[string]string, overrides map[string]string) map[string]string {
 	merged := make(map[string]string, len(base)+len(overrides))
 	for key, value := range base {

--- a/charts/camunda-platform-8.9/test/unit/orchestration/configmap_unified_test.go
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/configmap_unified_test.go
@@ -284,6 +284,52 @@ func (s *ConfigmapTemplateTest) TestLegacyExporterDatastoreSourceAlignment() {
 			},
 		},
 		{
+			Name: "TestLegacyOpenSearchExporterUsesInheritedGlobalOptimizeSource",
+			Values: map[string]string{
+				"optimize.enabled":                                   "true",
+				"global.opensearch.enabled":                          "true",
+				"global.opensearch.url.host":                         "global-opensearch-host",
+				"orchestration.data.secondaryStorage.type":           "opensearch",
+				"orchestration.data.secondaryStorage.opensearch.url": "https://secondary-host:9443",
+			},
+			Expected: map[string]string{
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.url":    "https://global-opensearch-host:443",
+				"configmapApplication.camunda.data.secondary-storage.opensearch.url": "https://secondary-host:9443",
+			},
+		},
+		{
+			Name: "TestLegacyElasticsearchExporterUsesInheritedGlobalOptimizeSource",
+			Values: map[string]string{
+				"optimize.enabled":                                      "true",
+				"global.elasticsearch.enabled":                          "true",
+				"global.elasticsearch.url.host":                         "global-elasticsearch-host",
+				"orchestration.data.secondaryStorage.type":              "elasticsearch",
+				"orchestration.data.secondaryStorage.elasticsearch.url": "https://secondary-host:9443",
+			},
+			Expected: map[string]string{
+				"configmapApplication.zeebe.broker.exporters.elasticsearch.args.url":    "http://global-elasticsearch-host:9200",
+				"configmapApplication.camunda.data.secondary-storage.elasticsearch.url": "https://secondary-host:9443",
+			},
+		},
+		{
+			Name: "TestLegacyOpenSearchExporterRetainsSecondaryStorageCompatibilitySource",
+			Values: map[string]string{
+				"optimize.enabled":                                                        "false",
+				"global.opensearch.enabled":                                               "true",
+				"global.opensearch.url.host":                                              "global-opensearch-host",
+				"orchestration.exporters.zeebe.enabled":                                   "true",
+				"orchestration.data.secondaryStorage.type":                                "opensearch",
+				"orchestration.data.secondaryStorage.opensearch.url":                      "https://secondary-host:9443",
+				"orchestration.data.secondaryStorage.opensearch.auth.username":            "secondary-user",
+				"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "secondary-password",
+			},
+			Expected: map[string]string{
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.url":                     "https://secondary-host:9443",
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.authentication.username": "secondary-user",
+				"configmapApplication.zeebe.broker.exporters.opensearch.args.authentication.password": "${VALUES_OPENSEARCH_PASSWORD:}",
+			},
+		},
+		{
 			Name: "TestLegacyOpenSearchExporterUsesOptimizeAwsMode",
 			Values: mergeValues(distinctOpenSearchSources, map[string]string{
 				"optimize.database.opensearch.aws.enabled":                   "true",

--- a/charts/camunda-platform-8.9/test/unit/orchestration/statefulset_test.go
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/statefulset_test.go
@@ -913,6 +913,124 @@ func (s *StatefulSetTest) TestDifferentValuesInputs() {
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
 
+func (s *StatefulSetTest) TestLegacyExporterComponentPasswordEnv() {
+	collectDatastorePasswordEnv := func(expected map[string]string) func(t *testing.T, output string, err error) {
+		return func(t *testing.T, output string, err error) {
+			require.NoError(t, err)
+
+			var statefulSet appsv1.StatefulSet
+			helm.UnmarshalK8SYaml(t, output, &statefulSet)
+			require.NotEmpty(t, statefulSet.Spec.Template.Spec.Containers)
+
+			actual := map[string]string{}
+			for _, envVar := range statefulSet.Spec.Template.Spec.Containers[0].Env {
+				switch envVar.Name {
+				case "VALUES_OPENSEARCH_PASSWORD",
+					"VALUES_ELASTICSEARCH_PASSWORD",
+					"VALUES_OPTIMIZE_DATABASE_OPENSEARCH_PASSWORD",
+					"VALUES_OPTIMIZE_DATABASE_ELASTICSEARCH_PASSWORD":
+					actual[envVar.Name] = envVar.Value
+				}
+			}
+			require.Equal(t, expected, actual)
+		}
+	}
+
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "Distinct OpenSearch sources emit both passwords",
+			Values: map[string]string{
+				"optimize.enabled":                                                        "true",
+				"optimize.database.elasticsearch.enabled":                                 "false",
+				"optimize.database.opensearch.enabled":                                    "true",
+				"optimize.database.opensearch.url.host":                                   "optimize-host",
+				"optimize.database.opensearch.auth.secret.inlineSecret":                   "optimize-password",
+				"orchestration.data.secondaryStorage.type":                                "opensearch",
+				"orchestration.data.secondaryStorage.opensearch.url":                      "https://secondary-host:9443",
+				"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "secondary-password",
+			},
+			Verifier: collectDatastorePasswordEnv(map[string]string{
+				"VALUES_OPENSEARCH_PASSWORD":                   "secondary-password",
+				"VALUES_OPTIMIZE_DATABASE_OPENSEARCH_PASSWORD": "optimize-password",
+			}),
+		},
+		{
+			Name: "Optimize OpenSearch credentials alone emit the component password",
+			Values: map[string]string{
+				"optimize.enabled":                                      "true",
+				"optimize.database.elasticsearch.enabled":               "false",
+				"optimize.database.opensearch.enabled":                  "true",
+				"optimize.database.opensearch.url.host":                 "opensearch.example.com",
+				"optimize.database.opensearch.auth.secret.inlineSecret": "optimize-password",
+				"orchestration.data.secondaryStorage.type":              "opensearch",
+				"orchestration.data.secondaryStorage.opensearch.url":    "https://opensearch.example.com:443",
+			},
+			Verifier: collectDatastorePasswordEnv(map[string]string{
+				"VALUES_OPTIMIZE_DATABASE_OPENSEARCH_PASSWORD": "optimize-password",
+			}),
+		},
+		{
+			Name: "Elasticsearch exporter precedence omits the Optimize OpenSearch password",
+			Values: map[string]string{
+				"global.elasticsearch.enabled":                          "true",
+				"optimize.enabled":                                      "true",
+				"optimize.database.elasticsearch.enabled":               "false",
+				"optimize.database.opensearch.enabled":                  "true",
+				"optimize.database.opensearch.url.host":                 "optimize-host",
+				"optimize.database.opensearch.auth.secret.inlineSecret": "optimize-password",
+				"orchestration.data.secondaryStorage.type":              "elasticsearch",
+			},
+			Verifier: collectDatastorePasswordEnv(map[string]string{}),
+		},
+		{
+			Name: "AWS mode omits the Optimize OpenSearch password",
+			Values: map[string]string{
+				"optimize.enabled":                                      "true",
+				"optimize.database.elasticsearch.enabled":               "false",
+				"optimize.database.opensearch.enabled":                  "true",
+				"optimize.database.opensearch.url.host":                 "optimize-host",
+				"optimize.database.opensearch.aws.enabled":              "true",
+				"optimize.database.opensearch.auth.secret.inlineSecret": "optimize-password",
+				"orchestration.data.secondaryStorage.type":              "opensearch",
+				"orchestration.data.secondaryStorage.opensearch.url":    "https://secondary-host:9443",
+			},
+			Verifier: collectDatastorePasswordEnv(map[string]string{}),
+		},
+		{
+			Name: "Disabled Optimize omits the component OpenSearch password",
+			Values: map[string]string{
+				"optimize.enabled":                                      "false",
+				"optimize.database.elasticsearch.enabled":               "false",
+				"optimize.database.opensearch.enabled":                  "true",
+				"optimize.database.opensearch.url.host":                 "optimize-host",
+				"optimize.database.opensearch.auth.secret.inlineSecret": "optimize-password",
+				"orchestration.data.secondaryStorage.type":              "elasticsearch",
+			},
+			Verifier: collectDatastorePasswordEnv(map[string]string{}),
+		},
+		{
+			Name: "Distinct Elasticsearch sources emit both passwords",
+			Values: map[string]string{
+				"optimize.enabled":                                                           "true",
+				"optimize.database.opensearch.enabled":                                       "false",
+				"optimize.database.elasticsearch.enabled":                                    "true",
+				"optimize.database.elasticsearch.external":                                   "true",
+				"optimize.database.elasticsearch.url.host":                                   "optimize-host",
+				"optimize.database.elasticsearch.auth.secret.inlineSecret":                   "optimize-password",
+				"orchestration.data.secondaryStorage.type":                                   "elasticsearch",
+				"orchestration.data.secondaryStorage.elasticsearch.url":                      "https://secondary-host:9443",
+				"orchestration.data.secondaryStorage.elasticsearch.auth.secret.inlineSecret": "secondary-password",
+			},
+			Verifier: collectDatastorePasswordEnv(map[string]string{
+				"VALUES_ELASTICSEARCH_PASSWORD":                   "secondary-password",
+				"VALUES_OPTIMIZE_DATABASE_ELASTICSEARCH_PASSWORD": "optimize-password",
+			}),
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
 func (s *StatefulSetTest) TestOpenSearchPasswordEnv() {
 	verifyOpenSearchPasswordEnv := func(expected ...corev1.EnvVar) func(t *testing.T, output string, err error) {
 		return func(t *testing.T, output string, err error) {

--- a/charts/camunda-platform-8.9/test/unit/orchestration/statefulset_test.go
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/statefulset_test.go
@@ -997,6 +997,47 @@ func (s *StatefulSetTest) TestLegacyExporterComponentPasswordEnv() {
 			Verifier: collectDatastorePasswordEnv(map[string]string{}),
 		},
 		{
+			Name: "Optimize OpenSearch global fallback resolves the global secret not the secondary one",
+			Values: map[string]string{
+				"optimize.enabled":                                                        "true",
+				"global.opensearch.enabled":                                               "true",
+				"global.opensearch.url.host":                                              "global-opensearch-host",
+				"global.opensearch.auth.secret.inlineSecret":                              "global-password",
+				"orchestration.data.secondaryStorage.type":                                "opensearch",
+				"orchestration.data.secondaryStorage.opensearch.url":                      "https://secondary-host:9443",
+				"orchestration.data.secondaryStorage.opensearch.auth.secret.inlineSecret": "secondary-password",
+			},
+			Verifier: collectDatastorePasswordEnv(map[string]string{
+				"VALUES_OPENSEARCH_PASSWORD":                   "secondary-password",
+				"VALUES_OPTIMIZE_DATABASE_OPENSEARCH_PASSWORD": "global-password",
+			}),
+		},
+		{
+			Name: "Optimize source without any secret emits no password env",
+			Values: map[string]string{
+				"optimize.enabled":                                   "true",
+				"optimize.database.elasticsearch.enabled":            "false",
+				"optimize.database.opensearch.enabled":               "true",
+				"optimize.database.opensearch.url.host":              "optimize-host",
+				"optimize.database.opensearch.auth.username":         "optimize-user",
+				"orchestration.data.secondaryStorage.type":           "opensearch",
+				"orchestration.data.secondaryStorage.opensearch.url": "https://secondary-host:9443",
+			},
+			Verifier: collectDatastorePasswordEnv(map[string]string{}),
+		},
+		{
+			Name: "Elasticsearch authentication disabled omits the Optimize password",
+			Values: map[string]string{
+				"optimize.enabled":                                         "true",
+				"optimize.database.opensearch.enabled":                     "false",
+				"optimize.database.elasticsearch.enabled":                  "true",
+				"optimize.database.elasticsearch.url.host":                 "optimize-host",
+				"optimize.database.elasticsearch.auth.secret.inlineSecret": "optimize-password",
+				"orchestration.data.secondaryStorage.type":                 "elasticsearch",
+			},
+			Verifier: collectDatastorePasswordEnv(map[string]string{}),
+		},
+		{
 			Name: "Disabled Optimize omits the component OpenSearch password",
 			Values: map[string]string{
 				"optimize.enabled":                                      "false",

--- a/charts/camunda-platform-8.9/test/unit/orchestration/statefulset_test.go
+++ b/charts/camunda-platform-8.9/test/unit/orchestration/statefulset_test.go
@@ -1072,6 +1072,79 @@ func (s *StatefulSetTest) TestLegacyExporterComponentPasswordEnv() {
 	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }
 
+func (s *StatefulSetTest) TestLegacyExporterComponentTls() {
+	optimizeOpenSearchSource := map[string]string{
+		"optimize.enabled":                                   "true",
+		"optimize.database.elasticsearch.enabled":            "false",
+		"optimize.database.opensearch.enabled":               "true",
+		"optimize.database.opensearch.url.host":              "optimize-host",
+		"orchestration.data.secondaryStorage.type":           "opensearch",
+		"orchestration.data.secondaryStorage.opensearch.url": "https://secondary-host:9443",
+	}
+
+	testCases := []testhelpers.TestCase{
+		{
+			Name: "Optimize OpenSearch TLS reaches the Orchestration truststore",
+			Values: mergeValues(optimizeOpenSearchSource, map[string]string{
+				"optimize.database.opensearch.tls.secret.existingSecret":    "optimize-tls-secret",
+				"optimize.database.opensearch.tls.secret.existingSecretKey": "optimize-ca.jks",
+			}),
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.Contains(t, output, "-Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/optimize-ca.jks")
+				require.Contains(t, output, "secretName: \"optimize-tls-secret\"")
+			},
+		},
+		{
+			Name: "Optimize OpenSearch source ignores secondary storage TLS config",
+			Values: mergeValues(optimizeOpenSearchSource, map[string]string{
+				"optimize.database.opensearch.tls.secret.existingSecret":                      "optimize-tls-secret",
+				"optimize.database.opensearch.tls.secret.existingSecretKey":                   "optimize-ca.jks",
+				"orchestration.data.secondaryStorage.opensearch.tls.secret.existingSecret":    "secondary-tls-secret",
+				"orchestration.data.secondaryStorage.opensearch.tls.secret.existingSecretKey": "secondary-ca.jks",
+			}),
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.Contains(t, output, "-Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/optimize-ca.jks")
+				require.NotContains(t, output, "secondary-ca.jks")
+				require.NotContains(t, output, "secretName: \"secondary-tls-secret\"")
+			},
+		},
+		{
+			Name: "Optimize source without TLS keeps the secondary storage truststore",
+			Values: mergeValues(optimizeOpenSearchSource, map[string]string{
+				"orchestration.data.secondaryStorage.opensearch.tls.secret.existingSecret":    "secondary-tls-secret",
+				"orchestration.data.secondaryStorage.opensearch.tls.secret.existingSecretKey": "secondary-ca.jks",
+			}),
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.Contains(t, output, "-Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/secondary-ca.jks")
+				require.Contains(t, output, "secretName: \"secondary-tls-secret\"")
+			},
+		},
+		{
+			Name: "Optimize Elasticsearch TLS reaches the Orchestration truststore",
+			Values: map[string]string{
+				"optimize.enabled":                                             "true",
+				"optimize.database.opensearch.enabled":                         "false",
+				"optimize.database.elasticsearch.enabled":                      "true",
+				"optimize.database.elasticsearch.url.host":                     "optimize-host",
+				"optimize.database.elasticsearch.tls.secret.existingSecret":    "optimize-tls-secret",
+				"optimize.database.elasticsearch.tls.secret.existingSecretKey": "optimize-ca.jks",
+				"orchestration.data.secondaryStorage.type":                     "elasticsearch",
+				"orchestration.data.secondaryStorage.elasticsearch.url":        "https://secondary-host:9443",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+				require.Contains(t, output, "-Djavax.net.ssl.trustStore=/usr/local/camunda/certificates/optimize-ca.jks")
+				require.Contains(t, output, "secretName: \"optimize-tls-secret\"")
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
+}
+
 func (s *StatefulSetTest) TestOpenSearchPasswordEnv() {
 	verifyOpenSearchPasswordEnv := func(expected ...corev1.EnvVar) func(t *testing.T, output string, err error) {
 		return func(t *testing.T, output string, err error) {


### PR DESCRIPTION
### Which problem does the PR fix?

Closes #6773.

### What's in this PR?

The legacy Zeebe record exporter resolves its endpoint, username, password, AWS mode, and
truststore from the Optimize component chain whenever Optimize is enabled and the engine host
resolves (`orchestration.legacy<Engine>ExporterUsesOptimizeSource`, mirroring the gate the Optimize
deployment uses for its own connection env vars). When Optimize is not the consumer, the
pre-existing secondary-storage/global rendering is kept verbatim.

Resolution delegates to the same helpers the Optimize deployment consumes. New shared helpers
`optimize.effective{EsURL,OsURL,EsUsername,OsUsername,OsAwsEnabled}` join the existing
`optimize.effective{Es,Os}{Auth,Tls}Config`, and `optimize/deployment.yaml` plus
`_environment-config.yaml` are retargeted onto them, so the exporter and the Optimize deployment
resolve identically by construction. Optimize-owned exporters substitute
`${VALUES_OPTIMIZE_DATABASE_<ENGINE>_PASSWORD:}`; the variable is emitted only while the exporter's
authentication block renders and the component-then-global auth chain carries a secret. The generic
`${VALUES_<ENGINE>_PASSWORD:}` substitution remains on the compatibility path only, so the
secondary-storage secret can no longer reach the Optimize endpoint.

`orchestration.effectiveTlsConfig` prefers the Optimize-owned exporter's component truststore
(`orchestration.legacyExporterTlsConfig`) and falls through to the shared global/secondary chain
(`orchestration.sharedTlsConfig`) when Optimize carries no TLS secret. When both sides configure
different truststore secrets, `camunda.constraints.warnings` emits a `TRUSTSTORE CONFLICT` warning
naming the precedence and pointing at `global.tls.caBundle` for multi-CA pods.

Rendering changes vs `main`, all requiring Optimize enabled:

| Configuration | main | this PR |
|---|---|---|
| Secondary-storage URL set, Optimize endpoint resolves | exporter uses secondary URL | exporter uses the Optimize chain URL |
| Only `optimize.database.<engine>.auth.secret` set | no password env, empty password | `VALUES_OPTIMIZE_DATABASE_<ENGINE>_PASSWORD` emitted |
| Password substitution in the exporter | `${VALUES_<ENGINE>_PASSWORD:}` | `${VALUES_OPTIMIZE_DATABASE_<ENGINE>_PASSWORD:}` |
| Username set only under secondary storage | crossed onto the exporter | Optimize chain username |
| `secondaryStorage.opensearch.aws.enabled` only | exporter in AWS mode | exporter keeps basic auth, matching Optimize |
| `optimize.database.opensearch.aws.enabled` only, exporter not Optimize-owned | exporter in AWS mode | AWS mode stays with its source |
| `optimize.database.<engine>.tls.secret` set | ignored by the Orchestration JVM | mounted as the Orchestration truststore |
| Optimize disabled (compatibility path) | — | byte-identical render; the cross-source AWS row above is the one exception |

Tests cover inherited global endpoints and global AWS fallback (8.9, where those keys are still
supported), fallback credentials and no-secret contracts, component TLS including the
keep-secondary-truststore fall-through, the truststore-conflict warning, and typed verifiers for
structural absence (`Authentication == nil` / `AWS != nil`). The 8.10 suites contain no
8.9-deprecated values. Elasticsearch and OpenSearch, charts 8.9 and 8.10. No new values keys, so no
`values.schema.json` change; golden files are unchanged.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
