### PR TITLE
test: keep single-node CI Elasticsearch ready after a reschedule

### DIFF
--- a/test/integration/companion-values/elasticsearch-qa.yaml
+++ b/test/integration/companion-values/elasticsearch-qa.yaml
@@ -11,6 +11,9 @@ minimumMasterNodes: 1
 
 protocol: http
 
+# See elasticsearch.yaml for why this must not gate on green.
+clusterHealthCheckParams: "wait_for_status=yellow&timeout=1s"
+
 imageTag: "8.18.0"
 
 createCert: false
@@ -53,6 +56,12 @@ lifecycle:
           curl -fsS --connect-timeout 5 -X PUT "http://localhost:9200/_index_template/camunda-ci-auto-expand-replicas" \
             -H 'Content-Type: application/json' \
             -d '{"index_patterns":["*operate*","*orchestration*","*optimize*","*tasklist*","*camunda*","*zeebe*","op-*","opt-*","orch-*"],"priority":1,"template":{"settings":{"index.auto_expand_replicas":"0-1"}}}'
+          # Patch indices recovered from the PV; the template above only applies
+          # at index-creation time. Non-fatal — see elasticsearch.yaml.
+          curl -fsS --connect-timeout 5 -X PUT \
+            "http://localhost:9200/_all/_settings?expand_wildcards=open&ignore_unavailable=true" \
+            -H 'Content-Type: application/json' \
+            -d '{"index.auto_expand_replicas":"0-1"}' || true
 
 resources:
   requests:

--- a/test/integration/companion-values/elasticsearch.yaml
+++ b/test/integration/companion-values/elasticsearch.yaml
@@ -11,6 +11,14 @@ minimumMasterNodes: 1
 
 protocol: http
 
+# The chart's readiness probe stores its "already started" marker at
+# /tmp/.es_start_file, which is lost whenever the pod is rescheduled onto
+# another node. A rescheduled pod therefore re-runs the startup branch and
+# blocks on _cluster/health?wait_for_status=<status>. Gate on yellow: all
+# primaries assigned, which is the strongest status a single-node cluster
+# reaches while any recovered index still carries a replica.
+clusterHealthCheckParams: "wait_for_status=yellow&timeout=1s"
+
 # Use ES 8.18.0 — the elastic/elasticsearch Helm chart 8.5.1 defaults to its
 # own app version (8.5.1) but Camunda 8.10 requires ES 8.6+ (specifically for
 # the unassignedPrimaryShards field in HealthResponse). The Bitnami subchart
@@ -99,6 +107,14 @@ lifecycle:
           curl -fsS --connect-timeout 5 -X PUT "http://localhost:9200/_index_template/camunda-ci-auto-expand-replicas" \
             -H 'Content-Type: application/json' \
             -d '{"index_patterns":["*operate*","*orchestration*","*optimize*","*tasklist*","*camunda*","*zeebe*","op-*","opt-*","orch-*"],"priority":1,"template":{"settings":{"index.auto_expand_replicas":"0-1"}}}'
+          # The index template above only applies at index-creation time, so it
+          # cannot fix indices recovered from the PV after a reschedule. Patch
+          # the recovered indices in place; non-fatal because a fresh volume has
+          # nothing to patch and system indices may reject the write.
+          curl -fsS --connect-timeout 5 -X PUT \
+            "http://localhost:9200/_all/_settings?expand_wildcards=open&ignore_unavailable=true" \
+            -H 'Content-Type: application/json' \
+            -d '{"index.auto_expand_replicas":"0-1"}' || true
 
 resources:
   requests:


### PR DESCRIPTION
### Which problem does the PR fix?

The single-node Elasticsearch companion used by the CI e2e scenarios can be left
permanently unready by any node-level disruption, taking connectors, optimize and
zeebe down behind it.

The `elastic/elasticsearch` readiness probe records that startup finished by
touching `/tmp/.es_start_file`. That marker is lost when the pod is rescheduled
onto another node, so the probe re-enters its startup branch and blocks on
`_cluster/health?wait_for_status=green`. A single-node cluster cannot reach green
while any recovered index still carries a replica, so the pod stays `0/1`
indefinitely.

Observed in [camunda/camunda run 32021568903](https://github.com/camunda/camunda/actions/runs/32021568903).
A node-level disruption (`Multi-Attach error` on the ES volume; the pod moved
from `...-general-v2-02-3c0acbe0-h65b` to `...-general-v2-01-292647d3-6pbx`) left
`elasticsearch-master-0` at `0/1` for 18 minutes. From the diagnostics artifact of
the preceding run, which hit the same failure:

```
Readiness probe failed: Waiting for elasticsearch cluster to become ready
  (request params: "wait_for_status=green&timeout=1s")   [x65 over 14m]
Cluster health status changed from [RED] to [YELLOW]
  (reason: [shards started [[optimize-alert_v4][0]]])
recovered [83] indices into cluster_state
```

Exactly one health transition, RED to YELLOW, and never green. 14 of 18 e2e tests
failed as a result.

### What's in this PR?

Two changes to both companion values files (`elasticsearch.yaml` and the QA
variant, which duplicates rather than inherits):

**1. Gate the readiness probe on yellow.** Yellow means every primary is
assigned, which is the strongest status this topology can reach. Green is an
unsatisfiable gate here rather than a meaningful one.

**2. Patch recovered indices in place from the `postStart` hook.** The existing
`auto_expand_replicas` index template only applies at index-creation time — ES
logs that it *"will take precedence during new index creation"* — so it cannot
reach the 83 indices recovered from the PV.

The second change is what makes the first safe. The `auto_expand_replicas`
template was added because a yellow cluster caused intermittent `all shards
failed` 503s on `_search`; relaxing the probe alone would trade the deadlock for
those 503s. Patching the recovered indices drives replicas to 0 on a single node,
so the cluster actually reaches green and yellow becomes a floor rather than the
steady state. The `PUT` is non-fatal (`|| true`) because a fresh volume has
nothing to patch and system indices may reject the write.

Not addressed here: which specific index held the cluster yellow. No run captures
shard-level state — #6877 adds that.

**Validation**

- `helm template elastic/elasticsearch --version 8.5.1 -f <values>` renders the
  probe with `wait_for_status=yellow` in all 5 occurrences and zero remaining
  `green`.
- The rendered `postStart` hook is valid bash (`bash -n`; shellcheck clean apart
  from SC2148, an artifact of extracting the fragment).
- `go test ./matrix/...` passes; the registry snapshot references the values file
  by path, so no golden regeneration is required.
- **Not yet validated on a live cluster.** The failure only reproduces on a
  *restart*, not a fresh install, so the meaningful gate is: deploy a namespace,
  `kubectl delete pod elasticsearch-master-0`, and confirm it returns to `1/1`.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
