### PR TITLE
ci: derive Optimize e2e endpoints from the Optimize release

### DIFF
--- a/.github/actions/playwright-e2e-tests/action.yaml
+++ b/.github/actions/playwright-e2e-tests/action.yaml
@@ -69,6 +69,25 @@ inputs:
       TEST_NAMESPACE resolves to the orchestration namespace.
     required: false
     default: ""
+  optimize-namespace:
+    description: >-
+      For a topology whose Optimize runs as its own release: the namespace
+      running the Optimize instance that serves this leg. render-e2e-env.sh
+      derives Optimize from the orchestration namespace and sets
+      IS_OPTIMIZE=false when it finds none there, which skips every Optimize
+      spec while still reporting success. Requires hub-namespace.
+    required: false
+    default: ""
+  optimize-context-path:
+    description: >-
+      Ingress path that Optimize release is served on, e.g. /optimize-orcha.
+    required: false
+    default: ""
+  modeler-cluster-name:
+    description: >-
+      Web Modeler cluster targeted by this topology leg.
+    required: false
+    default: ""
   namespace-override:
     description: >-
       Overrides the namespace workflow-vars would otherwise compute from
@@ -232,6 +251,13 @@ runs:
         TEST_EXCLUDE: ${{ inputs.exclude }}
         TEST_AUTH_TYPE: ${{ inputs.auth }}
         HUB_NAMESPACE: ${{ inputs.hub-namespace }}
+        # E2E_ARG_-prefixed because these only build the argument list below. The Playwright suite
+        # reads OPTIMIZE_CONTEXT_PATH itself as `process.env.OPTIMIZE_CONTEXT_PATH ?? '/optimize'`,
+        # and `??` does not fall back on an empty string: exporting the bare name here made every
+        # non-topology leg navigate to the ingress root instead of /optimize.
+        E2E_ARG_OPTIMIZE_NAMESPACE: ${{ inputs.optimize-namespace }}
+        E2E_ARG_OPTIMIZE_CONTEXT_PATH: ${{ inputs.optimize-context-path }}
+        E2E_ARG_MODELER_CLUSTER_NAME: ${{ inputs.modeler-cluster-name }}
         REQUIRE_SM_810_TEST_SUITE: ${{ inputs.hub-namespace != '' }}
       run: |
         cd "$GITHUB_WORKSPACE/scripts"
@@ -260,6 +286,9 @@ runs:
         E2E_ARGS+=(--trace retain-on-failure --verbose)
         [[ -n "$EXTRA_FLAGS" ]] && E2E_ARGS+=("$EXTRA_FLAGS")
         [[ -n "$HUB_NAMESPACE" ]] && E2E_ARGS+=(--hub-namespace "${HUB_NAMESPACE}")
+        [[ -n "$E2E_ARG_OPTIMIZE_NAMESPACE" ]] && E2E_ARGS+=(--optimize-namespace "${E2E_ARG_OPTIMIZE_NAMESPACE}")
+        [[ -n "$E2E_ARG_OPTIMIZE_CONTEXT_PATH" ]] && E2E_ARGS+=(--optimize-context-path "${E2E_ARG_OPTIMIZE_CONTEXT_PATH}")
+        [[ -n "$E2E_ARG_MODELER_CLUSTER_NAME" ]] && E2E_ARGS+=(--modeler-cluster-name "${E2E_ARG_MODELER_CLUSTER_NAME}")
 
         ./run-e2e-tests.sh "${E2E_ARGS[@]}"
 

--- a/.github/workflows/test-integration-runner.yaml
+++ b/.github/workflows/test-integration-runner.yaml
@@ -1466,6 +1466,10 @@ jobs:
     timeout-minutes: 40
     strategy:
       fail-fast: false
+      # One leg per Optimize instance can share an orchestration_suffix, so legs
+      # would otherwise run the stateful smoke suite against the same
+      # orchestration/Modeler deployment at once and interfere with each other.
+      max-parallel: 1
       matrix:
         include: ${{ fromJson(inputs.topology-smoke-matrix) }}
     permissions:
@@ -1530,7 +1534,6 @@ jobs:
           GKE_WIP:          ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_WORKLOAD_IDENTITY_PROVIDER }}
           GKE_SA:           ${{ steps.test-credentials-secret.outputs.DISTRO_CI_GCP_SERVICE_ACCOUNT }}
           CI_DEPLOYMENT_TTL: ${{ env.CI_DEPLOYMENT_TTL }}
-          MODELER_CLUSTER_NAME: ${{ matrix.modeler_cluster_name }}
         with:
           camunda-helm-git-ref: ${{ inputs.camunda-helm-git-ref }}
           camunda-helm-dir: ${{ inputs.camunda-helm-dir }}
@@ -1542,6 +1545,9 @@ jobs:
           namespace-prefix: ${{ inputs.namespace-prefix }}
           namespace-override: "${{ steps.base-vars.outputs.namespace }}-${{ matrix.orchestration_suffix }}"
           hub-namespace: "${{ steps.base-vars.outputs.namespace }}-${{ inputs.topology-hub-suffix }}"
+          optimize-namespace: "${{ matrix.optimize_suffix && format('{0}-{1}', steps.base-vars.outputs.namespace, matrix.optimize_suffix) || '' }}"
+          optimize-context-path: "${{ matrix.optimize_context_path || '' }}"
+          modeler-cluster-name: ${{ matrix.modeler_cluster_name }}
           binary-artifact-name: ${{ inputs.binary-artifact-name }}
           deployment-ttl: ${{ env.CI_DEPLOYMENT_TTL }}
           auth: ${{ inputs.auth }}

--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -2011,7 +2011,6 @@ integration:
           tier: 2
           infra-type:
             gke: distroci
-          skip-e2e: true
           topology:
             name: hub-2orch-2optimize
             releases:

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/multinamespace-optimize.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/multinamespace-optimize.yaml
@@ -6,14 +6,6 @@ platforms:
   - gke
 infra-type:
   gke: distroci
-# The topology smoke matrix carries each leg's optimize-suffix and context path
-# (see matrix/plan.go's planTopologyMetadata), but the e2e runner still derives
-# its Optimize endpoint from the orchestration namespace, which is not where
-# Optimize runs here. Until the runner consumes that mapping this scenario
-# asserts deploy-time coverage only: both Optimize releases render their own
-# OIDC client and audience and reach readiness against the Orchestration they
-# serve. Drop this key in the same change that teaches the runner the mapping.
-skip-e2e: true
 topology:
   name: hub-2orch-2optimize
   shared-storage: elasticsearch

