### PR TITLE
fix: allow root path as optimize client redirect uri in identity configmap

### DIFF
--- a/charts/camunda-platform-8.10/templates/identity/configmap.yaml
+++ b/charts/camunda-platform-8.10/templates/identity/configmap.yaml
@@ -84,6 +84,7 @@ data:
               root-url: {{ tpl $optimize.redirectUrl $ | quote }}
               redirect-uris:
                 - "/api/authentication/callback"
+                - "/"
           {{- end }}
           {{- if $connectors.enabled }}
             - name: {{ printf "Connectors %s" $displayName | quote }}
@@ -210,6 +211,7 @@ data:
               root-url: {{ tpl .Values.global.identity.auth.optimize.redirectUrl $ | quote }}
               redirect-uris:
                 - "/api/authentication/callback"
+                - "/"
           apis:
             - name: Optimize API
               audience: {{ include "camundaPlatform.authAudienceOptimize" . | quote }}

--- a/charts/camunda-platform-8.10/test/unit/identity/configmap_test.go
+++ b/charts/camunda-platform-8.10/test/unit/identity/configmap_test.go
@@ -425,10 +425,7 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 					"Orchestration OIDC config should not be present when orchestration is disabled")
 			},
 		}, {
-			// Test: the Optimize client must accept both its dedicated callback path
-			// and the bare root path as valid OIDC redirect targets, so browser
-			// sessions redirected to "/" (e.g. after a Keycloak logout) don't fail
-			// with an invalid_redirect_uri error. See camunda/camunda#59963.
+			// Test: Optimize redirect-uris include both the callback path and the root path. See camunda/camunda#59963.
 			Name:                 "TestOptimizeRedirectUrisIncludesRoot",
 			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
 			Values: map[string]string{
@@ -443,7 +440,7 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 
 				applicationYaml := configmap.Data["application.yaml"]
 
-				s.Require().Contains(applicationYaml, "- \"/api/authentication/callback\"\n            - \"/\"\n",
+				s.Require().Regexp(`redirect-uris:\s*\n\s*-\s*"/api/authentication/callback"\s*\n\s*-\s*"/"\s*\n`, applicationYaml,
 					"Optimize redirect-uris should include both the callback path and the root path")
 			},
 		}, {

--- a/charts/camunda-platform-8.10/test/unit/identity/configmap_test.go
+++ b/charts/camunda-platform-8.10/test/unit/identity/configmap_test.go
@@ -425,6 +425,28 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 					"Orchestration OIDC config should not be present when orchestration is disabled")
 			},
 		}, {
+			// Test: the Optimize client must accept both its dedicated callback path
+			// and the bare root path as valid OIDC redirect targets, so browser
+			// sessions redirected to "/" (e.g. after a Keycloak logout) don't fail
+			// with an invalid_redirect_uri error. See camunda/camunda#59963.
+			Name:                 "TestOptimizeRedirectUrisIncludesRoot",
+			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
+			Values: map[string]string{
+				"identity.enabled":                      "true",
+				"global.identity.auth.enabled":          "true",
+				"global.security.authentication.method": "oidc",
+				"optimize.enabled":                      "true",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				var configmap corev1.ConfigMap
+				helm.UnmarshalK8SYaml(t, output, &configmap)
+
+				applicationYaml := configmap.Data["application.yaml"]
+
+				s.Require().Contains(applicationYaml, "- \"/api/authentication/callback\"\n            - \"/\"\n",
+					"Optimize redirect-uris should include both the callback path and the root path")
+			},
+		}, {
 			// Test: Optimize disabled should NOT include optimize config in identity configmap
 			Name:                 "TestOptimizeDisabledExcludesOptimizeConfig",
 			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},

--- a/charts/camunda-platform-8.10/test/unit/topology/topology_test.go
+++ b/charts/camunda-platform-8.10/test/unit/topology/topology_test.go
@@ -77,7 +77,7 @@ func TestHubTopologyOptimizeRedirectUrisIncludesRoot(t *testing.T) {
 
 	output := helm.RenderTemplate(t, options, chartPath(t), "camunda", []string{"templates/identity/configmap.yaml"})
 
-	require.Contains(t, output, "redirect-uris:\n                - \"/api/authentication/callback\"\n                - \"/\"\n")
+	require.Regexp(t, `redirect-uris:\s*\n\s*-\s*"/api/authentication/callback"\s*\n\s*-\s*"/"\s*\n`, output)
 }
 
 func TestHubTopologySuppressesDefaultWorkloadPlane(t *testing.T) {

--- a/charts/camunda-platform-8.10/test/unit/topology/topology_test.go
+++ b/charts/camunda-platform-8.10/test/unit/topology/topology_test.go
@@ -61,6 +61,25 @@ func TestHubTopologyRendersRemoteIdentityPresetsAndHubInventory(t *testing.T) {
 	require.NotContains(t, output, `keycloak:\n`)
 }
 
+func TestHubTopologyOptimizeRedirectUrisIncludesRoot(t *testing.T) {
+	valuesFile := filepath.Join("testdata", "hub-keycloak.yaml")
+	options := &helm.Options{
+		ValuesFiles: []string{valuesFile},
+		SetValues: map[string]string{
+			"global.topology.clusters[0].components.optimize.enabled":                  "true",
+			"global.topology.clusters[0].components.optimize.clientId":                 "optimize-east",
+			"global.topology.clusters[0].components.optimize.audience":                 "optimize-east-api",
+			"global.topology.clusters[0].components.optimize.redirectUrl":              "https://east.example.com/optimize",
+			"global.topology.clusters[0].components.optimize.secret.existingSecret":    "east-oidc",
+			"global.topology.clusters[0].components.optimize.secret.existingSecretKey": "optimize-secret",
+		},
+	}
+
+	output := helm.RenderTemplate(t, options, chartPath(t), "camunda", []string{"templates/identity/configmap.yaml"})
+
+	require.Contains(t, output, "redirect-uris:\n                - \"/api/authentication/callback\"\n                - \"/\"\n")
+}
+
 func TestHubTopologySuppressesDefaultWorkloadPlane(t *testing.T) {
 	output := render(t, "hub-generic.yaml")
 


### PR DESCRIPTION
### Which problem does the PR fix?

Fixes camunda/camunda#59963.

### What's in this PR?

Adds `"/"` alongside `"/api/authentication/callback"` in the Optimize client's `redirect-uris` in `charts/camunda-platform-8.10/templates/identity/configmap.yaml`, in both the standard single-cluster block and the topology/hub-mode block. Identity's `ClientInitializationService` reconciles (not just creates) the Keycloak client's redirect-uris on every startup, so existing deployments will pick this up automatically on restart — no manual Keycloak edit needed.

Added unit tests covering both blocks (`test/unit/identity/configmap_test.go`, `test/unit/topology/topology_test.go`); no golden fixtures needed regeneration since the default golden scenario doesn't render the optimize block.

**Backport question for the reviewer:** `crev` flagged that the identical Optimize `redirect-uris` block (missing `"/"`) exists unconditionally in charts 8.9, 8.8, 8.7 (`supportStandard`), and 8.6 (`supportExtended`) — not behind any version-gated flag. I couldn't find anything in this repo (no version-gated SSO/logout feature, no relevant ADR) that would scope this bug to 8.10-only. Leaving the backport decision to the reviewer: should the same one-line fix land on 8.9/8.8/8.7/8.6 as well, either in this PR or as follow-ups?

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [x] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
