### PR TITLE
fix(8.10): preserve Hub securityContext and resource defaults on partial override

### DIFF
--- a/charts/camunda-platform-8.10/README.md
+++ b/charts/camunda-platform-8.10/README.md
@@ -651,7 +651,7 @@ Please see the corresponding [release guide](../../docs/release.md) to find out 
 | ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
 | `camundaHub`                              | configuration for Camunda Hub (WebModeler + Console).                                                                                               |         |
 | `camundaHub.enabled`                      | if true, deploys Camunda Hub: the Web Modeler component plus the in-modeler Console UI.                                                             | `false` |
-| `camundaHub.contextPath`                  | can be used to make Camunda Hub available on a custom sub-path. This 8.10 alpha override replaces camundaHub.webModeler.contextPath.                | `""`    |
+| `camundaHub.contextPath`                  | can be used to make Camunda Hub available on a custom sub-path. This 8.10 alpha override replaces camundaHub.webModeler.contextPath.                | `nil`   |
 | `camundaHub.automountServiceAccountToken` | can be used to override the automatic mounting of the service account token at the pod level. When unset, the ServiceAccount configuration is used. | `nil`   |
 
 ### WebModeler Parameters

--- a/charts/camunda-platform-8.10/templates/camunda-hub/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/camunda-hub/_helpers.tpl
@@ -16,13 +16,24 @@ Enablement gates live in templates/common/_helpers.tpl ("camundaHub.webModelerEn
 {{- define "camundaHub.mergeInto" -}}
     {{- /* NOTE: Mutates .dst in place and emits nothing; callers read the mutated map, not the return value. */ -}}
     {{- $dst := .dst -}}
+    {{- $path := .path | default "camundaHub" -}}
     {{- range $key, $srcValue := .src -}}
+        {{- $dstValue := index $dst $key -}}
+        {{- $dstIsMap := and (hasKey $dst $key) (kindIs "map" $dstValue) -}}
+        {{- $dstIsSet := and (hasKey $dst $key) (not (kindIs "invalid" $dstValue)) -}}
         {{- /* NOTE: A nil value means "not specified" so chart-declared placeholders fall through to webModeler.*; false, 0 and "" are real overrides. */ -}}
         {{- if kindIs "invalid" $srcValue -}}
-        {{- else if and (kindIs "map" $srcValue) (hasKey $dst $key) (kindIs "map" (index $dst $key)) -}}
-            {{- include "camundaHub.mergeInto" (dict "dst" (index $dst $key) "src" $srcValue) -}}
+        {{- else if and (kindIs "map" $srcValue) $dstIsMap -}}
+            {{- include "camundaHub.mergeInto" (dict "dst" $dstValue "src" $srcValue "path" (printf "%s.%s" $path $key)) -}}
+        {{- else if and $dstIsSet (ne (kindIs "map" $srcValue) $dstIsMap) -}}
+            {{- fail (printf "[camunda][error] %s.%s is a %s but the corresponding webModeler value is a %s; these types cannot be merged. Set %s.%s to a %s, or set its nested keys individually."
+                $path $key (kindOf $srcValue) (kindOf $dstValue) $path $key (kindOf $dstValue)) -}}
         {{- else -}}
             {{- $_ := set $dst $key $srcValue -}}
         {{- end -}}
     {{- end -}}
+{{- end -}}
+
+{{- define "camundaHub.contextPath" -}}
+    {{- (include "camundaHub.values" . | fromYaml).contextPath -}}
 {{- end -}}

--- a/charts/camunda-platform-8.10/templates/camunda-hub/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/camunda-hub/_helpers.tpl
@@ -1,20 +1,28 @@
 {{/* vim: set filetype=mustache: */}}
 
 {{/*
-********************************************************************************
 Camunda Hub helpers.
 
-The camundaHub component consolidates Console and WebModeler into a single
-logical unit. The backward-compatibility shim helpers that bridge the legacy
-console.* / webModeler.* keys to the new camundaHub.* key live in
-templates/common/_helpers.tpl (see "camundaHub.consoleEnabled",
-"camundaHub.webModelerEnabled").
-
-This file is reserved for any camundaHub-specific helpers that do NOT belong
-in the common shim layer. For now, no additional helpers are needed because:
-  - Console and WebModeler templates continue to use their own _helpers.tpl
-  - Resource names are intentionally preserved for smooth 8.9 → 8.10 upgrade
-  - The shim helpers in common/_helpers.tpl handle the enabled-check and
-    value-merge logic
-********************************************************************************
+Enablement gates live in templates/common/_helpers.tpl ("camundaHub.webModelerEnabled",
+"camundaHub.consoleEnabled") and are driven by global.topology.mode.
 */}}
+
+{{- define "camundaHub.values" -}}
+    {{- $merged := deepCopy (.Values.webModeler | default dict) -}}
+    {{- include "camundaHub.mergeInto" (dict "dst" $merged "src" (.Values.camundaHub | default dict)) -}}
+    {{- toYaml $merged -}}
+{{- end -}}
+
+{{- define "camundaHub.mergeInto" -}}
+    {{- /* NOTE: Mutates .dst in place and emits nothing; callers read the mutated map, not the return value. */ -}}
+    {{- $dst := .dst -}}
+    {{- range $key, $srcValue := .src -}}
+        {{- /* NOTE: A nil value means "not specified" so chart-declared placeholders fall through to webModeler.*; false, 0 and "" are real overrides. */ -}}
+        {{- if kindIs "invalid" $srcValue -}}
+        {{- else if and (kindIs "map" $srcValue) (hasKey $dst $key) (kindIs "map" (index $dst $key)) -}}
+            {{- include "camundaHub.mergeInto" (dict "dst" (index $dst $key) "src" $srcValue) -}}
+        {{- else -}}
+            {{- $_ := set $dst $key $srcValue -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}

--- a/charts/camunda-platform-8.10/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/common/_helpers.tpl
@@ -508,14 +508,14 @@ Web Modeler templates.
       {{- if eq .component "websockets" }}
         {{- printf "%s://%s%s" $proto (tpl .context.Values.global.host .context) (include "webModeler.websocketContextPath" .context) -}}
       {{- else -}}
-        {{- printf "%s://%s%s" $proto (tpl .context.Values.global.host .context) (or .context.Values.camundaHub.contextPath .context.Values.webModeler.contextPath) -}}
+        {{- printf "%s://%s%s" $proto (tpl .context.Values.global.host .context) (include "camundaHub.contextPath" .context) -}}
       {{- end -}}
     {{- else if and $.context.Values.global.gateway.enabled (tpl .context.Values.global.host .context) -}}
       {{- $baseURL := include "camundaPlatform.gatewayExternalURL" (dict "context" .context "host" .context.Values.global.host) -}}
       {{- if eq .component "websockets" }}
         {{- printf "%s%s" $baseURL (include "webModeler.websocketContextPath" .context) -}}
       {{- else -}}
-        {{- printf "%s%s" $baseURL (or .context.Values.camundaHub.contextPath .context.Values.webModeler.contextPath) -}}
+        {{- printf "%s%s" $baseURL (include "camundaHub.contextPath" .context) -}}
       {{- end -}}
     {{- else -}}
       {{- if eq .component "websockets" -}}
@@ -820,8 +820,8 @@ Release templates.
     id: hub
     version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" (dict "image" (mustMergeOverwrite (deepCopy .Values.webModeler.image) (.Values.camundaHub.image | default dict)))) }}
     url: {{ include "camundaPlatform.webModelerExternalURL" . }}
-    readiness: {{ printf "%s%s" $baseURLInternal (include "camundaPlatform.joinpath" (list (or .Values.camundaHub.contextPath .Values.webModeler.contextPath) (or .Values.camundaHub.restapi.readinessProbe.probePath .Values.webModeler.restapi.readinessProbe.probePath))) }}
-    metrics: {{ printf "%s%s" $baseURLInternal (include "camundaPlatform.joinpath" (list (or .Values.camundaHub.contextPath .Values.webModeler.contextPath) (or .Values.camundaHub.restapi.metrics.prometheus .Values.webModeler.restapi.metrics.prometheus))) }}
+    readiness: {{ printf "%s%s" $baseURLInternal (include "camundaPlatform.joinpath" (list (include "camundaHub.contextPath" .) (or .Values.camundaHub.restapi.readinessProbe.probePath .Values.webModeler.restapi.readinessProbe.probePath))) }}
+    metrics: {{ printf "%s%s" $baseURLInternal (include "camundaPlatform.joinpath" (list (include "camundaHub.contextPath" .) (or .Values.camundaHub.restapi.metrics.prometheus .Values.webModeler.restapi.metrics.prometheus))) }}
   {{- end }}
 
   {{- if eq (include "camundaPlatform.optimizeEnabled" .) "true" }}
@@ -913,7 +913,7 @@ required by camunda.modeler.clusters (introduced in 8.10 Hub/WebModeler).
     version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" (dict "image" (mustMergeOverwrite (deepCopy .Values.webModeler.image) (.Values.camundaHub.image | default dict)))) | quote }}
     urls:
       webapp: {{ include "camundaPlatform.webModelerExternalURL" . | quote }}
-      readiness: {{ printf "%s%s" $baseURLInternal (include "camundaPlatform.joinpath" (list (or .Values.camundaHub.contextPath .Values.webModeler.contextPath) (or .Values.camundaHub.restapi.readinessProbe.probePath .Values.webModeler.restapi.readinessProbe.probePath))) | quote }}
+      readiness: {{ printf "%s%s" $baseURLInternal (include "camundaPlatform.joinpath" (list (include "camundaHub.contextPath" .) (or .Values.camundaHub.restapi.readinessProbe.probePath .Values.webModeler.restapi.readinessProbe.probePath))) | quote }}
   {{- end }}
 {{- end }}
 {{- if or (eq (include "camundaPlatform.orchestrationEnabled" .) "true") (eq (include "camundaPlatform.optimizeEnabled" .) "true") (eq (include "camundaPlatform.connectorsEnabled" .) "true") }}

--- a/charts/camunda-platform-8.10/templates/common/ingress-http.yaml
+++ b/charts/camunda-platform-8.10/templates/common/ingress-http.yaml
@@ -46,13 +46,13 @@ spec:
             pathType: {{ .Values.global.ingress.pathType }}
           {{- end }}
           {{- end }}
-          {{- if and (eq (include "camundaHub.webModelerEnabled" .) "true") (or .Values.camundaHub.contextPath .Values.webModeler.contextPath) }}
+          {{- if and (eq (include "camundaHub.webModelerEnabled" .) "true") (include "camundaHub.contextPath" .) }}
           - backend:
               service:
                 name: {{ template "webModeler.restapi.fullname" . }}
                 port:
                   number: {{ (or .Values.camundaHub.restapi.service.port .Values.webModeler.restapi.service.port) }}
-            path: {{ (or .Values.camundaHub.contextPath .Values.webModeler.contextPath) }}
+            path: {{ (include "camundaHub.contextPath" .) }}
             pathType: {{ .Values.global.ingress.pathType }}
           - backend:
               service:

--- a/charts/camunda-platform-8.10/templates/web-modeler/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/web-modeler/_helpers.tpl
@@ -161,9 +161,10 @@ app.kubernetes.io/component: {{ .componentName }}
 [web-modeler] Check if username and password is provided for the SMTP server
 */}}
 {{- define "webModeler.restapi.mail.authEnabled" -}}