--- a/scripts/deploy-camunda/cmd/e2e_env.go
+++ b/scripts/deploy-camunda/cmd/e2e_env.go
@@ -43,6 +43,8 @@ func newE2EEnvMergeCommand() *cobra.Command {
 	var (
 		orchestrationNamespace string
 		hubNamespace           string
+		optimizeNamespace      string
+		optimizeContextPath    string
 		chartPath              string
 		output                 string
 		renderScript           string
@@ -55,6 +57,9 @@ func newE2EEnvMergeCommand() *cobra.Command {
 		Use:   "merge",
 		Short: "Merge orchestration endpoints with Hub auth into one .env",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateOptimizeFlags(optimizeNamespace, optimizeContextPath); err != nil {
+				return err
+			}
 			renderArgs := []string{
 				renderScript,
 				"--absolute-chart-path", chartPath,
@@ -113,11 +118,29 @@ func newE2EEnvMergeCommand() *cobra.Command {
 				"DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET":     clientSecret,
 			}
 
+			if optimizeNamespace != "" {
+				if err := assertOptimizeDeployed(kubeContext, optimizeNamespace); err != nil {
+					return err
+				}
+				optimizeHost, err := resolveIngressHost(kubeContext, optimizeNamespace)
+				if err != nil {
+					return fmt.Errorf("optimize namespace %q: %w", optimizeNamespace, err)
+				}
+				for k, v := range optimizeEnvOverrides(optimizeHost, optimizeContextPath) {
+					overrides[k] = v
+				}
+			}
+
 			content, err := os.ReadFile(output)
 			if err != nil {
 				return err
 			}
 			merged := mergeEnvOverrides(string(content), overrides)
+			if optimizeNamespace != "" {
+				if err := assertOptimizeEnabled(merged, optimizeNamespace); err != nil {
+					return err
+				}
+			}
 			if err := os.WriteFile(output, []byte(merged), 0o600); err != nil {
 				return err
 			}
@@ -132,6 +155,8 @@ func newE2EEnvMergeCommand() *cobra.Command {
 
 	cmd.Flags().StringVar(&orchestrationNamespace, "orchestration-namespace", "", "orchestration release namespace")
 	cmd.Flags().StringVar(&hubNamespace, "hub-namespace", "", "Hub release namespace")
+	cmd.Flags().StringVar(&optimizeNamespace, "optimize-namespace", "", "namespace of the Optimize-only release serving this leg; render-e2e-env.sh derives Optimize from the orchestration namespace, which is not where Optimize runs in a topology using the optimize release role")
+	cmd.Flags().StringVar(&optimizeContextPath, "optimize-context-path", "", "ingress path the Optimize-only release is served on, e.g. /optimize-orcha")
 	cmd.Flags().StringVar(&chartPath, "absolute-chart-path", "", "absolute chart path")
 	cmd.Flags().StringVar(&output, "output", ".env", "output .env path")
 	cmd.Flags().StringVar(&renderScript, "render-script", "scripts/render-e2e-env.sh", "path to render-e2e-env.sh")
@@ -143,6 +168,75 @@ func newE2EEnvMergeCommand() *cobra.Command {
 	_ = cmd.MarkFlagRequired("absolute-chart-path")
 
 	return cmd
+}
+
+// validateOptimizeFlags rejects the half-configured Optimize targeting that
+// optimizeEnvOverrides cannot turn into a usable endpoint. A namespace without a
+// path builds https://<host>, the ingress root rather than Optimize; a path
+// without a namespace is never read at all; and a path missing its leading
+// slash concatenates into a malformed URL. Each one lands the leg on something
+// that is not Optimize, so refuse before any cluster lookup happens.
+func validateOptimizeFlags(optimizeNamespace, optimizeContextPath string) error {
+	if (optimizeNamespace == "") != (optimizeContextPath == "") {
+		return fmt.Errorf("--optimize-namespace and --optimize-context-path must be set together (got namespace %q, context path %q); one without the other cannot address the Optimize release", optimizeNamespace, optimizeContextPath)
+	}
+	if optimizeContextPath != "" && !strings.HasPrefix(optimizeContextPath, "/") {
+		return fmt.Errorf("--optimize-context-path %q must start with %q; it is joined onto the ingress host and would otherwise build a malformed URL", optimizeContextPath, "/")
+	}
+	return nil
+}
+
+// optimizeEnvOverrides points the e2e env at an Optimize running as its own release, in its own
+// namespace on the Hub host.
+//
+// Both URL keys are required and must agree. 32 call sites read CAMUNDA_OPTIMIZE_BASE_URL, but
+// NavigationPage.goToOptimize and goToOptimizeWithoutAccess navigate with OPTIMIZE_CONTEXT_PATH, whose
+// default "/optimize" resolves against Playwright's baseURL — the orchestration host — and lands on an
+// nginx 404. Setting only the first made the Optimize specs pass while Basic Navigation and the
+// all-apps smoke flow failed on a 404 page. Absolute URLs, like MODELER_CONTEXT_PATH, because
+// page.goto honours an absolute URL over baseURL.
+func optimizeEnvOverrides(optimizeHost, optimizeContextPath string) map[string]string {
+	url := "https://" + optimizeHost + optimizeContextPath
+	return map[string]string{
+		"CAMUNDA_OPTIMIZE_BASE_URL": url,
+		"OPTIMIZE_CONTEXT_PATH":     url,
+		"IS_OPTIMIZE":               "true",
+	}
+}
+
+// assertOptimizeDeployed fails when a leg declares an Optimize namespace that
+// runs no Optimize workload. Without it the merged env would point at nothing
+// and, because render-e2e-env.sh only sets IS_OPTIMIZE from the orchestration
+// namespace and every Optimize spec is guarded on that variable, the suite
+// would report success having silently skipped Optimize entirely.
+func assertOptimizeDeployed(kubeContext, namespace string) error {
+	args := []string{}
+	if kubeContext != "" {
+		args = append(args, "--context", kubeContext)
+	}
+	args = append(args, "-n", namespace, "get", "deployment",
+		"-l", "app.kubernetes.io/component=optimize",
+		"-o", "jsonpath={.items[*].metadata.name}")
+	out, err := exec.Command("kubectl", args...).Output()
+	if err != nil {
+		return fmt.Errorf("look for an Optimize deployment in namespace %q: %w", namespace, err)
+	}
+	if len(strings.Fields(string(out))) == 0 {
+		return fmt.Errorf("no Optimize deployment found in namespace %q; every Optimize spec is guarded on IS_OPTIMIZE, so continuing would skip Optimize coverage and still report success", namespace)
+	}
+	return nil
+}
+
+// assertOptimizeEnabled guards the merge itself: the rendered env carries
+// IS_OPTIMIZE=false for a topology whose Optimize runs outside the
+// orchestration namespace, and that value must have been overridden.
+func assertOptimizeEnabled(merged, namespace string) error {
+	for _, line := range strings.Split(merged, "\n") {
+		if strings.TrimSpace(line) == "IS_OPTIMIZE=false" {
+			return fmt.Errorf("merged env still sets IS_OPTIMIZE=false while Optimize runs in namespace %q; Optimize specs would be skipped", namespace)
+		}
+	}
+	return nil
 }
 
 // resolveSecretKey reads and base64-decodes one key from the Hub

--- a/scripts/deploy-camunda/cmd/e2e_env_test.go
+++ b/scripts/deploy-camunda/cmd/e2e_env_test.go
@@ -221,3 +221,128 @@ func TestMergeEnvOverridesIgnoresLinesWithoutEquals(t *testing.T) {
 		t.Fatalf("mergeEnvOverrides() = %q, want %q", got, want)
 	}
 }
+
+func TestAssertOptimizeEnabledRejectsDisabledOptimize(t *testing.T) {
+	merged := "CAMUNDA_OPTIMIZE_BASE_URL=https://hub.example.com/optimize-orcha\nIS_OPTIMIZE=false\n"
+
+	err := assertOptimizeEnabled(merged, "ns-opta")
+	if err == nil || !strings.Contains(err.Error(), "IS_OPTIMIZE=false") {
+		t.Fatalf("expected a hard failure when Optimize specs would be skipped, got %v", err)
+	}
+}
+
+func TestAssertOptimizeEnabledAcceptsOverriddenOptimize(t *testing.T) {
+	merged := mergeEnvOverrides(
+		"CAMUNDA_OPTIMIZE_BASE_URL=https://orcha.example.com/optimize\nIS_OPTIMIZE=false\n",
+		map[string]string{
+			"CAMUNDA_OPTIMIZE_BASE_URL": "https://hub.example.com/optimize-orcha",
+			"IS_OPTIMIZE":               "true",
+		},
+	)
+
+	if !strings.Contains(merged, "IS_OPTIMIZE=true") {
+		t.Fatalf("merge did not enable Optimize: %q", merged)
+	}
+	if !strings.Contains(merged, "CAMUNDA_OPTIMIZE_BASE_URL=https://hub.example.com/optimize-orcha") {
+		t.Fatalf("merge did not repoint Optimize at the Hub host: %q", merged)
+	}
+	if err := assertOptimizeEnabled(merged, "ns-opta"); err != nil {
+		t.Fatalf("expected the overridden env to pass, got %v", err)
+	}
+}
+
+// Both Optimize URL keys must be set and agree. CAMUNDA_OPTIMIZE_BASE_URL alone made the Optimize
+// specs pass while Basic Navigation and the all-apps smoke flow failed on an nginx 404, because
+// NavigationPage.goToOptimize navigates with OPTIMIZE_CONTEXT_PATH, whose default "/optimize" resolves
+// against the orchestration host rather than the Hub host where the Optimize release runs.
+func TestOptimizeEnvOverridesSetsBothUrlKeys(t *testing.T) {
+	got := optimizeEnvOverrides("hub.example.com", "/optimize-orcha")
+
+	want := "https://hub.example.com/optimize-orcha"
+	for _, key := range []string{"CAMUNDA_OPTIMIZE_BASE_URL", "OPTIMIZE_CONTEXT_PATH"} {
+		if got[key] != want {
+			t.Errorf("%s = %q, want %q", key, got[key], want)
+		}
+	}
+	if got["CAMUNDA_OPTIMIZE_BASE_URL"] != got["OPTIMIZE_CONTEXT_PATH"] {
+		t.Errorf("the two Optimize URL keys disagree: %q vs %q", got["CAMUNDA_OPTIMIZE_BASE_URL"], got["OPTIMIZE_CONTEXT_PATH"])
+	}
+	if got["IS_OPTIMIZE"] != "true" {
+		t.Errorf("IS_OPTIMIZE = %q, want \"true\"; every Optimize spec is guarded on it", got["IS_OPTIMIZE"])
+	}
+}
+
+// The URLs must be absolute: page.goto honours an absolute URL over Playwright's baseURL, which is the
+// orchestration host and therefore the wrong place to look for a separate Optimize release.
+func TestOptimizeEnvOverridesUsesAbsoluteUrls(t *testing.T) {
+	for _, v := range optimizeEnvOverrides("hub.example.com", "/optimize-orcha-ta") {
+		if v == "true" {
+			continue
+		}
+		if !strings.HasPrefix(v, "https://") {
+			t.Errorf("override %q must be an absolute URL", v)
+		}
+	}
+}
+
+func TestValidateOptimizeFlagsRejectsNamespaceWithoutContextPath(t *testing.T) {
+	err := validateOptimizeFlags("matrix-810-mns-opt-orcha", "")
+	if err == nil {
+		t.Fatal("expected an error when --optimize-namespace is set without --optimize-context-path")
+	}
+	if !strings.Contains(err.Error(), "must be set together") {
+		t.Fatalf("expected error to say the flags pair, got: %v", err)
+	}
+}
+
+func TestValidateOptimizeFlagsRejectsContextPathWithoutNamespace(t *testing.T) {
+	err := validateOptimizeFlags("", "/optimize-orcha")
+	if err == nil {
+		t.Fatal("expected an error when --optimize-context-path is set without --optimize-namespace")
+	}
+	if !strings.Contains(err.Error(), "must be set together") {
+		t.Fatalf("expected error to say the flags pair, got: %v", err)
+	}
+}
+
+func TestValidateOptimizeFlagsRejectsContextPathWithoutLeadingSlash(t *testing.T) {
+	err := validateOptimizeFlags("matrix-810-mns-opt-orcha", "optimize-orcha")
+	if err == nil {
+		t.Fatal("expected an error when --optimize-context-path has no leading slash")
+	}
+	if !strings.Contains(err.Error(), "must start with") {
+		t.Fatalf("expected error to name the missing leading slash, got: %v", err)
+	}
+}
+
+func TestValidateOptimizeFlagsAcceptsBothSetAndBothOmitted(t *testing.T) {
+	if err := validateOptimizeFlags("matrix-810-mns-opt-orcha", "/optimize-orcha"); err != nil {
+		t.Fatalf("expected a paired namespace and context path to validate, got: %v", err)
+	}
+	if err := validateOptimizeFlags("", ""); err != nil {
+		t.Fatalf("expected both flags omitted to validate, got: %v", err)
+	}
+}
+
+func TestE2EEnvMergeRejectsHalfConfiguredOptimizeBeforeRendering(t *testing.T) {
+	cmd := newE2EEnvMergeCommand()
+	cmd.SetArgs([]string{
+		"--orchestration-namespace", "matrix-810-mns-orcha",
+		"--hub-namespace", "matrix-810-mns-hub",
+		"--absolute-chart-path", "/workspace/charts/camunda-platform-8.10",
+		"--render-script", "/nonexistent/render-e2e-env.sh",
+		"--optimize-namespace", "matrix-810-mns-opt-orcha",
+	})
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected an error when only --optimize-namespace is supplied")
+	}
+	// The render script is deliberately bogus: the flag check must fail first,
+	// proving it runs before any cluster or filesystem work.
+	if !strings.Contains(err.Error(), "must be set together") {
+		t.Fatalf("expected the flag pairing error ahead of the render step, got: %v", err)
+	}
+}

--- a/scripts/deploy-camunda/cmd/matrix.go
+++ b/scripts/deploy-camunda/cmd/matrix.go
@@ -1421,6 +1421,114 @@ func runTopologyEntry(ctx context.Context, entry matrix.Entry, opts matrix.RunOp
 		}
 	}
 
+	return runTopologyE2ELegs(ctx, entry, opts, platform, contexts, crossRefEnv, orchestrationIndices)
+}
+
+// runTopologyE2ELegs runs e2e once the entire topology is deployed. Reaching this point means every
+// release's helm install returned successfully, and helm --wait already gated each one on workload
+// readiness, so the topology is up.
+//
+// Legs come from matrix.TopologyE2ELegs, the same computation that produces the CI smoke matrix, so
+// a local run and a CI run agree on how many legs a topology has and which namespaces each targets.
+// Legs run sequentially and every failure is collected: one tenant's failure must not hide another's
+// result.
+func runTopologyE2ELegs(
+	ctx context.Context,
+	entry matrix.Entry,
+	opts matrix.RunOptions,
+	platform string,
+	contexts []*deploy.ScenarioContext,
+	crossRefEnv map[string]string,
+	orchestrationIndices []int,
+) error {
+	if !opts.TestE2E && !opts.TestAll {
+		return nil
+	}
+	if entry.SkipE2E {
+		fmt.Fprintf(os.Stdout, "topology %s: e2e skipped (skip-e2e)\n", entry.Scenario)
+		return nil
+	}
+
+	legs := matrix.TopologyE2ELegs(entry.Topology)
+	if len(legs) == 0 {
+		return nil
+	}
+
+	// Namespaces are only knowable per release index, so map each release's suffix to its context.
+	nsBySuffix := map[string]string{}
+	relBySuffix := map[string]matrix.TopologyRelease{}
+	hubNamespace := ""
+	for i, rel := range entry.Topology.Releases {
+		nsBySuffix[rel.NamespaceSuffix] = contexts[i].Namespace
+		relBySuffix[rel.NamespaceSuffix] = rel
+		if rel.Role == "hub" {
+			hubNamespace = contexts[i].Namespace
+		}
+	}
+	// Without the Hub namespace, run-e2e-tests.sh renders the env from the orchestration namespace
+	// alone, so Web Modeler, Management Identity and Keycloak resolve to the orchestration host where
+	// they do not exist and the setup project times out before any test runs.
+	if hubNamespace == "" {
+		return fmt.Errorf("topology %s: no hub release, so the e2e env cannot resolve Identity, Keycloak or Web Modeler", entry.Scenario)
+	}
+
+	var failures []string
+	for _, leg := range legs {
+		orchestrationNamespace := nsBySuffix[leg.OrchestrationSuffix]
+		if orchestrationNamespace == "" {
+			failures = append(failures, fmt.Sprintf("leg %q: no deployed namespace for that orchestration release", leg.OrchestrationSuffix))
+			continue
+		}
+		optimizeNamespace := ""
+		if leg.OptimizeSuffix != "" {
+			optimizeNamespace = nsBySuffix[leg.OptimizeSuffix]
+			if optimizeNamespace == "" {
+				failures = append(failures, fmt.Sprintf("leg %q: no deployed namespace for optimize release %q", leg.OrchestrationSuffix, leg.OptimizeSuffix))
+				continue
+			}
+		}
+
+		rel := relBySuffix[leg.OrchestrationSuffix]
+		releaseEntry := synthesizeReleaseEntry(entry, rel, platform)
+		releaseOpts := synthesizeReleaseOpts(opts, platform, orchestrationNamespace)
+		if hostKey := topologyReleaseHostKey(rel.Role, rel.NamespaceSuffix, len(orchestrationIndices)); hostKey != "" {
+			if host := crossRefEnv[hostKey]; host != "" {
+				releaseOpts.ExtraHelmSets = append(releaseOpts.ExtraHelmSets, "global.host="+host)
+			}
+		}
+
+		flags, namespace, _, _, cleanup, buildErr := matrix.BuildEntryFlags(releaseEntry, releaseOpts)
+		if buildErr != nil {
+			cleanup()
+			failures = append(failures, fmt.Sprintf("leg %q: build flags: %v", leg.OrchestrationSuffix, buildErr))
+			continue
+		}
+		applyTopologyReleaseOverrides(flags, buildTopologyReleaseEnv(crossRefEnv, rel))
+		// synthesizeReleaseEntry disables e2e for the deploy loop; re-enable it for this leg only.
+		flags.Test.RunE2ETests = true
+		flags.Test.HubNamespace = hubNamespace
+		flags.Test.OptimizeNamespace = optimizeNamespace
+		flags.Test.OptimizeContextPath = leg.OptimizeContextPath
+		flags.Test.ModelerClusterName = leg.ModelerClusterName
+
+		testErr := deploy.RunTests(ctx, flags, namespace)
+		cleanup()
+
+		label := leg.OrchestrationSuffix
+		if leg.OptimizeSuffix != "" {
+			label = fmt.Sprintf("%s+%s", leg.OrchestrationSuffix, leg.OptimizeSuffix)
+		}
+		status := "OK"
+		if testErr != nil {
+			status = fmt.Sprintf("FAILED: %v", testErr)
+			failures = append(failures, fmt.Sprintf("leg %q: %v", label, testErr))
+		}
+		fmt.Fprintf(os.Stdout, "topology e2e %s/%s (namespace %s): %s\n", entry.Scenario, label, namespace, status)
+	}
+
+	if len(failures) > 0 {
+		return fmt.Errorf("topology %s: e2e failed for %d of %d legs:\n  - %s", entry.Scenario, len(failures), len(legs), strings.Join(failures, "\n  - "))
+	}
 	return nil
 }
 
@@ -1559,6 +1667,10 @@ func synthesizeReleaseEntry(entry matrix.Entry, rel matrix.TopologyRelease, plat
 	if rel.Role == "orchestration" {
 		releaseEntry.PostDeploy = entry.PostDeploy
 	}
+	// e2e is a topology-level concern, not a per-release one: a release's deploy returns while later
+	// releases are still undeployed, so testing here would test a partial topology (and would repeat
+	// for every orchestration release). runTopologyEntry runs the legs once the whole topology is up.
+	releaseEntry.SkipE2E = true
 	return releaseEntry
 }
 

--- a/scripts/deploy-camunda/cmd/topology_dispatch_test.go
+++ b/scripts/deploy-camunda/cmd/topology_dispatch_test.go
@@ -148,6 +148,26 @@ func TestSynthesizeReleaseEntry_HubCarriesOwnLayers(t *testing.T) {
 	}
 }
 
