### PR TITLE
deps: update camunda/camunda:8.10-snapshot docker digest to 203e55f

### DIFF
--- a/charts/camunda-platform-8.10/values-digest.yaml
+++ b/charts/camunda-platform-8.10/values-digest.yaml
@@ -49,7 +49,7 @@ orchestration:
   image:
     repository: camunda/camunda
     tag: 8.10-SNAPSHOT
-    digest: "sha256:9d758dfa3f8112fa17ee225717690cac7c0bf708988fff0938d43e34cc216c39"
+    digest: "sha256:203e55f2047c956eb8580c9d289dcf43eecbaff85c2c01e2ef44133f55359850"
 
 #
 # Identity


### PR DESCRIPTION
### Which problem does the PR fix?

Split out from #6815. That PR (Renovate) grouped two digest bumps (optimize + orchestration); the orchestration bump was reverted there because it's suspected of causing 8.10 merge-queue CI failures — the post-deploy Hub Ping check (`esa0`, `mns`, `keyco`, `esoi` install scenarios) times out waiting for the orchestration cluster to register with Web Modeler.

Note: the Hub Ping Java code itself (`dist/.../commons/hub/ping/*`) is byte-identical between the old and new orchestration image digest, so the regression (if any) isn't a straightforward code diff in that path — could be `camunda/hub` (Web Modeler) image drift (it's unpinned/floating on `SNAPSHOT` tag) or a timing/flakiness issue in Zeebe's dynamic-config cluster-ID gossip. Needs investigation before merging.

### What's in this PR?

Bumps `orchestration.image.digest` in `charts/camunda-platform-8.10/values-digest.yaml`:
`sha256:9d758dfa3f8112fa17ee225717690cac7c0bf708988fff0938d43e34cc216c39` → `sha256:203e55f2047c956eb8580c9d289dcf43eecbaff85c2c01e2ef44133f55359850`

Kept as a draft pending root-cause of the Hub Ping CI failures — do not merge until that's resolved or confirmed unrelated.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?