### PR TITLE
test(8.9,8.10): share one elasticsearch across the 8.10 upgrade-minor flow

### DIFF
--- a/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry-snapshot.yaml
@@ -315,7 +315,7 @@ integration:
                 - RDBMS_POSTGRESQL_USERNAME
                 - RDBMS_POSTGRESQL_PASSWORD
         - name: keycloak-rba
-          enabled: false
+          enabled: true
           shortname: kerba
           auth: keycloak
           flow: upgrade-minor
@@ -326,7 +326,7 @@ integration:
             eks: preemptible
             gke: distroci
           identity: keycloak
-          persistence: elasticsearch
+          persistence: elasticsearch-companion
           features:
             - rba
           dependencies:

--- a/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/manifest.yaml
@@ -50,7 +50,7 @@ integration:
       enabled: false
     - id: keycloak-rba
       shortname: kerba
-      enabled: false
+      enabled: true
     - id: keycloak-original-upgrade
       shortname: keyc
       enabled: false

--- a/charts/camunda-platform-8.10/test/ci/registry/scenarios/keycloak-rba.yaml
+++ b/charts/camunda-platform-8.10/test/ci/registry/scenarios/keycloak-rba.yaml
@@ -3,7 +3,7 @@ auth: keycloak
 flows:
   - upgrade-minor
 identity: keycloak
-persistence: elasticsearch
+persistence: elasticsearch-companion
 features:
   - rba
 platforms:

--- a/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/persistence/elasticsearch-companion.yaml
+++ b/charts/camunda-platform-8.10/test/integration/scenarios/chart-full-setup/values/persistence/elasticsearch-companion.yaml
@@ -1,0 +1,1 @@
+elasticsearch.yaml

--- a/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/persistence/elasticsearch-companion.yaml
+++ b/charts/camunda-platform-8.9/test/integration/scenarios/chart-full-setup/values/persistence/elasticsearch-companion.yaml
@@ -1,0 +1,26 @@
+# Elasticsearch backend configuration for 8.9 — companion chart
+# Layer 3: Backend - Elasticsearch (companion chart)
+#
+# Selected by 8.10 upgrade-minor scenarios so that the install step (which runs
+# the previous chart from this directory) and the upgrade step share one
+# Elasticsearch. 8.10 has no Bitnami Elasticsearch subchart, so pointing both
+# steps at the companion `elastic/elasticsearch` release keeps secondary storage
+# readable across the upgrade.
+#
+# Scenarios selecting this layer must declare the `elasticsearch` dependency.
+
+elasticsearch:
+  enabled: false
+
+global:
+  elasticsearch:
+    enabled: true
+    url:
+      host: "elasticsearch-master"
+
+orchestration:
+  data:
+    secondaryStorage:
+      type: elasticsearch
+      elasticsearch:
+        url: "http://elasticsearch-master:9200"


### PR DESCRIPTION
### Which problem does the PR fix?

The 8.10 `upgrade-minor` integration flow writes to **two different Elasticsearch
instances**, which silently discards all secondary-storage data across the upgrade.

Step 1 (install of the previously released chart) resolves its values from the
*previous* version's scenario dir — `step1Flags.Deployment.ScenarioPath` in
`scripts/deploy-camunda/matrix/runner_upgrade.go` — where 8.9's
`values/persistence/elasticsearch.yaml` enables the in-chart Bitnami
Elasticsearch subchart. Step 2 upgrades to 8.10, whose layer points at the
companion `elastic/elasticsearch` release. 8.10 removed the Bitnami subchart, so
the two steps never shared a store and 8.10 starts against empty indices:

```
SchemaManager - Validate '0' existing indices based on '41' descriptors
SchemaManager - Found '41' missing indices
```

The broker's RocksDB state survives on its PVC, so the identity-setup
re-initialization that 8.10 runs on every start has every `CREATE` /
`ADD_ENTITY` rejected as already-existing and therefore never re-exported into
the new indices. Only roles genuinely new in 8.10 are created. Admin users
resolve with no roles and the webapps report "You don't have access to this
component", which is what the `kerba` Playwright suite trips over.

Measured on a GKE `upgrade-minor` run, same index names in both clusters:

| `camunda-*` index | Bitnami (8.9 wrote) | companion (8.10 reads) |
| --- | --- | --- |
| `role-8.8.0_` | 10 | 0 |
| `authorization-8.8.0_` | 51 | 0 |

This is pre-existing and independent of any chart-rendering change. `kerba` and
the other affected scenarios were disabled, so it went unnoticed; scenarios that
are enabled pass only because their assertions never read pre-upgrade state.

### What's in this PR?

An `elasticsearch-companion` persistence layer that both steps of the upgrade
share, so one Elasticsearch spans the upgrade boundary. This is also the only
path 8.10 supports, since the Bitnami subchart is gone.

- `charts/camunda-platform-8.9/.../values/persistence/elasticsearch-companion.yaml`
  disables the Bitnami subchart and points at the companion release. New file, so
  no existing 8.9 scenario changes behaviour.
- `charts/camunda-platform-8.10/.../values/persistence/elasticsearch-companion.yaml`
  is a **symlink** to `persistence/elasticsearch.yaml`. 8.10 needs no different
  values, and the symlink keeps the security mapping-rule env block from drifting
  between the two names. (`values/features/enterprise.yaml` already uses this
  pattern.)
- `keycloak-rba` selects the new layer and is re-enabled so CI exercises the fix.
- `registry-snapshot.yaml` regenerated with `make go.update-registry-golden`.

Chosen over the alternatives: changing 8.9's existing `elasticsearch` layer would
alter every 8.9 scenario (none of which declare an `elasticsearch` dependency),
and reindexing Bitnami → companion between steps needs
`reindex.remote.whitelist` on the destination for materially less benefit.

Verified on GKE (`deploy-camunda matrix run --versions 8.10 --shortname-filter
kerba --flow-filter upgrade-minor`): `Success: 1, Failed: 0` in 7m08s, the
Bitnami subchart never deployed, and after the upgrade the companion instance
holds all 10 role and 51 authorization documents — 0 and 0 without this change.

Only `keycloak-rba` opts in here. The same split affects `keycloak-mt`,
`keycloak-original-upgrade` and the seven `hub-*` upgrade scenarios; tracked in #6907 so this change stays reviewable.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?