+// e2e must never run inside the deploy loop: a release's deploy returns while later releases are
+// still undeployed, so a leg run here would test a partial topology, and would repeat for every
+// orchestration release. runTopologyEntry runs the legs after the whole topology is up.
+func TestSynthesizeReleaseEntry_NoRoleRunsE2EDuringDeploy(t *testing.T) {
+	baseEntry := matrix.Entry{
+		Version:   "8.10",
+		ChartPath: "charts/camunda-platform-8.10",
+		Scenario:  "multinamespace",
+		Shortname: "mns",
+		Auth:      "keycloak",
+	}
+
+	for _, rel := range testTopologyReleases() {
+		entry := synthesizeReleaseEntry(baseEntry, rel, "gke")
+		if !entry.SkipE2E {
+			t.Errorf("role %q: SkipE2E = false, want true (e2e is a topology-level phase)", rel.Role)
+		}
+	}
+}
+
 func TestSynthesizeReleaseEntry_OrchestrationHasNoDependencies(t *testing.T) {
 	hook := &matrix.LifecycleHook{Script: "post-deploy-hub-ping.sh"}
 	baseEntry := matrix.Entry{Version: "8.10", ChartPath: "charts/camunda-platform-8.10", Scenario: "multinamespace", Shortname: "mns", Auth: "keycloak", PostDeploy: hook}

--- a/scripts/deploy-camunda/config/merge.go
+++ b/scripts/deploy-camunda/config/merge.go
@@ -145,6 +145,22 @@ type TestFlags struct {
 	OutputTestEnv     bool   // Generate .env file for E2E tests after deployment
 	OutputTestEnvPath string // Path for the test .env file output
 	KubeContext       string
+	// HubNamespace names the namespace running the central Identity, Keycloak and Web Modeler in a
+	// multi-namespace topology. Without it run-e2e-tests.sh renders the env from the orchestration
+	// namespace alone, so Modeler, Identity and Keycloak resolve to the orchestration host where they
+	// do not exist, and the setup project times out before any test runs.
+	HubNamespace string
+	// OptimizeNamespace and OptimizeContextPath describe a topology whose Optimize runs as its own
+	// release: the e2e env must then derive CAMUNDA_OPTIMIZE_BASE_URL from that release's namespace
+	// and ingress path rather than from the orchestration namespace being tested. Empty for a
+	// single-release deployment, where Optimize shares the namespace under test.
+	OptimizeNamespace   string
+	OptimizeContextPath string
+	// ModelerClusterName names the cluster this leg's tests must deploy to in the Hub's Web Modeler.
+	// One Hub Web Modeler serves every orchestration release in a topology, so without it the suite
+	// deploys to whichever cluster Modeler preselects and a leg targeting any other release asserts
+	// against a cluster that never received the records.
+	ModelerClusterName string
 }
 
 // SelectionFlags holds selection + composition model flags.

--- a/scripts/deploy-camunda/deploy/test.go
+++ b/scripts/deploy-camunda/deploy/test.go
@@ -118,7 +118,12 @@ func RunTests(ctx context.Context, flags *config.RuntimeFlags, namespace string)
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			output, err := runE2ETests(testCtx, repoRoot, chartPath, namespace, flags.Test.KubeContext, flags.Test.TestExclude, flags.Selection.Persistence, flags.E2EOutputWriter)
+			output, err := runE2ETests(testCtx, repoRoot, chartPath, namespace, flags.Test.KubeContext, flags.Test.TestExclude, flags.Selection.Persistence, topologyTarget{
+				HubNamespace:        flags.Test.HubNamespace,
+				OptimizeNamespace:   flags.Test.OptimizeNamespace,
+				OptimizeContextPath: flags.Test.OptimizeContextPath,
+				ModelerClusterName:  flags.Test.ModelerClusterName,
+			}, flags.E2EOutputWriter)
 			resultCh <- TestResult{Type: "e2e", Error: err, Output: output}
 		}()
 	}