+  {{- $hub := include "camundaHub.values" . | fromYaml -}}
   {{- $authEnabled := false -}}
-  {{- if and (typeIs "string" (or .Values.camundaHub.restapi.mail.smtpUser .Values.webModeler.restapi.mail.smtpUser)) (ne (or .Values.camundaHub.restapi.mail.smtpUser .Values.webModeler.restapi.mail.smtpUser) "") }}
-    {{- if or (and (typeIs "string" (or .Values.camundaHub.restapi.mail.smtpPassword .Values.webModeler.restapi.mail.smtpPassword)) (ne (or .Values.camundaHub.restapi.mail.smtpPassword .Values.webModeler.restapi.mail.smtpPassword) "")) (or .Values.camundaHub.restapi.mail.existingSecret .Values.webModeler.restapi.mail.existingSecret) }}
+  {{- if and (typeIs "string" $hub.restapi.mail.smtpUser) (ne $hub.restapi.mail.smtpUser "") }}
+    {{- if or (and (typeIs "string" $hub.restapi.mail.smtpPassword) (ne $hub.restapi.mail.smtpPassword "")) $hub.restapi.mail.existingSecret }}
       {{- $authEnabled = true }}
     {{- end }}
   {{- end }}

--- a/charts/camunda-platform-8.10/templates/web-modeler/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/web-modeler/_helpers.tpl
@@ -174,14 +174,14 @@ app.kubernetes.io/component: {{ .componentName }}
 [web-modeler] Create the context path for the WebSocket app (= configured context path + suffix "-ws").
 */}}
 {{- define "webModeler.websocketContextPath" -}}
-  {{- (or .Values.camundaHub.contextPath .Values.webModeler.contextPath) }}-ws
+  {{- (include "camundaHub.contextPath" .) }}-ws
 {{- end -}}
 
 {{/*
 [web-modeler] Get the host name on which the WebSocket server is reachable from the client.
 */}}
 {{- define "webModeler.publicWebsocketHost" -}}
-  {{- if and .Values.global.ingress.enabled (or .Values.camundaHub.contextPath .Values.webModeler.contextPath) }}
+  {{- if and .Values.global.ingress.enabled (include "camundaHub.contextPath" .) }}
     {{- tpl .Values.global.host $ }}
   {{- else -}}
     {{- (or .Values.camundaHub.websockets.publicHost .Values.webModeler.websockets.publicHost) }}
@@ -192,7 +192,7 @@ app.kubernetes.io/component: {{ .componentName }}
 [web-modeler] Get the port number on which the WebSocket server is reachable from the client.
 */}}
 {{- define "webModeler.publicWebsocketPort" -}}
-  {{- if and .Values.global.ingress.enabled (or .Values.camundaHub.contextPath .Values.webModeler.contextPath) }}
+  {{- if and .Values.global.ingress.enabled (include "camundaHub.contextPath" .) }}
     {{- .Values.global.ingress.tls.enabled | ternary "443" "80" }}
   {{- else }}
     {{- (or .Values.camundaHub.websockets.publicPort .Values.webModeler.websockets.publicPort) }}
@@ -203,7 +203,7 @@ app.kubernetes.io/component: {{ .componentName }}
 [web-modeler] Check if TLS must be enabled for WebSocket connections from the client.
 */}}
 {{- define "webModeler.websocketTlsEnabled" -}}
-  {{- if and .Values.global.ingress.enabled (or .Values.camundaHub.contextPath .Values.webModeler.contextPath) }}
+  {{- if and .Values.global.ingress.enabled (include "camundaHub.contextPath" .) }}
     {{- .Values.global.ingress.tls.enabled }}
   {{- else -}}
     false

--- a/charts/camunda-platform-8.10/templates/web-modeler/configmap-restapi.yaml
+++ b/charts/camunda-platform-8.10/templates/web-modeler/configmap-restapi.yaml
@@ -32,7 +32,7 @@ data:
           client:
             host: {{ include "webModeler.publicWebsocketHost" . | quote }}
             port: {{ include "webModeler.publicWebsocketPort" . | quote }}
-            {{- if and .Values.global.ingress.enabled (or .Values.camundaHub.contextPath .Values.webModeler.contextPath) }}
+            {{- if and .Values.global.ingress.enabled (include "camundaHub.contextPath" .) }}
             path: {{ include "webModeler.websocketContextPath" . | quote }}
             {{- end }}
             force-tls: {{ include "webModeler.websocketTlsEnabled" . }}
@@ -124,13 +124,13 @@ data:
           max-file-size: {{ .Values.global.config.requestBodySize | quote }}
           max-request-size: {{ .Values.global.config.requestBodySize | quote }}
 
-    {{- if (or .Values.camundaHub.contextPath .Values.webModeler.contextPath) }}
+    {{- if (include "camundaHub.contextPath" .) }}
     server:
       servlet:
-        context-path: {{ include "camundaPlatform.joinpath" (list (or .Values.camundaHub.contextPath .Values.webModeler.contextPath)) | quote }}
+        context-path: {{ include "camundaPlatform.joinpath" (list (include "camundaHub.contextPath" .)) | quote }}
     management:
       server:
-        base-path: {{ include "camundaPlatform.joinpath" (list (or .Values.camundaHub.contextPath .Values.webModeler.contextPath)) | quote }}
+        base-path: {{ include "camundaPlatform.joinpath" (list (include "camundaHub.contextPath" .)) | quote }}
     {{- end }}
 
     logging:

--- a/charts/camunda-platform-8.10/templates/web-modeler/configmap-restapi.yaml
+++ b/charts/camunda-platform-8.10/templates/web-modeler/configmap-restapi.yaml
@@ -1,4 +1,5 @@
 {{- if eq (include "camundaHub.webModelerEnabled" .) "true" -}}
