### PR TITLE
chore: report credential failures instead of masking them as missing inputs

### DIFF
--- a/scripts/deploy-camunda/cmd/credentials.go
+++ b/scripts/deploy-camunda/cmd/credentials.go
@@ -146,7 +146,7 @@ func resolveRegistryCredentialsFromEnvironment(docker *config.DockerFlags) error
 					Str("registry", item.registry).
 					Str("set", set).
 					Str("unset", unset).
-					Msg("Ignoring half-configured registry credentials from the environment; trying the keyring next")
+					Msg("Ignoring half-configured registry credentials from the environment; trying other credential sources")
 				continue
 			}
 			*item.username, *item.password = username, password

--- a/scripts/deploy-camunda/cmd/credentials.go
+++ b/scripts/deploy-camunda/cmd/credentials.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"scripts/camunda-core/pkg/logging"
 	"scripts/deploy-camunda/config"
 	"scripts/deploy-camunda/credentials"
 	"scripts/deploy-camunda/matrix"
@@ -137,7 +138,16 @@ func resolveRegistryCredentialsFromEnvironment(docker *config.DockerFlags) error
 				continue
 			}
 			if username == "" || password == "" {
-				return fmt.Errorf("%s/%s must both be set", pair[0], pair[1])
+				set, unset := pair[0], pair[1]
+				if username == "" {
+					set, unset = pair[1], pair[0]
+				}
+				logging.Logger.Warn().
+					Str("registry", item.registry).
+					Str("set", set).
+					Str("unset", unset).
+					Msg("Ignoring half-configured registry credentials from the environment; trying the keyring next")
+				continue
 			}
 			*item.username, *item.password = username, password
 			break

--- a/scripts/deploy-camunda/cmd/credentials_test.go
+++ b/scripts/deploy-camunda/cmd/credentials_test.go
@@ -198,9 +198,6 @@ func TestCredentialsConfigureStoresPairWithoutPrintingSecret(t *testing.T) {
 	}
 }
 
-// A shell profile that exports only DOCKERHUB_USERNAME must not mask a keyring credential. The
-// half-set pair used to abort resolution with "DOCKERHUB_USERNAME/DOCKERHUB_PASSWORD must both be
-// set", so a correctly configured keyring failed to deploy until the stray var was unset.
 func TestResolveRegistryCredentialsFallsBackWhenEnvPairIsHalfSet(t *testing.T) {
 	store := useMemoryCredentialStore(t)
 	store.values[credentials.DockerHubRegistry] = credentials.Credential{Username: "stored", Password: "stored-token"}

--- a/scripts/deploy-camunda/cmd/credentials_test.go
+++ b/scripts/deploy-camunda/cmd/credentials_test.go
@@ -197,3 +197,21 @@ func TestCredentialsConfigureStoresPairWithoutPrintingSecret(t *testing.T) {
 		t.Fatal("configure output exposed secret")
 	}
 }
+
+// A shell profile that exports only DOCKERHUB_USERNAME must not mask a keyring credential. The
+// half-set pair used to abort resolution with "DOCKERHUB_USERNAME/DOCKERHUB_PASSWORD must both be
+// set", so a correctly configured keyring failed to deploy until the stray var was unset.
+func TestResolveRegistryCredentialsFallsBackWhenEnvPairIsHalfSet(t *testing.T) {
+	store := useMemoryCredentialStore(t)
+	store.values[credentials.DockerHubRegistry] = credentials.Credential{Username: "stored", Password: "stored-token"}
+	t.Setenv("DOCKERHUB_USERNAME", "half-set")
+	t.Setenv("DOCKERHUB_PASSWORD", "")
+
+	flags := config.DockerFlags{EnsureDockerHub: true}
+	if err := resolveRegistryCredentials(&flags); err != nil {
+		t.Fatalf("half-set env pair must not fail resolution: %v", err)
+	}
+	if flags.DockerHubUsername != "stored" || flags.DockerHubPassword != "stored-token" {
+		t.Fatalf("expected the keyring credential to win, got %#v", flags)
+	}
+}

--- a/scripts/render-e2e-env.sh
+++ b/scripts/render-e2e-env.sh
@@ -441,7 +441,17 @@ render_env_validate_args() {
     exit 1
   fi
 
-  if ! $kubectl_cmd get namespace "$namespace" > /dev/null 2>&1; then
+  local ns_probe_err ns_probe_rc=0
+  # 2>&1 >/dev/null captures stderr while discarding stdout; the order matters.
+  ns_probe_err="$($kubectl_cmd get namespace "$namespace" 2>&1 >/dev/null)" || ns_probe_rc=$?
+  if [[ $ns_probe_rc -ne 0 ]]; then
+    if grep -qiE 'reauthentication|unauthoriz|forbidden|credential|token|unable to connect|dial tcp|connection refused|no such host|certificate|timeout' <<< "$ns_probe_err"; then
+      echo "Error: cannot query the Kubernetes API, so namespace '$namespace' could not be verified." >&2
+      echo "       This is an API/credential failure, not a missing namespace." >&2
+      echo "       kubectl: ${ns_probe_err//$'\n'/ }" >&2
+      echo "       Re-authenticate (e.g. 'gcloud auth login') and retry." >&2
+      exit 1
+    fi
     echo "Error: namespace '$namespace' not found in the current Kubernetes context" >&2
     exit 1
   fi

--- a/scripts/render-e2e-env.sh
+++ b/scripts/render-e2e-env.sh
@@ -413,16 +413,35 @@ Options:
 EOF
 }
 