@@ -158,22 +163,56 @@ func RunTests(ctx context.Context, flags *config.RuntimeFlags, namespace string)
 	return nil
 }
 
-// runE2ETests executes the e2e test script.
-func runE2ETests(ctx context.Context, repoRoot, chartPath, namespace, kubeContext, testExclude, persistence string, outputSink io.Writer) (string, error) {
+// topologyTarget points the e2e env at the other namespaces of a multi-namespace topology. Zero value
+// means a single-release deployment, where every app shares the namespace under test.
+type topologyTarget struct {
+	// HubNamespace runs the central Identity, Keycloak and Web Modeler. Setting it is what makes
+	// run-e2e-tests.sh merge the Hub's absolute URLs into the env instead of deriving every app from
+	// the orchestration host.
+	HubNamespace string
+	// OptimizeNamespace and OptimizeContextPath locate an Optimize that runs as its own release.
+	OptimizeNamespace   string
+	OptimizeContextPath string
+	// ModelerClusterName selects this leg's cluster in the Hub's Web Modeler deploy dialog.
+	ModelerClusterName string
+}
+
+func (o topologyTarget) isSet() bool {
+	return o.HubNamespace != "" || o.OptimizeNamespace != "" || o.OptimizeContextPath != "" ||
+		o.ModelerClusterName != ""
+}
+
+func runE2ETests(ctx context.Context, repoRoot, chartPath, namespace, kubeContext, testExclude, persistence string, topology topologyTarget, outputSink io.Writer) (string, error) {
 	scriptPath := filepath.Join(repoRoot, "scripts", "run-e2e-tests.sh")
 
 	if _, err := os.Stat(scriptPath); err != nil {
 		return "", fmt.Errorf("e2e test script not found at %s: %w", scriptPath, err)
 	}
 
-	logging.Logger.Info().
+	event := logging.Logger.Info().
 		Str("script", scriptPath).
 		Str("chartPath", chartPath).
 		Str("namespace", namespace).
 		Str("kubeContext", kubeContext).
-		Str("persistence", persistence).
-		Msg("Running e2e tests")
+		Str("persistence", persistence)
+	if topology.isSet() {
+		event = event.
+			Str("hubNamespace", topology.HubNamespace).
+			Str("optimizeNamespace", topology.OptimizeNamespace).
+			Str("optimizeContextPath", topology.OptimizeContextPath).
+			Str("modelerClusterName", topology.ModelerClusterName)
+	}
+	event.Msg("Running e2e tests")
 
+	args := e2eScriptArgs(chartPath, namespace, kubeContext, testExclude, persistence, topology)
+
+	return executeScript(ctx, scriptPath, args, "e2e", outputSink)
+}
+
+// e2eScriptArgs builds the run-e2e-tests.sh argument list. Extracted so the topology arguments are
+// unit-testable: omitting --hub-namespace silently rendered the e2e env from the orchestration
+// namespace alone, which surfaced as a Web Modeler timeout rather than as a missing argument.
+func e2eScriptArgs(chartPath, namespace, kubeContext, testExclude, persistence string, topology topologyTarget) []string {
 	args := []string{
 		"--absolute-chart-path", chartPath,
 		"--namespace", namespace,
@@ -196,8 +235,19 @@ func runE2ETests(ctx context.Context, repoRoot, chartPath, namespace, kubeContex
 	if strings.Contains(persistence, "opensearch") {
 		args = append(args, "--opensearch")
 	}
-
-	return executeScript(ctx, scriptPath, args, "e2e", outputSink)
+	if topology.HubNamespace != "" {
+		args = append(args, "--hub-namespace", topology.HubNamespace)
+	}
+	if topology.OptimizeNamespace != "" {
+		args = append(args, "--optimize-namespace", topology.OptimizeNamespace)
+	}
+	if topology.OptimizeContextPath != "" {
+		args = append(args, "--optimize-context-path", topology.OptimizeContextPath)
+	}
+	if topology.ModelerClusterName != "" {
+		args = append(args, "--modeler-cluster-name", topology.ModelerClusterName)
+	}
+	return args
 }
 
 // isFullSuiteChart returns true if the chart path indicates version 8.10 or

--- a/scripts/deploy-camunda/deploy/test_args_test.go
+++ b/scripts/deploy-camunda/deploy/test_args_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploy
+
+import (
+	"testing"
+)
+
+func hasFlagValue(args []string, flag, value string) bool {
+	for i, a := range args {
+		if a == flag {
+			return i+1 < len(args) && args[i+1] == value
+		}
+	}
+	return false
+}
+
+func hasFlag(args []string, flag string) bool {
+	for _, a := range args {
+		if a == flag {
+			return true
+		}
+	}
+	return false
+}
+
+// A topology leg must forward every namespace it was given. Dropping --hub-namespace rendered the e2e
+// env from the orchestration namespace alone, so Web Modeler, Management Identity and Keycloak
+// resolved to the orchestration host where they do not exist, and the setup project timed out with no
+// hint that an argument was missing.
+func TestE2EScriptArgs_ForwardsTopologyNamespaces(t *testing.T) {
+	args := e2eScriptArgs(
+		"/repo/charts/camunda-platform-8.10",
+		"ns-orcha",
+		"gke-ctx",
+		"",
+		"elasticsearch-external",
+		topologyTarget{
+			HubNamespace:        "ns-hub",
+			OptimizeNamespace:   "ns-opta",
+			OptimizeContextPath: "/optimize-orcha",
+			ModelerClusterName:  "Orchestration A",
+		},
+	)
+
+	for _, tc := range []struct{ flag, value string }{
+		{"--namespace", "ns-orcha"},
+		{"--hub-namespace", "ns-hub"},
+		{"--optimize-namespace", "ns-opta"},
+		{"--optimize-context-path", "/optimize-orcha"},
+		{"--modeler-cluster-name", "Orchestration A"},
+		{"--kube-context", "gke-ctx"},
+	} {
+		if !hasFlagValue(args, tc.flag, tc.value) {
+			t.Errorf("%s %s missing from args: %v", tc.flag, tc.value, args)
+		}
+	}
+}
+
+// A single-release deployment must not gain topology flags: --hub-namespace switches
+// run-e2e-tests.sh onto the merge path, which needs a Hub namespace to read from.
+func TestE2EScriptArgs_OmitsTopologyFlagsForSingleRelease(t *testing.T) {
+	args := e2eScriptArgs("/repo/charts/camunda-platform-8.10", "ns", "", "", "elasticsearch", topologyTarget{})
+
+	for _, flag := range []string{"--hub-namespace", "--optimize-namespace", "--optimize-context-path", "--modeler-cluster-name"} {
+		if hasFlag(args, flag) {
+			t.Errorf("%s must be omitted for a single-release deployment, got %v", flag, args)
+		}
+	}
+}
+
+// 8.10+ runs the full suite; older charts are restricted to the smoke project.
+func TestE2EScriptArgs_SmokeOnlyBelow810(t *testing.T) {
+	if hasFlag(e2eScriptArgs("/repo/charts/camunda-platform-8.10", "ns", "", "", "", topologyTarget{}), "--run-smoke-tests") {
+		t.Error("8.10 must run the full suite")
+	}
+	if !hasFlag(e2eScriptArgs("/repo/charts/camunda-platform-8.9", "ns", "", "", "", topologyTarget{}), "--run-smoke-tests") {
+		t.Error("8.9 must be restricted to the smoke project")
+	}
+}
+
+func TestE2EScriptArgs_OpenSearchFromPersistence(t *testing.T) {
+	if !hasFlag(e2eScriptArgs("/c/camunda-platform-8.10", "ns", "", "", "opensearch-self-signed", topologyTarget{}), "--opensearch") {
+		t.Error("--opensearch must be derived from the persistence layer name")
+	}
+	if hasFlag(e2eScriptArgs("/c/camunda-platform-8.10", "ns", "", "", "elasticsearch", topologyTarget{}), "--opensearch") {
+		t.Error("--opensearch must not be set for an elasticsearch persistence layer")
+	}
+}

--- a/scripts/deploy-camunda/matrix/plan.go
+++ b/scripts/deploy-camunda/matrix/plan.go
@@ -79,18 +79,16 @@ type topologySmokeEntry struct {
 	ModelerClusterID    string `json:"modeler_cluster_id"`
 	ModelerClusterName  string `json:"modeler_cluster_name"`
 	ShardIndex          string `json:"shard_index"`
-	// Optimize is empty unless role "optimize" releases declare
-	// `serves: <orchestration_suffix>`. When populated, this leg's Optimize
-	// instances run in their own namespaces on the Hub host rather than in the
-	// orchestration namespace, so an e2e run must not derive an Optimize
-	// endpoint from OrchestrationSuffix. One entry per Physical Tenant served by
-	// this orchestration release, in declaration order.
-	Optimize []topologySmokeOptimize `json:"optimize,omitempty"`
-}
-
-type topologySmokeOptimize struct {
-	Suffix      string `json:"suffix"`
-	ContextPath string `json:"context_path"`
+	// OptimizeSuffix and OptimizeContextPath are empty unless a role "optimize"
+	// release declares `serves: <orchestration_suffix>`. When set, this leg's
+	// Optimize runs in its own namespace on the Hub host rather than in the
+	// orchestration namespace, so the e2e env must not derive its Optimize
+	// endpoint from OrchestrationSuffix. The e2e suite reads a single
+	// CAMUNDA_OPTIMIZE_BASE_URL, so an orchestration release serving several
+	// Physical Tenants produces one leg per tenant rather than one leg carrying
+	// a list.
+	OptimizeSuffix      string `json:"optimize_suffix,omitempty"`
+	OptimizeContextPath string `json:"optimize_context_path,omitempty"`
 }
 
 // PlanResult is the computed build matrix.
@@ -459,36 +457,82 @@ func groupPlanEntries(version string, entries []Entry) []PlanEntry {
 	return out
 }
 
+// TopologyE2ELeg is one e2e invocation for a topology: an orchestration release to test against,
+// plus the Optimize release serving it when Optimize runs as its own release. It is the shared
+// source of truth for both the CI smoke matrix (marshalled by planTopologyMetadata) and the local
+// runner's post-deploy test phase, so the two cannot disagree about how many legs a topology has or
+// which namespaces each one targets.
+//
+// An orchestration release serving several Physical Tenants yields one leg per tenant rather than
+// one leg carrying a list, because the e2e suite reads a single CAMUNDA_OPTIMIZE_BASE_URL.
+type TopologyE2ELeg struct {
+	OrchestrationSuffix string
+	// OptimizeSuffix and OptimizeContextPath are empty unless a role "optimize" release declares
+	// `serves: <OrchestrationSuffix>`, in which case Optimize lives in its own namespace on the Hub
+	// host and the e2e env must not derive its endpoint from OrchestrationSuffix.
+	OptimizeSuffix      string
+	OptimizeContextPath string
+	ModelerClusterID    string
+	ModelerClusterName  string
+}
+
+// TopologyE2ELegs computes the e2e legs for a topology. A nil topology yields no legs.
+func TopologyE2ELegs(topology *Topology) []TopologyE2ELeg {
+	if topology == nil {
+		return nil
+	}
+	optimizeByServed := map[string][]TopologyRelease{}
+	for _, release := range topology.Releases {
+		if release.Role == "optimize" && release.Serves != "" {
+			optimizeByServed[release.Serves] = append(optimizeByServed[release.Serves], release)
+		}
+	}
+	legs := []TopologyE2ELeg{}
+	for _, release := range topology.Releases {
+		if release.Role != "orchestration" {
+			continue
+		}
+		base := TopologyE2ELeg{
+			OrchestrationSuffix: release.NamespaceSuffix,
+			ModelerClusterID:    release.ModelerClusterID,
+			ModelerClusterName:  release.ModelerClusterName,
+		}
+		served := optimizeByServed[release.NamespaceSuffix]
+		if len(served) == 0 {
+			legs = append(legs, base)
+			continue
+		}
+		for _, optimize := range served {
+			leg := base
+			leg.OptimizeSuffix = optimize.NamespaceSuffix
+			leg.OptimizeContextPath = optimize.OptimizeContextPath
+			legs = append(legs, leg)
+		}
+	}
+	return legs
+}
+
 func planTopologyMetadata(topology *Topology) (string, string, string) {
 	suffixes := []string{}
-	smoke := []topologySmokeEntry{}
 	hubSuffix := ""
 	if topology != nil {
-		optimizeByServed := map[string][]topologySmokeOptimize{}
-		for _, release := range topology.Releases {
-			if release.Role == "optimize" && release.Serves != "" {
-				optimizeByServed[release.Serves] = append(optimizeByServed[release.Serves], topologySmokeOptimize{
-					Suffix:      release.NamespaceSuffix,
-					ContextPath: release.OptimizeContextPath,
-				})
-			}
-		}
 		for _, release := range topology.Releases {
 			suffixes = append(suffixes, release.NamespaceSuffix)
 			if release.Role == "hub" {
 				hubSuffix = release.NamespaceSuffix
 			}
-			if release.Role == "orchestration" {
-				entry := topologySmokeEntry{
-					OrchestrationSuffix: release.NamespaceSuffix,
-					ModelerClusterID:    release.ModelerClusterID,
-					ModelerClusterName:  release.ModelerClusterName,
-					ShardIndex:          strconv.Itoa(len(smoke) + 1),
-				}
-				entry.Optimize = optimizeByServed[release.NamespaceSuffix]
-				smoke = append(smoke, entry)
-			}
 		}
+	}
+	smoke := []topologySmokeEntry{}
+	for i, leg := range TopologyE2ELegs(topology) {
+		smoke = append(smoke, topologySmokeEntry{
+			OrchestrationSuffix: leg.OrchestrationSuffix,
+			ModelerClusterID:    leg.ModelerClusterID,
+			ModelerClusterName:  leg.ModelerClusterName,
+			ShardIndex:          strconv.Itoa(i + 1),
+			OptimizeSuffix:      leg.OptimizeSuffix,
+			OptimizeContextPath: leg.OptimizeContextPath,
+		})
 	}
 	suffixesJSON, _ := json.Marshal(suffixes)
 	smokeJSON, _ := json.Marshal(smoke)

--- a/scripts/deploy-camunda/matrix/plan_test.go
+++ b/scripts/deploy-camunda/matrix/plan_test.go
@@ -151,12 +151,12 @@ func TestPlanTopologySmokeMatrixMapsOptimizeReleases(t *testing.T) {
 	if entry.TopologyNamespaceSuffixes != `["hub","orcha","orchb","opta","optb"]` {
 		t.Errorf("topologyNamespaceSuffixes = %q", entry.TopologyNamespaceSuffixes)
 	}
-	wantSmoke := `[{"orchestration_suffix":"orcha","modeler_cluster_id":"orcha","modeler_cluster_name":"Orchestration A","shard_index":"1","optimize":[{"suffix":"opta","context_path":"/optimize-orcha"}]},{"orchestration_suffix":"orchb","modeler_cluster_id":"orchb","modeler_cluster_name":"Orchestration B","shard_index":"2","optimize":[{"suffix":"optb","context_path":"/optimize-orchb"}]}]`
+	wantSmoke := `[{"orchestration_suffix":"orcha","modeler_cluster_id":"orcha","modeler_cluster_name":"Orchestration A","shard_index":"1","optimize_suffix":"opta","optimize_context_path":"/optimize-orcha"},{"orchestration_suffix":"orchb","modeler_cluster_id":"orchb","modeler_cluster_name":"Orchestration B","shard_index":"2","optimize_suffix":"optb","optimize_context_path":"/optimize-orchb"}]`
 	if entry.TopologySmokeMatrix != wantSmoke {
 		t.Errorf("topologySmokeMatrix = %q, want %q", entry.TopologySmokeMatrix, wantSmoke)
 	}
-	if entry.SkipE2E != "true" {
-		t.Errorf("skipE2E = %q, want true until the e2e runner consumes optimize_suffix", entry.SkipE2E)
+	if entry.SkipE2E != "false" {
+		t.Errorf("skipE2E = %q, want false now that the e2e runner consumes optimize_suffix", entry.SkipE2E)
 	}
 }
 
@@ -614,5 +614,91 @@ func TestPlanTierFilter(t *testing.T) {
 	}
 	if len(tier1.Include) == 0 || len(tier1.Include) > len(all.Include) {
 		t.Errorf("tier-1 entries = %d, all = %d; want 0 < tier1 <= all", len(tier1.Include), len(all.Include))
+	}
+}
+
+// TopologyE2ELegs is the single source of truth for both the CI smoke matrix and the local runner's
+// post-deploy test phase, so these cases pin the leg count and per-leg targeting that both rely on.
+func TestTopologyE2ELegs(t *testing.T) {
+	orchestration := func(suffix string) TopologyRelease {
+		return TopologyRelease{Role: "orchestration", NamespaceSuffix: suffix, ModelerClusterID: suffix}
+	}
+	optimize := func(suffix, serves, path string) TopologyRelease {
+		return TopologyRelease{Role: "optimize", NamespaceSuffix: suffix, Serves: serves, OptimizeContextPath: path}
+	}
+	hub := TopologyRelease{Role: "hub", NamespaceSuffix: "hub"}
+
+	cases := []struct {
+		name     string
+		topology *Topology
+		want     []TopologyE2ELeg
+	}{
+		{
+			name:     "nil topology yields no legs",
+			topology: nil,
+			want:     nil,
+		},
+		{
+			// Optimize runs in-release, so the leg must carry no Optimize fields and the e2e env
+			// keeps deriving its endpoint from the orchestration namespace.
+			name:     "in-release optimize yields one leg per orchestration release",
+			topology: &Topology{Releases: []TopologyRelease{hub, orchestration("orcha"), orchestration("orchb")}},
+			want: []TopologyE2ELeg{
+				{OrchestrationSuffix: "orcha", ModelerClusterID: "orcha"},
+				{OrchestrationSuffix: "orchb", ModelerClusterID: "orchb"},
+			},
+		},
+		{
+			name: "one optimize release per orchestration release",
+			topology: &Topology{Releases: []TopologyRelease{
+				hub,
+				orchestration("orcha"), orchestration("orchb"),
+				optimize("opta", "orcha", "/optimize-orcha"),
+				optimize("optb", "orchb", "/optimize-orchb"),
+			}},
+			want: []TopologyE2ELeg{
+				{OrchestrationSuffix: "orcha", ModelerClusterID: "orcha", OptimizeSuffix: "opta", OptimizeContextPath: "/optimize-orcha"},
+				{OrchestrationSuffix: "orchb", ModelerClusterID: "orchb", OptimizeSuffix: "optb", OptimizeContextPath: "/optimize-orchb"},
+			},
+		},
+		{
+			// The physicaltenants shape: one cluster serving two Physical Tenants. The suite reads a
+			// single CAMUNDA_OPTIMIZE_BASE_URL, so this must fan out to one leg per tenant rather
+			// than one leg carrying both.
+			name: "one orchestration release serving two tenants yields two legs",
+			topology: &Topology{Releases: []TopologyRelease{
+				hub,
+				orchestration("orcha"),
+				optimize("optta", "orcha", "/optimize-orcha-ta"),
+				optimize("opttb", "orcha", "/optimize-orcha-tb"),
+			}},
+			want: []TopologyE2ELeg{
+				{OrchestrationSuffix: "orcha", ModelerClusterID: "orcha", OptimizeSuffix: "optta", OptimizeContextPath: "/optimize-orcha-ta"},
+				{OrchestrationSuffix: "orcha", ModelerClusterID: "orcha", OptimizeSuffix: "opttb", OptimizeContextPath: "/optimize-orcha-tb"},
+			},
+		},
+		{
+			// An optimize release without `serves` cannot be attributed to an orchestration release,
+			// so it must not silently become a leg.
+			name: "optimize release without serves is ignored",
+			topology: &Topology{Releases: []TopologyRelease{
+				hub, orchestration("orcha"), optimize("opta", "", "/optimize"),
+			}},
+			want: []TopologyE2ELeg{{OrchestrationSuffix: "orcha", ModelerClusterID: "orcha"}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := TopologyE2ELegs(tc.topology)
+			if len(got) != len(tc.want) {
+				t.Fatalf("legs = %d (%+v), want %d (%+v)", len(got), got, len(tc.want), tc.want)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Errorf("leg[%d] = %+v, want %+v", i, got[i], tc.want[i])
+				}
+			}
+		})
 	}
 }

--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -58,6 +58,50 @@ validate_args() {
   log "DEBUG: Arguments validated successfully"
 }
 
+resolve_deploy_camunda() {
+  # An asdf `reshim golang` leaves a ~/.asdf/shims/deploy-camunda that only resolves for the golang
+  # version the binary was installed under. When .tool-versions pins a different version the shim
+  # exits non-zero for every invocation while still shadowing a working $GOPATH/bin build, so probe
+  # candidates by running one instead of trusting `command -v`.
+  local candidate
+  for candidate in "${DEPLOY_CAMUNDA:-}" "$(command -v deploy-camunda 2> /dev/null)" \
+    "$(go env GOPATH 2> /dev/null)/bin/deploy-camunda" "$HOME/go/bin/deploy-camunda"; do
+    if [[ -n "$candidate" && -x "$candidate" ]] && "$candidate" e2e-env --help > /dev/null 2>&1; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+build_rerun_cmd() {
+  # Reconstructs the invocation from the parsed arguments so a failing run prints a
+  # command that reproduces it. Reads the same globals the run itself used; the
+  # topology arguments come from the *_ARG snapshots taken before "$ENV_FILE" was
+  # sourced, since that file replaces OPTIMIZE_CONTEXT_PATH with an absolute URL.
+  local -a cmd=(./scripts/run-e2e-tests.sh --absolute-chart-path "$ABSOLUTE_CHART_PATH" --namespace "$NAMESPACE")
+  [[ -n "$KUBE_CONTEXT" ]] && cmd+=(--kube-context "$KUBE_CONTEXT")
+  [[ -n "$TEST_EXCLUDE" ]] && cmd+=(--test-exclude "$TEST_EXCLUDE")
+  [[ "$RUN_SMOKE_TESTS" == "true" ]] && cmd+=(--run-smoke-tests)
+  [[ "$IS_OPENSEARCH" == "true" ]] && cmd+=(--opensearch)
+  [[ "$IS_RBA" == "true" ]] && cmd+=(--rba)
+  [[ "$IS_MT" == "true" ]] && cmd+=(--mt)
+  [[ "$IS_AUTH0" == "true" ]] && cmd+=(--auth0)
+  [[ -n "$VIDEO_MODE" ]] && cmd+=(--video "$VIDEO_MODE")
+  [[ -n "$TRACE_MODE" ]] && cmd+=(--trace "$TRACE_MODE")
+  [[ -n "$RETRIES" ]] && cmd+=(--retries "$RETRIES")
+  [[ -n "$LOCAL_TEST_SUITE" ]] && cmd+=(--local-test-suite "$LOCAL_TEST_SUITE")
+  # Without these a failing topology leg prints a rerun command that targets an
+  # orchestration-only environment: it cannot reproduce the failure, and it would skip
+  # Optimize again rather than reporting it.
+  [[ -n "$HUB_NAMESPACE_ARG" ]] && cmd+=(--hub-namespace "$HUB_NAMESPACE_ARG")
+  [[ -n "$OPTIMIZE_NAMESPACE_ARG" ]] && cmd+=(--optimize-namespace "$OPTIMIZE_NAMESPACE_ARG")
+  [[ -n "$OPTIMIZE_CONTEXT_PATH_ARG" ]] && cmd+=(--optimize-context-path "$OPTIMIZE_CONTEXT_PATH_ARG")
+  [[ -n "$MODELER_CLUSTER_NAME_ARG" ]] && cmd+=(--modeler-cluster-name "$MODELER_CLUSTER_NAME_ARG")
+  printf '%q ' "${cmd[@]}"
+  printf '\n'
+}
+
 usage() {
   cat << EOF
 This script runs the integration tests for the Camunda Platform Helm chart.
@@ -87,6 +131,12 @@ Options:
   --hub-namespace NAMESPACE                   For a multi-namespace topology: the namespace running the central
                                                Identity/Keycloak. --namespace is then the orchestration namespace.
                                                Requires deploy-camunda on PATH (used to merge the .env).
+  --optimize-namespace NAMESPACE              For a topology whose Optimize runs as its own release: the namespace
+                                               running it. Without this, Optimize is derived from --namespace and
+                                               every Optimize spec is skipped. Requires --hub-namespace.
+  --optimize-context-path PATH                 Ingress path that Optimize release is served on, e.g. /optimize-orcha.
+  --modeler-cluster-name NAME                  For a topology with several orchestration releases: the cluster this leg
+                                               must deploy to in the Hub's Web Modeler.
   -v | --verbose                              Show verbose output.
   -h | --help                                 Show this help message and exit.
 EOF
@@ -117,6 +167,9 @@ TRACE_MODE=""
 RETRIES=""
 LOCAL_TEST_SUITE=""
 HUB_NAMESPACE=""
+OPTIMIZE_NAMESPACE=""
+OPTIMIZE_CONTEXT_PATH=""
+MODELER_CLUSTER_NAME_ARG=""
 
 check_required_cmds
 
@@ -199,6 +252,18 @@ while [[ $# -gt 0 ]]; do
       HUB_NAMESPACE="$2"
       shift 2
       ;;
+    --optimize-namespace)
+      OPTIMIZE_NAMESPACE="$2"
+      shift 2
+      ;;
+    --optimize-context-path)
+      OPTIMIZE_CONTEXT_PATH="$2"
+      shift 2
+      ;;
+    --modeler-cluster-name)
+      MODELER_CLUSTER_NAME_ARG="$2"
+      shift 2
+      ;;
     -v | --verbose)
       VERBOSE=true
       shift
@@ -219,6 +284,24 @@ log "DEBUG: Starting run-e2e-tests.sh"
 log "DEBUG: Chart: $ABSOLUTE_CHART_PATH, Namespace: $NAMESPACE, KubeContext: $KUBE_CONTEXT"
 
 validate_args "$ABSOLUTE_CHART_PATH" "$NAMESPACE" "$KUBE_CONTEXT"
+
+# The Optimize flags are only read on the topology path below, which is selected by
+# --hub-namespace. Without this guard they are silently dropped, render-e2e-env.sh sets
+# IS_OPTIMIZE=false, and the suite reports success having skipped every Optimize spec --
+# precisely the silent gap the flags exist to close.
+if [[ -z "$HUB_NAMESPACE" ]] && { [[ -n "$OPTIMIZE_NAMESPACE" ]] || [[ -n "$OPTIMIZE_CONTEXT_PATH" ]]; }; then
+  echo "Error: --optimize-namespace/--optimize-context-path require --hub-namespace." >&2
+  echo "       They are read only on the multi-namespace topology path; without it they would be" >&2
+  echo "       ignored and the run would silently skip Optimize coverage while still passing." >&2
+  exit 1
+fi
+
+# Snapshot the topology targeting args before "$ENV_FILE" is sourced below. That file sets
+# OPTIMIZE_CONTEXT_PATH to an absolute URL, which would otherwise replace the ingress path the
+# caller passed in the rerun command printed on failure.
+HUB_NAMESPACE_ARG="$HUB_NAMESPACE"
+OPTIMIZE_NAMESPACE_ARG="$OPTIMIZE_NAMESPACE"
+OPTIMIZE_CONTEXT_PATH_ARG="$OPTIMIZE_CONTEXT_PATH"
 
 TEST_SUITE_PATH="${ABSOLUTE_CHART_PATH%/}/test/e2e"
 hostname=$(get_ingress_hostname "$NAMESPACE" "$KUBE_CONTEXT")
@@ -249,9 +332,21 @@ log "DEBUG: Test suite path: $TEST_SUITE_PATH"
 ENV_FILE="${TEST_SUITE_PATH%/}/.env.${NAMESPACE}"
 trap 'rm -f "$ENV_FILE"' EXIT
 
+# The suite resolves this itself as `process.env.OPTIMIZE_CONTEXT_PATH ?? '/optimize'`, and `??` does
+# not fall back on an empty string. Assigning "" above keeps any inherited export flag, so clear the
+# name outright rather than leaving it exported and empty; the topology path sets it in $ENV_FILE.
+[[ -z "$OPTIMIZE_CONTEXT_PATH" ]] && unset OPTIMIZE_CONTEXT_PATH
+
 if [[ -n "$HUB_NAMESPACE" ]]; then
   log "DEBUG: Multi-namespace topology - merging orchestration ($NAMESPACE) + Hub ($HUB_NAMESPACE) into $ENV_FILE"
-  deploy-camunda e2e-env merge \
+  DEPLOY_CAMUNDA_BIN=$(resolve_deploy_camunda) || {
+    echo "Error: no working deploy-camunda found; refusing to run tests against an unmerged env." >&2
+    echo "       Tried \$DEPLOY_CAMUNDA, PATH ($(command -v deploy-camunda || echo 'not found')), and \$GOPATH/bin." >&2
+    echo "       Build it with 'make install.deploy-camunda', or set DEPLOY_CAMUNDA to a working binary." >&2
+    exit 1
+  }
+  log "DEBUG: Using deploy-camunda at $DEPLOY_CAMUNDA_BIN"
+  "$DEPLOY_CAMUNDA_BIN" e2e-env merge \
     --orchestration-namespace "$NAMESPACE" \
     --hub-namespace "$HUB_NAMESPACE" \
     --absolute-chart-path "$ABSOLUTE_CHART_PATH" \
@@ -259,7 +354,16 @@ if [[ -n "$HUB_NAMESPACE" ]]; then
     --ci="$IS_CI" \
     --run-smoke-tests="$RUN_SMOKE_TESTS" \
     --render-script "$SCRIPT_DIR/render-e2e-env.sh" \
-    ${KUBE_CONTEXT:+--kube-context "$KUBE_CONTEXT"}
+    ${OPTIMIZE_NAMESPACE:+--optimize-namespace "$OPTIMIZE_NAMESPACE"} \
+    ${OPTIMIZE_CONTEXT_PATH:+--optimize-context-path "$OPTIMIZE_CONTEXT_PATH"} \
+    ${KUBE_CONTEXT:+--kube-context "$KUBE_CONTEXT"} || {
+    # This script does not run under `set -e`, so without this guard a failed merge falls through and
+    # Playwright runs against a stale or orchestration-only .env: Modeler and Identity point at the
+    # wrong host and the setup project times out, which reads as a product failure rather than a
+    # missing merge.
+    echo "Error: '$DEPLOY_CAMUNDA_BIN e2e-env merge' failed; refusing to run tests against an unmerged env." >&2
+    exit 1
+  }
 else
   render_env_file "$ENV_FILE" "$TEST_SUITE_PATH" "$hostname" "$NAMESPACE" "$IS_CI" "$IS_OPENSEARCH" "$IS_RBA" "$IS_MT" "$RUN_SMOKE_TESTS" "$KUBE_CONTEXT" "$IS_AUTH0"
 fi
@@ -281,6 +385,7 @@ export PLAYWRIGHT_HTML_REPORT="${TEST_SUITE_PATH}/playwright-report/${NAMESPACE}
 [[ -n "$TRACE_MODE" ]] && export PLAYWRIGHT_E2E_TRACE="$TRACE_MODE"
 [[ -n "$RETRIES" ]] && export PLAYWRIGHT_E2E_RETRIES="$RETRIES"
 [[ -n "$LOCAL_TEST_SUITE" ]] && export PLAYWRIGHT_E2E_LOCAL_TEST_SUITE="$LOCAL_TEST_SUITE"
+[[ -n "$MODELER_CLUSTER_NAME_ARG" ]] && export MODELER_CLUSTER_NAME="$MODELER_CLUSTER_NAME_ARG"
 
 log "$TEST_SUITE_PATH"
 log "Running smoke tests: $RUN_SMOKE_TESTS"
@@ -289,18 +394,7 @@ log "DEBUG: ENV_FILE='${ENV_FILE}'"
 log "DEBUG: PLAYWRIGHT_HTML_REPORT='${PLAYWRIGHT_HTML_REPORT}'"
 
 # Build the rerun command for display on failure
-RERUN_CMD="./scripts/run-e2e-tests.sh --absolute-chart-path ${ABSOLUTE_CHART_PATH} --namespace ${NAMESPACE}"
-[[ -n "$KUBE_CONTEXT" ]] && RERUN_CMD+=" --kube-context ${KUBE_CONTEXT}"
-[[ -n "$TEST_EXCLUDE" ]] && RERUN_CMD+=" --test-exclude \"${TEST_EXCLUDE}\""
-[[ "$RUN_SMOKE_TESTS" == "true" ]] && RERUN_CMD+=" --run-smoke-tests"
-[[ "$IS_OPENSEARCH" == "true" ]] && RERUN_CMD+=" --opensearch"
-[[ "$IS_RBA" == "true" ]] && RERUN_CMD+=" --rba"
-[[ "$IS_MT" == "true" ]] && RERUN_CMD+=" --mt"
-[[ "$IS_AUTH0" == "true" ]] && RERUN_CMD+=" --auth0"
-[[ -n "$VIDEO_MODE" ]] && RERUN_CMD+=" --video ${VIDEO_MODE}"
-[[ -n "$TRACE_MODE" ]] && RERUN_CMD+=" --trace ${TRACE_MODE}"
-[[ -n "$RETRIES" ]] && RERUN_CMD+=" --retries ${RETRIES}"
-[[ -n "$LOCAL_TEST_SUITE" ]] && RERUN_CMD+=" --local-test-suite ${LOCAL_TEST_SUITE}"
+RERUN_CMD="$(build_rerun_cmd)"
 
 run_playwright_tests "$TEST_SUITE_PATH" "$SHOW_HTML_REPORT" "$SHARD_INDEX" "$SHARD_TOTAL" "blob" "$TEST_EXCLUDE" "$RUN_SMOKE_TESTS" "$PLAYWRIGHT_DEBUG" "$NAMESPACE" "$KUBE_CONTEXT" "$RERUN_CMD" "$IS_AUTH0"
 

--- a/test/scripts/run_e2e_tests.bats
+++ b/test/scripts/run_e2e_tests.bats
@@ -1,0 +1,134 @@
+#!/usr/bin/env bats
+
+# Tests for scripts/run-e2e-tests.sh.
+#
+# Two behaviours here exist to stop a topology leg reporting success while
+# having skipped Optimize entirely, and to make a failing leg reproducible:
+#
+#   * the Optimize targeting flags are read only on the multi-namespace path
+#     selected by --hub-namespace, so supplying them without it must fail
+#     rather than fall through to the orchestration-only render;
+#   * the printed rerun command must carry the topology targeting, or it reruns
+#     against an orchestration-only environment that cannot reproduce anything.
+
+setup() {
+  here="$(cd "$(dirname "${BATS_TEST_FILENAME}")" && pwd)"
+  if ROOT="$(git -C "$here" rev-parse --show-toplevel 2>/dev/null)"; then
+    :
+  else
+    ROOT="$(cd "$here/../.." && pwd)"
+  fi
+  export ROOT
+  export SCRIPT="$ROOT/scripts/run-e2e-tests.sh"
+  export CHART_PATH="$ROOT/charts/camunda-platform-8.10"
+
+  TMPDIR_TEST="$(mktemp -d)"
+  export TMPDIR_TEST
+  export PATH="$TMPDIR_TEST/bin:$PATH"
+  mkdir -p "$TMPDIR_TEST/bin"
+
+  # validate_args runs before the guard under test and needs the namespace to
+  # exist; everything else the script would reach is past the exit points here.
+  cat > "$TMPDIR_TEST/bin/kubectl" << 'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$TMPDIR_TEST/bin/kubectl"
+}
+
+teardown() {
+  rm -rf "$TMPDIR_TEST"
+}
+
+@test "topology smoke CI passes the Modeler cluster through the action and CLI" {
+  workflow="$ROOT/.github/workflows/test-integration-runner.yaml"
+  action="$ROOT/.github/actions/playwright-e2e-tests/action.yaml"
+
+  run grep -F 'modeler-cluster-name: ${{ matrix.modeler_cluster_name }}' "$workflow"
+  [ "$status" -eq 0 ]
+
+  run grep -F 'E2E_ARG_MODELER_CLUSTER_NAME: ${{ inputs.modeler-cluster-name }}' "$action"
+  [ "$status" -eq 0 ]
+
+  run grep -F 'E2E_ARGS+=(--modeler-cluster-name "${E2E_ARG_MODELER_CLUSTER_NAME}")' "$action"
+  [ "$status" -eq 0 ]
+}
+
+@test "--optimize-namespace without --hub-namespace is rejected" {
+  run "$SCRIPT" --absolute-chart-path "$CHART_PATH" --namespace test-ns \
+    --optimize-namespace opt-ns --optimize-context-path /optimize-orcha
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"require --hub-namespace"* ]]
+}
+
+@test "--optimize-context-path without --hub-namespace is rejected" {
+  run "$SCRIPT" --absolute-chart-path "$CHART_PATH" --namespace test-ns \
+    --optimize-context-path /optimize-orcha
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"require --hub-namespace"* ]]
+}
+
+@test "the rerun command carries the topology targeting arguments" {
+  ABSOLUTE_CHART_PATH="$CHART_PATH"
+  NAMESPACE="matrix-810-mns-orcha"
+  KUBE_CONTEXT=""
+  TEST_EXCLUDE=""
+  RUN_SMOKE_TESTS="true"
+  IS_OPENSEARCH="false"
+  IS_RBA="false"
+  IS_MT="false"
+  IS_AUTH0="false"
+  VIDEO_MODE=""
+  TRACE_MODE=""
+  RETRIES=""
+  LOCAL_TEST_SUITE=""
+  HUB_NAMESPACE_ARG="matrix-810-mns-hub"
+  OPTIMIZE_NAMESPACE_ARG="matrix-810-mns-opt-orcha"
+  OPTIMIZE_CONTEXT_PATH_ARG="/optimize-orcha"
+  MODELER_CLUSTER_NAME_ARG="Orchestration A"
+
+  # Only the function is wanted, so define it from the script's own source.
+  eval "$(sed -n '/^build_rerun_cmd() {/,/^}/p' "$SCRIPT")"
+
+  run build_rerun_cmd
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--namespace matrix-810-mns-orcha"* ]]
+  [[ "$output" == *"--hub-namespace matrix-810-mns-hub"* ]]
+  [[ "$output" == *"--optimize-namespace matrix-810-mns-opt-orcha"* ]]
+  [[ "$output" == *"--optimize-context-path /optimize-orcha"* ]]
+  [[ "$output" == *"--modeler-cluster-name Orchestration\\ A"* ]]
+}
+
+@test "the rerun command omits topology flags for an ordinary single-namespace run" {
+  ABSOLUTE_CHART_PATH="$CHART_PATH"
+  NAMESPACE="matrix-810-single"
+  KUBE_CONTEXT=""
+  TEST_EXCLUDE=""
+  RUN_SMOKE_TESTS="true"
+  IS_OPENSEARCH="false"
+  IS_RBA="false"
+  IS_MT="false"
+  IS_AUTH0="false"
+  VIDEO_MODE=""
+  TRACE_MODE=""
+  RETRIES=""
+  LOCAL_TEST_SUITE=""
+  HUB_NAMESPACE_ARG=""
+  OPTIMIZE_NAMESPACE_ARG=""
+  OPTIMIZE_CONTEXT_PATH_ARG=""
+  MODELER_CLUSTER_NAME_ARG=""
+
+  eval "$(sed -n '/^build_rerun_cmd() {/,/^}/p' "$SCRIPT")"
+
+  run build_rerun_cmd
+
+  # A false trailing conditional must not leak out as a failing exit status.
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--namespace matrix-810-single"* ]]
+  [[ "$output" != *"--hub-namespace"* ]]
+  [[ "$output" != *"--optimize-"* ]]
+  [[ "$output" != *"--modeler-cluster-name"* ]]
+}


