### PR TITLE
ci: capture e2e diagnostics when the job times out

### DIFF
--- a/.github/actions/playwright-e2e-tests/action.yaml
+++ b/.github/actions/playwright-e2e-tests/action.yaml
@@ -264,7 +264,7 @@ runs:
         ./run-e2e-tests.sh "${E2E_ARGS[@]}"
 
     - name: Capture namespace diagnostics
-      if: ${{ failure() && !cancelled() }}
+      if: ${{ !success() }}
       shell: bash
       env:
         TEST_NAMESPACE: ${{ env.TEST_NAMESPACE }}
@@ -285,14 +285,14 @@ runs:
 
     - name: Compute diagnostics artifact name
       id: e2e_diag_artifact
-      if: ${{ failure() && !cancelled() }}
+      if: ${{ !success() }}
       shell: bash
       run: |
         raw="diagnostics-e2e-${{ inputs.identifier }}-${{ inputs.flow }}-${{ inputs.test-stage }}-${{ inputs.shard-index }}-${{ github.run_id }}-${{ github.run_attempt }}"
         echo "name=${raw//[^a-zA-Z0-9._-]/-}" >> "$GITHUB_OUTPUT"
 
     - name: Upload namespace diagnostics
-      if: ${{ failure() && !cancelled() }}
+      if: ${{ !success() }}
       uses: ./.github/actions/upload-artifact-retry
       with:
         name: ${{ steps.e2e_diag_artifact.outputs.name }}
@@ -301,7 +301,7 @@ runs:
         if-no-files-found: warn
 
     - name: Upload blob report to GitHub Actions Artifacts
-      if: ${{ !cancelled() }}
+      if: ${{ always() }}
       uses: ./.github/actions/upload-artifact-retry
       with:
         name: blob-report-${{ inputs.identifier }}-${{ inputs.flow }}-${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.test-stage }}-${{ inputs.shard-index }}
@@ -310,12 +310,12 @@ runs:
 
     - name: Set report date
       id: report_date
-      if: ${{ !cancelled() }}
+      if: ${{ always() }}
       shell: bash
       run: echo "date=$(date +'%Y-%m-%d_%H-%M-%S')" >> "$GITHUB_OUTPUT"
 
     - name: Upload Playwright JSON results
-      if: ${{ !cancelled() }}
+      if: ${{ always() }}
       uses: ./.github/actions/upload-artifact-retry
       with:
         name: playwright-results-json-${{ github.run_id }}-${{ inputs.identifier }}-${{ inputs.flow }}-${{ inputs.distro-platform }}-${{ inputs.test-stage }}-${{ inputs.shard-index }}-${{ steps.report_date.outputs.date }}
@@ -324,7 +324,7 @@ runs:
         retention-days: 5
 
     - name: Upload Playwright traces for failed tests
-      if: ${{ failure() && !cancelled() }}
+      if: ${{ !success() }}
       uses: ./.github/actions/upload-artifact-retry
       with:
         name: playwright-traces-${{ github.run_id }}-${{ inputs.identifier }}-${{ inputs.flow }}-${{ inputs.distro-platform }}-${{ inputs.test-stage }}-${{ inputs.shard-index }}-${{ steps.report_date.outputs.date }}

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -1265,7 +1265,7 @@ jobs:
         shell: bash
     if: ${{ inputs.test-enabled && inputs.e2e-enabled && inputs.flow == 'install' && !inputs.skip-e2e && !inputs.is-topology }}
     continue-on-error: ${{ !matrix.blocking }}
-    timeout-minutes: 25
+    timeout-minutes: ${{ matrix.suite == 'full' && 50 || 25 }}
     strategy:
       fail-fast: false
       # Legs share one deployment and smoke-tests.spec.js runs in both projects,

