### PR TITLE
chore: gofmt the repo for the Go 1.27 alignment rules

### DIFF
--- a/charts/camunda-platform-8.10/test/unit/common/helpers_normalize_secret_test.go
+++ b/charts/camunda-platform-8.10/test/unit/common/helpers_normalize_secret_test.go
@@ -52,8 +52,8 @@ func (s *normalizeSecretConfigTest) TestSecretHelperFunctionsWithOpenSearch() {
 		{
 			Name: "opensearch new style secret creates env vars",
 			Values: map[string]string{
-				"orchestration.enabled":                                                        "true",
-				"orchestration.data.secondaryStorage.type":                                     "opensearch",
+				"orchestration.enabled":                    "true",
+				"orchestration.data.secondaryStorage.type": "opensearch",
 				"orchestration.data.secondaryStorage.opensearch.auth.secret.existingSecret":    "my-opensearch-secret",
 				"orchestration.data.secondaryStorage.opensearch.auth.secret.existingSecretKey": "my-key",
 			},

--- a/charts/camunda-platform-8.8/test/unit/identity/deployment_test.go
+++ b/charts/camunda-platform-8.8/test/unit/identity/deployment_test.go
@@ -991,10 +991,10 @@ func (s *deploymentTemplateTest) TestDifferentValuesInputs() {
 			Name:                 "TestConnectorsDisabledExcludesOidcSecretEnvVar",
 			HelmOptionsExtraArgs: map[string][]string{"install": {"--debug"}},
 			Values: map[string]string{
-				"identity.enabled":                      "true",
-				"global.identity.auth.enabled":          "true",
-				"global.security.authentication.method": "oidc",
-				"connectors.enabled":                    "false",
+				"identity.enabled":                                               "true",
+				"global.identity.auth.enabled":                                   "true",
+				"global.security.authentication.method":                          "oidc",
+				"connectors.enabled":                                             "false",
 				"orchestration.security.authentication.oidc.existingSecret.name": "orchestration-oidc-secret",
 			},
 			Verifier: func(t *testing.T, output string, err error) {

--- a/charts/camunda-platform-8.9/test/unit/common/helpers_normalize_secret_test.go
+++ b/charts/camunda-platform-8.9/test/unit/common/helpers_normalize_secret_test.go
@@ -52,8 +52,8 @@ func (s *normalizeSecretConfigTest) TestSecretHelperFunctionsWithOpenSearch() {
 		{
 			Name: "opensearch new style secret creates env vars",
 			Values: map[string]string{
-				"orchestration.enabled":                                                        "true",
-				"orchestration.data.secondaryStorage.type":                                     "opensearch",
+				"orchestration.enabled":                    "true",
+				"orchestration.data.secondaryStorage.type": "opensearch",
 				"orchestration.data.secondaryStorage.opensearch.auth.secret.existingSecret":    "my-opensearch-secret",
 				"orchestration.data.secondaryStorage.opensearch.auth.secret.existingSecretKey": "my-key",
 			},


### PR DESCRIPTION
## Problem

The repo-wide `gofmt` gate (`.github/workflows/repo-go-format.yaml`) is failing on `main` and on every open PR whose merge commit picks up the current toolchain pin.

`deps: update minor-updates (minor) (#6936)` moved `.tool-versions` from `golang 1.26.6` to `1.27.0`. Go 1.27 changed how `gofmt` groups aligned map-literal entries, so three test files that were correctly formatted under 1.26 are no longer formatted under 1.27:

- `charts/camunda-platform-8.10/test/unit/common/helpers_normalize_secret_test.go`
- `charts/camunda-platform-8.9/test/unit/common/helpers_normalize_secret_test.go`
- `charts/camunda-platform-8.8/test/unit/identity/deployment_test.go`

The gate installs Go from `.tool-versions` and is deliberately neither path-filtered nor chart-scoped, so it fails on PRs that touch none of these files. It is also easy to miss locally: any Go up to and including the previous pin reports the tree clean, so the failure only appears once CI resolves 1.27.

## Change

`gofmt -w` with Go 1.27.0 across all tracked Go files. Nothing else.

## Verification

- `gofmt -l $(git ls-files '*.go')` with Go 1.27.0: clean. Reproduced the failure on unmodified `main` first — same three files.
- **Whitespace only**: `git diff -w` is empty. `gofmt` preserves semantics by construction.
- `go vet` passes on all three affected packages.
- `camunda-platform/test/unit/common` (8.10) passes with the reformatted file.