### PR DESCRIPTION
### Which problem does the PR fix?

Part of #6749. The e2e coverage for the `optimize` release role was **silently absent**, which is
worse than absent: it produced a green build.

`scripts/render-e2e-env.sh:257` counts Optimize pods **in the orchestration namespace** and sets
`IS_OPTIMIZE=false` when it finds none. With Optimize running as its own release there are none
there, and every Optimize spec is guarded on that variable —
`tests/SM-8.9/optimize-user-flows.spec.ts:12`, `smoke-tests.spec.ts:112`,
`web-modeler-user-flows.spec.ts:267`. So removing `skip-e2e` would not have gone red; it would have
skipped all Optimize coverage and passed.

Two further hardcodings pointed the wrong way even if the flag were forced on:
`render-e2e-env.sh:363` emits `CAMUNDA_OPTIMIZE_BASE_URL=https://$hostname/optimize` — wrong host
*and* wrong path, since these releases are served on the Hub host at `/optimize-<cluster>` — and
`e2e-env merge` overrode **zero** `OPTIMIZE_*` variables.

### Follow-up fix on this branch

`fix(ci): stop exporting an empty OPTIMIZE_CONTEXT_PATH to the e2e suite`.

The first version of this PR set `OPTIMIZE_CONTEXT_PATH` and `OPTIMIZE_NAMESPACE` in the composite
action's `env:` block purely to build its own argument list. The *arguments* were gated on non-empty;
the *environment variables* were not, so every leg without a split-Optimize topology exported
`OPTIMIZE_CONTEXT_PATH=""` and Playwright inherited it. The suite resolves the path itself as
`process.env.OPTIMIZE_CONTEXT_PATH ?? '/optimize'`, and `??` does not fall back on an empty string,
so `page.goto('')` resolved to the ingress root instead of `/optimize`.

