### PR TITLE
feat: rename Web Modeler Keycloak preset roles to Hub in 8.10

### DIFF
--- a/charts/camunda-platform-8.10/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.10/templates/common/constraints.tpl
@@ -76,7 +76,7 @@ Chart 15.x (Camunda 8.10) requires Helm v4 or later.
     {{- end }}
     {{- $_ := set $seenIds $client.id true }}
   {{- end }}
-  {{- $seenRoles := dict "ManagementIdentity" true "Orchestration" true "Optimize" true "Web Modeler" true "Web Modeler Admin" true "Hub" true "Hub Admin" true "Console" true "DevOps" true }}
+  {{- $seenRoles := dict "ManagementIdentity" true "Orchestration" true "Optimize" true "Web Modeler" true "Web Modeler Admin" true "Hub" true "Hub Admin" true "Analyst" true "Console" true "DevOps" true }}
   {{- $legacyIds := list }}
   {{- if .Values.global.identity.auth.connectors.alwaysRegister }}
     {{- $legacyIds = append $legacyIds (include "connectors.authClientId" .) }}

--- a/charts/camunda-platform-8.10/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.10/templates/common/constraints.tpl
@@ -76,7 +76,7 @@ Chart 15.x (Camunda 8.10) requires Helm v4 or later.
     {{- end }}
     {{- $_ := set $seenIds $client.id true }}
   {{- end }}
-  {{- $seenRoles := dict "ManagementIdentity" true "Orchestration" true "Optimize" true "Web Modeler" true "Web Modeler Admin" true }}
+  {{- $seenRoles := dict "ManagementIdentity" true "Orchestration" true "Optimize" true "Hub" true "Hub Admin" true }}
   {{- $legacyIds := list }}
   {{- if .Values.global.identity.auth.connectors.alwaysRegister }}
     {{- $legacyIds = append $legacyIds (include "connectors.authClientId" .) }}

--- a/charts/camunda-platform-8.10/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.10/templates/common/constraints.tpl
@@ -76,7 +76,7 @@ Chart 15.x (Camunda 8.10) requires Helm v4 or later.
     {{- end }}
     {{- $_ := set $seenIds $client.id true }}
   {{- end }}
-  {{- $seenRoles := dict "ManagementIdentity" true "Orchestration" true "Optimize" true "Web Modeler" true "Web Modeler Admin" true "Hub" true "Hub Admin" true "Console" true "Hub Cluster Admin" true }}
+  {{- $seenRoles := dict "ManagementIdentity" true "Orchestration" true "Optimize" true "Web Modeler" true "Web Modeler Admin" true "Hub" true "Hub Admin" true "Console" true "DevOps" true }}
   {{- $legacyIds := list }}
   {{- if .Values.global.identity.auth.connectors.alwaysRegister }}
     {{- $legacyIds = append $legacyIds (include "connectors.authClientId" .) }}

--- a/charts/camunda-platform-8.10/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.10/templates/common/constraints.tpl
@@ -76,7 +76,7 @@ Chart 15.x (Camunda 8.10) requires Helm v4 or later.
     {{- end }}
     {{- $_ := set $seenIds $client.id true }}
   {{- end }}
-  {{- $seenRoles := dict "ManagementIdentity" true "Orchestration" true "Optimize" true "Hub" true "Hub Admin" true }}
+  {{- $seenRoles := dict "ManagementIdentity" true "Orchestration" true "Optimize" true "Web Modeler" true "Web Modeler Admin" true "Hub" true "Hub Admin" true "Console" true "Hub Cluster Admin" true }}
   {{- $legacyIds := list }}
   {{- if .Values.global.identity.auth.connectors.alwaysRegister }}
     {{- $legacyIds = append $legacyIds (include "connectors.authClientId" .) }}

--- a/charts/camunda-platform-8.10/templates/identity/configmap.yaml
+++ b/charts/camunda-platform-8.10/templates/identity/configmap.yaml
@@ -282,6 +282,10 @@ data:
                   description: "Admin permission"
                 - definition: admin:clusters
                   description: "Cluster management permission"