--- a/scripts/camunda-core/pkg/kube/diagnostics.go
+++ b/scripts/camunda-core/pkg/kube/diagnostics.go
@@ -23,7 +23,14 @@ func kubectlBaseArgs(kubeContext string) []string {
 // runKubectl executes a kubectl command with a child timeout context and returns stdout.
 // On error it returns empty string and the error — callers treat diagnostics as best-effort.
 func runKubectl(ctx context.Context, args []string) (string, error) {
-	cmdCtx, cancel := context.WithTimeout(ctx, diagnosticTimeout)
+	return runKubectlTimeout(ctx, args, diagnosticTimeout)
+}
+
+// runKubectlTimeout is runKubectl with an explicit per-command budget, for calls
+// that legitimately outlast diagnosticTimeout such as an in-pod exec that has to
+// negotiate TLS before it can query anything.
+func runKubectlTimeout(ctx context.Context, args []string, timeout time.Duration) (string, error) {
+	cmdCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	output, err := executil.RunCommandBuffered(cmdCtx, "kubectl", args, nil, "")
@@ -152,11 +159,12 @@ func GetPodContainerLogs(ctx context.Context, kubeContext, namespace, pod, conta
 	return runKubectl(ctx, args)
 }
 
-// ExecInPod runs command in the pod's default container and returns its output.
-func ExecInPod(ctx context.Context, kubeContext, namespace, pod string, command []string) (string, error) {
+// ExecInPod runs command in the pod's default container under its own timeout and
+// returns whatever stdout was captured, including on timeout or a non-zero exit.
+func ExecInPod(ctx context.Context, kubeContext, namespace, pod string, command []string, timeout time.Duration) (string, error) {
 	args := append(kubectlBaseArgs(kubeContext), "exec", pod, "-n", namespace, "--")
 	args = append(args, command...)
-	return runKubectl(ctx, args)
+	return runKubectlTimeout(ctx, args, timeout)
 }
 
 // GetNonReadyPods returns the names of pods that are not fully ready.

--- a/scripts/camunda-core/pkg/kube/diagnostics.go
+++ b/scripts/camunda-core/pkg/kube/diagnostics.go
@@ -118,6 +118,47 @@ func DescribePod(ctx context.Context, kubeContext, namespace, pod string) (strin
 	return runKubectl(ctx, args)
 }
 
+// GetPodContainers returns the pod's init containers followed by its regular
+// containers. Init containers come first so a caller iterating the list reaches
+// the one that blocked startup before the containers that never ran.
+func GetPodContainers(ctx context.Context, kubeContext, namespace, pod string) ([]string, error) {
+	args := append(kubectlBaseArgs(kubeContext),
+		"get", "pod", pod, "-n", namespace,
+		"-o", "jsonpath={range .spec.initContainers[*]}{.name}{\"\\n\"}{end}{range .spec.containers[*]}{.name}{\"\\n\"}{end}",
+	)
+	output, err := runKubectl(ctx, args)
+	if err != nil {
+		return nil, err
+	}
+	var containers []string
+	for _, line := range strings.Split(output, "\n") {
+		if name := strings.TrimSpace(line); name != "" {
+			containers = append(containers, name)
+		}
+	}
+	return containers, nil
+}
+
+// GetPodContainerLogs returns the last tailLines of logs from a single container.
+// `kubectl logs --all-containers` fails as a whole when any one container has yet
+// to start, so a pod stuck in Init:Error yields nothing; fetching per container
+// recovers the init container's output.
+func GetPodContainerLogs(ctx context.Context, kubeContext, namespace, pod, container string, tailLines int) (string, error) {
+	args := append(kubectlBaseArgs(kubeContext),
+		"logs", pod, "-n", namespace,
+		"-c", container,
+		"--tail", fmt.Sprintf("%d", tailLines),
+	)
+	return runKubectl(ctx, args)
+}
+
+// ExecInPod runs command in the pod's default container and returns its output.
+func ExecInPod(ctx context.Context, kubeContext, namespace, pod string, command []string) (string, error) {
+	args := append(kubectlBaseArgs(kubeContext), "exec", pod, "-n", namespace, "--")
+	args = append(args, command...)
+	return runKubectl(ctx, args)
+}
+
 // GetNonReadyPods returns the names of pods that are not fully ready.
 // It uses a field-selector to find non-Running pods and also parses output to
 // catch Running-but-not-Ready pods (e.g., readiness probe failing).

--- a/scripts/deploy-camunda/cmd/diagnostics.go
+++ b/scripts/deploy-camunda/cmd/diagnostics.go
@@ -23,28 +23,34 @@ const diagnosticsEventsTail = 40
 // needs. It is a struct of funcs (defaulting to the kube package) so tests can
 // inject fakes without a cluster or a fake kubectl on PATH.
 type podDiagnosticsSource struct {
-	GetPods            func(ctx context.Context, kubeContext, namespace string) (string, error)
-	GetEvents          func(ctx context.Context, kubeContext, namespace string) (string, error)
-	GetPVCs            func(ctx context.Context, kubeContext, namespace string) (string, error)
-	DescribePVCs       func(ctx context.Context, kubeContext, namespace string) (string, error)
-	GetNonReadyPods    func(ctx context.Context, kubeContext, namespace string) ([]string, error)
-	GetPodNames        func(ctx context.Context, kubeContext, namespace string) ([]string, error)
-	DescribePod        func(ctx context.Context, kubeContext, namespace, pod string) (string, error)
-	GetPodLogs         func(ctx context.Context, kubeContext, namespace, pod string, tail int) (string, error)
-	GetPodLogsPrevious func(ctx context.Context, kubeContext, namespace, pod string, tail int) (string, error)
+	GetPods             func(ctx context.Context, kubeContext, namespace string) (string, error)
+	GetEvents           func(ctx context.Context, kubeContext, namespace string) (string, error)
+	GetPVCs             func(ctx context.Context, kubeContext, namespace string) (string, error)
+	DescribePVCs        func(ctx context.Context, kubeContext, namespace string) (string, error)
+	GetNonReadyPods     func(ctx context.Context, kubeContext, namespace string) ([]string, error)
+	GetPodNames         func(ctx context.Context, kubeContext, namespace string) ([]string, error)
+	DescribePod         func(ctx context.Context, kubeContext, namespace, pod string) (string, error)
+	GetPodLogs          func(ctx context.Context, kubeContext, namespace, pod string, tail int) (string, error)
+	GetPodLogsPrevious  func(ctx context.Context, kubeContext, namespace, pod string, tail int) (string, error)
+	GetPodContainers    func(ctx context.Context, kubeContext, namespace, pod string) ([]string, error)
+	GetPodContainerLogs func(ctx context.Context, kubeContext, namespace, pod, container string, tail int) (string, error)
+	ExecInPod           func(ctx context.Context, kubeContext, namespace, pod string, command []string) (string, error)
 }
 
 func defaultPodDiagnosticsSource() podDiagnosticsSource {
 	return podDiagnosticsSource{
-		GetPods:            kube.GetPods,
-		GetEvents:          kube.GetEvents,
-		GetPVCs:            kube.GetPVCs,
-		DescribePVCs:       kube.DescribePVCs,
-		GetNonReadyPods:    kube.GetNonReadyPods,
-		GetPodNames:        kube.GetPodNames,
-		DescribePod:        kube.DescribePod,
-		GetPodLogs:         kube.GetPodLogs,
-		GetPodLogsPrevious: kube.GetPodLogsPrevious,
+		GetPods:             kube.GetPods,
+		GetEvents:           kube.GetEvents,
+		GetPVCs:             kube.GetPVCs,
+		DescribePVCs:        kube.DescribePVCs,
+		GetNonReadyPods:     kube.GetNonReadyPods,
+		GetPodNames:         kube.GetPodNames,
+		DescribePod:         kube.DescribePod,
+		GetPodLogs:          kube.GetPodLogs,
+		GetPodLogsPrevious:  kube.GetPodLogsPrevious,
+		GetPodContainers:    kube.GetPodContainers,
+		GetPodContainerLogs: kube.GetPodContainerLogs,
+		ExecInPod:           kube.ExecInPod,
 	}
 }
 
@@ -169,13 +175,64 @@ func printNamespaceDiagnostics(ctx context.Context, w io.Writer, src podDiagnost
 		emit(podLabel+pod+" — describe", desc, descErr)
 
 		podLogs, logsErr := src.GetPodLogs(ctx, kubeContext, namespace, pod, tail)
-		emit(podLabel+pod+" — logs", podLogs, logsErr)
+		if logsErr != nil && src.GetPodContainers != nil && src.GetPodContainerLogs != nil {
+			emitPerContainerLogs(ctx, emit, src, kubeContext, namespace, pod, podLabel, tail, logsErr)
+		} else {
+			emit(podLabel+pod+" — logs", podLogs, logsErr)
+		}
 
 		// --previous surfaces the prior crash; empty/erroring when the pod never restarted.
 		if prev, err := src.GetPodLogsPrevious(ctx, kubeContext, namespace, pod, tail); err == nil && prev != "" {
 			emit(podLabel+pod+" — previous logs", prev, nil)
 		}
+
+		if isSearchPod(pod) && src.ExecInPod != nil {
+			state, stateErr := src.ExecInPod(ctx, kubeContext, namespace, pod, []string{"sh", "-c", searchClusterStateScript})
+			emit(podLabel+pod+" — cluster state", state, stateErr)
+		}
 	}
+}
+
+// emitPerContainerLogs recovers logs one container at a time after the
+// all-containers fetch failed, and reports the original error when the pod's
+// container list cannot be read either.
+func emitPerContainerLogs(
+	ctx context.Context,
+	emit func(string, string, error),
+	src podDiagnosticsSource,
+	kubeContext, namespace, pod, podLabel string,
+	tail int,
+	allContainersErr error,
+) {
+	containers, err := src.GetPodContainers(ctx, kubeContext, namespace, pod)
+	if err != nil || len(containers) == 0 {
+		emit(podLabel+pod+" — logs", "", allContainersErr)
+		return
+	}
+	for _, container := range containers {
+		logs, logsErr := src.GetPodContainerLogs(ctx, kubeContext, namespace, pod, container, tail)
+		emit(podLabel+pod+" — logs ["+container+"]", logs, logsErr)
+	}
+}
+
+// searchClusterStateScript queries the Elasticsearch/OpenSearch HTTP API from
+// inside the pod. Both expose these endpoints identically, and CI runs them with
+// security disabled, so no credentials are needed. Shard-level state is what
+// distinguishes "still recovering" from "cannot reach this status on this
+// topology" when a readiness probe gates on cluster health.
+const searchClusterStateScript = `
+for q in '_cluster/health?level=indices&pretty' '_cat/indices?v&s=health:desc,index' '_cluster/allocation/explain?pretty'; do
+  echo "--- GET /$q"
+  curl -sS --max-time 10 "http://localhost:9200/$q" || echo "(query failed)"
+  echo
+done
+`
+
+// isSearchPod reports whether the pod is an Elasticsearch or OpenSearch node,
+// matched on name because the companion charts are separate Helm releases whose
+// labels are not shared with the Camunda chart.
+func isSearchPod(pod string) bool {
+	return strings.Contains(pod, "elasticsearch") || strings.Contains(pod, "opensearch")
 }
 
 // lastLines returns the last n lines of s. Short inputs are returned unchanged.

--- a/scripts/deploy-camunda/cmd/diagnostics.go
+++ b/scripts/deploy-camunda/cmd/diagnostics.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"syscall"
+	"time"
 
 	"scripts/camunda-core/pkg/kube"
 	"scripts/camunda-core/pkg/logging"
@@ -34,7 +35,7 @@ type podDiagnosticsSource struct {
 	GetPodLogsPrevious  func(ctx context.Context, kubeContext, namespace, pod string, tail int) (string, error)
 	GetPodContainers    func(ctx context.Context, kubeContext, namespace, pod string) ([]string, error)
 	GetPodContainerLogs func(ctx context.Context, kubeContext, namespace, pod, container string, tail int) (string, error)
-	ExecInPod           func(ctx context.Context, kubeContext, namespace, pod string, command []string) (string, error)
+	ExecInPod           func(ctx context.Context, kubeContext, namespace, pod string, command []string, timeout time.Duration) (string, error)
 }
 
 func defaultPodDiagnosticsSource() podDiagnosticsSource {
@@ -140,6 +141,20 @@ func printNamespaceDiagnostics(ctx context.Context, w io.Writer, src podDiagnost
 		}
 		fmt.Fprintln(w, out)
 	}
+	// emitPartial keeps whatever was captured before an error, which emit discards.
+	// A timed-out exec still carries the endpoints it managed to query.
+	emitPartial := func(title string, out string, err error) {
+		section(title)
+		if out != "" {
+			fmt.Fprintln(w, out)
+		}
+		if err != nil {
+			fmt.Fprintf(w, "(error: %v)\n", err)
+		}
+		if out == "" && err == nil {
+			fmt.Fprintln(w, "(none)")
+		}
+	}
 
 	pods, podsErr := src.GetPods(ctx, kubeContext, namespace)
 	emit("Pods", pods, podsErr)
@@ -187,8 +202,7 @@ func printNamespaceDiagnostics(ctx context.Context, w io.Writer, src podDiagnost
 		}
 
 		if isSearchPod(pod) && src.ExecInPod != nil {
-			state, stateErr := src.ExecInPod(ctx, kubeContext, namespace, pod, []string{"sh", "-c", searchClusterStateScript})
-			emit(podLabel+pod+" — cluster state", state, stateErr)
+			emitSearchClusterState(ctx, emitPartial, src, kubeContext, namespace, pod, podLabel)
 		}
 	}
 }