That failed `Basic Navigation` and `Most Common Flow User Flow With All Apps` on 8.9 and 8.10 — the
only suites reading that variable — after five 60s login retries, while 8.7 and 8.8 stayed green,
which made it look like a version-specific product regression. Both env vars are now
`E2E_ARG_`-prefixed so they cannot collide with what the suite consumes, and `run-e2e-tests.sh`
clears an inherited empty value.

**Companion PR:** `camunda/c8-cross-component-e2e-tests#3059` changes those `??` operators to `||`,
so a set-but-empty context path is harmless for any future caller. Independent of this PR; neither
blocks the other.

### What's in this PR?

`deploy-camunda e2e-env merge` gains `--optimize-namespace` and `--optimize-context-path`. When
set it resolves that release's live ingress host (reusing the existing `resolveIngressHost`, the
same way Hub endpoints are already resolved) and repoints `CAMUNDA_OPTIMIZE_BASE_URL` at it.

The logic lives in Go rather than in `render-e2e-env.sh`, per `AGENTS.md`: *"NEVER implement CI
logic (>20 lines) in bash."* The shell and action changes are pure flag plumbing.

**Two guards turn the silent skip into a failure**, which is the point of the PR:

- `assertOptimizeDeployed` — the declared namespace must actually run an Optimize deployment.
- `assertOptimizeEnabled` — the merged env must not still say `IS_OPTIMIZE=false`. `mergeEnvOverrides`
  replaces keys in place rather than appending, so this is a real invariant on the merge.

