### PR TITLE
refactor(8.10): read merged Hub values across the remaining templates

### DIFF
--- a/charts/camunda-platform-8.10/templates/camunda-hub/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/camunda-hub/_helpers.tpl
@@ -33,7 +33,3 @@ Enablement gates live in templates/common/_helpers.tpl ("camundaHub.webModelerEn
         {{- end -}}
     {{- end -}}
 {{- end -}}
-
-{{- define "camundaHub.contextPath" -}}
-    {{- (include "camundaHub.values" . | fromYaml).contextPath -}}
-{{- end -}}

--- a/charts/camunda-platform-8.10/templates/common/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/common/_helpers.tpl
@@ -503,19 +503,20 @@ Web Modeler templates.
 
 {{- define "camundaPlatform.getExternalURLModeler" -}}
   {{- if eq (include "camundaHub.webModelerEnabled" .context) "true" -}}
+    {{- $hub := include "camundaHub.values" .context | fromYaml -}}
     {{- if $.context.Values.global.ingress.enabled -}}
       {{ $proto := ternary "https" "http" .context.Values.global.ingress.tls.enabled -}}
       {{- if eq .component "websockets" }}
         {{- printf "%s://%s%s" $proto (tpl .context.Values.global.host .context) (include "webModeler.websocketContextPath" .context) -}}
       {{- else -}}
-        {{- printf "%s://%s%s" $proto (tpl .context.Values.global.host .context) (include "camundaHub.contextPath" .context) -}}
+        {{- printf "%s://%s%s" $proto (tpl .context.Values.global.host .context) $hub.contextPath -}}
       {{- end -}}
     {{- else if and $.context.Values.global.gateway.enabled (tpl .context.Values.global.host .context) -}}
       {{- $baseURL := include "camundaPlatform.gatewayExternalURL" (dict "context" .context "host" .context.Values.global.host) -}}
       {{- if eq .component "websockets" }}
         {{- printf "%s%s" $baseURL (include "webModeler.websocketContextPath" .context) -}}
       {{- else -}}
-        {{- printf "%s%s" $baseURL (include "camundaHub.contextPath" .context) -}}
+        {{- printf "%s%s" $baseURL $hub.contextPath -}}
       {{- end -}}
     {{- else -}}
       {{- if eq .component "websockets" -}}
@@ -814,14 +815,15 @@ Release templates.
   {{- end }}
 
   {{- if eq (include "camundaHub.webModelerEnabled" .) "true" }}
-  {{-  $proto := (lower (or .Values.camundaHub.restapi.readinessProbe.scheme .Values.webModeler.restapi.readinessProbe.scheme)) -}}
-  {{- $baseURLInternal := printf "%s://%s.%s:%v" $proto (include "webModeler.restapi.fullname" .) .Release.Namespace (or .Values.camundaHub.restapi.service.managementPort .Values.webModeler.restapi.service.managementPort) }}
+  {{- $hub := include "camundaHub.values" . | fromYaml -}}
+  {{-  $proto := (lower $hub.restapi.readinessProbe.scheme) -}}
+  {{- $baseURLInternal := printf "%s://%s.%s:%v" $proto (include "webModeler.restapi.fullname" .) .Release.Namespace $hub.restapi.service.managementPort }}
   - name: WebModeler
     id: hub
-    version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" (dict "image" (mustMergeOverwrite (deepCopy .Values.webModeler.image) (.Values.camundaHub.image | default dict)))) }}
+    version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" (dict "image" ($hub.image))) }}
     url: {{ include "camundaPlatform.webModelerExternalURL" . }}
-    readiness: {{ printf "%s%s" $baseURLInternal (include "camundaPlatform.joinpath" (list (include "camundaHub.contextPath" .) (or .Values.camundaHub.restapi.readinessProbe.probePath .Values.webModeler.restapi.readinessProbe.probePath))) }}
-    metrics: {{ printf "%s%s" $baseURLInternal (include "camundaPlatform.joinpath" (list (include "camundaHub.contextPath" .) (or .Values.camundaHub.restapi.metrics.prometheus .Values.webModeler.restapi.metrics.prometheus))) }}
+    readiness: {{ printf "%s%s" $baseURLInternal (include "camundaPlatform.joinpath" (list $hub.contextPath $hub.restapi.readinessProbe.probePath)) }}
+    metrics: {{ printf "%s%s" $baseURLInternal (include "camundaPlatform.joinpath" (list $hub.contextPath $hub.restapi.metrics.prometheus)) }}
   {{- end }}
 
   {{- if eq (include "camundaPlatform.optimizeEnabled" .) "true" }}
@@ -887,10 +889,11 @@ required by camunda.modeler.clusters (introduced in 8.10 Hub/WebModeler).
 ********************************************************************************
 */}}
 {{- define "camundaPlatform.defaultWebModelerCluster" -}}
+    {{- $hub := include "camundaHub.values" . | fromYaml -}}
 {{- if or (eq (include "camundaPlatform.identityEnabled" .) "true") (eq (include "camundaHub.webModelerEnabled" .) "true") }}
 - id: "management-cluster"
   name: "hub"
-  version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" (dict "image" (mustMergeOverwrite (deepCopy .Values.webModeler.image) (.Values.camundaHub.image | default dict)))) | quote }}
+  version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" (dict "image" ($hub.image))) | quote }}
   authentication: {{ include "webModeler.authConfigValue" . | quote }}
   authorizations:
     enabled: false
@@ -906,14 +909,14 @@ required by camunda.modeler.clusters (introduced in 8.10 Hub/WebModeler).
       readiness: {{ printf "%s%s" $baseURLInternal .Values.identity.readinessProbe.probePath | quote }}
   {{- end }}
   {{- if eq (include "camundaHub.webModelerEnabled" .) "true" }}
-  {{- $proto := (lower (or .Values.camundaHub.restapi.readinessProbe.scheme .Values.webModeler.restapi.readinessProbe.scheme)) }}
-  {{- $baseURLInternal := printf "%s://%s.%s:%v" $proto (include "webModeler.restapi.fullname" .) .Release.Namespace (or .Values.camundaHub.restapi.service.managementPort .Values.webModeler.restapi.service.managementPort) }}
+  {{- $proto := (lower $hub.restapi.readinessProbe.scheme) }}
+  {{- $baseURLInternal := printf "%s://%s.%s:%v" $proto (include "webModeler.restapi.fullname" .) .Release.Namespace $hub.restapi.service.managementPort }}
   - name: WebModeler
     type: hub
-    version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" (dict "image" (mustMergeOverwrite (deepCopy .Values.webModeler.image) (.Values.camundaHub.image | default dict)))) | quote }}
+    version: {{ include "camundaPlatform.imageTagByParams" (dict "base" .Values.global "overlay" (dict "image" ($hub.image))) | quote }}
     urls:
       webapp: {{ include "camundaPlatform.webModelerExternalURL" . | quote }}