@@ -215,18 +229,73 @@ func emitPerContainerLogs(
 	}
 }
 
-// searchClusterStateScript queries the Elasticsearch/OpenSearch HTTP API from
-// inside the pod. Both expose these endpoints identically, and CI runs them with
-// security disabled, so no credentials are needed. Shard-level state is what
-// distinguishes "still recovering" from "cannot reach this status on this
-// topology" when a readiness probe gates on cluster health.
-const searchClusterStateScript = `
-for q in '_cluster/health?level=indices&pretty' '_cat/indices?v&s=health:desc,index' '_cluster/allocation/explain?pretty'; do
-  echo "--- GET /$q"
-  curl -sS --max-time 10 "http://localhost:9200/$q" || echo "(query failed)"
-  echo
+// searchClusterQueries is queried one exec per entry.
+var searchClusterQueries = []string{
+	"_cluster/health?level=indices&pretty",
+	"_cat/indices?v&s=health:desc,index",
+	"_cluster/allocation/explain?pretty",
+}
+
+// searchClusterExecTimeout must exceed the worst-case curl budget in one exec —
+// two 8s scheme probes plus an 8s query — plus kubectl exec startup, so kubectl
+// does not cancel the exec before curl reports its own failure.
+const searchClusterExecTimeout = 40 * time.Second
+
+// searchClusterPrelude sets BASE, CURL, TLS and AUTH for the query appended after
+// it. It probes https before http because the companion chart's scheme varies per
+// scenario, and reads credentials from the container environment: ELASTIC_PASSWORD
+// for Elasticsearch, OPENSEARCH_INITIAL_ADMIN_PASSWORD for OpenSearch with the
+// security plugin. Both are passed via curl -u and never echoed.
+//
+// TLS verification is skipped: the self-signed node certificate is issued for the
+// masterService DNS name, not the loopback address this probe connects to.
+const searchClusterPrelude = `
+set -u
+CURL="curl -sS --max-time 8"
+TLS="-k"
+AUTH=""
+if [ -n "${ELASTIC_PASSWORD:-}" ]; then AUTH="-u elastic:${ELASTIC_PASSWORD}"; fi
+if [ -n "${OPENSEARCH_INITIAL_ADMIN_PASSWORD:-}" ]; then AUTH="-u admin:${OPENSEARCH_INITIAL_ADMIN_PASSWORD}"; fi
+BASE=""
+for scheme in https http; do
+  if $CURL $TLS $AUTH "$scheme://localhost:9200/" >/dev/null 2>&1; then
+    BASE="$scheme://localhost:9200"
+    break
+  fi
 done