**One leg per Optimize instance.** The suite reads a single `CAMUNDA_OPTIMIZE_BASE_URL`, so a leg
cannot cover several Optimizes. `planTopologyMetadata` therefore emits one smoke leg per Optimize
instance instead of one leg carrying a list — which is what PR 1 of this stack shipped, and this PR
supersedes. An orchestration release serving several Physical Tenants gets a leg per tenant;
scenarios with no `optimize` releases keep exactly one leg per orchestration release, asserted by
the existing `multinamespace-2orch` expectation being unchanged.

With the runner consuming the mapping, `multinamespace-optimize` no longer sets `skip-e2e`.

**Each leg now names its Modeler cluster.** One Hub Web Modeler serves every orchestration release
in a topology and deploys to a single cluster, so a leg has to say which cluster it targets. The
suite reads `MODELER_CLUSTER_NAME` and selects that cluster in the deploy dialog, and the workflow
has set it per shard since #6688 — but nothing in the local path did, so a local topology run could
not distinguish its legs. `ModelerClusterName` now travels from the leg into the test flags and on
to `run-e2e-tests.sh` as `--modeler-cluster-name`, which exports it for Playwright.
`dotenv.config()` does not override an existing process env var, so the exported value wins over
the rendered `.env`.

### Verification

`go test ./...` in `scripts/deploy-camunda` passes, including the registry golden and the two new
`assertOptimize*` tests. `bash -n` on `run-e2e-tests.sh` and YAML parse checks on the changed action
and workflow.