+validate_namespace_access() {
+  local namespace="$1"
+  local kube_context="${2:-}"
+  local kubectl_cmd=(kubectl)
+  local ns_probe_output ns_probe_rc=0
+
+  if [[ -n "$kube_context" ]]; then
+    kubectl_cmd+=("--context=$kube_context")
+  fi
+
+  ns_probe_output="$("${kubectl_cmd[@]}" get namespace "$namespace" --ignore-not-found -o name 2>&1)" || ns_probe_rc=$?
+  if [[ $ns_probe_rc -ne 0 ]]; then
+    echo "Error: cannot query the Kubernetes API, so namespace '$namespace' could not be verified." >&2
+    echo "       This is an API, connectivity, or credential failure, not a missing namespace." >&2
+    echo "       kubectl: ${ns_probe_output//$'\n'/ }" >&2
+    echo "       Check Kubernetes access and retry." >&2
+    exit 1
+  fi
+  if [[ -z "$ns_probe_output" ]]; then
+    echo "Error: namespace '$namespace' not found in the current Kubernetes context" >&2
+    exit 1
+  fi
+}
+
 render_env_validate_args() {
   local chart_path="$1"
   local namespace="$2"
   local output="$3"
   local kube_context="${4:-}"
-  local kubectl_cmd="kubectl"
-
-  if [[ -n "$kube_context" ]]; then
-    kubectl_cmd="kubectl --context=$kube_context"
-  fi
 
   log "DEBUG: Validating arguments"
 
@@ -441,20 +460,7 @@ render_env_validate_args() {
     exit 1
   fi
 
-  local ns_probe_err ns_probe_rc=0
-  # 2>&1 >/dev/null captures stderr while discarding stdout; the order matters.
-  ns_probe_err="$($kubectl_cmd get namespace "$namespace" 2>&1 >/dev/null)" || ns_probe_rc=$?
-  if [[ $ns_probe_rc -ne 0 ]]; then
-    if grep -qiE 'reauthentication|unauthoriz|forbidden|credential|token|unable to connect|dial tcp|connection refused|no such host|certificate|timeout' <<< "$ns_probe_err"; then
-      echo "Error: cannot query the Kubernetes API, so namespace '$namespace' could not be verified." >&2
-      echo "       This is an API/credential failure, not a missing namespace." >&2
-      echo "       kubectl: ${ns_probe_err//$'\n'/ }" >&2
-      echo "       Re-authenticate (e.g. 'gcloud auth login') and retry." >&2
-      exit 1
-    fi
-    echo "Error: namespace '$namespace' not found in the current Kubernetes context" >&2
-    exit 1
-  fi
+  validate_namespace_access "$namespace" "$kube_context"
 
   if [[ -z "$output" ]]; then
     echo "Error: --output is required" >&2

--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -36,7 +36,17 @@ validate_args() {
     exit 1
   fi
 
-  if ! $kubectl_cmd get namespace "$namespace" > /dev/null 2>&1; then
+  local ns_probe_err ns_probe_rc=0
+  # 2>&1 >/dev/null captures stderr while discarding stdout; the order matters.
+  ns_probe_err="$($kubectl_cmd get namespace "$namespace" 2>&1 >/dev/null)" || ns_probe_rc=$?
+  if [[ $ns_probe_rc -ne 0 ]]; then
+    if grep -qiE 'reauthentication|unauthoriz|forbidden|credential|token|unable to connect|dial tcp|connection refused|no such host|certificate|timeout' <<< "$ns_probe_err"; then
+      echo "Error: cannot query the Kubernetes API, so namespace '$namespace' could not be verified." >&2
+      echo "       This is an API/credential failure, not a missing namespace." >&2
+      echo "       kubectl: ${ns_probe_err//$'\n'/ }" >&2
+      echo "       Re-authenticate (e.g. 'gcloud auth login') and retry." >&2
+      exit 1
+    fi
     echo "Error: namespace '$namespace' not found in the current Kubernetes context" >&2
     exit 1
   fi

--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -13,11 +13,6 @@ validate_args() {
   local chart_path="$1"
   local namespace="$2"
   local kube_context="${3:-}"
-  local kubectl_cmd="kubectl"
-  
-  if [[ -n "$kube_context" ]]; then
-    kubectl_cmd="kubectl --context=$kube_context"
-  fi
   
   log "DEBUG: Validating arguments"
 
@@ -36,20 +31,7 @@ validate_args() {
     exit 1
   fi
 
-  local ns_probe_err ns_probe_rc=0
-  # 2>&1 >/dev/null captures stderr while discarding stdout; the order matters.
-  ns_probe_err="$($kubectl_cmd get namespace "$namespace" 2>&1 >/dev/null)" || ns_probe_rc=$?
-  if [[ $ns_probe_rc -ne 0 ]]; then
-    if grep -qiE 'reauthentication|unauthoriz|forbidden|credential|token|unable to connect|dial tcp|connection refused|no such host|certificate|timeout' <<< "$ns_probe_err"; then
-      echo "Error: cannot query the Kubernetes API, so namespace '$namespace' could not be verified." >&2
-      echo "       This is an API/credential failure, not a missing namespace." >&2
-      echo "       kubectl: ${ns_probe_err//$'\n'/ }" >&2
-      echo "       Re-authenticate (e.g. 'gcloud auth login') and retry." >&2
-      exit 1
-    fi
-    echo "Error: namespace '$namespace' not found in the current Kubernetes context" >&2
-    exit 1
-  fi
+  validate_namespace_access "$namespace" "$kube_context"
   
   log "DEBUG: Arguments validated successfully"
 }

--- a/test/scripts/e2e_namespace_validation.bats
+++ b/test/scripts/e2e_namespace_validation.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+
+setup() {
+  if ROOT="$(git -C "$here" rev-parse --show-toplevel 2>/dev/null)"; then
+    :
+  else
+    ROOT="$(cd "$here/../.." && pwd)"
+  fi
+  export ROOT
+
+  log() {
+    :
+  }
+  source "$ROOT/scripts/render-e2e-env.sh"
+}
+
+@test "namespace validation accepts an existing namespace" {
+  kubectl() {
+    printf '%s\n' 'namespace/test-namespace'
+  }
+
+  run validate_namespace_access test-namespace
+
+  [ "$status" -eq 0 ]
+}
+
+@test "namespace validation reports a missing namespace" {
+  kubectl() {
+    return 0
+  }
+
+  run validate_namespace_access test-namespace
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"namespace 'test-namespace' not found"* ]]
+}
+
+@test "namespace validation preserves API failures" {
+  kubectl() {
+    printf '%s\n' 'Unable to connect to the server: token expired' >&2
+    return 1
+  }
+
+  run validate_namespace_access test-namespace test-context
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"cannot query the Kubernetes API"* ]]
+  [[ "$output" == *"token expired"* ]]
+  [[ "$output" != *"namespace 'test-namespace' not found"* ]]
+}


