### PR TITLE
test(8.10): restore the connectors configmap golden to generated output

### DIFF
--- a/charts/camunda-platform-8.10/test/unit/connectors/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/connectors/golden/configmap.golden.yaml
@@ -59,4 +59,3 @@ data:
     logging:
       level:
         io.camunda.connector: INFO
-    


### PR DESCRIPTION
### Which problem does the PR fix?

`TestGoldenDefaultsTemplateConnectors/TestContainerGoldenTestDefaults#03` fails on `main`.

#6872 (`deps: update patch-updates (patch)`, merged 16 Aug) added a trailing blank line to `charts/camunda-platform-8.10/test/unit/connectors/golden/configmap.golden.yaml`:

```diff
@@ -59,3 +59,4 @@ data:
     logging:
       level:
         io.camunda.connector: INFO
+
```

The renderer does not emit that line, so the golden comparison has failed on every commit since. Reproduced on a clean worktree at `f9f683da4` with no local changes, so it is not specific to any branch.

I found this while verifying an unrelated 8.10 change and confirmed it was pre-existing rather than mine.

### What's in this PR?

Regenerated the golden with `make go.update-golden-only chartPath=charts/camunda-platform-8.10`. One file changes, and the result is byte-identical to the file as it stood before #6872.

No template or values change, so nothing about the rendered chart changes. `make go.test chartPath=charts/camunda-platform-8.10` passes on every package.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