-      readiness: {{ printf "%s%s" $baseURLInternal (include "camundaPlatform.joinpath" (list (include "camundaHub.contextPath" .) (or .Values.camundaHub.restapi.readinessProbe.probePath .Values.webModeler.restapi.readinessProbe.probePath))) | quote }}
+      readiness: {{ printf "%s%s" $baseURLInternal (include "camundaPlatform.joinpath" (list $hub.contextPath $hub.restapi.readinessProbe.probePath)) | quote }}
   {{- end }}
 {{- end }}
 {{- if or (eq (include "camundaPlatform.orchestrationEnabled" .) "true") (eq (include "camundaPlatform.optimizeEnabled" .) "true") (eq (include "camundaPlatform.connectorsEnabled" .) "true") }}

--- a/charts/camunda-platform-8.10/templates/common/ingress-http.yaml
+++ b/charts/camunda-platform-8.10/templates/common/ingress-http.yaml
@@ -1,3 +1,7 @@
+{{- $hub := dict -}}
+{{- if eq (include "camundaHub.webModelerEnabled" .) "true" -}}
+{{- $hub = include "camundaHub.values" . | fromYaml -}}
+{{- end -}}
 {{- if and .Values.global.ingress.enabled (not .Values.global.ingress.external) -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -46,19 +50,19 @@ spec:
             pathType: {{ .Values.global.ingress.pathType }}
           {{- end }}
           {{- end }}
-          {{- if and (eq (include "camundaHub.webModelerEnabled" .) "true") (include "camundaHub.contextPath" .) }}
+          {{- if and (eq (include "camundaHub.webModelerEnabled" .) "true") $hub.contextPath }}
           - backend:
               service:
                 name: {{ template "webModeler.restapi.fullname" . }}
                 port:
-                  number: {{ (or .Values.camundaHub.restapi.service.port .Values.webModeler.restapi.service.port) }}
-            path: {{ (include "camundaHub.contextPath" .) }}
+                  number: {{ $hub.restapi.service.port }}
+            path: {{ $hub.contextPath }}
             pathType: {{ .Values.global.ingress.pathType }}
           - backend:
               service:
                 name: {{ template "webModeler.websockets.fullname" . }}
                 port:
-                  number:  {{ (or .Values.camundaHub.websockets.service.port .Values.webModeler.websockets.service.port) }}
+                  number:  {{ $hub.websockets.service.port }}
             path: {{ template "webModeler.websocketContextPath" . }}
             pathType: {{ .Values.global.ingress.pathType }}
           {{- end }}

--- a/charts/camunda-platform-8.10/templates/service-monitor/web-modeler-service-monitor.yaml
+++ b/charts/camunda-platform-8.10/templates/service-monitor/web-modeler-service-monitor.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.prometheusServiceMonitor.enabled (eq (include "camundaHub.webModelerEnabled" .) "true") -}}
+{{- $hub := include "camundaHub.values" . | fromYaml -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -12,7 +13,7 @@ spec:
       app.kubernetes.io/component: restapi
   endpoints:
     - honorLabels: true
-      path: {{ (or .Values.camundaHub.restapi.metrics.prometheus .Values.webModeler.restapi.metrics.prometheus) }}
+      path: {{ $hub.restapi.metrics.prometheus }}
       port: http-management
       interval: {{ .Values.prometheusServiceMonitor.scrapeInterval }}
 {{- end }}

--- a/charts/camunda-platform-8.10/templates/web-modeler/_helpers.tpl
+++ b/charts/camunda-platform-8.10/templates/web-modeler/_helpers.tpl
@@ -11,15 +11,10 @@ web-modeler
 Create a default fully qualified app name.
 */}}
 {{- define "webModeler.fullname" -}}
-  {{/* mustMergeOverwrite is used instead of or because camundaHub has intermediate
-       sub-maps that make it truthy even when no overrides are set. Only merge the
-       fields consumed by componentFullname and versionLabel. */}}
+    {{- $hub := include "camundaHub.values" . | fromYaml -}}
   {{- include "camundaPlatform.componentFullname" (dict
       "componentName" "web-modeler"
-      "componentValues" (mustMergeOverwrite (deepCopy .Values.webModeler) (dict
-          "fullnameOverride" .Values.camundaHub.fullnameOverride
-          "nameOverride" .Values.camundaHub.nameOverride
-          "image" .Values.camundaHub.image))
+      "componentValues" $hub
       "context" $
   ) -}}
 {{- end -}}
@@ -40,15 +35,17 @@ Create a fully qualified name for the websockets objects.
 {{- end -}}
 
 {{- define "webModeler.extraLabels" -}}
+    {{- $hub := include "camundaHub.values" . | fromYaml -}}
 app.kubernetes.io/component: web-modeler
-app.kubernetes.io/version: {{ include "camundaPlatform.versionLabel" (dict "base" .Values.global "overlay" (mustMergeOverwrite (deepCopy .Values.webModeler) .Values.camundaHub) "chart" .Chart) | quote }}
+app.kubernetes.io/version: {{ include "camundaPlatform.versionLabel" (dict "base" .Values.global "overlay" $hub "chart" .Chart) | quote }}
 {{- end -}}
 
 {{/*
 Define common labels for all Web Modeler components.
 */}}
 {{- define "webModeler.commonLabels" -}}
-{{- $values := merge (deepCopy .Values) (dict "nameOverride" (include "webModeler.name" .) "image" (or .Values.camundaHub.image .Values.webModeler.image)) }}
+    {{- $hub := include "camundaHub.values" . | fromYaml -}}
+{{- $values := merge (deepCopy .Values) (dict "nameOverride" (include "webModeler.name" .) "image" $hub.image) }}
 {{- template "camundaPlatform.labels" (dict "Chart" .Chart "Release" .Release "Values" $values) }}
 {{- end -}}
 
@@ -101,7 +98,8 @@ app.kubernetes.io/component: {{ .componentName }}
 [web-modeler] Get the image pull secrets.
 */}}
 {{- define "webModeler.imagePullSecrets" -}}
-  {{- $image := mustMergeOverwrite (deepCopy .Values.webModeler.image) (.Values.camundaHub.image | default dict) }}
+    {{- $hub := include "camundaHub.values" . | fromYaml -}}
+  {{- $image := $hub.image }}
   {{- include "camundaPlatform.componentImagePullSecrets" (dict "Values" (set (deepCopy .Values) "image" $image)) }}
 {{- end }}
 
@@ -109,8 +107,9 @@ app.kubernetes.io/component: {{ .componentName }}
 [web-modeler] Get the full name (<registry>/<repository>:<tag>) of the restapi Docker image
 */}}
 {{- define "webModeler.restapi.image" -}}
-  {{- $image := mustMergeOverwrite (deepCopy .Values.webModeler.image) (.Values.camundaHub.image | default dict) }}
-  {{- $image = mustMergeOverwrite $image (mustMergeOverwrite (deepCopy .Values.webModeler.restapi.image) (.Values.camundaHub.restapi.image | default dict)) }}
+    {{- $hub := include "camundaHub.values" . | fromYaml -}}
+  {{- $image := $hub.image }}
+  {{- $image = mustMergeOverwrite $image ($hub.restapi.image) }}
   {{- include "camundaPlatform.imageByParams" (dict "base" .Values.global "overlay" (dict "image" $image)) }}
 {{- end }}
 