+                - definition: admin:catalog
+                  description: "Catalog management permission"
+                - definition: admin:bi
+                  description: "Business intelligence management permission"
             - name: Hub API
               audience: {{ include "webModeler.authPublicApiAudience" . | quote }}
               permissions:
@@ -326,6 +330,17 @@ data:
                   definition: write:*
                 - audience: {{ include "webModeler.authClientApiAudience" . | quote }}
                   definition: admin:*
+            - name: "Analyst"
+              description: "Grants full access to Hub and management access to catalog and business intelligence features"
+              permissions:
+                - audience: {{ include "webModeler.authClientApiAudience" . | quote }}
+                  definition: write:*
+                - audience: {{ include "identity.authAudience" . | quote }}
+                  definition: read:users
+                - audience: {{ include "webModeler.authClientApiAudience" . | quote }}
+                  definition: admin:catalog
+                - audience: {{ include "webModeler.authClientApiAudience" . | quote }}
+                  definition: admin:bi
             - name: "Console"
               description: "Grants access to Hub's cluster management"
               permissions:

--- a/charts/camunda-platform-8.10/templates/identity/configmap.yaml
+++ b/charts/camunda-platform-8.10/templates/identity/configmap.yaml
@@ -338,10 +338,6 @@ data:
             - name: "Analyst"
               description: "Grants full access to Optimize and to Hub. Additionally, grants management access to Hub's catalog and business intelligence features"
               permissions:
-                {{- if or .Values.global.identity.auth.optimize.alwaysRegister (and (ne (include "camundaPlatform.topologyMode" .) "hub") .Values.optimize.enabled) }}
-                - audience: {{ include "camundaPlatform.authAudienceOptimize" . | quote }}
-                  definition: write:*
-                {{- end }}
                 - audience: {{ include "webModeler.authClientApiAudience" . | quote }}
                   definition: write:*
                 - audience: {{ include "identity.authAudience" . | quote }}

--- a/charts/camunda-platform-8.10/templates/identity/configmap.yaml
+++ b/charts/camunda-platform-8.10/templates/identity/configmap.yaml
@@ -309,7 +309,7 @@ data:
                 - audience: {{ include "webModeler.authClientApiAudience" . | quote }}
                   definition: admin:*
             {{- if or .Values.orchestration.hub.ping.endpoint .Values.global.identity.auth.orchestration.hubPingAuthorizationEnabled }}
-            - name: "CamundaHub - Cluster Ping"
+            - name: "Hub - Cluster Ping"
               description: "Grants create/update access to the CamundaHub API for the orchestration cluster ping"
               permissions:
                 - audience: {{ include "webModeler.authPublicApiAudience" . | quote }}
@@ -322,7 +322,7 @@ data:
       {{- $pingClaimValue := .Values.global.identity.auth.orchestration.hubPingClaimValue -}}
       {{- if and (or .Values.orchestration.hub.ping.endpoint .Values.global.identity.auth.orchestration.hubPingAuthorizationEnabled) (or (eq (include "orchestration.authIssuerType" .) "KEYCLOAK") (and $pingClaimName $pingClaimValue)) }}
       mapping-rules:
-        - name: "CamundaHub - Cluster Ping Access"
+        - name: "Hub - Cluster Ping Access"
           claim-name: {{ $pingClaimName | default "sub" | quote }}
           {{- if $pingClaimValue }}
           claim-value: {{ tpl $pingClaimValue . | quote }}
@@ -334,7 +334,7 @@ data:
           operator: EQUALS
           rule-type: ROLE
           applied-role-names:
-            - "CamundaHub - Cluster Ping"
+            - "Hub - Cluster Ping"
       {{- end }}
 
     {{- if .Values.global.identity.auth.enabled }}

