### PR TITLE
feat: migrate Identity presets from Web Modeler to Hub

### DIFF
--- a/charts/camunda-platform-8.10/templates/common/constraints.tpl
+++ b/charts/camunda-platform-8.10/templates/common/constraints.tpl
@@ -76,7 +76,7 @@ Chart 15.x (Camunda 8.10) requires Helm v4 or later.
     {{- end }}
     {{- $_ := set $seenIds $client.id true }}
   {{- end }}
-  {{- $seenRoles := dict "ManagementIdentity" true "Orchestration" true "Optimize" true "Web Modeler" true "Web Modeler Admin" true }}
+  {{- $seenRoles := dict "ManagementIdentity" true "Orchestration" true "Optimize" true "Web Modeler" true "Web Modeler Admin" true "Hub" true "Hub Admin" true "Console" true "DevOps" true }}
   {{- $legacyIds := list }}
   {{- if .Values.global.identity.auth.connectors.alwaysRegister }}
     {{- $legacyIds = append $legacyIds (include "connectors.authClientId" .) }}

--- a/charts/camunda-platform-8.10/templates/identity/configmap.yaml
+++ b/charts/camunda-platform-8.10/templates/identity/configmap.yaml
@@ -266,21 +266,23 @@ data:
         {{- end }}
         webmodeler:
           applications:
-            - name: "Web Modeler"
+            - name: "Hub"
               id: ${CAMUNDA_WEBMODELER_CLIENT_ID:${VALUES_KEYCLOAK_INIT_WEBMODELER_CLIENT_ID:web-modeler}}
               type: public
               root-url: {{ tpl (or .Values.global.identity.auth.camundaHub.redirectUrl .Values.global.identity.auth.webModeler.redirectUrl) $ | quote }}
               redirect-uris:
                 - "/login-callback"
           apis:
-            - name: Web Modeler Internal API
+            - name: Hub Internal API
               audience: {{ include "webModeler.authClientApiAudience" . | quote }}
               permissions:
                 - definition: write:*
                   description: "Write permission"
                 - definition: admin:*
                   description: "Admin permission"
-            - name: Web Modeler API
+                - definition: admin:clusters
+                  description: "Cluster management permission"
+            - name: Hub API
               audience: {{ include "webModeler.authPublicApiAudience" . | quote }}
               permissions:
                 - definition: create:*
@@ -293,14 +295,14 @@ data:
                   description: "Allows delete access for all resources"
           roles:
             - name: "Web Modeler"
-              description: "Grants full access to Web Modeler"
+              description: "Grants full access to Hub"
               permissions:
                 - audience: {{ include "webModeler.authClientApiAudience" . | quote }}
                   definition: write:*
                 - audience: {{ include "identity.authAudience" . | quote }}
                   definition: read:users
             - name: "Web Modeler Admin"
-              description: "Grants elevated access to Web Modeler"
+              description: "Grants elevated access to Hub"
               permissions:
                 - audience: {{ include "identity.authAudience" . | quote }}
                   definition: read:users
@@ -308,6 +310,40 @@ data:
                   definition: write:*
                 - audience: {{ include "webModeler.authClientApiAudience" . | quote }}
                   definition: admin:*
+            - name: "Hub"
+              description: "Grants full access to Hub"
+              permissions:
+                - audience: {{ include "webModeler.authClientApiAudience" . | quote }}
+                  definition: write:*
+                - audience: {{ include "identity.authAudience" . | quote }}
+                  definition: read:users
+            - name: "Hub Admin"
+              description: "Grants elevated access to Hub"
+              permissions:
+                - audience: {{ include "identity.authAudience" . | quote }}
+                  definition: read:users
+                - audience: {{ include "webModeler.authClientApiAudience" . | quote }}
+                  definition: write:*
+                - audience: {{ include "webModeler.authClientApiAudience" . | quote }}
+                  definition: admin:*
+            - name: "Console"
+              description: "Grants access to Hub's cluster management"
+              permissions:
+                - audience: {{ include "webModeler.authClientApiAudience" . | quote }}
+                  definition: write:*
+                - audience: {{ include "identity.authAudience" . | quote }}
+                  definition: read:users
+                - audience: {{ include "webModeler.authClientApiAudience" . | quote }}
+                  definition: admin:clusters
+            - name: "DevOps"
+              description: "Grants access to Hub's cluster management"
+              permissions:
+                - audience: {{ include "webModeler.authClientApiAudience" . | quote }}
+                  definition: write:*
+                - audience: {{ include "identity.authAudience" . | quote }}
+                  definition: read:users
+                - audience: {{ include "webModeler.authClientApiAudience" . | quote }}
+                  definition: admin:clusters
             {{- if or .Values.orchestration.hub.ping.endpoint .Values.global.identity.auth.orchestration.hubPingAuthorizationEnabled }}
             - name: "CamundaHub - Cluster Ping"
               description: "Grants create/update access to the CamundaHub API for the orchestration cluster ping"
@@ -464,8 +500,9 @@ data:
             - Optimize
             {{- end }}
             {{- if eq (include "camundaHub.webModelerEnabled" .) "true" }}
-            - Web Modeler
-            - Web Modeler Admin
+            - Hub
+            - Hub Admin
+            - DevOps
             {{- end }}
             {{- if or .Values.global.identity.auth.orchestration.alwaysRegister (and (ne (include "camundaPlatform.topologyMode" .) "hub") (or .Values.global.identity.auth.orchestration.hubPingAuthorizationEnabled (eq (include "orchestration.authMethod" .) "oidc"))) }}
             - Orchestration