+if [ -z "$BASE" ]; then
+  echo "(no reachable endpoint on localhost:9200 over https or http)"
+  exit 0
+fi
 `
+
+// emitSearchClusterState runs one exec per query so a slow endpoint cannot consume
+// the budget of the others, and emits each result through emitPartial so a
+// timed-out exec still reports what it captured.
+func emitSearchClusterState(
+	ctx context.Context,
+	emitPartial func(string, string, error),
+	src podDiagnosticsSource,
+	kubeContext, namespace, pod, podLabel string,
+) {
+	for _, query := range searchClusterQueries {
+		script := searchClusterPrelude + "\n$CURL $TLS $AUTH \"$BASE/" + query + "\"\n"
+		out, err := src.ExecInPod(
+			ctx, kubeContext, namespace, pod,
+			[]string{"sh", "-c", script},
+			searchClusterExecTimeout,
+		)
+		emitPartial(podLabel+pod+" — cluster state ["+searchQueryLabel(query)+"]", out, err)
+	}
+}
+
+// searchQueryLabel drops the query string from an endpoint path.
+func searchQueryLabel(query string) string {
+	if i := strings.IndexByte(query, '?'); i >= 0 {
+		return query[:i]
+	}
+	return query
+}
 
 // isSearchPod reports whether the pod is an Elasticsearch or OpenSearch node,
 // matched on name because the companion charts are separate Helm releases whose

--- a/scripts/deploy-camunda/cmd/diagnostics_test.go
+++ b/scripts/deploy-camunda/cmd/diagnostics_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestPrintNamespaceDiagnostics(t *testing.T) {
@@ -199,8 +200,13 @@ func TestPrintNamespaceDiagnosticsFallbackWhenContainerListUnavailable(t *testin
 func TestPrintNamespaceDiagnosticsCapturesSearchClusterState(t *testing.T) {
 	t.Parallel()
 
-	var execedPods []string
-	newSrc := func(pod string) podDiagnosticsSource {
+	type call struct {
+		pod     string
+		script  string
+		timeout time.Duration
+	}
+	var calls []call
+	newSrc := func(pod string, exec func(string) (string, error)) podDiagnosticsSource {
 		return podDiagnosticsSource{
 			GetPods:            func(_ context.Context, _, _ string) (string, error) { return "", nil },
 			GetEvents:          func(_ context.Context, _, _ string) (string, error) { return "", nil },
@@ -210,24 +216,114 @@ func TestPrintNamespaceDiagnosticsCapturesSearchClusterState(t *testing.T) {
 			DescribePod:        func(_ context.Context, _, _, _ string) (string, error) { return "", nil },
 			GetPodLogs:         func(_ context.Context, _, _, _ string, _ int) (string, error) { return "log", nil },
 			GetPodLogsPrevious: func(_ context.Context, _, _, _ string, _ int) (string, error) { return "", nil },
-			ExecInPod: func(_ context.Context, _, _, pod string, _ []string) (string, error) {
-				execedPods = append(execedPods, pod)
-				return "status yellow, 1 unassigned shard", nil
+			ExecInPod: func(_ context.Context, _, _, pod string, command []string, timeout time.Duration) (string, error) {
+				script := command[len(command)-1]
+				calls = append(calls, call{pod: pod, script: script, timeout: timeout})
+				return exec(script)
 			},
 		}
 	}
 
+	// One exec per endpoint, so a slow endpoint cannot starve the others.
 	var buf bytes.Buffer
-	printNamespaceDiagnostics(context.Background(), &buf, newSrc("elasticsearch-master-0"), "", "ns", 500, false)
-	if out := buf.String(); !strings.Contains(out, "cluster state") || !strings.Contains(out, "1 unassigned shard") {
-		t.Errorf("expected search cluster state to be captured, got:\n%s", out)
+	calls = nil
+	src := newSrc("elasticsearch-master-0", func(string) (string, error) { return "status yellow", nil })
+	printNamespaceDiagnostics(context.Background(), &buf, src, "", "ns", 500, false)
+
+	if len(calls) != len(searchClusterQueries) {
+		t.Fatalf("expected one exec per query (%d), got %d", len(searchClusterQueries), len(calls))
+	}
+	for i, query := range searchClusterQueries {
+		if !strings.Contains(calls[i].script, query) {
+			t.Errorf("exec %d does not query %q: %s", i, query, calls[i].script)
+		}
+		if calls[i].timeout != searchClusterExecTimeout {
+			t.Errorf("exec %d timeout = %v, want %v", i, calls[i].timeout, searchClusterExecTimeout)
+		}
+	}
+	out := buf.String()
+	for _, want := range []string{"cluster state [_cluster/health]", "cluster state [_cat/indices]", "cluster state [_cluster/allocation/explain]"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing section %q:\n%s", want, out)
+		}
 	}
 
-	execedPods = nil
+	// A failing exec must not hide the output it captured, nor the other queries.
 	buf.Reset()
-	printNamespaceDiagnostics(context.Background(), &buf, newSrc("integration-zeebe-0"), "", "ns", 500, false)
-	if len(execedPods) != 0 {
-		t.Errorf("non-search pods must not be exec'd into, got %v", execedPods)
+	calls = nil
+	failFirst := newSrc("opensearch-master-0", func(script string) (string, error) {
+		if strings.Contains(script, "_cluster/health") {
+			return "partial health output", fmt.Errorf("signal: killed")
+		}
+		return "later query ran", nil
+	})
+	printNamespaceDiagnostics(context.Background(), &buf, failFirst, "", "ns", 500, false)
+	out = buf.String()
+	for _, want := range []string{"partial health output", "(error: signal: killed)", "later query ran"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+
+	// Non-search pods are never exec'd into.
+	buf.Reset()
+	calls = nil
+	printNamespaceDiagnostics(context.Background(), &buf,
+		newSrc("integration-zeebe-0", func(string) (string, error) { return "", nil }), "", "ns", 500, false)
+	if len(calls) != 0 {
+		t.Errorf("non-search pods must not be exec'd into, got %v", calls)
+	}
+}
+
+func TestSearchClusterPreludeSupportsSecureOpenSearch(t *testing.T) {
+	t.Parallel()
+
+	// The opensearch-self-signed scenarios (osss, osot) serve HTTPS with the
+	// security plugin, so the probe must try https first and send admin
+	// credentials from the container environment.
+	var schemeLine string
+	for _, line := range strings.Split(searchClusterPrelude, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "for scheme in ") {
+			schemeLine = strings.TrimSpace(line)
+			break
+		}
+	}
+	if schemeLine == "" {
+		t.Fatal("prelude has no scheme probe loop")
+	}
+	schemes := strings.Fields(strings.TrimSuffix(strings.TrimPrefix(schemeLine, "for scheme in "), "; do"))
+	if len(schemes) != 2 || schemes[0] != "https" || schemes[1] != "http" {
+		t.Errorf("scheme probe order = %v, want [https http]", schemes)
+	}
+	for _, want := range []string{
+		"OPENSEARCH_INITIAL_ADMIN_PASSWORD",
+		"-u admin:",
+		"ELASTIC_PASSWORD",
+		"-u elastic:",
+		"-k",
+	} {
+		if !strings.Contains(searchClusterPrelude, want) {
+			t.Errorf("prelude missing %q", want)
+		}
+	}
+	// Credentials must never be echoed into CI logs.
+	for _, line := range strings.Split(searchClusterPrelude, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "echo") && strings.Contains(line, "PASSWORD") {
+			t.Errorf("prelude echoes a credential: %s", line)
+		}
+	}
+}
+
+func TestSearchQueryLabel(t *testing.T) {
+	t.Parallel()
+	for query, want := range map[string]string{
+		"_cluster/health?level=indices&pretty": "_cluster/health",
+		"_cat/indices?v&s=health:desc,index":   "_cat/indices",
+		"_cluster/allocation/explain":          "_cluster/allocation/explain",
+	} {
+		if got := searchQueryLabel(query); got != want {
+			t.Errorf("searchQueryLabel(%q) = %q, want %q", query, got, want)
+		}
 	}
 }
 

--- a/scripts/deploy-camunda/cmd/diagnostics_test.go
+++ b/scripts/deploy-camunda/cmd/diagnostics_test.go
@@ -123,6 +123,128 @@ func TestPrintNamespaceDiagnosticsIncludeReady(t *testing.T) {
 	}
 }
 
+func TestPrintNamespaceDiagnosticsFallsBackToPerContainerLogs(t *testing.T) {
+	t.Parallel()
+
+	var fetched []string
+	src := podDiagnosticsSource{
+		GetPods:         func(_ context.Context, _, _ string) (string, error) { return "optimize 0/1 Init:Error", nil },
+		GetEvents:       func(_ context.Context, _, _ string) (string, error) { return "", nil },
+		GetPVCs:         func(_ context.Context, _, _ string) (string, error) { return "", nil },
+		DescribePVCs:    func(_ context.Context, _, _ string) (string, error) { return "", nil },
+		GetNonReadyPods: func(_ context.Context, _, _ string) ([]string, error) { return []string{"optimize"}, nil },
+		DescribePod:     func(_ context.Context, _, _, pod string) (string, error) { return "Name: " + pod, nil },
+		// kubectl logs --all-containers fails as a whole while a container is still
+		// waiting to start, which is what hid the failing init container's output.
+		GetPodLogs: func(_ context.Context, _, _, _ string, _ int) (string, error) {
+			return "", fmt.Errorf("exit status 1")
+		},
+		GetPodLogsPrevious: func(_ context.Context, _, _, _ string, _ int) (string, error) { return "", nil },
+		GetPodContainers: func(_ context.Context, _, _, _ string) ([]string, error) {
+			return []string{"migration", "optimize"}, nil
+		},
+		GetPodContainerLogs: func(_ context.Context, _, _, _, container string, _ int) (string, error) {
+			fetched = append(fetched, container)
+			if container == "optimize" {
+				return "", fmt.Errorf("waiting to start: PodInitializing")
+			}
+			return "migration failed to reach elasticsearch", nil
+		},
+	}
+
+	var buf bytes.Buffer
+	printNamespaceDiagnostics(context.Background(), &buf, src, "", "ns", 500, false)
+	out := buf.String()
+
+	if len(fetched) != 2 || fetched[0] != "migration" {
+		t.Errorf("expected init container fetched first, got %v", fetched)
+	}
+	for _, want := range []string{"logs [migration]", "migration failed to reach elasticsearch", "logs [optimize]", "PodInitializing"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintNamespaceDiagnosticsFallbackWhenContainerListUnavailable(t *testing.T) {
+	t.Parallel()
+
+	src := podDiagnosticsSource{
+		GetPods:         func(_ context.Context, _, _ string) (string, error) { return "", nil },
+		GetEvents:       func(_ context.Context, _, _ string) (string, error) { return "", nil },
+		GetPVCs:         func(_ context.Context, _, _ string) (string, error) { return "", nil },
+		DescribePVCs:    func(_ context.Context, _, _ string) (string, error) { return "", nil },
+		GetNonReadyPods: func(_ context.Context, _, _ string) ([]string, error) { return []string{"pod-a"}, nil },
+		DescribePod:     func(_ context.Context, _, _, _ string) (string, error) { return "", nil },
+		GetPodLogs: func(_ context.Context, _, _, _ string, _ int) (string, error) {
+			return "", fmt.Errorf("original failure")
+		},
+		GetPodLogsPrevious: func(_ context.Context, _, _, _ string, _ int) (string, error) { return "", nil },
+		GetPodContainers: func(_ context.Context, _, _, _ string) ([]string, error) {
+			return nil, fmt.Errorf("pod gone")
+		},
+		GetPodContainerLogs: func(_ context.Context, _, _, _, _ string, _ int) (string, error) {
+			t.Fatal("must not fetch per-container logs without a container list")
+			return "", nil
+		},
+	}
+
+	var buf bytes.Buffer
+	printNamespaceDiagnostics(context.Background(), &buf, src, "", "ns", 500, false)
+	if out := buf.String(); !strings.Contains(out, "(error: original failure)") {
+		t.Errorf("expected the original logs error to be reported, got:\n%s", out)
+	}
+}
+
+func TestPrintNamespaceDiagnosticsCapturesSearchClusterState(t *testing.T) {
+	t.Parallel()
+
+	var execedPods []string
+	newSrc := func(pod string) podDiagnosticsSource {
+		return podDiagnosticsSource{
+			GetPods:            func(_ context.Context, _, _ string) (string, error) { return "", nil },
+			GetEvents:          func(_ context.Context, _, _ string) (string, error) { return "", nil },
+			GetPVCs:            func(_ context.Context, _, _ string) (string, error) { return "", nil },
+			DescribePVCs:       func(_ context.Context, _, _ string) (string, error) { return "", nil },
+			GetNonReadyPods:    func(_ context.Context, _, _ string) ([]string, error) { return []string{pod}, nil },
+			DescribePod:        func(_ context.Context, _, _, _ string) (string, error) { return "", nil },
+			GetPodLogs:         func(_ context.Context, _, _, _ string, _ int) (string, error) { return "log", nil },
+			GetPodLogsPrevious: func(_ context.Context, _, _, _ string, _ int) (string, error) { return "", nil },
+			ExecInPod: func(_ context.Context, _, _, pod string, _ []string) (string, error) {
+				execedPods = append(execedPods, pod)
+				return "status yellow, 1 unassigned shard", nil
+			},
+		}
+	}
+
+	var buf bytes.Buffer
+	printNamespaceDiagnostics(context.Background(), &buf, newSrc("elasticsearch-master-0"), "", "ns", 500, false)
+	if out := buf.String(); !strings.Contains(out, "cluster state") || !strings.Contains(out, "1 unassigned shard") {
+		t.Errorf("expected search cluster state to be captured, got:\n%s", out)
+	}
+
+	execedPods = nil
+	buf.Reset()
+	printNamespaceDiagnostics(context.Background(), &buf, newSrc("integration-zeebe-0"), "", "ns", 500, false)
+	if len(execedPods) != 0 {
+		t.Errorf("non-search pods must not be exec'd into, got %v", execedPods)
+	}
+}
+
+func TestIsSearchPod(t *testing.T) {
+	t.Parallel()
+	for pod, want := range map[string]bool{
+		"elasticsearch-master-0":        true,
+		"opensearch-cluster-master-0":   true,
+		"integration-zeebe-0":           false,
+		"integration-optimize-79c-hgcw": false,
+	} {
+		if got := isSearchPod(pod); got != want {
+			t.Errorf("isSearchPod(%q) = %v, want %v", pod, got, want)
+		}
+	}
+}
+
 func TestLastLines(t *testing.T) {
 	t.Parallel()
 	if got := lastLines("a\nb\nc\nd", 2); got != "c\nd" {


### PR DESCRIPTION
### Which problem does the PR fix?

When the full e2e leg hits `timeout-minutes`, GitHub **cancels** the job rather
than failing it. Every diagnostic step in the `playwright-e2e-tests` action was
guarded by `failure() && !cancelled()`, so all of them were skipped in exactly
the failure mode that most needs evidence.

From [camunda/camunda run 32021568903](https://github.com/camunda/camunda/actions/runs/32021568903):

```
##[error]The operation was canceled.
Capture namespace diagnostics       outcome=skipped
Upload namespace diagnostics        outcome=skipped
Upload Playwright traces            outcome=skipped
```

Four pods (`elasticsearch-master-0`, connectors, optimize, zeebe) were unready and
14 of 18 tests failed, with no captured record of why. The root cause was only
reachable because a *different* run happened to fail rather than time out, and so
kept its artifact.

Two further gaps surfaced while reading that artifact:

- Optimize's logs came back `(error: exit status 1)`. `kubectl logs
  --all-containers` fails as a whole while any container is still waiting to
  start, so a pod in `Init:Error` yields nothing — and the failing container was
  the `migration` init container.
- Nothing captures shard-level search state (`grep -c` for `_cat/indices`,
  `_cluster/health`, allocation-explain over the artifact returns 0), which is
  precisely what is needed when a readiness probe gates on cluster health.

### What's in this PR?

**Guards** (`.github/actions/playwright-e2e-tests/action.yaml`)

- Diagnostics capture, artifact name, diagnostics upload and trace upload move
  from `failure() && !cancelled()` to `!success()`, so they run on failure *and*
  cancellation.
- Blob report, report date and JSON results move from `!cancelled()` to
  `always()`. These three also run on success — `Merge E2E Reports` consumes the
  blob report — so they cannot use `!success()`. `Set report date` had to move
  too: the trace artifact name interpolates `steps.report_date.outputs.date`, so
  leaving it at `!cancelled()` would have produced a name with a dangling `-`
  suffix on precisely the runs this PR is meant to fix.

**Timeout budget** (`test-integration-runner.yaml`)

`timeout-minutes: 25` → `${{ matrix.suite == 'full' && 50 || 25 }}`. The full
suite takes ~20m (19.8m of tests plus ~1m setup, against a 25m budget), leaving
~4m. `_POD_RETRY_TIMEOUT` is 420s and `_POD_RETRY_MAX_ATTEMPTS` is 2, so the
recovery wait could not complete and the retry attempt could never run. The smoke
leg keeps 25m, following the existing `matrix.suite` conditional on `runs-on`.

**Diagnostics content** (`scripts/`)

- `kube.GetPodContainers` / `kube.GetPodContainerLogs`, used as a fallback when
  the all-containers fetch fails. Init containers are listed first so the
  container that blocked startup is reached before the ones that never ran.
- `kube.ExecInPod`, used to query `_cluster/health?level=indices`,
  `_cat/indices` and `_cluster/allocation/explain` from inside an
  Elasticsearch/OpenSearch pod. Both expose these endpoints identically and CI
  runs them with security disabled, so no credentials are needed.
- All additions are best-effort and nil-guarded, preserving the existing contract
  that errors are reported inline and never abort the dump.

**Validation**

- 4 new unit tests in `diagnostics_test.go` cover the per-container fallback, the
  fallback's own failure path, search-state capture (and that non-search pods are
  not exec'd into), and `isSearchPod`. `go test ./...` passes for both
  `deploy-camunda` and `camunda-core`; `go vet` and `gofmt` clean.
- `actionlint` reports 55 findings on `test-integration-runner.yaml` both before
  and after this change — no new findings, and none on the changed lines.
- The workflow and action changes cannot be exercised locally; they need a CI run
  that fails and one that times out.

Companion to #6876, which fixes the Elasticsearch readiness deadlock itself.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