### PR DESCRIPTION
### Which problem does the PR fix?

Two diagnostics in the local deploy path report a credential problem as something
else. Both were hit during the investigation on #6891 and each sent the debugging
in the wrong direction.

**1. A half-set env pair aborts credential resolution before the keyring is tried.**

`resolveRegistryCredentialsFromEnvironment` fails hard when one half of a registry
pair is set:

```go
if username == "" || password == "" {
    return fmt.Errorf("%s/%s must both be set", pair[0], pair[1])
}
```

`resolveRegistryCredentials` calls it before the keyring loop, so the error returns
early and the keyring is never consulted. On a machine where
`deploy-camunda credentials status` reports both registries configured, a shell
profile exporting a bare `DOCKERHUB_USERNAME` is enough to fail the deploy. The
error names the two env vars, so the natural response is to go hunting for the
password rather than to unset the stray variable.

**2. Any Kubernetes API failure is reported as a missing namespace.**

`run-e2e-tests.sh` and `render-e2e-env.sh` both probe with stderr discarded:

```bash
if ! $kubectl_cmd get namespace "$namespace" > /dev/null 2>&1; then
  echo "Error: namespace '$namespace' not found in the current Kubernetes context" >&2
```

When a `gcloud` token expires mid-run, this is what surfaces. It is
indistinguishable from a genuinely deleted namespace, and it points at namespace
lifecycle and TTLs instead of at re-authentication.

### What's in this PR?

- `resolveRegistryCredentialsFromEnvironment` skips a half-set pair with a warning
  naming which var is set and which is missing, then falls through to the remaining
  pairs, the keyring, and any env files. A fully-set pair still wins over the
  keyring, so existing precedence is unchanged.
- A shared namespace validator uses `kubectl --ignore-not-found -o name`: successful
  empty output retains the missing-namespace message, while nonzero results report
  the original API, connectivity, or credential error. Both E2E entry points use
  the same validator.
- Go and Bats regressions cover the half-set credential fallback and all namespace
  probe outcomes.

Verified with `make test`. No chart files are touched, hence the `chore:` prefix.

### Checklist

Please make sure to follow our [Contributing Guide](../docs/contribution-and-collaboration.md).

**Before opening the PR:**

- [ ] In the repo's root dir, run `make go.update-golden-only`.
- [ ] There is no other open [pull request](../pulls) for the same update/change.
- [ ] Tests for charts are added (if needed).
- [ ] In-repo [documentation](../docs/contribution-and-collaboration.md#contribution-policy) are updated (if needed).

**After opening the PR:**

- [ ] Did you sign our CLA (Contributor License Agreement)? It will show once you open the PR.
- [ ] Did all checks/tests pass in the PR?