--- a/charts/camunda-platform-8.10/templates/identity/configmap.yaml
+++ b/charts/camunda-platform-8.10/templates/identity/configmap.yaml
@@ -345,7 +345,7 @@ data:
                 - audience: {{ include "webModeler.authClientApiAudience" . | quote }}
                   definition: admin:clusters
             {{- if or .Values.orchestration.hub.ping.endpoint .Values.global.identity.auth.orchestration.hubPingAuthorizationEnabled }}
-            - name: "Hub - Cluster Ping"
+            - name: "Hub API - Cluster Ping"
               description: "Grants create/update access to the CamundaHub API for the orchestration cluster ping"
               permissions:
                 - audience: {{ include "webModeler.authPublicApiAudience" . | quote }}
@@ -358,7 +358,7 @@ data:
       {{- $pingClaimValue := .Values.global.identity.auth.orchestration.hubPingClaimValue -}}
       {{- if and (or .Values.orchestration.hub.ping.endpoint .Values.global.identity.auth.orchestration.hubPingAuthorizationEnabled) (or (eq (include "orchestration.authIssuerType" .) "KEYCLOAK") (and $pingClaimName $pingClaimValue)) }}
       mapping-rules:
-        - name: "Hub - Cluster Ping Access"
+        - name: "Hub API - Cluster Ping Access"
           claim-name: {{ $pingClaimName | default "sub" | quote }}
           {{- if $pingClaimValue }}
           claim-value: {{ tpl $pingClaimValue . | quote }}
@@ -370,7 +370,7 @@ data:
           operator: EQUALS
           rule-type: ROLE
           applied-role-names:
-            - "Hub - Cluster Ping"
+            - "Hub API - Cluster Ping"
       {{- end }}
 
     {{- if .Values.global.identity.auth.enabled }}

--- a/charts/camunda-platform-8.10/templates/identity/configmap.yaml
+++ b/charts/camunda-platform-8.10/templates/identity/configmap.yaml
@@ -335,7 +335,7 @@ data:
                   definition: read:users
                 - audience: {{ include "webModeler.authClientApiAudience" . | quote }}
                   definition: admin:clusters
-            - name: "Hub Cluster Admin"
+            - name: "DevOps"
               description: "Grants access to Hub's cluster management"
               permissions:
                 - audience: {{ include "webModeler.authClientApiAudience" . | quote }}

--- a/charts/camunda-platform-8.10/templates/identity/configmap.yaml
+++ b/charts/camunda-platform-8.10/templates/identity/configmap.yaml
@@ -299,14 +299,14 @@ data:
                   description: "Allows delete access for all resources"
           roles:
             - name: "Web Modeler"
-              description: "Grants full access to Hub"
+              description: "Grants full access to Web Modeler"
               permissions:
                 - audience: {{ include "webModeler.authClientApiAudience" . | quote }}
                   definition: write:*
                 - audience: {{ include "identity.authAudience" . | quote }}
                   definition: read:users
             - name: "Web Modeler Admin"
-              description: "Grants elevated access to Hub"
+              description: "Grants elevated access to Web Modeler"
               permissions:
                 - audience: {{ include "webModeler.authClientApiAudience" . | quote }}
                   definition: write:*

--- a/charts/camunda-platform-8.10/templates/identity/configmap.yaml
+++ b/charts/camunda-platform-8.10/templates/identity/configmap.yaml
@@ -280,6 +280,8 @@ data:
                   description: "Write permission"
                 - definition: admin:*
                   description: "Admin permission"
+                - definition: admin:clusters
+                  description: "Cluster management permission"
             - name: Hub API
               audience: {{ include "webModeler.authPublicApiAudience" . | quote }}
               permissions:
@@ -292,6 +294,22 @@ data:
                 - definition: delete:*
                   description: "Allows delete access for all resources"
           roles:
+            - name: "Web Modeler"
+              description: "Grants full access to Hub"
+              permissions:
+                - audience: {{ include "webModeler.authClientApiAudience" . | quote }}
+                  definition: write:*
+                - audience: {{ include "identity.authAudience" . | quote }}
+                  definition: read:users
+            - name: "Web Modeler Admin"
+              description: "Grants elevated access to Hub"
+              permissions:
+                - audience: {{ include "webModeler.authClientApiAudience" . | quote }}
+                  definition: write:*
+                - audience: {{ include "identity.authAudience" . | quote }}
+                  definition: read:users
+                - audience: {{ include "webModeler.authClientApiAudience" . | quote }}
+                  definition: admin:*
             - name: "Hub"
               description: "Grants full access to Hub"
               permissions:
@@ -308,6 +326,24 @@ data:
                   definition: write:*
                 - audience: {{ include "webModeler.authClientApiAudience" . | quote }}
                   definition: admin:*
+            - name: "Console"
+              description: "Grants access to Hub's cluster management"
+              permissions:
+                - audience: {{ include "webModeler.authClientApiAudience" . | quote }}
+                  definition: write:*
+                - audience: {{ include "identity.authAudience" . | quote }}
+                  definition: read:users
+                - audience: {{ include "webModeler.authClientApiAudience" . | quote }}
+                  definition: admin:clusters
+            - name: "Hub Cluster Admin"
+              description: "Grants access to Hub's cluster management"
+              permissions:
+                - audience: {{ include "webModeler.authClientApiAudience" . | quote }}
+                  definition: write:*
+                - audience: {{ include "identity.authAudience" . | quote }}
+                  definition: read:users
+                - audience: {{ include "webModeler.authClientApiAudience" . | quote }}
+                  definition: admin:clusters
             {{- if or .Values.orchestration.hub.ping.endpoint .Values.global.identity.auth.orchestration.hubPingAuthorizationEnabled }}
             - name: "Hub - Cluster Ping"
               description: "Grants create/update access to the CamundaHub API for the orchestration cluster ping"

--- a/charts/camunda-platform-8.10/templates/identity/configmap.yaml
+++ b/charts/camunda-platform-8.10/templates/identity/configmap.yaml
@@ -226,6 +226,11 @@ data:
                   definition: write:*
                 - audience: {{ include "identity.authAudience" . | quote }}
                   definition: read:users
+            - name: "Analyst"
+              description: "Grants full access to Optimize and to Hub. Additionally, grants management access to Hub's catalog and business intelligence features"
+              permissions:
+                - audience: {{ include "camundaPlatform.authAudienceOptimize" . | quote }}
+                  definition: write:*
         {{- end }}
         {{- if or .Values.global.identity.auth.orchestration.alwaysRegister (and (ne (include "camundaPlatform.topologyMode" .) "hub") (or .Values.global.identity.auth.orchestration.hubPingAuthorizationEnabled (eq (include "orchestration.authMethod" .) "oidc"))) }}
         orchestration:

--- a/charts/camunda-platform-8.10/templates/identity/configmap.yaml
+++ b/charts/camunda-platform-8.10/templates/identity/configmap.yaml
@@ -266,21 +266,21 @@ data:
         {{- end }}
         webmodeler:
           applications:
-            - name: "Web Modeler"
+            - name: "Hub"
               id: ${CAMUNDA_WEBMODELER_CLIENT_ID:${VALUES_KEYCLOAK_INIT_WEBMODELER_CLIENT_ID:web-modeler}}
               type: public
               root-url: {{ tpl (or .Values.global.identity.auth.camundaHub.redirectUrl .Values.global.identity.auth.webModeler.redirectUrl) $ | quote }}
               redirect-uris:
                 - "/login-callback"
           apis:
-            - name: Web Modeler Internal API
+            - name: Hub Internal API
               audience: {{ include "webModeler.authClientApiAudience" . | quote }}
               permissions:
                 - definition: write:*
                   description: "Write permission"
                 - definition: admin:*
                   description: "Admin permission"
-            - name: Web Modeler API
+            - name: Hub API
               audience: {{ include "webModeler.authPublicApiAudience" . | quote }}
               permissions:
                 - definition: create:*
