### PR TITLE
test: persist CI companion postgresql data and cover Services in diagnostics

### DIFF
--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -478,6 +478,13 @@ jobs:
               # Remove any stale Helm release left behind by a cancelled/completed previous run.
               # Without this, 'helm install' fails with "cannot re-use a name that is still in use".
               helm uninstall integration --namespace $TEST_NAMESPACE --wait --timeout 2m0s 2>/dev/null || true
+              # Companions are separate releases, so the uninstall above does not touch them.
+              # Kubernetes never garbage-collects PVCs created from volumeClaimTemplates, so the
+              # delete is what stops a new pod binding the previous run's database.
+              helm uninstall postgresql --namespace $TEST_NAMESPACE --wait --timeout 2m0s 2>/dev/null || true
+              helm uninstall keycloak --namespace $TEST_NAMESPACE --wait --timeout 2m0s 2>/dev/null || true
+              kubectl delete pvc -l app.kubernetes.io/component=postgresql \
+                --namespace $TEST_NAMESPACE --ignore-not-found 2>/dev/null || true
             fi
           fi
           kubectl create ns $TEST_NAMESPACE --dry-run=client -o yaml | kubectl apply -f -

--- a/.github/workflows/test-local-template.yaml
+++ b/.github/workflows/test-local-template.yaml
@@ -64,6 +64,7 @@ jobs:
         uses: ./.github/actions/install-tool-versions
         with:
           tools: |
+            golang
             helm
             kind
             kubectl
@@ -159,15 +160,10 @@ jobs:
           # two manifests validating against divergent port allow-lists.
           check camunda-platform-zeebe internal kubernetes.io/h2c
           check camunda-platform-zeebe command kubernetes.io/h2c
-      - name: Get Pods
+      - name: Namespace diagnostics
         if: failure()
-        run: |
-          kubectl get pods --namespace ${{ env.TEST_NAMESPACE }}
-      - name: Debug - Get Pods info
-        if: failure()
-        run: |
-          kubectl get pods --namespace ${{ env.TEST_NAMESPACE }} -o yaml
-          kubectl describe pods --namespace ${{ env.TEST_NAMESPACE }}
+        continue-on-error: true
+        run: make diagnostics.print namespace=${{ env.TEST_NAMESPACE }}
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,12 @@ build.dx-tooling:
 	make build.vault-secret-mapper
 	make build.release-tools
 
+# diagnostics.print: dump namespace state (pods, events, PVCs, Services, endpoints,
+# pod describe+logs) for a failing deploy. namespace= is required.
+.PHONY: diagnostics.print
+diagnostics.print:
+	cd scripts/deploy-camunda && go run . diagnostics print --namespace $(namespace) --include-ready
+
 .PHONY: install.dx-tooling
 install.dx-tooling:
 	make install.prepare-helm-values

--- a/charts/camunda-platform-8.10/test/integration/scenarios/pre-setup-scripts/post-deploy-hub-ping.sh
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/pre-setup-scripts/post-deploy-hub-ping.sh
@@ -11,7 +11,7 @@ if [[ -n "${HUB_NAMESPACE:-}" ]]; then
 fi
 
 for attempt in {1..60}; do