@@ -118,8 +117,9 @@ app.kubernetes.io/component: {{ .componentName }}
 [web-modeler] Get the full name (<registry>/<repository>:<tag>) of the websockets Docker image
 */}}
 {{- define "webModeler.websockets.image" -}}
-  {{- $image := mustMergeOverwrite (deepCopy .Values.webModeler.image) (.Values.camundaHub.image | default dict) }}
-  {{- $image = mustMergeOverwrite $image (mustMergeOverwrite (deepCopy .Values.webModeler.websockets.image) (.Values.camundaHub.websockets.image | default dict)) }}
+    {{- $hub := include "camundaHub.values" . | fromYaml -}}
+  {{- $image := $hub.image }}
+  {{- $image = mustMergeOverwrite $image ($hub.websockets.image) }}
   {{- include "camundaPlatform.imageByParams" (dict "base" .Values.global "overlay" (dict "image" $image)) }}
 {{- end }}
 
@@ -127,8 +127,9 @@ app.kubernetes.io/component: {{ .componentName }}
 [web-modeler] Create the name of the service account to use
 */}}
 {{- define "webModeler.serviceAccountName" -}}
-    {{- $saName := (or .Values.camundaHub.serviceAccount.name .Values.webModeler.serviceAccount.name) -}}
-    {{- if (or .Values.camundaHub.serviceAccount.enabled .Values.webModeler.serviceAccount.enabled) -}}
+    {{- $hub := include "camundaHub.values" . | fromYaml -}}
+    {{- $saName := $hub.serviceAccount.name -}}
+    {{- if $hub.serviceAccount.enabled -}}
         {{- $saName | default (include "webModeler.fullname" .) -}}
     {{- else -}}
         {{- $saName | default "default" -}}
@@ -139,13 +140,14 @@ app.kubernetes.io/component: {{ .componentName }}
 [web-modeler] Get the database JDBC url for the external PostgreSQL.
 */}}
 {{- define "webModeler.restapi.databaseUrl" -}}
-  {{- if (or .Values.camundaHub.restapi.externalDatabase.url .Values.webModeler.restapi.externalDatabase.url) -}}
-    {{- (or .Values.camundaHub.restapi.externalDatabase.url .Values.webModeler.restapi.externalDatabase.url) -}}
-  {{- else if (or .Values.camundaHub.restapi.externalDatabase.host .Values.webModeler.restapi.externalDatabase.host) -}}
+    {{- $hub := include "camundaHub.values" . | fromYaml -}}
+  {{- if $hub.restapi.externalDatabase.url -}}
+    {{- $hub.restapi.externalDatabase.url -}}
+  {{- else if $hub.restapi.externalDatabase.host -}}
     {{- printf "jdbc:postgresql://%s:%s/%s"
-        (or .Values.camundaHub.restapi.externalDatabase.host .Values.webModeler.restapi.externalDatabase.host)
-        (toString (or .Values.camundaHub.restapi.externalDatabase.port .Values.webModeler.restapi.externalDatabase.port))
-        (or .Values.camundaHub.restapi.externalDatabase.database .Values.webModeler.restapi.externalDatabase.database)
+        $hub.restapi.externalDatabase.host
+        (toString $hub.restapi.externalDatabase.port)
+        $hub.restapi.externalDatabase.database
       -}}
   {{- end -}}
 {{- end -}}
@@ -154,14 +156,15 @@ app.kubernetes.io/component: {{ .componentName }}
 [web-modeler] Get the database user.
 */}}
 {{- define "webModeler.restapi.databaseUser" -}}
-  {{- (or .Values.camundaHub.restapi.externalDatabase.username .Values.webModeler.restapi.externalDatabase.username) -}}
+    {{- $hub := include "camundaHub.values" . | fromYaml -}}
+  {{- $hub.restapi.externalDatabase.username -}}
 {{- end -}}
 
 {{/*
 [web-modeler] Check if username and password is provided for the SMTP server
 */}}
 {{- define "webModeler.restapi.mail.authEnabled" -}}
-  {{- $hub := include "camundaHub.values" . | fromYaml -}}
+    {{- $hub := include "camundaHub.values" . | fromYaml -}}
   {{- $authEnabled := false -}}
   {{- if and (typeIs "string" $hub.restapi.mail.smtpUser) (ne $hub.restapi.mail.smtpUser "") }}
     {{- if or (and (typeIs "string" $hub.restapi.mail.smtpPassword) (ne $hub.restapi.mail.smtpPassword "")) $hub.restapi.mail.existingSecret }}
@@ -175,17 +178,19 @@ app.kubernetes.io/component: {{ .componentName }}
 [web-modeler] Create the context path for the WebSocket app (= configured context path + suffix "-ws").
 */}}
 {{- define "webModeler.websocketContextPath" -}}
-  {{- (include "camundaHub.contextPath" .) }}-ws
+    {{- $hub := include "camundaHub.values" . | fromYaml -}}
+  {{- $hub.contextPath }}-ws
 {{- end -}}
 
 {{/*
 [web-modeler] Get the host name on which the WebSocket server is reachable from the client.
 */}}
 {{- define "webModeler.publicWebsocketHost" -}}
-  {{- if and .Values.global.ingress.enabled (include "camundaHub.contextPath" .) }}
+    {{- $hub := include "camundaHub.values" . | fromYaml -}}
+  {{- if and .Values.global.ingress.enabled $hub.contextPath }}
     {{- tpl .Values.global.host $ }}
   {{- else -}}
-    {{- (or .Values.camundaHub.websockets.publicHost .Values.webModeler.websockets.publicHost) }}
+    {{- $hub.websockets.publicHost }}
   {{- end }}
 {{- end -}}
 
@@ -193,10 +198,11 @@ app.kubernetes.io/component: {{ .componentName }}
 [web-modeler] Get the port number on which the WebSocket server is reachable from the client.
 */}}
 {{- define "webModeler.publicWebsocketPort" -}}
-  {{- if and .Values.global.ingress.enabled (include "camundaHub.contextPath" .) }}
+    {{- $hub := include "camundaHub.values" . | fromYaml -}}
+  {{- if and .Values.global.ingress.enabled $hub.contextPath }}
     {{- .Values.global.ingress.tls.enabled | ternary "443" "80" }}
   {{- else }}
-    {{- (or .Values.camundaHub.websockets.publicPort .Values.webModeler.websockets.publicPort) }}
+    {{- $hub.websockets.publicPort }}
   {{- end }}
 {{- end -}}
 
@@ -204,7 +210,8 @@ app.kubernetes.io/component: {{ .componentName }}
 [web-modeler] Check if TLS must be enabled for WebSocket connections from the client.
 */}}
 {{- define "webModeler.websocketTlsEnabled" -}}
-  {{- if and .Values.global.ingress.enabled (include "camundaHub.contextPath" .) }}
+    {{- $hub := include "camundaHub.values" . | fromYaml -}}
+  {{- if and .Values.global.ingress.enabled $hub.contextPath }}
     {{- .Values.global.ingress.tls.enabled }}
   {{- else -}}
     false