+{{- $hub := include "camundaHub.values" . | fromYaml -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -48,14 +49,14 @@ data:
         {{- end }}
 
         mail:
-          {{- $fromAddress := or .Values.camundaHub.restapi.mail.fromAddress .Values.webModeler.restapi.mail.fromAddress }}
+          {{- $fromAddress := $hub.restapi.mail.fromAddress }}
           {{- $restapiExtraConfig := or .Values.camundaHub.restapi.extraConfiguration .Values.webModeler.restapi.extraConfiguration }}
           {{- if $fromAddress }}
           from-address: {{ $fromAddress | quote }}
           {{- else if ne (include "camundaPlatform.extraConfigHasPath" (dict "extraConfiguration" $restapiExtraConfig "path" (list "camunda" "modeler" "mail" "from-address"))) "true" }}
           from-address: {{ required "The value 'webModeler.restapi.mail.fromAddress' is required (or supply camunda.modeler.mail.from-address via webModeler.restapi.extraConfiguration)" "" | quote }}
           {{- end }}
-          from-name: {{ (or .Values.camundaHub.restapi.mail.fromName .Values.webModeler.restapi.mail.fromName) | quote }}
+          from-name: {{ $hub.restapi.mail.fromName | quote }}
 
         oauth2:
           client-id: {{ include "webModeler.authClientId" . | quote }}
@@ -98,15 +99,15 @@ data:
         username: {{ include "webModeler.restapi.databaseUser" . | quote }}
 
       mail:
-        host: {{ (or .Values.camundaHub.restapi.mail.smtpHost .Values.webModeler.restapi.mail.smtpHost) | quote }}
-        port: {{ (or .Values.camundaHub.restapi.mail.smtpPort .Values.webModeler.restapi.mail.smtpPort) }}
-        {{- if (or .Values.camundaHub.restapi.mail.smtpUser .Values.webModeler.restapi.mail.smtpUser) }}
-        username: {{ (or .Values.camundaHub.restapi.mail.smtpUser .Values.webModeler.restapi.mail.smtpUser) | quote }}
+        host: {{ $hub.restapi.mail.smtpHost | quote }}
+        port: {{ $hub.restapi.mail.smtpPort }}
+        {{- if $hub.restapi.mail.smtpUser }}
+        username: {{ $hub.restapi.mail.smtpUser | quote }}
         {{- end }}
         properties:
           mail.smtp.auth: {{ include "webModeler.restapi.mail.authEnabled" . }}
-          mail.smtp.starttls.enable: {{ (or .Values.camundaHub.restapi.mail.smtpTlsEnabled .Values.webModeler.restapi.mail.smtpTlsEnabled) }}
-          mail.smtp.starttls.required: {{ (or .Values.camundaHub.restapi.mail.smtpTlsEnabled .Values.webModeler.restapi.mail.smtpTlsEnabled) }}
+          mail.smtp.starttls.enable: {{ $hub.restapi.mail.smtpTlsEnabled }}
+          mail.smtp.starttls.required: {{ $hub.restapi.mail.smtpTlsEnabled }}
 
       security:
         oauth2:

--- a/charts/camunda-platform-8.10/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform-8.10/templates/web-modeler/deployment-restapi.yaml
@@ -1,5 +1,5 @@
-{{- $hub := include "camundaHub.values" . | fromYaml }}
 {{- if eq (include "camundaHub.webModelerEnabled" .) "true" -}}
+{{- $hub := include "camundaHub.values" . | fromYaml -}}
 {{- $deploymentStrategy := $hub.persistence.deploymentStrategy | default "RollingUpdate" -}}
 {{- if not (has $deploymentStrategy (list "RollingUpdate" "Recreate")) -}}
 {{- fail "webModeler.persistence.deploymentStrategy (or camundaHub.persistence.deploymentStrategy) value must be one of 'RollingUpdate', 'Recreate'" -}}

--- a/charts/camunda-platform-8.10/templates/web-modeler/deployment-restapi.yaml
+++ b/charts/camunda-platform-8.10/templates/web-modeler/deployment-restapi.yaml
@@ -1,9 +1,10 @@
+{{- $hub := include "camundaHub.values" . | fromYaml }}
 {{- if eq (include "camundaHub.webModelerEnabled" .) "true" -}}
-{{- $deploymentStrategy := (or .Values.camundaHub.persistence.deploymentStrategy .Values.webModeler.persistence.deploymentStrategy) | default "RollingUpdate" -}}
+{{- $deploymentStrategy := $hub.persistence.deploymentStrategy | default "RollingUpdate" -}}
 {{- if not (has $deploymentStrategy (list "RollingUpdate" "Recreate")) -}}
 {{- fail "webModeler.persistence.deploymentStrategy (or camundaHub.persistence.deploymentStrategy) value must be one of 'RollingUpdate', 'Recreate'" -}}
 {{- end -}}
-{{- if and (eq $deploymentStrategy "Recreate") (not (or .Values.camundaHub.persistence.enabled .Values.webModeler.persistence.enabled)) -}}
+{{- if and (eq $deploymentStrategy "Recreate") (not $hub.persistence.enabled) -}}
 {{- fail "webModeler.persistence.deploymentStrategy (or camundaHub.persistence.deploymentStrategy): Recreate requires persistence.enabled: true on the same values path. The default chart-managed path uses a per-pod ephemeral volume with no Multi-Attach contention, so Recreate is only useful when existingClaim points to a ReadWriteOnce volume; without persistence it only adds upgrade downtime" -}}
 {{- end -}}
 apiVersion: apps/v1
@@ -15,19 +16,19 @@ metadata:
 spec:
   strategy:
     type: {{ $deploymentStrategy }}
-  replicas: {{ (or .Values.camundaHub.restapi.replicas .Values.webModeler.restapi.replicas) }}
+  replicas: {{ $hub.restapi.replicas }}
   selector:
     matchLabels: {{- include "webModeler.restapi.matchLabels" . | nindent 6 }}
   template:
     metadata:
       labels: {{- include "webModeler.restapi.labels" . | nindent 8 }}
-      {{- if (or .Values.camundaHub.restapi.podLabels .Values.webModeler.restapi.podLabels) }}
-      {{- tpl (toYaml (or .Values.camundaHub.restapi.podLabels .Values.webModeler.restapi.podLabels)) $ | nindent 8 }}
+      {{- if $hub.restapi.podLabels }}
+      {{- tpl (toYaml $hub.restapi.podLabels) $ | nindent 8 }}
       {{- end }}
-      {{- if or (and (eq (include "camundaPlatform.hasCaBundle" .) "true") .Values.global.tls.caBundle.autoRollout) (or .Values.camundaHub.restapi.podAnnotations .Values.webModeler.restapi.podAnnotations) }}
+      {{- if or (and (eq (include "camundaPlatform.hasCaBundle" .) "true") .Values.global.tls.caBundle.autoRollout) $hub.restapi.podAnnotations }}
       annotations:
         {{- with (include "camundaPlatform.caBundleChecksumAnnotation" .) }}{{ . | nindent 8 }}{{- end }}
-        {{- with (or .Values.camundaHub.restapi.podAnnotations .Values.webModeler.restapi.podAnnotations) }}
+        {{- with $hub.restapi.podAnnotations }}
         {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
       {{- end }}
@@ -38,15 +39,15 @@ spec:
         {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
         {{- include "camundaPlatform.caBundleInitContainer" (dict "context" $ "image" (include "webModeler.restapi.image" $)) | nindent 8 }}
         {{- end }}
-        {{- with (or .Values.camundaHub.restapi.initContainers .Values.webModeler.restapi.initContainers) }}
+        {{- with $hub.restapi.initContainers }}
         {{- tpl (toYaml . | nindent 8) $ }}
         {{- end }}
       containers:
         - name: {{ include "webModeler.name" . }}-restapi
           image: {{ include "webModeler.restapi.image" . | quote }}
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
-          {{- if (or .Values.camundaHub.restapi.containerSecurityContext .Values.webModeler.restapi.containerSecurityContext) }}
-          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" (or .Values.camundaHub.restapi.containerSecurityContext .Values.webModeler.restapi.containerSecurityContext) "context" $) | nindent 12 }}
+          {{- if $hub.restapi.containerSecurityContext }}
+          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" $hub.restapi.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}
           env:
             {{- include "camundaPlatform.emitEnvVarFromSecretConfig" (dict
@@ -54,14 +55,14 @@ spec:
                 "config" .Values.global.license
             ) | nindent 12 }}
             - name: JAVA_OPTIONS
-              value: {{ (or .Values.camundaHub.restapi.javaOpts .Values.webModeler.restapi.javaOpts) | default "-XX:MaxRAMPercentage=80.0" | quote }}
+              value: {{ $hub.restapi.javaOpts | default "-XX:MaxRAMPercentage=80.0" | quote }}
             {{- include "camundaPlatform.emitEnvVarFromSecretConfig" (dict
                 "envName" "SPRING_DATASOURCE_PASSWORD"
-                "config" (or .Values.camundaHub.restapi.externalDatabase .Values.webModeler.restapi.externalDatabase)
+                "config" $hub.restapi.externalDatabase
             ) | nindent 12 }}
             {{- include "camundaPlatform.emitEnvVarFromSecretConfig" (dict
                 "envName" "RESTAPI_MAIL_PASSWORD"
-                "config" (or .Values.camundaHub.restapi.mail .Values.webModeler.restapi.mail)
+                "config" $hub.restapi.mail
             ) | nindent 12 }}
             - name: RESTAPI_PUSHER_APP_ID
               valueFrom:
@@ -70,18 +71,18 @@ spec:
                   key: pusher-app-id
             {{- include "camundaPlatform.emitEnvVarFromSecretConfig" (dict
                 "envName" "RESTAPI_PUSHER_KEY"
-                "config" (mustMergeOverwrite (deepCopy .Values.webModeler.restapi.pusher.client) .Values.camundaHub.restapi.pusher.client)
+                "config" ($hub.restapi.pusher.client)
                 "defaultSecretName" (include "webModeler.fullname" .)
                 "defaultSecretKey" "pusher-app-key"
             ) | nindent 12 }}
             {{- include "camundaPlatform.emitEnvVarFromSecretConfig" (dict
                 "envName" "RESTAPI_PUSHER_SECRET"
-                "config" (mustMergeOverwrite (deepCopy .Values.webModeler.restapi.pusher) .Values.camundaHub.restapi.pusher)
+                "config" ($hub.restapi.pusher)
                 "defaultSecretName" (include "webModeler.fullname" .)
                 "defaultSecretKey" "pusher-app-secret"
             ) | nindent 12 }}
             - name: ZEEBE_CLIENT_CONFIG_PATH
-              value: {{ (or .Values.camundaHub.restapi.zeebeClientConfigPath .Values.webModeler.restapi.zeebeClientConfigPath) | default "/tmp/zeebe_client_cache.txt" | quote }}
+              value: {{ $hub.restapi.zeebeClientConfigPath | default "/tmp/zeebe_client_cache.txt" | quote }}
             - name: CAMUNDA_MODELER_FEATURE_CONSOLE_ENABLED
               value: {{ include "camundaHub.consoleEnabled" . | quote }}
             - name: CAMUNDA_MODELER_FEATURE_GLOBAL_NAVIGATION_V2_ENABLED
@@ -106,25 +107,25 @@ spec:
             {{- include "camundaPlatform.caBundleEnv" . | nindent 12 }}
             {{- include "camundaPlatform.caBundleJavaToolOptionsEnv" . | nindent 12 }}
           {{- end }}
-          {{- with (or .Values.camundaHub.restapi.env .Values.webModeler.restapi.env) }}
+          {{- with $hub.restapi.env }}
             {{- tpl (toYaml .) $ | nindent 12 }}
             {{- end }}
-          {{- $documentStoreEnvFrom := ne (include "camundaPlatform.extraConfigHasPath" (dict "extraConfiguration" (or .Values.camundaHub.restapi.extraConfiguration .Values.webModeler.restapi.extraConfiguration) "path" (list "camunda" "document"))) "true" }}
-          {{- if or $documentStoreEnvFrom (or .Values.camundaHub.restapi.envFrom .Values.webModeler.restapi.envFrom) }}
+          {{- $documentStoreEnvFrom := ne (include "camundaPlatform.extraConfigHasPath" (dict "extraConfiguration" $hub.restapi.extraConfiguration "path" (list "camunda" "document"))) "true" }}
+          {{- if or $documentStoreEnvFrom $hub.restapi.envFrom }}
           envFrom:
           {{- if $documentStoreEnvFrom }}
             - configMapRef:
                 name: {{ include "camundaPlatform.fullname" . }}-documentstore-env-vars
           {{- end }}
-          {{- if (or .Values.camundaHub.restapi.envFrom .Values.webModeler.restapi.envFrom) }}
-            {{- (or .Values.camundaHub.restapi.envFrom .Values.webModeler.restapi.envFrom) | toYaml | nindent 12 }}
+          {{- if $hub.restapi.envFrom }}
+            {{- $hub.restapi.envFrom | toYaml | nindent 12 }}
           {{- end }}
           {{- end }}
-          {{- if (or .Values.camundaHub.restapi.command .Values.webModeler.restapi.command) }}
-          command: {{ toYaml (or .Values.camundaHub.restapi.command .Values.webModeler.restapi.command) | nindent 10 }}
+          {{- if $hub.restapi.command }}
+          command: {{ toYaml $hub.restapi.command | nindent 10 }}
           {{- end }}
           resources:
-            {{- toYaml (or .Values.camundaHub.restapi.resources .Values.webModeler.restapi.resources) | nindent 12 }}
+            {{- toYaml $hub.restapi.resources | nindent 12 }}
           ports:
             - containerPort: 8081
               name: http
@@ -132,41 +133,41 @@ spec:
             - containerPort: 8091
               name: http-management
               protocol: TCP
-          {{- if (or .Values.camundaHub.restapi.startupProbe.enabled .Values.webModeler.restapi.startupProbe.enabled) }}
+          {{- if $hub.restapi.startupProbe.enabled }}
           startupProbe:
             httpGet:
-              path: {{ include "camundaPlatform.joinpath" (list (or .Values.camundaHub.contextPath .Values.webModeler.contextPath) (or .Values.camundaHub.restapi.startupProbe.probePath .Values.webModeler.restapi.startupProbe.probePath)) }}
-              scheme: {{ (or .Values.camundaHub.restapi.startupProbe.scheme .Values.webModeler.restapi.startupProbe.scheme) }}
+              path: {{ include "camundaPlatform.joinpath" (list $hub.contextPath $hub.restapi.startupProbe.probePath) }}
+              scheme: {{ $hub.restapi.startupProbe.scheme }}
               port: http-management
-            initialDelaySeconds: {{ (or .Values.camundaHub.restapi.startupProbe.initialDelaySeconds .Values.webModeler.restapi.startupProbe.initialDelaySeconds) }}
-            periodSeconds: {{ (or .Values.camundaHub.restapi.startupProbe.periodSeconds .Values.webModeler.restapi.startupProbe.periodSeconds) }}
-            successThreshold: {{ (or .Values.camundaHub.restapi.startupProbe.successThreshold .Values.webModeler.restapi.startupProbe.successThreshold) }}
-            failureThreshold: {{ (or .Values.camundaHub.restapi.startupProbe.failureThreshold .Values.webModeler.restapi.startupProbe.failureThreshold) }}
-            timeoutSeconds: {{ (or .Values.camundaHub.restapi.startupProbe.timeoutSeconds .Values.webModeler.restapi.startupProbe.timeoutSeconds) }}
+            initialDelaySeconds: {{ $hub.restapi.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ $hub.restapi.startupProbe.periodSeconds }}
+            successThreshold: {{ $hub.restapi.startupProbe.successThreshold }}
+            failureThreshold: {{ $hub.restapi.startupProbe.failureThreshold }}
+            timeoutSeconds: {{ $hub.restapi.startupProbe.timeoutSeconds }}
           {{- end }}
-          {{- if (or .Values.camundaHub.restapi.readinessProbe.enabled .Values.webModeler.restapi.readinessProbe.enabled) }}
+          {{- if $hub.restapi.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: {{ include "camundaPlatform.joinpath" (list (or .Values.camundaHub.contextPath .Values.webModeler.contextPath) (or .Values.camundaHub.restapi.readinessProbe.probePath .Values.webModeler.restapi.readinessProbe.probePath)) }}
-              scheme: {{ (or .Values.camundaHub.restapi.readinessProbe.scheme .Values.webModeler.restapi.readinessProbe.scheme) }}
+              path: {{ include "camundaPlatform.joinpath" (list $hub.contextPath $hub.restapi.readinessProbe.probePath) }}
+              scheme: {{ $hub.restapi.readinessProbe.scheme }}
               port: http-management
-            initialDelaySeconds: {{ (or .Values.camundaHub.restapi.readinessProbe.initialDelaySeconds .Values.webModeler.restapi.readinessProbe.initialDelaySeconds) }}
-            periodSeconds: {{ (or .Values.camundaHub.restapi.readinessProbe.periodSeconds .Values.webModeler.restapi.readinessProbe.periodSeconds) }}
-            successThreshold: {{ (or .Values.camundaHub.restapi.readinessProbe.successThreshold .Values.webModeler.restapi.readinessProbe.successThreshold) }}
-            failureThreshold: {{ (or .Values.camundaHub.restapi.readinessProbe.failureThreshold .Values.webModeler.restapi.readinessProbe.failureThreshold) }}
-            timeoutSeconds: {{ (or .Values.camundaHub.restapi.readinessProbe.timeoutSeconds .Values.webModeler.restapi.readinessProbe.timeoutSeconds) }}
+            initialDelaySeconds: {{ $hub.restapi.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ $hub.restapi.readinessProbe.periodSeconds }}
+            successThreshold: {{ $hub.restapi.readinessProbe.successThreshold }}
+            failureThreshold: {{ $hub.restapi.readinessProbe.failureThreshold }}
+            timeoutSeconds: {{ $hub.restapi.readinessProbe.timeoutSeconds }}
           {{- end }}
-          {{- if (or .Values.camundaHub.restapi.livenessProbe.enabled .Values.webModeler.restapi.livenessProbe.enabled) }}
+          {{- if $hub.restapi.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: {{ include "camundaPlatform.joinpath" (list (or .Values.camundaHub.contextPath .Values.webModeler.contextPath) (or .Values.camundaHub.restapi.livenessProbe.probePath .Values.webModeler.restapi.livenessProbe.probePath)) }}
-              scheme: {{ (or .Values.camundaHub.restapi.livenessProbe.scheme .Values.webModeler.restapi.livenessProbe.scheme) }}
+              path: {{ include "camundaPlatform.joinpath" (list $hub.contextPath $hub.restapi.livenessProbe.probePath) }}
+              scheme: {{ $hub.restapi.livenessProbe.scheme }}
               port: http-management
-            initialDelaySeconds: {{ (or .Values.camundaHub.restapi.livenessProbe.initialDelaySeconds .Values.webModeler.restapi.livenessProbe.initialDelaySeconds) }}
-            periodSeconds: {{ (or .Values.camundaHub.restapi.livenessProbe.periodSeconds .Values.webModeler.restapi.livenessProbe.periodSeconds) }}
-            successThreshold: {{ (or .Values.camundaHub.restapi.livenessProbe.successThreshold .Values.webModeler.restapi.livenessProbe.successThreshold) }}
-            failureThreshold: {{ (or .Values.camundaHub.restapi.livenessProbe.failureThreshold .Values.webModeler.restapi.livenessProbe.failureThreshold) }}
-            timeoutSeconds: {{ (or .Values.camundaHub.restapi.livenessProbe.timeoutSeconds .Values.webModeler.restapi.livenessProbe.timeoutSeconds) }}
+            initialDelaySeconds: {{ $hub.restapi.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ $hub.restapi.livenessProbe.periodSeconds }}
+            successThreshold: {{ $hub.restapi.livenessProbe.successThreshold }}
+            failureThreshold: {{ $hub.restapi.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ $hub.restapi.livenessProbe.timeoutSeconds }}
           {{- end }}
           volumeMounts:
             - name: tmp
@@ -174,7 +175,7 @@ spec:
             - name: config
               mountPath: /home/runner/config/application.yaml
               subPath: application.yaml
-          {{- with (or .Values.camundaHub.restapi.extraConfiguration .Values.webModeler.restapi.extraConfiguration) }}
+          {{- with $hub.restapi.extraConfiguration }}
           {{- include "camundaPlatform.extraConfigurationVolumeMounts" (dict "extraConfig" . "volumeName" "config" "basePath" "/home/runner/config") | trim | nindent 12 }}
           {{- end }}
             {{- if .Values.global.documentStore.type.gcp.enabled }}
@@ -186,35 +187,35 @@ spec:
             {{- include "camundaPlatform.caBundleVolumeMount" . | nindent 12 }}
             {{- include "camundaPlatform.caBundleTruststoreVolumeMount" . | nindent 12 }}
             {{- end }}
-            {{- if (or .Values.camundaHub.restapi.extraVolumeMounts .Values.webModeler.restapi.extraVolumeMounts) }}
-            {{- (or .Values.camundaHub.restapi.extraVolumeMounts .Values.webModeler.restapi.extraVolumeMounts) | toYaml | nindent 12 }}
+            {{- if $hub.restapi.extraVolumeMounts }}
+            {{- $hub.restapi.extraVolumeMounts | toYaml | nindent 12 }}
             {{- end }}
-        {{- if (or .Values.camundaHub.restapi.sidecars .Values.webModeler.restapi.sidecars) }}
-        {{- (or .Values.camundaHub.restapi.sidecars .Values.webModeler.restapi.sidecars) | toYaml | nindent 8 }}
+        {{- if $hub.restapi.sidecars }}
+        {{- $hub.restapi.sidecars | toYaml | nindent 8 }}
         {{- end }}
       volumes:
         - name: tmp
-          {{- if and (or .Values.camundaHub.persistence.enabled .Values.webModeler.persistence.enabled) (or .Values.camundaHub.persistence.existingClaim .Values.webModeler.persistence.existingClaim) }}
+          {{- if and $hub.persistence.enabled $hub.persistence.existingClaim }}
           persistentVolumeClaim:
-            claimName: {{ (or .Values.camundaHub.persistence.existingClaim .Values.webModeler.persistence.existingClaim) }}
-          {{- else if (or .Values.camundaHub.persistence.enabled .Values.webModeler.persistence.enabled) }}
+            claimName: {{ $hub.persistence.existingClaim }}
+          {{- else if $hub.persistence.enabled }}
           ephemeral:
             volumeClaimTemplate:
-              {{- with (or .Values.camundaHub.persistence.annotations .Values.webModeler.persistence.annotations) }}
+              {{- with $hub.persistence.annotations }}
               metadata:
                 annotations: {{- toYaml . | nindent 18 }}
               {{- end }}
               spec:
-                accessModes: {{ (or .Values.camundaHub.persistence.accessModes .Values.webModeler.persistence.accessModes) | default (list "ReadWriteOnce") | toYaml | nindent 18 }}
-                {{- with (or .Values.camundaHub.persistence.storageClassName .Values.webModeler.persistence.storageClassName) }}
+                accessModes: {{ $hub.persistence.accessModes | default (list "ReadWriteOnce") | toYaml | nindent 18 }}
+                {{- with $hub.persistence.storageClassName }}
                 storageClassName: {{ . | quote }}
                 {{- end }}
-                {{- with (or .Values.camundaHub.persistence.selector .Values.webModeler.persistence.selector) }}
+                {{- with $hub.persistence.selector }}
                 selector: {{- toYaml . | nindent 18 }}
                 {{- end }}
                 resources:
                   requests:
-                    storage: {{ (or .Values.camundaHub.persistence.size .Values.webModeler.persistence.size) | default "1Gi" | quote }}
+                    storage: {{ $hub.persistence.size | default "1Gi" | quote }}
           {{- else }}
           emptyDir: {}
           {{- end }}
@@ -232,31 +233,31 @@ spec:
         {{- include "camundaPlatform.caBundleVolume" . | nindent 8 }}
         {{- include "camundaPlatform.caBundleTruststoreVolume" . | nindent 8 }}
         {{- end }}
-        {{- if (or .Values.camundaHub.restapi.extraVolumes .Values.webModeler.restapi.extraVolumes) }}
-        {{- (or .Values.camundaHub.restapi.extraVolumes .Values.webModeler.restapi.extraVolumes) | toYaml | nindent 8 }}
+        {{- if $hub.restapi.extraVolumes }}
+        {{- $hub.restapi.extraVolumes | toYaml | nindent 8 }}
         {{- end }}
       serviceAccountName: {{ include "webModeler.serviceAccountName" . }}
-      {{- if kindIs "bool" .Values.camundaHub.automountServiceAccountToken }}
-      automountServiceAccountToken: {{ .Values.camundaHub.automountServiceAccountToken }}
+      {{- if kindIs "bool" $hub.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ $hub.automountServiceAccountToken }}
       {{- end }}
-      {{- if (or .Values.camundaHub.restapi.dnsConfig .Values.webModeler.restapi.dnsConfig) }}
-      dnsConfig: {{- toYaml (or .Values.camundaHub.restapi.dnsConfig .Values.webModeler.restapi.dnsConfig) | nindent 8 }}
+      {{- if $hub.restapi.dnsConfig }}
+      dnsConfig: {{- toYaml $hub.restapi.dnsConfig | nindent 8 }}
       {{- end }}
-      {{- if (or .Values.camundaHub.restapi.dnsPolicy .Values.webModeler.restapi.dnsPolicy) }}
-      dnsPolicy: {{ (or .Values.camundaHub.restapi.dnsPolicy .Values.webModeler.restapi.dnsPolicy) | quote }}
+      {{- if $hub.restapi.dnsPolicy }}
+      dnsPolicy: {{ $hub.restapi.dnsPolicy | quote }}
       {{- end }}
-      {{- if (or .Values.camundaHub.restapi.podSecurityContext .Values.webModeler.restapi.podSecurityContext) }}
-      securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" (or .Values.camundaHub.restapi.podSecurityContext .Values.webModeler.restapi.podSecurityContext) "context" $) | nindent 8 }}
+      {{- if $hub.restapi.podSecurityContext }}
+      securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" $hub.restapi.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
-      {{- with (or .Values.camundaHub.restapi.nodeSelector .Values.webModeler.restapi.nodeSelector) | default .Values.global.nodeSelector }}
+      {{- with $hub.restapi.nodeSelector | default .Values.global.nodeSelector }}
       nodeSelector:
         {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with (or .Values.camundaHub.restapi.affinity .Values.webModeler.restapi.affinity) }}
+      {{- with $hub.restapi.affinity }}
       affinity:
         {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with (or .Values.camundaHub.restapi.tolerations .Values.webModeler.restapi.tolerations) }}
+      {{- with $hub.restapi.tolerations }}
       tolerations:
         {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/camunda-platform-8.10/templates/web-modeler/deployment-websockets.yaml
+++ b/charts/camunda-platform-8.10/templates/web-modeler/deployment-websockets.yaml
@@ -1,5 +1,5 @@
-{{- $hub := include "camundaHub.values" . | fromYaml }}
 {{- if eq (include "camundaHub.webModelerEnabled" .) "true" -}}
+{{- $hub := include "camundaHub.values" . | fromYaml -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/camunda-platform-8.10/templates/web-modeler/deployment-websockets.yaml
+++ b/charts/camunda-platform-8.10/templates/web-modeler/deployment-websockets.yaml
@@ -1,3 +1,4 @@
+{{- $hub := include "camundaHub.values" . | fromYaml }}
 {{- if eq (include "camundaHub.webModelerEnabled" .) "true" -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -14,13 +15,13 @@ spec:
   template:
     metadata:
       labels: {{- include "webModeler.websockets.labels" . | nindent 8 }}
-      {{- if (or .Values.camundaHub.websockets.podLabels .Values.webModeler.websockets.podLabels) }}
-      {{- tpl (toYaml (or .Values.camundaHub.websockets.podLabels .Values.webModeler.websockets.podLabels)) $ | nindent 8 }}
+      {{- if $hub.websockets.podLabels }}
+      {{- tpl (toYaml $hub.websockets.podLabels) $ | nindent 8 }}
       {{- end }}
-      {{- if or (and (eq (include "camundaPlatform.hasCaBundle" .) "true") .Values.global.tls.caBundle.autoRollout) (or .Values.camundaHub.websockets.podAnnotations .Values.webModeler.websockets.podAnnotations) }}
+      {{- if or (and (eq (include "camundaPlatform.hasCaBundle" .) "true") .Values.global.tls.caBundle.autoRollout) $hub.websockets.podAnnotations }}
       annotations:
         {{- with (include "camundaPlatform.caBundleChecksumAnnotation" .) }}{{ . | nindent 8 }}{{- end }}
-        {{- with (or .Values.camundaHub.websockets.podAnnotations .Values.webModeler.websockets.podAnnotations) }}
+        {{- with $hub.websockets.podAnnotations }}
         {{- tpl (toYaml .) $ | nindent 8 }}
         {{- end }}
       {{- end }}
@@ -28,13 +29,13 @@ spec:
       imagePullSecrets:
         {{- include "webModeler.imagePullSecrets" . | nindent 8 }}
       initContainers:
-        {{- tpl ((or .Values.camundaHub.websockets.initContainers .Values.webModeler.websockets.initContainers) | default list | toYaml | nindent 8) $ }}
+        {{- tpl ($hub.websockets.initContainers | default list | toYaml | nindent 8) $ }}
       containers:
         - name: {{ include "webModeler.name" . }}-websockets
           image: {{ include "webModeler.websockets.image" . | quote }}
           imagePullPolicy: {{ .Values.global.image.pullPolicy }}
-          {{- if (or .Values.camundaHub.websockets.containerSecurityContext .Values.webModeler.websockets.containerSecurityContext) }}
-          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" (or .Values.camundaHub.websockets.containerSecurityContext .Values.webModeler.websockets.containerSecurityContext) "context" $) | nindent 12 }}
+          {{- if $hub.websockets.containerSecurityContext }}
+          securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" $hub.websockets.containerSecurityContext "context" $) | nindent 12 }}
           {{- end }}
           env:
             {{- include "camundaPlatform.emitEnvVarFromSecretConfig" (dict
@@ -50,90 +51,90 @@ spec:
                   key: pusher-app-id
             {{- include "camundaPlatform.emitEnvVarFromSecretConfig" (dict
                 "envName" "PUSHER_APP_KEY"
-                "config" (mustMergeOverwrite (deepCopy .Values.webModeler.restapi.pusher.client) .Values.camundaHub.restapi.pusher.client)
+                "config" ($hub.restapi.pusher.client)
                 "defaultSecretName" (include "webModeler.fullname" .)
                 "defaultSecretKey" "pusher-app-key"
             ) | nindent 12 }}
             {{- include "camundaPlatform.emitEnvVarFromSecretConfig" (dict
                 "envName" "PUSHER_APP_SECRET"
-                "config" (mustMergeOverwrite (deepCopy .Values.webModeler.restapi.pusher) .Values.camundaHub.restapi.pusher)
+                "config" ($hub.restapi.pusher)
                 "defaultSecretName" (include "webModeler.fullname" .)
                 "defaultSecretKey" "pusher-app-secret"
             ) | nindent 12 }}
-            {{- if and .Values.global.ingress.enabled (or .Values.camundaHub.contextPath .Values.webModeler.contextPath) }}
+            {{- if and .Values.global.ingress.enabled $hub.contextPath }}
             - name: PUSHER_APP_PATH
               value: {{ include "webModeler.websocketContextPath" . | quote }}
             {{- end }}
           {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
             {{- include "camundaPlatform.caBundleEnv" . | nindent 12 }}
           {{- end }}
-          {{- with (or .Values.camundaHub.websockets.env .Values.webModeler.websockets.env) }}
+          {{- with $hub.websockets.env }}
             {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
-          {{- if (or .Values.camundaHub.websockets.envFrom .Values.webModeler.websockets.envFrom) }}
+          {{- if $hub.websockets.envFrom }}
           envFrom:
-            {{- (or .Values.camundaHub.websockets.envFrom .Values.webModeler.websockets.envFrom) | toYaml | nindent 12 }}
+            {{- $hub.websockets.envFrom | toYaml | nindent 12 }}
           {{- end }}
-          {{- if (or .Values.camundaHub.websockets.command .Values.webModeler.websockets.command)}}
-          command: {{ toYaml (or .Values.camundaHub.websockets.command .Values.webModeler.websockets.command) | nindent 10 }}
+          {{- if $hub.websockets.command}}
+          command: {{ toYaml $hub.websockets.command | nindent 10 }}
           {{- end }}
           resources:
-            {{- toYaml (or .Values.camundaHub.websockets.resources .Values.webModeler.websockets.resources) | nindent 12 }}
+            {{- toYaml $hub.websockets.resources | nindent 12 }}
           ports:
             - containerPort: 8060
               name: http
               protocol: TCP
-          {{- if (or .Values.camundaHub.websockets.startupProbe.enabled .Values.webModeler.websockets.startupProbe.enabled) }}
+          {{- if $hub.websockets.startupProbe.enabled }}
           startupProbe:
             httpGet:
-              path: {{ (or .Values.camundaHub.websockets.startupProbe.probePath .Values.webModeler.websockets.startupProbe.probePath) }}
-              scheme: {{ (or .Values.camundaHub.websockets.startupProbe.scheme .Values.webModeler.websockets.startupProbe.scheme) }}
+              path: {{ $hub.websockets.startupProbe.probePath }}
+              scheme: {{ $hub.websockets.startupProbe.scheme }}
               port: http
-            initialDelaySeconds: {{ (or .Values.camundaHub.websockets.startupProbe.initialDelaySeconds .Values.webModeler.websockets.startupProbe.initialDelaySeconds) }}
-            periodSeconds: {{ (or .Values.camundaHub.websockets.startupProbe.periodSeconds .Values.webModeler.websockets.startupProbe.periodSeconds) }}
-            successThreshold: {{ (or .Values.camundaHub.websockets.startupProbe.successThreshold .Values.webModeler.websockets.startupProbe.successThreshold) }}
-            failureThreshold: {{ (or .Values.camundaHub.websockets.startupProbe.failureThreshold .Values.webModeler.websockets.startupProbe.failureThreshold) }}
-            timeoutSeconds: {{ (or .Values.camundaHub.websockets.startupProbe.timeoutSeconds .Values.webModeler.websockets.startupProbe.timeoutSeconds) }}
+            initialDelaySeconds: {{ $hub.websockets.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ $hub.websockets.startupProbe.periodSeconds }}
+            successThreshold: {{ $hub.websockets.startupProbe.successThreshold }}
+            failureThreshold: {{ $hub.websockets.startupProbe.failureThreshold }}
+            timeoutSeconds: {{ $hub.websockets.startupProbe.timeoutSeconds }}
           {{- end }}
-          {{- if (or .Values.camundaHub.websockets.readinessProbe.enabled .Values.webModeler.websockets.readinessProbe.enabled) }}
+          {{- if $hub.websockets.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: {{ (or .Values.camundaHub.websockets.readinessProbe.probePath .Values.webModeler.websockets.readinessProbe.probePath) }}
-              scheme: {{ (or .Values.camundaHub.websockets.readinessProbe.scheme .Values.webModeler.websockets.readinessProbe.scheme) }}
+              path: {{ $hub.websockets.readinessProbe.probePath }}
+              scheme: {{ $hub.websockets.readinessProbe.scheme }}
               port: http
-            initialDelaySeconds: {{ (or .Values.camundaHub.websockets.readinessProbe.initialDelaySeconds .Values.webModeler.websockets.readinessProbe.initialDelaySeconds) }}
-            periodSeconds: {{ (or .Values.camundaHub.websockets.readinessProbe.periodSeconds .Values.webModeler.websockets.readinessProbe.periodSeconds) }}
-            successThreshold: {{ (or .Values.camundaHub.websockets.readinessProbe.successThreshold .Values.webModeler.websockets.readinessProbe.successThreshold) }}
-            failureThreshold: {{ (or .Values.camundaHub.websockets.readinessProbe.failureThreshold .Values.webModeler.websockets.readinessProbe.failureThreshold) }}
-            timeoutSeconds: {{ (or .Values.camundaHub.websockets.readinessProbe.timeoutSeconds .Values.webModeler.websockets.readinessProbe.timeoutSeconds) }}
+            initialDelaySeconds: {{ $hub.websockets.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ $hub.websockets.readinessProbe.periodSeconds }}
+            successThreshold: {{ $hub.websockets.readinessProbe.successThreshold }}
+            failureThreshold: {{ $hub.websockets.readinessProbe.failureThreshold }}
+            timeoutSeconds: {{ $hub.websockets.readinessProbe.timeoutSeconds }}
           {{- end }}
-          {{- if (or .Values.camundaHub.websockets.livenessProbe.enabled .Values.webModeler.websockets.livenessProbe.enabled) }}
+          {{- if $hub.websockets.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: {{ (or .Values.camundaHub.websockets.livenessProbe.probePath .Values.webModeler.websockets.livenessProbe.probePath) }}
-              scheme: {{ (or .Values.camundaHub.websockets.livenessProbe.scheme .Values.webModeler.websockets.livenessProbe.scheme) }}
+              path: {{ $hub.websockets.livenessProbe.probePath }}
+              scheme: {{ $hub.websockets.livenessProbe.scheme }}
               port: http
-            initialDelaySeconds: {{ (or .Values.camundaHub.websockets.livenessProbe.initialDelaySeconds .Values.webModeler.websockets.livenessProbe.initialDelaySeconds) }}
-            periodSeconds: {{ (or .Values.camundaHub.websockets.livenessProbe.periodSeconds .Values.webModeler.websockets.livenessProbe.periodSeconds) }}
-            successThreshold: {{ (or .Values.camundaHub.websockets.livenessProbe.successThreshold .Values.webModeler.websockets.livenessProbe.successThreshold) }}
-            failureThreshold: {{ (or .Values.camundaHub.websockets.livenessProbe.failureThreshold .Values.webModeler.websockets.livenessProbe.failureThreshold) }}
-            timeoutSeconds: {{ (or .Values.camundaHub.websockets.livenessProbe.timeoutSeconds .Values.webModeler.websockets.livenessProbe.timeoutSeconds) }}
+            initialDelaySeconds: {{ $hub.websockets.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ $hub.websockets.livenessProbe.periodSeconds }}
+            successThreshold: {{ $hub.websockets.livenessProbe.successThreshold }}
+            failureThreshold: {{ $hub.websockets.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ $hub.websockets.livenessProbe.timeoutSeconds }}
           {{- end }}
           volumeMounts:
             - name: config
               mountPath: /home/webapp/config/application.yaml
               subPath: application.yaml
-          {{- with (or .Values.camundaHub.websockets.extraConfiguration .Values.webModeler.websockets.extraConfiguration) }}
+          {{- with $hub.websockets.extraConfiguration }}
           {{- include "camundaPlatform.extraConfigurationVolumeMounts" (dict "extraConfig" . "volumeName" "config" "basePath" "/home/webapp/config") | trim | nindent 12 }}
           {{- end }}
           {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
           {{- include "camundaPlatform.caBundleVolumeMount" . | nindent 12 }}
           {{- end }}
-          {{- if (or .Values.camundaHub.websockets.extraVolumeMounts .Values.webModeler.websockets.extraVolumeMounts) }}
-          {{- (or .Values.camundaHub.websockets.extraVolumeMounts .Values.webModeler.websockets.extraVolumeMounts) | toYaml | nindent 12 }}
+          {{- if $hub.websockets.extraVolumeMounts }}
+          {{- $hub.websockets.extraVolumeMounts | toYaml | nindent 12 }}
           {{- end }}
-        {{- if (or .Values.camundaHub.websockets.sidecars .Values.webModeler.websockets.sidecars) }}
-        {{- (or .Values.camundaHub.websockets.sidecars .Values.webModeler.websockets.sidecars) | toYaml | nindent 8 }}
+        {{- if $hub.websockets.sidecars }}
+        {{- $hub.websockets.sidecars | toYaml | nindent 8 }}
         {{- end }}
       volumes:
         - name: config
@@ -142,31 +143,31 @@ spec:
       {{- if eq (include "camundaPlatform.hasCaBundle" .) "true" }}
       {{- include "camundaPlatform.caBundleVolume" . | nindent 8 }}
       {{- end }}
-      {{- if (or .Values.camundaHub.websockets.extraVolumes .Values.webModeler.websockets.extraVolumes) }}
-      {{- (or .Values.camundaHub.websockets.extraVolumes .Values.webModeler.websockets.extraVolumes) | toYaml | nindent 8 }}
+      {{- if $hub.websockets.extraVolumes }}
+      {{- $hub.websockets.extraVolumes | toYaml | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "webModeler.serviceAccountName" . }}
-      {{- if kindIs "bool" .Values.camundaHub.automountServiceAccountToken }}
-      automountServiceAccountToken: {{ .Values.camundaHub.automountServiceAccountToken }}
+      {{- if kindIs "bool" $hub.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ $hub.automountServiceAccountToken }}
       {{- end }}
-      {{- if (or .Values.camundaHub.websockets.dnsConfig .Values.webModeler.websockets.dnsConfig) }}
-      dnsConfig: {{- toYaml (or .Values.camundaHub.websockets.dnsConfig .Values.webModeler.websockets.dnsConfig) | nindent 8 }}
+      {{- if $hub.websockets.dnsConfig }}
+      dnsConfig: {{- toYaml $hub.websockets.dnsConfig | nindent 8 }}
       {{- end }}
-      {{- if (or .Values.camundaHub.websockets.dnsPolicy .Values.webModeler.websockets.dnsPolicy) }}
-      dnsPolicy: {{ (or .Values.camundaHub.websockets.dnsPolicy .Values.webModeler.websockets.dnsPolicy) | quote }}
+      {{- if $hub.websockets.dnsPolicy }}
+      dnsPolicy: {{ $hub.websockets.dnsPolicy | quote }}
       {{- end }}
-      {{- if (or .Values.camundaHub.websockets.podSecurityContext .Values.webModeler.websockets.podSecurityContext) }}
-      securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" (or .Values.camundaHub.websockets.podSecurityContext .Values.webModeler.websockets.podSecurityContext) "context" $) | nindent 8 }}
+      {{- if $hub.websockets.podSecurityContext }}
+      securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" $hub.websockets.podSecurityContext "context" $) | nindent 8 }}
       {{- end }}
-      {{- with (or .Values.camundaHub.websockets.nodeSelector .Values.webModeler.websockets.nodeSelector) | default .Values.global.nodeSelector }}
+      {{- with $hub.websockets.nodeSelector | default .Values.global.nodeSelector }}
       nodeSelector:
         {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with (or .Values.camundaHub.websockets.affinity .Values.webModeler.websockets.affinity) }}
+      {{- with $hub.websockets.affinity }}
       affinity:
         {{ toYaml . | nindent 8 }}
       {{- end }}
-      {{- with (or .Values.camundaHub.websockets.tolerations .Values.webModeler.websockets.tolerations) }}
+      {{- with $hub.websockets.tolerations }}
       tolerations:
         {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/camunda-platform-8.10/templates/web-modeler/httproute.yaml
+++ b/charts/camunda-platform-8.10/templates/web-modeler/httproute.yaml
@@ -32,7 +32,7 @@ spec:
   - matches:
     - path:
         type: PathPrefix
-        value: {{ (or .Values.camundaHub.contextPath .Values.webModeler.contextPath) }}
+        value: {{ (include "camundaHub.contextPath" .) }}
     backendRefs:
     - name: {{ template "webModeler.restapi.fullname" . }}
       namespace: {{ .Release.Namespace }}

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/camunda_hub_shim_test.go
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/camunda_hub_shim_test.go
@@ -494,6 +494,36 @@ func (s *CamundaHubShimTemplateTest) TestListValuedOverrideReplacesLegacyList() 
 	s.Require().Equal("hub", tolerations[0].Key)
 }
 
+func (s *CamundaHubShimTemplateTest) TestFalsySmtpTlsOverrideReachesTheConfigMap() {
+	values := map[string]string{
+		"camundaHub.enabled":                     "true",
+		"webModeler.enabled":                     "true",
+		"webModeler.restapi.mail.smtpTlsEnabled": "true",
+		"camundaHub.restapi.mail.smtpTlsEnabled": "false",
+	}
+	properties := s.renderRestAPIConfigMap(values).Spring.Mail.Properties
+	s.Require().Equal(false, properties["mail.smtp.starttls.enable"])
+	s.Require().Equal(false, properties["mail.smtp.starttls.required"])
+}
+
+func (s *CamundaHubShimTemplateTest) TestServiceAnnotationsStillReplaceLegacyMap() {
+	values := map[string]string{
+		"camundaHub.enabled": "true",
+		"webModeler.enabled": "true",
+		"webModeler.restapi.service.annotations.legacykey": "legacyval",
+		"camundaHub.restapi.service.annotations.hubkey":    "hubval",
+	}
+	output, err := s.renderWebModeler(values, []string{"templates/web-modeler/service-restapi.yaml"})
+	s.Require().NoError(err)
+
+	var service corev1.Service
+	helm.UnmarshalK8SYaml(s.T(), output, &service)
+	annotations := service.Annotations
+	s.Require().Equal("hubval", annotations["hubkey"])
+	s.Require().NotContains(annotations, "legacykey",
+		"services are not on the merged view yet; values.yaml documents this scope boundary")
+}
+
 func (s *CamundaHubShimTemplateTest) TestResourceNamesStableBetweenLegacyAndCamundaHubValues() {
 	legacyValues := map[string]string{
 		"camundaHub.enabled":                  "false",

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/camunda_hub_shim_test.go
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/camunda_hub_shim_test.go
@@ -241,7 +241,7 @@ func (s *CamundaHubShimTemplateTest) TestLegacyOnlyValuesStillApply() {
 	s.Require().Equal(int32(2), *deployment.Spec.Replicas)
 }
 
-func (s *CamundaHubShimTemplateTest) TestFalsyCamundaHubOverrideDoesNotOverrideTruthyLegacyValue() {
+func (s *CamundaHubShimTemplateTest) TestFalsyCamundaHubOverrideWinsOverTruthyLegacyValue() {
 	values := map[string]string{
 		"camundaHub.enabled":                        "true",
 		"camundaHub.restapi.readinessProbe.enabled": "false",
@@ -253,7 +253,97 @@ func (s *CamundaHubShimTemplateTest) TestFalsyCamundaHubOverrideDoesNotOverrideT
 	s.Require().NoError(err)
 
 	deployment := s.unmarshalDeployment(output)
-	s.Require().NotNil(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe)
+	s.Require().Nil(deployment.Spec.Template.Spec.Containers[0].ReadinessProbe)
+}
+
+func (s *CamundaHubShimTemplateTest) TestUnsetCamundaHubKeyFallsThroughToLegacyValue() {
+	values := map[string]string{
+		"camundaHub.enabled":                  "true",
+		"webModeler.enabled":                  "true",
+		"webModeler.contextPath":              "/modeler",
+		"webModeler.restapi.mail.fromAddress": "example@example.com",
+	}
+	output, err := s.renderWebModelerRestAPI(values)
+	s.Require().NoError(err)
+
+	probe := s.unmarshalDeployment(output).Spec.Template.Spec.Containers[0].ReadinessProbe
+	s.Require().NotNil(probe)
+	s.Require().Equal("/modeler/health/readiness", probe.HTTPGet.Path)
+}
+
+func (s *CamundaHubShimTemplateTest) TestPartialContainerSecurityContextOverrideKeepsSiblingDefaults() {
+	values := map[string]string{
+		"camundaHub.enabled": "true",
+		"camundaHub.restapi.containerSecurityContext.runAsUser": "2000",
+		"webModeler.enabled":                  "true",
+		"webModeler.restapi.mail.fromAddress": "example@example.com",
+	}
+	output, err := s.renderWebModelerRestAPI(values)
+	s.Require().NoError(err)
+
+	securityContext := s.unmarshalDeployment(output).Spec.Template.Spec.Containers[0].SecurityContext
+	s.Require().NotNil(securityContext)
+	s.Require().Equal(int64(2000), *securityContext.RunAsUser)
+	s.Require().True(*securityContext.ReadOnlyRootFilesystem)
+	s.Require().True(*securityContext.RunAsNonRoot)
+	s.Require().False(*securityContext.AllowPrivilegeEscalation)
+	s.Require().NotNil(securityContext.SeccompProfile)
+	s.Require().Equal(corev1.SeccompProfileTypeRuntimeDefault, securityContext.SeccompProfile.Type)
+}
+
+func (s *CamundaHubShimTemplateTest) TestPartialPodSecurityContextOverrideKeepsSiblingDefaults() {
+	values := map[string]string{
+		"camundaHub.enabled":                            "true",
+		"camundaHub.restapi.podSecurityContext.fsGroup": "3000",
+		"webModeler.enabled":                            "true",
+		"webModeler.restapi.mail.fromAddress":           "example@example.com",
+	}
+	output, err := s.renderWebModelerRestAPI(values)
+	s.Require().NoError(err)
+
+	securityContext := s.unmarshalDeployment(output).Spec.Template.Spec.SecurityContext
+	s.Require().NotNil(securityContext)
+	s.Require().Equal(int64(3000), *securityContext.FSGroup)
+	s.Require().True(*securityContext.RunAsNonRoot)
+	s.Require().NotNil(securityContext.SeccompProfile)
+	s.Require().Equal(corev1.SeccompProfileTypeRuntimeDefault, securityContext.SeccompProfile.Type)
+}
+
+func (s *CamundaHubShimTemplateTest) TestPartialResourcesOverrideKeepsSiblingDefaults() {
+	values := map[string]string{
+		"camundaHub.enabled":                      "true",
+		"camundaHub.restapi.resources.limits.cpu": "2",
+		"webModeler.enabled":                      "true",
+		"webModeler.restapi.mail.fromAddress":     "example@example.com",
+	}
+	output, err := s.renderWebModelerRestAPI(values)
+	s.Require().NoError(err)
+
+	resources := s.unmarshalDeployment(output).Spec.Template.Spec.Containers[0].Resources
+	s.Require().Equal("2", resources.Limits.Cpu().String())
+	s.Require().False(resources.Limits.Memory().IsZero())
+	s.Require().False(resources.Requests.Cpu().IsZero())
+	s.Require().False(resources.Requests.Memory().IsZero())
+}
+
+func (s *CamundaHubShimTemplateTest) TestPartialWebsocketsSecurityContextOverrideKeepsSiblingDefaults() {
+	values := map[string]string{
+		"camundaHub.enabled": "true",
+		"camundaHub.websockets.containerSecurityContext.runAsUser": "2000",
+		"webModeler.enabled":                  "true",
+		"webModeler.restapi.mail.fromAddress": "example@example.com",
+	}
+	output, err := s.renderWebModeler(values, []string{"templates/web-modeler/deployment-websockets.yaml"})
+	s.Require().NoError(err)
+
+	securityContext := s.unmarshalDeployment(output).Spec.Template.Spec.Containers[0].SecurityContext
+	s.Require().NotNil(securityContext)
+	s.Require().Equal(int64(2000), *securityContext.RunAsUser)
+	s.Require().True(*securityContext.ReadOnlyRootFilesystem)
+	s.Require().True(*securityContext.RunAsNonRoot)
+	s.Require().False(*securityContext.AllowPrivilegeEscalation)
+	s.Require().NotNil(securityContext.SeccompProfile)
+	s.Require().Equal(corev1.SeccompProfileTypeRuntimeDefault, securityContext.SeccompProfile.Type)
 }
 
 func (s *CamundaHubShimTemplateTest) TestResourceNamesStableBetweenLegacyAndCamundaHubValues() {

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/camunda_hub_shim_test.go
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/camunda_hub_shim_test.go
@@ -431,6 +431,69 @@ func (s *CamundaHubShimTemplateTest) TestScalarOverrideOfLegacyMapFailsFast() {
 	s.Require().ErrorContains(err, "camundaHub.restapi.containerSecurityContext is a bool")
 }
 
+func (s *CamundaHubShimTemplateTest) TestScalarOverrideOfLegacyMapIsIgnoredWhenHubDisabled() {
+	values := map[string]string{
+		"camundaHub.enabled":                          "false",
+		"webModeler.enabled":                          "false",
+		"console.enabled":                             "false",
+		"camundaHub.restapi.containerSecurityContext": "false",
+	}
+	output, err := s.renderWebModeler(values, []string{"templates/orchestration/statefulset.yaml"})
+	s.Require().NoError(err, "a stray camundaHub override must not fail rendering while Hub is disabled")
+	s.Require().Contains(output, "kind: StatefulSet")
+}
+
+func (s *CamundaHubShimTemplateTest) TestMailResetAppliesToTheConfigMap() {
+	legacyOnly := map[string]string{
+		"camundaHub.enabled":               "true",
+		"webModeler.enabled":               "true",
+		"webModeler.restapi.mail.smtpUser": "legacyuser",
+	}
+	s.Require().Equal("legacyuser", s.renderRestAPIConfigMap(legacyOnly).Spring.Mail.Username)
+
+	reset := map[string]string{
+		"camundaHub.enabled":               "true",
+		"webModeler.enabled":               "true",
+		"webModeler.restapi.mail.smtpUser": "legacyuser",
+		"camundaHub.restapi.mail.smtpUser": "",
+	}
+	s.Require().Empty(s.renderRestAPIConfigMap(reset).Spring.Mail.Username)
+}
+
+func (s *CamundaHubShimTemplateTest) TestContextPathResetRemovesIngressPaths() {
+	values := map[string]string{
+		"camundaHub.enabled":     "true",
+		"webModeler.enabled":     "true",
+		"global.ingress.enabled": "true",
+		"global.host":            "example.com",
+		"webModeler.contextPath": "/modeler",
+	}
+	output, err := s.renderWebModeler(values, []string{"templates/common/ingress-http.yaml"})
+	s.Require().NoError(err)
+	s.Require().Contains(output, "path: /modeler")
+	s.Require().Contains(output, "path: /modeler-ws")
+
+	values["camundaHub.contextPath"] = ""
+	output, err = s.renderWebModeler(values, []string{"templates/common/ingress-http.yaml"})
+	s.Require().NoError(err)
+	s.Require().NotContains(output, "path: /modeler")
+}
+
+func (s *CamundaHubShimTemplateTest) TestListValuedOverrideReplacesLegacyList() {
+	values := map[string]string{
+		"camundaHub.enabled":                    "true",
+		"webModeler.enabled":                    "true",
+		"webModeler.restapi.tolerations[0].key": "legacy",
+		"camundaHub.restapi.tolerations[0].key": "hub",
+	}
+	output, err := s.renderWebModelerRestAPI(values)
+	s.Require().NoError(err)
+
+	tolerations := s.unmarshalDeployment(output).Spec.Template.Spec.Tolerations
+	s.Require().Len(tolerations, 1, "arrays replace wholesale rather than appending")
+	s.Require().Equal("hub", tolerations[0].Key)
+}
+
 func (s *CamundaHubShimTemplateTest) TestResourceNamesStableBetweenLegacyAndCamundaHubValues() {
 	legacyValues := map[string]string{
 		"camundaHub.enabled":                  "false",

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/camunda_hub_shim_test.go
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/camunda_hub_shim_test.go
@@ -346,6 +346,91 @@ func (s *CamundaHubShimTemplateTest) TestPartialWebsocketsSecurityContextOverrid
 	s.Require().Equal(corev1.SeccompProfileTypeRuntimeDefault, securityContext.SeccompProfile.Type)
 }
 
+func (s *CamundaHubShimTemplateTest) TestPartialWebsocketsResourcesOverrideKeepsSiblingDefaults() {
+	values := map[string]string{
+		"camundaHub.enabled":                         "true",
+		"webModeler.enabled":                         "true",
+		"camundaHub.websockets.resources.limits.cpu": "2",
+	}
+	output, err := s.renderWebModeler(values, []string{"templates/web-modeler/deployment-websockets.yaml"})
+	s.Require().NoError(err)
+
+	resources := s.unmarshalDeployment(output).Spec.Template.Spec.Containers[0].Resources
+	s.Require().Equal("2", resources.Limits.Cpu().String())
+	s.Require().False(resources.Limits.Memory().IsZero())
+	s.Require().False(resources.Requests.Cpu().IsZero())
+	s.Require().False(resources.Requests.Memory().IsZero())
+}
+
+func (s *CamundaHubShimTemplateTest) TestPusherAppPathResolvesViaLegacyContextPath() {
+	values := map[string]string{
+		"camundaHub.enabled":     "true",
+		"webModeler.enabled":     "true",
+		"webModeler.contextPath": "/modeler",
+		"global.ingress.enabled": "true",
+		"global.host":            "example.com",
+	}
+	output, err := s.renderWebModeler(values, []string{"templates/web-modeler/deployment-websockets.yaml"})
+	s.Require().NoError(err)
+
+	pusherPath := envVarByName(s.unmarshalDeployment(output).Spec.Template.Spec.Containers[0].Env, "PUSHER_APP_PATH")
+	s.Require().NotNil(pusherPath)
+	s.Require().Equal("/modeler-ws", pusherPath.Value)
+}
+
+func (s *CamundaHubShimTemplateTest) TestLegacyOnlyPersistenceStillCreatesVolumeClaim() {
+	values := map[string]string{
+		"camundaHub.enabled":             "true",
+		"webModeler.enabled":             "true",
+		"webModeler.persistence.enabled": "true",
+		"webModeler.persistence.size":    "5Gi",
+	}
+	output, err := s.renderWebModelerRestAPI(values)
+	s.Require().NoError(err)
+
+	volumes := s.unmarshalDeployment(output).Spec.Template.Spec.Volumes
+	var tmpVolume *corev1.Volume
+	for i := range volumes {
+		if volumes[i].Name == "tmp" {
+			tmpVolume = &volumes[i]
+		}
+	}
+	s.Require().NotNil(tmpVolume)
+	s.Require().Nil(tmpVolume.EmptyDir, "legacy webModeler.persistence must not fall through to emptyDir")
+	s.Require().NotNil(tmpVolume.Ephemeral)
+	s.Require().Equal(
+		"5Gi",
+		tmpVolume.Ephemeral.VolumeClaimTemplate.Spec.Resources.Requests.Storage().String(),
+	)
+}
+
+func (s *CamundaHubShimTemplateTest) TestContextPathResetStaysConsistentAcrossDeploymentAndConfigMap() {
+	values := map[string]string{
+		"camundaHub.enabled":     "true",
+		"webModeler.enabled":     "true",
+		"webModeler.contextPath": "/modeler",
+		"camundaHub.contextPath": "",
+	}
+	output, err := s.renderWebModelerRestAPI(values)
+	s.Require().NoError(err)
+
+	probe := s.unmarshalDeployment(output).Spec.Template.Spec.Containers[0].ReadinessProbe
+	s.Require().NotNil(probe)
+	s.Require().Equal("/health/readiness", probe.HTTPGet.Path)
+	s.Require().Empty(s.renderRestAPIConfigMap(values).Server.Servlet.ContextPath)
+}
+
+func (s *CamundaHubShimTemplateTest) TestScalarOverrideOfLegacyMapFailsFast() {
+	values := map[string]string{
+		"camundaHub.enabled":                          "true",
+		"webModeler.enabled":                          "true",
+		"camundaHub.restapi.containerSecurityContext": "false",
+	}
+	_, err := s.renderWebModelerRestAPI(values)
+	s.Require().Error(err)
+	s.Require().ErrorContains(err, "camundaHub.restapi.containerSecurityContext is a bool")
+}
+
 func (s *CamundaHubShimTemplateTest) TestResourceNamesStableBetweenLegacyAndCamundaHubValues() {
 	legacyValues := map[string]string{
 		"camundaHub.enabled":                  "false",

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/types.go
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/types.go
@@ -18,7 +18,8 @@ type DatasourceYAML struct {
 }
 
 type MailYAML struct {
-	Username string `yaml:"username"`
+	Username   string         `yaml:"username"`
+	Properties map[string]any `yaml:"properties"`
 }
 
 type SpringSecurityYAML struct {

--- a/charts/camunda-platform-8.10/values.schema.extra.json
+++ b/charts/camunda-platform-8.10/values.schema.extra.json
@@ -1379,6 +1379,11 @@
             "default": {},
             "additionalProperties": true,
             "properties": {
+                "contextPath": {
+                    "type": ["string", "null"],
+                    "description": "can be used to make Camunda Hub available on a custom sub-path. This 8.10 alpha override replaces camundaHub.webModeler.contextPath.",
+                    "default": null
+                },
                 "automountServiceAccountToken": {
                     "type": ["boolean", "null"],
                     "description": "can be used to override the automatic mounting of the service account token at the pod level. When unset, the ServiceAccount configuration is used.",

--- a/charts/camunda-platform-8.10/values.schema.json
+++ b/charts/camunda-platform-8.10/values.schema.json
@@ -2077,9 +2077,13 @@
                     "default": false
                 },
                 "contextPath": {
-                    "type": "string",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
                     "description": "can be used to make Camunda Hub available on a custom sub-path. This 8.10 alpha override replaces camundaHub.webModeler.contextPath.",
-                    "default": ""
+                    "default": null,
+                    "nullable": true
                 },
                 "automountServiceAccountToken": {
                     "type": [

--- a/charts/camunda-platform-8.10/values.yaml
+++ b/charts/camunda-platform-8.10/values.yaml
@@ -1192,6 +1192,13 @@ camundaHub:
   ## setting only camundaHub.restapi.containerSecurityContext.runAsUser preserves the remaining
   ## securityContext fields. Explicit false, 0 and "" override the legacy value; an unset (null)
   ## key falls through to it.
+  ##
+  ## Maps merge key by key, so a map here cannot remove a legacy key: camundaHub.restapi.nodeSelector
+  ## {zone: us-east} over webModeler.restapi.nodeSelector {tier: compute} yields both keys. Arrays
+  ## replace wholesale, matching Helm's own convention, so camundaHub.restapi.tolerations fully
+  ## replaces the legacy list. To replace a scheduling map outright, set it on webModeler.* instead.
+  ## Setting a key here to a scalar where webModeler.* has a map (or vice versa) is a hard error
+  ## rather than a silent subtree replacement.
   ## @skip camundaHub.image
   image: {}
   ## @skip camundaHub.security

--- a/charts/camunda-platform-8.10/values.yaml
+++ b/charts/camunda-platform-8.10/values.yaml
@@ -1199,6 +1199,12 @@ camundaHub:
   ## replaces the legacy list. To replace a scheduling map outright, set it on webModeler.* instead.
   ## Setting a key here to a scalar where webModeler.* has a map (or vice versa) is a hard error
   ## rather than a silent subtree replacement.
+  ##
+  ## These rules currently apply to the values read by the Web Modeler restapi and websockets
+  ## workloads, to camundaHub.contextPath, and to camundaHub.restapi.mail. Every other consumer
+  ## (the services, service account, shared secret, the shared and websockets configmaps, the
+  ## HTTPRoute and the service monitor) still takes the first truthy value, so a map set there
+  ## replaces the legacy map rather than merging into it, and a falsy override there is ignored.
   ## @skip camundaHub.image
   image: {}
   ## @skip camundaHub.security

--- a/charts/camunda-platform-8.10/values.yaml
+++ b/charts/camunda-platform-8.10/values.yaml
@@ -1184,19 +1184,14 @@ camundaHub:
   ## Equivalent to setting both webModeler.enabled=true and console.enabled=true on the legacy keys.
   enabled: false
 
-  ## @param camundaHub.contextPath can be used to make Camunda Hub available on a custom sub-path. This 8.10 alpha override replaces camundaHub.webModeler.contextPath.
-  contextPath: ""
+  ## @param camundaHub.contextPath [nullable] can be used to make Camunda Hub available on a custom sub-path. This 8.10 alpha override replaces camundaHub.webModeler.contextPath.
+  contextPath:
 
   ## Any values set here take precedence over the legacy top-level webModeler.* values.
-  ## Only intermediate maps are defined so `or` falls through to legacy values by default.
-  ## To override a value, set it explicitly under camundaHub (e.g. camundaHub.contextPath: /modeler).
-  ##
-  ## NOTE: The `or` function returns the first truthy value. This means camundaHub overrides
-  ## cannot set a value to a falsy form (false, 0, or ""). For example, setting
-  ## camundaHub.restapi.readinessProbe.enabled=false will NOT disable the probe
-  ## if the legacy webModeler.restapi.readinessProbe.enabled is true. Use the legacy keys
-  ## directly for falsy overrides.
-  ## Exception: camundaHub.image.* (and the per-component restapi/websockets image maps) are merged additively over the legacy image maps, so partial overrides (e.g. only registry) keep the legacy tag.
+  ## Values are deep-merged over webModeler.*, so a partial override keeps the sibling defaults:
+  ## setting only camundaHub.restapi.containerSecurityContext.runAsUser preserves the remaining
+  ## securityContext fields. Explicit false, 0 and "" override the legacy value; an unset (null)
+  ## key falls through to it.
   ## @skip camundaHub.image
   image: {}
   ## @skip camundaHub.security


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes part of #6848.

`camundaHub.*` values were coalesced onto `webModeler.*` with 210 inline `or` expressions. `or` returns the first *truthy* operand, so overriding one key of a map subtree replaced the whole subtree:

```console
$ helm template t . \
    --set orchestration.data.secondaryStorage.type=elasticsearch \
    --set camundaHub.enabled=true --set identity.enabled=true \
    --set webModeler.restapi.mail.fromAddress=a@b.com \
    --set camundaHub.restapi.containerSecurityContext.runAsUser=2000 \
    --show-only templates/web-modeler/deployment-restapi.yaml
```

```diff
-             allowPrivilegeEscalation: false
-             readOnlyRootFilesystem: true
-             runAsNonRoot: true
-             seccompProfile:
-               type: RuntimeDefault
+             runAsUser: 2000
```

A one-line UID override left the container with privilege escalation allowed, a writable root filesystem, no `runAsNonRoot` and no seccomp profile. The same applied to `podSecurityContext` on both workloads, and to `resources`, which lost its memory limit and both requests (Burstable to BestEffort). No error, no warning; `helm lint` and schema validation both pass.

Only users who set `camundaHub.*` are affected. Those keys are new in 8.10 and 8.10 is still alpha, so no released deployment is exposed, and 8.9 and earlier have no shim.

### What's in this PR?

Adds `camundaHub.values` in `templates/camunda-hub/_helpers.tpl` — a presence-based deep merge of `camundaHub.*` over `webModeler.*` — and converts both deployment templates to read the merged result.

Merging is keyed on `hasKey`, not truthiness. That single choice fixes both the subtree-replacement defect and the separate defect where a falsy `camundaHub.*` override was silently ignored.

`mustMergeOverwrite` was rejected: it wraps mergo, whose zero-value handling varies by version, which would leave falsy overrides broken. The merge is an explicit recursion that mutates a `deepCopy` of `webModeler.*` in place.

A nil value means "not specified" and falls through to the legacy value, matching the `[nullable]` convention already used by `camundaHub.automountServiceAccountToken`. This matters because `values.yaml` *declares* placeholder defaults under `camundaHub`: without the nil rule, the declared `camundaHub.contextPath: ""` would clobber a legacy `webModeler.contextPath`. `contextPath` therefore becomes nullable, with the string-or-null type declared in `values.schema.extra.json`.

`camundaHub.webModelerEnabled` and `camundaHub.consoleEnabled` keep reading `.Values` directly — they are enablement gates driven by `global.topology.mode`, not value resolution.

Goldens are unchanged: they render from chart defaults, where the `camundaHub` side is empty. Behaviour changes only for users who set partial `camundaHub.*` overrides, who stop losing defaults — release-noted separately.

`TestFalsyCamundaHubOverrideDoesNotOverrideTruthyLegacyValue` asserted the old behaviour and is inverted. Five tests are added covering partial `containerSecurityContext`, `podSecurityContext` and `resources` overrides on both workloads, plus legacy fall-through.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
