### PR TITLE
ci: attach the Bitnami tag versioning to the datasources [ready]

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -102,12 +102,13 @@
     },
   },
   packageRules: [
-    // Bitnami Premium tags are '<x.y.z>-debian-<n>-rN'. 'docker' versioning does not
-    // move across the '-rN' revision and the customManagers fall back to 'semver',
-    // which rejects the tag outright -- and a rejected tag is not an error: Renovate
-    // drops the dependency with 'skipReason: invalid-value' and it silently stops
-    // being updated. Attaching the versioning to the datasources makes the inline
-    // 'versioning=' in values-enterprise.yaml redundant rather than load-bearing.
+    // Bitnami Premium tags are '<x.y.z>-debian-<n>-rN'. The values-enterprise.yaml
+    // customManager falls back to 'docker' when an annotation carries no inline
+    // 'versioning=', and 'docker' does not order across the '-rN' revision. That
+    // failure is silent: the dependency resolves, there is no skipReason and no
+    // warning, it is simply never offered an update again. Attaching the versioning
+    // to the datasources makes the inline 'versioning=' in values-enterprise.yaml
+    // redundant rather than load-bearing.
     {
       description: 'Bitnami Premium tags carry a -rN revision the default versionings cannot move.',
       matchDatasources: [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -102,6 +102,25 @@
     },
   },
   packageRules: [
+    // Bitnami Premium tags are '<x.y.z>-debian-<n>-rN'. 'docker' versioning does not
+    // move across the '-rN' revision and the customManagers fall back to 'semver',
+    // which rejects the tag outright -- and a rejected tag is not an error: Renovate
+    // drops the dependency with 'skipReason: invalid-value' and it silently stops
+    // being updated. Attaching the versioning to the datasources makes the inline
+    // 'versioning=' in values-enterprise.yaml redundant rather than load-bearing.
+    {
+      description: 'Bitnami Premium tags carry a -rN revision the default versionings cannot move.',
+      matchDatasources: [
+        'custom.bitnami-postgresql-camunda',
+        'custom.bitnami-os-shell-camunda',
+        'custom.bitnami-postgres-exporter-camunda',
+        'custom.bitnami-elasticsearch-camunda',
+        'custom.bitnami-elasticsearch-exporter-camunda',
+        'custom.bitnami-keycloak-config-cli-camunda',
+        'custom.bitnami-keycloak-camunda',
+      ],
+      versioning: 'regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(-(?<compatibility>debian-\\d+)-r(?<build>\\d+))?$',
+    },
     // vendor-ee/postgresql in the 8.7/8.8/8.9 enterprise values is sourced from
     // the bitnami-postgresql-camunda custom datasource (see customManagers);
     // disable the docker/helm-values tracking for it so it is not bumped twice.


### PR DESCRIPTION
## Why

The custom manager that reads `values-enterprise.yaml` falls back to `docker` when an annotation carries no inline `versioning=`:

```json5
versioningTemplate: '{{#if versioning}}{{{versioning}}}{{else}}docker{{/if}}',
```

and, as the comment right above it already says, `docker` versioning does not order across the `-rN` build suffix Bitnami Premium tags carry. What that comment does not say is how it fails: the dependency **resolves cleanly** — no error, no `skipReason`, nothing on the Dependency Dashboard — and simply stops being offered updates.

Verified with a local lookup (`renovate --platform=local --dry-run=lookup`) on a `values-enterprise.yaml` whose annotation omits the inline versioning:

| config | resolved versioning | skipReason | updates offered |
|---|---|---|---|
| `main` | `docker` | none | **none** |
| this branch | the `-rN` regex | none | `minor -> 18.6.0-debian-12-r3` |

So every annotation is one forgotten `versioning=` away from a silently frozen image, and the only thing standing between the two is that whoever wrote the current three remembered to paste a 90-character regex.

## What

Attach that regex to the seven `custom.bitnami-*-camunda` datasources instead of asking each annotation to carry it. The inline `versioning=` becomes redundant rather than load-bearing.

The existing annotations in `charts/camunda-platform-8.{7,8,9}/values-enterprise.yaml` pass exactly this regex, so **nothing changes for them** — a packageRule `versioning` overrides the inline one with the same value. They are left in place: they are correct, and they document the tag shape where a reader meets it.

## Notes

* The same rule was added to the shared preset in camunda/infraex-common-config#582. This repository declares its own copy of the `customDatasources` rather than extending that preset, so it needs its own copy of the rule — worth deciding separately whether that duplication should stay.
* `renovate-config-validator --strict` reports `Config migration necessary` on this file. That is pre-existing on `main` (unchanged by this PR) and not addressed here.