@@ -227,7 +234,8 @@ app.kubernetes.io/component: {{ .componentName }}
 {{- end -}}
 
 {{- define "webModeler.authMethod" -}}
-    {{- (or .Values.camundaHub.security.authentication.method .Values.webModeler.security.authentication.method) | default (
+    {{- $hub := include "camundaHub.values" . | fromYaml -}}
+    {{- $hub.security.authentication.method | default (
         .Values.global.security.authentication.method | default "none"
     ) -}}
 {{- end -}}

--- a/charts/camunda-platform-8.10/templates/web-modeler/configmap-restapi.yaml
+++ b/charts/camunda-platform-8.10/templates/web-modeler/configmap-restapi.yaml
@@ -1,5 +1,6 @@
 {{- if eq (include "camundaHub.webModelerEnabled" .) "true" -}}
 {{- $hub := include "camundaHub.values" . | fromYaml -}}
+{{- $hub := include "camundaHub.values" . | fromYaml -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,9 +8,9 @@ metadata:
   labels: {{- include "webModeler.labels" . | nindent 4 }}
   annotations: {{- toYaml .Values.global.annotations | nindent 4 }}
 data:
-  {{- if (or .Values.camundaHub.restapi.configuration .Values.webModeler.restapi.configuration) }}
+  {{- if $hub.restapi.configuration }}
   application.yaml: |
-    {{ (or .Values.camundaHub.restapi.configuration .Values.webModeler.restapi.configuration) | indent 4 | trim }}
+    {{ $hub.restapi.configuration | indent 4 | trim }}
   {{- else }}
   application.yaml: |
     camunda:
@@ -29,11 +30,11 @@ data:
 
         pusher:
           host: {{ include "webModeler.websockets.fullname" . | quote }}
-          port: {{ (or .Values.camundaHub.websockets.service.port .Values.webModeler.websockets.service.port) }}
+          port: {{ $hub.websockets.service.port }}
           client:
             host: {{ include "webModeler.publicWebsocketHost" . | quote }}
             port: {{ include "webModeler.publicWebsocketPort" . | quote }}
-            {{- if and .Values.global.ingress.enabled (include "camundaHub.contextPath" .) }}
+            {{- if and .Values.global.ingress.enabled $hub.contextPath }}
             path: {{ include "webModeler.websocketContextPath" . | quote }}
             {{- end }}
             force-tls: {{ include "webModeler.websocketTlsEnabled" . }}
@@ -50,7 +51,7 @@ data:
 
         mail:
           {{- $fromAddress := $hub.restapi.mail.fromAddress }}
-          {{- $restapiExtraConfig := or .Values.camundaHub.restapi.extraConfiguration .Values.webModeler.restapi.extraConfiguration }}
+          {{- $restapiExtraConfig := $hub.restapi.extraConfiguration }}
           {{- if $fromAddress }}
           from-address: {{ $fromAddress | quote }}
           {{- else if ne (include "camundaPlatform.extraConfigHasPath" (dict "extraConfiguration" $restapiExtraConfig "path" (list "camunda" "modeler" "mail" "from-address"))) "true" }}
@@ -67,10 +68,10 @@ data:
           url: {{ tpl (or .Values.global.identity.auth.camundaHub.redirectUrl .Values.global.identity.auth.webModeler.redirectUrl) $ | quote }}
           https-only: {{ hasPrefix "https://" (tpl (or .Values.global.identity.auth.camundaHub.redirectUrl .Values.global.identity.auth.webModeler.redirectUrl) $) | quote }}
 
-        {{- if or .Values.orchestration.enabled (eq (include "camundaPlatform.topologyMode" .) "hub") (or .Values.camundaHub.restapi.clusters .Values.webModeler.restapi.clusters) }}
+        {{- if or .Values.orchestration.enabled (eq (include "camundaPlatform.topologyMode" .) "hub") $hub.restapi.clusters }}
         clusters:
-          {{- if (or .Values.camundaHub.restapi.clusters .Values.webModeler.restapi.clusters) }}
-            {{- (or .Values.camundaHub.restapi.clusters .Values.webModeler.restapi.clusters) | toYaml | nindent 10 }}
+          {{- if $hub.restapi.clusters }}
+            {{- $hub.restapi.clusters | toYaml | nindent 10 }}
           {{- else}}
             {{- if eq (include "camundaPlatform.topologyMode" .) "hub" }}
               {{- include "camundaPlatform.topologyWebModelerClusters" . | nindent 10 }}
@@ -82,7 +83,7 @@ data:
 
     spring:
       {{- $springImports := list }}
-      {{- range (or .Values.camundaHub.restapi.extraConfiguration .Values.webModeler.restapi.extraConfiguration) }}
+      {{- range $hub.restapi.extraConfiguration }}
         {{- if not (and (hasKey . "springImport") (eq .springImport false)) }}
           {{- $springImports = append $springImports . }}
         {{- end }}
@@ -125,19 +126,19 @@ data:
           max-file-size: {{ .Values.global.config.requestBodySize | quote }}
           max-request-size: {{ .Values.global.config.requestBodySize | quote }}
 
-    {{- if (include "camundaHub.contextPath" .) }}
+    {{- if $hub.contextPath }}
     server:
       servlet:
-        context-path: {{ include "camundaPlatform.joinpath" (list (include "camundaHub.contextPath" .)) | quote }}
+        context-path: {{ include "camundaPlatform.joinpath" (list $hub.contextPath) | quote }}
     management:
       server:
-        base-path: {{ include "camundaPlatform.joinpath" (list (include "camundaHub.contextPath" .)) | quote }}
+        base-path: {{ include "camundaPlatform.joinpath" (list $hub.contextPath) | quote }}
     {{- end }}
 
     logging:
-{{- with (or .Values.camundaHub.restapi.logging .Values.webModeler.restapi.logging) }}
+{{- with $hub.restapi.logging }}
 {{ . | toYaml | indent 6 }}
 {{- end }}
   {{- end }}
-  {{- include "camundaPlatform.renderExtraConfiguration" (dict "extraConfig" (or .Values.camundaHub.restapi.extraConfiguration .Values.webModeler.restapi.extraConfiguration)) }}
+  {{- include "camundaPlatform.renderExtraConfiguration" (dict "extraConfig" $hub.restapi.extraConfiguration) }}
 {{- end }}

--- a/charts/camunda-platform-8.10/templates/web-modeler/configmap-shared.yaml
+++ b/charts/camunda-platform-8.10/templates/web-modeler/configmap-shared.yaml
@@ -1,4 +1,5 @@
 {{- if eq (include "camundaHub.webModelerEnabled" .) "true" -}}
+{{- $hub := include "camundaHub.values" . | fromYaml -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,9 +8,9 @@ metadata:
   annotations: {{- toYaml .Values.global.annotations | nindent 4 }}
 data:
   pusher-app-id: web-modeler
-  {{- if (or .Values.camundaHub.configuration .Values.webModeler.configuration) }}
+  {{- if $hub.configuration }}
   application.yaml: |
-    {{ (or .Values.camundaHub.configuration .Values.webModeler.configuration) | indent 4 | trim }}
+    {{ $hub.configuration | indent 4 | trim }}
   {{- end }}
-  {{- include "camundaPlatform.renderExtraConfiguration" (dict "extraConfig" (or .Values.camundaHub.extraConfiguration .Values.webModeler.extraConfiguration)) }}
+  {{- include "camundaPlatform.renderExtraConfiguration" (dict "extraConfig" $hub.extraConfiguration) }}
 {{- end }}

--- a/charts/camunda-platform-8.10/templates/web-modeler/configmap-websockets.yaml
+++ b/charts/camunda-platform-8.10/templates/web-modeler/configmap-websockets.yaml
@@ -1,4 +1,5 @@
 {{- if eq (include "camundaHub.webModelerEnabled" .) "true" -}}
+{{- $hub := include "camundaHub.values" . | fromYaml -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,11 +7,11 @@ metadata:
   labels: {{- include "webModeler.labels" . | nindent 4 }}
   annotations: {{- toYaml .Values.global.annotations | nindent 4 }}
 data:
-  {{- if (or .Values.camundaHub.websockets.configuration .Values.webModeler.websockets.configuration) }}
+  {{- if $hub.websockets.configuration }}
   application.yaml: |
-    {{ (or .Values.camundaHub.websockets.configuration .Values.webModeler.websockets.configuration) | indent 4 | trim }}
+    {{ $hub.websockets.configuration | indent 4 | trim }}
   {{- else }}
   application.yaml: |
   {{- end }}
-  {{- include "camundaPlatform.renderExtraConfiguration" (dict "extraConfig" (or .Values.camundaHub.websockets.extraConfiguration .Values.webModeler.websockets.extraConfiguration)) }}
+  {{- include "camundaPlatform.renderExtraConfiguration" (dict "extraConfig" $hub.websockets.extraConfiguration) }}
 {{- end }}

--- a/charts/camunda-platform-8.10/templates/web-modeler/httproute.yaml
+++ b/charts/camunda-platform-8.10/templates/web-modeler/httproute.yaml
@@ -1,5 +1,6 @@
 {{- if and .Values.global.gateway.enabled (not .Values.global.gateway.external) -}}
 {{- if eq (include "camundaHub.webModelerEnabled" .) "true" }}
+{{- $hub := include "camundaHub.values" . | fromYaml -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -32,11 +33,11 @@ spec:
   - matches:
     - path:
         type: PathPrefix
-        value: {{ (include "camundaHub.contextPath" .) }}
+        value: {{ $hub.contextPath }}
     backendRefs:
     - name: {{ template "webModeler.restapi.fullname" . }}
       namespace: {{ .Release.Namespace }}
-      port: {{ (or .Values.camundaHub.restapi.service.port .Values.webModeler.restapi.service.port) }}
+      port: {{ $hub.restapi.service.port }}
   - matches:
     - path:
         type: PathPrefix
@@ -44,6 +45,6 @@ spec:
     backendRefs:
     - name: {{ template "webModeler.websockets.fullname" . }}
       namespace: {{ .Release.Namespace }}
-      port: {{ (or .Values.camundaHub.websockets.service.port .Values.webModeler.websockets.service.port) }}
+      port: {{ $hub.websockets.service.port }}
 {{- end }}
 {{- end }}

--- a/charts/camunda-platform-8.10/templates/web-modeler/secret-shared.yaml
+++ b/charts/camunda-platform-8.10/templates/web-modeler/secret-shared.yaml
@@ -1,6 +1,7 @@
 {{- if eq (include "camundaHub.webModelerEnabled" .) "true" -}}
-{{- $usePusherSecret := not (eq "true" (include "camundaPlatform.hasSecretConfig" (dict "config" (mustMergeOverwrite (deepCopy .Values.webModeler.restapi.pusher) .Values.camundaHub.restapi.pusher)))) -}}
-{{- $usePusherAppKey := not (eq "true" (include "camundaPlatform.hasSecretConfig" (dict "config" (mustMergeOverwrite (deepCopy .Values.webModeler.restapi.pusher.client) .Values.camundaHub.restapi.pusher.client)))) -}}
+{{- $hub := include "camundaHub.values" . | fromYaml -}}
+{{- $usePusherSecret := not (eq "true" (include "camundaPlatform.hasSecretConfig" (dict "config" ($hub.restapi.pusher)))) -}}
+{{- $usePusherAppKey := not (eq "true" (include "camundaPlatform.hasSecretConfig" (dict "config" ($hub.restapi.pusher.client)))) -}}
 {{- if or $usePusherSecret $usePusherAppKey }}
 apiVersion: v1
 kind: Secret

--- a/charts/camunda-platform-8.10/templates/web-modeler/service-restapi.yaml
+++ b/charts/camunda-platform-8.10/templates/web-modeler/service-restapi.yaml
@@ -1,4 +1,5 @@
 {{- if eq (include "camundaHub.webModelerEnabled" .) "true" -}}
+{{- $hub := include "camundaHub.values" . | fromYaml -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -9,24 +10,24 @@ metadata:
     {{- if .Values.global.annotations}}
       {{- toYaml .Values.global.annotations | nindent 4 }}
     {{- end }}
-    {{- if (or .Values.camundaHub.restapi.service.annotations .Values.webModeler.restapi.service.annotations)}}
-      {{- toYaml (or .Values.camundaHub.restapi.service.annotations .Values.webModeler.restapi.service.annotations) | nindent 4 }}
+    {{- if $hub.restapi.service.annotations}}
+      {{- toYaml $hub.restapi.service.annotations | nindent 4 }}
     {{- end }}
 spec:
-  type: {{ (or .Values.camundaHub.restapi.service.type .Values.webModeler.restapi.service.type) }}
+  type: {{ $hub.restapi.service.type }}
   ports:
-    - port: {{ (or .Values.camundaHub.restapi.service.port .Values.webModeler.restapi.service.port) }}
+    - port: {{ $hub.restapi.service.port }}
       name: http
       targetPort: 8081
       protocol: TCP
-      {{- with include "camundaPlatform.appProtocol" (dict "portName" "http" "knownPorts" (list "http" "http-management") "appProtocols" (or .Values.camundaHub.restapi.service.appProtocols .Values.webModeler.restapi.service.appProtocols)) }}
+      {{- with include "camundaPlatform.appProtocol" (dict "portName" "http" "knownPorts" (list "http" "http-management") "appProtocols" $hub.restapi.service.appProtocols) }}
       appProtocol: {{ . | quote }}
       {{- end }}
-    - port: {{ (or .Values.camundaHub.restapi.service.managementPort .Values.webModeler.restapi.service.managementPort) }}
+    - port: {{ $hub.restapi.service.managementPort }}
       name: http-management
       targetPort: 8091
       protocol: TCP
-      {{- with include "camundaPlatform.appProtocol" (dict "portName" "http-management" "knownPorts" (list "http" "http-management") "appProtocols" (or .Values.camundaHub.restapi.service.appProtocols .Values.webModeler.restapi.service.appProtocols)) }}
+      {{- with include "camundaPlatform.appProtocol" (dict "portName" "http-management" "knownPorts" (list "http" "http-management") "appProtocols" $hub.restapi.service.appProtocols) }}
       appProtocol: {{ . | quote }}
       {{- end }}
   selector:

--- a/charts/camunda-platform-8.10/templates/web-modeler/service-websockets.yaml
+++ b/charts/camunda-platform-8.10/templates/web-modeler/service-websockets.yaml
@@ -1,4 +1,5 @@
 {{- if eq (include "camundaHub.webModelerEnabled" .) "true" -}}
+{{- $hub := include "camundaHub.values" . | fromYaml -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -9,17 +10,17 @@ metadata:
     {{- if .Values.global.annotations}}
       {{- toYaml .Values.global.annotations | nindent 4 }}
     {{- end }}
-    {{- if (or .Values.camundaHub.websockets.service.annotations .Values.webModeler.websockets.service.annotations)}}
-      {{- toYaml (or .Values.camundaHub.websockets.service.annotations .Values.webModeler.websockets.service.annotations) | nindent 4 }}
+    {{- if $hub.websockets.service.annotations}}
+      {{- toYaml $hub.websockets.service.annotations | nindent 4 }}
     {{- end }}
 spec:
-  type: {{ (or .Values.camundaHub.websockets.service.type .Values.webModeler.websockets.service.type) }}
+  type: {{ $hub.websockets.service.type }}
   ports:
-    - port: {{ (or .Values.camundaHub.websockets.service.port .Values.webModeler.websockets.service.port) }}
+    - port: {{ $hub.websockets.service.port }}
       name: http
       targetPort: 8060
       protocol: TCP
-      {{- with include "camundaPlatform.appProtocol" (dict "portName" "http" "knownPorts" (list "http") "appProtocols" (or .Values.camundaHub.websockets.service.appProtocols .Values.webModeler.websockets.service.appProtocols)) }}
+      {{- with include "camundaPlatform.appProtocol" (dict "portName" "http" "knownPorts" (list "http") "appProtocols" $hub.websockets.service.appProtocols) }}
       appProtocol: {{ . | quote }}
       {{- end }}
   selector:

--- a/charts/camunda-platform-8.10/templates/web-modeler/serviceaccount.yaml
+++ b/charts/camunda-platform-8.10/templates/web-modeler/serviceaccount.yaml
@@ -1,5 +1,6 @@
 {{- if eq (include "camundaHub.webModelerEnabled" .) "true" -}}
-{{- if or .Values.camundaHub.serviceAccount.enabled .Values.webModeler.serviceAccount.enabled -}}
+{{- $hub := include "camundaHub.values" . | fromYaml -}}
+{{- if $hub.serviceAccount.enabled -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -8,17 +9,14 @@ metadata:
     {{- include "common.tplvalues.merge-overwrite" (dict
       "values" (list
         (include "webModeler.labels" .)
-        .Values.webModeler.serviceAccount.labels
+        $hub.serviceAccount.labels
       )
       "context" .
     ) | nindent 4 }}
-  {{- with (or .Values.camundaHub.serviceAccount.annotations .Values.webModeler.serviceAccount.annotations) }}
+  {{- with $hub.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-automountServiceAccountToken: {{ (or
-  .Values.camundaHub.serviceAccount.automountServiceAccountToken
-  .Values.webModeler.serviceAccount.automountServiceAccountToken
-) }}
+automountServiceAccountToken: {{ ($hub.serviceAccount.automountServiceAccountToken ) }}
 {{- end }}
 {{- end }}

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/camunda_hub_shim_test.go
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/camunda_hub_shim_test.go
@@ -506,7 +506,7 @@ func (s *CamundaHubShimTemplateTest) TestFalsySmtpTlsOverrideReachesTheConfigMap
 	s.Require().Equal(false, properties["mail.smtp.starttls.required"])
 }
 
-func (s *CamundaHubShimTemplateTest) TestServiceAnnotationsStillReplaceLegacyMap() {
+func (s *CamundaHubShimTemplateTest) TestServiceAnnotationsMergeWithLegacyMap() {
 	values := map[string]string{
 		"camundaHub.enabled": "true",
 		"webModeler.enabled": "true",
@@ -520,8 +520,8 @@ func (s *CamundaHubShimTemplateTest) TestServiceAnnotationsStillReplaceLegacyMap
 	helm.UnmarshalK8SYaml(s.T(), output, &service)
 	annotations := service.Annotations
 	s.Require().Equal("hubval", annotations["hubkey"])
-	s.Require().NotContains(annotations, "legacykey",
-		"services are not on the merged view yet; values.yaml documents this scope boundary")
+	s.Require().Equal("legacyval", annotations["legacykey"],
+		"services now read the merged view, so a Hub annotations map keeps the legacy keys")
 }
 
 func (s *CamundaHubShimTemplateTest) TestResourceNamesStableBetweenLegacyAndCamundaHubValues() {

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/camunda_hub_shim_test.go
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/camunda_hub_shim_test.go
@@ -623,8 +623,86 @@ func (s *CamundaHubShimTemplateTest) TestRemovedConsoleEnvVarsAreNotRendered() {
 	s.Require().NotContains(output, "CAMUNDA_CONSOLE_")
 }
 
+func (s *CamundaHubShimTemplateTest) TestServiceAccountLabelsMergeAcrossCamundaHubAndLegacy() {
+	values := map[string]string{
+		"camundaHub.enabled":                          "true",
+		"webModeler.enabled":                          "true",
+		"webModeler.serviceAccount.labels.legacyonly": "legacyvalue",
+		"camundaHub.serviceAccount.labels.hubonly":    "hubvalue",
+	}
+	output, err := s.renderWebModeler(values, []string{"templates/web-modeler/serviceaccount.yaml"})
+	s.Require().NoError(err)
+
+	serviceAccount := s.unmarshalServiceAccount(output)
+	s.Require().Equal("hubvalue", serviceAccount.Labels["hubonly"])
+	s.Require().Equal("legacyvalue", serviceAccount.Labels["legacyonly"])
+}
+
+func (s *CamundaHubShimTemplateTest) TestFalsyServiceAccountEnabledOverrideSuppressesServiceAccount() {
+	values := map[string]string{
+		"camundaHub.enabled":                "true",
+		"webModeler.enabled":                "true",
+		"webModeler.serviceAccount.enabled": "true",
+		"camundaHub.serviceAccount.enabled": "false",
+	}
+	_, err := s.renderWebModeler(values, []string{"templates/web-modeler/serviceaccount.yaml"})
+	s.Require().Error(err)
+}
+
+func (s *CamundaHubShimTemplateTest) TestCamundaHubFullnameOverrideAppliesToServiceNames() {
+	values := map[string]string{
+		"camundaHub.enabled":          "true",
+		"webModeler.enabled":          "true",
+		"camundaHub.fullnameOverride": "hubname",
+	}
+	output, err := s.renderWebModeler(values, []string{"templates/web-modeler/service-restapi.yaml"})
+	s.Require().NoError(err)
+
+	s.Require().Equal("hubname-restapi", s.unmarshalService(output).Name)
+}
+
+func (s *CamundaHubShimTemplateTest) TestPartialServiceOverrideKeepsLegacySiblings() {
+	values := map[string]string{
+		"camundaHub.enabled": "true",
+		"webModeler.enabled": "true",
+		"webModeler.restapi.service.annotations.legacyann": "keepme",
+		"camundaHub.restapi.service.port":                  "8888",
+	}
+	output, err := s.renderWebModeler(values, []string{"templates/web-modeler/service-restapi.yaml"})
+	s.Require().NoError(err)
+
+	service := s.unmarshalService(output)
+	s.Require().Equal("keepme", service.Annotations["legacyann"])
+	s.Require().Equal(int32(8888), service.Spec.Ports[0].Port)
+}
+
+func (s *CamundaHubShimTemplateTest) TestPartialExternalDatabaseOverrideKeepsLegacySiblings() {
+	values := map[string]string{
+		"camundaHub.enabled":                           "true",
+		"webModeler.enabled":                           "true",
+		"webModeler.restapi.externalDatabase.host":     "legacyhost",
+		"webModeler.restapi.externalDatabase.port":     "5433",
+		"webModeler.restapi.externalDatabase.database": "legacydb",
+		"camundaHub.restapi.externalDatabase.host":     "hubhost",
+	}
+	application := s.renderRestAPIConfigMap(values)
+	s.Require().Equal("jdbc:postgresql://hubhost:5433/legacydb", application.Spring.Datasource.Url)
+}
+
 func (s *CamundaHubShimTemplateTest) renderWebModelerRestAPI(values map[string]string) (string, error) {
 	return s.renderWebModeler(values, []string{"templates/web-modeler/deployment-restapi.yaml"})
+}
+
+func (s *CamundaHubShimTemplateTest) unmarshalServiceAccount(output string) corev1.ServiceAccount {
+	var serviceAccount corev1.ServiceAccount
+	helm.UnmarshalK8SYaml(s.T(), output, &serviceAccount)
+	return serviceAccount
+}
+
+func (s *CamundaHubShimTemplateTest) unmarshalService(output string) corev1.Service {
+	var service corev1.Service
+	helm.UnmarshalK8SYaml(s.T(), output, &service)
+	return service
 }
 
 func (s *CamundaHubShimTemplateTest) renderWebModeler(values map[string]string, templates []string) (string, error) {

--- a/charts/camunda-platform-8.10/test/unit/web-modeler/camunda_hub_shim_test.go
+++ b/charts/camunda-platform-8.10/test/unit/web-modeler/camunda_hub_shim_test.go
@@ -645,8 +645,12 @@ func (s *CamundaHubShimTemplateTest) TestFalsyServiceAccountEnabledOverrideSuppr
 		"webModeler.serviceAccount.enabled": "true",
 		"camundaHub.serviceAccount.enabled": "false",
 	}
-	_, err := s.renderWebModeler(values, []string{"templates/web-modeler/serviceaccount.yaml"})
-	s.Require().Error(err)
+	output, err := s.renderWebModeler(values, []string{"templates/web-modeler/serviceaccount.yaml"})
+	if err != nil {
+		s.Require().ErrorContains(err, "could not find template templates/web-modeler/serviceaccount.yaml in chart")
+		return
+	}
+	s.Require().Empty(strings.TrimSpace(output))
 }
 
 func (s *CamundaHubShimTemplateTest) TestCamundaHubFullnameOverrideAppliesToServiceNames() {

--- a/charts/camunda-platform-8.10/values.schema.extra.json
+++ b/charts/camunda-platform-8.10/values.schema.extra.json
@@ -1397,13 +1397,13 @@
                 },
                 "security": {
                     "type": "object",
-                    "description": "override values for the Camunda Hub security section; set values take precedence over the legacy webModeler.security values. Overrides go through Helm's `or`, so falsy values (false, 0, \"\") do not override the legacy value \u2014 set those on webModeler.security directly.",
+                    "description": "override values for the Camunda Hub security section; set values are deep-merged over the legacy webModeler.security values, so a partial override keeps the sibling defaults. An explicit false, 0 or \"\" overrides the legacy value; an unset (null) key falls through to it. Maps merge key by key, while arrays replace the legacy list wholesale.",
                     "default": {},
                     "additionalProperties": true,
                     "properties": {
                         "authentication": {
                             "type": "object",
-                            "description": "override values for the Camunda Hub authentication section; set values take precedence over the legacy webModeler.security.authentication values. Overrides go through Helm's `or`, so falsy values (false, 0, \"\") do not override the legacy value \u2014 set those on webModeler.security.authentication directly.",
+                            "description": "override values for the Camunda Hub authentication section; set values are deep-merged over the legacy webModeler.security.authentication values, so a partial override keeps the sibling defaults. An explicit false, 0 or \"\" overrides the legacy value; an unset (null) key falls through to it. Maps merge key by key, while arrays replace the legacy list wholesale.",
                             "default": {},
                             "additionalProperties": true
                         }
@@ -1411,19 +1411,19 @@
                 },
                 "restapi": {
                     "type": "object",
-                    "description": "override values for the Camunda Hub restapi component; set values take precedence over the legacy webModeler.restapi values. Overrides go through Helm's `or`, so falsy values (false, 0, \"\") do not override the legacy value \u2014 set those on webModeler.restapi directly. The image and pusher maps are the exception: they are merged over their legacy counterparts, so falsy values do apply there.",
+                    "description": "override values for the Camunda Hub restapi component; set values are deep-merged over the legacy webModeler.restapi values, so a partial override keeps the sibling defaults. An explicit false, 0 or \"\" overrides the legacy value; an unset (null) key falls through to it. Maps merge key by key, while arrays replace the legacy list wholesale.",
                     "default": {},
                     "additionalProperties": true
                 },
                 "websockets": {
                     "type": "object",
-                    "description": "override values for the Camunda Hub websockets component; set values take precedence over the legacy webModeler.websockets values. Overrides go through Helm's `or`, so falsy values (false, 0, \"\") do not override the legacy value \u2014 set those on webModeler.websockets directly. The image map is the exception: it is merged over its legacy counterpart, so falsy values do apply there.",
+                    "description": "override values for the Camunda Hub websockets component; set values are deep-merged over the legacy webModeler.websockets values, so a partial override keeps the sibling defaults. An explicit false, 0 or \"\" overrides the legacy value; an unset (null) key falls through to it. Maps merge key by key, while arrays replace the legacy list wholesale.",
                     "default": {},
                     "additionalProperties": true
                 },
                 "serviceAccount": {
                     "type": "object",
-                    "description": "override values for the Camunda Hub service account; set values take precedence over the legacy webModeler.serviceAccount values. Overrides go through Helm's `or`, so falsy values (false, 0, \"\") do not override the legacy value \u2014 set those on webModeler.serviceAccount directly.",
+                    "description": "override values for the Camunda Hub service account; set values are deep-merged over the legacy webModeler.serviceAccount values, so a partial override keeps the sibling defaults. An explicit false, 0 or \"\" overrides the legacy value; an unset (null) key falls through to it. Maps merge key by key, while arrays replace the legacy list wholesale.",
                     "default": {},
                     "additionalProperties": true
                 },

--- a/charts/camunda-platform-8.10/values.schema.json
+++ b/charts/camunda-platform-8.10/values.schema.json
@@ -2102,13 +2102,13 @@
                 },
                 "security": {
                     "type": "object",
-                    "description": "override values for the Camunda Hub security section; set values take precedence over the legacy webModeler.security values. Overrides go through Helm's `or`, so falsy values (false, 0, \"\") do not override the legacy value — set those on webModeler.security directly.",
+                    "description": "override values for the Camunda Hub security section; set values are deep-merged over the legacy webModeler.security values, so a partial override keeps the sibling defaults. An explicit false, 0 or \"\" overrides the legacy value; an unset (null) key falls through to it. Maps merge key by key, while arrays replace the legacy list wholesale.",
                     "default": {},
                     "additionalProperties": true,
                     "properties": {
                         "authentication": {
                             "type": "object",
-                            "description": "override values for the Camunda Hub authentication section; set values take precedence over the legacy webModeler.security.authentication values. Overrides go through Helm's `or`, so falsy values (false, 0, \"\") do not override the legacy value — set those on webModeler.security.authentication directly.",
+                            "description": "override values for the Camunda Hub authentication section; set values are deep-merged over the legacy webModeler.security.authentication values, so a partial override keeps the sibling defaults. An explicit false, 0 or \"\" overrides the legacy value; an unset (null) key falls through to it. Maps merge key by key, while arrays replace the legacy list wholesale.",
                             "default": {},
                             "additionalProperties": true
                         }
@@ -2116,19 +2116,19 @@
                 },
                 "restapi": {
                     "type": "object",
-                    "description": "override values for the Camunda Hub restapi component; set values take precedence over the legacy webModeler.restapi values. Overrides go through Helm's `or`, so falsy values (false, 0, \"\") do not override the legacy value — set those on webModeler.restapi directly. The image and pusher maps are the exception: they are merged over their legacy counterparts, so falsy values do apply there.",
+                    "description": "override values for the Camunda Hub restapi component; set values are deep-merged over the legacy webModeler.restapi values, so a partial override keeps the sibling defaults. An explicit false, 0 or \"\" overrides the legacy value; an unset (null) key falls through to it. Maps merge key by key, while arrays replace the legacy list wholesale.",
                     "default": {},
                     "additionalProperties": true
                 },
                 "websockets": {
                     "type": "object",
-                    "description": "override values for the Camunda Hub websockets component; set values take precedence over the legacy webModeler.websockets values. Overrides go through Helm's `or`, so falsy values (false, 0, \"\") do not override the legacy value — set those on webModeler.websockets directly. The image map is the exception: it is merged over its legacy counterpart, so falsy values do apply there.",
+                    "description": "override values for the Camunda Hub websockets component; set values are deep-merged over the legacy webModeler.websockets values, so a partial override keeps the sibling defaults. An explicit false, 0 or \"\" overrides the legacy value; an unset (null) key falls through to it. Maps merge key by key, while arrays replace the legacy list wholesale.",
                     "default": {},
                     "additionalProperties": true
                 },
                 "serviceAccount": {
                     "type": "object",
-                    "description": "override values for the Camunda Hub service account; set values take precedence over the legacy webModeler.serviceAccount values. Overrides go through Helm's `or`, so falsy values (false, 0, \"\") do not override the legacy value — set those on webModeler.serviceAccount directly.",
+                    "description": "override values for the Camunda Hub service account; set values are deep-merged over the legacy webModeler.serviceAccount values, so a partial override keeps the sibling defaults. An explicit false, 0 or \"\" overrides the legacy value; an unset (null) key falls through to it. Maps merge key by key, while arrays replace the legacy list wholesale.",
                     "default": {},
                     "additionalProperties": true
                 },

--- a/charts/camunda-platform-8.10/values.yaml
+++ b/charts/camunda-platform-8.10/values.yaml
@@ -1199,12 +1199,6 @@ camundaHub:
   ## replaces the legacy list. To replace a scheduling map outright, set it on webModeler.* instead.
   ## Setting a key here to a scalar where webModeler.* has a map (or vice versa) is a hard error
   ## rather than a silent subtree replacement.
-  ##
-  ## These rules currently apply to the values read by the Web Modeler restapi and websockets
-  ## workloads, to camundaHub.contextPath, and to camundaHub.restapi.mail. Every other consumer
-  ## (the services, service account, shared secret, the shared and websockets configmaps, the
-  ## HTTPRoute and the service monitor) still takes the first truthy value, so a map set there
-  ## replaces the legacy map rather than merging into it, and a falsy override there is ignored.
   ## @skip camundaHub.image
   image: {}
   ## @skip camundaHub.security


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes the remainder of #6848. Stacked on #6849, which introduces the `camundaHub.values` merge helper and converts the two deployment templates.

After #6849 the inline `or .Values.camundaHub.X .Values.webModeler.X` coalescing still existed in the configmaps, services, serviceaccount, shared secret, HTTPRoute, ingress, service monitor and both helper files. Each remaining site re-implemented precedence, so any value added later could silently miss one and fall through to the legacy value.

### What's in this PR?

Converts the remaining templates to read the merged Hub values.

`webModeler.serviceAccount.labels` had no `camundaHub` override path at all and is now reachable through the merged view.

`webModeler.fullname` previously hand-picked `fullnameOverride`, `nameOverride` and `image` into a partial `mustMergeOverwrite`, with a comment explaining that plain `or` was unusable because `camundaHub` has intermediate sub-maps that are truthy even when unset — the same trap this series removes. It now passes the merged values straight to `componentFullname`, so a naming-relevant key added later cannot be missed.

Two things deliberately keep reading `.Values` directly:

- the enablement gates (`camundaHub.webModelerEnabled`, `camundaHub.consoleEnabled`), which are driven by `global.topology.mode`
- the deprecation checks in `constraints.tpl`, whose job is to inspect what the user literally set — reading the merged view there would produce false warnings

Five tests cover the behaviour the conversion newly makes reachable, so a regression in a converted site fails a test rather than passing silently: `camundaHub.serviceAccount.labels` (previously no override path existed), the falsy `camundaHub.serviceAccount.enabled=false` override, `camundaHub.fullnameOverride` reaching the rendered object names through `webModeler.fullname`, a partial `camundaHub.restapi.service` override keeping the legacy annotations, and a partial `camundaHub.restapi.externalDatabase` override keeping the legacy port and database.

One rendering behaviour is worth calling out for review, since it follows from the falsy-override semantics rather than from this conversion: an explicit `camundaHub.contextPath: ""` now genuinely overrides a legacy `webModeler.contextPath`, which drops the two Web Modeler ingress paths. That lands in the same state the chart already produces whenever `contextPath` is unset — verified against the base commit — so it is pre-existing behaviour reached by a new route, not a regression from this PR.

Goldens are unchanged. `make go.test`, `helm lint --strict` and `make helm.schema-validate-values` all pass on this branch.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