--- a/charts/camunda-platform-8.10/test/unit/identity/golden/configmap.golden.yaml
+++ b/charts/camunda-platform-8.10/test/unit/identity/golden/configmap.golden.yaml
@@ -51,21 +51,23 @@ data:
                   definition: write
         webmodeler:
           applications:
-            - name: "Web Modeler"
+            - name: "Hub"
               id: ${CAMUNDA_WEBMODELER_CLIENT_ID:${VALUES_KEYCLOAK_INIT_WEBMODELER_CLIENT_ID:web-modeler}}
               type: public
               root-url: "http://localhost:8070"
               redirect-uris:
                 - "/login-callback"
           apis:
-            - name: Web Modeler Internal API
+            - name: Hub Internal API
               audience: "web-modeler-api"
               permissions:
                 - definition: write:*
                   description: "Write permission"
                 - definition: admin:*
                   description: "Admin permission"
-            - name: Web Modeler API
+                - definition: admin:clusters
+                  description: "Cluster management permission"
+            - name: Hub API
               audience: "web-modeler-public-api"
               permissions:
                 - definition: create:*
@@ -78,14 +80,14 @@ data:
                   description: "Allows delete access for all resources"
           roles:
             - name: "Web Modeler"
-              description: "Grants full access to Web Modeler"
+              description: "Grants full access to Hub"
               permissions:
                 - audience: "web-modeler-api"
                   definition: write:*
                 - audience: "camunda-identity-resource-server"
                   definition: read:users
             - name: "Web Modeler Admin"
-              description: "Grants elevated access to Web Modeler"
+              description: "Grants elevated access to Hub"
               permissions:
                 - audience: "camunda-identity-resource-server"
                   definition: read:users
@@ -93,6 +95,40 @@ data:
                   definition: write:*
                 - audience: "web-modeler-api"
                   definition: admin:*
+            - name: "Hub"
+              description: "Grants full access to Hub"
+              permissions:
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+            - name: "Hub Admin"
+              description: "Grants elevated access to Hub"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "web-modeler-api"
+                  definition: admin:*
+            - name: "Console"
+              description: "Grants access to Hub's cluster management"
+              permissions:
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+                - audience: "web-modeler-api"
+                  definition: admin:clusters
+            - name: "DevOps"
+              description: "Grants access to Hub's cluster management"
+              permissions:
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+                - audience: "web-modeler-api"
+                  definition: admin:clusters
     keycloak:
       url: "https://keycloak.example.com:8443/auth/"
       setup:


### PR DESCRIPTION
### Related

* Mirrors https://github.com/camunda/identity/pull/4541 (Management Identity built-in presets)
* Companion PR for docker-compose: https://github.com/camunda/camunda-distributions/pull/742
* Relates to https://github.com/camunda/camunda-hub/issues/21467
* Relates to https://github.com/camunda/camunda-hub/issues/25470

### Description

Applies the Web Modeler to Hub preset migration from camunda/identity#4541 to the chart's Identity configuration.

**Why the chart needs its own change.** The rendered ConfigMap is mounted at `/app/config/application.yaml`, a default Spring config location, so it layers on top of the `application.yaml` inside the Identity image rather than replacing it. Map keys merge across sources, but a collection is bound from a single source. Since the chart declares `identity.component-presets.webmodeler`, its `apis` and `roles` lists win outright and inherit nothing from the image, so every role the upstream PR adds has to be spelled out here too.

**Labels.** `Web Modeler` becomes `Hub` in the application and API display names, and in the role descriptions. The `webmodeler` preset key, the client id and both audiences are deliberately unchanged, matching the upstream backward-compatibility decision.

**Cluster management.** A new `admin:clusters` permission is added to Hub's internal API. This is the permission that replaces the standalone Console client, which camunda/identity#4541 deletes. Two roles grant it:

* `Console`, so that anyone holding the role today keeps cluster admin access once the Identity image stops shipping the console preset. The chart never declared a `console` preset of its own, so that preset currently reaches Helm installations from the image defaults and will disappear when the upstream PR ships.
* `DevOps`, the equivalent for new installations.

`Hub` and `Hub Admin` are added alongside the existing `Web Modeler` and `Web Modeler Admin` roles, which stay for backward compatibility. All four new names are reserved in `constraints.tpl` so a `global.topology.clusters[].components[].roleName` cannot silently collide with a built-in role.

### Is there anything else to consider?

**Two judgement calls worth a look:**

* The first user now gets `Hub`, `Hub Admin` and `DevOps` instead of `Web Modeler` and `Web Modeler Admin`. The permission sets are identical, so this is a naming change rather than an access change, but it does affect upgrades and not just fresh installs.
* The ping role here is named `CamundaHub - Cluster Ping` while camunda/identity#4541 renames its equivalent to `Hub API - Cluster Ping`. I left the chart's name alone: it is self-consistent with the mapping rule this chart renders, and renaming it would break that mapping on existing installations. Flagging it so the divergence is a deliberate choice rather than an oversight.

`test/integration/scenarios/chart-full-setup/values/base-qa.yaml` still assigns the legacy `Web Modeler` and `Web Modeler Admin` names to its test users. Those roles still exist, so it keeps working, and I left it untouched to keep the diff scoped.