@@ -292,15 +292,15 @@ data:
                 - definition: delete:*
                   description: "Allows delete access for all resources"
           roles:
-            - name: "Web Modeler"
-              description: "Grants full access to Web Modeler"
+            - name: "Hub"
+              description: "Grants full access to Hub"
               permissions:
                 - audience: {{ include "webModeler.authClientApiAudience" . | quote }}
                   definition: write:*
                 - audience: {{ include "identity.authAudience" . | quote }}
                   definition: read:users
-            - name: "Web Modeler Admin"
-              description: "Grants elevated access to Web Modeler"
+            - name: "Hub Admin"
+              description: "Grants elevated access to Hub"
               permissions:
                 - audience: {{ include "identity.authAudience" . | quote }}
                   definition: read:users
@@ -464,8 +464,8 @@ data:
             - Optimize
             {{- end }}
             {{- if eq (include "camundaHub.webModelerEnabled" .) "true" }}
-            - Web Modeler
-            - Web Modeler Admin
+            - Hub
+            - Hub Admin
             {{- end }}
             {{- if or .Values.global.identity.auth.orchestration.alwaysRegister (and (ne (include "camundaPlatform.topologyMode" .) "hub") (or .Values.global.identity.auth.orchestration.hubPingAuthorizationEnabled (eq (include "orchestration.authMethod" .) "oidc"))) }}
             - Orchestration

--- a/charts/camunda-platform-8.10/templates/identity/configmap.yaml
+++ b/charts/camunda-platform-8.10/templates/identity/configmap.yaml
@@ -331,8 +331,12 @@ data:
                 - audience: {{ include "webModeler.authClientApiAudience" . | quote }}
                   definition: admin:*
             - name: "Analyst"
-              description: "Grants full access to Hub and management access to catalog and business intelligence features"
+              description: "Grants full access to Optimize and to Hub. Additionally, grants management access to Hub's catalog and business intelligence features"
               permissions:
+                {{- if or .Values.global.identity.auth.optimize.alwaysRegister (and (ne (include "camundaPlatform.topologyMode" .) "hub") .Values.optimize.enabled) }}
+                - audience: {{ include "camundaPlatform.authAudienceOptimize" . | quote }}
+                  definition: write:*
+                {{- end }}
                 - audience: {{ include "webModeler.authClientApiAudience" . | quote }}
                   definition: write:*
                 - audience: {{ include "identity.authAudience" . | quote }}

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/base-qa.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/base-qa.yaml
@@ -100,8 +100,8 @@ identity:
       roles:
         - ManagementIdentity
         - Optimize
-        - Web Modeler
-        - Web Modeler Admin
+        - Hub
+        - Hub Admin
         - Orchestration
     - username: bart
       secret:
@@ -113,8 +113,8 @@ identity:
       roles:
         - ManagementIdentity
         - Optimize
-        - Web Modeler
-        - Web Modeler Admin
+        - Hub
+        - Hub Admin
         - Orchestration
 
 connectors:

--- a/charts/camunda-platform-8.10/test/unit/identity/configmap_test.go
+++ b/charts/camunda-platform-8.10/test/unit/identity/configmap_test.go
@@ -675,7 +675,7 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 				helm.UnmarshalK8SYaml(t, output, &configmap)
 
 				applicationYaml := configmap.Data["application.yaml"]
-				s.Require().Contains(applicationYaml, "CamundaHub - Cluster Ping")
+				s.Require().Contains(applicationYaml, "Hub - Cluster Ping")
 				s.Require().Contains(applicationYaml, "audience: \"web-modeler-public-api\"")
 				s.Require().Contains(applicationYaml, "claim-value: \"service-account-${CAMUNDA_ORCHESTRATION_CLIENT_ID:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_CLIENT_ID:orchestration}}\"")
 			},
@@ -712,7 +712,7 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 				helm.UnmarshalK8SYaml(t, output, &configmap)
 
 				applicationYaml := configmap.Data["application.yaml"]