The leg wiring was measured on GKE with `multinamespace-2orch`. Before it, the second leg scored
7 passed / 12 failed with 314 "not found in table", because both legs deployed to whichever cluster
Modeler preselects and the second then asserted against a cluster holding no records. With the
variable wired through it scores 15 passed / 4 failed, and with
camunda/c8-cross-component-e2e-tests#3042 (which applies the same selection to the two deploy paths
that lacked it) it reaches **16 passed / 3 failed** — exact parity with the first leg, the three
remainders being pre-existing `connectors-user-flows` failures that fail identically on both legs.

### Not in this PR

- Physical-tenant-aware e2e specs. `grep -riE 'physical.?tenant' tests/` in the e2e suite returns
  nothing, so tenant-scoped web-app URLs (`/physical-tenants/<id>/operate`) have no coverage. That
  belongs in `c8-cross-component-e2e-tests`.
- Removing the `IS_OPTIMIZE` guard pattern itself. It is a reasonable switch for deployments that
  genuinely omit Optimize; this PR only stops it from firing by accident.

### Design contracts inherited from #6884

The endpoints this PR derives come from the topology declaration, so contract 3 under **Settled
design contracts** in #6884 applies: `RELEASE_OPTIMIZE_CONTEXT_PATH`, `SERVED_NAMESPACE`,
`SERVED_HOST`, `SERVED_ORCHESTRATION_INDEX_PREFIX` and the `ORCH_*` references are generated,
reserved, and applied after a release's own `env`, and `Topology.Validate` rejects a release `env`
entry that names one. Reading or re-deriving those values anywhere else re-opens the divergence
between what is deployed and what the smoke matrix reports.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

### To-Do

- [ ] Confirm on GKE that a smoke leg now reaches its tenant's Optimize (PR 4 of the stack).