-  query_result="$(kubectl exec -n "${database_namespace}" deployment/postgresql -- \
+  query_result="$(kubectl exec -n "${database_namespace}" statefulset/postgresql -- \
     sh -c 'psql --set ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname webmodeler --tuples-only --no-align --field-separator="|" --command "SELECT c.name, p.property_value FROM clusters c JOIN cluster_discovered_properties p ON p.cluster_id = c.id WHERE c.name = '\''$1'\'' AND p.property_key = '\''verification'\''"' sh "${expected_cluster_name}" 2>/dev/null)" || true
   if [[ "${query_result}" == "${expected_cluster_name}|inherited-oidc-credentials" ]]; then
     echo "Authenticated Hub ping registered the orchestration cluster."

--- a/charts/camunda-platform-8.10/test/unit/companion/companion_test.go
+++ b/charts/camunda-platform-8.10/test/unit/companion/companion_test.go
@@ -15,7 +15,6 @@
 package companion
 
 import (
-	"flag"
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
@@ -23,8 +22,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
-
-var _ = flag.Bool("update-golden", false, "accepted for chart-wide golden updates")
 
 // unmarshalStatefulSet fails the test case when rendering errored, then decodes
 // the rendered manifest.

--- a/charts/camunda-platform-8.10/test/unit/companion/companion_test.go
+++ b/charts/camunda-platform-8.10/test/unit/companion/companion_test.go
@@ -1,0 +1,50 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package companion
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = flag.Bool("update-golden", false, "accepted for chart-wide golden updates")
+
+// unmarshalStatefulSet fails the test case when rendering errored, then decodes
+// the rendered manifest.
+func unmarshalStatefulSet(t *testing.T, output string, err error) appsv1.StatefulSet {
+	t.Helper()
+	require.NoError(t, err)
+
+	var statefulSet appsv1.StatefulSet
+	helm.UnmarshalK8SYaml(t, output, &statefulSet)
+	return statefulSet
+}
+
+// podVolume returns the named pod-level volume, or nil when the StatefulSet does
+// not declare one. A nil result for "data" means the volume comes from a
+// volumeClaimTemplate instead.
+func podVolume(statefulSet appsv1.StatefulSet, name string) *corev1.Volume {
+	for i := range statefulSet.Spec.Template.Spec.Volumes {
+		if statefulSet.Spec.Template.Spec.Volumes[i].Name == name {
+			return &statefulSet.Spec.Template.Spec.Volumes[i]
+		}
+	}
+	return nil
+}

--- a/charts/camunda-platform-8.10/test/unit/companion/golden/internal-keycloak-26-postgresql-statefulset.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/companion/golden/internal-keycloak-26-postgresql-statefulset.golden.yaml
@@ -25,6 +25,7 @@ spec:
         app.kubernetes.io/name: internal-keycloak
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/component: postgresql
+        camunda.io/controller: statefulset
     spec:
       containers:
         - name: postgresql

--- a/charts/camunda-platform-8.10/test/unit/companion/golden/internal-keycloak-26-postgresql-statefulset.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/companion/golden/internal-keycloak-26-postgresql-statefulset.golden.yaml
@@ -1,0 +1,95 @@
+---
+# Source: internal-keycloak/templates/postgresql-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: camunda-platform-test-internal-keycloak-postgresql
+  labels:
+    app.kubernetes.io/name: internal-keycloak
+    app.kubernetes.io/instance: camunda-platform-test
+    app.kubernetes.io/component: postgresql
+    app.kubernetes.io/version: "16-alpine"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  serviceName: camunda-platform-test-internal-keycloak-postgresql
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: internal-keycloak
+      app.kubernetes.io/instance: camunda-platform-test
+      app.kubernetes.io/component: postgresql
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: internal-keycloak
+        app.kubernetes.io/instance: camunda-platform-test
+        app.kubernetes.io/component: postgresql
+    spec:
+      containers:
+        - name: postgresql
+          image: docker.io/postgres:16-alpine
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: POSTGRES_DB
+              value: "keycloak"
+            - name: POSTGRES_USER
+              value: "keycloak"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-platform-test-internal-keycloak-postgresql
+                  key: postgresql-password
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          ports:
+            - name: postgresql
+              containerPort: 5432
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - "keycloak"
+                - -d
+                - "keycloak"
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - "keycloak"
+                - -d
+                - "keycloak"
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 3
+          resources:
+            limits:
+              cpu: 500m
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          app.kubernetes.io/name: internal-keycloak
+          app.kubernetes.io/instance: camunda-platform-test
+          app.kubernetes.io/component: postgresql
+          app.kubernetes.io/version: "16-alpine"
+          app.kubernetes.io/managed-by: Helm
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "2Gi"

--- a/charts/camunda-platform-8.10/test/unit/companion/golden/internal-postgresql-statefulset.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/companion/golden/internal-postgresql-statefulset.golden.yaml
@@ -101,4 +101,4 @@ spec:
           - ReadWriteOnce
         resources:
           requests:
-            storage: "1Gi"
+            storage: "4Gi"

--- a/charts/camunda-platform-8.10/test/unit/companion/golden/internal-postgresql-statefulset.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/companion/golden/internal-postgresql-statefulset.golden.yaml
@@ -1,0 +1,103 @@
+---
+# Source: internal-postgresql/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: camunda-platform-test-internal-postgresql
+  labels:
+    app.kubernetes.io/name: internal-postgresql
+    app.kubernetes.io/instance: camunda-platform-test
+    app.kubernetes.io/component: postgresql
+    app.kubernetes.io/version: "16"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  serviceName: camunda-platform-test-internal-postgresql
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: internal-postgresql
+      app.kubernetes.io/instance: camunda-platform-test
+      app.kubernetes.io/component: postgresql
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: internal-postgresql
+        app.kubernetes.io/instance: camunda-platform-test
+        app.kubernetes.io/component: postgresql
+    spec:
+      containers:
+        - name: postgresql
+          image: docker.io/postgres:16-alpine
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: POSTGRES_DB
+              value: "identity"
+            - name: POSTGRES_USER
+              value: "app"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-platform-test-internal-postgresql
+                  key: postgresql-password
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          ports:
+            - name: postgresql
+              containerPort: 5432
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - "app"
+                - -d
+                - "identity"
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - "app"
+                - -d
+                - "identity"
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 3
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+            - name: initdb
+              mountPath: /docker-entrypoint-initdb.d
+              readOnly: true
+      volumes:
+        - name: initdb
+          configMap:
+            name: camunda-platform-test-internal-postgresql-initdb
+            defaultMode: 0755
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          app.kubernetes.io/name: internal-postgresql
+          app.kubernetes.io/instance: camunda-platform-test
+          app.kubernetes.io/component: postgresql
+          app.kubernetes.io/version: "16"
+          app.kubernetes.io/managed-by: Helm
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "1Gi"

--- a/charts/camunda-platform-8.10/test/unit/companion/golden/internal-postgresql-statefulset.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/companion/golden/internal-postgresql-statefulset.golden.yaml
@@ -25,6 +25,7 @@ spec:
         app.kubernetes.io/name: internal-postgresql
         app.kubernetes.io/instance: camunda-platform-test
         app.kubernetes.io/component: postgresql
+        camunda.io/controller: statefulset
     spec:
       containers:
         - name: postgresql

--- a/charts/camunda-platform-8.10/test/unit/companion/goldenfiles_test.go
+++ b/charts/camunda-platform-8.10/test/unit/companion/goldenfiles_test.go
@@ -1,0 +1,54 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package companion
+
+import (
+	"camunda-platform/test/unit/utils"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestGoldenDefaultsTemplateCompanionPostgresql(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../../internal-postgresql")
+	require.NoError(t, err)
+
+	suite.Run(t, &utils.TemplateGoldenTest{
+		ChartPath:      chartPath,
+		Release:        "camunda-platform-test",
+		Namespace:      "camunda-platform",
+		GoldenFileName: "internal-postgresql-statefulset",
+		Templates:      []string{"templates/statefulset.yaml"},
+	})
+}
+
+func TestGoldenDefaultsTemplateCompanionKeycloakPostgresql(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../../internal-keycloak-26")
+	require.NoError(t, err)
+
+	suite.Run(t, &utils.TemplateGoldenTest{
+		ChartPath:      chartPath,
+		Release:        "camunda-platform-test",
+		Namespace:      "camunda-platform",
+		GoldenFileName: "internal-keycloak-26-postgresql-statefulset",
+		Templates:      []string{"templates/postgresql-statefulset.yaml"},
+	})
+}

--- a/charts/camunda-platform-8.10/test/unit/companion/keycloak_postgresql_statefulset_test.go
+++ b/charts/camunda-platform-8.10/test/unit/companion/keycloak_postgresql_statefulset_test.go
@@ -68,6 +68,10 @@ func (s *KeycloakPostgresqlStatefulSetTest) TestStorageDifferentValuesInputs() {
 
 				require.Nil(t, podVolume(statefulSet, "data"),
 					"data must come from the claim template, not a pod volume")
+
+				require.Equal(t, "statefulset", statefulSet.Spec.Template.Labels["camunda.io/controller"])
+				require.NotContains(t, statefulSet.Spec.Selector.MatchLabels, "camunda.io/controller",
+					"spec.selector must stay free of the discriminator; it is immutable after creation")
 			},
 		}, {
 			Name: "TestStorageDisabledFallsBackToEmptyDir",

--- a/charts/camunda-platform-8.10/test/unit/companion/keycloak_postgresql_statefulset_test.go
+++ b/charts/camunda-platform-8.10/test/unit/companion/keycloak_postgresql_statefulset_test.go
@@ -1,0 +1,117 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package companion
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type KeycloakPostgresqlStatefulSetTest struct {
+	suite.Suite
+	chartPath string
+	release   string
+	namespace string
+	templates []string
+}
+
+func TestKeycloakPostgresqlStatefulSetTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../../internal-keycloak-26")
+	require.NoError(t, err)
+
+	suite.Run(t, &KeycloakPostgresqlStatefulSetTest{
+		chartPath: chartPath,
+		release:   "keycloak-test",
+		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
+		templates: []string{"templates/postgresql-statefulset.yaml"},
+	})
+}
+
+func (s *KeycloakPostgresqlStatefulSetTest) render(values map[string]string) appsv1.StatefulSet {
+	s.T().Helper()
+
+	output := helm.RenderTemplate(
+		s.T(),
+		&helm.Options{
+			SetValues:      values,
+			KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+		},
+		s.chartPath,
+		s.release,
+		s.templates,
+	)
+
+	var statefulSet appsv1.StatefulSet
+	helm.UnmarshalK8SYaml(s.T(), output, &statefulSet)
+	return statefulSet
+}
+
+func (s *KeycloakPostgresqlStatefulSetTest) dataVolume(statefulSet appsv1.StatefulSet) *corev1.Volume {
+	for i := range statefulSet.Spec.Template.Spec.Volumes {
+		if statefulSet.Spec.Template.Spec.Volumes[i].Name == "data" {
+			return &statefulSet.Spec.Template.Spec.Volumes[i]
+		}
+	}
+	return nil
+}
+
+func (s *KeycloakPostgresqlStatefulSetTest) TestStorageEnabledByDefaultUsesVolumeClaimTemplate() {
+	statefulSet := s.render(map[string]string{})
+
+	s.Require().Equal("StatefulSet", statefulSet.Kind)
+	s.Require().NotEmpty(statefulSet.Spec.ServiceName)
+	s.Require().Len(statefulSet.Spec.VolumeClaimTemplates, 1)
+
+	claim := statefulSet.Spec.VolumeClaimTemplates[0]
+	s.Require().Equal("data", claim.Name)
+	s.Require().Equal("2Gi", claim.Spec.Resources.Requests.Storage().String())
+	s.Require().Nil(claim.Spec.StorageClassName)
+
+	s.Require().Nil(s.dataVolume(statefulSet), "data must come from the claim template, not a pod volume")
+}
+
+func (s *KeycloakPostgresqlStatefulSetTest) TestStorageDisabledFallsBackToEmptyDir() {
+	statefulSet := s.render(map[string]string{"postgresql.storage.enabled": "false"})
+
+	s.Require().Empty(statefulSet.Spec.VolumeClaimTemplates)
+
+	volume := s.dataVolume(statefulSet)
+	s.Require().NotNil(volume)
+	s.Require().NotNil(volume.EmptyDir)
+}
+
+func (s *KeycloakPostgresqlStatefulSetTest) TestStorageClassNameIsRendered() {
+	statefulSet := s.render(map[string]string{
+		"postgresql.storage.storageClassName": "standard-rwo",
+		"postgresql.storage.size":             "5Gi",
+	})
+
+	s.Require().Len(statefulSet.Spec.VolumeClaimTemplates, 1)
+	claim := statefulSet.Spec.VolumeClaimTemplates[0]
+	s.Require().NotNil(claim.Spec.StorageClassName)
+	s.Require().Equal("standard-rwo", *claim.Spec.StorageClassName)
+	s.Require().Equal("5Gi", claim.Spec.Resources.Requests.Storage().String())
+}

--- a/charts/camunda-platform-8.10/test/unit/companion/keycloak_postgresql_statefulset_test.go
+++ b/charts/camunda-platform-8.10/test/unit/companion/keycloak_postgresql_statefulset_test.go
@@ -15,17 +15,14 @@
 package companion
 
 import (
+	"camunda-platform/test/unit/testhelpers"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 )
 
 type KeycloakPostgresqlStatefulSetTest struct {
@@ -50,68 +47,57 @@ func TestKeycloakPostgresqlStatefulSetTemplate(t *testing.T) {
 	})
 }
 
-func (s *KeycloakPostgresqlStatefulSetTest) render(values map[string]string) appsv1.StatefulSet {
-	s.T().Helper()
+func (s *KeycloakPostgresqlStatefulSetTest) TestStorageDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name:   "TestStorageEnabledByDefaultUsesVolumeClaimTemplate",
+			Values: map[string]string{},
+			Verifier: func(t *testing.T, output string, err error) {
+				statefulSet := unmarshalStatefulSet(t, output, err)
 
-	output := helm.RenderTemplate(
-		s.T(),
-		&helm.Options{
-			SetValues:      values,
-			KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+				require.Equal(t, "StatefulSet", statefulSet.Kind)
+				require.NotEmpty(t, statefulSet.Spec.ServiceName)
+				require.Len(t, statefulSet.Spec.VolumeClaimTemplates, 1)
+
+				claim := statefulSet.Spec.VolumeClaimTemplates[0]
+				require.Equal(t, "data", claim.Name)
+				require.Equal(t, "2Gi", claim.Spec.Resources.Requests.Storage().String())
+				require.Nil(t, claim.Spec.StorageClassName)
+
+				require.Nil(t, podVolume(statefulSet, "data"),
+					"data must come from the claim template, not a pod volume")
+			},
+		}, {
+			Name: "TestStorageDisabledFallsBackToEmptyDir",
+			Values: map[string]string{
+				"postgresql.storage.enabled": "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				statefulSet := unmarshalStatefulSet(t, output, err)
+
+				require.Empty(t, statefulSet.Spec.VolumeClaimTemplates)
+
+				volume := podVolume(statefulSet, "data")
+				require.NotNil(t, volume)
+				require.NotNil(t, volume.EmptyDir)
+			},
+		}, {
+			Name: "TestStorageClassNameIsRendered",
+			Values: map[string]string{
+				"postgresql.storage.storageClassName": "standard-rwo",
+				"postgresql.storage.size":             "5Gi",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				statefulSet := unmarshalStatefulSet(t, output, err)
+
+				require.Len(t, statefulSet.Spec.VolumeClaimTemplates, 1)
+				claim := statefulSet.Spec.VolumeClaimTemplates[0]
+				require.NotNil(t, claim.Spec.StorageClassName)
+				require.Equal(t, "standard-rwo", *claim.Spec.StorageClassName)
+				require.Equal(t, "5Gi", claim.Spec.Resources.Requests.Storage().String())
+			},
 		},
-		s.chartPath,
-		s.release,
-		s.templates,
-	)
-
-	var statefulSet appsv1.StatefulSet
-	helm.UnmarshalK8SYaml(s.T(), output, &statefulSet)
-	return statefulSet
-}
-
-func (s *KeycloakPostgresqlStatefulSetTest) dataVolume(statefulSet appsv1.StatefulSet) *corev1.Volume {
-	for i := range statefulSet.Spec.Template.Spec.Volumes {
-		if statefulSet.Spec.Template.Spec.Volumes[i].Name == "data" {
-			return &statefulSet.Spec.Template.Spec.Volumes[i]
-		}
 	}
-	return nil
-}
 
-func (s *KeycloakPostgresqlStatefulSetTest) TestStorageEnabledByDefaultUsesVolumeClaimTemplate() {
-	statefulSet := s.render(map[string]string{})
-
-	s.Require().Equal("StatefulSet", statefulSet.Kind)
-	s.Require().NotEmpty(statefulSet.Spec.ServiceName)
-	s.Require().Len(statefulSet.Spec.VolumeClaimTemplates, 1)
-
-	claim := statefulSet.Spec.VolumeClaimTemplates[0]
-	s.Require().Equal("data", claim.Name)
-	s.Require().Equal("2Gi", claim.Spec.Resources.Requests.Storage().String())
-	s.Require().Nil(claim.Spec.StorageClassName)
-
-	s.Require().Nil(s.dataVolume(statefulSet), "data must come from the claim template, not a pod volume")
-}
-
-func (s *KeycloakPostgresqlStatefulSetTest) TestStorageDisabledFallsBackToEmptyDir() {
-	statefulSet := s.render(map[string]string{"postgresql.storage.enabled": "false"})
-
-	s.Require().Empty(statefulSet.Spec.VolumeClaimTemplates)
-
-	volume := s.dataVolume(statefulSet)
-	s.Require().NotNil(volume)
-	s.Require().NotNil(volume.EmptyDir)
-}
-
-func (s *KeycloakPostgresqlStatefulSetTest) TestStorageClassNameIsRendered() {
-	statefulSet := s.render(map[string]string{
-		"postgresql.storage.storageClassName": "standard-rwo",
-		"postgresql.storage.size":             "5Gi",
-	})
-
-	s.Require().Len(statefulSet.Spec.VolumeClaimTemplates, 1)
-	claim := statefulSet.Spec.VolumeClaimTemplates[0]
-	s.Require().NotNil(claim.Spec.StorageClassName)
-	s.Require().Equal("standard-rwo", *claim.Spec.StorageClassName)
-	s.Require().Equal("5Gi", claim.Spec.Resources.Requests.Storage().String())
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }

--- a/charts/camunda-platform-8.10/test/unit/companion/keycloak_postgresql_statefulset_test.go
+++ b/charts/camunda-platform-8.10/test/unit/companion/keycloak_postgresql_statefulset_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
 )
 
 type KeycloakPostgresqlStatefulSetTest struct {
@@ -63,6 +64,7 @@ func (s *KeycloakPostgresqlStatefulSetTest) TestStorageDifferentValuesInputs() {
 				require.Equal(t, "data", claim.Name)
 				require.Equal(t, "2Gi", claim.Spec.Resources.Requests.Storage().String())
 				require.Nil(t, claim.Spec.StorageClassName)
+				require.Equal(t, []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}, claim.Spec.AccessModes)
 
 				require.Nil(t, podVolume(statefulSet, "data"),
 					"data must come from the claim template, not a pod volume")

--- a/charts/camunda-platform-8.10/test/unit/companion/postgresql_statefulset_test.go
+++ b/charts/camunda-platform-8.10/test/unit/companion/postgresql_statefulset_test.go
@@ -15,21 +15,16 @@
 package companion
 
 import (
-	"flag"
+	"camunda-platform/test/unit/testhelpers"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
-
-var _ = flag.Bool("update-golden", false, "accepted for chart-wide golden updates")
 
 type PostgresqlStatefulSetTest struct {
 	suite.Suite
@@ -53,69 +48,58 @@ func TestPostgresqlStatefulSetTemplate(t *testing.T) {
 	})
 }
 
-func (s *PostgresqlStatefulSetTest) render(values map[string]string) appsv1.StatefulSet {
-	s.T().Helper()
+func (s *PostgresqlStatefulSetTest) TestPersistenceDifferentValuesInputs() {
+	testCases := []testhelpers.TestCase{
+		{
+			Name:   "TestPersistenceEnabledByDefaultUsesVolumeClaimTemplate",
+			Values: map[string]string{},
+			Verifier: func(t *testing.T, output string, err error) {
+				statefulSet := unmarshalStatefulSet(t, output, err)
 
-	output := helm.RenderTemplate(
-		s.T(),
-		&helm.Options{
-			SetValues:      values,
-			KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+				require.Equal(t, "StatefulSet", statefulSet.Kind)
+				require.NotEmpty(t, statefulSet.Spec.ServiceName)
+				require.Len(t, statefulSet.Spec.VolumeClaimTemplates, 1)
+
+				claim := statefulSet.Spec.VolumeClaimTemplates[0]
+				require.Equal(t, "data", claim.Name)
+				require.Equal(t, []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}, claim.Spec.AccessModes)
+				require.Equal(t, "1Gi", claim.Spec.Resources.Requests.Storage().String())
+				require.Nil(t, claim.Spec.StorageClassName)
+
+				require.Nil(t, podVolume(statefulSet, "data"),
+					"data must come from the claim template, not a pod volume")
+			},
+		}, {
+			Name: "TestPersistenceDisabledFallsBackToEmptyDir",
+			Values: map[string]string{
+				"persistence.enabled": "false",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				statefulSet := unmarshalStatefulSet(t, output, err)
+
+				require.Empty(t, statefulSet.Spec.VolumeClaimTemplates)
+
+				volume := podVolume(statefulSet, "data")
+				require.NotNil(t, volume)
+				require.NotNil(t, volume.EmptyDir)
+			},
+		}, {
+			Name: "TestPersistenceStorageClassIsRendered",
+			Values: map[string]string{
+				"persistence.storageClass": "hyperdisk-balanced",
+				"persistence.size":         "2Gi",
+			},
+			Verifier: func(t *testing.T, output string, err error) {
+				statefulSet := unmarshalStatefulSet(t, output, err)
+
+				require.Len(t, statefulSet.Spec.VolumeClaimTemplates, 1)
+				claim := statefulSet.Spec.VolumeClaimTemplates[0]
+				require.NotNil(t, claim.Spec.StorageClassName)
+				require.Equal(t, "hyperdisk-balanced", *claim.Spec.StorageClassName)
+				require.Equal(t, "2Gi", claim.Spec.Resources.Requests.Storage().String())
+			},
 		},
-		s.chartPath,
-		s.release,
-		s.templates,
-	)
-
-	var statefulSet appsv1.StatefulSet
-	helm.UnmarshalK8SYaml(s.T(), output, &statefulSet)
-	return statefulSet
-}
-
-func (s *PostgresqlStatefulSetTest) dataVolume(statefulSet appsv1.StatefulSet) *corev1.Volume {
-	for i := range statefulSet.Spec.Template.Spec.Volumes {
-		if statefulSet.Spec.Template.Spec.Volumes[i].Name == "data" {
-			return &statefulSet.Spec.Template.Spec.Volumes[i]
-		}
 	}
-	return nil
-}
 
-func (s *PostgresqlStatefulSetTest) TestPersistenceEnabledByDefaultUsesVolumeClaimTemplate() {
-	statefulSet := s.render(map[string]string{})
-
-	s.Require().Equal("StatefulSet", statefulSet.Kind)
-	s.Require().NotEmpty(statefulSet.Spec.ServiceName)
-	s.Require().Len(statefulSet.Spec.VolumeClaimTemplates, 1)
-
-	claim := statefulSet.Spec.VolumeClaimTemplates[0]
-	s.Require().Equal("data", claim.Name)
-	s.Require().Equal([]corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}, claim.Spec.AccessModes)
-	s.Require().Equal("1Gi", claim.Spec.Resources.Requests.Storage().String())
-	s.Require().Nil(claim.Spec.StorageClassName)
-
-	s.Require().Nil(s.dataVolume(statefulSet), "data must come from the claim template, not a pod volume")
-}
-
-func (s *PostgresqlStatefulSetTest) TestPersistenceDisabledFallsBackToEmptyDir() {
-	statefulSet := s.render(map[string]string{"persistence.enabled": "false"})
-
-	s.Require().Empty(statefulSet.Spec.VolumeClaimTemplates)
-
-	volume := s.dataVolume(statefulSet)
-	s.Require().NotNil(volume)
-	s.Require().NotNil(volume.EmptyDir)
-}
-
-func (s *PostgresqlStatefulSetTest) TestPersistenceStorageClassIsRendered() {
-	statefulSet := s.render(map[string]string{
-		"persistence.storageClass": "hyperdisk-balanced",
-		"persistence.size":         "2Gi",
-	})
-
-	s.Require().Len(statefulSet.Spec.VolumeClaimTemplates, 1)
-	claim := statefulSet.Spec.VolumeClaimTemplates[0]
-	s.Require().NotNil(claim.Spec.StorageClassName)
-	s.Require().Equal("hyperdisk-balanced", *claim.Spec.StorageClassName)
-	s.Require().Equal("2Gi", claim.Spec.Resources.Requests.Storage().String())
+	testhelpers.RunTestCasesE(s.T(), s.chartPath, s.release, s.namespace, s.templates, testCases)
 }

--- a/charts/camunda-platform-8.10/test/unit/companion/postgresql_statefulset_test.go
+++ b/charts/camunda-platform-8.10/test/unit/companion/postgresql_statefulset_test.go
@@ -63,7 +63,8 @@ func (s *PostgresqlStatefulSetTest) TestPersistenceDifferentValuesInputs() {
 				claim := statefulSet.Spec.VolumeClaimTemplates[0]
 				require.Equal(t, "data", claim.Name)
 				require.Equal(t, []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}, claim.Spec.AccessModes)
-				require.Equal(t, "1Gi", claim.Spec.Resources.Requests.Storage().String())
+				require.Equal(t, "4Gi", claim.Spec.Resources.Requests.Storage().String(),
+					"hyperdisk-balanced, used by the ARM CI pool, rejects disks smaller than 4GB")
 				require.Nil(t, claim.Spec.StorageClassName)
 
 				require.Nil(t, podVolume(statefulSet, "data"),

--- a/charts/camunda-platform-8.10/test/unit/companion/postgresql_statefulset_test.go
+++ b/charts/camunda-platform-8.10/test/unit/companion/postgresql_statefulset_test.go
@@ -1,0 +1,118 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package companion
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type PostgresqlStatefulSetTest struct {
+	suite.Suite
+	chartPath string
+	release   string
+	namespace string
+	templates []string
+}
+
+func TestPostgresqlStatefulSetTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../../../internal-postgresql")
+	require.NoError(t, err)
+
+	suite.Run(t, &PostgresqlStatefulSetTest{
+		chartPath: chartPath,
+		release:   "postgresql-test",
+		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
+		templates: []string{"templates/statefulset.yaml"},
+	})
+}
+
+func (s *PostgresqlStatefulSetTest) render(values map[string]string) appsv1.StatefulSet {
+	s.T().Helper()
+
+	output := helm.RenderTemplate(
+		s.T(),
+		&helm.Options{
+			SetValues:      values,
+			KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+		},
+		s.chartPath,
+		s.release,
+		s.templates,
+	)
+
+	var statefulSet appsv1.StatefulSet
+	helm.UnmarshalK8SYaml(s.T(), output, &statefulSet)
+	return statefulSet
+}
+
+func (s *PostgresqlStatefulSetTest) dataVolume(statefulSet appsv1.StatefulSet) *corev1.Volume {
+	for i := range statefulSet.Spec.Template.Spec.Volumes {
+		if statefulSet.Spec.Template.Spec.Volumes[i].Name == "data" {
+			return &statefulSet.Spec.Template.Spec.Volumes[i]
+		}
+	}
+	return nil
+}
+
+func (s *PostgresqlStatefulSetTest) TestPersistenceEnabledByDefaultUsesVolumeClaimTemplate() {
+	statefulSet := s.render(map[string]string{})
+
+	s.Require().Equal("StatefulSet", statefulSet.Kind)
+	s.Require().NotEmpty(statefulSet.Spec.ServiceName)
+	s.Require().Len(statefulSet.Spec.VolumeClaimTemplates, 1)
+
+	claim := statefulSet.Spec.VolumeClaimTemplates[0]
+	s.Require().Equal("data", claim.Name)
+	s.Require().Equal([]corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}, claim.Spec.AccessModes)
+	s.Require().Equal("1Gi", claim.Spec.Resources.Requests.Storage().String())
+	s.Require().Nil(claim.Spec.StorageClassName)
+
+	s.Require().Nil(s.dataVolume(statefulSet), "data must come from the claim template, not a pod volume")
+}
+
+func (s *PostgresqlStatefulSetTest) TestPersistenceDisabledFallsBackToEmptyDir() {
+	statefulSet := s.render(map[string]string{"persistence.enabled": "false"})
+
+	s.Require().Empty(statefulSet.Spec.VolumeClaimTemplates)
+
+	volume := s.dataVolume(statefulSet)
+	s.Require().NotNil(volume)
+	s.Require().NotNil(volume.EmptyDir)
+}
+
+func (s *PostgresqlStatefulSetTest) TestPersistenceStorageClassIsRendered() {
+	statefulSet := s.render(map[string]string{
+		"persistence.storageClass": "hyperdisk-balanced",
+		"persistence.size":         "2Gi",
+	})
+
+	s.Require().Len(statefulSet.Spec.VolumeClaimTemplates, 1)
+	claim := statefulSet.Spec.VolumeClaimTemplates[0]
+	s.Require().NotNil(claim.Spec.StorageClassName)
+	s.Require().Equal("hyperdisk-balanced", *claim.Spec.StorageClassName)
+	s.Require().Equal("2Gi", claim.Spec.Resources.Requests.Storage().String())
+}

--- a/charts/camunda-platform-8.10/test/unit/companion/postgresql_statefulset_test.go
+++ b/charts/camunda-platform-8.10/test/unit/companion/postgresql_statefulset_test.go
@@ -68,6 +68,10 @@ func (s *PostgresqlStatefulSetTest) TestPersistenceDifferentValuesInputs() {
 
 				require.Nil(t, podVolume(statefulSet, "data"),
 					"data must come from the claim template, not a pod volume")
+
+				require.Equal(t, "statefulset", statefulSet.Spec.Template.Labels["camunda.io/controller"])
+				require.NotContains(t, statefulSet.Spec.Selector.MatchLabels, "camunda.io/controller",
+					"spec.selector must stay free of the discriminator; it is immutable after creation")
 			},
 		}, {
 			Name: "TestPersistenceDisabledFallsBackToEmptyDir",

--- a/charts/camunda-platform-8.10/test/unit/companion/postgresql_statefulset_test.go
+++ b/charts/camunda-platform-8.10/test/unit/companion/postgresql_statefulset_test.go
@@ -15,6 +15,7 @@
 package companion
 
 import (
+	"flag"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -27,6 +28,8 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
+
+var _ = flag.Bool("update-golden", false, "accepted for chart-wide golden updates")
 
 type PostgresqlStatefulSetTest struct {
 	suite.Suite

--- a/charts/camunda-platform-8.10/test/unit/companion/service_selector_test.go
+++ b/charts/camunda-platform-8.10/test/unit/companion/service_selector_test.go
@@ -1,0 +1,75 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package companion
+
+import (
+	"camunda-platform/test/unit/testhelpers"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type CompanionServiceSelectorTest struct {
+	suite.Suite
+	namespace string
+}
+
+func TestCompanionServiceSelectorTemplate(t *testing.T) {
+	t.Parallel()
+
+	suite.Run(t, &CompanionServiceSelectorTest{
+		namespace: "camunda-platform-" + strings.ToLower(random.UniqueId()),
+	})
+}
+
+func (s *CompanionServiceSelectorTest) assertSelectorIsolated(chart, template string) {
+	s.T().Helper()
+
+	chartPath, err := filepath.Abs(chart)
+	s.Require().NoError(err)
+
+	testCases := []testhelpers.TestCase{
+		{
+			Name:   "TestServiceSelectorExcludesLegacyDeploymentPods",
+			Values: map[string]string{},
+			Verifier: func(t *testing.T, output string, err error) {
+				require.NoError(t, err)
+
+				var service corev1.Service
+				helm.UnmarshalK8SYaml(t, output, &service)
+
+				require.Equal(t, "statefulset", service.Spec.Selector["camunda.io/controller"],
+					"Service must only select pods the StatefulSet owns")
+				require.Equal(t, "postgresql", service.Spec.Selector["app.kubernetes.io/component"])
+			},
+		},
+	}
+
+	testhelpers.RunTestCasesE(s.T(), chartPath, "camunda-platform-test", s.namespace, []string{template}, testCases)
+}
+
+func (s *CompanionServiceSelectorTest) TestPostgresqlServiceSelector() {
+	s.assertSelectorIsolated("../../../../internal-postgresql", "templates/service.yaml")
+}
+
+func (s *CompanionServiceSelectorTest) TestKeycloakPostgresqlServiceSelector() {
+	s.assertSelectorIsolated("../../../../internal-keycloak-26", "templates/postgresql-service.yaml")
+}

--- a/charts/internal-keycloak-26/Chart.yaml
+++ b/charts/internal-keycloak-26/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: internal-keycloak
 description: Minimal internal Keycloak chart for Camunda CI integration tests. Not for production use.
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "26.3.3"
 maintainers:
   - name: Camunda Services GmbH

--- a/charts/internal-keycloak-26/templates/_helpers.tpl
+++ b/charts/internal-keycloak-26/templates/_helpers.tpl
@@ -67,6 +67,14 @@ app.kubernetes.io/component: postgresql
 {{- end }}
 
 {{/*
+PostgreSQL pod selector labels. Superset of keycloak.postgresql.selectorLabels.
+*/}}
+{{- define "keycloak.postgresql.podSelectorLabels" -}}
+{{ include "keycloak.postgresql.selectorLabels" . }}
+camunda.io/controller: statefulset
+{{- end }}
+
+{{/*
 Keycloak admin password secret name.
 */}}
 {{- define "keycloak.secretName" -}}

--- a/charts/internal-keycloak-26/templates/postgresql-service.yaml
+++ b/charts/internal-keycloak-26/templates/postgresql-service.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    {{- include "keycloak.postgresql.selectorLabels" . | nindent 4 }}
+    {{- include "keycloak.postgresql.podSelectorLabels" . | nindent 4 }}
   ports:
     - name: postgresql
       port: 5432

--- a/charts/internal-keycloak-26/templates/postgresql-statefulset.yaml
+++ b/charts/internal-keycloak-26/templates/postgresql-statefulset.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "keycloak.postgresql.selectorLabels" . | nindent 8 }}
+        {{- include "keycloak.postgresql.podSelectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/internal-keycloak-26/templates/postgresql-statefulset.yaml
+++ b/charts/internal-keycloak-26/templates/postgresql-statefulset.yaml
@@ -1,14 +1,14 @@
 {{- if .Values.postgresql.enabled }}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "keycloak.postgresql.fullname" . }}
   labels:
     {{- include "keycloak.postgresql.labels" . | nindent 4 }}
 spec:
   replicas: 1
-  strategy:
-    type: Recreate
+  serviceName: {{ include "keycloak.postgresql.fullname" . }}
+  podManagementPolicy: Parallel
   selector:
     matchLabels:
       {{- include "keycloak.postgresql.selectorLabels" . | nindent 6 }}
@@ -72,7 +72,25 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /var/lib/postgresql/data
+      {{- if not .Values.postgresql.storage.enabled }}
       volumes:
         - name: data
           emptyDir: {}
+      {{- end }}
+  {{- if .Values.postgresql.storage.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          {{- include "keycloak.postgresql.labels" . | nindent 10 }}
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- if .Values.postgresql.storage.storageClassName }}
+        storageClassName: {{ .Values.postgresql.storage.storageClassName | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.postgresql.storage.size | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/internal-keycloak-26/values.yaml
+++ b/charts/internal-keycloak-26/values.yaml
@@ -119,7 +119,10 @@ postgresql:
     limits:
       cpu: 500m
       memory: 256Mi
-  ## @param postgresql.storage.size PVC size for PostgreSQL data.
   storage:
+    ## @param postgresql.storage.enabled Back the data directory with a PersistentVolumeClaim.
+    enabled: true
+    ## @param postgresql.storage.size PVC size for PostgreSQL data.
     size: 2Gi
+    ## @param postgresql.storage.storageClassName StorageClass for the PVC ("" uses the cluster default).
     storageClassName: ""

--- a/charts/internal-postgresql/Chart.yaml
+++ b/charts/internal-postgresql/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: internal-postgresql
 description: Minimal PostgreSQL chart for Camunda CI integration tests. Not for production use.
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "16"
 maintainers:
   - name: Camunda Services GmbH

--- a/charts/internal-postgresql/templates/_helpers.tpl
+++ b/charts/internal-postgresql/templates/_helpers.tpl
@@ -41,6 +41,14 @@ app.kubernetes.io/component: postgresql
 {{- end }}
 
 {{/*
+Pod selector labels. Superset of postgresql.selectorLabels.
+*/}}
+{{- define "postgresql.podSelectorLabels" -}}
+{{ include "postgresql.selectorLabels" . }}
+camunda.io/controller: statefulset
+{{- end }}
+
+{{/*
 PostgreSQL password secret name.
 */}}
 {{- define "postgresql.secretName" -}}

--- a/charts/internal-postgresql/templates/service.yaml
+++ b/charts/internal-postgresql/templates/service.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   selector:
-    {{- include "postgresql.selectorLabels" . | nindent 4 }}
+    {{- include "postgresql.podSelectorLabels" . | nindent 4 }}
   ports:
     - name: postgresql
       port: {{ .Values.service.port }}

--- a/charts/internal-postgresql/templates/statefulset.yaml
+++ b/charts/internal-postgresql/templates/statefulset.yaml
@@ -1,13 +1,13 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "postgresql.fullname" . }}
   labels:
     {{- include "postgresql.labels" . | nindent 4 }}
 spec:
   replicas: 1
-  strategy:
-    type: Recreate
+  serviceName: {{ include "postgresql.fullname" . }}
+  podManagementPolicy: Parallel
   selector:
     matchLabels:
       {{- include "postgresql.selectorLabels" . | nindent 6 }}
@@ -131,8 +131,10 @@ spec:
               readOnly: true
             {{- end }}
       volumes:
+        {{- if not .Values.persistence.enabled }}
         - name: data
           emptyDir: {}
+        {{- end }}
         - name: initdb
           configMap:
             name: {{ include "postgresql.fullname" . }}-initdb
@@ -144,3 +146,19 @@ spec:
         - name: tls
           emptyDir: {}
         {{- end }}
+  {{- if .Values.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          {{- include "postgresql.labels" . | nindent 10 }}
+      spec:
+        accessModes:
+          {{- toYaml .Values.persistence.accessModes | nindent 10 }}
+        {{- if .Values.persistence.storageClass }}
+        storageClassName: {{ .Values.persistence.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size | quote }}
+  {{- end }}

--- a/charts/internal-postgresql/templates/statefulset.yaml
+++ b/charts/internal-postgresql/templates/statefulset.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "postgresql.selectorLabels" . | nindent 8 }}
+        {{- include "postgresql.podSelectorLabels" . | nindent 8 }}
       {{- with .Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/charts/internal-postgresql/values.yaml
+++ b/charts/internal-postgresql/values.yaml
@@ -48,6 +48,17 @@ databases:
   - identity
   - webmodeler
 
+persistence:
+  ## @param persistence.enabled Back the data directory with a PersistentVolumeClaim.
+  enabled: true
+  ## @param persistence.size Size of the requested volume.
+  size: 1Gi
+  ## @param persistence.storageClass StorageClass for the volume ("" uses the cluster default).
+  storageClass: ""
+  ## @param persistence.accessModes Access modes for the requested volume.
+  accessModes:
+    - ReadWriteOnce
+
 service:
   type: ClusterIP
   port: 5432

--- a/charts/internal-postgresql/values.yaml
+++ b/charts/internal-postgresql/values.yaml
@@ -51,8 +51,9 @@ databases:
 persistence:
   ## @param persistence.enabled Back the data directory with a PersistentVolumeClaim.
   enabled: true
-  ## @param persistence.size Size of the requested volume.
-  size: 1Gi
+  ## @param persistence.size Size of the requested volume. Keep this at or above 4Gi:
+  ## hyperdisk-balanced, used by the ARM CI pool, rejects disks smaller than 4GB.
+  size: 4Gi
   ## @param persistence.storageClass StorageClass for the volume ("" uses the cluster default).
   storageClass: ""
   ## @param persistence.accessModes Access modes for the requested volume.

--- a/scripts/camunda-core/pkg/kube/diagnostics.go
+++ b/scripts/camunda-core/pkg/kube/diagnostics.go
@@ -88,6 +88,28 @@ func GetPVCs(ctx context.Context, kubeContext, namespace string) (string, error)
 	return runKubectl(ctx, args)
 }
 
+// GetServices returns the output of `kubectl get svc -n <namespace> -o wide`.
+func GetServices(ctx context.Context, kubeContext, namespace string) (string, error) {
+	args := append(kubectlBaseArgs(kubeContext), "get", "svc", "-n", namespace, "-o", "wide")
+	return runKubectl(ctx, args)
+}
+
+// GetServicesYAML returns `kubectl get svc -n <namespace> -o yaml`. YAML is used
+// rather than describe because describe omits appProtocol; the YAML carries both
+// the per-port appProtocol and the selector, which together explain a Service that
+// resolves to no backends.
+func GetServicesYAML(ctx context.Context, kubeContext, namespace string) (string, error) {
+	args := append(kubectlBaseArgs(kubeContext), "get", "svc", "-n", namespace, "-o", "yaml")
+	return runKubectl(ctx, args)
+}
+
+// GetEndpoints returns the output of `kubectl get endpoints -n <namespace>`, which
+// shows which pods actually back each Service.
+func GetEndpoints(ctx context.Context, kubeContext, namespace string) (string, error) {
+	args := append(kubectlBaseArgs(kubeContext), "get", "endpoints", "-n", namespace)
+	return runKubectl(ctx, args)
+}
+
 // DescribePVCs returns the output of `kubectl describe pvc -n <namespace>`, which
 // includes the events explaining why a claim is stuck (e.g., waiting for a consumer,
 // provisioning errors, multi-attach conflicts).

--- a/scripts/deploy-camunda/cmd/diagnostics.go
+++ b/scripts/deploy-camunda/cmd/diagnostics.go
@@ -17,6 +17,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// errNotCollected marks a section whose collector was not wired on the source.
+var errNotCollected = fmt.Errorf("not collected")
+
 // diagnosticsEventsTail bounds the events dump so the in-log output stays readable.
 const diagnosticsEventsTail = 40
 
@@ -28,6 +31,9 @@ type podDiagnosticsSource struct {
 	GetEvents           func(ctx context.Context, kubeContext, namespace string) (string, error)
 	GetPVCs             func(ctx context.Context, kubeContext, namespace string) (string, error)
 	DescribePVCs        func(ctx context.Context, kubeContext, namespace string) (string, error)
+	GetServices         func(ctx context.Context, kubeContext, namespace string) (string, error)
+	GetServicesYAML     func(ctx context.Context, kubeContext, namespace string) (string, error)
+	GetEndpoints        func(ctx context.Context, kubeContext, namespace string) (string, error)
 	GetNonReadyPods     func(ctx context.Context, kubeContext, namespace string) ([]string, error)
 	GetPodNames         func(ctx context.Context, kubeContext, namespace string) ([]string, error)
 	DescribePod         func(ctx context.Context, kubeContext, namespace, pod string) (string, error)
@@ -44,6 +50,9 @@ func defaultPodDiagnosticsSource() podDiagnosticsSource {
 		GetEvents:           kube.GetEvents,
 		GetPVCs:             kube.GetPVCs,
 		DescribePVCs:        kube.DescribePVCs,
+		GetServices:         kube.GetServices,
+		GetServicesYAML:     kube.GetServicesYAML,
+		GetEndpoints:        kube.GetEndpoints,
 		GetNonReadyPods:     kube.GetNonReadyPods,
 		GetPodNames:         kube.GetPodNames,
 		DescribePod:         kube.DescribePod,
@@ -79,7 +88,7 @@ func newDiagnosticsPrintCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "print",
-		Short: "Print namespace diagnostics (pods, events, PVCs, pod describe+logs) to stdout",
+		Short: "Print namespace diagnostics (pods, events, PVCs, Services, endpoints, pod describe+logs) to stdout",
 		Long: `Print a best-effort namespace diagnostics dump for CI logs.
 
 Backs the failed-pods-info GitHub action. Structured diagnostics are also
@@ -156,17 +165,35 @@ func printNamespaceDiagnostics(ctx context.Context, w io.Writer, src podDiagnost
 		}
 	}
 
-	pods, podsErr := src.GetPods(ctx, kubeContext, namespace)
+	// collect tolerates an unset collector so a partially-populated source degrades
+	// to a "(not collected)" section instead of panicking mid-dump.
+	collect := func(fn func(context.Context, string, string) (string, error)) (string, error) {
+		if fn == nil {
+			return "", errNotCollected
+		}
+		return fn(ctx, kubeContext, namespace)
+	}
+
+	pods, podsErr := collect(src.GetPods)
 	emit("Pods", pods, podsErr)
 
-	events, eventsErr := src.GetEvents(ctx, kubeContext, namespace)
+	events, eventsErr := collect(src.GetEvents)
 	emit(fmt.Sprintf("Events (last %d)", diagnosticsEventsTail), lastLines(events, diagnosticsEventsTail), eventsErr)
 
-	pvcs, pvcsErr := src.GetPVCs(ctx, kubeContext, namespace)
+	pvcs, pvcsErr := collect(src.GetPVCs)
 	emit("PersistentVolumeClaims", pvcs, pvcsErr)
 
-	pvcDesc, pvcDescErr := src.DescribePVCs(ctx, kubeContext, namespace)
+	pvcDesc, pvcDescErr := collect(src.DescribePVCs)
 	emit("PVC describe", pvcDesc, pvcDescErr)
+
+	services, servicesErr := collect(src.GetServices)
+	emit("Services", services, servicesErr)
+
+	serviceYAML, serviceYAMLErr := collect(src.GetServicesYAML)
+	emit("Service spec (YAML)", serviceYAML, serviceYAMLErr)
+
+	endpoints, endpointsErr := collect(src.GetEndpoints)
+	emit("Endpoints", endpoints, endpointsErr)
 
 	listPods, listTitle, podLabel := src.GetNonReadyPods, "Non-ready pods", "Non-ready pod: "
 	if includeReady {

--- a/scripts/deploy-camunda/cmd/diagnostics_test.go
+++ b/scripts/deploy-camunda/cmd/diagnostics_test.go
@@ -353,3 +353,61 @@ func TestLastLines(t *testing.T) {
 		t.Errorf("empty input should stay empty, got %q", got)
 	}
 }
+
+// TestPrintNamespaceDiagnosticsIncludesServiceState covers the shape that pod-only
+// diagnostics cannot explain: every pod is Ready, but a Service selects nothing, so
+// traffic goes nowhere. The dump must carry the Service ports (including
+// appProtocol) and the resolved Endpoints.
+func TestPrintNamespaceDiagnosticsIncludesServiceState(t *testing.T) {
+	src := podDiagnosticsSource{
+		GetPods:   func(_ context.Context, _, _ string) (string, error) { return "pod-a 1/1 Running", nil },
+		GetEvents: func(_ context.Context, _, _ string) (string, error) { return "", nil },
+		GetServices: func(_ context.Context, _, _ string) (string, error) {
+			return "camunda-platform-zeebe-gateway ClusterIP 10.0.0.1 26500/TCP", nil
+		},
+		GetServicesYAML: func(_ context.Context, _, _ string) (string, error) {
+			return "  ports:\n  - appProtocol: kubernetes.io/h2c\n    name: grpc\n    port: 26500\n  selector:\n    app.kubernetes.io/component: postgresql", nil
+		},
+		GetEndpoints: func(_ context.Context, _, _ string) (string, error) {
+			return "camunda-platform-zeebe-gateway <none>", nil
+		},
+		GetNonReadyPods: func(_ context.Context, _, _ string) ([]string, error) { return nil, nil },
+	}
+
+	var buf bytes.Buffer
+	printNamespaceDiagnostics(context.Background(), &buf, src, "", "camunda-platform", 10, false)
+	out := buf.String()
+
+	for _, want := range []string{
+		"===== Services =====",
+		"===== Service spec (YAML) =====",
+		"===== Endpoints =====",
+		"appProtocol: kubernetes.io/h2c",
+		"app.kubernetes.io/component: postgresql",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("diagnostics dump missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+// TestPrintNamespaceDiagnosticsToleratesUnsetCollectors guards the struct-of-funcs
+// source against a caller that has not wired every collector: the dump must degrade
+// to a labelled section rather than panicking part-way through.
+func TestPrintNamespaceDiagnosticsToleratesUnsetCollectors(t *testing.T) {
+	src := podDiagnosticsSource{
+		GetPods:         func(_ context.Context, _, _ string) (string, error) { return "pod-a 1/1 Running", nil },
+		GetNonReadyPods: func(_ context.Context, _, _ string) ([]string, error) { return nil, nil },
+	}
+
+	var buf bytes.Buffer
+	printNamespaceDiagnostics(context.Background(), &buf, src, "", "camunda-platform", 10, false)
+	out := buf.String()
+
+	if !strings.Contains(out, "===== Services =====") {
+		t.Errorf("expected a Services section even when unset\n---\n%s", out)
+	}
+	if !strings.Contains(out, "not collected") {
+		t.Errorf("expected unset collectors to be labelled\n---\n%s", out)
+	}
+}

--- a/scripts/deploy-camunda/deploy/deploy.go
+++ b/scripts/deploy-camunda/deploy/deploy.go
@@ -432,7 +432,9 @@ func executeDeployment(ctx context.Context, prepared *PreparedScenario, flags *c
 		PostInfraHooks:        flags.PostInfraHooks,
 		CompanionNodeSelector: compNS,
 		CompanionTolerations:  compTol,
-		CompanionElasticsearchStorageClass: func() string {
+		// ARM nodes (c4a-standard-8) can't attach pd-balanced disks, which is
+		// what the cluster default class provisions; see the arm feature values.
+		CompanionStorageClass: func() string {
 			if flags.Selection.InfraType == "arm" {
 				return "hyperdisk-balanced"
 			}

--- a/scripts/deploy-camunda/pkg/deployer/helm.go
+++ b/scripts/deploy-camunda/pkg/deployer/helm.go
@@ -217,6 +217,18 @@ func formatArgs(args []string) string {
 // shared repositories.yaml and must not run concurrently.
 var companionRepoMu sync.Mutex
 
+// companionStorageClassPaths maps a companion release name to the Helm value
+// that sets the storage class on its claim template. Only companions whose pods
+// follow CompanionNodeSelector onto the infra pool belong here: the pool's
+// machine type constrains which disk types can attach, so their PVCs must use a
+// compatible class. The keycloak companion's postgresql StatefulSet is
+// deliberately absent — it declares no nodeSelector, so it stays on the default
+// pool where the cluster default class works.
+var companionStorageClassPaths = map[string]string{
+	"elasticsearch": "volumeClaimTemplate.storageClassName",
+	"postgresql":    "persistence.storageClass",
+}
+
 // deployCompanionCharts deploys all configured companion charts concurrently,
 // blocking until every companion is ready or the first failure cancels the rest.
 // Returns the first error encountered; nil means all companions are up.
@@ -310,8 +322,8 @@ func deployCompanionChart(ctx context.Context, cc types.CompanionChart, o types.
 		}
 		args = append(args, "--set-json", "tolerations="+string(b))
 	}
-	if cc.ReleaseName == "elasticsearch" && o.CompanionElasticsearchStorageClass != "" {
-		args = append(args, "--set", "volumeClaimTemplate.storageClassName="+o.CompanionElasticsearchStorageClass)
+	if path, ok := companionStorageClassPaths[cc.ReleaseName]; ok && o.CompanionStorageClass != "" {
+		args = append(args, "--set", path+"="+o.CompanionStorageClass)
 	}
 
 	_, runErr := helmRunWithRetry(ctx, args)

--- a/scripts/deploy-camunda/pkg/deployer/helm_test.go
+++ b/scripts/deploy-camunda/pkg/deployer/helm_test.go
@@ -286,10 +286,34 @@ func TestDeployCompanionChart(t *testing.T) {
 				ReleaseName: "elasticsearch",
 			},
 			opts: types.Options{
-				Namespace:                          "ns",
-				CompanionElasticsearchStorageClass: "hyperdisk-balanced",
+				Namespace:             "ns",
+				CompanionStorageClass: "hyperdisk-balanced",
 			},
 			wantArgs: []string{"--set", "volumeClaimTemplate.storageClassName=hyperdisk-balanced"},
+		},
+		{
+			name: "postgresql companion storage class override",
+			cc: types.CompanionChart{
+				ChartRef:    "internal-postgresql",
+				ReleaseName: "postgresql",
+			},
+			opts: types.Options{
+				Namespace:             "ns",
+				CompanionStorageClass: "hyperdisk-balanced",
+			},
+			wantArgs: []string{"--set", "persistence.storageClass=hyperdisk-balanced"},
+		},
+		{
+			name: "keycloak companion is excluded from the storage class override",
+			cc: types.CompanionChart{
+				ChartRef:    "internal-keycloak-26",
+				ReleaseName: "keycloak",
+			},
+			opts: types.Options{
+				Namespace:             "ns",
+				CompanionStorageClass: "hyperdisk-balanced",
+			},
+			notWantArgs: []string{"hyperdisk-balanced"},
 		},
 		{
 			name: "unmarshalable tolerations value propagates as HelmError",

--- a/scripts/deploy-camunda/pkg/types/types.go
+++ b/scripts/deploy-camunda/pkg/types/types.go
@@ -92,8 +92,11 @@ type Options struct {
 	CompanionNodeSelector map[string]string
 	// CompanionTolerations is node scheduling applied to companion chart installs so they run on the same infra pool as the main chart.
 	CompanionTolerations []map[string]interface{}
-	// CompanionElasticsearchStorageClass overrides the Elastic companion PVC storage class.
-	CompanionElasticsearchStorageClass string
+	// CompanionStorageClass overrides the PVC storage class for companion
+	// charts that provision persistent volumes. Applied per release via
+	// companionStorageClassPaths, which maps a release name to the value key
+	// that chart exposes for its claim template.
+	CompanionStorageClass string
 }
 
 // CompanionChart represents a Helm chart that should be deployed as a


### PR DESCRIPTION
### Which problem does the PR fix?

No GitHub issue yet. Raised from a nightly triage in [#ask-distribution](https://camunda.slack.com/archives/C0AK0AVKRL0/p1787036978641699?thread_ts=1787034584.449719).

Two `Docker Build, Helm Deploy & E2E Tests (SaaS + Helm)` runs on `camunda/camunda` `main` hung for ~25 minutes on Modeler login and were reported as a Keycloak or product problem:

- https://github.com/camunda/camunda/actions/runs/32103766300
- https://github.com/camunda/camunda/actions/runs/32103899174

They were neither. From the GKE and GCP logs:

1. At `06:07:45` GCE logged `compute.instances.preempted` for `gke-distro-ci-workflow-general-v2-01-292647d3-fzmc`. The AlwaysGreen pools (`workflow-general-v2-01/02` on `distro-ci`) are `spot: true`.
2. The eviction took Keycloak, Elasticsearch and Postgres out of both namespaces at `06:07:09`.
3. `charts/internal-postgresql` backed its data directory with `emptyDir`, so Postgres came back **empty**.
4. `web-modeler-restapi` was on a different node and was **not** restarted, so Liquibase never re-ran. From `06:08:34` it logged continuously:

   ```
   PSQLException: ERROR: relation "cluster_apps" does not exist
                         relation "files" does not exist
                         relation "users" does not exist
   ```

5. Every `POST /modeler/api/internal/login` returned 500 for the rest of the run.

Keycloak was healthy throughout. Ingress access logs show `200` on `/auth/realms/camunda-platform/protocol/openid-connect/token` and the `/modeler/login-callback` redirect completing normally. The "browser stuck on Keycloak" symptom is an artifact of how the Playwright retry helper reports the last URL.

This is a regression from the 8.10 Bitnami removal. 8.9 used `webModelerPostgresql` (Bitnami StatefulSet, `persistence.enabled: true` by default, so a PVC). 8.10 replaced it with a Deployment plus `emptyDir`. The stable/8.9 run caught by the **same** preemption in the **same second** recovered and passed 18/18.

### What's in this PR?

**Both CI companion Postgres charts move from Deployment with `emptyDir` to StatefulSet with a `volumeClaimTemplate`.** In each template: `kind` changes, `strategy: Recreate` is replaced by `serviceName` plus `podManagementPolicy: Parallel`, and the `emptyDir` volume is kept behind a flag as the fallback. The existing ClusterIP Service is reused, since nothing needs stable per-pod DNS. `PGDATA` already pointed at a `pgdata` subdirectory, so a mounted PVC does not trip `initdb` over `lost+found`. TLS init container, probes, `nodeSelector` and the `initdb` ConfigMap mount are untouched.

`charts/internal-postgresql` hosts **both** the `identity` and `webmodeler` databases, so Identity is covered by the same change.

`charts/internal-keycloak-26` gets the same treatment for two reasons. Its `values.yaml` already declared `postgresql.storage.size` and `postgresql.storage.storageClassName` and **no template consumed either**, so the chart advertised a PVC it never created. Those values are now wired up, with `postgresql.storage.enabled` added to keep the ephemeral behaviour available. Separately, its template sets no `nodeSelector`, so the Keycloak database schedules independently of the Keycloak pod, landing on `workflow-default-v2-01` while Keycloak runs on the alwaysgreen pool. Both pools are Spot, so it is exposed to the same failure and only escaped because its node was not the one preempted.

**`post-deploy-hub-ping.sh` now targets `statefulset/postgresql`.** The hook execs into the companion Postgres to poll Hub's database. Once the chart rendered a StatefulSet, `kubectl exec deployment/postgresql` returned NotFound, the error was swallowed by `|| true`, and the hook burned all 60 attempts before failing the `esa0`, `esoi` and `keyco` install jobs. This was a regression introduced by this PR and caught by its own CI.

**Tests.** `charts/camunda-platform-8.10/test/unit/companion/` covers both converted templates: claim template, `emptyDir` fallback, StorageClass and AccessModes, written table-driven through `testhelpers.RunTestCasesE`, plus `goldenfiles_test.go` running `utils.TemplateGoldenTest` over both with committed snapshots.

No file under `charts/camunda-platform-8.10/` outside `test/` is touched, and both companion charts describe themselves as "Not for production use", which is why this is typed `test:`.

#### Why a PVC is affordable in a ~10 minute environment

Measured on the PVC-backed `elasticsearch-master-0` in the same namespace during the incident: detach from the dead node plus reattach took **50s** (`FailedAttachVolume` at 06:07:11, `SuccessfulAttachVolume` at 06:08:01). Install-time provisioning was ~35s. That replaces an unrecoverable failure.

**Service selector isolation.** The Service selector and the StatefulSet pod template carry `camunda.io/controller: statefulset`. A Deployment left over from the previous chart version has only the old label set, so it can no longer be selected as a backend for the companion database Service. `.spec.selector` on the StatefulSet deliberately keeps the original labels, since it is immutable after creation and the pod labels are a superset; a unit test asserts that so it is not "tidied" later.

**Namespace diagnostics now cover Services.** `deploy-camunda diagnostics print` was pod-centric (pods, events, PVCs, per-pod describe and logs), which cannot explain a namespace where every pod is Ready but a Service resolves to no backends. It now also emits `Services`, the Service spec as YAML, and `Endpoints`. YAML rather than `describe`, because `kubectl describe svc` omits `appProtocol` — verified against a live cluster. Collectors are nil-tolerant, so a source that has not wired every function degrades to a labelled section instead of panicking mid-dump. The KIND workflow, the only test workflow with no diagnostics at all, now calls the shared `make diagnostics.print` target on failure with `--include-ready`, replacing two hand-rolled `kubectl` steps.

#### Verification

On GKE (`distro-ci`, the same Spot pools that were preempted), installed with the alwaysgreen `nodeSelector` and `tolerations`, then forced a cross-node reschedule to exercise the PD detach and reattach:

```
baseline node: gke-distro-ci-workflow-general-v2-02-3c0acbe0-h9f9
new node:      gke-distro-ci-workflow-general-v2-01-292647d3-nlrg
recovery took 31s

SELECT * FROM cluster_apps;
 id
----
 42
```

The run reproduced the same `FailedAttachVolume ... Multi-Attach error` seen in the incident, resolving ~21s later. Same test for the Keycloak companion across `workflow-default-v2-01` returned its row too.

On kind, the before and after:

```
with this PR (persistence on), pod deleted:   SELECT * FROM cluster_apps;  ->  42
control (persistence.enabled=false):          ERROR: relation "cluster_apps" does not exist
```

`helm lint --strict` passes both charts. `go test ./test/unit/companion/...` passes, and mutating a golden or an expected value makes the relevant test fail, so the assertions are load-bearing. `make go.test chartPath=charts/camunda-platform-8.10` is clean except `TestGoldenDefaultsTemplateConnectors`, which fails identically on a clean `origin/main` worktree and is unrelated.

#### On the Deployment to StatefulSet migration

Review threads raised upgrade safety, first as an immutable-kind 422 and then as old and new pods overlapping behind the Service selector. Neither reproduces, and selector isolation is implemented anyway (above) for the one case the measurements do not cover: a Deployment Helm does not own, from a manual apply or a different release name, which Helm never deletes. Verified on kind for both charts — a rogue Deployment carrying the old labels is an endpoint before the upgrade and excluded after it, while the Service keeps serving the StatefulSet database. `helm upgrade` across the kind change succeeds for both charts, and sampling Service endpoints every 0.1s with and without `--wait` never showed more than one endpoint. Helm issues the Deployment delete in the same reconcile pass as the StatefulSet create, and the new pod cannot become an endpoint for at least `readinessProbe.initialDelaySeconds: 5` after its container starts. Details and numbers are in the two file threads.

#### Follow-ups, deliberately not in this PR

- `scripts/base_playwright_script.sh:1003` classified this incident as `legitimate test failure`. Its spot-preemption retry only checks current pod readiness, and after the preemption every pod was Running and Ready, just with an empty database, while Modeler returned HTTP 500 rather than a connection error. Needs a retry-versus-fail-fast decision first.
- The missing `nodeSelector` on the Keycloak companion, which is the scheduling split described above.
- A stale trailing-whitespace line in `connectors/golden/configmap.golden.yaml` on `main`. It is what makes `TestGoldenDefaultsTemplateConnectors` fail, `make go.update-golden-only` fixes it, and every contributor running that checklist step picks it up. Left out to keep this PR scoped.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