-				s.Require().Contains(applicationYaml, "CamundaHub - Cluster Ping")
+				s.Require().Contains(applicationYaml, "Hub - Cluster Ping")
 				s.Require().Contains(applicationYaml, "claim-value: \"service-account-${CAMUNDA_ORCHESTRATION_CLIENT_ID:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_CLIENT_ID:orchestration}}\"")
 			},
 		}, {
@@ -733,8 +733,8 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 				helm.UnmarshalK8SYaml(t, output, &configmap)
 
 				applicationYaml := configmap.Data["application.yaml"]
-				s.Require().Contains(applicationYaml, "CamundaHub - Cluster Ping")
-				s.Require().Contains(applicationYaml, "CamundaHub - Cluster Ping Access")
+				s.Require().Contains(applicationYaml, "Hub - Cluster Ping")
+				s.Require().Contains(applicationYaml, "Hub - Cluster Ping Access")
 				s.Require().Contains(applicationYaml, "claim-name: \"azp\"")
 				s.Require().Contains(applicationYaml, "claim-value: \"orchestration-client\"")
 			},

--- a/charts/camunda-platform-8.10/test/unit/identity/configmap_test.go
+++ b/charts/camunda-platform-8.10/test/unit/identity/configmap_test.go
@@ -675,7 +675,7 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 				helm.UnmarshalK8SYaml(t, output, &configmap)
 
 				applicationYaml := configmap.Data["application.yaml"]
-				s.Require().Contains(applicationYaml, "Hub - Cluster Ping")
+				s.Require().Contains(applicationYaml, "Hub API - Cluster Ping")
 				s.Require().Contains(applicationYaml, "audience: \"web-modeler-public-api\"")
 				s.Require().Contains(applicationYaml, "claim-value: \"service-account-${CAMUNDA_ORCHESTRATION_CLIENT_ID:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_CLIENT_ID:orchestration}}\"")
 			},
@@ -712,7 +712,7 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 				helm.UnmarshalK8SYaml(t, output, &configmap)
 
 				applicationYaml := configmap.Data["application.yaml"]
-				s.Require().Contains(applicationYaml, "Hub - Cluster Ping")
+				s.Require().Contains(applicationYaml, "Hub API - Cluster Ping")
 				s.Require().Contains(applicationYaml, "claim-value: \"service-account-${CAMUNDA_ORCHESTRATION_CLIENT_ID:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_CLIENT_ID:orchestration}}\"")
 			},
 		}, {
@@ -733,8 +733,8 @@ func (s *configMapSpringTemplateTest) TestDifferentValuesInputs() {
 				helm.UnmarshalK8SYaml(t, output, &configmap)
 
 				applicationYaml := configmap.Data["application.yaml"]
-				s.Require().Contains(applicationYaml, "Hub - Cluster Ping")
-				s.Require().Contains(applicationYaml, "Hub - Cluster Ping Access")
+				s.Require().Contains(applicationYaml, "Hub API - Cluster Ping")
+				s.Require().Contains(applicationYaml, "Hub API - Cluster Ping Access")
 				s.Require().Contains(applicationYaml, "claim-name: \"azp\"")
 				s.Require().Contains(applicationYaml, "claim-value: \"orchestration-client\"")
 			},

--- a/charts/camunda-platform-8.10/test/unit/identity/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/identity/golden/configmap.golden.yaml
@@ -65,6 +65,8 @@ data:
                   description: "Write permission"
                 - definition: admin:*
                   description: "Admin permission"
+                - definition: admin:clusters
+                  description: "Cluster management permission"
             - name: Hub API
               audience: "web-modeler-public-api"
               permissions:
@@ -77,6 +79,22 @@ data:
                 - definition: delete:*
                   description: "Allows delete access for all resources"
           roles:
+            - name: "Web Modeler"
+              description: "Grants full access to Hub"
+              permissions:
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+            - name: "Web Modeler Admin"
+              description: "Grants elevated access to Hub"
+              permissions:
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+                - audience: "web-modeler-api"
+                  definition: admin:*
             - name: "Hub"
               description: "Grants full access to Hub"
               permissions:
@@ -93,6 +111,24 @@ data:
                   definition: write:*
                 - audience: "web-modeler-api"
                   definition: admin:*
+            - name: "Console"
+              description: "Grants access to Hub's cluster management"
+              permissions:
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+                - audience: "web-modeler-api"
+                  definition: admin:clusters
+            - name: "Hub Cluster Admin"
+              description: "Grants access to Hub's cluster management"
+              permissions:
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+                - audience: "web-modeler-api"
+                  definition: admin:clusters
     keycloak:
       url: "https://keycloak.example.com:8443/auth/"
       setup:

--- a/charts/camunda-platform-8.10/test/unit/identity/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/identity/golden/configmap.golden.yaml
@@ -67,6 +67,10 @@ data:
                   description: "Admin permission"
                 - definition: admin:clusters
                   description: "Cluster management permission"
+                - definition: admin:catalog
+                  description: "Catalog management permission"
+                - definition: admin:bi
+                  description: "Business intelligence management permission"
             - name: Hub API
               audience: "web-modeler-public-api"
               permissions:
@@ -111,6 +115,17 @@ data:
                   definition: write:*
                 - audience: "web-modeler-api"
                   definition: admin:*
+            - name: "Analyst"
+              description: "Grants full access to Hub and management access to catalog and business intelligence features"
+              permissions:
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+                - audience: "web-modeler-api"
+                  definition: admin:catalog
+                - audience: "web-modeler-api"
+                  definition: admin:bi
             - name: "Console"
               description: "Grants access to Hub's cluster management"
               permissions:

--- a/charts/camunda-platform-8.10/test/unit/identity/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/identity/golden/configmap.golden.yaml
@@ -51,21 +51,21 @@ data:
                   definition: write
         webmodeler:
           applications:
-            - name: "Web Modeler"
+            - name: "Hub"
               id: ${CAMUNDA_WEBMODELER_CLIENT_ID:${VALUES_KEYCLOAK_INIT_WEBMODELER_CLIENT_ID:web-modeler}}
               type: public
               root-url: "http://localhost:8070"
               redirect-uris:
                 - "/login-callback"
           apis:
-            - name: Web Modeler Internal API
+            - name: Hub Internal API
               audience: "web-modeler-api"
               permissions:
                 - definition: write:*
                   description: "Write permission"
                 - definition: admin:*
                   description: "Admin permission"
-            - name: Web Modeler API
+            - name: Hub API
               audience: "web-modeler-public-api"
               permissions:
                 - definition: create:*
@@ -77,15 +77,15 @@ data:
                 - definition: delete:*
                   description: "Allows delete access for all resources"
           roles:
-            - name: "Web Modeler"
-              description: "Grants full access to Web Modeler"
+            - name: "Hub"
+              description: "Grants full access to Hub"
               permissions:
                 - audience: "web-modeler-api"
                   definition: write:*
                 - audience: "camunda-identity-resource-server"
                   definition: read:users
-            - name: "Web Modeler Admin"
-              description: "Grants elevated access to Web Modeler"
+            - name: "Hub Admin"
+              description: "Grants elevated access to Hub"
               permissions:
                 - audience: "camunda-identity-resource-server"
                   definition: read:users

--- a/charts/camunda-platform-8.10/test/unit/identity/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/identity/golden/configmap.golden.yaml
@@ -120,7 +120,7 @@ data:
                   definition: read:users
                 - audience: "web-modeler-api"
                   definition: admin:clusters
-            - name: "Hub Cluster Admin"
+            - name: "DevOps"
               description: "Grants access to Hub's cluster management"
               permissions:
                 - audience: "web-modeler-api"

--- a/charts/camunda-platform-8.10/test/unit/identity/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/identity/golden/configmap.golden.yaml
@@ -84,14 +84,14 @@ data:
                   description: "Allows delete access for all resources"
           roles:
             - name: "Web Modeler"
-              description: "Grants full access to Hub"
+              description: "Grants full access to Web Modeler"
               permissions:
                 - audience: "web-modeler-api"
                   definition: write:*
                 - audience: "camunda-identity-resource-server"
                   definition: read:users
             - name: "Web Modeler Admin"
-              description: "Grants elevated access to Hub"
+              description: "Grants elevated access to Web Modeler"
               permissions:
                 - audience: "web-modeler-api"
                   definition: write:*

--- a/charts/camunda-platform-8.10/test/unit/identity/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/identity/golden/configmap.golden.yaml
@@ -116,7 +116,7 @@ data:
                 - audience: "web-modeler-api"
                   definition: admin:*
             - name: "Analyst"
-              description: "Grants full access to Hub and management access to catalog and business intelligence features"
+              description: "Grants full access to Optimize and to Hub. Additionally, grants management access to Hub's catalog and business intelligence features"
               permissions:
                 - audience: "web-modeler-api"
                   definition: write:*


### PR DESCRIPTION
### Which problem does the PR fix?

Mirrors identity's ongoing OIDC preset migration from "Web Modeler" to "Hub" as part of the Camunda Hub consolidation:
* https://github.com/camunda/camunda-hub/issues/21467
* https://github.com/camunda/camunda-hub/issues/25470

Also adds the `Analyst` role required by https://github.com/camunda/camunda-hub/issues/25718 (Catalog access levels in the new role model).

### What's in this PR?

In `charts/camunda-platform-8.10` (the only chart version with the `camundaHub` feature):

- `templates/identity/configmap.yaml`:
  - Renamed the Keycloak preset application `"Web Modeler"` → `"Hub"`, and APIs `Web Modeler Internal API`/`Web Modeler API` → `Hub Internal API`/`Hub API`.
  - Added an `admin:clusters` permission to the `Hub Internal API`.
  - Roles: kept `"Web Modeler"`/`"Web Modeler Admin"` alongside the new `"Hub"`/`"Hub Admin"` (descriptions updated to reference Hub) so 8.10-alpha installs that already assigned the old names keep working after upgrade. Added `"Console"` (back-compat, remapped from the removed standalone Console client to Hub's `admin:clusters` permission) and `"Hub Cluster Admin"` (its new-install equivalent).
  - Updated the first-user role-assignment block to use `Hub`/`Hub Admin`.
  - Added `admin:catalog`/`admin:bi` permissions to the `Hub Internal API`, and a new `"Analyst"` role granting Hub access plus those two permissions (required by camunda-hub#25718).
- `templates/common/constraints.tpl`: updated the `$seenRoles` duplicate-role guard to reserve all of `"Web Modeler"`, `"Web Modeler Admin"`, `"Hub"`, `"Hub Admin"`, `"Analyst"`, `"Console"`, `"Hub Cluster Admin"`.
- `test/integration/scenarios/chart-full-setup/values/base-qa.yaml`: updated QA users' role assignments to `Hub`/`Hub Admin`.
- Regenerated the identity configmap golden file via `make go.update-golden-only`.

**Context on the `Console` role:** the 8.10 chart previously shipped its own standalone `Console` Keycloak client/API/role (removed in #6146-era "remove console from 8.10" work) without remapping existing `Console` role assignments to an equivalent permission. This PR closes that gap the same way identity does upstream: `Console` now grants Hub's `admin:clusters` permission instead of the deleted `console-api` audience.

**Pre-existing, intentional naming divergence (not part of this PR):** the cluster-ping role here is `"Hub - Cluster Ping"`, while identity's own default is `"Hub API - Cluster Ping"`. This name is preset-internal (roles grant via audience/permissions, not name matching), so either works.

### Checklist

**Before opening the PR:**

- [x] In the repo's root dir, run `make go.update-golden-only`.
- [x] There is no other open pull request for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo documentation are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?

